### PR TITLE
test(for-loops): add aggregation-exit GOTO and variable scoping tests

### DIFF
--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -422,7 +422,7 @@ export function createRunbook(options: CreateRunbookOptions): string {
     }
 
     // Step-level transitions (use ALL/ANY qualifiers when step has substeps or FOR)
-    const hasAggregation = !!(step.for || step.substeps);
+    const hasAggregation = step.for != null || step.substeps != null;
     if (step.pass) lines.push(`- PASS${hasAggregation ? ' ALL' : ''}: ${step.pass}`);
     if (step.fail) lines.push(`- FAIL${hasAggregation ? ' ANY' : ''}: ${step.fail}`);
     lines.push('');

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -312,6 +312,34 @@ export function findActionOutput(stdout: string): Record<string, unknown> | null
 
 
 /**
+ * Configuration for a substep within a FOR loop or parent step.
+ */
+export interface SubstepConfig {
+  /** Substep title (after the qualified number) */
+  title: string;
+  /** PASS transition for the substep */
+  pass?: string;
+  /** FAIL transition for the substep */
+  fail?: string;
+  /** Additional markdown content before command block */
+  content?: string;
+  /** Bash command to execute */
+  command?: string;
+}
+
+/**
+ * Configuration for a FOR clause on a step.
+ */
+export interface ForClauseConfig {
+  /** Loop variable name (e.g., "item" → `FOR item IN start TO end`) */
+  variable?: string;
+  /** Loop start value (number or template var like "{{Min}}") */
+  start: number | string;
+  /** Loop end value (number or template var like "{{Max}}") */
+  end: number | string;
+}
+
+/**
  * Configuration for a runbook step.
  */
 export interface StepConfig {
@@ -325,6 +353,10 @@ export interface StepConfig {
   command?: string;
   /** Additional markdown content before command block */
   content?: string;
+  /** FOR clause for loop steps */
+  for?: ForClauseConfig;
+  /** Substeps (H3 headers with qualified numbering) */
+  substeps?: SubstepConfig[];
 }
 
 /**
@@ -380,19 +412,51 @@ export function createRunbook(options: CreateRunbookOptions): string {
 
   // Steps
   steps.forEach((step, index) => {
-    lines.push(`## ${String(index + 1)}. ${step.title}`);
-    if (step.pass) lines.push(`- PASS: ${step.pass}`);
-    if (step.fail) lines.push(`- FAIL: ${step.fail}`);
-    lines.push('');
-    if (step.content) {
-      lines.push(step.content);
-      lines.push('');
+    const stepNum = index + 1;
+    lines.push(`## ${String(stepNum)}. ${step.title}`);
+
+    // FOR clause (before transitions)
+    if (step.for) {
+      const varName = step.for.variable ?? 'i';
+      lines.push(`- FOR ${varName} IN ${String(step.for.start)} TO ${String(step.for.end)}`);
     }
-    if (step.command) {
-      lines.push('```bash');
-      lines.push(step.command);
-      lines.push('```');
-      lines.push('');
+
+    // Step-level transitions (use ALL/ANY qualifiers when step has substeps or FOR)
+    const hasAggregation = !!(step.for || step.substeps);
+    if (step.pass) lines.push(`- PASS${hasAggregation ? ' ALL' : ''}: ${step.pass}`);
+    if (step.fail) lines.push(`- FAIL${hasAggregation ? ' ANY' : ''}: ${step.fail}`);
+    lines.push('');
+
+    if (step.substeps) {
+      // Render substeps as H3 headers with qualified numbering
+      step.substeps.forEach((sub, subIndex) => {
+        lines.push(`### ${String(stepNum)}.${String(subIndex + 1)} ${sub.title}`);
+        if (sub.pass) lines.push(`- PASS: ${sub.pass}`);
+        if (sub.fail) lines.push(`- FAIL: ${sub.fail}`);
+        lines.push('');
+        if (sub.content) {
+          lines.push(sub.content);
+          lines.push('');
+        }
+        if (sub.command) {
+          lines.push('```bash');
+          lines.push(sub.command);
+          lines.push('```');
+          lines.push('');
+        }
+      });
+    } else {
+      // Step-level content/command (no substeps)
+      if (step.content) {
+        lines.push(step.content);
+        lines.push('');
+      }
+      if (step.command) {
+        lines.push('```bash');
+        lines.push(step.command);
+        lines.push('```');
+        lines.push('');
+      }
     }
   });
 

--- a/packages/cli/__tests__/integration/for-loop-variables.test.ts
+++ b/packages/cli/__tests__/integration/for-loop-variables.test.ts
@@ -515,4 +515,79 @@ rd echo item={{item}}
     const allText = JSON.stringify(stepEnteredEvents);
     expect(allText).not.toContain('{{item}}');
   });
+
+  it('{{item}} preserved as literal outside FOR loop', async () => {
+    await writeFile(
+      join(workspace.cwd, 'item-outside-for.runbook.md'),
+      `---
+name: Item Outside FOR
+---
+# Item Outside
+
+## 1. Step with item reference {{item}}
+\`\`\`bash
+rd echo value={{item}}
+\`\`\`
+`
+    );
+
+    const result = runCli('run --json item-outside-for.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    const events = result.stdout
+      .split('\n')
+      .filter(line => line.startsWith('{'))
+      .map(line => JSON.parse(line));
+
+    const stepEnteredEvents = events.filter(
+      (e: Record<string, unknown>) => e.type === 'step_entered'
+    );
+
+    expect(stepEnteredEvents.length).toBeGreaterThanOrEqual(1);
+    // {{item}} should be preserved as literal since there's no FOR loop
+    expect(stepEnteredEvents[0].description).toContain('{{item}}');
+  });
+
+  it('FOR loop variable {{item}} does not leak into subsequent step', async () => {
+    await writeFile(
+      join(workspace.cwd, 'for-scope.runbook.md'),
+      `---
+name: FOR Variable Scope
+---
+# FOR Variable Scope
+
+## 1. Loop step
+- FOR item IN 1 TO 2
+- PASS ALL: CONTINUE
+### 1.1 Process item {{item}}
+\`\`\`bash
+rd echo item={{item}}
+\`\`\`
+
+## 2. After loop uses {{item}}
+\`\`\`bash
+rd echo after={{item}}
+\`\`\`
+`
+    );
+
+    const result = runCli('run --json for-scope.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    const events = result.stdout
+      .split('\n')
+      .filter(line => line.startsWith('{'))
+      .map(line => JSON.parse(line));
+
+    const stepEnteredEvents = events.filter(
+      (e: Record<string, unknown>) => e.type === 'step_entered'
+    );
+
+    // 2 FOR iterations + step 2 = 3 step_entered events
+    expect(stepEnteredEvents).toHaveLength(3);
+    expect(stepEnteredEvents[0].description).toContain('Process item 1');
+    expect(stepEnteredEvents[1].description).toContain('Process item 2');
+    // Step 2: {{item}} should be preserved as literal, NOT expanded to '2'
+    expect(stepEnteredEvents[2].description).toContain('{{item}}');
+  });
 });

--- a/packages/cli/__tests__/integration/for-loop-variables.test.ts
+++ b/packages/cli/__tests__/integration/for-loop-variables.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { createTestWorkspace, runCli, type TestWorkspace } from '../helpers/test-utils.js';
+import { createTestWorkspace, createRunbook, runCli, type TestWorkspace } from '../helpers/test-utils.js';
 import { writeFile } from 'fs/promises';
 import { join } from 'path';
 
@@ -15,22 +15,20 @@ describe('Per-step variable expansion ({{Step}}, {{Index}}, FOR loop variables)'
   });
 
   it('expands loop variables in JSON output for all iterations', async () => {
-    await writeFile(
-      join(workspace.cwd, 'for-vars.runbook.md'),
-      `---
-name: FOR Vars Test
----
-# FOR Vars
-
-## 1. Process items
-- FOR item IN 1 TO 3
-- PASS ALL: CONTINUE
-### 1.1 Handle item {{item}} index {{Index}}
-\`\`\`bash
-rd echo item={{item}} index={{Index}}
-\`\`\`
-`
-    );
+    const content = createRunbook({
+      name: 'FOR Vars Test',
+      title: 'FOR Vars',
+      steps: [{
+        title: 'Process items',
+        for: { variable: 'item', start: 1, end: 3 },
+        pass: 'CONTINUE',
+        substeps: [{
+          title: 'Handle item {{item}} index {{Index}}',
+          command: 'rd echo item={{item}} index={{Index}}',
+        }],
+      }],
+    });
+    await writeFile(join(workspace.cwd, 'for-vars.runbook.md'), content);
 
     const result = runCli('run --json for-vars.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -76,24 +74,15 @@ rd echo item={{item}} index={{Index}}
   });
 
   it('expands {{Step}} to step number for a simple step', async () => {
-    await writeFile(
-      join(workspace.cwd, 'step-var-simple.runbook.md'),
-      `---
-name: Step Var Simple
----
-# Step Var
-
-## 1. Running step {{Step}}
-\`\`\`bash
-rd echo step={{Step}}
-\`\`\`
-
-## 2. Running step {{Step}}
-\`\`\`bash
-rd echo step={{Step}}
-\`\`\`
-`
-    );
+    const content = createRunbook({
+      name: 'Step Var Simple',
+      title: 'Step Var',
+      steps: [
+        { title: 'Running step {{Step}}', command: 'rd echo step={{Step}}' },
+        { title: 'Running step {{Step}}', command: 'rd echo step={{Step}}' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'step-var-simple.runbook.md'), content);
 
     const result = runCli('run --json step-var-simple.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -127,32 +116,25 @@ rd echo step={{Step}}
   });
 
   it('expands {{Step}} to qualified ID for a substep', async () => {
-    await writeFile(
-      join(workspace.cwd, 'step-var-substep.runbook.md'),
-      `---
-name: Step Var Substep
----
-# Step Var Substep
-
-## 1. Parent step
-- PASS ALL: CONTINUE
-
-### 1.1 Substep {{Step}}
-\`\`\`bash
-rd echo step={{Step}}
-\`\`\`
-
-### 1.2 Substep {{Step}}
-\`\`\`bash
-rd echo step={{Step}}
-\`\`\`
-
-## 2. Done at {{Step}}
-\`\`\`bash
-rd echo done={{Step}}
-\`\`\`
-`
-    );
+    const content = createRunbook({
+      name: 'Step Var Substep',
+      title: 'Step Var Substep',
+      steps: [
+        {
+          title: 'Parent step',
+          pass: 'CONTINUE',
+          substeps: [
+            { title: 'Substep {{Step}}', command: 'rd echo step={{Step}}' },
+            { title: 'Substep {{Step}}', command: 'rd echo step={{Step}}' },
+          ],
+        },
+        {
+          title: 'Done at {{Step}}',
+          command: 'rd echo done={{Step}}',
+        },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'step-var-substep.runbook.md'), content);
 
     const result = runCli('run --json step-var-substep.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -187,22 +169,20 @@ rd echo done={{Step}}
   });
 
   it('expands {{Step}} alongside {{Index}} in FOR loop steps', async () => {
-    await writeFile(
-      join(workspace.cwd, 'step-var-for.runbook.md'),
-      `---
-name: Step Var FOR
----
-# Step Var FOR
-
-## 1. Loop step
-- FOR i IN 1 TO 2
-- PASS ALL: CONTINUE
-### 1.1 Iteration {{Index}} of step {{Step}}
-\`\`\`bash
-rd echo step={{Step}} index={{Index}}
-\`\`\`
-`
-    );
+    const content = createRunbook({
+      name: 'Step Var FOR',
+      title: 'Step Var FOR',
+      steps: [{
+        title: 'Loop step',
+        for: { variable: 'i', start: 1, end: 2 },
+        pass: 'CONTINUE',
+        substeps: [{
+          title: 'Iteration {{Index}} of step {{Step}}',
+          command: 'rd echo step={{Step}} index={{Index}}',
+        }],
+      }],
+    });
+    await writeFile(join(workspace.cwd, 'step-var-for.runbook.md'), content);
 
     const result = runCli('run --json step-var-for.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -233,22 +213,20 @@ rd echo step={{Step}} index={{Index}}
   });
 
   it('expands loop variables on first iteration (bootstrap from forClause)', async () => {
-    await writeFile(
-      join(workspace.cwd, 'for-bootstrap.runbook.md'),
-      `---
-name: FOR Bootstrap
----
-# FOR Bootstrap
-
-## 1. First step is FOR
-- FOR i IN 1 TO 2
-- PASS ALL: CONTINUE
-### 1.1 Process iteration {{i}}
-\`\`\`bash
-rd echo iteration={{i}}
-\`\`\`
-`
-    );
+    const content = createRunbook({
+      name: 'FOR Bootstrap',
+      title: 'FOR Bootstrap',
+      steps: [{
+        title: 'First step is FOR',
+        for: { variable: 'i', start: 1, end: 2 },
+        pass: 'CONTINUE',
+        substeps: [{
+          title: 'Process iteration {{i}}',
+          command: 'rd echo iteration={{i}}',
+        }],
+      }],
+    });
+    await writeFile(join(workspace.cwd, 'for-bootstrap.runbook.md'), content);
 
     const result = runCli('run --json for-bootstrap.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -271,20 +249,16 @@ rd echo iteration={{i}}
     expect(stepEnteredEvents[0].description).not.toContain('{{i}}');
   });
 
-  it('{{Index}} preserved as literal outside FOR loop (I1)', async () => {
-    await writeFile(
-      join(workspace.cwd, 'index-outside-for.runbook.md'),
-      `---
-name: Index Outside FOR
----
-# Index Outside
-
-## 1. Step with Index reference {{Index}}
-\`\`\`bash
-rd echo value={{Index}}
-\`\`\`
-`
-    );
+  it('{{Index}} preserved as literal outside FOR loop', async () => {
+    const content = createRunbook({
+      name: 'Index Outside FOR',
+      title: 'Index Outside',
+      steps: [{
+        title: 'Step with Index reference {{Index}}',
+        command: 'rd echo value={{Index}}',
+      }],
+    });
+    await writeFile(join(workspace.cwd, 'index-outside-for.runbook.md'), content);
 
     const result = runCli('run --json index-outside-for.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -303,7 +277,9 @@ rd echo value={{Index}}
     expect(stepEnteredEvents[0].description).toContain('{{Index}}');
   });
 
-  it('{{Step}} expands to named identifier for named step (I2)', async () => {
+  it('{{Step}} expands to named identifier for named step', async () => {
+    // Named steps use a non-numeric identifier (e.g., "ErrorHandler.") which
+    // can't be expressed with createRunbook's auto-numbering, so use raw markdown
     await writeFile(
       join(workspace.cwd, 'step-named.runbook.md'),
       `---
@@ -347,29 +323,24 @@ rd echo step={{Step}}
     expect(commandStartedEvents[1].command).toContain('step=ErrorHandler');
   });
 
-  it('expands loop variables in prompt text (I3)', async () => {
-    await writeFile(
-      join(workspace.cwd, 'for-prompt.runbook.md'),
-      `---
-name: FOR Prompt Test
----
-# FOR Prompt
-
-## 1. Process items
-- FOR item IN 1 TO 2
-- PASS ALL: CONTINUE
-
-### 1.1 Handle item {{item}}
-- PASS: CONTINUE
-- FAIL: STOP
-
-Process item number {{item}} carefully.
-
-\`\`\`bash
-rd echo item={{item}}
-\`\`\`
-`
-    );
+  it('expands loop variables in prompt text', async () => {
+    const content = createRunbook({
+      name: 'FOR Prompt Test',
+      title: 'FOR Prompt',
+      steps: [{
+        title: 'Process items',
+        for: { variable: 'item', start: 1, end: 2 },
+        pass: 'CONTINUE',
+        substeps: [{
+          title: 'Handle item {{item}}',
+          pass: 'CONTINUE',
+          fail: 'STOP',
+          content: 'Process item number {{item}} carefully.',
+          command: 'rd echo item={{item}}',
+        }],
+      }],
+    });
+    await writeFile(join(workspace.cwd, 'for-prompt.runbook.md'), content);
 
     const result = runCli('run --json for-prompt.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -388,26 +359,22 @@ rd echo item={{item}}
     expect(stepEnteredEvents[0].prompt).toContain('Process item number 1 carefully.');
   });
 
-  it('FOR with variable bounds resolves through Phase 1 expansion (I4)', async () => {
-    await writeFile(
-      join(workspace.cwd, 'for-var-bounds.runbook.md'),
-      `---
-name: FOR Var Bounds
-vars:
-  Max: 3
----
-# FOR Var Bounds
-
-## 1. Process
-- FOR item IN 1 TO {{Max}}
-- PASS ALL: CONTINUE
-
-### 1.1 Iteration {{Index}}
-\`\`\`bash
-rd echo iter={{Index}}
-\`\`\`
-`
-    );
+  it('FOR with variable bounds resolves through Phase 1 expansion', async () => {
+    const content = createRunbook({
+      name: 'FOR Var Bounds',
+      title: 'FOR Var Bounds',
+      vars: { Max: 3 },
+      steps: [{
+        title: 'Process',
+        for: { variable: 'item', start: 1, end: '{{Max}}' },
+        pass: 'CONTINUE',
+        substeps: [{
+          title: 'Iteration {{Index}}',
+          command: 'rd echo iter={{Index}}',
+        }],
+      }],
+    });
+    await writeFile(join(workspace.cwd, 'for-var-bounds.runbook.md'), content);
 
     const result = runCli('run --json for-var-bounds.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -428,29 +395,21 @@ rd echo iter={{Index}}
     expect(stepEnteredEvents[2].description).toContain('Iteration 3');
   });
 
-  it('FOR with multiple substeps expands variables in each (I5)', async () => {
-    await writeFile(
-      join(workspace.cwd, 'for-multi-sub.runbook.md'),
-      `---
-name: FOR Multi Substep
----
-# FOR Multi Substep
-
-## 1. Process
-- FOR item IN 1 TO 2
-- PASS ALL: CONTINUE
-
-### 1.1 Fetch item {{item}}
-\`\`\`bash
-rd echo fetch={{item}}
-\`\`\`
-
-### 1.2 Store item {{item}}
-\`\`\`bash
-rd echo store={{item}}
-\`\`\`
-`
-    );
+  it('FOR with multiple substeps expands variables in each', async () => {
+    const content = createRunbook({
+      name: 'FOR Multi Substep',
+      title: 'FOR Multi Substep',
+      steps: [{
+        title: 'Process',
+        for: { variable: 'item', start: 1, end: 2 },
+        pass: 'CONTINUE',
+        substeps: [
+          { title: 'Fetch item {{item}}', command: 'rd echo fetch={{item}}' },
+          { title: 'Store item {{item}}', command: 'rd echo store={{item}}' },
+        ],
+      }],
+    });
+    await writeFile(join(workspace.cwd, 'for-multi-sub.runbook.md'), content);
 
     const result = runCli('run --json for-multi-sub.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -476,24 +435,21 @@ rd echo store={{item}}
     expect(stepEnteredEvents[3].description).toContain('Store item 2');
   });
 
-  it('FOR with single iteration (1 TO 1) works correctly (I6)', async () => {
-    await writeFile(
-      join(workspace.cwd, 'for-single-iter.runbook.md'),
-      `---
-name: FOR Single Iter
----
-# FOR Single Iteration
-
-## 1. Single
-- FOR item IN 1 TO 1
-- PASS ALL: CONTINUE
-
-### 1.1 Only iteration {{item}}
-\`\`\`bash
-rd echo item={{item}}
-\`\`\`
-`
-    );
+  it('FOR with single iteration (1 TO 1) works correctly', async () => {
+    const content = createRunbook({
+      name: 'FOR Single Iter',
+      title: 'FOR Single Iteration',
+      steps: [{
+        title: 'Single',
+        for: { variable: 'item', start: 1, end: 1 },
+        pass: 'CONTINUE',
+        substeps: [{
+          title: 'Only iteration {{item}}',
+          command: 'rd echo item={{item}}',
+        }],
+      }],
+    });
+    await writeFile(join(workspace.cwd, 'for-single-iter.runbook.md'), content);
 
     const result = runCli('run --json for-single-iter.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -517,19 +473,15 @@ rd echo item={{item}}
   });
 
   it('{{item}} preserved as literal outside FOR loop', async () => {
-    await writeFile(
-      join(workspace.cwd, 'item-outside-for.runbook.md'),
-      `---
-name: Item Outside FOR
----
-# Item Outside
-
-## 1. Step with item reference {{item}}
-\`\`\`bash
-rd echo value={{item}}
-\`\`\`
-`
-    );
+    const content = createRunbook({
+      name: 'Item Outside FOR',
+      title: 'Item Outside',
+      steps: [{
+        title: 'Step with item reference {{item}}',
+        command: 'rd echo value={{item}}',
+      }],
+    });
+    await writeFile(join(workspace.cwd, 'item-outside-for.runbook.md'), content);
 
     const result = runCli('run --json item-outside-for.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
@@ -546,30 +498,36 @@ rd echo value={{item}}
     expect(stepEnteredEvents.length).toBeGreaterThanOrEqual(1);
     // {{item}} should be preserved as literal since there's no FOR loop
     expect(stepEnteredEvents[0].description).toContain('{{item}}');
+
+    // Command should also preserve {{item}} as literal
+    const commandEvents = events.filter(
+      (e: Record<string, unknown>) => e.type === 'command_started'
+    );
+    expect(commandEvents.length).toBeGreaterThanOrEqual(1);
+    expect(commandEvents[0].command).toContain('{{item}}');
   });
 
   it('FOR loop variable {{item}} does not leak into subsequent step', async () => {
-    await writeFile(
-      join(workspace.cwd, 'for-scope.runbook.md'),
-      `---
-name: FOR Variable Scope
----
-# FOR Variable Scope
-
-## 1. Loop step
-- FOR item IN 1 TO 2
-- PASS ALL: CONTINUE
-### 1.1 Process item {{item}}
-\`\`\`bash
-rd echo item={{item}}
-\`\`\`
-
-## 2. After loop uses {{item}}
-\`\`\`bash
-rd echo after={{item}}
-\`\`\`
-`
-    );
+    const content = createRunbook({
+      name: 'FOR Variable Scope',
+      title: 'FOR Variable Scope',
+      steps: [
+        {
+          title: 'Loop step',
+          for: { variable: 'item', start: 1, end: 2 },
+          pass: 'CONTINUE',
+          substeps: [{
+            title: 'Process item {{item}}',
+            command: 'rd echo item={{item}}',
+          }],
+        },
+        {
+          title: 'After loop uses {{item}}',
+          command: 'rd echo after={{item}}',
+        },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'for-scope.runbook.md'), content);
 
     const result = runCli('run --json for-scope.runbook.md', workspace);
     expect(result.exitCode).toBe(0);

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -2762,6 +2762,221 @@ describe('runbook compiler', () => {
       expect(snapshot.value).toBe('STOPPED');
       expect(snapshot.context.lastAction).toEqual({ type: 'STOP' });
     });
+
+    it('PASS ALL failure triggers fail-path GOTO to non-FOR step', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          forClause: { start: 1, end: 2 },
+          description: 'Loop that GOTOs on fail',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+            fail: { kind: 'fail', retry: 0, action: { type: 'GOTO', target: { step: '3' } } }
+          },
+          substeps: [{
+            id: '1',
+            description: 'Process',
+            transitions: {
+              all: true,
+              pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+              fail: { kind: 'fail', retry: 0, action: { type: 'CONTINUE' } }
+            }
+          }]
+        },
+        {
+          name: '2',
+          description: 'Skipped',
+          transitions: { ...DEFAULT_TRANSITIONS, pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } } }
+        },
+        {
+          name: '3',
+          description: 'Error handler',
+          transitions: { ...DEFAULT_TRANSITIONS, pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } } }
+        }
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // iter 1 passes
+      actor.send({ type: 'FAIL' }); // iter 2 fails
+
+      // PASS ALL with one failure → aggregation fails → GOTO 3
+      const snapshot = actor.getSnapshot();
+      expect(snapshot.value).toBe('step::3');
+      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3' });
+      expect(snapshot.context.iterationResults).toEqual(['pass', 'fail']);
+      expect(snapshot.context.forStack).toEqual([]);
+    });
+
+    it('PASS ALL failure triggers fail-path GOTO AT to target FOR step', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          forClause: { start: 1, end: 2 },
+          description: 'Loop that GOTOs AT on fail',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+            fail: { kind: 'fail', retry: 0, action: { type: 'GOTO', target: { step: '3', at: 2 } } }
+          },
+          substeps: [{
+            id: '1',
+            description: 'Process',
+            transitions: {
+              all: true,
+              pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+              fail: { kind: 'fail', retry: 0, action: { type: 'CONTINUE' } }
+            }
+          }]
+        },
+        {
+          name: '2',
+          description: 'Skipped',
+          transitions: { ...DEFAULT_TRANSITIONS, pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } } }
+        },
+        {
+          name: '3',
+          forClause: { start: 1, end: 4 },
+          description: 'Recovery loop',
+          substeps: [{
+            id: '1',
+            description: 'Recover',
+            transitions: {
+              all: true,
+              pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+              fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } }
+            }
+          }]
+        }
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // iter 1 passes
+      actor.send({ type: 'FAIL' }); // iter 2 fails
+
+      // PASS ALL with one failure → aggregation fails → GOTO 3 AT 2
+      const snapshot = actor.getSnapshot();
+      expect(snapshot.value).toBe('step::3::1');
+      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3', at: 2 });
+      expect(snapshot.context.forStack).toEqual([{ stepId: '3', iteration: 2, start: 1, end: 4 }]);
+      expect(snapshot.context.iterationResults).toEqual([]);
+    });
+
+    it('PASS ANY success triggers pass-path GOTO to non-FOR step', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          forClause: { start: 1, end: 3 },
+          description: 'Loop with PASS ANY and GOTO',
+          transitions: {
+            all: false,
+            pass: { kind: 'pass', retry: 0, action: { type: 'GOTO', target: { step: '3' } } },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } }
+          },
+          substeps: [{
+            id: '1',
+            description: 'Process',
+            transitions: {
+              all: true,
+              pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+              fail: { kind: 'fail', retry: 0, action: { type: 'CONTINUE' } }
+            }
+          }]
+        },
+        {
+          name: '2',
+          description: 'Skipped',
+          transitions: { ...DEFAULT_TRANSITIONS, pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } } }
+        },
+        {
+          name: '3',
+          description: 'Success handler',
+          transitions: { ...DEFAULT_TRANSITIONS, pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } } }
+        }
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'FAIL' }); // iter 1 fails
+      actor.send({ type: 'PASS' }); // iter 2 passes
+      actor.send({ type: 'FAIL' }); // iter 3 fails
+
+      // PASS ANY with one pass → aggregation passes → GOTO 3
+      const snapshot = actor.getSnapshot();
+      expect(snapshot.value).toBe('step::3');
+      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3' });
+      expect(snapshot.context.iterationResults).toEqual(['fail', 'pass', 'fail']);
+      expect(snapshot.context.forStack).toEqual([]);
+    });
+
+    it('BREAK triggers aggregation and exits via pass-path GOTO', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          forClause: { start: 1, end: 5 },
+          description: 'Loop with BREAK and GOTO',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass', retry: 0, action: { type: 'GOTO', target: { step: '3' } } },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } }
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+                fail: { kind: 'fail', retry: 0, action: { type: 'CONTINUE' } }
+              }
+            },
+            {
+              id: '2',
+              description: 'Maybe break',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass', retry: 0, action: { type: 'BREAK' } },
+                fail: { kind: 'fail', retry: 0, action: { type: 'CONTINUE' } }
+              }
+            }
+          ]
+        },
+        {
+          name: '2',
+          description: 'Skipped',
+          transitions: { ...DEFAULT_TRANSITIONS, pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } } }
+        },
+        {
+          name: '3',
+          description: 'Post-break target',
+          transitions: { ...DEFAULT_TRANSITIONS, pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } } }
+        }
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Iteration 1: substep 1 PASS→CONTINUE, substep 2 PASS→BREAK
+      actor.send({ type: 'PASS' }); // sub 1
+      actor.send({ type: 'PASS' }); // sub 2 → BREAK
+
+      // BREAK with iterationResult='pass', results=['pass']
+      // PASS ALL: no failures → aggregation passes → GOTO 3
+      const snapshot = actor.getSnapshot();
+      expect(snapshot.value).toBe('step::3');
+      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3' });
+      expect(snapshot.context.iterationResults).toEqual(['pass']);
+      expect(snapshot.context.forStack).toEqual([]);
+    });
   });
 
   describe('descending FOR loop ranges', () => {

--- a/site/scripts/build-snapshot.ts
+++ b/site/scripts/build-snapshot.ts
@@ -48,7 +48,7 @@ function resolveAllBinSymlinks(nodeModulesDir: string) {
             copyFileSync(resolvedTarget, filePath);
           }
         }
-      } else if (entry.name === 'node_modules' && entry.isDirectory()) {
+      } else if (entry.isDirectory() && entry.name !== '.bin') {
         walkAndResolve(fullPath);
       }
     }

--- a/site/scripts/build-snapshot.ts
+++ b/site/scripts/build-snapshot.ts
@@ -26,6 +26,36 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, '..', '..');
 
+/**
+ * Recursively walk a node_modules tree resolving symlinks in all `.bin` directories.
+ * The WebContainer snapshot tool cannot serialize symlinks, so each symlink is
+ * replaced with a copy of its target file.
+ */
+function resolveAllBinSymlinks(nodeModulesDir: string) {
+  function walkAndResolve(dir: string) {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.name === '.bin' && entry.isDirectory()) {
+        const binFiles = readdirSync(fullPath);
+        for (const file of binFiles) {
+          const filePath = join(fullPath, file);
+          const stat = lstatSync(filePath);
+          if (stat.isSymbolicLink()) {
+            const target = readlinkSync(filePath);
+            const resolvedTarget = resolve(fullPath, target);
+            unlinkSync(filePath);
+            copyFileSync(resolvedTarget, filePath);
+          }
+        }
+      } else if (entry.name === 'node_modules' && entry.isDirectory()) {
+        walkAndResolve(fullPath);
+      }
+    }
+  }
+  walkAndResolve(nodeModulesDir);
+}
+
 async function buildSnapshot() {
   console.log('Creating WebContainer snapshot with @rundown-org/cli...');
 
@@ -112,21 +142,11 @@ async function buildSnapshot() {
       execSync('npm install', { cwd: tempDir, stdio: 'inherit' });
     }
 
-    // 4. Resolve symlinks in .bin directory (snapshot tool can't handle symlinks)
-    const binDir = join(tempDir, 'node_modules', '.bin');
-    if (existsSync(binDir)) {
-      console.log('Resolving symlinks in node_modules/.bin...');
-      const files = readdirSync(binDir);
-      for (const file of files) {
-        const filePath = join(binDir, file);
-        const stat = lstatSync(filePath);
-        if (stat.isSymbolicLink()) {
-          const target = readlinkSync(filePath);
-          const resolvedTarget = resolve(binDir, target);
-          unlinkSync(filePath);
-          copyFileSync(resolvedTarget, filePath);
-        }
-      }
+    // 4. Resolve symlinks in all .bin directories (snapshot tool can't handle symlinks)
+    const nodeModulesDir = join(tempDir, 'node_modules');
+    if (existsSync(nodeModulesDir)) {
+      console.log('Resolving symlinks in node_modules/.bin directories...');
+      resolveAllBinSymlinks(nodeModulesDir);
     }
 
     // 5. Create binary snapshot (includes node_modules!)

--- a/site/scripts/build-snapshot.ts
+++ b/site/scripts/build-snapshot.ts
@@ -44,6 +44,10 @@ function resolveAllBinSymlinks(nodeModulesDir: string) {
           if (stat.isSymbolicLink()) {
             const target = readlinkSync(filePath);
             const resolvedTarget = resolve(fullPath, target);
+            if (!existsSync(resolvedTarget)) {
+              console.warn(`Skipping broken symlink: ${filePath} → ${resolvedTarget}`);
+              continue;
+            }
             unlinkSync(filePath);
             copyFileSync(resolvedTarget, filePath);
           }


### PR DESCRIPTION
Cover gaps in FOR loop test coverage:
- PASS ALL fail-path GOTO and GOTO AT to target FOR step
- PASS ANY pass-path GOTO to non-FOR step
- BREAK triggering aggregation with pass-path GOTO exit
- {{item}} preserved as literal outside FOR loop
- FOR loop variable {{item}} does not leak into subsequent step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched tests to a programmatic runbook builder, expanded test coverage for FOR loops, substeps, loop-variable handling, literal token preservation, scope leakage, and extensive post-loop aggregation and GOTO/AT control-flow scenarios. Public test helper surface expanded to expose the runbook builder and configuration options for substeps and FOR clauses.

* **Chores**
  * Improved snapshot build to normalize binary links across all package bin directories for more consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->