### PR TITLE
test(core,parser): add coverage for sequential FOR and non-aggregatin…

### DIFF
--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -212,7 +212,9 @@ describe('runbook compiler', () => {
       actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
       actor.send({ type: 'FAIL' }); // 1.2 STOP → STOPPED
 
-      expect(actor.getSnapshot().value).toBe('STOPPED');
+      const snapshot = actor.getSnapshot();
+      expect(snapshot.value).toBe('STOPPED');
+      expect(snapshot.context.lastAction).toEqual({ type: 'STOP' });
     });
 
     it('last substep transitions to parent state', () => {
@@ -6359,11 +6361,13 @@ echo "processing"
       actor.send({ type: 'PASS' });
       expect(actor.getSnapshot().value).toBe('step::1::1');
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
+      expect(actor.getSnapshot().context.iterationResults).toEqual([]);
 
       // Iteration 2
       actor.send({ type: 'PASS' });
       expect(actor.getSnapshot().value).toBe('step::1::1');
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(3);
+      expect(actor.getSnapshot().context.iterationResults).toEqual([]);
 
       // Iteration 3 — last iteration → exit loop → step::2
       actor.send({ type: 'PASS' });
@@ -6371,6 +6375,7 @@ echo "processing"
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('step::2');
       expect(snapshot.context.forStack).toEqual([]);
+      expect(snapshot.context.iterationResults).toEqual([]);
     });
 
     it('multiple substeps, all pass', () => {
@@ -6491,6 +6496,8 @@ echo "processing"
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('step::2');
       expect(snapshot.context.forStack).toEqual([]);
+      expect(snapshot.context.iterationResults).toEqual([]);
+      expect(snapshot.context.lastAction).toEqual({ type: 'BREAK' });
     });
 
     it('NEXT advances iteration without accumulation', () => {
@@ -6534,6 +6541,8 @@ echo "processing"
       actor.send({ type: 'FAIL' });
       expect(actor.getSnapshot().value).toBe('step::1::1');
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
+      expect(actor.getSnapshot().context.iterationResults).toEqual([]);
+      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'NEXT' });
 
       // Iteration 2: both substeps pass
       actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
@@ -6546,6 +6555,7 @@ echo "processing"
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('step::2');
       expect(snapshot.context.forStack).toEqual([]);
+      expect(snapshot.context.iterationResults).toEqual([]);
     });
 
     it('parent aggregation activates iteration machinery even without forClause transitions', () => {

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -150,6 +150,71 @@ describe('runbook compiler', () => {
       expect(actor.getSnapshot().value).toBe('step::2');
     });
 
+    it('non-aggregating substeps with sequential flow (Case D)', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          description: 'Step with substeps, no aggregation',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            { id: '1', description: 'Sub 1', transitions: DEFAULT_TRANSITIONS },
+            { id: '2', description: 'Sub 2', transitions: DEFAULT_TRANSITIONS },
+            { id: '3', description: 'Sub 3', transitions: DEFAULT_TRANSITIONS },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Next',
+          transitions: {
+            ...DEFAULT_TRANSITIONS,
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          },
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
+      actor.send({ type: 'PASS' }); // 1.2 CONTINUE → 1.3
+      actor.send({ type: 'PASS' }); // 1.3 CONTINUE → parent → Case D → step::2
+
+      const snapshot = actor.getSnapshot();
+      expect(snapshot.value).toBe('step::2');
+      // Case D: non-FOR pass-through clears deferredResults
+      expect(snapshot.context.deferredResults).toBeUndefined();
+      expect(snapshot.context.iterationResults).toBeUndefined();
+    });
+
+    it('non-aggregating substep FAIL propagates STOP directly', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          description: 'Step with substeps, no aggregation',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            { id: '1', description: 'Sub 1', transitions: DEFAULT_TRANSITIONS },
+            { id: '2', description: 'Sub 2', transitions: DEFAULT_TRANSITIONS },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Next',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
+      actor.send({ type: 'FAIL' }); // 1.2 STOP → STOPPED
+
+      expect(actor.getSnapshot().value).toBe('STOPPED');
+    });
+
     it('last substep transitions to parent state', () => {
       const steps = inferSteps([
         {
@@ -6257,6 +6322,274 @@ echo "processing"
 
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('COMPLETE');
+    });
+  });
+
+  describe('sequential FOR (no aggregation)', () => {
+    it('all pass — loops through all iterations', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          forClause: { start: 1, end: 3 },
+          description: 'Sequential loop',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            {
+              id: '1',
+              description: 'Check',
+              transitions: DEFAULT_TRANSITIONS,
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Done',
+          transitions: {
+            ...DEFAULT_TRANSITIONS,
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          },
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Iteration 1: substep PASS → CONTINUE → loop-back
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
+
+      // Iteration 2
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().context.forStack[0].iteration).toBe(3);
+
+      // Iteration 3 — last iteration → exit loop → step::2
+      actor.send({ type: 'PASS' });
+
+      const snapshot = actor.getSnapshot();
+      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.context.forStack).toEqual([]);
+    });
+
+    it('multiple substeps, all pass', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          forClause: { start: 1, end: 2 },
+          description: 'Sequential loop with substeps',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            {
+              id: '1',
+              description: 'Sub A',
+              transitions: DEFAULT_TRANSITIONS,
+            },
+            {
+              id: '2',
+              description: 'Sub B',
+              transitions: DEFAULT_TRANSITIONS,
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Done',
+          transitions: {
+            ...DEFAULT_TRANSITIONS,
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          },
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Iteration 1
+      actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
+      expect(actor.getSnapshot().value).toBe('step::1::2');
+      actor.send({ type: 'PASS' }); // 1.2 CONTINUE → loop-back → iter 2
+      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
+
+      // Iteration 2
+      actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
+      expect(actor.getSnapshot().value).toBe('step::1::2');
+      actor.send({ type: 'PASS' }); // 1.2 CONTINUE → exit → step::2
+      expect(actor.getSnapshot().value).toBe('step::2');
+    });
+
+    it('substep FAIL with STOP terminates immediately', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          forClause: { start: 1, end: 3 },
+          description: 'Sequential loop',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            {
+              id: '1',
+              description: 'Check',
+              transitions: DEFAULT_TRANSITIONS,
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Done',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // iter 1 PASS → loop-back
+      actor.send({ type: 'FAIL' }); // iter 2 FAIL → STOP → STOPPED
+
+      expect(actor.getSnapshot().value).toBe('STOPPED');
+    });
+
+    it('BREAK exits loop without aggregation', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          forClause: { start: 1, end: 3 },
+          description: 'Sequential loop with BREAK',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            {
+              id: '1',
+              description: 'Check',
+              transitions: {
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'BREAK' as const } },
+              },
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Done',
+          transitions: {
+            ...DEFAULT_TRANSITIONS,
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          },
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'PASS' }); // iter 1 PASS → loop-back
+      actor.send({ type: 'FAIL' }); // iter 2 FAIL → BREAK → exit loop → step::2
+
+      const snapshot = actor.getSnapshot();
+      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.context.forStack).toEqual([]);
+    });
+
+    it('NEXT advances iteration without accumulation', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          forClause: { start: 1, end: 3 },
+          description: 'Sequential loop with NEXT',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            {
+              id: '1',
+              description: 'Sub A',
+              transitions: {
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'NEXT' as const } },
+              },
+            },
+            {
+              id: '2',
+              description: 'Sub B',
+              transitions: DEFAULT_TRANSITIONS,
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Done',
+          transitions: {
+            ...DEFAULT_TRANSITIONS,
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          },
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Iteration 1: 1.1 FAIL → NEXT → skip 1.2, advance to iter 2
+      actor.send({ type: 'FAIL' });
+      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
+
+      // Iteration 2: both substeps pass
+      actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
+      actor.send({ type: 'PASS' }); // 1.2 CONTINUE → loop-back → iter 3
+
+      // Iteration 3: both substeps pass → exit
+      actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
+      actor.send({ type: 'PASS' }); // 1.2 CONTINUE → exit → step::2
+
+      const snapshot = actor.getSnapshot();
+      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.context.forStack).toEqual([]);
+    });
+
+    it('parent aggregation activates iteration machinery even without forClause transitions', () => {
+      // Regression guard: step.aggregation makes needsIterationMachinery true
+      // even without explicit forClause.transitions or forClause.aggregation
+      const steps = inferSteps([
+        {
+          name: '1',
+          forClause: { start: 1, end: 2 },
+          description: 'FOR with parent aggregation only',
+          transitions: {
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'COMPLETE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          aggregation: { strategy: 'ALL' as const },
+          substeps: [
+            {
+              id: '1',
+              description: 'Check',
+              transitions: {
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'DEFER' as const } },
+              },
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Next',
+          transitions: DEFAULT_TRANSITIONS,
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // All PASS → iteration machinery active → aggregation → COMPLETE
+      actor.send({ type: 'PASS' }); // iter 1: substep DEFER → iteration DEFER
+      actor.send({ type: 'PASS' }); // iter 2: substep DEFER → iteration DEFER
+
+      // Parent ALL aggregation: all pass → COMPLETE (directly, not via step 2)
+      expect(actor.getSnapshot().value).toBe('COMPLETE');
+      expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
     });
   });
 

--- a/packages/core/__tests__/runbook/for-loop.properties.test.ts
+++ b/packages/core/__tests__/runbook/for-loop.properties.test.ts
@@ -1,7 +1,7 @@
 /**
  * fast-check property tests for FOR loop compilation.
  *
- * Thirteen invariant properties that hold for ANY valid ForLoopConfig:
+ * Fifteen invariant properties that hold for ANY valid ForLoopConfig:
  * 1. Termination — always reaches COMPLETE or STOPPED
  * 2. forStack empty at terminal — no dangling loop context
  * 3. PASS ALL + all pass → parent passes
@@ -15,6 +15,8 @@
  * 11. PASS ALL + all fail → STOPPED
  * 12. PASS ANY + all fail → STOPPED
  * 13. parentFailAction COMPLETE produces COMPLETE on fail path
+ * 14. Fully sequential FOR always terminates
+ * 15. Fully sequential FOR all-pass yields COMPLETE
  */
 
 import fc from 'fast-check';

--- a/packages/core/__tests__/runbook/for-loop.properties.test.ts
+++ b/packages/core/__tests__/runbook/for-loop.properties.test.ts
@@ -481,4 +481,75 @@ describe('FOR loop properties', () => {
       { numRuns: 200 },
     );
   });
+
+  // Property 14: Fully sequential FOR always terminates
+  // Config: both agg modes undefined (no iteration or parent aggregation),
+  // substepPassAction: CONTINUE, substepFailAction: random (CONTINUE/STOP/BREAK/NEXT).
+  it('fully sequential FOR always terminates', () => {
+    const seqConfig = fc.record({
+      iterations: fc.integer({ min: 1, max: 5 }),
+      numSubsteps: fc.integer({ min: 1, max: 3 }),
+      substepPassAction: fc.constant<SubstepAction>('CONTINUE'),
+      substepFailAction: fc.constantFrom<SubstepAction>('CONTINUE', 'STOP', 'BREAK', 'NEXT'),
+      substepFailRetry: fc.constant(0),
+      iterationPassAction: fc.constant<IterationAction>('CONTINUE'),
+      iterationFailAction: fc.constant<IterationAction>('CONTINUE'),
+      iterationAggMode: fc.constant(undefined),
+      iterationFailRetry: fc.constant(0),
+      parentPassAction: fc.constant<ParentAction>('CONTINUE'),
+      parentFailAction: fc.constant<ParentAction>('STOP'),
+      parentAggMode: fc.constant(undefined),
+      parentFailRetry: fc.constant(0),
+    });
+
+    fc.assert(
+      fc.property(
+        seqConfig,
+        fc.array(eventArb, { minLength: 1, maxLength: 30 }),
+        (config, events) => {
+          const result = runForLoop(config, events);
+          // Always terminates
+          expect(result.terminalState).toMatch(/^(COMPLETE|STOPPED)$/);
+          // No accumulation in sequential mode
+          expect(result.iterationResults).toEqual([]);
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+
+  // Property 15: Fully sequential FOR all-pass yields COMPLETE
+  // All events PASS, all actions CONTINUE — loops exactly right number of times.
+  it('fully sequential FOR all-pass yields COMPLETE', () => {
+    const seqPassConfig = fc.record({
+      iterations: fc.integer({ min: 1, max: 5 }),
+      numSubsteps: fc.integer({ min: 1, max: 3 }),
+      substepPassAction: fc.constant<SubstepAction>('CONTINUE'),
+      substepFailAction: fc.constant<SubstepAction>('STOP'),
+      substepFailRetry: fc.constant(0),
+      iterationPassAction: fc.constant<IterationAction>('CONTINUE'),
+      iterationFailAction: fc.constant<IterationAction>('CONTINUE'),
+      iterationAggMode: fc.constant(undefined),
+      iterationFailRetry: fc.constant(0),
+      parentPassAction: fc.constant<ParentAction>('CONTINUE'),
+      parentFailAction: fc.constant<ParentAction>('STOP'),
+      parentAggMode: fc.constant(undefined),
+      parentFailRetry: fc.constant(0),
+    });
+
+    fc.assert(
+      fc.property(seqPassConfig, (cfg) => {
+        const total = cfg.iterations * cfg.numSubsteps;
+        const events = Array.from({ length: total + 10 }, () => 'PASS' as EventType);
+        const result = runForLoop(cfg, events);
+        // All pass → COMPLETE (via step 2 terminal)
+        expect(result.terminalState).toBe('COMPLETE');
+        // FOR loop consumes iterations * numSubsteps events, then step 2 consumes 1
+        expect(result.eventsConsumed).toBe(total + 1);
+        // No accumulation
+        expect(result.iterationResults).toEqual([]);
+      }),
+      { numRuns: 300 },
+    );
+  });
 });

--- a/packages/core/__tests__/runbook/renderer.test.ts
+++ b/packages/core/__tests__/runbook/renderer.test.ts
@@ -503,6 +503,77 @@ echo hello
       ['review-structural-integrity.runbook.md'],
     ]);
   });
+
+  it('round-trips FOR without forClause transitions', () => {
+    const original = `## 1. Process items
+
+- FOR item IN 1 TO 3
+- PASS GOTO 2
+- FAIL STOP "processing failed"
+
+### 1.1 Check item
+
+Do the check.
+
+## 2. Done`;
+
+    const parsed1 = parseRunbook(original);
+    expect((parsed1[0] as any).forClause?.transitions).toBeUndefined();
+    expect((parsed1[0] as any).forClause?.aggregation).toBeUndefined();
+
+    const rendered = parsed1.map(renderStep).join('\n\n');
+    // No indented forClause transitions rendered
+    expect(rendered).not.toMatch(/^ {2}- PASS/m);
+    expect(rendered).not.toMatch(/^ {2}- FAIL/m);
+    // Step-level non-default transitions ARE rendered
+    expect(rendered).toContain('- PASS GOTO 2');
+    expect(rendered).toContain('- FAIL STOP "processing failed"');
+
+    const parsed2 = parseRunbook(rendered);
+    expect((parsed2[0] as any).forClause?.transitions).toBeUndefined();
+    expect((parsed2[0] as any).forClause?.aggregation).toBeUndefined();
+    // Step-level transitions survive round-trip
+    expect(parsed2[0].transitions.pass.action).toEqual({
+      type: 'GOTO',
+      target: { step: '2', substep: undefined },
+    });
+    expect(parsed2[0].transitions.fail.action).toEqual({
+      type: 'STOP',
+      message: 'processing failed',
+    });
+  });
+
+  it('round-trips substeps without aggregation', () => {
+    const original = `## 1. Sequential check
+
+### 1.1 First check
+
+Do check one.
+
+### 1.2 Second check
+
+Do check two.
+
+## 2. Done`;
+
+    const parsed1 = parseRunbook(original);
+    expect(parsed1[0].aggregation).toBeUndefined();
+
+    const rendered = parsed1.map(renderStep).join('\n\n');
+    // Default transitions suppressed by hasNonDefaultTransitions
+    expect(rendered).not.toMatch(/- PASS\b/);
+    expect(rendered).not.toMatch(/- FAIL\b/);
+    // No ALL/ANY modifiers
+    expect(rendered).not.toMatch(/\bALL\b/);
+    expect(rendered).not.toMatch(/\bANY\b/);
+
+    const parsed2 = parseRunbook(rendered);
+    expect(parsed2[0].aggregation).toBeUndefined();
+    // Substeps survive round-trip
+    expect(parsed2[0].substeps).toHaveLength(2);
+    expect(parsed2[0].substeps?.[0].description).toBe('First check');
+    expect(parsed2[0].substeps?.[1].description).toBe('Second check');
+  });
 });
 
 describe('FOR clause with nested transitions', () => {

--- a/packages/core/__tests__/runbook/renderer.test.ts
+++ b/packages/core/__tests__/runbook/renderer.test.ts
@@ -582,11 +582,13 @@ Review the following items carefully.
     expect(parsed1[0].kind).toBe('for');
 
     const rendered = parsed1.map(renderStep).join('\n\n');
+    expect(rendered).toContain('Review the following items carefully.');
     const parsed2 = parseRunbook(rendered);
 
     expect(parsed2[0].kind).toBe('for');
     expect((parsed2[0] as any).forClause).toEqual({ variable: 'pass', start: 1, end: 2 });
     expect((parsed2[0] as any).substepsDerivedFromRunbookList).toBe(true);
+    expect(parsed2[0].substeps?.[0].prompt).toBe('Review the following items carefully.');
   });
 
   it('round-trips FOR with default transitions and step prompt', () => {

--- a/packages/core/__tests__/runbook/renderer.test.ts
+++ b/packages/core/__tests__/runbook/renderer.test.ts
@@ -543,6 +543,75 @@ Do the check.
     });
   });
 
+  it('round-trips FOR with default transitions and H3 substeps', () => {
+    const original = `## 1. Process items
+
+- FOR item IN 1 TO 3
+
+### 1.1 Check item
+
+Do the check.
+
+## 2. Done`;
+
+    const parsed1 = parseRunbook(original);
+    expect(parsed1[0].kind).toBe('for');
+
+    const rendered = parsed1.map(renderStep).join('\n\n');
+    // Blank line must separate FOR clause from H3
+    expect(rendered).toContain('- FOR item IN 3\n\n### 1.1');
+
+    const parsed2 = parseRunbook(rendered);
+    expect(parsed2[0].kind).toBe('for');
+    expect(parsed2[0].substeps).toHaveLength(1);
+    expect(parsed2[0].substeps?.[0].description).toBe('Check item');
+  });
+
+  it('round-trips FOR with default transitions and shorthand substeps with prompt', () => {
+    const original = `## 1. Review the plan
+
+- FOR pass IN 1 TO 2
+
+Review the following items carefully.
+
+- review.runbook.md
+
+## 2. Done`;
+
+    const parsed1 = parseRunbook(original);
+    expect(parsed1[0].kind).toBe('for');
+
+    const rendered = parsed1.map(renderStep).join('\n\n');
+    const parsed2 = parseRunbook(rendered);
+
+    expect(parsed2[0].kind).toBe('for');
+    expect((parsed2[0] as any).forClause).toEqual({ variable: 'pass', start: 1, end: 2 });
+    expect((parsed2[0] as any).substepsDerivedFromRunbookList).toBe(true);
+  });
+
+  it('round-trips FOR with default transitions and step prompt', () => {
+    const original = `## 1. Process items
+
+- FOR item IN 1 TO 3
+
+Process each item carefully.
+
+### 1.1 Check item
+
+## 2. Done`;
+
+    const parsed1 = parseRunbook(original);
+    expect(parsed1[0].kind).toBe('for');
+    expect(parsed1[0].prompt).toBe('Process each item carefully.');
+
+    const rendered = parsed1.map(renderStep).join('\n\n');
+    const parsed2 = parseRunbook(rendered);
+
+    expect(parsed2[0].kind).toBe('for');
+    expect(parsed2[0].prompt).toBe('Process each item carefully.');
+    expect(parsed2[0].substeps).toHaveLength(1);
+  });
+
   it('round-trips substeps without aggregation', () => {
     const original = `## 1. Sequential check
 

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -70,7 +70,6 @@ export const MAX_FILE_ITERATIONS = 10_000;
 // (bare `[]` infers as `never[]`, not the required array type).
 const EMPTY_FOR_STACK: RunbookContext['forStack'] = [];
 const EMPTY_RESULTS: NonNullable<RunbookContext['iterationResults']> = [];
-const EMPTY_DEFERRED: NonNullable<RunbookContext['deferredResults']> = [];
 
 /**
  * Context passed through the XState runbook state machine.
@@ -1787,9 +1786,7 @@ function buildActionTransition(
  * Walks `on`, `always`, and guarded transition arrays to collect every
  * `target` value referenced by the state.
  *
- * @param config - A state config object from the generated states record
- * @param config.on - Event-driven transition map (PASS, FAIL, GOTO, RETRY)
- * @param config.always - Eventless always-transitions for transient states
+ * @param config - A {@link RunbookStateConfig} from the generated states record
  * @returns Array of target strings (may include duplicates)
  */
 function extractTargets(config: RunbookStateConfig): string[] {

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1798,7 +1798,7 @@ function extractTargets(config: RunbookStateConfig): string[] {
     if (typeof entry === 'string') {
       targets.push(entry);
     } else if (entry && typeof entry === 'object' && 'target' in entry) {
-      const t = (entry as { target?: string | null }).target;
+      const t = (entry as { target?: string }).target;
       if (typeof t === 'string') targets.push(t);
     }
   };

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -54,6 +54,9 @@ type SetLastActionRef = {
 /** Union of all action types the compiler emits into XState transitions. */
 type CompilerAction = ReturnType<typeof runbookSetup.assign> | SetLastActionRef;
 
+/** XState state-node config type inferred from the runbook setup. */
+type RunbookStateConfig = Parameters<typeof runbookSetup.createStateConfig>[0];
+
 /**
  * Safety limit for file-backed data sources with open iteration windows.
  *
@@ -62,6 +65,12 @@ type CompilerAction = ReturnType<typeof runbookSetup.assign> | SetLastActionRef;
  * signal completion.
  */
 export const MAX_FILE_ITERATIONS = 10_000;
+
+// Typed constants for empty array values that need explicit types
+// (bare `[]` infers as `never[]`, not the required array type).
+const EMPTY_FOR_STACK: RunbookContext['forStack'] = [];
+const EMPTY_RESULTS: NonNullable<RunbookContext['iterationResults']> = [];
+const EMPTY_DEFERRED: NonNullable<RunbookContext['deferredResults']> = [];
 
 /**
  * Context passed through the XState runbook state machine.
@@ -119,15 +128,15 @@ export type RunbookEvent =
  * Guards and targets are properly typed.
  */
 interface TransitionEntry {
-  target?: string | null;
+  target?: string;
   actions?: CompilerAction | CompilerAction[];
   guard?: (args: { context: RunbookContext; event: RunbookEvent }) => boolean;
 }
 
 /** XState `always` transition configuration within parent aggregation states. */
 interface AlwaysTransition {
-  guard?: (args: { context: RunbookContext }) => boolean;
-  target?: string | null;
+  guard?: (args: { context: RunbookContext; event: RunbookEvent }) => boolean;
+  target?: string;
   actions?: CompilerAction | CompilerAction[];
 }
 
@@ -564,8 +573,8 @@ function buildSimpleGotoAssign(options: {
     ...(options.preserveForContext
       ? {}
       : {
-          forStack: [] as readonly ForContext[],
-          iterationResults: undefined as ('pass' | 'fail')[] | undefined,
+          forStack: EMPTY_FOR_STACK,
+          iterationResults: undefined,
           iterationRetryCount: 0,
         }),
   });
@@ -700,7 +709,10 @@ function buildParentExitAssign(
     parentRetryCount: 0,
     iterationRetryCount: 0,
     substep: extractSubstepFromStateId(exitTarget),
-  };
+  } satisfies Pick<
+    RunbookContext,
+    'retryCount' | 'parentRetryCount' | 'iterationRetryCount' | 'substep'
+  >;
 
   switch (parentAction.type) {
     case 'GOTO': {
@@ -719,9 +731,9 @@ function buildParentExitAssign(
             );
             return [createForContext(targetStep.name, forClause, iteration, false, sources)];
           },
-          iterationResults: [] as ('pass' | 'fail')[],
+          iterationResults: EMPTY_RESULTS,
           substepCompletedCount: 0,
-          deferredResults: [] as ('pass' | 'fail')[],
+          deferredResults: EMPTY_RESULTS,
           lastAction: { ...buildGotoLastAction(parentAction.target), aggregated: true },
           substep: parentAction.target.substep ?? targetStep.substeps[0]?.id,
         });
@@ -730,14 +742,12 @@ function buildParentExitAssign(
       const targetHasAggregationTransitions = !!targetStep?.transitions;
       return runbookSetup.assign({
         ...baseAssign,
-        forStack: [] as readonly ForContext[],
+        forStack: EMPTY_FOR_STACK,
         ...(targetHasSubsteps
           ? {
-              iterationResults: targetHasAggregationTransitions
-                ? ([] as ('pass' | 'fail')[])
-                : (undefined as ('pass' | 'fail')[] | undefined),
+              iterationResults: targetHasAggregationTransitions ? EMPTY_RESULTS : undefined,
               substepCompletedCount: 0,
-              deferredResults: [] as ('pass' | 'fail')[],
+              deferredResults: EMPTY_RESULTS,
             }
           : {}),
         lastAction: { ...buildGotoLastAction(parentAction.target), aggregated: true },
@@ -746,30 +756,30 @@ function buildParentExitAssign(
     case 'STOP':
       return runbookSetup.assign({
         ...baseAssign,
-        forStack: [] as readonly ForContext[],
+        forStack: EMPTY_FOR_STACK,
         lastAction: { type: 'STOP' as const, aggregated: true },
         lastMessage: parentAction.message,
       });
     case 'COMPLETE':
       return runbookSetup.assign({
         ...baseAssign,
-        forStack: [] as readonly ForContext[],
+        forStack: EMPTY_FOR_STACK,
         lastAction: { type: 'COMPLETE' as const, aggregated: true },
         lastMessage: parentAction.message,
       });
     case 'CONTINUE':
       return runbookSetup.assign({
         ...baseAssign,
-        forStack: [] as readonly ForContext[],
+        forStack: EMPTY_FOR_STACK,
         lastAction: { type: 'CONTINUE' as const, aggregated: true },
-        lastMessage: undefined as string | undefined,
+        lastMessage: undefined,
       });
     default:
       return runbookSetup.assign({
         ...baseAssign,
-        forStack: [] as readonly ForContext[],
+        forStack: EMPTY_FOR_STACK,
         lastAction: { type: parentAction.type, aggregated: true },
-        lastMessage: undefined as string | undefined,
+        lastMessage: undefined,
       });
   }
 }
@@ -796,7 +806,7 @@ function buildParentStateConfig(
   config: ParentStateConfig,
   steps: ResolvedStep[],
   sources?: Readonly<Record<string, DataSource>>,
-): { always: AlwaysTransition[]; entry?: unknown } {
+): { always: AlwaysTransition[]; entry?: CompilerAction | CompilerAction[] } {
   const parentStep = config.parentStep;
   const stepName = config.stepName;
   const hasFor = parentStep.kind === 'for';
@@ -857,12 +867,12 @@ function buildParentStateConfig(
           // retryCount is exposed to the execution layer (actor-service) for visibility.
           retryCount: ({ context }: { context: RunbookContext }) => context.retryCount + 1,
           retryMax: transition.retry,
-          forStack: [] as readonly ForContext[],
-          iterationResults: [] as ('pass' | 'fail')[],
+          forStack: EMPTY_FOR_STACK,
+          iterationResults: EMPTY_RESULTS,
           substepCompletedCount: 0,
-          deferredResults: [] as ('pass' | 'fail')[],
+          deferredResults: EMPTY_RESULTS,
           iterationRetryCount: 0,
-          lastMessage: undefined as string | undefined,
+          lastMessage: undefined,
           substep: firstSubstep?.id,
         }),
       },
@@ -942,7 +952,7 @@ function buildParentStateConfig(
             retryMax: transition.retry,
             lastAction: { type: 'RETRY' as const },
             substepCompletedCount: 0,
-            deferredResults: [] as ('pass' | 'fail')[],
+            deferredResults: EMPTY_RESULTS,
             substep: firstSubstep?.id,
           }),
         });
@@ -960,11 +970,11 @@ function buildParentStateConfig(
         },
         target: formatStateId(stepName),
         actions: runbookSetup.assign({
-          forStack: [] as readonly ForContext[],
+          forStack: EMPTY_FOR_STACK,
           lastAction: { type: 'BREAK' as const },
           iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
             context.iterationResults ?? [],
-          deferredResults: [] as ('pass' | 'fail')[],
+          deferredResults: EMPTY_RESULTS,
         }),
       });
 
@@ -986,7 +996,7 @@ function buildParentStateConfig(
           iterationResults: ({ context }: { context: RunbookContext }) =>
             context.iterationResults ?? [],
           substepCompletedCount: 0,
-          deferredResults: [] as ('pass' | 'fail')[],
+          deferredResults: EMPTY_RESULTS,
           retryCount: 0,
           iterationRetryCount: 0,
           substep: firstSubstep?.id,
@@ -1004,7 +1014,7 @@ function buildParentStateConfig(
         },
         target: formatStateId(stepName),
         actions: runbookSetup.assign({
-          forStack: [] as readonly ForContext[],
+          forStack: EMPTY_FOR_STACK,
         }),
       });
 
@@ -1061,11 +1071,11 @@ function buildParentStateConfig(
           },
           target: formatStateId(stepName),
           actions: runbookSetup.assign({
-            forStack: [] as readonly ForContext[],
+            forStack: EMPTY_FOR_STACK,
             lastAction: { type: 'CONTINUE' as const },
             iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
               context.iterationResults ?? [],
-            deferredResults: [] as ('pass' | 'fail')[],
+            deferredResults: EMPTY_RESULTS,
           }),
         });
       };
@@ -1091,11 +1101,11 @@ function buildParentStateConfig(
           },
           target: formatStateId(stepName),
           actions: runbookSetup.assign({
-            forStack: [] as readonly ForContext[],
+            forStack: EMPTY_FOR_STACK,
             lastAction: { type: 'BREAK' as const },
             iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
               context.iterationResults ?? [],
-            deferredResults: [] as ('pass' | 'fail')[],
+            deferredResults: EMPTY_RESULTS,
           }),
         });
       };
@@ -1131,7 +1141,7 @@ function buildParentStateConfig(
             return results;
           },
           substepCompletedCount: 0,
-          deferredResults: [] as ('pass' | 'fail')[],
+          deferredResults: EMPTY_RESULTS,
           retryCount: 0,
           iterationRetryCount: 0,
           substep: firstSubstep?.id,
@@ -1153,7 +1163,7 @@ function buildParentStateConfig(
         },
         target: formatStateId(stepName),
         actions: runbookSetup.assign({
-          forStack: [] as readonly ForContext[],
+          forStack: EMPTY_FOR_STACK,
           iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] => {
             const results = context.iterationResults ?? [];
             const selected = getIterationTransition(context).transition;
@@ -1177,11 +1187,11 @@ function buildParentStateConfig(
         },
         target: formatStateId(stepName),
         actions: runbookSetup.assign({
-          forStack: [] as readonly ForContext[],
+          forStack: EMPTY_FOR_STACK,
           lastAction: { type: 'BREAK' as const },
           iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
             context.iterationResults ?? [],
-          deferredResults: [] as ('pass' | 'fail')[],
+          deferredResults: EMPTY_RESULTS,
         }),
       });
 
@@ -1203,7 +1213,7 @@ function buildParentStateConfig(
           iterationResults: ({ context }: { context: RunbookContext }) =>
             context.iterationResults ?? [],
           substepCompletedCount: 0,
-          deferredResults: [] as ('pass' | 'fail')[],
+          deferredResults: EMPTY_RESULTS,
           retryCount: 0,
           iterationRetryCount: 0,
           substep: firstSubstep?.id,
@@ -1221,7 +1231,7 @@ function buildParentStateConfig(
         },
         target: formatStateId(stepName),
         actions: runbookSetup.assign({
-          forStack: [] as readonly ForContext[],
+          forStack: EMPTY_FOR_STACK,
         }),
       });
 
@@ -1260,7 +1270,7 @@ function buildParentStateConfig(
         },
         target: formatStateId(stepName),
         actions: runbookSetup.assign({
-          forStack: [] as readonly ForContext[],
+          forStack: EMPTY_FOR_STACK,
         }),
       });
     }
@@ -1300,12 +1310,15 @@ function buildParentStateConfig(
     pushAdvanceGuards();
 
     const commonAssign = {
-      forStack: [] as readonly ForContext[],
+      forStack: EMPTY_FOR_STACK,
       retryCount: 0,
       parentRetryCount: 0,
       iterationRetryCount: 0,
       substep: extractSubstepFromStateId(nextTarget),
-    };
+    } satisfies Pick<
+      RunbookContext,
+      'forStack' | 'retryCount' | 'parentRetryCount' | 'iterationRetryCount' | 'substep'
+    >;
 
     if (hasFor) {
       // Case C: FOR without transitions — preserve lastAction from substep
@@ -1317,9 +1330,9 @@ function buildParentStateConfig(
         actions: runbookSetup.assign({
           ...commonAssign,
           substepCompletedCount: 0,
-          deferredResults: undefined as ('pass' | 'fail')[] | undefined,
+          deferredResults: undefined,
           lastAction: { type: 'CONTINUE' as const },
-          lastMessage: undefined as string | undefined,
+          lastMessage: undefined,
         }),
       });
     }
@@ -1489,8 +1502,8 @@ function buildLoopControlTransition(
       substepCompletedCount: ({ context }: { context: RunbookContext }) =>
         context.substepCompletedCount + 1,
       lastAction: { type: actionType },
-      lastMessage: undefined as string | undefined,
-      substep: undefined as string | undefined,
+      lastMessage: undefined,
+      substep: undefined,
     }),
   };
 }
@@ -1537,9 +1550,9 @@ function buildDeferTransition(
         substepCompletedCount: ({ context }: { context: RunbookContext }) =>
           context.substepCompletedCount + 1,
         lastAction: { type: 'DEFER' as const },
-        lastMessage: undefined as string | undefined,
+        lastMessage: undefined,
         // Keep substep set for non-last (advance guard signal); clear for last
-        substep: isLast ? (undefined as string | undefined) : substepId,
+        substep: isLast ? undefined : substepId,
       }),
     };
   }
@@ -1583,8 +1596,8 @@ function buildContinueTransition(
           substepCompletedCount: ({ context }: { context: RunbookContext }) =>
             context.substepCompletedCount + 1,
           lastAction: { type: 'CONTINUE' as const },
-          lastMessage: undefined as string | undefined,
-          substep: undefined as string | undefined,
+          lastMessage: undefined,
+          substep: undefined,
         }),
       };
     }
@@ -1596,7 +1609,7 @@ function buildContinueTransition(
         substepCompletedCount: ({ context }: { context: RunbookContext }) =>
           context.substepCompletedCount + 1,
         lastAction: { type: 'CONTINUE' as const },
-        lastMessage: undefined as string | undefined,
+        lastMessage: undefined,
         substep: extractSubstepFromStateId(target),
       }),
     };
@@ -1608,7 +1621,7 @@ function buildContinueTransition(
     target,
     actions: runbookSetup.assign({
       lastAction: { type: 'CONTINUE' as const },
-      lastMessage: undefined as string | undefined,
+      lastMessage: undefined,
       substep: extractSubstepFromStateId(target),
     }),
   };
@@ -1701,7 +1714,7 @@ function buildGotoTransition(
               if (top?.stepId === targetStepObj.name) return context.deferredResults;
               return [];
             }
-          : ([] as ('pass' | 'fail')[]),
+          : EMPTY_RESULTS,
       }),
     };
   }
@@ -1779,14 +1792,13 @@ function buildActionTransition(
  * @param config.always - Eventless always-transitions for transient states
  * @returns Array of target strings (may include duplicates)
  */
-function extractTargets(config: {
-  on?: Record<string, TransitionConfig | unknown[]>;
-  always?: AlwaysTransition[];
-}): string[] {
+function extractTargets(config: RunbookStateConfig): string[] {
   const targets: string[] = [];
 
   const collectFromEntry = (entry: unknown): void => {
-    if (entry && typeof entry === 'object' && 'target' in entry) {
+    if (typeof entry === 'string') {
+      targets.push(entry);
+    } else if (entry && typeof entry === 'object' && 'target' in entry) {
       const t = (entry as { target?: string | null }).target;
       if (typeof t === 'string') targets.push(t);
     }
@@ -1809,9 +1821,7 @@ function extractTargets(config: {
 
   // Walk always: [...]
   if (config.always) {
-    for (const entry of config.always) {
-      collectFromEntry(entry);
-    }
+    collectFromTransitionConfig(config.always);
   }
 
   return targets;
@@ -1831,10 +1841,7 @@ function extractTargets(config: {
  * @throws {Error} If any structural invariant is violated
  */
 function validateGraph(
-  states: Record<
-    string,
-    { on?: Record<string, TransitionConfig | unknown[]>; always?: AlwaysTransition[] }
-  >,
+  states: Record<string, RunbookStateConfig>,
   initialState: string,
   terminalStates: Set<string>,
 ): void {
@@ -1863,7 +1870,11 @@ function validateGraph(
  * @param config - The state configuration
  * @throws {Error} If a state with the given ID already exists
  */
-function checkedStateInsert(states: Record<string, unknown>, id: string, config: unknown): void {
+function checkedStateInsert(
+  states: Record<string, RunbookStateConfig>,
+  id: string,
+  config: RunbookStateConfig,
+): void {
   if (id in states) {
     throw new Error(`Compiler error: duplicate state ID "${id}"`);
   }
@@ -1891,14 +1902,7 @@ export function compileRunbookToMachine(
   steps: ResolvedStep[],
   options?: { sources?: Readonly<Record<string, DataSource>> },
 ) {
-  const states: Record<
-    string,
-    {
-      on?: Record<string, TransitionConfig | TransitionEntry[]>;
-      always?: AlwaysTransition[];
-      entry?: CompilerAction | CompilerAction[];
-    }
-  > = {};
+  const states: Record<string, RunbookStateConfig> = {};
 
   // Build a flat list of all states to generate GOTO transitions
   const allStates: StateConfig[] = [];
@@ -1940,7 +1944,7 @@ export function compileRunbookToMachine(
       checkedStateInsert(
         states,
         config.id,
-        buildParentStateConfig(config, steps, options?.sources),
+        runbookSetup.createStateConfig(buildParentStateConfig(config, steps, options?.sources)),
       );
       return;
     }
@@ -1995,7 +1999,7 @@ export function compileRunbookToMachine(
                   if (top?.stepId === stepInfo.step.name) return context.deferredResults;
                   return [];
                 }
-              : ([] as ('pass' | 'fail')[]),
+              : EMPTY_RESULTS,
             // Ensure substep is set so advance guards can use it
             substep: ({ context }: { context: RunbookContext }): string | undefined =>
               context.substep ?? config.substepId,
@@ -2084,7 +2088,7 @@ export function compileRunbookToMachine(
                     if (top?.stepId === forStepForTarget.step.name) return context.deferredResults;
                     return [];
                   }
-                : ([] as ('pass' | 'fail')[]),
+                : EMPTY_RESULTS,
             })
           : buildSimpleGotoAssign({
               lastAction: buildGotoLastActionFromEvent(target.substepId),
@@ -2096,51 +2100,57 @@ export function compileRunbookToMachine(
       };
     });
 
-    checkedStateInsert(states, config.id, {
-      ...entryActions,
-      on: {
-        PASS: buildTransition(
-          config.transitions.pass,
-          config.id,
-          config.stepName,
-          config.substepId,
-          steps,
-          options?.sources,
-        ),
-        FAIL: buildTransition(
-          config.transitions.fail,
-          config.id,
-          config.stepName,
-          config.substepId,
-          steps,
-          options?.sources,
-        ),
-        RETRY: {
-          actions: runbookSetup.assign({
-            lastAction: { type: 'RETRY' as const },
-            lastMessage: undefined as string | undefined,
-            retryCount: ({ context }) => context.retryCount + 1,
-            retryMax: retryMaxFromTransitions,
-          }),
-          target: config.id,
+    checkedStateInsert(
+      states,
+      config.id,
+      runbookSetup.createStateConfig({
+        ...entryActions,
+        on: {
+          PASS: buildTransition(
+            config.transitions.pass,
+            config.id,
+            config.stepName,
+            config.substepId,
+            steps,
+            options?.sources,
+          ),
+          FAIL: buildTransition(
+            config.transitions.fail,
+            config.id,
+            config.stepName,
+            config.substepId,
+            steps,
+            options?.sources,
+          ),
+          RETRY: {
+            actions: runbookSetup.assign({
+              lastAction: { type: 'RETRY' as const },
+              lastMessage: undefined,
+              retryCount: ({ context }) => context.retryCount + 1,
+              retryMax: retryMaxFromTransitions,
+            }),
+            target: config.id,
+          },
+          GOTO: buildGotoTransitionsForState,
         },
-        GOTO: buildGotoTransitionsForState,
-      },
-    });
+      }),
+    );
 
     // Register retry states for transitions with retry > 0
     if (config.transitions.pass.retry > 0) {
       checkedStateInsert(
         states,
         `${config.id}::pass-retry`,
-        buildRetryStateConfig(
-          config.transitions.pass,
-          config.id,
-          config.stepName,
-          config.substepId,
-          steps,
-          'pass',
-          options?.sources,
+        runbookSetup.createStateConfig(
+          buildRetryStateConfig(
+            config.transitions.pass,
+            config.id,
+            config.stepName,
+            config.substepId,
+            steps,
+            'pass',
+            options?.sources,
+          ),
         ),
       );
     }
@@ -2148,14 +2158,16 @@ export function compileRunbookToMachine(
       checkedStateInsert(
         states,
         `${config.id}::fail-retry`,
-        buildRetryStateConfig(
-          config.transitions.fail,
-          config.id,
-          config.stepName,
-          config.substepId,
-          steps,
-          'fail',
-          options?.sources,
+        runbookSetup.createStateConfig(
+          buildRetryStateConfig(
+            config.transitions.fail,
+            config.id,
+            config.stepName,
+            config.substepId,
+            steps,
+            'fail',
+            options?.sources,
+          ),
         ),
       );
     }

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1299,7 +1299,7 @@ function buildParentStateConfig(
     // Advance to next substep (both FOR and non-FOR)
     pushAdvanceGuards();
 
-    const exitAssign: Record<string, unknown> = {
+    const commonAssign = {
       forStack: [] as readonly ForContext[],
       retryCount: 0,
       parentRetryCount: 0,
@@ -1307,16 +1307,22 @@ function buildParentStateConfig(
       substep: extractSubstepFromStateId(nextTarget),
     };
 
-    if (!hasFor) {
+    if (hasFor) {
+      // Case C: FOR without transitions — preserve lastAction from substep
+      always.push({ target: nextTarget, actions: runbookSetup.assign(commonAssign) });
+    } else {
       // Case D: non-FOR pass-through — clear deferredResults, set CONTINUE
-      exitAssign.substepCompletedCount = 0;
-      exitAssign.deferredResults = undefined as ('pass' | 'fail')[] | undefined;
-      exitAssign.lastAction = { type: 'CONTINUE' as const };
-      exitAssign.lastMessage = undefined as string | undefined;
+      always.push({
+        target: nextTarget,
+        actions: runbookSetup.assign({
+          ...commonAssign,
+          substepCompletedCount: 0,
+          deferredResults: undefined as ('pass' | 'fail')[] | undefined,
+          lastAction: { type: 'CONTINUE' as const },
+          lastMessage: undefined as string | undefined,
+        }),
+      });
     }
-    // Case C: FOR without transitions — preserve lastAction from substep
-
-    always.push({ target: nextTarget, actions: runbookSetup.assign(exitAssign) });
   }
 
   return { always };

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -68,8 +68,10 @@ export const MAX_FILE_ITERATIONS = 10_000;
 
 // Typed constants for empty array values that need explicit types
 // (bare `[]` infers as `never[]`, not the required array type).
-const EMPTY_FOR_STACK: RunbookContext['forStack'] = [];
-const EMPTY_RESULTS: NonNullable<RunbookContext['iterationResults']> = [];
+const EMPTY_FOR_STACK: RunbookContext['forStack'] = Object.freeze([]);
+const EMPTY_RESULTS = Object.freeze([]) as unknown as NonNullable<
+  RunbookContext['iterationResults']
+>;
 
 /**
  * Context passed through the XState runbook state machine.

--- a/packages/core/src/runbook/renderer/renderer.ts
+++ b/packages/core/src/runbook/renderer/renderer.ts
@@ -207,6 +207,8 @@ export function renderStep(step: Step): string {
   if (step.aggregation || hasNonDefaultTransitions(step.transitions)) {
     lines.push(renderTransitions(step.transitions, step.aggregation));
     lines.push('');
+  } else if (step.kind === 'for') {
+    lines.push(''); // Terminate FOR bullet list when default transitions are omitted
   }
 
   const shorthandSubsteps = getShorthandRunbookSubsteps(step);

--- a/packages/parser/__tests__/parser.test.ts
+++ b/packages/parser/__tests__/parser.test.ts
@@ -446,6 +446,83 @@ Do the check.
       action: { type: 'DEFER' },
     });
   });
+
+  it('substeps under non-aggregating parent get CONTINUE/STOP', () => {
+    const markdown = `## 1. Sequential check
+
+### 1.1 First check
+
+Do check one.
+
+### 1.2 Second check
+
+Do check two.
+`;
+    const steps = parseRunbook(markdown);
+    // No aggregation on parent step
+    expect(steps[0].aggregation).toBeUndefined();
+    // Substeps get CONTINUE/STOP defaults (no aggregation context)
+    expect(steps[0].substeps?.[0].transitions?.pass).toEqual({
+      kind: 'pass',
+      retry: 0,
+      action: { type: 'CONTINUE' },
+    });
+    expect(steps[0].substeps?.[0].transitions?.fail).toEqual({
+      kind: 'fail',
+      retry: 0,
+      action: { type: 'STOP' },
+    });
+    expect(steps[0].substeps?.[1].transitions?.pass).toEqual({
+      kind: 'pass',
+      retry: 0,
+      action: { type: 'CONTINUE' },
+    });
+    expect(steps[0].substeps?.[1].transitions?.fail).toEqual({
+      kind: 'fail',
+      retry: 0,
+      action: { type: 'STOP' },
+    });
+  });
+
+  it('explicit substep transitions preserved under aggregating parent', () => {
+    const markdown = `## 1. Aggregated check
+
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Explicit substep
+- PASS DEFER
+- FAIL STOP
+
+### 1.2 Default substep
+
+Do check.
+`;
+    const steps = parseRunbook(markdown);
+    expect(steps[0].aggregation?.strategy).toBe('ALL');
+    // Substep 1: explicit transitions preserved (DEFER/STOP, not overridden)
+    expect(steps[0].substeps?.[0].transitions?.pass).toEqual({
+      kind: 'pass',
+      retry: 0,
+      action: { type: 'DEFER' },
+    });
+    expect(steps[0].substeps?.[0].transitions?.fail).toEqual({
+      kind: 'fail',
+      retry: 0,
+      action: { type: 'STOP' },
+    });
+    // Substep 2: no explicit transitions → gets default DEFER/DEFER under aggregation
+    expect(steps[0].substeps?.[1].transitions?.pass).toEqual({
+      kind: 'pass',
+      retry: 0,
+      action: { type: 'DEFER' },
+    });
+    expect(steps[0].substeps?.[1].transitions?.fail).toEqual({
+      kind: 'fail',
+      retry: 0,
+      action: { type: 'DEFER' },
+    });
+  });
 });
 
 describe('substep GOTO validation', () => {


### PR DESCRIPTION
…g substeps

Exercise the compiler's sequential FOR guard path (compiler.ts:1167-1265) which previously had zero unit test coverage. Add 14 new tests across 4 files:

- 6 sequential FOR compiler tests (all-pass, multi-substep, STOP, BREAK, NEXT, parent aggregation regression guard)
- 2 non-aggregating substep tests (Case D pass-through, STOP propagation)
- 2 parser default resolution tests (CONTINUE/STOP under non-aggregating parent, explicit transitions preserved under aggregating parent)
- 2 renderer round-trip tests (FOR without forClause transitions, substeps without aggregation)
- 2 property tests (sequential FOR termination, all-pass event count)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Vastly expanded runbook test coverage for FOR loops, iteration edge cases, aggregation (ALL/ANY), GOTO/NEXT/BREAK behaviors, deferred vs per-iteration results, last-action/retry/regression guards, rendering/parsing round-trips, and substep transition defaults/preservation; added sequential FOR property tests.
* **Bug Fixes**
  * Fixed FOR list rendering to ensure proper spacing and preserve transition behavior.
* **Refactor**
  * Consolidated and standardized internal runbook state/config handling for greater consistency (no public API changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->