### PR TITLE
fix: align BREAK with NEXT as non-accumulating in FOR loop iterations

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -87,8 +87,8 @@ Step-level `runbooks` syntax is shorthand for implicit sequential substeps (`###
 If prompt text appears before a step-level `runbooks` shorthand body, it is attached to the first generated implicit substep only.
 
 where transition is:
-  - { PASS | FAIL | YES | NO } [ { ALL | ANY } ]: result
-  | - DEFER                         -- shorthand for PASS: DEFER + FAIL: DEFER
+  - { PASS | FAIL | YES | NO } [ { ALL | ANY } ] result
+  | - DEFER                         -- shorthand for PASS DEFER + FAIL DEFER
 
 Transitions must appear as list items with the `-` bullet prefix (a dash followed by a space). Paragraph-style transitions (without prefix) are not valid.
 
@@ -204,7 +204,7 @@ The FOR clause is a step-level annotation that makes a step iterate its substeps
 - Step-level runbook lists satisfy the FOR-substep requirement via implicit sequential substeps
 - Parent FOR step transitions aggregate across iterations using ALL/ANY modifiers
 - FOR-level nested transitions execute at iteration scope; RETRY evaluates before the exhausted action
-- Iteration-level `BREAK` includes the current iteration result in parent aggregation; iteration-level `GOTO`/`STOP`/`COMPLETE` bypass parent aggregation
+- Iteration-level `BREAK` exits the loop without recording the current iteration result (non-accumulating, same as NEXT); iteration-level `GOTO`/`STOP`/`COMPLETE` bypass parent aggregation
 - Nested bullets under `FOR` must be transition bullets; non-transition nested bullets are invalid
 
 ### Execution Path Notation
@@ -258,8 +258,8 @@ Canonical runtime targeting is `step + substep + iteration`.
 
 | Input | Expands To |
 |-------|------------|
-| `PASS: X` | `PASS ALL: X` |
-| `FAIL: X` | `FAIL ANY: X` |
+| `PASS X` | `PASS ALL X` |
+| `FAIL X` | `FAIL ANY X` |
 
 ### RETRY Defaults
 
@@ -282,9 +282,9 @@ The fallback action cannot be RETRY (nested RETRY is invalid).
 
 | Condition         | Expands To |
 |-------------------|------------|
-| None defined      | `PASS ALL: CONTINUE` + `FAIL ANY: STOP` |
-| Only PASS defined | Adds `FAIL ANY: STOP` |
-| Only FAIL defined | Adds `PASS ALL: CONTINUE` |
+| None defined      | `PASS ALL CONTINUE` + `FAIL ANY STOP` |
+| Only PASS defined | Adds `FAIL ANY STOP` |
+| Only FAIL defined | Adds `PASS ALL CONTINUE` |
 
 **Convention:** Always write both transitions explicitly. The parser supports implicit defaults, but runbooks should be readable without memorizing the default table.
 

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -198,8 +198,8 @@ In WebContainer environments (e.g., StackBlitz), nested process spawning may not
 Example of a step that auto-executes:
 ````markdown
 ## 3. Run tests
-- PASS: CONTINUE
-- FAIL: RETRY 2
+- PASS CONTINUE
+- FAIL RETRY 2
 
 ```bash
 npm test
@@ -209,8 +209,8 @@ npm test
 Example of a prompted step:
 ````markdown
 ## 4. Code review
-- PASS: CONTINUE
-- FAIL: STOP
+- PASS CONTINUE
+- FAIL STOP
 
 Review the implementation for issues.
 `rundown pass` if acceptable, `rundown fail` if blocked.
@@ -229,8 +229,8 @@ Steps can iterate their substeps over a numeric range using a FOR annotation. FO
 - FAIL ANY: STOP
 
 ### 1. Process item
-- PASS: CONTINUE
-- FAIL: BREAK
+- PASS CONTINUE
+- FAIL BREAK
 ````
 
 Step-level runbook lists are shorthand for implicit sequential substeps (`.1`, `.2`, ...), so FOR execution is equivalent across these forms:
@@ -293,7 +293,7 @@ FOR-level nested transitions (nested bullets directly under `- FOR ...`) run at 
 | Action | Effect |
 |--------|--------|
 | `CONTINUE` | Keep iterating |
-| `BREAK` | Exit loop; include current iteration result in parent aggregation |
+| `BREAK` | Exit loop immediately (non-accumulating — same as NEXT) |
 | `GOTO` | Jump immediately; bypass parent FOR aggregation |
 | `STOP` | Stop immediately; bypass parent FOR aggregation |
 | `COMPLETE` | Complete immediately; bypass parent FOR aggregation |
@@ -351,8 +351,8 @@ log_file: file:data/results.jsonl
 - PASS ALL: CONTINUE
 - FAIL ANY: STOP
 ### 1 Handle item
-- PASS: CONTINUE
-- FAIL: BREAK
+- PASS CONTINUE
+- FAIL BREAK
 Handle {{item}} (iteration {{Index}}).
 ````
 
@@ -1007,8 +1007,8 @@ Agent decides next action based on context.
 
 ```markdown
 ## 5. Check remaining
-- PASS: CONTINUE
-- FAIL: STOP
+- PASS CONTINUE
+- FAIL STOP
 
 Check TodoWrite for remaining items.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -127,7 +127,7 @@ Aggregation modifiers must form complementary pairs: `PASS ALL` with `FAIL ANY` 
 **Defaults**:
 *   If only `PASS` defined: `FAIL` -> `STOP`.
 *   If only `FAIL` defined: `PASS` -> `CONTINUE`.
-*   If neither is defined: `PASS: CONTINUE`, `FAIL: STOP`.
+*   If neither is defined: `PASS CONTINUE`, `FAIL STOP`.
 
 When only one transition side specifies an aggregation modifier, the defaulted side receives its complement (`PASS ALL` defaults `FAIL ANY`, and vice versa).
 
@@ -144,7 +144,7 @@ When only one transition side specifies an aggregation modifier, the defaulted s
 | `NEXT` | FOR Substep, FOR Iteration-Level | Skip to next iteration (no result accumulation). |
 | `BREAK` | FOR Substep, FOR Iteration-Level | Exit loop immediately. |
 
-> **Shorthand:** A standalone `- DEFER` bullet (without PASS/FAIL prefix) expands to `- PASS: DEFER` + `- FAIL: DEFER`. This is convenient for substeps where both outcomes should propagate to parent aggregation. DEFER is not valid at step level.
+> **Shorthand:** A standalone `- DEFER` bullet (without PASS/FAIL prefix) expands to `- PASS DEFER` + `- FAIL DEFER`. This is convenient for substeps where both outcomes should propagate to parent aggregation. DEFER is not valid at step level.
 
 GOTO targeting the containing step (self-reference) without an AT qualifier may create an infinite loop. Use RETRY for bounded re-execution.
 
@@ -182,7 +182,7 @@ Steps annotated with `FOR` execute their substeps repeatedly.
 *   **Iteration-level transitions**: Nested `PASS`/`FAIL` transitions under a `FOR` clause execute per iteration. Allowed actions: `DEFER` (default, loop back with accumulation), `NEXT` (loop back without accumulation), `CONTINUE` (exit loop), `BREAK` (exit loop), `GOTO`, `STOP`, `COMPLETE` (optionally wrapped by `RETRY`).
 *   **Nested bullet rule**: Nested bullets under `FOR` must be transition bullets; non-transition nested bullets are invalid and fail parse.
 *   **Retry order**: Iteration-level `RETRY` semantics are deterministic: retry first, then execute the exhausted action. RETRY is universal — it fires for ALL substep actions (including `BREAK` and `NEXT`) based on the iteration result, not the substep action. After retries are exhausted, the substep's action takes effect:
-    *   `BREAK` → exit loop, go to parent aggregation (current iteration's DEFER'd results included)
+    *   `BREAK` → exit loop (non-accumulating, same as NEXT)
     *   `NEXT` → skip to next iteration (or aggregation at end, non-accumulating)
     *   `DEFER`/`CONTINUE` → configured iteration-level transition applies
 * **Execution model**: Each iteration executes its substeps. Each substep produces a **result** (pass/fail). Substep **handlers** map results to **actions**. Only two actions are loop control: `NEXT` (advance to next iteration) and `BREAK` (exit loop). All other actions (`CONTINUE`, `GOTO`, `STOP`, `COMPLETE`) are general flow control that exit the loop as a side effect.
@@ -198,7 +198,7 @@ Substeps execute → each produces RESULT (pass/fail)
 
     DEFER     → record iteration result, advance to next iteration
     NEXT      → advance to next iteration (do NOT record result)
-    BREAK     → record iteration result, exit loop → step-level HANDLER
+    BREAK     → exit loop (do NOT record result) → step-level HANDLER
     CONTINUE  → exit loop → step-level HANDLER (current iteration result NOT recorded)
     GOTO/STOP/COMPLETE → exit loop, bypass step-level HANDLER entirely
 ```
@@ -209,7 +209,7 @@ Substeps execute → each produces RESULT (pass/fail)
 | :--- | :--- | :--- | :--- |
 | `DEFER` | No (accumulate + loop back) | Yes | After final iteration |
 | `NEXT` | Yes (skip + loop back) | No | After final iteration |
-| `BREAK` | Yes (exit) | Yes | Yes |
+| `BREAK` | Yes (exit) | No | Yes |
 | `CONTINUE` | No (flow control) | No | Yes |
 | `GOTO` | No (flow control) | No | No (bypassed) |
 | `STOP` | No (flow control) | No | No (bypassed) |

--- a/packages/cli/__tests__/integration/for-loop-transitions.test.ts
+++ b/packages/cli/__tests__/integration/for-loop-transitions.test.ts
@@ -332,8 +332,12 @@ Final step.
       // Attempt 3 (retry 2): retries exhausted → BREAK exits loop
       expect(runCli('fail', workspace).exitCode).toBe(0);
       const result = runCli('fail', workspace);
-      // BREAK exits loop → aggregation: deferredResults=[fail] → fail → PASS ALL fails → STOP
-      expect(result.exitCode).toBe(1);
+      // BREAK exits loop (non-accumulating) → iterationResults = []
+      // PASS ALL: vacuous pass → CONTINUE → step 2
+      expect(result.exitCode).toBe(0);
+      // Step 2: PASS → COMPLETE
+      const result2 = runCli('pass', workspace);
+      expect(result2.exitCode).toBe(0);
     });
   });
 });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -7730,6 +7730,7 @@ echo "processing"
         actor.send({ type: 'FAIL' });
         expect(actor.getSnapshot().context.deferredResults).toEqual([]);
         // BREAK is non-accumulating — iterationResults stays ['pass'] (from iteration 1)
+        expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']);
         // PASS ALL with ['pass'] → all pass → COMPLETE
         expect(actor.getSnapshot().value).toBe('COMPLETE');
       });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -1365,7 +1365,7 @@ describe('runbook compiler', () => {
       expect(actor.getSnapshot().value).toBe('step::2');
       expect(actor.getSnapshot().context.forStack).toEqual([]);
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
-      expect(actor.getSnapshot().context.deferredResults).toEqual(['pass']);
+      expect(actor.getSnapshot().context.deferredResults).toEqual([]);
     });
 
     it('NEXT outside FOR loop goes to STOPPED', () => {
@@ -2669,7 +2669,7 @@ describe('runbook compiler', () => {
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('step::2');
       expect(snapshot.context.iterationResults).toEqual(['pass', 'pass']);
-      expect(snapshot.context.deferredResults).toEqual(['pass']);
+      expect(snapshot.context.deferredResults).toEqual([]);
     });
 
     it('NEXT at last iteration triggers aggregation', () => {
@@ -3209,7 +3209,7 @@ describe('runbook compiler', () => {
       expect(snapshot.value).toBe('step::3');
       expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3', aggregated: true });
       expect(snapshot.context.iterationResults).toEqual([]);
-      expect(snapshot.context.deferredResults).toEqual(['pass']);
+      expect(snapshot.context.deferredResults).toEqual([]);
       expect(snapshot.context.forStack).toEqual([]);
     });
   });
@@ -5756,7 +5756,7 @@ echo "processing"
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('step::2');
       expect(snapshot.context.iterationResults).toEqual(['pass']);
-      expect(snapshot.context.deferredResults).toEqual(['fail']);
+      expect(snapshot.context.deferredResults).toEqual([]);
     });
 
     it('default FOR transitions (no explicit nested transitions) — DEFER loops back', () => {
@@ -6908,10 +6908,10 @@ echo "processing"
         actor.send({ type: 'PASS' });
         expect(actor.getSnapshot().value).toBe('step::1::2');
 
-        // Sub 2: FAIL → BREAK (does NOT feed deferredResults, ends loop)
+        // Sub 2: FAIL → BREAK (clears deferredResults, exits loop)
         actor.send({ type: 'FAIL' });
-        expect(actor.getSnapshot().context.deferredResults).toEqual(['pass']);
-        // computeIterationResult(['pass']) → ALL: pass → PASS ALL → COMPLETE
+        expect(actor.getSnapshot().context.deferredResults).toEqual([]);
+        // BREAK is non-accumulating → iterationResults = [] → PASS ALL: vacuous pass → COMPLETE
         expect(actor.getSnapshot().value).toBe('COMPLETE');
       });
 
@@ -6951,9 +6951,9 @@ echo "processing"
 
         // Sub 1: FAIL → DEFER feeds ['fail']
         actor.send({ type: 'FAIL' });
-        // Sub 2: PASS → BREAK (flow control only)
+        // Sub 2: PASS → BREAK (clears deferredResults, exits loop)
         actor.send({ type: 'PASS' });
-        expect(actor.getSnapshot().context.deferredResults).toEqual(['fail']);
+        expect(actor.getSnapshot().context.deferredResults).toEqual([]);
         // BREAK is non-accumulating → iterationResults = [] → PASS ALL: vacuous pass → COMPLETE
         expect(actor.getSnapshot().value).toBe('COMPLETE');
       });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -1229,11 +1229,11 @@ describe('runbook compiler', () => {
       expect(topBreak1.iteration).toBe(1);
 
       // Iteration 1: FAIL on substep 1 → BREAK → exit loop
-      // BREAK exits loop and includes current iteration result
+      // BREAK is non-accumulating — current iteration result NOT added to iterationResults
       actor.send({ type: 'FAIL' });
       expect(actor.getSnapshot().value).toBe('step::4');
       expect(actor.getSnapshot().context.forStack).toEqual([]);
-      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']);
+      expect(actor.getSnapshot().context.iterationResults).toEqual([]);
       expect(actor.getSnapshot().context.deferredResults).toEqual([]);
     });
 
@@ -1293,7 +1293,7 @@ describe('runbook compiler', () => {
       expect(actor.getSnapshot().context.deferredResults).toEqual([]);
     });
 
-    it('BREAK exits loop and includes current iteration result', () => {
+    it('BREAK exits loop without accumulating current iteration', () => {
       const steps = inferSteps([
         {
           name: '1',
@@ -1357,14 +1357,14 @@ describe('runbook compiler', () => {
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
 
       // Iteration 3: PASS (DEFER) → FAIL (BREAK) → exit loop
-      // BREAK includes current iteration result — iteration 3's result IS added to iterationResults
-      // Parent aggregation sees ['pass', 'pass', 'pass'] from all 3 iterations → all pass → CONTINUE
+      // BREAK is non-accumulating — iteration 3's result is NOT added to iterationResults
+      // Parent aggregation sees ['pass', 'pass'] from iterations 1-2 (DEFER'd) → all pass → CONTINUE
       actor.send({ type: 'PASS' });
       expect(actor.getSnapshot().value).toBe('step::1::2');
       actor.send({ type: 'FAIL' });
       expect(actor.getSnapshot().value).toBe('step::2');
       expect(actor.getSnapshot().context.forStack).toEqual([]);
-      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass', 'pass']);
+      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
       expect(actor.getSnapshot().context.deferredResults).toEqual(['pass']);
     });
 
@@ -2663,12 +2663,12 @@ describe('runbook compiler', () => {
       actor.send({ type: 'PASS' });
       actor.send({ type: 'FAIL' });
 
-      // BREAK at iter 3: substep 1's DEFER'd result is in deferredResults
-      // deferredResults = ['pass'] → computeIterationResult = pass → all iterations pass
-      // PASS ALL: allResults [pass, pass, pass] → passes → CONTINUE to step 2
+      // BREAK at iter 3: non-accumulating — current iteration result NOT added
+      // iterationResults = ['pass', 'pass'] (from iterations 1-2 via DEFER loop-back)
+      // PASS ALL: all pass → CONTINUE to step 2
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('step::2');
-      expect(snapshot.context.iterationResults).toEqual(['pass', 'pass', 'pass']);
+      expect(snapshot.context.iterationResults).toEqual(['pass', 'pass']);
       expect(snapshot.context.deferredResults).toEqual(['pass']);
     });
 
@@ -3203,13 +3203,12 @@ describe('runbook compiler', () => {
       actor.send({ type: 'PASS' }); // sub 1
       actor.send({ type: 'PASS' }); // sub 2 → BREAK
 
-      // BREAK on iteration 1: substep 1 DEFER'd 'pass', substep 2 BREAK (no append)
-      // deferredResults = ['pass'] → computeIterationResult = pass
-      // PASS ALL: no failures → aggregation passes → GOTO 3
+      // BREAK on iteration 1: substep 2 BREAK is non-accumulating
+      // iterationResults = [] (empty) → vacuous pass on PASS ALL → GOTO 3
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('step::3');
       expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3', aggregated: true });
-      expect(snapshot.context.iterationResults).toEqual(['pass']);
+      expect(snapshot.context.iterationResults).toEqual([]);
       expect(snapshot.context.deferredResults).toEqual(['pass']);
       expect(snapshot.context.forStack).toEqual([]);
     });
@@ -6259,9 +6258,9 @@ echo "processing"
 
       const snapshot = actor.getSnapshot();
       // iterationRetryCount reset to 0 by parent exit assign (intermediate checks proved retry fired)
-      // BREAK exits loop → aggregation: iterationResults=[] + current iter ['fail'] = ['fail']
-      // PASS ALL: fails → STOP
-      expect(snapshot.value).toBe('STOPPED');
+      // BREAK exits loop (non-accumulating) → iterationResults = []
+      // PASS ALL: vacuous pass → CONTINUE → step::2
+      expect(snapshot.value).toBe('step::2');
     });
 
     it('substep NEXT bypasses iteration-level retry', () => {
@@ -6400,10 +6399,10 @@ echo "processing"
 
       const snapshot = actor.getSnapshot();
       // iterationRetryCount reset to 0 by parent exit assign (intermediate checks proved retry fired)
-      // iterationResults: [pass, fail] (iteration 1 from loop-back, iteration 2 from BREAK exit)
-      // Aggregation: [pass, fail] → PASS ALL fails → STOP
-      expect(snapshot.value).toBe('STOPPED');
-      expect(snapshot.context.iterationResults).toEqual(['pass', 'fail']);
+      // iterationResults: ['pass'] (iteration 1 from loop-back; iteration 2 BREAK'd = non-accumulating)
+      // Aggregation: ['pass'] → PASS ALL passes → CONTINUE → step::2
+      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.context.iterationResults).toEqual(['pass']);
     });
   });
 
@@ -6955,8 +6954,8 @@ echo "processing"
         // Sub 2: PASS → BREAK (flow control only)
         actor.send({ type: 'PASS' });
         expect(actor.getSnapshot().context.deferredResults).toEqual(['fail']);
-        // computeIterationResult(['fail']) → ALL: has fail → fail → FAIL ALL → STOP
-        expect(actor.getSnapshot().value).toBe('STOPPED');
+        // BREAK is non-accumulating → iterationResults = [] → PASS ALL: vacuous pass → COMPLETE
+        expect(actor.getSnapshot().value).toBe('COMPLETE');
       });
     });
 
@@ -7730,8 +7729,8 @@ echo "processing"
         // Iteration 2: FAIL → BREAK (deferredResults for this iteration = [], NOT ['fail'])
         actor.send({ type: 'FAIL' });
         expect(actor.getSnapshot().context.deferredResults).toEqual([]);
-        // computeIterationResult([]) → vacuous pass → iteration results [pass, pass]
-        // PASS ALL with all pass → COMPLETE
+        // BREAK is non-accumulating — iterationResults stays ['pass'] (from iteration 1)
+        // PASS ALL with ['pass'] → all pass → COMPLETE
         expect(actor.getSnapshot().value).toBe('COMPLETE');
       });
     });

--- a/packages/core/__tests__/runbook/for-loop-design-invariants.test.ts
+++ b/packages/core/__tests__/runbook/for-loop-design-invariants.test.ts
@@ -8,7 +8,7 @@
  * Properties:
  * 1. RETRY is universal — fires for every substep action type
  * 2. NEXT never accumulates iteration results
- * 3. BREAK includes current iteration's deferred results in aggregation
+ * 3. BREAK is non-accumulating — deferred results discarded
  * 4. Iteration-level BREAK is non-accumulating
  * 5. Only DEFER accumulates at iteration level
  */
@@ -310,13 +310,14 @@ describe('FOR loop design invariants', () => {
     });
   });
 
-  // Property 3: BREAK includes current iteration's deferred results in aggregation
+  // Property 3: BREAK is non-accumulating — deferred results discarded
   //
-  // When BREAK exits the loop, substeps that already DEFER'd within the current
-  // iteration still count in parent aggregation. If they didn't, aggregation would
-  // see empty results → vacuous pass → COMPLETE. STOPPED proves they were included.
-  describe('BREAK includes deferred results in aggregation', () => {
-    it('BREAK after DEFER produces STOPPED via parent PASS ALL', () => {
+  // When BREAK exits the loop, the current iteration's result is NOT added to
+  // iterationResults (same as NEXT). Parent aggregation sees only prior DEFER'd
+  // iterations. With no prior iterations, iterationResults is empty → vacuous pass
+  // → COMPLETE.
+  describe('BREAK is non-accumulating — deferred results discarded', () => {
+    it('BREAK after DEFER produces COMPLETE via vacuous pass (non-accumulating)', () => {
       fc.assert(
         fc.property(
           fc.integer({ min: 1, max: 3 }),
@@ -346,10 +347,9 @@ describe('FOR loop design invariants', () => {
 
             const result = runFromSteps(buildCustomSteps(opts), events);
 
-            // BREAK exits loop. deferredResults has 'fail' entries from DEFER substeps.
-            // Aggregation: PASS ALL with failures → parent fails → STOP → STOPPED.
-            // If BREAK dropped deferred results: empty → vacuous pass → COMPLETE (wrong).
-            expect(result.terminalState).toBe('STOPPED');
+            // BREAK exits loop (non-accumulating). Current iteration's result is NOT added.
+            // iterationResults is empty → PASS ALL: vacuous pass → CONTINUE → COMPLETE.
+            expect(result.terminalState).toBe('COMPLETE');
           },
         ),
         { numRuns: 200 },

--- a/packages/core/__tests__/runbook/for-loop.properties.test.ts
+++ b/packages/core/__tests__/runbook/for-loop.properties.test.ts
@@ -8,7 +8,7 @@
  * 4. PASS ANY + at least one pass → parent passes
  * 5. STOP at substep → STOPPED regardless
  * 6. COMPLETE at substep → COMPLETE regardless
- * 7. BREAK tallies result before exit
+ * 7. BREAK is non-accumulating — does not tally current iteration
  * 8. Iteration monotonicity (no RETRY)
  * 9. Termination with random event sequences (mixed patterns)
  * 10. parentPassAction COMPLETE produces COMPLETE in FOR loop
@@ -240,8 +240,8 @@ describe('FOR loop properties', () => {
     );
   });
 
-  // Property 7: BREAK tallies result before exit (iteration results not empty)
-  it('BREAK on first substep records at least one iteration result', () => {
+  // Property 7: BREAK is non-accumulating — does not tally current iteration
+  it('BREAK does not accumulate current iteration but prior DEFER iterations remain', () => {
     const breakConfig = fc.record({
       iterations: fc.integer({ min: 2, max: 5 }),
       numSubsteps: fc.integer({ min: 1, max: 3 }),
@@ -271,11 +271,11 @@ describe('FOR loop properties', () => {
         for (let i = 0; i < 20; i++) events.push('PASS');
 
         const result = runForLoop(config, events);
-        // After BREAK: iteration 1 result should be in iterationResults
-        // The machine records DEFER'd iterations in iterationResults.
-        // Iteration 1 is DEFER'd, so it should appear.
+        // After BREAK: iteration 1 (DEFER'd) is in iterationResults.
+        // Iteration 2 (BREAK'd) is NOT accumulated — non-accumulating like NEXT.
+        // So iterationResults has exactly 1 entry (from iteration 1's DEFER).
         expect(result.terminalState).toMatch(/^(COMPLETE|STOPPED)$/);
-        expect(result.iterationResults.length).toBeGreaterThanOrEqual(1);
+        expect(result.iterationResults.length).toBe(1);
       }),
       { numRuns: 200 },
     );

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -991,6 +991,7 @@ function buildParentStateConfig(
         lastAction: { type: 'BREAK' as const },
         iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
           context.iterationResults ?? [],
+        deferredResults: [] as ('pass' | 'fail')[],
       }),
     });
 
@@ -1081,6 +1082,7 @@ function buildParentStateConfig(
           lastAction: { type: 'BREAK' as const },
           iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
             context.iterationResults ?? [],
+          deferredResults: [] as ('pass' | 'fail')[],
         }),
       });
     };

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1079,6 +1079,8 @@ function buildParentStateConfig(
         actions: runbookSetup.assign({
           forStack: [] as readonly ForContext[],
           lastAction: { type: 'BREAK' as const },
+          iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
+            context.iterationResults ?? [],
         }),
       });
     };

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -977,8 +977,8 @@ function buildParentStateConfig(
     // 2. BREAK exit: substep BREAK exits the loop (after any configured retry).
     // BREAK is a pure signal — forStack is cleared HERE when the loop actually exits,
     // not in the substep transition. This allows retry to re-run substeps before BREAK takes effect.
-    // The current iteration's DEFER'd results are persisted to iterationResults here
-    // so aggregation reads from a uniform source — every iteration is treated identically.
+    // Non-accumulating (same as NEXT): the current iteration's result is NOT added to
+    // iterationResults. Only prior DEFER'd iterations remain in the aggregate.
     always.push({
       guard: ({ context }: { context: RunbookContext }) => {
         if (context.substep !== undefined) return false;
@@ -989,10 +989,8 @@ function buildParentStateConfig(
       actions: runbookSetup.assign({
         forStack: [] as readonly ForContext[],
         lastAction: { type: 'BREAK' as const },
-        iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] => [
-          ...(context.iterationResults ?? []),
-          computeIterationResult(context),
-        ],
+        iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
+          context.iterationResults ?? [],
       }),
     });
 
@@ -1058,6 +1056,34 @@ function buildParentStateConfig(
     };
     pushIterationContinueExit('pass', forTransitions.pass);
     pushIterationContinueExit('fail', forTransitions.fail);
+
+    // 3c. Iteration-level BREAK: exit loop without accumulation.
+    // Like CONTINUE exit but sets lastAction to BREAK. Non-accumulating (same as NEXT).
+    const pushIterationBreakExit = (
+      kind: 'pass' | 'fail',
+      transition: { retry: number; action: Action },
+    ): void => {
+      if (transition.action.type !== 'BREAK') return;
+
+      always.push({
+        guard: ({ context }: { context: RunbookContext }) => {
+          if (context.substep !== undefined) return false;
+          if (context.forStack.length === 0) return false;
+          if (context.lastAction?.type === 'BREAK' || context.lastAction?.type === 'NEXT')
+            return false;
+          const selected = getIterationTransition(context);
+          if (selected.result !== kind) return false;
+          return transition.retry <= 0 || context.iterationRetryCount >= transition.retry;
+        },
+        target: formatStateId(stepName),
+        actions: runbookSetup.assign({
+          forStack: [] as readonly ForContext[],
+          lastAction: { type: 'BREAK' as const },
+        }),
+      });
+    };
+    pushIterationBreakExit('pass', forTransitions.pass);
+    pushIterationBreakExit('fail', forTransitions.fail);
 
     // 4a. NEXT loop-back: substep NEXT advances to next iteration (no accumulation).
     // Fires when lastAction is NEXT and more iterations remain.

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1052,6 +1052,9 @@ function buildParentStateConfig(
         actions: runbookSetup.assign({
           forStack: [] as readonly ForContext[],
           lastAction: { type: 'CONTINUE' as const },
+          iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
+            context.iterationResults ?? [],
+          deferredResults: [] as ('pass' | 'fail')[],
         }),
       });
     };

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -6,6 +6,7 @@ import {
   isSourced,
   stepHasSubsteps,
   isAccumulatingAction,
+  isBreakAction,
   isTerminalAction,
   isStepExitAction,
 } from '@rundown-org/parser';
@@ -1067,7 +1068,7 @@ function buildParentStateConfig(
       kind: 'pass' | 'fail',
       transition: { retry: number; action: Action },
     ): void => {
-      if (transition.action.type !== 'BREAK') return;
+      if (!isBreakAction(transition.action)) return;
 
       always.push({
         guard: ({ context }: { context: RunbookContext }) => {

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -55,6 +55,9 @@ export type { StepExitAction } from '@rundown-org/parser';
 /** Terminal action that bypasses aggregation (STOP, COMPLETE, or GOTO). */
 export type { TerminalAction } from '@rundown-org/parser';
 
+/** FOR loop BREAK action — exits the loop without accumulation. */
+export type { BreakAction } from '@rundown-org/parser';
+
 /**
  * Step transition configuration for pass/fail outcomes.
  *

--- a/packages/parser/fixtures/conformance/valid
+++ b/packages/parser/fixtures/conformance/valid
@@ -1,1 +1,1 @@
-../../../../runbooks/patterns
+../../../../runbooks

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -7,6 +7,7 @@ import {
 import type {
   Action,
   AccumulatingAction,
+  BreakAction,
   LoopControlAction,
   StepExitAction,
   TerminalAction,
@@ -59,6 +60,16 @@ export function isStepExitAction(action: Action): action is StepExitAction {
  */
 export function isTerminalAction(action: Action): action is TerminalAction {
   return action.type === 'STOP' || action.type === 'COMPLETE' || action.type === 'GOTO';
+}
+
+/**
+ * Check if an action is a BREAK action (exits FOR loop without accumulation).
+ *
+ * @param action - The action to check
+ * @returns True if the action is a BreakAction
+ */
+export function isBreakAction(action: Action): action is BreakAction {
+  return action.type === 'BREAK';
 }
 
 /**

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -27,6 +27,7 @@ export {
   validateNEXTUsage,
   validateDEFERUsage,
   isAccumulatingAction,
+  isBreakAction,
   isLoopControlAction,
   isStepExitAction,
   isTerminalAction,

--- a/packages/parser/src/schemas.ts
+++ b/packages/parser/src/schemas.ts
@@ -131,7 +131,7 @@ const CompleteActionSchema = z.object({
 const StopActionSchema = z.object({ type: z.literal('STOP'), message: z.string().optional() });
 const GotoActionSchema = z.object({ type: z.literal('GOTO'), target: StepIdSchema });
 const NextActionSchema = z.object({ type: z.literal('NEXT') });
-const BreakActionSchema = z.object({ type: z.literal('BREAK') });
+export const BreakActionSchema = z.object({ type: z.literal('BREAK') });
 
 /**
  * Schema for actions that accumulate iteration results into parent aggregation.
@@ -187,6 +187,9 @@ export type StepExitAction = Readonly<z.output<typeof StepExitActionSchema>>;
 
 /** Terminal action that bypasses aggregation (STOP, COMPLETE, or GOTO). */
 export type TerminalAction = Readonly<z.output<typeof TerminalActionSchema>>;
+
+/** FOR loop BREAK action — exits the loop without accumulation. */
+export type BreakAction = Readonly<z.output<typeof BreakActionSchema>>;
 
 /** Union of all action types. */
 export type Action = Readonly<z.output<typeof ActionSchema>>;

--- a/runbooks/for-loops/for-break-no-retry.runbook.md
+++ b/runbooks/for-loops/for-break-no-retry.runbook.md
@@ -1,6 +1,6 @@
 ---
 name: for-break-no-retry
-description: Substep BREAK with no retry configured — BREAK exits immediately
+description: Substep BREAK with no retry configured — BREAK exits immediately (non-accumulating)
 scenarios:
   break-immediate:
     commands:
@@ -8,12 +8,14 @@ scenarios:
       # Iter 1: sub1 FAIL (DEFER feeds 'fail'), sub2 FAIL (BREAK exits loop)
       - rd fail
       - rd fail
-    result: STOP
+      # BREAK is non-accumulating → iterationResults=[] → vacuous pass → CONTINUE → step 2
+      - rd pass
+    result: COMPLETE
 ---
 # BREAK Without Retry
 
 BREAK exits the loop immediately when no iteration-level retry is configured.
-Current iteration's DEFER'd results are included in parent aggregation.
+BREAK is non-accumulating — the current iteration's result is not added to parent aggregation.
 
 ## 1. Process items
 - FOR i IN 1 TO 3

--- a/runbooks/for-loops/for-break-retry.runbook.md
+++ b/runbooks/for-loops/for-break-retry.runbook.md
@@ -1,6 +1,6 @@
 ---
 name: for-break-retry
-description: Substep BREAK + iteration RETRY — retry fires, then BREAK exits
+description: Substep BREAK + iteration RETRY — retry fires, then BREAK exits (non-accumulating)
 scenarios:
   break-after-retry:
     commands:
@@ -11,7 +11,9 @@ scenarios:
       # Attempt 2 (retry): sub1 FAIL, sub2 FAIL (BREAK) → retries exhausted, BREAK exits
       - rd fail
       - rd fail
-    result: STOP
+      # BREAK is non-accumulating → iterationResults=[] → vacuous pass → CONTINUE → step 2
+      - rd pass
+    result: COMPLETE
 ---
 # BREAK + Iteration RETRY
 

--- a/runbooks/for-loops/for-iter-pass-break.runbook.md
+++ b/runbooks/for-loops/for-iter-pass-break.runbook.md
@@ -1,11 +1,11 @@
 ---
 name: for-iter-pass-break
-description: Iteration-level PASS BREAK exits loop after recording iteration result.
+description: Iteration-level PASS BREAK exits loop (non-accumulating).
 tags:
   - for-loops
 scenarios:
   break-fires:
-    description: Pass triggers BREAK — iteration result recorded, parent sees pass → CONTINUE
+    description: Pass triggers BREAK — non-accumulating, parent sees vacuous pass → CONTINUE
     commands:
       - rd run --prompted for-iter-pass-break.runbook.md
       - rd pass

--- a/runbooks/for-loops/for-substep-break-respects-retry.runbook.md
+++ b/runbooks/for-loops/for-substep-break-respects-retry.runbook.md
@@ -1,6 +1,6 @@
 ---
 name: for-substep-break-respects-retry
-description: Substep BREAK respects iteration-level retry before exiting
+description: Substep BREAK respects iteration-level retry before exiting (non-accumulating)
 scenarios:
   break-respects-retry:
     commands:
@@ -14,7 +14,9 @@ scenarios:
       # Attempt 3 (retry 2): retries exhausted → BREAK exits loop
       - rd fail
       - rd fail
-    result: STOP
+      # BREAK is non-accumulating → iterationResults=[] → vacuous pass → CONTINUE → step 2
+      - rd pass
+    result: COMPLETE
 ---
 # Substep BREAK Respects Iteration Retry
 

--- a/runbooks/scenario-suite.yaml
+++ b/runbooks/scenario-suite.yaml
@@ -161,13 +161,15 @@ cases:
     result: COMPLETE
 
   for-substep-break-respects-retry:
-    description: Substep BREAK respects iteration-level retry
+    description: Substep BREAK respects iteration-level retry (non-accumulating)
     file: for-loops/for-substep-break-respects-retry.runbook.md
     commands:
       - rd run --prompted for-substep-break-respects-retry.runbook.md
       - rd fail
       - rd fail
-    result: STOP
+      # BREAK is non-accumulating → iterationResults=[] → vacuous pass → step 2
+      - rd pass
+    result: COMPLETE
 
   for-iteration-retry-after-retry:
     description: Each iteration fails once then passes on retry via iteration-level RETRY


### PR DESCRIPTION
BREAK no longer records the current iteration result to iterationResults, matching NEXT semantics. Previously BREAK accumulated via computeIterationResult, which was inconsistent with the spec's intent that BREAK exits the loop without contributing to aggregation.

Changes:
- Guard 2 (substep-level BREAK) preserves existing iterationResults instead of appending computeIterationResult
- New pushIterationBreakExit guard handles iteration-level BREAK explicitly (previously fell through to XState compound state re-entry)
- Updated compiler tests, property tests, design invariant tests, integration tests, scenario runbooks, and documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * BREAK now exits loops without recording the current iteration result (non-accumulating — same as NEXT); parent aggregation includes only prior results.

* **Documentation**
  * Switched notation to space-separated forms (e.g., PASS CONTINUE); clarified DEFER shorthand expansion and updated runbook examples, tables, and notes to reflect non-accumulating BREAK semantics and resulting outcome changes.

* **Tests**
  * Updated expectations and snapshots across core and CLI tests to match non-accumulating BREAK behavior.

* **Chores**
  * Adjusted a parser fixture path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->