### PR TITLE
feat: warn on undefined template variables preserved as literal text

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -243,8 +243,8 @@ Canonical runtime targeting is `step + substep + iteration`.
 | Pattern             | Variable  | Expansion                               |
 |---------------------|-----------|-----------------------------------------|
 | `{{VariableName}}`  | defined   | literal variable value                  |
-| `{{VariableName}}`  | undefined | preserved as literal `{{VariableName}}` |
-| `{{path.to.value}}` | missing path | preserved as literal `{{path.to.value}}` |
+| `{{VariableName}}`  | undefined | preserved as literal `{{VariableName}}` (warning emitted to stderr) |
+| `{{path.to.value}}` | missing path | preserved as literal `{{path.to.value}}` (warning emitted to stderr) |
 
 
  VariableName: `/^[a-zA-Z_][a-zA-Z0-9_]*$/`

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -561,7 +561,7 @@ Top-level aliases are retained for ergonomics:
 
 ### Undefined Variables
 
-Undefined variables and missing dotted paths are preserved as literal placeholders (`{{variable}}`, `{{context.parent.missing}}`) rather than causing an error.
+Undefined variables and missing dotted paths are preserved as literal placeholders (`{{variable}}`, `{{context.parent.missing}}`) rather than causing an error. A deduplicated warning is emitted to stderr for each undefined variable.
 
 ### State Persistence
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -196,7 +196,7 @@ Variables use Handlebars syntax: `{{variable}}`.
 | `{{context.vars.NAME}}` | Global | User/config/frontmatter variable namespace. |
 | Loop Var | Loop | Current item/index (e.g., `{{batch}}`). |
 
-*   **Undefined**: Preserved as literal text.
+*   **Undefined**: Preserved as literal text. A warning is emitted to stderr for each undefined variable.
 *   **Evaluation**: Global vars expanded once; Step/Loop vars expanded per iteration.
 *   **Parent variables**: `{{context.parent.vars.NAME}}` exposes the parent's resolved template variables. Only non-context keys propagate. Available via both chain (`context.parent.parent.vars.*`) and array (`context.ancestors.N.vars.*`) addressing.
 *   **Depth limit**: Parent context chain addressing is capped at 32 levels. Exceeding this limit produces an error.

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -102,6 +102,7 @@ jest.unstable_mockModule('../../src/services/template-renderer', () => ({
   substituteRunbookVariables: jest.fn((runbook: unknown) => runbook),
   expandForClauseVariables: jest.fn((content: string) => content),
   expandLoopVariables: jest.fn((text: string) => text),
+  warnUnresolvedRunbookVariables: jest.fn(),
 }));
 
 // Mock node:fs/promises

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -103,6 +103,7 @@ jest.unstable_mockModule('../../src/services/template-renderer', () => ({
   substituteRunbookVariables: jest.fn((runbook: unknown) => runbook),
   expandForClauseVariables: jest.fn((content: string) => content),
   expandLoopVariables: jest.fn((text: string) => text),
+  warnUnresolvedRunbookVariables: jest.fn(),
 }));
 
 // Mock node:fs/promises

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import { parseRunbookDocument } from '@rundown-org/core';
 import {
   expandLoopVariables,
@@ -7,6 +7,8 @@ import {
   substituteRunbookVariables,
   expandLoopVariablesForCommand,
   expandForClauseVariables,
+  collectUnresolvedVariables,
+  warnUnresolvedRunbookVariables,
 } from '../../src/services/template-renderer.js';
 
 describe('expandLoopVariables', () => {
@@ -413,6 +415,97 @@ describe('expandLoopVariablesForCommand', () => {
       'context.parent.index': '7',
     };
     expect(expandLoopVariables('Index={{context.parent.index}}', variables)).toBe('Index=7');
+  });
+});
+
+describe('collectUnresolvedVariables', () => {
+  it('should return variable names from unresolved placeholders', () => {
+    expect(collectUnresolvedVariables('Hello {{name}} and {{age}}')).toEqual(['name', 'age']);
+  });
+
+  it('should return empty array when no placeholders', () => {
+    expect(collectUnresolvedVariables('No variables here')).toEqual([]);
+  });
+
+  it('should handle dotted paths', () => {
+    expect(collectUnresolvedVariables('{{item.name}} and {{config.port}}')).toEqual([
+      'item.name',
+      'config.port',
+    ]);
+  });
+
+  it('should handle spaces in braces', () => {
+    expect(collectUnresolvedVariables('{{ name }}')).toEqual(['name']);
+  });
+
+  it('should return duplicates when same variable appears multiple times', () => {
+    expect(collectUnresolvedVariables('{{x}} and {{x}}')).toEqual(['x', 'x']);
+  });
+});
+
+describe('warnUnresolvedRunbookVariables', () => {
+  it('should warn for unresolved variables in description', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = '# Test\n\n## 1. Deploy\n\nDeploy to {{environment}}.';
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: Undefined variable "{{environment}}" preserved as literal text',
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should warn for unresolved variables in command code', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = '# Test\n\n## 1. Deploy\n\n```bash\ngit checkout {{BRANCH}}\n```';
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: Undefined variable "{{BRANCH}}" preserved as literal text',
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should deduplicate warnings for same variable', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown =
+      '# Test\n\n## 1. Deploy {{env}}\n\nDeploy to {{env}}.\n\n## 2. Verify {{env}}\n\nCheck {{env}}.';
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('should not warn when all variables are resolved', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = '# Test\n\n## 1. Deploy\n\nDeploy to {{environment}}.';
+    const runbook = parseRunbookDocument(rawMarkdown);
+    const substituted = substituteRunbookVariables(runbook, { environment: 'staging' });
+    warnUnresolvedRunbookVariables(substituted);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('should warn for unresolved variables in title', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = '# {{project}} Runbook\n\n## 1. Start\n\nGo.';
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: Undefined variable "{{project}}" preserved as literal text',
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should warn for unresolved variables in prompt', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = '# Test\n\n## 1. Check\n\n> Is {{service}} running?\n';
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: Undefined variable "{{service}}" preserved as literal text',
+    );
+    warnSpy.mockRestore();
   });
 });
 

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -507,6 +507,25 @@ describe('warnUnresolvedRunbookVariables', () => {
     );
     warnSpy.mockRestore();
   });
+
+  it('should warn for unresolved variables in substep runbook paths', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = [
+      '# Test',
+      '',
+      '## 1. Main step',
+      '',
+      '### 1.1 Sub',
+      '',
+      '- deploy-{{region}}.runbook.md',
+    ].join('\n');
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: Undefined variable "{{region}}" preserved as literal text',
+    );
+    warnSpy.mockRestore();
+  });
 });
 
 describe('expandForClauseVariables', () => {

--- a/packages/cli/src/helpers/runbook-loader.ts
+++ b/packages/cli/src/helpers/runbook-loader.ts
@@ -17,6 +17,7 @@ import type { RunbookState } from '@rundown-org/core';
 import {
   substituteRunbookVariables,
   expandForClauseVariables,
+  warnUnresolvedRunbookVariables,
 } from '../services/template-renderer.js';
 
 /**
@@ -47,7 +48,9 @@ export function getRunbookFromState(state: RunbookState, _cwd: string): readonly
     const sourceKeys = new Set(Object.keys(state.sources ?? {}));
     const forExpanded = expandForClauseVariables(state.runbookSrc, state.templateVars, sourceKeys);
     const runbook = parseRunbookDocument(forExpanded, state.runbook);
-    return substituteRunbookVariables(runbook, state.templateVars).steps;
+    const substituted = substituteRunbookVariables(runbook, state.templateVars);
+    warnUnresolvedRunbookVariables(substituted);
+    return substituted.steps;
   }
 
   const runbook = parseRunbookDocument(state.runbookSrc, state.runbook);

--- a/packages/cli/src/helpers/runbook-loader.ts
+++ b/packages/cli/src/helpers/runbook-loader.ts
@@ -23,12 +23,20 @@ import {
 /**
  * Load and parse runbook steps from state.
  *
+ * When `templateVars` is present in state, variables are re-applied via AST-level
+ * substitution. Any unresolved template variables emit a warning to stderr.
+ *
  * @param state - Runbook state containing runbookSrc and optionally templateVars
  * @param _cwd - Unused, kept for signature compatibility
  * @returns Parsed steps from runbookSrc (with variables substituted if templateVars present)
  * @throws Error if runbookSrc is missing (corrupted state)
  * @throws {RunbookSyntaxError} if runbookSrc fails to parse as a runbook document
  *         (thrown by parseRunbookDocument)
+ *
+ * @remarks
+ * When `state.templateVars` is present and substitution leaves unresolved
+ * `{{variable}}` placeholders, a deduplicated warning per variable is written
+ * to stderr via `console.warn`.
  *
  * @example
  * ```typescript

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -45,6 +45,7 @@ import {
 import {
   substituteRunbookVariables,
   expandForClauseVariables,
+  warnUnresolvedRunbookVariables,
 } from '../services/template-renderer.js';
 import { getPolicyEvaluator, getPolicyPrompter } from '../services/policy-context.js';
 
@@ -273,6 +274,7 @@ export async function prepareRunbook(
 
   // Substitute variables into parsed AST
   const runbook = substituteRunbookVariables(rawRunbook, templateVars);
+  warnUnresolvedRunbookVariables(runbook);
 
   // Validate sourced FOR clauses reference defined data sources
   try {

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -337,6 +337,11 @@ export function warnUnresolvedRunbookVariables(runbook: Runbook): void {
           if (ss.command) {
             collect(ss.command.code);
           }
+          if (ss.runbooks) {
+            for (const rb of ss.runbooks) {
+              collect(rb);
+            }
+          }
         }
         break;
     }

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -286,6 +286,68 @@ export function substituteRunbookVariables(
 }
 
 /**
+ * Collect unresolved template variable names from text.
+ *
+ * Scans for remaining `{{...}}` placeholders and returns the variable names.
+ *
+ * @param text - Text that may contain unresolved placeholders
+ * @returns Array of unresolved variable names
+ */
+export function collectUnresolvedVariables(text: string): string[] {
+  const matches: string[] = [];
+  for (const match of text.matchAll(TEMPLATE_PATH_REGEX)) {
+    matches.push(match[1]);
+  }
+  return matches;
+}
+
+/**
+ * Emit warnings for any unresolved template variables in a substituted runbook.
+ *
+ * Walks the runbook AST collecting all remaining `{{...}}` placeholders,
+ * then emits a deduplicated warning per variable to stderr.
+ *
+ * @param runbook - Runbook AST after variable substitution
+ */
+export function warnUnresolvedRunbookVariables(runbook: Runbook): void {
+  const unresolved = new Set<string>();
+
+  const collect = (text: string | undefined): void => {
+    if (!text) return;
+    for (const name of collectUnresolvedVariables(text)) {
+      unresolved.add(name);
+    }
+  };
+
+  collect(runbook.title);
+  collect(runbook.description);
+
+  for (const step of runbook.steps) {
+    collect(step.description);
+    collect(step.prompt);
+    switch (step.kind) {
+      case 'command':
+        collect(step.command.code);
+        break;
+      case 'substeps':
+      case 'for':
+        for (const ss of step.substeps) {
+          collect(ss.description);
+          collect(ss.prompt);
+          if (ss.command) {
+            collect(ss.command.code);
+          }
+        }
+        break;
+    }
+  }
+
+  for (const name of unresolved) {
+    console.warn(`Warning: Undefined variable "{{${name}}}" preserved as literal text`);
+  }
+}
+
+/**
  * Expand loop variables in command code with shell escaping.
  *
  * @param text - Command text containing placeholders


### PR DESCRIPTION
Add collectUnresolvedVariables and warnUnresolvedRunbookVariables utilities that scan substituted runbook ASTs for remaining {{...}} placeholders and emit deduplicated warnings to stderr. Called after substituteRunbookVariables in both runbook-pipeline and runbook-loader paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Undefined or unresolved template variables now emit deduplicated warnings to stderr while preserving the literal placeholder text.
  * Runbooks are scanned and reported for unresolved placeholders across titles, descriptions, commands and step fields.

* **Documentation**
  * Clarified behavior for undefined variables and missing dotted paths.
  * Documented reserved keys (step, index, context) and dotted-path support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->