### PR TITLE
fix(cli,docs): restore FOR bounds fallback behavior, sync SPEC.md and…

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,6 +23,7 @@ reviews:
       - main
 
   path_filters:
+    - "**"
     - "!.worktrees/**"
     - "!.work/**"
     - "!site/node_modules/**"

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -96,6 +96,8 @@ Note: Transition keywords (`PASS`, `YES`, `FAIL`, `NO`) are matched as whole wor
 
 Aggregation always waits for all DEFER'd results before evaluating. `ALL`/`ANY` evaluates over the count of DEFER'd results.
 
+The parsed Transitions object includes an `aggregation` field (`'ALL'` | `'ANY'` | `'none'`) alongside the `pass` and `fail` handlers.
+
 where result is:
   action | RETRY [ count ] [ action ]
 
@@ -114,6 +116,8 @@ where message is:
 where target is:
   step-identifier [ "AT" index ]
   | substep-identifier [ "AT" index ]
+
+> **Internal:** The compiler internally represents "advance to next step" as `GOTO NEXT`. This cannot be written in runbook syntax — the parser rejects `NEXT` as a GOTO target. The `StepId` schema includes an optional `qualifier` field for this internal representation.
 
 where index is:
   positive_integer | "{{" [ ws ] variable_name [ ws ] "}}"
@@ -172,6 +176,8 @@ where vars_map is:
   (YAML mapping of variable names to string, number, or boolean values)
 
 Note: Frontmatter `vars` are not included in the parsed Runbook AST. They are consumed by the CLI template rendering pipeline. Reserved variable names (`step`, `index`, `context`, case-insensitive) are rejected with an error diagnostic.
+
+The `ParseResult` includes a `frontmatter` field containing the validated `RunbookFrontmatter` (or `null` if no frontmatter is present), alongside the parsed `Runbook` AST.
 
 ---
 
@@ -293,6 +299,8 @@ The fallback action cannot be RETRY (nested RETRY is invalid).
 | Only FAIL defined | Adds `PASS ALL CONTINUE` |
 
 **Convention:** Always write both transitions explicitly. The parser supports implicit defaults, but runbooks should be readable without memorizing the default table.
+
+> **Implementation note:** The parser produces `undefined` transitions when none are defined. The runtime compiler applies the defaults shown above via `DEFAULT_TRANSITIONS`. This is consistent with the existing note that aggregation modifier defaults are semantic rather than parser-level.
 
 ### Message Convention
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -43,13 +43,15 @@ Named identifiers must match `/^[A-Za-z_][A-Za-z0-9_]*$/`.
 ### 2.2 Content Order
 Step content must appear in this strict order:
 1.  **FOR Annotation**: Loop definition (optional). Must appear immediately after the step header as a bullet item.
-2.  **Transitions**: Control flow rules (optional). Must appear as bullet items immediately after FOR (or after step header if no FOR). Any text between the header and transitions is an error.
+2.  **Transitions**: Control flow rules (optional). Must appear as bullet items immediately after FOR (or after step header if no FOR). Transitions must appear before any prompt text or body content.
 3.  **Prompt**: Text instructions.
 4.  **Body**: One of: Code Block or Substeps. A step-level runbook list is shorthand for implicit sequential substeps (`.1`, `.2`, ...).
 
 ## 3. Step Bodies
 
 A step must contain exactly one type of body content.
+
+Steps are represented as a discriminated union on `kind`: `'base'` (prompt-only), `'command'` (executable code block), `'substeps'` (nested H3 steps), `'for'` (loop with substeps).
 
 ### 3.1 Code Blocks
 Executes a command or displays a prompt. Max one code block per step.
@@ -137,7 +139,8 @@ When only one transition side specifies an aggregation modifier, the defaulted s
 
 | Action | Context | Effect |
 | :--- | :--- | :--- |
-| `CONTINUE` | Any | Proceed to next sequential unit. |
+| `CONTINUE` | Step | Proceed to next step. |
+| `CONTINUE` | FOR Iteration-Level | Exit loop (result accumulated). |
 | `DEFER` | Substep, FOR Iteration-Level | Pass result up one level for aggregation. |
 | `STOP [msg]` | Any | Terminate execution immediately (failure). |
 | `COMPLETE [msg]` | Any | Terminate execution immediately (success). |
@@ -155,6 +158,8 @@ GOTO targeting the containing step (self-reference) without an AT qualifier may 
 *   `GOTO 3` (FOR step, no AT): Defaults to the loop's start value (e.g., `1` for `FOR 1 TO 10`, `5` for `FOR 5 TO 1`).
 *   `GOTO 3 AT 1`: Jump to Step 3, iteration 1 (if FOR step).
 *   `GOTO 3 AT {{Index}}`: Re-enter Step 3 at current iteration.
+
+> **Internal:** The compiler uses a `GOTO NEXT` representation internally to advance to the next step. This cannot be written in markdown syntax — `NEXT` is rejected as a GOTO target by the parser.
 
 ## 5. Iteration (FOR)
 
@@ -181,7 +186,8 @@ Steps annotated with `FOR` execute their substeps repeatedly.
 *   **Constraint**: FOR steps MUST have substeps. Step-level runbook-list shorthand qualifies because it is canonicalized to implicit substeps.
 *   **Scope**: Loop variable available in substeps as `{{var}}`.
 *   **Aggregation**: Transitions on the parent FOR step evaluate the aggregate result of all iterations.
-*   **Iteration-level transitions**: Nested `PASS`/`FAIL` transitions under a `FOR` clause execute per iteration. Allowed actions: `DEFER` (default, loop back with accumulation), `NEXT` (loop back without accumulation), `CONTINUE` (exit loop), `BREAK` (exit loop), `GOTO`, `STOP`, `COMPLETE` (optionally wrapped by `RETRY`).
+*   **Iteration-level transitions**: Nested `PASS`/`FAIL` transitions under a `FOR` clause are stored on the `forClause.transitions` field and execute per iteration. Allowed actions: `DEFER` (default, loop back with accumulation), `NEXT` (loop back without accumulation), `CONTINUE` (exit loop), `BREAK` (exit loop), `GOTO`, `STOP`, `COMPLETE` (optionally wrapped by `RETRY`).
+*   **CONTINUE at iteration scope**: At step level, CONTINUE proceeds to the next step. At FOR iteration level, CONTINUE exits the loop — the current iteration result IS accumulated (unlike NEXT/BREAK which do not accumulate), and execution continues with the step after the FOR step.
 *   **Nested bullet rule**: Nested bullets under `FOR` must be transition bullets; non-transition nested bullets are invalid and fail parse.
 *   **Retry order**: Iteration-level `RETRY` semantics are deterministic: retry first, then execute the exhausted action. RETRY is universal — it fires for ALL substep actions (including `BREAK` and `NEXT`) based on the iteration result, not the substep action. After retries are exhausted, the substep's action takes effect:
     *   `BREAK` → exit loop (non-accumulating, same as NEXT)
@@ -235,14 +241,21 @@ Variables use Handlebars syntax: `{{variable}}`.
 *   **Undefined**: Preserved as literal text. A warning is emitted to stderr for each undefined variable.
 *   **Evaluation**: Global vars expanded once; Step/Loop vars expanded per iteration.
 *   **Parent variables**: `{{context.parent.vars.NAME}}` exposes the parent's resolved template variables. Only non-context keys propagate. Available via both chain (`context.parent.parent.vars.*`) and array (`context.ancestors.N.vars.*`) addressing.
-*   **Depth limit**: Parent context chain addressing is capped at 32 levels. Exceeding this limit produces an error.
+*   **Depth limit**: Parent context chain addressing is capped at 32 levels (enforced on the delegation ancestor chain depth). Exceeding this limit produces an error.
 *   **Path resolution**: Dotted paths are supported consistently (for example `{{context.parent.index}}`).
 *   **Reserved keys**: Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive — any case variant such as `STEP`, `Step`, `INDEX` is also reserved) and cannot be overridden by user variables. The CLI rejects these names in frontmatter `vars:`, `--var` flags, `--var-file` contents, and `.rundown/config.yaml` with an error diagnostic.
+*   **Precedence** (highest to lowest):
+    1. `--var` flags
+    2. `--var-file` contents
+    3. `.rundown/config.yaml` (auto-discovered)
+    4. Frontmatter `vars:` field
+    5. Inherited delegation variables (parent context)
+    6. Built-in defaults (`Date`, `RunId`, `WorkPath`, etc.)
 
 ## 7. Conformance
 
 1.  **Strict Hierarchy**: H2 -> H3. No H4.
-2.  **Sequential IDs**: 1, 2, 3... (gaps invalid).
+2.  **Sequential IDs**: Numeric steps must be sequential (1, 2, 3...; gaps invalid). Named steps do not participate in sequential numbering.
 3.  **Strict Ordering**: FOR -> Transitions -> Prompt -> Body.
 4.  **Exclusivity**: Only one body type (Code OR Substeps). Step-level runbook lists are shorthand for Substeps.
 5.  **Single Code Block**: Max one code block per step (executable or display-only).

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -103,7 +103,7 @@ jest.unstable_mockModule('../../src/services/variable-discovery', () => ({
 // Mock template-renderer
 jest.unstable_mockModule('../../src/services/template-renderer', () => ({
   substituteRunbookVariables: jest.fn((runbook: unknown) => runbook),
-  resolveForBounds: jest.fn((runbook: unknown) => runbook),
+  resolveForBounds: jest.fn((runbook: unknown) => ({ runbook, warnings: [] })),
   expandLoopVariables: jest.fn((text: string) => text),
   warnUnresolvedRunbookVariables: jest.fn().mockReturnValue([]),
   collectUnresolvedRunbookVariables: jest.fn().mockReturnValue(new Set()),

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -104,7 +104,7 @@ jest.unstable_mockModule('../../src/services/variable-discovery', () => ({
 // Mock template-renderer
 jest.unstable_mockModule('../../src/services/template-renderer', () => ({
   substituteRunbookVariables: jest.fn((runbook: unknown) => runbook),
-  resolveForBounds: jest.fn((runbook: unknown) => runbook),
+  resolveForBounds: jest.fn((runbook: unknown) => ({ runbook, warnings: [] })),
   expandLoopVariables: jest.fn((text: string) => text),
   warnUnresolvedRunbookVariables: jest.fn().mockReturnValue([]),
   collectUnresolvedRunbookVariables: jest.fn().mockReturnValue(new Set()),
@@ -225,7 +225,10 @@ beforeEach(() => {
   (resolveVariables as jest.Mock).mockResolvedValue({ vars: {}, sources: {}, warnings: [] });
   (buildStepVariables as jest.Mock).mockReturnValue({ Step: '1.1' });
   (substituteRunbookVariables as jest.Mock).mockImplementation((runbook: unknown) => runbook);
-  (resolveForBounds as jest.Mock).mockImplementation((runbook: unknown) => runbook);
+  (resolveForBounds as jest.Mock).mockImplementation((runbook: unknown) => ({
+    runbook,
+    warnings: [],
+  }));
   (expandLoopVariables as jest.Mock).mockImplementation((text: string) => text);
   (warnUnresolvedRunbookVariables as jest.Mock).mockReturnValue([]);
   (collectUnresolvedRunbookVariables as jest.Mock).mockReturnValue(new Set());
@@ -482,7 +485,7 @@ describe('prepareRunbook', () => {
     expect(substituteRunbookVariables).not.toHaveBeenCalled();
   });
 
-  it('returns PrepareFailure when resolveForBounds encounters unresolved variable', async () => {
+  it('returns PrepareFailure when resolveForBounds throws for invalid value', async () => {
     resolveRunbookFile.mockResolvedValue('/test/for-bounds.md');
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -499,14 +502,16 @@ describe('prepareRunbook', () => {
       }),
     );
     (resolveForBounds as jest.Mock).mockImplementation(() => {
-      throw new Error('Unresolved FOR bound "{{Max}}" in step "1" — variable "Max" is not defined');
+      throw new Error(
+        'FOR end bound "{{Max}}" in step "1" resolved to "hello" — must be a positive integer',
+      );
     });
 
     const result = await prepareRunbook('for-bounds.md', {}, '/test');
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe('VALIDATION_ERROR');
-      expect(result.error).toContain('Unresolved FOR bound');
+      expect(result.error).toContain('must be a positive integer');
     }
   });
 

--- a/packages/cli/__tests__/integration/for-loop-variables.test.ts
+++ b/packages/cli/__tests__/integration/for-loop-variables.test.ts
@@ -5,7 +5,7 @@ import {
   runCli,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
-import { writeFile } from 'node:fs/promises';
+import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 describe('Per-step variable expansion ({{Step}}, {{Index}}, FOR loop variables)', () => {
@@ -663,5 +663,91 @@ rd echo step={{Step}}
 
     const allEventText = JSON.stringify(commandStartedEvents);
     expect(allEventText).not.toContain('{{context.vars.env}}');
+  });
+
+  it('windowed source fallback does not treat source as template variable', async () => {
+    await mkdir(join(workspace.cwd, '.rundown'), { recursive: true });
+    await writeFile(
+      join(workspace.cwd, '.rundown', 'config.yaml'),
+      `items:\n  - alpha\n  - beta\n  - gamma\n`,
+    );
+
+    await writeFile(
+      join(workspace.cwd, 'fallback.runbook.md'),
+      `---
+name: Fallback Source
+---
+# Fallback
+
+## 1. Process items
+- FOR item IN 1 TO {{N}} OF {{ items }}
+- PASS ALL CONTINUE
+
+### 1.1 Handle item
+- PASS CONTINUE
+
+\`\`\`bash
+rd echo item={{item}}
+\`\`\`
+`,
+    );
+
+    const result = runCli('resolve --json fallback.runbook.md', workspace);
+    const output = JSON.parse(result.stdout);
+
+    expect(output.valid).toBe(true);
+
+    if (output.unresolved) {
+      expect(output.unresolved).not.toContain('items');
+    }
+
+    const msgs = (output.warnings ?? []).map((w: { message: string }) => w.message);
+    expect(msgs).toEqual(expect.arrayContaining([expect.stringContaining('unresolved FOR bound')]));
+
+    const itemsWarning = msgs.find((m: string) => m.includes('{{items}}'));
+    expect(itemsWarning).toBeUndefined();
+  });
+
+  it('windowed source fallback with transitions resolves without error', async () => {
+    await mkdir(join(workspace.cwd, '.rundown'), { recursive: true });
+    await writeFile(
+      join(workspace.cwd, '.rundown', 'config.yaml'),
+      `items:\n  - alpha\n  - beta\n`,
+    );
+
+    await writeFile(
+      join(workspace.cwd, 'fallback-trans.runbook.md'),
+      `---
+name: Fallback Transitions
+---
+# Fallback
+
+## 1. Process items
+- FOR item IN 1 TO {{N}} OF {{ items }}
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.1 Handle item
+- PASS CONTINUE
+
+\`\`\`bash
+rd echo item={{item}}
+\`\`\`
+`,
+    );
+
+    // Verify resolve succeeds and reports the fallback warning
+    const result = runCli('resolve --json fallback-trans.runbook.md', workspace);
+    const output = JSON.parse(result.stdout);
+
+    expect(output.valid).toBe(true);
+
+    // Fallback warning should be present
+    const msgs = (output.warnings ?? []).map((w: { message: string }) => w.message);
+    expect(msgs).toEqual(expect.arrayContaining([expect.stringContaining('unresolved FOR bound')]));
+
+    // 'items' should NOT appear as an unresolved variable (it's a source, not a template var)
+    const itemsWarning = msgs.find((m: string) => m.includes('{{items}}'));
+    expect(itemsWarning).toBeUndefined();
   });
 });

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -820,19 +820,25 @@ describe('resolveForBounds', () => {
     expect(() => resolveForBounds(runbook, { Neg: '-5' })).toThrow('must be a positive integer');
   });
 
-  it('resolves source window with start BoundRef and no end', () => {
+  it('resolves windowed source with both BoundRefs', () => {
     const unresolved: ParsedForClause = {
       unresolved: true as const,
       variable: 'item',
       start: { ref: 'Begin' },
+      end: { ref: 'End' },
       source: 'items',
     };
     const runbook = makeRunbook([makeForStep(unresolved)]);
-    const { runbook: result } = resolveForBounds(runbook, { Begin: '3' });
-    expect(result.steps[0].forClause).toEqual({ variable: 'item', start: 3, source: 'items' });
+    const { runbook: result } = resolveForBounds(runbook, { Begin: '3', End: '7' });
+    expect(result.steps[0].forClause).toEqual({
+      variable: 'item',
+      start: 3,
+      end: 7,
+      source: 'items',
+    });
   });
 
-  it('falls back source window with undefined BoundRef', () => {
+  it('falls back windowed source with undefined BoundRef', () => {
     const unresolved: ParsedForClause = {
       unresolved: true as const,
       variable: 'x',

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -850,7 +850,137 @@ describe('resolveForBounds', () => {
     const { runbook: result, warnings } = resolveForBounds(runbook, {});
     const step = result.steps[0] as StepWithSubsteps;
     expect(step.kind).toBe('substeps');
-    expect(step.prompt).toContain('FOR x IN 1 TO {{N}} OF {{ items }}');
+    expect(step.prompt).toContain('FOR x IN 1 TO {{N}} OF items');
     expect(warnings).toHaveLength(1);
+  });
+
+  it('fallback source ref is not treated as a template variable', () => {
+    const unresolved: ParsedForClause = {
+      unresolved: true as const,
+      variable: 'x',
+      start: 1,
+      end: { ref: 'N' },
+      source: 'items',
+    };
+    const runbook = makeRunbook([makeForStep(unresolved)]);
+    const { runbook: resolved } = resolveForBounds(runbook, {});
+    const substituted = substituteRunbookVariables(resolved, { items: 'a,b,c' });
+    const step = substituted.steps[0] as StepWithSubsteps;
+    expect(step.prompt).toContain('OF items');
+    expect(step.prompt).not.toContain('a,b,c');
+  });
+
+  it('fallback source ref does not trigger unresolved variable warning', () => {
+    const unresolved: ParsedForClause = {
+      unresolved: true as const,
+      variable: 'x',
+      start: 1,
+      end: { ref: 'N' },
+      source: 'myData',
+    };
+    const runbook = makeRunbook([makeForStep(unresolved)]);
+    const { runbook: resolved } = resolveForBounds(runbook, {});
+    const substituted = substituteRunbookVariables(resolved, {});
+    const warnings = warnUnresolvedRunbookVariables(substituted);
+    const sourceWarning = warnings.find((w) => w.includes('myData'));
+    expect(sourceWarning).toBeUndefined();
+  });
+
+  it('preserves iteration transitions in fallback prompt text', () => {
+    const transitions: Transitions = {
+      aggregation: 'none' as const,
+      pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+      fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+    };
+    const unresolved: ParsedForClause = {
+      unresolved: true as const,
+      variable: 'item',
+      start: 1,
+      end: { ref: 'Missing' },
+      transitions,
+    };
+    const runbook = makeRunbook([makeForStep(unresolved)]);
+    const { runbook: result } = resolveForBounds(runbook, {});
+    const step = result.steps[0] as StepWithSubsteps;
+    expect(step.prompt).toContain('FOR item IN 1 TO {{Missing}}');
+    expect(step.prompt).toContain('- PASS CONTINUE');
+    expect(step.prompt).toContain('- FAIL STOP');
+  });
+
+  it('preserves transitions with aggregation modifiers in fallback', () => {
+    const transitions: Transitions = {
+      aggregation: 'ALL' as const,
+      pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+      fail: { kind: 'fail' as const, retry: 0, action: { type: 'BREAK' as const } },
+    };
+    const unresolved: ParsedForClause = {
+      unresolved: true as const,
+      variable: 'item',
+      start: 1,
+      end: { ref: 'N' },
+      transitions,
+    };
+    const runbook = makeRunbook([makeForStep(unresolved)]);
+    const { runbook: result } = resolveForBounds(runbook, {});
+    const step = result.steps[0] as StepWithSubsteps;
+    expect(step.prompt).toContain('- PASS ALL DEFER');
+    expect(step.prompt).toContain('- FAIL ANY BREAK');
+  });
+
+  it('preserves transitions with retry in fallback', () => {
+    const transitions: Transitions = {
+      aggregation: 'none' as const,
+      pass: { kind: 'pass' as const, retry: 3, action: { type: 'CONTINUE' as const } },
+      fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+    };
+    const unresolved: ParsedForClause = {
+      unresolved: true as const,
+      variable: 'item',
+      start: 1,
+      end: { ref: 'N' },
+      transitions,
+    };
+    const runbook = makeRunbook([makeForStep(unresolved)]);
+    const { runbook: result } = resolveForBounds(runbook, {});
+    const step = result.steps[0] as StepWithSubsteps;
+    expect(step.prompt).toContain('- PASS RETRY 3 CONTINUE');
+    expect(step.prompt).toContain('- FAIL STOP');
+  });
+
+  it('does not add transition lines when forClause has no transitions', () => {
+    const unresolved: ParsedForClause = {
+      unresolved: true as const,
+      variable: 'item',
+      start: 1,
+      end: { ref: 'Missing' },
+    };
+    const runbook = makeRunbook([makeForStep(unresolved)]);
+    const { runbook: result } = resolveForBounds(runbook, {});
+    const step = result.steps[0] as StepWithSubsteps;
+    expect(step.prompt).toBe('FOR item IN 1 TO {{Missing}}');
+    expect(step.prompt).not.toContain('PASS');
+    expect(step.prompt).not.toContain('FAIL');
+  });
+
+  it('preserves transitions on windowed source fallback', () => {
+    const transitions: Transitions = {
+      aggregation: 'ANY' as const,
+      pass: { kind: 'pass' as const, retry: 0, action: { type: 'NEXT' as const } },
+      fail: { kind: 'fail' as const, retry: 0, action: { type: 'COMPLETE' as const } },
+    };
+    const unresolved: ParsedForClause = {
+      unresolved: true as const,
+      variable: 'x',
+      start: 1,
+      end: { ref: 'N' },
+      source: 'items',
+      transitions,
+    };
+    const runbook = makeRunbook([makeForStep(unresolved)]);
+    const { runbook: result } = resolveForBounds(runbook, {});
+    const step = result.steps[0] as StepWithSubsteps;
+    expect(step.prompt).toContain('FOR x IN 1 TO {{N}} OF items');
+    expect(step.prompt).toContain('- PASS ANY NEXT');
+    expect(step.prompt).toContain('- FAIL ALL COMPLETE');
   });
 });

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -5,6 +5,7 @@ import type {
   Step,
   BaseStep,
   StepWithFor,
+  StepWithSubsteps,
   ParsedForClause,
   Transitions,
 } from '@rundown-org/parser';
@@ -651,14 +652,15 @@ describe('resolveForBounds', () => {
 
   it('passes through runbook with no FOR steps', () => {
     const runbook = makeRunbook([makeBaseStep()]);
-    const result = resolveForBounds(runbook, {});
+    const { runbook: result, warnings } = resolveForBounds(runbook, {});
     expect(result.steps).toEqual(runbook.steps);
+    expect(warnings).toEqual([]);
   });
 
   it('passes through already-resolved FOR clause', () => {
     const resolved: ParsedForClause = { variable: 'item', start: 1, end: 10 };
     const runbook = makeRunbook([makeForStep(resolved)]);
-    const result = resolveForBounds(runbook, {});
+    const { runbook: result } = resolveForBounds(runbook, {});
     expect(result.steps[0].forClause).toEqual(resolved);
   });
 
@@ -670,7 +672,7 @@ describe('resolveForBounds', () => {
       end: { ref: 'Max' },
     };
     const runbook = makeRunbook([makeForStep(unresolved)]);
-    const result = resolveForBounds(runbook, { Max: '5' });
+    const { runbook: result } = resolveForBounds(runbook, { Max: '5' });
     expect(result.steps[0].forClause).toEqual({ variable: 'batch', start: 1, end: 5 });
   });
 
@@ -682,7 +684,7 @@ describe('resolveForBounds', () => {
       end: { ref: 'Max' },
     };
     const runbook = makeRunbook([makeForStep(unresolved)]);
-    const result = resolveForBounds(runbook, { Min: '2', Max: '8' });
+    const { runbook: result } = resolveForBounds(runbook, { Min: '2', Max: '8' });
     expect(result.steps[0].forClause).toEqual({ variable: 'item', start: 2, end: 8 });
   });
 
@@ -695,11 +697,11 @@ describe('resolveForBounds', () => {
       source: 'items',
     };
     const runbook = makeRunbook([makeForStep(unresolved)]);
-    const result = resolveForBounds(runbook, { N: '5' });
+    const { runbook: result } = resolveForBounds(runbook, { N: '5' });
     expect(result.steps[0].forClause).toEqual({ variable: 'x', start: 1, end: 5, source: 'items' });
   });
 
-  it('throws for undefined variable', () => {
+  it('falls back to prompt text for undefined variable', () => {
     const unresolved: ParsedForClause = {
       unresolved: true as const,
       variable: 'item',
@@ -707,7 +709,27 @@ describe('resolveForBounds', () => {
       end: { ref: 'Missing' },
     };
     const runbook = makeRunbook([makeForStep(unresolved)]);
-    expect(() => resolveForBounds(runbook, {})).toThrow('not defined');
+    const { runbook: result, warnings } = resolveForBounds(runbook, {});
+    const step = result.steps[0] as StepWithSubsteps;
+    expect(step.kind).toBe('substeps');
+    expect(step.prompt).toContain('FOR item IN 1 TO {{Missing}}');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('preserved as prompt text');
+  });
+
+  it('falls back when one bound defined and other undefined', () => {
+    const unresolved: ParsedForClause = {
+      unresolved: true as const,
+      variable: 'item',
+      start: { ref: 'Min' },
+      end: { ref: 'Max' },
+    };
+    const runbook = makeRunbook([makeForStep(unresolved)]);
+    const { runbook: result, warnings } = resolveForBounds(runbook, { Min: '2' });
+    const step = result.steps[0] as StepWithSubsteps;
+    expect(step.kind).toBe('substeps');
+    expect(step.prompt).toContain('FOR item IN {{Min}} TO {{Max}}');
+    expect(warnings).toHaveLength(1);
   });
 
   it('throws for non-integer value', () => {
@@ -756,7 +778,7 @@ describe('resolveForBounds', () => {
       transitions,
     };
     const runbook = makeRunbook([makeForStep(unresolved)]);
-    const result = resolveForBounds(runbook, { N: '3' });
+    const { runbook: result } = resolveForBounds(runbook, { N: '3' });
     expect(result.steps[0].forClause).toEqual({
       variable: 'item',
       start: 1,
@@ -772,7 +794,7 @@ describe('resolveForBounds', () => {
       end: { ref: 'Count' },
     };
     const runbook = makeRunbook([makeForStep(unresolved)]);
-    const result = resolveForBounds(runbook, { Count: '5' });
+    const { runbook: result } = resolveForBounds(runbook, { Count: '5' });
     expect(result.steps[0].forClause).toEqual({ start: 1, end: 5 });
   });
 
@@ -806,7 +828,23 @@ describe('resolveForBounds', () => {
       source: 'items',
     };
     const runbook = makeRunbook([makeForStep(unresolved)]);
-    const result = resolveForBounds(runbook, { Begin: '3' });
+    const { runbook: result } = resolveForBounds(runbook, { Begin: '3' });
     expect(result.steps[0].forClause).toEqual({ variable: 'item', start: 3, source: 'items' });
+  });
+
+  it('falls back source window with undefined BoundRef', () => {
+    const unresolved: ParsedForClause = {
+      unresolved: true as const,
+      variable: 'x',
+      start: 1,
+      end: { ref: 'N' },
+      source: 'items',
+    };
+    const runbook = makeRunbook([makeForStep(unresolved)]);
+    const { runbook: result, warnings } = resolveForBounds(runbook, {});
+    const step = result.steps[0] as StepWithSubsteps;
+    expect(step.kind).toBe('substeps');
+    expect(step.prompt).toContain('FOR x IN 1 TO {{N}} OF {{ items }}');
+    expect(warnings).toHaveLength(1);
   });
 });

--- a/packages/cli/src/helpers/runbook-loader.ts
+++ b/packages/cli/src/helpers/runbook-loader.ts
@@ -66,7 +66,7 @@ export function getRunbookFromState(state: RunbookState, _cwd: string): readonly
   if (state.templateVars) {
     const { runbook, diagnostics } = parseRunbookDocument(state.runbookSrc, state.runbook);
     checkDiagnostics(diagnostics);
-    const resolved = resolveForBounds(runbook, state.templateVars);
+    const { runbook: resolved } = resolveForBounds(runbook, state.templateVars);
     const substituted = substituteRunbookVariables(resolved, state.templateVars);
     // Unresolved variable warnings were already shown at startup via the pipeline path.
     // Suppress them here to avoid duplicating warnings and leaking into --json output.

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -464,7 +464,9 @@ export async function prepareRunbook(
   // Resolve FOR clause bounds ({{Max}} → 10)
   let resolvedRunbook: ResolvedRunbook;
   try {
-    resolvedRunbook = resolveForBounds(rawRunbook, templateVars);
+    const result = resolveForBounds(rawRunbook, templateVars);
+    resolvedRunbook = result.runbook;
+    allWarnings.push(...result.warnings);
   } catch (err) {
     return {
       ok: false,

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -204,11 +204,8 @@ function boundToString(bound: Bound): string {
  */
 function reconstructForLine(fc: UnresolvedForClause): string {
   if (fc.source !== undefined) {
-    const prefix = `FOR ${fc.variable} IN`;
-    if (fc.end !== undefined) {
-      return `${prefix} ${boundToString(fc.start)} TO ${boundToString(fc.end)} OF {{ ${fc.source} }}`;
-    }
-    return `${prefix} {{ ${fc.source} }}`;
+    // UnresolvedSourceWindow always has both start and end (windowed syntax only)
+    return `FOR ${fc.variable} IN ${boundToString(fc.start)} TO ${boundToString(fc.end)} OF {{ ${fc.source} }}`;
   }
   const prefix = fc.variable ? `FOR ${fc.variable} IN` : 'FOR';
   return `${prefix} ${boundToString(fc.start)} TO ${boundToString(fc.end)}`;
@@ -228,7 +225,7 @@ function allBoundRefsDefined(
   if (typeof fc.start !== 'number') {
     if (resolveTemplatePath(fc.start.ref, variables) === undefined) return false;
   }
-  if (fc.end !== undefined && typeof fc.end !== 'number') {
+  if (typeof fc.end !== 'number') {
     if (resolveTemplatePath(fc.end.ref, variables) === undefined) return false;
   }
   return true;
@@ -280,26 +277,20 @@ export function resolveForBounds(
     }
 
     const start = resolveBound(fc.start, variables, step.name, 'start');
-    const end =
-      fc.end !== undefined ? resolveBound(fc.end, variables, step.name, 'end') : undefined;
+    const end = resolveBound(fc.end, variables, step.name, 'end');
 
     let resolved: ForClause;
     if (fc.source !== undefined) {
-      // SourceWindow — end is optional
+      // WindowedSourceWindow — both bounds required
       resolved = {
         variable: fc.variable,
         start,
+        end,
         source: fc.source,
-        ...(end !== undefined && { end }),
         ...(fc.transitions && { transitions: fc.transitions }),
       };
     } else {
-      // NumericWindow — end is required (UnresolvedNumericWindow.end: Bound is non-optional)
-      if (end === undefined) {
-        throw new Error(
-          `FOR end bound in step "${step.name}" is required for numeric range — this indicates a parser bug`,
-        );
-      }
+      // NumericWindow — both bounds required
       resolved = {
         start,
         end,

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -17,6 +17,8 @@ import type {
   ResolvedRunbook,
   ResolvedStep,
   ResolvedStepWithFor,
+  StepWithSubsteps,
+  UnresolvedForClause,
 } from '@rundown-org/parser';
 import { isUnresolvedForClause, MAX_FOR_BOUND } from '@rundown-org/parser';
 
@@ -173,21 +175,87 @@ function resolveBound(
 }
 
 /**
+ * Result of resolving FOR clause bounds in a runbook.
+ */
+export interface ResolveForBoundsResult {
+  /** Runbook with all resolvable FOR bounds resolved. */
+  readonly runbook: ResolvedRunbook;
+  /** Warnings for steps where bounds could not be resolved (preserved as prompt text). */
+  readonly warnings: readonly string[];
+}
+
+/**
+ * Render a single FOR bound back to its source text form.
+ *
+ * @param bound - Numeric literal or unresolved template reference
+ * @returns String representation suitable for reconstruction
+ */
+function boundToString(bound: Bound): string {
+  return typeof bound === 'number' ? String(bound) : `{{${bound.ref}}}`;
+}
+
+/**
+ * Reconstruct the original FOR line text from an unresolved FOR clause.
+ *
+ * Used when falling back to prompt text for steps with undefined bound variables.
+ *
+ * @param fc - Unresolved FOR clause to reconstruct
+ * @returns Reconstructed FOR line text
+ */
+function reconstructForLine(fc: UnresolvedForClause): string {
+  if (fc.source !== undefined) {
+    const prefix = `FOR ${fc.variable} IN`;
+    if (fc.end !== undefined) {
+      return `${prefix} ${boundToString(fc.start)} TO ${boundToString(fc.end)} OF {{ ${fc.source} }}`;
+    }
+    return `${prefix} {{ ${fc.source} }}`;
+  }
+  const prefix = fc.variable ? `FOR ${fc.variable} IN` : 'FOR';
+  return `${prefix} ${boundToString(fc.start)} TO ${boundToString(fc.end)}`;
+}
+
+/**
+ * Check whether all BoundRef variables in an unresolved FOR clause are defined.
+ *
+ * @param fc - Unresolved FOR clause to check
+ * @param variables - Template variable map
+ * @returns `true` if every BoundRef variable resolves to a defined value
+ */
+function allBoundRefsDefined(
+  fc: UnresolvedForClause,
+  variables: Readonly<Record<string, unknown>>,
+): boolean {
+  if (typeof fc.start !== 'number') {
+    if (resolveTemplatePath(fc.start.ref, variables) === undefined) return false;
+  }
+  if (fc.end !== undefined && typeof fc.end !== 'number') {
+    if (resolveTemplatePath(fc.end.ref, variables) === undefined) return false;
+  }
+  return true;
+}
+
+/**
  * Resolve unresolved FOR clause bounds in a parsed runbook.
  *
  * Walks all steps, resolving any `BoundRef` values in FOR clauses to concrete
  * numbers using the provided template variables. Steps without FOR clauses or
  * with already-resolved bounds are passed through unchanged.
  *
+ * When a bound variable is undefined, the step falls back to a `StepWithSubsteps`
+ * with the FOR line preserved as prompt text. This matches the spec behavior:
+ * "the FOR clause is not parsed and the line is preserved as literal prompt text."
+ *
  * @param runbook - Parsed runbook AST (may contain unresolved FOR bounds)
  * @param variables - Template variable map for bound resolution
- * @returns New runbook AST with all FOR bounds resolved to numbers
- * @throws {Error} When a bound variable is undefined or resolves to a non-integer
+ * @returns Result with resolved runbook and any fallback warnings
+ * @throws {Error} When a bound variable is defined but resolves to a non-integer or out-of-range value
  */
 export function resolveForBounds(
   runbook: Runbook,
   variables: Readonly<Record<string, unknown>>,
-): ResolvedRunbook {
+): ResolveForBoundsResult {
+  const warnings: string[] = [];
+
   const resolvedSteps = runbook.steps.map((step): ResolvedStep => {
     if (step.kind !== 'for') return step;
     if (!isUnresolvedForClause(step.forClause)) {
@@ -196,6 +264,21 @@ export function resolveForBounds(
     }
 
     const fc = step.forClause;
+
+    // If any BoundRef variable is undefined, fall back to prompt text
+    if (!allBoundRefsDefined(fc, variables)) {
+      const forLine = reconstructForLine(fc);
+      const { forClause: _, kind: __, ...rest } = step;
+      const fallbackStep: StepWithSubsteps = {
+        ...rest,
+        kind: 'substeps',
+        substeps: step.substeps,
+        prompt: forLine + (step.prompt ? `\n${step.prompt}` : ''),
+      };
+      warnings.push(`Step "${step.name}": unresolved FOR bound — preserved as prompt text`);
+      return fallbackStep;
+    }
+
     const start = resolveBound(fc.start, variables, step.name, 'start');
     const end =
       fc.end !== undefined ? resolveBound(fc.end, variables, step.name, 'end') : undefined;
@@ -233,7 +316,7 @@ export function resolveForBounds(
     return resolvedForStep;
   });
 
-  return { ...runbook, steps: resolvedSteps };
+  return { runbook: { ...runbook, steps: resolvedSteps }, warnings };
 }
 
 // ─── Secure AST-level substitution ───────────────────────────────────────────

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -19,8 +19,11 @@ import type {
   ResolvedStepWithFor,
   StepWithSubsteps,
   UnresolvedForClause,
+  Transitions,
+  TransitionObject,
+  Action,
 } from '@rundown-org/parser';
-import { isUnresolvedForClause, MAX_FOR_BOUND } from '@rundown-org/parser';
+import { isUnresolvedForClause, MAX_FOR_BOUND, stepIdToString } from '@rundown-org/parser';
 
 /**
  * Shared placeholder matcher used across startup and runtime substitution.
@@ -205,10 +208,49 @@ function boundToString(bound: Bound): string {
 function reconstructForLine(fc: UnresolvedForClause): string {
   if (fc.source !== undefined) {
     // UnresolvedSourceWindow always has both start and end (windowed syntax only)
-    return `FOR ${fc.variable} IN ${boundToString(fc.start)} TO ${boundToString(fc.end)} OF {{ ${fc.source} }}`;
+    return `FOR ${fc.variable} IN ${boundToString(fc.start)} TO ${boundToString(fc.end)} OF ${fc.source}`;
   }
   const prefix = fc.variable ? `FOR ${fc.variable} IN` : 'FOR';
   return `${prefix} ${boundToString(fc.start)} TO ${boundToString(fc.end)}`;
+}
+
+function renderActionText(action: Action): string {
+  switch (action.type) {
+    case 'CONTINUE':
+      return 'CONTINUE';
+    case 'DEFER':
+      return 'DEFER';
+    case 'COMPLETE':
+      return action.message ? `COMPLETE "${action.message}"` : 'COMPLETE';
+    case 'STOP':
+      return action.message ? `STOP "${action.message}"` : 'STOP';
+    case 'GOTO':
+      return `GOTO ${stepIdToString(action.target)}`;
+    case 'NEXT':
+      return 'NEXT';
+    case 'BREAK':
+      return 'BREAK';
+  }
+}
+
+function renderTransitionActionText(transition: TransitionObject): string {
+  const actionStr = renderActionText(transition.action);
+  return transition.retry > 0 ? `RETRY ${String(transition.retry)} ${actionStr}` : actionStr;
+}
+
+function aggregationModifier(aggregation: 'ALL' | 'ANY' | 'none', kind: 'pass' | 'fail'): string {
+  if (aggregation === 'none') return '';
+  if (kind === 'pass') return aggregation === 'ALL' ? ' ALL' : ' ANY';
+  return aggregation === 'ALL' ? ' ANY' : ' ALL';
+}
+
+function renderTransitionsText(transitions: Transitions): string {
+  const passAgg = aggregationModifier(transitions.aggregation, 'pass');
+  const failAgg = aggregationModifier(transitions.aggregation, 'fail');
+  return [
+    `- PASS${passAgg} ${renderTransitionActionText(transitions.pass)}`,
+    `- FAIL${failAgg} ${renderTransitionActionText(transitions.fail)}`,
+  ].join('\n');
 }
 
 /**
@@ -264,13 +306,16 @@ export function resolveForBounds(
 
     // If any BoundRef variable is undefined, fall back to prompt text
     if (!allBoundRefsDefined(fc, variables)) {
-      const forLine = reconstructForLine(fc);
+      let forText = reconstructForLine(fc);
+      if (fc.transitions) {
+        forText += `\n${renderTransitionsText(fc.transitions)}`;
+      }
       const { forClause: _, kind: __, ...rest } = step;
       const fallbackStep: StepWithSubsteps = {
         ...rest,
         kind: 'substeps',
         substeps: step.substeps,
-        prompt: forLine + (step.prompt ? `\n${step.prompt}` : ''),
+        prompt: forText + (step.prompt ? `\n${step.prompt}` : ''),
       };
       warnings.push(`Step "${step.name}": unresolved FOR bound — preserved as prompt text`);
       return fallbackStep;

--- a/packages/core/__tests__/runbook/renderer.test.ts
+++ b/packages/core/__tests__/runbook/renderer.test.ts
@@ -221,7 +221,7 @@ describe('renderForClause coverage', () => {
       kind: 'for',
       name: '1',
       description: 'Iterate',
-      forClause: { variable: 'item', start: 1, end: undefined, source: 'items' },
+      forClause: { variable: 'item', start: 1, source: 'items' },
       substeps: [{ id: '1', description: 'Process' }],
     };
     const result = renderStep(step);

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -444,11 +444,13 @@ function createForContext(
       throw new Error(`Data source "${forClause.source}" is not defined`);
     }
 
+    const windowEnd = 'end' in forClause ? forClause.end : undefined;
+
     switch (ds.kind) {
       case 'array': {
         source = { kind: 'array', items: ds.items };
         start = Math.max(1, Math.min(forClause.start, ds.items.length));
-        const requestedEnd = forClause.end ?? ds.items.length;
+        const requestedEnd = windowEnd ?? ds.items.length;
         end = ds.items.length === 0 ? start : Math.max(1, Math.min(requestedEnd, ds.items.length));
         break;
       }
@@ -461,7 +463,7 @@ function createForContext(
           snapshot: null,
         };
         start = forClause.start;
-        end = forClause.end; // undefined for open windows
+        end = windowEnd; // undefined for full source (open) windows
         break;
       }
     }

--- a/packages/core/src/runbook/renderer/renderer.ts
+++ b/packages/core/src/runbook/renderer/renderer.ts
@@ -114,12 +114,12 @@ function renderForClause(forClause: ParsedForClause): string[] {
   const lines: string[] = [];
 
   if (forClause.source !== undefined) {
-    if (forClause.start === 1 && forClause.end === undefined) {
-      lines.push(`- FOR ${forClause.variable} IN {{ ${forClause.source} }}`);
-    } else {
+    if ('end' in forClause) {
       lines.push(
         `- FOR ${forClause.variable} IN ${String(forClause.start)} TO ${String(forClause.end)} OF {{ ${forClause.source} }}`,
       );
+    } else {
+      lines.push(`- FOR ${forClause.variable} IN {{ ${forClause.source} }}`);
     }
   } else if (forClause.variable) {
     if (forClause.start === 1) {

--- a/packages/parser/__tests__/guards.test.ts
+++ b/packages/parser/__tests__/guards.test.ts
@@ -6,6 +6,7 @@ import {
   hasRunbooks,
   hasForClause,
   isSourced,
+  isWindowed,
   isBaseStep,
   isStepWithCommand,
   isStepWithSubsteps,
@@ -15,7 +16,15 @@ import {
   resolvedStepHasSubsteps,
   areAllStepsResolved,
 } from '../src/guards.js';
-import type { Step, Substep, ForClause, ResolvedStep } from '../src/ast.js';
+import type {
+  Step,
+  Substep,
+  ForClause,
+  ResolvedStep,
+  FullSourceWindow,
+  WindowedSourceWindow,
+  SourceWindow,
+} from '../src/ast.js';
 
 const createStep = (overrides: Record<string, unknown> = {}): Step => {
   const obj: Record<string, unknown> = { name: '1', description: 'Test step', ...overrides };
@@ -279,6 +288,26 @@ describe('isSourced', () => {
     if (!isSourced(fc)) {
       const _end: number = fc.end;
       expect(_end).toBe(10);
+    }
+  });
+});
+
+describe('isWindowed', () => {
+  it('returns true for a WindowedSourceWindow (has end)', () => {
+    const fc: WindowedSourceWindow = { variable: 'item', start: 1, end: 10, source: 'items' };
+    expect(isWindowed(fc)).toBe(true);
+  });
+
+  it('returns false for a FullSourceWindow (no end)', () => {
+    const fc: FullSourceWindow = { variable: 'server', start: 1, source: 'servers' };
+    expect(isWindowed(fc as SourceWindow)).toBe(false);
+  });
+
+  it('narrows type so fc.end is number after guard', () => {
+    const fc: SourceWindow = { variable: 'item', start: 1, end: 5, source: 'items' };
+    if (isWindowed(fc)) {
+      const _end: number = fc.end;
+      expect(_end).toBe(5);
     }
   });
 });

--- a/packages/parser/src/ast.ts
+++ b/packages/parser/src/ast.ts
@@ -47,22 +47,45 @@ export interface NumericWindow {
 }
 
 /**
- * Data-source FOR window — values come from a named source.
+ * Full data-source FOR window — iterates all items from a named source.
  *
- * `FOR server IN {{ servers }}` or `FOR item IN 1 TO 10 OF {{ items }}`.
+ * `FOR server IN {{ servers }}` — start is always 1, no end bound.
  */
-export interface SourceWindow {
+export interface FullSourceWindow {
   /** Named loop variable (required — data sources must name the binding) */
   readonly variable: string;
-  /** Start of iteration range (positive integer, defaults to 1) */
+  /** Start of iteration range (defaults to 1 when produced by the parser) */
   readonly start: number;
-  /** End of iteration range (undefined = open, iterate all items) */
-  readonly end?: number;
   /** Key in the sources map */
   readonly source: string;
   /** Iteration-level transition handlers for FOR loops */
   readonly transitions?: Transitions;
 }
+
+/**
+ * Windowed data-source FOR window — iterates a slice of a named source.
+ *
+ * `FOR item IN 1 TO 10 OF {{ items }}` — both start and end bounds required.
+ */
+export interface WindowedSourceWindow {
+  /** Named loop variable (required — data sources must name the binding) */
+  readonly variable: string;
+  /** Start of iteration range (positive integer) */
+  readonly start: number;
+  /** End of iteration range (positive integer, always present for windowed) */
+  readonly end: number;
+  /** Key in the sources map */
+  readonly source: string;
+  /** Iteration-level transition handlers for FOR loops */
+  readonly transitions?: Transitions;
+}
+
+/**
+ * Data-source FOR window — values come from a named source.
+ *
+ * Discriminated by the presence of `end`: absent = full source, present = windowed.
+ */
+export type SourceWindow = FullSourceWindow | WindowedSourceWindow;
 
 /**
  * A FOR clause defines a window over a source.
@@ -105,17 +128,20 @@ export interface UnresolvedNumericWindow {
 }
 
 /**
- * Data-source FOR window with at least one unresolved bound.
+ * Windowed data-source FOR window with at least one unresolved bound.
  *
- * Structurally mirrors {@link SourceWindow} but allows `BoundRef` values
+ * Structurally mirrors {@link WindowedSourceWindow} but allows `BoundRef` values
  * in `start` and/or `end`. Tagged with `unresolved: true` so consumers
  * can narrow with `'unresolved' in fc`.
+ *
+ * Only the windowed syntax (`start TO end OF {{ source }}`) can produce unresolved
+ * bounds — the full source syntax (`FOR var IN {{ source }}`) has no bounds to resolve.
  */
 export interface UnresolvedSourceWindow {
   readonly unresolved: true;
   readonly variable: string;
   readonly start: Bound;
-  readonly end?: Bound;
+  readonly end: Bound;
   readonly source: string;
   readonly transitions?: Transitions;
 }

--- a/packages/parser/src/guards.ts
+++ b/packages/parser/src/guards.ts
@@ -4,6 +4,7 @@ import type {
   Command,
   ForClause,
   SourceWindow,
+  WindowedSourceWindow,
   StepHavingSubsteps,
   ResolvedStep,
   ResolvedStepHavingSubsteps,
@@ -89,6 +90,17 @@ export function hasForClause(step: Step): step is StepWithFor {
  */
 export function isSourced(fc: ForClause): fc is SourceWindow {
   return fc.source !== undefined;
+}
+
+/**
+ * Type guard: narrows a SourceWindow to WindowedSourceWindow (sliced data source).
+ *
+ * @param fc - The source window to check
+ * @returns True if the clause has an explicit end bound (`fc is WindowedSourceWindow`),
+ *   enabling type narrowing to guarantee `fc.end` is a number
+ */
+export function isWindowed(fc: SourceWindow): fc is WindowedSourceWindow {
+  return 'end' in fc;
 }
 
 /**

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -61,6 +61,7 @@ export {
   // eslint-disable-next-line @typescript-eslint/no-deprecated -- backward-compatible re-export
   hasForClause,
   isSourced,
+  isWindowed,
   isBaseStep,
   isStepWithCommand,
   isStepWithSubsteps,

--- a/packages/parser/src/schemas.ts
+++ b/packages/parser/src/schemas.ts
@@ -48,17 +48,35 @@ export const NumericWindowSchema = z.object({
 });
 
 /**
- * Zod schema for SourceWindow
- *
- * Validates data-source FOR loop specifications.
+ * Zod schema for FullSourceWindow — iterates all items from a data source.
  */
-export const SourceWindowSchema = z.object({
+export const FullSourceWindowSchema = z.object({
   variable: z.string().regex(NAMED_IDENTIFIER_PATTERN),
   start: z.number().int().positive().max(MAX_FOR_BOUND),
-  end: z.number().int().positive().max(MAX_FOR_BOUND).optional(),
   source: z.string().regex(NAMED_IDENTIFIER_PATTERN),
   transitions: z.lazy(() => TransitionsSchema.optional()),
 });
+
+/**
+ * Zod schema for WindowedSourceWindow — iterates a slice of a data source.
+ */
+export const WindowedSourceWindowSchema = z.object({
+  variable: z.string().regex(NAMED_IDENTIFIER_PATTERN),
+  start: z.number().int().positive().max(MAX_FOR_BOUND),
+  end: z.number().int().positive().max(MAX_FOR_BOUND),
+  source: z.string().regex(NAMED_IDENTIFIER_PATTERN),
+  transitions: z.lazy(() => TransitionsSchema.optional()),
+});
+
+/**
+ * Zod schema for SourceWindow (union of full and windowed).
+ *
+ * Validates data-source FOR loop specifications.
+ * WindowedSourceWindowSchema is listed first because it is stricter (requires `end`);
+ * Zod tries union members in order and the looser FullSourceWindowSchema would match
+ * windowed inputs if it were first, silently stripping the `end` field.
+ */
+export const SourceWindowSchema = z.union([WindowedSourceWindowSchema, FullSourceWindowSchema]);
 
 /**
  * Zod schema for ForClause
@@ -96,13 +114,13 @@ export const UnresolvedNumericWindowSchema = z.object({
 });
 
 /**
- * Zod schema for UnresolvedSourceWindow.
+ * Zod schema for UnresolvedSourceWindow (windowed only — end is required).
  */
 export const UnresolvedSourceWindowSchema = z.object({
   unresolved: z.literal(true),
   variable: z.string().regex(NAMED_IDENTIFIER_PATTERN),
   start: BoundSchema,
-  end: BoundSchema.optional(),
+  end: BoundSchema,
   source: z.string().regex(NAMED_IDENTIFIER_PATTERN),
   transitions: z.lazy(() => TransitionsSchema.optional()),
 });


### PR DESCRIPTION
… FORMAT.md

Commit 475b7f40 changed resolveForBounds to throw on undefined FOR bound variables. The documented (correct) behavior is to preserve the FOR line as literal prompt text, allowing orchestrating agents to handle unresolved bounds. This restores that fallback: undefined variables produce a warning and the step becomes a StepWithSubsteps with the FOR line as prompt text. Invalid values (non-integer, out-of-range) still throw.

Also syncs SPEC.md and FORMAT.md with implementation:
- Add GOTO NEXT internal compiler note
- Clarify CONTINUE context-dependent semantics (step vs FOR iteration)
- Document forClause.transitions field for iteration-level transitions
- Add variable precedence table
- Clarify depth limit scope (delegation ancestor chain)
- Clarify sequential ID rule (named steps exempt)
- Fix text-before-transitions wording
- Add step kind discriminant note
- Document Transitions.aggregation field in FORMAT.md
- Add implicit transitions parser/runtime note
- Add ParseResult.frontmatter note