### PR TITLE
feat(claude-code-plugin): add Claude Code plugin package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3330,6 +3330,10 @@
         "win32"
       ]
     },
+    "node_modules/@rundown-org/claude-code-plugin": {
+      "resolved": "packages/claude-code-plugin",
+      "link": true
+    },
     "node_modules/@rundown-org/cli": {
       "resolved": "packages/cli",
       "link": true
@@ -5939,6 +5943,46 @@
       "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
       "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -12687,6 +12731,48 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "packages/claude-code-plugin": {
+      "name": "@rundown-org/claude-code-plugin",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rundown-org/cli": "*",
+        "commander": "^14.0.2",
+        "js-yaml": "^4.1.1",
+        "mdast-util-from-markdown": "^2.0.2",
+        "minimatch": "^10.1.1",
+        "unist-util-visit": "^5.0.0",
+        "zod": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.0",
+        "@types/js-yaml": "^4.0.9",
+        "@types/mdast": "^4.0.4",
+        "@types/node": "^20.0.0",
+        "fast-check": "^4.5.2",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20.12.0"
+      }
+    },
+    "packages/claude-code-plugin/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/cli": {
       "name": "@rundown-org/cli",
       "version": "1.0.0",
@@ -13500,6 +13586,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "packages/mcp": {
+      "name": "@rundown-org/mcp",
+      "version": "1.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.0",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "rundown-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20.12.0"
       }
     },
     "packages/parser": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "site"
   ],
   "scripts": {
-    "build": "npm run build -w packages/parser && npm run build -w packages/core && npm run build -w packages/cli",
+    "build": "npm run build -w packages/parser && npm run build -w packages/core && npm run build -w packages/cli && npm run build -w packages/claude-code-plugin",
     "build:site": "npm run build -w site",
     "build:all": "npm run build && npm run build -w site",
     "test": "npm run test -w packages/parser && npm run test -w packages/core && npm run test -w packages/cli",

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "rundown",
+  "version": "1.0.0",
+  "description": "Claude Code plugin for runbook orchestration and workflow execution",
+  "author": {
+    "name": "Toby Hede",
+    "email": "toby@rundown.org"
+  },
+  "repository": "https://github.com/rundown-org/rundown"
+}

--- a/packages/claude-code-plugin/commands/execute.md
+++ b/packages/claude-code-plugin/commands/execute.md
@@ -1,0 +1,31 @@
+---
+description: Execute an implementation plan with workflow orchestration
+argument-hint: <plan-file>
+---
+
+# Execute Plan
+
+Execute implementation plans with workflow orchestration.
+
+## Usage
+
+```
+/rundown:execute <plan-file>
+```
+
+- `$1` - plan file path (required)
+
+<instructions>
+## Instructions
+
+## MANDATORY: Skill Activation
+
+Use and follow the executing-plans skill exactly as written.
+
+Path: `${CLAUDE_PLUGIN_ROOT}skills/executing-plans/SKILL.md`
+Tool: `Skill(skill: "rundown:executing-plans")`
+
+Do NOT proceed without completing skill activation.
+</instructions>
+
+ARGUMENTS: $ARGUMENTS

--- a/packages/claude-code-plugin/commands/verify.md
+++ b/packages/claude-code-plugin/commands/verify.md
@@ -1,0 +1,22 @@
+---
+description: Verify with independent agents and consensus-based collation
+---
+
+# Verify
+
+Dispatch N independent review agents, collate findings by consensus ratio, cross-check exclusive findings.
+
+<instructions>
+## Instructions
+
+## MANDATORY: Skill Activation
+
+Use and follow the verifying-by-consensus skill exactly as written.
+
+Path: `${CLAUDE_PLUGIN_ROOT}skills/verifying-by-consensus/SKILL.md`
+Tool: `Skill(skill: "rundown:verifying-by-consensus")`
+
+Do NOT proceed without completing skill activation.
+</instructions>
+
+ARGUMENTS: $ARGUMENTS

--- a/packages/claude-code-plugin/hooks.json
+++ b/packages/claude-code-plugin/hooks.json
@@ -1,0 +1,74 @@
+{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": ".*",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js"
+      }]
+    }],
+    "SessionEnd": [{
+      "matcher": ".*",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js"
+      }]
+    }],
+    "UserPromptSubmit": [{
+      "matcher": ".*",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js"
+      }]
+    }],
+    "SubagentStop": [{
+      "matcher": ".*",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js"
+      }]
+    }],
+    "PreToolUse": [{
+      "matcher": ".*",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js"
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": ".*",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js"
+      }]
+    }],
+    "Stop": [{
+      "matcher": ".*",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js"
+      }]
+    }],
+    "Notification": [{
+      "matcher": ".*",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js"
+      }]
+    }],
+    "PreCompact": [{
+      "matcher": ".*",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js"
+      }]
+    }],
+    "PermissionRequest": [{
+      "matcher": ".*",
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js"
+      }]
+    }]
+  }
+}

--- a/packages/claude-code-plugin/jest.config.js
+++ b/packages/claude-code-plugin/jest.config.js
@@ -1,0 +1,33 @@
+export default {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/__tests__'],
+  testMatch: ['**/*.test.ts'],
+  collectCoverageFrom: ['src/**/*.ts'],
+  coverageReporters: ['text', 'lcov', 'html'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: {
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          target: 'ES2022',
+          lib: ['ES2022'],
+          strict: true,
+          esModuleInterop: true,
+          allowSyntheticDefaultImports: true,
+          skipLibCheck: true,
+          forceConsistentCasingInFileNames: true,
+          resolveJsonModule: true,
+          isolatedModules: true,
+        },
+      },
+    ],
+  },
+};

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@rundown-org/claude-code-plugin",
+  "version": "1.0.0",
+  "description": "Claude Code plugin for runbook orchestration and workflow execution",
+  "type": "module",
+  "main": "dist/cli.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js"
+    }
+  },
+  "files": [
+    "dist",
+    ".claude-plugin",
+    "commands",
+    "hooks.json",
+    "runbooks",
+    "rundown-plugin.json",
+    "scripts",
+    "skills",
+    "templates",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
+    "test:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage",
+    "clean": "rm -rf dist",
+    "lint": "eslint src/**/*.ts __tests__/**/*.ts"
+  },
+  "keywords": [
+    "rundown",
+    "runbook",
+    "claude-code",
+    "plugin",
+    "workflow"
+  ],
+  "author": "Toby Hede",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rundown-org/rundown.git",
+    "directory": "packages/claude-code-plugin"
+  },
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "dependencies": {
+    "@rundown-org/cli": "*",
+    "commander": "^14.0.2",
+    "js-yaml": "^4.1.1",
+    "mdast-util-from-markdown": "^2.0.2",
+    "minimatch": "^10.1.1",
+    "unist-util-visit": "^5.0.0",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "@types/js-yaml": "^4.0.9",
+    "@types/mdast": "^4.0.4",
+    "@types/node": "^20.0.0",
+    "fast-check": "^4.5.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/claude-code-plugin/runbooks/execute-plan.runbook.md
+++ b/packages/claude-code-plugin/runbooks/execute-plan.runbook.md
@@ -1,0 +1,108 @@
+# Execute Plan
+
+Execute an implementation plan in batches with review checkpoints.
+
+## 1. Review plan
+
+Read and review the implementation plan.
+
+Is the plan clear and complete?
+
+- YES: CONTINUE
+- NO: STOP
+
+
+## 2. For each batch of tasks
+
+### 2.{n} Dispatch code agent
+  - implement-task.runbook.md
+
+- PASS ALL: CONTINUE
+- FAIL ANY: GOTO 4
+
+
+## CodeReview
+Dispatch code review agent
+  - code-review.runbook.md
+
+- PASS: GOTO 2
+- FAIL: GOTO {N}.1
+
+
+## 3. Check batch
+
+```bash
+tsv echo npm run lint && tsv echo npm run build && tsv echo npm test
+```
+
+- PASS: CONTINUE
+- FAIL: GOTO 4
+
+## 4. Handle failures
+
+Analyze failures and present options to orchestrator.
+
+**Prompt:** Summarize failures and present:
+- FIX: Attempt inline fixes (syntax, imports, types)
+- REVISE: Plan needs modification
+- ABORT: Stop execution
+
+**tsv pass:** Orchestrator chose FIX, issues are resolvable
+**tsv fail:** Orchestrator chose REVISE or ABORT
+
+- PASS: GOTO 5
+- FAIL: STOP "STOPPED: Orchestrator decision required"
+
+## 5. Apply fixes
+
+Apply inline fixes within plan constraints.
+
+**HOW changes** (`tsv pass`): syntax, imports, types, test setup
+**WHAT changes** (`tsv fail`): algorithm, library, data structure, scope
+
+When uncertain, `tsv fail`.
+
+- PASS: GOTO 3
+- FAIL: STOP "STOPPED: Requires plan revision"
+
+## 6. Code review
+
+Review batch changes before proceeding.
+
+**Prompt:** Dispatch code review for batch changes.
+Categorize findings: BLOCKING or NON-BLOCKING.
+
+**tsv pass:** No blocking issues (or fixed)
+**tsv fail:** Blocking issues remain
+
+- PASS: CONTINUE
+- FAIL: STOP "STOPPED: Code review issues"
+
+## 7. Check remaining
+
+Evaluate remaining work.
+
+**tsv yes:** More batches remain → goto 2
+**tsv no:** All batches complete
+
+- PASS: GOTO 2
+- FAIL: CONTINUE
+
+## 8. Final validation
+
+```bash
+tsv echo npm run lint && tsv echo npm run build && tsv echo npm test
+```
+
+- PASS: CONTINUE
+- FAIL: STOP "STOPPED: Final validation failed"
+
+## 9. Complete
+
+```
+STATUS: COMPLETE
+PLAN: {plan_name}
+BATCHES: {count}
+```
+
+- PASS: COMPLETE

--- a/packages/claude-code-plugin/runbooks/implement-task.runbook.md
+++ b/packages/claude-code-plugin/runbooks/implement-task.runbook.md
@@ -1,0 +1,67 @@
+# Implement Task
+
+Execute tasks from the implementation plan sequentially.
+
+## {N}. Task
+
+### {N}.1 Implement
+
+Follow the plan exactly.
+
+Required changes from plan?
+
+- NO: GOTO {N}.3
+- YES: GOTO {N}.2
+
+### {N}.2 Evaluate
+
+Assess changes to logic, dependencies, scope, interfaces.
+
+Within implementation boundaries?
+
+- YES: CONTINUE
+- NO: STOP "STOPPED: Changes exceed implementation boundaries"
+
+### {N}.3 Checks
+
+```bash
+tsv echo npm run lint && tsv echo npm run build
+```
+
+- PASS: CONTINUE
+- FAIL: GOTO {N}.5
+
+### {N}.4 Tests
+
+```bash
+tsv echo npm test
+```
+
+- PASS: CONTINUE
+- FAIL: GOTO {N}.5
+
+### {N}.5 Troubleshoot
+
+Can you fix without changing approach?
+
+- YES: GOTO {N}.6
+- NO: STOP "STOPPED: Requires plan revision"
+
+### {N}.6 Apply fixes
+
+Apply inline fixes.
+
+- PASS: GOTO {N}.3
+- FAIL: STOP "STOPPED: Could not apply fixes"
+
+### {N}.7 Complete
+
+```
+STATUS: OK
+TASK: {N}
+```
+
+More tasks?
+
+- YES: GOTO NEXT
+- NO: COMPLETE

--- a/packages/claude-code-plugin/runbooks/verify.runbook.md
+++ b/packages/claude-code-plugin/runbooks/verify.runbook.md
@@ -1,0 +1,57 @@
+# N-Verification Workflow
+
+Orchestrate N independent reviews, collation, and cross-check.
+
+## 1. Dispatch review agents
+
+Dispatch $count review agents in parallel. Each agent independently reviews
+the subject using verify-review.md template.
+
+### 1.{n}
+ - workflow.one.md
+ - workflow.two.md
+
+Dispatch review agent.
+
+**Prompt:** Review the subject independently. Write findings to
+`.work/{date}-verify-{agentId}.md` using the template.
+
+- PASS: CONTINUE
+- FAIL: RETRY 1
+
+## 2. Collate findings
+
+Compare all agent reviews. Categorize by consensus ratio:
+- Common (N/N): All agents found
+- Exclusive: (N-1)/N, (N-2)/N, ... 1/N
+
+**Prompt:** Read all review files from step 1. Use verify-collation.md template.
+Write collation to `.work/{date}-verify-collated.md`.
+
+Present Common findings to user immediately.
+
+- PASS: CONTINUE
+- FAIL: STOP "Collation failed"
+
+## 3. Cross-check exclusive findings
+
+Validate ALL exclusive findings against ground truth.
+Mark each as VALIDATED, INVALIDATED, or UNCERTAIN.
+
+**Prompt:** For each exclusive finding, verify against the actual implementation/docs/plan.
+Write results to `.work/{date}-verify-crosscheck.md`.
+
+- PASS: CONTINUE
+- FAIL: CONTINUE
+
+## 4. Present summary
+
+Present final verification summary with all findings and their status.
+
+**Prompt:** Summarize:
+- Common (N/N): Ready to implement
+- Exclusive VALIDATED: Should implement
+- Exclusive INVALIDATED: Can skip
+- Exclusive UNCERTAIN: User decides
+
+- PASS: COMPLETE

--- a/packages/claude-code-plugin/runbooks/walkthrough.runbook.md
+++ b/packages/claude-code-plugin/runbooks/walkthrough.runbook.md
@@ -1,0 +1,86 @@
+# Walkthrough Workflow
+
+Exercise all rundown workflow features with verification.
+
+## 1. Initialize
+
+Set up test environment and log workflow start.
+
+```bash
+mkdir -p .work
+rm -f .work/walkthrough.log .work/walkthrough-marker .work/walkthrough-retry-counter
+echo "workflow-started" >> .work/walkthrough.log
+touch .work/walkthrough-marker
+```
+
+- PASS: CONTINUE
+- FAIL: GOTO 6
+
+## 2. Parallel Subtasks
+
+Dispatch 2 agents in parallel to test agent binding and SubagentStart/Stop hooks.
+
+### 2.{n}
+
+Execute parallel agent task.
+
+**Prompt:** You are agent $n in the walkthrough.
+1. Append "agent-$n-started" to .work/walkthrough.log
+2. Wait briefly (simulate work)
+3. Append "agent-$n-complete" to .work/walkthrough.log
+4. Report STATUS: PASS
+
+- PASS: CONTINUE
+- FAIL: RETRY 1
+
+## 3. Gate Integration
+
+Run the walkthrough:gate-check gate to verify gate execution within workflows.
+
+```bash
+tsv gate walkthrough:gate-check
+```
+
+- PASS: CONTINUE
+- FAIL: RETRY 2
+
+## 4. Retry Mechanics
+
+Test retry behavior with a command that fails on first attempt, succeeds on second.
+
+```bash
+# Uses a counter file to track attempts
+COUNTER_FILE=".work/walkthrough-retry-counter"
+if [[ ! -f "$COUNTER_FILE" ]]; then
+  # First attempt - log and fail
+  echo "1" > "$COUNTER_FILE"
+  echo "retry-attempt-1" >> .work/walkthrough.log
+  exit 1
+else
+  # Second attempt - log and succeed
+  echo "retry-attempt-2" >> .work/walkthrough.log
+  exit 0
+fi
+```
+
+- PASS: CONTINUE
+- FAIL: RETRY 3
+
+## 5. Verification
+
+Run verification script to validate entire walkthrough execution.
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/walkthrough-verify.sh
+```
+
+- PASS: COMPLETE
+- FAIL: GOTO 6
+
+## 6. Error Handler
+
+Handle walkthrough failures.
+
+**Prompt:** The walkthrough encountered an error. Check .work/walkthrough.log for the execution trace and diagnose the issue.
+
+- FAIL: STOPPED

--- a/packages/claude-code-plugin/rundown-plugin.json
+++ b/packages/claude-code-plugin/rundown-plugin.json
@@ -1,0 +1,15 @@
+{
+  "gates": {
+    "check": {
+      "command": "npm run lint",
+      "on_pass": "CONTINUE",
+      "on_fail": "BLOCK"
+    }
+  },
+  "hooks": {
+    "PostToolUse": {
+      "enabled_tools": ["Edit", "Write", "Step", "Task"],
+      "gates": ["check"]
+    }
+  }
+}

--- a/packages/claude-code-plugin/scripts/walkthrough-verify.sh
+++ b/packages/claude-code-plugin/scripts/walkthrough-verify.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Verify walkthrough execution
+set -e
+
+LOG=".work/walkthrough.log"
+
+# Expected log entries (in order they should appear)
+EXPECTED=(
+  "workflow-started"
+  "agent-1-started"
+  "agent-1-complete"
+  "agent-2-started"
+  "agent-2-complete"
+  "gate-check-ran"
+  "retry-attempt-1"
+  "retry-attempt-2"
+)
+
+echo "=== Walkthrough Verification ==="
+
+# Check log exists
+if [[ ! -f "$LOG" ]]; then
+  echo "FAIL: Log file not found at $LOG"
+  exit 1
+fi
+
+echo "Log file found: $LOG"
+echo ""
+echo "Log contents:"
+cat "$LOG"
+echo ""
+
+# Check each expected entry exists
+MISSING=()
+for entry in "${EXPECTED[@]}"; do
+  if ! grep -q "$entry" "$LOG"; then
+    MISSING+=("$entry")
+  fi
+done
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "FAIL: Missing log entries:"
+  for m in "${MISSING[@]}"; do
+    echo "  - $m"
+  done
+  exit 1
+fi
+
+echo "All expected log entries found"
+
+# Check workflow state directory exists
+STATE_DIR=".claude/rundown/runbooks"
+if [[ ! -d "$STATE_DIR" ]]; then
+  echo "FAIL: Workflow state directory not found"
+  exit 1
+fi
+
+# Count state files
+STATE_COUNT=$(ls -1 "$STATE_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$STATE_COUNT" -eq 0 ]]; then
+  echo "FAIL: No workflow state files found"
+  exit 1
+fi
+
+echo "Workflow state directory verified ($STATE_COUNT state files)"
+
+# Append success marker
+echo "verification-passed" >> "$LOG"
+
+echo ""
+echo "=== PASS: Walkthrough verification complete ==="
+exit 0

--- a/packages/claude-code-plugin/skills/batching-plan-tasks/SKILL.md
+++ b/packages/claude-code-plugin/skills/batching-plan-tasks/SKILL.md
@@ -1,0 +1,186 @@
+ Part 2: Batching Skill Definition
+
+ Skill: cipherpowers:plan-to-batches
+
+ Purpose: Transform an implementation plan into executable batches
+ with code review checkpoints.
+
+ When to use: After receiving a complete implementation plan, before
+  execution begins.
+
+ ---
+ Input
+
+ A plan file containing:
+ - Numbered tasks (Task 0, 1, 2, ...)
+ - Each task specifies files to modify
+ - Some tasks have explicit dependencies (uses output from another
+ task)
+
+ ---
+ Process
+
+ Step 1: Build Dependency Graph
+
+ For each task, identify:
+
+ 1. Explicit Dependencies - Task mentions using output from another
+ task
+   - Example: "Uses as_physics_position() from Task 0"
+ 2. File Conflicts - Tasks modifying the same file
+   - Example: Tasks 1, 3, 4 all modify orbital_paths.rs
+ 3. Sequential Plugin Changes - Later tasks assume earlier task's
+ changes
+   - Example: Task 2 modifies plugin.rs after Task 1's changes to
+ same file
+
+ Output: Dependency matrix
+
+ Task 0: [] (no dependencies)
+ Task 1: [] (no dependencies)
+ Task 2: [1] (plugin.rs state)
+ Task 3: [1] (file conflict: orbital_paths.rs)
+ Task 4: [0, 1, 3] (accessor dependency + file conflict)
+
+ Step 2: Identify Parallelizable Groups
+
+ Tasks can run in parallel IFF:
+ - No dependency relationship (neither depends on the other)
+ - No file conflicts (modify different files)
+ - No implicit ordering (don't assume each other's changes)
+
+ Parallel candidates for this plan:
+ - Task 0 ↔ Task 1: Different files, no dependencies ✓ PARALLEL
+
+ Step 3: Group into Batches
+
+ Rules:
+ 1. Batch size: 2-4 tasks (default 3)
+ 2. All parallel tasks in one batch
+ 3. Sequential tasks in order of dependency
+ 4. Every batch ends with verification
+
+ Algorithm:
+ 1. Start with tasks that have no dependencies → first batch
+ (parallel if possible)
+ 2. Remove completed tasks from dependency lists
+ 3. Find tasks whose dependencies are now satisfied → next batch
+ 4. Repeat until all tasks batched
+
+ Step 4: Insert Code Reviews
+
+ - Code review after EVERY batch
+ - For parallel batches: review all parallel work together
+ - For sequential batches: review at end of batch (not between
+ tasks)
+
+ ---
+ Output Format
+
+ ## Batch Structure
+
+ ### Parallel Batch N (X tasks)
+ Execute in parallel.
+
+ | Task | Description | Files |
+ |------|-------------|-------|
+ | Task X | ... | ... |
+ | Task Y | ... | ... |
+
+ **Why parallel:** [explanation]
+
+ ### Code Review Checkpoint
+
+ ---
+
+ ### Sequential Batch M (Y tasks)
+ Execute sequentially.
+
+ | Task | Description | Depends On | Files |
+ |------|-------------|------------|-------|
+ | Task A | ... | Task X | ... |
+ | Task B | ... | Task A | ... |
+
+ **Why sequential:** [explanation]
+
+ ### Code Review Checkpoint
+
+ ---
+ Worked Example: This Plan
+
+ Input tasks:
+ - Task 0: types layer changes
+ - Task 1: remove toggle function
+ - Task 2: scheduling changes
+ - Task 3: change detection
+ - Task 4: typed accessors
+
+ Step 1 - Dependencies:
+ 0 → []
+ 1 → []
+ 2 → [1]
+ 3 → [1] (file)
+ 4 → [0, 1, 3] (accessor + file)
+
+ Step 2 - Parallel check:
+ - Task 0 files: types/render.rs, physics/components/mod.rs
+ - Task 1 files: orbital_paths.rs, mod.rs, plugin.rs,
+ orbital_path_visibility.rs
+ - No overlap → Tasks 0 and 1 can parallel
+
+ Step 3 - Batching:
+ - Batch 1: [0, 1] parallel (no deps, no file conflicts)
+ - After Batch 1: Tasks 2, 3, 4 have deps satisfied
+ - Batch 2: [2, 3, 4] sequential (file conflicts between 3/4,
+ plugin.rs ordering for 2)
+
+ Step 4 - Code reviews:
+ - Review after Batch 1
+ - Review after Batch 2
+
+ Output: 2 batches as shown in Part 1 above.
+
+ ---
+ Edge Cases
+
+ All tasks sequential:
+ - Single file being modified throughout
+ - Break into batches of 3 with reviews between
+
+ All tasks parallel:
+ - No file conflicts, no dependencies
+ - Single batch, but consider splitting if >4 tasks for manageable
+ review
+
+ Diamond dependencies:
+     A
+    / \
+   B   C
+    \ /
+     D
+ - Batch 1: A
+ - Batch 2: B, C (parallel)
+ - Batch 3: D
+
+ ---
+ Anti-Patterns
+
+ 1. Skipping code review - Reviews catch integration issues early
+ 2. Oversized batches - >4 tasks makes review overwhelming
+ 3. Undersized batches - 1 task per batch is too much overhead
+ 4. Ignoring file conflicts - Parallel edits to same file cause
+ merge hell
+ 5. Missing implicit dependencies - One task assumes another's
+ changes exist
+
+ ---
+ Verification Checklist
+
+ After all batches complete:
+
+ - mise run test:fast - All tests pass
+ - mise run check - No new warnings
+ - cargo run - Visual verification: paths render correctly
+ - Toggle paths with 'O' key - Still works
+ - Change camera focus (Tab key) - Paths update correctly
+ - No visual jitter when stationary

--- a/packages/claude-code-plugin/skills/executing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/executing-plans/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: executing-plans
+description: Use when partner provides a complete implementation plan to execute in controlled batches with review checkpoints - loads plan, reviews critically, executes tasks in batches, reports for review between batches
+workflow: execute-plan.runbook.md
+---
+
+# Executing Plans
+
+## Overview`
+
+Load plan, review critically, execute tasks in batches, report for review between batches.
+
+**Core principle:** Batch execution with checkpoints for architect review.
+
+**Announce at start:** "I'm using the executing-plans skill to implement this plan."
+
+## The Process
+
+### Step 1: Load and Review Plan
+1. Read plan file
+2. Review critically - identify any questions or concerns about the plan
+3. If concerns: Raise them with your human partner before starting
+4. If no concerns: Create TodoWrite and proceed
+
+### Step 2: Execute Batch
+**Default: First 3 tasks**
+
+For each task:
+1. Mark as in_progress
+2. **Select appropriate agent using semantic understanding (NOT keyword matching):**
+
+   **Analyze task requirements:**
+   - What is the task type? (implementation, debugging, review, docs)
+   - What is the complexity? (simple fix vs multi-component investigation)
+   - What technology? (Rust vs other languages)
+
+   **Agent selection:**
+   - Rust implementation → `rundown:rust-exec-agent` (minimal context for literal execution)
+   - General implementation → `rundown:code-exec-agent` (minimal context for literal execution)
+   - Complex, multi-layered debugging → `rundown:ultrathink-debugger`
+   - Documentation updates → `rundown:technical-writer`
+
+   **IMPORTANT:** Analyze the task semantically. Don't just match keywords.
+   - ❌ "don't use ultrathink" → ultrathink-debugger (keyword match)
+   - ✅ "don't use ultrathink" → general-purpose (semantic understanding)
+
+   See selecting-agents skill for detailed selection criteria.
+
+3. **Dispatch agent with embedded following-plans skill:**
+
+   **Include in agent prompt:**
+   ```
+   IMPORTANT: You MUST follow the plan exactly as specified.
+
+   Read and follow: @${CLAUDE_PLUGIN_ROOT}skills/following-plans/SKILL.md
+
+   This skill defines when you can make changes vs when you must report STOPPED.
+
+   REQUIRED: Your completion report MUST include STATUS:
+   - STATUS: OK (task completed as planned)
+   - STATUS: STOPPED (plan approach won't work, need approval for deviation)
+
+   The plan approach was chosen for specific reasons during design.
+   Do NOT rationalize "simpler" approaches without approval.
+   ```
+
+4. Follow each step exactly (plan has bite-sized steps)
+5. Run verifications as specified
+6. **Check agent completion status:**
+   - STATUS: OK → Mark as completed, continue
+   - STATUS: STOPPED → STOP, handle escalation (see Handling STOPPED Status)
+   - No STATUS → Agent violated protocol, escalate
+
+### Step 3: Review Batch (REQUIRED)
+
+<EXTREMELY-IMPORTANT>
+**REQUIRED SUB-SKILL:** Use rundown:requesting-code-review
+
+After batch complete:
+1. Follow requesting-code-review skill to dispatch code-review-agent
+2. Fix BLOCKING issues before continuing to next batch
+3. Address NON-BLOCKING feedback or defer with justification
+
+**Code review is mandatory between batches. No exceptions.**
+</EXTREMELY-IMPORTANT>
+
+**Optional:** If concerned about plan adherence, user can request `/verify execute` for dual-verification of batch implementation vs plan specification.
+
+### Step 4: Report
+When batch complete:
+- Show what was implemented
+- Show verification output
+- Say: "Ready for feedback."
+
+### Step 5: Continue
+Based on feedback:
+- Apply changes if needed
+- Execute next batch
+- Repeat until complete
+
+### Step 6: Complete Development
+
+After all tasks complete and verified:
+- Announce: "I'm using the finishing-a-development-branch skill to complete this work."
+- **REQUIRED SUB-SKILL:** Use rundown:finishing-a-development-branch
+- Follow that skill to verify tests, present options, execute choice
+
+## When to Stop and Ask for Help
+
+**STOP executing immediately when:**
+- Hit a blocker mid-batch (missing dependency, test fails, instruction unclear)
+- Plan has critical gaps preventing starting
+- You don't understand an instruction
+- Verification fails repeatedly
+
+**Ask for clarification rather than guessing.**
+
+## When to Revisit Earlier Steps
+
+**Return to Review (Step 1) when:**
+- Partner updates the plan based on your feedback
+- Fundamental approach needs rethinking
+
+**Don't force through blockers** - stop and ask.
+
+## Handling STOPPED Status
+
+<EXTREMELY-IMPORTANT>
+When an agent reports STATUS: STOPPED:
+
+1. **Read the STOPPED reason carefully**
+   - What does agent say won't work?
+   - What deviation does agent want to make?
+
+2. **Review plan and design context**
+   - Why was this approach chosen?
+   - Was the agent's "simpler" approach already considered and rejected?
+
+3. **Ask user what to do** via AskUserQuestion:
+   ```
+   Agent reported STOPPED on: {task}
+
+   Reason: {agent's reason}
+
+   Plan specified: {planned approach}
+   Agent wants: {agent's proposed deviation}
+
+   Options:
+   1. Trust agent - approve deviation from plan
+   2. Revise plan - update task with different approach
+   3. Enforce plan - agent must follow plan as written
+   4. Investigate - need more context before deciding
+   ```
+
+4. **Execute user decision:**
+   - Approve → Update plan, re-dispatch agent with approved approach
+   - Revise → Update plan file, re-dispatch agent
+   - Enforce → Re-dispatch agent with stronger "follow plan" guidance
+   - Investigate → Pause execution, gather more information
+
+**Never approve deviations without user input.**
+</EXTREMELY-IMPORTANT>
+
+## Related Skills
+
+**Agent selection guidance:**
+- Selecting Agents: `${CLAUDE_PLUGIN_ROOT}skills/selecting-agents/SKILL.md`
+
+**Code review workflow:**
+- Requesting Code Review: `${CLAUDE_PLUGIN_ROOT}skills/requesting-code-review/SKILL.md`
+
+**Finishing work:**
+- Finishing a Development Branch: `${CLAUDE_PLUGIN_ROOT}skills/finishing-a-development-branch/SKILL.md`
+
+**Plan compliance:**
+- Following Plans: `${CLAUDE_PLUGIN_ROOT}skills/following-plans/SKILL.md`
+
+## Remember
+- Review plan critically first
+- Embed following-plans skill in agent prompts
+- Select the right agent using semantic understanding (not keyword matching)
+- Check for STATUS in agent completions
+- Handle STOPPED status by asking user (never auto-approve deviations)
+- Code review after every batch (mandatory)
+- User can request `/verify execute` if concerned about plan adherence
+- Don't skip verifications
+- Reference skills when plan says to
+- Between batches: just report and wait
+- Stop when blocked, don't guess

--- a/packages/claude-code-plugin/skills/following-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/following-plans/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: following-plans
+description: Algorithmic decision tree for when to follow plan exactly vs when to report STOPPED - prevents scope creep and unauthorized deviations
+when_to_use: embedded in agent prompts during plan execution, not called directly
+version: 1.0.0
+---
+
+# Following Plans
+
+## Overview
+
+This skill is **embedded in agent prompts** during plan execution. It provides an algorithmic decision tree for determining when to follow the plan exactly vs when to report STOPPED.
+
+**Purpose:** Prevent agents from rationalizing "simpler approaches" that were already considered and rejected during design.
+
+## When to Use
+
+This skill is **embedded in agent prompts during plan execution**. It applies when:
+
+- Agent executing implementation plan encounters situation requiring deviation
+- Current approach in plan seems problematic or won't work
+- Agent discovers syntax errors or naming issues in plan
+- Agent wants to use "simpler approach" than plan specifies
+- Tests fail with planned approach
+- Plan contains contradictions or errors
+
+**This skill prevents:**
+- Unauthorized architectural changes during execution
+- Scope creep from "better ideas" during implementation
+- Rationalization of deviations without approval
+- Silent changes that break plan assumptions
+
+## Quick Reference
+
+```
+Is change syntax/naming only?
+├─ YES → Fix it, note in completion, STATUS: OK
+└─ NO → Does it change approach/architecture?
+    ├─ YES → Report STATUS: STOPPED with reason
+    └─ NO → Follow plan exactly, STATUS: OK
+```
+
+**Allowed without STOPPED:**
+- Syntax corrections (wrong function name in plan)
+- Error handling implementation details
+- Variable naming choices
+- Code organization within file
+- Test implementation details
+
+**Requires STOPPED:**
+- Different algorithm or approach
+- Different library/framework
+- Different data structure/API design
+- Skipping/adding planned functionality
+- Refactoring not in plan
+
+## Implementation Boundaries
+
+When evaluating changes from plan:
+
+| Domain | Within Boundaries (tsv pass) | Exceeds Boundaries (tsv fail) |
+|--------|-----------------------------|-------------------------------|
+| Logic | syntax/naming | algorithm changes |
+| Deps | calls within lib | swap library |
+| Scope | edge cases | add/skip features |
+| Interface | private | public APIs/schemas |
+
+## Algorithmic Decision Tree
+
+**Follow this exactly. No interpretation.**
+
+### Step 1: Check if this is a syntax/naming fix
+
+```
+Is the change you want to make limited to:
+- Correcting function/variable names
+- Fixing syntax errors
+- Updating import paths
+- Correcting typos in code
+
+YES → Make the change
+      Add note to task completion: "Fixed syntax: {what you fixed}"
+      Continue to Step 4
+
+NO → Continue to Step 2
+```
+
+### Step 2: Check if this changes approach/architecture
+
+```
+Does your change alter:
+- The overall approach or algorithm
+- The architecture or structure
+- Which libraries/frameworks to use
+- The data model or API design
+
+YES → STOP
+      Report STATUS: STOPPED
+      Continue to Step 3
+
+NO → Continue to Step 4
+```
+
+### Step 3: Report STOPPED (Required Format)
+
+<EXTREMELY-IMPORTANT>
+```
+STATUS: STOPPED
+REASON: [Explain why plan approach won't work and what you want to do instead]
+TASK: [Task identifier from plan]
+
+Example:
+STATUS: STOPPED
+REASON: Plan specifies JWT auth but existing service uses OAuth2. Implementing JWT would require refactoring auth service.
+TASK: Task 3 - Implement authentication middleware
+```
+
+**STOP HERE. Do not proceed with implementation.**
+</EXTREMELY-IMPORTANT>
+
+### Step 4: Follow plan exactly
+
+```
+Implement the task exactly as specified in plan.
+
+Report STATUS: OK when complete.
+```
+
+## Status Reporting (REQUIRED)
+
+<EXTREMELY-IMPORTANT>
+**Every task completion MUST include STATUS.**
+</EXTREMELY-IMPORTANT>
+
+### STATUS: OK
+
+Use when task completed as planned:
+```
+STATUS: OK
+TASK: Task 3 - Implement authentication middleware
+SUMMARY: Implemented JWT authentication middleware per plan specification.
+```
+
+### STATUS: STOPPED
+
+Use when plan approach won't work:
+```
+STATUS: STOPPED
+REASON: [Clear explanation]
+TASK: [Task identifier]
+```
+
+**Missing STATUS = gate will block you from proceeding.**
+
+## Red Flags (Rationalization Defense)
+
+If you're thinking ANY of these thoughts, you're about to violate the plan:
+
+| Thought | Reality |
+|---------|---------|
+| "This simpler approach would work better" | Simpler approach was likely considered and rejected in design. Report STOPPED. |
+| "The plan way seems harder than necessary" | Plan reflects design decisions you don't have context for. Follow plan or report STOPPED. |
+| "I can just use library X instead" | Library choice is architectural decision. Report STOPPED. |
+| "This is a minor architectural change" | All architecture changes require approval. Report STOPPED. |
+| "The tests would pass if I just..." | Making tests pass ≠ meeting requirements. Follow plan or report STOPPED. |
+| "I'll note the deviation in my summary" | Deviations require explicit approval BEFORE implementation. Report STOPPED. |
+
+**All of these mean: STOP. Report STATUS: STOPPED.**
+
+## What Counts as "Following Plan Exactly"
+
+**Allowed without STOPPED:**
+- Syntax corrections (wrong function name in plan)
+- Error handling implementation details (plan says "validate input", you choose validation approach)
+- Variable naming (plan says "store user data", you choose variable name)
+- Code organization within a file (where to place helper functions)
+- Test implementation details (plan says "add tests", you write specific test cases)
+
+**Requires STOPPED:**
+- Different algorithm or approach
+- Different library/framework
+- Different data structure
+- Different API design
+- Skipping planned functionality
+- Adding unplanned functionality
+- Refactoring not in plan
+
+## Common Scenarios
+
+### Scenario: Plan has wrong function name
+
+```
+Plan says: "Call getUserData()"
+Reality: Function is actually getUser()
+
+Decision: Fix syntax
+Action: Use getUser(), note in completion
+Status: OK
+```
+
+### Scenario: Plan approach seems unnecessarily complex
+
+```
+Plan says: "Implement manual JWT verification"
+Your thought: "Library X does this better and simpler"
+
+Decision: Architectural change
+Action: Report STOPPED
+Status: STOPPED
+Reason: Plan specifies manual JWT verification but library X provides simpler approach. Should we use library instead?
+```
+
+### Scenario: Tests fail with planned approach
+
+```
+Plan says: "Use synchronous file reads"
+Reality: Tests timeout with sync reads, async would fix
+
+Decision: Approach change
+Action: Report STOPPED
+Status: STOPPED
+Reason: Synchronous file reads cause test timeouts. Need async approach or different solution.
+```
+
+### Scenario: Plan contradicts itself
+
+```
+Plan Task 3: "Use PostgreSQL"
+Plan Task 5: "Query MongoDB"
+
+Decision: Plan error
+Action: Report STOPPED
+Status: STOPPED
+Reason: Plan specifies both PostgreSQL (Task 3) and MongoDB (Task 5). Which should be used?
+```
+
+## Common Mistakes
+
+**Mistake:** "This simpler approach would work better"
+- **Why wrong:** Simpler approach was likely considered and rejected in design
+- **Fix:** Report STATUS: STOPPED, don't implement
+
+**Mistake:** "This is a minor architectural change"
+- **Why wrong:** All architecture changes require approval
+- **Fix:** Report STATUS: STOPPED for any approach/architecture change
+
+**Mistake:** "I'll note the deviation in my summary"
+- **Why wrong:** Deviations require explicit approval BEFORE implementation
+- **Fix:** Report STATUS: STOPPED before making changes
+
+**Mistake:** "The tests would pass if I just use library X instead"
+- **Why wrong:** Making tests pass ≠ meeting requirements, library choice is architectural
+- **Fix:** Report STATUS: STOPPED, explain issue
+
+**Mistake:** "Forgot to include STATUS in my completion report"
+- **Why wrong:** Missing STATUS = gate will block you from proceeding
+- **Fix:** Always include STATUS: OK or STATUS: STOPPED
+
+## Remember
+
+- **Syntax fixes**: Allowed (note in completion)
+- **Approach changes**: Report STOPPED
+- **Architecture changes**: Report STOPPED
+- **Plan errors**: Report STOPPED
+- **Always provide STATUS**: OK or STOPPED
+- **When in doubt**: Report STOPPED
+
+**Better to report STOPPED unnecessarily than to deviate from plan without approval.**

--- a/packages/claude-code-plugin/skills/verifying-by-consensus/SKILL.md
+++ b/packages/claude-code-plugin/skills/verifying-by-consensus/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: verifying-by-consensus
+description: Dispatch N independent review agents, collate by consensus ratio, cross-check exclusive findings
+workflow: verify.runbook.md
+---
+
+# Verifying by Consensus
+
+## Overview
+
+Dispatch N agents to independently review the same subject. Collate findings:
+- **Common (N/N):** All agents found → act immediately
+- **Exclusive (<N/N):** Some agents found → cross-check validates
+
+## Agent Count Heuristics
+
+| Scope | Default N | Rationale |
+|-------|-----------|-----------|
+| Single file change | 2 | Focused review, two perspectives sufficient |
+| Multi-file feature | 2-3 | More surface area benefits from diversity |
+| Architecture change | 3 | Different perspectives valuable |
+| Security-sensitive | 3+ | Higher stakes warrant more eyes |
+
+**Override via args:** `--count 3` or `--agents "Explore,Plan,code-agent"`
+
+## Agent Selection
+
+1. **Explicit args:** If user provides `--agents`, use those
+2. **Available plugins:** Check for specialized agents (cipherpowers code-review-agent, etc.)
+3. **Built-in agents:** Use Claude's Explore, Plan agents with review prompts
+4. **Fallback:** N instances of same agent with different perspective prompts
+
+## Process
+
+**Announce:** "I'm using the verifying-by-consensus skill to verify [subject]."
+
+### Phase 1: Dispatch
+
+1. Determine N (default 2, or from args)
+2. Select agents (from args, plugins, or built-ins)
+3. Start workflow: `tsv run runbooks/verify.runbook.md`
+4. Dispatch agents with StepId prefix in description:
+   ```
+   Step(description="1.1 - Review [subject]", prompt="...", subagent_type="...")
+   Step(description="1.2 - Review [subject]", prompt="...", subagent_type="...")
+   ```
+
+**Hooks automate step binding:**
+
+| Manual command | Hook trigger | When |
+|----------------|--------------|------|
+| `tsv run --step 1.1` | PostToolUse (Step) | StepId detected in description |
+| `tsv run --agent {id}` | SubagentStart | Agent spawns |
+
+**Subagent protocol:**
+- Write findings to `.work/{date}-verify-{agentId}.md`
+- End response with `STATUS: PASS` or `STATUS: FAIL`
+
+### Phase 2: Collate
+
+After all agents complete, dispatch collation:
+- Read all N review files
+- Compare findings across agents
+- Categorize by consensus:
+  - **Common (N/N):** All agents found this issue
+  - **Exclusive:** Subcategorize by ratio (e.g., 2/3, 1/3)
+- Write collation to `.work/{date}-verify-collated.md`
+
+**Present immediately:**
+```
+Collation complete.
+
+## Common (N/N)
+[Issues all agents found - can implement now]
+
+## Exclusive
+### (N-1)/N
+[Issues most agents found]
+### 1/N
+[Issues one agent found]
+
+Cross-check starting for exclusive findings...
+```
+
+### Phase 3: Cross-Check
+
+Dispatch cross-check agent to validate ALL exclusive findings:
+- For each exclusive issue, verify against ground truth
+- Mark as: VALIDATED | INVALIDATED | UNCERTAIN
+- Write to `.work/{date}-verify-crosscheck.md`
+
+**Present when complete:**
+```
+Cross-check complete.
+
+VALIDATED: X issues (should address)
+INVALIDATED: X issues (can skip)
+UNCERTAIN: X issues (user decides)
+```
+
+### Phase 4: Complete
+
+```bash
+tsv complete
+```
+
+## Output Files
+
+All files saved to `.work/`:
+- `{date}-verify-{agentId}.md` - Individual reviews
+- `{date}-verify-collated.md` - Collation report
+- `{date}-verify-crosscheck.md` - Cross-check results
+
+## Templates
+
+Review template: `${CLAUDE_PLUGIN_ROOT}templates/verify-review.md`
+Collation template: `${CLAUDE_PLUGIN_ROOT}templates/verify-collation.md`

--- a/packages/claude-code-plugin/skills/workflow/SKILL.md
+++ b/packages/claude-code-plugin/skills/workflow/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: workflow
+description: Use when executing multi-step processes requiring state persistence and agent coordination - defines two-tier protocol where subagents report PASS/FAIL status and main agent handles dispatch, advancement, and failure troubleshooting
+---
+
+# Workflow Execution
+
+## Overview
+
+Workflows are multi-step processes with state tracking. **Two-tier orchestration:** subagents execute individual steps and report outcomes; main agent dispatches, monitors, and handles failures.
+
+**Core principle:** Subagents fail fast, main agent troubleshoots.
+
+## When to Use
+
+- Multi-step processes needing state persistence across context clears
+- Parallel subagent orchestration with status tracking
+- PASS/FAIL signaling between agents
+- Processes requiring retry/resume capability
+
+**Not for:** Single-step steps, ad-hoc commands
+
+---
+
+## For Subagents
+
+You're executing a workflow step. Your context shows:
+- **Step N:** What you need to do
+- **Attempt:** Retry count if applicable
+
+### Protocol
+
+1. Execute the step as described in the prompt
+2. End your response with a status line: `STATUS: PASS` or `STATUS: FAIL`
+3. If stuck, blocked, or unclear, report `STATUS: FAIL` - main agent will handle
+
+**Do NOT:**
+- Advance the parent workflow - only your orchestrator does that
+- Try to fix infrastructure issues - report FAIL and let main handle
+- Continue past errors - fail fast so main can troubleshoot
+
+**You CAN:** Run your own nested workflows with full `workflow` commands.
+
+---
+
+## For Main Agent
+
+You orchestrate the workflow. Use these commands:
+
+| Command | Purpose |
+|---------|---------|
+| `rundown run <file>` | Begin a runbook |
+| `rundown pass` | Mark current step as passed |
+| `rundown fail` | Mark current step as failed |
+| `rundown goto N` | Jump to specific step |
+| `rundown status` | Check current state |
+| `rundown complete` | Mark workflow finished |
+| `rundown stop` | Abort workflow |
+| `rundown stash` | Pause enforcement (for ad-hoc work) |
+| `rundown pop` | Resume enforcement |
+
+### Dispatching Steps
+
+Include StepId in Step tool description - hooks handle the rest automatically:
+```
+Step(description="2.1 - Review authentication code", ...)
+```
+
+The StepId format is `N.X` where N is step number, X is substep number.
+
+**Hook automation:**
+- PostToolUse hook parses StepId from description, calls `rundown run --step 2.1`
+- SubagentStart hook binds the agent to the queued step
+- SubagentStop hook parses STATUS line, calls `rundown next --pass/--fail --agent {id}`
+
+**Do NOT manually call `rundown run --step`** - hooks handle this.
+
+### Parallel Substeps
+
+For parallel execution (e.g., `### 2.{n}` substeps):
+1. Dispatch all agents in one message (multiple Step tool calls)
+2. Run `rundown status` to check agent completion
+3. When all agents report done, run `rundown next`
+
+### Dynamic Substep `{n}` Syntax
+
+`### N.{n}` marks dynamic substeps - orchestrator decides count at runtime.
+
+Dispatch with sequential StepIds in description:
+```
+Step(description="3.1 - Agent 1 review", ...)
+Step(description="3.2 - Agent 2 review", ...)
+```
+
+- `$n` in workflow prompts substitutes with substep number (1, 2, etc.)
+- Hooks handle step queuing and agent binding automatically
+
+### Handling Failures
+
+When subagent reports `STATUS: FAIL`: check output, discuss with user, then retry or jump (`--goto N`) or abort (`stop`).
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Subagent advances parent workflow | Only advance your own nested workflow, not parent's |
+| Subagent auto-retries on failure | Report `STATUS: FAIL` and let main handle |
+| Main agent auto-retries without user | Always discuss failures before retry |
+| Missing StepId in dispatch | Include `N.X` format in Step tool description |
+| Parallel steps without status check | Run `rundown status` before advancing |
+| Manually calling `rundown run --step` | Remove - hooks handle step queuing automatically |

--- a/packages/claude-code-plugin/skills/writing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-plans/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: writing-plans
+description: Use when design is complete and you need detailed implementation tasks for engineers with zero codebase context - creates comprehensive implementation plans with exact file paths, complete code examples, and verification steps assuming engineer has minimal domain knowledge
+---
+
+# Writing Plans
+
+## Overview
+
+Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
+
+Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
+
+**Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
+
+**Context:** This should be run in a dedicated worktree (created by brainstorming skill).
+
+**Save plans to:** `.work/YYYY-MM-DD-<feature-name>.md`
+
+## Bite-Sized Task Granularity
+
+**Each step is one action (2-5 minutes):**
+- "Write the failing test" - step
+- "Run it to make sure it fails" - step
+- "Implement the minimal code to make the test pass" - step
+- "Run the tests and make sure they pass" - step
+- "Commit" - step
+
+## Plan Document Header
+
+**Every plan MUST start with this header:**
+
+```markdown
+# [Feature Name] Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use rundown:executing-plans to implement this plan task-by-task.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+---
+```
+
+## Task Structure
+
+```markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py:123-145`
+- Test: `tests/exact/path/to/test.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_specific_behavior():
+    result = function(input)
+    assert result == expected
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: FAIL with "function not defined"
+
+**Step 3: Write minimal implementation**
+
+```python
+def function(input):
+    return expected
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+```
+```
+
+## Remember
+- Exact file paths always
+- Complete code in plan (not "add validation")
+- Exact commands with expected output
+- Reference relevant skills with @ syntax
+- SRP, DRY, YAGNI, TDD, frequent commits
+
+## Execution Handoff
+
+After saving the plan, offer execution choice:
+
+**"Plan complete and saved to `.work/<filename>.md`. Two execution options:**
+
+**1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+
+**Which approach?"**
+
+**If Subagent-Driven chosen:**
+- **REQUIRED SUB-SKILL:** Use rundown:subagent-driven-development
+- Stay in this session
+- Fresh subagent per task + code review
+
+**If Parallel Session chosen:**
+- Guide them to open new session in worktree
+- **REQUIRED SUB-SKILL:** New session uses rundown:executing-plans

--- a/packages/claude-code-plugin/src/action-handler.ts
+++ b/packages/claude-code-plugin/src/action-handler.ts
@@ -1,0 +1,45 @@
+// action-handler.ts
+import { type GateResult, type RundownPluginConfig, type HookInput } from './shared/index.js';
+
+export interface ActionResult {
+  continue: boolean;
+  context?: string;
+  blockReason?: string;
+  stopMessage?: string;
+  chainedGate?: string;
+}
+
+export function handleAction(
+  action: string,
+  gateResult: GateResult,
+  _config: RundownPluginConfig,
+  _input: HookInput
+): ActionResult {
+  switch (action) {
+    case 'CONTINUE':
+      return {
+        continue: true,
+        context: gateResult.additionalContext
+      };
+
+    case 'BLOCK':
+      return {
+        continue: false,
+        blockReason: gateResult.reason ?? 'Gate failed'
+      };
+
+    case 'STOP':
+      return {
+        continue: false,
+        stopMessage: gateResult.message ?? 'Gate stopped execution'
+      };
+
+    default:
+      // Gate chaining - action is another gate name
+      return {
+        continue: true,
+        context: gateResult.additionalContext,
+        chainedGate: action
+      };
+  }
+}

--- a/packages/claude-code-plugin/src/cli.ts
+++ b/packages/claude-code-plugin/src/cli.ts
@@ -1,0 +1,281 @@
+// cli.ts
+import {
+  type SessionState,
+  type SessionStateArrayKey,
+  SESSION_STATE_KEYS,
+  parseHookInput,
+  logger
+} from './shared/index.js';
+import { dispatch } from './dispatcher.js';
+import { Session } from './session.js';
+
+interface OutputMessage {
+  additionalContext?: string;
+  decision?: string;
+  reason?: string;
+  continue?: boolean;
+  message?: string;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  // Check if first arg is "session" - session management mode
+  if (args.length > 0 && args[0] === 'session') {
+    await handleSessionCommand(args.slice(1));
+    return;
+  }
+
+  // Check if first arg is "log-path" - return log file path for mise tasks
+  if (args.length > 0 && args[0] === 'log-path') {
+    console.log(logger.getLogFilePath());
+    return;
+  }
+
+  // Check if first arg is "log-dir" - return log directory for mise tasks
+  if (args.length > 0 && args[0] === 'log-dir') {
+    console.log(logger.getLogDir());
+    return;
+  }
+
+  // Otherwise, hook dispatch mode (existing behavior)
+  await handleHookDispatch();
+}
+
+/**
+ * Type guard for SessionState keys
+ */
+function isSessionStateKey(key: string): key is keyof SessionState {
+  return (SESSION_STATE_KEYS as readonly string[]).includes(key);
+}
+
+/**
+ * Type guard for array keys
+ */
+function isArrayKey(key: string): key is SessionStateArrayKey {
+  return key === 'edited_files' || key === 'file_extensions';
+}
+
+/**
+ * Handle session management commands with proper type safety
+ */
+async function handleSessionCommand(args: string[]): Promise<void> {
+  if (args.length < 1) {
+    console.error('Usage: hooks-app session [get|set|append|contains|clear] ...');
+    process.exit(1);
+  }
+
+  const [command, ...params] = args;
+  const cwd = params[params.length - 1] || '.';
+  const session = new Session(cwd);
+
+  try {
+    switch (command) {
+      case 'get': {
+        if (params.length < 2) {
+          console.error('Usage: hooks-app session get <key> [cwd]');
+          process.exit(1);
+        }
+        const [key] = params;
+        if (!isSessionStateKey(key)) {
+          console.error(`Invalid session key: ${key}`);
+          process.exit(1);
+        }
+        const value = await session.get(key);
+        console.log(value ?? '');
+        break;
+      }
+
+      case 'set': {
+        if (params.length < 3) {
+          console.error('Usage: hooks-app session set <key> <value> [cwd]');
+          process.exit(1);
+        }
+        const [key, value] = params;
+        if (!isSessionStateKey(key)) {
+          console.error(`Invalid session key: ${key}`);
+          process.exit(1);
+        }
+        // Type-safe set with runtime validation
+        if (key === 'active_command' || key === 'active_skill') {
+          await session.set(key, value === 'null' ? null : value);
+        } else if (key === 'metadata') {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(value);
+          } catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            console.error(`Invalid JSON for metadata: ${message}`);
+            process.exit(1);
+          }
+          if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            console.error('Metadata must be a JSON object');
+            process.exit(1);
+          }
+          await session.set(key, parsed as Record<string, unknown>);
+        } else {
+          console.error(`Cannot set ${key} via CLI (use get, append, or contains)`);
+          process.exit(1);
+        }
+        break;
+      }
+
+      case 'append': {
+        if (params.length < 3) {
+          console.error('Usage: hooks-app session append <key> <value> [cwd]');
+          process.exit(1);
+        }
+        const [key, value] = params;
+        if (!isArrayKey(key)) {
+          console.error(`Invalid array key: ${key} (must be edited_files or file_extensions)`);
+          process.exit(1);
+        }
+        await session.append(key, value);
+        break;
+      }
+
+      case 'contains': {
+        if (params.length < 3) {
+          console.error('Usage: hooks-app session contains <key> <value> [cwd]');
+          process.exit(1);
+        }
+        const [key, value] = params;
+        if (!isArrayKey(key)) {
+          console.error(`Invalid array key: ${key} (must be edited_files or file_extensions)`);
+          process.exit(1);
+        }
+        const result = await session.contains(key, value);
+        process.exit(result ? 0 : 1);
+        break;
+      }
+
+      case 'clear': {
+        await session.clear();
+        break;
+      }
+
+      default:
+        console.error(`Unknown session command: ${command}`);
+        process.exit(1);
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await logger.error('Session command failed', { command, error: errorMessage });
+    console.error(`Session error: ${errorMessage}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Handle hook dispatch (existing behavior)
+ */
+async function handleHookDispatch(): Promise<void> {
+  try {
+    // Read stdin
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+    const inputStr = Buffer.concat(chunks).toString('utf-8');
+
+    // ALWAYS log hook invocation (unconditional - for debugging)
+    await logger.always('HOOK_INVOKED', {
+      input_length: inputStr.length,
+      input_preview: inputStr.substring(0, 500)
+    });
+
+    // Log raw input at CLI entry point
+    await logger.debug('CLI received hook input', {
+      input_length: inputStr.length,
+      input_preview: inputStr.substring(0, 200)
+    });
+
+    // Parse and validate input
+    if (inputStr.length === 0) {
+      await logger.error('CLI received empty input', {
+        reason: 'stdin was empty - possible CLI race condition or cancelled operation'
+      });
+      console.error(
+        JSON.stringify({
+          continue: false,
+          message: 'Empty input received'
+        })
+      );
+      process.exit(1);
+    }
+
+    const parseResult = parseHookInput(inputStr);
+    if (!parseResult.success) {
+      await logger.error('CLI input validation failed', {
+        input_length: inputStr.length,
+        input_preview: inputStr.substring(0, 200),
+        error: parseResult.error
+      });
+      console.error(
+        JSON.stringify({
+          continue: false,
+          message: parseResult.error
+        })
+      );
+      process.exit(1);
+    }
+
+    const input = parseResult.data;
+
+    // Log parsed hook event
+    await logger.info('CLI dispatching hook', {
+      event: input.hook_event_name,
+      cwd: input.cwd,
+      tool: input.tool_name,
+      agent: input.agent_name,
+      command: input.command,
+      skill: input.skill
+    });
+
+    // Dispatch
+    const result = await dispatch(input);
+
+    // Build output
+    const output: OutputMessage = {};
+
+    if (result.context) {
+      output.additionalContext = result.context;
+    }
+
+    if (result.blockReason) {
+      output.decision = 'block';
+      output.reason = result.blockReason;
+    }
+
+    if (result.stopMessage) {
+      output.continue = false;
+      output.message = result.stopMessage;
+    }
+
+    // Log result
+    await logger.info('CLI hook completed', {
+      event: input.hook_event_name,
+      has_context: !!result.context,
+      has_block: !!result.blockReason,
+      has_stop: !!result.stopMessage,
+      output_keys: Object.keys(output)
+    });
+
+    // Write output
+    if (Object.keys(output).length > 0) {
+      console.log(JSON.stringify(output));
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await logger.error('Hook dispatch failed', { error: errorMessage });
+    console.error(
+      JSON.stringify({
+        continue: false,
+        message: `Unexpected error: ${String(error)}`
+      })
+    );
+    process.exit(1);
+  }
+}
+
+void main();

--- a/packages/claude-code-plugin/src/context.ts
+++ b/packages/claude-code-plugin/src/context.ts
@@ -1,0 +1,311 @@
+// context.ts
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { type HookInput, fileExists, logger } from './shared/index.js';
+import { Session } from './session.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Get the plugin root directory from CLAUDE_PLUGIN_ROOT env var.
+ * Falls back to computing relative to this file's location.
+ */
+function getPluginRoot(): string | null {
+  // First check env var (set by Claude Code when plugin is loaded)
+  const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (envRoot) {
+    return envRoot;
+  }
+
+  // Fallback: compute from this file's location
+  // This file is at: plugin/core/src/context.ts (dev)
+  // Or at: plugin/core/dist/context.js (built)
+  // Plugin root is: plugin/
+  try {
+    // Go up from src/ or dist/ -> core/ -> plugin/
+    return path.resolve(__dirname, '..', '..');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build context file paths for a given base directory.
+ * Returns array of paths following priority order:
+ * flat > slash-command subdir > slash-command nested > skill subdir > skill nested
+ */
+function buildContextPaths(
+  baseDir: string,
+  contextDir: string,
+  name: string,
+  stage: string
+): string[] {
+  return [
+    path.join(baseDir, contextDir, `${name}-${stage}.md`),
+    path.join(baseDir, contextDir, 'slash-command', `${name}-${stage}.md`),
+    path.join(baseDir, contextDir, 'slash-command', name, `${stage}.md`),
+    path.join(baseDir, contextDir, 'skill', `${name}-${stage}.md`),
+    path.join(baseDir, contextDir, 'skill', name, `${stage}.md`)
+  ];
+}
+
+/**
+ * Discover context file following priority order.
+ *
+ * Priority (project takes precedence over plugin):
+ * 1. Project: .claude/context/{name}-{stage}.md (and variations)
+ * 2. Plugin: ${CLAUDE_PLUGIN_ROOT}/context/{name}-{stage}.md (and variations)
+ */
+export async function discoverContextFile(
+  cwd: string,
+  name: string,
+  stage: string
+): Promise<string | null> {
+  // Project-level context (highest priority)
+  const projectPaths = buildContextPaths(cwd, '.claude/context', name, stage);
+
+  for (const filePath of projectPaths) {
+    if (await fileExists(filePath)) {
+      await logger.debug('Found project context file', { path: filePath, name, stage });
+      return filePath;
+    }
+  }
+
+  // Plugin-level context (fallback)
+  const pluginRoot = getPluginRoot();
+  if (pluginRoot) {
+    const pluginPaths = buildContextPaths(pluginRoot, 'context', name, stage);
+
+    for (const filePath of pluginPaths) {
+      if (await fileExists(filePath)) {
+        await logger.debug('Found plugin context file', { path: filePath, name, stage });
+        return filePath;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Discover agent-command scoped context file.
+ * Pattern: {agent}-{command}-{stage}.md
+ *
+ * Priority:
+ * 1. Project: {agent}-{command}-{stage}.md (most specific)
+ * 2. Project: {agent}-{stage}.md (agent-specific)
+ * 3. Plugin: {agent}-{command}-{stage}.md
+ * 4. Plugin: {agent}-{stage}.md
+ * 5. Standard discovery (backward compat, checks both project and plugin)
+ */
+async function discoverAgentCommandContext(
+  cwd: string,
+  agent: string,
+  commandOrSkill: string | null,
+  stage: string
+): Promise<string | null> {
+  // Strip namespace prefix from agent name (namespace:agent-name → agent-name)
+  const agentName = agent.replace(/^[^:]+:/, '');
+  const contextName = commandOrSkill?.replace(/^\//, '').replace(/^[^:]+:/, '');
+
+  // Project-level paths (highest priority)
+  const projectPaths: string[] = [];
+  if (contextName) {
+    projectPaths.push(
+      path.join(cwd, '.claude', 'context', `${agentName}-${contextName}-${stage}.md`)
+    );
+  }
+  projectPaths.push(path.join(cwd, '.claude', 'context', `${agentName}-${stage}.md`));
+
+  for (const filePath of projectPaths) {
+    if (await fileExists(filePath)) {
+      await logger.debug('Found project agent context file', {
+        path: filePath,
+        agent: agentName,
+        stage
+      });
+      return filePath;
+    }
+  }
+
+  // Plugin-level paths (fallback)
+  const pluginRoot = getPluginRoot();
+  if (pluginRoot) {
+    const pluginPaths: string[] = [];
+    if (contextName) {
+      pluginPaths.push(path.join(pluginRoot, 'context', `${agentName}-${contextName}-${stage}.md`));
+    }
+    pluginPaths.push(path.join(pluginRoot, 'context', `${agentName}-${stage}.md`));
+
+    for (const filePath of pluginPaths) {
+      if (await fileExists(filePath)) {
+        await logger.debug('Found plugin agent context file', {
+          path: filePath,
+          agent: agentName,
+          stage
+        });
+        return filePath;
+      }
+    }
+  }
+
+  // Backward compat: try standard discovery with command/skill name
+  // (discoverContextFile already checks both project and plugin)
+  if (contextName) {
+    const standardPath = await discoverContextFile(cwd, contextName, stage);
+    if (standardPath) {
+      return standardPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract name and stage from hook event.
+ * Returns { name, stage } for context file discovery.
+ *
+ * Mapping:
+ * - SlashCommandStart → { name: command, stage: 'start' }
+ * - SlashCommandEnd → { name: command, stage: 'end' }
+ * - SkillStart → { name: skill, stage: 'start' }
+ * - SkillEnd → { name: skill, stage: 'end' }
+ * - PreToolUse → { name: tool_name, stage: 'pre' }
+ * - PostToolUse → { name: tool_name, stage: 'post' }
+ * - SubagentStop → { name: agent_name, stage: 'end' } (special handling)
+ * - SubagentStart → { name: subagent_type, stage: 'start' } (synthetic event)
+ * - SubagentEnd → { name: subagent_type, stage: 'end' } (synthetic event)
+ * - UserPromptSubmit → { name: 'prompt', stage: 'submit' }
+ * - Stop → { name: 'agent', stage: 'stop' }
+ * - SessionStart → { name: 'session', stage: 'start' }
+ * - SessionEnd → { name: 'session', stage: 'end' }
+ * - Notification → { name: 'notification', stage: 'receive' }
+ */
+function extractNameAndStage(
+  hookEvent: string,
+  input: HookInput
+): { name: string; stage: string } | null {
+  switch (hookEvent) {
+    case 'SlashCommandStart':
+      return input.command
+        ? { name: input.command.replace(/^\//, '').replace(/^[^:]+:/, ''), stage: 'start' }
+        : null;
+
+    case 'SlashCommandEnd':
+      return input.command
+        ? { name: input.command.replace(/^\//, '').replace(/^[^:]+:/, ''), stage: 'end' }
+        : null;
+
+    case 'SkillStart':
+      return input.skill ? { name: input.skill.replace(/^[^:]+:/, ''), stage: 'start' } : null;
+
+    case 'SkillEnd':
+      return input.skill ? { name: input.skill.replace(/^[^:]+:/, ''), stage: 'end' } : null;
+
+    case 'PreToolUse':
+      return input.tool_name ? { name: input.tool_name.toLowerCase(), stage: 'pre' } : null;
+
+    case 'PostToolUse':
+      return input.tool_name ? { name: input.tool_name.toLowerCase(), stage: 'post' } : null;
+
+    case 'SubagentStop':
+      // SubagentStop has special handling - uses agent-command scoping
+      return null;
+
+    case 'UserPromptSubmit':
+      return { name: 'prompt', stage: 'submit' };
+
+    case 'Stop':
+      return { name: 'agent', stage: 'stop' };
+
+    case 'SessionStart':
+      return { name: 'session', stage: 'start' };
+
+    case 'SessionEnd':
+      return { name: 'session', stage: 'end' };
+
+    case 'Notification':
+      return { name: 'notification', stage: 'receive' };
+
+    case 'SubagentStart':
+      // Use agent type for context discovery
+      return input.subagent_type
+        ? { name: input.subagent_type.split(':').pop() ?? input.subagent_type, stage: 'start' }
+        : null;
+
+    case 'SubagentEnd':
+      return input.subagent_type
+        ? { name: input.subagent_type.split(':').pop() ?? input.subagent_type, stage: 'end' }
+        : null;
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Inject context from .claude/context/ files based on hook event.
+ * This is the PRIMARY built-in gate - automatic context injection.
+ *
+ * Convention:
+ * - .claude/context/{name}-{stage}.md
+ * - e.g., .claude/context/code-review-start.md
+ * - e.g., .claude/context/prompt-submit.md
+ */
+export async function injectContext(hookEvent: string, input: HookInput): Promise<string | null> {
+  await logger.debug('Context injection starting', { event: hookEvent, cwd: input.cwd });
+
+  // Handle SubagentStop with agent-command scoping (special case)
+  if (hookEvent === 'SubagentStop' && input.agent_name) {
+    const session = new Session(input.cwd);
+    const activeCommand = await session.get('active_command');
+    const activeSkill = await session.get('active_skill');
+    const commandOrSkill = activeCommand ?? activeSkill;
+
+    const contextFile = await discoverAgentCommandContext(
+      input.cwd,
+      input.agent_name,
+      commandOrSkill,
+      'end'
+    );
+
+    if (contextFile) {
+      const content = await fs.readFile(contextFile, 'utf-8');
+      await logger.info('Injecting agent context', {
+        event: hookEvent,
+        agent: input.agent_name,
+        file: contextFile
+      });
+      return content;
+    }
+
+    return null;
+  }
+
+  // Standard context discovery for all other hooks
+  const extracted = extractNameAndStage(hookEvent, input);
+  if (!extracted) {
+    await logger.debug('No name/stage extracted', { event: hookEvent });
+    return null;
+  }
+
+  const { name, stage } = extracted;
+  const contextFile = await discoverContextFile(input.cwd, name, stage);
+
+  if (contextFile) {
+    const content = await fs.readFile(contextFile, 'utf-8');
+    await logger.info('Injecting context', {
+      event: hookEvent,
+      name,
+      stage,
+      file: contextFile
+    });
+    return content;
+  }
+
+  await logger.debug('No context file found', { event: hookEvent, name, stage });
+  return null;
+}

--- a/packages/claude-code-plugin/src/dispatcher.ts
+++ b/packages/claude-code-plugin/src/dispatcher.ts
@@ -1,0 +1,434 @@
+// dispatcher.ts
+import {
+  type HookInput,
+  type HookConfig,
+  type GateConfig,
+  loadConfig,
+  logger
+} from './shared/index.js';
+import { injectContext } from './context.js';
+import { executeGate } from './gate-loader.js';
+import { handleAction } from './action-handler.js';
+import { Session } from './session.js';
+import { getWorkflowContext } from './workflow/context.js';
+import { minimatch } from 'minimatch';
+import path from 'path';
+import { detectSyntheticEvents } from './synthetic-events/detector.js';
+import { isSyntheticEvent } from './synthetic-events/types.js';
+
+export function shouldProcessHook(input: HookInput, hookConfig: HookConfig): boolean {
+  const hookEvent = input.hook_event_name;
+
+  // PostToolUse filtering
+  if (hookEvent === 'PostToolUse') {
+    if (hookConfig.enabled_tools && hookConfig.enabled_tools.length > 0) {
+      return hookConfig.enabled_tools.includes(input.tool_name ?? '');
+    }
+  }
+
+  // SubagentStop filtering
+  if (hookEvent === 'SubagentStop') {
+    if (hookConfig.enabled_agents && hookConfig.enabled_agents.length > 0) {
+      const agentName = input.agent_name ?? input.subagent_name ?? '';
+      return hookConfig.enabled_agents.includes(agentName);
+    }
+  }
+
+  // No filtering or other events
+  return true;
+}
+
+export interface DispatchResult {
+  context?: string;
+  blockReason?: string;
+  stopMessage?: string;
+}
+
+/**
+ * ERROR HANDLING: Circular gate chain prevention (max 10 gates per dispatch).
+ * Prevents infinite loops from misconfigured gate chains.
+ */
+const MAX_GATES_PER_DISPATCH = 10;
+
+// Built-in gates removed - context injection is the primary behavior
+// Context injection happens via injectContext() which discovers .claude/context/ files
+
+/**
+ * Check if gate should run based on keyword matching (UserPromptSubmit only).
+ * Gates without keywords always run (backwards compatible).
+ *
+ * Note: Uses substring matching, not word-boundary matching. This means "test"
+ * will match "latest" or "contest". This is intentional for flexibility - users
+ * can say "let's test this" or "testing the feature" and both will match.
+ * If word-boundary matching is needed in the future, consider using regex like:
+ * /\b${keyword}\b/i.test(message)
+ */
+export function gateMatchesKeywords(
+  gateConfig: GateConfig,
+  userMessage: string | undefined
+): boolean {
+  // No keywords = always run (backwards compatible)
+  if (!gateConfig.keywords || gateConfig.keywords.length === 0) {
+    return true;
+  }
+
+  // No user message = skip keyword gates
+  if (!userMessage) {
+    return false;
+  }
+
+  const lowerMessage = userMessage.toLowerCase();
+  return gateConfig.keywords.some((keyword) => lowerMessage.includes(keyword.toLowerCase()));
+}
+
+/**
+ * Check if gate should run based on file pattern matching (PostToolUse only).
+ * Gates without patterns always run (backwards compatible).
+ *
+ * Uses glob patterns matched against relative paths from project root.
+ * Multiple patterns use OR logic - gate runs if file matches ANY pattern.
+ *
+ * @param gateConfig - Gate configuration
+ * @param filePath - Absolute path to file being modified (from HookInput.file_path)
+ * @param cwd - Current working directory (project root)
+ * @returns true if gate should run, false otherwise
+ */
+export async function gateMatchesFilePattern(
+  gateConfig: GateConfig,
+  filePath: string | undefined,
+  cwd: string
+): Promise<boolean> {
+  // No patterns = always run (backwards compatible)
+  if (!gateConfig.file_patterns || gateConfig.file_patterns.length === 0) {
+    return true;
+  }
+
+  // No file path = skip pattern matching
+  if (!filePath) {
+    return false;
+  }
+
+  // FIX: Normalize relative paths to absolute paths before conversion
+  // If filePath is already relative, path.relative may produce incorrect results
+  const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(cwd, filePath);
+
+  // Convert absolute path to relative path from cwd
+  const relativePath = path.relative(cwd, absolutePath);
+
+  // FIX: Keep .some() implementation from Task 3, add logging separately
+  let matchedPattern: string | undefined;
+
+  // Check if file matches ANY pattern (OR logic)
+  try {
+    const matches = gateConfig.file_patterns.some((pattern) => {
+      const result = minimatch(relativePath, pattern, {
+        matchBase: false, // Match full path, not just basename (packages/cts/** shouldn't match unrelated/cts/)
+        dot: true // Allow patterns to match dotfiles like .config/settings.json
+      });
+      if (result) {
+        matchedPattern = pattern;
+      }
+      return result;
+    });
+
+    // FIX: Use await logger.debug() pattern (consistent with existing code)
+    if (matches && matchedPattern) {
+      await logger.debug('File pattern matched', {
+        relativePath,
+        pattern: matchedPattern,
+        absolutePath: filePath
+      });
+    }
+
+    return matches;
+  } catch (error) {
+    // FIX: Invalid glob pattern - log warning and skip gate
+    await logger.warn('Invalid file pattern - gate skipped', {
+      pattern: gateConfig.file_patterns,
+      error: error instanceof Error ? error.message : String(error),
+      relativePath
+    });
+    return false;
+  }
+}
+
+async function updateSessionState(input: HookInput): Promise<void> {
+  const session = new Session(input.cwd);
+  const event = input.hook_event_name;
+
+  try {
+    switch (event) {
+      case 'SlashCommandStart':
+        // command field set by synthetic dispatcher
+        if (input.command) {
+          await session.set('active_command', input.command); // Full name preserved
+        }
+        break;
+
+      case 'SlashCommandEnd':
+        await session.set('active_command', null);
+        break;
+
+      case 'SkillStart':
+        // skill field set by synthetic dispatcher
+        if (input.skill) {
+          await session.set('active_skill', input.skill); // Full name preserved
+        }
+        break;
+
+      case 'SkillEnd':
+        await session.set('active_skill', null);
+        break;
+
+      case 'SubagentStart':
+        // Store tool_use_id → stepId mapping for correlation
+        if (input.tool_use_id && input.step_id) {
+          const metadata = await session.get('metadata');
+          const mapping = (metadata.toolUseIdToStepId ?? {}) as Record<string, string>;
+          await session.set('metadata', {
+            ...metadata,
+            toolUseIdToStepId: {
+              ...mapping,
+              [input.tool_use_id]: input.step_id
+            }
+          });
+        }
+        break;
+
+      case 'PostToolUse':
+        if (input.file_path) {
+          await session.append('edited_files', input.file_path);
+
+          // Extract and track file extension
+          // Edge case: ext !== input.file_path prevents tracking entire filename
+          // as extension when file has no dot (e.g., "README")
+          const ext = input.file_path.split('.').pop();
+          if (ext && ext !== input.file_path) {
+            await session.append('file_extensions', ext);
+          }
+        }
+        break;
+    }
+  } catch (error) {
+    // Session state is best-effort, don't fail the hook if it errors
+    // Structured error logging for debugging
+    const errorData = {
+      error_type: error instanceof Error ? error.constructor.name : 'UnknownError',
+      error_message: error instanceof Error ? error.message : String(error),
+      hook_event: event,
+      cwd: input.cwd,
+      timestamp: new Date().toISOString()
+    };
+    console.error(`[Session Error] ${JSON.stringify(errorData)}`);
+  }
+}
+
+export async function dispatch(input: HookInput): Promise<DispatchResult> {
+  const hookEvent = input.hook_event_name;
+  const cwd = input.cwd;
+  const startTime = Date.now();
+
+  await logger.event('debug', hookEvent, {
+    tool: input.tool_name,
+    agent: input.agent_name ?? input.subagent_name,
+    file: input.file_path,
+    cwd
+  });
+
+  // Update session state (best-effort)
+  await updateSessionState(input);
+
+  // 1. ALWAYS run context injection FIRST (primary behavior)
+  // This discovers .claude/context/{name}-{stage}.md files
+  const contextContent = await injectContext(hookEvent, input);
+  let accumulatedContext = contextContent ?? '';
+
+  // Inject workflow context if active
+  const workflowContext = getWorkflowContext(input.cwd);
+  if (workflowContext) {
+    accumulatedContext = accumulatedContext
+      ? accumulatedContext + '\n\n' + workflowContext
+      : workflowContext;
+  }
+
+  // Synthetic event dispatch
+  // SAFETY: isSyntheticEvent() prevents recursive synthetic detection.
+  // If synthetic events are ever added to hooks.json, they would NOT
+  // trigger additional synthetic detection because detectSyntheticEvents()
+  // only maps real Claude Code events.
+  if (!isSyntheticEvent(hookEvent)) {
+    // Reuse single Session instance for synthetic dispatch
+    const syntheticSession = new Session(input.cwd);
+
+    // Special handling: Clear active_command on every UserPromptSubmit
+    // BEFORE potentially setting new one via SlashCommandStart
+    if (hookEvent === 'UserPromptSubmit') {
+      await syntheticSession.set('active_command', null);
+    }
+
+    const syntheticEvents = detectSyntheticEvents(input);
+
+    for (const synthetic of syntheticEvents) {
+      // Special handling: SlashCommandEnd should only dispatch if there was an active command
+      // and needs to pass the command name for context injection
+      let slashCommandEndCommand: string | undefined;
+      if (synthetic.syntheticEvent === 'SlashCommandEnd') {
+        const activeCommand = await syntheticSession.get('active_command');
+        if (!activeCommand) {
+          continue; // Skip SlashCommandEnd if no active command
+        }
+        slashCommandEndCommand = activeCommand;
+      }
+
+      // Build synthetic input with event-specific fields
+      const syntheticInput: HookInput = {
+        ...input,
+        hook_event_name: synthetic.syntheticEvent,
+        // Add event-specific fields (slashCommandEndCommand for SlashCommandEnd, synthetic.commandName for others)
+        ...(slashCommandEndCommand
+          ? { command: slashCommandEndCommand }
+          : synthetic.commandName && { command: synthetic.commandName }),
+        ...(synthetic.skillName && { skill: synthetic.skillName }),
+        ...(synthetic.stepId && { step_id: synthetic.stepId }),
+        ...(synthetic.toolUseId && { tool_use_id: synthetic.toolUseId }),
+        ...(synthetic.subagentType && { subagent_type: synthetic.subagentType })
+      };
+
+      // Recursive dispatch for synthetic event (full pipeline)
+      const syntheticResult = await dispatch(syntheticInput);
+
+      // Accumulate context from synthetic events (avoid leading newlines)
+      if (syntheticResult.context) {
+        accumulatedContext = accumulatedContext
+          ? accumulatedContext + '\n\n' + syntheticResult.context
+          : syntheticResult.context;
+      }
+
+      // Propagate blocks from synthetic events
+      if (syntheticResult.blockReason) {
+        return {
+          context: accumulatedContext,
+          blockReason: syntheticResult.blockReason
+        };
+      }
+    }
+  }
+
+  // 2. Load config for additional gates (optional)
+  const config = await loadConfig(cwd);
+  if (!config) {
+    await logger.debug('No rundown-plugin.json config found', { cwd });
+    // Return context injection result even without rundown-plugin.json
+    return accumulatedContext ? { context: accumulatedContext } : {};
+  }
+
+  // 3. Check if hook event has additional gates configured
+  const hookConfig = config.hooks[hookEvent];
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard for external data structure
+  if (!hookConfig) {
+    await logger.debug('Hook event not configured in rundown-plugin.json', { event: hookEvent });
+    // Return context injection result even if hook not in rundown-plugin.json
+    return accumulatedContext ? { context: accumulatedContext } : {};
+  }
+
+  // 4. Filter by enabled lists
+  if (!shouldProcessHook(input, hookConfig)) {
+    await logger.debug('Hook filtered out by enabled list', {
+      event: hookEvent,
+      tool: input.tool_name,
+      agent: input.agent_name
+    });
+    // Still return context injection result
+    return accumulatedContext ? { context: accumulatedContext } : {};
+  }
+
+  // 5. Run additional gates in sequence (from rundown-plugin.json)
+  const gates = hookConfig.gates ?? [];
+  let gatesExecuted = 0;
+
+  for (const gateName of gates) {
+    // Circuit breaker: prevent infinite chains
+    if (gatesExecuted >= MAX_GATES_PER_DISPATCH) {
+      return {
+        blockReason: `Exceeded max gate chain depth (${String(MAX_GATES_PER_DISPATCH)}). Check for circular references.`
+      };
+    }
+
+    const gateConfig = config.gates[gateName];
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard for missing gate definition
+    if (!gateConfig) {
+      // Graceful degradation: skip undefined gates with warning
+      accumulatedContext += `\nWarning: Gate '${gateName}' not defined, skipping`;
+      continue;
+    }
+
+    // Keyword filtering for UserPromptSubmit
+    if (hookEvent === 'UserPromptSubmit' && !gateMatchesKeywords(gateConfig, input.user_message)) {
+      await logger.debug('Gate skipped - no keyword match', { gate: gateName });
+      continue;
+    }
+
+    // File pattern filtering for PostToolUse
+    if (
+      hookEvent === 'PostToolUse' &&
+      !(await gateMatchesFilePattern(gateConfig, input.file_path, input.cwd))
+    ) {
+      await logger.debug('Gate skipped - no file pattern match', { gate: gateName });
+      continue;
+    }
+
+    gatesExecuted++;
+
+    // Execute gate
+    const gateStartTime = Date.now();
+    const { passed, result } = await executeGate(gateName, gateConfig, input, []);
+    const gateDuration = Date.now() - gateStartTime;
+
+    await logger.event('info', hookEvent, {
+      gate: gateName,
+      passed,
+      duration_ms: gateDuration,
+      tool: input.tool_name
+    });
+
+    // Determine action
+    const action = passed ? (gateConfig.on_pass ?? 'CONTINUE') : (gateConfig.on_fail ?? 'BLOCK');
+
+    // Handle action
+    const actionResult = handleAction(action, result, config, input);
+
+    if (actionResult.context) {
+      accumulatedContext += '\n' + actionResult.context;
+    }
+
+    if (!actionResult.continue) {
+      await logger.event('warn', hookEvent, {
+        gate: gateName,
+        action,
+        blocked: !!actionResult.blockReason,
+        stopped: !!actionResult.stopMessage,
+        duration_ms: Date.now() - startTime
+      });
+      return {
+        context: accumulatedContext,
+        blockReason: actionResult.blockReason,
+        stopMessage: actionResult.stopMessage
+      };
+    }
+
+    // Gate chaining
+    if (actionResult.chainedGate) {
+      gates.push(actionResult.chainedGate);
+    }
+  }
+
+  await logger.event('debug', hookEvent, {
+    status: 'completed',
+    gates_executed: gatesExecuted,
+    duration_ms: Date.now() - startTime
+  });
+
+  return {
+    context: accumulatedContext
+  };
+}

--- a/packages/claude-code-plugin/src/gate-loader.ts
+++ b/packages/claude-code-plugin/src/gate-loader.ts
@@ -1,0 +1,264 @@
+// gate-loader.ts
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import * as path from 'path';
+import {
+  type HookInput,
+  type GateResult,
+  type GateConfig,
+  resolvePluginPath,
+  loadConfigFile
+} from './shared/index.js';
+import * as builtinGates from './gates/index.js';
+
+const execAsync = promisify(exec);
+
+export interface ShellResult {
+  exitCode: number;
+  output: string;
+}
+
+/**
+ * Type guard for execution errors from child_process
+ * Represents error objects that can be thrown by exec/execSync
+ */
+interface ExecError extends Error {
+  killed?: boolean;
+  signal?: string;
+  code?: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+/**
+ * Type guard to safely access error properties
+ * Returns the error cast to ExecError, handling both CommonJS and ESM error objects
+ */
+function asExecError(error: unknown): ExecError {
+  // Check if error is an object with Error-like properties
+  // (handles both instanceof Error and plain objects from ESM)
+  if (error !== null && typeof error === 'object') {
+    const err = error as Record<string, unknown>;
+    return {
+      name: typeof err.name === 'string' ? err.name : 'Error',
+      message: typeof err.message === 'string' ? err.message : 'Unknown error',
+      killed: typeof err.killed === 'boolean' ? err.killed : false,
+      signal: typeof err.signal === 'string' ? err.signal : undefined,
+      code: typeof err.code === 'number' ? err.code : undefined,
+      stdout: typeof err.stdout === 'string' ? err.stdout : '',
+      stderr: typeof err.stderr === 'string' ? err.stderr : ''
+    };
+  }
+  return {
+    name: 'Error',
+    message: typeof error === 'string' ? error : 'Unknown error',
+    killed: false,
+    signal: undefined,
+    code: 1,
+    stdout: '',
+    stderr: ''
+  };
+}
+
+/**
+ * Execute shell command from gate configuration with timeout.
+ *
+ * SECURITY MODEL: rundown-plugin.json is trusted configuration (project-controlled, not user input).
+ * Commands are executed without sanitization because:
+ * 1. rundown-plugin.json is committed to repository or managed by project admins
+ * 2. Users cannot inject commands without write access to rundown-plugin.json
+ * 3. If rundown-plugin.json is compromised, the project is already compromised
+ *
+ * This is equivalent to package.json scripts or Makefile targets - trusted project configuration.
+ *
+ * ERROR HANDLING: Commands timeout after 30 seconds to prevent hung gates.
+ */
+export async function executeShellCommand(
+  command: string,
+  cwd: string,
+  timeoutMs = 30000
+): Promise<ShellResult> {
+  try {
+    const { stdout, stderr } = await execAsync(command, { cwd, timeout: timeoutMs });
+    return {
+      exitCode: 0,
+      output: stdout + stderr
+    };
+  } catch (error: unknown) {
+    // Type guard - safely access error properties
+    const err = asExecError(error);
+
+    // Check for timeout: killed=true and signal='SIGTERM'
+    if (err.killed && err.signal === 'SIGTERM') {
+      return {
+        exitCode: 124, // Standard timeout exit code
+        output: `Command timed out after ${String(timeoutMs)}ms`
+      };
+    }
+
+    return {
+      exitCode: err.code ?? 1,
+      output: (err.stdout ?? '') + (err.stderr ?? '')
+    };
+  }
+}
+
+/**
+ * Load and execute a built-in TypeScript gate
+ *
+ * Built-in gates are TypeScript modules in src/gates/ that export an execute function.
+ * Gate names use kebab-case and are mapped to camelCase module names:
+ * - "plugin-path" → pluginPath
+ * - "custom-gate" → customGate
+ */
+export async function executeBuiltinGate(gateName: string, input: HookInput): Promise<GateResult> {
+  try {
+    // Convert kebab-case to camelCase for module lookup
+    // "plugin-path" -> "pluginPath"
+    const moduleName = gateName.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+
+    // Look up the gate module from static imports
+    const gateModule = (
+      builtinGates as Record<
+        string,
+        { execute?: (input: HookInput) => GateResult | Promise<GateResult> }
+      >
+    )[moduleName];
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard for dynamic module lookup
+    if (!gateModule) {
+      throw new Error(`Gate module '${moduleName}' not found or missing execute function`);
+    }
+    if (typeof gateModule.execute !== 'function') {
+      throw new Error(`Gate module '${moduleName}' not found or missing execute function`);
+    }
+
+    return await gateModule.execute(input);
+  } catch (error) {
+    throw new Error(`Failed to load built-in gate ${gateName}: ${String(error)}`);
+  }
+}
+
+// Track plugin gate call stack to detect circular references
+const MAX_PLUGIN_DEPTH = 10;
+
+export async function executeGate(
+  gateName: string,
+  gateConfig: GateConfig,
+  input: HookInput,
+  pluginStack: string[] = []
+): Promise<{ passed: boolean; result: GateResult }> {
+  // Handle plugin gate reference
+  if (gateConfig.plugin && gateConfig.gate) {
+    // Circular reference detection
+    const gateRef = `${gateConfig.plugin}:${gateConfig.gate}`;
+    if (pluginStack.includes(gateRef)) {
+      throw new Error(
+        `Circular gate reference detected: ${pluginStack.join(' -> ')} -> ${gateRef}`
+      );
+    }
+
+    // Depth limit to prevent infinite recursion
+    if (pluginStack.length >= MAX_PLUGIN_DEPTH) {
+      throw new Error(
+        `Maximum plugin gate depth (${String(MAX_PLUGIN_DEPTH)}) exceeded: ${pluginStack.join(' -> ')} -> ${gateRef}`
+      );
+    }
+
+    const { gateConfig: pluginGateConfig, pluginRoot } = await loadPluginGate(
+      gateConfig.plugin,
+      gateConfig.gate
+    );
+
+    // Recursively execute the plugin's gate with updated stack
+    const newStack = [...pluginStack, gateRef];
+
+    // Execute the plugin's gate command in the plugin's directory
+    if (pluginGateConfig.command) {
+      const shellResult = await executeShellCommand(pluginGateConfig.command, pluginRoot);
+      const passed = shellResult.exitCode === 0;
+
+      return {
+        passed,
+        result: {
+          additionalContext: shellResult.output
+        }
+      };
+    } else if (pluginGateConfig.plugin && pluginGateConfig.gate) {
+      // Plugin gate references another plugin gate - recurse
+      return executeGate(gateRef, pluginGateConfig, input, newStack);
+    } else {
+      throw new Error(`Plugin gate '${gateConfig.plugin}:${gateConfig.gate}' has no command`);
+    }
+  }
+
+  if (gateConfig.command) {
+    // Shell command gate (existing behavior)
+    const shellResult = await executeShellCommand(gateConfig.command, input.cwd);
+    const passed = shellResult.exitCode === 0;
+
+    return {
+      passed,
+      result: {
+        additionalContext: shellResult.output
+      }
+    };
+  } else {
+    // Built-in TypeScript gate
+    const result = await executeBuiltinGate(gateName, input);
+    const passed = !result.decision && result.continue !== false;
+
+    return {
+      passed,
+      result
+    };
+  }
+}
+
+export interface PluginGateResult {
+  gateConfig: GateConfig;
+  pluginRoot: string;
+}
+
+/**
+ * Load a gate definition from another plugin.
+ *
+ * SECURITY: Plugins are trusted by virtue of being explicitly installed by the user.
+ * This function loads plugin configuration and does NOT validate command safety.
+ * The trust boundary is at plugin installation, not at gate reference.
+ *
+ * However, we do validate that the loaded config has the expected structure to
+ * prevent runtime errors from malformed plugin configurations.
+ *
+ * @param pluginName - Name of the plugin (e.g., 'cipherpowers')
+ * @param gateName - Name of the gate within the plugin
+ * @returns The gate config and the plugin root path for execution context
+ */
+export async function loadPluginGate(
+  pluginName: string,
+  gateName: string
+): Promise<PluginGateResult> {
+  const pluginRoot = resolvePluginPath(pluginName);
+  const gatesPath = path.join(pluginRoot, 'rundown-plugin.json');
+
+  const pluginConfig = await loadConfigFile(gatesPath);
+  if (!pluginConfig) {
+    throw new Error(`Cannot find rundown-plugin.json for plugin '${pluginName}' at ${gatesPath}`);
+  }
+
+  // Validate plugin config has gates object
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard validating external config structure
+  if (!pluginConfig.gates || typeof pluginConfig.gates !== 'object') {
+    throw new Error(
+      `Invalid rundown-plugin.json structure in plugin '${pluginName}': missing or invalid 'gates' object`
+    );
+  }
+
+  const gateConfig = pluginConfig.gates[gateName];
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard for missing gate in loaded plugin config
+  if (!gateConfig) {
+    throw new Error(`Gate '${gateName}' not found in plugin '${pluginName}'`);
+  }
+
+  return { gateConfig, pluginRoot };
+}

--- a/packages/claude-code-plugin/src/gates/index.ts
+++ b/packages/claude-code-plugin/src/gates/index.ts
@@ -1,0 +1,12 @@
+// gates/index.ts
+/**
+ * Built-in gates registry
+ *
+ * All TypeScript gates are exported here for easy discovery and import.
+ */
+
+export * as pluginPath from './plugin-path.js';
+export * as workflowStepTracker from './workflow-step-tracker.js';
+export * as workflowSubagentStart from './workflow-subagent-start.js';
+export * as workflowSubagentStop from './workflow-subagent-stop.js';
+export * as workflowSkillStart from './workflow-skill-start.js';

--- a/packages/claude-code-plugin/src/gates/plugin-path.ts
+++ b/packages/claude-code-plugin/src/gates/plugin-path.ts
@@ -1,0 +1,58 @@
+// gates/plugin-path.ts
+import { type HookInput, type GateResult } from '../shared/index.js';
+import * as path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Plugin Path Injection Gate
+ *
+ * Injects CLAUDE_PLUGIN_ROOT as context for agents to resolve file references.
+ * This gate provides the absolute path to the plugin root directory, enabling
+ * agents to properly resolve @${CLAUDE_PLUGIN_ROOT}/... file references.
+ *
+ * Typical usage: SubagentStop hook to inject path context when agents complete.
+ */
+
+export function execute(_input: HookInput): Promise<GateResult> {
+  // Determine plugin root:
+  // 1. Use CLAUDE_PLUGIN_ROOT if set (standard Claude Code environment)
+  // 2. Otherwise compute from this script's location
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT ?? computePluginRoot();
+
+  const contextMessage = `## Plugin Path Context
+
+For this session:
+\`\`\`
+CLAUDE_PLUGIN_ROOT=${pluginRoot}
+\`\`\`
+
+When you see file references like \`@\${CLAUDE_PLUGIN_ROOT}skills/...\`, resolve them using the path above.`;
+
+  return Promise.resolve({
+    additionalContext: contextMessage
+  });
+}
+
+/**
+ * Compute plugin root from this file's location
+ * This file is at: plugin/core/src/gates/plugin-path.ts
+ * Plugin root is: plugin/
+ *
+ * We go up 3 levels: gates/ -> src/ -> core/ -> plugin/
+ */
+function computePluginRoot(): string {
+  // In CommonJS, use __dirname
+  // __dirname is at: plugin/core/dist/gates/
+  // (after compilation from src/ to dist/)
+
+  // Go up 3 directories from dist/gates/
+  let pluginRoot = path.dirname(__dirname); // dist/
+  pluginRoot = path.dirname(pluginRoot); // core/
+  pluginRoot = path.dirname(pluginRoot); // plugin/
+
+  return pluginRoot;
+}

--- a/packages/claude-code-plugin/src/gates/workflow-skill-start.ts
+++ b/packages/claude-code-plugin/src/gates/workflow-skill-start.ts
@@ -1,0 +1,77 @@
+import { type HookInput, type GateResult } from '../shared/index.js';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Workflow Skill Start Gate
+ *
+ * Parses skill frontmatter for `workflow:` field and auto-starts
+ * the declared workflow when a skill begins.
+ */
+export function execute(input: HookInput): Promise<GateResult> {
+  // Only handle SkillStart
+  if (input.hook_event_name !== 'SkillStart') {
+    return Promise.resolve({});
+  }
+
+  const skillName = input.skill;
+  if (!skillName) return Promise.resolve({});
+
+  // Find skill file and parse frontmatter
+  const workflow = findSkillWorkflow(skillName, input.cwd);
+  if (!workflow) return Promise.resolve({});
+
+  // Start workflow via CLI
+  try {
+    execSync(`rundown run ${workflow}`, { cwd: input.cwd, stdio: 'pipe' });
+    return Promise.resolve({
+      additionalContext: `Started workflow: ${workflow}`
+    });
+  } catch {
+    // Graceful degradation - workflow start failed
+    return Promise.resolve({});
+  }
+}
+
+/**
+ * Find skill SKILL.md and extract workflow from frontmatter
+ */
+function findSkillWorkflow(skillName: string, cwd: string): string | undefined {
+  // Parse namespace:name format
+  const colonIndex = skillName.indexOf(':');
+  const name = colonIndex >= 0 ? skillName.substring(colonIndex + 1) : skillName;
+
+  // Search paths for SKILL.md
+  const searchPaths = [
+    // Plugin skills (via CLAUDE_PLUGIN_ROOT)
+    path.join(process.env.CLAUDE_PLUGIN_ROOT ?? '', 'skills', name, 'SKILL.md'),
+    // User skills (in project .claude directory)
+    path.join(cwd, '.claude', 'skills', name, 'SKILL.md')
+  ];
+
+  for (const skillPath of searchPaths) {
+    try {
+      const content = fs.readFileSync(skillPath, 'utf8');
+      const workflow = parseWorkflowFromFrontmatter(content);
+      if (workflow) return workflow;
+    } catch {
+      continue;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Parse workflow field from YAML frontmatter
+ */
+export function parseWorkflowFromFrontmatter(content: string): string | undefined {
+  // Match YAML frontmatter block
+  const match = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (!match) return undefined;
+
+  // Extract workflow field from frontmatter
+  const workflowMatch = /^workflow:\s*(.+)$/m.exec(match[1]);
+  return workflowMatch?.[1];
+}

--- a/packages/claude-code-plugin/src/gates/workflow-step-tracker.ts
+++ b/packages/claude-code-plugin/src/gates/workflow-step-tracker.ts
@@ -1,0 +1,21 @@
+import { type HookInput, type GateResult } from '../shared/index.js';
+import { trackStepDispatch } from '../workflow/hooks/step-tracker.js';
+
+/**
+ * Workflow Step Tracker Gate
+ *
+ * Wraps trackStepDispatch logic as a configurable gate.
+ * Enforces StepId prefix on Step tool descriptions when workflow is active.
+ */
+export function execute(input: HookInput): GateResult {
+  const result = trackStepDispatch(input);
+
+  if (result.violation) {
+    return {
+      decision: 'block',
+      reason: result.violation
+    };
+  }
+
+  return {};
+}

--- a/packages/claude-code-plugin/src/gates/workflow-subagent-start.ts
+++ b/packages/claude-code-plugin/src/gates/workflow-subagent-start.ts
@@ -1,0 +1,25 @@
+import { type HookInput, type GateResult } from '../shared/index.js';
+import { handleSubagentStart } from '../workflow/hooks/subagent-start.js';
+
+/**
+ * Workflow Subagent Start Gate
+ *
+ * Wraps handleSubagentStart logic as a configurable gate.
+ * Binds agents to pending tasks when workflow is active.
+ */
+export function execute(input: HookInput): GateResult {
+  const result = handleSubagentStart(input);
+
+  if (result.violation) {
+    return {
+      decision: 'block',
+      reason: result.violation
+    };
+  }
+
+  if (result.context) {
+    return { additionalContext: result.context };
+  }
+
+  return {};
+}

--- a/packages/claude-code-plugin/src/gates/workflow-subagent-stop.ts
+++ b/packages/claude-code-plugin/src/gates/workflow-subagent-stop.ts
@@ -1,0 +1,25 @@
+import { type HookInput, type GateResult } from '../shared/index.js';
+import { handleSubagentStop } from '../workflow/hooks/subagent-stop.js';
+
+/**
+ * Workflow Subagent Stop Gate
+ *
+ * Wraps handleSubagentStop logic as a configurable gate.
+ * Handles agent completion and advances workflow state.
+ */
+export function execute(input: HookInput): GateResult {
+  const result = handleSubagentStop(input);
+
+  if (result.violation) {
+    return {
+      decision: 'block',
+      reason: result.violation
+    };
+  }
+
+  if (result.context) {
+    return { additionalContext: result.context };
+  }
+
+  return {};
+}

--- a/packages/claude-code-plugin/src/index.ts
+++ b/packages/claude-code-plugin/src/index.ts
@@ -1,0 +1,31 @@
+// @rundown-org/claude-code-plugin main exports
+
+// Existing exports
+export { dispatch } from './dispatcher.js';
+export { executeGate } from './gate-loader.js';
+export { handleAction } from './action-handler.js';
+export { injectContext } from './context.js';
+
+// Exports from @rundown-org/claude-code-plugin/shared
+export {
+  loadConfig,
+  type HookInput,
+  type GateResult,
+  type GateExecute,
+  type GateConfig,
+  type HookConfig,
+  type RundownPluginConfig,
+  type SessionState,
+  type SessionStateArrayKey,
+  type SessionStateScalarKey,
+  logger,
+  type LogLevel
+} from './shared/index.js';
+
+// New session exports
+export { Session } from './session.js';
+
+// Synthetic events
+export { detectSyntheticEvents } from './synthetic-events/detector.js';
+export { isSyntheticEvent } from './synthetic-events/types.js';
+export type { SyntheticEvent, SyntheticEventName } from './synthetic-events/types.js';

--- a/packages/claude-code-plugin/src/session.ts
+++ b/packages/claude-code-plugin/src/session.ts
@@ -1,0 +1,200 @@
+import { promises as fs } from 'fs';
+import { dirname, join } from 'path';
+import {
+  type SessionState,
+  type SessionStateArrayKey,
+  SessionStateSchema,
+  type SessionLoadResult,
+  isNodeError,
+  isFileNotFoundError,
+  logger
+} from './shared/index.js';
+
+/**
+ * Manages session state with atomic file updates.
+ *
+ * State is stored in .claude/session/state.json relative to the project directory.
+ */
+export class Session {
+  private stateFile: string;
+
+  constructor(cwd = '.') {
+    this.stateFile = join(cwd, '.claude', 'session', 'state.json');
+  }
+
+  /**
+   * Get a session state value
+   */
+  async get<K extends keyof SessionState>(key: K): Promise<SessionState[K]> {
+    const state = await this.load();
+    return state[key];
+  }
+
+  /**
+   * Set a session state value
+   */
+  async set<K extends keyof SessionState>(key: K, value: SessionState[K]): Promise<void> {
+    const state = await this.load();
+    state[key] = value;
+    await this.save(state);
+  }
+
+  /**
+   * Append value to array field (deduplicated)
+   */
+  async append(key: SessionStateArrayKey, value: string): Promise<void> {
+    const state = await this.load();
+    const array = state[key];
+
+    if (!array.includes(value)) {
+      array.push(value);
+      state[key] = array;
+      await this.save(state);
+    }
+  }
+
+  /**
+   * Check if array contains value
+   */
+  async contains(key: SessionStateArrayKey, value: string): Promise<boolean> {
+    const state = await this.load();
+    return state[key].includes(value);
+  }
+
+  /**
+   * Clear session state (remove file)
+   */
+  async clear(): Promise<void> {
+    try {
+      await fs.unlink(this.stateFile);
+    } catch {
+      // File doesn't exist, that's fine
+    }
+  }
+
+  /**
+   * Load state from file with detailed error handling
+   * Returns result object with success/error discriminant
+   */
+  private async loadWithError(): Promise<SessionLoadResult<SessionState>> {
+    try {
+      const content = await fs.readFile(this.stateFile, 'utf-8');
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(content);
+      } catch (e) {
+        return {
+          success: false,
+          error: {
+            type: 'parse_error',
+            path: this.stateFile,
+            message: e instanceof Error ? e.message : String(e)
+          }
+        };
+      }
+
+      const result = SessionStateSchema.safeParse(parsed);
+      if (!result.success) {
+        return {
+          success: false,
+          error: {
+            type: 'validation_error',
+            path: this.stateFile,
+            message: result.error.issues.map((i) => i.message).join(', ')
+          }
+        };
+      }
+
+      return { success: true, data: result.data };
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ENOENT') {
+        return {
+          success: false,
+          error: { type: 'file_not_found', path: this.stateFile }
+        };
+      }
+      return {
+        success: false,
+        error: {
+          type: 'parse_error',
+          path: this.stateFile,
+          message: error instanceof Error ? error.message : String(error)
+        }
+      };
+    }
+  }
+
+  /**
+   * Load state from file or initialize new state
+   * Handles errors silently: missing file initialized, corrupted data logged and reinitialized
+   */
+  private async load(): Promise<SessionState> {
+    const result = await this.loadWithError();
+
+    if (result.success) {
+      return result.data;
+    }
+
+    const error = result.error;
+
+    if (isFileNotFoundError(error)) {
+      return this.initState();
+    }
+
+    // error has message field (parse_error or validation_error types)
+    const message = 'message' in error ? error.message : 'unknown error';
+    await logger.warn('Session state corrupted, reinitializing', {
+      path: error.path,
+      error_type: error.type,
+      message
+    });
+
+    return this.initState();
+  }
+
+  /**
+   * Save state to file atomically (write to temp, then rename)
+   *
+   * Performance note: File I/O adds small overhead (~1-5ms) per operation.
+   * Atomic writes prevent corruption but require temp file creation.
+   *
+   * Concurrency note: Atomic rename prevents file corruption (invalid JSON,
+   * partial writes) but does NOT prevent logical race conditions where
+   * concurrent operations overwrite each other's changes. This is acceptable
+   * because hooks run sequentially in practice. If true concurrent access is
+   * needed, add file locking or retry logic.
+   */
+  private async save(state: SessionState): Promise<void> {
+    await fs.mkdir(dirname(this.stateFile), { recursive: true });
+    const temp = this.stateFile + '.tmp';
+
+    try {
+      // Write to temp file
+      await fs.writeFile(temp, JSON.stringify(state, null, 2), 'utf-8');
+
+      // Atomic rename (prevents corruption from concurrent writes)
+      await fs.rename(temp, this.stateFile);
+    } catch (error) {
+      // Clean up temp file on error
+      try {
+        await fs.unlink(temp);
+      } catch {
+        // Ignore cleanup errors
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Initialize new session state
+   *
+   * Uses SessionStateSchema as single source of truth for default values.
+   * Session ID format: ISO timestamp with punctuation replaced (e.g., "2025-11-23T14-30-45")
+   * Unique per millisecond. Collisions possible if multiple sessions start in same millisecond,
+   * but unlikely in practice due to hook serialization.
+   */
+  private initState(): SessionState {
+    return SessionStateSchema.parse({});
+  }
+}

--- a/packages/claude-code-plugin/src/shared/config.ts
+++ b/packages/claude-code-plugin/src/shared/config.ts
@@ -1,0 +1,249 @@
+// packages/claude-code-plugin/src/shared/config.ts
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { type RundownPluginConfig, type GateConfig } from './types.js';
+import { fileExists } from './utils.js';
+import { logger } from './logger.js';
+
+const KNOWN_HOOK_EVENTS = [
+  'PreToolUse',
+  'PostToolUse',
+  'SubagentStart',
+  'SubagentStop',
+  'UserPromptSubmit',
+  'SlashCommandStart',
+  'SlashCommandEnd',
+  'SkillStart',
+  'SkillEnd',
+  'SessionStart',
+  'SessionEnd',
+  'Stop',
+  'Notification',
+  'PreCompact',
+  'PermissionRequest'
+];
+
+const KNOWN_ACTIONS = ['CONTINUE', 'BLOCK', 'STOP'];
+
+/**
+ * Validate file patterns in gate configuration.
+ * Validates types only - does not validate glob syntax (matches Jest/ESLint behavior).
+ * Called during config loading for fail-fast type checking.
+ *
+ * @param gateConfig - Gate configuration to validate
+ * @throws Error if any pattern is not a string
+ */
+export function validateFilePatterns(gateConfig: GateConfig): void {
+  if (!gateConfig.file_patterns || gateConfig.file_patterns.length === 0) {
+    return; // No patterns to validate
+  }
+
+  for (const pattern of gateConfig.file_patterns) {
+    if (typeof pattern !== 'string') {
+      throw new Error(`Invalid file pattern: expected string, got ${typeof pattern}`);
+    }
+    // No syntax validation - matches ecosystem patterns (Jest, ESLint, Webpack)
+  }
+}
+
+function validateGateConfig(gateName: string, gateConfig: GateConfig): void {
+  const hasPlugin = gateConfig.plugin !== undefined;
+  const hasGate = gateConfig.gate !== undefined;
+  const hasCommand = gateConfig.command !== undefined;
+
+  // plugin requires gate
+  if (hasPlugin && !hasGate) {
+    throw new Error(`Gate '${gateName}' has 'plugin' but missing 'gate' field`);
+  }
+
+  // gate requires plugin
+  if (hasGate && !hasPlugin) {
+    throw new Error(`Gate '${gateName}' has 'gate' but missing 'plugin' field`);
+  }
+
+  // command is mutually exclusive with plugin/gate
+  if (hasCommand && (hasPlugin || hasGate)) {
+    throw new Error(`Gate '${gateName}' cannot have both 'command' and 'plugin/gate'`);
+  }
+}
+
+/**
+ * Validate config invariants to catch configuration errors early.
+ * Throws descriptive errors when invariants are violated.
+ *
+ * @param config - The RundownPluginConfig to validate
+ * @throws Error if hook event names are unknown
+ * @throws Error if gates referenced in hooks don't exist
+ * @throws Error if gate actions are invalid
+ * @throws Error if gate file patterns are invalid
+ */
+export function validateConfig(config: RundownPluginConfig): void {
+  // Invariant: Hook event names must be known types
+  for (const hookName of Object.keys(config.hooks)) {
+    if (!KNOWN_HOOK_EVENTS.includes(hookName)) {
+      throw new Error(
+        `Unknown hook event: ${hookName}. Must be one of: ${KNOWN_HOOK_EVENTS.join(', ')}`
+      );
+    }
+  }
+
+  // Invariant: Gates referenced in hooks must exist in gates config
+  for (const [hookName, hookConfig] of Object.entries(config.hooks)) {
+    if (hookConfig.gates) {
+      for (const gateName of hookConfig.gates) {
+        if (!(gateName in config.gates)) {
+          throw new Error(`Hook '${hookName}' references undefined gate '${gateName}'`);
+        }
+      }
+    }
+  }
+
+  // Invariant: Gate actions must be CONTINUE/BLOCK/STOP or reference existing gates
+  for (const [gateName, gateConfig] of Object.entries(config.gates)) {
+    // Validate gate structure first
+    validateGateConfig(gateName, gateConfig);
+
+    // Validate file patterns if specified
+    try {
+      validateFilePatterns(gateConfig);
+    } catch (error) {
+      throw new Error(
+        `Gate "${gateName}" has invalid configuration: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    for (const action of [gateConfig.on_pass, gateConfig.on_fail]) {
+      if (action && !KNOWN_ACTIONS.includes(action) && !(action in config.gates)) {
+        throw new Error(
+          `Gate '${gateName}' action '${action}' is not CONTINUE/BLOCK/STOP or valid gate name`
+        );
+      }
+    }
+
+  }
+}
+
+/**
+ * Resolve plugin path using sibling convention.
+ * Assumes plugins are installed as siblings under the same parent directory.
+ *
+ * SECURITY: Plugin names are validated to prevent path traversal attacks.
+ * This does NOT mean untrusted plugins are safe - plugins are trusted by virtue
+ * of being explicitly installed by the user. This validation only prevents
+ * accidental or malicious config entries from accessing arbitrary paths.
+ *
+ * @param pluginName - Name of the plugin to resolve
+ * @returns Absolute path to the plugin root
+ * @throws Error if CLAUDE_PLUGIN_ROOT is not set or plugin name is invalid
+ */
+export function resolvePluginPath(pluginName: string): string {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (!pluginRoot) {
+    throw new Error('Cannot resolve plugin path: CLAUDE_PLUGIN_ROOT not set');
+  }
+
+  // Security: Reject plugin names with path separators or parent references
+  // Prevents path traversal attacks like "../../../etc" or "foo/bar"
+  if (pluginName.includes('/') || pluginName.includes('\\') || pluginName.includes('..')) {
+    throw new Error(`Invalid plugin name: '${pluginName}' (must not contain path separators)`);
+  }
+
+  // Sibling convention: plugins are in same parent directory
+  // e.g., ~/.claude/plugins/rundown -> ~/.claude/plugins/cipherpowers
+  return path.resolve(pluginRoot, '..', pluginName);
+}
+
+/**
+ * Get the plugin root directory from CLAUDE_PLUGIN_ROOT env var.
+ * Claude Code sets this automatically during hook execution.
+ */
+function getPluginRoot(): string | null {
+  return process.env.CLAUDE_PLUGIN_ROOT ?? null;
+}
+
+/**
+ * Load a single config file from disk.
+ *
+ * @param configPath - Absolute path to the configuration file
+ * @returns The parsed RundownPluginConfig, or null if file doesn't exist
+ * @throws Error if file exists but contains invalid JSON
+ */
+export async function loadConfigFile(configPath: string): Promise<RundownPluginConfig | null> {
+  if (await fileExists(configPath)) {
+    const content = await fs.readFile(configPath, 'utf-8');
+    return JSON.parse(content) as RundownPluginConfig;
+  }
+  return null;
+}
+
+/**
+ * Merge two configs. Project config takes precedence over plugin config.
+ * - hooks: project hooks override plugin hooks for same event
+ * - gates: project gates override plugin gates for same name
+ */
+function mergeConfigs(pluginConfig: RundownPluginConfig, projectConfig: RundownPluginConfig): RundownPluginConfig {
+  return {
+    hooks: {
+      ...pluginConfig.hooks,
+      ...projectConfig.hooks
+    },
+    gates: {
+      ...pluginConfig.gates,
+      ...projectConfig.gates
+    }
+  };
+}
+
+/**
+ * Load and merge project and plugin configs.
+ *
+ * Priority:
+ * 1. Project: .claude/rundown-plugin.json (highest)
+ * 2. Project: rundown-plugin.json
+ * 3. Plugin: ${CLAUDE_PLUGIN_ROOT}/rundown-plugin.json (fallback/defaults)
+ *
+ * Configs are MERGED - project overrides plugin for same keys.
+ *
+ * @param cwd - Current working directory to search for config files
+ * @returns The merged RundownPluginConfig, or null if no config found
+ * @throws Error if config is found but fails validation
+ */
+export async function loadConfig(cwd: string): Promise<RundownPluginConfig | null> {
+  const pluginRoot = getPluginRoot();
+
+  // Load plugin config first (defaults)
+  let mergedConfig: RundownPluginConfig | null = null;
+
+  if (pluginRoot) {
+    const pluginConfigPath = path.join(pluginRoot, 'rundown-plugin.json');
+    const pluginConfig = await loadConfigFile(pluginConfigPath);
+    if (pluginConfig) {
+      await logger.debug('Loaded plugin rundown-plugin.json', { path: pluginConfigPath });
+      mergedConfig = pluginConfig;
+    }
+  }
+
+  // Load project config (overrides)
+  const projectPaths = [path.join(cwd, '.claude', 'rundown-plugin.json'), path.join(cwd, 'rundown-plugin.json')];
+
+  for (const configPath of projectPaths) {
+    const projectConfig = await loadConfigFile(configPath);
+    if (projectConfig) {
+      await logger.debug('Loaded project rundown-plugin.json', { path: configPath });
+      if (mergedConfig) {
+        mergedConfig = mergeConfigs(mergedConfig, projectConfig);
+        await logger.debug('Merged project config with plugin config');
+      } else {
+        mergedConfig = projectConfig;
+      }
+      break; // Only load first project config found
+    }
+  }
+
+  // Validate merged config
+  if (mergedConfig) {
+    validateConfig(mergedConfig);
+  }
+
+  return mergedConfig;
+}

--- a/packages/claude-code-plugin/src/shared/errors.ts
+++ b/packages/claude-code-plugin/src/shared/errors.ts
@@ -1,0 +1,62 @@
+/**
+ * Type guard for NodeJS.ErrnoException.
+ * Checks if an unknown value is a Node.js error with an error code.
+ *
+ * @param error - The unknown value to check
+ * @returns True if error is a NodeJS.ErrnoException with 'code' property
+ */
+export function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+/**
+ * Type guard for Error instances.
+ * Checks if an unknown value is an Error object.
+ *
+ * @param error - The unknown value to check
+ * @returns True if error is an Error instance
+ */
+export function isError(error: unknown): error is Error {
+  return error instanceof Error;
+}
+
+/**
+ * Extract error message safely from any value.
+ * Handles Error instances, strings, and other types.
+ *
+ * @param error - The unknown error value to extract message from
+ * @returns The error message string
+ */
+export function getErrorMessage(error: unknown): string {
+  if (isError(error)) {
+    return error.message;
+  }
+  return String(error);
+}
+
+/**
+ * Discriminated union for session load errors
+ * Allows callers to handle each error type appropriately
+ */
+export type SessionLoadError =
+  | { type: 'file_not_found'; path: string }
+  | { type: 'parse_error'; path: string; message: string }
+  | { type: 'validation_error'; path: string; message: string };
+
+/**
+ * Result type for session load operations
+ */
+export type SessionLoadResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: SessionLoadError };
+
+/**
+ * Check if error is file not found (expected on first run).
+ * Type narrowing function for SessionLoadError discriminated union.
+ *
+ * @param error - The SessionLoadError to check
+ * @returns True if error type is 'file_not_found'
+ */
+export function isFileNotFoundError(error: SessionLoadError): boolean {
+  return error.type === 'file_not_found';
+}

--- a/packages/claude-code-plugin/src/shared/index.ts
+++ b/packages/claude-code-plugin/src/shared/index.ts
@@ -1,0 +1,21 @@
+// @rundown-org/claude-code-plugin shared - Shared types and utilities
+
+// Core types and schemas
+export * from './types.js';
+export {
+  HookInputSchema,
+  type ParseResult,
+  parseHookInput,
+  SessionStateSchema,
+  type ValidatedSessionState
+} from './schemas.js';
+
+// Errors
+export * from './errors.js';
+
+// Configuration loading
+export * from './config.js';
+
+// Utilities
+export * from './utils.js';
+export * from './logger.js';

--- a/packages/claude-code-plugin/src/shared/logger.ts
+++ b/packages/claude-code-plugin/src/shared/logger.ts
@@ -1,0 +1,209 @@
+// packages/claude-code-plugin/src/shared/logger.ts
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Log severity levels for rundown plugin logging.
+ * Controls which messages are written based on RUNDOWN_PLUGIN_LOG_LEVEL.
+ */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+interface LogEntry {
+  ts: string;
+  level: LogLevel;
+  event?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+const LOG_LEVELS: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3
+};
+
+/**
+ * Get the log directory path.
+ * Uses ${TMPDIR}/rundown-plugin/ for isolation.
+ */
+function getLogDir(): string {
+  return path.join(tmpdir(), 'rundown-plugin');
+}
+
+/**
+ * Get the log file path for today.
+ * Format: hooks-YYYY-MM-DD.log
+ */
+function getLogFilePath(): string {
+  const date = new Date().toISOString().split('T')[0];
+  return path.join(getLogDir(), `hooks-${date}.log`);
+}
+
+/**
+ * Check if logging is enabled via environment variable.
+ * Logging is ENABLED by default (env vars don't pass through from Claude CLI).
+ * Set RUNDOWN_PLUGIN_LOG=0 to disable.
+ */
+function isLoggingEnabled(): boolean {
+  return process.env.RUNDOWN_PLUGIN_LOG !== '0';
+}
+
+/**
+ * Get the minimum log level from environment.
+ * RUNDOWN_PLUGIN_LOG_LEVEL=debug|info|warn|error (default: info)
+ */
+function getMinLogLevel(): LogLevel {
+  const envLevel = process.env.RUNDOWN_PLUGIN_LOG_LEVEL;
+  if (envLevel && envLevel in LOG_LEVELS) {
+    return envLevel as LogLevel;
+  }
+  return 'info';
+}
+
+/**
+ * Check if a log level should be written based on minimum level.
+ */
+function shouldLog(level: LogLevel): boolean {
+  return LOG_LEVELS[level] >= LOG_LEVELS[getMinLogLevel()];
+}
+
+/**
+ * Ensure the log directory exists.
+ */
+async function ensureLogDir(): Promise<void> {
+  const dir = getLogDir();
+  await fs.mkdir(dir, { recursive: true });
+}
+
+/**
+ * Write a log entry to the log file.
+ * Each entry is a JSON line for easy parsing with jq.
+ */
+async function writeLog(entry: LogEntry): Promise<void> {
+  if (!isLoggingEnabled()) return;
+  if (!shouldLog(entry.level)) return;
+
+  try {
+    await ensureLogDir();
+    const line = JSON.stringify(entry) + '\n';
+    await fs.appendFile(getLogFilePath(), line, 'utf-8');
+  } catch {
+    // Silently fail - logging should never break the hook
+  }
+}
+
+/**
+ * Write a log entry unconditionally (bypasses RUNDOWN_PLUGIN_LOG check).
+ * Used for startup/diagnostic logging to verify hooks are being invoked.
+ */
+async function writeLogAlways(entry: LogEntry): Promise<void> {
+  try {
+    await ensureLogDir();
+    const line = JSON.stringify(entry) + '\n';
+    await fs.appendFile(getLogFilePath(), line, 'utf-8');
+  } catch {
+    // Silently fail - logging should never break the hook
+  }
+}
+
+/**
+ * Create a log entry with timestamp.
+ */
+function createEntry(level: LogLevel, message: string, data?: Record<string, unknown>): LogEntry {
+  return {
+    ts: new Date().toISOString(),
+    level,
+    message,
+    ...data
+  };
+}
+
+/**
+ * Logger interface for rundown plugin CLI.
+ *
+ * Enable logging: RUNDOWN_PLUGIN_LOG=1
+ * Set level: RUNDOWN_PLUGIN_LOG_LEVEL=debug|info|warn|error
+ *
+ * Logs are written to: ${TMPDIR}/rundown-plugin/hooks-YYYY-MM-DD.log
+ * Format: JSON lines (one JSON object per line)
+ *
+ * Example:
+ *   {"ts":"2025-11-25T10:30:00.000Z","level":"info","event":"PostToolUse","tool":"Edit"}
+ */
+export const logger = {
+  /**
+   * Log a debug message.
+   * @param message - The message to log
+   * @param data - Optional structured data to include
+   * @returns Promise that resolves when log is written
+   */
+  debug: (message: string, data?: Record<string, unknown>): Promise<void> =>
+    writeLog(createEntry('debug', message, data)),
+
+  /**
+   * Log an info message.
+   * @param message - The message to log
+   * @param data - Optional structured data to include
+   * @returns Promise that resolves when log is written
+   */
+  info: (message: string, data?: Record<string, unknown>): Promise<void> =>
+    writeLog(createEntry('info', message, data)),
+
+  /**
+   * Log a warning message.
+   * @param message - The message to log
+   * @param data - Optional structured data to include
+   * @returns Promise that resolves when log is written
+   */
+  warn: (message: string, data?: Record<string, unknown>): Promise<void> =>
+    writeLog(createEntry('warn', message, data)),
+
+  /**
+   * Log an error message.
+   * @param message - The message to log
+   * @param data - Optional structured data to include
+   * @returns Promise that resolves when log is written
+   */
+  error: (message: string, data?: Record<string, unknown>): Promise<void> =>
+    writeLog(createEntry('error', message, data)),
+
+  /**
+   * Log unconditionally (bypasses RUNDOWN_PLUGIN_LOG check).
+   * Used for startup/diagnostic logging to verify hooks are invoked.
+   * @param message - The message to log
+   * @param data - Optional structured data to include
+   * @returns Promise that resolves when log is written
+   */
+  always: (message: string, data?: Record<string, unknown>): Promise<void> =>
+    writeLogAlways(createEntry('info', message, data)),
+
+  /**
+   * Log a hook event with structured data.
+   * Convenience method for common hook logging pattern.
+   * @param level - The log level for this event
+   * @param event - The hook event name (e.g., "PostToolUse")
+   * @param data - Optional structured data to include
+   * @returns Promise that resolves when log is written
+   */
+  event: (level: LogLevel, event: string, data?: Record<string, unknown>): Promise<void> =>
+    writeLog({
+      ts: new Date().toISOString(),
+      level,
+      event,
+      ...data
+    }),
+
+  /**
+   * Get the current log file path (for mise tasks).
+   * @returns The absolute path to today's log file
+   */
+  getLogFilePath,
+
+  /**
+   * Get the log directory path (for mise tasks).
+   * @returns The absolute path to the log directory
+   */
+  getLogDir
+};

--- a/packages/claude-code-plugin/src/shared/schemas.ts
+++ b/packages/claude-code-plugin/src/shared/schemas.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+
+/**
+ * Zod schema for tool_input in Step tool calls
+ */
+const ToolInputSchema = z
+  .object({
+    description: z.string().optional(),
+    subagent_type: z.string().optional(),
+    prompt: z.string().optional(),
+    skill: z.string().optional()
+  })
+  .optional();
+
+/**
+ * Zod schema for HookInput - validates external input at system boundary
+ */
+export const HookInputSchema = z.object({
+  hook_event_name: z.string(),
+  cwd: z.string(),
+
+  // PostToolUse
+  tool_name: z.string().optional(),
+  file_path: z.string().optional(),
+  tool_input: ToolInputSchema,
+
+  // SubagentStart/SubagentStop
+  agent_id: z.string().optional(),
+  agent_name: z.string().optional(),
+  subagent_name: z.string().optional(),
+  output: z.string().optional(),
+  agent_transcript_path: z.string().optional(),
+
+  // UserPromptSubmit
+  user_message: z.string().optional(),
+
+  // SlashCommand/Skill
+  command: z.string().optional(),
+  skill: z.string().optional(),
+
+  // Synthetic event fields
+  tool_use_id: z.string().optional(),
+  tool_response: z.unknown().optional(),
+  step_id: z.string().optional(),
+  task_id: z.string().optional(),
+  subagent_type: z.string().optional()
+});
+
+export type HookInput = z.infer<typeof HookInputSchema>;
+
+/**
+ * Result type for parseHookInput
+ */
+export type ParseResult<T> = { success: true; data: T } | { success: false; error: string };
+
+/**
+ * Parse and validate HookInput from JSON string.
+ * Performs both JSON parsing and Zod schema validation.
+ *
+ * @param json - The JSON string to parse and validate
+ * @returns ParseResult with validated HookInput on success, or error message on failure
+ */
+export function parseHookInput(json: string): ParseResult<HookInput> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (e) {
+    return {
+      success: false,
+      error: `Invalid JSON input: ${e instanceof Error ? e.message : String(e)}`
+    };
+  }
+
+  const result = HookInputSchema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      success: false,
+      error: `Invalid input: ${result.error.issues.map((i) => i.message).join(', ')}`
+    };
+  }
+
+  return { success: true, data: result.data };
+}
+
+/**
+ * Session State Schema - Runtime Validation for Persisted State
+ */
+export const SessionStateSchema = z.object({
+  session_id: z.string().default(() => {
+    const now = new Date();
+    return now.toISOString().replace(/[:.]/g, '-').substring(0, 19);
+  }),
+  started_at: z.string().default(() => new Date().toISOString()),
+  active_command: z.string().nullable().default(null),
+  active_skill: z.string().nullable().default(null),
+  edited_files: z.array(z.string()).default([]),
+  file_extensions: z.array(z.string()).default([]),
+  metadata: z.record(z.string(), z.unknown()).default({})
+});
+
+/**
+ * Session state type inferred from SessionStateSchema.
+ * Represents validated session state with all defaults applied.
+ */
+export type ValidatedSessionState = z.infer<typeof SessionStateSchema>;

--- a/packages/claude-code-plugin/src/shared/types.ts
+++ b/packages/claude-code-plugin/src/shared/types.ts
@@ -1,0 +1,136 @@
+// packages/claude-code-plugin/src/shared/types.ts
+
+// Import HookInput from schemas (single source of truth for validation)
+import type { HookInput as SchemaHookInput } from './schemas.js';
+
+// Re-export for consumers
+export type HookInput = SchemaHookInput;
+
+/**
+ * Result from a gate execution.
+ * Determines how the hook system should proceed after running a gate.
+ */
+export interface GateResult {
+  // Success - add context and continue
+  additionalContext?: string;
+
+  // Block agent from proceeding
+  decision?: 'block';
+  reason?: string;
+
+  // Stop Claude entirely
+  continue?: false;
+  message?: string;
+}
+
+/**
+ * Function signature for gate execution.
+ * Gates receive hook input and return a result determining how to proceed.
+ */
+export type GateExecute = (input: HookInput) => Promise<GateResult>;
+
+export interface GateConfig {
+  /** Reference gate from another plugin (requires gate field) */
+  plugin?: string;
+
+  /** Gate name within the plugin's hooks/gates.json (requires plugin field) */
+  gate?: string;
+
+  /** Local shell command (mutually exclusive with plugin/gate) */
+  command?: string;
+
+  /**
+   * Keywords that trigger this gate (UserPromptSubmit hook only).
+   * When specified, the gate only runs if the user message contains one of these keywords.
+   * For all other hooks (PostToolUse, SubagentStop, etc.), this field is ignored.
+   * Gates without keywords always run (backwards compatible).
+   */
+  keywords?: string[];
+
+  /**
+   * File path glob patterns that trigger this gate (PostToolUse hook only).
+   * When specified, the gate only runs if the modified file matches one of these patterns.
+   * Patterns are matched against relative paths from project root using minimatch.
+   * Multiple patterns use OR logic - gate runs if file matches ANY pattern.
+   * For all other hooks (SubagentStop, UserPromptSubmit, etc.), this field is ignored.
+   * Gates without patterns always run (backwards compatible).
+   *
+   * @example
+   * file_patterns: ["packages/cts/**", "src/**\/*.ts", "*.json"]
+   */
+  file_patterns?: string[];
+
+  on_pass?: string;
+  on_fail?: string;
+}
+
+/**
+ * Configuration for a hook event.
+ * Specifies which tools, agents, and gates are enabled for this hook.
+ */
+export interface HookConfig {
+  /** Tool names that trigger this hook (PostToolUse only) */
+  enabled_tools?: string[];
+  /** Agent types that trigger this hook (SubagentStart/Stop only) */
+  enabled_agents?: string[];
+  /** Gate names to execute when this hook fires */
+  gates?: string[];
+}
+
+/**
+ * Root configuration for rundown plugin.
+ * Defines hooks and gates for the plugin.
+ */
+export interface RundownPluginConfig {
+  /** Hook event configurations keyed by event name */
+  hooks: Record<string, HookConfig>;
+  /** Gate configurations keyed by gate name */
+  gates: Record<string, GateConfig>;
+}
+
+// Session state interface
+export interface SessionState {
+  /** Unique session identifier (timestamp-based) */
+  session_id: string;
+
+  /** ISO 8601 timestamp when session started */
+  started_at: string;
+
+  /** Currently active slash command (e.g., "/execute") */
+  active_command: string | null;
+
+  /** Currently active skill (e.g., "executing-plans") */
+  active_skill: string | null;
+
+  /** Files edited during this session */
+  edited_files: string[];
+
+  /** File extensions edited during this session (deduplicated) */
+  file_extensions: string[];
+
+  /** Custom metadata for specific workflows */
+  metadata: Record<string, unknown>;
+}
+
+// Note: active_agent NOT included - Claude Code does not provide unique
+// agent identifiers. Use metadata field if you need custom agent tracking.
+
+/**
+ * All keys of SessionState as a const array
+ * Using satisfies ensures compile-time validation against interface
+ */
+export const SESSION_STATE_KEYS = [
+  'session_id',
+  'started_at',
+  'active_command',
+  'active_skill',
+  'edited_files',
+  'file_extensions',
+  'metadata'
+] as const satisfies readonly (keyof SessionState)[];
+
+/** Array field keys in SessionState (for type-safe operations) */
+export type SessionStateArrayKey = 'edited_files' | 'file_extensions';
+
+/** Scalar field keys in SessionState */
+export type SessionStateScalarKey = Exclude<keyof SessionState, SessionStateArrayKey | 'metadata'>;

--- a/packages/claude-code-plugin/src/shared/utils.ts
+++ b/packages/claude-code-plugin/src/shared/utils.ts
@@ -1,0 +1,18 @@
+// packages/claude-code-plugin/src/shared/utils.ts
+import * as fs from 'fs/promises';
+
+/**
+ * Check if a file exists at the given path.
+ * Used by config and context modules to probe file system.
+ *
+ * @param filePath - The absolute path to check
+ * @returns Promise resolving to true if file exists and is accessible, false otherwise
+ */
+export async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/claude-code-plugin/src/synthetic-events/detector.ts
+++ b/packages/claude-code-plugin/src/synthetic-events/detector.ts
@@ -1,0 +1,76 @@
+import type { HookInput } from '../shared/index.js';
+import type { SyntheticEvent } from './types.js';
+
+/**
+ * Detect synthetic events from Claude Code primitive events.
+ *
+ * StepId Format:
+ * - Must start with one or more digits (e.g., "1", "12")
+ * - May have optional decimal substep (e.g., "1.1", "1.2", "12.3")
+ * - Must be followed by a dash separator (-, –, or —)
+ */
+export function detectSyntheticEvents(input: HookInput): SyntheticEvent[] {
+  const events: SyntheticEvent[] = [];
+  const hookEvent = input.hook_event_name;
+  const toolName = input.tool_name;
+
+  // UserPromptSubmit → SlashCommandStart
+  if (hookEvent === 'UserPromptSubmit' && input.user_message) {
+    const cmdMatch = /^\/(\S+)/.exec(input.user_message);
+    if (cmdMatch) {
+      events.push({
+        originalEvent: 'UserPromptSubmit',
+        syntheticEvent: 'SlashCommandStart',
+        commandName: cmdMatch[1]
+      });
+    }
+  }
+
+  // Stop → SlashCommandEnd
+  if (hookEvent === 'Stop') {
+    events.push({
+      originalEvent: 'Stop',
+      syntheticEvent: 'SlashCommandEnd'
+    });
+  }
+
+  // PreToolUse Skill → SkillStart
+  if (hookEvent === 'PreToolUse' && toolName === 'Skill') {
+    const skillName = input.tool_input?.skill;
+    events.push({
+      originalEvent: 'PreToolUse',
+      syntheticEvent: 'SkillStart',
+      skillName
+    });
+  }
+
+  // PostToolUse Skill → SkillEnd
+  if (hookEvent === 'PostToolUse' && toolName === 'Skill') {
+    const skillName = input.tool_input?.skill;
+    events.push({
+      originalEvent: 'PostToolUse',
+      syntheticEvent: 'SkillEnd',
+      skillName
+    });
+  }
+
+  // PostToolUse Step/Task → SubagentStart
+  if (hookEvent === 'PostToolUse' && (toolName === 'Step' || toolName === 'Task')) {
+    const description = input.tool_input?.description;
+    const subagentType = input.tool_input?.subagent_type;
+    const toolUseId = input.tool_use_id;
+
+    // Parse StepId: "1.1 - Description" → "1.1"
+    const stepIdMatch = description ? /^(\d+(?:\.\d+)?)\s*[-–—]/.exec(description) : null;
+
+    events.push({
+      originalEvent: 'PostToolUse',
+      syntheticEvent: 'SubagentStart',
+      stepId: stepIdMatch?.[1] ?? input.step_id ?? input.task_id,
+      toolUseId,
+      subagentType
+    });
+  }
+
+  return events;
+}

--- a/packages/claude-code-plugin/src/synthetic-events/types.ts
+++ b/packages/claude-code-plugin/src/synthetic-events/types.ts
@@ -1,0 +1,46 @@
+// plugin/core/src/synthetic-events/types.ts
+
+export type SyntheticEventName =
+  | 'SkillStart'
+  | 'SkillEnd'
+  | 'SlashCommandStart'
+  | 'SlashCommandEnd'
+  | 'SubagentStart'
+  | 'SubagentEnd';
+
+export interface SyntheticEvent {
+  /** The Claude Code event that triggered detection */
+  originalEvent: string;
+
+  /** The synthetic event to dispatch */
+  syntheticEvent: SyntheticEventName;
+
+  /** For SkillStart/End - full skill name with namespace */
+  skillName?: string;
+
+  /** For SlashCommandStart/End - full command with namespace */
+  commandName?: string;
+
+  /** For SubagentStart - parsed StepId */
+  stepId?: string;
+
+  /** For SubagentStart - tool_use_id for correlation */
+  toolUseId?: string;
+
+  /** For SubagentStart - agent type from tool_input */
+  subagentType?: string;
+}
+
+/**
+ * Check if an event name is synthetic (not fired by Claude Code)
+ */
+export function isSyntheticEvent(eventName: string): eventName is SyntheticEventName {
+  return [
+    'SkillStart',
+    'SkillEnd',
+    'SlashCommandStart',
+    'SlashCommandEnd',
+    'SubagentStart',
+    'SubagentEnd'
+  ].includes(eventName);
+}

--- a/packages/claude-code-plugin/src/workflow/context.ts
+++ b/packages/claude-code-plugin/src/workflow/context.ts
@@ -1,0 +1,10 @@
+// src/workflow/context.ts
+
+/**
+ * Get workflow context for injection into agent prompts
+ * Note: Workflow state management is now delegated to rundown CLI
+ */
+export function getWorkflowContext(_cwd: string): string | null {
+  // Context is now injected via hooks calling rundown CLI
+  return null;
+}

--- a/packages/claude-code-plugin/src/workflow/hooks/index.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/index.ts
@@ -1,0 +1,4 @@
+// src/workflow/hooks/index.ts
+export { trackStepDispatch, type StepDispatchResult } from './step-tracker.js';
+export { handleSubagentStart, type SubagentStartResult } from './subagent-start.js';
+export { handleSubagentStop, type SubagentStopResult } from './subagent-stop.js';

--- a/packages/claude-code-plugin/src/workflow/hooks/rundown.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/rundown.ts
@@ -1,0 +1,39 @@
+// workflow/hooks/rundown.ts
+// Helper for executing rundown CLI from installed dependency
+
+import { createRequire } from 'module';
+import { execSync as nodeExecSync, type ExecSyncOptions } from 'child_process';
+
+const require = createRequire(import.meta.url);
+
+// Allow injection for testing
+let execSyncImpl: typeof nodeExecSync = nodeExecSync;
+
+export function setExecSync(fn: typeof nodeExecSync): void {
+  execSyncImpl = fn;
+}
+
+/**
+ * Get the path to the rundown CLI entry point.
+ * Uses require.resolve to find the installed @rundown/cli package.
+ */
+export function getRundownCliPath(): string {
+  return require.resolve('@rundown/cli');
+}
+
+/**
+ * Execute a rundown CLI command.
+ *
+ * @param args - Command arguments (e.g., "pass --agent abc123")
+ * @param cwd - Working directory for the command
+ * @returns Command output as string
+ */
+export function rundown(args: string, cwd: string): string {
+  const cliPath = getRundownCliPath();
+  const options: ExecSyncOptions = {
+    cwd,
+    stdio: 'pipe',
+    encoding: 'utf-8'
+  };
+  return execSyncImpl(`node ${cliPath} ${args}`, options) as string;
+}

--- a/packages/claude-code-plugin/src/workflow/hooks/step-tracker.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/step-tracker.ts
@@ -1,0 +1,37 @@
+// src/workflow/hooks/step-tracker.ts
+import type { HookInput } from '../../shared/index.js';
+import { rundown } from './rundown.js';
+
+export interface StepDispatchResult {
+  violation?: string;
+}
+
+/**
+ * Track Step tool dispatches in workflow state
+ */
+export function trackStepDispatch(input: HookInput): StepDispatchResult {
+  // Handle both Step and Task tool (Task for backward compatibility/LLM training)
+  if (input.tool_name !== 'Step' && input.tool_name !== 'Task') {
+    return {};
+  }
+
+  try {
+    const description = input.tool_input?.description ?? '';
+
+    if (!description.trim()) {
+      return {
+        violation: 'Step description cannot be empty'
+      };
+    }
+
+    try {
+      rundown(`run --step "${description}"`, input.cwd);
+      return {};
+    } catch {
+      return {};
+    }
+  } catch (error: unknown) {
+    console.error('Failed to track step dispatch:', error);
+    return {};
+  }
+}

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-start.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-start.ts
@@ -1,0 +1,68 @@
+import type { HookInput } from '../../shared/index.js';
+import { rundown } from './rundown.js';
+
+export interface SubagentStartResult {
+  context?: string;
+  violation?: string;
+}
+
+interface ExecSyncError extends Error {
+  stderr?: Buffer | string;
+}
+
+function isExecSyncError(error: unknown): error is ExecSyncError {
+  return error instanceof Error && 'status' in error && 'stderr' in error;
+}
+
+/**
+ * Handle SubagentStart hook
+ */
+export function handleSubagentStart(input: HookInput): SubagentStartResult {
+  if (input.hook_event_name !== 'SubagentStart') {
+    return {};
+  }
+
+  const agentId = input.agent_id;
+  if (!agentId) {
+    return {};
+  }
+
+  try {
+    const output = rundown(`run --agent ${agentId}`, input.cwd);
+
+    const context = parseStartAgentOutput(output, agentId);
+    return { context };
+  } catch (error) {
+    if (!isExecSyncError(error)) {
+      return {};
+    }
+    const stderr = error.stderr?.toString() ?? '';
+    if (stderr.includes('No pending step')) {
+      return {
+        violation: 'SubagentStart with no pending step. Step dispatch must precede agent start.'
+      };
+    }
+    return {};
+  }
+}
+
+function parseStartAgentOutput(output: string, agentId: string): string {
+  const lines = ['## Workflow Agent Context', '', `AGENT_ID: ${agentId}`, ''];
+
+  const stepMatch = /bound to step (\d+(?:\.\d+)?)/.exec(output);
+  if (stepMatch) {
+    lines.push(`STEP_ID: ${stepMatch[1]}`);
+  }
+
+  const workflowMatch = /Started child workflow: (.+)/.exec(output);
+  if (workflowMatch) {
+    lines.push(`WORKFLOW: ${workflowMatch[1]}`);
+  }
+
+  lines.push('', '## Commands', '');
+  lines.push(`rundown pass --agent ${agentId}`);
+  lines.push(`rundown fail --agent ${agentId}`);
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -1,0 +1,81 @@
+// src/workflow/hooks/subagent-stop.ts
+import type { HookInput } from '../../shared/index.js';
+import { rundown, setExecSync } from './rundown.js';
+
+export interface SubagentStopResult {
+  context?: string;
+  violation?: string;
+}
+
+// Re-export for testing
+export { setExecSync };
+
+/**
+ * Pattern for parsing STATUS field from agent output.
+ * Expected format: STATUS: OK|PASS|BLOCKED|FAIL (case-insensitive)
+ */
+const STATUS_PATTERN = /STATUS:\s*(OK|PASS|BLOCKED|FAIL)/i;
+
+/**
+ * Parse STATUS field from subagent output
+ */
+function parseAgentStatus(output?: string): 'pass' | 'fail' {
+  if (!output) return 'pass';
+
+  const match = STATUS_PATTERN.exec(output);
+  if (!match) return 'pass';
+
+  const status = match[1].toUpperCase();
+  return status === 'OK' || status === 'PASS' ? 'pass' : 'fail';
+}
+
+/**
+ * Handle SubagentStop hook
+ */
+export function handleSubagentStop(input: HookInput): SubagentStopResult {
+  if (input.hook_event_name !== 'SubagentStop') {
+    return {};
+  }
+
+  const agentId = input.agent_id;
+  if (!agentId) return {};
+
+  const status = parseAgentStatus(input.output);
+  const command = status === 'pass' ? 'pass' : 'fail';
+
+  try {
+    const output = rundown(`${command} --agent ${agentId}`, input.cwd);
+
+    const context = formatCompletionContext(output, agentId, status);
+    return { context };
+  } catch (error: unknown) {
+    const execError = error as { stderr?: Buffer | string };
+    const stderr = execError.stderr?.toString() ?? '';
+    if (stderr.includes('No binding for agent')) {
+      return {
+        violation: `SubagentStop for unknown agent: ${agentId}`
+      };
+    }
+    return {};
+  }
+}
+
+function formatCompletionContext(
+  cliOutput: string,
+  agentId: string,
+  result: 'pass' | 'fail'
+): string {
+  const lines: string[] = [];
+
+  if (result === 'fail') {
+    lines.push(`Agent ${agentId} FAILED.`);
+  } else {
+    lines.push(`Agent ${agentId} complete.`);
+  }
+
+  if (cliOutput.trim()) {
+    lines.push(cliOutput);
+  }
+
+  return lines.join('\n');
+}

--- a/packages/claude-code-plugin/templates/verify-collation.md
+++ b/packages/claude-code-plugin/templates/verify-collation.md
@@ -1,0 +1,59 @@
+# Verification Collation Report
+
+**Date:** [YYYY-MM-DD HH:mm]
+**Agent Count:** [N]
+**Reviews Collated:** [List of review files]
+**Cross-Check Status:** [PENDING | COMPLETE]
+
+## Executive Summary
+
+| Category | Count |
+|----------|-------|
+| Common (N/N) | X |
+| Exclusive Total | X |
+
+## Common (N/N)
+
+Issues all agents independently found. Very high confidence - implement immediately.
+
+### Issue 1: [Title]
+
+**Found by:** All [N] agents
+**Consensus:** N/N
+**Location:** [file:line]
+**Description:** [What's wrong]
+**Action:** Implement fix
+
+## Exclusive
+
+Issues found by fewer than all agents. Requires cross-check validation.
+
+### (N-1)/N
+
+#### Issue X: [Title]
+
+**Found by:** [Agent 1, Agent 2] (not Agent 3)
+**Consensus:** 2/3
+**Location:** [file:line]
+**Description:** [What's wrong]
+**Cross-Check Status:** [PENDING | VALIDATED | INVALIDATED | UNCERTAIN]
+
+### 1/N
+
+#### Issue Y: [Title]
+
+**Found by:** [Agent 2 only]
+**Consensus:** 1/3
+**Location:** [file:line]
+**Description:** [What's wrong]
+**Cross-Check Status:** [PENDING | VALIDATED | INVALIDATED | UNCERTAIN]
+
+## Recommendations
+
+### Immediate (Common)
+- [ ] Fix issue 1
+- [ ] Fix issue 2
+
+### Pending Cross-Check (Exclusive)
+- [ ] Issue X (awaiting validation)
+- [ ] Issue Y (awaiting validation)

--- a/packages/claude-code-plugin/templates/verify-review.md
+++ b/packages/claude-code-plugin/templates/verify-review.md
@@ -1,0 +1,39 @@
+# Review: [Subject]
+
+**Reviewer:** [Agent type/name]
+**Date:** [YYYY-MM-DD HH:mm]
+**Review Index:** [N of M]
+
+## Ground Truth
+
+[What this review is verifying against - implementation, docs, plan, etc.]
+
+## Findings
+
+### BLOCKING Issues
+
+Issues that must be addressed before proceeding.
+
+#### Issue 1: [Title]
+
+**Location:** [file:line or section]
+**Description:** [What's wrong]
+**Evidence:** [Quote or reference]
+**Recommendation:** [How to fix]
+
+### SUGGESTIONS
+
+Issues that should be considered but don't block.
+
+#### Suggestion 1: [Title]
+
+**Location:** [file:line or section]
+**Description:** [What could be improved]
+**Recommendation:** [How to improve]
+
+## Summary
+
+**BLOCKING count:** X
+**SUGGESTION count:** X
+
+**Conclusion:** [PASS | FAIL | NEEDS_WORK]

--- a/packages/claude-code-plugin/tsconfig.json
+++ b/packages/claude-code-plugin/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -17,6 +17,8 @@
     "packages/cli/src/**/*.ts",
     "packages/cli/__tests__/**/*.ts",
     "packages/cli/jest.setup.ts",
+    "packages/claude-code-plugin/src/**/*.ts",
+    "packages/claude-code-plugin/__tests__/**/*.ts",
     "eslint.config.js"
   ],
   "exclude": ["node_modules", "**/dist/**"]


### PR DESCRIPTION
Migrate turboshovel Claude Code plugin into rundown monorepo as @rundown-org/claude-code-plugin with full rename from turboshovel to rundown.

Includes:
- 6 workflow skills (executing-plans, writing-plans, workflow, etc.)
- 4 runbooks for plan execution and verification
- 10 hook event registrations
- TypeScript core with gates and workflow hooks
- Plugin configuration and assets

All turboshovel: prefixes renamed to rundown: prefixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Claude Code Plugin with executable commands for plan execution and verification workflows.
  * Introduced runbooks and skills for task batching, execution, verification by consensus, and plan following.
  * Added plugin hooks for session management, workflow orchestration, and gate-based extensibility.

* **Chores**
  * Extended build script to include the new plugin package compilation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->