### PR TITLE
docs: fix blocking documentation issues from dual-verification audit

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,15 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@rundown-org/parser", "@rundown-org/core", "@rundown-org/cli"]],
+  "fixed": [
+    [
+      "@rundown-org/parser",
+      "@rundown-org/core",
+      "@rundown-org/cli",
+      "@rundown-org/mcp",
+      "@rundown-org/claude-code-plugin"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -142,3 +142,8 @@ language_backend:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ rundown run [file] --sandbox-strict       # Fail if sandbox unavailable
 
 ## Policy Configuration
 
-Policy files are discovered from: `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, `rundown.config.js`, `rundown.config.cjs`, `rundown.config.mjs`, `package.json` (rundown field).
+Policy files are auto-discovered from: `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, `package.json` (rundown field). JavaScript config files (`.js`, `.cjs`, `.mjs`) are not auto-discovered — they require explicit `--policy <path>` with `--trust-js-policy`.
 
 See [docs/SECURITY.md](docs/SECURITY.md) for full security policy documentation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ Rundown is a monorepo managed with npm workspaces:
 - `packages/parser`: Markdown runbook parser and validator.
 - `packages/core`: Core runbook logic and CLI output formatting.
 - `packages/cli`: The `rd` command-line interface.
+- `packages/mcp`: MCP server for AI agent integration.
+- `packages/claude-code-plugin`: Claude Code plugin for runbook orchestration.
 - `site`: The Astro-based documentation and interactive demo site.
 - `runbooks`: A collection of pattern and example runbooks.
 
@@ -47,7 +49,7 @@ npm run cli -- run packages/cli/__tests__/fixtures/simple.runbook.md --allow-run
 
 ### Prerequisites
 
-- **Node.js**: v18 or later.
+- **Node.js**: v20.12.0 or later.
 - **npm**: v9 or later (for monorepo management).
 - **pnpm**: v9 or later (specifically used for the `site` package).
 
@@ -185,7 +187,7 @@ GitHub Actions runs on all pull requests and pushes to `main`:
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `ci.yml` | PRs and pushes to main | Builds, lints, and tests across Node.js 18, 20, and 22 |
+| `ci.yml` | PRs and pushes to main | Builds, lints, and tests across Node.js 20 and 22 |
 | `mutation.yml` | Manual dispatch or weekly schedule | Runs Stryker mutation testing per package |
 | `release.yml` | Pushes to main | Handles npm publishing via Changesets |
 
@@ -243,10 +245,12 @@ Releases are managed with [Changesets](https://github.com/changesets/changesets)
 
 ### Package Versioning
 
-All three npm packages use **fixed versioning** - they release together with the same version number:
+All npm packages use **fixed versioning** - they release together with the same version number:
 - `@rundown-org/parser`
 - `@rundown-org/core`
 - `@rundown-org/cli`
+- `@rundown-org/mcp`
+- `@rundown-org/claude-code-plugin`
 
 The `site` package is private and never published to npm.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ GitHub Actions runs on all pull requests and pushes to `main`:
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `ci.yml` | PRs and pushes to main | Builds, lints, and tests across Node.js 20 and 22 |
+| `ci.yml` | PRs and pushes to main | PRs run on Node.js 22; pushes to `main` and manual dispatch run on Node.js 20 and 22 |
 | `mutation.yml` | Manual dispatch or weekly schedule | Runs Stryker mutation testing per package |
 | `release.yml` | Pushes to main | Handles npm publishing via Changesets |
 

--- a/docs/PROJECT-INTEGRATION.md
+++ b/docs/PROJECT-INTEGRATION.md
@@ -167,7 +167,7 @@ Not:
 - FAIL: STOP "Compilation failed."
 ```
 
-See [SPEC.md Authoring Conventions](./SPEC.md#authoring-conventions) for the full rationale.
+See [FORMAT.md Message Convention](./FORMAT.md#message-convention) for the full rationale.
 
 ## Worked Example: `pr-feedback`
 

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -47,7 +47,7 @@ This document provides a comprehensive guide and reference for the Rundown CLI (
 - [Integration with Claude Code](#integration-with-claude-code)
   - [Context Injection](#context-injection)
   - [Session Persistence](#session-persistence)
-- [Quick Reference](#quick-reference)
+- [CLI Quick Reference](#cli-quick-reference)
 
 ---
 
@@ -73,7 +73,7 @@ The CLI is an orchestration and control interface. Claude executes the actual wo
 
 ### Design Principles
 
-**Type-driven dispatch:** The state machine uses types and events to drive logic. Steps raise typed events; parent states dispatch on event type via `on:` handlers. Guards express domain conditions (e.g., "has more iterations"), never action-type checks. If a guard inspects `lastAction.type` to decide routing, that is a code smell — the event type system should handle the dispatch instead. `if` statements checking action types indicate missing structure in the state graph. Example: `IterationOutcome` is a discriminated union (`completed | break | next`) that encodes *why* an iteration ended. Retry config only exists on the `completed` variant, so TypeScript prevents accessing retry on loop-control exits at compile time. The single `lastAction.type` check is encapsulated inside `getIterationOutcome` — guards narrow on `outcome.kind` instead.
+**Type-driven dispatch:** The state machine uses types and events to drive logic. Steps raise typed events; parent states dispatch on event type via `on:` handlers. Guards express domain conditions (e.g., "has more iterations"), never action-type checks. If a guard inspects `lastAction.type` to decide routing, that is a code smell — the event type system should handle the dispatch instead. `if` statements checking action types indicate missing structure in the state graph. Example: `LastAction` is a discriminated union whose variants encode the full transition context. The `GOTO` variant carries `target`, `substep`, and `at` fields that don't exist on other variants like `CONTINUE` or `DEFER`, so TypeScript prevents accessing them without narrowing first.
 
 ---
 
@@ -437,7 +437,6 @@ Each runbook state file contains:
   "frameEntries": { "2|2": 1 },
   "activeFrameKey": "2|2",
   "activeEntry": 1,
-  "substepStates": [],
   "forStack": [
     {
       "stepId": "2",
@@ -752,7 +751,7 @@ rundown goto 3.1     # Jump to substep 3.1
 | `GOTO N.M AT I` | Any step | Jump to substep M of FOR step N at iteration I |
 | `GOTO Name AT I` | Any step | Enter named FOR step at iteration I |
 
-The `AT` qualifier is only valid when the target is a step with a FOR annotation. If `AT` is omitted for a FOR step, it defaults to iteration 1 (restart from beginning). See [SPEC.md GOTO](./SPEC.md#goto) for full details.
+The `AT` qualifier is only valid when the target is a step with a FOR annotation. If `AT` is omitted for a FOR step, it defaults to iteration 1 (restart from beginning). See [SPEC.md Actions](./SPEC.md#42-actions) for full details.
 
 ### Status Commands
 
@@ -1172,7 +1171,7 @@ Both runbook state and session tracking survive:
 
 ---
 
-## Quick Reference
+## CLI Quick Reference
 
 ```bash
 # Lifecycle

--- a/docs/SCENARIOS.md
+++ b/docs/SCENARIOS.md
@@ -36,7 +36,7 @@ scenario =
     [ "tags:" tag_list ]
 
 expect_block =
-  "result:" ( "COMPLETE" | "STOP" )
+  [ "result:" ( "COMPLETE" | "STOP" ) ]
   [ "steps:" step_assertion { step_assertion } ]
 
 step_assertion =

--- a/docs/SCENARIOS.md
+++ b/docs/SCENARIOS.md
@@ -31,9 +31,19 @@ scenario =
     [ "description:" text ]
     "commands:"
       "- " text { "- " text }
-    "result:" ( "COMPLETE" | "STOP" )
+    [ "result:" ( "COMPLETE" | "STOP" ) ]
+    [ "expect:" expect_block ]
     [ "tags:" tag_list ]
+
+expect_block =
+  "result:" ( "COMPLETE" | "STOP" )
+  [ "steps:" step_assertion { step_assertion } ]
+
+step_assertion =
+  "- " [ "at:" text ] [ "from:" text ] [ "action:" text ] [ "result:" ( "PASS" | "FAIL" ) ]
 ```
+
+At least one of top-level `result:` or `expect.result` must be specified. If both are present, they must match.
 
 ## Design Principles
 
@@ -62,6 +72,8 @@ runbooks/
   prompts/           # Explicit/implicit prompts, YES/NO, prompt code blocks
   composition/       # Runbook lists, substep runbook references
   delegation/        # Delegate, claim, abort, token lifecycle
+  stash-pop/         # Stash/pop enforcement control
+  variables/         # Template variables, built-ins, and context
   examples/          # Curated real-world runbooks (docs/explore reference)
 ```
 

--- a/docs/SCENARIOS.md
+++ b/docs/SCENARIOS.md
@@ -273,7 +273,7 @@ Numeric-looking values (e.g., `1.1`) should be quoted to prevent YAML 1.2 from p
 
 ```yaml
 expect:
-  result: COMPLETE              # Terminal outcome (required)
+  result: COMPLETE              # Terminal outcome (optional if top-level result: present)
 
   steps:                        # Transition assertions (optional, ordered)
     - at: "1.1"

--- a/docs/SCENARIOS.md
+++ b/docs/SCENARIOS.md
@@ -40,7 +40,7 @@ expect_block =
   [ "steps:" step_assertion { step_assertion } ]
 
 step_assertion =
-  "- " [ "at:" text ] [ "from:" text ] [ "action:" text ] [ "result:" ( "PASS" | "FAIL" ) ]
+  "- " [ "at:" text ] [ "from:" text ] [ "action:" text ] [ "result:" ( "PASS" | "FAIL" ) ] [ "command:" text ] [ "aggregated:" boolean ]
 ```
 
 At least one of top-level `result:` or `expect.result` must be specified. If both are present, they must match.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -70,9 +70,9 @@ Code block info string tags are matched case-insensitively. `BASH`, `Bash`, and 
 ### 3.2 Substeps
 
 Nested steps defined by H3 (`###`) headers.
-*   **Identifiers**: `### 1` (bare numeric), `### Name` (bare named), `### 1.1` (qualified numeric), or `### Step.Name` (qualified named). Bare forms inherit their parent step from document position — they belong to the H2 step they appear under. Qualified forms explicitly specify their parent.
-*   **Strict H3 rule**: When a step contains any valid substep, all H3 headers within that step must be valid substep identifiers.
-*   **Aggregation**: Parent step outcome is derived from substeps via transitions (`ALL`/`ANY`).
+* **Identifiers**: `### 1` (bare numeric), `### Name` (bare named), `### 1.1` (qualified numeric), or `### Step.Name` (qualified named). Bare forms inherit their parent step from document position — they belong to the H2 step they appear under. Qualified forms explicitly specify their parent.
+* **Strict H3 rule**: When a step contains any valid substep, all H3 headers within that step must be valid substep identifiers.
+* **Aggregation**: Parent step outcome is derived from substeps via transitions (`ALL`/`ANY`).
 
 ### 3.3 Runbook List Shorthand
 
@@ -185,11 +185,11 @@ Steps annotated with `FOR` execute their substeps repeatedly.
     *   `BREAK` → exit loop, go to parent aggregation (current iteration's DEFER'd results included)
     *   `NEXT` → skip to next iteration (or aggregation at end, non-accumulating)
     *   `DEFER`/`CONTINUE` → configured iteration-level transition applies
-*   **Execution model**: Each iteration executes its substeps. Each substep produces a **result** (pass/fail). Substep **handlers** map results to **actions**. Only two actions are loop control: `NEXT` (advance to next iteration) and `BREAK` (exit loop). All other actions (`CONTINUE`, `GOTO`, `STOP`, `COMPLETE`) are general flow control that exit the loop as a side effect.
+* **Execution model**: Each iteration executes its substeps. Each substep produces a **result** (pass/fail). Substep **handlers** map results to **actions**. Only two actions are loop control: `NEXT` (advance to next iteration) and `BREAK` (exit loop). All other actions (`CONTINUE`, `GOTO`, `STOP`, `COMPLETE`) are general flow control that exit the loop as a side effect.
 
 **Iteration execution flow:**
 
-```
+```text
 Substeps execute → each produces RESULT (pass/fail)
                  → substep HANDLER maps RESULT to ACTION
                  → DEFER'd results accumulate within iteration

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
       "biome lint --no-errors-on-unmatched"
     ]
   },
+  "engines": {
+    "node": ">=20.12.0"
+  },
   "overrides": {
     "hono": "^4.12.0",
     "lodash": "^4.17.23",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "check:lint:typed": "eslint .",
     "fix:lint:fast": "biome lint --write .",
     "fix:lint:typed": "eslint . --fix",
-    "fix:lint": "npm run lint:fast:fix && npm run lint:typed:fix",
+    "fix:lint": "npm run fix:lint:fast && npm run fix:lint:typed",
     "lint": "npm run check:lint:fast && npm run check:lint:typed",
     "verify": "run-s check:format check:spell check:lint:fast check:lint:typed test",
     "cli": "node packages/cli/dist/cli.js",

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -309,6 +309,54 @@ describe('prepareRunbook', () => {
     );
   });
 
+  it('adds context.vars.* aliases for inherited user vars', async () => {
+    resolveRunbookFile.mockResolvedValue('/test/child.md');
+    (
+      core.parseRunbookDocument as jest.MockedFunction<typeof core.parseRunbookDocument>
+    ).mockReturnValue({ steps: [makeStep()] } as any);
+    (resolveVariables as jest.Mock).mockResolvedValue({
+      vars: {},
+      sources: {},
+    });
+
+    const result = await prepareRunbook('child.md', {}, '/test', {
+      inheritedUserVars: { Region: 'us-west' },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(substituteRunbookVariables).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        Region: 'us-west',
+        'context.vars.Region': 'us-west',
+      }),
+    );
+  });
+
+  it('child vars override inherited in context.vars.* aliases', async () => {
+    resolveRunbookFile.mockResolvedValue('/test/child.md');
+    (
+      core.parseRunbookDocument as jest.MockedFunction<typeof core.parseRunbookDocument>
+    ).mockReturnValue({ steps: [makeStep()] } as any);
+    (resolveVariables as jest.Mock).mockResolvedValue({
+      vars: { Region: 'eu-central' },
+      sources: {},
+    });
+
+    const result = await prepareRunbook('child.md', {}, '/test', {
+      inheritedUserVars: { Region: 'us-west' },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(substituteRunbookVariables).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        Region: 'eu-central',
+        'context.vars.Region': 'eu-central',
+      }),
+    );
+  });
+
   it('returns error when validateSources throws', async () => {
     resolveRunbookFile.mockResolvedValue('/test/sourced.md');
     (parser.isSourced as jest.MockedFunction<typeof parser.isSourced>).mockReturnValue(true);

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -523,6 +523,135 @@ describe('warnUnresolvedRunbookVariables', () => {
       'Warning: Undefined variable "{{region}}" preserved as literal text',
     );
   });
+
+  it('should suppress FOR variable inside own substeps', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = [
+      '# Test',
+      '',
+      '## 1. Deploy',
+      '- FOR item IN 1 TO 3',
+      '',
+      '### 1.1 Process',
+      '',
+      'Handle {{item}}.',
+    ].join('\n');
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('should warn for FOR variable referenced outside FOR scope', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = [
+      '# Test',
+      '',
+      '## 1. Before',
+      '',
+      'Use {{item}} here.',
+      '',
+      '## 2. Loop',
+      '- FOR item IN 1 TO 3',
+      '',
+      '### 2.1 Process',
+      '',
+      'Handle {{item}}.',
+    ].join('\n');
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      'Warning: Undefined variable "{{item}}" preserved as literal text',
+    );
+  });
+
+  it('should scope Index/index suppression to FOR substeps only', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = [
+      '# Test',
+      '',
+      '## 1. Before',
+      '',
+      'At {{Index}} position.',
+      '',
+      '## 2. Loop',
+      '- FOR item IN 1 TO 3',
+      '',
+      '### 2.1 Process',
+      '',
+      'Iteration {{Index}}.',
+    ].join('\n');
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      'Warning: Undefined variable "{{Index}}" preserved as literal text',
+    );
+  });
+
+  it('should warn for FOR variable in FOR step own description', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = [
+      '# Test',
+      '',
+      '## 1. Process {{item}}',
+      '- FOR item IN 1 TO 3',
+      '',
+      '### 1.1 Sub',
+      '',
+      'Handle {{item}}.',
+    ].join('\n');
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      'Warning: Undefined variable "{{item}}" preserved as literal text',
+    );
+  });
+
+  it('should scope multiple FOR steps independently', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = [
+      '# Test',
+      '',
+      '## 1. Servers',
+      '- FOR server IN 1 TO 2',
+      '',
+      '### 1.1 Deploy',
+      '',
+      'Deploy to {{server}}.',
+      '',
+      '## 2. Environments',
+      '- FOR env IN 1 TO 2',
+      '',
+      '### 2.1 Check',
+      '',
+      'Check {{server}} in {{env}}.',
+    ].join('\n');
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      'Warning: Undefined variable "{{server}}" preserved as literal text',
+    );
+  });
+
+  it('should suppress dotted FOR variable paths inside FOR scope', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawMarkdown = [
+      '# Test',
+      '',
+      '## 1. Deploy',
+      '- FOR item IN 1 TO 3',
+      '',
+      '### 1.1 Process',
+      '',
+      'Name: {{item.name}}, Region: {{item.region}}.',
+    ].join('\n');
+    const runbook = parseRunbookDocument(rawMarkdown);
+    warnUnresolvedRunbookVariables(runbook);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
 });
 
 describe('expandForClauseVariables', () => {

--- a/packages/cli/src/commands/scenario-suite.ts
+++ b/packages/cli/src/commands/scenario-suite.ts
@@ -117,7 +117,7 @@ async function executeSuiteCase(
         validateRelativePath(ref);
         const dest = join(runbooksDir, ref);
         mkdirSync(dirname(dest), { recursive: true });
-        // Try main runbook's directory first (bare filenames), then suite directory (paths with subdirs)
+        // Try main runbook's directory first (bare filenames), then suite directory (nested paths)
         let copied = false;
         for (const base of [mainRunbookSourceDir, suiteDir]) {
           try {

--- a/packages/cli/src/commands/scenario-suite.ts
+++ b/packages/cli/src/commands/scenario-suite.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Command } from 'commander';
-import { dirname, isAbsolute, join, normalize, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, normalize, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { rm } from 'node:fs/promises';
 import { copyFileSync, existsSync, mkdirSync, mkdtempSync } from 'node:fs';
@@ -96,20 +96,46 @@ async function executeSuiteCase(
       };
     }
 
+    // Also copy flat to runbooks root so bare-filename commands resolve
+    const flatDest = join(runbooksDir, basename(suiteCase.file));
+    if (flatDest !== destPath) {
+      copyFileSync(runbookPath, flatDest);
+    }
+
     // Copy any referenced child runbooks into the isolated workspace
     const runbookPattern = /(?:^|[\s])([^\s=]+\.runbook\.md)/g;
+    const mainBasename = basename(suiteCase.file);
     const referenced = new Set<string>();
     for (const cmd of suiteCase.commands) {
       for (const match of cmd.matchAll(runbookPattern)) {
-        if (match[1] !== suiteCase.file) referenced.add(match[1]);
+        if (match[1] !== suiteCase.file && match[1] !== mainBasename) referenced.add(match[1]);
       }
     }
+    const mainRunbookSourceDir = dirname(resolve(suiteDir, suiteCase.file));
     for (const ref of referenced) {
       try {
         validateRelativePath(ref);
         const dest = join(runbooksDir, ref);
         mkdirSync(dirname(dest), { recursive: true });
-        copyFileSync(resolve(suiteDir, ref), dest);
+        // Try main runbook's directory first (bare filenames), then suite directory (paths with subdirs)
+        let copied = false;
+        for (const base of [mainRunbookSourceDir, suiteDir]) {
+          try {
+            copyFileSync(resolve(base, ref), dest);
+            copied = true;
+            break;
+          } catch {
+            // try next base
+          }
+        }
+        if (!copied) {
+          return {
+            passed: false,
+            scenario: caseName,
+            expected: effectiveResult,
+            actual: `CHILD_RUNBOOK_NOT_FOUND: ${ref}`,
+          };
+        }
       } catch (err: unknown) {
         if (
           err instanceof Error &&

--- a/packages/cli/src/commands/scenario-suite.ts
+++ b/packages/cli/src/commands/scenario-suite.ts
@@ -124,8 +124,15 @@ async function executeSuiteCase(
             copyFileSync(resolve(base, ref), dest);
             copied = true;
             break;
-          } catch {
-            // try next base
+          } catch (e: unknown) {
+            if (
+              e instanceof Error &&
+              'code' in e &&
+              (e as NodeJS.ErrnoException).code === 'ENOENT'
+            ) {
+              continue; // try next base
+            }
+            throw e; // permission/IO errors propagate immediately
           }
         }
         if (!copied) {

--- a/packages/cli/src/helpers/runbook-loader.ts
+++ b/packages/cli/src/helpers/runbook-loader.ts
@@ -57,7 +57,17 @@ export function getRunbookFromState(state: RunbookState, _cwd: string): readonly
     const forExpanded = expandForClauseVariables(state.runbookSrc, state.templateVars, sourceKeys);
     const runbook = parseRunbookDocument(forExpanded, state.runbook);
     const substituted = substituteRunbookVariables(runbook, state.templateVars);
-    warnUnresolvedRunbookVariables(substituted);
+    const forVars = new Set<string>();
+    for (const step of substituted.steps) {
+      if (step.kind === 'for') {
+        if (step.forClause.variable) forVars.add(step.forClause.variable);
+        forVars.add('Index');
+        forVars.add('index');
+      }
+    }
+    warnUnresolvedRunbookVariables(substituted, {
+      suppressedVariables: forVars.size > 0 ? forVars : undefined,
+    });
     return substituted.steps;
   }
 

--- a/packages/cli/src/helpers/runbook-loader.ts
+++ b/packages/cli/src/helpers/runbook-loader.ts
@@ -57,17 +57,7 @@ export function getRunbookFromState(state: RunbookState, _cwd: string): readonly
     const forExpanded = expandForClauseVariables(state.runbookSrc, state.templateVars, sourceKeys);
     const runbook = parseRunbookDocument(forExpanded, state.runbook);
     const substituted = substituteRunbookVariables(runbook, state.templateVars);
-    const forVars = new Set<string>();
-    for (const step of substituted.steps) {
-      if (step.kind === 'for') {
-        if (step.forClause.variable) forVars.add(step.forClause.variable);
-        forVars.add('Index');
-        forVars.add('index');
-      }
-    }
-    warnUnresolvedRunbookVariables(substituted, {
-      suppressedVariables: forVars.size > 0 ? forVars : undefined,
-    });
+    warnUnresolvedRunbookVariables(substituted);
     return substituted.steps;
   }
 

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -203,8 +203,9 @@ function buildContextVars(vars: Readonly<Record<string, string>>): Record<string
  * @param file - Runbook file path or name
  * @param varOpts - Variable options from CLI flags
  * @param cwd - Current working directory
- * @param options - Optional settings including inherited context variables from parent runbook
+ * @param options - Optional settings including inherited variables from parent runbook
  * @param options.inheritedContextVars - Context variables inherited from a parent delegation
+ * @param options.inheritedUserVars - User variables inherited from a parent delegation
  * @returns PreparedRunbook or error result
  * @throws {Error} On unexpected errors during variable resolution or parsing
  */

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -196,6 +196,36 @@ function buildContextVars(vars: Readonly<Record<string, string>>): Record<string
 }
 
 /**
+ * Build the complete template variable map from all sources.
+ *
+ * Merges inherited user vars with locally resolved vars, computes `context.vars.*`
+ * aliases from the full user-var set, and overlays inherited context vars.
+ *
+ * @param localVars - Variables resolved from this runbook's frontmatter, config, and CLI flags
+ * @param options - Optional inherited variables from parent delegation
+ * @param options.inheritedUserVars - User variables inherited from a parent delegation
+ * @param options.inheritedContextVars - Context variables inherited from a parent delegation
+ * @returns Complete template variable map ready for substitution
+ */
+function buildTemplateVars(
+  localVars: Readonly<Record<string, string>>,
+  options?: {
+    inheritedUserVars?: Readonly<Record<string, string>>;
+    inheritedContextVars?: Readonly<Record<string, string>>;
+  },
+): Record<string, string> {
+  const effectiveUserVars: Record<string, string> = {
+    ...(options?.inheritedUserVars ?? {}), // parent --var (overridable)
+    ...localVars, // child frontmatter + claim --var (overrides)
+  };
+  return {
+    ...effectiveUserVars,
+    ...buildContextVars(effectiveUserVars), // aliases from FULL user-var set
+    ...(options?.inheritedContextVars ?? {}), // context.parent.vars.* etc.
+  };
+}
+
+/**
  * Prepare a runbook from file: resolve, load, parse, substitute variables.
  *
  * This is the shared pipeline used by file start and delegation claim.
@@ -263,12 +293,7 @@ export async function prepareRunbook(
     }
     throw error;
   }
-  const templateVars: Record<string, string> = {
-    ...(options?.inheritedUserVars ?? {}), // delegate --var (overridable by child/claim)
-    ...mergedVariables, // child frontmatter + claim --var
-    ...buildContextVars(mergedVariables), // context.vars.* aliases
-    ...(options?.inheritedContextVars ?? {}), // context.parent.vars.* etc.
-  };
+  const templateVars = buildTemplateVars(mergedVariables, options);
 
   // Pre-expand FOR clause bounds (parser needs numeric values)
   const forExpandedContent = expandForClauseVariables(
@@ -282,17 +307,7 @@ export async function prepareRunbook(
 
   // Substitute variables into parsed AST
   const runbook = substituteRunbookVariables(rawRunbook, templateVars);
-  const forVars = new Set<string>();
-  for (const step of rawRunbook.steps) {
-    if (step.kind === 'for') {
-      if (step.forClause.variable) forVars.add(step.forClause.variable);
-      forVars.add('Index');
-      forVars.add('index');
-    }
-  }
-  warnUnresolvedRunbookVariables(runbook, {
-    suppressedVariables: forVars.size > 0 ? forVars : undefined,
-  });
+  warnUnresolvedRunbookVariables(runbook);
 
   // Validate sourced FOR clauses reference defined data sources
   try {

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -214,6 +214,7 @@ export async function prepareRunbook(
   cwd: string,
   options?: {
     inheritedContextVars?: Readonly<Record<string, string>>;
+    inheritedUserVars?: Readonly<Record<string, string>>;
   },
 ): Promise<
   | { ok: true; prepared: PreparedRunbook }
@@ -262,9 +263,10 @@ export async function prepareRunbook(
     throw error;
   }
   const templateVars: Record<string, string> = {
-    ...mergedVariables,
-    ...buildContextVars(mergedVariables),
-    ...(options?.inheritedContextVars ?? {}),
+    ...(options?.inheritedUserVars ?? {}), // delegate --var (overridable by child/claim)
+    ...mergedVariables, // child frontmatter + claim --var
+    ...buildContextVars(mergedVariables), // context.vars.* aliases
+    ...(options?.inheritedContextVars ?? {}), // context.parent.vars.* etc.
   };
 
   // Pre-expand FOR clause bounds (parser needs numeric values)
@@ -279,7 +281,17 @@ export async function prepareRunbook(
 
   // Substitute variables into parsed AST
   const runbook = substituteRunbookVariables(rawRunbook, templateVars);
-  warnUnresolvedRunbookVariables(runbook);
+  const forVars = new Set<string>();
+  for (const step of rawRunbook.steps) {
+    if (step.kind === 'for') {
+      if (step.forClause.variable) forVars.add(step.forClause.variable);
+      forVars.add('Index');
+      forVars.add('index');
+    }
+  }
+  warnUnresolvedRunbookVariables(runbook, {
+    suppressedVariables: forVars.size > 0 ? forVars : undefined,
+  });
 
   // Validate sourced FOR clauses reference defined data sources
   try {
@@ -603,9 +615,18 @@ export async function claimAndLaunch(
     // 4e. Reconstitute context vars from frozen snapshot
     const inheritedContextVars = reconstituteContextVars(freshDelegation.contextSnapshot);
 
+    // Extract parent user-level vars for top-level inheritance in child
+    const inheritedUserVars: Record<string, string> = {};
+    for (const [key, value] of Object.entries(freshDelegation.contextSnapshot.vars)) {
+      if (!key.startsWith('context.')) {
+        inheritedUserVars[key] = value;
+      }
+    }
+
     // 4f. Prepare child runbook
     const prepResult = await prepareRunbook(freshDelegation.childRunbookPath, varOpts, cwd, {
       inheritedContextVars,
+      inheritedUserVars,
     });
     if (!prepResult.ok) {
       return {

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -302,25 +302,47 @@ export function collectUnresolvedVariables(text: string): string[] {
 }
 
 /**
+ * Check whether a variable name is a dotted path rooted at a FOR loop variable.
+ *
+ * For example, if `forVars` contains `"item"`, then `"item.name"` returns `true`
+ * but `"item"` alone returns `false` (exact matches are handled by `Set.has`).
+ *
+ * @param name - Unresolved variable name (possibly dotted, e.g. `"item.name"`)
+ * @param forVars - Set of FOR loop variable names to match against
+ * @returns `true` if `name` is a dotted path whose root segment is in `forVars`
+ */
+function isForVariablePath(name: string, forVars: ReadonlySet<string>): boolean {
+  const dotIndex = name.indexOf('.');
+  if (dotIndex === -1) return false;
+  return forVars.has(name.slice(0, dotIndex));
+}
+
+/**
  * Emit warnings for any unresolved template variables in a substituted runbook.
  *
  * Walks the runbook AST collecting all remaining `{{...}}` placeholders,
- * then emits a deduplicated warning per variable to stderr.
+ * then emits a deduplicated warning per variable to stderr. FOR loop variables
+ * (including `Index`/`index`) are only suppressed within their own FOR step's
+ * substeps — they still produce warnings when referenced outside FOR scope.
  *
  * @param runbook - Runbook AST after variable substitution
- * @param options - Optional settings for warning suppression
- * @param options.suppressedVariables - Set of variable names to skip warnings for
  */
-export function warnUnresolvedRunbookVariables(
-  runbook: Runbook,
-  options?: { suppressedVariables?: ReadonlySet<string> },
-): void {
+export function warnUnresolvedRunbookVariables(runbook: Runbook): void {
   const unresolved = new Set<string>();
 
   const collect = (text: string | undefined): void => {
     if (!text) return;
     for (const name of collectUnresolvedVariables(text)) {
       unresolved.add(name);
+    }
+  };
+
+  const collectScoped = (text: string | undefined, suppressed: ReadonlySet<string>): void => {
+    if (!text) return;
+    for (const name of collectUnresolvedVariables(text)) {
+      if (!suppressed.has(name) && !isForVariablePath(name, suppressed)) {
+        unresolved.add(name);
+      }
     }
   };
 
@@ -335,25 +357,30 @@ export function warnUnresolvedRunbookVariables(
         collect(step.command.code);
         break;
       case 'substeps':
-      case 'for':
         for (const ss of step.substeps) {
           collect(ss.description);
           collect(ss.prompt);
-          if (ss.command) {
-            collect(ss.command.code);
-          }
-          if (ss.runbooks) {
-            for (const rb of ss.runbooks) {
-              collect(rb);
-            }
-          }
+          if (ss.command) collect(ss.command.code);
+          if (ss.runbooks) for (const rb of ss.runbooks) collect(rb);
         }
         break;
+      case 'for': {
+        const forSuppressed = new Set<string>();
+        if (step.forClause.variable) forSuppressed.add(step.forClause.variable);
+        forSuppressed.add('Index');
+        forSuppressed.add('index');
+        for (const ss of step.substeps) {
+          collectScoped(ss.description, forSuppressed);
+          collectScoped(ss.prompt, forSuppressed);
+          if (ss.command) collectScoped(ss.command.code, forSuppressed);
+          if (ss.runbooks) for (const rb of ss.runbooks) collectScoped(rb, forSuppressed);
+        }
+        break;
+      }
     }
   }
 
   for (const name of unresolved) {
-    if (options?.suppressedVariables?.has(name)) continue;
     console.warn(`Warning: Undefined variable "{{${name}}}" preserved as literal text`);
   }
 }

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -308,8 +308,13 @@ export function collectUnresolvedVariables(text: string): string[] {
  * then emits a deduplicated warning per variable to stderr.
  *
  * @param runbook - Runbook AST after variable substitution
+ * @param options - Optional settings for warning suppression
+ * @param options.suppressedVariables - Set of variable names to skip warnings for
  */
-export function warnUnresolvedRunbookVariables(runbook: Runbook): void {
+export function warnUnresolvedRunbookVariables(
+  runbook: Runbook,
+  options?: { suppressedVariables?: ReadonlySet<string> },
+): void {
   const unresolved = new Set<string>();
 
   const collect = (text: string | undefined): void => {
@@ -348,6 +353,7 @@ export function warnUnresolvedRunbookVariables(runbook: Runbook): void {
   }
 
   for (const name of unresolved) {
+    if (options?.suppressedVariables?.has(name)) continue;
     console.warn(`Warning: Undefined variable "{{${name}}}" preserved as literal text`);
   }
 }

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -38,6 +38,7 @@ To ensure clarity and consistency across all pattern examples, we follow a holis
 | `prompts/` | User prompts and input handling |
 | `composition/` | Parent runbooks, agents, and delegation |
 | `delegation/` | Delegate/claim patterns for child runbooks |
+| `stash-pop/` | Stash/pop enforcement control |
 | `variables/` | Template variables, built-ins, and context |
 
 ## Creating New Patterns
@@ -45,7 +46,7 @@ To ensure clarity and consistency across all pattern examples, we follow a holis
 1. Choose the appropriate category directory
 2. Use descriptive filename: `feature-variant.runbook.md`
 3. Add scenarios following the naming taxonomy above
-4. Include `result: pass` or `result: fail` in scenario metadata
+4. Include `result: COMPLETE` or `result: STOP` in scenario metadata (or use `expect:` block for step-level assertions)
 
 ## See Also
 


### PR DESCRIPTION
- Fix CLAUDE.md false claim that JS config files are auto-discovered (security)
- Fix CONTRIBUTING.md Node.js version (v18 → v20.12.0), CI matrix (remove 18), add missing mcp/plugin packages
- Fix broken links in PROJECT-INTEGRATION.md and RUNDOWN.md
- Replace phantom IterationOutcome/getIterationOutcome types with actual LastAction example
- Fix package.json fix:lint script referencing nonexistent targets
- Reconcile SCENARIOS.md BNF grammar with expect: block format
- Fix RUNDOWN.md duplicate substepStates JSON key and duplicate ToC anchor
- Update SCENARIOS.md and runbooks/README.md directory listings
- Fix runbooks/README.md incorrect scenario result values (pass/fail → COMPLETE/STOP)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `line_ending` configuration option for language backend
  * Introduced optional `expect` block in scenario grammar for step-level assertions
  * Added support for inherited user variables in nested runbook execution
  * Implemented FOR-loop variable scoping for improved variable handling

* **Documentation**
  * Updated policy configuration guidance on JavaScript auto-discovery
  * Expanded Rundown and SPEC documentation with revised examples and clarifications
  * Updated scenario creation guidelines with new result values
  * Added new `stash-pop` pattern category to runbook structure

* **Chores**
  * Updated Node.js requirement to v20.12.0+
  * Updated CI workflow matrix configuration
  * Refactored npm script naming

* **Tests**
  * Added comprehensive test coverage for inherited variable handling and FOR-scope scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->