### PR TITLE
Named substeps

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -74,30 +74,29 @@ read_only: true
 #  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
 #  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
 #  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
-excluded_tools: [
-  'read_file',
-  'create_text_file',
-  'list_dir',
-  'find_file',
-  'search_for_pattern',
-  'replace_content',
-  'execute_shell_command',
-  'initial_instructions',
-  'onboarding',
-  'check_onboarding_performed',
-  'prepare_for_new_conversation',
-  'switch_modes',
-  'get_current_config',
-  'activate_project',
-  'think_about_collected_information',
-  'think_about_task_adherence',
-  'think_about_whether_you_are_done',
-  'write_memory',
-  'read_memory',
-  'list_memories',
-  'edit_memory',
-  'delete_memory'
-]
+excluded_tools:
+- 'read_file'
+- 'create_text_file'
+- 'list_dir'
+- 'find_file'
+- 'search_for_pattern'
+- 'replace_content'
+- 'execute_shell_command'
+- 'initial_instructions'
+- 'onboarding'
+- 'check_onboarding_performed'
+- 'prepare_for_new_conversation'
+- 'switch_modes'
+- 'get_current_config'
+- 'activate_project'
+- 'think_about_collected_information'
+- 'think_about_task_adherence'
+- 'think_about_whether_you_are_done'
+- 'write_memory'
+- 'read_memory'
+- 'list_memories'
+- 'edit_memory'
+- 'delete_memory'
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
@@ -126,3 +125,16 @@ default_modes:
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
 fixed_tools: []
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:

--- a/docs/AGENT-ORCHESTRATION.md
+++ b/docs/AGENT-ORCHESTRATION.md
@@ -119,9 +119,9 @@ The runbook handles flow (check → invoke skill → write); the skill handles c
 
 ---
 
-### 4. Substeps with Agent Types
+### 4. Substeps with Agent Dispatch
 
-A runbook defines substeps, each delegated to a typed subagent. The parent agent orchestrates; subagents execute. Agent types are declared in H3 substep headers.
+A runbook defines substeps, each delegated to a subagent. The parent agent orchestrates; subagents execute. Agent type context injection is driven by runtime hook events, not substep header syntax.
 
 **When to use:** Tasks with distinct subtasks that benefit from specialised agents. Each subagent gets its own context and instructions via context injection.
 
@@ -131,16 +131,16 @@ A runbook defines substeps, each delegated to a typed subagent. The parent agent
 - PASS ALL: CONTINUE
 - FAIL ANY: GOTO 4
 
-### 2.1 Code review (code-review-agent)
+### 2.1 Code review
 Review the implementation for correctness and style.
 
-### 2.2 Test review (test-agent)
+### 2.2 Test review
 Verify test coverage and assertions.
 ```
 
 **Command sequence:**
 ```bash
-# Parent queues substep with agent type
+# Parent queues substep
 rd run --step 2.1
 
 # Subagent binds to pending step
@@ -150,7 +150,7 @@ rd run --agent subagent-abc
 rd pass --agent subagent-abc
 ```
 
-The agent type (`code-review-agent`, `test-agent`) drives context injection — see [Context File Discovery](#context-file-discovery).
+Agent type context injection is driven by runtime hook events — see [Context File Discovery](#context-file-discovery).
 
 **Dispatch frontier and identity:**
 - `run --step` requires a parseable step identifier; when the active step has substeps, step-only dispatch (`N`) is rejected and `N.M` is required.
@@ -312,8 +312,8 @@ When substeps involve agents, transition rules use aggregate conditions:
 - PASS ALL: CONTINUE
 - FAIL ANY: GOTO 4
 
-### 2.1 First reviewer (code-review-agent)
-### 2.2 Second reviewer (code-agent)
+### 2.1 First reviewer
+### 2.2 Second reviewer
 ```
 
 | Condition | Meaning |

--- a/docs/AGENT-ORCHESTRATION.md
+++ b/docs/AGENT-ORCHESTRATION.md
@@ -15,7 +15,7 @@ How Rundown orchestrates work through agents. This document covers the five orch
   - [1. Sequential Runbook Steps](#1-sequential-runbook-steps)
   - [2. Skill-Guided Single Agent](#2-skill-guided-single-agent)
   - [3. Runbook + Skill Composition](#3-runbook--skill-composition)
-  - [4. Substeps with Agent Types](#4-substeps-with-agent-types)
+  - [4. Substeps with Agent Dispatch](#4-substeps-with-agent-dispatch)
   - [5. Parallel Fan-Out / Fan-In](#5-parallel-fan-out--fan-in)
 - [Choosing a Model](#choosing-a-model)
 - [Agent Type Conventions](#agent-type-conventions)
@@ -139,6 +139,7 @@ Verify test coverage and assertions.
 ```
 
 **Command sequence:**
+
 ```bash
 # Parent queues substep
 rd run --step 2.1
@@ -210,7 +211,7 @@ Each agent writes its findings to `.work/{date}-verify-{agentId}.md`, ending wit
 | Linear checklist, CI pipeline | [Sequential Steps](#1-sequential-runbook-steps) | Low |
 | Methodology guidance, flexible execution | [Skill-Guided](#2-skill-guided-single-agent) | Low |
 | Enforced ordering + methodology | [Runbook + Skill](#3-runbook--skill-composition) | Medium |
-| Distinct subtasks, specialised agents | [Substeps with Agent Types](#4-substeps-with-agent-types) | Medium |
+| Distinct subtasks, specialised agents | [Substeps with Agent Dispatch](#4-substeps-with-agent-dispatch) | Medium |
 | Independent review, consensus | [Parallel Fan-Out](#5-parallel-fan-out--fan-in) | High |
 
 **Decision flow:**

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -46,16 +46,14 @@ where substeps is:
   substep [ substep ... ]
 
 where substep is:
-  "###" substep_id title [ "(" agent_type ")" ]
+  "###" substep_id [ separator ] [ title ]
     [ transition ... ]
     [ prompt ]
-    [{ code_block  | runbooks }]
-
-where agent_type is:
-  text    -- agent identifier for delegation (e.g., "code-review-agent")
+    [{ code_block | runbooks }]
 
 where substep_id is:
-  positive_integer                              -- short form (parent prefix omitted)
+  positive_integer                              -- bare numeric (parent positionally assigned)
+  | name                                        -- bare named (parent positionally assigned)
   | parent_ref "." ( positive_integer | name )  -- qualified form
 
 where parent_ref is:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -70,8 +70,8 @@ Code block info string tags are matched case-insensitively. `BASH`, `Bash`, and 
 ### 3.2 Substeps
 
 Nested steps defined by H3 (`###`) headers.
-*   **Identifiers**: `### 1`, `### 1.1` (sequential), or `### Name` (named).
-*   **Agent type**: Optional parenthesized suffix specifying the agent type for delegation: `### 1.2 Description (agent-type)`. The agent type is extracted and set on the substep AST node as `agentType`.
+*   **Identifiers**: `### 1` (bare numeric), `### Name` (bare named), `### 1.1` (qualified numeric), or `### Step.Name` (qualified named). Bare forms are positionally assigned to the preceding H2 step.
+*   **Strict H3 rule**: When a step contains any valid substep, all H3 headers within that step must be valid substep identifiers.
 *   **Aggregation**: Parent step outcome is derived from substeps via transitions (`ALL`/`ANY`).
 
 ### 3.3 Runbook List Shorthand

--- a/packages/claude-code-plugin/src/gates/on-subagent-stop.ts
+++ b/packages/claude-code-plugin/src/gates/on-subagent-stop.ts
@@ -2,14 +2,10 @@ import type { HookInput, GateResult } from '../shared/index.js';
 import { handleSubagentStop } from '../workflow/hooks/subagent-stop.js';
 
 /**
- * Workflow Subagent Stop Gate
+ * Evaluate subagent stop conditions and translate them into a gate decision.
  *
- * Wraps handleSubagentStop logic as a configurable gate.
- * Handles delegation abort on agent failure.
- *
- * @param input - Hook input containing subagent lifecycle metadata
- * @returns Gate result: block on violation, context on abort, or empty
- * @throws Propagates errors from handleSubagentStop if session I/O fails
+ * @param input - Hook input provided to the subagent-stop handler
+ * @returns A GateResult: `decision: 'block'` and `reason` when a violation is present; `additionalContext` when context is returned; or an empty object otherwise.
  */
 export async function execute(input: HookInput): Promise<GateResult> {
   const result = await handleSubagentStop(input);

--- a/packages/claude-code-plugin/src/workflow/hooks/delegation-detector.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/delegation-detector.ts
@@ -24,10 +24,12 @@ export interface DelegationDetection {
 const CLAIM_MARKER_PATTERN = /^RD_CLAIM_TOKEN=(rdtk_[A-Z0-9]{32})$/m;
 
 /**
- * Detect a delegation marker in a single text field.
+ * Finds a delegation marker in a text field.
+ *
+ * Scans the provided text for a canonical RD_CLAIM_TOKEN line and, if present, returns the captured raw token.
  *
  * @param text - Text to scan for a delegation marker
- * @returns Detection result with token, or null if no marker found
+ * @returns The detected `DelegationDetection` with the extracted `token`, or `null` if no marker is found
  */
 export function detectDelegationMarker(text: string): DelegationDetection | null {
   if (!text) return null;

--- a/packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts
@@ -16,14 +16,16 @@ export interface DelegationDispatchResult {
 }
 
 /**
- * Handle PreToolUse(Task) events that contain a delegation marker.
+ * Detect delegation markers in a PreToolUse Task event, persist the delegation token in
+ * session metadata for abort correlation, and produce a Markdown context instructing
+ * the subagent to claim the token and report results.
  *
- * Detects `RD_CLAIM_TOKEN=` markers in Task prompt/description,
- * enriches the subagent prompt with `rd claim <token>` instructions,
- * and stores the token in session metadata for SubagentStop abort correlation.
+ * The context includes a claim command (`rd claim <token>`) and may include best-effort
+ * runbook/step hints when available.
  *
- * @param input - Hook input from Claude Code
- * @returns Dispatch result with context enrichment or empty object
+ * @param input - Hook input received from Claude Code for the event
+ * @returns A Dispatch result containing `context` with the delegation instructions when a token
+ *          is found; an empty object when no delegation is detected or the event is not applicable.
  */
 export async function handleDelegationDispatch(
   input: HookInput,

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -15,13 +15,10 @@ export interface SubagentStopResult {
 const STATUS_PATTERN = /STATUS:\s*(OK|PASS|BLOCKED|FAIL)/i;
 
 /**
- * Parse STATUS field from subagent output using {@link STATUS_PATTERN}.
+ * Determine whether a subagent STATUS in the given output indicates a pass or a fail.
  *
- * Maps OK/PASS to 'pass' and BLOCKED/FAIL to 'fail'.
- * Missing or unrecognized status defaults to 'pass'.
- *
- * @param output - Raw subagent output text to scan for STATUS field
- * @returns Normalized status: 'pass' for OK/PASS/missing, 'fail' for BLOCKED/FAIL
+ * @param output - Raw subagent output text to search for a `STATUS:` field
+ * @returns `pass` if `STATUS` is `OK` or `PASS` (case-insensitive) or if no `STATUS` is present; `fail` otherwise
  */
 export function parseAgentStatus(output?: string): 'pass' | 'fail' {
   if (!output) return 'pass';
@@ -34,11 +31,12 @@ export function parseAgentStatus(output?: string): 'pass' | 'fail' {
 }
 
 /**
- * Handle SubagentStop hook with delegation-aware abort.
+ * Handle a SubagentStop hook by consuming any active delegation token and aborting its delegation if the subagent failed.
  *
- * On failure, if a delegation token is active in session metadata,
- * calls `rd abort <token> --force` to cancel the delegation.
- * Successful delegations self-complete via the child run's own pass/fail.
+ * Consumes the session's `delegation_active_token` (if present). If the parsed agent status is a failure and a token was active, attempts a best-effort abort of the delegation and returns a context message; otherwise returns an empty result.
+ *
+ * @param input - Hook event payload (includes cwd, hook_event_name, and last_assistant_message)
+ * @returns An object with `context` when an abort was attempted, or an empty object if no action was taken
  */
 export async function handleSubagentStop(input: HookInput): Promise<SubagentStopResult> {
   if (input.hook_event_name !== 'SubagentStop') {

--- a/packages/core/__tests__/runbook/renderer.test.ts
+++ b/packages/core/__tests__/runbook/renderer.test.ts
@@ -89,9 +89,9 @@ describe('renderSubstep', () => {
     expect(renderSubstep(substep, '3')).toBe('### 3.1 First reviewer');
   });
 
-  it('renders substep with agent type', () => {
-    const substep: Substep = { id: '2', description: 'Second reviewer', agentType: 'code-agent' };
-    expect(renderSubstep(substep, '1')).toBe('### 1.2 Second reviewer (code-agent)');
+  it('renders substep without agent type', () => {
+    const substep: Substep = { id: '2', description: 'Second reviewer' };
+    expect(renderSubstep(substep, '1')).toBe('### 1.2 Second reviewer');
   });
 
   it('renders substep with child runbooks', () => {
@@ -120,12 +120,12 @@ describe('renderStep', () => {
       description: 'Dispatch reviewers',
       substeps: [
         { id: '1', description: 'First reviewer' },
-        { id: '2', description: 'Second reviewer', agentType: 'code-agent' },
+        { id: '2', description: 'Second reviewer' },
       ],
     };
     const result = renderStep(step);
     expect(result).toContain('### 3.1 First reviewer');
-    expect(result).toContain('### 3.2 Second reviewer (code-agent)');
+    expect(result).toContain('### 3.2 Second reviewer');
   });
 
   it('renders step with command', () => {
@@ -322,8 +322,8 @@ echo hello
 - PASS ALL: CONTINUE
 - FAIL ANY: STOP
 
-### 1.1 First reviewer (code-review-agent)
-### 1.2 Second reviewer (code-agent)
+### 1.1 First reviewer
+### 1.2 Second reviewer
 
 ## 2. Complete`;
 
@@ -337,9 +337,8 @@ echo hello
     expect(parsed2[0].substeps).toHaveLength(2);
     expect(parsed2[0].substeps?.[0].id).toBe('1');
     expect(parsed2[0].substeps?.[0].description).toBe('First reviewer');
-    expect(parsed2[0].substeps?.[0].agentType).toBe('code-review-agent');
     expect(parsed2[0].substeps?.[1].id).toBe('2');
-    expect(parsed2[0].substeps?.[1].agentType).toBe('code-agent');
+    expect(parsed2[0].substeps?.[1].description).toBe('Second reviewer');
   });
 
   it('round-trips runbook with GOTO substep targets', () => {

--- a/packages/core/src/runbook/renderer/renderer.ts
+++ b/packages/core/src/runbook/renderer/renderer.ts
@@ -54,19 +54,16 @@ export function renderTransitions(transitions: Transitions): string {
 /**
  * Render a Substep to Markdown.
  *
- * Generates an H3 header with the substep ID, description, optional
- * agent type suffix, and runbook references.
+ * Generates an H3 header with the substep ID, description,
+ * and runbook references.
  *
  * @param substep - The Substep to render
  * @param parentStepName - The parent step name (e.g., "1", "ErrorHandler")
  * @returns Markdown H3 header string for the substep
  */
 export function renderSubstep(substep: Substep, parentStepName: string): string {
-  const agentSuffix = substep.agentType ? ` (${substep.agentType})` : '';
   const lines: string[] = [];
-  lines.push(
-    renderHeading(3, `${parentStepName}.${substep.id}`, `${substep.description}${agentSuffix}`),
-  );
+  lines.push(renderHeading(3, `${parentStepName}.${substep.id}`, substep.description));
   if (substep.runbooks?.length) {
     lines.push('');
     for (const runbookPath of substep.runbooks) {

--- a/packages/parser/__tests__/helpers.test.ts
+++ b/packages/parser/__tests__/helpers.test.ts
@@ -609,7 +609,6 @@ describe('extractSubstepHeader with named substeps', () => {
         stepRef: '1',
         id: '1',
         description: 'First substep',
-        agentType: undefined,
       });
     });
   });
@@ -621,7 +620,6 @@ describe('extractSubstepHeader with named substeps', () => {
         stepRef: '1',
         id: 'Cleanup',
         description: 'Handle cleanup',
-        agentType: undefined,
       });
     });
 
@@ -631,7 +629,6 @@ describe('extractSubstepHeader with named substeps', () => {
         stepRef: 'ErrorHandler',
         id: 'Recover',
         description: 'Recovery logic',
-        agentType: undefined,
       });
     });
 
@@ -641,12 +638,56 @@ describe('extractSubstepHeader with named substeps', () => {
         stepRef: '1',
         id: 'A',
         description: 'Do',
-        agentType: undefined,
       });
     });
 
     it('rejects reserved word as substep name', () => {
       expect(extractSubstepHeader('1.NEXT Invalid')).toBeNull();
+    });
+  });
+
+  describe('bare named substeps', () => {
+    it('parses bare name with no description', () => {
+      expect(extractSubstepHeader('ErrorHandler')).toEqual({
+        id: 'ErrorHandler',
+        description: '',
+      });
+    });
+
+    it('parses bare name with description', () => {
+      expect(extractSubstepHeader('ErrorHandler Handle the error')).toEqual({
+        id: 'ErrorHandler',
+        description: 'Handle the error',
+      });
+    });
+
+    it('parses bare name with colon separator', () => {
+      expect(extractSubstepHeader('ErrorHandler: Handle the error')).toEqual({
+        id: 'ErrorHandler',
+        description: 'Handle the error',
+      });
+    });
+
+    it('parses bare name with paren separator', () => {
+      expect(extractSubstepHeader('ErrorHandler) Title')).toEqual({
+        id: 'ErrorHandler',
+        description: 'Title',
+      });
+    });
+
+    it('rejects reserved word GOTO', () => {
+      expect(extractSubstepHeader('GOTO')).toBeNull();
+    });
+
+    it('rejects reserved word PASS', () => {
+      expect(extractSubstepHeader('PASS')).toBeNull();
+    });
+
+    it('accepts underscore-prefixed identifier', () => {
+      expect(extractSubstepHeader('_private')).toEqual({
+        id: '_private',
+        description: '',
+      });
     });
   });
 });
@@ -1096,8 +1137,11 @@ describe('extractSubstepHeader edge cases', () => {
     expect(extractSubstepHeader('')).toBeNull();
   });
 
-  it('returns null for string without dot', () => {
-    expect(extractSubstepHeader('NoDot')).toBeNull();
+  it('parses bare name (no dot) as bare named substep', () => {
+    expect(extractSubstepHeader('NoDot')).toEqual({
+      id: 'NoDot',
+      description: '',
+    });
   });
 
   it('returns null for string starting with dot', () => {
@@ -1116,23 +1160,21 @@ describe('extractSubstepHeader edge cases', () => {
     expect(extractSubstepHeader('1.@invalid Something')).toBeNull();
   });
 
-  it('extracts agent type from parentheses at end', () => {
+  it('treats former agent-type parentheses as description text', () => {
     const result = extractSubstepHeader('1.1 Run tests (test-agent)');
     expect(result).toEqual({
       stepRef: '1',
       id: '1',
-      description: 'Run tests',
-      agentType: 'test-agent',
+      description: 'Run tests (test-agent)',
     });
   });
 
-  it('extracts agent type without description', () => {
+  it('treats standalone agent-type parentheses as description text', () => {
     const result = extractSubstepHeader('1.1 (code-agent)');
     expect(result).toEqual({
       stepRef: '1',
       id: '1',
-      description: '',
-      agentType: 'code-agent',
+      description: '(code-agent)',
     });
   });
 
@@ -1142,7 +1184,6 @@ describe('extractSubstepHeader edge cases', () => {
       stepRef: '1',
       id: '1',
       description: '',
-      agentType: undefined,
     });
   });
 });
@@ -1523,7 +1564,6 @@ describe('C2: substep short form (bare numeric)', () => {
     expect(extractSubstepHeader('1')).toEqual({
       id: '1',
       description: '',
-      agentType: undefined,
     });
   });
 
@@ -1531,23 +1571,20 @@ describe('C2: substep short form (bare numeric)', () => {
     expect(extractSubstepHeader('2 Review code')).toEqual({
       id: '2',
       description: 'Review code',
-      agentType: undefined,
     });
   });
 
-  it('parses "3 Review (agent)" with agent type', () => {
+  it('treats former agent-type parentheses as description text', () => {
     expect(extractSubstepHeader('3 Review (agent)')).toEqual({
       id: '3',
-      description: 'Review',
-      agentType: 'agent',
+      description: 'Review (agent)',
     });
   });
 
-  it('parses "1 (code-agent)" with agent only', () => {
+  it('treats standalone agent-type parentheses as description text', () => {
     expect(extractSubstepHeader('1 (code-agent)')).toEqual({
       id: '1',
-      description: '',
-      agentType: 'code-agent',
+      description: '(code-agent)',
     });
   });
 
@@ -1560,7 +1597,6 @@ describe('C2: substep short form (bare numeric)', () => {
       stepRef: '1',
       id: '1',
       description: 'Description',
-      agentType: undefined,
     });
   });
 });

--- a/packages/parser/__tests__/helpers.test.ts
+++ b/packages/parser/__tests__/helpers.test.ts
@@ -1152,8 +1152,11 @@ describe('extractSubstepHeader edge cases', () => {
     expect(extractSubstepHeader('@invalid.1 Something')).toBeNull();
   });
 
-  it('returns null for nothing after dot', () => {
-    expect(extractSubstepHeader('1.')).toBeNull();
+  it('treats trailing dot on bare numeric as separator', () => {
+    expect(extractSubstepHeader('1.')).toEqual({
+      id: '1',
+      description: '',
+    });
   });
 
   it('returns null for invalid substep id', () => {
@@ -1585,6 +1588,34 @@ describe('C2: substep short form (bare numeric)', () => {
     expect(extractSubstepHeader('1 (code-agent)')).toEqual({
       id: '1',
       description: '(code-agent)',
+    });
+  });
+
+  it('strips trailing period separator from bare numeric', () => {
+    expect(extractSubstepHeader('1. Title')).toEqual({
+      id: '1',
+      description: 'Title',
+    });
+  });
+
+  it('strips trailing paren separator from bare numeric', () => {
+    expect(extractSubstepHeader('1) Title')).toEqual({
+      id: '1',
+      description: 'Title',
+    });
+  });
+
+  it('strips trailing colon separator from bare numeric', () => {
+    expect(extractSubstepHeader('2: Review code')).toEqual({
+      id: '2',
+      description: 'Review code',
+    });
+  });
+
+  it('handles bare numeric with separator and no description', () => {
+    expect(extractSubstepHeader('3.')).toEqual({
+      id: '3',
+      description: '',
     });
   });
 

--- a/packages/parser/__tests__/parser.test.ts
+++ b/packages/parser/__tests__/parser.test.ts
@@ -1623,10 +1623,10 @@ Do iteration.
 
   it('H3 header with unparsable format is ignored when only content', () => {
     // H3 that doesn't match substep pattern — hasSeenContent becomes true
-    // but no substep is created
+    // but no substep is created (use @-prefixed text which is not a valid identifier)
     const md = `## 1 Step
 
-### Random notes
+### @random notes
 `;
     const steps = parseRunbook(md);
     expect(steps[0].substeps).toBeUndefined();
@@ -1720,5 +1720,92 @@ Do something.
     expect(steps).toHaveLength(1);
     expect(steps[0].name).toBe('1');
     expect(steps[0].description).toBe('Step 1');
+  });
+});
+
+describe('strict H3 validation', () => {
+  it('throws when unrecognized H3 appears after valid substep', () => {
+    const md = `## 1. Setup
+
+### 1.1 First substep
+
+### @invalid heading
+`;
+    expect(() => parseRunbook(md)).toThrow(/unrecognized H3 headers/);
+  });
+
+  it('throws when unrecognized H3 appears before valid substep', () => {
+    const md = `## 1. Setup
+
+### @invalid heading
+
+### 1.1 First substep
+`;
+    expect(() => parseRunbook(md)).toThrow(/unrecognized H3 headers/);
+  });
+
+  it('allows unrecognized H3 in step with no valid substeps', () => {
+    const md = `## 1. Setup
+
+### @invalid heading
+
+Some content.
+`;
+    expect(() => parseRunbook(md)).not.toThrow();
+  });
+
+  it('recognizes bare named substep (not treated as unrecognized)', () => {
+    const md = `## 1. Setup
+
+### Cleanup
+
+Some content.
+`;
+    const steps = parseRunbook(md);
+    expect(steps[0].substeps).toHaveLength(1);
+    expect(steps[0].substeps?.[0].id).toBe('Cleanup');
+  });
+});
+
+describe('bare named substep parsing', () => {
+  it('parses bare named substep with id only', () => {
+    const md = `## 1. Setup
+
+### ErrorHandler
+
+Handle errors.
+`;
+    const steps = parseRunbook(md);
+    expect(steps[0].substeps).toHaveLength(1);
+    expect(steps[0].substeps?.[0].id).toBe('ErrorHandler');
+  });
+
+  it('parses mixed bare numeric and bare named substeps', () => {
+    const md = `## 1. Setup
+
+### 1
+
+First task.
+
+### Cleanup
+
+Clean up.
+`;
+    const steps = parseRunbook(md);
+    expect(steps[0].substeps).toHaveLength(2);
+    expect(steps[0].substeps?.[0].id).toBe('1');
+    expect(steps[0].substeps?.[1].id).toBe('Cleanup');
+  });
+
+  it('bare named substep has no stepRef (positional assignment)', () => {
+    const md = `## 1. Setup
+
+### ErrorHandler
+`;
+    const steps = parseRunbook(md);
+    // Bare named substeps don't have stepRef in the parsed header
+    // (they are positionally assigned to parent H2)
+    expect(steps[0].substeps).toHaveLength(1);
+    expect(steps[0].substeps?.[0].id).toBe('ErrorHandler');
   });
 });

--- a/packages/parser/src/ast.ts
+++ b/packages/parser/src/ast.ts
@@ -62,8 +62,6 @@ export interface Substep {
   readonly id: string;
   /** Human-readable description from the substep header */
   readonly description: string;
-  /** Agent type, e.g., "code-review-agent" from "(code-review-agent)" */
-  readonly agentType?: string;
   /** Executable command from code block */
   readonly command?: Command;
   /** Single consolidated prompt text */

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -201,13 +201,18 @@ export function extractSubstepHeader(text: string): ParsedSubstepHeader | null {
   if (!trimmed) return null;
 
   const spaceIdx = trimmed.indexOf(' ');
-  const firstToken = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
+  const firstTokenRaw = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
 
-  // Branch 1: Bare positive integer (e.g., "1", "2 Description", "3) Title")
+  // Strip trailing separator chars (e.g., "1." → "1", "3)" → "3")
+  let tokenEnd = firstTokenRaw.length;
+  while (tokenEnd > 0 && TRAILING_SEPARATORS.has(firstTokenRaw[tokenEnd - 1])) tokenEnd--;
+  const firstToken = firstTokenRaw.slice(0, tokenEnd);
+
+  // Branch 1: Bare positive integer (e.g., "1", "2 Description", "1. Title", "3) Title")
   if (/^\d+$/.test(firstToken)) {
     const num = parseInt(firstToken, 10);
     if (num > 0) {
-      const afterFirstToken = spaceIdx !== -1 ? trimmed.slice(spaceIdx) : '';
+      const afterFirstToken = trimmed.slice(firstTokenRaw.length);
       const description = stripSeparator(afterFirstToken);
       return { id: firstToken, description };
     }

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -55,7 +55,8 @@ export function parseQuotedOrIdentifier(text: string): string {
  *
  * Represents the structured data extracted from substep headers like:
  * - "1.2 Description" (numeric)
- * - "ErrorHandler.Recover Description (agent)" (named with agent type)
+ * - "ErrorHandler.Recover Description" (named)
+ * - "ErrorHandler Handle the error" (bare named)
  */
 export interface ParsedSubstepHeader {
   /** Reference to parent step: "1" or named identifier like "ErrorHandler". Undefined for short form (parent inferred from context). */
@@ -64,8 +65,6 @@ export interface ParsedSubstepHeader {
   id: string;
   /** Human-readable description from the header */
   description: string;
-  /** Optional agent type specified in parentheses at end of header */
-  agentType?: string;
 }
 
 /**
@@ -184,59 +183,15 @@ function isValidSubstepId(s: string): boolean {
 }
 
 /**
- * Parse description and optional agent type from remainder text after a substep ID.
- *
- * Recognizes these patterns:
- * - "Description" → description only
- * - "Description (agent-type)" → description + agent
- * - "(agent-type)" → agent only, empty description
- *
- * Uses lastIndexOf to avoid ReDoS from (.+?)\s+ backtracking.
- *
- * @param remainder - The text after the substep ID (trimmed)
- * @returns Object with description and optional agentType
- */
-function parseDescriptionAndAgent(remainder: string): {
-  description: string;
-  agentType?: string;
-} {
-  if (!remainder) return { description: '' };
-
-  // Check for agent suffix: "description (agent-type)"
-  const lastParenOpen = remainder.lastIndexOf(' (');
-  if (lastParenOpen > 0 && remainder.endsWith(')')) {
-    const possibleAgent = remainder.slice(lastParenOpen + 2, -1).trim();
-    if (possibleAgent) {
-      return {
-        description: remainder.slice(0, lastParenOpen).trim(),
-        agentType: possibleAgent,
-      };
-    }
-    return { description: remainder };
-  }
-
-  if (remainder.startsWith('(') && remainder.endsWith(')')) {
-    // Just agent, no description: "(agent-type)"
-    const agent = remainder.slice(1, -1).trim();
-    if (agent) {
-      return { description: '', agentType: agent };
-    }
-    return { description: remainder };
-  }
-
-  return { description: remainder };
-}
-
-/**
  * Extract substep header from H3 text.
  *
  * Parses substep headers in these formats:
- * - Short form: "1", "2 Description", "3 Review (agent)" (parent inferred from context)
- * - Numeric: "1.2" or "1.2 Description"
- * - Named: "1.Cleanup", "ErrorHandler.Recover" (with optional description)
- * - With agent: "1.2 Description (agent-type)" or "1.2 (agent-type)"
+ * 1. Bare positive integer: "1", "2 Description" (parent inferred from context)
+ * 2. Dot-qualified: "1.2", "ErrorHandler.Recover Description"
+ * 3. Bare named: "ErrorHandler", "Cleanup: Handle it" (parent inferred from context)
  *
- * Description is optional per spec.
+ * Description is optional per spec. Separator characters (`:`, `)`, `—`, `→`, `-`, `.`)
+ * between the identifier and description are stripped.
  *
  * @param text - The raw H3 header text (without the ### prefix)
  * @returns Parsed substep header data, or null if text is not a valid substep header
@@ -245,42 +200,59 @@ export function extractSubstepHeader(text: string): ParsedSubstepHeader | null {
   const trimmed = text.trim();
   if (!trimmed) return null;
 
-  // Handle short form: bare positive integer (e.g., "1", "2 Description", "3 Review (agent)")
   const spaceIdx = trimmed.indexOf(' ');
   const firstToken = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
+
+  // Branch 1: Bare positive integer (e.g., "1", "2 Description", "3) Title")
   if (/^\d+$/.test(firstToken)) {
     const num = parseInt(firstToken, 10);
     if (num > 0) {
-      const remainder = spaceIdx !== -1 ? trimmed.slice(spaceIdx + 1).trim() : '';
-      const { description, agentType } = parseDescriptionAndAgent(remainder);
-      return { id: firstToken, description, agentType };
+      const afterFirstToken = spaceIdx !== -1 ? trimmed.slice(spaceIdx) : '';
+      const description = stripSeparator(afterFirstToken);
+      return { id: firstToken, description };
     }
   }
 
-  // Find the dot separating step reference from substep ID
+  // Branch 2: Dot-qualified (e.g., "1.2", "ErrorHandler.Recover Description")
   const dotIndex = trimmed.indexOf('.');
-  if (dotIndex === -1 || dotIndex === 0) return null;
+  if (dotIndex > 0) {
+    const stepPart = trimmed.slice(0, dotIndex);
+    if (isValidStepRef(stepPart)) {
+      const afterDot = trimmed.slice(dotIndex + 1);
+      if (!afterDot) return null;
 
-  const stepPart = trimmed.slice(0, dotIndex);
-  if (!isValidStepRef(stepPart)) return null;
+      const spaceIndex = afterDot.indexOf(' ');
+      const substepId = spaceIndex === -1 ? afterDot : afterDot.slice(0, spaceIndex);
+      if (!isValidSubstepId(substepId)) return null;
 
-  const afterDot = trimmed.slice(dotIndex + 1);
-  if (!afterDot) return null;
+      const remainder = spaceIndex !== -1 ? afterDot.slice(spaceIndex) : '';
+      const description = stripSeparator(remainder);
 
-  // Find where substep ID ends (first space or end of string)
-  const spaceIndex = afterDot.indexOf(' ');
-  const substepId = spaceIndex === -1 ? afterDot : afterDot.slice(0, spaceIndex);
-  if (!isValidSubstepId(substepId)) return null;
+      return {
+        stepRef: stepPart,
+        id: substepId,
+        description,
+      };
+    }
+  }
 
-  const remainder = spaceIndex !== -1 ? afterDot.slice(spaceIndex + 1).trim() : '';
-  const { description, agentType } = parseDescriptionAndAgent(remainder);
+  // Branch 3: Bare named (e.g., "ErrorHandler", "Cleanup: Handle it")
+  // Strip trailing separator chars from firstToken
+  let end = firstToken.length;
+  while (end > 0 && TRAILING_SEPARATORS.has(firstToken[end - 1])) end--;
+  const strippedName = firstToken.slice(0, end);
 
-  return {
-    stepRef: stepPart,
-    id: substepId,
-    description,
-    agentType,
-  };
+  if (
+    strippedName &&
+    NAMED_IDENTIFIER_PATTERN.test(strippedName) &&
+    !isReservedWord(strippedName)
+  ) {
+    const afterFirstToken = spaceIdx !== -1 ? trimmed.slice(spaceIdx) : '';
+    const description = stripSeparator(afterFirstToken);
+    return { id: strippedName, description };
+  }
+
+  return null;
 }
 
 /**

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -53,7 +53,6 @@ function extractText(node: PhrasingContent | Heading | Paragraph | ListItem): st
 interface SubstepBuilder {
   id: string;
   description: string;
-  agentType?: string;
   content: string;
   command?: Command;
   promptText: string;
@@ -79,6 +78,7 @@ interface StepBuilder {
   forClause?: ForClause;
   hasSeenForClause: boolean;
   forConditionals?: ParsedConditional[];
+  invalidH3s: Array<{ line: number; text: string }>;
 }
 
 /**
@@ -167,7 +167,6 @@ export function parseRunbookDocument(
       const substep: Substep = {
         id: ps.id,
         description: ps.description,
-        agentType: ps.agentType,
         command: ps.command,
         prompt: promptText.trim() || undefined,
         transitions: transitions ?? undefined,
@@ -221,6 +220,7 @@ export function parseRunbookDocument(
           content: '',
           line: node.position?.start.line,
           hasSeenForClause: false,
+          invalidH3s: [],
         };
       }
     }
@@ -233,13 +233,12 @@ export function parseRunbookDocument(
       }
       finalizePendingSubstep();
 
-      // Mark that parent step has seen content (substeps count as content)
-      currentStep.hasSeenContent = true;
-
       const headingText = extractText(node);
       const parsed = extractSubstepHeader(headingText);
 
       if (parsed) {
+        // Mark that parent step has seen content (substeps count as content)
+        currentStep.hasSeenContent = true;
         if (parsed.stepRef !== undefined && parsed.stepRef !== currentStep.name) {
           throw new RunbookSyntaxError(
             `Substep ${headingText} does not belong to step ${currentStep.name}`,
@@ -255,7 +254,6 @@ export function parseRunbookDocument(
         currentStep.pendingSubstep = {
           id: parsed.id,
           description: parsed.description,
-          agentType: parsed.agentType,
           content: '',
           command: undefined,
           promptText: '',
@@ -265,6 +263,11 @@ export function parseRunbookDocument(
           pendingConditionals: [],
           line: node.position?.start.line,
         };
+      } else {
+        currentStep.invalidH3s.push({
+          line: node.position?.start.line ?? 0,
+          text: headingText,
+        });
       }
     }
 
@@ -562,6 +565,15 @@ function finalizeStep(
     if (forTrans) {
       step.forClause = { ...step.forClause, transitions: forTrans };
     }
+  }
+
+  // Strict H3 validation: if a step has valid substeps, all H3s must be valid substep identifiers
+  if (step.substeps.length > 0 && step.invalidH3s.length > 0) {
+    const lines = step.invalidH3s.map((h) => `line ${String(h.line)}: "${h.text}"`).join(', ');
+    throw new RunbookSyntaxError(
+      `Step "${step.name}" has substeps but also has unrecognized H3 headers (${lines}). ` +
+        `When a step contains substeps, all H3 headers must be valid substep identifiers.`,
+    );
   }
 
   const runbooks = extractRunbookList(step.content);

--- a/packages/parser/src/schemas.ts
+++ b/packages/parser/src/schemas.ts
@@ -192,7 +192,6 @@ export type Transitions = Readonly<z.output<typeof TransitionsSchema>>;
 export const SubstepSchema = z.object({
   id: z.string(),
   description: z.string(),
-  agentType: z.string().optional(),
   runbooks: z.array(z.string()).readonly().optional(),
   command: CommandSchema.optional(),
   prompt: z.string().min(1).optional(), // .min(1) prevents empty strings


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed agent-type annotations from substep examples and clarified substep dispatch terminology
  * Updated specification and format guidance for substep headers

* **New Features**
  * Support for bare named substep identifiers (e.g., "ErrorHandler")
  * Strict H3 validation when a step contains substeps
  * New project configuration options: initial_prompt, symbol_info_budget, language_backend

* **Refactor**
  * Simplified substep headers and parsing to drop agent-type annotations

* **Tests**
  * Updated and expanded tests to match new header formats and validation rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->