### PR TITLE
docs: plan review runbooks design

### DIFF
--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -5,6 +5,12 @@ import { compileRunbookToMachine, MAX_FILE_ITERATIONS } from '../../src/runbook/
 import type { Step } from '../../src/runbook/types.js';
 
 describe('runbook compiler', () => {
+  const DEFAULT_TRANSITIONS = {
+    all: true,
+    pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+    fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+  };
+
   describe('static step compilation', () => {
     it('generates discrete states for substeps', () => {
       const steps: Step[] = [
@@ -1946,12 +1952,6 @@ describe('runbook compiler', () => {
       expect(ctx.iterationResults).toEqual([]);
     });
   });
-
-  const DEFAULT_TRANSITIONS = {
-    all: true,
-    pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
-    fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
-  };
 
   describe('implicit 1..1 loop model', () => {
     it('non-FOR step with substeps creates implicit ForContext on entry', () => {
@@ -4771,6 +4771,132 @@ echo "processing"
 
       actor.send({ type: 'FAIL' }); // 1.2 -> parent -> retries exhausted
       expect(actor.getSnapshot().value).toBe('STOPPED');
+    });
+
+    it('cross-step substep GOTO resets parentRetryCount before target parent retries', () => {
+      const substepContinueTransitions = {
+        all: true,
+        pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+        fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+      };
+
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Source with parent retry',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 1, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Jump to target',
+              transitions: {
+                all: true,
+                pass: {
+                  kind: 'pass' as const,
+                  retry: 0,
+                  action: { type: 'GOTO' as const, target: { step: '2', substep: '2' } },
+                },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Fail to trigger parent retry',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Target with parent retry',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 1, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            { id: '1', description: 'Target 1', transitions: substepContinueTransitions },
+            { id: '2', description: 'Target 2', transitions: substepContinueTransitions },
+          ],
+        },
+        { name: '3', description: 'Done', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'FAIL' }); // 1.1 -> 1.2
+      actor.send({ type: 'FAIL' }); // 1.2 -> parent retry #1 -> 1.1
+      expect(actor.getSnapshot().context.parentRetryCount).toBe(1);
+
+      actor.send({ type: 'PASS' }); // 1.1 -> GOTO 2.2 (bypass parent)
+      expect(actor.getSnapshot().value).toBe('step::2::2');
+      expect(actor.getSnapshot().context.parentRetryCount).toBe(0);
+
+      actor.send({ type: 'FAIL' }); // 2.2 -> parent should retry, not exhaust
+      expect(actor.getSnapshot().value).toBe('step::2::1');
+    });
+
+    it('cross-step GOTO event resets parentRetryCount before target parent retries', () => {
+      const substepContinueTransitions = {
+        all: true,
+        pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+        fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+      };
+
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Source with parent retry',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 1, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            { id: '1', description: 'Source 1', transitions: substepContinueTransitions },
+            { id: '2', description: 'Source 2', transitions: substepContinueTransitions },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Target with parent retry',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 1, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            { id: '1', description: 'Target 1', transitions: substepContinueTransitions },
+            { id: '2', description: 'Target 2', transitions: substepContinueTransitions },
+          ],
+        },
+        { name: '3', description: 'Done', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'FAIL' }); // 1.1 -> 1.2
+      actor.send({ type: 'FAIL' }); // 1.2 -> parent retry #1 -> 1.1
+      expect(actor.getSnapshot().context.parentRetryCount).toBe(1);
+
+      actor.send({ type: 'GOTO', target: { step: '2', substep: '2' } });
+      expect(actor.getSnapshot().value).toBe('step::2::2');
+      expect(actor.getSnapshot().context.parentRetryCount).toBe(0);
+
+      actor.send({ type: 'FAIL' }); // 2.2 -> parent should retry, not exhaust
+      expect(actor.getSnapshot().value).toBe('step::2::1');
     });
 
     it('parent COMPLETE action forces early completion', () => {

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -4315,6 +4315,78 @@ echo "processing"
       expect(actor.getSnapshot().value).toBe('step::3');
     });
 
+    it('parent GOTO to non-first implicit substep does not reuse prior aggregation results', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Source with mixed outcomes',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: {
+              kind: 'fail' as const,
+              retry: 0,
+              action: { type: 'GOTO' as const, target: { step: '2', substep: '2' } },
+            },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Source check 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Source check 2',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Target implicit step',
+          transitions: {
+            all: true,
+            pass: {
+              kind: 'pass' as const,
+              retry: 0,
+              action: { type: 'GOTO' as const, target: { step: '3' } },
+            },
+            fail: {
+              kind: 'fail' as const,
+              retry: 0,
+              action: { type: 'GOTO' as const, target: { step: '4' } },
+            },
+          },
+          substeps: [
+            { id: '1', description: 'Target check 1', transitions: DEFAULT_TRANSITIONS },
+            { id: '2', description: 'Target check 2', transitions: DEFAULT_TRANSITIONS },
+          ],
+        },
+        { name: '3', description: 'Pass handler', transitions: DEFAULT_TRANSITIONS },
+        { name: '4', description: 'Fail handler', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // 1.1
+      actor.send({ type: 'FAIL' }); // 1.2 -> parent FAIL -> GOTO 2.2
+      expect(actor.getSnapshot().value).toBe('step::2::2');
+
+      actor.send({ type: 'PASS' }); // 2.2 -> parent PASS ALL -> should route to 3
+      expect(actor.getSnapshot().value).toBe('step::3');
+    });
+
     it('PASS ANY: CONTINUE advances when any passes', () => {
       const steps: Step[] = [
         {
@@ -4647,6 +4719,57 @@ echo "processing"
 
       // Second attempt: fail -> parent -> exhausted (retryCount >= 1) -> STOPPED
       actor.send({ type: 'FAIL' });
+      expect(actor.getSnapshot().value).toBe('STOPPED');
+    });
+
+    it('parent retry exhausts after configured attempts across multiple substeps', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Multi-substep retry',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 1, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Check 2',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'FAIL' }); // 1.1 -> 1.2
+      expect(actor.getSnapshot().value).toBe('step::1::2');
+
+      actor.send({ type: 'FAIL' }); // 1.2 -> parent -> retry #1
+      expect(actor.getSnapshot().value).toBe('step::1::1');
+
+      actor.send({ type: 'FAIL' }); // 1.1 -> 1.2
+      expect(actor.getSnapshot().value).toBe('step::1::2');
+
+      actor.send({ type: 'FAIL' }); // 1.2 -> parent -> retries exhausted
       expect(actor.getSnapshot().value).toBe('STOPPED');
     });
 

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -22,7 +22,7 @@ describe('runbook compiler', () => {
       const stateIds = Object.keys(machine.config.states);
       expect(stateIds).toContain('step::1::1');
       expect(stateIds).toContain('step::1::2');
-      expect(stateIds).not.toContain('step::1');
+      expect(stateIds).toContain('step::1'); // parent aggregation state
     });
 
     it('generates single state for step without substeps', () => {
@@ -36,6 +36,114 @@ describe('runbook compiler', () => {
       // @ts-expect-error - accessing internal states property
       const stateIds = Object.keys(machine.config.states);
       expect(stateIds).toContain('step::1');
+    });
+
+    it('parent state passes through for non-FOR step without transitions', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Non-FOR step, no transitions',
+          substeps: [
+            { id: '1', description: 'Sub 1', transitions: DEFAULT_TRANSITIONS },
+            { id: '2', description: 'Sub 2', transitions: DEFAULT_TRANSITIONS },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Next step',
+          transitions: {
+            ...DEFAULT_TRANSITIONS,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'COMPLETE' as const } },
+          },
+        },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // 1.1
+      actor.send({ type: 'PASS' }); // 1.2 -> parent -> step::2
+
+      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().context.iterationResults).toBeUndefined();
+    });
+
+    it('last substep transitions to parent state', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Step with substeps',
+          forClause: { start: 1, end: 3 },
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            { id: '1', description: 'Sub 1', transitions: DEFAULT_TRANSITIONS },
+            { id: '2', description: 'Sub 2', transitions: DEFAULT_TRANSITIONS },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // 1.1 -> 1.2
+      actor.send({ type: 'PASS' }); // 1.2 -> parent -> loop-back -> 1.1
+
+      // Should be back at first substep (iteration 2)
+      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
+      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']);
+    });
+
+    it('non-FOR substeps with FAIL ANY: STOP stops on any failure', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Review step',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Check 2',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'FAIL' }); // 1.1 fails, CONTINUE to 1.2
+      actor.send({ type: 'PASS' }); // 1.2 passes -> parent -> FAIL ANY -> STOPPED
+
+      expect(actor.getSnapshot().value).toBe('STOPPED');
+      expect(actor.getSnapshot().context.iterationResults).toEqual(['fail', 'pass']);
     });
   });
 
@@ -4109,6 +4217,472 @@ echo "processing"
       }
 
       actor.stop();
+    });
+  });
+
+  describe('non-FOR substep aggregation', () => {
+    it('PASS ALL: CONTINUE advances when all pass', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Review step',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Check 2',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // 1.1 passes
+      actor.send({ type: 'PASS' }); // 1.2 passes -> parent -> PASS ALL -> step::2
+
+      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
+    });
+
+    it('FAIL ANY: GOTO routes to target step on failure', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Review step',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: {
+              kind: 'fail' as const,
+              retry: 0,
+              action: { type: 'GOTO' as const, target: { step: '3' } },
+            },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Check 2',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Skipped', transitions: DEFAULT_TRANSITIONS },
+        { name: '3', description: 'Error handler', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // 1.1 passes
+      actor.send({ type: 'FAIL' }); // 1.2 fails -> parent -> FAIL ANY -> GOTO 3
+
+      expect(actor.getSnapshot().value).toBe('step::3');
+    });
+
+    it('PASS ANY: CONTINUE advances when any passes', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Review step',
+          transitions: {
+            all: false,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Check 2',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'FAIL' }); // 1.1 fails
+      actor.send({ type: 'PASS' }); // 1.2 passes -> parent -> PASS ANY -> step::2
+
+      expect(actor.getSnapshot().value).toBe('step::2');
+    });
+
+    it('single substep aggregation works correctly', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Review step',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Only check',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      // Test FAIL path
+      const machine1 = compileRunbookToMachine(steps);
+      const actor1 = createActor(machine1);
+      actor1.start();
+      actor1.send({ type: 'FAIL' });
+      expect(actor1.getSnapshot().value).toBe('STOPPED');
+
+      // Test PASS path
+      const machine2 = compileRunbookToMachine(steps);
+      const actor2 = createActor(machine2);
+      actor2.start();
+      actor2.send({ type: 'PASS' });
+      expect(actor2.getSnapshot().value).toBe('step::2');
+    });
+
+    it('three substeps with mixed results and PASS ALL stops on failure', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Review step',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Check 2',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '3',
+              description: 'Check 3',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // 1.1 passes
+      actor.send({ type: 'FAIL' }); // 1.2 fails
+      actor.send({ type: 'PASS' }); // 1.3 passes -> parent -> PASS ALL -> STOPPED
+
+      expect(actor.getSnapshot().value).toBe('STOPPED');
+      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'fail', 'pass']);
+    });
+
+    it('FOR loop iterates through parent state', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'FOR loop',
+          forClause: { start: 1, end: 3 },
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [{ id: '1', description: 'Sub 1', transitions: DEFAULT_TRANSITIONS }],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // iteration 1 -> parent -> loop-back
+      actor.send({ type: 'PASS' }); // iteration 2 -> parent -> loop-back
+      actor.send({ type: 'PASS' }); // iteration 3 -> parent -> PASS ALL -> step::2
+
+      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass', 'pass']);
+    });
+
+    it('BREAK exits FOR loop via parent state', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'FOR loop',
+          forClause: { start: 1, end: 3 },
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Sub 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'BREAK' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // iteration 1 pass -> parent -> loop-back
+      actor.send({ type: 'FAIL' }); // iteration 2 fail -> BREAK -> parent -> skip loop-back -> step::2
+
+      expect(actor.getSnapshot().value).toBe('step::2');
+    });
+
+    it('NEXT skips to next iteration via parent state', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'FOR loop',
+          forClause: { start: 1, end: 3 },
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Sub 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'NEXT' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Sub 2',
+              transitions: DEFAULT_TRANSITIONS,
+            },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Iteration 1: substep 1 passes -> NEXT -> parent -> loop-back (skips substep 2)
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('step::1::1'); // back at first substep, iteration 2
+
+      // Iteration 2: substep 1 passes -> NEXT -> parent -> loop-back
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('step::1::1'); // iteration 3
+
+      // Iteration 3: substep 1 passes -> NEXT -> parent -> aggregation -> step::2
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('step::2');
+    });
+
+    it('FAIL ALL: STOP stops when all substeps fail under PASS ANY mode', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Review step',
+          transitions: {
+            all: false,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Check 2',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'FAIL' }); // 1.1 fails
+      actor.send({ type: 'FAIL' }); // 1.2 fails -> parent -> FAIL ALL -> STOPPED
+
+      expect(actor.getSnapshot().value).toBe('STOPPED');
+      expect(actor.getSnapshot().context.iterationResults).toEqual(['fail', 'fail']);
+    });
+
+    it('parent transitions with retry re-runs substeps before terminal action', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Retry step',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 1, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // First attempt: fail -> parent -> retry (retryCount < 1) -> back to 1.1
+      actor.send({ type: 'FAIL' });
+      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().context.retryCount).toBe(1);
+
+      // Second attempt: fail -> parent -> exhausted (retryCount >= 1) -> STOPPED
+      actor.send({ type: 'FAIL' });
+      expect(actor.getSnapshot().value).toBe('STOPPED');
+    });
+
+    it('parent COMPLETE action forces early completion', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Complete step',
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'COMPLETE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check 1',
+              transitions: {
+                all: true,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+          ],
+        },
+        { name: '2', description: 'Should be skipped', transitions: DEFAULT_TRANSITIONS },
+      ];
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // 1.1 passes -> parent -> PASS ALL -> COMPLETE
+
+      expect(actor.getSnapshot().value).toBe('COMPLETE');
+      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'COMPLETE' });
     });
   });
 });

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -69,6 +69,19 @@ type AssignAction = (...args: never[]) => unknown;
 type TransitionConfig = TransitionEntry | TransitionEntry[];
 
 /**
+ * Internal state configuration entry used to track all XState states during compilation.
+ * Parent aggregation states (isParentState=true) are built via buildParentStateConfig.
+ */
+interface StateConfig {
+  id: string;
+  stepName: string;
+  substepId?: string;
+  transitions: Transitions;
+  isParentState?: boolean;
+  parentStep?: Step;
+}
+
+/**
  * DEFAULT Transitions according to RUNDOWN-SPEC 1.0.0
  * PASS ALL: CONTINUE
  * FAIL ANY: STOP
@@ -158,19 +171,6 @@ function isLastSubstepOfStep(
 
   const lastSubstepId = step.substeps[step.substeps.length - 1].id;
   return substepId === lastSubstepId;
-}
-
-/**
- * Get the first substep state ID for a step.
- *
- * @param step - The step to get the first substep from
- * @returns The state ID of the first substep, or null if step has no substeps
- */
-function getFirstSubstepOfStep(step: Step): string | null {
-  if (step.substeps && step.substeps.length > 0) {
-    return formatStateId(step.name, step.substeps[0].id);
-  }
-  return null;
 }
 
 /** Peek at the top of the FOR context stack. */
@@ -456,71 +456,41 @@ function findNextStateId(stepName: string, substepId: string | undefined, steps:
   return 'COMPLETE';
 }
 
-/** Build the exit-loop assign action for CONTINUE/NEXT/BREAK at the last substep. */
-function buildLoopExitAssign(
-  actionType: 'CONTINUE' | 'NEXT' | 'BREAK',
-  exitTarget: string,
-  iterationResult: 'pass' | 'fail',
-  isImplicit?: boolean,
-): AssignAction {
-  return assign({
-    forStack: [] as readonly ForContext[],
-    iterationResults: isImplicit
-      ? (undefined as ('pass' | 'fail')[] | undefined)
-      : ({ context }: { context: RunbookContext }) => {
-          const results = context.iterationResults ?? [];
-          return [...results, iterationResult];
-        },
-    lastAction: { type: actionType },
-    lastMessage: undefined as string | undefined,
-    retryCount: 0,
-    substep: extractSubstepFromStateId(exitTarget),
-  });
-}
-
 /**
- * Build assign action for aggregation exit paths that applies parent transition action semantics.
+ * Build assign action for parent state exit paths.
  *
- * Unlike `buildLoopExitAssign` which records the substep exit mechanism (CONTINUE/NEXT/BREAK),
- * this function records the parent step's transition action (GOTO/STOP/COMPLETE/CONTINUE) as
- * the lastAction, and initializes forStack when the target is a FOR step.
+ * Designed for use in `always` transitions
+ * of parent aggregation states. Does not record iteration results (that happens at
+ * the substep level). Records the parent step's transition action as lastAction and
+ * initializes forStack when the target is a FOR step.
  *
  * @param parentAction - The parent step's transition action
  * @param exitTarget - The resolved XState target state ID
- * @param iterationResult - Result of the current (final) iteration
  * @param steps - The full steps array (for GOTO target lookup)
+ * @param sources - Optional data sources for GOTO to FOR step initialization
  * @returns XState assign action
  */
-function buildAggregationExitAssign(
+function buildParentExitAssign(
   parentAction: Action,
   exitTarget: string,
-  iterationResult: 'pass' | 'fail',
   steps: Step[],
   sources?: Readonly<Record<string, DataSource>>,
 ): AssignAction {
   const baseAssign = {
     retryCount: 0,
     substep: extractSubstepFromStateId(exitTarget),
-    iterationResults: ({ context }: { context: RunbookContext }) => {
-      const results = context.iterationResults ?? [];
-      return [...results, iterationResult];
-    },
   };
 
   switch (parentAction.type) {
     case 'GOTO': {
       const targetStep = steps.find((s) => s.name === parentAction.target.step);
-      const targetForClause = targetStep?.forClause;
-
-      if (targetStep?.substeps?.length && targetForClause) {
-        // GOTO to a FOR step: initialize FOR context for the target.
-        // targetForClause is truthy here so the step has an explicit FOR clause (not implicit).
+      if (targetStep?.substeps?.length && targetStep.forClause) {
         return assign({
           ...baseAssign,
           forStack: [
             createForContext(
               targetStep.name,
-              targetForClause,
+              targetStep.forClause,
               parentAction.target.at !== undefined ? Number(parentAction.target.at) : undefined,
               false,
               sources,
@@ -531,7 +501,6 @@ function buildAggregationExitAssign(
           substep: parentAction.target.substep ?? targetStep.substeps[0]?.id,
         });
       }
-
       return assign({
         ...baseAssign,
         forStack: [] as readonly ForContext[],
@@ -559,9 +528,7 @@ function buildAggregationExitAssign(
         lastAction: { type: 'CONTINUE' as const },
         lastMessage: undefined as string | undefined,
       });
-    case 'NEXT':
-    case 'BREAK':
-      // Defensive: shouldn't appear as parent aggregation actions
+    default:
       return assign({
         ...baseAssign,
         forStack: [] as readonly ForContext[],
@@ -569,6 +536,153 @@ function buildAggregationExitAssign(
         lastMessage: undefined as string | undefined,
       });
   }
+}
+
+/**
+ * Build the `always` (eventless) transition configuration for a parent aggregation state.
+ *
+ * Parent states are intermediate states that a step's last substep transitions to after
+ * completing. The parent state then immediately (via `always`) routes to the correct
+ * next state based on accumulated iteration results and configured transitions.
+ *
+ * Handles four cases:
+ * - Case A: FOR step with transitions — loop-back guard + aggregation pass/fail guards
+ * - Case B: Non-FOR step with transitions — aggregation pass/fail guards only
+ * - Case C: FOR step without transitions — loop-back guard + unconditional exit
+ * - Case D: Non-FOR step without transitions — unconditional pass-through
+ *
+ * @param config - The parent state config (must have isParentState=true)
+ * @param steps - The full steps array
+ * @param sources - Optional data sources for GOTO to FOR step initialization
+ * @returns XState state config with `always` transitions
+ */
+function buildParentStateConfig(
+  config: StateConfig,
+  steps: Step[],
+  sources?: Readonly<Record<string, DataSource>>,
+): { always: unknown; entry?: unknown } {
+  if (!config.parentStep) {
+    throw new Error('parentStep required for parent state config');
+  }
+  const parentStep = config.parentStep;
+  const stepName = config.stepName;
+  const hasFor = !!parentStep.forClause;
+  const hasTransitions = !!parentStep.transitions;
+  const nextTarget = findNextStateId(stepName, undefined, steps);
+  const firstSubstep = parentStep.substeps?.[0];
+  const firstSubstepStateId = firstSubstep ? formatStateId(stepName, firstSubstep.id) : nextTarget;
+
+  interface AlwaysTransition {
+    guard?: (args: { context: RunbookContext }) => boolean;
+    target: string;
+    actions: unknown;
+  }
+  const always: AlwaysTransition[] = [];
+
+  // Loop-back guard (Cases A & C: FOR steps)
+  if (hasFor) {
+    always.push({
+      guard: ({ context }: { context: RunbookContext }) => {
+        if (context.lastAction?.type === 'BREAK') return false;
+        const top = peekForStack(context.forStack);
+        return top !== undefined && hasMoreIterations(top);
+      },
+      target: firstSubstepStateId,
+      actions: assign({
+        forStack: ({ context }: { context: RunbookContext }) => {
+          const top = peekForStack(context.forStack);
+          if (!top) return context.forStack;
+          return [{ ...top, iteration: nextIteration(top), currentValue: undefined }];
+        },
+        retryCount: 0,
+        substep: firstSubstep?.id,
+      }),
+    });
+  }
+
+  type GuardFn = (args: { context: RunbookContext }) => boolean;
+
+  // Build retry-aware transition entries for one aggregated outcome branch.
+  const buildOutcomeEntries = (
+    branchGuard: GuardFn,
+    transition: { retry: number; action: Action },
+    target: string,
+  ): AlwaysTransition[] => {
+    const exhausted = {
+      guard: ({ context }: { context: RunbookContext }) =>
+        branchGuard({ context }) &&
+        (transition.retry <= 0 || context.retryCount >= transition.retry),
+      target,
+      actions: [
+        buildParentExitAssign(transition.action, target, steps, sources),
+        assign({
+          retryCount: 0,
+          retryMax: transition.retry > 0 ? transition.retry : undefined,
+        }),
+      ],
+    };
+
+    if (transition.retry <= 0) return [exhausted];
+
+    return [
+      {
+        guard: ({ context }: { context: RunbookContext }) =>
+          branchGuard({ context }) && context.retryCount < transition.retry,
+        target: firstSubstepStateId,
+        actions: assign({
+          lastAction: { type: 'RETRY' as const },
+          retryCount: ({ context }: { context: RunbookContext }) => context.retryCount + 1,
+          retryMax: transition.retry,
+          forStack: [] as readonly ForContext[],
+          iterationResults: [] as ('pass' | 'fail')[],
+          lastMessage: undefined as string | undefined,
+          substep: firstSubstep?.id,
+        }),
+      },
+      exhausted,
+    ];
+  };
+
+  // Aggregation guards (Cases A & B: steps with explicit transitions)
+  if (hasTransitions) {
+    const parentTransitions = parentStep.transitions!;
+    const passTarget = resolveActionTarget(parentTransitions.pass.action, stepName, steps);
+    const failTarget = resolveActionTarget(parentTransitions.fail.action, stepName, steps);
+
+    const aggregationPasses = ({ context }: { context: RunbookContext }): boolean => {
+      const results = context.iterationResults ?? [];
+      const hasFailed = results.some((r) => r === 'fail');
+      const passCount = results.filter((r) => r === 'pass').length;
+      return shouldAggregationPass(hasFailed, passCount, parentTransitions.all);
+    };
+
+    const passBranchGuard: GuardFn = aggregationPasses;
+    const failBranchGuard: GuardFn = ({ context }) => !aggregationPasses({ context });
+
+    always.push(
+      ...buildOutcomeEntries(passBranchGuard, parentTransitions.pass, passTarget),
+      ...buildOutcomeEntries(failBranchGuard, parentTransitions.fail, failTarget),
+    );
+  } else {
+    // Unconditional exit (Cases C & D: no explicit transitions)
+    const exitAssign: Record<string, unknown> = {
+      forStack: [] as readonly ForContext[],
+      retryCount: 0,
+      substep: extractSubstepFromStateId(nextTarget),
+    };
+
+    if (!hasFor) {
+      // Case D: non-FOR pass-through — clear iterationResults, set CONTINUE
+      exitAssign.iterationResults = undefined as ('pass' | 'fail')[] | undefined;
+      exitAssign.lastAction = { type: 'CONTINUE' as const };
+      exitAssign.lastMessage = undefined as string | undefined;
+    }
+    // Case C: FOR without transitions — preserve lastAction from substep
+
+    always.push({ target: nextTarget, actions: assign(exitAssign) });
+  }
+
+  return { always };
 }
 
 /**
@@ -603,113 +717,6 @@ function resolveActionTarget(action: Action, stepName: string, steps: Step[]): s
 }
 
 /**
- * Build exit transitions for a FOR loop with optional aggregation.
- *
- * When the parent step has aggregation transitions (PASS ALL/FAIL ANY or PASS ANY/FAIL ALL),
- * returns guarded transitions that route based on accumulated iteration results.
- * Otherwise returns a single unconditional exit transition.
- *
- * @param parentStep - The parent step owning the FOR loop
- * @param exitTarget - Default exit target (next step after the loop)
- * @param iterationResult - Result of the current (final) iteration
- * @param actionType - The exit mechanism (CONTINUE, NEXT, or BREAK)
- * @param steps - The full steps array
- * @param isImplicit - Whether this is an implicit (synthetic 1..1) FOR loop
- * @returns Array of exit transition entries (1 for unconditional, 2 for aggregation)
- */
-function buildAggregationExitTransitions(
-  parentStep: Step,
-  exitTarget: string,
-  iterationResult: 'pass' | 'fail',
-  actionType: 'CONTINUE' | 'NEXT' | 'BREAK',
-  steps: Step[],
-  isImplicit?: boolean,
-  sources?: Readonly<Record<string, DataSource>>,
-): TransitionEntry[] {
-  // No aggregation for implicit FOR loops or steps without explicit FOR + transitions
-  if (isImplicit || !parentStep.forClause || !parentStep.transitions) {
-    return [
-      {
-        target: exitTarget,
-        actions: buildLoopExitAssign(actionType, exitTarget, iterationResult, isImplicit),
-      },
-    ];
-  }
-
-  const parentTransitions = parentStep.transitions;
-  const passTarget = resolveActionTarget(parentTransitions.pass.action, parentStep.name, steps);
-  const failTarget = resolveActionTarget(parentTransitions.fail.action, parentStep.name, steps);
-
-  // Helper: compute aggregation pass/fail from accumulated results + current iteration.
-  // Used by both guards (mutually exclusive and exhaustive).
-  const aggregationPasses = ({ context }: { context: RunbookContext }): boolean => {
-    const results = [...(context.iterationResults ?? []), iterationResult];
-    const hasFailed = results.some((r) => r === 'fail');
-    const passCount = results.filter((r) => r === 'pass').length;
-    return shouldAggregationPass(hasFailed, passCount, parentTransitions.all);
-  };
-
-  return [
-    {
-      guard: aggregationPasses,
-      target: passTarget,
-      actions: buildAggregationExitAssign(
-        parentTransitions.pass.action,
-        passTarget,
-        iterationResult,
-        steps,
-        sources,
-      ),
-    },
-    {
-      guard: ({ context }: { context: RunbookContext }) => !aggregationPasses({ context }),
-      target: failTarget,
-      actions: buildAggregationExitAssign(
-        parentTransitions.fail.action,
-        failTarget,
-        iterationResult,
-        steps,
-        sources,
-      ),
-    },
-  ];
-}
-
-/** Build the loop-back guarded transition shared by CONTINUE and NEXT. */
-function buildLoopBackTransition(
-  actionType: 'CONTINUE' | 'NEXT',
-  firstSubstepStateId: string | null,
-  iterationResult: 'pass' | 'fail',
-  firstSubstepId: string | undefined,
-): TransitionEntry {
-  return {
-    guard: ({ context }: { context: RunbookContext }) => {
-      const top = peekForStack(context.forStack);
-      return top !== undefined && hasMoreIterations(top);
-    },
-    target: firstSubstepStateId,
-    actions: assign({
-      forStack: ({ context }: { context: RunbookContext }) => {
-        const top = peekForStack(context.forStack);
-        if (!top) return context.forStack;
-        const nextIter = nextIteration(top);
-        // All source types: clear currentValue on loop-back.
-        // The ForIterationService resolves it before the next execution.
-        return [{ ...top, iteration: nextIter, currentValue: undefined }];
-      },
-      iterationResults: ({ context }: { context: RunbookContext }) => {
-        const results = context.iterationResults ?? [];
-        return [...results, iterationResult];
-      },
-      lastAction: { type: actionType },
-      lastMessage: undefined as string | undefined,
-      retryCount: 0,
-      substep: firstSubstepId,
-    }),
-  };
-}
-
-/**
  * Build XState transition config from a terminal Action.
  */
 function buildActionTransition(
@@ -724,39 +731,52 @@ function buildActionTransition(
     case 'CONTINUE': {
       const target = findNextStateId(stepName, substepId, steps);
 
-      // Check if we're at the last substep of a FOR loop
-      const isLastSubstep = isLastSubstepOfStep(stepName, substepId, steps);
       const currentStep = steps.find((s) => s.name === stepName);
 
-      // If at last substep of FOR loop, use guarded transitions for loop-back or exit
+      // Check if we're at the last substep of a step with substeps
+      const isLastSubstep = isLastSubstepOfStep(stepName, substepId, steps);
+
+      // If at last substep, route to parent aggregation state
       if (isLastSubstep && currentStep) {
-        const firstSubstepStateId = getFirstSubstepOfStep(currentStep);
         const iterationResult: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
         const isImplicit = !currentStep.forClause;
 
-        return [
-          buildLoopBackTransition(
-            'CONTINUE',
-            firstSubstepStateId,
-            iterationResult,
-            currentStep.substeps?.[0]?.id,
-          ),
-          ...buildAggregationExitTransitions(
-            currentStep,
-            target,
-            iterationResult,
-            'CONTINUE',
-            steps,
-            isImplicit,
-            sources,
-          ),
-        ];
+        return {
+          target: formatStateId(stepName),
+          actions: assign({
+            iterationResults:
+              isImplicit && !currentStep.transitions
+                ? (undefined as ('pass' | 'fail')[] | undefined)
+                : ({ context }: { context: RunbookContext }) => {
+                    const results = context.iterationResults ?? [];
+                    return [...results, iterationResult];
+                  },
+            lastAction: { type: 'CONTINUE' as const },
+            lastMessage: undefined as string | undefined,
+            substep: undefined as string | undefined,
+          }),
+        };
       }
 
-      // Normal CONTINUE (not in FOR loop)
+      // Non-last substep CONTINUE: advance to next sibling substep
+      const shouldAccumulate = !!(
+        currentStep?.substeps?.length &&
+        !currentStep.forClause &&
+        currentStep.transitions
+      );
+
       return {
         target,
         actions: assign({
+          ...(shouldAccumulate
+            ? {
+                iterationResults: ({ context }: { context: RunbookContext }) => {
+                  const results = context.iterationResults ?? [];
+                  const result: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
+                  return [...results, result];
+                },
+              }
+            : {}),
           lastAction: { type: 'CONTINUE' as const },
           lastMessage: undefined as string | undefined,
           retryCount: 0,
@@ -827,7 +847,9 @@ function buildActionTransition(
               if (top?.stepId === targetStepObj.name) {
                 return context.iterationResults;
               }
-              return isImplicit ? undefined : ([] as ('pass' | 'fail')[]);
+              return isImplicit && !targetStepObj.transitions
+                ? undefined
+                : ([] as ('pass' | 'fail')[]);
             },
             lastAction: buildGotoLastAction(action.target),
             retryCount: isGotoToSelf
@@ -862,54 +884,43 @@ function buildActionTransition(
     case 'NEXT': {
       const currentStep = steps.find((s) => s.name === stepName);
       if (!currentStep?.forClause) {
-        // NEXT outside FOR loop - should not happen (validator catches this)
         return { target: 'STOPPED', actions: assign({ lastAction: { type: 'NEXT' as const } }) };
       }
-
-      const firstSubstepStateId = getFirstSubstepOfStep(currentStep);
-      const lastSubstep = currentStep.substeps?.[currentStep.substeps.length - 1];
-      const exitTarget = findNextStateId(stepName, lastSubstep?.id, steps);
       const iterationResult: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
-
-      return [
-        buildLoopBackTransition(
-          'NEXT',
-          firstSubstepStateId,
-          iterationResult,
-          currentStep.substeps?.[0]?.id,
-        ),
-        ...buildAggregationExitTransitions(
-          currentStep,
-          exitTarget,
-          iterationResult,
-          'NEXT',
-          steps,
-          undefined,
-          sources,
-        ),
-      ];
+      return {
+        target: formatStateId(stepName),
+        actions: assign({
+          iterationResults: ({ context }: { context: RunbookContext }) => {
+            const results = context.iterationResults ?? [];
+            return [...results, iterationResult];
+          },
+          lastAction: { type: 'NEXT' as const },
+          lastMessage: undefined as string | undefined,
+          retryCount: 0,
+          substep: undefined as string | undefined,
+        }),
+      };
     }
 
     case 'BREAK': {
       const currentStep = steps.find((s) => s.name === stepName);
       if (!currentStep?.forClause) {
-        // BREAK outside FOR loop - should not happen (validator catches this)
         return { target: 'STOPPED', actions: assign({ lastAction: { type: 'BREAK' as const } }) };
       }
-
-      const lastSubstep = currentStep.substeps?.[currentStep.substeps.length - 1];
-      const exitTarget = findNextStateId(stepName, lastSubstep?.id, steps);
       const iterationResult: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
-
-      return buildAggregationExitTransitions(
-        currentStep,
-        exitTarget,
-        iterationResult,
-        'BREAK',
-        steps,
-        undefined,
-        sources,
-      );
+      return {
+        target: formatStateId(stepName),
+        actions: assign({
+          iterationResults: ({ context }: { context: RunbookContext }) => {
+            const results = context.iterationResults ?? [];
+            return [...results, iterationResult];
+          },
+          lastAction: { type: 'BREAK' as const },
+          lastMessage: undefined as string | undefined,
+          retryCount: 0,
+          substep: undefined as string | undefined,
+        }),
+      };
     }
   }
 }
@@ -932,15 +943,16 @@ export function compileRunbookToMachine(
   steps: Step[],
   options?: { sources?: Readonly<Record<string, DataSource>> },
 ) {
-  const states: Record<string, { on: Record<string, unknown>; entry?: unknown }> = {};
+  const states: Record<
+    string,
+    {
+      on?: Record<string, unknown>;
+      always?: unknown;
+      entry?: unknown;
+    }
+  > = {};
 
   // Build a flat list of all states to generate GOTO transitions
-  interface StateConfig {
-    id: string;
-    stepName: string;
-    substepId?: string;
-    transitions: Transitions;
-  }
   const allStates: StateConfig[] = [];
 
   steps.forEach((step) => {
@@ -954,6 +966,14 @@ export function compileRunbookToMachine(
           transitions: substep.transitions ?? DEFAULT_TRANSITIONS,
         });
       });
+      // Parent aggregation state
+      allStates.push({
+        id: formatStateId(stepName),
+        stepName,
+        transitions: step.transitions ?? DEFAULT_TRANSITIONS,
+        isParentState: true,
+        parentStep: step,
+      });
     } else {
       allStates.push({
         id: formatStateId(stepName),
@@ -965,6 +985,11 @@ export function compileRunbookToMachine(
 
   // Build the machine states
   allStates.forEach((config) => {
+    if (config.isParentState) {
+      states[config.id] = buildParentStateConfig(config, steps, options?.sources);
+      return;
+    }
+
     // Extract retryMax from transitions (check both PASS and FAIL)
     const retryMaxFromTransitions =
       config.transitions.pass.retry > 0
@@ -1009,8 +1034,9 @@ export function compileRunbookToMachine(
         }
       : {};
 
-    // Build per-state GOTO transitions
-    const buildGotoTransitionsForState = allStates.map((target) => {
+    // Build per-state GOTO transitions (skip parent states — they are transient)
+    const gotoTargets = allStates.filter((t) => !t.isParentState);
+    const buildGotoTransitionsForState = gotoTargets.map((target) => {
       // Compute isGotoToSelf at build time since target and config are known
       const isGotoToSelf = target.id === config.id;
 
@@ -1076,7 +1102,9 @@ export function compileRunbookToMachine(
                 if (top?.stepId === forStepForTarget.step.name) {
                   return context.iterationResults;
                 }
-                return forStepForTarget.implicit ? undefined : ([] as ('pass' | 'fail')[]);
+                return forStepForTarget.implicit && !forStepForTarget.step.transitions
+                  ? undefined
+                  : ([] as ('pass' | 'fail')[]);
               },
               lastAction: ({ event }: { event: RunbookEvent }): LastAction | undefined => {
                 if (event.type !== 'GOTO') return undefined;

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -380,13 +380,26 @@ function appendIterationResult(iterationResult: 'pass' | 'fail') {
   };
 }
 
-function buildLoopControlAssign(actionType: 'NEXT' | 'BREAK', iterationResult: 'pass' | 'fail') {
+/** Build assign action for substep-to-parent transition with iteration result. */
+function buildSubstepToParentAssign(
+  stepName: string,
+  iterationResult: 'pass' | 'fail',
+  actionType: 'CONTINUE' | 'NEXT' | 'BREAK',
+  isPassThrough?: boolean,
+): TransitionEntry {
   return {
-    iterationResults: appendIterationResult(iterationResult),
-    lastAction: { type: actionType },
-    lastMessage: undefined as string | undefined,
-    retryCount: 0,
-    substep: undefined as string | undefined,
+    target: formatStateId(stepName),
+    actions: assign({
+      iterationResults: isPassThrough
+        ? (undefined as ('pass' | 'fail')[] | undefined)
+        : ({ context }: { context: RunbookContext }) => {
+            const results = context.iterationResults ?? [];
+            return [...results, iterationResult];
+          },
+      lastAction: { type: actionType },
+      lastMessage: undefined as string | undefined,
+      substep: undefined as string | undefined,
+    }),
   };
 }
 
@@ -667,8 +680,8 @@ function buildParentStateConfig(
           lastAction: { type: 'RETRY' as const },
           parentRetryCount: ({ context }: { context: RunbookContext }) =>
             context.parentRetryCount + 1,
-          // Keep retryCount in sync for downstream consumers that surface retry progress
-          // but currently only read context.retryCount.
+          // Increment both counters: parentRetryCount tracks parent-level exhaustion,
+          // retryCount is exposed to the execution layer (actor-service) for visibility.
           retryCount: ({ context }: { context: RunbookContext }) => context.retryCount + 1,
           retryMax: transition.retry,
           forStack: [] as readonly ForContext[],
@@ -780,23 +793,18 @@ function buildActionTransition(
       if (isLastSubstep && currentStep) {
         const isImplicit = !currentStep.forClause;
 
-        return {
-          target: formatStateId(stepName),
-          actions: assign({
-            iterationResults:
-              isImplicit && !currentStep.transitions
-                ? (undefined as ('pass' | 'fail')[] | undefined)
-                : appendIterationResult(iterationResult),
-            lastAction: { type: 'CONTINUE' as const },
-            lastMessage: undefined as string | undefined,
-            substep: undefined as string | undefined,
-          }),
-        };
+        return buildSubstepToParentAssign(
+          stepName,
+          iterationResult,
+          'CONTINUE',
+          isImplicit && !currentStep.transitions,
+        );
       }
 
       // Non-last substep CONTINUE: advance to next sibling substep
       // FOR loops aggregate once per iteration at the parent state (last substep),
       // not per substep, so only implicit (non-FOR) aggregate steps accumulate here.
+      // FOR loops accumulate one result per iteration (at last substep), not per substep
       const shouldAccumulate = !!(
         currentStep?.substeps?.length &&
         !currentStep.forClause &&
@@ -925,10 +933,7 @@ function buildActionTransition(
         return { target: 'STOPPED', actions: assign({ lastAction: { type: 'NEXT' as const } }) };
       }
       const iterationResult: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
-      return {
-        target: formatStateId(stepName),
-        actions: assign(buildLoopControlAssign('NEXT', iterationResult)),
-      };
+      return buildSubstepToParentAssign(stepName, iterationResult, 'NEXT', false);
     }
 
     case 'BREAK': {
@@ -937,10 +942,7 @@ function buildActionTransition(
         return { target: 'STOPPED', actions: assign({ lastAction: { type: 'BREAK' as const } }) };
       }
       const iterationResult: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
-      return {
-        target: formatStateId(stepName),
-        actions: assign(buildLoopControlAssign('BREAK', iterationResult)),
-      };
+      return buildSubstepToParentAssign(stepName, iterationResult, 'BREAK', false);
     }
   }
 }

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -23,6 +23,8 @@ export const MAX_FILE_ITERATIONS = 10_000;
 export interface RunbookContext {
   /** Current retry count for the active step */
   retryCount: number;
+  /** Retry count for parent-step aggregation retries (separate from substep retryCount). */
+  parentRetryCount: number;
   /** Maximum retries allowed for current RETRY action (source of truth for retry limits) */
   retryMax?: number;
   /** Current substep ID within the active step */
@@ -478,6 +480,7 @@ function buildParentExitAssign(
 ): AssignAction {
   const baseAssign = {
     retryCount: 0,
+    parentRetryCount: 0,
     substep: extractSubstepFromStateId(exitTarget),
   };
 
@@ -501,11 +504,17 @@ function buildParentExitAssign(
           substep: parentAction.target.substep ?? targetStep.substeps[0]?.id,
         });
       }
+      const targetHasSubsteps = !!targetStep?.substeps?.length;
+      const targetHasAggregationTransitions = !!targetStep?.transitions;
       return assign({
         ...baseAssign,
         forStack: [] as readonly ForContext[],
-        ...(targetStep?.substeps?.length && targetStep.transitions
-          ? { iterationResults: [] as ('pass' | 'fail')[] }
+        ...(targetHasSubsteps
+          ? {
+              iterationResults: targetHasAggregationTransitions
+                ? ([] as ('pass' | 'fail')[])
+                : (undefined as ('pass' | 'fail')[] | undefined),
+            }
           : {}),
         lastAction: buildGotoLastAction(parentAction.target),
       });
@@ -614,12 +623,13 @@ function buildParentStateConfig(
     const exhausted = {
       guard: ({ context }: { context: RunbookContext }) =>
         branchGuard({ context }) &&
-        (transition.retry <= 0 || context.retryCount >= transition.retry),
+        (transition.retry <= 0 || context.parentRetryCount >= transition.retry),
       target,
       actions: [
         buildParentExitAssign(transition.action, target, steps, sources),
         assign({
           retryCount: 0,
+          parentRetryCount: 0,
           retryMax: transition.retry > 0 ? transition.retry : undefined,
         }),
       ],
@@ -630,10 +640,12 @@ function buildParentStateConfig(
     return [
       {
         guard: ({ context }: { context: RunbookContext }) =>
-          branchGuard({ context }) && context.retryCount < transition.retry,
+          branchGuard({ context }) && context.parentRetryCount < transition.retry,
         target: firstSubstepStateId,
         actions: assign({
           lastAction: { type: 'RETRY' as const },
+          parentRetryCount: ({ context }: { context: RunbookContext }) =>
+            context.parentRetryCount + 1,
           retryCount: ({ context }: { context: RunbookContext }) => context.retryCount + 1,
           retryMax: transition.retry,
           forStack: [] as readonly ForContext[],
@@ -671,6 +683,7 @@ function buildParentStateConfig(
     const exitAssign: Record<string, unknown> = {
       forStack: [] as readonly ForContext[],
       retryCount: 0,
+      parentRetryCount: 0,
       substep: extractSubstepFromStateId(nextTarget),
     };
 
@@ -1187,6 +1200,7 @@ export function compileRunbookToMachine(
     initial: allStates.length > 0 ? allStates[0].id : 'step::1',
     context: {
       retryCount: 0,
+      parentRetryCount: 0,
       retryMax: undefined,
       substep: undefined,
       variables: {},

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -71,17 +71,35 @@ type AssignAction = (...args: never[]) => unknown;
 type TransitionConfig = TransitionEntry | TransitionEntry[];
 
 /**
- * Internal state configuration entry used to track all XState states during compilation.
- * Parent aggregation states (isParentState=true) are built via buildParentStateConfig.
+ * Child/leaf state configuration — represents a concrete substep or simple step.
  */
-interface StateConfig {
+interface ChildStateConfig {
   id: string;
   stepName: string;
   substepId?: string;
   transitions: Transitions;
-  isParentState?: boolean;
-  parentStep?: Step;
+  isParentState?: false;
 }
+
+/**
+ * Parent aggregation state configuration — represents a transient step that
+ * aggregates substep results via `always` transitions.
+ */
+interface ParentStateConfig {
+  id: string;
+  stepName: string;
+  substepId?: string;
+  transitions: Transitions;
+  isParentState: true;
+  parentStep: Step;
+}
+
+/**
+ * Internal state configuration entry used to track all XState states during compilation.
+ * Discriminated on `isParentState` so that `parentStep` is guaranteed present
+ * when `isParentState` is `true`.
+ */
+type StateConfig = ChildStateConfig | ParentStateConfig;
 
 /**
  * DEFAULT Transitions according to RUNDOWN-SPEC 1.0.0
@@ -522,17 +540,17 @@ function buildParentExitAssign(
     case 'GOTO': {
       const targetStep = steps.find((s) => s.name === parentAction.target.step);
       if (targetStep?.substeps?.length && targetStep.forClause) {
+        const forClause = targetStep.forClause;
         return assign({
           ...baseAssign,
-          forStack: [
-            createForContext(
-              targetStep.name,
-              targetStep.forClause,
-              parentAction.target.at !== undefined ? Number(parentAction.target.at) : undefined,
-              false,
-              sources,
-            ),
-          ],
+          forStack: ({ context }: { context: RunbookContext }): readonly ForContext[] => {
+            const iteration = resolveAtValueRuntime(
+              parentAction.target.at,
+              forClause.start,
+              context.forStack,
+            );
+            return [createForContext(targetStep.name, forClause, iteration, false, sources)];
+          },
           iterationResults: [] as ('pass' | 'fail')[],
           lastAction: buildGotoLastAction(parentAction.target),
           substep: parentAction.target.substep ?? targetStep.substeps[0]?.id,
@@ -597,19 +615,16 @@ function buildParentExitAssign(
  * - Case C: FOR step without transitions — loop-back guard + unconditional exit
  * - Case D: Non-FOR step without transitions — unconditional pass-through
  *
- * @param config - The parent state config (must have isParentState=true)
+ * @param config - The parent state config (discriminated by isParentState=true)
  * @param steps - The full steps array
  * @param sources - Optional data sources for GOTO to FOR step initialization
  * @returns XState state config with `always` transitions
  */
 function buildParentStateConfig(
-  config: StateConfig,
+  config: ParentStateConfig,
   steps: Step[],
   sources?: Readonly<Record<string, DataSource>>,
 ): { always: unknown; entry?: unknown } {
-  if (!config.parentStep) {
-    throw new Error('parentStep required for parent state config');
-  }
   const parentStep = config.parentStep;
   const stepName = config.stepName;
   const hasFor = !!parentStep.forClause;
@@ -662,8 +677,6 @@ function buildParentStateConfig(
       actions: [
         buildParentExitAssign(transition.action, target, steps, sources),
         assign({
-          retryCount: 0,
-          parentRetryCount: 0,
           retryMax: transition.retry > 0 ? transition.retry : undefined,
         }),
       ],
@@ -1005,6 +1018,9 @@ export function compileRunbookToMachine(
     }
   });
 
+  // Pre-filter GOTO targets once (skip parent states — they are transient)
+  const gotoTargets = allStates.filter((t) => !t.isParentState);
+
   // Build the machine states
   allStates.forEach((config) => {
     if (config.isParentState) {
@@ -1056,8 +1072,7 @@ export function compileRunbookToMachine(
         }
       : {};
 
-    // Build per-state GOTO transitions (skip parent states — they are transient)
-    const gotoTargets = allStates.filter((t) => !t.isParentState);
+    // Build per-state GOTO transitions
     const buildGotoTransitionsForState = gotoTargets.map((target) => {
       // Compute isGotoToSelf at build time since target and config are known
       const isGotoToSelf = target.id === config.id;

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -539,7 +539,7 @@ function buildParentExitAssign(
 }
 
 /**
- * Build the `always` (eventless) transition configuration for a parent aggregation state.
+ * Build the `always` (event-less) transition configuration for a parent aggregation state.
  *
  * Parent states are intermediate states that a step's last substep transitions to after
  * completing. The parent state then immediately (via `always`) routes to the correct

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -504,6 +504,9 @@ function buildParentExitAssign(
       return assign({
         ...baseAssign,
         forStack: [] as readonly ForContext[],
+        ...(targetStep?.substeps?.length && targetStep.transitions
+          ? { iterationResults: [] as ('pass' | 'fail')[] }
+          : {}),
         lastAction: buildGotoLastAction(parentAction.target),
       });
     }
@@ -645,7 +648,7 @@ function buildParentStateConfig(
 
   // Aggregation guards (Cases A & B: steps with explicit transitions)
   if (hasTransitions) {
-    const parentTransitions = parentStep.transitions!;
+    const parentTransitions = parentStep.transitions;
     const passTarget = resolveActionTarget(parentTransitions.pass.action, stepName, steps);
     const failTarget = resolveActionTarget(parentTransitions.fail.action, stepName, steps);
 
@@ -779,7 +782,6 @@ function buildActionTransition(
             : {}),
           lastAction: { type: 'CONTINUE' as const },
           lastMessage: undefined as string | undefined,
-          retryCount: 0,
           substep: extractSubstepFromStateId(target),
         }),
       };

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -349,6 +349,7 @@ function buildSimpleGotoAssign(options: {
   resolvedSubstepId: GotoAssignValue<string | undefined>;
   isGotoToSelf: boolean;
   preserveForContext?: boolean;
+  preserveParentRetryCount?: boolean;
 }): AssignAction {
   return assign({
     lastAction: ({ event }: { event: RunbookEvent }) => {
@@ -356,6 +357,9 @@ function buildSimpleGotoAssign(options: {
         ? options.lastAction({ event })
         : options.lastAction;
     },
+    parentRetryCount: options.preserveParentRetryCount
+      ? ({ context }: { context: RunbookContext }) => context.parentRetryCount
+      : 0,
     retryCount: options.isGotoToSelf
       ? ({ context }: { context: RunbookContext }) => context.retryCount + 1
       : 0,
@@ -367,6 +371,23 @@ function buildSimpleGotoAssign(options: {
           iterationResults: undefined as ('pass' | 'fail')[] | undefined,
         }),
   });
+}
+
+function appendIterationResult(iterationResult: 'pass' | 'fail') {
+  return ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] => {
+    const results = context.iterationResults ?? [];
+    return [...results, iterationResult];
+  };
+}
+
+function buildLoopControlAssign(actionType: 'NEXT' | 'BREAK', iterationResult: 'pass' | 'fail') {
+  return {
+    iterationResults: appendIterationResult(iterationResult),
+    lastAction: { type: actionType },
+    lastMessage: undefined as string | undefined,
+    retryCount: 0,
+    substep: undefined as string | undefined,
+  };
 }
 
 /**
@@ -646,6 +667,8 @@ function buildParentStateConfig(
           lastAction: { type: 'RETRY' as const },
           parentRetryCount: ({ context }: { context: RunbookContext }) =>
             context.parentRetryCount + 1,
+          // Keep retryCount in sync for downstream consumers that surface retry progress
+          // but currently only read context.retryCount.
           retryCount: ({ context }: { context: RunbookContext }) => context.retryCount + 1,
           retryMax: transition.retry,
           forStack: [] as readonly ForContext[],
@@ -751,10 +774,10 @@ function buildActionTransition(
 
       // Check if we're at the last substep of a step with substeps
       const isLastSubstep = isLastSubstepOfStep(stepName, substepId, steps);
+      const iterationResult: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
 
       // If at last substep, route to parent aggregation state
       if (isLastSubstep && currentStep) {
-        const iterationResult: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
         const isImplicit = !currentStep.forClause;
 
         return {
@@ -763,10 +786,7 @@ function buildActionTransition(
             iterationResults:
               isImplicit && !currentStep.transitions
                 ? (undefined as ('pass' | 'fail')[] | undefined)
-                : ({ context }: { context: RunbookContext }) => {
-                    const results = context.iterationResults ?? [];
-                    return [...results, iterationResult];
-                  },
+                : appendIterationResult(iterationResult),
             lastAction: { type: 'CONTINUE' as const },
             lastMessage: undefined as string | undefined,
             substep: undefined as string | undefined,
@@ -775,6 +795,8 @@ function buildActionTransition(
       }
 
       // Non-last substep CONTINUE: advance to next sibling substep
+      // FOR loops aggregate once per iteration at the parent state (last substep),
+      // not per substep, so only implicit (non-FOR) aggregate steps accumulate here.
       const shouldAccumulate = !!(
         currentStep?.substeps?.length &&
         !currentStep.forClause &&
@@ -786,11 +808,7 @@ function buildActionTransition(
         actions: assign({
           ...(shouldAccumulate
             ? {
-                iterationResults: ({ context }: { context: RunbookContext }) => {
-                  const results = context.iterationResults ?? [];
-                  const result: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
-                  return [...results, result];
-                },
+                iterationResults: appendIterationResult(iterationResult),
               }
             : {}),
           lastAction: { type: 'CONTINUE' as const },
@@ -867,6 +885,10 @@ function buildActionTransition(
                 : ([] as ('pass' | 'fail')[]);
             },
             lastAction: buildGotoLastAction(action.target),
+            parentRetryCount:
+              targetStepObj.name === stepName
+                ? ({ context }: { context: RunbookContext }) => context.parentRetryCount
+                : 0,
             retryCount: isGotoToSelf
               ? ({ context }: { context: RunbookContext }) => context.retryCount + 1
               : 0,
@@ -892,6 +914,7 @@ function buildActionTransition(
           resolvedSubstepId,
           isGotoToSelf,
           preserveForContext: isIntraLoopGoto,
+          preserveParentRetryCount: isGotoToSelf || isIntraLoopGoto,
         }),
       };
     }
@@ -904,16 +927,7 @@ function buildActionTransition(
       const iterationResult: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
       return {
         target: formatStateId(stepName),
-        actions: assign({
-          iterationResults: ({ context }: { context: RunbookContext }) => {
-            const results = context.iterationResults ?? [];
-            return [...results, iterationResult];
-          },
-          lastAction: { type: 'NEXT' as const },
-          lastMessage: undefined as string | undefined,
-          retryCount: 0,
-          substep: undefined as string | undefined,
-        }),
+        actions: assign(buildLoopControlAssign('NEXT', iterationResult)),
       };
     }
 
@@ -925,16 +939,7 @@ function buildActionTransition(
       const iterationResult: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
       return {
         target: formatStateId(stepName),
-        actions: assign({
-          iterationResults: ({ context }: { context: RunbookContext }) => {
-            const results = context.iterationResults ?? [];
-            return [...results, iterationResult];
-          },
-          lastAction: { type: 'BREAK' as const },
-          lastMessage: undefined as string | undefined,
-          retryCount: 0,
-          substep: undefined as string | undefined,
-        }),
+        actions: assign(buildLoopControlAssign('BREAK', iterationResult)),
       };
     }
   }
@@ -1133,6 +1138,10 @@ export function compileRunbookToMachine(
                   ...(at !== undefined && { at }),
                 };
               },
+              parentRetryCount:
+                target.stepName === config.stepName
+                  ? ({ context }: { context: RunbookContext }) => context.parentRetryCount
+                  : 0,
               retryCount: 0,
               substep: ({ event }: { event: RunbookEvent }) =>
                 event.type === 'GOTO' ? (event.target.substep ?? target.substepId) : undefined,
@@ -1153,6 +1162,7 @@ export function compileRunbookToMachine(
               resolvedSubstepId: ({ event }: { event: RunbookEvent }) =>
                 event.type === 'GOTO' ? (event.target.substep ?? target.substepId) : undefined,
               isGotoToSelf,
+              preserveParentRetryCount: isGotoToSelf,
             }),
       };
     });


### PR DESCRIPTION
Three-stage pipeline (gate → parallel dual-review → synthesis) that decomposes the 35-item plan review checklist into focused runbooks for parallel agent execution. Identifies two infrastructure prereqs: FOR + step-level runbooks support, and implicit loop aggregation fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Greatly expanded coverage for parent-state aggregation, complex loop patterns, iteration tracking, GOTO/NEXT/RETRY behaviors, last-action accuracy, and multi-step edge cases.

* **Refactor**
  * Overhauled aggregation and transition routing in the runbook compiler to improve iteration/result accumulation and transition correctness.
  * Runtime context now tracks parent-level retry counts to support parent-aggregation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->