### PR TITLE
test: extend property-based test coverage for core compiler

### DIFF
--- a/packages/core/__tests__/runbook/compiler-property-helpers.ts
+++ b/packages/core/__tests__/runbook/compiler-property-helpers.ts
@@ -1,0 +1,202 @@
+/**
+ * Shared helpers for compiler property-based tests.
+ *
+ * Provides:
+ * - Step builders: inferSteps, makeAction, makeTransitionObject, makeTransitions
+ * - General runner: runMachine — compile, send events, pad to terminal, extract context
+ * - Arbitraries: eventArb, simpleActionArb, substepActionArb, eventsArb
+ */
+
+import fc from 'fast-check';
+import { createActor, type AnyStateMachine } from 'xstate';
+import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
+import type {
+  Step,
+  BaseStep,
+  StepWithCommand,
+  StepWithSubsteps,
+  StepWithFor,
+  Transitions,
+  TransitionObject,
+  Action,
+  LastAction,
+} from '../../src/runbook/types.js';
+
+// ---------------------------------------------------------------------------
+// Step type inference (pattern from compiler.test.ts)
+// ---------------------------------------------------------------------------
+
+/** Input type: Step variants without the `kind` discriminant. */
+export type StepInput =
+  | Omit<BaseStep, 'kind'>
+  | Omit<StepWithCommand, 'kind'>
+  | Omit<StepWithSubsteps, 'kind'>
+  | Omit<StepWithFor, 'kind'>;
+
+/** Infer and inject `kind` on each step object so raw literals satisfy the Step union. */
+export function inferSteps(raw: StepInput[]): Step[] {
+  return raw.map((s) => {
+    const kind =
+      'forClause' in s ? 'for' : 'substeps' in s ? 'substeps' : 'command' in s ? 'command' : 'base';
+    return { ...s, kind } as Step;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Action / Transition builders (fresh equivalents — not imported from for-loop-test-helpers)
+// ---------------------------------------------------------------------------
+
+export function makeAction(type: string): Action {
+  switch (type) {
+    case 'CONTINUE':
+      return { type: 'CONTINUE' };
+    case 'DEFER':
+      return { type: 'DEFER' };
+    case 'NEXT':
+      return { type: 'NEXT' };
+    case 'BREAK':
+      return { type: 'BREAK' };
+    case 'STOP':
+      return { type: 'STOP' };
+    case 'COMPLETE':
+      return { type: 'COMPLETE' };
+    case 'GOTO':
+      return { type: 'GOTO', target: { step: '1' } };
+    default:
+      return { type: 'CONTINUE' };
+  }
+}
+
+export function makeTransitionObject(
+  kind: 'pass' | 'fail',
+  action: string,
+  retry = 0,
+): TransitionObject {
+  return { kind, retry, action: makeAction(action) };
+}
+
+export function makeTransitions(
+  aggregation: 'ALL' | 'ANY' | 'none',
+  passAction: string,
+  failAction: string,
+  failRetry = 0,
+): Transitions {
+  return {
+    aggregation,
+    pass: makeTransitionObject('pass', passAction),
+    fail: makeTransitionObject('fail', failAction, failRetry),
+  };
+}
+
+/** Default transitions: PASS ALL → CONTINUE, FAIL → STOP */
+export const DEFAULT_TRANSITIONS: Transitions = {
+  aggregation: 'ALL',
+  pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+  fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+};
+
+/** DEFER transitions: PASS → DEFER, FAIL → DEFER */
+export const DEFER_TRANSITIONS: Transitions = {
+  aggregation: 'ALL',
+  pass: { kind: 'pass', retry: 0, action: { type: 'DEFER' } },
+  fail: { kind: 'fail', retry: 0, action: { type: 'DEFER' } },
+};
+
+// ---------------------------------------------------------------------------
+// General runner
+// ---------------------------------------------------------------------------
+
+export interface GeneralRunResult {
+  terminalState: string;
+  lastAction?: LastAction;
+  lastMessage?: string;
+  retryCount: number;
+  parentRetryCount: number;
+  iterationRetryCount: number;
+  forStackLength: number;
+  deferredResults: readonly ('pass' | 'fail')[];
+  substepCompletedCount: number;
+  eventsConsumed: number;
+  statesVisited: string[];
+}
+
+/**
+ * Compile steps into an XState machine, send events, pad with PASS to terminal.
+ *
+ * Returns a snapshot of the terminal context for property assertions.
+ */
+export function runMachine(
+  steps: Step[],
+  events: ('PASS' | 'FAIL')[],
+  opts?: { maxPad?: number },
+): GeneralRunResult {
+  const machine = compileRunbookToMachine(steps);
+  const actor = createActor(machine as AnyStateMachine);
+
+  const statesVisited: string[] = [];
+  let eventsConsumed = 0;
+
+  actor.start();
+  statesVisited.push(String(actor.getSnapshot().value));
+
+  // Send provided events
+  for (const event of events) {
+    const snap = actor.getSnapshot();
+    if (snap.status === 'done') break;
+    actor.send({ type: event });
+    eventsConsumed++;
+    const after = actor.getSnapshot();
+    const stateStr = String(after.value);
+    if (statesVisited[statesVisited.length - 1] !== stateStr) {
+      statesVisited.push(stateStr);
+    }
+  }
+
+  // Pad with PASS to reach terminal
+  const maxPad = opts?.maxPad ?? 200;
+  for (let i = 0; i < maxPad; i++) {
+    const snap = actor.getSnapshot();
+    if (snap.status === 'done') break;
+    actor.send({ type: 'PASS' });
+    eventsConsumed++;
+    const after = actor.getSnapshot();
+    const stateStr = String(after.value);
+    if (statesVisited[statesVisited.length - 1] !== stateStr) {
+      statesVisited.push(stateStr);
+    }
+  }
+
+  const snap = actor.getSnapshot();
+  return {
+    terminalState: String(snap.value),
+    lastAction: snap.context.lastAction,
+    lastMessage: snap.context.lastMessage,
+    retryCount: snap.context.retryCount,
+    parentRetryCount: snap.context.parentRetryCount,
+    iterationRetryCount: snap.context.iterationRetryCount,
+    forStackLength: snap.context.forStack.length,
+    deferredResults: snap.context.deferredResults ?? [],
+    substepCompletedCount: snap.context.substepCompletedCount,
+    eventsConsumed,
+    statesVisited,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+export const eventArb: fc.Arbitrary<'PASS' | 'FAIL'> = fc.constantFrom('PASS', 'FAIL');
+
+export const simpleActionArb: fc.Arbitrary<'CONTINUE' | 'STOP' | 'COMPLETE'> = fc.constantFrom(
+  'CONTINUE',
+  'STOP',
+  'COMPLETE',
+);
+
+export const substepActionArb: fc.Arbitrary<'CONTINUE' | 'DEFER' | 'STOP' | 'COMPLETE'> =
+  fc.constantFrom('CONTINUE', 'DEFER', 'STOP', 'COMPLETE');
+
+export function eventsArb(minLen: number, maxLen: number): fc.Arbitrary<('PASS' | 'FAIL')[]> {
+  return fc.array(eventArb, { minLength: minLen, maxLength: maxLen });
+}

--- a/packages/core/__tests__/runbook/goto-transition.properties.test.ts
+++ b/packages/core/__tests__/runbook/goto-transition.properties.test.ts
@@ -17,7 +17,7 @@ import { inferSteps, makeTransitions, type StepInput } from './compiler-property
 function buildLinearBaseSteps(numSteps: number): StepInput[] {
   return Array.from({ length: numSteps }, (_, i) => ({
     name: String(i + 1),
-    description: `Step ${i + 1}`,
+    description: `Step ${String(i + 1)}`,
     transitions: makeTransitions('ALL', i === numSteps - 1 ? 'COMPLETE' : 'CONTINUE', 'STOP'),
   }));
 }
@@ -93,7 +93,7 @@ describe('GOTO transition properties', () => {
           ]);
 
           // The target step's state ID should appear in visited states
-          expect(result.statesVisited).toContain(`step::${targetStep}`);
+          expect(result.statesVisited).toContain(`step::${String(targetStep)}`);
         },
       ),
       { numRuns: 200 },
@@ -120,7 +120,7 @@ describe('GOTO transition properties', () => {
 
           // Steps between 1 and target should not be visited
           for (let i = 2; i < targetStep; i++) {
-            expect(result.statesVisited).not.toContain(`step::${i}`);
+            expect(result.statesVisited).not.toContain(`step::${String(i)}`);
           }
         },
       ),

--- a/packages/core/__tests__/runbook/goto-transition.properties.test.ts
+++ b/packages/core/__tests__/runbook/goto-transition.properties.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Property tests for GOTO transition correctness.
+ *
+ * Tests GOTO lands on correct state, skips intermediates, and preserves lastAction.
+ * Four properties at 200 runs each (800 total).
+ */
+
+import fc from 'fast-check';
+import { createActor, type AnyStateMachine } from 'xstate';
+import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
+import { inferSteps, makeTransitions, type StepInput } from './compiler-property-helpers.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildLinearBaseSteps(numSteps: number): StepInput[] {
+  return Array.from({ length: numSteps }, (_, i) => ({
+    name: String(i + 1),
+    description: `Step ${i + 1}`,
+    transitions: makeTransitions('ALL', i === numSteps - 1 ? 'COMPLETE' : 'CONTINUE', 'STOP'),
+  }));
+}
+
+/** Run machine with explicit event sequence including GOTOs, no auto-pad. */
+function runWithEvents(
+  steps: StepInput[],
+  events: ({ type: 'PASS' } | { type: 'FAIL' } | { type: 'GOTO'; target: { step: string } })[],
+): {
+  terminalState: string;
+  statesVisited: string[];
+  lastAction?: { type: string; target?: string };
+} {
+  const compiled = inferSteps(steps);
+  const machine = compileRunbookToMachine(compiled);
+  const actor = createActor(machine as AnyStateMachine);
+
+  const statesVisited: string[] = [];
+  actor.start();
+  statesVisited.push(String(actor.getSnapshot().value));
+
+  for (const event of events) {
+    const snap = actor.getSnapshot();
+    if (snap.status === 'done') break;
+    actor.send(event);
+    const after = actor.getSnapshot();
+    const stateStr = String(after.value);
+    if (statesVisited[statesVisited.length - 1] !== stateStr) {
+      statesVisited.push(stateStr);
+    }
+  }
+
+  // Pad with PASS to reach terminal
+  for (let i = 0; i < 50; i++) {
+    const snap = actor.getSnapshot();
+    if (snap.status === 'done') break;
+    actor.send({ type: 'PASS' });
+    const after = actor.getSnapshot();
+    const stateStr = String(after.value);
+    if (statesVisited[statesVisited.length - 1] !== stateStr) {
+      statesVisited.push(stateStr);
+    }
+  }
+
+  const snap = actor.getSnapshot();
+  const la = snap.context.lastAction;
+  return {
+    terminalState: String(snap.value),
+    statesVisited,
+    lastAction: la
+      ? { type: la.type, ...(la.type === 'GOTO' ? { target: la.target } : {}) }
+      : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+describe('GOTO transition properties', () => {
+  // Property 1: GOTO lands on correct state
+  it('GOTO transitions to the correct target state', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 3, max: 5 }),
+        fc.integer({ min: 1, max: 5 }),
+        (numSteps, rawTarget) => {
+          const targetStep = ((rawTarget - 1) % numSteps) + 1;
+          const steps = buildLinearBaseSteps(numSteps);
+
+          const result = runWithEvents(steps, [
+            { type: 'GOTO', target: { step: String(targetStep) } },
+          ]);
+
+          // The target step's state ID should appear in visited states
+          expect(result.statesVisited).toContain(`step::${targetStep}`);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 2: Forward GOTO skips intermediate steps
+  it('forward GOTO skips intermediate steps', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 4, max: 6 }),
+        fc.integer({ min: 3, max: 6 }),
+        (numSteps, rawTarget) => {
+          // Ensure target is at least step 3 (skipping step 2)
+          const targetStep = Math.min(((rawTarget - 1) % (numSteps - 2)) + 3, numSteps);
+          if (targetStep <= 2) return; // guard
+
+          const steps = buildLinearBaseSteps(numSteps);
+
+          // Start at step 1, GOTO to targetStep (skipping step 2..targetStep-1)
+          const result = runWithEvents(steps, [
+            { type: 'GOTO', target: { step: String(targetStep) } },
+          ]);
+
+          // Steps between 1 and target should not be visited
+          for (let i = 2; i < targetStep; i++) {
+            expect(result.statesVisited).not.toContain(`step::${i}`);
+          }
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 3: Backward GOTO re-enters previous step
+  it('backward GOTO re-enters previous step', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 3, max: 5 }), (numSteps) => {
+        const steps = buildLinearBaseSteps(numSteps);
+
+        // Advance to step 2, then GOTO back to step 1
+        const result = runWithEvents(steps, [
+          { type: 'PASS' }, // advance from step 1 to step 2
+          { type: 'GOTO', target: { step: '1' } }, // back to step 1
+        ]);
+
+        // Step 1 should appear at both beginning and after the GOTO
+        const step1Indices = result.statesVisited
+          .map((s, i) => (s === 'step::1' ? i : -1))
+          .filter((i) => i >= 0);
+        expect(step1Indices.length).toBeGreaterThanOrEqual(2);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 4: lastAction preserves GOTO target
+  it('lastAction records GOTO with correct target after transition', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 3, max: 5 }),
+        fc.integer({ min: 1, max: 5 }),
+        (numSteps, rawTarget) => {
+          const targetStep = ((rawTarget - 1) % numSteps) + 1;
+          const steps = buildLinearBaseSteps(numSteps);
+
+          // Send GOTO then immediately check state (before any PASS padding)
+          const compiled = inferSteps(steps);
+          const machine = compileRunbookToMachine(compiled);
+          const actor = createActor(machine as AnyStateMachine);
+          actor.start();
+
+          actor.send({ type: 'GOTO', target: { step: String(targetStep) } });
+          const snap = actor.getSnapshot();
+
+          expect(snap.context.lastAction?.type).toBe('GOTO');
+          if (snap.context.lastAction?.type === 'GOTO') {
+            expect(snap.context.lastAction.target).toBe(String(targetStep));
+          }
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/goto-transition.properties.test.ts
+++ b/packages/core/__tests__/runbook/goto-transition.properties.test.ts
@@ -79,6 +79,8 @@ function runWithEvents(
 
 describe('GOTO transition properties', () => {
   // Property 1: GOTO lands on correct state
+  // Assert the immediate post-GOTO state (no PASS padding) to avoid masking
+  // routing regressions where linear progression could reach the target anyway.
   it('GOTO transitions to the correct target state', () => {
     fc.assert(
       fc.property(
@@ -88,12 +90,16 @@ describe('GOTO transition properties', () => {
           const targetStep = ((rawTarget - 1) % numSteps) + 1;
           const steps = buildLinearBaseSteps(numSteps);
 
-          const result = runWithEvents(steps, [
-            { type: 'GOTO', target: { step: String(targetStep) } },
-          ]);
+          const compiled = inferSteps(steps);
+          const machine = compileRunbookToMachine(compiled);
+          const actor = createActor(machine as AnyStateMachine);
+          actor.start();
 
-          // The target step's state ID should appear in visited states
-          expect(result.statesVisited).toContain(`step::${String(targetStep)}`);
+          actor.send({ type: 'GOTO', target: { step: String(targetStep) } });
+          const snap = actor.getSnapshot();
+
+          // Immediate state after GOTO must be the target (no padding involved)
+          expect(String(snap.value)).toBe(`step::${String(targetStep)}`);
         },
       ),
       { numRuns: 200 },

--- a/packages/core/__tests__/runbook/graph-invariants.properties.test.ts
+++ b/packages/core/__tests__/runbook/graph-invariants.properties.test.ts
@@ -12,7 +12,6 @@ import {
   inferSteps,
   makeTransitions,
   DEFER_TRANSITIONS,
-  DEFAULT_TRANSITIONS,
   type StepInput,
 } from './compiler-property-helpers.js';
 import type { Substep } from '../../src/runbook/types.js';
@@ -49,7 +48,7 @@ function buildStepsFromShapes(shapes: StepShape[]): StepInput[] {
 
     const substeps: Substep[] = Array.from({ length: shape.numSubsteps }, (_, i) => ({
       id: String(i + 1),
-      description: `Substep ${i + 1}`,
+      description: `Substep ${String(i + 1)}`,
       transitions: DEFER_TRANSITIONS,
     }));
 

--- a/packages/core/__tests__/runbook/graph-invariants.properties.test.ts
+++ b/packages/core/__tests__/runbook/graph-invariants.properties.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Property tests for structural graph invariants of compiled machines.
+ *
+ * Tests structural properties across topology shapes (base, substeps, for).
+ * Five properties at 300 runs each (1,500 total).
+ */
+
+import fc from 'fast-check';
+import type { AnyStateMachine } from 'xstate';
+import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
+import {
+  inferSteps,
+  makeTransitions,
+  DEFER_TRANSITIONS,
+  DEFAULT_TRANSITIONS,
+  type StepInput,
+} from './compiler-property-helpers.js';
+import type { Substep } from '../../src/runbook/types.js';
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+interface StepShape {
+  kind: 'base' | 'substeps' | 'for';
+  numSubsteps: number;
+  iterations: number;
+}
+
+const stepShapeArb: fc.Arbitrary<StepShape> = fc.record({
+  kind: fc.constantFrom<'base' | 'substeps' | 'for'>('base', 'substeps', 'for'),
+  numSubsteps: fc.integer({ min: 1, max: 3 }),
+  iterations: fc.integer({ min: 1, max: 4 }),
+});
+
+function buildStepsFromShapes(shapes: StepShape[]): StepInput[] {
+  return shapes.map((shape, idx) => {
+    const name = String(idx + 1);
+    const isLast = idx === shapes.length - 1;
+    const passAction = isLast ? 'COMPLETE' : 'CONTINUE';
+
+    if (shape.kind === 'base') {
+      return {
+        name,
+        description: `Step ${name}`,
+        transitions: makeTransitions('ALL', passAction, 'STOP'),
+      };
+    }
+
+    const substeps: Substep[] = Array.from({ length: shape.numSubsteps }, (_, i) => ({
+      id: String(i + 1),
+      description: `Substep ${i + 1}`,
+      transitions: DEFER_TRANSITIONS,
+    }));
+
+    if (shape.kind === 'for') {
+      return {
+        name,
+        description: `FOR step ${name}`,
+        forClause: {
+          start: 1,
+          end: shape.iterations,
+          transitions: makeTransitions('ALL', 'DEFER', 'DEFER'),
+        },
+        transitions: makeTransitions('ALL', passAction, 'STOP'),
+        substeps,
+      };
+    }
+
+    // substeps kind
+    return {
+      name,
+      description: `Step ${name} with substeps`,
+      transitions: makeTransitions('ALL', passAction, 'STOP'),
+      substeps,
+    };
+  });
+}
+
+// Helper: extract state configs from a compiled machine
+function getStates(machine: AnyStateMachine): Record<string, unknown> {
+  return (machine.config.states ?? {}) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+describe('Graph invariant properties', () => {
+  const shapesArb = fc.array(stepShapeArb, { minLength: 1, maxLength: 4 });
+
+  // Property 1: Compilation succeeds for any valid config
+  it('any valid config compiles without throwing', () => {
+    fc.assert(
+      fc.property(shapesArb, (shapes) => {
+        const steps = inferSteps(buildStepsFromShapes(shapes));
+        expect(() => compileRunbookToMachine(steps)).not.toThrow();
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 2: Terminal states exist
+  it('compiled machine always has COMPLETE and STOPPED final states', () => {
+    fc.assert(
+      fc.property(shapesArb, (shapes) => {
+        const steps = inferSteps(buildStepsFromShapes(shapes));
+        const machine = compileRunbookToMachine(steps);
+        const states = getStates(machine);
+        expect(states).toHaveProperty('COMPLETE');
+        expect(states).toHaveProperty('STOPPED');
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 3: Initial state is first step
+  it('initial state matches first step state ID', () => {
+    fc.assert(
+      fc.property(shapesArb, (shapes) => {
+        const steps = inferSteps(buildStepsFromShapes(shapes));
+        const machine = compileRunbookToMachine(steps);
+        const initial = machine.config.initial;
+        const firstStep = steps[0];
+
+        if (firstStep.kind === 'substeps' || firstStep.kind === 'for') {
+          expect(initial).toBe(`step::${firstStep.name}::${firstStep.substeps[0].id}`);
+        } else {
+          expect(initial).toBe(`step::${firstStep.name}`);
+        }
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 4: Every non-terminal, non-parent state has PASS and FAIL handlers
+  it('leaf states have PASS and FAIL event handlers', () => {
+    fc.assert(
+      fc.property(shapesArb, (shapes) => {
+        const steps = inferSteps(buildStepsFromShapes(shapes));
+        const machine = compileRunbookToMachine(steps);
+        const states = getStates(machine);
+
+        for (const [id, config] of Object.entries(states)) {
+          if (id === 'COMPLETE' || id === 'STOPPED') continue;
+          const cfg = config as Record<string, unknown>;
+          // Parent aggregation states use `always`, not `on`
+          if (cfg.always) continue;
+          // Retry states also use `always`
+          if (id.includes('::pass-retry') || id.includes('::fail-retry')) continue;
+          const on = cfg.on as Record<string, unknown> | undefined;
+          expect(on).toBeDefined();
+          expect(on).toHaveProperty('PASS');
+          expect(on).toHaveProperty('FAIL');
+        }
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 5: All transition targets exist in state map or are terminal
+  it('all transition targets reference existing states', () => {
+    fc.assert(
+      fc.property(shapesArb, (shapes) => {
+        const steps = inferSteps(buildStepsFromShapes(shapes));
+        const machine = compileRunbookToMachine(steps);
+        const states = getStates(machine);
+        const allIds = new Set(Object.keys(states));
+
+        const extractTargets = (obj: unknown): string[] => {
+          const targets: string[] = [];
+          if (!obj || typeof obj !== 'object') return targets;
+          if ('target' in obj) {
+            const t = (obj as { target?: string }).target;
+            if (typeof t === 'string') targets.push(t);
+          }
+          if (Array.isArray(obj)) {
+            for (const item of obj) targets.push(...extractTargets(item));
+          }
+          for (const val of Object.values(obj as Record<string, unknown>)) {
+            if (val && typeof val === 'object') targets.push(...extractTargets(val));
+          }
+          return targets;
+        };
+
+        for (const [_id, config] of Object.entries(states)) {
+          if (_id === 'COMPLETE' || _id === 'STOPPED') continue;
+          const cfg = config as Record<string, unknown>;
+          const targets = [...extractTargets(cfg.on), ...extractTargets(cfg.always)];
+          for (const target of targets) {
+            expect(allIds.has(target)).toBe(true);
+          }
+        }
+      }),
+      { numRuns: 300 },
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/linear-sequence.properties.test.ts
+++ b/packages/core/__tests__/runbook/linear-sequence.properties.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Property tests for linear step sequences.
+ *
+ * Tests compilation of N sequential base steps with PASS/FAIL transitions.
+ * Five properties at 200 runs each (1,000 total).
+ */
+
+import fc from 'fast-check';
+import {
+  inferSteps,
+  makeTransitions,
+  runMachine,
+  simpleActionArb,
+  type StepInput,
+} from './compiler-property-helpers.js';
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+interface LinearConfig {
+  numSteps: number;
+  passActions: ('CONTINUE' | 'STOP' | 'COMPLETE')[];
+  failActions: ('CONTINUE' | 'STOP' | 'COMPLETE')[];
+}
+
+const linearConfigArb: fc.Arbitrary<LinearConfig> = fc
+  .integer({ min: 1, max: 6 })
+  .chain((numSteps) =>
+    fc.record({
+      numSteps: fc.constant(numSteps),
+      passActions: fc.tuple(
+        ...Array.from({ length: numSteps - 1 }, () => simpleActionArb),
+        fc.constant('COMPLETE' as const),
+      ) as fc.Arbitrary<('CONTINUE' | 'STOP' | 'COMPLETE')[]>,
+      failActions: fc.array(simpleActionArb, {
+        minLength: numSteps,
+        maxLength: numSteps,
+      }),
+    }),
+  );
+
+function buildLinearSteps(config: LinearConfig): StepInput[] {
+  return Array.from({ length: config.numSteps }, (_, i) => ({
+    name: String(i + 1),
+    description: `Step ${i + 1}`,
+    transitions: makeTransitions('ALL', config.passActions[i], config.failActions[i]),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+describe('Linear sequence properties', () => {
+  // Property 1: Termination — any all-PASS event sequence terminates
+  it('always terminates in COMPLETE or STOPPED', () => {
+    fc.assert(
+      fc.property(linearConfigArb, (config) => {
+        const steps = inferSteps(buildLinearSteps(config));
+        const events = Array.from({ length: config.numSteps + 5 }, () => 'PASS' as const);
+        const result = runMachine(steps, events);
+        expect(result.terminalState).toMatch(/^(COMPLETE|STOPPED)$/);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 2: All-CONTINUE-PASS reaches COMPLETE
+  it('all-CONTINUE pass actions with all-PASS events produces COMPLETE', () => {
+    const allContinueConfig: fc.Arbitrary<LinearConfig> = fc
+      .integer({ min: 1, max: 6 })
+      .map((numSteps) => ({
+        numSteps,
+        passActions: [
+          ...Array.from({ length: numSteps - 1 }, () => 'CONTINUE' as const),
+          'COMPLETE' as const,
+        ],
+        failActions: Array.from({ length: numSteps }, () => 'STOP' as const),
+      }));
+
+    fc.assert(
+      fc.property(allContinueConfig, (config) => {
+        const steps = inferSteps(buildLinearSteps(config));
+        const events = Array.from({ length: config.numSteps + 5 }, () => 'PASS' as const);
+        const result = runMachine(steps, events);
+        expect(result.terminalState).toBe('COMPLETE');
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 3: STOP propagation — FAIL at step K with FAIL:STOP produces STOPPED
+  it('FAIL at a step with FAIL:STOP produces STOPPED', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 6 }),
+        fc.integer({ min: 0, max: 5 }),
+        (numSteps, stopIdx) => {
+          const adjustedIdx = stopIdx % numSteps;
+          const passActions = [
+            ...Array.from({ length: numSteps - 1 }, () => 'CONTINUE' as const),
+            'COMPLETE' as const,
+          ];
+          const failActions = Array.from({ length: numSteps }, () => 'STOP' as const);
+          const config: LinearConfig = { numSteps, passActions, failActions };
+          const steps = inferSteps(buildLinearSteps(config));
+
+          // Send PASS to reach step adjustedIdx, then FAIL
+          const events: ('PASS' | 'FAIL')[] = [
+            ...Array.from({ length: adjustedIdx }, () => 'PASS' as const),
+            'FAIL',
+          ];
+          const result = runMachine(steps, events);
+          expect(result.terminalState).toBe('STOPPED');
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 4: Early COMPLETE — PASS:COMPLETE at step K < last skips later steps
+  it('early COMPLETE skips later steps', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 2, max: 6 }),
+        fc.integer({ min: 0, max: 4 }),
+        (numSteps, earlyIdx) => {
+          const adjustedIdx = earlyIdx % (numSteps - 1); // ensure not last step
+          const passActions = Array.from({ length: numSteps }, (_, i) =>
+            i === adjustedIdx ? ('COMPLETE' as const) : ('CONTINUE' as const),
+          );
+          // Override last to COMPLETE too (standard)
+          passActions[numSteps - 1] = 'COMPLETE';
+          const failActions = Array.from({ length: numSteps }, () => 'STOP' as const);
+          const config: LinearConfig = { numSteps, passActions, failActions };
+          const steps = inferSteps(buildLinearSteps(config));
+
+          const events = Array.from({ length: numSteps + 5 }, () => 'PASS' as const);
+          const result = runMachine(steps, events);
+          expect(result.terminalState).toBe('COMPLETE');
+
+          // Steps after the early COMPLETE step should not be visited
+          for (let i = adjustedIdx + 2; i <= numSteps; i++) {
+            expect(result.statesVisited).not.toContain(`step::${i}`);
+          }
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 5: Step count matches events consumed
+  it('all-CONTINUE config consumes exactly numSteps PASS events', () => {
+    const allContinueConfig: fc.Arbitrary<LinearConfig> = fc
+      .integer({ min: 1, max: 6 })
+      .map((numSteps) => ({
+        numSteps,
+        passActions: [
+          ...Array.from({ length: numSteps - 1 }, () => 'CONTINUE' as const),
+          'COMPLETE' as const,
+        ],
+        failActions: Array.from({ length: numSteps }, () => 'STOP' as const),
+      }));
+
+    fc.assert(
+      fc.property(allContinueConfig, (config) => {
+        const steps = inferSteps(buildLinearSteps(config));
+        // Send exactly numSteps PASS events (no padding)
+        const events = Array.from({ length: config.numSteps }, () => 'PASS' as const);
+        const result = runMachine(steps, events, { maxPad: 0 });
+        expect(result.terminalState).toBe('COMPLETE');
+        expect(result.eventsConsumed).toBe(config.numSteps);
+      }),
+      { numRuns: 200 },
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/linear-sequence.properties.test.ts
+++ b/packages/core/__tests__/runbook/linear-sequence.properties.test.ts
@@ -43,7 +43,7 @@ const linearConfigArb: fc.Arbitrary<LinearConfig> = fc
 function buildLinearSteps(config: LinearConfig): StepInput[] {
   return Array.from({ length: config.numSteps }, (_, i) => ({
     name: String(i + 1),
-    description: `Step ${i + 1}`,
+    description: `Step ${String(i + 1)}`,
     transitions: makeTransitions('ALL', config.passActions[i], config.failActions[i]),
   }));
 }
@@ -142,7 +142,7 @@ describe('Linear sequence properties', () => {
 
           // Steps after the early COMPLETE step should not be visited
           for (let i = adjustedIdx + 2; i <= numSteps; i++) {
-            expect(result.statesVisited).not.toContain(`step::${i}`);
+            expect(result.statesVisited).not.toContain(`step::${String(i)}`);
           }
         },
       ),

--- a/packages/core/__tests__/runbook/retry-exhaustion.properties.test.ts
+++ b/packages/core/__tests__/runbook/retry-exhaustion.properties.test.ts
@@ -12,7 +12,6 @@ import {
   makeTransitionObject,
   runMachine,
   DEFER_TRANSITIONS,
-  type StepInput,
 } from './compiler-property-helpers.js';
 import type { Substep, Transitions } from '../../src/runbook/types.js';
 
@@ -95,7 +94,7 @@ describe('Retry exhaustion properties', () => {
         (numSubsteps, parentRetry) => {
           const substeps: Substep[] = Array.from({ length: numSubsteps }, (_, i) => ({
             id: String(i + 1),
-            description: `Sub ${i + 1}`,
+            description: `Sub ${String(i + 1)}`,
             transitions: DEFER_TRANSITIONS,
           }));
 

--- a/packages/core/__tests__/runbook/retry-exhaustion.properties.test.ts
+++ b/packages/core/__tests__/runbook/retry-exhaustion.properties.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Property tests for three-level retry exhaustion.
+ *
+ * Tests substep retry, parent retry, and iteration retry independently.
+ * Five properties at 300 runs each (1,500 total).
+ */
+
+import fc from 'fast-check';
+import {
+  inferSteps,
+  makeTransitions,
+  makeTransitionObject,
+  runMachine,
+  DEFER_TRANSITIONS,
+  type StepInput,
+} from './compiler-property-helpers.js';
+import type { Substep, Transitions } from '../../src/runbook/types.js';
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+describe('Retry exhaustion properties', () => {
+  // Property 1: Substep retry — pass before exhaustion
+  it('substep passes if PASS arrives before retry exhaustion', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 3 }),
+        fc.integer({ min: 0, max: 2 }),
+        (retryMax, failsBefore) => {
+          const adjustedFails = Math.min(failsBefore, retryMax - 1);
+          if (retryMax < 1) return; // need at least 1 retry to test
+
+          const transitions: Transitions = {
+            aggregation: 'ALL',
+            pass: makeTransitionObject('pass', 'COMPLETE'),
+            fail: makeTransitionObject('fail', 'STOP', retryMax),
+          };
+          const steps = inferSteps([
+            {
+              name: '1',
+              description: 'Retryable step',
+              transitions,
+            },
+          ]);
+
+          // Send adjustedFails FAILs then a PASS
+          const events: ('PASS' | 'FAIL')[] = [
+            ...Array.from({ length: Math.max(0, adjustedFails) }, () => 'FAIL' as const),
+            'PASS',
+          ];
+          const result = runMachine(steps, events);
+          expect(result.terminalState).toBe('COMPLETE');
+          expect(result.retryCount).toBe(Math.max(0, adjustedFails));
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 2: Substep retry — exhaustion fires action
+  it('substep retry exhaustion fires the exhausted action', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 3 }), (retryMax) => {
+        const transitions: Transitions = {
+          aggregation: 'ALL',
+          pass: makeTransitionObject('pass', 'COMPLETE'),
+          fail: makeTransitionObject('fail', 'STOP', retryMax),
+        };
+        const steps = inferSteps([
+          {
+            name: '1',
+            description: 'Retryable step',
+            transitions,
+          },
+        ]);
+
+        // Send retryMax+1 consecutive FAILs to exhaust retries
+        const events = Array.from({ length: retryMax + 1 }, () => 'FAIL' as const);
+        const result = runMachine(steps, events);
+        expect(result.terminalState).toBe('STOPPED');
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 3: Parent retry exhaustion
+  // Verify that with parentRetry=R, exactly (R+1)*numSubsteps FAILs produce STOPPED,
+  // while R*numSubsteps FAILs followed by all PASS produces COMPLETE (still retrying).
+  it('parent retry exhaustion fires the exhausted action', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 2 }),
+        fc.integer({ min: 1, max: 2 }),
+        (numSubsteps, parentRetry) => {
+          const substeps: Substep[] = Array.from({ length: numSubsteps }, (_, i) => ({
+            id: String(i + 1),
+            description: `Sub ${i + 1}`,
+            transitions: DEFER_TRANSITIONS,
+          }));
+
+          const steps = inferSteps([
+            {
+              name: '1',
+              description: 'Step with parent retry',
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: makeTransitionObject('pass', 'COMPLETE'),
+                fail: makeTransitionObject('fail', 'STOP', parentRetry),
+              },
+              substeps,
+            },
+          ]);
+
+          // Exhaustion path: (parentRetry+1) rounds of all-FAIL → STOPPED
+          const exhaustionEvents = Array.from(
+            { length: numSubsteps * (parentRetry + 1) },
+            () => 'FAIL' as const,
+          );
+          const exhaustionResult = runMachine(steps, exhaustionEvents);
+          expect(exhaustionResult.terminalState).toBe('STOPPED');
+
+          // Recovery path: parentRetry rounds of all-FAIL, then all-PASS → COMPLETE
+          const recoveryEvents: ('PASS' | 'FAIL')[] = [
+            ...Array.from({ length: numSubsteps * parentRetry }, () => 'FAIL' as const),
+            ...Array.from({ length: numSubsteps + 5 }, () => 'PASS' as const),
+          ];
+          const recoveryResult = runMachine(steps, recoveryEvents);
+          expect(recoveryResult.terminalState).toBe('COMPLETE');
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 4: Iteration retry exhaustion (FOR loop)
+  // Verify that with iterRetry=R, (R+1) FAILs exhaust iteration retry and reach STOPPED,
+  // while R FAILs followed by PASS allows the iteration to pass and reach COMPLETE.
+  it('iteration retry exhaustion fires the exhausted action', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 2 }), (iterRetry) => {
+        const substeps: Substep[] = [
+          { id: '1', description: 'Sub 1', transitions: DEFER_TRANSITIONS },
+        ];
+
+        const steps = inferSteps([
+          {
+            name: '1',
+            description: 'FOR step with iteration retry',
+            forClause: {
+              start: 1,
+              end: 1, // single iteration to isolate iteration retry
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: makeTransitionObject('pass', 'DEFER'),
+                fail: makeTransitionObject('fail', 'DEFER', iterRetry),
+              },
+            },
+            transitions: makeTransitions('ALL', 'COMPLETE', 'STOP'),
+            substeps,
+          },
+        ]);
+
+        // Exhaustion path: iterRetry+1 consecutive FAILs → STOPPED
+        const exhaustionEvents = Array.from({ length: iterRetry + 1 }, () => 'FAIL' as const);
+        const exhaustionResult = runMachine(steps, exhaustionEvents);
+        expect(exhaustionResult.terminalState).toBe('STOPPED');
+
+        // Recovery path: iterRetry FAILs then PASS → COMPLETE
+        const recoveryEvents: ('PASS' | 'FAIL')[] = [
+          ...Array.from({ length: iterRetry }, () => 'FAIL' as const),
+          'PASS',
+        ];
+        const recoveryResult = runMachine(steps, recoveryEvents);
+        expect(recoveryResult.terminalState).toBe('COMPLETE');
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 5: Retry counter independence
+  it('incrementing one retry counter does not affect others', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 2 }), (retryMax) => {
+        // Simple step with substep-level retry only — parent and iteration should stay 0
+        const transitions: Transitions = {
+          aggregation: 'ALL',
+          pass: makeTransitionObject('pass', 'COMPLETE'),
+          fail: makeTransitionObject('fail', 'STOP', retryMax),
+        };
+        const steps = inferSteps([
+          {
+            name: '1',
+            description: 'Step with substep retry only',
+            transitions,
+          },
+        ]);
+
+        // Send one FAIL then PASS (retry once, then pass)
+        const events: ('PASS' | 'FAIL')[] = ['FAIL', 'PASS'];
+        const result = runMachine(steps, events);
+        expect(result.terminalState).toBe('COMPLETE');
+        expect(result.retryCount).toBe(1);
+        expect(result.parentRetryCount).toBe(0);
+        expect(result.iterationRetryCount).toBe(0);
+      }),
+      { numRuns: 300 },
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/retry-exhaustion.properties.test.ts
+++ b/packages/core/__tests__/runbook/retry-exhaustion.properties.test.ts
@@ -2,7 +2,7 @@
  * Property tests for three-level retry exhaustion.
  *
  * Tests substep retry, parent retry, and iteration retry independently.
- * Five properties at 300 runs each (1,500 total).
+ * Seven properties at 300 runs each (2,100 total).
  */
 
 import fc from 'fast-check';
@@ -202,6 +202,99 @@ describe('Retry exhaustion properties', () => {
         expect(result.retryCount).toBe(1);
         expect(result.parentRetryCount).toBe(0);
         expect(result.iterationRetryCount).toBe(0);
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 5b: Parent retry resets iteration retry counter
+  // After parent retry fires, iteration retry must be available again.
+  // If iterationRetryCount leaked across parent retry, the second round of
+  // iteration FAILs would exhaust immediately → premature STOPPED.
+  it('parent retry resets iteration retry counter', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 2 }), (retry) => {
+        const substeps: Substep[] = [
+          { id: '1', description: 'Sub 1', transitions: DEFER_TRANSITIONS },
+        ];
+        const steps = inferSteps([
+          {
+            name: '1',
+            description: 'FOR step with both retry levels',
+            forClause: {
+              start: 1,
+              end: 1,
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: makeTransitionObject('pass', 'DEFER'),
+                fail: makeTransitionObject('fail', 'DEFER', retry),
+              },
+            },
+            transitions: {
+              aggregation: 'ALL' as const,
+              pass: makeTransitionObject('pass', 'COMPLETE'),
+              fail: makeTransitionObject('fail', 'STOP', retry),
+            },
+            substeps,
+          },
+        ]);
+        // Round 1: (retry+1) FAILs exhaust iteration → parent FAIL → parent retry
+        // Round 2: retry FAILs use iteration retries (proves counter was reset) then PASS
+        const events: ('PASS' | 'FAIL')[] = [
+          ...Array.from({ length: retry + 1 }, () => 'FAIL' as const),
+          ...Array.from({ length: retry }, () => 'FAIL' as const),
+          'PASS',
+        ];
+        const result = runMachine(steps, events);
+        // If iterationRetryCount was NOT reset by parent retry,
+        // the retry-th FAIL in round 2 would exhaust immediately → STOPPED.
+        expect(result.terminalState).toBe('COMPLETE');
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 5c: Iteration retry does not increment parent retry counter
+  // After iteration retries fire, parent retry must still be fully available.
+  // If iterationRetryCount leaked into parentRetryCount, parent retry would
+  // exhaust prematurely → STOPPED instead of recovery.
+  it('iteration retry does not increment parent retry counter', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 2 }), (retry) => {
+        const substeps: Substep[] = [
+          { id: '1', description: 'Sub 1', transitions: DEFER_TRANSITIONS },
+        ];
+        const steps = inferSteps([
+          {
+            name: '1',
+            description: 'FOR step with both retry levels',
+            forClause: {
+              start: 1,
+              end: 1,
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: makeTransitionObject('pass', 'DEFER'),
+                fail: makeTransitionObject('fail', 'DEFER', retry),
+              },
+            },
+            transitions: {
+              aggregation: 'ALL' as const,
+              pass: makeTransitionObject('pass', 'COMPLETE'),
+              fail: makeTransitionObject('fail', 'STOP', retry),
+            },
+            substeps,
+          },
+        ]);
+        // (retry+1) FAILs exhaust iteration retries → parent FAIL → parent retry
+        // Then PASS → COMPLETE
+        // If iteration retry leaked into parentRetryCount, parent retry would
+        // already be at `retry` → exhausted → STOPPED instead of recovery.
+        const events: ('PASS' | 'FAIL')[] = [
+          ...Array.from({ length: retry + 1 }, () => 'FAIL' as const),
+          'PASS',
+        ];
+        const result = runMachine(steps, events);
+        expect(result.terminalState).toBe('COMPLETE');
       }),
       { numRuns: 300 },
     );

--- a/packages/core/__tests__/runbook/substep-aggregation.properties.test.ts
+++ b/packages/core/__tests__/runbook/substep-aggregation.properties.test.ts
@@ -30,7 +30,7 @@ function buildAggregationSteps(opts: {
 }): StepInput[] {
   const substeps: Substep[] = Array.from({ length: opts.numSubsteps }, (_, i) => ({
     id: String(i + 1),
-    description: `Substep ${i + 1}`,
+    description: `Substep ${String(i + 1)}`,
     transitions: opts.substepActions[i] === 'DEFER' ? DEFER_TRANSITIONS : DEFAULT_TRANSITIONS,
   }));
 

--- a/packages/core/__tests__/runbook/substep-aggregation.properties.test.ts
+++ b/packages/core/__tests__/runbook/substep-aggregation.properties.test.ts
@@ -162,35 +162,31 @@ describe('Substep aggregation properties', () => {
   // Property 5: CONTINUE substeps don't feed deferredResults
   it('only DEFER substeps contribute to deferredResults count', () => {
     fc.assert(
-      fc.property(
-        fc.integer({ min: 2, max: 4 }),
-        fc.integer({ min: 1, max: 3 }),
-        (numSubsteps, numDefer) => {
-          const adjustedNumDefer = Math.min(numDefer, numSubsteps);
-          const substepActions = Array.from({ length: numSubsteps }, (_, i) =>
-            i < adjustedNumDefer ? ('DEFER' as const) : ('CONTINUE' as const),
-          );
-          // With mixed DEFER/CONTINUE substeps, only DEFER substeps feed deferredResults
-          // Parent transitions need to be set so we can observe the deferredResults
-          const steps = inferSteps(
-            buildAggregationSteps({
-              numSubsteps,
-              aggregationMode: 'ALL',
-              substepActions,
-              parentPassAction: 'CONTINUE',
-              parentFailAction: 'STOP',
-            }),
-          );
-          const events = Array.from({ length: numSubsteps + 5 }, () => 'PASS' as const);
-          const result = runMachine(steps, events);
-          // Machine reached terminal — deferredResults in terminal context
-          // reflects accumulated DEFER substep count
-          // Note: deferredResults may be reset by parent exit, but the aggregation
-          // correctly counted only DEFER substeps. We verify by outcome:
-          // ALL aggregation with only PASS results from DEFER substeps → parent passes
-          expect(result.terminalState).toBe('COMPLETE');
-        },
-      ),
+      fc.property(fc.integer({ min: 2, max: 4 }), (numSubsteps) => {
+        // First substep is DEFER, rest are CONTINUE
+        const substepActions = Array.from({ length: numSubsteps }, (_, i) =>
+          i === 0 ? ('DEFER' as const) : ('CONTINUE' as const),
+        );
+        const steps = inferSteps(
+          buildAggregationSteps({
+            numSubsteps,
+            aggregationMode: 'ANY',
+            substepActions,
+            parentPassAction: 'CONTINUE',
+            parentFailAction: 'STOP',
+          }),
+        );
+        // FAIL the DEFER substep (index 0), PASS all CONTINUE substeps
+        const events: ('PASS' | 'FAIL')[] = [
+          'FAIL',
+          ...Array.from({ length: numSubsteps - 1 }, () => 'PASS' as const),
+        ];
+        const result = runMachine(steps, events);
+        // ANY aggregation: if CONTINUE substeps leaked into deferredResults,
+        // their PASS results would satisfy ANY and fire parent PASS → COMPLETE.
+        // Only DEFER substep's FAIL should be in deferredResults → parent FAIL → STOPPED.
+        expect(result.terminalState).toBe('STOPPED');
+      }),
       { numRuns: 200 },
     );
   });

--- a/packages/core/__tests__/runbook/substep-aggregation.properties.test.ts
+++ b/packages/core/__tests__/runbook/substep-aggregation.properties.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Property tests for non-FOR substep aggregation with DEFER semantics.
+ *
+ * Tests DEFER routing, deferredResults accumulation, and ALL/ANY aggregation.
+ * Six properties at 200 runs each (1,200 total).
+ */
+
+import fc from 'fast-check';
+import {
+  inferSteps,
+  makeTransitions,
+  runMachine,
+  DEFER_TRANSITIONS,
+  DEFAULT_TRANSITIONS,
+  type StepInput,
+} from './compiler-property-helpers.js';
+import type { Substep } from '../../src/runbook/types.js';
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+function buildAggregationSteps(opts: {
+  numSubsteps: number;
+  aggregationMode: 'ALL' | 'ANY';
+  substepActions: ('DEFER' | 'CONTINUE')[];
+  parentPassAction: string;
+  parentFailAction: string;
+  parentFailRetry?: number;
+}): StepInput[] {
+  const substeps: Substep[] = Array.from({ length: opts.numSubsteps }, (_, i) => ({
+    id: String(i + 1),
+    description: `Substep ${i + 1}`,
+    transitions: opts.substepActions[i] === 'DEFER' ? DEFER_TRANSITIONS : DEFAULT_TRANSITIONS,
+  }));
+
+  return [
+    {
+      name: '1',
+      description: 'Aggregation step',
+      transitions: makeTransitions(
+        opts.aggregationMode,
+        opts.parentPassAction,
+        opts.parentFailAction,
+        opts.parentFailRetry ?? 0,
+      ),
+      substeps,
+    },
+    {
+      name: '2',
+      description: 'Terminal step',
+      transitions: makeTransitions('ALL', 'COMPLETE', 'STOP'),
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+describe('Substep aggregation properties', () => {
+  // Property 1: ALL-pass with all PASS + DEFER
+  it('ALL aggregation with all PASS+DEFER substeps fires parent PASS path', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 4 }), (numSubsteps) => {
+        const steps = inferSteps(
+          buildAggregationSteps({
+            numSubsteps,
+            aggregationMode: 'ALL',
+            substepActions: Array.from({ length: numSubsteps }, () => 'DEFER' as const),
+            parentPassAction: 'CONTINUE',
+            parentFailAction: 'STOP',
+          }),
+        );
+        const events = Array.from({ length: numSubsteps + 5 }, () => 'PASS' as const);
+        const result = runMachine(steps, events);
+        expect(result.terminalState).toBe('COMPLETE');
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 2: ALL-fail with any FAIL + DEFER
+  it('ALL aggregation with any FAIL+DEFER substep fires parent FAIL path', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 4 }),
+        fc.integer({ min: 0, max: 3 }),
+        (numSubsteps, failIdx) => {
+          const adjustedFailIdx = failIdx % numSubsteps;
+          const steps = inferSteps(
+            buildAggregationSteps({
+              numSubsteps,
+              aggregationMode: 'ALL',
+              substepActions: Array.from({ length: numSubsteps }, () => 'DEFER' as const),
+              parentPassAction: 'CONTINUE',
+              parentFailAction: 'STOP',
+            }),
+          );
+          // Send PASS for all substeps except failIdx which gets FAIL
+          const events: ('PASS' | 'FAIL')[] = Array.from({ length: numSubsteps }, (_, i) =>
+            i === adjustedFailIdx ? 'FAIL' : 'PASS',
+          );
+          const result = runMachine(steps, events);
+          expect(result.terminalState).toBe('STOPPED');
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 3: ANY-pass with at least one PASS + DEFER
+  it('ANY aggregation with at least one PASS+DEFER substep fires parent PASS path', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 2, max: 4 }),
+        fc.integer({ min: 0, max: 3 }),
+        (numSubsteps, passIdx) => {
+          const adjustedPassIdx = passIdx % numSubsteps;
+          const steps = inferSteps(
+            buildAggregationSteps({
+              numSubsteps,
+              aggregationMode: 'ANY',
+              substepActions: Array.from({ length: numSubsteps }, () => 'DEFER' as const),
+              parentPassAction: 'CONTINUE',
+              parentFailAction: 'STOP',
+            }),
+          );
+          // All FAIL except one PASS
+          const events: ('PASS' | 'FAIL')[] = Array.from({ length: numSubsteps }, (_, i) =>
+            i === adjustedPassIdx ? 'PASS' : 'FAIL',
+          );
+          const result = runMachine(steps, events);
+          expect(result.terminalState).toBe('COMPLETE');
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 4: ANY-fail with all FAIL + DEFER
+  it('ANY aggregation with all FAIL+DEFER substeps fires parent FAIL path', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 4 }), (numSubsteps) => {
+        const steps = inferSteps(
+          buildAggregationSteps({
+            numSubsteps,
+            aggregationMode: 'ANY',
+            substepActions: Array.from({ length: numSubsteps }, () => 'DEFER' as const),
+            parentPassAction: 'CONTINUE',
+            parentFailAction: 'STOP',
+          }),
+        );
+        const events = Array.from({ length: numSubsteps }, () => 'FAIL' as const);
+        const result = runMachine(steps, events);
+        expect(result.terminalState).toBe('STOPPED');
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 5: CONTINUE substeps don't feed deferredResults
+  it('only DEFER substeps contribute to deferredResults count', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 2, max: 4 }),
+        fc.integer({ min: 1, max: 3 }),
+        (numSubsteps, numDefer) => {
+          const adjustedNumDefer = Math.min(numDefer, numSubsteps);
+          const substepActions = Array.from({ length: numSubsteps }, (_, i) =>
+            i < adjustedNumDefer ? ('DEFER' as const) : ('CONTINUE' as const),
+          );
+          // With mixed DEFER/CONTINUE substeps, only DEFER substeps feed deferredResults
+          // Parent transitions need to be set so we can observe the deferredResults
+          const steps = inferSteps(
+            buildAggregationSteps({
+              numSubsteps,
+              aggregationMode: 'ALL',
+              substepActions,
+              parentPassAction: 'CONTINUE',
+              parentFailAction: 'STOP',
+            }),
+          );
+          const events = Array.from({ length: numSubsteps + 5 }, () => 'PASS' as const);
+          const result = runMachine(steps, events);
+          // Machine reached terminal — deferredResults in terminal context
+          // reflects accumulated DEFER substep count
+          // Note: deferredResults may be reset by parent exit, but the aggregation
+          // correctly counted only DEFER substeps. We verify by outcome:
+          // ALL aggregation with only PASS results from DEFER substeps → parent passes
+          expect(result.terminalState).toBe('COMPLETE');
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 6: Aggregated flag on parent exit
+  it('parent aggregation sets aggregated flag on lastAction', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 3 }),
+        fc.constantFrom('ALL' as const, 'ANY' as const),
+        (numSubsteps, mode) => {
+          const steps = inferSteps(
+            buildAggregationSteps({
+              numSubsteps,
+              aggregationMode: mode,
+              substepActions: Array.from({ length: numSubsteps }, () => 'DEFER' as const),
+              parentPassAction: 'COMPLETE',
+              parentFailAction: 'STOP',
+            }),
+          );
+          const events = Array.from({ length: numSubsteps }, () => 'PASS' as const);
+          const result = runMachine(steps, events);
+          expect(result.terminalState).toBe('COMPLETE');
+          // Parent aggregation fired → aggregated flag must be set
+          expect(result.lastAction?.aggregated).toBe(true);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/terminal-propagation.properties.test.ts
+++ b/packages/core/__tests__/runbook/terminal-propagation.properties.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Property tests for STOP/COMPLETE propagation across all topology shapes.
+ *
+ * Tests that terminal actions propagate correctly and validates the
+ * aggregated flag and no-mapping design principle.
+ * Five properties at 200 runs each (1,000 total).
+ */
+
+import fc from 'fast-check';
+import {
+  inferSteps,
+  makeTransitions,
+  runMachine,
+  eventArb,
+  DEFER_TRANSITIONS,
+  type StepInput,
+} from './compiler-property-helpers.js';
+import type { Substep } from '../../src/runbook/types.js';
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+type Topology = 'base' | 'substep' | 'for-substep';
+type TerminalAction = 'STOP' | 'COMPLETE';
+
+const topologyArb: fc.Arbitrary<Topology> = fc.constantFrom('base', 'substep', 'for-substep');
+const terminalActionArb: fc.Arbitrary<TerminalAction> = fc.constantFrom('STOP', 'COMPLETE');
+
+function buildTerminalSteps(
+  topology: Topology,
+  terminalAction: TerminalAction,
+  triggerEvent: 'PASS' | 'FAIL',
+): StepInput[] {
+  const passAction = triggerEvent === 'PASS' ? terminalAction : 'CONTINUE';
+  const failAction = triggerEvent === 'FAIL' ? terminalAction : 'CONTINUE';
+
+  if (topology === 'base') {
+    return [
+      {
+        name: '1',
+        description: 'Base step',
+        transitions: makeTransitions('ALL', passAction, failAction),
+      },
+    ];
+  }
+
+  const substepTransitions = makeTransitions('ALL', passAction, failAction);
+  const substeps: Substep[] = [{ id: '1', description: 'Sub 1', transitions: substepTransitions }];
+
+  if (topology === 'substep') {
+    return [
+      {
+        name: '1',
+        description: 'Step with substep',
+        substeps,
+      },
+    ];
+  }
+
+  // for-substep
+  return [
+    {
+      name: '1',
+      description: 'FOR step',
+      forClause: { start: 1, end: 2 },
+      substeps,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+describe('Terminal propagation properties', () => {
+  // Property 1: STOP always produces STOPPED
+  it('STOP always produces STOPPED across all topologies', () => {
+    fc.assert(
+      fc.property(topologyArb, eventArb, (topology, event) => {
+        const steps = inferSteps(buildTerminalSteps(topology, 'STOP', event));
+        const result = runMachine(steps, [event]);
+        expect(result.terminalState).toBe('STOPPED');
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 2: COMPLETE always produces COMPLETE
+  it('COMPLETE always produces COMPLETE across all topologies', () => {
+    fc.assert(
+      fc.property(topologyArb, eventArb, (topology, event) => {
+        const steps = inferSteps(buildTerminalSteps(topology, 'COMPLETE', event));
+        const result = runMachine(steps, [event]);
+        expect(result.terminalState).toBe('COMPLETE');
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 3: Direct terminal — no aggregated flag
+  it('direct STOP/COMPLETE from substep has no aggregated flag', () => {
+    fc.assert(
+      fc.property(terminalActionArb, eventArb, (action, event) => {
+        const substepTransitions = makeTransitions('ALL', action, action);
+        const steps = inferSteps([
+          {
+            name: '1',
+            description: 'Step with substep',
+            transitions: makeTransitions('ALL', 'CONTINUE', 'STOP'),
+            substeps: [{ id: '1', description: 'Sub 1', transitions: substepTransitions }],
+          },
+        ]);
+        const result = runMachine(steps, [event]);
+        expect(result.terminalState).toBe(action === 'STOP' ? 'STOPPED' : 'COMPLETE');
+        // Direct terminal from substep — no aggregated flag
+        expect(result.lastAction?.aggregated).toBeUndefined();
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 4: Aggregated terminal — aggregated flag set
+  it('terminal action from parent aggregation has aggregated flag', () => {
+    fc.assert(
+      fc.property(terminalActionArb, eventArb, (action, event) => {
+        // Substeps use DEFER to feed aggregation; parent resolves to terminal
+        const steps = inferSteps([
+          {
+            name: '1',
+            description: 'Step with substep',
+            transitions: makeTransitions('ALL', action, action),
+            substeps: [{ id: '1', description: 'Sub 1', transitions: DEFER_TRANSITIONS }],
+          },
+        ]);
+        const result = runMachine(steps, [event]);
+        const expectedTerminal = action === 'STOP' ? 'STOPPED' : 'COMPLETE';
+        expect(result.terminalState).toBe(expectedTerminal);
+        // Aggregated terminal — flag must be set
+        expect(result.lastAction?.aggregated).toBe(true);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // Property 5: No action mapping — lastAction.type is never CONTINUE at terminal
+  // when a terminal action (STOP/COMPLETE) was configured
+  it('terminal lastAction.type is never CONTINUE when STOP/COMPLETE configured', () => {
+    fc.assert(
+      fc.property(terminalActionArb, topologyArb, eventArb, (action, topology, event) => {
+        const steps = inferSteps(buildTerminalSteps(topology, action, event));
+        const result = runMachine(steps, [event]);
+        // After terminal action fires, lastAction.type should match the configured action
+        expect(result.lastAction?.type).toBe(action);
+      }),
+      { numRuns: 200 },
+    );
+  });
+});


### PR DESCRIPTION
Add 30 new fast-check properties across 6 test suites (~7,000 runs) covering linear sequences, graph invariants, terminal propagation, substep aggregation with DEFER semantics, three-level retry exhaustion, and GOTO transitions. Shared helpers in compiler-property-helpers.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive property-based testing framework and public test utilities for the runbook compiler to simulate runs, generate event sequences, and inspect outcomes.
  * Introduced new property suites covering GOTO behavior, graph invariants, linear sequences, retry exhaustion, substep aggregation, and terminal propagation.
  * Improved assertions for transitions, retries, visitation, and aggregated terminal reporting to strengthen correctness and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->