### PR TITLE
refactor(parser): reduce cognitive complexity via function extraction

### DIFF
--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -44,6 +44,36 @@ function isHeading(node: Node): node is Heading {
 }
 
 /**
+ * Type guard to narrow Node to Code.
+ *
+ * @param node - The mdast node to check
+ * @returns True if the node is a Code block
+ */
+function isCode(node: Node): node is Code {
+  return node.type === 'code';
+}
+
+/**
+ * Type guard to narrow Node to Paragraph.
+ *
+ * @param node - The mdast node to check
+ * @returns True if the node is a Paragraph
+ */
+function isParagraph(node: Node): node is Paragraph {
+  return node.type === 'paragraph';
+}
+
+/**
+ * Type guard to narrow Node to ListItem.
+ *
+ * @param node - The mdast node to check
+ * @returns True if the node is a ListItem
+ */
+function isListItem(node: Node): node is ListItem {
+  return node.type === 'listItem';
+}
+
+/**
  * Extract plain text from an mdast node, recursing into children.
  *
  * @param node - The mdast node to extract text from
@@ -102,6 +132,439 @@ interface StepBuilder {
   invalidH3s: Array<{ line: number; text: string }>;
 }
 
+/** Mutable state for the visit callback. */
+interface VisitorContext {
+  steps: Step[];
+  title: string | undefined;
+  preamble: string;
+  currentStep: StepBuilder | null;
+  pendingConditionals: ParsedConditional[];
+  implicitText: string;
+  inPreamble: boolean;
+}
+
+/** Narrowed context where a step is active. Handlers that require currentStep take this. */
+interface ActiveStepContext extends VisitorContext {
+  currentStep: StepBuilder;
+}
+
+function hasActiveStep(ctx: VisitorContext): ctx is ActiveStepContext {
+  return ctx.currentStep !== null;
+}
+
+function finalizePendingSubstep(ctx: VisitorContext): void {
+  if (ctx.currentStep?.pendingSubstep) {
+    const ps = ctx.currentStep.pendingSubstep;
+    const runbooks = extractRunbookList(ps.content);
+
+    // Validate NEXT usage before converting to transitions
+    validateLoopControlUsage(ps.pendingConditionals, ctx.currentStep.forClause !== undefined);
+
+    const converted = convertToTransitions(ps.pendingConditionals);
+
+    // Build prompt from promptText and remaining content
+    let promptText = ps.promptText;
+    if (ps.content.trim()) {
+      const contentWithoutRunbooks = ps.content
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('-') || !line.includes('.runbook.md'))
+        .join('\n')
+        .trim();
+      if (contentWithoutRunbooks) {
+        promptText += `${contentWithoutRunbooks}\n`;
+      }
+    }
+
+    // Substep transitions: explicit if authored, placeholder DEFAULT_TRANSITIONS if not.
+    // finalizeStep will override DEFAULT_TRANSITIONS with context-aware defaults.
+    const substep: Substep = {
+      id: ps.id,
+      description: ps.description,
+      command: ps.command,
+      prompt: promptText.trim() || undefined,
+      transitions: converted?.transitions ?? DEFAULT_TRANSITIONS,
+      runbooks: runbooks.length > 0 ? runbooks : undefined,
+      line: ps.line,
+    };
+    ctx.currentStep.substeps.push(substep);
+    ctx.currentStep.pendingSubstep = undefined;
+  }
+}
+
+function handleH1Heading(node: Heading, ctx: VisitorContext): void {
+  const headingText = extractText(node);
+  const looksLikeStep = /^\d+[.:\-)\s]/.test(headingText);
+  if (looksLikeStep) {
+    throw new RunbookSyntaxError(
+      `H1 headers (# ...) cannot be used as step headers. Use H2 (## ${headingText}) instead.`,
+    );
+  }
+  ctx.title ??= headingText;
+}
+
+function handleH4PlusHeading(node: Heading): void {
+  throw new RunbookSyntaxError(
+    `H4+ headings are not allowed in runbooks. Found heading at depth ${String(node.depth)}. Use ## for steps and ### for substeps only.`,
+  );
+}
+
+function handleH2Heading(node: Heading, ctx: VisitorContext): void {
+  ctx.inPreamble = false;
+  finalizePendingSubstep(ctx);
+
+  if (ctx.currentStep) {
+    ctx.steps.push(finalizeStep(ctx.currentStep, ctx.pendingConditionals, ctx.implicitText));
+    ctx.pendingConditionals = [];
+    ctx.implicitText = '';
+  }
+
+  const headingText = extractText(node);
+  const parsed = extractStepHeader(headingText);
+  if (parsed) {
+    ctx.currentStep = {
+      name: parsed.name,
+      description: parsed.description,
+      promptText: '',
+      hasSeenContent: false,
+      hasSeenTransitions: false,
+      hasSeenPromptText: false,
+      substeps: [],
+      content: '',
+      line: node.position?.start.line,
+      hasSeenForClause: false,
+      invalidH3s: [],
+    };
+  }
+}
+
+function handleH3Heading(node: Heading, ctx: ActiveStepContext): void {
+  ctx.inPreamble = false;
+  if (ctx.currentStep.pendingSubstep) {
+    // H3 #2+: flush inter-substep conditionals to preceding substep
+    ctx.currentStep.pendingSubstep.pendingConditionals.push(...ctx.pendingConditionals);
+    ctx.pendingConditionals = [];
+  } else if (ctx.pendingConditionals.length > 0) {
+    // First H3: save step-level conditionals separately
+    ctx.currentStep.stepConditionals = [...ctx.pendingConditionals];
+    ctx.pendingConditionals = [];
+  }
+  finalizePendingSubstep(ctx);
+
+  const headingText = extractText(node);
+  const parsed = extractSubstepHeader(headingText);
+
+  if (parsed) {
+    // Mark that parent step has seen content (substeps count as content)
+    ctx.currentStep.hasSeenContent = true;
+    if (parsed.stepRef !== undefined && parsed.stepRef !== ctx.currentStep.name) {
+      throw new RunbookSyntaxError(
+        `Substep ${headingText} does not belong to step ${ctx.currentStep.name}`,
+      );
+    }
+
+    const duplicateId = ctx.currentStep.substeps.find((s) => s.id === parsed.id);
+    if (duplicateId) {
+      const stepLabel = ctx.currentStep.name;
+      throw new RunbookSyntaxError(`Duplicate substep ID '${parsed.id}' in step ${stepLabel}`);
+    }
+
+    ctx.currentStep.pendingSubstep = {
+      id: parsed.id,
+      description: parsed.description,
+      content: '',
+      command: undefined,
+      promptText: '',
+      hasSeenContent: false,
+      hasSeenTransitions: false,
+      hasSeenPromptText: false,
+      pendingConditionals: [],
+      line: node.position?.start.line,
+    };
+  } else {
+    ctx.currentStep.invalidH3s.push({
+      line: node.position?.start.line ?? 0,
+      text: headingText,
+    });
+  }
+}
+
+function handleCodeBlock(node: Code, ctx: ActiveStepContext): void {
+  // mdast splits the code fence info string on the first space:
+  //   ```bash prompt  →  lang: "bash", meta: "prompt"
+  // Reconstruct the full string so isExecutableCodeBlock/isPromptCodeBlock
+  // can check multi-word patterns like "bash prompt".
+  const fullLang = node.lang && node.meta ? `${node.lang} ${node.meta}` : node.lang;
+
+  // Determine command based on code block type
+  let cmd: Command | undefined;
+
+  if (isExecutableCodeBlock(fullLang)) {
+    // bash/sh/shell → direct command
+    cmd = {
+      code: node.value.trim(),
+      lang: node.lang?.split(/\s+/)[0],
+    };
+  } else if (isPromptCodeBlock(fullLang)) {
+    // prompt or non-executable tagged → rd prompt command (outputs with fences)
+    const escaped = escapeForShellSingleQuote(node.value.trim());
+    cmd = {
+      code: `rd prompt '${escaped}'`,
+      lang: 'prompt',
+    };
+  } else {
+    // Bare code fence (no info string) — reject as invalid
+    throw new RunbookSyntaxError(
+      `Code block without language tag in Step ${ctx.currentStep.name}. ` +
+        `Use a language tag (e.g., \`\`\`bash) or \`\`\`prompt for display-only blocks.`,
+    );
+  }
+
+  if (ctx.currentStep.pendingSubstep) {
+    if (ctx.currentStep.pendingSubstep.command) {
+      throw new RunbookSyntaxError(
+        `Multiple code blocks per substep not allowed in substep ${ctx.currentStep.pendingSubstep.id} (display-only fences like json/yaml count as code blocks)`,
+      );
+    }
+    ctx.currentStep.pendingSubstep.command = cmd;
+    ctx.currentStep.pendingSubstep.hasSeenContent = true;
+  } else {
+    if (ctx.currentStep.command) {
+      const stepLabel = ctx.currentStep.name;
+      throw new RunbookSyntaxError(
+        `Multiple code blocks per step not allowed in Step ${stepLabel} (display-only fences like json/yaml count as code blocks).`,
+      );
+    }
+    ctx.currentStep.command = cmd;
+    ctx.currentStep.hasSeenContent = true;
+  }
+}
+
+function handlePreambleParagraph(node: Paragraph, ctx: VisitorContext): void {
+  const text = extractText(node);
+  ctx.preamble += `${text}\n`;
+}
+
+function handleStepParagraph(node: Paragraph, ctx: ActiveStepContext): void {
+  const text = extractText(node);
+  const lines = text.split('\n');
+
+  for (const line of lines) {
+    if (line.trim()) {
+      // Paragraphs are always treated as prompt text — transitions must use bullet-prefix (list items)
+      // Check ordering - text must come before content (code blocks, runbooks)
+      if (ctx.currentStep.pendingSubstep) {
+        // In substeps: text cannot appear after code blocks/runbooks
+        if (ctx.currentStep.pendingSubstep.hasSeenContent) {
+          const stepLabel = ctx.currentStep.name;
+          // E17-R2: Include line number in error for better DX
+          const lineNum = node.position?.start.line
+            ? ` (line ${String(node.position.start.line)})`
+            : '';
+          throw new RunbookSyntaxError(
+            `Substep ${stepLabel}.${ctx.currentStep.pendingSubstep.id}${lineNum}: Prompt text must appear before code blocks or runbooks.`,
+          );
+        }
+        ctx.currentStep.pendingSubstep.promptText += `${line.trim()}\n`;
+        ctx.currentStep.pendingSubstep.hasSeenPromptText = true;
+      } else {
+        if (ctx.currentStep.hasSeenContent) {
+          const stepLabel = ctx.currentStep.name;
+          // E17-R2: Include line number in error for better DX
+          const lineNum = node.position?.start.line
+            ? ` (line ${String(node.position.start.line)})`
+            : '';
+          throw new RunbookSyntaxError(
+            `Step ${stepLabel}${lineNum}: Prompt text must appear before code blocks, substeps, or runbooks.`,
+          );
+        }
+        ctx.implicitText += `${line.trim()}\n`;
+        ctx.currentStep.hasSeenPromptText = true;
+      }
+    }
+  }
+}
+
+function handleForClause(
+  forClause: ParsedForClause,
+  listItemNode: ListItem,
+  ctx: ActiveStepContext,
+): void {
+  // Enforce: only one FOR per step
+  if (ctx.currentStep.hasSeenForClause) {
+    throw new RunbookSyntaxError(
+      `Step "${ctx.currentStep.name}" has multiple FOR clauses; only one is allowed`,
+    );
+  }
+  // Enforce ordering: FOR must appear before transitions and content
+  if (ctx.currentStep.hasSeenTransitions) {
+    throw new RunbookSyntaxError(
+      `Step "${ctx.currentStep.name}": FOR clause must appear before transitions`,
+    );
+  }
+  if (ctx.currentStep.hasSeenContent || ctx.currentStep.hasSeenPromptText) {
+    throw new RunbookSyntaxError(
+      `Step "${ctx.currentStep.name}": FOR clause must appear before content`,
+    );
+  }
+  ctx.currentStep.forClause = forClause;
+  ctx.currentStep.hasSeenForClause = true;
+
+  // Check for nested list (FOR-level transitions)
+  const nestedList = listItemNode.children.find((c): c is List => c.type === 'list');
+  if (nestedList) {
+    const forConditionals: ParsedConditional[] = [];
+    for (const nestedItem of nestedList.children) {
+      const nestedParagraph = nestedItem.children.find((c) => c.type === 'paragraph');
+      if (!nestedParagraph) {
+        throw new RunbookSyntaxError(
+          `Invalid nested bullet under FOR clause in step "${ctx.currentStep.name}": only transitions (PASS/FAIL/DEFER) are allowed`,
+        );
+      }
+      const nestedText = extractText(
+        nestedParagraph as PhrasingContent | Heading | Paragraph | ListItem,
+      );
+      const cond = parseConditional(nestedText);
+      if (!cond) {
+        throw new RunbookSyntaxError(
+          `Invalid nested bullet under FOR clause in step "${ctx.currentStep.name}": only transitions (PASS/FAIL/DEFER) are allowed`,
+        );
+      }
+      if (Array.isArray(cond)) {
+        forConditionals.push(...cond);
+      } else {
+        forConditionals.push(cond);
+      }
+    }
+    if (forConditionals.length > 0) {
+      ctx.currentStep.forConditionals = forConditionals;
+    }
+  }
+}
+
+function handleListItemTransition(
+  conditionals: ParsedConditional[],
+  node: Node,
+  ctx: ActiveStepContext,
+): void {
+  if (ctx.currentStep.pendingSubstep) {
+    // Reject transitions after prompt text or content (header-adjacent requirement)
+    if (
+      ctx.currentStep.pendingSubstep.hasSeenPromptText ||
+      ctx.currentStep.pendingSubstep.hasSeenContent
+    ) {
+      const stepLabel = ctx.currentStep.name;
+      const lineNum = node.position?.start.line
+        ? ` (line ${String(node.position.start.line)})`
+        : '';
+      throw new RunbookSyntaxError(
+        `Substep ${stepLabel}.${ctx.currentStep.pendingSubstep.id}${lineNum}: Transitions must appear immediately after the substep header, before any content.`,
+      );
+    }
+    ctx.currentStep.pendingSubstep.pendingConditionals.push(...conditionals);
+    ctx.currentStep.pendingSubstep.hasSeenTransitions = true;
+  } else {
+    // Reject transitions after prompt text or content (header-adjacent requirement)
+    if (ctx.currentStep.hasSeenPromptText || ctx.currentStep.hasSeenContent) {
+      const stepLabel = ctx.currentStep.name;
+      const lineNum = node.position?.start.line
+        ? ` (line ${String(node.position.start.line)})`
+        : '';
+      throw new RunbookSyntaxError(
+        `Step ${stepLabel}${lineNum}: Transitions must appear immediately after the step header, before any content.`,
+      );
+    }
+    ctx.pendingConditionals.push(...conditionals);
+    ctx.currentStep.hasSeenTransitions = true;
+  }
+}
+
+function handleListItemContent(
+  text: string,
+  isRunbookRef: boolean,
+  node: Node,
+  ctx: ActiveStepContext,
+): void {
+  if (ctx.currentStep.pendingSubstep) {
+    // FIXED: Check ordering BEFORE adding content (C2 fix)
+    // In substeps: text cannot appear after transitions
+    if (ctx.currentStep.pendingSubstep.hasSeenTransitions && !isRunbookRef) {
+      const stepLabel = ctx.currentStep.name;
+      // E17-R2: Include line number in error for better DX
+      const lineNum = node.position?.start.line
+        ? ` (line ${String(node.position.start.line)})`
+        : '';
+      throw new RunbookSyntaxError(
+        `Substep ${stepLabel}.${ctx.currentStep.pendingSubstep.id}${lineNum}: Prompt text must appear before code blocks or runbooks.`,
+      );
+    }
+    // Only add content after validation passes
+    ctx.currentStep.pendingSubstep.content += ` - ${text}\n`;
+    // Mark content seen if runbook list
+    if (isRunbookRef) {
+      ctx.currentStep.pendingSubstep.hasSeenContent = true;
+    }
+  } else {
+    // FIXED: Check ordering BEFORE adding content (C2 fix)
+    if (ctx.currentStep.hasSeenContent && !isRunbookRef) {
+      const stepLabel = ctx.currentStep.name;
+      // E17-R2: Include line number in error for better DX
+      const lineNum = node.position?.start.line
+        ? ` (line ${String(node.position.start.line)})`
+        : '';
+      throw new RunbookSyntaxError(
+        `Step ${stepLabel}${lineNum}: Prompt text must appear before code blocks, substeps, or runbooks.`,
+      );
+    }
+    // Only add content after validation passes
+    const itemText = ` - ${text}\n`;
+    ctx.currentStep.content += itemText;
+    if (!isRunbookRef) {
+      ctx.implicitText += itemText;
+    } else {
+      // Mark content seen if runbook list
+      ctx.currentStep.hasSeenContent = true;
+    }
+  }
+}
+
+function handleListItem(node: ListItem, ctx: ActiveStepContext): typeof SKIP | void {
+  const firstParagraph = node.children.find((c) => c.type === 'paragraph');
+  if (!firstParagraph) return;
+
+  const text = extractText(firstParagraph as PhrasingContent | Heading | Paragraph | ListItem);
+
+  // Check for FOR clause BEFORE conditionals
+  const forResult = parseForClause(text);
+
+  // Throw if text looks like a FOR clause but didn't parse,
+  // unless it contains template variables ({{...}}) that need runtime expansion
+  if (forResult === null && text.trim().startsWith('FOR ')) {
+    throw new RunbookSyntaxError(`Invalid FOR clause: ${text.trim()}`);
+  }
+
+  if (forResult && !ctx.currentStep.pendingSubstep) {
+    // FOR is only valid at step level, not substep level
+    handleForClause(forResult, node, ctx);
+    return SKIP; // Don't process this list item further
+  }
+
+  // If FOR text appears in a substep context, that's an error
+  if (forResult && ctx.currentStep.pendingSubstep) {
+    throw new RunbookSyntaxError(
+      `FOR is only valid on steps (H2), not substeps (H3) (found on "${ctx.currentStep.name}.${ctx.currentStep.pendingSubstep.id}")`,
+    );
+  }
+
+  const conditionalResult = parseConditional(text);
+  if (conditionalResult) {
+    const conditionals = Array.isArray(conditionalResult) ? conditionalResult : [conditionalResult];
+    handleListItemTransition(conditionals, node, ctx);
+  } else {
+    const isRunbookRef = /^\S+\.runbook\.md$/.test(text.trim());
+    handleListItemContent(text, isRunbookRef, node, ctx);
+  }
+}
+
 /**
  * Parse runbook markdown into Step array (compatibility wrapper).
  *
@@ -151,434 +614,71 @@ export function parseRunbookDocument(markdown: string, basename?: string): Parse
   const { frontmatter, content } = extractFrontmatter(markdown);
   const tree = fromMarkdown(content);
 
-  const steps: Step[] = [];
-  let title: string | undefined;
-  let preamble = '';
-
-  let currentStep: StepBuilder | null = null;
-  let pendingConditionals: ParsedConditional[] = [];
-  let implicitText = '';
-  let inPreamble = true;
-
-  const finalizePendingSubstep = (): void => {
-    if (currentStep?.pendingSubstep) {
-      const ps = currentStep.pendingSubstep;
-      const runbooks = extractRunbookList(ps.content);
-
-      // Validate NEXT usage before converting to transitions
-      validateLoopControlUsage(ps.pendingConditionals, currentStep.forClause !== undefined);
-
-      const converted = convertToTransitions(ps.pendingConditionals);
-
-      // Build prompt from promptText and remaining content
-      let promptText = ps.promptText;
-      if (ps.content.trim()) {
-        const contentWithoutRunbooks = ps.content
-          .split('\n')
-          .filter((line) => !line.trim().startsWith('-') || !line.includes('.runbook.md'))
-          .join('\n')
-          .trim();
-        if (contentWithoutRunbooks) {
-          promptText += `${contentWithoutRunbooks}\n`;
-        }
-      }
-
-      // Substep transitions: explicit if authored, placeholder DEFAULT_TRANSITIONS if not.
-      // finalizeStep will override DEFAULT_TRANSITIONS with context-aware defaults.
-      const substep: Substep = {
-        id: ps.id,
-        description: ps.description,
-        command: ps.command,
-        prompt: promptText.trim() || undefined,
-        transitions: converted?.transitions ?? DEFAULT_TRANSITIONS,
-        runbooks: runbooks.length > 0 ? runbooks : undefined,
-        line: ps.line,
-      };
-      currentStep.substeps.push(substep);
-      currentStep.pendingSubstep = undefined;
-    }
+  const ctx: VisitorContext = {
+    steps: [],
+    title: undefined,
+    preamble: '',
+    currentStep: null,
+    pendingConditionals: [],
+    implicitText: '',
+    inPreamble: true,
   };
 
   visit(tree, (node: Node, _index, parent: Node | undefined) => {
-    if (isHeading(node) && node.depth === 1) {
-      const headingText = extractText(node);
-      const looksLikeStep = /^\d+[.:\-)\s]/.test(headingText);
-      if (looksLikeStep) {
-        throw new RunbookSyntaxError(
-          `H1 headers (# ...) cannot be used as step headers. Use H2 (## ${headingText}) instead.`,
-        );
-      }
-      title ??= headingText;
-    }
-
-    if (isHeading(node) && node.depth >= 4) {
-      throw new RunbookSyntaxError(
-        `H4+ headings are not allowed in runbooks. Found heading at depth ${String(node.depth)}. Use ## for steps and ### for substeps only.`,
-      );
-    }
-
-    if (isHeading(node) && node.depth === 2) {
-      inPreamble = false;
-      finalizePendingSubstep();
-
-      if (currentStep) {
-        steps.push(finalizeStep(currentStep, pendingConditionals, implicitText));
-        pendingConditionals = [];
-        implicitText = '';
-      }
-
-      const headingText = extractText(node);
-      const parsed = extractStepHeader(headingText);
-      if (parsed) {
-        currentStep = {
-          name: parsed.name,
-          description: parsed.description,
-          promptText: '',
-          hasSeenContent: false,
-          hasSeenTransitions: false,
-          hasSeenPromptText: false,
-          substeps: [],
-          content: '',
-          line: node.position?.start.line,
-          hasSeenForClause: false,
-          invalidH3s: [],
-        };
-      }
-    }
-
-    if (isHeading(node) && node.depth === 3 && currentStep) {
-      inPreamble = false;
-      if (currentStep.pendingSubstep) {
-        // H3 #2+: flush inter-substep conditionals to preceding substep
-        currentStep.pendingSubstep.pendingConditionals.push(...pendingConditionals);
-        pendingConditionals = [];
-      } else if (pendingConditionals.length > 0) {
-        // First H3: save step-level conditionals separately
-        currentStep.stepConditionals = [...pendingConditionals];
-        pendingConditionals = [];
-      }
-      finalizePendingSubstep();
-
-      const headingText = extractText(node);
-      const parsed = extractSubstepHeader(headingText);
-
-      if (parsed) {
-        // Mark that parent step has seen content (substeps count as content)
-        currentStep.hasSeenContent = true;
-        if (parsed.stepRef !== undefined && parsed.stepRef !== currentStep.name) {
-          throw new RunbookSyntaxError(
-            `Substep ${headingText} does not belong to step ${currentStep.name}`,
-          );
-        }
-
-        const duplicateId = currentStep.substeps.find((s) => s.id === parsed.id);
-        if (duplicateId) {
-          const stepLabel = currentStep.name;
-          throw new RunbookSyntaxError(`Duplicate substep ID '${parsed.id}' in step ${stepLabel}`);
-        }
-
-        currentStep.pendingSubstep = {
-          id: parsed.id,
-          description: parsed.description,
-          content: '',
-          command: undefined,
-          promptText: '',
-          hasSeenContent: false,
-          hasSeenTransitions: false,
-          hasSeenPromptText: false,
-          pendingConditionals: [],
-          line: node.position?.start.line,
-        };
-      } else {
-        currentStep.invalidH3s.push({
-          line: node.position?.start.line ?? 0,
-          text: headingText,
-        });
-      }
-    }
-
-    if (node.type === 'code' && currentStep) {
-      const codeNode = node as Code;
-
-      // mdast splits the code fence info string on the first space:
-      //   ```bash prompt  →  lang: "bash", meta: "prompt"
-      // Reconstruct the full string so isExecutableCodeBlock/isPromptCodeBlock
-      // can check multi-word patterns like "bash prompt".
-      const fullLang =
-        codeNode.lang && codeNode.meta ? `${codeNode.lang} ${codeNode.meta}` : codeNode.lang;
-
-      // Determine command based on code block type
-      let cmd: Command | undefined;
-
-      if (isExecutableCodeBlock(fullLang)) {
-        // bash/sh/shell → direct command
-        cmd = {
-          code: codeNode.value.trim(),
-          lang: codeNode.lang?.split(/\s+/)[0],
-        };
-      } else if (isPromptCodeBlock(fullLang)) {
-        // prompt or non-executable tagged → rd prompt command (outputs with fences)
-        const escaped = escapeForShellSingleQuote(codeNode.value.trim());
-        cmd = {
-          code: `rd prompt '${escaped}'`,
-          lang: 'prompt',
-        };
-      } else {
-        // Bare code fence (no info string) — reject as invalid
-        throw new RunbookSyntaxError(
-          `Code block without language tag in Step ${currentStep.name}. ` +
-            `Use a language tag (e.g., \`\`\`bash) or \`\`\`prompt for display-only blocks.`,
-        );
-      }
-
-      if (currentStep.pendingSubstep) {
-        if (currentStep.pendingSubstep.command) {
-          throw new RunbookSyntaxError(
-            `Multiple code blocks per substep not allowed in substep ${currentStep.pendingSubstep.id} (display-only fences like json/yaml count as code blocks)`,
-          );
-        }
-        currentStep.pendingSubstep.command = cmd;
-        currentStep.pendingSubstep.hasSeenContent = true;
-      } else {
-        if (currentStep.command) {
-          const stepLabel = currentStep.name;
-          throw new RunbookSyntaxError(
-            `Multiple code blocks per step not allowed in Step ${stepLabel} (display-only fences like json/yaml count as code blocks).`,
-          );
-        }
-        currentStep.command = cmd;
-        currentStep.hasSeenContent = true;
-      }
-    }
-
-    if (node.type === 'paragraph' && parent && parent.type !== 'listItem') {
-      const paragraphNode = node as Paragraph;
-      const text = extractText(paragraphNode);
-
-      if (inPreamble) {
-        preamble += `${text}\n`;
+    if (isHeading(node)) {
+      if (node.depth === 1) {
+        handleH1Heading(node, ctx);
         return;
       }
-
-      if (currentStep) {
-        const lines = text.split('\n');
-
-        for (const line of lines) {
-          if (line.trim()) {
-            // Paragraphs are always treated as prompt text — transitions must use bullet-prefix (list items)
-            // Check ordering - text must come before content (code blocks, runbooks)
-            if (currentStep.pendingSubstep) {
-              // In substeps: text cannot appear after code blocks/runbooks
-              if (currentStep.pendingSubstep.hasSeenContent) {
-                const stepLabel = currentStep.name;
-                // E17-R2: Include line number in error for better DX
-                const lineNum = node.position?.start.line
-                  ? ` (line ${String(node.position.start.line)})`
-                  : '';
-                throw new RunbookSyntaxError(
-                  `Substep ${stepLabel}.${currentStep.pendingSubstep.id}${lineNum}: Prompt text must appear before code blocks or runbooks.`,
-                );
-              }
-              currentStep.pendingSubstep.promptText += `${line.trim()}\n`;
-              currentStep.pendingSubstep.hasSeenPromptText = true;
-            } else {
-              if (currentStep.hasSeenContent) {
-                const stepLabel = currentStep.name;
-                // E17-R2: Include line number in error for better DX
-                const lineNum = node.position?.start.line
-                  ? ` (line ${String(node.position.start.line)})`
-                  : '';
-                throw new RunbookSyntaxError(
-                  `Step ${stepLabel}${lineNum}: Prompt text must appear before code blocks, substeps, or runbooks.`,
-                );
-              }
-              implicitText += `${line.trim()}\n`;
-              currentStep.hasSeenPromptText = true;
-            }
-          }
-        }
+      if (node.depth >= 4) {
+        handleH4PlusHeading(node);
+        return;
       }
-    }
-
-    if (node.type === 'listItem' && currentStep) {
-      const listItemNode = node as ListItem;
-      const firstParagraph = listItemNode.children.find((c) => c.type === 'paragraph');
-      if (firstParagraph) {
-        const text = extractText(
-          firstParagraph as PhrasingContent | Heading | Paragraph | ListItem,
-        );
-
-        // Check for FOR clause BEFORE conditionals
-        const forClause = parseForClause(text);
-
-        // Throw if text looks like a FOR clause but didn't parse,
-        // unless it contains template variables ({{...}}) that need runtime expansion
-        if (forClause === null && text.trim().startsWith('FOR ')) {
-          throw new RunbookSyntaxError(`Invalid FOR clause: ${text.trim()}`);
-        }
-
-        if (forClause && !currentStep.pendingSubstep) {
-          // FOR is only valid at step level, not substep level
-          // Enforce: only one FOR per step
-          if (currentStep.hasSeenForClause) {
-            throw new RunbookSyntaxError(
-              `Step "${currentStep.name}" has multiple FOR clauses; only one is allowed`,
-            );
-          }
-          // Enforce ordering: FOR must appear before transitions and content
-          if (currentStep.hasSeenTransitions) {
-            throw new RunbookSyntaxError(
-              `Step "${currentStep.name}": FOR clause must appear before transitions`,
-            );
-          }
-          if (currentStep.hasSeenContent || currentStep.hasSeenPromptText) {
-            throw new RunbookSyntaxError(
-              `Step "${currentStep.name}": FOR clause must appear before content`,
-            );
-          }
-          currentStep.forClause = forClause;
-          currentStep.hasSeenForClause = true;
-
-          // Check for nested list (FOR-level transitions)
-          const nestedList = listItemNode.children.find((c): c is List => c.type === 'list');
-          if (nestedList) {
-            const forConditionals: ParsedConditional[] = [];
-            for (const nestedItem of nestedList.children) {
-              const nestedParagraph = nestedItem.children.find((c) => c.type === 'paragraph');
-              if (!nestedParagraph) {
-                throw new RunbookSyntaxError(
-                  `Invalid nested bullet under FOR clause in step "${currentStep.name}": only transitions (PASS/FAIL/DEFER) are allowed`,
-                );
-              }
-              const nestedText = extractText(
-                nestedParagraph as PhrasingContent | Heading | Paragraph | ListItem,
-              );
-              const cond = parseConditional(nestedText);
-              if (!cond) {
-                throw new RunbookSyntaxError(
-                  `Invalid nested bullet under FOR clause in step "${currentStep.name}": only transitions (PASS/FAIL/DEFER) are allowed`,
-                );
-              }
-              if (Array.isArray(cond)) {
-                forConditionals.push(...cond);
-              } else {
-                forConditionals.push(cond);
-              }
-            }
-            if (forConditionals.length > 0) {
-              currentStep.forConditionals = forConditionals;
-            }
-          }
-          return SKIP; // Don't process this list item further
-        }
-
-        // If FOR text appears in a substep context, that's an error
-        if (forClause && currentStep.pendingSubstep) {
-          throw new RunbookSyntaxError(
-            `FOR is only valid on steps (H2), not substeps (H3) (found on "${currentStep.name}.${currentStep.pendingSubstep.id}")`,
-          );
-        }
-
-        const conditionalResult = parseConditional(text);
-        if (conditionalResult) {
-          const conditionals = Array.isArray(conditionalResult)
-            ? conditionalResult
-            : [conditionalResult];
-          if (currentStep.pendingSubstep) {
-            // Reject transitions after prompt text or content (header-adjacent requirement)
-            if (
-              currentStep.pendingSubstep.hasSeenPromptText ||
-              currentStep.pendingSubstep.hasSeenContent
-            ) {
-              const stepLabel = currentStep.name;
-              const lineNum = node.position?.start.line
-                ? ` (line ${String(node.position.start.line)})`
-                : '';
-              throw new RunbookSyntaxError(
-                `Substep ${stepLabel}.${currentStep.pendingSubstep.id}${lineNum}: Transitions must appear immediately after the substep header, before any content.`,
-              );
-            }
-            currentStep.pendingSubstep.pendingConditionals.push(...conditionals);
-            currentStep.pendingSubstep.hasSeenTransitions = true;
-          } else {
-            // Reject transitions after prompt text or content (header-adjacent requirement)
-            if (currentStep.hasSeenPromptText || currentStep.hasSeenContent) {
-              const stepLabel = currentStep.name;
-              const lineNum = node.position?.start.line
-                ? ` (line ${String(node.position.start.line)})`
-                : '';
-              throw new RunbookSyntaxError(
-                `Step ${stepLabel}${lineNum}: Transitions must appear immediately after the step header, before any content.`,
-              );
-            }
-            pendingConditionals.push(...conditionals);
-            currentStep.hasSeenTransitions = true;
-          }
-        } else if (currentStep.pendingSubstep) {
-          // FIXED: Check ordering BEFORE adding content (C2 fix)
-          const isRunbookRef = /^\S+\.runbook\.md$/.test(text.trim());
-          // In substeps: text cannot appear after transitions
-          if (currentStep.pendingSubstep.hasSeenTransitions && !isRunbookRef) {
-            const stepLabel = currentStep.name;
-            // E17-R2: Include line number in error for better DX
-            const lineNum = node.position?.start.line
-              ? ` (line ${String(node.position.start.line)})`
-              : '';
-            throw new RunbookSyntaxError(
-              `Substep ${stepLabel}.${currentStep.pendingSubstep.id}${lineNum}: Prompt text must appear before code blocks or runbooks.`,
-            );
-          }
-          // Only add content after validation passes
-          currentStep.pendingSubstep.content += ` - ${text}\n`;
-          // Mark content seen if runbook list
-          if (isRunbookRef) {
-            currentStep.pendingSubstep.hasSeenContent = true;
-          }
-        } else {
-          // FIXED: Check ordering BEFORE adding content (C2 fix)
-          const isRunbookRef = /^\S+\.runbook\.md$/.test(text.trim());
-          if (currentStep.hasSeenContent && !isRunbookRef) {
-            const stepLabel = currentStep.name;
-            // E17-R2: Include line number in error for better DX
-            const lineNum = node.position?.start.line
-              ? ` (line ${String(node.position.start.line)})`
-              : '';
-            throw new RunbookSyntaxError(
-              `Step ${stepLabel}${lineNum}: Prompt text must appear before code blocks, substeps, or runbooks.`,
-            );
-          }
-          // Only add content after validation passes
-          const itemText = ` - ${text}\n`;
-          currentStep.content += itemText;
-          if (!isRunbookRef) {
-            implicitText += itemText;
-          } else {
-            // Mark content seen if runbook list
-            currentStep.hasSeenContent = true;
-          }
-        }
+      if (node.depth === 2) {
+        handleH2Heading(node, ctx);
+        return;
       }
+      if (node.depth === 3 && hasActiveStep(ctx)) {
+        handleH3Heading(node, ctx);
+        return;
+      }
+      return;
     }
+    if (isCode(node) && hasActiveStep(ctx)) {
+      handleCodeBlock(node, ctx);
+      return;
+    }
+    if (isParagraph(node) && parent && parent.type !== 'listItem') {
+      if (ctx.inPreamble) {
+        handlePreambleParagraph(node, ctx);
+        return;
+      }
+      if (hasActiveStep(ctx)) {
+        handleStepParagraph(node, ctx);
+        return;
+      }
+      return;
+    }
+    if (isListItem(node) && hasActiveStep(ctx)) return handleListItem(node, ctx);
   });
 
-  finalizePendingSubstep();
+  finalizePendingSubstep(ctx);
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- currentStep changes in the loop
-  if (currentStep) {
-    steps.push(finalizeStep(currentStep, pendingConditionals, implicitText));
+  if (ctx.currentStep) {
+    ctx.steps.push(finalizeStep(ctx.currentStep, ctx.pendingConditionals, ctx.implicitText));
   }
 
-  const diagnostics = validateRunbook(steps);
+  const diagnostics = validateRunbook(ctx.steps);
 
   return {
     runbook: {
-      title,
-      description: preamble.trim() || undefined,
+      title: ctx.title,
+      description: ctx.preamble.trim() || undefined,
       name: frontmatter?.name ?? (basename ? nameFromFilename(basename) : undefined),
       version: frontmatter?.version,
       author: frontmatter?.author,
       tags: frontmatter?.tags,
-      steps,
+      steps: ctx.steps,
     },
     frontmatter,
     diagnostics,

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -132,7 +132,11 @@ interface StepBuilder {
   invalidH3s: Array<{ line: number; text: string }>;
 }
 
-/** Mutable state for the visit callback. */
+/**
+ * Mutable state threaded through all handler functions during AST walking.
+ * Each handler receives and mutates this context to accumulate parsing results.
+ * @see ActiveStepContext — narrowed variant where `currentStep` is guaranteed non-null
+ */
 interface VisitorContext {
   steps: Step[];
   title: string | undefined;
@@ -527,6 +531,13 @@ function handleListItemContent(
   }
 }
 
+/**
+ * Process a list item node within an active step.
+ *
+ * @param node - The list item AST node
+ * @param ctx - Active step context (currentStep guaranteed non-null)
+ * @returns `SKIP` when a FOR clause is handled (prevents child traversal), `void` otherwise
+ */
 function handleListItem(node: ListItem, ctx: ActiveStepContext): typeof SKIP | void {
   const firstParagraph = node.children.find((c) => c.type === 'paragraph');
   if (!firstParagraph) return;

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -537,6 +537,7 @@ function handleListItemContent(
  * @param node - The list item AST node
  * @param ctx - Active step context (currentStep guaranteed non-null)
  * @returns `SKIP` when a FOR clause is handled (prevents child traversal), `void` otherwise
+ * @throws {RunbookSyntaxError} If text looks like a FOR clause but fails to parse, or if FOR appears in a substep context
  */
 function handleListItem(node: ListItem, ctx: ActiveStepContext): typeof SKIP | void {
   const firstParagraph = node.children.find((c) => c.type === 'paragraph');

--- a/packages/parser/src/step-id.ts
+++ b/packages/parser/src/step-id.ts
@@ -60,6 +60,141 @@ export interface ParseStepIdOptions {
 }
 
 /**
+ * Validate a substep identifier: reject reserved words and non-positive numeric values.
+ *
+ * @param substep - The substep string to validate
+ * @returns True if the substep is valid, false if it should be rejected
+ */
+function isValidSubstepInStepId(substep: string): boolean {
+  if (NAMED_IDENTIFIER_PATTERN.test(substep) && isReservedWord(substep)) {
+    return false;
+  }
+  if (/^\d+$/.test(substep)) {
+    const substepNum = parseInt(substep, 10);
+    if (substepNum < 1) return false;
+  }
+  return true;
+}
+
+/**
+ * Parse the AT suffix from a step ID string.
+ *
+ * @param input - The full input string potentially containing " AT value"
+ * @returns Parsed AT value and remaining step input, or null if AT value is invalid
+ */
+function parseAtSuffix(input: string): { atValue: StepId['at']; stepInput: string } | null {
+  const atIndex = input.indexOf(' AT ');
+  if (atIndex === -1) return { atValue: undefined, stepInput: input };
+
+  const atStr = input.slice(atIndex + 4).trim();
+  const stepInput = input.slice(0, atIndex).trim();
+
+  // Parse AT value as positive integer or template variable
+  const num = parseInt(atStr, 10);
+  if (!Number.isNaN(num) && String(num) === atStr && num > 0) {
+    return { atValue: num, stepInput };
+  }
+  if (/^\{\{\s*[a-zA-Z_][a-zA-Z0-9_]*\s*\}\}$/.test(atStr)) {
+    return { atValue: atStr, stepInput };
+  }
+  return null; // Invalid AT value
+}
+
+/**
+ * Parse three-level numeric format: 1.2.1, 1.2.Cleanup (step.iteration.substep).
+ *
+ * @param stepInput - The step input string (AT suffix already removed)
+ * @param atValue - Parsed AT value (must be undefined for three-level — contradictory otherwise)
+ * @param requireSeparator - Whether a trailing separator is required
+ * @returns Parsed StepId or null if not matching
+ */
+function parseThreeLevelNumeric(
+  stepInput: string,
+  atValue: StepId['at'],
+  requireSeparator: boolean,
+): StepId | null {
+  const pattern = requireSeparator
+    ? /^(\d+)\.(\d+)\.(\d+|[A-Za-z_][A-Za-z0-9_]*)[\s\-:]/
+    : /^(\d+)\.(\d+)\.(\d+|[A-Za-z_][A-Za-z0-9_]*)$/;
+
+  const match = stepInput.match(pattern);
+  if (!match) return null;
+
+  // Three-level with explicit AT suffix is contradictory — reject
+  if (atValue !== undefined) return null;
+
+  const stepStr = match[1];
+  const iterationStr = match[2];
+  const substep = match[3];
+
+  const stepNum = parseInt(stepStr, 10);
+  if (stepNum <= 0) return null;
+
+  const iterationNum = parseInt(iterationStr, 10);
+  if (iterationNum < 1) return null;
+
+  if (substep && !isValidSubstepInStepId(substep)) return null;
+
+  return { step: stepStr, substep, at: iterationNum };
+}
+
+/**
+ * Parse two-level numeric format: 1, 1.2, 1.Name.
+ *
+ * @param stepInput - The step input string (AT suffix already removed)
+ * @param atValue - Parsed AT value to attach if present
+ * @param requireSeparator - Whether a trailing separator is required
+ * @returns Parsed StepId or null if not matching
+ */
+function parseTwoLevelNumeric(
+  stepInput: string,
+  atValue: StepId['at'],
+  requireSeparator: boolean,
+): StepId | null {
+  const pattern = requireSeparator
+    ? /^(\d+)(?:\.(\d+|[A-Za-z_][A-Za-z0-9_]*))?[\s\-:]/
+    : /^(\d+)(?:\.(\d+|[A-Za-z_][A-Za-z0-9_]*))?$/;
+
+  const match = stepInput.match(pattern);
+  if (!match) return null;
+
+  const stepStr = match[1];
+  const stepNum = parseInt(stepStr, 10);
+
+  // Validate step number is positive
+  if (stepNum <= 0) return null;
+
+  const substep = match[2];
+
+  if (substep && !isValidSubstepInStepId(substep)) return null;
+
+  return { step: stepStr, substep, ...(atValue !== undefined ? { at: atValue } : {}) };
+}
+
+/**
+ * Parse named step format: Cleanup, ErrorHandler.1, ErrorHandler.Recover.
+ *
+ * @param stepInput - The step input string (AT suffix already removed)
+ * @param atValue - Parsed AT value to attach if present
+ * @returns Parsed StepId or null if not matching
+ */
+function parseNamedStep(stepInput: string, atValue: StepId['at']): StepId | null {
+  const pattern = /^([A-Za-z_][A-Za-z0-9_]*)(?:\.(\d+|[A-Za-z_][A-Za-z0-9_]*))?$/;
+  const match = pattern.exec(stepInput);
+  if (!match) return null;
+
+  const stepName = match[1];
+  const substep = match[2];
+
+  // Reject reserved words as step names (NEXT already handled in caller)
+  if (isReservedWord(stepName)) return null;
+
+  if (substep && !isValidSubstepInStepId(substep)) return null;
+
+  return { step: stepName, substep, ...(atValue !== undefined ? { at: atValue } : {}) };
+}
+
+/**
  * Parse a StepId from a string representation.
  *
  * Supports these formats:
@@ -77,31 +212,13 @@ export function parseStepIdFromString(input: string, options?: ParseStepIdOption
   if (!input) return null;
 
   // Reject quoted strings - names must be identifiers
-  if (input.startsWith('"')) {
-    return null;
-  }
+  if (input.startsWith('"')) return null;
 
   const requireSeparator = options?.requireSeparator ?? false;
 
-  // Handle AT suffix: "3 AT 1", "3.1 AT {{Index}}"
-  const atIndex = input.indexOf(' AT ');
-  let atValue: number | string | undefined;
-  let stepInput = input;
-
-  if (atIndex !== -1) {
-    const atStr = input.slice(atIndex + 4).trim();
-    stepInput = input.slice(0, atIndex).trim();
-
-    // Parse AT value as positive integer or template variable
-    const num = parseInt(atStr, 10);
-    if (!Number.isNaN(num) && String(num) === atStr && num > 0) {
-      atValue = num;
-    } else if (/^\{\{\s*[a-zA-Z_][a-zA-Z0-9_]*\s*\}\}$/.test(atStr)) {
-      atValue = atStr;
-    } else {
-      return null; // Invalid AT value
-    }
-  }
+  const atResult = parseAtSuffix(input);
+  if (!atResult) return null;
+  const { atValue, stepInput } = atResult;
 
   // Reject dynamic format placeholders {N}, {n}, and NEXT
   if (
@@ -114,94 +231,11 @@ export function parseStepIdFromString(input: string, options?: ParseStepIdOption
     return null;
   }
 
-  // === THREE-LEVEL NUMERIC: 1.2.1, 1.2.Cleanup (step.iteration.substep) ===
-  const threeLevelPattern = requireSeparator
-    ? /^(\d+)\.(\d+)\.(\d+|[A-Za-z_][A-Za-z0-9_]*)[\s\-:]/
-    : /^(\d+)\.(\d+)\.(\d+|[A-Za-z_][A-Za-z0-9_]*)$/;
-
-  const threeLevelMatch = stepInput.match(threeLevelPattern);
-  if (threeLevelMatch) {
-    // Three-level with explicit AT suffix is contradictory — reject
-    if (atValue !== undefined) return null;
-
-    const stepStr = threeLevelMatch[1];
-    const iterationStr = threeLevelMatch[2];
-    const substep = threeLevelMatch[3];
-
-    const stepNum = parseInt(stepStr, 10);
-    if (stepNum <= 0) return null;
-
-    const iterationNum = parseInt(iterationStr, 10);
-    if (iterationNum < 1) return null;
-
-    if (substep && NAMED_IDENTIFIER_PATTERN.test(substep) && isReservedWord(substep)) {
-      return null;
-    }
-
-    if (substep && /^\d+$/.test(substep)) {
-      const substepNum = parseInt(substep, 10);
-      if (substepNum < 1) return null;
-    }
-
-    return { step: stepStr, substep, at: iterationNum };
-  }
-
-  // === NUMERIC STEP HANDLING: 1, 1.2, 1.Name ===
-  const numericPattern = requireSeparator
-    ? /^(\d+)(?:\.(\d+|[A-Za-z_][A-Za-z0-9_]*))?[\s\-:]/
-    : /^(\d+)(?:\.(\d+|[A-Za-z_][A-Za-z0-9_]*))?$/;
-
-  const numericMatch = stepInput.match(numericPattern);
-  if (numericMatch) {
-    const stepStr = numericMatch[1];
-    const stepNum = parseInt(stepStr, 10);
-
-    // Validate step number is positive
-    if (stepNum <= 0) return null;
-
-    const substep = numericMatch[2];
-
-    // Reject reserved words as named substeps (e.g., 1.CONTINUE)
-    if (substep && NAMED_IDENTIFIER_PATTERN.test(substep) && isReservedWord(substep)) {
-      return null;
-    }
-
-    // Validate numeric substep is positive
-    if (substep && /^\d+$/.test(substep)) {
-      const substepNum = parseInt(substep, 10);
-      if (substepNum < 1) return null;
-    }
-
-    return { step: stepStr, substep, ...(atValue !== undefined ? { at: atValue } : {}) };
-  }
-
-  // === NAMED STEP HANDLING: Cleanup, ErrorHandler.1, ErrorHandler.Recover ===
-  const namedPattern = /^([A-Za-z_][A-Za-z0-9_]*)(?:\.(\d+|[A-Za-z_][A-Za-z0-9_]*))?$/;
-  const namedMatch = namedPattern.exec(stepInput);
-  if (namedMatch) {
-    const stepName = namedMatch[1];
-    const substep = namedMatch[2];
-
-    // Reject reserved words as step names (NEXT already handled above)
-    if (isReservedWord(stepName)) {
-      return null;
-    }
-
-    // Reject reserved words as substep names
-    if (substep && NAMED_IDENTIFIER_PATTERN.test(substep) && isReservedWord(substep)) {
-      return null;
-    }
-
-    // Validate numeric substep is positive
-    if (substep && /^\d+$/.test(substep)) {
-      const substepNum = parseInt(substep, 10);
-      if (substepNum < 1) return null;
-    }
-
-    return { step: stepName, substep, ...(atValue !== undefined ? { at: atValue } : {}) };
-  }
-
-  return null;
+  return (
+    parseThreeLevelNumeric(stepInput, atValue, requireSeparator) ??
+    parseTwoLevelNumeric(stepInput, atValue, requireSeparator) ??
+    parseNamedStep(stepInput, atValue)
+  );
 }
 
 /**

--- a/packages/parser/src/validator.ts
+++ b/packages/parser/src/validator.ts
@@ -18,6 +18,17 @@ export interface ValidationDiagnostic {
 /** @deprecated Use ValidationDiagnostic */
 export type ValidationError = ValidationDiagnostic;
 
+/** Valid action types for FOR iteration-level transitions. */
+const FOR_ALLOWED_ACTIONS = [
+  'CONTINUE',
+  'DEFER',
+  'NEXT',
+  'BREAK',
+  'GOTO',
+  'STOP',
+  'COMPLETE',
+] as const satisfies readonly Action['type'][];
+
 function error(line: number | undefined, message: string): ValidationDiagnostic {
   return { severity: 'error', line, message };
 }
@@ -141,16 +152,6 @@ function validateForStep(
 
   // FOR iteration-level transitions allow full loop control and terminal routing.
   if (step.forClause.transitions) {
-    const FOR_ALLOWED_ACTIONS = [
-      'CONTINUE',
-      'DEFER',
-      'NEXT',
-      'BREAK',
-      'GOTO',
-      'STOP',
-      'COMPLETE',
-    ] as const satisfies readonly Action['type'][];
-
     if (
       !(FOR_ALLOWED_ACTIONS as readonly string[]).includes(
         step.forClause.transitions.pass.action.type,

--- a/packages/parser/src/validator.ts
+++ b/packages/parser/src/validator.ts
@@ -1,6 +1,7 @@
 import { StepSchema, ActionSchema } from './schemas.js';
-import type { Step, Action } from './ast.js';
+import type { Step, Action, StepWithFor, StepWithSubsteps } from './ast.js';
 import { isLoopControlAction, isAccumulatingAction } from './helpers.js';
+import { stepHasSubsteps, isStepWithSubsteps, isStepWithFor } from './guards.js';
 
 /**
  * Represents a validation diagnostic found during runbook analysis.
@@ -37,6 +38,265 @@ function getErrorContext(step: Step, substepId?: string): string {
 }
 
 /**
+ * Validate each step against the schema, tracking failures.
+ *
+ * @param steps - All steps in the runbook
+ * @param diagnostics - Array to which validation diagnostics are appended (mutated)
+ * @returns Set of steps that failed schema validation
+ */
+function validateStepSchemas(
+  steps: readonly Step[],
+  diagnostics: ValidationDiagnostic[],
+): Set<Step> {
+  const schemaFailedSteps = new Set<Step>();
+  for (const step of steps) {
+    const result = StepSchema.safeParse(step);
+    if (!result.success) {
+      diagnostics.push(
+        error(
+          step.line,
+          `Step ${step.name} failed schema validation: ${result.error.issues.map((i) => i.message).join(', ')}`,
+        ),
+      );
+      schemaFailedSteps.add(step);
+    }
+  }
+  return schemaFailedSteps;
+}
+
+/**
+ * Validate numeric step sequencing.
+ *
+ * @param steps - All steps in the runbook
+ * @param diagnostics - Array to which validation diagnostics are appended (mutated)
+ */
+function validateNumericSequencing(
+  steps: readonly Step[],
+  diagnostics: ValidationDiagnostic[],
+): void {
+  // Conformance Rule 3: Sequencing
+  // Only numeric steps must be sequential; named steps can appear anywhere
+  const numericSteps = steps.filter((s) => /^\d+$/.test(s.name));
+  if (numericSteps.length > 0) {
+    // Check that numeric steps are sequential (ignoring named steps)
+    let expectedNum = 1;
+    for (const step of steps) {
+      if (/^\d+$/.test(step.name)) {
+        const stepNum = parseInt(step.name, 10);
+        if (stepNum !== expectedNum) {
+          diagnostics.push(
+            error(
+              step.line,
+              `Numeric steps must be sequential. Expected step ${String(expectedNum)}, found step ${String(stepNum)}.`,
+            ),
+          );
+        }
+        expectedNum++;
+      }
+    }
+  }
+}
+
+/**
+ * Detect duplicate step names.
+ *
+ * @param steps - All steps in the runbook
+ * @param diagnostics - Array to which validation diagnostics are appended (mutated)
+ */
+function validateStepNameUniqueness(
+  steps: readonly Step[],
+  diagnostics: ValidationDiagnostic[],
+): void {
+  const seenNames = new Map<string, number | undefined>();
+  for (const step of steps) {
+    if (seenNames.has(step.name)) {
+      const firstLine = seenNames.get(step.name);
+      const suffix = firstLine !== undefined ? ` (first defined at line ${String(firstLine)})` : '';
+      diagnostics.push(error(step.line, `Duplicate step name "${step.name}"${suffix}`));
+    } else {
+      seenNames.set(step.name, step.line);
+    }
+  }
+}
+
+/**
+ * Validate a FOR step's iteration-level transitions, loop-control usage, and aggregation.
+ *
+ * @param step - The FOR step to validate
+ * @param steps - All steps in the runbook (for GOTO target resolution)
+ * @param diagnostics - Array to which validation diagnostics are appended (mutated)
+ * @returns Set of transition kinds ('pass'/'fail') where loop-control errors were reported
+ */
+function validateForStep(
+  step: StepWithFor,
+  steps: readonly Step[],
+  diagnostics: ValidationDiagnostic[],
+): ReadonlySet<'pass' | 'fail'> {
+  const reported = new Set<'pass' | 'fail'>();
+
+  // FOR steps always have substeps by type, but validate non-empty
+  if (step.substeps.length === 0) {
+    diagnostics.push(error(step.line, `FOR step "${step.name}" must have at least one substep`));
+  }
+
+  // FOR iteration-level transitions allow full loop control and terminal routing.
+  if (step.forClause.transitions) {
+    const FOR_ALLOWED_ACTIONS = [
+      'CONTINUE',
+      'DEFER',
+      'NEXT',
+      'BREAK',
+      'GOTO',
+      'STOP',
+      'COMPLETE',
+    ] as const satisfies readonly Action['type'][];
+
+    if (
+      !(FOR_ALLOWED_ACTIONS as readonly string[]).includes(
+        step.forClause.transitions.pass.action.type,
+      )
+    ) {
+      diagnostics.push(
+        error(
+          step.line,
+          `FOR-level PASS transition in step "${step.name}" uses ${step.forClause.transitions.pass.action.type}; allowed actions are ${FOR_ALLOWED_ACTIONS.join(', ')}`,
+        ),
+      );
+    }
+    if (
+      !(FOR_ALLOWED_ACTIONS as readonly string[]).includes(
+        step.forClause.transitions.fail.action.type,
+      )
+    ) {
+      diagnostics.push(
+        error(
+          step.line,
+          `FOR-level FAIL transition in step "${step.name}" uses ${step.forClause.transitions.fail.action.type}; allowed actions are ${FOR_ALLOWED_ACTIONS.join(', ')}`,
+        ),
+      );
+    }
+
+    // Reuse GOTO validation logic for FOR-level transitions.
+    if (step.forClause.transitions.pass.action.type === 'GOTO') {
+      validateAction(step.forClause.transitions.pass.action, undefined, steps, step, diagnostics);
+    }
+    if (step.forClause.transitions.fail.action.type === 'GOTO') {
+      validateAction(step.forClause.transitions.fail.action, undefined, steps, step, diagnostics);
+    }
+  }
+
+  // Parent FOR step must not use NEXT/BREAK in its own transitions.
+  if (isLoopControlAction(step.transitions.pass.action)) {
+    diagnostics.push(
+      error(
+        step.line,
+        `${step.transitions.pass.action.type} cannot appear on the FOR step itself, only on its substeps (step "${step.name}")`,
+      ),
+    );
+    reported.add('pass');
+  }
+  if (isLoopControlAction(step.transitions.fail.action)) {
+    diagnostics.push(
+      error(
+        step.line,
+        `${step.transitions.fail.action.type} cannot appear on the FOR step itself, only on its substeps (step "${step.name}")`,
+      ),
+    );
+    reported.add('fail');
+  }
+
+  // FOR iteration-level aggregation checks
+  if (step.forClause.aggregation) {
+    const allSubstepsExplicitNonDefer = step.substeps.every((sub) => {
+      return (
+        !isAccumulatingAction(sub.transitions.pass.action) &&
+        !isAccumulatingAction(sub.transitions.fail.action)
+      );
+    });
+    if (allSubstepsExplicitNonDefer && step.substeps.length > 0) {
+      diagnostics.push(
+        error(
+          step.line,
+          `FOR step "${step.name}" has iteration-level aggregation but no substep uses DEFER. ` +
+            `Use DEFER on at least one substep to propagate results.`,
+        ),
+      );
+    }
+  } else if (!step.aggregation) {
+    const hasSubstepDefer = step.substeps.some((sub) => {
+      return (
+        isAccumulatingAction(sub.transitions.pass.action) ||
+        isAccumulatingAction(sub.transitions.fail.action)
+      );
+    });
+    if (hasSubstepDefer) {
+      diagnostics.push(
+        warn(
+          step.line,
+          `FOR step "${step.name}" has substep using DEFER but no iteration-level aggregation (ALL/ANY). ` +
+            `DEFER results have no consumer.`,
+        ),
+      );
+    }
+  }
+
+  return reported;
+}
+
+/**
+ * Validate aggregation rules for non-FOR steps with substeps.
+ *
+ * Rule 4: Aggregation ON but no substep DEFERs — aggregation is vacuous.
+ * Rule 5: DEFER without aggregation — DEFER results have no consumer.
+ *
+ * @param step - The substep-bearing step to validate
+ * @param diagnostics - Array to which validation diagnostics are appended (mutated)
+ */
+function validateSubstepAggregation(
+  step: StepWithSubsteps,
+  diagnostics: ValidationDiagnostic[],
+): void {
+  // Rule 4: Aggregation ON but no substep DEFERs — aggregation is vacuous.
+  if (step.aggregation) {
+    const allSubstepsNonDefer = step.substeps.every((sub) => {
+      const passIsDefer = isAccumulatingAction(sub.transitions.pass.action);
+      const failIsDefer = isAccumulatingAction(sub.transitions.fail.action);
+      return !passIsDefer && !failIsDefer;
+    });
+
+    if (allSubstepsNonDefer && step.substeps.length > 0) {
+      diagnostics.push(
+        error(
+          step.line,
+          `Step "${step.name}" has substeps but no substep uses DEFER. ` +
+            `Use DEFER on at least one substep to propagate results to parent.`,
+        ),
+      );
+    }
+  }
+
+  // Rule 5: DEFER without aggregation — DEFER results have no consumer.
+  if (!step.aggregation) {
+    const hasSubstepDefer = step.substeps.some((sub) => {
+      return (
+        isAccumulatingAction(sub.transitions.pass.action) ||
+        isAccumulatingAction(sub.transitions.fail.action)
+      );
+    });
+
+    if (hasSubstepDefer) {
+      diagnostics.push(
+        warn(
+          step.line,
+          `Step "${step.name}" has substep using DEFER but no aggregation (ALL/ANY). ` +
+            `DEFER results have no consumer.`,
+        ),
+      );
+    }
+  }
+}
+
+/**
  * Validates a parsed runbook against Rundown specification rules.
  *
  * Checks for conformance with:
@@ -58,59 +318,9 @@ export function validateRunbook(steps: readonly Step[]): ValidationDiagnostic[] 
     ];
   }
 
-  // Schema validation for each step — track failures so the detailed
-  // validation loop below can skip structurally invalid steps that
-  // would otherwise throw TypeErrors on missing fields.
-  const schemaFailedSteps = new Set<Step>();
-  for (const step of steps) {
-    const result = StepSchema.safeParse(step);
-    if (!result.success) {
-      diagnostics.push(
-        error(
-          step.line,
-          `Step ${step.name} failed schema validation: ${result.error.issues.map((i) => i.message).join(', ')}`,
-        ),
-      );
-      schemaFailedSteps.add(step);
-    }
-  }
-
-  // Conformance Rule 3: Sequencing
-  // Only numeric steps must be sequential; named steps can appear anywhere
-  if (steps.length > 0) {
-    // Filter out named steps for sequencing check
-    const numericSteps = steps.filter((s) => /^\d+$/.test(s.name));
-    if (numericSteps.length > 0) {
-      // Check that numeric steps are sequential (ignoring named steps)
-      let expectedNum = 1;
-      for (const step of steps) {
-        if (/^\d+$/.test(step.name)) {
-          const stepNum = parseInt(step.name, 10);
-          if (stepNum !== expectedNum) {
-            diagnostics.push(
-              error(
-                step.line,
-                `Numeric steps must be sequential. Expected step ${String(expectedNum)}, found step ${String(stepNum)}.`,
-              ),
-            );
-          }
-          expectedNum++;
-        }
-      }
-    }
-  }
-
-  // Step-name uniqueness: detect duplicate step names/numbers
-  const seenNames = new Map<string, number | undefined>();
-  for (const step of steps) {
-    if (seenNames.has(step.name)) {
-      const firstLine = seenNames.get(step.name);
-      const suffix = firstLine !== undefined ? ` (first defined at line ${String(firstLine)})` : '';
-      diagnostics.push(error(step.line, `Duplicate step name "${step.name}"${suffix}`));
-    } else {
-      seenNames.set(step.name, step.line);
-    }
-  }
+  const schemaFailedSteps = validateStepSchemas(steps, diagnostics);
+  validateNumericSequencing(steps, diagnostics);
+  validateStepNameUniqueness(steps, diagnostics);
 
   for (const step of steps) {
     // Skip detailed validation for steps that failed schema validation —
@@ -121,10 +331,10 @@ export function validateRunbook(steps: readonly Step[]): ValidationDiagnostic[] 
     // The discriminated union enforces exclusivity by design:
     // 'command' steps have command, 'substeps'/'for' steps have substeps, 'base' has neither.
     // This check is kept for schema validation of externally-constructed steps.
-    const stepHasCommand = step.kind === 'command';
-    const stepHasSubsteps = step.kind === 'substeps' || step.kind === 'for';
+    const isCommand = step.kind === 'command';
+    const hasSubsteps = stepHasSubsteps(step);
 
-    const contentCount = [stepHasCommand, stepHasSubsteps].filter(Boolean).length;
+    const contentCount = [isCommand, hasSubsteps].filter(Boolean).length;
     if (contentCount > 1) {
       diagnostics.push(
         error(
@@ -140,109 +350,10 @@ export function validateRunbook(steps: readonly Step[]): ValidationDiagnostic[] 
     let failLoopControlReported = false;
 
     // FOR step validation
-    if (step.kind === 'for') {
-      // FOR steps always have substeps by type, but validate non-empty
-      if (step.substeps.length === 0) {
-        diagnostics.push(
-          error(step.line, `FOR step "${step.name}" must have at least one substep`),
-        );
-      }
-
-      // FOR iteration-level transitions allow full loop control and terminal routing.
-      if (step.forClause.transitions) {
-        const allowedActions = ['CONTINUE', 'DEFER', 'NEXT', 'BREAK', 'GOTO', 'STOP', 'COMPLETE'];
-        if (!allowedActions.includes(step.forClause.transitions.pass.action.type)) {
-          diagnostics.push(
-            error(
-              step.line,
-              `FOR-level PASS transition in step "${step.name}" uses ${step.forClause.transitions.pass.action.type}; allowed actions are ${allowedActions.join(', ')}`,
-            ),
-          );
-        }
-        if (!allowedActions.includes(step.forClause.transitions.fail.action.type)) {
-          diagnostics.push(
-            error(
-              step.line,
-              `FOR-level FAIL transition in step "${step.name}" uses ${step.forClause.transitions.fail.action.type}; allowed actions are ${allowedActions.join(', ')}`,
-            ),
-          );
-        }
-
-        // Reuse GOTO validation logic for FOR-level transitions.
-        if (step.forClause.transitions.pass.action.type === 'GOTO') {
-          validateAction(
-            step.forClause.transitions.pass.action,
-            undefined,
-            steps,
-            step,
-            diagnostics,
-          );
-        }
-        if (step.forClause.transitions.fail.action.type === 'GOTO') {
-          validateAction(
-            step.forClause.transitions.fail.action,
-            undefined,
-            steps,
-            step,
-            diagnostics,
-          );
-        }
-      }
-
-      // Parent FOR step must not use NEXT/BREAK in its own transitions.
-      if (isLoopControlAction(step.transitions.pass.action)) {
-        diagnostics.push(
-          error(
-            step.line,
-            `${step.transitions.pass.action.type} cannot appear on the FOR step itself, only on its substeps (step "${step.name}")`,
-          ),
-        );
-        passLoopControlReported = true;
-      }
-      if (isLoopControlAction(step.transitions.fail.action)) {
-        diagnostics.push(
-          error(
-            step.line,
-            `${step.transitions.fail.action.type} cannot appear on the FOR step itself, only on its substeps (step "${step.name}")`,
-          ),
-        );
-        failLoopControlReported = true;
-      }
-
-      // FOR iteration-level aggregation checks
-      if (step.forClause.aggregation) {
-        const allSubstepsExplicitNonDefer = step.substeps.every((sub) => {
-          return (
-            !isAccumulatingAction(sub.transitions.pass.action) &&
-            !isAccumulatingAction(sub.transitions.fail.action)
-          );
-        });
-        if (allSubstepsExplicitNonDefer && step.substeps.length > 0) {
-          diagnostics.push(
-            error(
-              step.line,
-              `FOR step "${step.name}" has iteration-level aggregation but no substep uses DEFER. ` +
-                `Use DEFER on at least one substep to propagate results.`,
-            ),
-          );
-        }
-      } else if (!step.aggregation) {
-        const hasSubstepDefer = step.substeps.some((sub) => {
-          return (
-            isAccumulatingAction(sub.transitions.pass.action) ||
-            isAccumulatingAction(sub.transitions.fail.action)
-          );
-        });
-        if (hasSubstepDefer) {
-          diagnostics.push(
-            warn(
-              step.line,
-              `FOR step "${step.name}" has substep using DEFER but no iteration-level aggregation (ALL/ANY). ` +
-                `DEFER results have no consumer.`,
-            ),
-          );
-        }
-      }
+    if (isStepWithFor(step)) {
+      const reported = validateForStep(step, steps, diagnostics);
+      passLoopControlReported = reported.has('pass');
+      failLoopControlReported = reported.has('fail');
     }
 
     if (
@@ -263,7 +374,7 @@ export function validateRunbook(steps: readonly Step[]): ValidationDiagnostic[] 
       validateAction(step.transitions.fail.action, undefined, steps, step, diagnostics);
     }
 
-    if (step.kind === 'substeps' || step.kind === 'for') {
+    if (stepHasSubsteps(step)) {
       for (const substep of step.substeps) {
         const sHasCommand = substep.command !== undefined;
         const sHasRunbooks = substep.runbooks !== undefined && substep.runbooks.length > 0;
@@ -281,43 +392,8 @@ export function validateRunbook(steps: readonly Step[]): ValidationDiagnostic[] 
         validateAction(substep.transitions.fail.action, substep.id, steps, step, diagnostics);
       }
 
-      // Rule 4: Aggregation ON but no substep DEFERs — aggregation is vacuous.
-      if (step.aggregation && step.kind !== 'for') {
-        const allSubstepsNonDefer = step.substeps.every((sub) => {
-          const passIsDefer = isAccumulatingAction(sub.transitions.pass.action);
-          const failIsDefer = isAccumulatingAction(sub.transitions.fail.action);
-          return !passIsDefer && !failIsDefer;
-        });
-
-        if (allSubstepsNonDefer && step.substeps.length > 0) {
-          diagnostics.push(
-            error(
-              step.line,
-              `Step "${step.name}" has substeps but no substep uses DEFER. ` +
-                `Use DEFER on at least one substep to propagate results to parent.`,
-            ),
-          );
-        }
-      }
-
-      // Rule 5: DEFER without aggregation — DEFER results have no consumer.
-      if (!step.aggregation && step.kind !== 'for') {
-        const hasSubstepDefer = step.substeps.some((sub) => {
-          return (
-            isAccumulatingAction(sub.transitions.pass.action) ||
-            isAccumulatingAction(sub.transitions.fail.action)
-          );
-        });
-
-        if (hasSubstepDefer) {
-          diagnostics.push(
-            warn(
-              step.line,
-              `Step "${step.name}" has substep using DEFER but no aggregation (ALL/ANY). ` +
-                `DEFER results have no consumer.`,
-            ),
-          );
-        }
+      if (isStepWithSubsteps(step)) {
+        validateSubstepAggregation(step, diagnostics);
       }
     }
   }
@@ -356,6 +432,107 @@ function validateGotoAtTarget(
     }
   }
   return true;
+}
+
+/** Resolved GOTO target with the step object and optional substep. */
+interface ResolvedGotoTarget {
+  stepObj: Step;
+  substep: string | undefined;
+}
+
+/**
+ * Resolve GOTO target step by name. Returns null if target doesn't exist (diagnostic pushed).
+ *
+ * @param action - The GOTO action to resolve
+ * @param currentSubstepId - ID of the current substep, or undefined if at step level
+ * @param steps - All steps in the runbook
+ * @param currentStepObj - The Step containing this action
+ * @param diagnostics - Array to which validation diagnostics are appended (mutated)
+ * @returns Resolved target or null if not found
+ */
+function resolveGotoTarget(
+  action: Extract<Action, { type: 'GOTO' }>,
+  currentSubstepId: string | undefined,
+  steps: readonly Step[],
+  currentStepObj: Step,
+  diagnostics: ValidationDiagnostic[],
+): ResolvedGotoTarget | null {
+  const targetStep = action.target.step;
+  const stepObj = steps.find((s) => s.name === targetStep);
+  if (!stepObj) {
+    const context = getErrorContext(currentStepObj, currentSubstepId);
+    diagnostics.push(
+      error(
+        currentStepObj.line,
+        `Step ${context}: GOTO target step "${targetStep}" does not exist.`,
+      ),
+    );
+    return null;
+  }
+  return { stepObj, substep: action.target.substep };
+}
+
+/**
+ * Validate a GOTO action: target existence, AT validity, substep existence, and self-loops.
+ *
+ * @param action - The GOTO action to validate
+ * @param currentSubstepId - ID of the current substep, or undefined if at step level
+ * @param steps - All steps in the runbook
+ * @param currentStepObj - The Step containing this action
+ * @param diagnostics - Array to which validation diagnostics are appended (mutated)
+ */
+function validateGotoAction(
+  action: Extract<Action, { type: 'GOTO' }>,
+  currentSubstepId: string | undefined,
+  steps: readonly Step[],
+  currentStepObj: Step,
+  diagnostics: ValidationDiagnostic[],
+): void {
+  const resolved = resolveGotoTarget(action, currentSubstepId, steps, currentStepObj, diagnostics);
+  if (!resolved) return;
+
+  const targetStep = action.target.step;
+
+  if (!validateGotoAtTarget(action, resolved.stepObj, targetStep, currentStepObj, diagnostics))
+    return;
+
+  if (resolved.substep) {
+    if (!stepHasSubsteps(resolved.stepObj)) {
+      const context = getErrorContext(currentStepObj, currentSubstepId);
+      diagnostics.push(
+        error(
+          currentStepObj.line,
+          `Step ${context}: GOTO ${targetStep}.${resolved.substep} invalid - step "${targetStep}" has no substeps.`,
+        ),
+      );
+      return;
+    }
+
+    const substepExists = resolved.stepObj.substeps.some((s) => s.id === resolved.substep);
+    if (!substepExists) {
+      const context = getErrorContext(currentStepObj, currentSubstepId);
+      diagnostics.push(
+        error(
+          currentStepObj.line,
+          `Step ${context}: GOTO ${targetStep}.${resolved.substep} invalid - substep does not exist.`,
+        ),
+      );
+      return;
+    }
+  }
+
+  // Self-loop detection: compare step names, not numeric values
+  // AT-qualified GOTOs change iteration, so they're not true self-loops
+  if (
+    targetStep === currentStepObj.name &&
+    resolved.substep === currentSubstepId &&
+    action.target.at === undefined
+  ) {
+    const context = getErrorContext(currentStepObj, currentSubstepId);
+    diagnostics.push(
+      warn(currentStepObj.line, `Step ${context}: GOTO self without RETRY may loop indefinitely`),
+    );
+  }
 }
 
 /**
@@ -417,123 +594,6 @@ export function validateAction(
   }
 
   if (action.type === 'GOTO') {
-    const targetStep = action.target.step;
-    const targetSubstep = action.target.substep;
-
-    // Handle named step target (not numeric strings - those are handled below)
-    if (typeof targetStep === 'string' && !/^\d+$/.test(targetStep)) {
-      const namedStep = steps.find((s) => s.name === targetStep);
-      if (!namedStep) {
-        const context = getErrorContext(currentStepObj, currentSubstepId);
-        diagnostics.push(
-          error(
-            currentStepObj.line,
-            `Step ${context}: GOTO target step "${targetStep}" does not exist.`,
-          ),
-        );
-        return;
-      }
-
-      if (!validateGotoAtTarget(action, namedStep, targetStep, currentStepObj, diagnostics)) return;
-
-      if (targetSubstep) {
-        if (namedStep.kind !== 'substeps' && namedStep.kind !== 'for') {
-          const context = getErrorContext(currentStepObj, currentSubstepId);
-          diagnostics.push(
-            error(
-              currentStepObj.line,
-              `Step ${context}: GOTO ${targetStep}.${targetSubstep} invalid - step "${targetStep}" has no substeps.`,
-            ),
-          );
-          return;
-        }
-
-        const substepExists = namedStep.substeps.some((s) => s.id === targetSubstep);
-        if (!substepExists) {
-          const context = getErrorContext(currentStepObj, currentSubstepId);
-          diagnostics.push(
-            error(
-              currentStepObj.line,
-              `Step ${context}: GOTO ${targetStep}.${targetSubstep} invalid - substep does not exist.`,
-            ),
-          );
-          return;
-        }
-      }
-
-      // Self-loop detection for named steps
-      if (
-        targetStep === currentStepObj.name &&
-        targetSubstep === currentSubstepId &&
-        action.target.at === undefined
-      ) {
-        const context = getErrorContext(currentStepObj, currentSubstepId);
-        diagnostics.push(
-          warn(
-            currentStepObj.line,
-            `Step ${context}: GOTO self without RETRY may loop indefinitely`,
-          ),
-        );
-      }
-      return;
-    }
-
-    // At this point, targetStep is a numeric string (e.g., "1", "2")
-    // We've already handled named steps above
-    // Look up by name, not array index (named steps can appear anywhere)
-    const targetStepObj = steps.find((s) => s.name === targetStep);
-
-    if (!targetStepObj) {
-      const context = getErrorContext(currentStepObj, currentSubstepId);
-      diagnostics.push(
-        error(
-          currentStepObj.line,
-          `Step ${context}: GOTO target step "${targetStep}" does not exist.`,
-        ),
-      );
-      return;
-    }
-
-    if (!validateGotoAtTarget(action, targetStepObj, targetStep, currentStepObj, diagnostics))
-      return;
-
-    if (targetSubstep) {
-      if (targetStepObj.kind !== 'substeps' && targetStepObj.kind !== 'for') {
-        const context = getErrorContext(currentStepObj, currentSubstepId);
-        diagnostics.push(
-          error(
-            currentStepObj.line,
-            `Step ${context}: GOTO ${targetStep}.${targetSubstep} invalid - step "${targetStep}" has no substeps.`,
-          ),
-        );
-        return;
-      }
-
-      const substepExists = targetStepObj.substeps.some((s) => s.id === targetSubstep);
-      if (!substepExists) {
-        const context = getErrorContext(currentStepObj, currentSubstepId);
-        diagnostics.push(
-          error(
-            currentStepObj.line,
-            `Step ${context}: GOTO ${targetStep}.${targetSubstep} invalid - substep does not exist.`,
-          ),
-        );
-        return;
-      }
-    }
-
-    // Self-loop detection: compare step names, not numeric values
-    // AT-qualified GOTOs change iteration, so they're not true self-loops
-    if (
-      targetStep === currentStepObj.name &&
-      targetSubstep === currentSubstepId &&
-      action.target.at === undefined
-    ) {
-      const context = getErrorContext(currentStepObj, currentSubstepId);
-      diagnostics.push(
-        warn(currentStepObj.line, `Step ${context}: GOTO self without RETRY may loop indefinitely`),
-      );
-      return;
-    }
+    validateGotoAction(action, currentSubstepId, steps, currentStepObj, diagnostics);
   }
 }


### PR DESCRIPTION
Extract monolithic functions into focused, type-safe handlers:

- parser.ts: decompose 360-line visit callback (210→19 complexity) into 11 handlers with VisitorContext/ActiveStepContext narrowing
- validator.ts: consolidate duplicate GOTO branches into single resolveGotoTarget/validateGotoAction path; extract validateRunbook phases (validateStepSchemas, validateForStep, etc.) (113→29)
- step-id.ts: extract parseAtSuffix, per-format parsers, and shared isValidSubstepInStepId validation (58→<15)

No behavior changes. All 895 parser tests and 2,951 monorepo tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced parser with more granular error diagnostics and detailed contextual information for invalid structural scenarios.
  * Improved internal code organization and modularity for better overall reliability and maintainability.
  * Strengthened runbook structure validation with comprehensive checks for step sequencing, naming uniqueness, and referential integrity of navigation targets.
  * Better handling of advanced step constructs and conditional flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->