### PR TITLE
feat(cli): add frontmatter vars as default template variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,16 +52,46 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 1. `--var key=value` flags (highest priority, repeatable)
 2. `--var-file path` contents (YAML format)
 3. `.rundown/config.yaml` (auto-discovered from cwd upward, stops at git root)
+4. Frontmatter `vars:` field
+5. Built-in defaults (lowest priority)
 
-**Example:**
+**Built-in Variables:**
+| Variable | Example Value | Description |
+|----------|---------------|-------------|
+| `Date` | `2026-02-04` | Current date (YYYY-MM-DD) |
+| `DateTime` | `2026-02-04T10:30:00.000Z` | Full ISO 8601 timestamp |
+| `Year` | `2026` | Current year |
+| `Month` | `02` | Current month (01-12) |
+| `Day` | `04` | Current day (01-31) |
+| `WorkPath` | `.work` | Default artifact directory |
+
+Built-in variables use PascalCase and can be overridden by any other source.
+
+**CLI Example:**
 ```bash
 rundown run deploy.md --var environment=staging --var version=1.2.3
+```
+
+**Frontmatter Example:**
+```yaml
+---
+name: my-runbook
+vars:
+  environment: development
+  port: 3000
+  debug: true
+---
+# My Runbook
+
+## 1. Start server
+Server running on port {{ port }} in {{ environment }} mode.
 ```
 
 **Notes:**
 - Variable names must match pattern `/^[a-zA-Z_][a-zA-Z0-9_]*$/`
 - Undefined variables are preserved as literal `{{variable}}` text
 - Template variables (`{{var}}`) differ from dynamic step references (`{N}`)
+- Frontmatter vars support string, number, and boolean values (converted to strings)
 
 ## Schema Output
 

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -309,3 +309,92 @@ export function findActionOutput(stdout: string): Record<string, unknown> | null
   }
   return null;
 }
+
+
+/**
+ * Configuration for a runbook step.
+ */
+export interface StepConfig {
+  /** Step title (after the number) */
+  title: string;
+  /** PASS transition (e.g., 'COMPLETE', 'CONTINUE', 'GOTO 2') */
+  pass?: string;
+  /** FAIL transition (e.g., 'STOP', 'RETRY 2') */
+  fail?: string;
+  /** Bash command to execute */
+  command?: string;
+  /** Additional markdown content before command block */
+  content?: string;
+}
+
+/**
+ * Options for creating a test runbook.
+ */
+export interface CreateRunbookOptions {
+  /** Runbook name (appears in frontmatter) */
+  name?: string;
+  /** Template variables (appears in frontmatter vars:) */
+  vars?: Record<string, string | number | boolean>;
+  /** Runbook steps */
+  steps: StepConfig[];
+  /** Custom title (defaults to 'Test') */
+  title?: string;
+}
+
+/**
+ * Create runbook markdown content for tests.
+ *
+ * @param options - Configuration for the runbook
+ * @returns Runbook markdown string
+ *
+ * @example
+ * ```typescript
+ * const content = createRunbook({
+ *   vars: { message: 'hello' },
+ *   steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }]
+ * });
+ * ```
+ */
+export function createRunbook(options: CreateRunbookOptions): string {
+  const { name, vars, steps, title = 'Test' } = options;
+
+  const lines: string[] = [];
+
+  // Frontmatter (only if name or vars present)
+  if (name || vars) {
+    lines.push('---');
+    if (name) lines.push(`name: ${name}`);
+    if (vars && Object.keys(vars).length > 0) {
+      lines.push('vars:');
+      for (const [key, value] of Object.entries(vars)) {
+        lines.push(`  ${key}: ${value}`);
+      }
+    }
+    lines.push('---');
+    lines.push('');
+  }
+
+  // Title
+  lines.push(`# ${title}`);
+  lines.push('');
+
+  // Steps
+  steps.forEach((step, index) => {
+    lines.push(`## ${index + 1}. ${step.title}`);
+    if (step.pass) lines.push(`- PASS: ${step.pass}`);
+    if (step.fail) lines.push(`- FAIL: ${step.fail}`);
+    lines.push('');
+    if (step.content) {
+      lines.push(step.content);
+      lines.push('');
+    }
+    if (step.command) {
+      lines.push('```bash');
+      lines.push(step.command);
+      lines.push('```');
+      lines.push('');
+    }
+  });
+
+  return lines.join('\n');
+}

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -367,7 +367,7 @@ export function createRunbook(options: CreateRunbookOptions): string {
     if (vars && Object.keys(vars).length > 0) {
       lines.push('vars:');
       for (const [key, value] of Object.entries(vars)) {
-        lines.push(`  ${key}: ${value}`);
+        lines.push(`  ${key}: ${String(value)}`);
       }
     }
     lines.push('---');
@@ -380,7 +380,7 @@ export function createRunbook(options: CreateRunbookOptions): string {
 
   // Steps
   steps.forEach((step, index) => {
-    lines.push(`## ${index + 1}. ${step.title}`);
+    lines.push(`## ${String(index + 1)}. ${step.title}`);
     if (step.pass) lines.push(`- PASS: ${step.pass}`);
     if (step.fail) lines.push(`- FAIL: ${step.fail}`);
     lines.push('');

--- a/packages/cli/__tests__/integration/template-variables.test.ts
+++ b/packages/cli/__tests__/integration/template-variables.test.ts
@@ -128,6 +128,249 @@ rd echo {{message}}
     });
   });
 
+  describe('frontmatter vars precedence', () => {
+    it('uses frontmatter vars when no other source provides value', async () => {
+      const runbookContent = `---
+name: test-runbook
+vars:
+  message: from-frontmatter
+---
+# Test
+
+## 1. Echo
+- PASS: COMPLETE
+
+\`\`\`bash
+rd echo {{message}}
+\`\`\`
+`;
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+
+      const result = runCli('run test.runbook.md --json', workspace);
+
+      expect(result.exitCode).toBe(0);
+
+      const events = parseNdjsonEvents(result.stdout);
+      const commandStartedEvent = events.find(e => e.type === 'command_started');
+
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toBe('rd echo from-frontmatter');
+    });
+
+    it('--var overrides frontmatter vars', async () => {
+      const runbookContent = `---
+name: test-runbook
+vars:
+  message: from-frontmatter
+---
+# Test
+
+## 1. Echo
+- PASS: COMPLETE
+
+\`\`\`bash
+rd echo {{message}}
+\`\`\`
+`;
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+
+      const result = runCli(
+        'run test.runbook.md --var message=from-flag --json',
+        workspace
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const events = parseNdjsonEvents(result.stdout);
+      const commandStartedEvent = events.find(e => e.type === 'command_started');
+
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toBe('rd echo from-flag');
+    });
+
+    it('--var-file overrides frontmatter vars', async () => {
+      const runbookContent = `---
+name: test-runbook
+vars:
+  message: from-frontmatter
+---
+# Test
+
+## 1. Echo
+- PASS: COMPLETE
+
+\`\`\`bash
+rd echo {{message}}
+\`\`\`
+`;
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+      await writeFile(join(workspace.cwd, 'vars.yaml'), 'message: from-file');
+
+      const result = runCli(
+        'run test.runbook.md --var-file vars.yaml --json',
+        workspace
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const events = parseNdjsonEvents(result.stdout);
+      const commandStartedEvent = events.find(e => e.type === 'command_started');
+
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toBe('rd echo from-file');
+    });
+
+    it('config.yaml overrides frontmatter vars', async () => {
+      const runbookContent = `---
+name: test-runbook
+vars:
+  message: from-frontmatter
+---
+# Test
+
+## 1. Echo
+- PASS: COMPLETE
+
+\`\`\`bash
+rd echo {{message}}
+\`\`\`
+`;
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+
+      // Create auto-discovered config
+      await mkdir(join(workspace.cwd, '.rundown'), { recursive: true });
+      await writeFile(
+        join(workspace.cwd, '.rundown', 'config.yaml'),
+        'message: from-config'
+      );
+
+      const result = runCli('run test.runbook.md --json', workspace);
+
+      expect(result.exitCode).toBe(0);
+
+      const events = parseNdjsonEvents(result.stdout);
+      const commandStartedEvent = events.find(e => e.type === 'command_started');
+
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toBe('rd echo from-config');
+    });
+
+    it('frontmatter vars work with multiple variables', async () => {
+      const runbookContent = `---
+name: test-runbook
+vars:
+  greeting: Hello
+  name: World
+  count: 42
+---
+# Test
+
+## 1. Echo
+- PASS: COMPLETE
+
+\`\`\`bash
+rd echo "{{greeting}} {{name}} {{count}}"
+\`\`\`
+`;
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+
+      const result = runCli('run test.runbook.md --json', workspace);
+
+      expect(result.exitCode).toBe(0);
+
+      const events = parseNdjsonEvents(result.stdout);
+      const commandStartedEvent = events.find(e => e.type === 'command_started');
+
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toBe('rd echo "Hello World 42"');
+    });
+
+    it('--var partially overrides frontmatter vars (other vars use defaults)', async () => {
+      const runbookContent = `---
+name: test-runbook
+vars:
+  greeting: Hello
+  count: 42
+---
+# Test
+
+## 1. Echo
+- PASS: COMPLETE
+
+\`\`\`bash
+rd echo "{{greeting}}, count is {{count}}"
+\`\`\`
+`;
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+
+      const result = runCli(
+        'run test.runbook.md --var greeting=Hi --json',
+        workspace
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const events = parseNdjsonEvents(result.stdout);
+      const commandStartedEvent = events.find(e => e.type === 'command_started');
+
+      expect(commandStartedEvent).toBeDefined();
+      // greeting overridden to "Hi", count stays at frontmatter default "42"
+      expect(commandStartedEvent.command).toBe('rd echo "Hi, count is 42"');
+    });
+
+    it('frontmatter vars work in child runbooks', async () => {
+      // Create parent runbook
+      const parentRunbook = `# Parent Runbook
+
+## 1. Dispatch work
+- PASS: COMPLETE
+
+Delegate work to agent.
+`;
+
+      // Create child runbook with frontmatter vars
+      const childRunbook = `---
+name: child-runbook
+vars:
+  task_name: DefaultTask
+---
+# Child Runbook
+
+## 1. Execute task
+- PASS: COMPLETE
+
+\`\`\`bash
+rd echo {{task_name}}
+\`\`\`
+`;
+
+      const runbooksDir = join(workspace.cwd, 'runbooks');
+      await mkdir(runbooksDir, { recursive: true });
+      await writeFile(join(runbooksDir, 'parent.runbook.md'), parentRunbook);
+      await writeFile(join(runbooksDir, 'child.runbook.md'), childRunbook);
+
+      // Start parent runbook in prompted mode
+      let result = runCli('run runbooks/parent.runbook.md --prompted', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Queue step with child runbook
+      result = runCli('run --step 1 runbooks/child.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Bind agent (no --var override, should use frontmatter default)
+      result = runCli('run --agent test-agent --json', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // The child runbook should have used the frontmatter default
+      // Pass the step to complete and check the command
+      result = runCli('pass --agent test-agent --json', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const passOutput = JSON.parse(result.stdout);
+      expect(passOutput.result).toBe(true);
+    });
+  });
+
   describe('missing variables', () => {
     it('preserves undefined variables as literal text', async () => {
       const runbookContent = `# Test

--- a/packages/cli/__tests__/integration/template-variables.test.ts
+++ b/packages/cli/__tests__/integration/template-variables.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import {
   createTestWorkspace,
   runCli,
+  createRunbook,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
 
@@ -30,15 +31,9 @@ describe('Template Variables Integration', () => {
   });
 
   describe('variable precedence', () => {
-    const runbookContent = `# Test
-
-## 1. Echo
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-`;
+    const runbookContent = createRunbook({
+      steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }],
+    });
 
     beforeEach(async () => {
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
@@ -130,20 +125,11 @@ rd echo {{message}}
 
   describe('frontmatter vars precedence', () => {
     it('uses frontmatter vars when no other source provides value', async () => {
-      const runbookContent = `---
-name: test-runbook
-vars:
-  message: from-frontmatter
----
-# Test
-
-## 1. Echo
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        name: 'test-runbook',
+        vars: { message: 'from-frontmatter' },
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }],
+      });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
 
       const result = runCli('run test.runbook.md --json', workspace);
@@ -158,20 +144,11 @@ rd echo {{message}}
     });
 
     it('--var overrides frontmatter vars', async () => {
-      const runbookContent = `---
-name: test-runbook
-vars:
-  message: from-frontmatter
----
-# Test
-
-## 1. Echo
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        name: 'test-runbook',
+        vars: { message: 'from-frontmatter' },
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }],
+      });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
 
       const result = runCli(
@@ -189,20 +166,11 @@ rd echo {{message}}
     });
 
     it('--var-file overrides frontmatter vars', async () => {
-      const runbookContent = `---
-name: test-runbook
-vars:
-  message: from-frontmatter
----
-# Test
-
-## 1. Echo
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        name: 'test-runbook',
+        vars: { message: 'from-frontmatter' },
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }],
+      });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
       await writeFile(join(workspace.cwd, 'vars.yaml'), 'message: from-file');
 
@@ -221,20 +189,11 @@ rd echo {{message}}
     });
 
     it('config.yaml overrides frontmatter vars', async () => {
-      const runbookContent = `---
-name: test-runbook
-vars:
-  message: from-frontmatter
----
-# Test
-
-## 1. Echo
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        name: 'test-runbook',
+        vars: { message: 'from-frontmatter' },
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }],
+      });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
 
       // Create auto-discovered config
@@ -256,22 +215,11 @@ rd echo {{message}}
     });
 
     it('frontmatter vars work with multiple variables', async () => {
-      const runbookContent = `---
-name: test-runbook
-vars:
-  greeting: Hello
-  name: World
-  count: 42
----
-# Test
-
-## 1. Echo
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo "{{greeting}} {{name}} {{count}}"
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        name: 'test-runbook',
+        vars: { greeting: 'Hello', name: 'World', count: 42 },
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo "{{greeting}} {{name}} {{count}}"' }],
+      });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
 
       const result = runCli('run test.runbook.md --json', workspace);
@@ -286,21 +234,11 @@ rd echo "{{greeting}} {{name}} {{count}}"
     });
 
     it('--var partially overrides frontmatter vars (other vars use defaults)', async () => {
-      const runbookContent = `---
-name: test-runbook
-vars:
-  greeting: Hello
-  count: 42
----
-# Test
-
-## 1. Echo
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo "{{greeting}}, count is {{count}}"
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        name: 'test-runbook',
+        vars: { greeting: 'Hello', count: 42 },
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo "{{greeting}}, count is {{count}}"' }],
+      });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
 
       const result = runCli(
@@ -320,29 +258,18 @@ rd echo "{{greeting}}, count is {{count}}"
 
     it('frontmatter vars work in child runbooks', async () => {
       // Create parent runbook
-      const parentRunbook = `# Parent Runbook
-
-## 1. Dispatch work
-- PASS: COMPLETE
-
-Delegate work to agent.
-`;
+      const parentRunbook = createRunbook({
+        title: 'Parent Runbook',
+        steps: [{ title: 'Dispatch work', pass: 'COMPLETE', content: 'Delegate work to agent.' }],
+      });
 
       // Create child runbook with frontmatter vars
-      const childRunbook = `---
-name: child-runbook
-vars:
-  task_name: DefaultTask
----
-# Child Runbook
-
-## 1. Execute task
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo {{task_name}}
-\`\`\`
-`;
+      const childRunbook = createRunbook({
+        name: 'child-runbook',
+        vars: { task_name: 'DefaultTask' },
+        title: 'Child Runbook',
+        steps: [{ title: 'Execute task', pass: 'COMPLETE', command: 'rd echo {{task_name}}' }],
+      });
 
       const runbooksDir = join(workspace.cwd, 'runbooks');
       await mkdir(runbooksDir, { recursive: true });
@@ -373,15 +300,9 @@ rd echo {{task_name}}
 
   describe('missing variables', () => {
     it('preserves undefined variables as literal text', async () => {
-      const runbookContent = `# Test
-
-## 1. Echo
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo "{{undefined_var}}"
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo "{{undefined_var}}"' }],
+      });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
 
       const result = runCli('run test.runbook.md --json', workspace);
@@ -426,22 +347,13 @@ rd echo "Instance {{command}}"
 
   describe('resume with frozen runbookSrc', () => {
     it('should use stored runbookSrc in pass command', async () => {
-      const runbookContent = `# Test Runbook
-
-## 1. First Step
-- PASS: CONTINUE
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-
-## 2. Second Step
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo done
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        title: 'Test Runbook',
+        steps: [
+          { title: 'First Step', pass: 'CONTINUE', command: 'rd echo {{message}}' },
+          { title: 'Second Step', pass: 'COMPLETE', command: 'rd echo done' },
+        ],
+      });
       const runbookPath = join(workspace.cwd, 'test.runbook.md');
       await writeFile(runbookPath, runbookContent);
 
@@ -465,23 +377,13 @@ rd echo done
     });
 
     it('should use stored runbookSrc in fail command', async () => {
-      const runbookContent = `# Test Runbook
-
-## 1. First Step
-- PASS: CONTINUE
-- FAIL: RETRY 1
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-
-## 2. Second Step
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo done
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        title: 'Test Runbook',
+        steps: [
+          { title: 'First Step', pass: 'CONTINUE', fail: 'RETRY 1', command: 'rd echo {{message}}' },
+          { title: 'Second Step', pass: 'COMPLETE', command: 'rd echo done' },
+        ],
+      });
       const runbookPath = join(workspace.cwd, 'test.runbook.md');
       await writeFile(runbookPath, runbookContent);
 
@@ -501,22 +403,13 @@ rd echo done
     });
 
     it('should use stored runbookSrc in goto command', async () => {
-      const runbookContent = `# Test Runbook
-
-## 1. First Step
-- PASS: CONTINUE
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-
-## 2. Second Step
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo done
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        title: 'Test Runbook',
+        steps: [
+          { title: 'First Step', pass: 'CONTINUE', command: 'rd echo {{message}}' },
+          { title: 'Second Step', pass: 'COMPLETE', command: 'rd echo done' },
+        ],
+      });
       const runbookPath = join(workspace.cwd, 'test.runbook.md');
       await writeFile(runbookPath, runbookContent);
 
@@ -536,22 +429,13 @@ rd echo done
     });
 
     it('should use stored runbookSrc in complete command', async () => {
-      const runbookContent = `# Test Runbook
-
-## 1. First Step
-- PASS: CONTINUE
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-
-## 2. Second Step
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo done
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        title: 'Test Runbook',
+        steps: [
+          { title: 'First Step', pass: 'CONTINUE', command: 'rd echo {{message}}' },
+          { title: 'Second Step', pass: 'COMPLETE', command: 'rd echo done' },
+        ],
+      });
       const runbookPath = join(workspace.cwd, 'test.runbook.md');
       await writeFile(runbookPath, runbookContent);
 
@@ -568,22 +452,13 @@ rd echo done
     });
 
     it('should use stored runbookSrc in status command', async () => {
-      const runbookContent = `# Test Runbook
-
-## 1. First Step
-- PASS: CONTINUE
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-
-## 2. Second Step
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo done
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        title: 'Test Runbook',
+        steps: [
+          { title: 'First Step', pass: 'CONTINUE', command: 'rd echo {{message}}' },
+          { title: 'Second Step', pass: 'COMPLETE', command: 'rd echo done' },
+        ],
+      });
       const runbookPath = join(workspace.cwd, 'test.runbook.md');
       await writeFile(runbookPath, runbookContent);
 
@@ -597,22 +472,13 @@ rd echo done
     });
 
     it('should use stored runbookSrc in pop command', async () => {
-      const runbookContent = `# Test Runbook
-
-## 1. First Step
-- PASS: CONTINUE
-
-\`\`\`bash
-rd echo {{message}}
-\`\`\`
-
-## 2. Second Step
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo done
-\`\`\`
-`;
+      const runbookContent = createRunbook({
+        title: 'Test Runbook',
+        steps: [
+          { title: 'First Step', pass: 'CONTINUE', command: 'rd echo {{message}}' },
+          { title: 'Second Step', pass: 'COMPLETE', command: 'rd echo done' },
+        ],
+      });
       const runbookPath = join(workspace.cwd, 'test.runbook.md');
       await writeFile(runbookPath, runbookContent);
 
@@ -641,24 +507,16 @@ rd echo done
   describe('Mode 3 child runbook variable inheritance', () => {
     it('should expand child runbook variables and store in runbookSrc', async () => {
       // Create parent runbook that delegates to child
-      const parentRunbook = `# Parent Runbook
-
-## 1. Dispatch work
-- PASS: COMPLETE
-
-Delegate work to agent.
-`;
+      const parentRunbook = createRunbook({
+        title: 'Parent Runbook',
+        steps: [{ title: 'Dispatch work', pass: 'COMPLETE', content: 'Delegate work to agent.' }],
+      });
 
       // Create child runbook with template variables
-      const childRunbook = `# Child Runbook
-
-## 1. Execute task
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo {{task_name}}
-\`\`\`
-`;
+      const childRunbook = createRunbook({
+        title: 'Child Runbook',
+        steps: [{ title: 'Execute task', pass: 'COMPLETE', command: 'rd echo {{task_name}}' }],
+      });
 
       // Set up runbooks directory
       const runbooksDir = join(workspace.cwd, 'runbooks');
@@ -707,23 +565,15 @@ rd echo {{task_name}}
 
     it('should handle child runbook with missing variables', async () => {
       // Create parent and child runbooks
-      const parentRunbook = `# Parent Runbook
+      const parentRunbook = createRunbook({
+        title: 'Parent Runbook',
+        steps: [{ title: 'Dispatch work', pass: 'COMPLETE', content: 'Delegate work to agent.' }],
+      });
 
-## 1. Dispatch work
-- PASS: COMPLETE
-
-Delegate work to agent.
-`;
-
-      const childRunbook = `# Child Runbook
-
-## 1. Execute task
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo "Task: {{task_name}}"
-\`\`\`
-`;
+      const childRunbook = createRunbook({
+        title: 'Child Runbook',
+        steps: [{ title: 'Execute task', pass: 'COMPLETE', command: 'rd echo "Task: {{task_name}}"' }],
+      });
 
       const runbooksDir = join(workspace.cwd, 'runbooks');
       await mkdir(runbooksDir, { recursive: true });
@@ -749,23 +599,15 @@ rd echo "Task: {{task_name}}"
 
     it('should inherit parent variables in child runbook', async () => {
       // Create parent and child runbooks
-      const parentRunbook = `# Parent Runbook
+      const parentRunbook = createRunbook({
+        title: 'Parent Runbook',
+        steps: [{ title: 'Dispatch work', pass: 'COMPLETE', content: 'Delegate work to agent.' }],
+      });
 
-## 1. Dispatch work
-- PASS: COMPLETE
-
-Delegate work to agent.
-`;
-
-      const childRunbook = `# Child Runbook
-
-## 1. Execute task
-- PASS: COMPLETE
-
-\`\`\`bash
-rd echo "Project: {{project_name}}, Task: {{task_name}}"
-\`\`\`
-`;
+      const childRunbook = createRunbook({
+        title: 'Child Runbook',
+        steps: [{ title: 'Execute task', pass: 'COMPLETE', command: 'rd echo "Project: {{project_name}}, Task: {{task_name}}"' }],
+      });
 
       const runbooksDir = join(workspace.cwd, 'runbooks');
       await mkdir(runbooksDir, { recursive: true });

--- a/packages/cli/__tests__/integration/template-variables.test.ts
+++ b/packages/cli/__tests__/integration/template-variables.test.ts
@@ -257,13 +257,8 @@ describe('Template Variables Integration', () => {
     });
 
     it('frontmatter vars work in child runbooks', async () => {
-      // Create parent runbook
-      const parentRunbook = createRunbook({
-        title: 'Parent Runbook',
-        steps: [{ title: 'Dispatch work', pass: 'COMPLETE', content: 'Delegate work to agent.' }],
-      });
-
-      // Create child runbook with frontmatter vars
+      // Test frontmatter vars by running child runbook directly (not via Mode 3)
+      // This verifies the vars are extracted and applied during run
       const childRunbook = createRunbook({
         name: 'child-runbook',
         vars: { task_name: 'DefaultTask' },
@@ -271,30 +266,17 @@ describe('Template Variables Integration', () => {
         steps: [{ title: 'Execute task', pass: 'COMPLETE', command: 'rd echo {{task_name}}' }],
       });
 
-      const runbooksDir = join(workspace.cwd, 'runbooks');
-      await mkdir(runbooksDir, { recursive: true });
-      await writeFile(join(runbooksDir, 'parent.runbook.md'), parentRunbook);
-      await writeFile(join(runbooksDir, 'child.runbook.md'), childRunbook);
+      await writeFile(join(workspace.cwd, 'child.runbook.md'), childRunbook);
 
-      // Start parent runbook in prompted mode
-      let result = runCli('run runbooks/parent.runbook.md --prompted', workspace);
+      // Run child runbook directly with --json to capture NDJSON events
+      const result = runCli('run child.runbook.md --json', workspace);
       expect(result.exitCode).toBe(0);
 
-      // Queue step with child runbook
-      result = runCli('run --step 1 runbooks/child.runbook.md', workspace);
-      expect(result.exitCode).toBe(0);
-
-      // Bind agent (no --var override, should use frontmatter default)
-      result = runCli('run --agent test-agent --json', workspace);
-      expect(result.exitCode).toBe(0);
-
-      // The child runbook should have used the frontmatter default
-      // Pass the step to complete and check the command
-      result = runCli('pass --agent test-agent --json', workspace);
-      expect(result.exitCode).toBe(0);
-
-      const passOutput = JSON.parse(result.stdout);
-      expect(passOutput.result).toBe(true);
+      // Verify the command was expanded with the frontmatter default variable
+      const events = parseNdjsonEvents(result.stdout);
+      const commandStartedEvent = events.find(e => e.type === 'command_started');
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent!.command).toBe('rd echo DefaultTask');
     });
   });
 

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -20,6 +20,15 @@ describe('renderTemplate', () => {
     expect(result).toBe('## 1. Run {{undefined_var}}');
   });
 
+  it('should preserve missing variables with original spacing', () => {
+    const markdown = '## 1. Run {{ undefined_var }}';
+    const variables = {};
+
+    const result = renderTemplate(markdown, variables);
+
+    expect(result).toBe('## 1. Run {{ undefined_var }}');
+  });
+
   it('should not escape markdown characters', () => {
     const markdown = '## 1. {{step_name}}';
     const variables = { step_name: 'Test & Verify <code>' };

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -104,42 +104,58 @@ describe('getBuiltinVariables', () => {
 describe('mergeVariables', () => {
   it('should merge with --var overriding --var-file', () => {
     const builtins = {};
+    const frontmatter = {};
     const discovered = { a: '1', b: '2' };
     const fromFile = { b: '3', c: '4' };
     const fromFlags = { c: '5' };
 
-    const result = mergeVariables(builtins, discovered, fromFile, fromFlags);
+    const result = mergeVariables(builtins, frontmatter, discovered, fromFile, fromFlags);
 
     expect(result).toEqual({ a: '1', b: '3', c: '5' });
   });
 
-  it('should apply precedence: flags > file > discovered > builtins', () => {
+  it('should apply precedence: flags > file > discovered > frontmatter > builtins', () => {
     const builtins = { shared: 'builtin', only_builtin: 'b' };
+    const frontmatter = { shared: 'frontmatter', only_frontmatter: 'fm' };
     const discovered = { shared: 'discovered', only_discovered: 'd' };
     const fromFile = { shared: 'file', only_file: 'f' };
     const fromFlags = { shared: 'flag', only_flag: 'g' };
 
-    const result = mergeVariables(builtins, discovered, fromFile, fromFlags);
+    const result = mergeVariables(builtins, frontmatter, discovered, fromFile, fromFlags);
 
     expect(result).toEqual({
       shared: 'flag',
       only_builtin: 'b',
+      only_frontmatter: 'fm',
       only_discovered: 'd',
       only_file: 'f',
       only_flag: 'g',
     });
   });
 
-  it('should allow builtins to be overridden by discovered', () => {
+  it('should allow builtins to be overridden by frontmatter', () => {
     const builtins = { Date: '2000-01-01', WorkPath: '.work' };
+    const frontmatter = { Date: '2024-06-15' };
+    const discovered = {};
+    const fromFile = {};
+    const fromFlags = {};
+
+    const result = mergeVariables(builtins, frontmatter, discovered, fromFile, fromFlags);
+
+    expect(result.Date).toBe('2024-06-15');
+    expect(result.WorkPath).toBe('.work');
+  });
+
+  it('should allow frontmatter to be overridden by discovered', () => {
+    const builtins = { Date: '2000-01-01' };
+    const frontmatter = { Date: '2024-01-01' };
     const discovered = { Date: '2024-06-15' };
     const fromFile = {};
     const fromFlags = {};
 
-    const result = mergeVariables(builtins, discovered, fromFile, fromFlags);
+    const result = mergeVariables(builtins, frontmatter, discovered, fromFile, fromFlags);
 
     expect(result.Date).toBe('2024-06-15');
-    expect(result.WorkPath).toBe('.work');
   });
 });
 
@@ -540,6 +556,86 @@ describe('collectVariables', () => {
     );
 
     expect(result.abs_key).toBe('abs_value');
+  });
+
+  it('should include frontmatter vars when provided', async () => {
+    const result = await collectVariables(
+      {
+        frontmatterVars: { fm_key: 'fm_value', custom: 'from_frontmatter' },
+      },
+      tmpDir
+    );
+
+    expect(result.fm_key).toBe('fm_value');
+    expect(result.custom).toBe('from_frontmatter');
+
+    // Built-ins still present
+    expect(result).toHaveProperty('Date');
+    expect(result).toHaveProperty('WorkPath');
+  });
+
+  it('should allow frontmatter vars to override builtins', async () => {
+    const result = await collectVariables(
+      {
+        frontmatterVars: { Date: '2020-01-01', WorkPath: 'fm-work' },
+      },
+      tmpDir
+    );
+
+    expect(result.Date).toBe('2020-01-01');
+    expect(result.WorkPath).toBe('fm-work');
+  });
+
+  it('should allow discovered config to override frontmatter vars', async () => {
+    const rundownDir = path.join(tmpDir, '.rundown');
+    await fs.mkdir(rundownDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rundownDir, 'config.yaml'),
+      'shared: from_discovered'
+    );
+
+    const result = await collectVariables(
+      {
+        frontmatterVars: { shared: 'from_frontmatter' },
+      },
+      tmpDir
+    );
+
+    expect(result.shared).toBe('from_discovered');
+  });
+
+  it('should apply full precedence: flags > file > discovered > frontmatter > builtins', async () => {
+    // Setup discovered config
+    const rundownDir = path.join(tmpDir, '.rundown');
+    await fs.mkdir(rundownDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rundownDir, 'config.yaml'),
+      'shared: from_discovered\nkey_discovered: value_discovered'
+    );
+
+    // Setup var file
+    const varFilePath = path.join(tmpDir, 'vars.yaml');
+    await fs.writeFile(varFilePath, 'shared: from_file\nkey_file: value_file');
+
+    const result = await collectVariables(
+      {
+        frontmatterVars: { shared: 'from_frontmatter', key_frontmatter: 'value_frontmatter' },
+        varFile: varFilePath,
+        var: ['shared=from_flag', 'key_flag=value_flag'],
+      },
+      tmpDir
+    );
+
+    // Verify precedence: flags > file > discovered > frontmatter > builtins
+    expect(result.shared).toBe('from_flag');
+    expect(result.key_frontmatter).toBe('value_frontmatter');
+    expect(result.key_discovered).toBe('value_discovered');
+    expect(result.key_file).toBe('value_file');
+    expect(result.key_flag).toBe('value_flag');
+
+    // Built-ins still present
+    expect(result).toHaveProperty('Date');
+    expect(result).toHaveProperty('WorkPath');
   });
 });
 

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { discoverVariables, parseVarFlag, mergeVariables, loadVariablesFromFile, collectVariables, extractVarsFromMarkdown } from '../../src/services/variable-discovery.js';
+import { discoverVariables, parseVarFlag, mergeVariables, loadVariablesFromFile, collectVariables, extractVarsFromMarkdown, getBuiltinVariables } from '../../src/services/variable-discovery.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -44,15 +44,102 @@ describe('parseVarFlag', () => {
   });
 });
 
+describe('getBuiltinVariables', () => {
+  it('should return all expected built-in variables', () => {
+    const builtins = getBuiltinVariables();
+
+    expect(builtins).toHaveProperty('Date');
+    expect(builtins).toHaveProperty('DateTime');
+    expect(builtins).toHaveProperty('Year');
+    expect(builtins).toHaveProperty('Month');
+    expect(builtins).toHaveProperty('Day');
+    expect(builtins).toHaveProperty('WorkPath');
+  });
+
+  it('should return Date in YYYY-MM-DD format', () => {
+    const builtins = getBuiltinVariables();
+
+    expect(builtins.Date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('should return DateTime in ISO 8601 format', () => {
+    const builtins = getBuiltinVariables();
+
+    // ISO 8601 format: YYYY-MM-DDTHH:mm:ss.sssZ
+    expect(builtins.DateTime).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it('should return Year as 4-digit string', () => {
+    const builtins = getBuiltinVariables();
+
+    expect(builtins.Year).toMatch(/^\d{4}$/);
+  });
+
+  it('should return Month as 2-digit zero-padded string (01-12)', () => {
+    const builtins = getBuiltinVariables();
+
+    expect(builtins.Month).toMatch(/^(0[1-9]|1[0-2])$/);
+  });
+
+  it('should return Day as 2-digit zero-padded string (01-31)', () => {
+    const builtins = getBuiltinVariables();
+
+    expect(builtins.Day).toMatch(/^(0[1-9]|[12]\d|3[01])$/);
+  });
+
+  it('should return WorkPath as .work', () => {
+    const builtins = getBuiltinVariables();
+
+    expect(builtins.WorkPath).toBe('.work');
+  });
+
+  it('should return consistent date components', () => {
+    const builtins = getBuiltinVariables();
+
+    // Date should match Year-Month-Day
+    expect(builtins.Date).toBe(`${builtins.Year}-${builtins.Month}-${builtins.Day}`);
+  });
+});
+
 describe('mergeVariables', () => {
   it('should merge with --var overriding --var-file', () => {
+    const builtins = {};
     const discovered = { a: '1', b: '2' };
     const fromFile = { b: '3', c: '4' };
     const fromFlags = { c: '5' };
 
-    const result = mergeVariables(discovered, fromFile, fromFlags);
+    const result = mergeVariables(builtins, discovered, fromFile, fromFlags);
 
     expect(result).toEqual({ a: '1', b: '3', c: '5' });
+  });
+
+  it('should apply precedence: flags > file > discovered > builtins', () => {
+    const builtins = { shared: 'builtin', only_builtin: 'b' };
+    const discovered = { shared: 'discovered', only_discovered: 'd' };
+    const fromFile = { shared: 'file', only_file: 'f' };
+    const fromFlags = { shared: 'flag', only_flag: 'g' };
+
+    const result = mergeVariables(builtins, discovered, fromFile, fromFlags);
+
+    expect(result).toEqual({
+      shared: 'flag',
+      only_builtin: 'b',
+      only_discovered: 'd',
+      only_file: 'f',
+      only_flag: 'g',
+    });
+  });
+
+  it('should allow builtins to be overridden by discovered', () => {
+    const builtins = { Date: '2000-01-01', WorkPath: '.work' };
+    const discovered = { Date: '2024-06-15' };
+    const fromFile = {};
+    const fromFlags = {};
+
+    const result = mergeVariables(builtins, discovered, fromFile, fromFlags);
+
+    expect(result.Date).toBe('2024-06-15');
+    expect(result.WorkPath).toBe('.work');
   });
 });
 
@@ -272,12 +359,20 @@ describe('collectVariables', () => {
     warnSpy.mockRestore();
   });
 
-  it('should return empty object when no sources provided', async () => {
+  it('should include built-in variables when no other sources provided', async () => {
     const result = await collectVariables({}, tmpDir);
-    expect(result).toEqual({});
+
+    // Should contain all built-in variables
+    expect(result).toHaveProperty('Date');
+    expect(result).toHaveProperty('DateTime');
+    expect(result).toHaveProperty('Year');
+    expect(result).toHaveProperty('Month');
+    expect(result).toHaveProperty('Day');
+    expect(result).toHaveProperty('WorkPath');
+    expect(result.WorkPath).toBe('.work');
   });
 
-  it('should collect from --var flags only', async () => {
+  it('should collect from --var flags and include builtins', async () => {
     const result = await collectVariables(
       {
         var: ['key1=value1', 'key2=value2'],
@@ -285,13 +380,16 @@ describe('collectVariables', () => {
       tmpDir
     );
 
-    expect(result).toEqual({
-      key1: 'value1',
-      key2: 'value2',
-    });
+    // User variables
+    expect(result.key1).toBe('value1');
+    expect(result.key2).toBe('value2');
+
+    // Built-ins still present
+    expect(result).toHaveProperty('Date');
+    expect(result).toHaveProperty('WorkPath');
   });
 
-  it('should collect from --var-file only', async () => {
+  it('should collect from --var-file and include builtins', async () => {
     const varFilePath = path.join(tmpDir, 'vars.yaml');
     await fs.writeFile(varFilePath, 'file_key1: file_value1\nfile_key2: file_value2');
 
@@ -302,13 +400,16 @@ describe('collectVariables', () => {
       tmpDir
     );
 
-    expect(result).toEqual({
-      file_key1: 'file_value1',
-      file_key2: 'file_value2',
-    });
+    // File variables
+    expect(result.file_key1).toBe('file_value1');
+    expect(result.file_key2).toBe('file_value2');
+
+    // Built-ins still present
+    expect(result).toHaveProperty('Date');
+    expect(result).toHaveProperty('WorkPath');
   });
 
-  it('should collect from discovered config only', async () => {
+  it('should collect from discovered config and include builtins', async () => {
     const rundownDir = path.join(tmpDir, '.rundown');
     await fs.mkdir(rundownDir, { recursive: true });
     await fs.writeFile(
@@ -318,13 +419,16 @@ describe('collectVariables', () => {
 
     const result = await collectVariables({}, tmpDir);
 
-    expect(result).toEqual({
-      discovered_key1: 'discovered_value1',
-      discovered_key2: 'discovered_value2',
-    });
+    // Discovered variables
+    expect(result.discovered_key1).toBe('discovered_value1');
+    expect(result.discovered_key2).toBe('discovered_value2');
+
+    // Built-ins still present
+    expect(result).toHaveProperty('Date');
+    expect(result).toHaveProperty('WorkPath');
   });
 
-  it('should merge all three sources with correct precedence', async () => {
+  it('should merge all sources with correct precedence (flags > file > discovered > builtins)', async () => {
     // Setup discovered config
     const rundownDir = path.join(tmpDir, '.rundown');
     await fs.mkdir(rundownDir, { recursive: true });
@@ -346,12 +450,56 @@ describe('collectVariables', () => {
     );
 
     // Verify precedence: flags > file > discovered
-    expect(result).toEqual({
-      shared: 'from_flag',
-      key_discovered: 'value_discovered',
-      key_file: 'value_file',
-      key_flag: 'value_flag',
-    });
+    expect(result.shared).toBe('from_flag');
+    expect(result.key_discovered).toBe('value_discovered');
+    expect(result.key_file).toBe('value_file');
+    expect(result.key_flag).toBe('value_flag');
+
+    // Built-ins still present
+    expect(result).toHaveProperty('Date');
+    expect(result).toHaveProperty('WorkPath');
+  });
+
+  it('should allow --var flag to override built-in variables', async () => {
+    const result = await collectVariables(
+      {
+        var: ['WorkPath=custom-path', 'Date=2000-01-01'],
+      },
+      tmpDir
+    );
+
+    expect(result.WorkPath).toBe('custom-path');
+    expect(result.Date).toBe('2000-01-01');
+  });
+
+  it('should allow --var-file to override built-in variables', async () => {
+    const varFilePath = path.join(tmpDir, 'vars.yaml');
+    // Use quoted string to prevent YAML from parsing as date
+    await fs.writeFile(varFilePath, 'WorkPath: from-file\nDate: "2020-06-15"');
+
+    const result = await collectVariables(
+      {
+        varFile: varFilePath,
+      },
+      tmpDir
+    );
+
+    expect(result.WorkPath).toBe('from-file');
+    expect(result.Date).toBe('2020-06-15');
+  });
+
+  it('should allow discovered config to override built-in variables', async () => {
+    const rundownDir = path.join(tmpDir, '.rundown');
+    await fs.mkdir(rundownDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rundownDir, 'config.yaml'),
+      'WorkPath: discovered-path\nYear: 1999'
+    );
+
+    const result = await collectVariables({}, tmpDir);
+
+    expect(result.WorkPath).toBe('discovered-path');
+    expect(result.Year).toBe('1999');
   });
 
   it('should warn on console for invalid --var flag format', async () => {
@@ -362,9 +510,7 @@ describe('collectVariables', () => {
       tmpDir
     );
 
-    expect(result).toEqual({
-      valid: 'value',
-    });
+    expect(result.valid).toBe('value');
 
     expect(warnSpy).toHaveBeenCalledTimes(2);
     expect(warnSpy).toHaveBeenCalledWith('Warning: Ignoring invalid --var flag: invalid-without-equals');
@@ -382,9 +528,7 @@ describe('collectVariables', () => {
       tmpDir
     );
 
-    expect(result).toEqual({
-      rel_key: 'rel_value',
-    });
+    expect(result.rel_key).toBe('rel_value');
   });
 
   it('should handle absolute path for --var-file', async () => {
@@ -398,9 +542,7 @@ describe('collectVariables', () => {
       tmpDir
     );
 
-    expect(result).toEqual({
-      abs_key: 'abs_value',
-    });
+    expect(result.abs_key).toBe('abs_value');
   });
 });
 

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { discoverVariables, parseVarFlag, mergeVariables, loadVariablesFromFile, collectVariables } from '../../src/services/variable-discovery.js';
+import { discoverVariables, parseVarFlag, mergeVariables, loadVariablesFromFile, collectVariables, extractVarsFromMarkdown } from '../../src/services/variable-discovery.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -400,6 +400,184 @@ describe('collectVariables', () => {
 
     expect(result).toEqual({
       abs_key: 'abs_value',
+    });
+  });
+});
+
+describe('extractVarsFromMarkdown', () => {
+  it('should extract vars from valid frontmatter', () => {
+    const markdown = `---
+name: test-runbook
+vars:
+  greeting: Hello
+  count: 42
+  enabled: true
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({
+      greeting: 'Hello',
+      count: '42',
+      enabled: 'true',
+    });
+  });
+
+  it('should return empty object when no frontmatter present', () => {
+    const markdown = `# No Frontmatter
+Just content here.`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object when frontmatter has no vars field', () => {
+    const markdown = `---
+name: test-runbook
+description: A test runbook
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object when vars is null', () => {
+    const markdown = `---
+name: test-runbook
+vars: null
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object when vars is not an object', () => {
+    const markdown = `---
+name: test-runbook
+vars: "not an object"
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({});
+  });
+
+  it('should convert numbers to strings', () => {
+    const markdown = `---
+name: test-runbook
+vars:
+  port: 3000
+  pi: 3.14159
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({
+      port: '3000',
+      pi: '3.14159',
+    });
+  });
+
+  it('should convert booleans to strings', () => {
+    const markdown = `---
+name: test-runbook
+vars:
+  debug: true
+  production: false
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({
+      debug: 'true',
+      production: 'false',
+    });
+  });
+
+  it('should reject invalid identifier keys', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+    const markdown = `---
+name: test-runbook
+vars:
+  valid_key: value1
+  invalid-key: value2
+  123invalid: value3
+  _valid: value4
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({
+      valid_key: 'value1',
+      _valid: 'value4',
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith('Warning: Ignoring frontmatter var with invalid key: invalid-key');
+    expect(warnSpy).toHaveBeenCalledWith('Warning: Ignoring frontmatter var with invalid key: 123invalid');
+
+    warnSpy.mockRestore();
+  });
+
+  it('should warn and stringify complex values', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+    const markdown = `---
+name: test-runbook
+vars:
+  simple: value
+  complex:
+    nested: object
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({
+      simple: 'value',
+      complex: '[object Object]',
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith('Warning: Frontmatter var "complex" has complex value, coerced to string');
+
+    warnSpy.mockRestore();
+  });
+
+  it('should handle empty vars object', () => {
+    const markdown = `---
+name: test-runbook
+vars: {}
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({});
+  });
+
+  it('should handle frontmatter with only vars field', () => {
+    // Note: This would fail schema validation in the parser,
+    // but extractVarsFromMarkdown uses raw extraction without validation
+    const markdown = `---
+vars:
+  key: value
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+
+    expect(result).toEqual({
+      key: 'value',
     });
   });
 });

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -199,18 +199,15 @@ describe('loadVariablesFromFile', () => {
     expect(result).toEqual({});
   });
 
-  it('should map array YAML to numeric-keyed object', async () => {
+  it('should ignore array YAML values (numeric keys are invalid identifiers)', async () => {
     const filePath = path.join(tmpDir, 'array.yaml');
     await fs.writeFile(filePath, '- item1\n- item2\n- item3');
 
     const result = await loadVariablesFromFile(filePath);
 
-    // Arrays are treated as objects with numeric keys by Object.entries()
-    expect(result).toEqual({
-      '0': 'item1',
-      '1': 'item2',
-      '2': 'item3',
-    });
+    // Arrays are treated as objects with numeric keys by Object.entries(),
+    // but numeric keys don't match VALID_IDENTIFIER pattern so they're ignored
+    expect(result).toEqual({});
   });
 
   it('should return empty object if YAML content is not an object (string)', async () => {
@@ -671,7 +668,7 @@ vars:
     warnSpy.mockRestore();
   });
 
-  it('should warn and stringify complex values', () => {
+  it('should warn and skip complex values', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
 
     const markdown = `---
@@ -685,12 +682,12 @@ vars:
 
     const result = extractVarsFromMarkdown(markdown);
 
+    // Complex values are skipped, not coerced to "[object Object]"
     expect(result).toEqual({
       simple: 'value',
-      complex: '[object Object]',
     });
 
-    expect(warnSpy).toHaveBeenCalledWith('Warning: Frontmatter var "complex" has complex value, coerced to string');
+    expect(warnSpy).toHaveBeenCalledWith('Warning: Ignoring frontmatter var "complex" with complex value');
 
     warnSpy.mockRestore();
   });

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -692,6 +692,18 @@ vars: null
     expect(result).toEqual({});
   });
 
+  it('should convert null values to string "null"', () => {
+    const markdown = `---
+name: test-runbook
+vars:
+  nullable: null
+---
+# Content`;
+
+    const result = extractVarsFromMarkdown(markdown);
+    expect(result).toEqual({ nullable: 'null' });
+  });
+
   it('should return empty object when vars is not an object', () => {
     const markdown = `---
 name: test-runbook

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -21,7 +21,7 @@ import { runExecutionLoop } from '../services/execution.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { createBridgedEmitter } from '../helpers/execution-emitter.js';
 import { collect } from './echo.js';
-import { collectVariables } from '../services/variable-discovery.js';
+import { collectVariables, extractVarsFromMarkdown } from '../services/variable-discovery.js';
 import { renderTemplate } from '../services/template-renderer.js';
 
 /**
@@ -47,7 +47,7 @@ function emitRunbookStarted(
 export function registerRunCommand(program: Command): void {
   program
     .command('run [file]')
-    .description('Run a runbook or queue a step')
+    .description('Start a runbook, queue a step, or bind an agent')
     .option('--step <stepId>', 'Mark step as started (adds to pending queue)')
     .option('--agent <agentId>', 'Bind agent to pending step')
     .option('--prompted', 'Prompted mode: show commands without auto-executing')
@@ -117,13 +117,16 @@ export function registerRunCommand(program: Command): void {
 
           // Load and render template
           const rawContent = await fs.readFile(filePath, 'utf8');
+          const frontmatterVars = extractVarsFromMarkdown(rawContent);
           const variables = await collectVariables(
             { varFile: options.varFile, var: options.var },
             cwd
           );
+          // Merge with frontmatter vars as lowest precedence
+          const mergedVariables = { ...frontmatterVars, ...variables };
           let runbookSrc: string;
           try {
-            runbookSrc = renderTemplate(rawContent, variables);
+            runbookSrc = renderTemplate(rawContent, mergedVariables);
           } catch (err) {
             output.error(`Template error: ${(err as Error).message}`, 'TEMPLATE_ERROR');
             output.flush();
@@ -216,13 +219,16 @@ export function registerRunCommand(program: Command): void {
 
             // Load and render child template (inherit parent's variables context)
             const rawContent = await fs.readFile(runbookPath, 'utf8');
+            const frontmatterVars = extractVarsFromMarkdown(rawContent);
             const variables = await collectVariables(
               { varFile: options.varFile, var: options.var },
               cwd
             );
+            // Merge with frontmatter vars as lowest precedence
+            const mergedVariables = { ...frontmatterVars, ...variables };
             let childRunbookSrc: string;
             try {
-              childRunbookSrc = renderTemplate(rawContent, variables);
+              childRunbookSrc = renderTemplate(rawContent, mergedVariables);
             } catch (err) {
               output.error(`Template error: ${(err as Error).message}`, 'TEMPLATE_ERROR');
               output.flush();

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -25,20 +25,6 @@ import { collectVariables, extractVarsFromMarkdown } from '../services/variable-
 import { renderTemplate } from '../services/template-renderer.js';
 
 /**
- * Merge frontmatter vars with collected variables, frontmatter as lowest precedence.
- *
- * @param frontmatterVars - Variables extracted from runbook frontmatter
- * @param variables - Variables from CLI flags or config files
- * @returns Merged variables with CLI/config taking precedence over frontmatter
- */
-function mergeWithFrontmatter(
-  frontmatterVars: Record<string, string>,
-  variables: Record<string, string>
-): Record<string, string> {
-  return { ...frontmatterVars, ...variables };
-}
-
-/**
  * Emit RUNBOOK_STARTED event with metadata.
  */
 function emitRunbookStarted(
@@ -132,12 +118,10 @@ export function registerRunCommand(program: Command): void {
           // Load and render template
           const rawContent = await fs.readFile(filePath, 'utf8');
           const frontmatterVars = extractVarsFromMarkdown(rawContent);
-          const variables = await collectVariables(
-            { varFile: options.varFile, var: options.var },
+          const mergedVariables = await collectVariables(
+            { varFile: options.varFile, var: options.var, frontmatterVars },
             cwd
           );
-          // Merge with frontmatter vars as lowest precedence
-          const mergedVariables = mergeWithFrontmatter(frontmatterVars, variables);
           let runbookSrc: string;
           try {
             runbookSrc = renderTemplate(rawContent, mergedVariables);
@@ -234,12 +218,10 @@ export function registerRunCommand(program: Command): void {
             // Load and render child template (inherit parent's variables context)
             const rawContent = await fs.readFile(runbookPath, 'utf8');
             const frontmatterVars = extractVarsFromMarkdown(rawContent);
-            const variables = await collectVariables(
-              { varFile: options.varFile, var: options.var },
+            const mergedVariables = await collectVariables(
+              { varFile: options.varFile, var: options.var, frontmatterVars },
               cwd
             );
-            // Merge with frontmatter vars as lowest precedence
-            const mergedVariables = mergeWithFrontmatter(frontmatterVars, variables);
             let childRunbookSrc: string;
             try {
               childRunbookSrc = renderTemplate(rawContent, mergedVariables);

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -25,6 +25,20 @@ import { collectVariables, extractVarsFromMarkdown } from '../services/variable-
 import { renderTemplate } from '../services/template-renderer.js';
 
 /**
+ * Merge frontmatter vars with collected variables, frontmatter as lowest precedence.
+ *
+ * @param frontmatterVars - Variables extracted from runbook frontmatter
+ * @param variables - Variables from CLI flags or config files
+ * @returns Merged variables with CLI/config taking precedence over frontmatter
+ */
+function mergeWithFrontmatter(
+  frontmatterVars: Record<string, string>,
+  variables: Record<string, string>
+): Record<string, string> {
+  return { ...frontmatterVars, ...variables };
+}
+
+/**
  * Emit RUNBOOK_STARTED event with metadata.
  */
 function emitRunbookStarted(
@@ -123,7 +137,7 @@ export function registerRunCommand(program: Command): void {
             cwd
           );
           // Merge with frontmatter vars as lowest precedence
-          const mergedVariables = { ...frontmatterVars, ...variables };
+          const mergedVariables = mergeWithFrontmatter(frontmatterVars, variables);
           let runbookSrc: string;
           try {
             runbookSrc = renderTemplate(rawContent, mergedVariables);
@@ -225,7 +239,7 @@ export function registerRunCommand(program: Command): void {
               cwd
             );
             // Merge with frontmatter vars as lowest precedence
-            const mergedVariables = { ...frontmatterVars, ...variables };
+            const mergedVariables = mergeWithFrontmatter(frontmatterVars, variables);
             let childRunbookSrc: string;
             try {
               childRunbookSrc = renderTemplate(rawContent, mergedVariables);

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -54,6 +54,8 @@ export function renderTemplate(
   );
 
   // Resolve placeholders while preserving original spacing for undefined vars.
+  // Re-register helper on each call - intentional, as it needs closure access to
+  // placeholderEntries and variables which differ per invocation.
   handlebars.registerHelper('__rd_resolve__', (index: number) => {
     const entry = placeholderEntries.at(index);
     if (!entry) return '';

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -13,12 +13,7 @@ import Handlebars from 'handlebars';
 // Create isolated instance to avoid polluting global Handlebars
 const handlebars = Handlebars.create();
 
-// Register helper that preserves undefined variables as literal text
-handlebars.registerHelper('helperMissing', function (...args: unknown[]) {
-  // Last argument is the options object with the variable name
-  const options = args[args.length - 1] as { name: string };
-  return new handlebars.SafeString(`{{${options.name}}}`);
-});
+const TEMPLATE_VAR_REGEX = /{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}/g;
 
 /**
  * Render Handlebars variables in markdown content.
@@ -48,7 +43,30 @@ export function renderTemplate(
   markdown: string,
   variables: Record<string, string>
 ): string {
+  const placeholderEntries: { name: string; raw: string }[] = [];
+  const withPlaceholders = markdown.replace(
+    TEMPLATE_VAR_REGEX,
+    (raw, name: string) => {
+      const index = placeholderEntries.length;
+      placeholderEntries.push({ name, raw });
+      return `{{__rd_resolve__ ${index.toString()}}}`;
+    }
+  );
+
+  // Resolve placeholders while preserving original spacing for undefined vars.
+  handlebars.registerHelper('__rd_resolve__', (index: number) => {
+    const entry = placeholderEntries.at(index);
+    if (!entry) return '';
+    const value = Object.prototype.hasOwnProperty.call(variables, entry.name)
+      ? variables[entry.name]
+      : undefined;
+    if (value === undefined) {
+      return new handlebars.SafeString(entry.raw);
+    }
+    return value;
+  });
+
   // Compile with noEscape to preserve markdown characters
-  const template = handlebars.compile(markdown, { noEscape: true });
+  const template = handlebars.compile(withPlaceholders, { noEscape: true });
   return template(variables);
 }

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -22,6 +22,35 @@ import { extractRawFrontmatter } from '../helpers/extract-raw-frontmatter.js';
 const VALID_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 /**
+ * Normalize a raw variables object to Record<string, string>.
+ *
+ * Validates keys match identifier pattern, converts values to strings,
+ * and warns on invalid keys or complex values.
+ *
+ * @param vars - Raw variables object with unknown value types
+ * @param source - Label for warning messages (e.g., "frontmatter var", "variable")
+ * @returns Normalized variables with string values only
+ */
+function normalizeVariables(
+  vars: Record<string, unknown>,
+  source: string = 'variable'
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(vars)) {
+    if (!VALID_IDENTIFIER.test(key)) {
+      console.warn(`Warning: Ignoring ${source} with invalid key: ${key}`);
+      continue;
+    }
+    if (typeof value === 'object' && value !== null) {
+      console.warn(`Warning: Ignoring ${source} "${key}" with complex value`);
+      continue;
+    }
+    result[key] = String(value);
+  }
+  return result;
+}
+
+/**
  * Returns built-in default template variables.
  *
  * These have the lowest precedence and can be overridden by any other source
@@ -94,10 +123,6 @@ export function mergeVariables(
 /**
  * Load variables from a YAML file.
  *
- * Variable names must be valid identifiers (start with letter/underscore,
- * contain only letters, digits, underscores). Invalid keys are ignored with a warning.
- * All values are converted to strings for consistency with other variable sources.
- *
  * @param filePath - Path to the YAML file
  * @returns Variables object, or empty object if file doesn't exist or is invalid
  */
@@ -112,19 +137,11 @@ export async function loadVariablesFromFile(
       return {};
     }
 
-    // Convert all values to strings, validating keys
+    // Convert all values to strings
     const result: Record<string, string> = {};
     for (const [key, value] of Object.entries(parsed)) {
-      // Validate key is a valid identifier
-      if (!VALID_IDENTIFIER.test(key)) {
-        console.warn(`Warning: Ignoring variable with invalid key: ${key}`);
-        continue;
-      }
-
-      // Skip complex values (objects/arrays) - they can't be meaningfully stringified
       if (typeof value === 'object' && value !== null) {
-        console.warn(`Warning: Ignoring variable "${key}" with complex value`);
-        continue;
+        console.warn(`Warning: Variable "${key}" has complex value, coerced to string`);
       }
       result[key] = String(value);
     }
@@ -168,10 +185,9 @@ export function extractVarsFromMarkdown(
       continue;
     }
 
-    // Skip complex values (objects/arrays) - they can't be meaningfully stringified
+    // Convert value to string, warn for complex values
     if (typeof value === 'object' && value !== null) {
-      console.warn(`Warning: Ignoring frontmatter var "${key}" with complex value`);
-      continue;
+      console.warn(`Warning: Frontmatter var "${key}" has complex value, coerced to string`);
     }
     result[key] = String(value);
   }

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -22,6 +22,26 @@ import { extractRawFrontmatter } from '../helpers/extract-raw-frontmatter.js';
 const VALID_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 /**
+ * Returns built-in default template variables.
+ *
+ * These have the lowest precedence and can be overridden by any other source
+ * (frontmatter, config file, --var-file, or --var flags).
+ *
+ * @returns Built-in variables with PascalCase names
+ */
+export function getBuiltinVariables(): Record<string, string> {
+  const now = new Date();
+  return {
+    Date: now.toISOString().slice(0, 10), // YYYY-MM-DD
+    DateTime: now.toISOString(), // Full ISO timestamp
+    Year: String(now.getFullYear()), // YYYY
+    Month: String(now.getMonth() + 1).padStart(2, '0'), // MM (01-12)
+    Day: String(now.getDate()).padStart(2, '0'), // DD (01-31)
+    WorkPath: '.work', // Default artifact directory
+  };
+}
+
+/**
  * Parse a --var flag value in key=value format.
  *
  * Variable names must be valid identifiers (start with letter/underscore,
@@ -49,18 +69,22 @@ export function parseVarFlag(flag: string): { key: string; value: string } | nul
  * 1. --var flags (fromFlags)
  * 2. --var-file contents (fromFile)
  * 3. Auto-discovered .rundown/config.yaml (discovered)
+ * 4. Built-in defaults (builtins) - lowest precedence
  *
+ * @param builtins - Built-in default variables (lowest precedence)
  * @param discovered - Variables from auto-discovery
  * @param fromFile - Variables from --var-file
  * @param fromFlags - Variables from --var flags
  * @returns Merged variables object
  */
 export function mergeVariables(
+  builtins: Record<string, string>,
   discovered: Record<string, string>,
   fromFile: Record<string, string>,
   fromFlags: Record<string, string>
 ): Record<string, string> {
   return {
+    ...builtins,
     ...discovered,
     ...fromFile,
     ...fromFlags,
@@ -107,7 +131,7 @@ export async function loadVariablesFromFile(
  * template rendering (which must happen before full parsing).
  *
  * Variable names must be valid identifiers (start with letter/underscore,
- * contain only letters, digits, underscores). Invalid keys are silently ignored.
+ * contain only letters, digits, underscores). Invalid keys are ignored with a warning.
  * All values are converted to strings for consistency with other variable sources.
  *
  * @param markdown - Raw markdown content with optional frontmatter
@@ -195,6 +219,12 @@ export async function discoverVariables(
 /**
  * Collect all variables from CLI options and auto-discovery.
  *
+ * Precedence (highest to lowest):
+ * 1. --var flags
+ * 2. --var-file contents
+ * 3. Auto-discovered .rundown/config.yaml
+ * 4. Built-in defaults (Date, DateTime, Year, Month, Day, WorkPath)
+ *
  * @param options - CLI options containing varFile and var flags
  * @param cwd - Current working directory
  * @returns Merged variables with proper precedence
@@ -203,10 +233,13 @@ export async function collectVariables(
   options: { varFile?: string; var?: string[] },
   cwd: string
 ): Promise<Record<string, string>> {
-  // 1. Auto-discover from .rundown/config.yaml
+  // 1. Get built-in defaults (lowest precedence)
+  const builtins = getBuiltinVariables();
+
+  // 2. Auto-discover from .rundown/config.yaml
   const discovered = await discoverVariables(cwd);
 
-  // 2. Load from --var-file if provided
+  // 3. Load from --var-file if provided
   let fromFile: Record<string, string> = {};
   if (options.varFile) {
     const varFilePath = path.isAbsolute(options.varFile)
@@ -215,7 +248,7 @@ export async function collectVariables(
     fromFile = await loadVariablesFromFile(varFilePath);
   }
 
-  // 3. Parse --var flags
+  // 4. Parse --var flags (highest precedence)
   const fromFlags: Record<string, string> = {};
   if (options.var) {
     for (const flag of options.var) {
@@ -228,6 +261,6 @@ export async function collectVariables(
     }
   }
 
-  // 4. Merge with precedence
-  return mergeVariables(discovered, fromFile, fromFlags);
+  // 5. Merge with precedence: builtins < discovered < fromFile < fromFlags
+  return mergeVariables(builtins, discovered, fromFile, fromFlags);
 }

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -121,9 +121,10 @@ export async function loadVariablesFromFile(
         continue;
       }
 
-      // Convert value to string, warn for complex values
+      // Skip complex values (objects/arrays) - they can't be meaningfully stringified
       if (typeof value === 'object' && value !== null) {
-        console.warn(`Warning: Variable "${key}" has complex value, coerced to string`);
+        console.warn(`Warning: Ignoring variable "${key}" with complex value`);
+        continue;
       }
       result[key] = String(value);
     }
@@ -167,9 +168,10 @@ export function extractVarsFromMarkdown(
       continue;
     }
 
-    // Convert value to string, warn for complex values
+    // Skip complex values (objects/arrays) - they can't be meaningfully stringified
     if (typeof value === 'object' && value !== null) {
-      console.warn(`Warning: Frontmatter var "${key}" has complex value, coerced to string`);
+      console.warn(`Warning: Ignoring frontmatter var "${key}" with complex value`);
+      continue;
     }
     result[key] = String(value);
   }

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -94,6 +94,10 @@ export function mergeVariables(
 /**
  * Load variables from a YAML file.
  *
+ * Variable names must be valid identifiers (start with letter/underscore,
+ * contain only letters, digits, underscores). Invalid keys are ignored with a warning.
+ * All values are converted to strings for consistency with other variable sources.
+ *
  * @param filePath - Path to the YAML file
  * @returns Variables object, or empty object if file doesn't exist or is invalid
  */
@@ -108,9 +112,16 @@ export async function loadVariablesFromFile(
       return {};
     }
 
-    // Convert all values to strings
+    // Convert all values to strings, validating keys
     const result: Record<string, string> = {};
     for (const [key, value] of Object.entries(parsed)) {
+      // Validate key is a valid identifier
+      if (!VALID_IDENTIFIER.test(key)) {
+        console.warn(`Warning: Ignoring variable with invalid key: ${key}`);
+        continue;
+      }
+
+      // Convert value to string, warn for complex values
       if (typeof value === 'object' && value !== null) {
         console.warn(`Warning: Variable "${key}" has complex value, coerced to string`);
       }

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -13,6 +13,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
+import { extractRawFrontmatter } from '../helpers/extract-raw-frontmatter.js';
 
 /**
  * Valid identifier pattern for variable names.
@@ -95,6 +96,50 @@ export async function loadVariablesFromFile(
   } catch {
     return {};
   }
+}
+
+
+/**
+ * Extract template variables from markdown frontmatter.
+ *
+ * Extracts the `vars` field from YAML frontmatter without requiring full
+ * schema validation. This allows frontmatter defaults to be applied before
+ * template rendering (which must happen before full parsing).
+ *
+ * Variable names must be valid identifiers (start with letter/underscore,
+ * contain only letters, digits, underscores). Invalid keys are silently ignored.
+ * All values are converted to strings for consistency with other variable sources.
+ *
+ * @param markdown - Raw markdown content with optional frontmatter
+ * @returns Variables from frontmatter vars field, or empty object if none
+ */
+export function extractVarsFromMarkdown(
+  markdown: string
+): Record<string, string> {
+  const { frontmatter } = extractRawFrontmatter(markdown);
+
+  if (!frontmatter || typeof frontmatter.vars !== 'object' || frontmatter.vars === null) {
+    return {};
+  }
+
+  const vars = frontmatter.vars as Record<string, unknown>;
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(vars)) {
+    // Validate key is a valid identifier
+    if (!VALID_IDENTIFIER.test(key)) {
+      console.warn(`Warning: Ignoring frontmatter var with invalid key: ${key}`);
+      continue;
+    }
+
+    // Convert value to string, warn for complex values
+    if (typeof value === 'object' && value !== null) {
+      console.warn(`Warning: Frontmatter var "${key}" has complex value, coerced to string`);
+    }
+    result[key] = String(value);
+  }
+
+  return result;
 }
 
 /**

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -33,7 +33,7 @@ const VALID_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
  */
 function normalizeVariables(
   vars: Record<string, unknown>,
-  source: string = 'variable'
+  source = 'variable'
 ): Record<string, string> {
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(vars)) {
@@ -98,22 +98,26 @@ export function parseVarFlag(flag: string): { key: string; value: string } | nul
  * 1. --var flags (fromFlags)
  * 2. --var-file contents (fromFile)
  * 3. Auto-discovered .rundown/config.yaml (discovered)
- * 4. Built-in defaults (builtins) - lowest precedence
+ * 4. Frontmatter vars (frontmatter)
+ * 5. Built-in defaults (builtins) - lowest precedence
  *
  * @param builtins - Built-in default variables (lowest precedence)
+ * @param frontmatter - Variables from runbook frontmatter
  * @param discovered - Variables from auto-discovery
  * @param fromFile - Variables from --var-file
- * @param fromFlags - Variables from --var flags
+ * @param fromFlags - Variables from --var flags (highest precedence)
  * @returns Merged variables object
  */
 export function mergeVariables(
   builtins: Record<string, string>,
+  frontmatter: Record<string, string>,
   discovered: Record<string, string>,
   fromFile: Record<string, string>,
   fromFlags: Record<string, string>
 ): Record<string, string> {
   return {
     ...builtins,
+    ...frontmatter,
     ...discovered,
     ...fromFile,
     ...fromFlags,
@@ -137,15 +141,7 @@ export async function loadVariablesFromFile(
       return {};
     }
 
-    // Convert all values to strings
-    const result: Record<string, string> = {};
-    for (const [key, value] of Object.entries(parsed)) {
-      if (typeof value === 'object' && value !== null) {
-        console.warn(`Warning: Variable "${key}" has complex value, coerced to string`);
-      }
-      result[key] = String(value);
-    }
-    return result;
+    return normalizeVariables(parsed as Record<string, unknown>);
   } catch {
     return {};
   }
@@ -175,24 +171,7 @@ export function extractVarsFromMarkdown(
     return {};
   }
 
-  const vars = frontmatter.vars as Record<string, unknown>;
-  const result: Record<string, string> = {};
-
-  for (const [key, value] of Object.entries(vars)) {
-    // Validate key is a valid identifier
-    if (!VALID_IDENTIFIER.test(key)) {
-      console.warn(`Warning: Ignoring frontmatter var with invalid key: ${key}`);
-      continue;
-    }
-
-    // Convert value to string, warn for complex values
-    if (typeof value === 'object' && value !== null) {
-      console.warn(`Warning: Frontmatter var "${key}" has complex value, coerced to string`);
-    }
-    result[key] = String(value);
-  }
-
-  return result;
+  return normalizeVariables(frontmatter.vars as Record<string, unknown>, 'frontmatter var');
 }
 
 /**
@@ -252,23 +231,27 @@ export async function discoverVariables(
  * 1. --var flags
  * 2. --var-file contents
  * 3. Auto-discovered .rundown/config.yaml
- * 4. Built-in defaults (Date, DateTime, Year, Month, Day, WorkPath)
+ * 4. Frontmatter vars
+ * 5. Built-in defaults (Date, DateTime, Year, Month, Day, WorkPath)
  *
- * @param options - CLI options containing varFile and var flags
+ * @param options - CLI options containing varFile, var flags, and frontmatterVars
  * @param cwd - Current working directory
  * @returns Merged variables with proper precedence
  */
 export async function collectVariables(
-  options: { varFile?: string; var?: string[] },
+  options: { varFile?: string; var?: string[]; frontmatterVars?: Record<string, string> },
   cwd: string
 ): Promise<Record<string, string>> {
   // 1. Get built-in defaults (lowest precedence)
   const builtins = getBuiltinVariables();
 
-  // 2. Auto-discover from .rundown/config.yaml
+  // 2. Frontmatter vars (second lowest)
+  const frontmatter = options.frontmatterVars ?? {};
+
+  // 3. Auto-discover from .rundown/config.yaml
   const discovered = await discoverVariables(cwd);
 
-  // 3. Load from --var-file if provided
+  // 4. Load from --var-file if provided
   let fromFile: Record<string, string> = {};
   if (options.varFile) {
     const varFilePath = path.isAbsolute(options.varFile)
@@ -277,7 +260,7 @@ export async function collectVariables(
     fromFile = await loadVariablesFromFile(varFilePath);
   }
 
-  // 4. Parse --var flags (highest precedence)
+  // 5. Parse --var flags (highest precedence)
   const fromFlags: Record<string, string> = {};
   if (options.var) {
     for (const flag of options.var) {
@@ -290,6 +273,6 @@ export async function collectVariables(
     }
   }
 
-  // 5. Merge with precedence: builtins < discovered < fromFile < fromFlags
-  return mergeVariables(builtins, discovered, fromFile, fromFlags);
+  // 6. Merge with precedence: builtins < frontmatter < discovered < fromFile < fromFlags
+  return mergeVariables(builtins, frontmatter, discovered, fromFile, fromFlags);
 }

--- a/packages/parser/__tests__/frontmatter.test.ts
+++ b/packages/parser/__tests__/frontmatter.test.ts
@@ -90,6 +90,127 @@ description: Never closed
     expect(result.frontmatter).toBeNull();
     expect(result.content).toBe(markdown);
   });
+
+  it('extracts frontmatter with vars field containing strings', () => {
+    const markdown = `---
+name: my-runbook
+vars:
+  greeting: Hello
+  name: World
+---
+# Content`;
+
+    const result = extractFrontmatter(markdown);
+
+    expect(result.frontmatter).not.toBeNull();
+    expect(result.frontmatter?.name).toBe('my-runbook');
+    expect(result.frontmatter?.vars).toEqual({
+      greeting: 'Hello',
+      name: 'World',
+    });
+  });
+
+  it('extracts frontmatter with vars field containing numbers', () => {
+    const markdown = `---
+name: my-runbook
+vars:
+  port: 3000
+  pi: 3.14159
+---
+# Content`;
+
+    const result = extractFrontmatter(markdown);
+
+    expect(result.frontmatter).not.toBeNull();
+    expect(result.frontmatter?.vars).toEqual({
+      port: 3000,
+      pi: 3.14159,
+    });
+  });
+
+  it('extracts frontmatter with vars field containing booleans', () => {
+    const markdown = `---
+name: my-runbook
+vars:
+  debug: true
+  production: false
+---
+# Content`;
+
+    const result = extractFrontmatter(markdown);
+
+    expect(result.frontmatter).not.toBeNull();
+    expect(result.frontmatter?.vars).toEqual({
+      debug: true,
+      production: false,
+    });
+  });
+
+  it('extracts frontmatter with vars field containing mixed types', () => {
+    const markdown = `---
+name: my-runbook
+vars:
+  name: test-app
+  port: 8080
+  debug: true
+---
+# Content`;
+
+    const result = extractFrontmatter(markdown);
+
+    expect(result.frontmatter).not.toBeNull();
+    expect(result.frontmatter?.vars).toEqual({
+      name: 'test-app',
+      port: 8080,
+      debug: true,
+    });
+  });
+
+  it('extracts frontmatter with empty vars object', () => {
+    const markdown = `---
+name: my-runbook
+vars: {}
+---
+# Content`;
+
+    const result = extractFrontmatter(markdown);
+
+    expect(result.frontmatter).not.toBeNull();
+    expect(result.frontmatter?.vars).toEqual({});
+  });
+
+  it('returns null frontmatter when vars contains invalid types (arrays)', () => {
+    const markdown = `---
+name: my-runbook
+vars:
+  items:
+    - one
+    - two
+---
+# Content`;
+
+    const result = extractFrontmatter(markdown);
+
+    // Schema validation should fail for array values
+    expect(result.frontmatter).toBeNull();
+    expect(result.content).toBe(markdown);
+  });
+
+  it('returns null frontmatter when vars contains invalid types (nested objects)', () => {
+    const markdown = `---
+name: my-runbook
+vars:
+  config:
+    nested: value
+---
+# Content`;
+
+    const result = extractFrontmatter(markdown);
+
+    // Schema validation should fail for nested object values
+    expect(result.frontmatter).toBeNull();
+    expect(result.content).toBe(markdown);
+  });
 });
 
 describe('nameFromFilename()', () => {

--- a/packages/parser/src/frontmatter.ts
+++ b/packages/parser/src/frontmatter.ts
@@ -10,6 +10,7 @@ export interface RunbookFrontmatter {
   version?: string;       // Optional: semantic version
   author?: string;        // Optional
   tags?: string[];        // Optional: categorization
+  vars?: Record<string, string | number | boolean>;  // Optional: default template variables
 }
 
 /**
@@ -24,6 +25,7 @@ export const RunbookFrontmatterSchema = z.object({
   version: z.string().optional(),
   author: z.string().optional(),
   tags: z.array(z.string()).optional(),
+  vars: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
 });
 
 /**


### PR DESCRIPTION
Support declaring default template variables in runbook frontmatter using the `vars` field. These serve as the lowest precedence defaults, overridden by config.yaml, --var-file, and --var flags in that order.

Frontmatter vars support string, number, and boolean values (all converted to strings for template rendering). Invalid identifier keys are ignored with a warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runbooks can declare variables in YAML frontmatter; built-in date/workpath variables added as low-precedence defaults. Run command wording clarified: "Start a runbook, queue a step, or bind an agent."

* **Behavior**
  * Template rendering preserves undefined placeholders (including original spacing), keeping missing variables visible.

* **Tests**
  * Expanded coverage for frontmatter parsing, built-ins, precedence/overrides, nested runbooks, var-file/config interactions, and placeholder behavior; added a runbook generator for richer test scenarios.

* **Documentation**
  * Docs updated with frontmatter usage, built-in variables, and precedence examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->