### PR TITLE
docs: sync documentation with implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `WorkPath` | `.work` | Default artifact directory |
 | `Step` | `3.1` | Current qualified step identifier |
 
-Built-in variables use PascalCase and can be overridden by any other source.
+Built-in variables use PascalCase. The date/time variables (`Date`, `DateTime`, `Year`, `Month`, `Day`) and `WorkPath` are static run-time variables set once per execution and can be overridden via `--var`. The `Step` variable (and `Index` during FOR loops) are dynamic per-step variables that reflect the current execution position and cannot be overridden via `--var`.
 
 **CLI Example:**
 ```bash
@@ -181,10 +181,12 @@ See [docs/SECURITY.md](docs/SECURITY.md) for full security policy documentation.
 ## Development Commands
 
 ```bash
-npm run build      # Build all packages
-npm run test       # Run all tests (Jest)
-npm run lint       # Lint all packages
-npm run lint:fix   # Auto-fix lint issues
+npm run build         # Build all packages
+npm run test          # Run all tests (Jest)
+npm run lint          # Lint all packages
+npm run lint:fix      # Auto-fix lint issues
+npm run format        # Format all packages
+npm run format:check  # Check formatting
 ```
 
 ## TSDoc Standards
@@ -268,6 +270,12 @@ Currently supported internally: `echo`, `prompt`. Unsupported commands fall back
 ## Documentation
 
 - [docs/SPEC.md](docs/SPEC.md) - Rundown specification
+- [docs/FORMAT.md](docs/FORMAT.md) - Formal BNF-style grammar
 - [docs/MCP.md](docs/MCP.md) - MCP server reference
+- [docs/SECURITY.md](docs/SECURITY.md) - Security policy configuration
+- [docs/RUNDOWN.md](docs/RUNDOWN.md) - Rundown internal architecture
+- [docs/CLI-OUTPUT-SPEC.md](docs/CLI-OUTPUT-SPEC.md) - CLI output format specification
+- [docs/PATTERNS.md](docs/PATTERNS.md) - Runbook authoring patterns
+- [docs/SCRIPTING.md](docs/SCRIPTING.md) - Scripting and automation guide
 - [docs/AGENT-ORCHESTRATION.md](docs/AGENT-ORCHESTRATION.md) - Agent orchestration models and patterns
 - [docs/PROJECT-INTEGRATION.md](docs/PROJECT-INTEGRATION.md) - Project integration guide

--- a/README.md
+++ b/README.md
@@ -140,11 +140,17 @@ The `rd` command is an alias for `rundown`.
 | [@rundown-org/parser](packages/parser) | Markdown runbook parser |
 | [@rundown-org/core](packages/core) | Runbook state management and XState compilation |
 | [@rundown-org/cli](packages/cli) | Command-line interface |
+| [@rundown-org/mcp](packages/mcp) | MCP server for AI agent integration |
 | [@rundown-org/claude-code-plugin](packages/claude-code-plugin) | Claude Code plugin for runbook orchestration |
 
 ## Documentation
 
 - [SPEC.md](docs/SPEC.md) - Rundown format specification
+- [MCP.md](docs/MCP.md) - MCP server reference
+- [SECURITY.md](docs/SECURITY.md) - Security policy configuration
+- [RUNDOWN.md](docs/RUNDOWN.md) - Rundown internal architecture
+- [AGENT-ORCHESTRATION.md](docs/AGENT-ORCHESTRATION.md) - Agent orchestration models and patterns
+- [PROJECT-INTEGRATION.md](docs/PROJECT-INTEGRATION.md) - Project integration guide
 
 ## Contributing
 

--- a/docs/AGENT-ORCHESTRATION.md
+++ b/docs/AGENT-ORCHESTRATION.md
@@ -128,14 +128,14 @@ A runbook defines substeps, each delegated to a typed subagent. The parent agent
 **Example:**
 ```markdown
 ## 2. Review changes
+- PASS ALL: CONTINUE
+- FAIL ANY: GOTO 4
+
 ### 2.1 Code review (code-review-agent)
 Review the implementation for correctness and style.
 
 ### 2.2 Test review (test-agent)
 Verify test coverage and assertions.
-
-- PASS ALL: CONTINUE
-- FAIL ANY: GOTO 4
 ```
 
 **Command sequence:**
@@ -164,7 +164,7 @@ Multiple independent agents are dispatched in parallel, their results collected 
 
 | Phase | Description |
 |-------|-------------|
-| **Dispatch** | Launch N agents with `Step(subagent_type="...")` |
+| **Dispatch** | Launch N agents with `Step(subagent_type="...")` (`Task` is accepted as an alias for `Step` for backward compatibility) |
 | **Execute** | Each agent works independently, writes findings to `.work/` |
 | **Collate** | Main agent reads all findings, categorises as Common (N/N agreement) vs Exclusive |
 | **Cross-check** | Optional: dispatch agent to validate exclusive findings |
@@ -289,11 +289,11 @@ When substeps involve agents, transition rules use aggregate conditions:
 
 ```markdown
 ## 2. Review
-### 2.1 First reviewer (code-review-agent)
-### 2.2 Second reviewer (code-agent)
-
 - PASS ALL: CONTINUE
 - FAIL ANY: GOTO 4
+
+### 2.1 First reviewer (code-review-agent)
+### 2.2 Second reviewer (code-agent)
 ```
 
 | Condition | Meaning |

--- a/docs/CLI-OUTPUT-SPEC.md
+++ b/docs/CLI-OUTPUT-SPEC.md
@@ -6,7 +6,7 @@
 
 | Type | Format | Detection |
 |------|--------|-----------|
-| **Error** | `{ "error": "msg", "code": "CODE" }` | `error` field exists |
+| **Error** | `{ "result": false, "error": "msg", "code": "CODE" }` | `error` field exists |
 | **Workflow** | `{ "result": bool, "action": "...", ... }` | `result` field exists |
 | **List** | `[...]` | `Array.isArray()` |
 
@@ -14,7 +14,7 @@
 
 - **Lists**: Raw arrays `[...]` (no wrapper object)
 - **Workflow commands**: Include `result` boolean (pass, fail, stop, complete, stash, pop)
-- **Errors**: `{ "error": "message", "code": "CODE" }` - no `result` field (redundant)
+- **Errors**: `{ "result": false, "error": "message", "code": "CODE" }` - include `result: false`
 - **Position**: `{ "current": string, "total": number|string }`
 - **Action field**: Shows transition (e.g., "CONTINUE", "GOTO 3", "RETRY"), not command name
 
@@ -67,9 +67,9 @@ def67890  stashed  2/5   onboarding.runbook.md      New Hire Setup
 
 **Text:**
 ```text
-NAME              DESCRIPTION                    TAGS
-deploy            Deploy to production           deploy, ci
-onboarding        New hire setup                 hr, setup
+NAME              SOURCE   DESCRIPTION                    TAGS
+deploy            project  Deploy to production           deploy, ci
+onboarding        plugin   New hire setup                 hr, setup
 ```
 
 **JSON:**
@@ -77,7 +77,7 @@ onboarding        New hire setup                 hr, setup
 [
   {
     "name": "deploy",
-    "source": "runbooks",
+    "source": "project",
     "description": "Deploy to production",
     "tags": ["deploy", "ci"],
     "path": ".claude/rundown/runbooks/deploy.runbook.md"
@@ -419,6 +419,7 @@ No stashed runbook to restore.
 **JSON:**
 ```json
 {
+  "result": false,
   "error": "No stashed runbook to restore",
   "code": "NO_STASHED_RUNBOOK"
 }
@@ -589,6 +590,7 @@ Available: success, failure
 **JSON:**
 ```json
 {
+  "result": false,
   "error": "Scenario \"unknown\" not found",
   "code": "SCENARIO_NOT_FOUND",
   "details": {
@@ -686,7 +688,7 @@ Hello world
 
 ## Error Output (all commands)
 
-Error responses use `error` and `code` fields. No `result` field (the presence of `error` indicates failure).
+Error responses include `result: false` along with `error` and `code` fields.
 
 ### No active runbook
 
@@ -698,6 +700,7 @@ No active runbook.
 **JSON:**
 ```json
 {
+  "result": false,
   "error": "No active runbook",
   "code": "NO_ACTIVE_RUNBOOK"
 }
@@ -713,6 +716,7 @@ Error: Runbook file not found: missing.runbook.md
 **JSON:**
 ```json
 {
+  "result": false,
   "error": "Runbook file not found: missing.runbook.md",
   "code": "RUNBOOK_NOT_FOUND"
 }

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -122,6 +122,7 @@ where frontmatter is:
     [ "version:" text ]
     [ "author:" text ]
     [ "tags:" tag_list ]
+    [ "vars:" vars_map ]
     [ scenarios ]
   "---"
 
@@ -135,6 +136,10 @@ where tag_list is:
 where tag is:
   text
   (any string - convention is lowercase alphanumeric with hyphens)
+
+where vars_map is:
+  variable_name ":" value { variable_name ":" value }
+  (YAML mapping of variable names to string, number, or boolean values)
 
 where scenarios is:
   "scenarios:"

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -152,7 +152,7 @@ The server delegates all operations to the CLI with `--json` flag for machine-re
 | `pass` | Mark step passed | - | `agent` |
 | `fail` | Mark step failed | - | `agent` |
 | `goto` | Jump to step | `step` | - |
-| `complete` | Force early completion | - | `message`, `agentId` |
+| `complete` | Force early completion | - | `message` |
 | `stop` | Stop runbook | - | `message` |
 
 > **Note:** The CLI `stash` and `pop` commands are not exposed via MCP. These commands manage local session state which is typically not needed in MCP agent workflows.
@@ -427,7 +427,6 @@ Force early completion of a runbook (runbooks auto-complete on final step).
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `message` | string | No | Completion message |
-| `agentId` | string | No | Agent ID for completing runbook in agent-specific stack |
 
 **Example:**
 ```json
@@ -447,7 +446,7 @@ Force early completion of a runbook (runbooks auto-complete on final step).
 }
 ```
 
-**CLI Equivalent:** `rundown complete [<message>] [--agent <agentId>] --json`
+**CLI Equivalent:** `rundown complete [<message>] --json`
 
 ---
 

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -815,11 +815,11 @@ Main agent runs runbook, dispatches subagents for substeps.
 **Runbook structure:**
 ```markdown
 ## 2. Execute batch
-### 2.1 Process item
-  - task.runbook.md
-
 - PASS ALL: CONTINUE
 - FAIL ANY: GOTO 4
+
+### 2.1 Process item
+  - task.runbook.md
 ```
 
 **Command sequence:**
@@ -907,9 +907,9 @@ List commands (`rd ls`, `rd scenario ls`) use aligned tables following Linux CLI
 
 Example (`rd ls --all`):
 ```
-NAME           DESCRIPTION                    TAGS
-retry-success  Tests RETRY before exhaustion  retry, auto-exec
-simple         Basic two-step runbook
+NAME           SOURCE   DESCRIPTION                    TAGS
+retry-success  bundled  Tests RETRY before exhaustion  retry, auto-exec
+simple         project  Basic two-step runbook
 ```
 
 Example (`rd scenario ls`):


### PR DESCRIPTION
Fix 6 blocking inaccuracies found by dual-verification audit:
- Remove phantom agentId parameter from MCP complete tool docs
- Fix transition ordering in RUNDOWN.md and AGENT-ORCHESTRATION.md examples
- Add result: false to error response format in CLI-OUTPUT-SPEC.md
- Add missing SOURCE column to rd ls --all examples
- Fix invalid source enum value in CLI-OUTPUT-SPEC.md JSON example
- Add @rundown-org/mcp to README.md packages table

Additional improvements:
- Expand documentation links in CLAUDE.md and README.md
- Distinguish static vs dynamic built-in variables in CLAUDE.md
- Add format/format:check to development commands
- Add vars: field to FORMAT.md frontmatter grammar
- Note Task alias for Step in AGENT-ORCHESTRATION.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Error responses now include explicit success/failure indicators for clarity
  * Expanded documentation with new guides on MCP, Security, Agent Orchestration, and Project Integration
  * Added new frontmatter field for variable declarations
  * Updated CLI output tables to display resource source information
  * Refined CLI tool parameter requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->