### PR TITLE
add --index flag to step-targeting commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,16 @@ rundown run [file] --json # Output execution events as JSON
 rundown run [file] --var key=value  # Set template variable (repeatable)
 rundown run [file] --var-file path  # Load variables from YAML file
 rundown run [file] --prompted  # Show commands without auto-executing
+rundown run [file] --step <stepId>   # Jump to step after starting (requires --prompted)
+rundown run [file] --index <number>  # FOR loop iteration to target (requires --step)
 rundown pass             # Mark current step as passed (aliases: yes, ok)
+rundown pass --step <stepId>         # Target specific substep
+rundown pass --index <number>        # FOR loop iteration (requires --step)
 rundown fail             # Mark current step as failed (alias: no)
+rundown fail --step <stepId>         # Target specific substep
+rundown fail --index <number>        # FOR loop iteration (requires --step)
 rundown goto <step>      # Jump to step (e.g., '3', '3.1' for substep)
+rundown goto <step> --index <number> # FOR loop iteration to target
 rundown status           # Show current state
 rundown stop [message]   # Abort runbook with optional message
 rundown complete [message] # Force early completion (runbooks auto-complete on final step)
@@ -56,6 +63,7 @@ rundown delegate                        # Infer substep and runbook from state
 rundown delegate --step <id>            # Infer runbook from substep reference
 rundown delegate <runbook> --step <id>  # Explicit delegation
 rundown delegate <runbook> --step <id> --var key=value  # With variables
+rundown delegate --index <number>       # FOR loop iteration to target
 rundown claim <token>                   # Claim a delegation token and launch child
 rundown claim <token> --var key=value   # Claim with variables
 rundown abort <token>                   # Cancel a delegation token (--force for claimed)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ rundown delegate                        # Infer substep and runbook from state
 rundown delegate --step <id>            # Infer runbook from substep reference
 rundown delegate <runbook> --step <id>  # Explicit delegation
 rundown delegate <runbook> --step <id> --var key=value  # With variables
-rundown delegate --index <number>       # FOR loop iteration to target
+rundown delegate --step <id> --index <number>  # FOR loop iteration to target
 rundown claim <token>                   # Claim a delegation token and launch child
 rundown claim <token> --var key=value   # Claim with variables
 rundown abort <token>                   # Cancel a delegation token (--force for claimed)

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -376,4 +376,12 @@ This step stops on pass.
       expect(parseResult.success).toBe(true);
     });
   });
+
+  describe('option validation', () => {
+    it('rejects --index without --step', async () => {
+      const result = await runCliInProcess('pass --index 1', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('--index requires --step');
+    });
+  });
 });

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -101,4 +101,21 @@ describe('start command', () => {
       expect(session.active).toBeNull();
     });
   });
+
+  describe('option validation', () => {
+    it('rejects --step without --prompted', async () => {
+      const result = await runCliInProcess('run runbooks/simple.runbook.md --step 1', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('--step requires --prompted');
+    });
+
+    it('rejects --index without --step', async () => {
+      const result = await runCliInProcess(
+        'run runbooks/simple.runbook.md --prompted --index 1',
+        workspace,
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('--index requires --step');
+    });
+  });
 });

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -600,4 +600,61 @@ describe('handleDelegationCompletion', () => {
 
     expect(output.flush).toHaveBeenCalled();
   });
+
+  it('passes parentFrameKey as frameKeyOverride to drain', async () => {
+    const delegation = makeDelegationLinkage({ parentFrameKey: '1|3' as any });
+    const childState = makeState('child-run-id', { delegation });
+    const parentState = makeState('parent-run-id', {
+      substepStates: [{ id: '1', frameKey: '1|3', status: 'pending', delegation: null }],
+    });
+
+    const states = new Map([[parentState.id, parentState]]);
+    const manager = makeManager(states);
+    const _lock = makeLock();
+    const lifecycleService = makeLifecycleService();
+    const output = makeOutput();
+
+    wireMocks(manager, lifecycleService);
+
+    (drainResolvedCompletions as jest.Mock).mockResolvedValue({
+      status: 'continue',
+      applied: 0,
+      state: parentState,
+    });
+
+    await handleDelegationCompletion(childState, 'pass', '/test', output);
+
+    expect(drainResolvedCompletions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        frameKeyOverride: '1|3',
+      }),
+    );
+  });
+
+  it('does not pass frameKeyOverride when parentFrameKey is undefined', async () => {
+    const delegation = makeDelegationLinkage({ parentFrameKey: undefined });
+    const childState = makeState('child-run-id', { delegation });
+    const parentState = makeState('parent-run-id', {
+      substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
+    });
+
+    const states = new Map([[parentState.id, parentState]]);
+    const manager = makeManager(states);
+    const _lock = makeLock();
+    const lifecycleService = makeLifecycleService();
+    const output = makeOutput();
+
+    wireMocks(manager, lifecycleService);
+
+    (drainResolvedCompletions as jest.Mock).mockResolvedValue({
+      status: 'continue',
+      applied: 0,
+      state: parentState,
+    });
+
+    await handleDelegationCompletion(childState, 'pass', '/test', output);
+
+    const drainCall = (drainResolvedCompletions as jest.Mock).mock.calls[0][0];
+    expect(drainCall.frameKeyOverride).toBeUndefined();
+  });
 });

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -269,6 +269,86 @@ describe('validateGotoTarget', () => {
       expect(result.target).toEqual({ step: '1', substep: '2' });
     }
   });
+
+  describe('--index option', () => {
+    it('sets target.at from --index on FOR step', () => {
+      (
+        core.parseStepIdFromString as jest.MockedFunction<typeof core.parseStepIdFromString>
+      ).mockReturnValue({ step: '1' });
+
+      const steps = [
+        makeStep({ name: '1', forClause: { variable: 'x', start: 1, end: 5 } as any }),
+      ];
+      const result = validateGotoTarget('1', steps, '3');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.target.at).toBe(3);
+      }
+    });
+
+    it('rejects --index on non-FOR step', () => {
+      (
+        core.parseStepIdFromString as jest.MockedFunction<typeof core.parseStepIdFromString>
+      ).mockReturnValue({ step: '1' });
+
+      const steps = [makeStep({ name: '1' })]; // No forClause
+      const result = validateGotoTarget('1', steps, '3');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe('INVALID_AT_TARGET');
+      }
+    });
+
+    it('rejects conflicting --index and AT', () => {
+      (
+        core.parseStepIdFromString as jest.MockedFunction<typeof core.parseStepIdFromString>
+      ).mockReturnValue({ step: '1', at: 5 });
+
+      const steps = [
+        makeStep({ name: '1', forClause: { variable: 'x', start: 1, end: 10 } as any }),
+      ];
+      const result = validateGotoTarget('1 AT 5', steps, '3');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe('CONFLICTING_INDEX');
+      }
+    });
+
+    it('accepts matching --index and AT (idempotent)', () => {
+      (
+        core.parseStepIdFromString as jest.MockedFunction<typeof core.parseStepIdFromString>
+      ).mockReturnValue({ step: '1', at: 3 });
+
+      const steps = [
+        makeStep({ name: '1', forClause: { variable: 'x', start: 1, end: 5 } as any }),
+      ];
+      const result = validateGotoTarget('1 AT 3', steps, '3');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.target.at).toBe(3);
+      }
+    });
+
+    it('rejects invalid --index value', () => {
+      (
+        core.parseStepIdFromString as jest.MockedFunction<typeof core.parseStepIdFromString>
+      ).mockReturnValue({ step: '1' });
+
+      const steps = [
+        makeStep({ name: '1', forClause: { variable: 'x', start: 1, end: 5 } as any }),
+      ];
+      const result = validateGotoTarget('1', steps, 'abc');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe('INVALID_SYNTAX');
+      }
+    });
+  });
 });
 
 describe('executeGoto', () => {

--- a/packages/cli/__tests__/helpers/index-option.test.ts
+++ b/packages/cli/__tests__/helpers/index-option.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from '@jest/globals';
-import { resolveIndexOption, IndexOptionError } from '../../src/helpers/index-option.js';
+import {
+  resolveIndexOption,
+  IndexOptionError,
+  validateIndexRequiresStep,
+} from '../../src/helpers/index-option.js';
 
 describe('resolveIndexOption', () => {
   it('returns undefined when both inputs are undefined', () => {
@@ -67,11 +71,29 @@ describe('resolveIndexOption', () => {
 
   it('error has INVALID_SYNTAX code for bad input', () => {
     try {
-      resolveIndexOption('notanumber', undefined);
+      resolveIndexOption('bad-input', undefined);
       expect.unreachable('should have thrown');
     } catch (error) {
       expect(error).toBeInstanceOf(IndexOptionError);
       expect((error as IndexOptionError).code).toBe('INVALID_SYNTAX');
     }
+  });
+});
+
+describe('validateIndexRequiresStep', () => {
+  it('returns undefined when both are undefined', () => {
+    expect(validateIndexRequiresStep(undefined, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when --step is provided without --index', () => {
+    expect(validateIndexRequiresStep(undefined, '1.1')).toBeUndefined();
+  });
+
+  it('returns undefined when both --index and --step are provided', () => {
+    expect(validateIndexRequiresStep('3', '1.1')).toBeUndefined();
+  });
+
+  it('returns error when --index is provided without --step', () => {
+    expect(validateIndexRequiresStep('3', undefined)).toBe('--index requires --step');
   });
 });

--- a/packages/cli/__tests__/helpers/index-option.test.ts
+++ b/packages/cli/__tests__/helpers/index-option.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from '@jest/globals';
+import { resolveIndexOption, IndexOptionError } from '../../src/helpers/index-option.js';
+
+describe('resolveIndexOption', () => {
+  it('returns undefined when both inputs are undefined', () => {
+    expect(resolveIndexOption(undefined, undefined)).toBeUndefined();
+  });
+
+  it('parses valid --index as positive integer', () => {
+    expect(resolveIndexOption('1', undefined)).toBe(1);
+    expect(resolveIndexOption('5', undefined)).toBe(5);
+    expect(resolveIndexOption('100', undefined)).toBe(100);
+  });
+
+  it('rejects non-numeric --index', () => {
+    expect(() => resolveIndexOption('abc', undefined)).toThrow(IndexOptionError);
+    expect(() => resolveIndexOption('abc', undefined)).toThrow('Invalid --index value');
+  });
+
+  it('rejects zero --index', () => {
+    expect(() => resolveIndexOption('0', undefined)).toThrow(IndexOptionError);
+  });
+
+  it('rejects negative --index', () => {
+    expect(() => resolveIndexOption('-1', undefined)).toThrow(IndexOptionError);
+  });
+
+  it('rejects floating point --index', () => {
+    expect(() => resolveIndexOption('1.5', undefined)).toThrow(IndexOptionError);
+  });
+
+  it('rejects empty string --index', () => {
+    expect(() => resolveIndexOption('', undefined)).toThrow(IndexOptionError);
+  });
+
+  it('returns parsedAt when only parsedAt is provided (number)', () => {
+    expect(resolveIndexOption(undefined, 3)).toBe(3);
+  });
+
+  it('returns undefined when only parsedAt is a template string', () => {
+    expect(resolveIndexOption(undefined, '{{ Index }}')).toBeUndefined();
+  });
+
+  it('returns value when both match (idempotent)', () => {
+    expect(resolveIndexOption('3', 3)).toBe(3);
+  });
+
+  it('throws CONFLICTING_INDEX when --index and parsedAt differ', () => {
+    try {
+      resolveIndexOption('2', 5);
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(IndexOptionError);
+      expect((error as IndexOptionError).code).toBe('CONFLICTING_INDEX');
+    }
+  });
+
+  it('throws CONFLICTING_INDEX when --index conflicts with template AT', () => {
+    try {
+      resolveIndexOption('3', '{{ Index }}');
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(IndexOptionError);
+      expect((error as IndexOptionError).code).toBe('CONFLICTING_INDEX');
+    }
+  });
+
+  it('error has INVALID_SYNTAX code for bad input', () => {
+    try {
+      resolveIndexOption('notanumber', undefined);
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(IndexOptionError);
+      expect((error as IndexOptionError).code).toBe('INVALID_SYNTAX');
+    }
+  });
+});

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { mockErrorHelpers } from './mock-error-helpers';
+
+// Mock @rundown-org/core
+jest.unstable_mockModule('@rundown-org/core', () => ({
+  RunbookStateManager: jest.fn(),
+  RunbookActorService: jest.fn(),
+  SessionService: jest.fn(),
+  ExecutionLifecycleService: jest.fn(),
+  extractLastAction: jest.fn().mockReturnValue(undefined),
+  formatTransitionAction: jest.fn().mockReturnValue('CONTINUE'),
+  parseActionType: jest.fn().mockReturnValue('CONTINUE'),
+  parseStepIdFromString: jest.fn(),
+  buildCompletionKey: jest.fn(
+    (frameKey: string, entry: number, substep?: string) =>
+      `${frameKey}:${String(entry)}:${substep ?? ''}`,
+  ),
+  buildFrameKey: jest.fn((step: string, iteration?: number) =>
+    iteration !== undefined ? `${step}[${String(iteration)}]` : step,
+  ),
+  buildResolvedCompletion: jest.fn().mockReturnValue({ result: 'pass' }),
+  deriveExecutionAt: jest.fn(
+    (step: string, substep?: string, iteration?: number) =>
+      `${step}${iteration !== undefined ? `[${String(iteration)}]` : ''}${substep ? `.${substep}` : ''}`,
+  ),
+  deriveActiveFrame: jest.fn().mockReturnValue({ step: '1', iteration: undefined, frameKey: '1' }),
+  ...mockErrorHelpers,
+}));
+
+// Mock @rundown-org/parser
+jest.unstable_mockModule('@rundown-org/parser', () => ({
+  resolvedStepHasSubsteps: jest.fn(),
+}));
+
+// Mock runbook-loader
+jest.unstable_mockModule('../../src/helpers/runbook-loader', () => ({
+  getRunbookFromState: jest.fn().mockReturnValue([]),
+}));
+
+// Mock execution service
+jest.unstable_mockModule('../../src/services/execution', () => ({
+  drainResolvedCompletions: jest.fn().mockResolvedValue({ status: 'done', applied: 0 }),
+  findStepOrThrow: jest.fn(),
+  runExecutionLoop: jest.fn().mockResolvedValue('done'),
+}));
+
+// Mock execution-emitter
+jest.unstable_mockModule('../../src/helpers/execution-emitter', () => ({
+  createBridgedEmitter: jest.fn().mockReturnValue({}),
+}));
+
+// Mock transition-orchestrator
+jest.unstable_mockModule('../../src/helpers/transition-orchestrator', () => ({
+  orchestrateTransition: jest.fn().mockResolvedValue({ status: 'done' }),
+}));
+
+const core = await import('@rundown-org/core');
+const { resolvedStepHasSubsteps } = await import('@rundown-org/parser');
+const { findStepOrThrow } = await import('../../src/services/execution');
+const { executeTransition, createPassTransitionConfig } = await import(
+  '../../src/helpers/transitions'
+);
+
+function makeCtx(stateOverrides: Record<string, unknown> = {}): any {
+  const state = {
+    id: 'run-1',
+    step: '1',
+    substep: '1',
+    activeEntry: 1,
+    activeFrameKey: '1',
+    ...stateOverrides,
+  };
+  return {
+    output: { action: jest.fn(), flush: jest.fn(), status: jest.fn(), warning: jest.fn() },
+    manager: { update: jest.fn<any>().mockResolvedValue(undefined) },
+    actorService: {
+      updateFromActor: jest.fn<any>().mockResolvedValue({
+        state: { ...state },
+        snapshot: {},
+      }),
+    },
+    sessionService: {},
+    lifecycleService: {
+      ensureActiveEntry: jest.fn<any>().mockResolvedValue({ state, entryId: 1 }),
+      getResolvedCompletion: jest.fn<any>().mockResolvedValue(null),
+      upsertResolvedCompletion: jest.fn<any>().mockResolvedValue(undefined),
+    },
+    state,
+    steps: [
+      {
+        name: '1',
+        kind: 'substeps',
+        substeps: [{ id: '1' }, { id: '2' }],
+      },
+    ],
+    actor: { send: jest.fn(), stop: jest.fn() },
+    cwd: '/test',
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: step has substeps
+  (findStepOrThrow as jest.Mock).mockReturnValue({
+    name: '1',
+    kind: 'substeps',
+    substeps: [{ id: '1' }, { id: '2' }],
+  });
+  (resolvedStepHasSubsteps as jest.MockedFunction<typeof resolvedStepHasSubsteps>).mockReturnValue(
+    true,
+  );
+  // Default: parseStepIdFromString returns valid parse
+  (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+  // Reset buildCompletionKey
+  (core.buildCompletionKey as jest.Mock).mockImplementation(
+    (frameKey: string, entry: number, substep?: string) =>
+      `${frameKey}:${String(entry)}:${substep ?? ''}`,
+  );
+});
+
+describe('executeTransition with ExplicitTarget', () => {
+  it('throws when explicitTarget is provided but not in substep mode', async () => {
+    const ctx = makeCtx({ substep: undefined }); // No active substep
+    (findStepOrThrow as jest.Mock).mockReturnValue({ name: '1', kind: 'base' });
+    (
+      resolvedStepHasSubsteps as jest.MockedFunction<typeof resolvedStepHasSubsteps>
+    ).mockReturnValue(false);
+
+    const config = createPassTransitionConfig();
+    await expect(executeTransition(ctx, config, { stepId: '1.1' })).rejects.toThrow(
+      '--step requires the runbook to be at a substep',
+    );
+  });
+
+  it('uses explicit target for completion key when provided', async () => {
+    const ctx = makeCtx();
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config, { stepId: '1.1' });
+
+    // Verify parseStepIdFromString was called with the explicit step ID
+    expect(core.parseStepIdFromString).toHaveBeenCalledWith('1.1');
+    // Verify completion was recorded (substep completion path was entered)
+    expect(ctx.lifecycleService.upsertResolvedCompletion).toHaveBeenCalled();
+  });
+
+  it('uses explicit target with --index for iteration targeting', async () => {
+    const ctx = makeCtx();
+    // parseStepIdFromString returns step without AT (index comes from --index flag)
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config, { stepId: '1.1', index: '3' });
+
+    // buildFrameKey should have been called with iteration=3
+    expect(core.buildFrameKey).toHaveBeenCalledWith('1', 3);
+  });
+
+  it('throws on invalid step ID in explicit target', async () => {
+    const ctx = makeCtx();
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue(null);
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(ctx, config, { stepId: 'invalid!!!' })).rejects.toThrow(
+      'Invalid step target: invalid!!!',
+    );
+  });
+
+  it('throws IndexOptionError on conflicting --index and AT', async () => {
+    const ctx = makeCtx();
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1', at: 5 });
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(ctx, config, { stepId: '1.1', index: '3' })).rejects.toThrow(
+      'conflicts with AT',
+    );
+  });
+
+  it('uses cursor.substep (not activeState.substep) for completion key', async () => {
+    const ctx = makeCtx({ substep: '1' }); // Active substep is '1'
+    // Explicit target points to substep '2'
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '2' });
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config, { stepId: '1.2' });
+
+    // buildCompletionKey should use '2' (from explicit target), not '1' (from activeState)
+    const completionKeyCall = (core.buildCompletionKey as jest.Mock).mock.calls[0];
+    expect(completionKeyCall[2]).toBe('2'); // substep argument
+  });
+
+  it('falls back to activeCursorTarget when no explicit target', async () => {
+    const ctx = makeCtx({ substep: '1' });
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config); // No explicit target
+
+    // buildCompletionKey should use activeState.substep ('1')
+    const completionKeyCall = (core.buildCompletionKey as jest.Mock).mock.calls[0];
+    expect(completionKeyCall[2]).toBe('1');
+  });
+});

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -57,7 +57,7 @@ jest.unstable_mockModule('../../src/helpers/transition-orchestrator', () => ({
 
 const core = await import('@rundown-org/core');
 const { resolvedStepHasSubsteps } = await import('@rundown-org/parser');
-const { findStepOrThrow } = await import('../../src/services/execution');
+const { findStepOrThrow, drainResolvedCompletions } = await import('../../src/services/execution');
 const { executeTransition, createPassTransitionConfig } = await import(
   '../../src/helpers/transitions'
 );
@@ -498,5 +498,41 @@ describe('executeTransition with ExplicitTarget', () => {
       expect.any(String),
       expect.any(Object),
     );
+  });
+
+  it('passes frameKeyOverride to drain when explicit target provided', async () => {
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(forStep);
+    const ctx = makeCtx({ substep: '1' });
+    ctx.steps = [forStep];
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config, { stepId: '1.1', index: '3' });
+
+    expect(drainResolvedCompletions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        frameKeyOverride: expect.any(String),
+      }),
+    );
+    // The override should be the cursor's frameKey (built from step + index)
+    const drainCall = (drainResolvedCompletions as jest.Mock).mock.calls[0][0];
+    expect(drainCall.frameKeyOverride).toBe(core.buildFrameKey('1', 3));
+  });
+
+  it('does not pass frameKeyOverride when no explicit target', async () => {
+    const ctx = makeCtx({ substep: '1' });
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config); // No explicit target
+
+    expect(drainResolvedCompletions).toHaveBeenCalled();
+    const drainCall = (drainResolvedCompletions as jest.Mock).mock.calls[0][0];
+    expect(drainCall.frameKeyOverride).toBeUndefined();
   });
 });

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -306,14 +306,16 @@ describe('executeTransition with ExplicitTarget', () => {
     expect(ctx.lifecycleService.upsertResolvedCompletion).toHaveBeenCalled();
   });
 
-  it('throws when --index provided but step is not a FOR step', async () => {
+  it('throws when --index provided but step is not a FOR or PROMPTED-FOR step', async () => {
     // Default step is kind: 'substeps' (not FOR)
+    // This test also covers the delegate.ts validation path (Issue C),
+    // which uses the same kind-check pattern with parsedTarget?.step.
     const ctx = makeCtx({ substep: '1' });
     (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
     const config = createPassTransitionConfig();
 
     await expect(executeTransition(ctx, config, { stepId: '1.1', index: '3' })).rejects.toThrow(
-      '--index requires step "1" to be a FOR step',
+      '--index requires step "1" to be a FOR or PROMPTED-FOR step',
     );
   });
 
@@ -399,6 +401,71 @@ describe('executeTransition with ExplicitTarget', () => {
     expect(call).toBeDefined();
   });
 
+  it('allows --index on prompted-for step without bounds check', async () => {
+    const promptedForStep = {
+      name: '1',
+      kind: 'prompted-for',
+      // No forClause — prompted-for has no executable bounds
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(promptedForStep);
+    const ctx = makeCtx({ substep: '1' });
+    ctx.steps = [promptedForStep];
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    // Should NOT throw — prompted-for accepts --index without bounds validation
+    await executeTransition(ctx, config, { stepId: '1.1', index: '3' });
+
+    expect(core.buildFrameKey).toHaveBeenCalledWith('1', 3);
+    expect(ctx.lifecycleService.upsertResolvedCompletion).toHaveBeenCalled();
+  });
+
+  it('defaults to active iteration when --step used in prompted-for loop without --index', async () => {
+    const promptedForStep = {
+      name: '1',
+      kind: 'prompted-for',
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(promptedForStep);
+    (core.deriveActiveFrame as jest.Mock).mockReturnValue({
+      step: '1',
+      iteration: 3,
+      frameKey: '1[3]',
+    });
+    const ctx = makeCtx({ substep: '1', activeFrameKey: '1[3]', activeEntry: 2 });
+    ctx.steps = [promptedForStep];
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config, { stepId: '1.1' }); // No --index
+
+    expect(core.buildFrameKey).toHaveBeenCalledWith('1', 3);
+  });
+
+  it('throws when --step uses template AT expression without --index', async () => {
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(forStep);
+    const ctx = makeCtx({ substep: '1' });
+    ctx.steps = [forStep];
+    // parsed.at is a template string — not resolvable in pass/fail context
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({
+      step: '1',
+      substep: '1',
+      at: '{{Index}}',
+    });
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(ctx, config, { stepId: '1.1' })).rejects.toThrow(
+      'template AT expression',
+    );
+  });
+
   it('detects duplicate when sentinel completion already exists for same substep', async () => {
     const ctx = makeCtx({ substep: '1', activeFrameKey: '1', activeEntry: 2 });
     (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
@@ -415,7 +482,7 @@ describe('executeTransition with ExplicitTarget', () => {
       async (_id: string, key: string) => {
         // Return match for the cross-check (sentinel) key, miss for the exact key
         const sentinelCall = builtKeys.find((k) => k.entry === 0);
-        if (sentinelCall && key === sentinelCall.key) return { result: 'pass' };
+        if (sentinelCall?.key === key) return { result: 'pass' };
         return null;
       },
     );

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -366,4 +366,59 @@ describe('executeTransition with ExplicitTarget', () => {
       'must include a substep',
     );
   });
+
+  it('defaults to active iteration when --step used in FOR loop without --index', async () => {
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(forStep);
+    (core.deriveActiveFrame as jest.Mock).mockReturnValue({
+      step: '1',
+      iteration: 3,
+      frameKey: '1[3]',
+    });
+    const ctx = makeCtx({
+      substep: '1',
+      activeFrameKey: '1[3]',
+      activeEntry: 2,
+    });
+    ctx.steps = [forStep];
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config, { stepId: '1.1' }); // No --index
+
+    // buildFrameKey should use iteration 3 (not undefined)
+    expect(core.buildFrameKey).toHaveBeenCalledWith('1', 3);
+    // Entry should be activeEntry (2), not sentinel (0), since frame matches
+    const completionKeyCalls = (core.buildCompletionKey as jest.Mock).mock.calls;
+    const call = completionKeyCalls.find((c: unknown[]) => c[1] === 2);
+    expect(call).toBeDefined();
+  });
+
+  it('detects duplicate when sentinel completion already exists for same substep', async () => {
+    const ctx = makeCtx({ substep: '1', activeFrameKey: '1', activeEntry: 2 });
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    ctx.lifecycleService.getResolvedCompletion.mockImplementation(
+      async (_id: string, key: string) => {
+        if (key.includes(':0:')) return { result: 'pass' }; // sentinel key
+        return null; // exact key
+      },
+    );
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config, { stepId: '1.1' });
+
+    // Should NOT write a new completion (sentinel already covers it)
+    expect(ctx.lifecycleService.upsertResolvedCompletion).not.toHaveBeenCalled();
+    // Should emit duplicate status
+    expect(ctx.output.status).toHaveBeenCalledWith(
+      'completion_duplicate',
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
 });

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -355,4 +355,15 @@ describe('executeTransition with ExplicitTarget', () => {
     const runtimeTargetCall = completionKeyCalls.find((c: unknown[]) => c[1] === 2);
     expect(runtimeTargetCall).toBeDefined();
   });
+
+  it('throws when explicit target has no substep (bare step ID)', async () => {
+    const ctx = makeCtx({ substep: '1' });
+    // parseStepIdFromString('1') returns step without substep
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1' });
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(ctx, config, { stepId: '1' })).rejects.toThrow(
+      'must include a substep',
+    );
+  });
 });

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -402,10 +402,21 @@ describe('executeTransition with ExplicitTarget', () => {
   it('detects duplicate when sentinel completion already exists for same substep', async () => {
     const ctx = makeCtx({ substep: '1', activeFrameKey: '1', activeEntry: 2 });
     (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    // Track which keys were built so we can identify the cross-check key
+    const builtKeys: Array<{ frameKey: string; entry: number; substep?: string; key: string }> = [];
+    (core.buildCompletionKey as jest.Mock).mockImplementation(
+      (frameKey: string, entry: number, substep?: string) => {
+        const key = `${frameKey}:${String(entry)}:${substep ?? ''}`;
+        builtKeys.push({ frameKey, entry, substep, key });
+        return key;
+      },
+    );
     ctx.lifecycleService.getResolvedCompletion.mockImplementation(
       async (_id: string, key: string) => {
-        if (key.includes(':0:')) return { result: 'pass' }; // sentinel key
-        return null; // exact key
+        // Return match for the cross-check (sentinel) key, miss for the exact key
+        const sentinelCall = builtKeys.find((k) => k.entry === 0);
+        if (sentinelCall && key === sentinelCall.key) return { result: 'pass' };
+        return null;
       },
     );
     const config = createPassTransitionConfig();

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -11,6 +11,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   formatTransitionAction: jest.fn().mockReturnValue('CONTINUE'),
   parseActionType: jest.fn().mockReturnValue('CONTINUE'),
   parseStepIdFromString: jest.fn(),
+  SENTINEL_ENTRY: 0,
   buildCompletionKey: jest.fn(
     (frameKey: string, entry: number, substep?: string) =>
       `${frameKey}:${String(entry)}:${substep ?? ''}`,
@@ -145,7 +146,15 @@ describe('executeTransition with ExplicitTarget', () => {
   });
 
   it('uses explicit target with --index for iteration targeting', async () => {
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(forStep);
     const ctx = makeCtx();
+    ctx.steps = [forStep];
     // parseStepIdFromString returns step without AT (index comes from --index flag)
     (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
     const config = createPassTransitionConfig();
@@ -209,5 +218,141 @@ describe('executeTransition with ExplicitTarget', () => {
     // buildCompletionKey should use activeState.substep ('1')
     const completionKeyCall = (core.buildCompletionKey as jest.Mock).mock.calls[0];
     expect(completionKeyCall[2]).toBe('1');
+  });
+
+  it('throws when target substep does not exist in the step', async () => {
+    const ctx = makeCtx({ substep: '1' });
+    // Step has substeps ['1', '2'], but target references substep '99'
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '99' });
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(ctx, config, { stepId: '1.99' })).rejects.toThrow(
+      'substep "99" does not exist',
+    );
+  });
+
+  it('throws when --index targets iteration above FOR end', async () => {
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(forStep);
+    const ctx = makeCtx({ substep: '1' });
+    ctx.steps = [forStep];
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(ctx, config, { stepId: '1.1', index: '6' })).rejects.toThrow(
+      'exceeds FOR end 5',
+    );
+  });
+
+  it('throws when --index targets iteration below FOR start', async () => {
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 3, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(forStep);
+    const ctx = makeCtx({ substep: '1' });
+    ctx.steps = [forStep];
+    // resolveIndexOption rejects < 1, but FOR start > 1 can still be below start
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(ctx, config, { stepId: '1.1', index: '2' })).rejects.toThrow(
+      'below FOR start 3',
+    );
+  });
+
+  it('allows --index within FOR bounds', async () => {
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(forStep);
+    const ctx = makeCtx({ substep: '1' });
+    ctx.steps = [forStep];
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    // Should not throw
+    await executeTransition(ctx, config, { stepId: '1.1', index: '3' });
+
+    expect(ctx.lifecycleService.upsertResolvedCompletion).toHaveBeenCalled();
+  });
+
+  it('skips upper bound check for open-window file source', async () => {
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, source: 'items', variable: 'item' },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(forStep);
+    const ctx = makeCtx({ substep: '1' });
+    ctx.steps = [forStep];
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    // Index 999 should succeed since FullSourceWindow has no end bound
+    await executeTransition(ctx, config, { stepId: '1.1', index: '999' });
+
+    expect(ctx.lifecycleService.upsertResolvedCompletion).toHaveBeenCalled();
+  });
+
+  it('throws when --index provided but step is not a FOR step', async () => {
+    // Default step is kind: 'substeps' (not FOR)
+    const ctx = makeCtx({ substep: '1' });
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(ctx, config, { stepId: '1.1', index: '3' })).rejects.toThrow(
+      '--index requires step "1" to be a FOR step',
+    );
+  });
+
+  it('uses entry=0 sentinel when targeting non-active frame', async () => {
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(forStep);
+    // Active frame is '1|' (iteration undefined), targeting '1|3' via --index 3
+    const ctx = makeCtx({ substep: '1', activeFrameKey: '1|', activeEntry: 2 });
+    ctx.steps = [forStep];
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    // buildFrameKey mock returns '1[3]' for iteration 3, which differs from activeFrameKey '1|'
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config, { stepId: '1.1', index: '3' });
+
+    // buildCompletionKey should have been called with entry=0 (sentinel)
+    const completionKeyCalls = (core.buildCompletionKey as jest.Mock).mock.calls;
+    // The toRuntimeTarget call uses buildCompletionKey; check entry argument
+    const runtimeTargetCall = completionKeyCalls.find((c: unknown[]) => c[1] === 0);
+    expect(runtimeTargetCall).toBeDefined();
+  });
+
+  it('uses activeEntry when targeting active frame', async () => {
+    // Active frame is '1' (mock default), target resolves to same frame
+    const ctx = makeCtx({ substep: '1', activeFrameKey: '1', activeEntry: 2 });
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '2' });
+    // buildFrameKey('1', undefined) returns '1' which matches activeFrameKey
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config, { stepId: '1.2' });
+
+    // buildCompletionKey should have been called with entry=2 (activeEntry)
+    const completionKeyCalls = (core.buildCompletionKey as jest.Mock).mock.calls;
+    const runtimeTargetCall = completionKeyCalls.find((c: unknown[]) => c[1] === 2);
+    expect(runtimeTargetCall).toBeDefined();
   });
 });

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -166,6 +166,17 @@ describe('executeTransition with ExplicitTarget', () => {
     );
   });
 
+  it('throws when explicit target step does not match active step', async () => {
+    const ctx = makeCtx({ step: '1', substep: '1' }); // Active step is '1'
+    // Explicit target points to step '2'
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '2', substep: '1' });
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(ctx, config, { stepId: '2.1' })).rejects.toThrow(
+      'targets step "2" but the active step is "1"',
+    );
+  });
+
   it('throws IndexOptionError on conflicting --index and AT', async () => {
     const ctx = makeCtx();
     (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1', at: 5 });

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -15,7 +15,11 @@ import { OutputEmitter } from '../services/output-emitter.js';
 import { resolveRunbookFile } from '../helpers/resolve-runbook.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
 import { inferDelegationTarget, inferRunbookFromStep } from '../helpers/delegate-inference.js';
-import { resolveIndexOption, IndexOptionError } from '../helpers/index-option.js';
+import {
+  resolveIndexOption,
+  IndexOptionError,
+  validateIndexRequiresStep,
+} from '../helpers/index-option.js';
 import { loadVariablesFromFile } from '../services/variable-discovery.js';
 import { collect } from './echo.js';
 
@@ -65,9 +69,9 @@ export function registerDelegateCommand(program: Command): void {
           async () => {
             const output = new OutputEmitter({ json: options.json });
 
-            // Validate option dependencies
-            if (options.index && !options.step) {
-              output.error('--index requires --step', 'INVALID_SYNTAX');
+            const depError = validateIndexRequiresStep(options.index, options.step);
+            if (depError) {
+              output.error(depError, 'INVALID_SYNTAX');
               output.flush();
               process.exit(1);
             }

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -56,7 +56,7 @@ export function registerDelegateCommand(program: Command): void {
     .command('delegate [runbook]')
     .description('Create a delegation token for a child runbook')
     .option('--step <stepId>', 'Step to delegate (e.g., 1.1 or 1.2.1 for step.iteration.substep)')
-    .option('--index <number>', 'FOR loop iteration to target')
+    .option('--index <number>', 'FOR loop iteration to target (requires --step)')
     .option('--var <key=value>', 'Set variable for child context (repeatable)', collect, [])
     .option('--var-file <path>', 'Load variables from YAML file')
     .option('--json', 'Output as JSON')

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -64,6 +64,14 @@ export function registerDelegateCommand(program: Command): void {
         await withErrorHandling(
           async () => {
             const output = new OutputEmitter({ json: options.json });
+
+            // Validate option dependencies
+            if (options.index && !options.step) {
+              output.error('--index requires --step', 'INVALID_SYNTAX');
+              output.flush();
+              process.exit(1);
+            }
+
             const cwd = getCwd();
 
             const manager = new RunbookStateManager(cwd);

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -147,6 +147,20 @@ export function registerDelegateCommand(program: Command): void {
               }
               throw error;
             }
+
+            // Validate --index requires a FOR step (three-level syntax validated in createDelegation)
+            if (explicitIteration !== undefined) {
+              const activeStep = steps.find((s) => s.name === state.step);
+              if (activeStep && activeStep.kind !== 'for' && activeStep.kind !== 'prompted-for') {
+                output.error(
+                  `--index requires step "${state.step}" to be a FOR step, but it is "${activeStep.kind}"`,
+                  'INVALID_INDEX',
+                );
+                output.flush();
+                process.exit(1);
+              }
+            }
+
             const activeFrameKey =
               explicitIteration !== undefined
                 ? buildFrameKey(state.step, explicitIteration)

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -15,6 +15,7 @@ import { OutputEmitter } from '../services/output-emitter.js';
 import { resolveRunbookFile } from '../helpers/resolve-runbook.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
 import { inferDelegationTarget, inferRunbookFromStep } from '../helpers/delegate-inference.js';
+import { resolveIndexOption, IndexOptionError } from '../helpers/index-option.js';
 import { loadVariablesFromFile } from '../services/variable-discovery.js';
 import { collect } from './echo.js';
 
@@ -51,13 +52,14 @@ export function registerDelegateCommand(program: Command): void {
     .command('delegate [runbook]')
     .description('Create a delegation token for a child runbook')
     .option('--step <stepId>', 'Step to delegate (e.g., 1.1 or 1.2.1 for step.iteration.substep)')
+    .option('--index <number>', 'FOR loop iteration to target')
     .option('--var <key=value>', 'Set variable for child context (repeatable)', collect, [])
     .option('--var-file <path>', 'Load variables from YAML file')
     .option('--json', 'Output as JSON')
     .action(
       async (
         runbookArg: string | undefined,
-        options: { step?: string; var: string[]; varFile?: string; json?: boolean },
+        options: { step?: string; index?: string; var: string[]; varFile?: string; json?: boolean },
       ) => {
         await withErrorHandling(
           async () => {
@@ -120,10 +122,19 @@ export function registerDelegateCommand(program: Command): void {
               extraVars = extraVars ? { ...extraVars, ...flagVars } : flagVars;
             }
 
-            // Compute frame key — use explicit iteration from three-level step ID if provided
+            // Compute frame key — use explicit iteration from --index or three-level step ID
             const parsedTarget = parseStepIdFromString(resolvedStepId);
-            const explicitIteration =
-              typeof parsedTarget?.at === 'number' ? parsedTarget.at : undefined;
+            let explicitIteration: number | undefined;
+            try {
+              explicitIteration = resolveIndexOption(options.index, parsedTarget?.at);
+            } catch (error) {
+              if (error instanceof IndexOptionError) {
+                output.error(error.message, error.code);
+                output.flush();
+                process.exit(1);
+              }
+              throw error;
+            }
             const activeFrameKey =
               explicitIteration !== undefined
                 ? buildFrameKey(state.step, explicitIteration)

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -150,10 +150,11 @@ export function registerDelegateCommand(program: Command): void {
 
             // Validate --index requires a FOR step (three-level syntax validated in createDelegation)
             if (explicitIteration !== undefined) {
-              const activeStep = steps.find((s) => s.name === state.step);
-              if (activeStep && activeStep.kind !== 'for' && activeStep.kind !== 'prompted-for') {
+              const targetStepName = parsedTarget?.step ?? state.step;
+              const targetStep = steps.find((s) => s.name === targetStepName);
+              if (targetStep && targetStep.kind !== 'for' && targetStep.kind !== 'prompted-for') {
                 output.error(
-                  `--index requires step "${state.step}" to be a FOR step, but it is "${activeStep.kind}"`,
+                  `--index requires step "${targetStepName}" to be a FOR step, but it is "${targetStep.kind}"`,
                   'INVALID_INDEX',
                 );
                 output.flush();

--- a/packages/cli/src/commands/fail.ts
+++ b/packages/cli/src/commands/fail.ts
@@ -11,6 +11,7 @@ import {
   type ExplicitTarget,
 } from '../helpers/transitions.js';
 import { handleDelegationCompletion } from '../helpers/delegation-completion.js';
+import { validateIndexRequiresStep } from '../helpers/index-option.js';
 
 /**
  * Registers the 'fail' command for marking steps as failed.
@@ -29,9 +30,9 @@ export function registerFailCommand(program: Command): void {
         async () => {
           const output = new OutputEmitter({ json: options.json });
 
-          // Validate option dependencies
-          if (options.index && !options.step) {
-            output.error('--index requires --step', 'INVALID_SYNTAX');
+          const depError = validateIndexRequiresStep(options.index, options.step);
+          if (depError) {
+            output.error(depError, 'INVALID_SYNTAX');
             output.flush();
             process.exit(1);
           }

--- a/packages/cli/src/commands/fail.ts
+++ b/packages/cli/src/commands/fail.ts
@@ -8,6 +8,7 @@ import {
   buildTransitionContext,
   createFailTransitionConfig,
   executeTransition,
+  type ExplicitTarget,
 } from '../helpers/transitions.js';
 import { handleDelegationCompletion } from '../helpers/delegation-completion.js';
 
@@ -20,11 +21,21 @@ export function registerFailCommand(program: Command): void {
     .command('fail')
     .alias('no')
     .description('Mark current step as failed (triggers FAIL transition)')
+    .option('--step <stepId>', 'Target specific substep')
+    .option('--index <number>', 'FOR loop iteration to target (requires --step)')
     .option('--json', 'Output as JSON')
-    .action(async (options: { json?: boolean }) => {
+    .action(async (options: { step?: string; index?: string; json?: boolean }) => {
       await withErrorHandling(
         async () => {
           const output = new OutputEmitter({ json: options.json });
+
+          // Validate option dependencies
+          if (options.index && !options.step) {
+            output.error('--index requires --step', 'INVALID_SYNTAX');
+            output.flush();
+            process.exit(1);
+          }
+
           const cwd = getCwd();
           const ctx = await buildTransitionContext(output, cwd);
 
@@ -37,8 +48,11 @@ export function registerFailCommand(program: Command): void {
           let shouldExitWithError = false;
           try {
             const failConfig = createFailTransitionConfig();
+            const explicitTarget: ExplicitTarget | undefined = options.step
+              ? { stepId: options.step, index: options.index }
+              : undefined;
 
-            const result = await executeTransition(ctx, failConfig);
+            const result = await executeTransition(ctx, failConfig, explicitTarget);
             if (result === 'stopped') shouldExitWithError = true;
 
             // Delegation propagation — fires when child run reaches terminal state

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -14,8 +14,9 @@ export function registerGotoCommand(program: Command): void {
   program
     .command('goto <step>')
     .description('Jump to specific step (e.g., "3" or "3.1" for substep)')
+    .option('--index <number>', 'FOR loop iteration to target')
     .option('--json', 'Output as JSON for programmatic use')
-    .action(async (stepArg: string, options: { json?: boolean }) => {
+    .action(async (stepArg: string, options: { index?: string; json?: boolean }) => {
       await withErrorHandling(
         async () => {
           const output = new OutputEmitter({ json: options.json });
@@ -28,7 +29,7 @@ export function registerGotoCommand(program: Command): void {
             return;
           }
 
-          const validation = validateGotoTarget(stepArg, ctx.steps);
+          const validation = validateGotoTarget(stepArg, ctx.steps, options.index);
           if (!validation.ok) {
             output.error(validation.error, validation.code, validation.details);
             output.flush();

--- a/packages/cli/src/commands/pass.ts
+++ b/packages/cli/src/commands/pass.ts
@@ -8,6 +8,7 @@ import {
   buildTransitionContext,
   createPassTransitionConfig,
   executeTransition,
+  type ExplicitTarget,
 } from '../helpers/transitions.js';
 import { handleDelegationCompletion } from '../helpers/delegation-completion.js';
 
@@ -20,11 +21,21 @@ export function registerPassCommand(program: Command): void {
     .command('pass')
     .aliases(['yes', 'ok'])
     .description('Mark current step as passed (triggers PASS transition)')
+    .option('--step <stepId>', 'Target specific substep')
+    .option('--index <number>', 'FOR loop iteration to target (requires --step)')
     .option('--json', 'Output as JSON')
-    .action(async (options: { json?: boolean }) => {
+    .action(async (options: { step?: string; index?: string; json?: boolean }) => {
       await withErrorHandling(
         async () => {
           const output = new OutputEmitter({ json: options.json });
+
+          // Validate option dependencies
+          if (options.index && !options.step) {
+            output.error('--index requires --step', 'INVALID_SYNTAX');
+            output.flush();
+            process.exit(1);
+          }
+
           const cwd = getCwd();
           const ctx = await buildTransitionContext(output, cwd);
 
@@ -37,8 +48,11 @@ export function registerPassCommand(program: Command): void {
           let shouldExitWithError = false;
           try {
             const passConfig = createPassTransitionConfig();
+            const explicitTarget: ExplicitTarget | undefined = options.step
+              ? { stepId: options.step, index: options.index }
+              : undefined;
 
-            const result = await executeTransition(ctx, passConfig);
+            const result = await executeTransition(ctx, passConfig, explicitTarget);
             if (result === 'stopped') shouldExitWithError = true;
 
             // Delegation propagation — fires when child run reaches terminal state

--- a/packages/cli/src/commands/pass.ts
+++ b/packages/cli/src/commands/pass.ts
@@ -11,6 +11,7 @@ import {
   type ExplicitTarget,
 } from '../helpers/transitions.js';
 import { handleDelegationCompletion } from '../helpers/delegation-completion.js';
+import { validateIndexRequiresStep } from '../helpers/index-option.js';
 
 /**
  * Registers the 'pass' command for marking steps as passed.
@@ -29,9 +30,9 @@ export function registerPassCommand(program: Command): void {
         async () => {
           const output = new OutputEmitter({ json: options.json });
 
-          // Validate option dependencies
-          if (options.index && !options.step) {
-            output.error('--index requires --step', 'INVALID_SYNTAX');
+          const depError = validateIndexRequiresStep(options.index, options.step);
+          if (depError) {
+            output.error(depError, 'INVALID_SYNTAX');
             output.flush();
             process.exit(1);
           }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -19,6 +19,7 @@ import {
   type RunPipelineContext,
 } from '../helpers/runbook-pipeline.js';
 import { buildGotoContext, validateGotoTarget, executeGoto } from '../helpers/goto-workflow.js';
+import { validateIndexRequiresStep } from '../helpers/index-option.js';
 
 /**
  * Registers the 'run' command for starting runbooks.
@@ -70,8 +71,9 @@ export function registerRunCommand(program: Command): void {
             output.flush();
             process.exit(1);
           }
-          if (options.index && !options.step) {
-            output.error('--index requires --step', 'INVALID_SYNTAX');
+          const depError = validateIndexRequiresStep(options.index, options.step);
+          if (depError) {
+            output.error(depError, 'INVALID_SYNTAX');
             output.flush();
             process.exit(1);
           }
@@ -107,6 +109,11 @@ export function registerRunCommand(program: Command): void {
             }
 
             // If --step provided and runbook is waiting (prompted mode), jump to the step
+            if (options.step && result.loopResult !== 'waiting') {
+              output.warning(
+                `--step ${options.step} ignored: runbook did not enter prompted mode (result: ${result.loopResult})`,
+              );
+            }
             if (options.step && result.loopResult === 'waiting') {
               const gotoCtx = await buildGotoContext(output, cwd);
               if (!gotoCtx) {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -18,6 +18,7 @@ import {
   startRunbook,
   type RunPipelineContext,
 } from '../helpers/runbook-pipeline.js';
+import { buildGotoContext, validateGotoTarget, executeGoto } from '../helpers/goto-workflow.js';
 
 /**
  * Registers the 'run' command for starting runbooks.
@@ -28,6 +29,8 @@ export function registerRunCommand(program: Command): void {
     .command('run [file]')
     .description('Start a runbook')
     .option('--prompted', 'Prompted mode: show commands without auto-executing')
+    .option('--step <stepId>', 'Jump to step after starting (requires --prompted)')
+    .option('--index <number>', 'FOR loop iteration to target (requires --step)')
     .option('--json', 'Output execution events as JSON')
     .option('--var-file <path>', 'Load variables from YAML file')
     .option('--var <key=value>', 'Set variable (repeatable)', collect, [])
@@ -36,6 +39,8 @@ export function registerRunCommand(program: Command): void {
         file: string | undefined,
         options: {
           prompted?: boolean;
+          step?: string;
+          index?: string;
           json?: boolean;
           varFile?: string;
           var?: string[];
@@ -58,6 +63,18 @@ export function registerRunCommand(program: Command): void {
             lifecycleService,
             cwd,
           };
+
+          // Validate --step / --index option dependencies
+          if (options.step && !options.prompted) {
+            output.error('--step requires --prompted', 'INVALID_SYNTAX');
+            output.flush();
+            process.exit(1);
+          }
+          if (options.index && !options.step) {
+            output.error('--index requires --step', 'INVALID_SYNTAX');
+            output.flush();
+            process.exit(1);
+          }
 
           const varOpts = { varFile: options.varFile, var: options.var };
 
@@ -87,6 +104,36 @@ export function registerRunCommand(program: Command): void {
               output.error(result.error, result.code, result.details);
               output.flush();
               process.exit(1);
+            }
+
+            // If --step provided and runbook is waiting (prompted mode), jump to the step
+            if (options.step && result.loopResult === 'waiting') {
+              const gotoCtx = await buildGotoContext(output, cwd);
+              if (!gotoCtx) {
+                output.error('Failed to build goto context after start', 'ENGINE_INIT_FAILED');
+                output.flush();
+                process.exit(1);
+              }
+
+              const validation = validateGotoTarget(options.step, gotoCtx.steps, options.index);
+              if (!validation.ok) {
+                output.error(validation.error, validation.code, validation.details);
+                output.flush();
+                process.exit(1);
+              }
+
+              const gotoResult = await executeGoto(gotoCtx, validation.target);
+              if (!gotoResult.ok) {
+                output.error(gotoResult.error, gotoResult.code);
+                output.flush();
+                process.exit(1);
+              }
+
+              output.flush();
+              if (gotoResult.loopResult === 'stopped') {
+                process.exit(1);
+              }
+              return;
             }
 
             output.flush();

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -109,11 +109,6 @@ export function registerRunCommand(program: Command): void {
             }
 
             // If --step provided and runbook is waiting (prompted mode), jump to the step
-            if (options.step && result.loopResult !== 'waiting') {
-              output.warning(
-                `--step ${options.step} ignored: runbook did not enter prompted mode (result: ${result.loopResult})`,
-              );
-            }
             if (options.step && result.loopResult === 'waiting') {
               const gotoCtx = await buildGotoContext(output, cwd);
               if (!gotoCtx) {
@@ -141,6 +136,10 @@ export function registerRunCommand(program: Command): void {
                 process.exit(1);
               }
               return;
+            } else if (options.step) {
+              output.warning(
+                `--step ${options.step} ignored: runbook did not enter prompted mode (result: ${result.loopResult})`,
+              );
             }
 
             output.flush();

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -164,6 +164,7 @@ export async function handleDelegationCompletion(
     currentState: parentState,
     transitionPolicy: delegationPolicy,
     computeActionResult: transitionConfig.computeActionResult,
+    ...(parentFrameKey ? { frameKeyOverride: parentFrameKey } : {}),
   });
 
   // 8. Check if parent reached terminal state — cascade if it also has delegation linkage

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -24,6 +24,7 @@ import {
 import { runExecutionLoop } from '../services/execution.js';
 import type { OutputEmitter } from '../services/output-emitter.js';
 import { createBridgedEmitter } from './execution-emitter.js';
+import { resolveIndexOption, IndexOptionError } from './index-option.js';
 import { getRunbookFromState } from './runbook-loader.js';
 
 /**
@@ -93,17 +94,21 @@ export async function buildGotoContext(
  * Validate a goto target against the runbook steps.
  *
  * Checks: valid format, step exists, AT only on FOR steps, substep exists.
+ * When `indexOption` is provided, it is merged into the target's `at` field
+ * via `resolveIndexOption`.
  *
  * @param stepArg - Raw step argument string (e.g., "3" or "3.1")
  * @param steps - Parsed runbook steps
+ * @param indexOption - Raw `--index` value from CLI (optional)
  * @returns Validation result with parsed target or error details
  */
 export function validateGotoTarget(
   stepArg: string,
   steps: readonly ResolvedStep[],
+  indexOption?: string,
 ): GotoValidationResult {
-  const target = parseStepIdFromString(stepArg);
-  if (!target) {
+  const parsed = parseStepIdFromString(stepArg);
+  if (!parsed) {
     return {
       ok: false,
       error: `Invalid step target: ${stepArg}. Format: N (step) or N.M (step.substep)`,
@@ -111,6 +116,25 @@ export function validateGotoTarget(
       details: { provided: stepArg },
     };
   }
+
+  // Merge --index with any AT from the step ID string
+  let resolvedAt: number | undefined;
+  try {
+    resolvedAt = resolveIndexOption(indexOption, parsed.at);
+  } catch (error) {
+    if (error instanceof IndexOptionError) {
+      return { ok: false, error: error.message, code: error.code };
+    }
+    throw error;
+  }
+
+  // Build mutable target with merged AT
+  const target: StepId =
+    resolvedAt !== undefined
+      ? { ...parsed, at: resolvedAt }
+      : parsed.at !== undefined
+        ? parsed
+        : { step: parsed.step, substep: parsed.substep };
 
   const stepIndex = steps.findIndex((s) => s.name === target.step);
   if (stepIndex === -1) {

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -101,6 +101,7 @@ export async function buildGotoContext(
  * @param steps - Parsed runbook steps
  * @param indexOption - Raw `--index` value from CLI (optional)
  * @returns Validation result with parsed target or error details
+ * @throws {Error} if an unexpected (non-IndexOptionError) error occurs during index resolution
  */
 export function validateGotoTarget(
   stepArg: string,

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -100,7 +100,8 @@ export async function buildGotoContext(
  * @param stepArg - Raw step argument string (e.g., "3" or "3.1")
  * @param steps - Parsed runbook steps
  * @param indexOption - Raw `--index` value from CLI (optional)
- * @returns Validation result with parsed target or error details
+ * @returns Validation result with parsed target or error details.
+ *   `IndexOptionError` from `resolveIndexOption` is caught and converted to a validation failure.
  * @throws {Error} if an unexpected (non-IndexOptionError) error occurs during index resolution
  */
 export function validateGotoTarget(

--- a/packages/cli/src/helpers/index-option.ts
+++ b/packages/cli/src/helpers/index-option.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared validation for the `--index` CLI option.
+ *
+ * Parses and validates `--index <number>` against any existing AT value
+ * from step ID parsing, ensuring consistent iteration targeting across
+ * all step-targeting commands.
+ *
+ * @module helpers/index-option
+ */
+
+/**
+ * Resolve `--index` flag against a parsed AT value from step ID syntax.
+ *
+ * Validates that the index is a positive integer and checks for conflicts
+ * with any AT value already parsed from the step ID string (e.g., "3 AT 2"
+ * or three-level "1.2.1").
+ *
+ * @param indexFlag - Raw `--index` value from CLI (string or undefined)
+ * @param parsedAt - AT value from `parseStepIdFromString` (number, template string, or undefined)
+ * @returns Resolved iteration index, or undefined if neither input is provided
+ * @throws {IndexOptionError} on invalid input or conflicting values
+ */
+export function resolveIndexOption(
+  indexFlag: string | undefined,
+  parsedAt: number | string | undefined,
+): number | undefined {
+  if (indexFlag === undefined && parsedAt === undefined) {
+    return undefined;
+  }
+
+  // Parse --index flag
+  let indexValue: number | undefined;
+  if (indexFlag !== undefined) {
+    const num = parseInt(indexFlag, 10);
+    if (Number.isNaN(num) || String(num) !== indexFlag || num < 1) {
+      throw new IndexOptionError(
+        `Invalid --index value: "${indexFlag}". Must be a positive integer (>= 1).`,
+        'INVALID_SYNTAX',
+      );
+    }
+    indexValue = num;
+  }
+
+  // Template variable AT (string) + numeric --index → error
+  if (typeof parsedAt === 'string' && indexValue !== undefined) {
+    throw new IndexOptionError(
+      `--index ${indexValue} conflicts with template AT expression "${parsedAt}"`,
+      'CONFLICTING_INDEX',
+    );
+  }
+
+  // Both numeric and they differ → error
+  if (typeof parsedAt === 'number' && indexValue !== undefined && parsedAt !== indexValue) {
+    throw new IndexOptionError(
+      `--index ${indexValue} conflicts with AT ${parsedAt} from step ID`,
+      'CONFLICTING_INDEX',
+    );
+  }
+
+  // Both match → return value (idempotent)
+  if (typeof parsedAt === 'number' && indexValue !== undefined && parsedAt === indexValue) {
+    return indexValue;
+  }
+
+  // Only --index provided
+  if (indexValue !== undefined) {
+    return indexValue;
+  }
+
+  // Only parsedAt provided (number)
+  if (typeof parsedAt === 'number') {
+    return parsedAt;
+  }
+
+  // parsedAt is a template string with no --index → pass through as undefined
+  // (the template will be resolved later by the execution engine)
+  return undefined;
+}
+
+/**
+ * Error thrown when `--index` validation fails.
+ */
+export class IndexOptionError extends Error {
+  /** Error code for structured output (e.g., 'INVALID_SYNTAX', 'CONFLICTING_INDEX') */
+  readonly code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = 'IndexOptionError';
+    this.code = code;
+  }
+}

--- a/packages/cli/src/helpers/index-option.ts
+++ b/packages/cli/src/helpers/index-option.ts
@@ -44,7 +44,7 @@ export function resolveIndexOption(
   // Template variable AT (string) + numeric --index → error
   if (typeof parsedAt === 'string' && indexValue !== undefined) {
     throw new IndexOptionError(
-      `--index ${indexValue} conflicts with template AT expression "${parsedAt}"`,
+      `--index ${String(indexValue)} conflicts with template AT expression "${parsedAt}"`,
       'CONFLICTING_INDEX',
     );
   }
@@ -52,7 +52,7 @@ export function resolveIndexOption(
   // Both numeric and they differ → error
   if (typeof parsedAt === 'number' && indexValue !== undefined && parsedAt !== indexValue) {
     throw new IndexOptionError(
-      `--index ${indexValue} conflicts with AT ${parsedAt} from step ID`,
+      `--index ${String(indexValue)} conflicts with AT ${String(parsedAt)} from step ID`,
       'CONFLICTING_INDEX',
     );
   }
@@ -78,12 +78,38 @@ export function resolveIndexOption(
 }
 
 /**
+ * Validate that `--index` is only used with `--step`.
+ *
+ * Returns an error message string if validation fails, or `undefined` if valid.
+ * Callers are responsible for emitting the error and exiting.
+ *
+ * @param index - Raw `--index` value from CLI
+ * @param step - Raw `--step` value from CLI
+ * @returns Error message if invalid, undefined if valid
+ */
+export function validateIndexRequiresStep(
+  index: string | undefined,
+  step: string | undefined,
+): string | undefined {
+  if (index && !step) {
+    return '--index requires --step';
+  }
+  return undefined;
+}
+
+/**
  * Error thrown when `--index` validation fails.
  */
 export class IndexOptionError extends Error {
   /** Error code for structured output (e.g., 'INVALID_SYNTAX', 'CONFLICTING_INDEX') */
   readonly code: string;
 
+  /**
+   * Create a new IndexOptionError.
+   *
+   * @param message - Human-readable error description
+   * @param code - Machine-readable error code (e.g., 'INVALID_SYNTAX', 'CONFLICTING_INDEX')
+   */
   constructor(message: string, code: string) {
     super(message);
     this.name = 'IndexOptionError';

--- a/packages/cli/src/helpers/index-option.ts
+++ b/packages/cli/src/helpers/index-option.ts
@@ -82,20 +82,23 @@ export function validateIndexRequiresStep(
   return undefined;
 }
 
+/** Machine-readable error codes for IndexOptionError. */
+export type IndexOptionErrorCode = 'INVALID_SYNTAX' | 'CONFLICTING_INDEX';
+
 /**
  * Error thrown when `--index` validation fails.
  */
 export class IndexOptionError extends Error {
-  /** Error code for structured output (e.g., 'INVALID_SYNTAX', 'CONFLICTING_INDEX') */
-  readonly code: string;
+  /** Error code for structured output. */
+  readonly code: IndexOptionErrorCode;
 
   /**
    * Create a new IndexOptionError.
    *
    * @param message - Human-readable error description
-   * @param code - Machine-readable error code (e.g., 'INVALID_SYNTAX', 'CONFLICTING_INDEX')
+   * @param code - Machine-readable error code
    */
-  constructor(message: string, code: string) {
+  constructor(message: string, code: IndexOptionErrorCode) {
     super(message);
     this.name = 'IndexOptionError';
     this.code = code;

--- a/packages/cli/src/helpers/index-option.ts
+++ b/packages/cli/src/helpers/index-option.ts
@@ -57,24 +57,9 @@ export function resolveIndexOption(
     );
   }
 
-  // Both match → return value (idempotent)
-  if (typeof parsedAt === 'number' && indexValue !== undefined && parsedAt === indexValue) {
-    return indexValue;
-  }
-
-  // Only --index provided
-  if (indexValue !== undefined) {
-    return indexValue;
-  }
-
-  // Only parsedAt provided (number)
-  if (typeof parsedAt === 'number') {
-    return parsedAt;
-  }
-
-  // parsedAt is a template string with no --index → pass through as undefined
-  // (the template will be resolved later by the execution engine)
-  return undefined;
+  // At this point: no conflicts. Return whichever numeric value is available.
+  // Template-string AT with no --index yields undefined (resolved later by execution engine).
+  return indexValue ?? (typeof parsedAt === 'number' ? parsedAt : undefined);
 }
 
 /**

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -288,6 +288,11 @@ export async function executeTransition(
       if (!parsed) {
         throw new Error(`Invalid step target: ${explicitTarget.stepId}`);
       }
+      if (parsed.step !== activeState.step) {
+        throw new Error(
+          `--step ${explicitTarget.stepId} targets step "${parsed.step}" but the active step is "${activeState.step}"`,
+        );
+      }
       const resolvedIndex = resolveIndexOption(explicitTarget.index, parsed.at);
       cursor = toRuntimeTarget(
         parsed.step,

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -16,6 +16,7 @@ import {
   extractLastAction,
   formatTransitionAction,
   parseActionType,
+  parseStepIdFromString,
   type ActionType,
   buildCompletionKey,
   buildFrameKey,
@@ -31,6 +32,7 @@ import {
   type StepTransitionedPayload,
 } from '@rundown-org/core';
 import { resolvedStepHasSubsteps } from '@rundown-org/parser';
+import { resolveIndexOption } from './index-option.js';
 import { getRunbookFromState } from './runbook-loader.js';
 import {
   drainResolvedCompletions,
@@ -229,6 +231,19 @@ function activeCursorTarget(state: RunbookState): RuntimeTarget {
 }
 
 /**
+ * Explicit target for directing a transition at a specific substep and iteration.
+ *
+ * Used by `pass --step` and `fail --step` to target a specific substep
+ * rather than the current cursor position.
+ */
+export interface ExplicitTarget {
+  /** Step ID string (e.g., "1.1") */
+  stepId: string;
+  /** Optional `--index` value (raw string from CLI) */
+  index?: string;
+}
+
+/**
  * Execute a transition with the given configuration.
  *
  * Main entry point for transition execution. Sends event to actor,
@@ -237,13 +252,16 @@ function activeCursorTarget(state: RunbookState): RuntimeTarget {
  *
  * @param ctx - Transition context
  * @param config - Transition configuration
+ * @param explicitTarget - Optional explicit target for directing transition at a specific substep
  * @returns `'continue'` for normal flow including completed/done paths, `'stopped'` if it reached a terminal state
  * @throws {Error} from `findStepOrThrow` if the active step is missing (state corruption),
  *   from `ensureActiveEntry` on lifecycle violations, or from orchestration failures
+ * @throws {IndexOptionError} if `--index` validation fails
  */
 export async function executeTransition(
   ctx: TransitionContext,
   config: TransitionConfig,
+  explicitTarget?: ExplicitTarget,
 ): Promise<'continue' | 'stopped'> {
   const { output, manager, actorService, state, steps, actor, cwd, lifecycleService } = ctx;
   const ensured = await lifecycleService.ensureActiveEntry(state.id, undefined, state);
@@ -256,7 +274,23 @@ export async function executeTransition(
   );
 
   if (isSubstepCompletion) {
-    const cursor = activeCursorTarget(activeState);
+    // If explicit target, build RuntimeTarget from parsed step ID + resolved index
+    let cursor: RuntimeTarget;
+    if (explicitTarget) {
+      const parsed = parseStepIdFromString(explicitTarget.stepId);
+      if (!parsed) {
+        throw new Error(`Invalid step target: ${explicitTarget.stepId}`);
+      }
+      const resolvedIndex = resolveIndexOption(explicitTarget.index, parsed.at);
+      cursor = toRuntimeTarget(
+        parsed.step,
+        parsed.substep,
+        resolvedIndex,
+        activeState.activeEntry ?? 1,
+      );
+    } else {
+      cursor = activeCursorTarget(activeState);
+    }
     const completionKey = buildCompletionKey(cursor.frameKey, cursor.entry, activeState.substep);
     const existing = await lifecycleService.getResolvedCompletion(activeState.id, completionKey);
     if (!existing) {

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -294,6 +294,12 @@ export async function executeTransition(
           `--step ${explicitTarget.stepId} targets step "${parsed.step}" but the active step is "${activeState.step}"`,
         );
       }
+      // Require substep — bare step IDs create unreachable completions
+      if (!parsed.substep) {
+        throw new Error(
+          `--step ${explicitTarget.stepId} must include a substep (e.g., "${parsed.step}.1")`,
+        );
+      }
       // Validate substep exists in the step definition
       if (parsed.substep && resolvedStepHasSubsteps(activeStep)) {
         const validIds = activeStep.substeps.map((s) => s.id);

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -312,6 +312,13 @@ export async function executeTransition(
 
       let resolvedIndex = resolveIndexOption(explicitTarget.index, parsed.at);
 
+      // Reject template AT expressions — they cannot be resolved in pass/fail context
+      if (typeof parsed.at === 'string') {
+        throw new Error(
+          `--step ${explicitTarget.stepId} uses template AT expression "${parsed.at}", which cannot be resolved here. Use --index <number> instead.`,
+        );
+      }
+
       // Default to active iteration when inside a FOR step without explicit --index
       if (
         resolvedIndex === undefined &&
@@ -323,21 +330,24 @@ export async function executeTransition(
 
       // Validate iteration bounds against step definition
       if (resolvedIndex !== undefined) {
-        if (activeStep.kind !== 'for') {
+        if (activeStep.kind !== 'for' && activeStep.kind !== 'prompted-for') {
           throw new Error(
-            `--index requires step "${parsed.step}" to be a FOR step, but it is "${activeStep.kind}"`,
+            `--index requires step "${parsed.step}" to be a FOR or PROMPTED-FOR step, but it is "${activeStep.kind}"`,
           );
         }
-        const fc = activeStep.forClause;
-        if (resolvedIndex < fc.start) {
-          throw new Error(
-            `--index ${String(resolvedIndex)} is below FOR start ${String(fc.start)} for step "${parsed.step}"`,
-          );
-        }
-        if ('end' in fc && resolvedIndex > fc.end) {
-          throw new Error(
-            `--index ${String(resolvedIndex)} exceeds FOR end ${String(fc.end)} for step "${parsed.step}"`,
-          );
+        // Bounds checks only apply to 'for' steps (prompted-for has no forClause)
+        if (activeStep.kind === 'for') {
+          const fc = activeStep.forClause;
+          if (resolvedIndex < fc.start) {
+            throw new Error(
+              `--index ${String(resolvedIndex)} is below FOR start ${String(fc.start)} for step "${parsed.step}"`,
+            );
+          }
+          if ('end' in fc && resolvedIndex > fc.end) {
+            throw new Error(
+              `--index ${String(resolvedIndex)} exceeds FOR end ${String(fc.end)} for step "${parsed.step}"`,
+            );
+          }
         }
       }
 

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -23,6 +23,7 @@ import {
   buildResolvedCompletion,
   deriveExecutionAt,
   deriveActiveFrame,
+  SENTINEL_ENTRY,
   type FrameKey,
   type AnyActorRef,
   type ResolvedStep,
@@ -293,12 +294,50 @@ export async function executeTransition(
           `--step ${explicitTarget.stepId} targets step "${parsed.step}" but the active step is "${activeState.step}"`,
         );
       }
+      // Validate substep exists in the step definition
+      if (parsed.substep && resolvedStepHasSubsteps(activeStep)) {
+        const validIds = activeStep.substeps.map((s) => s.id);
+        if (!validIds.includes(parsed.substep)) {
+          throw new Error(
+            `--step ${explicitTarget.stepId}: substep "${parsed.substep}" does not exist in step "${parsed.step}". Valid substeps: ${validIds.join(', ')}`,
+          );
+        }
+      }
+
       const resolvedIndex = resolveIndexOption(explicitTarget.index, parsed.at);
+
+      // Validate iteration bounds against step definition
+      if (resolvedIndex !== undefined) {
+        if (activeStep.kind !== 'for') {
+          throw new Error(
+            `--index requires step "${parsed.step}" to be a FOR step, but it is "${activeStep.kind}"`,
+          );
+        }
+        const fc = activeStep.forClause;
+        if (resolvedIndex < fc.start) {
+          throw new Error(
+            `--index ${String(resolvedIndex)} is below FOR start ${String(fc.start)} for step "${parsed.step}"`,
+          );
+        }
+        if ('end' in fc && resolvedIndex > fc.end) {
+          throw new Error(
+            `--index ${String(resolvedIndex)} exceeds FOR end ${String(fc.end)} for step "${parsed.step}"`,
+          );
+        }
+      }
+
+      // Use sentinel entry (0) for non-active frames to avoid entry prediction issues
+      const targetFrameKey = buildFrameKey(parsed.step, resolvedIndex);
+      const isActiveFrame =
+        targetFrameKey === (activeState.activeFrameKey ?? buildFrameKey(activeState.step));
+      const entryForCompletion = isActiveFrame ? (activeState.activeEntry ?? 1) : SENTINEL_ENTRY;
+
       cursor = toRuntimeTarget(
         parsed.step,
         parsed.substep,
         resolvedIndex,
-        activeState.activeEntry ?? 1,
+        entryForCompletion,
+        targetFrameKey,
       );
     } else {
       cursor = activeCursorTarget(activeState);

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -310,7 +310,16 @@ export async function executeTransition(
         }
       }
 
-      const resolvedIndex = resolveIndexOption(explicitTarget.index, parsed.at);
+      let resolvedIndex = resolveIndexOption(explicitTarget.index, parsed.at);
+
+      // Default to active iteration when inside a FOR step without explicit --index
+      if (
+        resolvedIndex === undefined &&
+        (activeStep.kind === 'for' || activeStep.kind === 'prompted-for')
+      ) {
+        const activeFrame = deriveActiveFrame(activeState);
+        resolvedIndex = activeFrame.iteration;
+      }
 
       // Validate iteration bounds against step definition
       if (resolvedIndex !== undefined) {
@@ -350,7 +359,13 @@ export async function executeTransition(
     }
     const targetSubstep = explicitTarget ? cursor.substep : activeState.substep;
     const completionKey = buildCompletionKey(cursor.frameKey, cursor.entry, targetSubstep);
-    const existing = await lifecycleService.getResolvedCompletion(activeState.id, completionKey);
+    let existing = await lifecycleService.getResolvedCompletion(activeState.id, completionKey);
+
+    // Also check sentinel key to prevent coexisting sentinel + exact completions
+    if (!existing && cursor.entry !== SENTINEL_ENTRY) {
+      const sentinelKey = buildCompletionKey(cursor.frameKey, SENTINEL_ENTRY, targetSubstep);
+      existing = await lifecycleService.getResolvedCompletion(activeState.id, sentinelKey);
+    }
     if (!existing) {
       const completion = buildResolvedCompletion({
         agentId: 'manual',

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -409,6 +409,7 @@ export async function executeTransition(
       currentState: activeState,
       transitionPolicy: config.policy,
       computeActionResult: config.computeActionResult,
+      ...(explicitTarget ? { frameKeyOverride: cursor.frameKey } : {}),
     });
     if (drained.status === 'stopped') {
       output.flush();

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -273,6 +273,13 @@ export async function executeTransition(
     activeStep.substeps.length
   );
 
+  // Guard: --step targets a substep, so reject if we're not in substep mode
+  if (explicitTarget && !isSubstepCompletion) {
+    throw new Error(
+      `--step requires the runbook to be at a substep, but step "${activeState.step}" has no active substep`,
+    );
+  }
+
   if (isSubstepCompletion) {
     // If explicit target, build RuntimeTarget from parsed step ID + resolved index
     let cursor: RuntimeTarget;
@@ -291,7 +298,8 @@ export async function executeTransition(
     } else {
       cursor = activeCursorTarget(activeState);
     }
-    const completionKey = buildCompletionKey(cursor.frameKey, cursor.entry, activeState.substep);
+    const targetSubstep = explicitTarget ? cursor.substep : activeState.substep;
+    const completionKey = buildCompletionKey(cursor.frameKey, cursor.entry, targetSubstep);
     const existing = await lifecycleService.getResolvedCompletion(activeState.id, completionKey);
     if (!existing) {
       const completion = buildResolvedCompletion({

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -361,10 +361,12 @@ export async function executeTransition(
     const completionKey = buildCompletionKey(cursor.frameKey, cursor.entry, targetSubstep);
     let existing = await lifecycleService.getResolvedCompletion(activeState.id, completionKey);
 
-    // Also check sentinel key to prevent coexisting sentinel + exact completions
-    if (!existing && cursor.entry !== SENTINEL_ENTRY) {
-      const sentinelKey = buildCompletionKey(cursor.frameKey, SENTINEL_ENTRY, targetSubstep);
-      existing = await lifecycleService.getResolvedCompletion(activeState.id, sentinelKey);
+    // Cross-check sentinel/exact keys to prevent coexisting completions for the same frame/substep
+    if (!existing) {
+      const crossEntry =
+        cursor.entry === SENTINEL_ENTRY ? (activeState.activeEntry ?? 1) : SENTINEL_ENTRY;
+      const crossKey = buildCompletionKey(cursor.frameKey, crossEntry, targetSubstep);
+      existing = await lifecycleService.getResolvedCompletion(activeState.id, crossKey);
     }
     if (!existing) {
       const completion = buildResolvedCompletion({

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -31,6 +31,7 @@ import {
   type ExecutionEventEmitter,
   type ForContext,
   type DataSource,
+  type FrameKey,
 } from '@rundown-org/core';
 import { isSourced, resolvedStepHasSubsteps, type ForClause } from '@rundown-org/parser';
 import { isInternalRdCommand, executeRdCommandInternal } from './internal-commands.js';
@@ -296,6 +297,8 @@ export interface DrainResolvedCompletionsArgs {
   computeActionResult?: (actionType: ActionType) => boolean;
   /** Optional command string for event context. */
   command?: string;
+  /** Override frame key for frame-scoped lookups (e.g., prompted-for with explicit --index). */
+  frameKeyOverride?: FrameKey;
 }
 
 /** Result of draining resolved substep completions. */
@@ -335,6 +338,7 @@ export type DrainResolvedCompletionsResult =
  * @param args.transitionPolicy - Policy governing transition orchestration
  * @param args.computeActionResult - Optional function to compute action result for transitions
  * @param args.command - Optional command string for event context
+ * @param args.frameKeyOverride - Optional frame key override for frame-scoped lookups (e.g., prompted-for with explicit --index)
  * @returns Drain result indicating continue/done/stopped with counts of applied and unresolved completions
  */
 export async function drainResolvedCompletions({
@@ -349,6 +353,7 @@ export async function drainResolvedCompletions({
   transitionPolicy,
   computeActionResult,
   command,
+  frameKeyOverride,
 }: DrainResolvedCompletionsArgs): Promise<DrainResolvedCompletionsResult> {
   let state = currentState;
   let applied = 0;
@@ -366,14 +371,11 @@ export async function drainResolvedCompletions({
     const ensured = await lifecycleService.ensureActiveEntry(runbookId, undefined, state);
     state = ensured.state;
 
-    const frame = deriveActiveFrame(state);
+    const derivedFrame = deriveActiveFrame(state);
+    const frameKey = frameKeyOverride ?? derivedFrame.frameKey;
     const entry = state.activeEntry ?? ensured.entry;
     const orderedSubsteps = currentStep.substeps.map((s) => s.id);
-    const resolved = await lifecycleService.listResolvedCompletions(
-      runbookId,
-      frame.frameKey,
-      entry,
-    );
+    const resolved = await lifecycleService.listResolvedCompletions(runbookId, frameKey, entry);
     const resolvedBySubstep = new Map(
       resolved
         .filter(
@@ -385,7 +387,7 @@ export async function drainResolvedCompletions({
 
     const unresolved = orderedSubsteps.filter((id) => !resolvedBySubstep.has(id)).length;
 
-    const cursorKey = buildCompletionKey(frame.frameKey, entry, state.substep);
+    const cursorKey = buildCompletionKey(frameKey, entry, state.substep);
     const completion = await lifecycleService.consumeResolvedCompletion(runbookId, cursorKey);
     if (!completion) {
       return { status: 'continue', state, unresolved, applied };

--- a/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
+++ b/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
@@ -401,6 +401,73 @@ describe('ExecutionLifecycleService', () => {
     });
   });
 
+  describe('listResolvedCompletions with sentinel', () => {
+    it('includes entry=0 sentinel alongside exact matches', async () => {
+      const state = await manager.create('test.md', mockRunbook, {
+        runbookPath: 'test.md',
+      });
+
+      const frameKey = buildFrameKey('1');
+      const sentinelCompletion = {
+        agentId: 'agent-sentinel',
+        result: 'pass' as const,
+        targetStep: '1',
+        targetFrameKey: frameKey,
+        targetEntry: 0,
+        completedAt: new Date().toISOString(),
+      };
+      const exactCompletion = {
+        agentId: 'agent-exact',
+        result: 'pass' as const,
+        targetStep: '1',
+        targetFrameKey: frameKey,
+        targetEntry: 2,
+        completedAt: new Date().toISOString(),
+      };
+
+      // Store sentinel (entry=0) and exact (entry=2)
+      await service.upsertResolvedCompletion(state.id, `${frameKey}|0|sub1`, sentinelCompletion);
+      await service.upsertResolvedCompletion(state.id, `${frameKey}|2|sub2`, exactCompletion);
+
+      // List with entry=2 should return both sentinel and exact
+      const listed = await service.listResolvedCompletions(state.id, frameKey, 2);
+      expect(listed).toHaveLength(2);
+      expect(listed.map((l) => l.completion.agentId).sort()).toEqual([
+        'agent-exact',
+        'agent-sentinel',
+      ]);
+    });
+  });
+
+  describe('consumeResolvedCompletion with sentinel', () => {
+    it('falls back to sentinel when exact key missing', async () => {
+      const state = await manager.create('test.md', mockRunbook, {
+        runbookPath: 'test.md',
+      });
+
+      const frameKey = buildFrameKey('1');
+      const sentinelCompletion = {
+        agentId: 'agent-sentinel',
+        result: 'pass' as const,
+        targetStep: '1',
+        targetFrameKey: frameKey,
+        targetEntry: 0,
+        completedAt: new Date().toISOString(),
+      };
+
+      // Store at sentinel key (entry=0)
+      await service.upsertResolvedCompletion(state.id, `${frameKey}|0|sub1`, sentinelCompletion);
+
+      // Try consuming with exact key (entry=3) — should fall back to sentinel
+      const consumed = await service.consumeResolvedCompletion(state.id, `${frameKey}|3|sub1`);
+      expect(consumed).toEqual(sentinelCompletion);
+
+      // Verify sentinel was removed
+      const remaining = await service.getResolvedCompletion(state.id, `${frameKey}|0|sub1`);
+      expect(remaining).toBeNull();
+    });
+  });
+
   describe('buildActiveCompletionKey', () => {
     it('builds key without substep', () => {
       // Use the created state directly (it has step='1')

--- a/packages/core/__tests__/runbook/targeting.test.ts
+++ b/packages/core/__tests__/runbook/targeting.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+  SENTINEL_ENTRY,
   buildCompletionKey,
   buildFrameKey,
   buildResolvedCompletion,
@@ -102,7 +103,7 @@ describe('targeting helpers', () => {
     it('accepts entry=0 as sentinel', () => {
       expect(parseCompletionKey('1|2|0|sub')).toEqual({
         frameKey: '1|2',
-        entry: 0,
+        entry: SENTINEL_ENTRY,
         substep: 'sub',
       });
     });

--- a/packages/core/__tests__/runbook/targeting.test.ts
+++ b/packages/core/__tests__/runbook/targeting.test.ts
@@ -99,8 +99,12 @@ describe('targeting helpers', () => {
       expect(parseCompletionKey('1|2||sub')).toBeNull();
     });
 
-    it('returns null for zero entry', () => {
-      expect(parseCompletionKey('1|2|0|sub')).toBeNull();
+    it('accepts entry=0 as sentinel', () => {
+      expect(parseCompletionKey('1|2|0|sub')).toEqual({
+        frameKey: '1|2',
+        entry: 0,
+        substep: 'sub',
+      });
     });
 
     it('returns null for negative entry', () => {

--- a/packages/core/__tests__/runbook/targeting.test.ts
+++ b/packages/core/__tests__/runbook/targeting.test.ts
@@ -110,6 +110,14 @@ describe('targeting helpers', () => {
     it('returns null for negative entry', () => {
       expect(parseCompletionKey('1|2|-1|sub')).toBeNull();
     });
+
+    it('rejects entry with trailing non-numeric characters', () => {
+      expect(parseCompletionKey('1||3abc|sub')).toBeNull();
+    });
+
+    it('rejects entry with leading non-numeric characters', () => {
+      expect(parseCompletionKey('1||abc3|sub')).toBeNull();
+    });
   });
 
   describe('buildResolvedCompletion', () => {

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -5,6 +5,7 @@ import {
   deriveActiveFrame,
   buildFrameKey,
   parseCompletionKey,
+  SENTINEL_ENTRY,
   type FrameKey,
 } from './targeting.js';
 import type { ResolvedCompletion, RunbookState } from './types.js';
@@ -175,11 +176,26 @@ export class ExecutionLifecycleService {
     const state = await this.manager.load(id);
     if (!state) return null;
 
-    const existing = state.resolvedCompletions?.[key];
+    let existing = state.resolvedCompletions?.[key];
+    let actualKey = key;
+
+    // Fall back to sentinel entry if exact key not found
+    if (!existing) {
+      const parsed = parseCompletionKey(key);
+      if (parsed && parsed.entry !== SENTINEL_ENTRY) {
+        const sentinelKey = buildCompletionKey(parsed.frameKey, SENTINEL_ENTRY, parsed.substep);
+        const sentinelMatch = state.resolvedCompletions?.[sentinelKey];
+        if (sentinelMatch) {
+          existing = sentinelMatch;
+          actualKey = sentinelKey;
+        }
+      }
+    }
+
     if (!existing) return null;
 
     const next = { ...(state.resolvedCompletions ?? {}) };
-    delete next[key];
+    delete next[actualKey];
     await this.manager.update(id, {
       resolvedCompletions: Object.keys(next).length > 0 ? next : {},
     });
@@ -202,9 +218,14 @@ export class ExecutionLifecycleService {
     const state = await this.manager.load(id);
     if (!state) return [];
 
-    const prefix = `${frameKey}|${String(entry)}|`;
+    const exactPrefix = `${frameKey}|${String(entry)}|`;
+    const sentinelPrefix = `${frameKey}|${String(SENTINEL_ENTRY)}|`;
     return Object.entries(state.resolvedCompletions ?? {})
-      .filter(([key]) => key.startsWith(prefix))
+      .filter(
+        ([key]) =>
+          key.startsWith(exactPrefix) ||
+          (entry !== SENTINEL_ENTRY && key.startsWith(sentinelPrefix)),
+      )
       .map(([key, completion]) => ({ key, completion }));
   }
 

--- a/packages/core/src/runbook/targeting.ts
+++ b/packages/core/src/runbook/targeting.ts
@@ -109,8 +109,8 @@ export function parseCompletionKey(
   if (parts.length !== 4) return null;
   const [step, iterationRaw, entryRaw, substepRaw] = parts;
   if (!step || !entryRaw) return null;
-  const entry = Number.parseInt(entryRaw, 10);
-  if (!Number.isFinite(entry) || entry < 0) return null;
+  if (!/^\d+$/.test(entryRaw)) return null;
+  const entry = Number(entryRaw);
   const frameKey = `${step}|${iterationRaw}` as FrameKey;
   return {
     frameKey,

--- a/packages/core/src/runbook/targeting.ts
+++ b/packages/core/src/runbook/targeting.ts
@@ -2,6 +2,15 @@ import type { StepPosition } from '../cli/types.js';
 import type { ForContext, ResolvedCompletion, RunbookState, SubstepState } from './types.js';
 
 /**
+ * Sentinel entry value for pre-recorded completions targeting non-active frames.
+ *
+ * Entry=0 means "matches any visit to this frame." The drain's exact-entry
+ * matching is preserved for inline completions (re-entry isolation), while
+ * pre-recorded completions use the sentinel for frame-only matching.
+ */
+export const SENTINEL_ENTRY = 0;
+
+/**
  * Nominal string type for frame identity keys.
  *
  * Format: `<step>|<iteration-or-empty>` (e.g., `"1|"`, `"1|2"`).
@@ -101,7 +110,7 @@ export function parseCompletionKey(
   const [step, iterationRaw, entryRaw, substepRaw] = parts;
   if (!step || !entryRaw) return null;
   const entry = Number.parseInt(entryRaw, 10);
-  if (!Number.isFinite(entry) || entry < 1) return null;
+  if (!Number.isFinite(entry) || entry < 0) return null;
   const frameKey = `${step}|${iterationRaw}` as FrameKey;
   return {
     frameKey,

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -189,7 +189,7 @@ const ResolvedCompletionSchema = z.object({
   targetSubstep: z.string().optional(),
   targetIteration: z.number().int().positive().max(MAX_FOR_BOUND).optional(),
   targetFrameKey: FrameKeySchema,
-  targetEntry: z.number().int().positive().max(MAX_FOR_BOUND),
+  targetEntry: z.number().int().nonnegative().max(MAX_FOR_BOUND),
   completedAt: z.string(),
 });
 


### PR DESCRIPTION
Add --index <number> option to goto, delegate, run, pass, and fail commands for explicit FOR loop iteration targeting. 
    
Also add --step to run, pass, and fail for step targeting.

Shared validation helper resolveIndexOption() validates --index as positive integer and detects conflicts with in line AT syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --step and --index options across run, pass, fail, goto, and delegate to target substeps and specific FOR-loop iterations; transitions accept explicit targets.
  * Added shared index-resolution and validation for CLI index semantics.
  * Introduced a completion sentinel (entry=0) to enable frame-level pre-recorded completions.

* **Tests**
  * Added extensive tests for index parsing/validation, explicit-target handling, goto validation, transitions, and sentinel completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->