### PR TITLE
feat(compiler): route stop and complete commands through XState

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,16 @@ rundown prompt <content> # Output content in markdown fences
 
 The `rd` command is an alias for `rundown`.
 
+### Exit Codes
+
+| Code | Name | Meaning |
+|------|------|---------|
+| `0` | Success | Command and runbook both succeeded |
+| `1` | Runbook Failed | Command succeeded; runbook was stopped or failed |
+| `2` | Command Error | CLI command itself failed (file not found, invalid args, engine error) |
+
+`rd echo` is exempt — it propagates its own configurable exit code.
+
 ## Template Variables
 
 Template variables use Handlebars syntax `{{variableName}}` and are expanded at run time.

--- a/docs/CLI-OUTPUT-SPEC.md
+++ b/docs/CLI-OUTPUT-SPEC.md
@@ -721,3 +721,34 @@ Error: Runbook file not found: missing.runbook.md
   "code": "RUNBOOK_NOT_FOUND"
 }
 ```
+
+## Exit Codes
+
+The CLI uses a three-tier exit code convention:
+
+| Code | Name | Meaning |
+|------|------|---------|
+| `0` | Success | Command and runbook both succeeded |
+| `1` | Runbook Failed | Command succeeded; runbook was stopped or failed |
+| `2` | Command Error | CLI command itself failed (file not found, invalid args, engine error) |
+
+### Examples by command
+
+| Command | Scenario | Exit Code |
+|---------|----------|-----------|
+| `rd run file.md` | Runbook completes successfully | `0` |
+| `rd run file.md` | Runbook stops (STOP transition) | `1` |
+| `rd run missing.md` | File not found | `2` |
+| `rd stop` | Active runbook stopped | `1` |
+| `rd stop` | No active runbook | `0` |
+| `rd complete` | Active runbook completed | `0` |
+| `rd check file.md` | No validation errors | `0` |
+| `rd check file.md` | Validation errors found | `1` |
+| `rd check missing.md` | File not found | `2` |
+| `rd pass` / `rd fail` | Triggers STOP | `1` |
+| `rd goto 999` | Step not found | `2` |
+| `rd echo --result fail` | Echo returns fail | `1` |
+| `rd scenario run f s` | Scenario passes | `0` |
+| `rd scenario run f s` | Scenario fails | `1` |
+
+**Note:** `rd echo` is exempt from the convention — it propagates its own configurable exit code via `result.exitCode`.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -174,3 +174,15 @@ scenarios:
 7.  **Source Validation**: FOR clauses referencing a data source must reference a defined source. Named variable required.
 8.  **FOR Requires Substeps**: A FOR-annotated step must contain substeps.
 9.  **No Nested RETRY**: RETRY fallback actions cannot be RETRY.
+
+## 9. CLI Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Runbook failed (stopped, validation errors, scenario mismatch) |
+| `2` | Command error (file not found, invalid args, parse crash) |
+
+10. **Stop Semantics**: `rd stop` exits `1` — the command succeeded; the runbook failed.
+11. **Check Semantics**: Validation errors exit `1`; file-not-found/parse errors exit `2`.
+12. **Echo Exempt**: `rd echo` propagates its own configurable exit code.

--- a/packages/cli/__tests__/check.test.ts
+++ b/packages/cli/__tests__/check.test.ts
@@ -93,7 +93,7 @@ Missing step 2.
   it('outputs FAIL for non-existent file', () => {
     const result = runCli('check /nonexistent/path/runbook.md', workspace);
 
-    expect(result.exitCode).toBe(1);
+    expect(result.exitCode).toBe(2);
     expect(result.stderr || result.stdout).toContain('FAIL');
     expect(result.stderr || result.stdout).toMatch(/not found|does not exist/i);
   });

--- a/packages/cli/__tests__/commands/echo.test.ts
+++ b/packages/cli/__tests__/commands/echo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { Command } from 'commander';
 import { createTestWorkspace, runCli, type TestWorkspace } from '../helpers/test-utils.js';
-import { registerEchoCommand } from '../../src/commands/echo.js';
+import { collect, registerEchoCommand } from '../../src/commands/echo.js';
 import { OutputEmitter } from '../../src/services/output-emitter.js';
 import { EXIT_COMMAND_ERROR } from '../../src/helpers/exit-codes.js';
 
@@ -19,6 +19,11 @@ describe('echo command', () => {
   it('exists and shows help', () => {
     const result = runCli('echo --help', workspace);
     expect(result.stdout).toContain('Echo command');
+  });
+
+  it('collect appends repeated result values', () => {
+    expect(collect('pass', [])).toEqual(['pass']);
+    expect(collect('fail', ['pass'])).toEqual(['pass', 'fail']);
   });
 
   describe('result sequence', () => {

--- a/packages/cli/__tests__/commands/echo.test.ts
+++ b/packages/cli/__tests__/commands/echo.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { Command } from 'commander';
 import { createTestWorkspace, runCli, type TestWorkspace } from '../helpers/test-utils.js';
+import { registerEchoCommand } from '../../src/commands/echo.js';
+import { OutputEmitter } from '../../src/services/output-emitter.js';
+import { EXIT_COMMAND_ERROR } from '../../src/helpers/exit-codes.js';
 
 describe('echo command', () => {
   let workspace: TestWorkspace;
@@ -60,6 +64,43 @@ describe('echo command', () => {
       const result = runCli('echo --result maybe npm install', workspace);
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Invalid result');
+    });
+
+    it('emits command error exit code in JSON payload on unexpected exceptions', async () => {
+      const cwdSpy = jest.spyOn(process, 'cwd').mockImplementation(() => {
+        throw new Error('boom');
+      });
+      const detailSpy = jest.spyOn(OutputEmitter.prototype, 'detail');
+      const flushSpy = jest
+        .spyOn(OutputEmitter.prototype, 'flush')
+        .mockImplementation(() => undefined);
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('process.exit');
+      }) as never);
+
+      try {
+        const program = new Command();
+        registerEchoCommand(program);
+
+        await expect(program.parseAsync(['node', 'rd', 'echo', '--json', 'hello'])).rejects.toThrow(
+          'process.exit',
+        );
+
+        expect(detailSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            result: false,
+            error: 'boom',
+            exitCode: EXIT_COMMAND_ERROR,
+          }),
+          'echo',
+        );
+        expect(exitSpy).toHaveBeenCalledWith(EXIT_COMMAND_ERROR);
+      } finally {
+        cwdSpy.mockRestore();
+        detailSpy.mockRestore();
+        flushSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/cli/__tests__/commands/goto.test.ts
+++ b/packages/cli/__tests__/commands/goto.test.ts
@@ -65,7 +65,7 @@ describe('goto command', () => {
     it('requires step number argument', async () => {
       const result = runCli('goto', workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('missing required argument');
     });
 

--- a/packages/cli/__tests__/commands/goto.test.ts
+++ b/packages/cli/__tests__/commands/goto.test.ts
@@ -58,7 +58,7 @@ describe('goto command', () => {
     it('rejects invalid step numbers', async () => {
       const result = runCli(['goto', '999'], workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr.length).toBeGreaterThan(0);
     });
 
@@ -72,7 +72,7 @@ describe('goto command', () => {
     it('rejects AT on non-FOR step', async () => {
       const result = runCli(['goto', '2 AT 5'], workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('INVALID_AT_TARGET');
     });
   });

--- a/packages/cli/__tests__/commands/json-output.test.ts
+++ b/packages/cli/__tests__/commands/json-output.test.ts
@@ -146,8 +146,8 @@ echo hello
       );
 
       const result = runCli(`check ${runbookPath} --json`, workspace);
-      // Exit code should be 1
-      expect(result.exitCode).toBe(1);
+      // Exit code 1 (validation error) or 2 (parse error) depending on parser behavior
+      expect(result.exitCode).toBeGreaterThan(0);
 
       const output = JSON.parse(result.stdout);
       expect(output.valid).toBe(false);
@@ -157,7 +157,7 @@ echo hello
 
     it('outputs error for non-existent file', () => {
       const result = runCli('check non-existent.md --json', workspace);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
 
       const output = JSON.parse(result.stdout);
       expect(output.valid).toBe(false);
@@ -225,7 +225,7 @@ echo hello
       );
 
       const result = runCli(`scenario show ${runbookPath} non-existent --json`, workspace);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       const output = JSON.parse(result.stdout);
 
       // Uses standard error format from output.error()

--- a/packages/cli/__tests__/commands/output-format.test.ts
+++ b/packages/cli/__tests__/commands/output-format.test.ts
@@ -184,7 +184,7 @@ describe('output format integration tests', () => {
     it('prints metadata and stopped message', async () => {
       const result = runCli('stop', workspace);
 
-      expect(result.exitCode).toBe(0);
+      expect(result.exitCode).toBe(1);
       expect(result.stdout).toContain('STOP');
       expect(result.stdout).toContain('simple.runbook.md');
     });

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -66,14 +66,14 @@ describe('start command', () => {
     it('fails if file does not exist', async () => {
       const result = runCli('run runbooks/nonexistent.md', workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('not found');
     });
 
     it('fails if no file argument provided', async () => {
       const result = runCli('run', workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('required');
     });
 
@@ -142,7 +142,7 @@ describe('start command', () => {
       runCli('stop', workspace);
 
       const result = runCli('run --step 2', workspace);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('No active runbook');
     });
 
@@ -151,7 +151,7 @@ describe('start command', () => {
       // Use '123abc' which starts with digit but contains letters - invalid format
       const result = runCli('run --step 123abc', workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('Invalid step ID');
     });
 
@@ -232,7 +232,7 @@ describe('start command', () => {
 
       // Try to bind another agent
       const result = runCli('run --agent agent2', workspace);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('No pending step');
     });
 
@@ -240,7 +240,7 @@ describe('start command', () => {
       runCli('stop', workspace);
 
       const result = runCli('run --agent test-agent', workspace);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('No active runbook');
     });
 

--- a/packages/cli/__tests__/commands/scenarios.test.ts
+++ b/packages/cli/__tests__/commands/scenarios.test.ts
@@ -80,7 +80,7 @@ name: no-scenarios
 
       const result = runCli('scenario ls no-scenarios.runbook.md', workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('No scenarios');
     });
   });
@@ -100,7 +100,7 @@ name: no-scenarios
     it('shows error for non-existent scenario', async () => {
       const result = runCli('scenario show test-runbook.runbook.md nonexistent', workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('not found');
       expect(result.stderr).toContain('SCENARIO_NOT_FOUND');
     });

--- a/packages/cli/__tests__/commands/schema-validation.test.ts
+++ b/packages/cli/__tests__/commands/schema-validation.test.ts
@@ -1053,7 +1053,7 @@ echo hello
       );
 
       const result = runCli(`check ${runbookPath} --json`, workspace);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBeGreaterThan(0);
     });
 
     it('returns 0 for JSON mode even when result is false', () => {

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { writeFile, rm } from 'node:fs/promises';
+import { writeFile, rm, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   createTestWorkspace,
   runCli,
   readSession,
+  readRunbookState,
   listRunbookStates,
-  type TestWorkspace,
+  writeSession,
+  getActiveState,
 } from '../helpers/test-utils.js';
 
 describe('status command', () => {
@@ -361,5 +363,175 @@ rd echo done
     expect(result.exitCode).toBe(0);
     const output = JSON.parse(result.stdout);
     expect(output.position.total).toBe(2);
+  });
+});
+
+describe('stop command error recovery', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('exits with code 2 and pops session when runbookSrc is missing (STATE_ERROR)', async () => {
+    // Start a real runbook to get valid state/session
+    runCli('run --prompted runbooks/simple.runbook.md', workspace);
+
+    // Get the active state ID, then strip runbookSrc to simulate corruption
+    const session = await readSession(workspace);
+    const stateId = session.active!;
+    expect(stateId).toBeTruthy();
+
+    const stateFilePath = join(workspace.statePath(), `${stateId}.json`);
+    const stateContent = await readFile(stateFilePath, 'utf-8');
+    const state = JSON.parse(stateContent);
+    delete state.runbookSrc;
+    await writeFile(stateFilePath, JSON.stringify(state, null, 2));
+
+    const result = runCli('stop', workspace);
+
+    expect(result.exitCode).toBe(2);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain('STATE_ERROR');
+
+    // Session should be cleared (broken runbook popped)
+    const afterSession = await readSession(workspace);
+    expect(afterSession.active).toBeNull();
+  });
+
+  it('exits with code 1 on successful stop', async () => {
+    runCli('run --prompted runbooks/simple.runbook.md', workspace);
+
+    const result = runCli('stop', workspace);
+
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe('complete command error recovery', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('exits with code 2 and pops session when runbookSrc is missing (STATE_ERROR)', async () => {
+    runCli('run --prompted runbooks/simple.runbook.md', workspace);
+
+    const session = await readSession(workspace);
+    const stateId = session.active!;
+    expect(stateId).toBeTruthy();
+
+    const stateFilePath = join(workspace.statePath(), `${stateId}.json`);
+    const stateContent = await readFile(stateFilePath, 'utf-8');
+    const state = JSON.parse(stateContent);
+    delete state.runbookSrc;
+    await writeFile(stateFilePath, JSON.stringify(state, null, 2));
+
+    const result = runCli('complete', workspace);
+
+    expect(result.exitCode).toBe(2);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain('STATE_ERROR');
+
+    const afterSession = await readSession(workspace);
+    expect(afterSession.active).toBeNull();
+  });
+
+  it('exits with code 0 on successful complete', async () => {
+    runCli('run --prompted runbooks/simple.runbook.md', workspace);
+
+    const result = runCli('complete', workspace);
+
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe('stop/complete state persistence via XState', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('stop sets lastAction and lastResult in persisted state', async () => {
+    runCli('run --prompted runbooks/simple.runbook.md', workspace);
+
+    // Get state ID before stop (stop clears session)
+    const session = await readSession(workspace);
+    const stateId = session.active!;
+
+    runCli('stop', workspace);
+
+    const state = await readRunbookState(workspace, stateId);
+    expect(state).not.toBeNull();
+    expect(state!.lastAction).toEqual({ type: 'STOP' });
+    expect(state!.lastResult).toBe('fail');
+  });
+
+  it('complete sets lastAction and lastResult in persisted state', async () => {
+    runCli('run --prompted runbooks/simple.runbook.md', workspace);
+
+    const session = await readSession(workspace);
+    const stateId = session.active!;
+
+    runCli('complete', workspace);
+
+    const state = await readRunbookState(workspace, stateId);
+    expect(state).not.toBeNull();
+    expect(state!.lastAction).toEqual({ type: 'COMPLETE' });
+    expect(state!.lastResult).toBe('pass');
+  });
+
+  it('stop sets variables.stopped in persisted state', async () => {
+    runCli('run --prompted runbooks/simple.runbook.md', workspace);
+
+    const session = await readSession(workspace);
+    const stateId = session.active!;
+
+    runCli(['stop', 'User cancelled'], workspace);
+
+    const state = await readRunbookState(workspace, stateId);
+    expect(state).not.toBeNull();
+    // The XState STOPPED entry action sets variables.stopped = true
+    expect(state!.variables).toBeDefined();
+    expect((state as any).variables.stopped).toBe(true);
+  });
+
+  it('complete sets variables.completed in persisted state', async () => {
+    runCli('run --prompted runbooks/simple.runbook.md', workspace);
+
+    const session = await readSession(workspace);
+    const stateId = session.active!;
+
+    runCli(['complete', 'All tests passed'], workspace);
+
+    const state = await readRunbookState(workspace, stateId);
+    expect(state).not.toBeNull();
+    // The XState COMPLETE entry action sets variables.completed = true
+    expect(state!.variables).toBeDefined();
+    expect((state as any).variables.completed).toBe(true);
+  });
+
+  it('stop with --json includes message in output', async () => {
+    runCli('run --prompted runbooks/simple.runbook.md', workspace);
+
+    const result = runCli(['stop', 'Deployment failed', '--json'], workspace);
+
+    expect(result.exitCode).toBe(1);
+    const output = JSON.parse(result.stdout);
+    expect(output.message).toBe('Deployment failed');
   });
 });

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -7,8 +7,7 @@ import {
   readSession,
   readRunbookState,
   listRunbookStates,
-  writeSession,
-  getActiveState,
+  type TestWorkspace,
 } from '../helpers/test-utils.js';
 
 describe('status command', () => {

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -232,13 +232,13 @@ describe('stop command', () => {
     await workspace.cleanup();
   });
 
-  it('deletes active runbook state', async () => {
+  it('preserves runbook state after stop', async () => {
     runCli('run --prompted runbooks/simple.runbook.md', workspace);
 
     runCli('stop', workspace);
 
     const states = await listRunbookStates(workspace);
-    expect(states).toHaveLength(0);
+    expect(states).toHaveLength(1);
   });
 
   it('clears active runbook', async () => {

--- a/packages/cli/__tests__/error-handling.test.ts
+++ b/packages/cli/__tests__/error-handling.test.ts
@@ -73,7 +73,15 @@ This doesn't have proper ## headers
     it('shows help on unknown command', async () => {
       const result = runCli('unknowncommand', workspace);
 
+      expect(result.exitCode).toBe(2);
       expect(result.stderr.length).toBeGreaterThan(0);
+    });
+
+    it('returns command error code for invalid options', async () => {
+      const result = runCli('run --bogus', workspace);
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toMatch(/unknown option/i);
     });
 
     it('shows specific error for invalid step format', async () => {

--- a/packages/cli/__tests__/error-handling.test.ts
+++ b/packages/cli/__tests__/error-handling.test.ts
@@ -25,7 +25,7 @@ This doesn't have proper ## headers
 
       const result = runCli('run invalid.md', workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr.toLowerCase()).toContain('syntax error');
     });
 
@@ -34,7 +34,7 @@ This doesn't have proper ## headers
 
       const result = runCli('run empty.md', workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr.toLowerCase()).toContain('syntax error');
     });
   });
@@ -43,7 +43,7 @@ This doesn't have proper ## headers
     it('handles missing runbook file', async () => {
       const result = runCli('run nonexistent.md', workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('not found');
     });
   });
@@ -81,7 +81,7 @@ This doesn't have proper ## headers
 
       const result = runCli('run --step invalid-format', workspace);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('Invalid step ID');
     });
   });

--- a/packages/cli/__tests__/helpers/runbook-loader.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-loader.test.ts
@@ -33,6 +33,34 @@ echo done
     expect(steps[1].name).toBe('2');
   });
 
+  it('applies templateVars when runbookSrc contains placeholders', () => {
+    const runbookSrc = `# Templated Runbook
+
+## 1. Deploy {{Service}}
+- PASS: COMPLETE
+
+\`\`\`bash
+echo {{Service}}
+\`\`\`
+`;
+
+    const state: Partial<RunbookState> = {
+      id: 'templated-id',
+      runbook: 'templated.runbook.md',
+      runbookSrc,
+      templateVars: {
+        Service: 'api-server',
+      },
+      sources: {},
+    };
+
+    const steps = getRunbookFromState(state as RunbookState, '/unused');
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].description).toContain('Deploy api-server');
+    expect(steps[0].command?.code).toContain('echo api-server');
+  });
+
   it('should throw when runbookSrc is missing (corrupted state)', () => {
     const state: Partial<RunbookState> = {
       id: 'corrupted-id',

--- a/packages/cli/__tests__/services/output-emitter.test.ts
+++ b/packages/cli/__tests__/services/output-emitter.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import type { OutputWriter, RunbookEventV1 } from '@rundown-org/core';
+import type { OutputRenderer } from '../../src/services/renderers/types.js';
+import { OutputEmitter } from '../../src/services/output-emitter.js';
+
+interface JsonCall {
+  data: unknown;
+  pretty: boolean | undefined;
+}
+
+type MockWriter = OutputWriter & {
+  jsonCalls: JsonCall[];
+};
+
+type MockRenderer = OutputRenderer & {
+  render: ReturnType<typeof jest.fn>;
+  flush: ReturnType<typeof jest.fn>;
+};
+
+function createMockWriter(): MockWriter {
+  const jsonCalls: JsonCall[] = [];
+  return {
+    jsonCalls,
+    write: () => undefined,
+    writeLine: () => undefined,
+    writeLines: () => undefined,
+    writeError: () => undefined,
+    writeJson: (data: unknown, pretty?: boolean) => {
+      jsonCalls.push({ data, pretty });
+    },
+  };
+}
+
+function createMockRenderer(): MockRenderer {
+  return {
+    render: jest.fn(),
+    flush: jest.fn(),
+  };
+}
+
+function createExecutionEvent(): RunbookEventV1 {
+  return {
+    v: '1',
+    type: 'COMMAND_STARTED',
+    ts: '2026-02-20T00:00:00.000Z',
+    runbookId: 'wf-test',
+    runbook: { name: 'test', path: '/test.runbook.md' },
+    seq: 1,
+    payload: {
+      command: 'echo hello',
+      displayCommand: 'echo hello',
+      position: { current: '1', total: 2 },
+    },
+  };
+}
+
+describe('OutputEmitter', () => {
+  it('selects renderer based on options', () => {
+    const writer = createMockWriter();
+    const customRenderer = createMockRenderer();
+
+    const customEmitter = new OutputEmitter({
+      writer,
+      json: true,
+      renderer: customRenderer,
+    });
+    const jsonEmitter = new OutputEmitter({ writer, json: true });
+    const textEmitter = new OutputEmitter({ writer });
+    const defaultWriterEmitter = new OutputEmitter();
+
+    expect(customEmitter.isJson()).toBe(false);
+    expect(jsonEmitter.isJson()).toBe(true);
+    expect(textEmitter.isJson()).toBe(false);
+    expect(defaultWriterEmitter.getWriter()).toBeDefined();
+  });
+
+  it('emits all output events via renderer and delegates writer methods', () => {
+    const writer = createMockWriter();
+    const renderer = createMockRenderer();
+    const emitter = new OutputEmitter({ writer, renderer });
+
+    emitter.list([{ id: 1 }], [{ header: 'ID', key: (item: { id: number }) => item.id }], {
+      emptyMessage: 'No items',
+      jsonMapper: (item) => ({ value: item.id }),
+    });
+    emitter.detail({ key: 'value' }, 'custom');
+    emitter.metadata({ file: 'runbook.md', state: 'running', prompted: true });
+    emitter.status(true, 'check', 'ok', { total: 1 });
+    emitter.action(
+      {
+        action: 'CONTINUE',
+        result: true,
+        command: 'echo hello',
+        from: { current: '1', total: 2 },
+        at: { current: '2', total: 2, substep: 'a' },
+      },
+      { complete: true, stopped: true },
+    );
+    emitter.stepSeparator({ current: '2', total: 3, substep: '1' });
+    emitter.message('info message');
+    emitter.success('success message');
+    emitter.warning('warning message');
+    emitter.error('new-style error', 'ERR_NEW', { source: 'new' });
+    emitter.error('legacy error', { code: 'ERR_OLD', details: { source: 'legacy' } });
+    emitter.error('plain error');
+    emitter.complete('done', { current: '3', total: 3 });
+    emitter.stopped('stopped', { current: '2', total: 3 });
+    emitter.noActiveRunbook('pass');
+    emitter.noActiveRunbook('goto', 'NO_RUNBOOK');
+    emitter.executionEvent(createExecutionEvent());
+    emitter.flush();
+    emitter.json({ direct: true });
+
+    const events = renderer.render.mock.calls.map((call) => call[0] as Record<string, unknown>);
+    const listEvent = events.find((event) => event.type === 'list');
+    const plainErrorEvent = events.find(
+      (event) => event.type === 'error' && event.message === 'plain error',
+    );
+    const defaultNoActiveRunbook = events.find(
+      (event) => event.type === 'no_active_runbook' && event.action === 'pass',
+    );
+    const explicitNoActiveRunbook = events.find(
+      (event) => event.type === 'no_active_runbook' && event.action === 'goto',
+    );
+
+    expect(listEvent).toBeDefined();
+    expect(listEvent?.emptyMessage).toBe('No items');
+    expect(listEvent?.jsonMapper).toBeInstanceOf(Function);
+    expect(
+      (listEvent?.jsonMapper as (item: { id: number }) => { value: number })({ id: 7 }),
+    ).toEqual({
+      value: 7,
+    });
+    expect(events).toContainEqual(expect.objectContaining({ type: 'detail', format: 'custom' }));
+    expect(events).toContainEqual(expect.objectContaining({ type: 'metadata' }));
+    expect(events).toContainEqual(expect.objectContaining({ type: 'status', action: 'check' }));
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'action', complete: true, stopped: true }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'step_separator',
+        position: { current: '2', total: 3, substep: '1' },
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'message', text: 'info message', level: 'info' }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'message', text: 'success message', level: 'success' }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'message', text: 'warning message', level: 'warning' }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'error', message: 'new-style error', code: 'ERR_NEW' }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'error', message: 'legacy error', code: 'ERR_OLD' }),
+    );
+    expect(plainErrorEvent).toEqual(
+      expect.objectContaining({ type: 'error', message: 'plain error', code: undefined }),
+    );
+    expect(events).toContainEqual(expect.objectContaining({ type: 'complete', message: 'done' }));
+    expect(events).toContainEqual(expect.objectContaining({ type: 'stopped', message: 'stopped' }));
+    expect(defaultNoActiveRunbook).toEqual(
+      expect.objectContaining({ type: 'no_active_runbook', code: 'NO_ACTIVE_RUNBOOK' }),
+    );
+    expect(explicitNoActiveRunbook).toEqual(
+      expect.objectContaining({ type: 'no_active_runbook', code: 'NO_RUNBOOK' }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'execution_event', event: createExecutionEvent() }),
+    );
+    expect(renderer.flush).toHaveBeenCalledTimes(1);
+    expect(writer.jsonCalls).toEqual([{ data: { direct: true }, pretty: undefined }]);
+  });
+});

--- a/packages/cli/__tests__/services/renderers/json-renderer.test.ts
+++ b/packages/cli/__tests__/services/renderers/json-renderer.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect } from '@jest/globals';
+import type { OutputWriter, RunbookEventV1, StepPosition } from '@rundown-org/core';
+import { JSONRenderer } from '../../../src/services/renderers/json-renderer.js';
+
+interface JsonWrite {
+  data: unknown;
+  pretty: boolean | undefined;
+}
+
+type MockWriter = OutputWriter & {
+  lines: string[];
+  jsonWrites: JsonWrite[];
+};
+
+function createMockWriter(): MockWriter {
+  const lines: string[] = [];
+  const jsonWrites: JsonWrite[] = [];
+  return {
+    lines,
+    jsonWrites,
+    write: (text: string) => {
+      lines.push(text);
+    },
+    writeLine: (text?: string) => {
+      lines.push(text ?? '');
+    },
+    writeLines: (texts: string[]) => {
+      lines.push(...texts);
+    },
+    writeError: (text: string) => {
+      lines.push(text);
+    },
+    writeJson: (data: unknown, pretty?: boolean) => {
+      jsonWrites.push({ data, pretty });
+    },
+  };
+}
+
+function pos(current = '1', total = 2, substep?: string): StepPosition {
+  return { current, total, substep };
+}
+
+function transitionEvent(
+  extras: Partial<RunbookEventV1> = {},
+  payload: RunbookEventV1['payload'] = {
+    action: 'CONTINUE',
+    from: pos('1', 2),
+    to: pos('2', 2),
+    result: true,
+  },
+): RunbookEventV1 {
+  return {
+    v: '1',
+    type: 'STEP_TRANSITIONED',
+    ts: '2026-02-20T00:00:00.000Z',
+    runbookId: 'wf-123',
+    runbook: { name: 'demo', path: '/demo.runbook.md' },
+    seq: 7,
+    payload,
+    ...extras,
+  } as RunbookEventV1;
+}
+
+describe('JSONRenderer', () => {
+  it('does nothing on flush when no output has been rendered', () => {
+    const writer = createMockWriter();
+    const renderer = new JSONRenderer({ writer });
+
+    renderer.flush();
+
+    expect(writer.jsonWrites).toHaveLength(0);
+    expect(writer.lines).toHaveLength(0);
+  });
+
+  it('renders list-only output as raw arrays (with and without jsonMapper)', () => {
+    const writer = createMockWriter();
+    const renderer = new JSONRenderer({ writer });
+
+    renderer.render({
+      type: 'list',
+      items: [{ id: 1 }, { id: 2 }],
+      columns: [{ header: 'ID', key: 'id' }],
+      jsonMapper: (item: { id: number }) => item.id,
+    });
+    renderer.flush();
+
+    renderer.render({
+      type: 'list',
+      items: ['a', 'b'],
+      columns: [{ header: 'Value', key: (item: string) => item }],
+    });
+    renderer.flush();
+
+    expect(writer.jsonWrites[0]).toEqual({ data: [1, 2], pretty: true });
+    expect(writer.jsonWrites[1]).toEqual({ data: ['a', 'b'], pretty: true });
+  });
+
+  it('renders mixed list/detail output as an object and defaults result=true', () => {
+    const writer = createMockWriter();
+    const renderer = new JSONRenderer({ writer });
+
+    renderer.render({
+      type: 'list',
+      items: [{ name: 'alpha' }],
+      columns: [{ header: 'Name', key: 'name' }],
+    });
+    renderer.render({
+      type: 'detail',
+      format: 'custom',
+      data: { mode: 'mixed' },
+    });
+    renderer.flush();
+
+    expect(writer.jsonWrites[0]).toEqual({
+      data: {
+        items: [{ name: 'alpha' }],
+        mode: 'mixed',
+        result: true,
+      },
+      pretty: true,
+    });
+  });
+
+  it('renders metadata, status, step separators, and informational messages', () => {
+    const writer = createMockWriter();
+    const renderer = new JSONRenderer({ writer });
+
+    renderer.render({
+      type: 'metadata',
+      metadata: { file: 'runbook.md', state: 'running', prompted: false },
+    });
+    renderer.render({
+      type: 'metadata',
+      metadata: { file: 'runbook.md', state: 'running', prompted: true },
+    });
+    renderer.render({
+      type: 'status',
+      result: true,
+      action: 'check',
+      message: 'ok',
+      data: { validated: 1 },
+    });
+    renderer.render({
+      type: 'status',
+      result: false,
+      action: 'check',
+    });
+    renderer.render({
+      type: 'step_separator',
+      position: pos('2', 3, '1'),
+    });
+    renderer.render({
+      type: 'message',
+      text: 'info',
+      level: 'info',
+    });
+    renderer.flush();
+
+    expect(writer.jsonWrites[0]).toEqual({
+      data: {
+        file: 'runbook.md',
+        state: 'running',
+        prompted: true,
+        result: false,
+        action: 'check',
+        message: 'info',
+        validated: 1,
+        position: { current: '2', total: 3, substep: '1' },
+      },
+      pretty: true,
+    });
+  });
+
+  it('renders action events with full and minimal payloads', () => {
+    const writer = createMockWriter();
+    const renderer = new JSONRenderer({ writer });
+
+    renderer.render({
+      type: 'action',
+      block: {
+        action: 'RETRY',
+      },
+    });
+    renderer.render({
+      type: 'action',
+      block: {
+        action: 'GOTO 2',
+        result: false,
+        command: 'rd echo fail',
+        from: pos('1', 3),
+        at: pos('2', 3, 'a'),
+      },
+      complete: true,
+      stopped: true,
+    });
+    renderer.flush();
+
+    expect(writer.jsonWrites[0]).toEqual({
+      data: {
+        action: 'GOTO 2',
+        result: false,
+        command: 'rd echo fail',
+        from: { current: '1', total: 3 },
+        to: { current: '2', total: 3, substep: 'a' },
+        complete: true,
+        stopped: true,
+      },
+      pretty: true,
+    });
+  });
+
+  it('renders message/error/no_active_runbook output and derives result from errors', () => {
+    const writer = createMockWriter();
+    const renderer = new JSONRenderer({ writer });
+
+    renderer.render({
+      type: 'message',
+      text: 'warning message',
+      level: 'warning',
+    });
+    renderer.render({
+      type: 'message',
+      text: 'fatal message',
+      level: 'error',
+    });
+    renderer.render({
+      type: 'error',
+      message: 'structured error',
+      code: 'ERR_CODE',
+      details: { retryable: false },
+    });
+    renderer.render({
+      type: 'error',
+      message: 'plain error',
+    });
+    renderer.render({
+      type: 'no_active_runbook',
+    });
+    renderer.render({
+      type: 'no_active_runbook',
+      action: 'pass',
+      code: 'NO_RUNBOOK',
+    });
+    renderer.flush();
+
+    expect(writer.jsonWrites[0]).toEqual({
+      data: {
+        message: 'warning message',
+        error: 'No active runbook',
+        result: false,
+        code: 'NO_RUNBOOK',
+        details: { retryable: false },
+        action: 'pass',
+      },
+      pretty: true,
+    });
+  });
+
+  it('renders complete and stopped events with and without optional fields', () => {
+    const writer = createMockWriter();
+    const renderer = new JSONRenderer({ writer });
+
+    renderer.render({
+      type: 'complete',
+    });
+    renderer.flush();
+
+    renderer.render({
+      type: 'stopped',
+      message: 'Stopped by user',
+      position: pos('3', 3),
+    });
+    renderer.flush();
+
+    expect(writer.jsonWrites[0]).toEqual({
+      data: {
+        result: true,
+        action: 'complete',
+      },
+      pretty: true,
+    });
+    expect(writer.jsonWrites[1]).toEqual({
+      data: {
+        result: false,
+        action: 'stop',
+        message: 'Stopped by user',
+        position: { current: '3', total: 3 },
+      },
+      pretty: true,
+    });
+  });
+
+  it('streams execution events as NDJSON and keeps compact JSON flush mode', () => {
+    const writer = createMockWriter();
+    const renderer = new JSONRenderer({ writer });
+
+    renderer.render({
+      type: 'execution_event',
+      event: transitionEvent({
+        agentId: 'agent-1',
+        parentRunbookId: 'parent-1',
+        parentStepId: 'step-7',
+      }),
+    });
+
+    renderer.render({
+      type: 'execution_event',
+      event: transitionEvent({
+        seq: 8,
+      }),
+    });
+    renderer.flush();
+
+    const firstLine = JSON.parse(writer.lines[0]);
+    const secondLine = JSON.parse(writer.lines[1]);
+
+    expect(firstLine).toMatchObject({
+      type: 'step_transitioned',
+      action: 'CONTINUE',
+      timestamp: '2026-02-20T00:00:00.000Z',
+      runbookId: 'wf-123',
+      seq: 7,
+      agentId: 'agent-1',
+      parentRunbookId: 'parent-1',
+      parentStepId: 'step-7',
+    });
+    expect(secondLine).toMatchObject({
+      type: 'step_transitioned',
+      runbookId: 'wf-123',
+      seq: 8,
+    });
+    expect(secondLine.agentId).toBeUndefined();
+    expect(secondLine.parentRunbookId).toBeUndefined();
+    expect(secondLine.parentStepId).toBeUndefined();
+    expect(writer.jsonWrites[0]).toEqual({
+      data: { result: true },
+      pretty: false,
+    });
+  });
+
+  it('resets internal state between flushes', () => {
+    const writer = createMockWriter();
+    const renderer = new JSONRenderer({ writer });
+
+    renderer.render({
+      type: 'message',
+      text: 'first',
+      level: 'info',
+    });
+    renderer.flush();
+
+    renderer.render({
+      type: 'list',
+      items: [1],
+      columns: [{ header: 'Value', key: (item: number) => item }],
+    });
+    renderer.flush();
+
+    expect(writer.jsonWrites[0]).toEqual({
+      data: { message: 'first', result: true },
+      pretty: true,
+    });
+    expect(writer.jsonWrites[1]).toEqual({
+      data: [1],
+      pretty: true,
+    });
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // packages/cli/src/cli.ts
 
-import { Command } from 'commander';
+import { Command, CommanderError } from 'commander';
 import { registerRunCommand } from './commands/run.js';
 import { registerGotoCommand } from './commands/goto.js';
 import { registerPassCommand } from './commands/pass.js';
@@ -92,4 +92,20 @@ registerPruneCommand(program);
 registerPromptCommand(program);
 registerScenariosCommand(program);
 
-program.parse();
+function enableExitOverride(command: Command): void {
+  command.exitOverride();
+  for (const subcommand of command.commands) {
+    enableExitOverride(subcommand);
+  }
+}
+
+enableExitOverride(program);
+
+try {
+  await program.parseAsync();
+} catch (error) {
+  if (error instanceof CommanderError) {
+    process.exit(error.code === 'commander.helpDisplayed' ? 0 : EXIT_COMMAND_ERROR);
+  }
+  throw error;
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,6 +20,7 @@ import { registerScenariosCommand } from './commands/scenarios.js';
 import { setColorEnabled } from '@rundown-org/core';
 import { initializePolicyContext, parsePolicyCliOptions } from './services/policy-context.js';
 import { outputCommandSchema } from './services/schema-service.js';
+import { EXIT_COMMAND_ERROR } from './helpers/exit-codes.js';
 
 // Handle --schema flag early, before Commander parses arguments
 // This allows schema output without requiring command arguments
@@ -29,11 +30,11 @@ if (process.argv.includes('--schema')) {
   const commandName = args.join(' ');
   if (commandName) {
     const success = outputCommandSchema(commandName);
-    process.exit(success ? 0 : 1);
+    process.exit(success ? 0 : EXIT_COMMAND_ERROR);
   } else {
     console.error('Usage: rd <command> --schema');
     console.error('Example: rd status --schema');
-    process.exit(1);
+    process.exit(EXIT_COMMAND_ERROR);
   }
 }
 

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import type { Command } from 'commander';
 import { parseRunbookDocument, validateRunbook, type Step } from '@rundown-org/parser';
 import { OutputEmitter } from '../services/output-emitter.js';
+import { EXIT_COMMAND_ERROR, EXIT_RUNBOOK_FAILED } from '../helpers/exit-codes.js';
 import { resolveRunbookFile } from '../helpers/resolve-runbook.js';
 
 function countSubsteps(steps: readonly Step[]): number {
@@ -37,7 +38,7 @@ export function registerCheckCommand(program: Command): void {
           'check',
         );
         output.flush();
-        process.exit(1);
+        process.exit(EXIT_COMMAND_ERROR);
       }
 
       try {
@@ -57,7 +58,7 @@ export function registerCheckCommand(program: Command): void {
             'check',
           );
           output.flush();
-          process.exit(1);
+          process.exit(EXIT_RUNBOOK_FAILED);
         }
 
         const stepCount = runbook.steps.length;
@@ -83,7 +84,7 @@ export function registerCheckCommand(program: Command): void {
           'check',
         );
         output.flush();
-        process.exit(1);
+        process.exit(EXIT_COMMAND_ERROR);
       }
     });
 }

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -69,6 +69,14 @@ export function registerCompleteCommand(program: Command): void {
             process.exit(1);
           }
 
+          // Update parent agent binding before popping (mirrors pass/fail behavior)
+          if (options.agent && state.parentRunbookId) {
+            await manager.updateAgentBinding(state.parentRunbookId, options.agent, {
+              status: 'done',
+              result: 'pass',
+            });
+          }
+
           await sessionService.popRunbook(options.agent);
 
           // Emit structured output - renderer decides format

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -67,19 +67,23 @@ export function registerCompleteCommand(program: Command): void {
             message,
           });
           if (!syncResult) {
+            await sessionService.popRunbook(options.agent);
             output.error('Failed to initialize runbook engine', 'ENGINE_INIT_FAILED');
             output.flush();
             process.exit(1);
             return; // Defensive: guards against mocked process.exit in tests
           }
 
-          // Persist COMPLETE metadata so historical state accurately reflects completion
-          await manager.update(state.id, {
-            lastAction: { type: 'COMPLETE' },
-            lastResult: 'pass',
-          });
+          // Best-effort metadata and binding updates — popRunbook must run regardless
+          try {
+            await manager.update(state.id, {
+              lastAction: { type: 'COMPLETE' },
+              lastResult: 'pass',
+            });
+          } catch {
+            // Non-fatal: actor already persisted terminal state via sendAndSync
+          }
 
-          // Update parent agent binding before popping (mirrors pass/fail behavior)
           if (options.agent && state.parentRunbookId) {
             try {
               await manager.updateAgentBinding(state.parentRunbookId, options.agent, {
@@ -88,7 +92,6 @@ export function registerCompleteCommand(program: Command): void {
               });
             } catch {
               // Non-fatal: parent state may be missing or corrupt.
-              // Proceed with popRunbook so session stack stays consistent.
             }
           }
 

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -57,6 +57,7 @@ export function registerCompleteCommand(program: Command): void {
             output.error(`Runbook state error: ${(err as Error).message}`, 'STATE_ERROR');
             output.flush();
             process.exit(1);
+            return; // Defensive: guards against mocked process.exit in tests
           }
 
           const actorService = new RunbookActorService(manager);
@@ -69,6 +70,7 @@ export function registerCompleteCommand(program: Command): void {
             output.error('Failed to initialize runbook engine', 'ENGINE_INIT_FAILED');
             output.flush();
             process.exit(1);
+            return; // Defensive: guards against mocked process.exit in tests
           }
 
           // Persist COMPLETE metadata so historical state accurately reflects completion
@@ -79,10 +81,15 @@ export function registerCompleteCommand(program: Command): void {
 
           // Update parent agent binding before popping (mirrors pass/fail behavior)
           if (options.agent && state.parentRunbookId) {
-            await manager.updateAgentBinding(state.parentRunbookId, options.agent, {
-              status: 'done',
-              result: 'pass',
-            });
+            try {
+              await manager.updateAgentBinding(state.parentRunbookId, options.agent, {
+                status: 'done',
+                result: 'pass',
+              });
+            } catch {
+              // Non-fatal: parent state may be missing or corrupt.
+              // Proceed with popRunbook so session stack stays consistent.
+            }
           }
 
           await sessionService.popRunbook(options.agent);

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -10,6 +10,7 @@ import {
 import { getCwd } from '../helpers/context.js';
 import { buildMetadata } from '../services/execution.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
+import { EXIT_COMMAND_ERROR } from '../helpers/exit-codes.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
 
@@ -56,7 +57,7 @@ export function registerCompleteCommand(program: Command): void {
             await sessionService.popRunbook(options.agent);
             output.error(`Runbook state error: ${(err as Error).message}`, 'STATE_ERROR');
             output.flush();
-            process.exit(1);
+            process.exit(EXIT_COMMAND_ERROR);
             return; // Defensive: guards against mocked process.exit in tests
           }
 
@@ -70,7 +71,7 @@ export function registerCompleteCommand(program: Command): void {
             await sessionService.popRunbook(options.agent);
             output.error('Failed to initialize runbook engine', 'ENGINE_INIT_FAILED');
             output.flush();
-            process.exit(1);
+            process.exit(EXIT_COMMAND_ERROR);
             return; // Defensive: guards against mocked process.exit in tests
           }
 

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -52,6 +52,8 @@ export function registerCompleteCommand(program: Command): void {
           try {
             steps = [...getRunbookFromState(state, cwd)];
           } catch (err) {
+            // Pop the broken runbook from the session so users can recover
+            await sessionService.popRunbook(options.agent);
             output.error(`Runbook state error: ${(err as Error).message}`, 'STATE_ERROR');
             output.flush();
             process.exit(1);
@@ -68,6 +70,12 @@ export function registerCompleteCommand(program: Command): void {
             output.flush();
             process.exit(1);
           }
+
+          // Persist COMPLETE metadata so historical state accurately reflects completion
+          await manager.update(state.id, {
+            lastAction: { type: 'COMPLETE' },
+            lastResult: 'pass',
+          });
 
           // Update parent agent binding before popping (mirrors pass/fail behavior)
           if (options.agent && state.parentRunbookId) {

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -1,7 +1,12 @@
 // packages/cli/src/commands/complete.ts
 
 import type { Command } from 'commander';
-import { RunbookStateManager, SessionService } from '@rundown-org/core';
+import {
+  RunbookStateManager,
+  SessionService,
+  RunbookActorService,
+  type Step,
+} from '@rundown-org/core';
 import { getCwd } from '../helpers/context.js';
 import { buildMetadata } from '../services/execution.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
@@ -30,8 +35,8 @@ export function registerCompleteCommand(program: Command): void {
     .action(async (message: string | undefined, options: { agent?: string; json?: boolean }) => {
       await withErrorHandling(
         async () => {
-          const output = new OutputEmitter({ json: options.json });
           const cwd = getCwd();
+          const output = new OutputEmitter({ json: options.json });
           const manager = new RunbookStateManager(cwd);
           const sessionService = new SessionService(manager);
           const state = await sessionService.getActive(options.agent);
@@ -42,17 +47,32 @@ export function registerCompleteCommand(program: Command): void {
             return;
           }
 
-          // Emit metadata
-          output.metadata(buildMetadata(state));
+          // Route through XState actor
+          let steps: Step[];
+          try {
+            steps = [...getRunbookFromState(state, cwd)];
+          } catch (err) {
+            output.error(`Runbook state error: ${(err as Error).message}`, 'STATE_ERROR');
+            output.flush();
+            process.exit(1);
+          }
 
-          const steps = getRunbookFromState(state, cwd);
-          await manager.update(state.id, {
-            step: steps[steps.length - 1].name,
-            variables: { ...state.variables, completed: true },
+          const actorService = new RunbookActorService(manager);
+
+          const syncResult = await actorService.sendAndSync(state.id, steps, {
+            type: 'COMPLETE',
+            message,
           });
+          if (!syncResult) {
+            output.error('Failed to initialize runbook engine', 'ENGINE_INIT_FAILED');
+            output.flush();
+            process.exit(1);
+          }
+
           await sessionService.popRunbook(options.agent);
 
-          // Emit completion
+          // Emit structured output - renderer decides format
+          output.metadata(buildMetadata(state));
           output.complete(message ?? 'Runbook completed successfully');
           output.flush();
         },

--- a/packages/cli/src/commands/echo.ts
+++ b/packages/cli/src/commands/echo.ts
@@ -2,6 +2,7 @@
 
 import type { Command } from 'commander';
 import { getCwd } from '../helpers/context.js';
+import { EXIT_COMMAND_ERROR } from '../helpers/exit-codes.js';
 import { DEFAULT_RESULT_SEQUENCE, executeEchoLogic } from '../helpers/echo-command.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 
@@ -73,7 +74,7 @@ export function registerEchoCommand(program: Command): void {
             'echo',
           );
           output.flush();
-          process.exit(1);
+          process.exit(EXIT_COMMAND_ERROR);
         }
       },
     );

--- a/packages/cli/src/commands/echo.ts
+++ b/packages/cli/src/commands/echo.ts
@@ -69,7 +69,7 @@ export function registerEchoCommand(program: Command): void {
             {
               result: false,
               error: message,
-              exitCode: 1,
+              exitCode: EXIT_COMMAND_ERROR,
             },
             'echo',
           );

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -13,6 +13,7 @@ import {
 import { getCwd } from '../helpers/context.js';
 import { runExecutionLoop } from '../services/execution.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
+import { EXIT_COMMAND_ERROR, EXIT_RUNBOOK_FAILED } from '../helpers/exit-codes.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { createBridgedEmitter } from '../helpers/execution-emitter.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
@@ -51,7 +52,7 @@ export function registerGotoCommand(program: Command): void {
               },
             );
             output.flush();
-            process.exit(1);
+            process.exit(EXIT_COMMAND_ERROR);
           }
 
           let steps: Step[];
@@ -60,7 +61,7 @@ export function registerGotoCommand(program: Command): void {
           } catch (err) {
             output.error(`Runbook state error: ${(err as Error).message}`, 'STATE_ERROR');
             output.flush();
-            process.exit(1);
+            process.exit(EXIT_COMMAND_ERROR);
           }
 
           // Validate step exists
@@ -71,7 +72,7 @@ export function registerGotoCommand(program: Command): void {
               available: steps.map((s) => s.name),
             });
             output.flush();
-            process.exit(1);
+            process.exit(EXIT_COMMAND_ERROR);
           }
 
           // Validate AT - target must be a FOR step
@@ -84,7 +85,7 @@ export function registerGotoCommand(program: Command): void {
                 { step: target.step, at: target.at },
               );
               output.flush();
-              process.exit(1);
+              process.exit(EXIT_COMMAND_ERROR);
             }
           }
 
@@ -100,7 +101,7 @@ export function registerGotoCommand(program: Command): void {
                 },
               );
               output.flush();
-              process.exit(1);
+              process.exit(EXIT_COMMAND_ERROR);
             }
             const substepExists = step.substeps.some((s) => s.id === target.substep);
             if (!substepExists) {
@@ -109,7 +110,7 @@ export function registerGotoCommand(program: Command): void {
                 available: step.substeps.map((s) => s.id),
               });
               output.flush();
-              process.exit(1);
+              process.exit(EXIT_COMMAND_ERROR);
             }
           }
 
@@ -125,7 +126,7 @@ export function registerGotoCommand(program: Command): void {
           if (!syncResult) {
             output.error('Failed to initialize runbook engine', 'ENGINE_INIT_FAILED');
             output.flush();
-            process.exit(1);
+            process.exit(EXIT_COMMAND_ERROR);
           }
 
           // Update lastAction and CLEAR lastResult (prevent stale PASS/FAIL leaking)
@@ -176,7 +177,7 @@ export function registerGotoCommand(program: Command): void {
           output.flush();
 
           if (loopResult === 'stopped') {
-            process.exit(1);
+            process.exit(EXIT_RUNBOOK_FAILED);
           }
         },
         { json: options.json },

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -19,6 +19,7 @@ import {
   type ExecutionEventEmitter,
 } from '@rundown-org/core';
 import { isSourced, type ForClause } from '@rundown-org/parser';
+import { EXIT_COMMAND_ERROR, EXIT_RUNBOOK_FAILED } from '../helpers/exit-codes.js';
 import { resolveRunbookFile } from '../helpers/resolve-runbook.js';
 import { getCwd } from '../helpers/context.js';
 import { runExecutionLoop } from '../services/execution.js';
@@ -113,7 +114,7 @@ export function registerRunCommand(program: Command): void {
             if (!state) {
               output.error('No active runbook', 'NO_ACTIVE_RUNBOOK');
               output.flush();
-              process.exit(1);
+              process.exit(EXIT_COMMAND_ERROR);
             }
 
             const stepId = parseStepIdFromString(options.step);
@@ -126,7 +127,7 @@ export function registerRunCommand(program: Command): void {
                 },
               );
               output.flush();
-              process.exit(1);
+              process.exit(EXIT_COMMAND_ERROR);
             }
 
             const pendingStep: PendingStep = {
@@ -163,7 +164,7 @@ export function registerRunCommand(program: Command): void {
                 },
               );
               output.flush();
-              process.exit(1);
+              process.exit(EXIT_COMMAND_ERROR);
             }
 
             // Load raw markdown and collect variables
@@ -195,7 +196,7 @@ export function registerRunCommand(program: Command): void {
                 runbook: file,
               });
               output.flush();
-              process.exit(1);
+              process.exit(EXIT_COMMAND_ERROR);
             }
 
             const runbookPath = path.relative(cwd, filePath);
@@ -243,7 +244,7 @@ export function registerRunCommand(program: Command): void {
             output.flush();
 
             if (result === 'stopped') {
-              process.exit(1);
+              process.exit(EXIT_RUNBOOK_FAILED);
             }
             return;
           }
@@ -254,7 +255,7 @@ export function registerRunCommand(program: Command): void {
             if (!state) {
               output.error('No active runbook', 'NO_ACTIVE_RUNBOOK');
               output.flush();
-              process.exit(1);
+              process.exit(EXIT_COMMAND_ERROR);
             }
 
             const pending = await lifecycleService.popPendingStep(state.id);
@@ -263,7 +264,7 @@ export function registerRunCommand(program: Command): void {
                 agent: options.agent,
               });
               output.flush();
-              process.exit(1);
+              process.exit(EXIT_COMMAND_ERROR);
             }
 
             await manager.bindAgent(state.id, options.agent, pending.stepId);
@@ -286,7 +287,7 @@ export function registerRunCommand(program: Command): void {
                   runbook: pending.runbook,
                 });
                 output.flush();
-                process.exit(1);
+                process.exit(EXIT_COMMAND_ERROR);
               }
 
               // Load raw child markdown and collect variables
@@ -317,7 +318,7 @@ export function registerRunCommand(program: Command): void {
                   runbook: pending.runbook,
                 });
                 output.flush();
-                process.exit(1);
+                process.exit(EXIT_COMMAND_ERROR);
               }
 
               // Inherit prompted flag from parent runbook
@@ -369,7 +370,7 @@ export function registerRunCommand(program: Command): void {
               output.flush();
 
               if (result === 'stopped') {
-                process.exit(1);
+                process.exit(EXIT_RUNBOOK_FAILED);
               }
             }
             return;
@@ -378,7 +379,7 @@ export function registerRunCommand(program: Command): void {
           if (!file && !options.step && !options.agent) {
             output.error('Runbook file, --step, or --agent option required', 'INVALID_SYNTAX');
             output.flush();
-            process.exit(1);
+            process.exit(EXIT_COMMAND_ERROR);
           }
         } catch (error) {
           if (isNodeError(error) && error.code === 'ENOENT') {
@@ -392,7 +393,7 @@ export function registerRunCommand(program: Command): void {
             output.error(getErrorMessage(error), 'UNKNOWN_ERROR');
           }
           output.flush();
-          process.exit(1);
+          process.exit(EXIT_COMMAND_ERROR);
         }
       },
     );

--- a/packages/cli/src/commands/scenarios.ts
+++ b/packages/cli/src/commands/scenarios.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { parseScenarios, type Scenario, type Scenarios } from '../schemas/scenarios.js';
+import { EXIT_COMMAND_ERROR, EXIT_RUNBOOK_FAILED } from '../helpers/exit-codes.js';
 import { resolveRunbookFile } from '../helpers/resolve-runbook.js';
 import { extractRawFrontmatter } from '../helpers/extract-raw-frontmatter.js';
 import { OutputEmitter } from '../services/output-emitter.js';
@@ -77,7 +78,7 @@ async function loadScenarios(file: string, output: OutputEmitter): Promise<Loade
   if (!filePath) {
     output.error(`Runbook file not found: ${file}`, 'RUNBOOK_NOT_FOUND');
     output.flush();
-    process.exit(1);
+    process.exit(EXIT_COMMAND_ERROR);
   }
 
   const content = await readFile(filePath, 'utf-8');
@@ -86,7 +87,7 @@ async function loadScenarios(file: string, output: OutputEmitter): Promise<Loade
   if (!frontmatter) {
     output.error('No frontmatter found in this runbook', 'VALIDATION_ERROR');
     output.flush();
-    process.exit(1);
+    process.exit(EXIT_COMMAND_ERROR);
   }
 
   const { scenarios, errors } = parseScenarios(frontmatter);
@@ -97,13 +98,13 @@ async function loadScenarios(file: string, output: OutputEmitter): Promise<Loade
       output.message(`  - ${error}`, 'error');
     }
     output.flush();
-    process.exit(1);
+    process.exit(EXIT_COMMAND_ERROR);
   }
 
   if (!scenarios || Object.keys(scenarios).length === 0) {
     output.error('No scenarios defined in this runbook', 'VALIDATION_ERROR');
     output.flush();
-    process.exit(1);
+    process.exit(EXIT_COMMAND_ERROR);
   }
 
   const name = (frontmatter.name as string | undefined) ?? file;
@@ -126,7 +127,7 @@ async function handleList(file: string, json?: boolean): Promise<void> {
   } catch (error) {
     output.error(error instanceof Error ? error.message : 'Unknown error', 'UNKNOWN_ERROR');
     output.flush();
-    process.exit(1);
+    process.exit(EXIT_COMMAND_ERROR);
   }
 }
 
@@ -145,7 +146,7 @@ async function handleShow(file: string, scenarioName: string, json?: boolean): P
   } catch (error) {
     output.error(error instanceof Error ? error.message : 'Unknown error', 'UNKNOWN_ERROR');
     output.flush();
-    process.exit(1);
+    process.exit(EXIT_COMMAND_ERROR);
   }
 }
 
@@ -191,7 +192,7 @@ function showScenarioDetails(name: string, scenarios: Scenarios, output: OutputE
       available: Object.keys(scenarios),
     });
     output.flush();
-    process.exit(1);
+    process.exit(EXIT_COMMAND_ERROR);
   }
 
   const scenario = scenarios[name];
@@ -263,7 +264,7 @@ async function runScenario(
       available: Object.keys(scenarios),
     });
     output.flush();
-    process.exit(1);
+    process.exit(EXIT_COMMAND_ERROR);
   }
 
   const scenario = scenarios[scenarioName];
@@ -374,7 +375,7 @@ async function runScenario(
     output.flush();
 
     if (!passed) {
-      process.exit(1);
+      process.exit(EXIT_RUNBOOK_FAILED);
     }
   } finally {
     // 7. Cleanup temp directory

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -10,6 +10,7 @@ import {
 import { getCwd } from '../helpers/context.js';
 import { buildMetadata } from '../services/execution.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
+import { EXIT_COMMAND_ERROR, EXIT_RUNBOOK_FAILED } from '../helpers/exit-codes.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
 
@@ -48,7 +49,7 @@ export function registerStopCommand(program: Command): void {
             await sessionService.popRunbook(options.agent);
             output.error(`Runbook state error: ${(err as Error).message}`, 'STATE_ERROR');
             output.flush();
-            process.exit(1);
+            process.exit(EXIT_COMMAND_ERROR);
             return; // Defensive: guards against mocked process.exit in tests
           }
 
@@ -62,7 +63,7 @@ export function registerStopCommand(program: Command): void {
             await sessionService.popRunbook(options.agent);
             output.error('Failed to initialize runbook engine', 'ENGINE_INIT_FAILED');
             output.flush();
-            process.exit(1);
+            process.exit(EXIT_COMMAND_ERROR);
             return; // Defensive: guards against mocked process.exit in tests
           }
 
@@ -94,7 +95,7 @@ export function registerStopCommand(program: Command): void {
           output.stopped(message ?? 'Runbook stopped');
           output.flush();
 
-          process.exit(1);
+          process.exit(EXIT_RUNBOOK_FAILED);
           return; // Defensive: guards against mocked process.exit in tests
         },
         { json: options.json },

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,11 +1,17 @@
 // packages/cli/src/commands/stop.ts
 
 import type { Command } from 'commander';
-import { RunbookStateManager, SessionService } from '@rundown-org/core';
+import {
+  RunbookStateManager,
+  SessionService,
+  RunbookActorService,
+  type Step,
+} from '@rundown-org/core';
 import { getCwd } from '../helpers/context.js';
 import { buildMetadata } from '../services/execution.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
+import { getRunbookFromState } from '../helpers/runbook-loader.js';
 
 /**
  * Registers the 'stop' command for aborting runbooks.
@@ -33,14 +39,36 @@ export function registerStopCommand(program: Command): void {
             return;
           }
 
-          // Delete and clear
-          await manager.delete(state.id);
+          // Route through XState actor
+          let steps: Step[];
+          try {
+            steps = [...getRunbookFromState(state, cwd)];
+          } catch (err) {
+            output.error(`Runbook state error: ${(err as Error).message}`, 'STATE_ERROR');
+            output.flush();
+            process.exit(1);
+          }
+
+          const actorService = new RunbookActorService(manager);
+
+          const syncResult = await actorService.sendAndSync(state.id, steps, {
+            type: 'STOP',
+            message,
+          });
+          if (!syncResult) {
+            output.error('Failed to initialize runbook engine', 'ENGINE_INIT_FAILED');
+            output.flush();
+            process.exit(1);
+          }
+
           await sessionService.popRunbook(options.agent);
 
           // Emit structured output - renderer decides format
           output.metadata(buildMetadata(state));
           output.stopped(message ?? 'Runbook stopped');
           output.flush();
+
+          process.exit(1);
         },
         { json: options.json },
       );

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -49,6 +49,7 @@ export function registerStopCommand(program: Command): void {
             output.error(`Runbook state error: ${(err as Error).message}`, 'STATE_ERROR');
             output.flush();
             process.exit(1);
+            return; // Defensive: guards against mocked process.exit in tests
           }
 
           const actorService = new RunbookActorService(manager);
@@ -61,6 +62,7 @@ export function registerStopCommand(program: Command): void {
             output.error('Failed to initialize runbook engine', 'ENGINE_INIT_FAILED');
             output.flush();
             process.exit(1);
+            return; // Defensive: guards against mocked process.exit in tests
           }
 
           // Persist STOP metadata so historical state accurately reflects termination
@@ -71,10 +73,15 @@ export function registerStopCommand(program: Command): void {
 
           // Update parent agent binding before popping (mirrors pass/fail behavior)
           if (options.agent && state.parentRunbookId) {
-            await manager.updateAgentBinding(state.parentRunbookId, options.agent, {
-              status: 'done',
-              result: 'fail',
-            });
+            try {
+              await manager.updateAgentBinding(state.parentRunbookId, options.agent, {
+                status: 'done',
+                result: 'fail',
+              });
+            } catch {
+              // Non-fatal: parent state may be missing or corrupt.
+              // Proceed with popRunbook so session stack stays consistent.
+            }
           }
 
           await sessionService.popRunbook(options.agent);
@@ -85,6 +92,7 @@ export function registerStopCommand(program: Command): void {
           output.flush();
 
           process.exit(1);
+          return; // Defensive: guards against mocked process.exit in tests
         },
         { json: options.json },
       );

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -59,19 +59,23 @@ export function registerStopCommand(program: Command): void {
             message,
           });
           if (!syncResult) {
+            await sessionService.popRunbook(options.agent);
             output.error('Failed to initialize runbook engine', 'ENGINE_INIT_FAILED');
             output.flush();
             process.exit(1);
             return; // Defensive: guards against mocked process.exit in tests
           }
 
-          // Persist STOP metadata so historical state accurately reflects termination
-          await manager.update(state.id, {
-            lastAction: { type: 'STOP' },
-            lastResult: 'fail',
-          });
+          // Best-effort metadata and binding updates — popRunbook must run regardless
+          try {
+            await manager.update(state.id, {
+              lastAction: { type: 'STOP' },
+              lastResult: 'fail',
+            });
+          } catch {
+            // Non-fatal: actor already persisted terminal state via sendAndSync
+          }
 
-          // Update parent agent binding before popping (mirrors pass/fail behavior)
           if (options.agent && state.parentRunbookId) {
             try {
               await manager.updateAgentBinding(state.parentRunbookId, options.agent, {
@@ -80,7 +84,6 @@ export function registerStopCommand(program: Command): void {
               });
             } catch {
               // Non-fatal: parent state may be missing or corrupt.
-              // Proceed with popRunbook so session stack stays consistent.
             }
           }
 

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -44,6 +44,8 @@ export function registerStopCommand(program: Command): void {
           try {
             steps = [...getRunbookFromState(state, cwd)];
           } catch (err) {
+            // Pop the broken runbook from the session so users can recover
+            await sessionService.popRunbook(options.agent);
             output.error(`Runbook state error: ${(err as Error).message}`, 'STATE_ERROR');
             output.flush();
             process.exit(1);
@@ -59,6 +61,20 @@ export function registerStopCommand(program: Command): void {
             output.error('Failed to initialize runbook engine', 'ENGINE_INIT_FAILED');
             output.flush();
             process.exit(1);
+          }
+
+          // Persist STOP metadata so historical state accurately reflects termination
+          await manager.update(state.id, {
+            lastAction: { type: 'STOP' },
+            lastResult: 'fail',
+          });
+
+          // Update parent agent binding before popping (mirrors pass/fail behavior)
+          if (options.agent && state.parentRunbookId) {
+            await manager.updateAgentBinding(state.parentRunbookId, options.agent, {
+              status: 'done',
+              result: 'fail',
+            });
           }
 
           await sessionService.popRunbook(options.agent);

--- a/packages/cli/src/helpers/exit-codes.ts
+++ b/packages/cli/src/helpers/exit-codes.ts
@@ -1,0 +1,17 @@
+/**
+ * CLI exit code constants for three-tier disambiguation.
+ *
+ * Scripts and parent processes can distinguish between runbook-level
+ * failures and command-level errors by inspecting the exit code.
+ *
+ * @module helpers/exit-codes
+ */
+
+/** Command and runbook both succeeded. */
+export const EXIT_SUCCESS = 0;
+
+/** Command succeeded; runbook was stopped or failed. */
+export const EXIT_RUNBOOK_FAILED = 1;
+
+/** Command itself failed (CLI-level error). */
+export const EXIT_COMMAND_ERROR = 2;

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -25,6 +25,7 @@ import {
   asTerminalSnapshotOrDefault,
 } from '@rundown-org/core';
 import { getRunbookFromState } from './runbook-loader.js';
+import { EXIT_RUNBOOK_FAILED } from './exit-codes.js';
 import {
   runExecutionLoop,
   formatActionForDisplay,
@@ -352,7 +353,7 @@ export async function handleTerminalState(
     output.flush();
 
     await applySideEffects(config.onStopped, config.lastResult);
-    process.exit(1);
+    process.exit(EXIT_RUNBOOK_FAILED);
     return 'stopped'; // Explicit return for clarity (process.exit never returns)
   }
 
@@ -411,7 +412,7 @@ export async function handleAgentBinding(
         retryEmitter,
       );
       output.flush();
-      if (loopResult === 'stopped') process.exit(1);
+      if (loopResult === 'stopped') process.exit(EXIT_RUNBOOK_FAILED);
       return true;
     } finally {
       actor.stop();
@@ -438,7 +439,7 @@ export async function handleAgentBinding(
         gotoEmitter,
       );
       output.flush();
-      if (loopResult === 'stopped') process.exit(1);
+      if (loopResult === 'stopped') process.exit(EXIT_RUNBOOK_FAILED);
       return true;
     } finally {
       actor.stop();
@@ -589,7 +590,7 @@ export async function executeTransition(
     output.flush();
 
     if (loopResult === 'stopped') {
-      process.exit(1);
+      process.exit(EXIT_RUNBOOK_FAILED);
     }
   } finally {
     actor.stop();

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -300,7 +300,7 @@ export async function handleTerminalState(
   positions: { prevPos: StepPosition; newPos: StepPosition },
   conditionResult: ConditionResult,
 ): Promise<'complete' | 'stopped' | 'continue'> {
-  const { output, manager, sessionService, state, steps, agentId } = ctx;
+  const { output, manager, sessionService, state, agentId } = ctx;
   const { prevPos, newPos } = positions;
 
   /**
@@ -339,11 +339,6 @@ export async function handleTerminalState(
     if (!check) continue;
 
     if (type === 'complete') {
-      await manager.update(state.id, {
-        step: steps[steps.length - 1].name,
-        variables: { ...state.variables, completed: true },
-      });
-
       output.complete(conditionResult.message, newPos);
       output.flush();
 
@@ -352,8 +347,6 @@ export async function handleTerminalState(
     }
 
     // type === 'stopped' (only other possibility)
-    await manager.update(state.id, { variables: { ...state.variables, stopped: true } });
-
     // stopped uses prevPos for output
     output.stopped(conditionResult.message, prevPos);
     output.flush();

--- a/packages/cli/src/helpers/wrapper.ts
+++ b/packages/cli/src/helpers/wrapper.ts
@@ -1,5 +1,6 @@
 import { isNodeError, getErrorMessage, RundownError, Errors } from '@rundown-org/core';
 import { RunbookSyntaxError } from '@rundown-org/parser';
+import { EXIT_COMMAND_ERROR } from './exit-codes.js';
 
 /**
  * Options for error handling behavior.
@@ -47,7 +48,7 @@ function toRundownError(error: unknown): RundownError {
  * Wraps an async function with standardized error handling for CLI commands.
  *
  * Catches errors, converts them to RundownError, and outputs appropriate
- * error messages before exiting with code 1.
+ * error messages before exiting with code 2 (command error).
  *
  * @param fn - Async function to execute with error handling
  * @param options - Error display options
@@ -67,6 +68,6 @@ export async function withErrorHandling(
       console.error(rundownError.toCliString(options.verbose));
     }
 
-    process.exit(1);
+    process.exit(EXIT_COMMAND_ERROR);
   }
 }

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -5118,16 +5118,31 @@ echo "processing"
           transitions: DEFAULT_TRANSITIONS,
         },
       ];
-      const machine = compileRunbookToMachine(steps);
-      const actor = createActor(machine);
-      actor.start();
 
-      actor.send({ type: 'STOP', message: 'abort now' });
-      const snap = actor.getSnapshot();
-      expect(snap.value).toBe('STOPPED');
-      expect(snap.context.lastAction).toEqual({ type: 'STOP' });
-      expect(snap.context.lastMessage).toBe('abort now');
-      expect(snap.context.variables).toEqual(expect.objectContaining({ stopped: true }));
+      // STOP from step 1
+      const machine1 = compileRunbookToMachine(steps);
+      const actor1 = createActor(machine1);
+      actor1.start();
+
+      actor1.send({ type: 'STOP', message: 'abort now' });
+      const snap1 = actor1.getSnapshot();
+      expect(snap1.value).toBe('STOPPED');
+      expect(snap1.context.lastAction).toEqual({ type: 'STOP' });
+      expect(snap1.context.lastMessage).toBe('abort now');
+      expect(snap1.context.variables).toEqual(expect.objectContaining({ stopped: true }));
+
+      // STOP from step 2
+      const machine2 = compileRunbookToMachine(steps);
+      const actor2 = createActor(machine2);
+      actor2.start();
+
+      actor2.send({ type: 'PASS' });
+      expect(actor2.getSnapshot().value).toBe('step::2');
+      actor2.send({ type: 'STOP', message: 'abort from step 2' });
+      const snap2 = actor2.getSnapshot();
+      expect(snap2.value).toBe('STOPPED');
+      expect(snap2.context.lastAction).toEqual({ type: 'STOP' });
+      expect(snap2.context.lastMessage).toBe('abort from step 2');
     });
 
     it('transitions to STOPPED from a substep', () => {
@@ -5151,22 +5166,9 @@ echo "processing"
       expect(snap.value).toBe('STOPPED');
       expect(snap.context.lastAction).toEqual({ type: 'STOP' });
       expect(snap.context.variables).toEqual(expect.objectContaining({ stopped: true }));
-    });
-
-    it('carries message through to context.lastMessage', () => {
-      const steps: Step[] = [
-        {
-          name: '1',
-          description: 'Step 1',
-          transitions: DEFAULT_TRANSITIONS,
-        },
-      ];
-      const machine = compileRunbookToMachine(steps);
-      const actor = createActor(machine);
-      actor.start();
-
-      actor.send({ type: 'STOP', message: 'emergency halt' });
-      expect(actor.getSnapshot().context.lastMessage).toBe('emergency halt');
+      expect(snap.context.forStack).toEqual([
+        expect.objectContaining({ stepId: '1', implicit: true }),
+      ]);
     });
 
     it('handles STOP without message', () => {
@@ -5186,6 +5188,40 @@ echo "processing"
       expect(snap.value).toBe('STOPPED');
       expect(snap.context.lastMessage).toBeUndefined();
     });
+
+    it('transitions to STOPPED during active FOR loop', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Loop step',
+          forClause: { start: 1, end: 3 },
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [{ id: '1', description: 'Sub 1', transitions: DEFAULT_TRANSITIONS }],
+        },
+      ];
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Complete iteration 1, enter iteration 2
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
+
+      actor.send({ type: 'STOP', message: 'abort from loop' });
+      const snap = actor.getSnapshot();
+      expect(snap.value).toBe('STOPPED');
+      expect(snap.context.lastAction).toEqual({ type: 'STOP' });
+      expect(snap.context.lastMessage).toBe('abort from loop');
+      expect(snap.context.forStack[0]).toEqual(
+        expect.objectContaining({ stepId: '1', iteration: 2 }),
+      );
+      expect(snap.context.iterationResults).toEqual(['pass']);
+    });
   });
 
   describe('COMPLETE event', () => {
@@ -5202,16 +5238,31 @@ echo "processing"
           transitions: DEFAULT_TRANSITIONS,
         },
       ];
-      const machine = compileRunbookToMachine(steps);
-      const actor = createActor(machine);
-      actor.start();
 
-      actor.send({ type: 'COMPLETE', message: 'done early' });
-      const snap = actor.getSnapshot();
-      expect(snap.value).toBe('COMPLETE');
-      expect(snap.context.lastAction).toEqual({ type: 'COMPLETE' });
-      expect(snap.context.lastMessage).toBe('done early');
-      expect(snap.context.variables).toEqual(expect.objectContaining({ completed: true }));
+      // COMPLETE from step 1
+      const machine1 = compileRunbookToMachine(steps);
+      const actor1 = createActor(machine1);
+      actor1.start();
+
+      actor1.send({ type: 'COMPLETE', message: 'done early' });
+      const snap1 = actor1.getSnapshot();
+      expect(snap1.value).toBe('COMPLETE');
+      expect(snap1.context.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(snap1.context.lastMessage).toBe('done early');
+      expect(snap1.context.variables).toEqual(expect.objectContaining({ completed: true }));
+
+      // COMPLETE from step 2
+      const machine2 = compileRunbookToMachine(steps);
+      const actor2 = createActor(machine2);
+      actor2.start();
+
+      actor2.send({ type: 'PASS' });
+      expect(actor2.getSnapshot().value).toBe('step::2');
+      actor2.send({ type: 'COMPLETE', message: 'done from step 2' });
+      const snap2 = actor2.getSnapshot();
+      expect(snap2.value).toBe('COMPLETE');
+      expect(snap2.context.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(snap2.context.lastMessage).toBe('done from step 2');
     });
 
     it('transitions to COMPLETE from a substep', () => {
@@ -5234,22 +5285,9 @@ echo "processing"
       expect(snap.value).toBe('COMPLETE');
       expect(snap.context.lastAction).toEqual({ type: 'COMPLETE' });
       expect(snap.context.variables).toEqual(expect.objectContaining({ completed: true }));
-    });
-
-    it('carries message through to context.lastMessage', () => {
-      const steps: Step[] = [
-        {
-          name: '1',
-          description: 'Step 1',
-          transitions: DEFAULT_TRANSITIONS,
-        },
-      ];
-      const machine = compileRunbookToMachine(steps);
-      const actor = createActor(machine);
-      actor.start();
-
-      actor.send({ type: 'COMPLETE', message: 'all checks passed' });
-      expect(actor.getSnapshot().context.lastMessage).toBe('all checks passed');
+      expect(snap.context.forStack).toEqual([
+        expect.objectContaining({ stepId: '1', implicit: true }),
+      ]);
     });
 
     it('handles COMPLETE without message', () => {
@@ -5268,6 +5306,40 @@ echo "processing"
       const snap = actor.getSnapshot();
       expect(snap.value).toBe('COMPLETE');
       expect(snap.context.lastMessage).toBeUndefined();
+    });
+
+    it('transitions to COMPLETE during active FOR loop', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Loop step',
+          forClause: { start: 1, end: 3 },
+          transitions: {
+            all: true,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [{ id: '1', description: 'Sub 1', transitions: DEFAULT_TRANSITIONS }],
+        },
+      ];
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Complete iteration 1, enter iteration 2
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
+
+      actor.send({ type: 'COMPLETE', message: 'early exit from loop' });
+      const snap = actor.getSnapshot();
+      expect(snap.value).toBe('COMPLETE');
+      expect(snap.context.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(snap.context.lastMessage).toBe('early exit from loop');
+      expect(snap.context.forStack[0]).toEqual(
+        expect.objectContaining({ stepId: '1', iteration: 2 }),
+      );
+      expect(snap.context.iterationResults).toEqual(['pass']);
     });
   });
 });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -3715,6 +3715,51 @@ echo "processing"
       actor.stop();
     });
 
+    it('clamps GOTO AT iteration to array bounds', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Start',
+          transitions: {
+            all: true,
+            pass: {
+              kind: 'pass',
+              retry: 0,
+              action: { type: 'GOTO', target: { step: '2', at: 99 } },
+            },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+          },
+        },
+        {
+          name: '2',
+          description: 'Loop step',
+          forClause: { start: 1, variable: 'item', source: 'items' },
+          transitions: {
+            all: true,
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+          },
+          substeps: [{ id: '1', description: 'Process', transitions: DEFAULT_TRANSITIONS }],
+        },
+      ];
+      const sources = {
+        items: { kind: 'array' as const, items: ['a', 'b', 'c'] },
+      };
+      const machine = compileRunbookToMachine(steps, { sources });
+      const actor = createActor(machine);
+      actor.start();
+
+      // GOTO 2 AT 99 → iteration should be clamped to array length (3)
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('step::2::1');
+      const top = actor.getSnapshot().context.forStack[0];
+      expect(top.iteration).toBe(3); // clamped from 99 to items.length
+      expect(top.start).toBe(1);
+      expect(top.end).toBe(3);
+
+      actor.stop();
+    });
+
     it('rejects undefined source variable', () => {
       const steps = createRunbook(`
 ## 1. Process items

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -5050,6 +5050,7 @@ echo "processing"
       actor.send({ type: 'FAIL' }); // retry 2/2
       actor.send({ type: 'FAIL' }); // exhausted → STOP
 
+      expect(snapshots.length).toBeGreaterThan(0);
       expect(snapshots.every((v) => !v.includes('retry'))).toBe(true);
     });
 
@@ -5100,6 +5101,173 @@ echo "processing"
       // (retryCount is shared, so FAIL's increment carries over to PASS)
       actor.send({ type: 'PASS' });
       expect(actor.getSnapshot().value).toBe('COMPLETE');
+    });
+  });
+
+  describe('STOP event', () => {
+    it('transitions to STOPPED from any step', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Step 1',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+        {
+          name: '2',
+          description: 'Step 2',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ];
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'STOP', message: 'abort now' });
+      const snap = actor.getSnapshot();
+      expect(snap.value).toBe('STOPPED');
+      expect(snap.context.lastAction).toEqual({ type: 'STOP' });
+      expect(snap.context.lastMessage).toBe('abort now');
+      expect(snap.context.variables).toEqual(expect.objectContaining({ stopped: true }));
+    });
+
+    it('transitions to STOPPED from a substep', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Parent',
+          substeps: [
+            { id: '1', description: 'Sub 1', transitions: DEFAULT_TRANSITIONS },
+            { id: '2', description: 'Sub 2', transitions: DEFAULT_TRANSITIONS },
+          ],
+        },
+      ];
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Start at substep 1.1, send STOP
+      actor.send({ type: 'STOP' });
+      const snap = actor.getSnapshot();
+      expect(snap.value).toBe('STOPPED');
+      expect(snap.context.lastAction).toEqual({ type: 'STOP' });
+      expect(snap.context.variables).toEqual(expect.objectContaining({ stopped: true }));
+    });
+
+    it('carries message through to context.lastMessage', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Step 1',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ];
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'STOP', message: 'emergency halt' });
+      expect(actor.getSnapshot().context.lastMessage).toBe('emergency halt');
+    });
+
+    it('handles STOP without message', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Step 1',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ];
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'STOP' });
+      const snap = actor.getSnapshot();
+      expect(snap.value).toBe('STOPPED');
+      expect(snap.context.lastMessage).toBeUndefined();
+    });
+  });
+
+  describe('COMPLETE event', () => {
+    it('transitions to COMPLETE from any step', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Step 1',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+        {
+          name: '2',
+          description: 'Step 2',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ];
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'COMPLETE', message: 'done early' });
+      const snap = actor.getSnapshot();
+      expect(snap.value).toBe('COMPLETE');
+      expect(snap.context.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(snap.context.lastMessage).toBe('done early');
+      expect(snap.context.variables).toEqual(expect.objectContaining({ completed: true }));
+    });
+
+    it('transitions to COMPLETE from a substep', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Parent',
+          substeps: [
+            { id: '1', description: 'Sub 1', transitions: DEFAULT_TRANSITIONS },
+            { id: '2', description: 'Sub 2', transitions: DEFAULT_TRANSITIONS },
+          ],
+        },
+      ];
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'COMPLETE' });
+      const snap = actor.getSnapshot();
+      expect(snap.value).toBe('COMPLETE');
+      expect(snap.context.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(snap.context.variables).toEqual(expect.objectContaining({ completed: true }));
+    });
+
+    it('carries message through to context.lastMessage', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Step 1',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ];
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'COMPLETE', message: 'all checks passed' });
+      expect(actor.getSnapshot().context.lastMessage).toBe('all checks passed');
+    });
+
+    it('handles COMPLETE without message', () => {
+      const steps: Step[] = [
+        {
+          name: '1',
+          description: 'Step 1',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ];
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'COMPLETE' });
+      const snap = actor.getSnapshot();
+      expect(snap.value).toBe('COMPLETE');
+      expect(snap.context.lastMessage).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -57,11 +57,13 @@ export type RunbookEvent =
   | { type: 'RETRY' }
   | { type: 'GOTO'; target: StepId }
   | {
-      type: 'STOP' /** Optional human-readable reason for aborting the runbook */;
+      type: 'STOP';
+      /** Optional human-readable reason for aborting the runbook */
       message?: string;
     }
   | {
-      type: 'COMPLETE' /** Optional human-readable reason for early completion */;
+      type: 'COMPLETE';
+      /** Optional human-readable reason for early completion */
       message?: string;
     };
 

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -359,7 +359,11 @@ function createForContext(
     end = forClause.end;
   }
 
-  const iteration = resolveAtValue(atValue, start);
+  let iteration = resolveAtValue(atValue, start);
+  // Clamp explicit AT values against array bounds to prevent out-of-range iterations
+  if (source.kind === 'array' && end !== undefined) {
+    iteration = Math.max(start, Math.min(iteration, end));
+  }
   const currentValue = undefined; // Resolved by ForIterationService before execution
   return {
     stepId: stepName,

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1163,13 +1163,17 @@ export function compileRunbookToMachine(
                 stepInfo.implicit,
                 options?.sources,
               ),
-            iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
+            iterationResults: ({
+              context,
+            }: {
+              context: RunbookContext;
+            }): ('pass' | 'fail')[] | undefined =>
               initIterationResults(
                 context.forStack,
                 context.iterationResults,
                 stepInfo.step.name,
-                true,
-              ) ?? [],
+                !stepInfo.implicit || !!stepInfo.step.transitions,
+              ),
           }),
         }
       : {};

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -152,6 +152,29 @@ function buildGotoLastAction(target: StepId): LastAction {
 }
 
 /**
+ * Build a lastAction function that extracts GOTO target info from an event.
+ *
+ * Returns a function compatible with XState assign that produces a
+ * {@link LastAction} from a GOTO event, or `undefined` for non-GOTO events.
+ * Reuses {@link buildGotoLastAction} internally.
+ *
+ * @param fallbackSubstepId - Substep ID to use when the event doesn't specify one
+ * @returns A function suitable for use as a lastAction assign value
+ */
+function buildGotoLastActionFromEvent(
+  fallbackSubstepId: string | undefined,
+): (args: { event: RunbookEvent }) => LastAction | undefined {
+  return ({ event }) => {
+    if (event.type !== 'GOTO') return undefined;
+    return buildGotoLastAction({
+      step: event.target.step,
+      substep: event.target.substep ?? fallbackSubstepId,
+      at: event.target.at,
+    });
+  };
+}
+
+/**
  * Check if a state represents the first substep of a step with substeps.
  * Returns step info with either the explicit forClause or a synthetic { start: 1, end: 1 }.
  *
@@ -336,6 +359,63 @@ function createForContext(
     source,
     currentValue,
   };
+}
+
+/**
+ * Initialise the forStack for a transition into a FOR step.
+ *
+ * If the topmost context already targets `targetStepName` (intra-loop GOTO),
+ * the existing stack is preserved. Otherwise a fresh single-entry stack is
+ * created via {@link createForContext}.
+ *
+ * @param currentForStack - The current forStack from machine context
+ * @param targetStepName - The step name being entered
+ * @param forClause - The FOR clause of the target step
+ * @param atValue - Optional AT value from a GOTO action
+ * @param implicit - Whether the FOR loop is implicit (no explicit FOR clause)
+ * @param sources - Optional data sources for sourced FOR loops
+ * @returns The forStack to assign
+ */
+function initForStack(
+  currentForStack: readonly ForContext[],
+  targetStepName: string,
+  forClause: ForClause,
+  atValue: number | string | undefined,
+  implicit: boolean,
+  sources?: Readonly<Record<string, DataSource>>,
+): readonly ForContext[] {
+  const top = peekForStack(currentForStack);
+  if (top?.stepId === targetStepName) {
+    return currentForStack;
+  }
+  const iteration = resolveAtValueRuntime(atValue, forClause.start, currentForStack);
+  return [createForContext(targetStepName, forClause, iteration, implicit, sources)];
+}
+
+/**
+ * Initialise iterationResults for a transition into a FOR step.
+ *
+ * If the topmost context already targets `targetStepName` (intra-loop GOTO),
+ * the existing results are preserved. Otherwise returns a fresh empty array
+ * when aggregation is needed, or `undefined` when it is not.
+ *
+ * @param currentForStack - The current forStack from machine context
+ * @param currentResults - The current iterationResults from machine context
+ * @param targetStepName - The step name being entered
+ * @param needsAggregation - Whether this step needs aggregation results
+ * @returns The iterationResults to assign
+ */
+function initIterationResults(
+  currentForStack: readonly ForContext[],
+  currentResults: ('pass' | 'fail')[] | undefined,
+  targetStepName: string,
+  needsAggregation: boolean,
+): ('pass' | 'fail')[] | undefined {
+  const top = peekForStack(currentForStack);
+  if (top?.stepId === targetStepName) {
+    return currentResults;
+  }
+  return needsAggregation ? [] : undefined;
 }
 
 /**
@@ -533,14 +613,15 @@ function buildParentExitAssign(
         const forClause = targetStep.forClause;
         return assign({
           ...baseAssign,
-          forStack: ({ context }: { context: RunbookContext }): readonly ForContext[] => {
-            const iteration = resolveAtValueRuntime(
-              parentAction.target.at,
-              forClause.start,
+          forStack: ({ context }: { context: RunbookContext }): readonly ForContext[] =>
+            initForStack(
               context.forStack,
-            );
-            return [createForContext(targetStep.name, forClause, iteration, false, sources)];
-          },
+              targetStep.name,
+              forClause,
+              parentAction.target.at,
+              false,
+              sources,
+            ),
           iterationResults: [] as ('pass' | 'fail')[],
           lastAction: buildGotoLastAction(parentAction.target),
           substep: parentAction.target.substep ?? targetStep.substeps[0]?.id,
@@ -916,36 +997,26 @@ function buildActionTransition(
         return {
           target: targetStateId,
           actions: assign({
-            forStack: ({ context }: { context: RunbookContext }): readonly ForContext[] => {
-              // Intra-loop GOTO: preserve existing forStack
-              const top = peekForStack(context.forStack);
-              if (top?.stepId === targetStepObj.name) {
-                return context.forStack;
-              }
-              // Cross-loop or fresh entry: create new context with runtime AT resolution
-              const iteration = resolveAtValueRuntime(
-                action.target.at,
-                forClause.start,
+            forStack: ({ context }: { context: RunbookContext }): readonly ForContext[] =>
+              initForStack(
                 context.forStack,
-              );
-              return [
-                createForContext(targetStepObj.name, forClause, iteration, isImplicit, sources),
-              ];
-            },
+                targetStepObj.name,
+                forClause,
+                action.target.at,
+                isImplicit,
+                sources,
+              ),
             iterationResults: ({
               context,
             }: {
               context: RunbookContext;
-            }): ('pass' | 'fail')[] | undefined => {
-              // Intra-loop GOTO: preserve existing results
-              const top = peekForStack(context.forStack);
-              if (top?.stepId === targetStepObj.name) {
-                return context.iterationResults;
-              }
-              return isImplicit && !targetStepObj.transitions
-                ? undefined
-                : ([] as ('pass' | 'fail')[]);
-            },
+            }): ('pass' | 'fail')[] | undefined =>
+              initIterationResults(
+                context.forStack,
+                context.iterationResults,
+                targetStepObj.name,
+                !isImplicit || !!targetStepObj.transitions,
+              ),
             lastAction: buildGotoLastAction(action.target),
             parentRetryCount:
               targetStepObj.name === stepName
@@ -1083,32 +1154,22 @@ export function compileRunbookToMachine(
     const entryActions = stepInfo
       ? {
           entry: assign({
-            forStack: ({ context }: { context: RunbookContext }) => {
-              const top = peekForStack(context.forStack);
-              // Loop-back: preserve current context
-              if (top?.stepId === stepInfo.step.name) {
-                return context.forStack;
-              }
-              // Fresh entry: push new context
-              return [
-                createForContext(
-                  stepInfo.step.name,
-                  stepInfo.forClause,
-                  undefined,
-                  stepInfo.implicit,
-                  options?.sources,
-                ),
-              ];
-            },
-            iterationResults: ({ context }: { context: RunbookContext }) => {
-              const top = peekForStack(context.forStack);
-              // Loop-back: preserve accumulated results
-              if (top?.stepId === stepInfo.step.name) {
-                return context.iterationResults ?? ([] as ('pass' | 'fail')[]);
-              }
-              // Fresh entry: always reset
-              return [] as ('pass' | 'fail')[];
-            },
+            forStack: ({ context }: { context: RunbookContext }): readonly ForContext[] =>
+              initForStack(
+                context.forStack,
+                stepInfo.step.name,
+                stepInfo.forClause,
+                undefined,
+                stepInfo.implicit,
+                options?.sources,
+              ),
+            iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
+              initIterationResults(
+                context.forStack,
+                context.iterationResults,
+                stepInfo.step.name,
+                true,
+              ) ?? [],
           }),
         }
       : {};
@@ -1140,7 +1201,6 @@ export function compileRunbookToMachine(
         target: target.id,
         actions: forStepForTarget
           ? assign({
-              // FOR step entry via GOTO event: initialize or preserve FOR context
               forStack: ({
                 context,
                 event,
@@ -1149,53 +1209,27 @@ export function compileRunbookToMachine(
                 event: RunbookEvent;
               }): readonly ForContext[] => {
                 if (event.type !== 'GOTO') return [];
-                // Intra-loop GOTO: preserve existing forStack
-                const top = peekForStack(context.forStack);
-                if (top?.stepId === forStepForTarget.step.name) {
-                  return context.forStack;
-                }
-                // Cross-loop or fresh entry: create new context with runtime AT resolution
-                const iteration = resolveAtValueRuntime(
-                  event.target.at,
-                  forStepForTarget.forClause.start,
+                return initForStack(
                   context.forStack,
+                  forStepForTarget.step.name,
+                  forStepForTarget.forClause,
+                  event.target.at,
+                  forStepForTarget.implicit,
+                  options?.sources,
                 );
-                return [
-                  createForContext(
-                    forStepForTarget.step.name,
-                    forStepForTarget.forClause,
-                    iteration,
-                    forStepForTarget.implicit,
-                    options?.sources,
-                  ),
-                ];
               },
               iterationResults: ({
                 context,
               }: {
                 context: RunbookContext;
-              }): ('pass' | 'fail')[] | undefined => {
-                // Intra-loop GOTO: preserve existing results
-                const top = peekForStack(context.forStack);
-                if (top?.stepId === forStepForTarget.step.name) {
-                  return context.iterationResults;
-                }
-                return forStepForTarget.implicit && !forStepForTarget.step.transitions
-                  ? undefined
-                  : ([] as ('pass' | 'fail')[]);
-              },
-              lastAction: ({ event }: { event: RunbookEvent }): LastAction | undefined => {
-                if (event.type !== 'GOTO') return undefined;
-                const step = event.target.step;
-                const substep = event.target.substep ?? target.substepId;
-                const at = event.target.at as number | `{{${string}}}` | undefined;
-                return {
-                  type: 'GOTO' as const,
-                  target: step,
-                  ...(substep && { substep }),
-                  ...(at !== undefined && { at }),
-                };
-              },
+              }): ('pass' | 'fail')[] | undefined =>
+                initIterationResults(
+                  context.forStack,
+                  context.iterationResults,
+                  forStepForTarget.step.name,
+                  !forStepForTarget.implicit || !!forStepForTarget.step.transitions,
+                ),
+              lastAction: buildGotoLastActionFromEvent(target.substepId),
               parentRetryCount:
                 target.stepName === config.stepName
                   ? ({ context }: { context: RunbookContext }) => context.parentRetryCount
@@ -1205,18 +1239,7 @@ export function compileRunbookToMachine(
                 event.type === 'GOTO' ? (event.target.substep ?? target.substepId) : undefined,
             })
           : buildSimpleGotoAssign({
-              lastAction: ({ event }: { event: RunbookEvent }): LastAction | undefined => {
-                if (event.type !== 'GOTO') return undefined;
-                const step = event.target.step;
-                const substep = event.target.substep ?? target.substepId;
-                const at = event.target.at as number | `{{${string}}}` | undefined;
-                return {
-                  type: 'GOTO' as const,
-                  target: step,
-                  ...(substep && { substep }),
-                  ...(at !== undefined && { at }),
-                };
-              },
+              lastAction: buildGotoLastActionFromEvent(target.substepId),
               resolvedSubstepId: ({ event }: { event: RunbookEvent }) =>
                 event.type === 'GOTO' ? (event.target.substep ?? target.substepId) : undefined,
               isGotoToSelf,

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -56,8 +56,14 @@ export type RunbookEvent =
   | { type: 'FAIL' }
   | { type: 'RETRY' }
   | { type: 'GOTO'; target: StepId }
-  | { type: 'STOP'; message?: string }
-  | { type: 'COMPLETE'; message?: string };
+  | {
+      type: 'STOP' /** Optional human-readable reason for aborting the runbook */;
+      message?: string;
+    }
+  | {
+      type: 'COMPLETE' /** Optional human-readable reason for early completion */;
+      message?: string;
+    };
 
 /**
  * XState transition configuration returned by transition builder functions.

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -400,7 +400,13 @@ function initForStack(
   if (top?.stepId === targetStepName) {
     return currentForStack;
   }
-  const iteration = resolveAtValueRuntime(atValue, forClause.start, currentForStack);
+  // Only resolve AT when explicitly provided; otherwise let createForContext
+  // use its own clamped start (important for sourced array loops where
+  // forClause.start may exceed the array length).
+  const iteration =
+    atValue !== undefined
+      ? resolveAtValueRuntime(atValue, forClause.start, currentForStack)
+      : undefined;
   return [createForContext(targetStepName, forClause, iteration, implicit, sources)];
 }
 

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -48,12 +48,16 @@ export interface RunbookContext {
  * - FAIL: Mark the current step as failed, triggering the FAIL transition
  * - RETRY: Increment retry count and re-enter the current step
  * - GOTO: Jump directly to a specific step by ID
+ * - STOP: Abort the runbook, transitioning to STOPPED final state
+ * - COMPLETE: Force early completion, transitioning to COMPLETE final state
  */
 export type RunbookEvent =
   | { type: 'PASS' }
   | { type: 'FAIL' }
   | { type: 'RETRY' }
-  | { type: 'GOTO'; target: StepId };
+  | { type: 'GOTO'; target: StepId }
+  | { type: 'STOP'; message?: string }
+  | { type: 'COMPLETE'; message?: string };
 
 /**
  * XState transition configuration returned by transition builder functions.
@@ -1282,6 +1286,22 @@ export function compileRunbookToMachine(
           target: config.id,
         },
         GOTO: buildGotoTransitionsForState,
+        STOP: {
+          target: 'STOPPED',
+          actions: assign({
+            lastAction: { type: 'STOP' as const },
+            lastMessage: ({ event }: { event: RunbookEvent }) =>
+              event.type === 'STOP' ? event.message : undefined,
+          }),
+        },
+        COMPLETE: {
+          target: 'COMPLETE',
+          actions: assign({
+            lastAction: { type: 'COMPLETE' as const },
+            lastMessage: ({ event }: { event: RunbookEvent }) =>
+              event.type === 'COMPLETE' ? event.message : undefined,
+          }),
+        },
       },
     };
 

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -613,15 +613,16 @@ function buildParentExitAssign(
         const forClause = targetStep.forClause;
         return assign({
           ...baseAssign,
-          forStack: ({ context }: { context: RunbookContext }): readonly ForContext[] =>
-            initForStack(
-              context.forStack,
-              targetStep.name,
-              forClause,
+          // Parent exit always creates fresh ForContext — never preserve an
+          // exhausted stack (initForStack's intra-loop check is wrong here).
+          forStack: ({ context }: { context: RunbookContext }): readonly ForContext[] => {
+            const iteration = resolveAtValueRuntime(
               parentAction.target.at,
-              false,
-              sources,
-            ),
+              forClause.start,
+              context.forStack,
+            );
+            return [createForContext(targetStep.name, forClause, iteration, false, sources)];
+          },
           iterationResults: [] as ('pass' | 'fail')[],
           lastAction: buildGotoLastAction(parentAction.target),
           substep: parentAction.target.substep ?? targetStep.substeps[0]?.id,


### PR DESCRIPTION
Add STOP and COMPLETE as first-class RunbookEvent types with transitions on every child state, replacing direct state manager calls in CLI commands.

- Expand RunbookEvent with STOP/COMPLETE event variants
- Add STOP/COMPLETE transitions to all child states in compiler
- Refactor stop.ts to use sendAndSync instead of manager.delete()
- Refactor complete.ts to use sendAndSync instead of manager.update()
- Remove redundant manager.update() calls in handleTerminalState
- Add 8 compiler tests for STOP/COMPLETE event handling
- Update CLI tests for new stop behavioral semantics

BREAKING CHANGE: `stop` command now preserves state with `stopped: true` instead of deleting it. Use `prune` to clean up old state files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stop now preserves runbook state and returns a non-zero exit status on failure; errors emit clear terminal states.

* **New Features**
  * STOP and COMPLETE record a final action and optional message; termination flows now coordinate via an actor-backed sync.

* **Improvements**
  * Parent runbook bindings updated after nested stop/complete; terminal-state persistence reduced.

* **Tests**
  * Expanded STOP/COMPLETE coverage across diverse runbook and loop scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->