### PR TITLE
docs: fix 7 documentation inaccuracies found by dual-verification review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,13 +311,13 @@ All exported symbols must have TSDoc documentation following these requirements:
  * - H2 step definitions with commands, prompts, and transitions
  *
  * @param markdown - The raw markdown content to parse
- * @param filename - Optional filename used to derive runbook name if not in frontmatter
+ * @param basename - Optional filename used to derive runbook name if not in frontmatter
  * @returns ParseResult with runbook AST and structural validation diagnostics
  * @see parseRunbook for simplified parsing returning only steps
  */
 export function parseRunbookDocument(
   markdown: string,
-  filename?: string,
+  basename?: string,
 ): ParseResult { ... }
 ```
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -48,7 +48,7 @@ docker compose -f docker-compose.verify.yml run --rm test-npm
 
 The Dockerfile uses a multi-stage build:
 
-- **`base`** — Shared foundation: `node:22-slim`, git, sudo, Claude Code, non-root `testuser`
+- **`base`** — Shared foundation: `node:24-slim`, git, sudo, Claude Code, non-root `testuser`
 - **`local`** — Copies pre-packed tarballs from `dist/` and installs them globally
 - **`npm`** — Defers installation to the entrypoint, which runs `npm install -g` at container start
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -55,7 +55,7 @@ npm install -g @rundown-org/mcp
 ```
 
 **Requirements:**
-- Node.js >= 20.12.0
+- Node.js >= 24.0.0
 - `@rundown-org/cli` installed (global or local)
 
 Verify installation:
@@ -512,7 +512,7 @@ Rundown MCP Server running
 | Check syntax | `validate` | `file` |
 | List runbooks | `list` | - |
 | Get status | `status` | - |
-| Start runbook | `run` | `file` |
+| Start runbook | `run` | - |
 | Step passed | `pass` | - |
 | Step failed | `fail` | - |
 | Jump to step | `goto` | `step` |

--- a/docs/PROJECT-INTEGRATION.md
+++ b/docs/PROJECT-INTEGRATION.md
@@ -167,7 +167,7 @@ Not:
 - FAIL STOP "Compilation failed."
 ```
 
-See [FORMAT.md Message Convention](./FORMAT.md#message-convention) for the full rationale.
+See [FORMAT.md Messages](./FORMAT.md#messages) for the full rationale.
 
 ## Worked Example: `pr-feedback`
 

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -294,7 +294,7 @@ FOR-level nested transitions (nested bullets directly under `- FOR ...`) run at 
 
 | Action | Effect |
 |--------|--------|
-| `CONTINUE` | Keep iterating |
+| `CONTINUE` | Exit loop (current result NOT recorded) → step-level handler |
 | `BREAK` | Exit loop immediately (non-accumulating — same as NEXT) |
 | `GOTO` | Jump immediately; bypass parent FOR aggregation |
 | `STOP` | Stop immediately; bypass parent FOR aggregation |

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -301,7 +301,7 @@ FOR-level nested transitions (nested bullets directly under `- FOR ...`) run at 
 | `COMPLETE` | Complete immediately; bypass parent FOR aggregation |
 | `RETRY N X` | Retry current iteration first, then execute exhausted action `X` |
 
-Parent FOR step transitions (`PASS ALL`, `FAIL ANY`, etc.) aggregate results across all iterations after normal loop completion or iteration-level `BREAK`.
+Parent FOR step transitions (`PASS ALL`, `FAIL ANY`, etc.) aggregate results across all iterations after normal loop completion, iteration-level `BREAK`, or iteration-level `CONTINUE`.
 
 **GOTO AT interaction:**
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -197,7 +197,7 @@ Steps annotated with `FOR` execute their substeps repeatedly.
 *   **Scope**: Loop variable available in substeps as `{{var}}`.
 *   **Aggregation**: Transitions on the parent FOR step evaluate the aggregate result of all iterations.
 *   **Iteration-level transitions**: Nested `PASS`/`FAIL` transitions under a `FOR` clause are stored on the `forClause.transitions` field and execute per iteration. Allowed actions: `DEFER` (default, loop back with accumulation), `NEXT` (loop back without accumulation), `CONTINUE` (exit loop), `BREAK` (exit loop), `GOTO`, `STOP`, `COMPLETE` (optionally wrapped by `RETRY`).
-*   **CONTINUE at iteration scope**: At step level, CONTINUE proceeds to the next step. At FOR iteration level, CONTINUE exits the loop — the current iteration result is NOT accumulated (same as NEXT/BREAK), and execution continues with the step after the FOR step.
+* **CONTINUE at iteration scope**: At step level, CONTINUE proceeds to the next step. At FOR iteration level, CONTINUE exits the loop — the current iteration result is NOT accumulated (same as NEXT/BREAK), and execution continues with the step after the FOR step.
 *   **Nested bullet rule**: Nested bullets under `FOR` must be transition bullets; non-transition nested bullets are invalid and fail parse.
 *   **Retry order**: Iteration-level `RETRY` semantics are deterministic: retry first, then execute the exhausted action. RETRY is universal — it fires for ALL substep actions (including `BREAK` and `NEXT`) based on the iteration result, not the substep action. After retries are exhausted, the substep's action takes effect:
     *   `BREAK` → exit loop (non-accumulating, same as NEXT)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -148,7 +148,7 @@ When only one transition side specifies an aggregation modifier, the defaulted s
 | Action | Context | Effect |
 | :--- | :--- | :--- |
 | `CONTINUE` | Step | Proceed to next step. |
-| `CONTINUE` | FOR Iteration-Level | Exit loop (result accumulated). |
+| `CONTINUE` | FOR Iteration-Level | Exit loop (result NOT accumulated). |
 | `DEFER` | Substep, FOR Iteration-Level | Pass result up one level for aggregation. |
 | `STOP [msg]` | Any | Terminate execution immediately (failure). |
 | `COMPLETE [msg]` | Any | Terminate execution immediately (success). |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -197,7 +197,7 @@ Steps annotated with `FOR` execute their substeps repeatedly.
 *   **Scope**: Loop variable available in substeps as `{{var}}`.
 *   **Aggregation**: Transitions on the parent FOR step evaluate the aggregate result of all iterations.
 *   **Iteration-level transitions**: Nested `PASS`/`FAIL` transitions under a `FOR` clause are stored on the `forClause.transitions` field and execute per iteration. Allowed actions: `DEFER` (default, loop back with accumulation), `NEXT` (loop back without accumulation), `CONTINUE` (exit loop), `BREAK` (exit loop), `GOTO`, `STOP`, `COMPLETE` (optionally wrapped by `RETRY`).
-*   **CONTINUE at iteration scope**: At step level, CONTINUE proceeds to the next step. At FOR iteration level, CONTINUE exits the loop — the current iteration result IS accumulated (unlike NEXT/BREAK which do not accumulate), and execution continues with the step after the FOR step.
+*   **CONTINUE at iteration scope**: At step level, CONTINUE proceeds to the next step. At FOR iteration level, CONTINUE exits the loop — the current iteration result is NOT accumulated (same as NEXT/BREAK), and execution continues with the step after the FOR step.
 *   **Nested bullet rule**: Nested bullets under `FOR` must be transition bullets; non-transition nested bullets are invalid and fail parse.
 *   **Retry order**: Iteration-level `RETRY` semantics are deterministic: retry first, then execute the exhausted action. RETRY is universal — it fires for ALL substep actions (including `BREAK` and `NEXT`) based on the iteration result, not the substep action. After retries are exhausted, the substep's action takes effect:
     *   `BREAK` → exit loop (non-accumulating, same as NEXT)


### PR DESCRIPTION
- CRITICAL: RUNDOWN.md CONTINUE at iteration scope exits loop, not "keep iterating"
- CRITICAL: SPEC.md CONTINUE result is NOT accumulated, not "IS accumulated"
- HIGH: MCP.md Node.js version 20.12.0 → 24.0.0
- HIGH: DOCKER.md node:22-slim → node:24-slim
- HIGH: PROJECT-INTEGRATION.md fix broken FORMAT.md#message-convention link
- HIGH: MCP.md run tool file parameter is optional, not required
- MEDIUM: CLAUDE.md parseRunbookDocument param filename → basename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js minimum version to >=24.0.0
  * Simplified Start runbook command by removing the file argument requirement
  * Clarified FOR loop control-flow: CONTINUE now aligns with non-accumulation and step-level transition handling
  * Updated Architecture and Docker documentation for base-image consistency

* **Chores**
  * Renamed a public API parameter for clarity (non-functional)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->