### PR TITLE
fix(cli): use target frame entry for cross-check duplicate detection

### DIFF
--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -500,6 +500,53 @@ describe('executeTransition with ExplicitTarget', () => {
     );
   });
 
+  it('cross-check uses target frame entry from frameEntries for non-active frames', async () => {
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    (findStepOrThrow as jest.Mock).mockReturnValue(forStep);
+    // Active frame is iteration 1, but we target iteration 3 (non-active frame)
+    // frameEntries records that iteration 3 was visited with entry 4
+    // Mock buildFrameKey produces "step[iteration]" format
+    const ctx = makeCtx({
+      substep: '1',
+      activeFrameKey: '1[1]',
+      activeEntry: 2,
+      frameEntries: { '1[3]': 4 },
+    });
+    ctx.steps = [forStep];
+    (core.parseStepIdFromString as jest.Mock).mockReturnValue({ step: '1', substep: '1' });
+    const builtKeys: Array<{ frameKey: string; entry: number; substep?: string; key: string }> = [];
+    (core.buildCompletionKey as jest.Mock).mockImplementation(
+      (frameKey: string, entry: number, substep?: string) => {
+        const key = `${frameKey}:${String(entry)}:${substep ?? ''}`;
+        builtKeys.push({ frameKey, entry, substep, key });
+        return key;
+      },
+    );
+    ctx.lifecycleService.getResolvedCompletion.mockImplementation(
+      async (_id: string, key: string) => {
+        // Primary key (sentinel) misses; cross-check (exact entry=4) hits
+        const crossCall = builtKeys.find((k) => k.entry === 4);
+        if (crossCall?.key === key) return { result: 'pass' };
+        return null;
+      },
+    );
+    const config = createPassTransitionConfig();
+
+    await executeTransition(ctx, config, { stepId: '1.1', index: '3' });
+
+    // Cross-check should use entry 4 from frameEntries['1|3'], not activeEntry (2)
+    const crossBuild = builtKeys.find((k) => k.entry === 4);
+    expect(crossBuild).toBeDefined();
+    expect(crossBuild!.frameKey).toBe('1[3]');
+    // Should NOT write a new completion (exact entry already covers it)
+    expect(ctx.lifecycleService.upsertResolvedCompletion).not.toHaveBeenCalled();
+  });
+
   it('passes frameKeyOverride to drain when explicit target provided', async () => {
     const forStep = {
       name: '1',

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -373,8 +373,12 @@ export async function executeTransition(
 
     // Cross-check sentinel/exact keys to prevent coexisting completions for the same frame/substep
     if (!existing) {
-      const crossEntry =
-        cursor.entry === SENTINEL_ENTRY ? (activeState.activeEntry ?? 1) : SENTINEL_ENTRY;
+      // Look up the target frame's entry (not the active frame's) for correct cross-check
+      const targetFrameEntry =
+        activeState.activeFrameKey === cursor.frameKey
+          ? (activeState.activeEntry ?? 1)
+          : (activeState.frameEntries?.[cursor.frameKey] ?? 1);
+      const crossEntry = cursor.entry === SENTINEL_ENTRY ? targetFrameEntry : SENTINEL_ENTRY;
       const crossKey = buildCompletionKey(cursor.frameKey, crossEntry, targetSubstep);
       existing = await lifecycleService.getResolvedCompletion(activeState.id, crossKey);
     }

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -245,19 +245,18 @@ export interface ExplicitTarget {
 }
 
 /**
- * Execute a transition with the given configuration.
+ * Execute a configured transition (pass or fail) against the current runbook state.
  *
- * Main entry point for transition execution. Sends event to actor,
- * updates state, emits action output, handles terminal states,
- * and runs execution loop if needed.
+ * When targeting a substep (via an explicit target), records or reuses a resolved completion and drains completions;
+ * otherwise sends the transition event to the actor, orchestrates the step-level transition, and runs the execution loop
+ * as needed. Emits CLI output for actions, completions, and stopped conditions.
  *
- * @param ctx - Transition context
- * @param config - Transition configuration
- * @param explicitTarget - Optional explicit target for directing transition at a specific substep
- * @returns `'continue'` for normal flow including completed/done paths, `'stopped'` if it reached a terminal state
- * @throws {Error} from `findStepOrThrow` if the active step is missing (state corruption),
- *   from `ensureActiveEntry` on lifecycle violations, or from orchestration failures
- * @throws {IndexOptionError} if `--index` validation fails
+ * @param ctx - Runtime transition context (output, services, state, steps, actor, cwd)
+ * @param config - Transition configuration that determines event type, result semantics, and terminal policy
+ * @param explicitTarget - Optional explicit target step/substep string (e.g., "2.1") and optional raw --index value to apply the transition to a specific substep/iteration
+ * @returns `'continue'` when execution proceeds or completes normally, `'stopped'` when a terminal stop was reached
+ * @throws {Error} if the active step is missing or an explicit target is invalid, or when lifecycle/orchestration validations fail
+ * @throws {IndexOptionError} if `--index` validation or resolution fails
  */
 export async function executeTransition(
   ctx: TransitionContext,

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -245,17 +245,17 @@ export interface ExplicitTarget {
 }
 
 /**
- * Execute a configured transition (pass or fail) against the current runbook state.
+ * Perform a pass/fail transition against the active runbook state.
  *
- * When targeting a substep (via an explicit target), records or reuses a resolved completion and drains completions;
- * otherwise sends the transition event to the actor, orchestrates the step-level transition, and runs the execution loop
- * as needed. Emits CLI output for actions, completions, and stopped conditions.
+ * Records or reuses a resolved completion when targeting a substep; otherwise sends the configured
+ * transition event to the runbook actor, orchestrates step-level changes, and runs the execution loop
+ * as required. Emits CLI output for actions, completions, runbook completion, and stopped conditions.
  *
- * @param ctx - Runtime transition context (output, services, state, steps, actor, cwd)
- * @param config - Transition configuration that determines event type, result semantics, and terminal policy
- * @param explicitTarget - Optional explicit target step/substep string (e.g., "2.1") and optional raw --index value to apply the transition to a specific substep/iteration
+ * @param ctx - Runtime transition context containing output, services, current state, parsed steps, actor, and cwd
+ * @param config - Transition configuration that determines the event type, persisted result, action-result mapping, and terminal policy
+ * @param explicitTarget - Optional explicit step/substep target (e.g., "2.1") and optional raw `--index` value to target a specific iteration
  * @returns `'continue'` when execution proceeds or completes normally, `'stopped'` when a terminal stop was reached
- * @throws {Error} if the active step is missing or an explicit target is invalid, or when lifecycle/orchestration validations fail
+ * @throws {Error} if the active step is missing, an explicit target is invalid, or lifecycle/orchestration validations fail
  * @throws {IndexOptionError} if `--index` validation or resolution fails
  */
 export async function executeTransition(


### PR DESCRIPTION
## Summary

- Fix sentinel/exact cross-check to use the **target frame's entry** from `frameEntries` instead of `activeState.activeEntry` when targeting non-active frames
- Prevents missing existing exact completions on a different frame during duplicate detection
- Outstanding commit from #120 that landed after the squash merge

## Test plan

- [x] 1153 tests pass (all existing + new test coverage)
- [x] Cherry-picked cleanly from `add-index-param` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying cross-check uses the configured entry for a non-active target frame and does not create a new completion.

* **Bug Fixes**
  * Fixed cross-check key construction to prefer the target frame's entry when applicable, improving correctness for multi-frame/subframe transitions and preventing unnecessary writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->