### PR TITLE
Ebnf grammar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ Data sources are referenced in FOR clauses: `FOR item IN {{ items }}`.
 - File paths must stay within the project root (symlinks resolved, traversal blocked)
 - `file:` values are routed to sources only — they do NOT appear as template variables
 
+**Note:** The `scenarios` frontmatter field is an internal testing/demo feature, not part of the public Rundown format specification. See [docs/SCENARIOS.md](docs/SCENARIOS.md).
+
 ## Schema Output
 
 The `--schema` flag outputs the JSON Schema for a command's `--json` output (supported by all commands with `--json` output):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,7 +341,7 @@ Currently supported internally: `echo`, `prompt`. Unsupported commands fall back
 ## Documentation
 
 - [docs/SPEC.md](docs/SPEC.md) - Rundown specification
-- [docs/FORMAT.md](docs/FORMAT.md) - Formal BNF-style grammar
+- [docs/FORMAT.md](docs/FORMAT.md) - W3C EBNF grammar for runbook syntax
 - [docs/MCP.md](docs/MCP.md) - MCP server reference
 - [docs/SECURITY.md](docs/SECURITY.md) - Security policy configuration
 - [docs/RUNDOWN.md](docs/RUNDOWN.md) - Rundown internal architecture

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -40,6 +40,7 @@ deps
 deserialized
 dotdot
 émoji
+EBNF
 env
 esac
 esm

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -39,8 +39,8 @@ delegatable
 deps
 deserialized
 dotdot
-émoji
 EBNF
+émoji
 env
 esac
 esm

--- a/docs/AGENT-ORCHESTRATION.md
+++ b/docs/AGENT-ORCHESTRATION.md
@@ -110,7 +110,7 @@ Tool: Skill(skill: "rundown:writing-plans")
 
 ## 2. Write the plan
 - PASS COMPLETE
-- FAIL RETRY 2
+- FAIL RETRY 2 STOP
 
 Write and save the implementation plan.
 ```

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -45,7 +45,7 @@ tags_field    ::= "tags:" newline tag_list
 vars_field    ::= "vars:" newline vars_map
 
 name_string   ::= [a-zA-Z0-9_-] ( [a-zA-Z0-9_ -]* [a-zA-Z0-9_-] )?
-tag_list      ::= ( ws "- " text newline )+
+tag_list      ::= ( ws "- " tag newline )+
 tag           ::= text
 vars_map      ::= ( ws variable_name ":" ws value newline )+
 value         ::= text

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -1,333 +1,246 @@
----
-version: 1.0.0
----
+# Rundown Grammar
 
-# Rundown Format
+W3C EBNF grammar for Rundown runbook syntax.
+See [SPEC.md](./SPEC.md) for execution semantics.
 
-Formal BNF-style grammar for Rundown runbook syntax. See [SPEC.md](./SPEC.md) for prose explanations and examples.
-
-## Grammar Notation
+## Notation
 
 | Symbol | Meaning |
 |--------|---------|
-| `[ x ]` | Optional element |
-| `{ x }` | Zero or more repetitions |
-| `x \| y` | Choice (x or y) |
-| `"text"` | Literal text |
-| `x ...` | One or more of x |
-| `positive_integer` | Integer > 0 (1, 2, 3, ...) |
-| `ws` | One or more horizontal whitespace characters (space or tab) |
+| `::=` | Production rule |
+| `\|` | Alternative |
+| `?` | Optional (zero or one) |
+| `*` | Zero or more |
+| `+` | One or more |
+| `( )` | Grouping |
+| `" "` | Literal string |
+| `[ ]` | Character class |
+
+`ws` denotes required whitespace (space or tab). `newline` denotes a line break. Keywords are case-sensitive unless noted.
 
 ---
 
-[ frontmatter ]
-# title
-[ description ]
+## Document Structure
 
-steps
+```
+runbook  ::= frontmatter? title? preamble? step+
+title    ::= "# " text newline
+preamble ::= text+
+```
 
-where steps is:
-  step [ step ... ]
+## Frontmatter
 
-where step is:
-  "##" step-identifier [ separator ] title
-    [ for_clause ]
-    [ transition ... ]
-    [ prompt ]
-    [{ code_block | substeps | runbooks }]
+```
+frontmatter ::= "---" newline yaml_block "---" newline
+```
 
-where separator is:
-  [ "." | ":" | "—" | "→" | "-" | ")" | " " ]+
+Known fields:
 
-where prompt is:
-  [ text ]
+```
+name_field    ::= "name:" ws name_string
+desc_field    ::= "description:" ws text
+version_field ::= "version:" ws text
+author_field  ::= "author:" ws text
+tags_field    ::= "tags:" newline tag_list
+vars_field    ::= "vars:" newline vars_map
 
-where substeps is:
-  substep [ substep ... ]
+name_string   ::= [a-zA-Z0-9_-] ( [a-zA-Z0-9_ -]* [a-zA-Z0-9_-] )?
+tag_list      ::= ( ws "- " text newline )+
+tag           ::= text
+vars_map      ::= ( ws variable_name ":" ws value newline )+
+value         ::= text
+```
 
-where substep is:
-  "###" substep_id [ separator ] [ title ]
-    [ transition ... ]
-    [ prompt ]
-    [{ code_block | runbooks }]
+Additional fields beyond those listed are preserved (open schema). All fields are optional.
 
-where substep_id is:
-  positive_integer                              -- bare numeric (parent positionally assigned)
-  | name                                        -- bare named (parent positionally assigned)
-  | parent_ref "." ( positive_integer | name )  -- qualified form
+## Steps
 
-where parent_ref is:
-  positive_integer    -- for static parent
-  | name              -- for named parent
+```
+step ::= "## " step_id separator? text? newline
+         for_clause?
+         transition*
+         prompt?
+         body?
+```
 
-where step-identifier is:
-  positive_integer | name
+Content must appear in the order shown: FOR, transitions, prompt, body.
 
-where substep-identifier is:
-  step-identifier "." ( positive_integer | name )
+## Substeps
 
-where name is:
-  [A-Za-z_][A-Za-z0-9_]*
-  (case-sensitive; must not be a reserved word: NEXT, CONTINUE, DEFER, COMPLETE, STOP, GOTO, RETRY, PASS, FAIL, YES, NO, ALL, ANY, BREAK, FOR, IN, TO, AT)
+```
+substep ::= "### " substep_id separator? text? newline
+            transition*
+            prompt?
+            ( code_block | runbook_list )?
+```
 
-where code_block is:
-  "```" info_string
-    content
-  "```"
+Substeps cannot contain nested substeps.
 
-where info_string is:
-  language [ ws "prompt" ]
+## Identifiers
 
-Note: A language tag is required — bare code fences (no info string) are invalid. `prompt` alone (without a language prefix) is valid for text-only prompts, e.g., ` ```prompt `. Non-executable language tags (e.g., `json`, `yaml`) are treated as prompt blocks.
+```
+step_id      ::= positive_integer | named_id
+substep_id   ::= positive_integer | named_id | qualified_id
+named_id     ::= [A-Za-z_] [A-Za-z0-9_]*
+qualified_id ::= step_ref "." ( positive_integer | named_id )
+step_ref     ::= positive_integer | named_id
+```
 
-where runbooks is:
-  - runbook_path [ ... ]
+`named_id` must not be a [reserved word](#reserved-words). Reserved word matching is case-sensitive.
 
-Step-level `runbooks` syntax is shorthand for implicit sequential substeps (`### N.1`, `### N.2`, ...), one workflow path per generated substep.
-If prompt text appears before a step-level `runbooks` shorthand body, it is attached to the first generated implicit substep only.
+## Separators
 
-where transition is:
-  - { PASS | FAIL | YES | NO } [ { ALL | ANY } ] result
-  | - DEFER                         -- shorthand for PASS DEFER + FAIL DEFER
+```
+separator ::= ( "." | ":" | "\u2014" | "\u2192" | "-" | ")" | " " )+
+```
 
-Transitions must appear as list items with the `-` bullet prefix (a dash followed by a space). Paragraph-style transitions (without prefix) are not valid.
+Unicode escapes: `\u2014` is em dash (—), `\u2192` is right arrow (→).
 
-Note: Transition keywords (`PASS`, `YES`, `FAIL`, `NO`) are matched as whole words — the keyword must be followed by a space. A bullet beginning with `NOTE` or `PASSING` is not treated as a transition.
+## FOR Clauses
 
-Aggregation always waits for all DEFER'd results before evaluating. `ALL`/`ANY` evaluates over the count of DEFER'd results.
+```
+for_clause  ::= "- FOR" ws for_variant newline
+                nested_transition*
 
-The parsed Transitions object includes an `aggregation` field (`'ALL'` | `'ANY'` | `'none'`) alongside the `pass` and `fail` handlers.
+for_variant ::= variable_name ws "IN" ws positive_integer ws "TO" ws positive_integer ws "OF" ws source_ref
+              | variable_name ws "IN" ws source_ref
+              | variable_name ws "IN" ws range
+              | range
 
-where result is:
-  action | RETRY [ count ] [ action ]
+range       ::= positive_integer ( ws "TO" ws positive_integer )?
+source_ref  ::= "{{" ws? variable_name ws? "}}"
 
-where action is:
-  CONTINUE | DEFER | COMPLETE [ message ] | STOP [ message ] | GOTO target | NEXT | BREAK
+nested_transition ::= ws "- " result_keyword ( ws aggregation )? ws action newline
+                    | ws "- DEFER" newline
+```
+
+Template variables (`{{var}}`) may appear in range bound positions. Source references (`{{ source }}`) in `FOR var IN {{ source }}` and `... OF {{ source }}` are data source identifiers.
+
+**Examples:**
+
+```markdown
+- FOR batch IN 1 TO 10
+- FOR 5
+- FOR item IN {{ tasks }}
+- FOR item IN 3 TO 7 OF {{ items }}
+```
+
+## Transitions
+
+```
+transition     ::= "- " result_keyword ( ws aggregation )? ws action newline
+                 | "- DEFER" newline
+
+result_keyword ::= "PASS" | "FAIL" | "YES" | "NO"
+aggregation    ::= "ALL" | "ANY"
+```
+
+`YES` is a syntactic alias for `PASS`. `NO` is a syntactic alias for `FAIL`. Transitions must use `-` bullet prefix. Transition keywords are matched as whole words — the keyword must be followed by whitespace.
+
+## Actions
+
+```
+action ::= "CONTINUE"
+         | "DEFER"
+         | "NEXT"
+         | "BREAK"
+         | "COMPLETE" ( ws message )?
+         | "STOP" ( ws message )?
+         | "GOTO" ws target
+         | "RETRY" ( ws positive_integer )? ( ws action )? ( ws message )?
+```
+
+Action keywords are matched before `message` in all positions. A bare message after RETRY count (e.g., `RETRY 3 "error"`) is shorthand for `RETRY 3 STOP "error"`. RETRY fallback action cannot be RETRY.
 
 Context constraints:
-- `DEFER` is only valid inside substeps or FOR iteration-level nested transitions
-- `NEXT` is only valid inside substeps of a FOR step and FOR iteration-level transitions
-- `BREAK` is valid inside substeps of a FOR step and FOR-level nested transitions
-- FOR-level nested transitions (nested bullets under `- FOR ...`) only allow terminal actions: `CONTINUE` (exit loop), `DEFER`, `NEXT` (loop back without accumulation), `BREAK`, `GOTO`, `STOP`, `COMPLETE` (optionally wrapped in `RETRY`)
 
-where message is:
-  name | "\"" text "\""
+| Action | Valid in |
+|--------|---------|
+| `DEFER` | Substeps, FOR nested transitions |
+| `NEXT` | FOR substeps, FOR nested transitions |
+| `BREAK` | FOR substeps, FOR nested transitions |
 
-where target is:
-  step-identifier [ "AT" index ]
-  | substep-identifier [ "AT" index ]
+FOR nested transitions allow: `CONTINUE`, `DEFER`, `NEXT`, `BREAK`, `GOTO`, `STOP`, `COMPLETE` (with optional `RETRY` wrapper).
 
-> **Internal:** The compiler internally represents "advance to next step" as `GOTO NEXT`. This cannot be written in runbook syntax — the parser rejects `NEXT` as a GOTO target. The `StepId` schema includes an optional `qualifier` field for this internal representation.
+## Targets
 
-where index is:
-  positive_integer | "{{" [ ws ] variable_name [ ws ] "}}"
+```
+target ::= ( step_id | substep_id ) ( ws "AT" ws index )?
+index  ::= positive_integer | template_variable
+```
 
-where for_clause is:
-  "- FOR" [ variable_name "IN" ] range
-  | "- FOR" variable_name "IN" source_ref
-  | "- FOR" variable_name "IN" positive_integer "TO" positive_integer "OF" source_ref
+`NEXT` is not a valid GOTO target.
 
-where source_ref is:
-  "{{" [ ws ] variable_name [ ws ] "}}"    -- references a named data source
+## Messages
 
-where range is:
-  positive_integer                              -- implicit start (1), end is positive_integer
-  | positive_integer "TO" positive_integer      -- explicit start and end
+```
+message       ::= named_id | quoted_string
+quoted_string ::= '"' text '"'
+```
 
-Whitespace inside `{{ }}` delimiters is optional.
+## Code Blocks
 
-Authoring note: Template variables (e.g., `{{count}}`, `1 TO {{max}}`) may be used in range positions. They are expanded to literal positive integers before parsing (see two-phase model below).
+```
+code_block ::= "```" info_string newline content "```" newline
 
-Note: Template variable bounds (e.g., `{{count}}`) are expanded to literal positive integers before the FOR clause is parsed (two-phase model: Handlebars expansion first, then parser processes the result). Source references in `FOR var IN {{ source }}` and `... OF {{ source }}` are NOT expanded — they are parsed as data source identifiers resolved at runtime.
+info_string ::= executable_lang ( ws "prompt" )?
+              | display_lang
+              | "prompt"
 
-When a template-variable bound cannot be resolved (undefined variable), the FOR clause line is preserved as literal prompt text rather than producing a parse error. This enables orchestrating agents to handle unresolved bounds.
+executable_lang ::= "bash" | "sh" | "shell"
+display_lang    ::= language_tag
+```
 
-where variable_name is:
-  `[a-zA-Z_][a-zA-Z0-9_]*`
-
-where frontmatter is:
-  "---"
-    [ "name:" name_string ]
-    [ "description:" text ]
-    [ "version:" text ]
-    [ "author:" text ]
-    [ "tags:" tag_list ]
-    [ "vars:" vars_map ]
-  "---"
-
-Additional fields beyond those listed are preserved in the parsed frontmatter (open schema). This allows forward-compatible extensions and user-defined metadata.
-
-Note: The frontmatter `description` field is used for runbook discovery and listing (e.g., `rd ls --all`). The Runbook's structural `description` in the parsed AST is derived from preamble text between the H1 title and first H2 step. These are independent values.
-
-where name_string is:
-  [a-zA-Z0-9_-]([a-zA-Z0-9_ -]*[a-zA-Z0-9_-])?
-  (alphanumeric with underscores, hyphens, and internal spaces;
-   must not start or end with a space)
-
-where tag_list is:
-  "- " tag { "- " tag }
-
-where tag is:
-  text
-  (any string - convention is lowercase alphanumeric with hyphens)
-
-where vars_map is:
-  variable_name ":" value { variable_name ":" value }
-  (YAML mapping of variable names to string, number, or boolean values)
-
-Note: Frontmatter `vars` are not included in the parsed Runbook AST. They are consumed by the CLI template rendering pipeline. Reserved variable names (`step`, `index`, `context`, case-insensitive) are rejected with an error diagnostic.
-
-The `ParseResult` includes a `frontmatter` field containing the validated `RunbookFrontmatter` (or `null` if no frontmatter is present), alongside the parsed `Runbook` AST.
-
----
-
-## FOR Clause
-
-The FOR clause is a step-level annotation that makes a step iterate its substeps. It appears as a bullet point before transitions.
-
-**Syntax variants:**
-
-| Form | Example | Description |
-|------|---------|-------------|
-| Named variable, ascending range | `- FOR batch IN 1 TO 10` | Iterates 1..10, `{{batch}}` available |
-| No variable, ascending range | `- FOR 1 TO 10` | Iterates 1..10, no named variable |
-| Named variable, descending range | `- FOR batch IN 10 TO 1` | Iterates 10..1, `{{batch}}` available |
-| No variable, descending range | `- FOR 10 TO 1` | Iterates 10..1, no named variable |
-| Named variable, implicit start | `- FOR batch IN 10` | Iterates 1..10, `{{batch}}` available |
-| No variable, implicit start | `- FOR 10` | Iterates 1..10, no named variable |
-| Variable bounds | `- FOR batch IN 1 TO {{Max}}` | End bound from template variable |
-| Named variable, source (all items) | `- FOR item IN {{ items }}` | Iterates all items from data source, `{{item}}` available |
-| Named variable, windowed source | `- FOR item IN 3 TO 7 OF {{ items }}` | Items 3–7 from data source, `{{item}}` available |
-
-**Direction inference:** When `start > end`, the loop iterates downward (step size −1). When `start <= end`, it iterates upward (step size +1). Single-number shorthand (`FOR N`) always ascends from 1.
-
-**Data source binding:** When a FOR clause references a data source, the named variable receives the data element at each iteration — not the iteration index. `{{Index}}` always holds the 1-based iteration number. A named variable is required for data source FOR clauses. Data sources are defined via `.rundown/config.yaml` or `--var-file`. See [RUNDOWN.md](./RUNDOWN.md#data-sources) for configuration details.
-
-**Rules:**
-- FOR must appear before transitions in the step's bullet list
-- `NEXT` is only valid inside substeps of a FOR step and FOR iteration-level transitions
-- `BREAK` is valid within substeps and FOR-level nested transitions
-- `AT` is only valid when the GOTO target is a FOR step (cross-step allowed, but the target must be FOR and have substeps)
-- Step-level runbook lists satisfy the FOR-substep requirement via implicit sequential substeps
-- Parent FOR step transitions aggregate across iterations using ALL/ANY modifiers
-- FOR-level nested transitions execute at iteration scope; RETRY evaluates before the exhausted action
-- Iteration-level `BREAK` exits the loop without recording the current iteration result (non-accumulating, same as NEXT); iteration-level `GOTO`/`STOP`/`COMPLETE` bypass parent aggregation
-- Nested bullets under `FOR` must be transition bullets; non-transition nested bullets are invalid
-
-### Execution Path Notation
-
-Runtime execution paths are often displayed as `STEP.INDEX.SUBSTEP` (for example `1.2.1`). This is display-only notation and not authoring syntax.
-
-Canonical runtime targeting is `step + substep + iteration`.
-
----
-
-## Built-In Variables
-
-| Variable | Value | Available |
-|----------|-------|-----------|
-| `{{Step}}` | Qualified step identifier (e.g., `3`, `3.1`, `ErrorHandler`; shorthand runbook-list steps execute as `N.1`, `N.2`, ...) | Always |
-| `{{Index}}` | Current loop iteration number (1-based) | Inside FOR steps |
-| `{{step}}` | Lowercase alias for current step identifier | Always |
-| `{{index}}` | Lowercase alias for current loop iteration number | Inside FOR steps |
-| `{{context.current.*}}` | Canonical current runbook context (`step`, `substep`, `index`, `at`) | Always |
-| `{{context.parent.*}}` | Parent runbook context (`step`, `substep`, `index`, `at`, `vars.*`) | Nested runbooks |
-| `{{context.ancestors.N.*}}` | Ancestor runbook contexts (`0` = nearest parent; includes `vars.*`) | Nested runbooks |
-| `{{context.vars.NAME}}` | User/config/frontmatter variables under canonical namespace | Always |
-
-`{{Step}}`/`{{Index}}` and lowercase aliases are expanded per-step/per-iteration. For data source loops, the named variable holds the data element while `{{Index}}`/`{{index}}` holds the iteration number. Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive) and cannot be overridden by user variables.
-
----
+Language tag is required — bare code fences are invalid. Tags are matched case-insensitively. Non-executable tags (e.g., `json`, `yaml`) are display-only.
 
 ## Template Variables
 
-| Pattern             | Variable  | Expansion                               |
-|---------------------|-----------|-----------------------------------------|
-| `{{VariableName}}`  | defined   | literal variable value                  |
-| `{{VariableName}}`  | undefined | preserved as literal `{{VariableName}}` (warning emitted to stderr) |
-| `{{path.to.value}}` | missing path | preserved as literal `{{path.to.value}}` (warning emitted to stderr) |
+```
+template_variable ::= "{{" ws? variable_path ws? "}}"
+variable_path     ::= variable_name ( "." variable_name )*
+variable_name     ::= [a-zA-Z_] [a-zA-Z0-9_]*
+```
 
+## Runbook Lists
 
- VariableName: `/^[a-zA-Z_][a-zA-Z0-9_]*$/`
+```
+runbook_list ::= ( "- " file_path newline )+
+```
 
----
+Step-level runbook lists are shorthand for implicit sequential substeps.
 
-## Expansion Rules
+## Body
 
-### Transition Aliases
+```
+body ::= code_block | substep+ | runbook_list
+```
 
-| Input | Expands To |
-|-------|------------|
-| `YES X` | `PASS X` |
-| `NO X` | `FAIL X` |
+A step contains at most one body type.
 
-### Modifier Defaults
+## Prompt
 
-When no aggregation modifier is written, the runtime applies these defaults:
+```
+prompt ::= text+
+```
 
-| Input | Runtime Behavior |
-|-------|------------------|
-| `PASS X` (no modifier) | Treated as `PASS ALL X` |
-| `FAIL X` (no modifier) | Treated as `FAIL ANY X` |
+Free-form text between transitions and body.
 
-Note: Unlike Transition Aliases and RETRY Defaults (which are literal parser expansions), modifier defaults are semantic — the parser stores no aggregation value, and the runtime applies ALL/ANY behavior implicitly.
+## Reserved Words
 
-### RETRY Defaults
+`ALL`, `ANY`, `AT`, `BREAK`, `COMPLETE`, `CONTINUE`, `DEFER`, `FAIL`, `FOR`, `GOTO`, `IN`, `NEXT`, `NO`, `PASS`, `RETRY`, `STOP`, `TO`, `YES`
 
-| Input | Expands To |
-|-------|------------|
-| `RETRY`              | `RETRY 1 STOP` |
-| `RETRY n`            | `RETRY n STOP` |
-| `RETRY n "message"`  | `RETRY n STOP "message"` |
-| `RETRY n action`     | `RETRY n action` |
+Case-sensitive: `NEXT` is reserved; `Next` and `NextStep` are valid.
 
-The fallback action cannot be RETRY (nested RETRY is invalid).
+## Lexical Rules
 
-### GOTO AT Defaults
-
-| Input | Expands To |
-|-------|------------|
-| `GOTO N` (FOR step) | `GOTO N AT <start>` (loop's start value) |
-| `GOTO N AT I` (FOR step) | `GOTO N AT I` |
-
-### Implicit Transitions
-
-| Condition         | Expands To |
-|-------------------|------------|
-| None defined      | `PASS ALL CONTINUE` + `FAIL ANY STOP` |
-| Only PASS defined | Adds `FAIL ANY STOP` |
-| Only FAIL defined | Adds `PASS ALL CONTINUE` |
-
-**Convention:** Always write both transitions explicitly. The parser supports implicit defaults, but runbooks should be readable without memorizing the default table.
-
-> **Implementation note:** The parser produces `undefined` transitions when none are defined. The runtime compiler applies the defaults shown above via `DEFAULT_TRANSITIONS`. This is consistent with the existing note that aggregation modifier defaults are semantic rather than parser-level.
-
-### Message Convention
-
-STOP and COMPLETE accept optional messages. Include a message only when it provides context beyond what the step title already communicates — such as actionable guidance or diagnostic hints. Omit when the step title makes the outcome self-evident.
-
-### Code Block Semantics
-
-| Info String | Behavior |
-|------------------------|----------|
-| `bash`, `sh`, `shell`  | Execute; exit 0=PASS, non-zero=FAIL |
-| `{language} prompt`    | Output only  |
-| other (e.g., `json`, `yaml`) | Output only (treated as prompt) |
-| *(none)*               | Invalid — bare code fences are rejected |
-
-Code block info string tags are matched case-insensitively. `BASH`, `Bash`, and `bash` are all treated as executable.
-
----
-
-## Formatting Notes
-
-Runbook files follow standard markdown formatting conventions:
-
-- **Blank lines around headings** (MD022) — headings should be surrounded by blank lines
-- **Blank lines around lists** (MD032) — transition bullet lists should be surrounded by blank lines
-- **Blank lines around fenced code blocks** (MD031) — code blocks should be surrounded by blank lines
-- **No multiple consecutive blank lines** (MD012)
-
-These rules are enforced by markdownlint. See `.markdownlint-cli2.yaml` for configuration.
-
-Note: All frontmatter fields (`name`, `description`, `version`, `author`, `tags`, `vars`) are optional per the schema. Preamble text between the H1 title and first H2 step is also optional.
+```
+positive_integer ::= [1-9] [0-9]*
+digit            ::= [0-9]
+text             ::= [^\n]+
+file_path        ::= [^\n]+
+language_tag     ::= [a-zA-Z] [a-zA-Z0-9]*
+ws               ::= ( " " | "\t" )+
+newline          ::= "\n"
+yaml_block       ::= (* opaque YAML content *)
+content          ::= (* opaque code block content *)
+```

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -96,6 +96,8 @@ separator ::= ( "." | ":" | "\u2014" | "\u2192" | "-" | ")" | " " )+
 
 Unicode escapes: `\u2014` is em dash (—), `\u2192` is right arrow (→).
 
+Separators are matched greedily — the longest sequence of separator characters between identifier and description text is consumed.
+
 ## FOR Clauses
 
 ```
@@ -137,6 +139,8 @@ aggregation    ::= "ALL" | "ANY"
 
 `YES` is a syntactic alias for `PASS`. `NO` is a syntactic alias for `FAIL`. Transitions must use `-` bullet prefix. Transition keywords are matched as whole words — the keyword must be followed by whitespace.
 
+**Disambiguation:** A `- ` bullet inside a step is resolved by priority: (1) FOR clause (`FOR` keyword), (2) transition (`PASS`, `FAIL`, `YES`, `NO`, or standalone `DEFER`), (3) runbook reference (`.runbook.md` suffix), (4) prompt text.
+
 ## Actions
 
 ```
@@ -150,7 +154,7 @@ action ::= "CONTINUE"
          | "RETRY" ( ws positive_integer )? ( ws action )? ( ws message )?
 ```
 
-Action keywords are matched before `message` in all positions. A bare message after RETRY count (e.g., `RETRY 3 "error"`) is shorthand for `RETRY 3 STOP "error"`. RETRY fallback action cannot be RETRY.
+Reserved words cannot appear as bare messages. Use quoted form for reserved-word messages (e.g., `RETRY 3 STOP "COMPLETE"`). Bare `RETRY` defaults to `RETRY 1 STOP`. `RETRY N` without fallback action defaults to `RETRY N STOP`. A bare message after RETRY count (e.g., `RETRY 3 "error"`) is shorthand for `RETRY 3 STOP "error"`. RETRY fallback action cannot be RETRY.
 
 Context constraints:
 
@@ -174,14 +178,17 @@ index  ::= positive_integer | template_variable
 ## Messages
 
 ```
-message       ::= named_id | quoted_string
+message       ::= bare_message | quoted_string
+bare_message  ::= named_id    /* must not be a reserved word */
 quoted_string ::= '"' text '"'
 ```
+
+`bare_message` must not be a [reserved word](#reserved-words). To use a reserved word as a message, use the quoted form: `PASS STOP "COMPLETE"`, not `PASS STOP COMPLETE`.
 
 ## Code Blocks
 
 ```
-code_block ::= "```" info_string newline content "```" newline
+code_block ::= backtick_fence info_string newline content backtick_fence newline
 
 info_string ::= executable_lang ( ws "prompt" )?
               | display_lang
@@ -191,7 +198,7 @@ executable_lang ::= "bash" | "sh" | "shell"
 display_lang    ::= language_tag
 ```
 
-Language tag is required — bare code fences are invalid. Tags are matched case-insensitively. Non-executable tags (e.g., `json`, `yaml`) are display-only.
+Opening fence is 3 or more backticks. Closing fence must use at least as many backticks as the opening fence (CommonMark §4.5). Language tag is required — bare code fences are invalid. Tags are matched case-insensitively. Non-executable tags (e.g., `json`, `yaml`) are display-only.
 
 ## Template Variables
 
@@ -242,5 +249,6 @@ language_tag     ::= [a-zA-Z] [a-zA-Z0-9]*
 ws               ::= ( " " | "\t" )+
 newline          ::= "\n"
 yaml_block       ::= (* opaque YAML content *)
+backtick_fence   ::= "```" "`"*    /* 3 or more; closing fence >= opening count */
 content          ::= (* opaque code block content *)
 ```

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -109,10 +109,12 @@ for_variant ::= variable_name ws "IN" ws positive_integer ws "TO" ws positive_in
               | variable_name ws "IN" ws range
               | range
 
-range       ::= positive_integer ( ws "TO" ws positive_integer )?
+range_value ::= positive_integer | template_variable
+range       ::= range_value ( ws "TO" ws range_value )?
 source_ref  ::= "{{" ws? variable_name ws? "}}"
 
 nested_transition ::= ws "- " result_keyword ( ws aggregation )? ws action newline
+                    | ws "- " result_keyword ( ws aggregation )? ws "RETRY" ws positive_integer ws action newline
                     | ws "- DEFER" newline
 ```
 
@@ -131,6 +133,7 @@ Template variables (`{{var}}`) may appear in range bound positions. Source refer
 
 ```
 transition     ::= "- " result_keyword ( ws aggregation )? ws action newline
+                 | "- " result_keyword ( ws aggregation )? ws "RETRY" ws positive_integer ws action newline
                  | "- DEFER" newline
 
 result_keyword ::= "PASS" | "FAIL" | "YES" | "NO"
@@ -151,10 +154,9 @@ action ::= "CONTINUE"
          | "COMPLETE" ( ws message )?
          | "STOP" ( ws message )?
          | "GOTO" ws target
-         | "RETRY" ( ws positive_integer )? ( ws action )? ( ws message )?
 ```
 
-Reserved words cannot appear as bare messages. Use quoted form for reserved-word messages (e.g., `RETRY 3 STOP "COMPLETE"`). Bare `RETRY` defaults to `RETRY 1 STOP`. `RETRY N` without fallback action defaults to `RETRY N STOP`. A bare message after RETRY count (e.g., `RETRY 3 "error"`) is shorthand for `RETRY 3 STOP "error"`. RETRY fallback action cannot be RETRY.
+Reserved words cannot appear as bare messages. Use quoted form for reserved-word messages (e.g., `RETRY 3 STOP "COMPLETE"`). When RETRY is used, both count and fallback action are required. RETRY fallback action cannot be RETRY.
 
 Context constraints:
 
@@ -191,7 +193,7 @@ quoted_string ::= '"' text '"'
 code_block ::= backtick_fence info_string newline content backtick_fence newline
 
 info_string ::= executable_lang ( ws "prompt" )?
-              | display_lang
+              | display_lang ( ws "prompt" )?
               | "prompt"
 
 executable_lang ::= "bash" | "sh" | "shell"

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -206,7 +206,7 @@ Opening fence is 3 or more backticks. Closing fence must use at least as many ba
 
 ```
 template_variable ::= "{{" ws? variable_path ws? "}}"
-variable_path     ::= variable_name ( "." variable_name )*
+variable_path     ::= variable_name ( "." ( variable_name | digit+ ) )*
 variable_name     ::= [a-zA-Z_] [a-zA-Z0-9_]*
 ```
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -22,7 +22,7 @@ See [SPEC.md](./SPEC.md) for execution semantics.
 
 ## Document Structure
 
-```
+```ebnf
 runbook  ::= frontmatter? title? preamble? step+
 title    ::= "# " text newline
 preamble ::= text+
@@ -30,13 +30,13 @@ preamble ::= text+
 
 ## Frontmatter
 
-```
+```ebnf
 frontmatter ::= "---" newline yaml_block "---" newline
 ```
 
 Known fields:
 
-```
+```ebnf
 name_field    ::= "name:" ws name_string
 desc_field    ::= "description:" ws text
 version_field ::= "version:" ws text
@@ -55,7 +55,7 @@ Additional fields beyond those listed are preserved (open schema). All fields ar
 
 ## Steps
 
-```
+```ebnf
 step ::= "## " step_id separator? text? newline
          for_clause?
          transition*
@@ -67,7 +67,7 @@ Content must appear in the order shown: FOR, transitions, prompt, body.
 
 ## Substeps
 
-```
+```ebnf
 substep ::= "### " substep_id separator? text? newline
             transition*
             prompt?
@@ -78,7 +78,7 @@ Substeps cannot contain nested substeps.
 
 ## Identifiers
 
-```
+```ebnf
 step_id      ::= positive_integer | named_id
 substep_id   ::= positive_integer | named_id | qualified_id
 named_id     ::= [A-Za-z_] [A-Za-z0-9_]*
@@ -90,7 +90,7 @@ step_ref     ::= positive_integer | named_id
 
 ## Separators
 
-```
+```ebnf
 separator ::= ( "." | ":" | "\u2014" | "\u2192" | "-" | ")" | " " )+
 ```
 
@@ -100,7 +100,7 @@ Separators are matched greedily — the longest sequence of separator characters
 
 ## FOR Clauses
 
-```
+```ebnf
 for_clause  ::= "- FOR" ws for_variant newline
                 nested_transition*
 
@@ -131,7 +131,7 @@ Template variables (`{{var}}`) may appear in range bound positions. Source refer
 
 ## Transitions
 
-```
+```ebnf
 transition     ::= "- " result_keyword ( ws aggregation )? ws action newline
                  | "- " result_keyword ( ws aggregation )? ws "RETRY" ws positive_integer ws action newline
                  | "- DEFER" newline
@@ -142,11 +142,11 @@ aggregation    ::= "ALL" | "ANY"
 
 `YES` is a syntactic alias for `PASS`. `NO` is a syntactic alias for `FAIL`. Transitions must use `-` bullet prefix. Transition keywords are matched as whole words — the keyword must be followed by whitespace.
 
-**Disambiguation:** A `- ` bullet inside a step is resolved by priority: (1) FOR clause (`FOR` keyword), (2) transition (`PASS`, `FAIL`, `YES`, `NO`, or standalone `DEFER`), (3) runbook reference (`.runbook.md` suffix), (4) prompt text.
+**Disambiguation:** A `-`-prefixed bullet inside a step is resolved by priority: (1) FOR clause (`FOR` keyword), (2) transition (`PASS`, `FAIL`, `YES`, `NO`, or standalone `DEFER`), (3) runbook reference (`.runbook.md` suffix), (4) prompt text.
 
 ## Actions
 
-```
+```ebnf
 action ::= "CONTINUE"
          | "DEFER"
          | "NEXT"
@@ -170,7 +170,7 @@ FOR nested transitions allow: `CONTINUE`, `DEFER`, `NEXT`, `BREAK`, `GOTO`, `STO
 
 ## Targets
 
-```
+```ebnf
 target ::= ( step_id | substep_id ) ( ws "AT" ws index )?
 index  ::= positive_integer | template_variable
 ```
@@ -179,7 +179,7 @@ index  ::= positive_integer | template_variable
 
 ## Messages
 
-```
+```ebnf
 message       ::= bare_message | quoted_string
 bare_message  ::= named_id    /* must not be a reserved word */
 quoted_string ::= '"' text '"'
@@ -189,7 +189,7 @@ quoted_string ::= '"' text '"'
 
 ## Code Blocks
 
-```
+```ebnf
 code_block ::= backtick_fence info_string newline content backtick_fence newline
 
 info_string ::= executable_lang ( ws "prompt" )?
@@ -204,7 +204,7 @@ Opening fence is 3 or more backticks. Closing fence must use at least as many ba
 
 ## Template Variables
 
-```
+```ebnf
 template_variable ::= "{{" ws? variable_path ws? "}}"
 variable_path     ::= variable_name ( "." ( variable_name | digit+ ) )*
 variable_name     ::= [a-zA-Z_] [a-zA-Z0-9_]*
@@ -212,7 +212,7 @@ variable_name     ::= [a-zA-Z_] [a-zA-Z0-9_]*
 
 ## Runbook Lists
 
-```
+```ebnf
 runbook_list ::= ( "- " file_path newline )+
 ```
 
@@ -220,7 +220,7 @@ Step-level runbook lists are shorthand for implicit sequential substeps.
 
 ## Body
 
-```
+```ebnf
 body ::= code_block | substep+ | runbook_list
 ```
 
@@ -228,7 +228,7 @@ A step contains at most one body type.
 
 ## Prompt
 
-```
+```ebnf
 prompt ::= text+
 ```
 
@@ -242,7 +242,7 @@ Case-sensitive: `NEXT` is reserved; `Next` and `NextStep` are valid.
 
 ## Lexical Rules
 
-```
+```ebnf
 positive_integer ::= [1-9] [0-9]*
 digit            ::= [0-9]
 text             ::= [^\n]+

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -199,7 +199,7 @@ Example of a step that auto-executes:
 ````markdown
 ## 3. Run tests
 - PASS CONTINUE
-- FAIL RETRY 2
+- FAIL RETRY 2 STOP
 
 ```bash
 npm test

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -145,11 +145,13 @@ When only one transition side specifies an aggregation modifier, the defaulted s
 | `STOP [msg]` | Any | Terminate execution immediately (failure). |
 | `COMPLETE [msg]` | Any | Terminate execution immediately (success). |
 | `GOTO {Target}` | Any | Jump to step/substep (e.g., `1`, `Error`). |
-| `RETRY [N] [Act]` | Any | Retry N times (default 1), then perform Action. |
+| `RETRY [N] [Act]` | Any | Retry N times (default 1), then perform Act (default STOP). |
 | `NEXT` | FOR Substep, FOR Iteration-Level | Skip to next iteration (no result accumulation). |
 | `BREAK` | FOR Substep, FOR Iteration-Level | Exit loop immediately. |
 
 > **Shorthand:** A standalone `- DEFER` bullet (without PASS/FAIL prefix) expands to `- PASS DEFER` + `- FAIL DEFER`. This is convenient for substeps where both outcomes should propagate to parent aggregation. DEFER is not valid at step level.
+
+> **RETRY defaults:** Count defaults to 1. Fallback action defaults to STOP. A bare message after count (e.g., `RETRY 3 "error"`) is shorthand for `RETRY 3 STOP "error"`. Nested RETRY (RETRY as fallback action) is invalid.
 
 GOTO targeting the containing step (self-reference) without an AT qualifier may create an infinite loop. Use RETRY for bounded re-execution.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -22,6 +22,14 @@ A Rundown document (`.runbook.md`) is a Markdown file with an optional YAML fron
 *   **H3**: Substep.
 *   **H4+**: Invalid.
 
+### 1.2 Frontmatter
+
+Frontmatter fields beyond `name`, `description`, `version`, `author`, `tags`, and `vars` are preserved (open schema). This allows forward-compatible extensions and user-defined metadata.
+
+The frontmatter `description` field provides a summary for runbook discovery and listing (`rd ls --all`). The `Runbook.description` in the parsed AST is derived from preamble text between the H1 title and first H2 step. These are independent values.
+
+*Note: A follow-up task will rename `Runbook.description` → `Runbook.preamble` to eliminate this naming ambiguity.*
+
 ## 2. Steps
 
 Steps are the fundamental units of execution defined by H2 headers.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -153,13 +153,13 @@ When only one transition side specifies an aggregation modifier, the defaulted s
 | `STOP [msg]` | Any | Terminate execution immediately (failure). |
 | `COMPLETE [msg]` | Any | Terminate execution immediately (success). |
 | `GOTO {Target}` | Any | Jump to step/substep (e.g., `1`, `Error`). |
-| `RETRY [N] [Act]` | Any | Retry N times (default 1), then perform Act (default STOP). |
+| `RETRY N Act` | Any | Retry N times, then perform Act (both required). |
 | `NEXT` | FOR Substep, FOR Iteration-Level | Skip to next iteration (no result accumulation). |
 | `BREAK` | FOR Substep, FOR Iteration-Level | Exit loop immediately. |
 
 > **Shorthand:** A standalone `- DEFER` bullet (without PASS/FAIL prefix) expands to `- PASS DEFER` + `- FAIL DEFER`. This is convenient for substeps where both outcomes should propagate to parent aggregation. DEFER is not valid at step level.
 
-> **RETRY defaults:** Count defaults to 1. Fallback action defaults to STOP. A bare message after count (e.g., `RETRY 3 "error"`) is shorthand for `RETRY 3 STOP "error"`. Nested RETRY (RETRY as fallback action) is invalid.
+> **RETRY syntax:** Both count and fallback action are required (e.g., `RETRY 3 STOP`). Nested RETRY (RETRY as fallback action) is invalid.
 
 GOTO targeting the containing step (self-reference) without an AT qualifier may create an infinite loop. Use RETRY for bounded re-execution.
 

--- a/packages/claude-code-plugin/runbooks/code-review/pr-feedback.runbook.md
+++ b/packages/claude-code-plugin/runbooks/code-review/pr-feedback.runbook.md
@@ -29,7 +29,7 @@ rd echo gh pr view --comments
 ## 2 Make Changes
 
 - PASS CONTINUE
-- FAIL RETRY 3
+- FAIL RETRY 3 STOP
 
 Make the necessary code changes to address feedback.
 

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -285,7 +285,7 @@ Final step.
       expect(state?.retryCount).toBe(2);
       expect(state?.step).toBe('1');
 
-      // Third fail - exhausted retries, should use on_fail (implicit STOP)
+      // Third fail - exhausted retries, triggers explicit STOP fallback
       result = await runCliInProcess('fail', workspace);
       expect(result.exitCode).toBe(1);
     });

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -258,7 +258,7 @@ Final step.
     it('consecutive fail commands maintain state consistency', async () => {
       // Create a runbook that transitions on second fail
       const multiFailRunbook = `## 1. Retry step
-- FAIL RETRY 2
+- FAIL RETRY 2 STOP
 - PASS CONTINUE
 
 Try this step.

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -266,7 +266,7 @@ This step stops on pass.
       const retryRunbook = `## 1. Retry on pass fail
 
 - PASS CONTINUE
-- FAIL RETRY 3
+- FAIL RETRY 3 STOP
 
 This step has FAIL: RETRY.
 

--- a/packages/cli/__tests__/fixtures/retry.runbook.md
+++ b/packages/cli/__tests__/fixtures/retry.runbook.md
@@ -1,7 +1,7 @@
 ## 1. Retry step
 
 - PASS CONTINUE
-- FAIL RETRY 3
+- FAIL RETRY 3 STOP
 
 May need multiple attempts.
 

--- a/packages/cli/__tests__/fixtures/simple.runbook.md
+++ b/packages/cli/__tests__/fixtures/simple.runbook.md
@@ -12,7 +12,7 @@ rd echo --result pass
 ## 2. Second step
 
 - PASS COMPLETE
-- FAIL RETRY 2
+- FAIL RETRY 2 STOP
 
 Do another thing.
 

--- a/packages/cli/__tests__/fixtures/substeps.runbook.md
+++ b/packages/cli/__tests__/fixtures/substeps.runbook.md
@@ -15,7 +15,7 @@ rd echo --result pass
 ### 1.2 Substep B
 
 - PASS CONTINUE
-- FAIL RETRY 2
+- FAIL RETRY 2 STOP
 
 Second substep.
 

--- a/packages/cli/__tests__/fixtures/with-failing-command.runbook.md
+++ b/packages/cli/__tests__/fixtures/with-failing-command.runbook.md
@@ -1,7 +1,7 @@
 ## 1. Execute failing command
 
 - PASS CONTINUE
-- FAIL RETRY 2
+- FAIL RETRY 2 STOP
 
 Run a command that fails then succeeds.
 

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -520,7 +520,7 @@ export interface StepConfig {
   title: string;
   /** PASS transition (e.g., 'COMPLETE', 'CONTINUE', 'GOTO 2') */
   pass?: string;
-  /** FAIL transition (e.g., 'STOP', 'RETRY 2') */
+  /** FAIL transition (e.g., 'STOP', 'RETRY 2 STOP') */
   fail?: string;
   /** Bash command to execute */
   command?: string;

--- a/packages/cli/__tests__/integration/template-variables.test.ts
+++ b/packages/cli/__tests__/integration/template-variables.test.ts
@@ -327,7 +327,7 @@ describe('Template Variables Integration', () => {
           {
             title: 'First Step',
             pass: 'CONTINUE',
-            fail: 'RETRY 1',
+            fail: 'RETRY 1 STOP',
             command: 'rd echo {{message}}',
           },
           { title: 'Second Step', pass: 'COMPLETE', command: 'rd echo done' },

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -1119,6 +1119,40 @@ describe('resolveForBounds', () => {
       expect(warnings[0]).toContain('preserved as prompt text');
     });
 
+    it('throws when forClause.transitions contain GOTO AT targeting a demoted step', () => {
+      // Step 1 is a FOR step with unresolved bounds (will be demoted)
+      const unresolvedFor: ParsedForClause = {
+        unresolved: true as const,
+        variable: 'item',
+        start: 1,
+        end: { ref: 'Missing' },
+      };
+      const demotedStep = makeForStep(unresolvedFor, '1');
+
+      // Step 2 is a resolved FOR step whose forClause.transitions has GOTO 1 AT 3
+      const resolvedFor: ParsedForClause = {
+        variable: 'x',
+        start: 1,
+        end: 5,
+        transitions: {
+          aggregation: 'none' as const,
+          pass: {
+            kind: 'pass' as const,
+            retry: 0,
+            action: { type: 'GOTO' as const, target: { step: '1', at: 3 } },
+          },
+          fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+        },
+      };
+      const resolvedStep = makeForStep(resolvedFor, '2');
+
+      const runbook = makeRunbook([demotedStep, resolvedStep]);
+      expect(() => resolveForBounds(runbook, {})).toThrow(RunbookSyntaxError);
+      expect(() => resolveForBounds(runbook, {})).toThrow(
+        'GOTO AT targets step "1" which has an unresolved FOR clause',
+      );
+    });
+
     it('does not throw for NEXT/BREAK in substep of a successfully resolved FOR step', () => {
       const resolvedFor: ParsedForClause = {
         unresolved: true as const,

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -1113,7 +1113,7 @@ describe('resolveForBounds', () => {
       };
 
       const runbook = makeRunbook([forStep, gotoStep]);
-      const { runbook: result, warnings } = resolveForBounds(runbook, {});
+      const { warnings } = resolveForBounds(runbook, {});
       // Should succeed with just the fallback warning
       expect(warnings).toHaveLength(1);
       expect(warnings[0]).toContain('preserved as prompt text');

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -8,7 +8,9 @@ import type {
   StepWithSubsteps,
   ParsedForClause,
   Transitions,
+  Substep,
 } from '@rundown-org/parser';
+import { RunbookSyntaxError } from '@rundown-org/parser';
 import {
   expandLoopVariables,
   shellEscapeValue,
@@ -982,5 +984,165 @@ describe('resolveForBounds', () => {
     expect(step.prompt).toContain('FOR x IN 1 TO {{N}} OF items');
     expect(step.prompt).toContain('- PASS ANY NEXT');
     expect(step.prompt).toContain('- FAIL ALL COMPLETE');
+  });
+
+  describe('post-resolution validation of demoted FOR steps', () => {
+    /** Build a FOR step with substeps that have transitions. */
+    function makeForStepWithSubstepTransitions(
+      forClause: ParsedForClause,
+      substeps: Substep[],
+      name = '1',
+    ): StepWithFor {
+      return {
+        kind: 'for',
+        name,
+        description: 'Loop step',
+        forClause,
+        substeps,
+      };
+    }
+
+    it('throws when GOTO AT targets a step with unresolved FOR bounds', () => {
+      // Step 1 is a FOR step with unresolved bounds (will be demoted)
+      const unresolvedFor: ParsedForClause = {
+        unresolved: true as const,
+        variable: 'item',
+        start: 1,
+        end: { ref: 'Missing' },
+      };
+      const forStep = makeForStep(unresolvedFor, '1');
+
+      // Step 2 has GOTO 1 AT 3 — targets step 1 which will be demoted
+      const gotoStep: BaseStep = {
+        kind: 'base',
+        name: '2',
+        description: 'Jump back',
+        transitions: {
+          aggregation: 'none' as const,
+          pass: {
+            kind: 'pass' as const,
+            retry: 0,
+            action: { type: 'GOTO' as const, target: { step: '1', at: 3 } },
+          },
+          fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+        },
+      };
+
+      const runbook = makeRunbook([forStep, gotoStep]);
+      expect(() => resolveForBounds(runbook, {})).toThrow(RunbookSyntaxError);
+      expect(() => resolveForBounds(runbook, {})).toThrow(
+        'GOTO AT targets step "1" which has an unresolved FOR clause',
+      );
+    });
+
+    it('throws when NEXT is in substep of a step with unresolved FOR bounds', () => {
+      const unresolvedFor: ParsedForClause = {
+        unresolved: true as const,
+        variable: 'item',
+        start: 1,
+        end: { ref: 'Missing' },
+      };
+      const substeps: Substep[] = [
+        {
+          id: '1',
+          description: 'Sub',
+          transitions: {
+            aggregation: 'none' as const,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'NEXT' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+        },
+      ];
+      const forStep = makeForStepWithSubstepTransitions(unresolvedFor, substeps, '1');
+      const runbook = makeRunbook([forStep]);
+      expect(() => resolveForBounds(runbook, {})).toThrow(RunbookSyntaxError);
+      expect(() => resolveForBounds(runbook, {})).toThrow(
+        'NEXT in step "1" requires a FOR loop, but the FOR clause is unresolved',
+      );
+    });
+
+    it('throws when BREAK is in substep of a step with unresolved FOR bounds', () => {
+      const unresolvedFor: ParsedForClause = {
+        unresolved: true as const,
+        variable: 'item',
+        start: 1,
+        end: { ref: 'Missing' },
+      };
+      const substeps: Substep[] = [
+        {
+          id: '1',
+          description: 'Sub',
+          transitions: {
+            aggregation: 'none' as const,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'BREAK' as const } },
+          },
+        },
+      ];
+      const forStep = makeForStepWithSubstepTransitions(unresolvedFor, substeps, '1');
+      const runbook = makeRunbook([forStep]);
+      expect(() => resolveForBounds(runbook, {})).toThrow(RunbookSyntaxError);
+      expect(() => resolveForBounds(runbook, {})).toThrow(
+        'BREAK in step "1" requires a FOR loop, but the FOR clause is unresolved',
+      );
+    });
+
+    it('does not throw for GOTO (without AT) to a demoted step', () => {
+      const unresolvedFor: ParsedForClause = {
+        unresolved: true as const,
+        variable: 'item',
+        start: 1,
+        end: { ref: 'Missing' },
+      };
+      const forStep = makeForStep(unresolvedFor, '1');
+
+      // Step 2 has GOTO 1 (no AT) — this is valid even for demoted steps
+      const gotoStep: BaseStep = {
+        kind: 'base',
+        name: '2',
+        description: 'Jump back',
+        transitions: {
+          aggregation: 'none' as const,
+          pass: {
+            kind: 'pass' as const,
+            retry: 0,
+            action: { type: 'GOTO' as const, target: { step: '1' } },
+          },
+          fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+        },
+      };
+
+      const runbook = makeRunbook([forStep, gotoStep]);
+      const { runbook: result, warnings } = resolveForBounds(runbook, {});
+      // Should succeed with just the fallback warning
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('preserved as prompt text');
+    });
+
+    it('does not throw for NEXT/BREAK in substep of a successfully resolved FOR step', () => {
+      const resolvedFor: ParsedForClause = {
+        unresolved: true as const,
+        variable: 'item',
+        start: 1,
+        end: { ref: 'Max' },
+      };
+      const substeps: Substep[] = [
+        {
+          id: '1',
+          description: 'Sub',
+          transitions: {
+            aggregation: 'none' as const,
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'NEXT' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'BREAK' as const } },
+          },
+        },
+      ];
+      const forStep = makeForStepWithSubstepTransitions(resolvedFor, substeps, '1');
+      const runbook = makeRunbook([forStep]);
+      // Provide the variable so the FOR clause resolves successfully
+      const { runbook: result, warnings } = resolveForBounds(runbook, { Max: '5' });
+      expect(warnings).toHaveLength(0);
+      expect(result.steps[0].kind).toBe('for');
+    });
   });
 });

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -308,9 +308,6 @@ function validateDemotedForSteps(
 
   const errors: string[] = [];
 
-  // Build a quick lookup of step names for GOTO AT target resolution
-  const stepNames = new Set(steps.map((s) => s.name));
-
   const checkAction = (action: Action, parentStepName: string, inDemotedStep: boolean): void => {
     // GOTO with AT targeting a demoted step
     if (action.type === 'GOTO' && action.target.at !== undefined) {

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -341,6 +341,11 @@ function validateDemotedForSteps(
   for (const step of steps) {
     const inDemoted = demotedStepNames.has(step.name);
 
+    // Check FOR clause transitions (iteration-level PASS/FAIL handlers)
+    if (step.kind === 'for') {
+      checkTransitions(step.forClause.transitions, step.name, false);
+    }
+
     // Check step-level transitions
     checkTransitions(step.transitions, step.name, false);
 

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -23,7 +23,13 @@ import type {
   TransitionObject,
   Action,
 } from '@rundown-org/parser';
-import { isUnresolvedForClause, MAX_FOR_BOUND, stepIdToString } from '@rundown-org/parser';
+import {
+  isUnresolvedForClause,
+  isLoopControlAction,
+  MAX_FOR_BOUND,
+  stepIdToString,
+  RunbookSyntaxError,
+} from '@rundown-org/parser';
 
 /**
  * Shared placeholder matcher used across startup and runtime substitution.
@@ -274,6 +280,87 @@ function allBoundRefsDefined(
 }
 
 /**
+ * Collect all actions from a transitions object.
+ *
+ * @param transitions - Pass/fail transition pair
+ * @returns Array of actions from both pass and fail handlers
+ */
+function collectActionsFromTransitions(transitions: Transitions): Action[] {
+  return [transitions.pass.action, transitions.fail.action];
+}
+
+/**
+ * Validate that loop-only controls (GOTO...AT, NEXT, BREAK) don't reference demoted steps.
+ *
+ * After `resolveForBounds()` demotes FOR steps with unresolved bounds to `kind: 'substeps'`,
+ * any loop-only controls that were validated against the original `kind: 'for'` become invalid.
+ * This function detects those cases and throws a `RunbookSyntaxError`.
+ *
+ * @param steps - Resolved steps after FOR bound resolution
+ * @param demotedStepNames - Set of step names that were demoted from FOR to substeps
+ * @throws {RunbookSyntaxError} When loop-only controls reference demoted steps
+ */
+function validateDemotedForSteps(
+  steps: readonly ResolvedStep[],
+  demotedStepNames: ReadonlySet<string>,
+): void {
+  if (demotedStepNames.size === 0) return;
+
+  const errors: string[] = [];
+
+  // Build a quick lookup of step names for GOTO AT target resolution
+  const stepNames = new Set(steps.map((s) => s.name));
+
+  const checkAction = (action: Action, parentStepName: string, inDemotedStep: boolean): void => {
+    // GOTO with AT targeting a demoted step
+    if (action.type === 'GOTO' && action.target.at !== undefined) {
+      const targetStep = action.target.step === 'NEXT' ? undefined : action.target.step;
+      if (targetStep && demotedStepNames.has(targetStep)) {
+        errors.push(
+          `GOTO AT targets step "${targetStep}" which has an unresolved FOR clause — AT requires a resolved loop`,
+        );
+      }
+    }
+
+    // NEXT/BREAK in substeps of a demoted step
+    if (isLoopControlAction(action) && inDemotedStep) {
+      errors.push(
+        `${action.type} in step "${parentStepName}" requires a FOR loop, but the FOR clause is unresolved`,
+      );
+    }
+  };
+
+  const checkTransitions = (
+    transitions: Transitions | undefined,
+    parentStepName: string,
+    inDemotedStep: boolean,
+  ): void => {
+    if (!transitions) return;
+    for (const action of collectActionsFromTransitions(transitions)) {
+      checkAction(action, parentStepName, inDemotedStep);
+    }
+  };
+
+  for (const step of steps) {
+    const inDemoted = demotedStepNames.has(step.name);
+
+    // Check step-level transitions
+    checkTransitions(step.transitions, step.name, false);
+
+    // Check substep transitions
+    if (step.kind === 'substeps' || step.kind === 'for') {
+      for (const substep of step.substeps) {
+        checkTransitions(substep.transitions, step.name, inDemoted);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new RunbookSyntaxError(errors[0]);
+  }
+}
+
+/**
  * Resolve unresolved FOR clause bounds in a parsed runbook.
  *
  * Walks all steps, resolving any `BoundRef` values in FOR clauses to concrete
@@ -284,16 +371,21 @@ function allBoundRefsDefined(
  * with the FOR line preserved as prompt text. This matches the spec behavior:
  * "the FOR clause is not parsed and the line is preserved as literal prompt text."
  *
+ * After resolution, validates that loop-only controls (GOTO...AT, NEXT, BREAK)
+ * don't reference steps whose FOR clauses were demoted due to unresolved bounds.
+ *
  * @param runbook - Parsed runbook AST (may contain unresolved FOR bounds)
  * @param variables - Template variable map for bound resolution
  * @returns Result with resolved runbook and any fallback warnings
  * @throws {Error} When a bound variable is defined but resolves to a non-integer or out-of-range value
+ * @throws {RunbookSyntaxError} When loop-only controls reference demoted FOR steps
  */
 export function resolveForBounds(
   runbook: Runbook,
   variables: Readonly<Record<string, unknown>>,
 ): ResolveForBoundsResult {
   const warnings: string[] = [];
+  const demotedStepNames = new Set<string>();
 
   const resolvedSteps = runbook.steps.map((step): ResolvedStep => {
     if (step.kind !== 'for') return step;
@@ -318,6 +410,7 @@ export function resolveForBounds(
         prompt: forText + (step.prompt ? `\n${step.prompt}` : ''),
       };
       warnings.push(`Step "${step.name}": unresolved FOR bound — preserved as prompt text`);
+      demotedStepNames.add(step.name);
       return fallbackStep;
     }
 
@@ -352,7 +445,12 @@ export function resolveForBounds(
     return resolvedForStep;
   });
 
-  return { runbook: { ...runbook, steps: resolvedSteps }, warnings };
+  const resolvedRunbook: ResolvedRunbook = { ...runbook, steps: resolvedSteps };
+
+  // Post-resolution validation: detect loop-only controls referencing demoted steps
+  validateDemotedForSteps(resolvedSteps, demotedStepNames);
+
+  return { runbook: resolvedRunbook, warnings };
 }
 
 // ─── Secure AST-level substitution ───────────────────────────────────────────

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -12,6 +12,7 @@ import type { StepId } from './step-id.js';
 import type { ForClause } from '@rundown-org/parser';
 import {
   isSourced,
+  isWindowed,
   resolvedStepHasSubsteps,
   isAccumulatingAction,
   isBreakAction,
@@ -444,7 +445,7 @@ function createForContext(
       throw new Error(`Data source "${forClause.source}" is not defined`);
     }
 
-    const windowEnd = 'end' in forClause ? forClause.end : undefined;
+    const windowEnd = isWindowed(forClause) ? forClause.end : undefined;
 
     switch (ds.kind) {
       case 'array': {

--- a/packages/core/src/runbook/renderer/renderer.ts
+++ b/packages/core/src/runbook/renderer/renderer.ts
@@ -1,5 +1,6 @@
 import type { Step, Action, Transitions, TransitionObject, Substep, Runbook } from '../types.js';
 import type { ParsedForClause } from '@rundown-org/parser';
+import { isWindowed } from '@rundown-org/parser';
 import { stepIdToString } from '../step-id.js';
 import { renderCodeFence, renderHeading } from './primitives.js';
 
@@ -114,7 +115,7 @@ function renderForClause(forClause: ParsedForClause): string[] {
   const lines: string[] = [];
 
   if (forClause.source !== undefined) {
-    if ('end' in forClause) {
+    if (isWindowed(forClause)) {
       lines.push(
         `- FOR ${forClause.variable} IN ${String(forClause.start)} TO ${String(forClause.end)} OF {{ ${forClause.source} }}`,
       );

--- a/packages/parser/__tests__/helpers.test.ts
+++ b/packages/parser/__tests__/helpers.test.ts
@@ -1387,6 +1387,14 @@ describe('strict RETRY syntax enforcement', () => {
     expect(() => parseConditional('FAIL RETRY STOP')).toThrow('Invalid FAIL transition');
   });
 
+  it('rejects RETRY with zero count', () => {
+    expect(() => parseConditional('FAIL RETRY 0 STOP')).toThrow('Invalid FAIL transition');
+  });
+
+  it('rejects RETRY with leading-zero count', () => {
+    expect(() => parseConditional('FAIL RETRY 03 STOP')).toThrow('Invalid FAIL transition');
+  });
+
   it('accepts RETRY with count and action', () => {
     const result = parseConditional('FAIL RETRY 3 STOP');
     expect(result).toEqual({

--- a/packages/parser/__tests__/helpers.test.ts
+++ b/packages/parser/__tests__/helpers.test.ts
@@ -1370,6 +1370,57 @@ describe('ParsedConditional with retry property', () => {
   });
 });
 
+describe('strict RETRY syntax enforcement', () => {
+  it('rejects bare RETRY (no count, no action)', () => {
+    expect(() => parseConditional('FAIL RETRY')).toThrow('Invalid FAIL transition');
+  });
+
+  it('rejects RETRY with count but no action', () => {
+    expect(() => parseConditional('FAIL RETRY 2')).toThrow('Invalid FAIL transition');
+  });
+
+  it('rejects RETRY with quoted message shorthand', () => {
+    expect(() => parseConditional('FAIL RETRY 3 "error"')).toThrow('Invalid FAIL transition');
+  });
+
+  it('rejects RETRY without count (RETRY STOP)', () => {
+    expect(() => parseConditional('FAIL RETRY STOP')).toThrow('Invalid FAIL transition');
+  });
+
+  it('accepts RETRY with count and action', () => {
+    const result = parseConditional('FAIL RETRY 3 STOP');
+    expect(result).toEqual({
+      type: 'fail',
+      retry: 3,
+      action: { type: 'STOP' },
+      modifier: null,
+      raw: 'RETRY 3 STOP',
+    });
+  });
+
+  it('accepts RETRY with count, action, and message', () => {
+    const result = parseConditional('FAIL RETRY 3 STOP "msg"');
+    expect(result).toEqual({
+      type: 'fail',
+      retry: 3,
+      action: { type: 'STOP', message: 'msg' },
+      modifier: null,
+      raw: 'RETRY 3 STOP "msg"',
+    });
+  });
+
+  it('accepts RETRY with aggregation', () => {
+    const result = parseConditional('FAIL ALL RETRY 3 STOP');
+    expect(result).toEqual({
+      type: 'fail',
+      retry: 3,
+      action: { type: 'STOP' },
+      modifier: 'ALL',
+      raw: 'RETRY 3 STOP',
+    });
+  });
+});
+
 describe('parseStepIdFromString with AT syntax', () => {
   it('parses numeric step with AT', () => {
     expect(parseStepIdFromString('3 AT 1')).toEqual({ step: '3', at: 1 });

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -595,7 +595,6 @@ export function parseAction(text: string): Action | null {
  * @returns Object with retry count and fallback action, or null if invalid
  */
 function parseRetryWithArgs(rest: string): { retry: number; action: Action } | null {
-  let retry = 1;
   let remaining = rest;
 
   // Parse leading digits manually to avoid ReDoS from (\d+)(?:\s+(.*))? backtracking
@@ -603,18 +602,17 @@ function parseRetryWithArgs(rest: string): { retry: number; action: Action } | n
   while (digitEnd < remaining.length && remaining[digitEnd] >= '0' && remaining[digitEnd] <= '9') {
     digitEnd++;
   }
-  if (digitEnd > 0 && (digitEnd >= remaining.length || /\s/.test(remaining[digitEnd]))) {
-    retry = parseInt(remaining.slice(0, digitEnd), 10);
-    remaining = remaining.slice(digitEnd).trimStart();
+  if (digitEnd === 0) {
+    return null;
   }
+  if (!(digitEnd >= remaining.length || /\s/.test(remaining[digitEnd]))) {
+    return null;
+  }
+  const retry = parseInt(remaining.slice(0, digitEnd), 10);
+  remaining = remaining.slice(digitEnd).trimStart();
 
   if (!remaining) {
-    return { retry, action: { type: 'STOP' } };
-  }
-
-  if (remaining.startsWith('"') && remaining.endsWith('"')) {
-    const message = remaining.slice(1, -1);
-    return { retry, action: { type: 'STOP', message } };
+    return null;
   }
 
   const action = parseAction(remaining);
@@ -644,16 +642,11 @@ function parseConditionalPrefix(
   let retry = 0;
   let action: Action | null = null;
 
-  if (actionStr.startsWith('RETRY')) {
-    if (actionStr === 'RETRY') {
-      retry = 1;
-      action = { type: 'STOP' };
-    } else if (actionStr.startsWith('RETRY ')) {
-      const retryResult = parseRetryWithArgs(actionStr.slice(6).trim());
-      if (retryResult) {
-        retry = retryResult.retry;
-        action = retryResult.action;
-      }
+  if (actionStr.startsWith('RETRY ')) {
+    const retryResult = parseRetryWithArgs(actionStr.slice(6).trim());
+    if (retryResult) {
+      retry = retryResult.retry;
+      action = retryResult.action;
     }
   } else {
     action = parseAction(actionStr);
@@ -671,7 +664,7 @@ function parseConditionalPrefix(
  *
  * Recognizes these formats:
  * - PASS/YES: triggers on step success (e.g., "PASS CONTINUE", "YES GOTO 2")
- * - FAIL/NO: triggers on step failure (e.g., "FAIL STOP", "NO RETRY 3")
+ * - FAIL/NO: triggers on step failure (e.g., "FAIL STOP", "NO RETRY 3 STOP")
  * - With aggregation: "PASS ALL CONTINUE", "FAIL ANY STOP"
  * - Standalone DEFER: shorthand for PASS DEFER + FAIL DEFER
  *

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -609,7 +609,7 @@ function parseRetryWithArgs(rest: string): { retry: number; action: Action } | n
     return null;
   }
   const retryText = remaining.slice(0, digitEnd);
-  if (retryText[0] === '0') {
+  if (retryText.startsWith('0')) {
     return null;
   }
   const retry = parseInt(retryText, 10);

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -608,7 +608,11 @@ function parseRetryWithArgs(rest: string): { retry: number; action: Action } | n
   if (!(digitEnd >= remaining.length || /\s/.test(remaining[digitEnd]))) {
     return null;
   }
-  const retry = parseInt(remaining.slice(0, digitEnd), 10);
+  const retryText = remaining.slice(0, digitEnd);
+  if (retryText[0] === '0') {
+    return null;
+  }
+  const retry = parseInt(retryText, 10);
   remaining = remaining.slice(digitEnd).trimStart();
 
   if (!remaining) {

--- a/runbooks/examples/deploy-service.runbook.md
+++ b/runbooks/examples/deploy-service.runbook.md
@@ -103,7 +103,7 @@ rd echo npm run database:migrate
 
 ### 3.3 Restart services
 
-- FAIL RETRY
+- FAIL RETRY 1 STOP
 
 ```bash
 rd echo npm run deploy:restart

--- a/runbooks/transitions/mixed-modifiers.runbook.md
+++ b/runbooks/transitions/mixed-modifiers.runbook.md
@@ -35,7 +35,7 @@ rd echo --result pass
 ## 2. Optimistic
 
 - PASS ANY GOTO 4
-- FAIL ALL RETRY 3
+- FAIL ALL RETRY 3 STOP
 
 ```bash
 rd echo --result pass

--- a/runbooks/transitions/pass-continue.runbook.md
+++ b/runbooks/transitions/pass-continue.runbook.md
@@ -40,7 +40,7 @@ rd echo --result pass
 ## 2. Test
 
 - PASS COMPLETE
-- FAIL RETRY 2
+- FAIL RETRY 2 STOP
 
 ```bash
 rd echo --result fail --result fail --result pass

--- a/site/public/this-is-rundown.runbook.md
+++ b/site/public/this-is-rundown.runbook.md
@@ -60,7 +60,7 @@ Rundown works *with* agents, adding guardrails that enforce transitions and impr
 
 ## 4 Execute the right commands at the right time
 - PASS CONTINUE
-- FAIL RETRY GOTO RECOVER
+- FAIL RETRY 1 GOTO RECOVER
 
 Embed commands for automatic execution. Catch failure, retry, and recover gracefully.
 

--- a/site/src/components/RunbookDemo.astro
+++ b/site/src/components/RunbookDemo.astro
@@ -29,7 +29,7 @@ const complexRunbook = `# Code Review Runbook
 Run code-review-agent.
 
 - PASS CONTINUE
-- FAIL RETRY 2
+- FAIL RETRY 2 STOP
 
 ## 2. Categorize issues
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted runbook grammar to W3C EBNF, added CLI output and Scenarios docs, clarified scenarios frontmatter is internal/testing, and updated examples/guides to match the new grammar.

* **Bug Fixes**
  * Enforced stricter RETRY syntax: a retry count and fallback action are now required; documentation and examples now show explicit STOP when retries are exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->