### PR TITLE
feat: enforce step-name uniqueness and add compile-time return type v…

### DIFF
--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1608,6 +1608,8 @@ function checkedStateInsert(states: Record<string, unknown>, id: string, config:
  * @returns An XState state machine definition
  * @throws {Error} When a GOTO target references a non-existent step or when graph invariants are violated (e.g., duplicate state IDs)
  */
+// Return type validated via `satisfies RunbookMachine` at the return site.
+// Explicit annotation would erase XState's inferred event types, breaking actor.send() downstream.
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
 export function compileRunbookToMachine(
   steps: Step[],
@@ -1932,5 +1934,5 @@ export function compileRunbookToMachine(
         }),
       },
     },
-  });
+  }) satisfies RunbookMachine;
 }

--- a/packages/parser/__tests__/validator.test.ts
+++ b/packages/parser/__tests__/validator.test.ts
@@ -778,6 +778,76 @@ describe('validator strict rules', () => {
     });
   });
 
+  describe('step-name uniqueness', () => {
+    it('rejects two numeric steps with same number', () => {
+      const steps = [
+        mockStep({ name: '1', line: 5, description: 'First' }),
+        mockStep({ name: '1', line: 10, description: 'Duplicate' }),
+      ];
+      const diagnostics = validateRunbook(steps);
+      const errors = filterErrors(diagnostics);
+      expect(errors.some((e) => e.message.includes('Duplicate step name "1"'))).toBe(true);
+      expect(errors.some((e) => e.message.includes('first defined at line 5'))).toBe(true);
+    });
+
+    it('rejects two named steps with same name', () => {
+      const steps = [
+        mockStep({ name: 'Setup', line: 3, description: 'First setup' }),
+        mockStep({ name: 'Setup', line: 20, description: 'Duplicate setup' }),
+      ];
+      const diagnostics = validateRunbook(steps);
+      const errors = filterErrors(diagnostics);
+      expect(errors.some((e) => e.message.includes('Duplicate step name "Setup"'))).toBe(true);
+    });
+
+    it('reports multiple errors for three+ duplicates', () => {
+      const steps = [
+        mockStep({ name: 'Deploy', line: 1, description: 'First' }),
+        mockStep({ name: 'Deploy', line: 10, description: 'Second' }),
+        mockStep({ name: 'Deploy', line: 20, description: 'Third' }),
+      ];
+      const diagnostics = validateRunbook(steps);
+      const dupeErrors = filterErrors(diagnostics).filter((e) =>
+        e.message.includes('Duplicate step name "Deploy"'),
+      );
+      expect(dupeErrors).toHaveLength(2);
+    });
+
+    it('allows mixed numeric and named steps with no conflicts', () => {
+      const steps = [
+        mockStep({ name: '1', description: 'First' }),
+        mockStep({ name: '2', description: 'Second' }),
+        mockStep({ name: 'Cleanup', description: 'Named step' }),
+      ];
+      const diagnostics = validateRunbook(steps);
+      const dupeErrors = filterErrors(diagnostics).filter((e) =>
+        e.message.includes('Duplicate step name'),
+      );
+      expect(dupeErrors).toHaveLength(0);
+    });
+
+    it('omits line reference when first occurrence has no line', () => {
+      const steps = [
+        mockStep({ name: 'X', description: 'No line' }),
+        mockStep({ name: 'X', line: 15, description: 'With line' }),
+      ];
+      const diagnostics = validateRunbook(steps);
+      const dupeErrors = filterErrors(diagnostics).filter((e) =>
+        e.message.includes('Duplicate step name "X"'),
+      );
+      expect(dupeErrors).toHaveLength(1);
+      expect(dupeErrors[0].message).not.toContain('first defined at line');
+    });
+  });
+
+  describe('step-name uniqueness integration', () => {
+    it('parseRunbookDocument rejects duplicate named steps', async () => {
+      const { parseRunbookDocument } = await import('../src/index.js');
+      const markdown = `# My Runbook\n\n## Setup\nFirst setup\n\n## Setup\nDuplicate setup\n`;
+      expect(() => parseRunbookDocument(markdown)).toThrow(/Duplicate step name "Setup"/);
+    });
+  });
+
   describe('parent transition reachability', () => {
     it('errors when all substeps have explicit non-DEFER transitions', () => {
       const steps = [

--- a/packages/parser/src/validator.ts
+++ b/packages/parser/src/validator.ts
@@ -95,6 +95,18 @@ export function validateRunbook(steps: readonly Step[]): ValidationDiagnostic[] 
     }
   }
 
+  // Step-name uniqueness: detect duplicate step names/numbers
+  const seenNames = new Map<string, number | undefined>();
+  for (const step of steps) {
+    if (seenNames.has(step.name)) {
+      const firstLine = seenNames.get(step.name);
+      const suffix = firstLine !== undefined ? ` (first defined at line ${String(firstLine)})` : '';
+      diagnostics.push(error(step.line, `Duplicate step name "${step.name}"${suffix}`));
+    } else {
+      seenNames.set(step.name, step.line);
+    }
+  }
+
   for (const step of steps) {
     // Conformance Rule 4: Exclusivity (Step level)
     // The discriminated union enforces exclusivity by design:


### PR DESCRIPTION
…alidation

Add duplicate step name detection in the parser validator, reporting all duplicates with first-occurrence line references. Add `satisfies RunbookMachine` to the compiler return to validate the type without erasing XState's inferred event types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to detect and reject duplicate step names with error messages that reference the first occurrence for easier debugging.

* **Tests**
  * Added comprehensive test coverage for duplicate step name validation across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->