### PR TITLE
Verify and sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ rundown ls               # List active runbooks
 rundown ls --all         # List available runbook files
 rundown ls --all --tags <tags>  # Filter by comma-separated tags
 rundown check <file>     # Check runbook for errors
+rundown resolve <file>   # Resolve and validate variables and data sources
 rundown echo             # Test helper: echo with configurable result
 rundown prune            # Remove runbook state (default: completed)
 rundown prune --dry-run  # Show what would be removed without deleting
@@ -46,7 +47,7 @@ rundown prune --all      # Prune all runbook state
 rundown scenario ls <file>           # List scenarios in a runbook
 rundown scenario show <file> <name>  # Show scenario details
 rundown scenario run <file> <name>   # Run a scenario
-rundown scenario run <file> <name> -q  # Run scenario (suppress output)
+rundown scenario run <file> <name> -q, --quiet  # Run scenario (suppress output)
 rundown scenario-suite ls <suite-file>           # List cases in a scenario suite
 rundown scenario-suite show <suite-file> <case>  # Show case details
 rundown scenario-suite run <suite-file> [case]   # Run a case (or all with --all)
@@ -71,7 +72,8 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 2. `--var-file path` contents (YAML format)
 3. `.rundown/config.yaml` (auto-discovered from cwd upward, stops at git root)
 4. Frontmatter `vars:` field
-5. Built-in defaults (lowest priority)
+5. Inherited delegation variables (parent context in delegation tree)
+6. Built-in defaults (lowest priority)
 
 **Built-in Variables:**
 | Variable | Example Value | Description |
@@ -82,7 +84,7 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `Month` | `02` | Current month (01-12) |
 | `Day` | `04` | Current day (01-31) |
 | `WorkPath` | `.work` | Default artifact directory |
-| `RunId` | `k7x2m9fp` | Unique-per-execution identifier |
+| `RunId` | `4a7f0c3e` | Unique-per-execution identifier |
 | `ContextId` | `a3b8c1d2` | Shared identity across delegation tree |
 | `Step` | `3.1` | Current qualified step identifier |
 | `Index` | `3` | Current loop iteration number (inside FOR) |
@@ -91,7 +93,7 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `context.current.index` | `3` | Current loop iteration (inside FOR) |
 | `context.current.at` | `3.1[3]` | Full execution position |
 
-Built-in variables use PascalCase. Lowercase aliases `step` and `index` are also available. The date/time variables (`Date`, `DateTime`, `Year`, `Month`, `Day`), `WorkPath`, `RunId`, and `ContextId` are static run-time variables set once per execution and can be overridden via `--var`. `RunId` is a fresh 8-character alphanumeric identifier generated per execution; each child in a delegation tree gets its own RunId. `ContextId` is a fresh 8-character alphanumeric identifier generated per execution; children in a delegation tree inherit the parent's ContextId via `--var`, providing a shared identity across the tree. It can be overridden via `--var` to use a meaningful name (e.g., `--var ContextId=sprint-42`). The `Step` variable (and `Index` during FOR loops), `context.current.*` variables, and their lowercase aliases are dynamic per-step variables that reflect the current execution position and cannot be overridden via `--var`. The variable name `context` is reserved and cannot be used as a user variable name.
+Built-in variables use PascalCase. Lowercase aliases `step` and `index` are also available. The date/time variables (`Date`, `DateTime`, `Year`, `Month`, `Day`), `WorkPath`, `RunId`, and `ContextId` are static run-time variables set once per execution and can be overridden via `--var`. `RunId` is a fresh 8-character hexadecimal identifier generated per execution; each child in a delegation tree gets its own RunId. `ContextId` is a fresh 8-character hexadecimal identifier generated per execution; children in a delegation tree inherit the parent's ContextId via `--var`, providing a shared identity across the tree. It can be overridden via `--var` to use a meaningful name (e.g., `--var ContextId=sprint-42`). The `Step` variable (and `Index` during FOR loops), `context.current.*` variables, and their lowercase aliases are dynamic per-step variables that reflect the current execution position and cannot be overridden via `--var`. The variable name `context` is reserved and cannot be used as a user variable name.
 
 **CLI Example:**
 ```bash
@@ -140,7 +142,7 @@ Data sources are referenced in FOR clauses: `FOR item IN {{ items }}`.
 
 ## Schema Output
 
-The `--schema` flag outputs the JSON Schema for a command's `--json` output (supported by most commands):
+The `--schema` flag outputs the JSON Schema for a command's `--json` output (supported by all commands with `--json` output):
 
 ```bash
 rd status --schema           # Status response schema
@@ -206,13 +208,14 @@ rundown run [file] --allow-write /path    # Allow writing to specific paths
 rundown run [file] --allow-env VAR        # Allow specific environment variables
 rundown run [file] --allow-all            # Bypass policy (trust mode)
 rundown run [file] --deny-all             # Block all commands
-rundown run [file] -y                     # Skip confirmation prompts
+rundown run [file] -y, --yes              # Skip confirmation prompts
 rundown run [file] --non-interactive      # CI mode (auto-deny)
 rundown run [file] --no-color             # Disable colored output
 rundown run [file] --policy ./policy.yaml # Custom policy file
 rundown run [file] --sandbox              # Enable OS-level sandbox (default)
 rundown run [file] --no-sandbox           # Disable sandbox (trust mode)
 rundown run [file] --sandbox-strict       # Fail if sandbox unavailable
+rundown run [file] --trust-js-policy      # Trust executable JS policy configs
 ```
 
 ## Policy Configuration

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -71,7 +71,7 @@ where name is:
   (case-sensitive; must not be a reserved word: NEXT, CONTINUE, DEFER, COMPLETE, STOP, GOTO, RETRY, PASS, FAIL, YES, NO, ALL, ANY, BREAK, FOR, IN, TO, AT)
 
 where code_block is:
-  "```" [ info_string ]
+  "```" info_string
     content
   "```"
 
@@ -91,6 +91,8 @@ where transition is:
   | - DEFER                         -- shorthand for PASS DEFER + FAIL DEFER
 
 Transitions must appear as list items with the `-` bullet prefix (a dash followed by a space). Paragraph-style transitions (without prefix) are not valid.
+
+Note: Transition keywords (`PASS`, `YES`, `FAIL`, `NO`) are matched as whole words — the keyword must be followed by a space. A bullet beginning with `NOTE` or `PASSING` is not treated as a transition.
 
 Aggregation always waits for all DEFER'd results before evaluating. `ALL`/`ANY` evaluates over the count of DEFER'd results.
 
@@ -127,12 +129,10 @@ where source_ref is:
 where range is:
   positive_integer                              -- implicit start (1), end is positive_integer
   | positive_integer "TO" positive_integer      -- explicit start and end
-  | positive_integer "TO" "{{" [ ws ] variable_name [ ws ] "}}"  -- variable end bound
-  | "{{" [ ws ] variable_name [ ws ] "}}" "TO" positive_integer  -- variable start bound
-  | "{{" [ ws ] variable_name [ ws ] "}}" "TO" "{{" [ ws ] variable_name [ ws ] "}}"  -- variable both bounds
-  | "{{" [ ws ] variable_name [ ws ] "}}"            -- count-only with template variable
 
 Whitespace inside `{{ }}` delimiters is optional.
+
+Authoring note: Template variables (e.g., `{{count}}`, `1 TO {{max}}`) may be used in range positions. They are expanded to literal positive integers before parsing (see two-phase model below).
 
 Note: Template variable bounds (e.g., `{{count}}`) are expanded to literal positive integers before the FOR clause is parsed (two-phase model: Handlebars expansion first, then parser processes the result). Source references in `FOR var IN {{ source }}` and `... OF {{ source }}` are NOT expanded — they are parsed as data source identifiers resolved at runtime.
 
@@ -170,7 +170,7 @@ where vars_map is:
   variable_name ":" value { variable_name ":" value }
   (YAML mapping of variable names to string, number, or boolean values)
 
-Note: Frontmatter `vars` are not included in the parsed Runbook AST. They are consumed by the CLI template rendering pipeline.
+Note: Frontmatter `vars` are not included in the parsed Runbook AST. They are consumed by the CLI template rendering pipeline. Reserved variable names (`step`, `index`, `context`, case-insensitive) are rejected with an error diagnostic.
 
 ---
 
@@ -256,18 +256,23 @@ Canonical runtime targeting is `step + substep + iteration`.
 
 ### Modifier Defaults
 
-| Input | Expands To |
-|-------|------------|
-| `PASS X` | `PASS ALL X` |
-| `FAIL X` | `FAIL ANY X` |
+When no aggregation modifier is written, the runtime applies these defaults:
+
+| Input | Runtime Behavior |
+|-------|------------------|
+| `PASS X` (no modifier) | Treated as `PASS ALL X` |
+| `FAIL X` (no modifier) | Treated as `FAIL ANY X` |
+
+Note: Unlike Transition Aliases and RETRY Defaults (which are literal parser expansions), modifier defaults are semantic — the parser stores no aggregation value, and the runtime applies ALL/ANY behavior implicitly.
 
 ### RETRY Defaults
 
 | Input | Expands To |
 |-------|------------|
-| `RETRY`          | `RETRY 1 STOP` |
-| `RETRY n`        | `RETRY n STOP` |
-| `RETRY n action` | `RETRY n action` |
+| `RETRY`              | `RETRY 1 STOP` |
+| `RETRY n`            | `RETRY n STOP` |
+| `RETRY n "message"`  | `RETRY n STOP "message"` |
+| `RETRY n action`     | `RETRY n action` |
 
 The fallback action cannot be RETRY (nested RETRY is invalid).
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -122,6 +122,8 @@ Syntax: `- {RESULT} [{AGGREGATION}]: {ACTION}`
 
 Aggregation modifiers must form complementary pairs: `PASS ALL` with `FAIL ANY` (pessimistic — any failure stops), or `PASS ANY` with `FAIL ALL` (optimistic — only total failure stops). Non-complementary combinations are invalid because they create evaluation gaps (ALL/ALL) or overlaps (ANY/ANY).
 
+Transition keywords (`PASS`, `YES`, `FAIL`, `NO`) are matched as whole words in list items — the keyword must be followed by whitespace and an action. Words that merely start with a keyword (e.g., `NOTE`, `PASSING`) are not treated as transitions.
+
 **Aggregation semantics:** Aggregation always waits for all DEFER'd results before evaluating. `ALL`/`ANY` evaluates over the count of DEFER'd results, not total substeps/iterations. This mirrors `Promise.allSettled` semantics — all results are collected before the outcome is determined.
 
 **Defaults**:
@@ -235,7 +237,7 @@ Variables use Handlebars syntax: `{{variable}}`.
 *   **Parent variables**: `{{context.parent.vars.NAME}}` exposes the parent's resolved template variables. Only non-context keys propagate. Available via both chain (`context.parent.parent.vars.*`) and array (`context.ancestors.N.vars.*`) addressing.
 *   **Depth limit**: Parent context chain addressing is capped at 32 levels. Exceeding this limit produces an error.
 *   **Path resolution**: Dotted paths are supported consistently (for example `{{context.parent.index}}`).
-*   **Reserved keys**: Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive — any case variant such as `STEP`, `Step`, `INDEX` is also reserved) and cannot be overridden by user variables.
+*   **Reserved keys**: Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive — any case variant such as `STEP`, `Step`, `INDEX` is also reserved) and cannot be overridden by user variables. The CLI rejects these names in frontmatter `vars:`, `--var` flags, `--var-file` contents, and `.rundown/config.yaml` with an error diagnostic.
 
 ## 7. Conformance
 

--- a/packages/cli/__tests__/commands/schema-validation.test.ts
+++ b/packages/cli/__tests__/commands/schema-validation.test.ts
@@ -62,7 +62,7 @@ describe('CLI JSON Output Schema Validation', () => {
         } catch {}
       }
       // Fallback: last parseable block
-      let lastParsed: unknown = undefined;
+      let lastParsed: unknown;
       for (const block of jsonBlocks) {
         try {
           lastParsed = JSON.parse(block);

--- a/packages/cli/src/commands/scenario-suite.ts
+++ b/packages/cli/src/commands/scenario-suite.ts
@@ -355,6 +355,7 @@ export function registerScenarioSuiteCommand(program: Command): void {
                 total: caseResults.length,
                 passed: passedCount,
                 failed: failedCount,
+                // Map internal `passed` boolean to schema-facing `result` field
                 cases: caseResults.map((cr) => ({
                   kind: cr.kind,
                   result: cr.passed,

--- a/packages/cli/src/services/renderers/json-renderer.ts
+++ b/packages/cli/src/services/renderers/json-renderer.ts
@@ -36,6 +36,7 @@ type JsonPosition = {
  * Collected JSON output from events.
  */
 interface JsonOutput {
+  kind?: string;
   stepResult?: 'PASS' | 'FAIL';
   action?: string;
   message?: string;

--- a/packages/core/src/runbook/file-provider.ts
+++ b/packages/core/src/runbook/file-provider.ts
@@ -3,6 +3,7 @@ import * as fsp from 'node:fs/promises';
 import * as readline from 'node:readline';
 import * as crypto from 'node:crypto';
 import type { FileFormat, FileSnapshot } from './types.js';
+import { logger } from '../logger.js';
 
 /** Maximum bytes to read for fingerprint computation */
 const FINGERPRINT_BYTES = 64 * 1024;
@@ -56,7 +57,12 @@ export async function createFileProvider(
   // Safety net: prevent unhandled error events after readline detaches its listener.
   // During normal operation, readline's own handler still fires and propagates errors
   // through the async iterator. This only matters for errors emitted after rl.close().
-  stream.on('error', () => {});
+  stream.on('error', (err) => {
+    void logger.debug('Post-close stream error in FileProvider', {
+      path: filePath,
+      error: String(err),
+    });
+  });
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
   const iterator = rl[Symbol.asyncIterator]();
 

--- a/packages/core/src/runbook/file-provider.ts
+++ b/packages/core/src/runbook/file-provider.ts
@@ -53,6 +53,10 @@ export async function createFileProvider(
   options?: { skipLines?: number },
 ): Promise<FileProvider> {
   const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
+  // Safety net: prevent unhandled error events after readline detaches its listener.
+  // During normal operation, readline's own handler still fires and propagates errors
+  // through the async iterator. This only matters for errors emitted after rl.close().
+  stream.on('error', () => {});
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
   const iterator = rl[Symbol.asyncIterator]();
 

--- a/packages/parser/__tests__/helpers.test.ts
+++ b/packages/parser/__tests__/helpers.test.ts
@@ -991,6 +991,11 @@ describe('parseConditional prefix matching', () => {
     expect(() => parseConditional('FAIL')).toThrow('Invalid FAIL transition');
     expect(() => parseConditional('YES')).toThrow('Invalid YES transition');
   });
+
+  it('returns null for tab-separated keyword and action (only spaces supported)', () => {
+    expect(parseConditional('PASS\tCONTINUE')).toBeNull();
+    expect(parseConditional('FAIL\tSTOP')).toBeNull();
+  });
 });
 
 describe('convertToTransitions aggregation conflicts', () => {

--- a/packages/parser/__tests__/helpers.test.ts
+++ b/packages/parser/__tests__/helpers.test.ts
@@ -942,6 +942,13 @@ describe('parseConditional error cases', () => {
   it('throws for NO with invalid action', () => {
     expect(() => parseConditional('NO NOTVALID')).toThrow('Invalid NO transition');
   });
+
+  it('throws for colon-separated syntax', () => {
+    expect(() => parseConditional('PASS: CONTINUE')).toThrow('Invalid transition syntax');
+    expect(() => parseConditional('FAIL: STOP')).toThrow('Invalid transition syntax');
+    expect(() => parseConditional('YES: CONTINUE')).toThrow('Invalid transition syntax');
+    expect(() => parseConditional('NO: STOP')).toThrow('Invalid transition syntax');
+  });
 });
 
 describe('parseConditional prefix matching', () => {

--- a/packages/parser/__tests__/helpers.test.ts
+++ b/packages/parser/__tests__/helpers.test.ts
@@ -944,6 +944,48 @@ describe('parseConditional error cases', () => {
   });
 });
 
+describe('parseConditional prefix matching', () => {
+  it('returns null for words starting with NO', () => {
+    expect(parseConditional('NOTE: this is content')).toBeNull();
+    expect(parseConditional('NOTHING')).toBeNull();
+    expect(parseConditional('NORMAL CONTINUE')).toBeNull();
+  });
+
+  it('returns null for words starting with PASS', () => {
+    expect(parseConditional('PASSING')).toBeNull();
+    expect(parseConditional('PASSWORD reset')).toBeNull();
+  });
+
+  it('returns null for words starting with FAIL', () => {
+    expect(parseConditional('FAILED')).toBeNull();
+    expect(parseConditional('FAILURE mode')).toBeNull();
+  });
+
+  it('returns null for words starting with YES', () => {
+    expect(parseConditional('YESTERDAY')).toBeNull();
+  });
+
+  it('still parses valid transitions', () => {
+    expect(parseConditional('NO STOP')).toMatchObject({ type: 'no', action: { type: 'STOP' } });
+    expect(parseConditional('PASS CONTINUE')).toMatchObject({
+      type: 'pass',
+      action: { type: 'CONTINUE' },
+    });
+    expect(parseConditional('FAIL STOP')).toMatchObject({ type: 'fail', action: { type: 'STOP' } });
+    expect(parseConditional('YES CONTINUE')).toMatchObject({
+      type: 'yes',
+      action: { type: 'CONTINUE' },
+    });
+  });
+
+  it('still throws for bare keywords without actions', () => {
+    expect(() => parseConditional('NO')).toThrow('Invalid NO transition');
+    expect(() => parseConditional('PASS')).toThrow('Invalid PASS transition');
+    expect(() => parseConditional('FAIL')).toThrow('Invalid FAIL transition');
+    expect(() => parseConditional('YES')).toThrow('Invalid YES transition');
+  });
+});
+
 describe('convertToTransitions aggregation conflicts', () => {
   it('throws for conflicting ALL/ALL modifiers', () => {
     const conditionals: ParsedConditional[] = [

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -676,6 +676,13 @@ export function parseConditional(text: string): ParseConditionalResult {
     return result;
   }
 
+  // Reject transition keywords followed by invalid separators (e.g., "PASS:", "FAIL:")
+  if (/^(?:PASS|FAIL|YES|NO)[^a-zA-Z0-9\s]/.test(trimmed)) {
+    throw new RunbookSyntaxError(
+      `Invalid transition syntax: "${trimmed}". Use space-separated format (e.g., "PASS CONTINUE")`,
+    );
+  }
+
   return null;
 }
 

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -644,7 +644,7 @@ export function parseConditional(text: string): ParseConditionalResult {
     ];
   }
 
-  if (trimmed.startsWith('PASS')) {
+  if (trimmed === 'PASS' || trimmed.startsWith('PASS ')) {
     const result = parseConditionalPrefix(trimmed.slice(4), 'pass');
     if (!result) {
       throw new RunbookSyntaxError(`Invalid PASS transition: ${trimmed}`);
@@ -652,7 +652,7 @@ export function parseConditional(text: string): ParseConditionalResult {
     return result;
   }
 
-  if (trimmed.startsWith('YES')) {
+  if (trimmed === 'YES' || trimmed.startsWith('YES ')) {
     const result = parseConditionalPrefix(trimmed.slice(3), 'yes');
     if (!result) {
       throw new RunbookSyntaxError(`Invalid YES transition: ${trimmed}`);
@@ -660,7 +660,7 @@ export function parseConditional(text: string): ParseConditionalResult {
     return result;
   }
 
-  if (trimmed.startsWith('FAIL')) {
+  if (trimmed === 'FAIL' || trimmed.startsWith('FAIL ')) {
     const result = parseConditionalPrefix(trimmed.slice(4), 'fail');
     if (!result) {
       throw new RunbookSyntaxError(`Invalid FAIL transition: ${trimmed}`);
@@ -668,7 +668,7 @@ export function parseConditional(text: string): ParseConditionalResult {
     return result;
   }
 
-  if (trimmed.startsWith('NO')) {
+  if (trimmed === 'NO' || trimmed.startsWith('NO ')) {
     const result = parseConditionalPrefix(trimmed.slice(2), 'no');
     if (!result) {
       throw new RunbookSyntaxError(`Invalid NO transition: ${trimmed}`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `rundown resolve <file>` and new `context.current.*` template variables; RunId/ContextId now show as 8‑char hex; `-q, --quiet` for scenario runs and `-y` also exposed as `--yes`.
* **Behavior Changes**
  * Template variable precedence reordered; `--schema` documented as valid for all commands that produce `--json`.
* **Bug Fixes**
  * Transition keywords now require whole-word + space and reject invalid separators.
* **Documentation**
  * Expanded authoring, templating, transition, and runtime semantics; examples updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->