### PR TITLE
fix: reject DEFER at step level instead of silently mapping to CONTINUE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,3 +346,11 @@ Currently supported internally: `echo`, `prompt`. Unsupported commands fall back
 - [docs/PROJECT-INTEGRATION.md](docs/PROJECT-INTEGRATION.md) - Project integration guide
 - [docs/DOCKER.md](docs/DOCKER.md) - Docker verification pipeline
 - [docs/TEST-RUNBOOK-STANDARD.md](docs/TEST-RUNBOOK-STANDARD.md) - Declarative test runbook standard
+
+## Design Principles
+
+**Type-driven dispatch.** Types drive logic everywhere possible. Use discriminated unions and type narrowing to make invalid states unrepresentable. Guards express domain conditions through typed return values, never raw action-type string checks. If logic branches on a string discriminant, that discriminant should be encoded in a purpose-built type that forces callers to narrow before accessing variant-specific fields. `if` statements checking action types in guards are code smells — missing type structure. See [docs/RUNDOWN.md](docs/RUNDOWN.md#design-principles) for state machine specifics.
+
+**No silent mapping.** Actions like STOP, COMPLETE, BREAK must propagate as themselves. Never silently convert one action type to another (e.g., mapping DEFER to CONTINUE). Each action type has distinct semantics that must be preserved through the entire dispatch chain.
+
+**No synthetic IDs.** Don't create artificial state identifiers (like `~channel` prefixes). Use XState's native event system and state graph structure.

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -148,6 +148,7 @@ turboshovel
 typename
 ultrathink
 unist
+unrepresentable
 unknowncommand
 unsandboxed
 unstash

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -101,6 +101,7 @@ where action is:
   CONTINUE | DEFER | COMPLETE [ message ] | STOP [ message ] | GOTO target | NEXT | BREAK
 
 Context constraints:
+- `DEFER` is only valid inside substeps or FOR iteration-level nested transitions
 - `NEXT` is only valid inside substeps of a FOR step
 - `BREAK` is valid inside substeps of a FOR step and FOR-level nested transitions
 - FOR-level nested transitions (nested bullets under `- FOR ...`) only allow terminal actions: `CONTINUE` (exit loop), `DEFER`, `NEXT` (loop back without accumulation), `BREAK`, `GOTO`, `STOP`, `COMPLETE` (optionally wrapped in `RETRY`)

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -73,7 +73,7 @@ The CLI is an orchestration and control interface. Claude executes the actual wo
 
 ### Design Principles
 
-**Type-driven dispatch:** The state machine uses types and events to drive logic. Steps raise typed events; parent states dispatch on event type via `on:` handlers. Guards express domain conditions (e.g., "has more iterations"), never action-type checks. If a guard inspects `lastAction.type` to decide routing, that is a code smell — the event type system should handle the dispatch instead. `if` statements checking action types indicate missing structure in the state graph.
+**Type-driven dispatch:** The state machine uses types and events to drive logic. Steps raise typed events; parent states dispatch on event type via `on:` handlers. Guards express domain conditions (e.g., "has more iterations"), never action-type checks. If a guard inspects `lastAction.type` to decide routing, that is a code smell — the event type system should handle the dispatch instead. `if` statements checking action types indicate missing structure in the state graph. Example: `IterationOutcome` is a discriminated union (`completed | break | next`) that encodes *why* an iteration ended. Retry config only exists on the `completed` variant, so TypeScript prevents accessing retry on loop-control exits at compile time. The single `lastAction.type` check is encapsulated inside `getIterationOutcome` — guards narrow on `outcome.kind` instead.
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -133,7 +133,7 @@ Aggregation modifiers must form complementary pairs: `PASS ALL` with `FAIL ANY` 
 | Action | Context | Effect |
 | :--- | :--- | :--- |
 | `CONTINUE` | Any | Proceed to next sequential unit. At FOR iteration level: exit loop. |
-| `DEFER` | Substep, FOR Iteration-Level, Step-Level | Pass result up one level for aggregation. |
+| `DEFER` | Substep, FOR Iteration-Level | Pass result up one level for aggregation. |
 | `STOP [msg]` | Any | Terminate execution immediately (failure). |
 | `COMPLETE [msg]` | Any | Terminate execution immediately (success). |
 | `GOTO {Target}` | Any | Jump to step/substep (e.g., `1`, `Error`). |
@@ -141,7 +141,7 @@ Aggregation modifiers must form complementary pairs: `PASS ALL` with `FAIL ANY` 
 | `NEXT` | FOR Substep, FOR Iteration-Level | Skip to next iteration (no result accumulation). |
 | `BREAK` | FOR Substep, FOR Iteration-Level | Exit loop immediately. |
 
-> **Shorthand:** A standalone `- DEFER` bullet (without PASS/FAIL prefix) expands to `- PASS: DEFER` + `- FAIL: DEFER`. This is convenient for substeps and steps where both outcomes should propagate to parent aggregation.
+> **Shorthand:** A standalone `- DEFER` bullet (without PASS/FAIL prefix) expands to `- PASS: DEFER` + `- FAIL: DEFER`. This is convenient for substeps where both outcomes should propagate to parent aggregation. DEFER is not valid at step level.
 
 GOTO targeting the containing step (self-reference) without an AT qualifier may create an infinite loop. Use RETRY for bounded re-execution.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -223,7 +223,7 @@ scenarios:
 3.  **Strict Ordering**: FOR -> Transitions -> Prompt -> Body.
 4.  **Exclusivity**: Only one body type (Code OR Substeps). Step-level runbook lists are shorthand for Substeps.
 5.  **Single Command**: Max one executable block per step.
-6.  **Loop Safety**: `NEXT` is only valid inside FOR substeps. `BREAK` is valid in FOR substeps and FOR iteration-level transitions.
+6.  **Loop Safety**: `NEXT` and `BREAK` are valid in FOR substeps and FOR iteration-level transitions.
 7.  **Source Validation**: FOR clauses referencing a data source must reference a defined source. Named variable required.
 8.  **FOR Requires Substeps**: A FOR-annotated step must contain substeps.
 9.  **No Nested RETRY**: RETRY fallback actions cannot be RETRY.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -227,7 +227,7 @@ scenarios:
 7.  **Source Validation**: FOR clauses referencing a data source must reference a defined source. Named variable required.
 8.  **FOR Requires Substeps**: A FOR-annotated step must contain substeps.
 9.  **No Nested RETRY**: RETRY fallback actions cannot be RETRY.
-10. **FOR Iteration Action Set**: FOR-level nested transitions only allow `CONTINUE`, `BREAK`, `GOTO`, `STOP`, `COMPLETE` (plus RETRY wrappers).
+10. **FOR Iteration Action Set**: FOR-level nested transitions only allow `CONTINUE`, `DEFER`, `NEXT`, `BREAK`, `GOTO`, `STOP`, `COMPLETE` (plus RETRY wrappers).
 
 ## 9. Compatibility
 

--- a/packages/cli/__tests__/integration/for-loop-transitions.test.ts
+++ b/packages/cli/__tests__/integration/for-loop-transitions.test.ts
@@ -271,4 +271,42 @@ describe('FOR loop transitions integration', () => {
       expect(result.stdout).toContain('COMPLETE');
     });
   });
+
+  // ===========================================================================
+  // Group 4: Substep Loop Control Bypasses Iteration Retry
+  // ===========================================================================
+  describe('substep loop-control bypasses iteration retry', () => {
+    it('substep BREAK skips iteration retry', async () => {
+      // Substep ON FAIL: BREAK should bypass iteration-level RETRY 2 BREAK
+      const filename = 'substep-break-bypass.runbook.md';
+      const content = `## 1. Process
+- FOR i IN 1 TO 3
+  - FAIL ANY: RETRY 2 BREAK
+- PASS ALL: CONTINUE
+- FAIL ANY: STOP
+
+### 1.1 Check
+- PASS: DEFER
+- FAIL: BREAK
+
+Do the check.
+
+## 2. Done
+- PASS: COMPLETE
+
+Final step.
+`;
+      await writeFile(join(workspace.cwd, filename), content);
+
+      // Start runbook in prompted mode
+      expect(runCli(`run --prompted ${filename}`, workspace).exitCode).toBe(0);
+
+      // Iteration 1: fail → substep BREAK fires (bypasses iteration-level retry)
+      const result = runCli('fail', workspace);
+      // BREAK exits loop → aggregation: [fail] → PASS ALL fails → STOP
+      expect(result.exitCode).toBe(1);
+      // Retry should NOT have fired
+      expect(result.stdout).not.toContain('RETRY');
+    });
+  });
 });

--- a/packages/cli/__tests__/integration/for-loop-transitions.test.ts
+++ b/packages/cli/__tests__/integration/for-loop-transitions.test.ts
@@ -285,11 +285,17 @@ describe('FOR loop transitions integration', () => {
 - PASS ALL: CONTINUE
 - FAIL ANY: STOP
 
-### 1.1 Check
+### 1.1 First check
+- PASS: DEFER
+- FAIL: DEFER
+
+Do the first check.
+
+### 1.2 Second check
 - PASS: DEFER
 - FAIL: BREAK
 
-Do the check.
+Do the second check.
 
 ## 2. Done
 - PASS: COMPLETE
@@ -301,9 +307,10 @@ Final step.
       // Start runbook in prompted mode
       expect(runCli(`run --prompted ${filename}`, workspace).exitCode).toBe(0);
 
-      // Iteration 1: fail → substep BREAK fires (bypasses iteration-level retry)
+      // Iteration 1: substep 1.1 FAIL (DEFER accumulates fail), substep 1.2 FAIL (BREAK exits)
+      expect(runCli('fail', workspace).exitCode).toBe(0);
       const result = runCli('fail', workspace);
-      // BREAK exits loop → aggregation: [fail] → PASS ALL fails → STOP
+      // BREAK exits loop → aggregation: deferredResults=[fail] → fail → PASS ALL fails → STOP
       expect(result.exitCode).toBe(1);
       // Retry should NOT have fired
       expect(result.stdout).not.toContain('RETRY');

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -6943,6 +6943,364 @@ echo "processing"
         expect(actorAny.getSnapshot().value).toBe('COMPLETE');
       });
 
+      it('S1: 3 substeps DEFER+CONTINUE+DEFER, 2 iterations — CONTINUE in middle is invisible', () => {
+        const steps = inferSteps([
+          {
+            name: '1',
+            forClause: { start: 1, end: 2, transitions: FOR_DEFER_TRANSITIONS },
+            description: 'FOR loop',
+            transitions: PASS_ALL_TRANSITIONS,
+            substeps: [
+              {
+                id: '1',
+                description: 'Sub 1 (DEFER)',
+                transitions: makeSubstepTransitions('DEFER', 'DEFER'),
+              },
+              {
+                id: '2',
+                description: 'Sub 2 (CONTINUE)',
+                transitions: makeSubstepTransitions('CONTINUE', 'CONTINUE'),
+              },
+              {
+                id: '3',
+                description: 'Sub 3 (DEFER)',
+                transitions: makeSubstepTransitions('DEFER', 'DEFER'),
+              },
+            ],
+          },
+        ]);
+        const machine = compileRunbookToMachine(steps);
+        const actor = createActor(machine);
+        actor.start();
+
+        // Iter 1: sub1=PASS(DEFER), sub2=FAIL(CONTINUE), sub3=PASS(DEFER)
+        actor.send({ type: 'PASS' }); // sub1 → DEFER feeds 'pass'
+        actor.send({ type: 'FAIL' }); // sub2 → CONTINUE (invisible)
+        actor.send({ type: 'PASS' }); // sub3 → DEFER feeds 'pass'
+        // deferredResults=['pass','pass'] → ALL: pass → iter pass → DEFER → loopback
+        expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']);
+
+        // Iter 2: sub1=PASS(DEFER), sub2=PASS(CONTINUE), sub3=PASS(DEFER)
+        actor.send({ type: 'PASS' }); // sub1 → DEFER feeds 'pass'
+        actor.send({ type: 'PASS' }); // sub2 → CONTINUE (invisible)
+        actor.send({ type: 'PASS' }); // sub3 → DEFER feeds 'pass'
+        // deferredResults=['pass','pass'] → ALL: pass → iter pass
+        // Parent: iterationResults=['pass'] + inline pass → ALL: pass → COMPLETE
+        expect(actor.getSnapshot().value).toBe('COMPLETE');
+      });
+
+      it('S2: 3 substeps DEFER+CONTINUE+DEFER, 1 iteration — hidden failure', () => {
+        const steps = inferSteps([
+          {
+            name: '1',
+            forClause: { start: 1, end: 1, transitions: FOR_DEFER_TRANSITIONS },
+            description: 'FOR loop',
+            transitions: PASS_ALL_TRANSITIONS,
+            substeps: [
+              {
+                id: '1',
+                description: 'Sub 1 (DEFER)',
+                transitions: makeSubstepTransitions('DEFER', 'DEFER'),
+              },
+              {
+                id: '2',
+                description: 'Sub 2 (CONTINUE)',
+                transitions: makeSubstepTransitions('CONTINUE', 'CONTINUE'),
+              },
+              {
+                id: '3',
+                description: 'Sub 3 (DEFER)',
+                transitions: makeSubstepTransitions('DEFER', 'DEFER'),
+              },
+            ],
+          },
+        ]);
+        const machine = compileRunbookToMachine(steps);
+        const actor = createActor(machine);
+        actor.start();
+
+        // sub1=PASS(DEFER), sub2=FAIL(CONTINUE), sub3=PASS(DEFER)
+        actor.send({ type: 'PASS' }); // sub1 → DEFER feeds 'pass'
+        actor.send({ type: 'FAIL' }); // sub2 → CONTINUE (failure invisible)
+        actor.send({ type: 'PASS' }); // sub3 → DEFER feeds 'pass'
+        // deferredResults=['pass','pass'] → ALL: pass → COMPLETE
+        expect(actor.getSnapshot().context.deferredResults).toEqual(['pass', 'pass']);
+        expect(actor.getSnapshot().value).toBe('COMPLETE');
+      });
+
+      it('S3: 2 substeps CONTINUE+DEFER with iteration-level CONTINUE on pass', () => {
+        const steps = inferSteps([
+          {
+            name: '1',
+            forClause: {
+              start: 1,
+              end: 3,
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'DEFER' as const } },
+              },
+            },
+            description: 'FOR loop',
+            transitions: PASS_ALL_TRANSITIONS,
+            substeps: [
+              {
+                id: '1',
+                description: 'Sub 1 (CONTINUE)',
+                transitions: makeSubstepTransitions('CONTINUE', 'CONTINUE'),
+              },
+              {
+                id: '2',
+                description: 'Sub 2 (DEFER)',
+                transitions: makeSubstepTransitions('DEFER', 'DEFER'),
+              },
+            ],
+          },
+        ]);
+        const machine = compileRunbookToMachine(steps);
+        const actor = createActor(machine);
+        actor.start();
+
+        // Iter 1: sub1=PASS(CONTINUE), sub2=PASS(DEFER)
+        actor.send({ type: 'PASS' }); // sub1 → CONTINUE (invisible)
+        actor.send({ type: 'PASS' }); // sub2 → DEFER feeds 'pass'
+        // deferredResults=['pass'] → ALL: pass → iter pass → CONTINUE → exits loop
+        // Parent: iterationResults=[] + partial feed → ALL: pass → COMPLETE
+        expect(actor.getSnapshot().value).toBe('COMPLETE');
+      });
+
+      it('S4: 2 substeps CONTINUE+DEFER, 3 iterations — DEFER loopback then CONTINUE exit', () => {
+        const steps = inferSteps([
+          {
+            name: '1',
+            forClause: {
+              start: 1,
+              end: 3,
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+              },
+            },
+            description: 'FOR loop',
+            transitions: PASS_ALL_TRANSITIONS,
+            substeps: [
+              {
+                id: '1',
+                description: 'Sub 1 (CONTINUE)',
+                transitions: makeSubstepTransitions('CONTINUE', 'CONTINUE'),
+              },
+              {
+                id: '2',
+                description: 'Sub 2 (DEFER)',
+                transitions: makeSubstepTransitions('DEFER', 'DEFER'),
+              },
+            ],
+          },
+        ]);
+        const machine = compileRunbookToMachine(steps);
+        const actor = createActor(machine);
+        actor.start();
+
+        // Iter 1: sub1=PASS(CONTINUE), sub2=PASS(DEFER)
+        actor.send({ type: 'PASS' }); // sub1 → CONTINUE (invisible)
+        actor.send({ type: 'PASS' }); // sub2 → DEFER feeds 'pass'
+        // deferredResults=['pass'] → ALL: pass → iter pass → DEFER → loopback
+        expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']);
+
+        // Iter 2: sub1=PASS(CONTINUE), sub2=PASS(DEFER)
+        actor.send({ type: 'PASS' }); // sub1 → CONTINUE (invisible)
+        actor.send({ type: 'PASS' }); // sub2 → DEFER feeds 'pass'
+        // deferredResults=['pass'] → ALL: pass → iter pass → DEFER → loopback
+        expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
+
+        // Iter 3: sub1=FAIL(CONTINUE), sub2=FAIL(DEFER)
+        actor.send({ type: 'FAIL' }); // sub1 → CONTINUE (invisible)
+        actor.send({ type: 'FAIL' }); // sub2 → DEFER feeds 'fail'
+        // deferredResults=['fail'] → ALL: fail → iter fail → CONTINUE → exits loop
+        // Parent: iterationResults=['pass','pass'] + inline fail → ALL fails → STOPPED
+        expect(actor.getSnapshot().value).toBe('STOPPED');
+      });
+
+      it('S5: 3 substeps CONTINUE+CONTINUE+DEFER — only last feeds results', () => {
+        const steps = inferSteps([
+          {
+            name: '1',
+            forClause: { start: 1, end: 1, transitions: FOR_DEFER_TRANSITIONS },
+            description: 'FOR loop',
+            transitions: PASS_ANY_TRANSITIONS,
+            substeps: [
+              {
+                id: '1',
+                description: 'Sub 1 (CONTINUE)',
+                transitions: makeSubstepTransitions('CONTINUE', 'CONTINUE'),
+              },
+              {
+                id: '2',
+                description: 'Sub 2 (CONTINUE)',
+                transitions: makeSubstepTransitions('CONTINUE', 'CONTINUE'),
+              },
+              {
+                id: '3',
+                description: 'Sub 3 (DEFER)',
+                transitions: makeSubstepTransitions('DEFER', 'DEFER'),
+              },
+            ],
+          },
+        ]);
+        const machine = compileRunbookToMachine(steps);
+        const actor = createActor(machine);
+        actor.start();
+
+        // sub1=PASS(CONTINUE), sub2=PASS(CONTINUE), sub3=FAIL(DEFER)
+        actor.send({ type: 'PASS' }); // sub1 → CONTINUE (invisible)
+        actor.send({ type: 'PASS' }); // sub2 → CONTINUE (invisible)
+        actor.send({ type: 'FAIL' }); // sub3 → DEFER feeds 'fail'
+        // deferredResults=['fail'] → ALL: fail → iter fail
+        // Parent ANY: ['fail'] → 0 passes → STOPPED
+        expect(actor.getSnapshot().context.deferredResults).toEqual(['fail']);
+        expect(actor.getSnapshot().value).toBe('STOPPED');
+      });
+
+      it('S6: 3 substeps DEFER+CONTINUE+DEFER, PASS ANY at iteration level', () => {
+        const FOR_ANY_DEFER_TRANSITIONS = {
+          aggregation: 'ANY' as const,
+          pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+          fail: { kind: 'fail' as const, retry: 0, action: { type: 'DEFER' as const } },
+        };
+        const steps = inferSteps([
+          {
+            name: '1',
+            forClause: { start: 1, end: 2, transitions: FOR_ANY_DEFER_TRANSITIONS },
+            description: 'FOR loop',
+            transitions: PASS_ALL_TRANSITIONS,
+            substeps: [
+              {
+                id: '1',
+                description: 'Sub 1 (DEFER)',
+                transitions: makeSubstepTransitions('DEFER', 'DEFER'),
+              },
+              {
+                id: '2',
+                description: 'Sub 2 (CONTINUE)',
+                transitions: makeSubstepTransitions('CONTINUE', 'CONTINUE'),
+              },
+              {
+                id: '3',
+                description: 'Sub 3 (DEFER)',
+                transitions: makeSubstepTransitions('DEFER', 'DEFER'),
+              },
+            ],
+          },
+        ]);
+        const machine = compileRunbookToMachine(steps);
+        const actor = createActor(machine);
+        actor.start();
+
+        // Iter 1: sub1=FAIL(DEFER), sub2=PASS(CONTINUE), sub3=FAIL(DEFER)
+        actor.send({ type: 'FAIL' }); // sub1 → DEFER feeds 'fail'
+        actor.send({ type: 'PASS' }); // sub2 → CONTINUE (invisible — would be 'pass' but hidden)
+        actor.send({ type: 'FAIL' }); // sub3 → DEFER feeds 'fail'
+        // deferredResults=['fail','fail'] → ANY: 0 passes → fail → DEFER → loopback
+        expect(actor.getSnapshot().context.iterationResults).toEqual(['fail']);
+
+        // Iter 2: sub1=FAIL(DEFER), sub2=FAIL(CONTINUE), sub3=PASS(DEFER)
+        actor.send({ type: 'FAIL' }); // sub1 → DEFER feeds 'fail'
+        actor.send({ type: 'FAIL' }); // sub2 → CONTINUE (invisible)
+        actor.send({ type: 'PASS' }); // sub3 → DEFER feeds 'pass'
+        // deferredResults=['fail','pass'] → ANY: 1 pass → pass → iter pass
+        // Parent: iterationResults=['fail'] + inline pass → ALL fails → STOPPED
+        expect(actor.getSnapshot().value).toBe('STOPPED');
+      });
+
+      it('S7: all-CONTINUE substeps, 3 iterations — vacuous pass propagation', () => {
+        const steps = inferSteps([
+          {
+            name: '1',
+            forClause: { start: 1, end: 3, transitions: FOR_DEFER_TRANSITIONS },
+            description: 'FOR loop',
+            transitions: PASS_ANY_TRANSITIONS,
+            substeps: [
+              {
+                id: '1',
+                description: 'Sub 1 (CONTINUE)',
+                transitions: makeSubstepTransitions('CONTINUE', 'CONTINUE'),
+              },
+              {
+                id: '2',
+                description: 'Sub 2 (CONTINUE)',
+                transitions: makeSubstepTransitions('CONTINUE', 'CONTINUE'),
+              },
+            ],
+          },
+        ]);
+        const machine = compileRunbookToMachine(steps);
+        const actor = createActor(machine);
+        actor.start();
+
+        // Iter 1: both FAIL → both CONTINUE → deferredResults=[] → ALL vacuous pass → DEFER
+        actor.send({ type: 'FAIL' });
+        actor.send({ type: 'FAIL' });
+        expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']);
+
+        // Iter 2: both FAIL → both CONTINUE → deferredResults=[] → ALL vacuous pass → DEFER
+        actor.send({ type: 'FAIL' });
+        actor.send({ type: 'FAIL' });
+        expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
+
+        // Iter 3: both FAIL → both CONTINUE → deferredResults=[] → ALL vacuous pass
+        // Parent: iterationResults=['pass','pass'] + inline pass → ANY: 3 passes → COMPLETE
+        actor.send({ type: 'FAIL' });
+        actor.send({ type: 'FAIL' });
+        expect(actor.getSnapshot().value).toBe('COMPLETE');
+      });
+
+      it('S8: asymmetric PASS→CONTINUE, FAIL→DEFER across 3 substeps', () => {
+        const steps = inferSteps([
+          {
+            name: '1',
+            forClause: { start: 1, end: 2, transitions: FOR_DEFER_TRANSITIONS },
+            description: 'FOR loop',
+            transitions: PASS_ALL_TRANSITIONS,
+            substeps: [
+              {
+                id: '1',
+                description: 'Sub 1 (pass→CONTINUE, fail→DEFER)',
+                transitions: makeSubstepTransitions('CONTINUE', 'DEFER'),
+              },
+              {
+                id: '2',
+                description: 'Sub 2 (pass→CONTINUE, fail→DEFER)',
+                transitions: makeSubstepTransitions('CONTINUE', 'DEFER'),
+              },
+              {
+                id: '3',
+                description: 'Sub 3 (pass→CONTINUE, fail→DEFER)',
+                transitions: makeSubstepTransitions('CONTINUE', 'DEFER'),
+              },
+            ],
+          },
+        ]);
+        const machine = compileRunbookToMachine(steps);
+        const actor = createActor(machine);
+        actor.start();
+
+        // Iter 1: sub1=PASS(CONTINUE), sub2=FAIL(DEFER), sub3=PASS(CONTINUE)
+        actor.send({ type: 'PASS' }); // sub1 → CONTINUE (pass hidden)
+        actor.send({ type: 'FAIL' }); // sub2 → DEFER feeds 'fail'
+        actor.send({ type: 'PASS' }); // sub3 → CONTINUE (pass hidden)
+        // deferredResults=['fail'] → ALL: fail → iter fail → DEFER → loopback
+        expect(actor.getSnapshot().context.iterationResults).toEqual(['fail']);
+
+        // Iter 2: sub1=PASS(CONTINUE), sub2=PASS(CONTINUE), sub3=PASS(CONTINUE)
+        actor.send({ type: 'PASS' }); // sub1 → CONTINUE (hidden)
+        actor.send({ type: 'PASS' }); // sub2 → CONTINUE (hidden)
+        actor.send({ type: 'PASS' }); // sub3 → CONTINUE (hidden)
+        // deferredResults=[] → ALL vacuous pass → iter pass
+        // Parent: iterationResults=['fail'] + inline pass → ALL fails → STOPPED
+        expect(actor.getSnapshot().value).toBe('STOPPED');
+      });
+
       it('non-FOR: all CONTINUE with PASS ANY → vacuous fail (no deferred results)', () => {
         // Non-FOR context: deferredResults directly used for parent aggregation
         // PASS ANY with zero results → no passes → STOPPED
@@ -7312,6 +7670,115 @@ echo "processing"
       ]);
 
       expect(() => compileRunbookToMachine(steps)).toThrow(/invariant violation/);
+    });
+
+    it('throws when DEFER appears as parent-step pass action (substeps)', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          description: 'Step with substeps',
+          substeps: [
+            { id: '1', description: 'Sub 1' },
+            { id: '2', description: 'Sub 2' },
+          ],
+          transitions: {
+            aggregation: 'ALL' as const,
+            pass: {
+              kind: 'pass' as const,
+              retry: 0,
+              action: { type: 'DEFER' as const },
+            },
+            fail: DEFAULT_TRANSITIONS.fail,
+          },
+        },
+        {
+          name: '2',
+          description: 'Second step',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ]);
+
+      expect(() => compileRunbookToMachine(steps)).toThrow(/invariant violation/i);
+    });
+
+    it('throws when DEFER appears as parent-step fail action (substeps)', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          description: 'Step with substeps',
+          substeps: [
+            { id: '1', description: 'Sub 1' },
+            { id: '2', description: 'Sub 2' },
+          ],
+          transitions: {
+            aggregation: 'ALL' as const,
+            pass: DEFAULT_TRANSITIONS.pass,
+            fail: {
+              kind: 'fail' as const,
+              retry: 0,
+              action: { type: 'DEFER' as const },
+            },
+          },
+        },
+        {
+          name: '2',
+          description: 'Second step',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ]);
+
+      expect(() => compileRunbookToMachine(steps)).toThrow(/invariant violation/i);
+    });
+
+    it('throws when DEFER appears as parent FOR step action', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          description: 'FOR step',
+          forClause: { start: 1, end: 3 },
+          substeps: [{ id: '1', description: 'Sub 1' }],
+          transitions: {
+            aggregation: 'ALL' as const,
+            pass: {
+              kind: 'pass' as const,
+              retry: 0,
+              action: { type: 'DEFER' as const },
+            },
+            fail: DEFAULT_TRANSITIONS.fail,
+          },
+        },
+        {
+          name: '2',
+          description: 'Second step',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ]);
+
+      expect(() => compileRunbookToMachine(steps)).toThrow(/invariant violation/i);
+    });
+
+    it('allows DEFER at substep level (non-regression)', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          description: 'Step with substeps',
+          substeps: [
+            {
+              id: '1',
+              description: 'Sub 1',
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'DEFER' as const } },
+              },
+            },
+            { id: '2', description: 'Sub 2' },
+          ],
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ]);
+
+      expect(() => compileRunbookToMachine(steps)).not.toThrow();
     });
 
     it('throws on duplicate state IDs', () => {

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -7698,7 +7698,7 @@ echo "processing"
         },
       ]);
 
-      expect(() => compileRunbookToMachine(steps)).toThrow(/invariant violation/i);
+      expect(() => compileRunbookToMachine(steps)).toThrow(/DEFER.*parent.step/i);
     });
 
     it('throws when DEFER appears as parent-step fail action (substeps)', () => {
@@ -7727,7 +7727,7 @@ echo "processing"
         },
       ]);
 
-      expect(() => compileRunbookToMachine(steps)).toThrow(/invariant violation/i);
+      expect(() => compileRunbookToMachine(steps)).toThrow(/DEFER.*parent.step/i);
     });
 
     it('throws when DEFER appears as parent FOR step action', () => {
@@ -7754,7 +7754,7 @@ echo "processing"
         },
       ]);
 
-      expect(() => compileRunbookToMachine(steps)).toThrow(/invariant violation/i);
+      expect(() => compileRunbookToMachine(steps)).toThrow(/DEFER.*parent.step/i);
     });
 
     it('allows DEFER at substep level (non-regression)', () => {

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -1151,7 +1151,8 @@ describe('runbook compiler', () => {
       const topNext2 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topNext2.iteration).toBe(2);
-      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']);
+      // NEXT skips accumulation — iteration result not recorded
+      expect(actor.getSnapshot().context.iterationResults).toEqual([]);
 
       // Iteration 2: PASS → NEXT → iteration 3
       actor.send({ type: 'PASS' });
@@ -1159,7 +1160,7 @@ describe('runbook compiler', () => {
       const topNext3 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topNext3.iteration).toBe(3);
-      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
+      expect(actor.getSnapshot().context.iterationResults).toEqual([]);
 
       // Iteration 3 (last): PASS → NEXT → exit loop
       actor.send({ type: 'PASS' });
@@ -1231,7 +1232,7 @@ describe('runbook compiler', () => {
       expect(actor.getSnapshot().context.deferredResults).toEqual([]);
     });
 
-    it('NEXT skips deferredResults but iteration-level DEFER still accumulates vacuous pass', () => {
+    it('NEXT skips accumulation — iteration results stay empty for NEXT-only iterations', () => {
       const steps = inferSteps([
         {
           name: '1',
@@ -1265,25 +1266,25 @@ describe('runbook compiler', () => {
       const actor = createActor(machine);
       actor.start();
 
-      // Iteration 1: FAIL → NEXT (deferredResults stays empty → vacuous pass at iteration level)
+      // Iteration 1: FAIL → NEXT (skips accumulation)
       actor.send({ type: 'FAIL' });
       const topNextRes1 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topNextRes1.iteration).toBe(2);
-      // Iteration-level DEFER accumulates vacuous pass (empty deferredResults → pass)
-      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']);
+      // NEXT skips accumulation — iterationResults stays empty
+      expect(actor.getSnapshot().context.iterationResults).toEqual([]);
 
-      // Iteration 2: PASS → NEXT (deferredResults stays empty → vacuous pass at iteration level)
+      // Iteration 2: PASS → NEXT (skips accumulation)
       actor.send({ type: 'PASS' });
       const topNextRes2 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topNextRes2.iteration).toBe(3);
-      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
+      expect(actor.getSnapshot().context.iterationResults).toEqual([]);
 
-      // Iteration 3 (last): PASS → NEXT → exit → PASS ALL: all vacuous passes → CONTINUE to step 2
+      // Iteration 3 (last): PASS → NEXT → exit → PASS ALL: empty results → vacuous pass → CONTINUE
       actor.send({ type: 'PASS' });
       expect(actor.getSnapshot().value).toBe('step::2');
-      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
+      expect(actor.getSnapshot().context.iterationResults).toEqual([]);
       expect(actor.getSnapshot().context.deferredResults).toEqual([]);
     });
 
@@ -2713,11 +2714,11 @@ describe('runbook compiler', () => {
       // Iteration 2: PASS substep 1 → NEXT (last iteration, exit loop)
       actor.send({ type: 'PASS' });
 
-      // NEXT doesn't populate deferredResults → vacuous pass at iteration level
-      // PASS ALL with all passes → aggregation passes → CONTINUE to step 2
+      // NEXT skips accumulation — no iteration results accumulated
+      // PASS ALL with empty results → vacuous pass → CONTINUE to step 2
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('step::2');
-      expect(snapshot.context.iterationResults).toEqual(['pass']);
+      expect(snapshot.context.iterationResults).toEqual([]);
       expect(snapshot.context.deferredResults).toEqual([]);
     });
 
@@ -6180,6 +6181,207 @@ echo "processing"
 
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('COMPLETE');
+    });
+  });
+
+  describe('substep loop-control bypasses iteration-level retry', () => {
+    it('substep BREAK bypasses iteration-level retry', () => {
+      // FOR with 3 items, 2 substeps: 1.1 DEFER (accumulates), 1.2 BREAK on fail
+      // Iteration FAIL ANY: RETRY 2 BREAK
+      // Iteration 1: 1.1 FAIL (DEFER accumulates 'fail'), 1.2 FAIL (BREAK exits)
+      // Without the fix, iteration-level RETRY 2 would fire; with the fix, BREAK bypasses it.
+      const steps = inferSteps([
+        {
+          name: '1',
+          forClause: {
+            start: 1,
+            end: 3,
+            transitions: {
+              aggregation: 'ALL' as const,
+              pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+              fail: { kind: 'fail' as const, retry: 2, action: { type: 'BREAK' as const } },
+            },
+          },
+          description: 'Loop with RETRY on fail',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            {
+              id: '1',
+              description: 'First check',
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'DEFER' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Second check',
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'BREAK' as const } },
+              },
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Done',
+          transitions: {
+            ...DEFAULT_TRANSITIONS,
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          },
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Iteration 1: substep 1.1 FAIL (DEFER accumulates 'fail'), substep 1.2 FAIL (BREAK)
+      actor.send({ type: 'FAIL' });
+      actor.send({ type: 'FAIL' });
+
+      const snapshot = actor.getSnapshot();
+      // Retry never fired — substep BREAK bypassed iteration-level RETRY 2
+      expect(snapshot.context.iterationRetryCount).toBe(0);
+      // BREAK exits loop → aggregation with deferredResults=[fail] → fail
+      // [fail] → PASS ALL fails → STOP
+      expect(snapshot.value).toBe('STOPPED');
+    });
+
+    it('substep NEXT bypasses iteration-level retry', () => {
+      // FOR with 3 items, iteration FAIL ANY: RETRY 2 DEFER, substep ON FAIL: NEXT
+      const steps = inferSteps([
+        {
+          name: '1',
+          forClause: {
+            start: 1,
+            end: 3,
+            transitions: {
+              aggregation: 'ALL' as const,
+              pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+              fail: { kind: 'fail' as const, retry: 2, action: { type: 'DEFER' as const } },
+            },
+          },
+          description: 'Loop with RETRY on fail',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            {
+              id: '1',
+              description: 'Check',
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'NEXT' as const } },
+              },
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Done',
+          transitions: {
+            ...DEFAULT_TRANSITIONS,
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          },
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Iteration 1: FAIL → substep NEXT fires (loops back, no retry)
+      actor.send({ type: 'FAIL' });
+      expect(actor.getSnapshot().context.iterationRetryCount).toBe(0);
+      // NEXT skips accumulation → iterationResults should be empty
+      expect(actor.getSnapshot().context.iterationResults).toEqual([]);
+
+      // Iteration 2: PASS → DEFER accumulates
+      actor.send({ type: 'PASS' });
+
+      // Iteration 3: PASS → last iteration, aggregation fires
+      actor.send({ type: 'PASS' });
+
+      // iterationResults: [pass] (iteration 2 loop-backed); iteration 3 computed inline as pass
+      // Step-level PASS ALL: [pass, pass] → CONTINUE → step 2
+      expect(actor.getSnapshot().value).toBe('step::2');
+    });
+
+    it('substep BREAK with iteration retry configured — retry never fires on BREAK', () => {
+      // FOR with 2 items, 2 substeps:
+      //   1.1 DEFER (accumulates result), 1.2 BREAK on fail (exits loop)
+      // Iteration FAIL ANY: RETRY 2 BREAK
+      // Iteration 1: 1.1 PASS (DEFER accumulates pass), 1.2 PASS (DEFER) → iteration pass → loop back
+      // Iteration 2: 1.1 FAIL (DEFER accumulates fail), 1.2 FAIL (BREAK) → bypasses retry
+      const steps = inferSteps([
+        {
+          name: '1',
+          forClause: {
+            start: 1,
+            end: 2,
+            transitions: {
+              aggregation: 'ALL' as const,
+              pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+              fail: { kind: 'fail' as const, retry: 2, action: { type: 'BREAK' as const } },
+            },
+          },
+          description: 'Loop with RETRY on fail only',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            {
+              id: '1',
+              description: 'First check',
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'DEFER' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Second check',
+              transitions: {
+                aggregation: 'ALL' as const,
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'BREAK' as const } },
+              },
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Done',
+          transitions: {
+            ...DEFAULT_TRANSITIONS,
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          },
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Iteration 1: substep 1.1 PASS (DEFER), substep 1.2 PASS (DEFER) → iteration pass → DEFER loops back
+      actor.send({ type: 'PASS' });
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().context.iterationRetryCount).toBe(0);
+
+      // Iteration 2: substep 1.1 FAIL (DEFER accumulates 'fail'), substep 1.2 FAIL (BREAK)
+      actor.send({ type: 'FAIL' });
+      actor.send({ type: 'FAIL' });
+
+      const snapshot = actor.getSnapshot();
+      // Substep BREAK bypasses iteration-level RETRY 2 — retry never fired
+      expect(snapshot.context.iterationRetryCount).toBe(0);
+      // iterationResults: [pass] (iteration 1 from loop-back)
+      // Current iteration computed from deferredResults=[fail] → fail
+      // Aggregation: [pass, fail] → PASS ALL fails → STOP
+      expect(snapshot.value).toBe('STOPPED');
+      expect(snapshot.context.iterationResults).toEqual(['pass']);
     });
   });
 

--- a/packages/core/__tests__/runbook/for-loop-test-helpers.ts
+++ b/packages/core/__tests__/runbook/for-loop-test-helpers.ts
@@ -24,7 +24,7 @@ import type {
 // ---------------------------------------------------------------------------
 
 export type SubstepAction = 'CONTINUE' | 'DEFER' | 'NEXT' | 'BREAK' | 'STOP' | 'COMPLETE';
-export type IterationAction = 'CONTINUE' | 'DEFER' | 'BREAK' | 'STOP' | 'COMPLETE';
+export type IterationAction = 'CONTINUE' | 'DEFER' | 'NEXT' | 'BREAK' | 'STOP' | 'COMPLETE';
 export type ParentAction = 'CONTINUE' | 'DEFER' | 'STOP' | 'COMPLETE';
 
 export interface ForLoopConfig {
@@ -280,6 +280,7 @@ export function predictOutcome(config: ForLoopConfig, events: EventType[]): Orac
     for (let iter = 1; iter <= config.iterations; iter++) {
       // Iteration retry loop
       let iterResult: 'pass' | 'fail' = 'fail';
+      let skipAccumulation = false;
       for (let iterRetry = 0; iterRetry <= config.iterationFailRetry; iterRetry++) {
         const deferredResults: ('pass' | 'fail')[] = [];
         let earlyExit: 'BREAK' | 'NEXT' | 'STOP' | 'COMPLETE' | null = null;
@@ -332,15 +333,15 @@ export function predictOutcome(config: ForLoopConfig, events: EventType[]): Orac
 
         // If BREAK at substep level, skip iteration-level retry and exit loop
         if (earlyExit === 'BREAK') {
-          // Check iteration-level transition for the result
-          const iterAction =
-            iterResult === 'pass' ? config.iterationPassAction : config.iterationFailAction;
-          if (iterAction === 'STOP') return 'STOPPED';
-          if (iterAction === 'COMPLETE') return 'COMPLETE';
-          // Record result and exit loop
           allIterationResults.push(iterResult);
-          // BREAK exits the iteration loop entirely
-          return aggregateParent(config, allIterationResults, iterResult);
+          // BREAK exits the iteration loop entirely → go to aggregation
+          return aggregateParent(config, allIterationResults);
+        }
+
+        // If NEXT at substep level, skip iteration-level retry and loop back without accumulation
+        if (earlyExit === 'NEXT') {
+          skipAccumulation = true;
+          break; // break out of iteration retry loop, proceed to next iteration
         }
 
         // Process iteration-level transition
@@ -362,20 +363,29 @@ export function predictOutcome(config: ForLoopConfig, events: EventType[]): Orac
 
         if (iterAction === 'BREAK') {
           allIterationResults.push(iterResult);
-          return aggregateParent(config, allIterationResults, iterResult);
+          return aggregateParent(config, allIterationResults);
+        }
+
+        // NEXT at iteration level: loop back without accumulation
+        if (iterAction === 'NEXT') {
+          skipAccumulation = true;
+          break; // break out of iteration retry loop, proceed to next iteration
         }
 
         // CONTINUE exits the loop (goes to next step)
         if (iterAction === 'CONTINUE') {
           allIterationResults.push(iterResult);
-          return aggregateParent(config, allIterationResults, iterResult);
+          return aggregateParent(config, allIterationResults);
         }
 
         // DEFER: record result and proceed to next iteration (loop back with accumulation)
         break; // break out of iteration retry loop
       }
 
-      allIterationResults.push(iterResult);
+      // DEFER accumulates; NEXT (substep or iteration-level) skips accumulation
+      if (!skipAccumulation) {
+        allIterationResults.push(iterResult);
+      }
     }
 
     // All iterations complete. Aggregate at parent level.
@@ -392,16 +402,15 @@ export function predictOutcome(config: ForLoopConfig, events: EventType[]): Orac
 }
 
 /**
- * Aggregate iteration results at the parent level, handling BREAK mid-loop.
- * Called when the loop exits early (BREAK).
+ * Aggregate iteration results at the parent level when the loop exits early.
+ *
+ * Called for BREAK (substep or iteration-level) and CONTINUE. The caller has
+ * already pushed the current iteration result into `completedResults`.
  */
 function aggregateParent(
   config: ForLoopConfig,
   completedResults: ('pass' | 'fail')[],
-  _currentIterResult: 'pass' | 'fail',
 ): OracleResult {
-  // For BREAK, the current iteration is the last one. Include it in aggregation.
-  // completedResults already includes the current iteration (added by caller).
   return aggregateParentFromAll(config, completedResults) ?? 'STOPPED';
 }
 

--- a/packages/core/__tests__/runbook/for-loop.properties.test.ts
+++ b/packages/core/__tests__/runbook/for-loop.properties.test.ts
@@ -31,6 +31,7 @@ import {
 
 const substepActionArb = fc.constantFrom<SubstepAction>(
   'CONTINUE',
+  'DEFER',
   'NEXT',
   'BREAK',
   'STOP',
@@ -39,6 +40,8 @@ const substepActionArb = fc.constantFrom<SubstepAction>(
 
 const iterationActionArb = fc.constantFrom<IterationAction>(
   'CONTINUE',
+  'DEFER',
+  'NEXT',
   'BREAK',
   'STOP',
   'COMPLETE',

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1316,6 +1316,7 @@ function buildLoopControlTransition(
  * @param steps - The full array of runbook steps
  * @param kind - Whether this is a 'pass' or 'fail' transition
  * @returns XState transition configuration
+ * @throws {Error} If DEFER is used at step level (invariant violation — should be rejected by parser/validator)
  */
 function buildDeferTransition(
   stepName: string,

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1305,7 +1305,7 @@ function buildLoopControlTransition(
  * DEFER always routes substeps to the parent aggregation state with result
  * accumulation, enabling fail-fast ALL/ANY evaluation. For non-last substeps,
  * the parent's advance guards handle routing to the next sibling.
- * At the step level (no substep), DEFER acts like CONTINUE.
+ * DEFER at step level is invalid and rejected by the parser/validator.
  *
  * **Aggregation and `lastAction` reporting:**
  * - Non-last substeps: DEFER routes to parent, the advance guard advances to the
@@ -1347,16 +1347,12 @@ function buildDeferTransition(
     };
   }
 
-  // Non-substep DEFER: behaves like CONTINUE (advance to next step)
-  const target = findNextStateId(stepName, substepId, steps);
-  return {
-    target,
-    actions: runbookSetup.assign({
-      lastAction: { type: 'DEFER' as const },
-      lastMessage: undefined as string | undefined,
-      substep: extractSubstepFromStateId(target),
-    }),
-  };
+  // Step-level DEFER should be rejected by the parser/validator.
+  // If we reach here, it's an invariant violation.
+  throw new Error(
+    `Invariant violation: DEFER at step level for "${stepName}". ` +
+      `DEFER is only valid in substep or FOR iteration contexts.`,
+  );
 }
 
 /**

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -852,14 +852,37 @@ function buildParentStateConfig(
       : 'fail';
   };
 
-  const getIterationTransition = (
-    context: RunbookContext,
-  ): {
-    result: 'pass' | 'fail';
-    transition: { retry: number; action: Action };
-  } => {
+  /**
+   * Discriminated union encoding *why* an iteration ended.
+   *
+   * - `completed`: iteration finished normally — retry config is accessible.
+   * - `break`: substep fired BREAK — retry is structurally unavailable.
+   * - `next`: substep fired NEXT — retry is structurally unavailable.
+   *
+   * TypeScript prevents accessing `.transition.retry` without narrowing to
+   * `kind === 'completed'` first, making retry bypass on loop-control exits
+   * a compile-time error rather than a runtime bug.
+   */
+  type IterationOutcome =
+    | { kind: 'completed'; result: 'pass' | 'fail'; transition: { retry: number; action: Action } }
+    | { kind: 'break'; result: 'pass' | 'fail' }
+    | { kind: 'next'; result: 'pass' | 'fail' };
+
+  /**
+   * Compute the iteration outcome, encoding exit reason in the type system.
+   *
+   * The `lastAction.type` check is encapsulated here so guards never inspect
+   * `lastAction.type` directly — they narrow on `outcome.kind` instead.
+   *
+   * @param context - Current runbook context
+   * @returns Discriminated outcome with retry config only on `completed` variant
+   */
+  const getIterationOutcome = (context: RunbookContext): IterationOutcome => {
     const result = computeIterationResult(context);
+    if (context.lastAction?.type === 'BREAK') return { kind: 'break', result };
+    if (context.lastAction?.type === 'NEXT') return { kind: 'next', result };
     return {
+      kind: 'completed',
       result,
       transition: result === 'pass' ? forTransitions.pass : forTransitions.fail,
     };
@@ -946,8 +969,9 @@ function buildParentStateConfig(
       always.push({
         guard: ({ context }: { context: RunbookContext }) => {
           if (context.substep !== undefined) return false; // mid-iteration — not ready
-          const iterResult = computeIterationResult(context);
-          return iterResult === kind && context.iterationRetryCount < transition.retry;
+          const outcome = getIterationOutcome(context);
+          if (outcome.kind !== 'completed') return false; // BREAK/NEXT bypass retry
+          return outcome.result === kind && context.iterationRetryCount < outcome.transition.retry;
         },
         target: firstSubstepStateId,
         actions: runbookSetup.assign({
@@ -982,9 +1006,12 @@ function buildParentStateConfig(
       always.push({
         guard: ({ context }: { context: RunbookContext }) => {
           if (context.substep !== undefined) return false; // mid-iteration — not ready
-          const selected = getIterationTransition(context);
-          if (selected.result !== kind) return false;
-          return transition.retry <= 0 || context.iterationRetryCount >= transition.retry;
+          const outcome = getIterationOutcome(context);
+          if (outcome.kind !== 'completed') return false; // BREAK/NEXT bypass direct-exit
+          if (outcome.result !== kind) return false;
+          return (
+            outcome.transition.retry <= 0 || context.iterationRetryCount >= outcome.transition.retry
+          );
         },
         target,
         actions: [
@@ -1013,9 +1040,12 @@ function buildParentStateConfig(
         guard: ({ context }: { context: RunbookContext }) => {
           if (context.substep !== undefined) return false;
           if (context.forStack.length === 0) return false; // Already exited loop
-          const selected = getIterationTransition(context);
-          if (selected.result !== kind) return false;
-          return transition.retry <= 0 || context.iterationRetryCount >= transition.retry;
+          const outcome = getIterationOutcome(context);
+          if (outcome.kind !== 'completed') return false; // BREAK/NEXT bypass CONTINUE exit
+          if (outcome.result !== kind) return false;
+          return (
+            outcome.transition.retry <= 0 || context.iterationRetryCount >= outcome.transition.retry
+          );
         },
         target: formatStateId(stepName),
         actions: runbookSetup.assign({
@@ -1031,9 +1061,15 @@ function buildParentStateConfig(
     always.push({
       guard: ({ context }: { context: RunbookContext }) => {
         if (context.substep !== undefined) return false; // mid-iteration — not ready
-        // BREAK clears forStack, so peekForStack returns undefined → naturally prevents loop-back
-        const selected = getIterationTransition(context).transition;
-        if (selected.action.type !== 'DEFER' && selected.action.type !== 'NEXT') return false;
+        const outcome = getIterationOutcome(context);
+        // Loop-back fires for NEXT (substep or iteration-level) or DEFER (configured action)
+        const isLoopBack =
+          outcome.kind === 'next' ||
+          (outcome.kind === 'completed' &&
+            (outcome.transition.action.type === 'DEFER' ||
+              outcome.transition.action.type === 'NEXT'));
+        if (!isLoopBack) return false;
+        // BREAK clears forStack → peekForStack returns undefined → naturally prevents loop-back
         const top = peekForStack(context.forStack);
         return top !== undefined && hasMoreIterations(top);
       },
@@ -1046,9 +1082,9 @@ function buildParentStateConfig(
         },
         iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] => {
           const results = context.iterationResults ?? [];
-          const selected = getIterationTransition(context).transition;
+          const outcome = getIterationOutcome(context);
           // DEFER accumulates iteration result; NEXT skips accumulation
-          if (selected.action.type === 'DEFER') {
+          if (outcome.kind === 'completed' && outcome.transition.action.type === 'DEFER') {
             return [...results, computeIterationResult(context)];
           }
           return results;
@@ -1076,10 +1112,11 @@ function buildParentStateConfig(
       // unless NEXT (which skips accumulation). DEFER and BREAK both include it.
       const allResults = hasFor
         ? (() => {
-            const selected = getIterationTransition(context).transition;
-            return selected.action.type === 'NEXT'
-              ? baseResults
-              : [...baseResults, computeIterationResult(context)];
+            const outcome = getIterationOutcome(context);
+            // NEXT skips accumulation of current iteration
+            if (outcome.kind === 'next') return baseResults;
+            // BREAK and completed both include current iteration
+            return [...baseResults, computeIterationResult(context)];
           })()
         : baseResults;
       const hasFailed = allResults.some((r) => r === 'fail');

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -794,11 +794,6 @@ function buildParentExitAssign(
         lastAction: { type: 'CONTINUE' as const, aggregated: true },
         lastMessage: undefined as string | undefined,
       });
-    case 'DEFER':
-      throw new Error(
-        'Invariant violation: DEFER appeared as parent-step exit action. ' +
-          'DEFER is only valid in substep or FOR iteration contexts.',
-      );
     default:
       return runbookSetup.assign({
         ...baseAssign,
@@ -1220,6 +1215,8 @@ function resolveActionTarget(action: Action, stepName: string, steps: Step[]): s
           : action.target.substep;
       return formatStateId(targetStep.name, substep);
     }
+    // DEFER/NEXT/BREAK are substep-only actions. This guard is the primary
+    // enforcement point for all parent-step paths (aggregation + direct exit).
     case 'NEXT':
     case 'BREAK':
     case 'DEFER':

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -795,12 +795,10 @@ function buildParentExitAssign(
         lastMessage: undefined as string | undefined,
       });
     case 'DEFER':
-      return runbookSetup.assign({
-        ...baseAssign,
-        forStack: [] as readonly ForContext[],
-        lastAction: { type: 'DEFER' as const, aggregated: true },
-        lastMessage: undefined as string | undefined,
-      });
+      throw new Error(
+        'Invariant violation: DEFER appeared as parent-step exit action. ' +
+          'DEFER is only valid in substep or FOR iteration contexts.',
+      );
     default:
       return runbookSetup.assign({
         ...baseAssign,
@@ -1206,7 +1204,6 @@ function buildRetryStateConfig(
 function resolveActionTarget(action: Action, stepName: string, steps: Step[]): string {
   switch (action.type) {
     case 'CONTINUE':
-    case 'DEFER':
       return findNextStateId(stepName, undefined, steps);
     case 'COMPLETE':
       return 'COMPLETE';
@@ -1225,9 +1222,10 @@ function resolveActionTarget(action: Action, stepName: string, steps: Step[]): s
     }
     case 'NEXT':
     case 'BREAK':
+    case 'DEFER':
       throw new Error(
         `Compiler invariant violation: ${action.type} appeared as parent-step action. ` +
-          `This should be caught by parser validateNEXTUsage.`,
+          `DEFER is only valid in substep or FOR iteration contexts.`,
       );
   }
 }

--- a/packages/parser/__tests__/helpers.test.ts
+++ b/packages/parser/__tests__/helpers.test.ts
@@ -12,6 +12,7 @@ import {
   parseConditional,
   convertToTransitions,
   validateNEXTUsage,
+  validateDEFERUsage,
   parseForClause,
   type ParsedConditional,
 } from '../src/index.js';
@@ -1121,6 +1122,37 @@ describe('validateNEXTUsage with first-class NEXT/BREAK', () => {
     ];
     expect(() => {
       validateNEXTUsage(conditionals, true);
+    }).not.toThrow();
+  });
+});
+
+describe('validateDEFERUsage', () => {
+  it('rejects DEFER in non-substep context', () => {
+    const conditionals: ParsedConditional[] = [
+      { type: 'pass', action: { type: 'DEFER' }, retry: 0, modifier: null, raw: 'DEFER' },
+    ];
+    expect(() => {
+      validateDEFERUsage(conditionals, false);
+    }).toThrow(
+      'DEFER is only valid within substeps or FOR iteration-level transitions, not at step level',
+    );
+  });
+
+  it('accepts DEFER in substep context', () => {
+    const conditionals: ParsedConditional[] = [
+      { type: 'pass', action: { type: 'DEFER' }, retry: 0, modifier: null, raw: 'DEFER' },
+    ];
+    expect(() => {
+      validateDEFERUsage(conditionals, true);
+    }).not.toThrow();
+  });
+
+  it('does not throw for non-DEFER actions in non-substep context', () => {
+    const conditionals: ParsedConditional[] = [
+      { type: 'pass', action: { type: 'CONTINUE' }, retry: 0, modifier: null, raw: 'CONTINUE' },
+    ];
+    expect(() => {
+      validateDEFERUsage(conditionals, false);
     }).not.toThrow();
   });
 });

--- a/packages/parser/__tests__/helpers.test.ts
+++ b/packages/parser/__tests__/helpers.test.ts
@@ -11,7 +11,7 @@ import {
   extractSubstepHeader,
   parseConditional,
   convertToTransitions,
-  validateNEXTUsage,
+  validateLoopControlUsage,
   validateDEFERUsage,
   parseForClause,
   type ParsedConditional,
@@ -1069,10 +1069,10 @@ describe('convertToTransitions aggregation conflicts', () => {
   });
 });
 
-describe('validateNEXTUsage with RETRY containing NEXT', () => {
+describe('validateLoopControlUsage with RETRY containing NEXT', () => {
   it('rejects RETRY with NEXT fallback in non-FOR context', () => {
     expect(() => {
-      validateNEXTUsage(
+      validateLoopControlUsage(
         [
           {
             type: 'fail',
@@ -1088,13 +1088,13 @@ describe('validateNEXTUsage with RETRY containing NEXT', () => {
   });
 });
 
-describe('validateNEXTUsage with first-class NEXT/BREAK', () => {
+describe('validateLoopControlUsage with first-class NEXT/BREAK', () => {
   it('rejects first-class NEXT outside FOR context', () => {
     const conditionals: ParsedConditional[] = [
       { type: 'pass', action: { type: 'NEXT' }, retry: 0, modifier: null, raw: 'NEXT' },
     ];
     expect(() => {
-      validateNEXTUsage(conditionals, false);
+      validateLoopControlUsage(conditionals, false);
     }).toThrow('NEXT is only valid within substeps of a FOR step');
   });
 
@@ -1103,7 +1103,7 @@ describe('validateNEXTUsage with first-class NEXT/BREAK', () => {
       { type: 'pass', action: { type: 'NEXT' }, retry: 0, modifier: null, raw: 'NEXT' },
     ];
     expect(() => {
-      validateNEXTUsage(conditionals, true);
+      validateLoopControlUsage(conditionals, true);
     }).not.toThrow();
   });
 
@@ -1112,7 +1112,7 @@ describe('validateNEXTUsage with first-class NEXT/BREAK', () => {
       { type: 'pass', action: { type: 'BREAK' }, retry: 0, modifier: null, raw: 'BREAK' },
     ];
     expect(() => {
-      validateNEXTUsage(conditionals, false);
+      validateLoopControlUsage(conditionals, false);
     }).toThrow('BREAK is only valid within substeps of a FOR step');
   });
 
@@ -1121,7 +1121,7 @@ describe('validateNEXTUsage with first-class NEXT/BREAK', () => {
       { type: 'pass', action: { type: 'BREAK' }, retry: 0, modifier: null, raw: 'BREAK' },
     ];
     expect(() => {
-      validateNEXTUsage(conditionals, true);
+      validateLoopControlUsage(conditionals, true);
     }).not.toThrow();
   });
 });

--- a/packages/parser/__tests__/parser.test.ts
+++ b/packages/parser/__tests__/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { parseRunbook, parseRunbookDocument } from '../src/index.js';
+import { parseRunbook, parseRunbookDocument, RunbookSyntaxError } from '../src/index.js';
 
 describe('Step-level runbooks', () => {
   it('parses runbook list in substep', () => {
@@ -1901,7 +1901,7 @@ echo "{{item}}"
     }
   });
 
-  it('standalone DEFER on step-level produces both pass and fail DEFER transitions', () => {
+  it('standalone DEFER on step-level throws syntax error', () => {
     const md = `## 1. Check
 
 - DEFER
@@ -1910,9 +1910,7 @@ echo "{{item}}"
 echo "check"
 \`\`\`
 `;
-    const steps = parseRunbook(md);
-    expect(steps[0].transitions).toBeDefined();
-    expect(steps[0].transitions!.pass.action).toEqual({ type: 'DEFER' });
-    expect(steps[0].transitions!.fail.action).toEqual({ type: 'DEFER' });
+    expect(() => parseRunbook(md)).toThrow(RunbookSyntaxError);
+    expect(() => parseRunbook(md)).toThrow(/DEFER is only valid/);
   });
 });

--- a/packages/parser/__tests__/validator.test.ts
+++ b/packages/parser/__tests__/validator.test.ts
@@ -486,6 +486,30 @@ describe('validator strict rules', () => {
       );
     });
 
+    it('rejects DEFER at step level', () => {
+      const steps: Step[] = [
+        {
+          kind: 'command',
+          name: '1',
+          description: 'Step with DEFER',
+          command: { type: 'shell', value: 'echo test' },
+          transitions: {
+            aggregation: 'ALL',
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+        },
+      ];
+      const errors = validateRunbook(steps);
+      expect(
+        errors.some((e) =>
+          e.message.includes(
+            'DEFER is only valid within substeps or FOR iteration-level transitions, not at step level',
+          ),
+        ),
+      ).toBe(true);
+    });
+
     it('accepts AT-qualified GOTO to self (not a true self-loop)', () => {
       const steps: Step[] = [
         {

--- a/packages/parser/__tests__/validator.test.ts
+++ b/packages/parser/__tests__/validator.test.ts
@@ -489,10 +489,9 @@ describe('validator strict rules', () => {
     it('rejects DEFER at step level', () => {
       const steps: Step[] = [
         {
-          kind: 'command',
+          kind: 'base',
           name: '1',
           description: 'Step with DEFER',
-          command: { type: 'shell', value: 'echo test' },
           transitions: {
             aggregation: 'ALL',
             pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
@@ -508,6 +507,26 @@ describe('validator strict rules', () => {
           ),
         ),
       ).toBe(true);
+    });
+
+    it('emits single error when both pass and fail are DEFER at step level', () => {
+      const steps: Step[] = [
+        {
+          kind: 'base',
+          name: '1',
+          description: 'Step with DEFER on both',
+          transitions: {
+            aggregation: 'ALL',
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'DEFER' as const } },
+          },
+        },
+      ];
+      const errors = validateRunbook(steps);
+      const deferErrors = errors.filter((e) =>
+        e.message.includes('DEFER is only valid within substeps'),
+      );
+      expect(deferErrors).toHaveLength(1);
     });
 
     it('accepts AT-qualified GOTO to self (not a true self-loop)', () => {

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -643,7 +643,7 @@ function resolveAggregationMode(
 }
 
 /**
- * Validate that first-class NEXT/BREAK are only used in FOR contexts.
+ * Validate that loop control actions (NEXT/BREAK) are only used in FOR contexts.
  *
  * The first-class `NEXT` and `BREAK` actions are for FOR loop control flow
  * and are only valid within substeps of a FOR step.
@@ -652,7 +652,10 @@ function resolveAggregationMode(
  * @param isForContext - Whether the current context is within a FOR step
  * @throws {RunbookSyntaxError} When NEXT/BREAK used outside FOR context
  */
-export function validateNEXTUsage(conditionals: ParsedConditional[], isForContext: boolean): void {
+export function validateLoopControlUsage(
+  conditionals: ParsedConditional[],
+  isForContext: boolean,
+): void {
   for (const conditional of conditionals) {
     // Check first-class NEXT/BREAK — requires FOR context
     if (conditional.action.type === 'NEXT' || conditional.action.type === 'BREAK') {
@@ -664,6 +667,9 @@ export function validateNEXTUsage(conditionals: ParsedConditional[], isForContex
     }
   }
 }
+
+/** @deprecated Use {@link validateLoopControlUsage} instead. */
+export const validateNEXTUsage = validateLoopControlUsage;
 
 /**
  * Validate that DEFER is only used in substep or FOR iteration-level contexts.

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -666,6 +666,31 @@ export function validateNEXTUsage(conditionals: ParsedConditional[], isForContex
 }
 
 /**
+ * Validate that DEFER is only used in substep or FOR iteration-level contexts.
+ *
+ * DEFER propagates a result to a parent aggregation state (ALL/ANY). At step
+ * level there is no parent aggregation, so DEFER is meaningless.
+ *
+ * @param conditionals - Array of parsed conditionals to check for DEFER usage
+ * @param isSubstepContext - Whether the current context is within a substep or FOR iteration
+ * @throws {RunbookSyntaxError} When DEFER used at step level
+ */
+export function validateDEFERUsage(
+  conditionals: ParsedConditional[],
+  isSubstepContext: boolean,
+): void {
+  for (const conditional of conditionals) {
+    if (conditional.action.type === 'DEFER') {
+      if (!isSubstepContext) {
+        throw new RunbookSyntaxError(
+          'DEFER is only valid within substeps or FOR iteration-level transitions, not at step level',
+        );
+      }
+    }
+  }
+}
+
+/**
  * Convert an array of parsed conditionals into a Transitions object.
  *
  * Combines PASS and FAIL conditionals into a unified Transitions structure,

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -23,6 +23,7 @@ export {
   escapeForShellSingleQuote,
   parseQuotedOrIdentifier,
   validateNEXTUsage,
+  validateDEFERUsage,
 } from './helpers.js';
 export type { ParsedStepHeader, ParsedSubstepHeader } from './helpers.js';
 export {

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -22,6 +22,8 @@ export {
   isPromptCodeBlock,
   escapeForShellSingleQuote,
   parseQuotedOrIdentifier,
+  validateLoopControlUsage,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- Re-exported for backward compatibility
   validateNEXTUsage,
   validateDEFERUsage,
 } from './helpers.js';

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -14,6 +14,7 @@ import {
   isPromptCodeBlock,
   escapeForShellSingleQuote,
   validateNEXTUsage,
+  validateDEFERUsage,
   parseForClause,
 } from './helpers.js';
 import { validateRunbook } from './validator.js';
@@ -585,6 +586,7 @@ function finalizeStep(
   // Validate NEXT usage before converting to transitions
   const effectiveConditionals = step.stepConditionals ?? pendingConditionals;
   validateNEXTUsage(effectiveConditionals, step.forClause !== undefined);
+  validateDEFERUsage(effectiveConditionals, false);
 
   const transitions = convertToTransitions(effectiveConditionals);
 

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -13,7 +13,7 @@ import {
   isExecutableCodeBlock,
   isPromptCodeBlock,
   escapeForShellSingleQuote,
-  validateNEXTUsage,
+  validateLoopControlUsage,
   validateDEFERUsage,
   parseForClause,
 } from './helpers.js';
@@ -155,7 +155,7 @@ export function parseRunbookDocument(
       const runbooks = extractRunbookList(ps.content);
 
       // Validate NEXT usage before converting to transitions
-      validateNEXTUsage(ps.pendingConditionals, currentStep.forClause !== undefined);
+      validateLoopControlUsage(ps.pendingConditionals, currentStep.forClause !== undefined);
 
       const transitions = convertToTransitions(ps.pendingConditionals);
 
@@ -585,7 +585,7 @@ function finalizeStep(
 
   // Validate NEXT usage before converting to transitions
   const effectiveConditionals = step.stepConditionals ?? pendingConditionals;
-  validateNEXTUsage(effectiveConditionals, step.forClause !== undefined);
+  validateLoopControlUsage(effectiveConditionals, step.forClause !== undefined);
   validateDEFERUsage(effectiveConditionals, false);
 
   const transitions = convertToTransitions(effectiveConditionals);

--- a/packages/parser/src/validator.ts
+++ b/packages/parser/src/validator.ts
@@ -203,15 +203,10 @@ export function validateRunbook(steps: readonly Step[]): ValidationDiagnostic[] 
     }
 
     if (step.transitions) {
-      if (step.transitions.pass.action.type === 'DEFER') {
-        diagnostics.push(
-          error(
-            step.line,
-            `DEFER is only valid within substeps or FOR iteration-level transitions, not at step level (step "${step.name}")`,
-          ),
-        );
-      }
-      if (step.transitions.fail.action.type === 'DEFER') {
+      if (
+        step.transitions.pass.action.type === 'DEFER' ||
+        step.transitions.fail.action.type === 'DEFER'
+      ) {
         diagnostics.push(
           error(
             step.line,

--- a/packages/parser/src/validator.ts
+++ b/packages/parser/src/validator.ts
@@ -203,6 +203,22 @@ export function validateRunbook(steps: readonly Step[]): ValidationDiagnostic[] 
     }
 
     if (step.transitions) {
+      if (step.transitions.pass.action.type === 'DEFER') {
+        diagnostics.push(
+          error(
+            step.line,
+            `DEFER is only valid within substeps or FOR iteration-level transitions, not at step level (step "${step.name}")`,
+          ),
+        );
+      }
+      if (step.transitions.fail.action.type === 'DEFER') {
+        diagnostics.push(
+          error(
+            step.line,
+            `DEFER is only valid within substeps or FOR iteration-level transitions, not at step level (step "${step.name}")`,
+          ),
+        );
+      }
       validateAction(step.transitions.pass.action, undefined, steps, step, diagnostics);
       validateAction(step.transitions.fail.action, undefined, steps, step, diagnostics);
     }

--- a/runbooks/patterns.scenario-suite.yaml
+++ b/runbooks/patterns.scenario-suite.yaml
@@ -164,7 +164,8 @@ cases:
     description: Substep BREAK bypasses iteration-level retry
     file: patterns/for-loops/for-substep-break-skips-retry.runbook.md
     commands:
-      - rd run --prompted for-substep-break-skips-retry.runbook.md --var items=a,b,c
+      - rd run --prompted for-substep-break-skips-retry.runbook.md
+      - rd fail
       - rd fail
     result: STOP
 

--- a/runbooks/patterns.scenario-suite.yaml
+++ b/runbooks/patterns.scenario-suite.yaml
@@ -160,6 +160,14 @@ cases:
       - rd run for-iteration-transitions.runbook.md
     result: COMPLETE
 
+  for-substep-break-skips-retry:
+    description: Substep BREAK bypasses iteration-level retry
+    file: patterns/for-loops/for-substep-break-skips-retry.runbook.md
+    commands:
+      - rd run --prompted for-substep-break-skips-retry.runbook.md --var items=a,b,c
+      - rd fail
+    result: STOP
+
   for-iteration-retry-after-retry:
     description: Each iteration fails once then passes on retry via iteration-level RETRY
     file: patterns/for-loops/for-iteration-retry.runbook.md

--- a/runbooks/patterns/for-loops/for-substep-break-skips-retry.runbook.md
+++ b/runbooks/patterns/for-loops/for-substep-break-skips-retry.runbook.md
@@ -1,0 +1,28 @@
+---
+name: for-substep-break-skips-retry
+description: Substep BREAK bypasses iteration-level retry
+scenarios:
+  break-skips-retry:
+    commands:
+      - rd run {{file}} --prompted -y --var items=a,b,c
+      - rd fail
+    result: STOP
+---
+# Substep BREAK Skips Iteration Retry
+
+## 1. Process items
+- FOR item IN {{ items }}
+  - FAIL ANY: RETRY 2 BREAK
+- PASS ALL: CONTINUE
+- FAIL ANY: STOP
+
+### 1.1 Check
+- PASS: DEFER
+- FAIL: BREAK
+
+Check the item.
+
+## 2. Done
+- PASS: COMPLETE
+
+All items processed.

--- a/runbooks/patterns/for-loops/for-substep-break-skips-retry.runbook.md
+++ b/runbooks/patterns/for-loops/for-substep-break-skips-retry.runbook.md
@@ -4,23 +4,30 @@ description: Substep BREAK bypasses iteration-level retry
 scenarios:
   break-skips-retry:
     commands:
-      - rd run {{file}} --prompted -y --var items=a,b,c
+      - rd run --prompted for-substep-break-skips-retry.runbook.md
+      - rd fail
       - rd fail
     result: STOP
 ---
 # Substep BREAK Skips Iteration Retry
 
 ## 1. Process items
-- FOR item IN {{ items }}
+- FOR i IN 1 TO 3
   - FAIL ANY: RETRY 2 BREAK
 - PASS ALL: CONTINUE
 - FAIL ANY: STOP
 
-### 1.1 Check
+### 1.1 First check
+- PASS: DEFER
+- FAIL: DEFER
+
+Do the first check.
+
+### 1.2 Second check
 - PASS: DEFER
 - FAIL: BREAK
 
-Check the item.
+Do the second check.
 
 ## 2. Done
 - PASS: COMPLETE


### PR DESCRIPTION
DEFER propagates a result to a parent aggregation state (ALL/ANY). At step level there is no parent aggregation, making DEFER meaningless. The compiler previously mapped step-level DEFER to CONTINUE silently, violating the "no mapping" design principle.

- Add validateDEFERUsage() in parser helpers (mirrors validateNEXTUsage)
- Call validation from finalizeStep() to reject step-level DEFER
- Add defense-in-depth check in validator for externally-constructed steps
- Replace compiler's silent DEFER→CONTINUE mapping with invariant assertion
- Update SPEC.md and FORMAT.md to remove step-level from DEFER valid contexts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DEFER is now rejected at step level; using it outside substeps or FOR-iteration contexts yields a clear syntax/validation error.

* **Documentation**
  * SPEC and FORMAT updated to state DEFER applies only to substeps and FOR iterations; shorthand and FOR-level action notes clarified.

* **New Features**
  * Parser/validator surface a specific error for invalid DEFER placement to prevent incorrect transition generation.

* **Tests**
  * Broad test additions covering FOR loops, substeps, DEFER/NEXT behavior, aggregation modes, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->