### PR TITLE
Fix delegated RunId inheritance and JSON failure handling

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,8 @@
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Skill(cipherpowers:verify)",
-      "Bash(git checkout:*)"
+      "Bash(git checkout:*)",
+      "Bash(git worktree:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,9 @@
       "Bash(git commit:*)",
       "Skill(cipherpowers:verify)",
       "Bash(git checkout:*)",
-      "Bash(git worktree:*)"
+      "Bash(git worktree add:*)",
+      "Bash(git worktree list:*)",
+      "Bash(git worktree remove:*)"
     ]
   }
 }

--- a/packages/cli/__tests__/commands/claim.test.ts
+++ b/packages/cli/__tests__/commands/claim.test.ts
@@ -249,6 +249,38 @@ Execute with {{Env}} environment.
       );
       expect(result.exitCode).toBe(0);
     });
+
+    it('preserves ContextId but generates a fresh RunId for claimed child runs', async () => {
+      await writeParentRunbook();
+      await writeChildRunbook();
+
+      let result = await runCliInProcess(
+        'run --prompted parent.runbook.md --var ContextId=ctx-parent',
+        workspace,
+      );
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      expect(parentState).not.toBeNull();
+      const parentTemplateVars = (parentState?.templateVars ?? {}) as Record<string, unknown>;
+
+      result = await runCliInProcess('delegate child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+      const token = extractToken(result.stdout);
+
+      result = await runCliInProcess(`claim ${token}`, workspace);
+      expect(result.exitCode).toBe(0);
+
+      const childState = await getActiveState(workspace);
+      expect(childState).not.toBeNull();
+      const childTemplateVars = (childState?.templateVars ?? {}) as Record<string, unknown>;
+
+      expect(parentTemplateVars.ContextId).toBe('ctx-parent');
+      expect(childTemplateVars.ContextId).toBe('ctx-parent');
+      expect(typeof parentTemplateVars.RunId).toBe('string');
+      expect(typeof childTemplateVars.RunId).toBe('string');
+      expect(childTemplateVars.RunId).not.toBe(parentTemplateVars.RunId);
+    });
   });
 
   describe('auto-propagation on claim', () => {

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -9,7 +9,7 @@ import {
   findActionOutput,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
-import { ActionResponseSchema } from '../helpers/schema-validator.js';
+import { ActionResponseSchema, ErrorResponseSchema } from '../helpers/schema-validator.js';
 
 describe('fail command', () => {
   let workspace: TestWorkspace;
@@ -131,14 +131,13 @@ Do work.
       // Parse JSON output
       const output = JSON.parse(result.stdout);
 
-      // The output must include 'action' field per ActionResponseSchema
-      // Currently this test FAILS because output.error() does not set action
-      expect(output).toHaveProperty('action');
-      expect(output.action).toBe('fail');
+      // No-active-runbook path emits an error response with kind: 'error'
+      expect(output).toHaveProperty('kind', 'error');
+      expect(output).toHaveProperty('action', 'fail');
       expect(output.code).toBe('NO_ACTIVE_RUNBOOK');
 
-      // Validate against schema
-      const parseResult = ActionResponseSchema.safeParse(output);
+      // Validate against ErrorResponseSchema (not ActionResponseSchema)
+      const parseResult = ErrorResponseSchema.safeParse(output);
       expect(parseResult.success).toBe(true);
     });
   });

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -133,7 +133,7 @@ Do work.
 
       // No-active-runbook path emits an error response with kind: 'error'
       expect(output).toHaveProperty('kind', 'error');
-      expect(output).toHaveProperty('action', 'fail');
+      expect(output).toHaveProperty('command', 'fail');
       expect(output.code).toBe('NO_ACTIVE_RUNBOOK');
 
       // Validate against ErrorResponseSchema (not ActionResponseSchema)

--- a/packages/cli/__tests__/commands/json-output.test.ts
+++ b/packages/cli/__tests__/commands/json-output.test.ts
@@ -85,6 +85,7 @@ echo hello
       const output = JSON.parse(result.stdout);
 
       expect(output).toEqual({
+        kind: 'status',
         active: false,
         stashed: false,
       });
@@ -254,6 +255,7 @@ echo hello
 
       // Uses standard error format from output.error()
       expect(output).toEqual({
+        kind: 'error',
         error: 'Scenario "non-existent" not found',
         code: 'SCENARIO_NOT_FOUND',
         details: { available: ['test-scenario'] },

--- a/packages/cli/__tests__/commands/resolve.test.ts
+++ b/packages/cli/__tests__/commands/resolve.test.ts
@@ -370,8 +370,8 @@ Say {{ greeting }} to {{ recipient }}.
     expect(unresolvedWarnings).toHaveLength(0);
   });
 
-  it('includes type discriminator in JSON output', async () => {
-    const runbookPath = path.join(workspace.cwd, 'type-field.runbook.md');
+  it('includes kind discriminant in JSON output', async () => {
+    const runbookPath = path.join(workspace.cwd, 'kind-field.runbook.md');
     fs.writeFileSync(
       runbookPath,
       `## Step 1
@@ -382,7 +382,7 @@ echo hello
     const result = await runCliInProcess(`resolve ${runbookPath} --json`, workspace);
     const output = JSON.parse(result.stdout);
 
-    expect(output.type).toBe('resolve');
+    expect(output.kind).toBe('resolve');
   });
 
   it('surfaces variable-discovery warnings in JSON output', async () => {

--- a/packages/cli/__tests__/commands/scenario-suite.test.ts
+++ b/packages/cli/__tests__/commands/scenario-suite.test.ts
@@ -252,7 +252,7 @@ cases:
       const parsed = JSON.parse(result.stdout.trim().split(/\n(?=\{)/)[0]);
       expect(parsed.passed).toBe(2);
       expect(parsed.failed).toBe(1);
-      const failedCase = parsed.cases.find((c: { passed: boolean }) => !c.passed);
+      const failedCase = parsed.cases.find((c: { result: boolean }) => !c.result);
       expect(failedCase.scenario).toBe('wrong-expectation');
       expect(failedCase.expected).toBe('COMPLETE');
       expect(failedCase.actual).toBe('STOP');
@@ -340,7 +340,7 @@ cases:
       const parsed = JSON.parse(result.stdout.trim().split(/\n(?=\{)/)[0]);
       expect(parsed.failed).toBe(1);
       const failedCase = parsed.cases[0];
-      expect(failedCase.passed).toBe(false);
+      expect(failedCase.result).toBe(false);
       expect(failedCase.actual).toContain('ERROR:');
       expect(failedCase.actual).toContain('CHILD_RUNBOOK_NOT_FOUND');
     }, 30000);

--- a/packages/cli/__tests__/commands/schema-validation.test.ts
+++ b/packages/cli/__tests__/commands/schema-validation.test.ts
@@ -48,13 +48,27 @@ describe('CLI JSON Output Schema Validation', () => {
     try {
       return JSON.parse(stdout);
     } catch {
-      // Try JSONL format - split on newlines that start a new JSON object and parse first valid block
+      // Try JSONL format - split on newlines that start a new JSON object
       const jsonBlocks = stdout.trim().split(/\n(?=\{)/);
+      // Prefer first block with 'kind' (accumulated CLI response discriminant).
+      // Streaming events use 'type', not 'kind', so the first 'kind' block is
+      // the real CLI response — any later 'kind' block may be a process.exit artifact.
       for (const block of jsonBlocks) {
         try {
-          return JSON.parse(block);
+          const parsed = JSON.parse(block);
+          if (typeof parsed === 'object' && parsed !== null && 'kind' in parsed) {
+            return parsed;
+          }
         } catch {}
       }
+      // Fallback: last parseable block
+      let lastParsed: unknown = undefined;
+      for (const block of jsonBlocks) {
+        try {
+          lastParsed = JSON.parse(block);
+        } catch {}
+      }
+      if (lastParsed !== undefined) return lastParsed;
       // Fallback: try to find any JSON object in the output
       const jsonMatch = stdout.match(/\{[\s\S]*?\n\}|\[[\s\S]*?\n\]/g);
       if (jsonMatch && jsonMatch.length > 0) {
@@ -283,10 +297,10 @@ echo hello
         `---
 name: test-runbook
 ---
-## Step 1
+## 1 First Step
 prompt: First step
 
-## Step 2
+## 2 Second Step
 echo done
 `,
       );
@@ -322,10 +336,10 @@ echo done
         `---
 name: test-runbook
 ---
-## Step 1
+## 1 First Step
 prompt: First step
 
-## Step 2
+## 2 Second Step
 echo done
 `,
       );

--- a/packages/cli/__tests__/commands/stash-pop.test.ts
+++ b/packages/cli/__tests__/commands/stash-pop.test.ts
@@ -78,6 +78,7 @@ describe('stash command', () => {
 
     expect(result.exitCode).toBe(1);
     expect(JSON.parse(result.stdout)).toEqual({
+      kind: 'error',
       error: 'A runbook is already stashed. Pop it first.',
       code: 'ALREADY_STASHED',
     });

--- a/packages/cli/__tests__/commands/stash-pop.test.ts
+++ b/packages/cli/__tests__/commands/stash-pop.test.ts
@@ -68,6 +68,20 @@ describe('stash command', () => {
     expect(afterState?.step).toBe(beforeState?.step);
     expect(afterState?.runbook).toBe(beforeState?.runbook);
   });
+
+  it('returns non-zero when another runbook is already stashed', async () => {
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md', workspace);
+    await runCliInProcess('stash', workspace);
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md', workspace);
+
+    const result = await runCliInProcess('stash --json', workspace);
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toEqual({
+      error: 'A runbook is already stashed. Pop it first.',
+      code: 'ALREADY_STASHED',
+    });
+  });
 });
 
 describe('pop command', () => {
@@ -116,6 +130,7 @@ describe('pop command', () => {
   it('fails if nothing stashed', async () => {
     const result = await runCliInProcess('pop', workspace);
 
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('No stashed runbook');
   });
 
@@ -165,6 +180,7 @@ rd echo "hello"
     const result = await runCliInProcess('pop', workspace);
 
     // Text mode should NOT be silent - should show error message on stderr
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('not found');
   });
 });

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -820,6 +820,97 @@ describe('claimAndLaunch', () => {
     );
   });
 
+  it('preserves ContextId but does not inherit parent RunId into child vars', async () => {
+    const tokenHash = 'sha256:mock';
+    const delegation = {
+      tokenHash,
+      childRunbookPath: 'child.md',
+      contextSnapshot: {
+        vars: {
+          RunId: 'parentrun',
+          ContextId: 'ctx-parent',
+          Region: 'us-west',
+          'context.vars.Region': 'us-west',
+        },
+        ancestors: [],
+      },
+      childRunId: null,
+      createdAt: new Date().toISOString(),
+      cancelledAt: null,
+    };
+
+    const parentState = makeState('parent-id', {
+      substepStates: [
+        {
+          id: '1',
+          status: 'pending',
+          delegation,
+        },
+      ],
+    });
+
+    const mockScanner = {
+      findByToken: jest
+        .fn<any>()
+        .mockResolvedValue({ parentState, stepId: '1', substepId: '1', delegation }),
+      findOrphanedChild: jest.fn<any>().mockResolvedValue(null),
+    };
+    (core.DelegationScanService as jest.Mock).mockImplementation(() => mockScanner);
+
+    resolveRunbookFile.mockResolvedValue('/test/child.md');
+    (
+      core.parseRunbookDocument as jest.MockedFunction<typeof core.parseRunbookDocument>
+    ).mockReturnValue({ steps: [makeStep()] } as any);
+    (resolveVariables as jest.Mock).mockResolvedValue({
+      vars: { RunId: 'childrun', ContextId: 'ctx-parent', Region: 'us-west' },
+      sources: {},
+    });
+
+    const mockManager = {
+      load: jest.fn<any>().mockResolvedValue(parentState),
+      create: jest.fn<any>().mockResolvedValue({
+        id: 'new-child-id',
+        title: 'Child',
+      }),
+      update: jest.fn<any>().mockResolvedValue(undefined),
+      initializeSubsteps: jest.fn<any>().mockResolvedValue(undefined),
+    };
+    (core.RunbookStateManager as jest.Mock).mockImplementation(() => mockManager);
+
+    (core.DelegationLock as jest.Mock).mockImplementation(() => ({
+      acquire: jest.fn<any>().mockResolvedValue(undefined),
+      release: jest.fn<any>().mockResolvedValue(undefined),
+    }));
+
+    runExecutionLoop.mockResolvedValue('waiting');
+
+    const ctx = {
+      output: { status: jest.fn(), flush: jest.fn() } as any,
+      manager: mockManager,
+      actorService: { initializeState: jest.fn<any>().mockResolvedValue(undefined) } as any,
+      sessionService: { pushRunbook: jest.fn<any>().mockResolvedValue(undefined) } as any,
+      lifecycleService: makeLifecycle(),
+      cwd: '/test',
+    };
+
+    const { claimAndLaunch } = await import('../../src/helpers/runbook-pipeline');
+    // cspell:disable-next-line
+    const result = await claimAndLaunch(ctx as any, 'rdtk_AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH', {});
+
+    expect(result.ok).toBe(true);
+    const resolveCall = (resolveVariables as jest.Mock).mock.calls.at(-1);
+    expect(resolveCall).toBeDefined();
+    expect(resolveCall?.[0]).toEqual(
+      expect.objectContaining({
+        inheritedVars: {
+          ContextId: 'ctx-parent',
+          Region: 'us-west',
+        },
+      }),
+    );
+    expect(resolveCall?.[0].inheritedVars).not.toHaveProperty('RunId');
+  });
+
   it('returns error when child runbook file not found', async () => {
     const tokenHash = 'sha256:mock';
     const delegation = {

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -827,7 +827,7 @@ describe('claimAndLaunch', () => {
       childRunbookPath: 'child.md',
       contextSnapshot: {
         vars: {
-          RunId: 'parentrun',
+          RunId: 'parent-run',
           ContextId: 'ctx-parent',
           Region: 'us-west',
           'context.vars.Region': 'us-west',
@@ -862,7 +862,7 @@ describe('claimAndLaunch', () => {
       core.parseRunbookDocument as jest.MockedFunction<typeof core.parseRunbookDocument>
     ).mockReturnValue({ steps: [makeStep()] } as any);
     (resolveVariables as jest.Mock).mockResolvedValue({
-      vars: { RunId: 'childrun', ContextId: 'ctx-parent', Region: 'us-west' },
+      vars: { RunId: 'child-run', ContextId: 'ctx-parent', Region: 'us-west' },
       sources: {},
     });
 

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { mockErrorHelpers } from './mock-error-helpers';
+import { mockErrorHelpers } from './mock-error-helpers.js';
 
 // Mock @rundown-org/core
 jest.unstable_mockModule('@rundown-org/core', () => ({

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -864,6 +864,7 @@ describe('claimAndLaunch', () => {
     (resolveVariables as jest.Mock).mockResolvedValue({
       vars: { RunId: 'child-run', ContextId: 'ctx-parent', Region: 'us-west' },
       sources: {},
+      warnings: [],
     });
 
     const mockManager = {

--- a/packages/cli/__tests__/schemas/status-response.test.ts
+++ b/packages/cli/__tests__/schemas/status-response.test.ts
@@ -85,4 +85,17 @@ describe('StatusResponseSchema', () => {
       expect(parseResult.success).toBe(true);
     });
   });
+
+  describe('required fields', () => {
+    it('rejects response without kind field', () => {
+      const statusResponse = {
+        active: false,
+        stashed: false,
+      };
+
+      const parseResult = StatusResponseSchema.safeParse(statusResponse);
+
+      expect(parseResult.success).toBe(false);
+    });
+  });
 });

--- a/packages/cli/__tests__/schemas/status-response.test.ts
+++ b/packages/cli/__tests__/schemas/status-response.test.ts
@@ -16,6 +16,7 @@ describe('StatusResponseSchema', () => {
       // ActionBlockData.result in packages/core/src/cli/types.ts is 'PASS' | 'FAIL'.
       // The schema must accept enum string values for lastAction.result.
       const statusResponse = {
+        kind: 'status',
         active: true,
         stashed: false,
         file: 'test.runbook.md',
@@ -40,6 +41,7 @@ describe('StatusResponseSchema', () => {
 
     it('accepts FAIL result for failed actions', () => {
       const statusResponse = {
+        kind: 'status',
         active: true,
         stashed: false,
         lastAction: {
@@ -55,6 +57,7 @@ describe('StatusResponseSchema', () => {
 
     it('accepts lastAction without result (optional field)', () => {
       const statusResponse = {
+        kind: 'status',
         active: true,
         stashed: false,
         lastAction: {
@@ -72,6 +75,7 @@ describe('StatusResponseSchema', () => {
   describe('minimal valid response', () => {
     it('accepts response with only required fields', () => {
       const statusResponse = {
+        kind: 'status',
         active: false,
         stashed: false,
       };

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -233,6 +233,7 @@ export function registerAbortCommand(program: Command): void {
             if (abortResult.status === 'already_cancelled') {
               if (options.json) {
                 output.json({
+                  kind: 'abort',
                   action: 'abort',
                   status: 'already_cancelled',
                   token: hint,
@@ -304,6 +305,7 @@ export function registerAbortCommand(program: Command): void {
           // 12. Output result
           if (options.json) {
             output.json({
+              kind: 'abort',
               action: 'abort',
               status: 'cancelled',
               token: hint,

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -20,7 +20,7 @@ export function registerCheckCommand(program: Command): void {
       if (!result.ok) {
         output.detail(
           {
-            type: 'check' as const,
+            kind: 'check' as const,
             valid: false,
             errors: [{ message: result.error }],
           },
@@ -37,7 +37,7 @@ export function registerCheckCommand(program: Command): void {
       if (errors.length > 0) {
         output.detail(
           {
-            type: 'check' as const,
+            kind: 'check' as const,
             valid: false,
             errors: errors.map((e) => ({ line: e.line, message: e.message })),
             warnings: warnings.map((w) => ({ line: w.line, message: w.message })),
@@ -50,7 +50,7 @@ export function registerCheckCommand(program: Command): void {
 
       output.detail(
         {
-          type: 'check' as const,
+          kind: 'check' as const,
           valid: true,
           errors: [],
           warnings: warnings.map((w) => ({ line: w.line, message: w.message })),

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -142,6 +142,7 @@ export function registerDelegateCommand(program: Command): void {
             // Output
             if (options.json) {
               output.json({
+                kind: 'delegate',
                 action: 'delegated',
                 step: resolvedStepId,
                 runbook: resolvedRunbook,

--- a/packages/cli/src/commands/pop.ts
+++ b/packages/cli/src/commands/pop.ts
@@ -36,6 +36,7 @@ export function registerPopCommand(program: Command): void {
           if (!state) {
             output.error('No stashed runbook to restore', 'NO_STASHED_RUNBOOK');
             output.flush();
+            process.exitCode = 1;
             return;
           }
 
@@ -70,6 +71,7 @@ export function registerPopCommand(program: Command): void {
               restoredId: state.id,
             });
             output.flush();
+            process.exitCode = 1;
             return;
           }
 

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -87,7 +87,7 @@ export function registerResolveCommand(program: Command): void {
       if (!loadResult.ok) {
         output.detail(
           {
-            type: 'resolve' as const,
+            kind: 'resolve' as const,
             valid: false,
             errors: [{ message: loadResult.error }],
           },
@@ -195,7 +195,7 @@ export function registerResolveCommand(program: Command): void {
 
       output.detail(
         {
-          type: 'resolve' as const,
+          kind: 'resolve' as const,
           valid: !hasErrors,
           errors,
           warnings: warnings.length > 0 ? warnings : undefined,

--- a/packages/cli/src/commands/scenario-suite.ts
+++ b/packages/cli/src/commands/scenario-suite.ts
@@ -355,7 +355,16 @@ export function registerScenarioSuiteCommand(program: Command): void {
                 total: caseResults.length,
                 passed: passedCount,
                 failed: failedCount,
-                cases: caseResults,
+                cases: caseResults.map((cr) => ({
+                  kind: cr.kind,
+                  result: cr.passed,
+                  scenario: cr.scenario,
+                  expected: cr.expected,
+                  actual: cr.actual,
+                  ...('stepAssertions' in cr && cr.stepAssertions
+                    ? { stepAssertions: cr.stepAssertions }
+                    : {}),
+                })),
               },
               'custom',
             );

--- a/packages/cli/src/commands/scenario-suite.ts
+++ b/packages/cli/src/commands/scenario-suite.ts
@@ -334,16 +334,12 @@ export function registerScenarioSuiteCommand(program: Command): void {
                   failedCount++;
                 }
               } catch (err: unknown) {
-                const msg =
-                  typeof err === 'object' && err !== null && 'message' in err
-                    ? String((err as { message: unknown }).message)
-                    : String(err);
                 caseResults.push({
                   kind: 'scenario_run',
                   passed: false,
                   scenario: name,
                   expected: getEffectiveResult(c),
-                  actual: `ERROR: ${msg}`,
+                  actual: `ERROR: ${getErrorMessage(err)}`,
                 });
                 failedCount++;
               }
@@ -397,16 +393,12 @@ export function registerScenarioSuiteCommand(program: Command): void {
             try {
               caseResult = await executeSuiteCase(caseName, c, suiteDir, runQuiet, output);
             } catch (err: unknown) {
-              const msg =
-                typeof err === 'object' && err !== null && 'message' in err
-                  ? String((err as { message: unknown }).message)
-                  : String(err);
               caseResult = {
                 kind: 'scenario_run',
                 passed: false,
                 scenario: caseName,
                 expected: getEffectiveResult(c),
-                actual: `ERROR: ${msg}`,
+                actual: `ERROR: ${getErrorMessage(err)}`,
               };
             }
 

--- a/packages/cli/src/commands/scenario-suite.ts
+++ b/packages/cli/src/commands/scenario-suite.ts
@@ -67,6 +67,7 @@ async function executeSuiteCase(
   quiet: boolean,
   output: OutputEmitter,
 ): Promise<{
+  kind: 'scenario_run';
   passed: boolean;
   scenario: string;
   expected: string;
@@ -92,6 +93,7 @@ async function executeSuiteCase(
     } catch (err: unknown) {
       if (isNodeError(err) && err.code === 'ENOENT') {
         return {
+          kind: 'scenario_run',
           passed: false,
           scenario: caseName,
           expected: effectiveResult,
@@ -175,6 +177,7 @@ async function executeSuiteCase(
     const assertionsPassed = stepAssertions ? stepAssertions.every((a) => a.matched) : true;
 
     return {
+      kind: 'scenario_run',
       passed: resultPassed && assertionsPassed,
       scenario: caseName,
       expected: effectiveResult,
@@ -336,6 +339,7 @@ export function registerScenarioSuiteCommand(program: Command): void {
                     ? String((err as { message: unknown }).message)
                     : String(err);
                 caseResults.push({
+                  kind: 'scenario_run',
                   passed: false,
                   scenario: name,
                   expected: getEffectiveResult(c),
@@ -349,6 +353,7 @@ export function registerScenarioSuiteCommand(program: Command): void {
 
             output.detail(
               {
+                kind: 'scenario_suite_run',
                 result: allPassed,
                 suite: result.suite.name,
                 total: caseResults.length,
@@ -397,6 +402,7 @@ export function registerScenarioSuiteCommand(program: Command): void {
                   ? String((err as { message: unknown }).message)
                   : String(err);
               caseResult = {
+                kind: 'scenario_run',
                 passed: false,
                 scenario: caseName,
                 expected: getEffectiveResult(c),
@@ -405,6 +411,7 @@ export function registerScenarioSuiteCommand(program: Command): void {
             }
 
             const detailData: Record<string, unknown> = {
+              kind: 'scenario_run',
               result: caseResult.passed,
               scenario: caseResult.scenario,
               expected: caseResult.expected,

--- a/packages/cli/src/commands/stash.ts
+++ b/packages/cli/src/commands/stash.ts
@@ -38,6 +38,7 @@ export function registerStashCommand(program: Command): void {
           if (!stashedId) {
             output.error('A runbook is already stashed. Pop it first.', 'ALREADY_STASHED');
             output.flush();
+            process.exitCode = 1;
             return;
           }
 

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -641,7 +641,7 @@ export async function claimAndLaunch(
     // Extract parent user-level vars for top-level inheritance in child
     const inheritedUserVars: Record<string, string> = {};
     for (const [key, value] of Object.entries(freshDelegation.contextSnapshot.vars)) {
-      if (!key.startsWith('context.')) {
+      if (!key.startsWith('context.') && key !== 'RunId') {
         inheritedUserVars[key] = value;
       }
     }

--- a/packages/cli/src/schemas/output-schemas.ts
+++ b/packages/cli/src/schemas/output-schemas.ts
@@ -76,7 +76,7 @@ export {
  */
 export const PromptResponseSchema = z
   .object({
-    /** Response kind discriminant */
+    /** Response type discriminant */
     kind: z.literal('prompt').describe('Response type discriminant'),
     output: z.string().describe('Prompt output text'),
   })

--- a/packages/cli/src/schemas/output-schemas.ts
+++ b/packages/cli/src/schemas/output-schemas.ts
@@ -76,6 +76,8 @@ export {
  */
 export const PromptResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('prompt').describe('Response type discriminant'),
     output: z.string().describe('Prompt output text'),
   })
   .describe('Response from the prompt command');

--- a/packages/cli/src/services/output-emitter.ts
+++ b/packages/cli/src/services/output-emitter.ts
@@ -306,13 +306,13 @@ export class OutputEmitter {
   /**
    * Emit "no active runbook" message.
    *
-   * @param action - Optional action/command that triggered this (for JSON output)
+   * @param command - Optional CLI command that triggered this (for JSON output)
    * @param code - Optional error code (defaults to 'NO_ACTIVE_RUNBOOK')
    */
-  noActiveRunbook(action?: string, code = 'NO_ACTIVE_RUNBOOK'): void {
+  noActiveRunbook(command?: string, code = 'NO_ACTIVE_RUNBOOK'): void {
     const event: NoActiveRunbookOutput = {
       type: 'no_active_runbook',
-      action,
+      command,
       code,
     };
     this.renderer.render(event);

--- a/packages/cli/src/services/renderers/json-renderer.ts
+++ b/packages/cli/src/services/renderers/json-renderer.ts
@@ -243,6 +243,7 @@ export class JSONRenderer implements OutputRenderer {
   private static readonly FORMAT_TO_KIND: Record<string, string> = {
     status: 'status',
     check: 'check',
+    resolve: 'resolve',
     echo: 'echo',
     prompt: 'prompt',
     scenario_result: 'scenario_run',
@@ -257,7 +258,7 @@ export class JSONRenderer implements OutputRenderer {
    * @param event - The detail output event
    */
   private deriveKindFromDetail(event: OutputEvent & { type: 'detail' }): void {
-    const kind = JSONRenderer.FORMAT_TO_KIND[event.format ?? ''];
+    const kind = JSONRenderer.FORMAT_TO_KIND[event.format];
     if (kind) {
       this.output.kind = kind;
     }

--- a/packages/cli/src/services/renderers/json-renderer.ts
+++ b/packages/cli/src/services/renderers/json-renderer.ts
@@ -176,8 +176,8 @@ export class JSONRenderer implements OutputRenderer {
       case 'no_active_runbook':
         this.output.error = 'No active runbook';
         this.output.kind = 'error';
-        if (event.action) {
-          this.output.action = event.action;
+        if (event.command) {
+          this.output.command = event.command;
         }
         if (event.code) {
           this.output.code = event.code;

--- a/packages/cli/src/services/renderers/json-renderer.ts
+++ b/packages/cli/src/services/renderers/json-renderer.ts
@@ -239,16 +239,6 @@ export class JSONRenderer implements OutputRenderer {
     Object.assign(this.output, event.data);
   }
 
-  /** Format-to-kind mapping for detail events. */
-  private static readonly FORMAT_TO_KIND: Record<string, string> = {
-    status: 'status',
-    check: 'check',
-    resolve: 'resolve',
-    echo: 'echo',
-    prompt: 'prompt',
-    scenario_result: 'scenario_run',
-  };
-
   /**
    * Derive response kind from a detail event's format.
    *
@@ -258,11 +248,36 @@ export class JSONRenderer implements OutputRenderer {
    * @param event - The detail output event
    */
   private deriveKindFromDetail(event: OutputEvent & { type: 'detail' }): void {
-    const kind = JSONRenderer.FORMAT_TO_KIND[event.format];
-    if (kind) {
-      this.output.kind = kind;
+    switch (event.format) {
+      case 'status':
+        this.output.kind = 'status';
+        return;
+      case 'check':
+        this.output.kind = 'check';
+        return;
+      case 'resolve':
+        this.output.kind = 'resolve';
+        return;
+      case 'echo':
+        this.output.kind = 'echo';
+        return;
+      case 'prompt':
+        this.output.kind = 'prompt';
+        return;
+      case 'scenario_result':
+        this.output.kind = 'scenario_run';
+        return;
+      case 'metadata':
+      case 'step':
+      case 'scenario':
+      case 'custom':
+        // kind set in data or by caller
+        return;
+      default: {
+        const _exhaustive: never = event.format;
+        void _exhaustive;
+      }
     }
-    // 'custom' and 'scenario' formats: kind must be in data or set by caller
   }
 
   /**

--- a/packages/cli/src/services/renderers/json-renderer.ts
+++ b/packages/cli/src/services/renderers/json-renderer.ts
@@ -96,6 +96,8 @@ export class JSONRenderer implements OutputRenderer {
         break;
       case 'detail':
         this.renderDetail(event);
+        // Derive kind from detail format
+        this.deriveKindFromDetail(event);
         break;
       case 'metadata':
         this.output.file = event.metadata.file;
@@ -112,9 +114,18 @@ export class JSONRenderer implements OutputRenderer {
         if (event.data) {
           Object.assign(this.output, event.data);
         }
+        // Derive kind from status action
+        if (event.action === 'stash') {
+          this.output.kind = 'stash';
+        } else if (event.action === 'pop') {
+          this.output.kind = 'pop';
+        } else {
+          this.output.kind = 'action';
+        }
         break;
       case 'action':
         this.renderAction(event);
+        this.output.kind = 'action';
         break;
       case 'step_separator':
         // JSON doesn't need separators, but capture position
@@ -132,6 +143,7 @@ export class JSONRenderer implements OutputRenderer {
         break;
       case 'error':
         this.output.error = event.message;
+        this.output.kind = 'error';
         if (event.code) {
           this.output.code = event.code;
         }
@@ -142,6 +154,7 @@ export class JSONRenderer implements OutputRenderer {
       case 'complete':
         this.output.action = 'complete';
         this.output.complete = true;
+        this.output.kind = 'action';
         if (event.message) {
           this.output.message = event.message;
         }
@@ -152,6 +165,7 @@ export class JSONRenderer implements OutputRenderer {
       case 'stopped':
         this.output.action = 'stop';
         this.output.stopped = true;
+        this.output.kind = 'action';
         if (event.message) {
           this.output.message = event.message;
         }
@@ -161,6 +175,7 @@ export class JSONRenderer implements OutputRenderer {
         break;
       case 'no_active_runbook':
         this.output.error = 'No active runbook';
+        this.output.kind = 'error';
         if (event.action) {
           this.output.action = event.action;
         }
@@ -222,6 +237,31 @@ export class JSONRenderer implements OutputRenderer {
    */
   private renderDetail(event: OutputEvent & { type: 'detail' }): void {
     Object.assign(this.output, event.data);
+  }
+
+  /** Format-to-kind mapping for detail events. */
+  private static readonly FORMAT_TO_KIND: Record<string, string> = {
+    status: 'status',
+    check: 'check',
+    echo: 'echo',
+    prompt: 'prompt',
+    scenario_result: 'scenario_run',
+  };
+
+  /**
+   * Derive response kind from a detail event's format.
+   *
+   * For named formats, maps directly to the corresponding kind.
+   * For 'custom' format, the kind should already be set in the data.
+   *
+   * @param event - The detail output event
+   */
+  private deriveKindFromDetail(event: OutputEvent & { type: 'detail' }): void {
+    const kind = JSONRenderer.FORMAT_TO_KIND[event.format ?? ''];
+    if (kind) {
+      this.output.kind = kind;
+    }
+    // 'custom' and 'scenario' formats: kind must be in data or set by caller
   }
 
   /**

--- a/packages/core/__tests__/events/subscribers/json.test.ts
+++ b/packages/core/__tests__/events/subscribers/json.test.ts
@@ -80,6 +80,7 @@ describe('JSONSubscriber', () => {
     );
 
     const summary = subscriber.getSummary();
+    expect(summary.kind).toBe('execution_summary');
     expect(summary.status).toBe('complete');
     expect(summary.commandsRun).toBe(1);
     expect(summary.commandsFailed).toBe(0);

--- a/packages/core/__tests__/output/schema.test.ts
+++ b/packages/core/__tests__/output/schema.test.ts
@@ -22,6 +22,7 @@ describe('isActionResponse type guard', () => {
   describe('correctly identifies ActionResponse', () => {
     it('returns true for ActionResponse with pass action', () => {
       const response: ActionResponse = {
+        kind: 'action',
         action: 'CONTINUE',
         command: 'pass',
         from: '1',
@@ -33,6 +34,7 @@ describe('isActionResponse type guard', () => {
 
     it('returns true for ActionResponse with fail action', () => {
       const response: ActionResponse = {
+        kind: 'action',
         action: 'RETRY',
         command: 'fail',
         from: '1',
@@ -43,6 +45,7 @@ describe('isActionResponse type guard', () => {
 
     it('returns true for ActionResponse with complete', () => {
       const response: ActionResponse = {
+        kind: 'action',
         action: 'COMPLETE',
         complete: true,
       };
@@ -52,6 +55,7 @@ describe('isActionResponse type guard', () => {
 
     it('returns true for ActionResponse with stopped', () => {
       const response: ActionResponse = {
+        kind: 'action',
         action: 'STOP',
         stopped: true,
       };
@@ -63,25 +67,25 @@ describe('isActionResponse type guard', () => {
   describe('correctly rejects StashResponse and PopResponse', () => {
     it('returns false for StashResponse', () => {
       const response: StashResponse = {
+        kind: 'stash',
         action: 'stash',
         stashedId: 'abc-123',
         runbook: { file: 'test.md', state: 'test-state.json' },
       };
 
-      // StashResponse has stashedId which is not present in ActionResponse
-      // The type guard should distinguish these
+      // StashResponse has kind='stash', not 'action'
       expect(isActionResponse(response as CLIResponse)).toBe(false);
     });
 
     it('returns false for PopResponse', () => {
       const response: PopResponse = {
+        kind: 'pop',
         action: 'pop',
         restoredId: 'abc-123',
         runbook: { file: 'test.md', state: 'test-state.json' },
       };
 
-      // PopResponse has restoredId which is not present in ActionResponse
-      // The type guard should distinguish these
+      // PopResponse has kind='pop', not 'action'
       expect(isActionResponse(response as CLIResponse)).toBe(false);
     });
   });
@@ -90,6 +94,7 @@ describe('isActionResponse type guard', () => {
 describe('isErrorResponse type guard', () => {
   it('returns true for ErrorResponse payloads without result', () => {
     const response: ErrorResponse = {
+      kind: 'error',
       error: 'No stashed runbook to restore',
       code: 'NO_STASHED_RUNBOOK',
     };
@@ -99,6 +104,7 @@ describe('isErrorResponse type guard', () => {
 
   it('returns false for action payloads', () => {
     const response: ActionResponse = {
+      kind: 'action',
       action: 'CONTINUE',
       command: 'pass',
     };
@@ -107,33 +113,33 @@ describe('isErrorResponse type guard', () => {
   });
 });
 
-describe('Check/Resolve type discriminator', () => {
-  it('CheckResponseSchema requires type: "check"', () => {
+describe('Check/Resolve kind discriminator', () => {
+  it('CheckResponseSchema requires kind: "check"', () => {
     const valid = CheckResponseSchema.safeParse({
-      type: 'check',
+      kind: 'check',
       valid: true,
       errors: [],
       stats: { steps: 1, substeps: 0 },
     });
     expect(valid.success).toBe(true);
 
-    const missingType = CheckResponseSchema.safeParse({
+    const missingKind = CheckResponseSchema.safeParse({
       valid: true,
       errors: [],
     });
-    expect(missingType.success).toBe(false);
+    expect(missingKind.success).toBe(false);
 
-    const wrongType = CheckResponseSchema.safeParse({
-      type: 'resolve',
+    const wrongKind = CheckResponseSchema.safeParse({
+      kind: 'resolve',
       valid: true,
       errors: [],
     });
-    expect(wrongType.success).toBe(false);
+    expect(wrongKind.success).toBe(false);
   });
 
-  it('ResolveResponseSchema requires type: "resolve"', () => {
+  it('ResolveResponseSchema requires kind: "resolve"', () => {
     const valid = ResolveResponseSchema.safeParse({
-      type: 'resolve',
+      kind: 'resolve',
       valid: true,
       errors: [],
       stats: { steps: 1, substeps: 0 },
@@ -141,38 +147,34 @@ describe('Check/Resolve type discriminator', () => {
     });
     expect(valid.success).toBe(true);
 
-    const missingType = ResolveResponseSchema.safeParse({
+    const missingKind = ResolveResponseSchema.safeParse({
       valid: true,
       errors: [],
     });
-    expect(missingType.success).toBe(false);
+    expect(missingKind.success).toBe(false);
 
-    const wrongType = ResolveResponseSchema.safeParse({
-      type: 'check',
+    const wrongKind = ResolveResponseSchema.safeParse({
+      kind: 'check',
       valid: true,
       errors: [],
     });
-    expect(wrongType.success).toBe(false);
+    expect(wrongKind.success).toBe(false);
   });
 
-  it('isCheckResponse discriminates on type field', () => {
-    const checkResp = { type: 'check', valid: true, errors: [] };
-    const resolveResp = { type: 'resolve', valid: true, errors: [] };
-    const noType = { valid: true, errors: [] };
+  it('isCheckResponse discriminates on kind field', () => {
+    const checkResp = { kind: 'check', valid: true, errors: [] } as CLIResponse;
+    const resolveResp = { kind: 'resolve', valid: true, errors: [] } as CLIResponse;
 
     expect(isCheckResponse(checkResp)).toBe(true);
     expect(isCheckResponse(resolveResp)).toBe(false);
-    expect(isCheckResponse(noType)).toBe(false);
   });
 
-  it('isResolveResponse discriminates on type field', () => {
-    const resolveResp = { type: 'resolve', valid: true, errors: [] };
-    const checkResp = { type: 'check', valid: true, errors: [] };
-    const noType = { valid: true, errors: [] };
+  it('isResolveResponse discriminates on kind field', () => {
+    const resolveResp = { kind: 'resolve', valid: true, errors: [] } as CLIResponse;
+    const checkResp = { kind: 'check', valid: true, errors: [] } as CLIResponse;
 
     expect(isResolveResponse(resolveResp)).toBe(true);
     expect(isResolveResponse(checkResp)).toBe(false);
-    expect(isResolveResponse(noType)).toBe(false);
   });
 });
 

--- a/packages/core/__tests__/output/schema.test.ts
+++ b/packages/core/__tests__/output/schema.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from '@jest/globals';
-import { isActionResponse, isCheckResponse, isResolveResponse } from '../../src/output/schema.js';
+import {
+  isActionResponse,
+  isCheckResponse,
+  isResolveResponse,
+  isErrorResponse,
+} from '../../src/output/schema.js';
 import {
   ResolveSourceInfoSchema,
   CheckResponseSchema,
@@ -7,6 +12,7 @@ import {
 } from '../../src/output/zod-schemas.js';
 import type {
   ActionResponse,
+  ErrorResponse,
   StashResponse,
   PopResponse,
   CLIResponse,
@@ -16,7 +22,6 @@ describe('isActionResponse type guard', () => {
   describe('correctly identifies ActionResponse', () => {
     it('returns true for ActionResponse with pass action', () => {
       const response: ActionResponse = {
-        result: true,
         action: 'CONTINUE',
         command: 'pass',
         from: '1',
@@ -28,7 +33,6 @@ describe('isActionResponse type guard', () => {
 
     it('returns true for ActionResponse with fail action', () => {
       const response: ActionResponse = {
-        result: false,
         action: 'RETRY',
         command: 'fail',
         from: '1',
@@ -39,7 +43,6 @@ describe('isActionResponse type guard', () => {
 
     it('returns true for ActionResponse with complete', () => {
       const response: ActionResponse = {
-        result: true,
         action: 'COMPLETE',
         complete: true,
       };
@@ -49,7 +52,6 @@ describe('isActionResponse type guard', () => {
 
     it('returns true for ActionResponse with stopped', () => {
       const response: ActionResponse = {
-        result: false,
         action: 'STOP',
         stopped: true,
       };
@@ -61,7 +63,6 @@ describe('isActionResponse type guard', () => {
   describe('correctly rejects StashResponse and PopResponse', () => {
     it('returns false for StashResponse', () => {
       const response: StashResponse = {
-        result: true,
         action: 'stash',
         stashedId: 'abc-123',
         runbook: { file: 'test.md', state: 'test-state.json' },
@@ -74,7 +75,6 @@ describe('isActionResponse type guard', () => {
 
     it('returns false for PopResponse', () => {
       const response: PopResponse = {
-        result: true,
         action: 'pop',
         restoredId: 'abc-123',
         runbook: { file: 'test.md', state: 'test-state.json' },
@@ -84,6 +84,26 @@ describe('isActionResponse type guard', () => {
       // The type guard should distinguish these
       expect(isActionResponse(response as CLIResponse)).toBe(false);
     });
+  });
+});
+
+describe('isErrorResponse type guard', () => {
+  it('returns true for ErrorResponse payloads without result', () => {
+    const response: ErrorResponse = {
+      error: 'No stashed runbook to restore',
+      code: 'NO_STASHED_RUNBOOK',
+    };
+
+    expect(isErrorResponse(response)).toBe(true);
+  });
+
+  it('returns false for action payloads', () => {
+    const response: ActionResponse = {
+      action: 'CONTINUE',
+      command: 'pass',
+    };
+
+    expect(isErrorResponse(response as CLIResponse)).toBe(false);
   });
 });
 

--- a/packages/core/__tests__/output/suite-schemas.test.ts
+++ b/packages/core/__tests__/output/suite-schemas.test.ts
@@ -3,6 +3,7 @@ import { ScenarioSuiteRunResponseSchema } from '../../src/output/zod-schemas.js'
 
 describe('ScenarioSuiteRunResponseSchema', () => {
   const validCase = {
+    kind: 'scenario_run' as const,
     result: true,
     scenario: 'happy-path',
     expected: 'COMPLETE',
@@ -10,6 +11,7 @@ describe('ScenarioSuiteRunResponseSchema', () => {
   };
 
   const failingCase = {
+    kind: 'scenario_run' as const,
     result: false,
     scenario: 'stop-path',
     expected: 'COMPLETE',
@@ -18,6 +20,7 @@ describe('ScenarioSuiteRunResponseSchema', () => {
 
   it('validates a correct suite run response with mixed results', () => {
     const response = {
+      kind: 'scenario_suite_run' as const,
       result: false,
       suite: 'Test Suite',
       total: 2,
@@ -32,6 +35,7 @@ describe('ScenarioSuiteRunResponseSchema', () => {
 
   it('validates a correct suite run response with all passing', () => {
     const allPassingCase = {
+      kind: 'scenario_run' as const,
       result: true,
       scenario: 'another-happy',
       expected: 'COMPLETE',
@@ -39,6 +43,7 @@ describe('ScenarioSuiteRunResponseSchema', () => {
     };
 
     const response = {
+      kind: 'scenario_suite_run' as const,
       result: true,
       suite: 'Test Suite',
       total: 2,
@@ -53,6 +58,7 @@ describe('ScenarioSuiteRunResponseSchema', () => {
 
   it('rejects when total does not equal cases.length', () => {
     const response = {
+      kind: 'scenario_suite_run' as const,
       result: true,
       suite: 'Test Suite',
       total: 5,
@@ -71,6 +77,7 @@ describe('ScenarioSuiteRunResponseSchema', () => {
 
   it('rejects when passed + failed does not equal total', () => {
     const response = {
+      kind: 'scenario_suite_run' as const,
       result: true,
       suite: 'Test Suite',
       total: 2,
@@ -89,6 +96,7 @@ describe('ScenarioSuiteRunResponseSchema', () => {
 
   it('rejects when passed count does not match cases with result === true', () => {
     const response = {
+      kind: 'scenario_suite_run' as const,
       result: true,
       suite: 'Test Suite',
       total: 2,
@@ -107,6 +115,7 @@ describe('ScenarioSuiteRunResponseSchema', () => {
 
   it('rejects when failed count does not match cases with result === false', () => {
     const response = {
+      kind: 'scenario_suite_run' as const,
       result: true,
       suite: 'Test Suite',
       total: 2,

--- a/packages/core/__tests__/runbook/delegation-schemas.test.ts
+++ b/packages/core/__tests__/runbook/delegation-schemas.test.ts
@@ -292,6 +292,7 @@ describe('DelegationStatusEntrySchema', () => {
 describe('StatusResponseSchema with delegations', () => {
   it('accepts delegations field', () => {
     const status = {
+      kind: 'status',
       active: true,
       stashed: false,
       delegations: [
@@ -303,12 +304,12 @@ describe('StatusResponseSchema with delegations', () => {
   });
 
   it('validates without delegations (backward compat)', () => {
-    const status = { active: true, stashed: false };
+    const status = { kind: 'status', active: true, stashed: false };
     expect(() => StatusResponseSchema.parse(status)).not.toThrow();
   });
 
   it('validates with empty delegations array', () => {
-    const status = { active: true, stashed: false, delegations: [] };
+    const status = { kind: 'status', active: true, stashed: false, delegations: [] };
     expect(() => StatusResponseSchema.parse(status)).not.toThrow();
   });
 });

--- a/packages/core/src/events/subscribers/json.ts
+++ b/packages/core/src/events/subscribers/json.ts
@@ -75,6 +75,7 @@ export class JSONSubscriber {
     const message = completeEvent ? completeEvent.payload.message : stoppedEvent?.payload.message;
 
     return {
+      kind: 'execution_summary' as const,
       runbookId: startedEvent?.runbookId,
       runbook: startedEvent?.runbook.path ?? startedEvent?.runbook.name,
       status,

--- a/packages/core/src/output/schema.ts
+++ b/packages/core/src/output/schema.ts
@@ -147,7 +147,7 @@ export function isErrorResponse(response: CLIResponse | ErrorResponse): response
  * @returns True if the response is an ActionResponse
  */
 export function isActionResponse(response: CLIResponse): response is ActionResponse {
-  return response.kind === 'action';
+  return 'kind' in response && response.kind === 'action';
 }
 
 /**
@@ -157,7 +157,7 @@ export function isActionResponse(response: CLIResponse): response is ActionRespo
  * @returns True if the response is a StatusResponse
  */
 export function isStatusResponse(response: CLIResponse): response is StatusResponse {
-  return response.kind === 'status';
+  return 'kind' in response && response.kind === 'status';
 }
 
 /**
@@ -170,7 +170,7 @@ export function isStatusResponse(response: CLIResponse): response is StatusRespo
  * @returns True if the response is a CheckResponse
  */
 export function isCheckResponse(response: CLIResponse): response is CheckResponse {
-  return response.kind === 'check';
+  return 'kind' in response && response.kind === 'check';
 }
 
 /**
@@ -182,7 +182,7 @@ export function isCheckResponse(response: CLIResponse): response is CheckRespons
  * @returns True if the response is a ResolveResponse
  */
 export function isResolveResponse(response: CLIResponse): response is ResolveResponse {
-  return response.kind === 'resolve';
+  return 'kind' in response && response.kind === 'resolve';
 }
 
 /**

--- a/packages/core/src/output/schema.ts
+++ b/packages/core/src/output/schema.ts
@@ -137,13 +137,13 @@ import type {
  * @returns True if the response is an ErrorResponse
  */
 export function isErrorResponse(response: CLIResponse | ErrorResponse): response is ErrorResponse {
-  return 'result' in response && !response.result && 'error' in response;
+  return 'error' in response && typeof response.error === 'string';
 }
 
 /**
  * Type guard to check if a response is an action response.
  *
- * Action responses have both `result` (boolean) and `action` (string) fields.
+ * Action responses have an `action` string field.
  * This distinguishes them from ErrorResponse which has `error` instead of `action`.
  *
  * @param response - The response to check
@@ -151,8 +151,6 @@ export function isErrorResponse(response: CLIResponse | ErrorResponse): response
  */
 export function isActionResponse(response: CLIResponse): response is ActionResponse {
   return (
-    'result' in response &&
-    typeof response.result === 'boolean' &&
     'action' in response &&
     typeof response.action === 'string' &&
     !('stashedId' in response) &&

--- a/packages/core/src/output/schema.ts
+++ b/packages/core/src/output/schema.ts
@@ -137,25 +137,17 @@ import type {
  * @returns True if the response is an ErrorResponse
  */
 export function isErrorResponse(response: CLIResponse | ErrorResponse): response is ErrorResponse {
-  return 'error' in response && typeof response.error === 'string';
+  return 'kind' in response && response.kind === 'error';
 }
 
 /**
  * Type guard to check if a response is an action response.
  *
- * Action responses have an `action` string field.
- * This distinguishes them from ErrorResponse which has `error` instead of `action`.
- *
  * @param response - The response to check
  * @returns True if the response is an ActionResponse
  */
 export function isActionResponse(response: CLIResponse): response is ActionResponse {
-  return (
-    'action' in response &&
-    typeof response.action === 'string' &&
-    !('stashedId' in response) &&
-    !('restoredId' in response)
-  );
+  return response.kind === 'action';
 }
 
 /**
@@ -164,56 +156,33 @@ export function isActionResponse(response: CLIResponse): response is ActionRespo
  * @param response - The response to check
  * @returns True if the response is a StatusResponse
  */
-export function isStatusResponse(response: unknown): response is StatusResponse {
-  return (
-    typeof response === 'object' &&
-    response !== null &&
-    'active' in response &&
-    typeof (response as StatusResponse).active === 'boolean'
-  );
+export function isStatusResponse(response: CLIResponse): response is StatusResponse {
+  return response.kind === 'status';
 }
 
 /**
  * Type guard to check if a response is a check response.
  *
- * Discriminates on the `type` field to distinguish from ResolveResponse,
+ * Discriminates on the `kind` field to distinguish from ResolveResponse,
  * which shares the same `valid`/`errors` shape.
  *
  * @param response - The response to check
  * @returns True if the response is a CheckResponse
  */
-export function isCheckResponse(response: unknown): response is CheckResponse {
-  return (
-    typeof response === 'object' &&
-    response !== null &&
-    'type' in response &&
-    (response as { type: unknown }).type === 'check' &&
-    'valid' in response &&
-    typeof (response as CheckResponse).valid === 'boolean' &&
-    'errors' in response &&
-    Array.isArray((response as CheckResponse).errors)
-  );
+export function isCheckResponse(response: CLIResponse): response is CheckResponse {
+  return response.kind === 'check';
 }
 
 /**
  * Type guard to check if a response is a resolve response.
  *
- * Discriminates on the `type` field to distinguish from CheckResponse.
+ * Discriminates on the `kind` field to distinguish from CheckResponse.
  *
  * @param response - The response to check
  * @returns True if the response is a ResolveResponse
  */
-export function isResolveResponse(response: unknown): response is ResolveResponse {
-  return (
-    typeof response === 'object' &&
-    response !== null &&
-    'type' in response &&
-    (response as { type: unknown }).type === 'resolve' &&
-    'valid' in response &&
-    typeof (response as ResolveResponse).valid === 'boolean' &&
-    'errors' in response &&
-    Array.isArray((response as ResolveResponse).errors)
-  );
+export function isResolveResponse(response: CLIResponse): response is ResolveResponse {
+  return response.kind === 'resolve';
 }
 
 /**

--- a/packages/core/src/output/types.ts
+++ b/packages/core/src/output/types.ts
@@ -183,13 +183,13 @@ export interface StoppedOutput extends BaseOutputEvent {
 /**
  * Event for "no active runbook" message.
  *
- * Optional action and code fields enable consistent JSON output
+ * Optional command and code fields enable consistent JSON output
  * that includes the triggering command and error code.
  */
 export interface NoActiveRunbookOutput extends BaseOutputEvent {
   type: 'no_active_runbook';
-  /** The action/command that triggered this (e.g., 'pass', 'fail', 'goto') */
-  action?: string;
+  /** The CLI command that triggered this (e.g., 'pass', 'fail', 'goto') */
+  command?: string;
   /** Error code for programmatic handling */
   code?: string;
 }

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -177,6 +177,8 @@ export const ErrorResponseSchema = z
     error: z.string().describe('Error message describing what went wrong'),
     /** Machine-readable error code for programmatic handling */
     code: ErrorCodeSchema.optional().describe('Error code for programmatic handling'),
+    /** CLI command that triggered the error (e.g., 'pass', 'fail', 'goto') */
+    command: z.string().optional().describe('CLI command that triggered the error'),
     /** Actionable context to help resolve the error */
     details: ErrorDetailsSchema.optional().describe('Additional error context'),
   })

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -171,6 +171,8 @@ export const SuccessResponseSchema = BaseResponseSchema.extend({
  */
 export const ErrorResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('error').describe('Response type discriminant'),
     /** Human-readable error message */
     error: z.string().describe('Error message describing what went wrong'),
     /** Machine-readable error code for programmatic handling */
@@ -195,6 +197,8 @@ export const ErrorResponseSchema = z
  */
 export const ActionResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('action').describe('Response type discriminant'),
     /** Step outcome (PASS or FAIL) */
     stepResult: z.enum(['PASS', 'FAIL']).optional().describe('Step outcome (PASS or FAIL)'),
     /** The action that was performed (e.g., "CONTINUE", "GOTO 3", "RETRY") */
@@ -256,6 +260,8 @@ export const DelegationStatusEntrySchema = z
  */
 export const StatusResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('status').describe('Response type discriminant'),
     /** Whether a runbook is currently active */
     active: z.boolean().describe('Whether a runbook is currently active'),
     /** Whether a runbook is stashed */
@@ -413,8 +419,8 @@ export const CheckValidationWarningSchema = z
  */
 export const CheckResponseSchema = z
   .object({
-    /** Response type discriminator */
-    type: z.literal('check').describe('Response type discriminator'),
+    /** Response kind discriminant */
+    kind: z.literal('check').describe('Response type discriminant'),
     /** Whether the runbook is valid */
     valid: z.boolean().describe('Whether the runbook is valid'),
     /** List of validation errors (empty if valid) */
@@ -465,8 +471,8 @@ export const ResolveSourceInfoSchema = z.discriminatedUnion('kind', [
  */
 export const ResolveResponseSchema = z
   .object({
-    /** Response type discriminator */
-    type: z.literal('resolve').describe('Response type discriminator'),
+    /** Response kind discriminant */
+    kind: z.literal('resolve').describe('Response type discriminant'),
     /** Whether the runbook resolved without errors */
     valid: z.boolean().describe('Whether the runbook resolved without errors'),
     /** Structural and resolution errors */
@@ -579,6 +585,8 @@ export const ScenarioStepAssertionResultSchema = z
  */
 export const ScenarioRunResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('scenario_run').describe('Response type discriminant'),
     /** Whether the scenario passed */
     result: z.boolean().describe('Whether the scenario passed'),
     /** Scenario name */
@@ -617,6 +625,8 @@ export const ScenarioErrorResponseSchema = z
  */
 export const EchoResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('echo').describe('Response type discriminant'),
     /** Whether the operation succeeded */
     result: z.boolean().describe('Whether the echo command succeeded'),
     /** The echoed output */
@@ -653,6 +663,8 @@ export const PruneResponseSchema = ActiveRunbookListSchema.describe(
  */
 export const StashResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('stash').describe('Response type discriminant'),
     action: z.literal('stash').describe('Action type'),
     /** ID of the stashed runbook - REQUIRED */
     stashedId: z.string().describe('ID of the stashed runbook'),
@@ -673,6 +685,8 @@ export const StashResponseSchema = z
  */
 export const PopResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('pop').describe('Response type discriminant'),
     action: z.literal('pop').describe('Action type'),
     /** ID of the restored runbook - REQUIRED */
     restoredId: z.string().describe('ID of the restored runbook'),
@@ -706,6 +720,8 @@ export const PopResponseSchema = z
  */
 export const ExecutionSummarySchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('execution_summary').describe('Response type discriminant'),
     runbookId: z.string().optional().describe('Runbook state identifier'),
     runbook: z.string().optional().describe('Runbook filename'),
     status: z.enum(['complete', 'stopped', 'running']).describe('Execution status'),
@@ -722,9 +738,10 @@ export const ExecutionSummarySchema = z
 /**
  * Combined run command response schema.
  */
-export const RunCommandResponseSchema = ExecutionSummarySchema.describe(
-  'Response from the run command',
-);
+export const RunCommandResponseSchema = ExecutionSummarySchema.extend({
+  /** Response kind discriminant (overrides base execution_summary) */
+  kind: z.literal('run').describe('Response type discriminant'),
+}).describe('Response from the run command');
 
 // ============================================================================
 // Abort Command Schema
@@ -737,6 +754,8 @@ export const RunCommandResponseSchema = ExecutionSummarySchema.describe(
  */
 export const AbortResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('abort').describe('Response type discriminant'),
     /** Action performed */
     action: z.literal('abort').describe('Action type'),
     /** Abort result status */
@@ -798,6 +817,8 @@ export const ScenarioSuiteCaseDetailSchema = ScenarioSuiteCaseEntrySchema.extend
  */
 export const ScenarioSuiteRunResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('scenario_suite_run').describe('Response type discriminant'),
     /** Whether all cases passed */
     result: z.boolean().describe('Whether all cases passed'),
     /** Suite name */
@@ -856,6 +877,8 @@ export const ScenarioSuiteRunResponseSchema = z
  */
 export const DelegateResponseSchema = z
   .object({
+    /** Response kind discriminant */
+    kind: z.literal('delegate').describe('Response type discriminant'),
     /** Action performed */
     action: z.literal('delegated').describe('Action type'),
     /** Step or substep ID that was delegated */
@@ -882,6 +905,8 @@ export const DelegateResponseSchema = z
  * runbook, so the response extends the execution summary with claim-specific fields.
  */
 export const ClaimResponseSchema = ExecutionSummarySchema.extend({
+  /** Response kind discriminant (overrides base execution_summary) */
+  kind: z.literal('claim').describe('Response type discriminant'),
   /** Action performed */
   action: z.literal('claimed').describe('Action type'),
   /** Truncated delegation token */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * stash/pop and related CLI error paths now set a non-zero exit code on failure.

* **New Features**
  * CLI JSON outputs now include a top-level kind discriminant across many response types (error/action/status/abort/delegate/stash/pop/run/claim/scenario_run/scenario_suite_run/execution_summary/prompt, etc.).
  * No-active-runbook output field renamed from action to command; execution summaries now include kind.

* **Tests**
  * Added/updated tests for stash/pop exit behavior, delegation variable inheritance (RunId exclusion), context/claim propagation, JSON kind outputs, and error-response validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->