### PR TITLE
fix(parser): use plain interface for Aggregation type to fix eslint r…

### DIFF
--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -7,7 +7,11 @@
     "lib": ["ES2022", "ESNext.Error"],
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@rundown-org/parser": ["./packages/parser/src/index.ts"],
+      "@rundown-org/core": ["./packages/core/src/index.ts"]
+    }
   },
   "include": [
     "packages/parser/src/**/*.ts",


### PR DESCRIPTION
…esolution

Zod-inferred type (z.output<typeof AggregationSchema>) couldn't be resolved by eslint's TypeScript plugin across the monorepo boundary, causing 20 unsafe assignment/member-access errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type definitions to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->