### PR TITLE
fix(core): suppress default transitions in renderer output, fix TSDoc…

### DIFF
--- a/packages/core/__tests__/runbook/renderer.test.ts
+++ b/packages/core/__tests__/runbook/renderer.test.ts
@@ -569,6 +569,7 @@ echo check
     expect((parsed1.steps[0] as any).forClause?.transitions).toBeDefined();
     expect((parsed1.steps[0] as any).forClause?.transitions?.pass.action.type).toBe('CONTINUE');
     expect((parsed1.steps[0] as any).forClause?.transitions?.fail.action.type).toBe('BREAK');
+    expect((parsed1.steps[0] as any).forClause?.aggregation).toEqual({ strategy: 'ALL' });
 
     const rendered = renderStep(parsed1.steps[0]);
     const { runbook: parsed2 } = parseRunbookDocument(rendered);
@@ -585,6 +586,7 @@ echo check
       retry: 0,
       action: { type: 'BREAK' },
     });
+    expect((parsed2.steps[0] as any).forClause?.aggregation).toEqual({ strategy: 'ALL' });
   });
 });
 

--- a/packages/core/src/runbook/renderer/renderer.ts
+++ b/packages/core/src/runbook/renderer/renderer.ts
@@ -73,12 +73,14 @@ function aggregationModifier(aggregation: Aggregation | undefined, kind: 'pass' 
  * @returns true if any transition is non-default
  */
 function hasNonDefaultTransitions(transitions: Transitions): boolean {
-  return (
-    transitions.pass.action.type !== 'CONTINUE' ||
-    transitions.pass.retry > 0 ||
-    transitions.fail.action.type !== 'STOP' ||
-    transitions.fail.retry > 0
-  );
+  const isDefaultPass = transitions.pass.action.type === 'CONTINUE' && transitions.pass.retry === 0;
+
+  const isDefaultFail =
+    transitions.fail.action.type === 'STOP' &&
+    !('message' in transitions.fail.action && transitions.fail.action.message) &&
+    transitions.fail.retry === 0;
+
+  return !(isDefaultPass && isDefaultFail);
 }
 
 /**

--- a/packages/core/src/runbook/renderer/renderer.ts
+++ b/packages/core/src/runbook/renderer/renderer.ts
@@ -56,7 +56,7 @@ function renderTransitionAction(transition: TransitionObject): string {
  * Pass and fail use inverted modifiers: when aggregation is ALL,
  * PASS shows ALL but FAIL shows ANY (and vice-versa).
  *
- * @param aggregation - The aggregation mode (ALL, ANY, or none)
+ * @param aggregation - The aggregation strategy, or undefined for no aggregation
  * @param kind - Whether this is for a pass or fail transition
  * @returns The modifier suffix string (e.g., " ALL", " ANY", or empty)
  */
@@ -64,6 +64,21 @@ function aggregationModifier(aggregation: Aggregation | undefined, kind: 'pass' 
   if (!aggregation) return '';
   if (kind === 'pass') return aggregation.strategy === 'ALL' ? ' ALL' : ' ANY';
   return aggregation.strategy === 'ALL' ? ' ANY' : ' ALL';
+}
+
+/**
+ * Check whether transitions differ from the base defaults (PASS CONTINUE / FAIL STOP).
+ *
+ * @param transitions - The transitions to check
+ * @returns true if any transition is non-default
+ */
+function hasNonDefaultTransitions(transitions: Transitions): boolean {
+  return (
+    transitions.pass.action.type !== 'CONTINUE' ||
+    transitions.pass.retry > 0 ||
+    transitions.fail.action.type !== 'STOP' ||
+    transitions.fail.retry > 0
+  );
 }
 
 /**
@@ -185,9 +200,11 @@ export function renderStep(step: Step): string {
     lines.push(...renderForClause(step.forClause));
   }
 
-  // Transitions
-  lines.push(renderTransitions(step.transitions, step.aggregation));
-  lines.push('');
+  // Transitions (only render when non-default or aggregation present)
+  if (step.aggregation || hasNonDefaultTransitions(step.transitions)) {
+    lines.push(renderTransitions(step.transitions, step.aggregation));
+    lines.push('');
+  }
 
   const shorthandSubsteps = getShorthandRunbookSubsteps(step);
   if (shorthandSubsteps?.length) {


### PR DESCRIPTION
… and test gaps

Only render step-level transitions when non-default or aggregation is present, preventing PASS CONTINUE / FAIL STOP clutter on base steps. Add hasNonDefaultTransitions helper, fix stale aggregationModifier TSDoc, and assert forClause.aggregation in FOR round-trip test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized runbook rendering to conditionally include transitions based on aggregation settings and non-default transition configurations, resulting in cleaner runbook output.

* **Tests**
  * Enhanced test coverage to verify that aggregation settings are correctly preserved throughout the runbook parsing and rendering cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->