### PR TITLE
docs: add claude-code-plugin path resolution research package

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -13,6 +13,7 @@
 # Technical terms
 # Test fixture words
 # Turborepo reference
+agentic
 aindex
 AKIA
 ancvar
@@ -44,6 +45,9 @@ EBNF
 env
 esac
 esm
+GOPATH
+gopath
+gopls
 Eventless
 exfiltration
 fdisk
@@ -163,6 +167,7 @@ userdel
 usermod
 userns
 varfile
+venvs
 vitest
 workflow
 workflows

--- a/docs/implement/claude-code-plugin/00-START-HERE.md
+++ b/docs/implement/claude-code-plugin/00-START-HERE.md
@@ -1,0 +1,38 @@
+# Claude Code Plugin: File Path Handling
+
+**Status:** Verified against official docs + source code
+**Last Verified:** 2026-03-19
+**Applies To:** Claude Code 1.0.33+, Plugin API v1
+
+---
+
+## Choose Your Path
+
+| Time | Goal | Start With |
+|------|------|------------|
+| 2 min | Just the rules | [QUICK-REFERENCE.md](QUICK-REFERENCE.md) |
+| 10 min | Understand the model | [README.md](README.md) |
+| 30 min | Build a plugin | README.md then [path-resolution.md](path-resolution.md) then [plugin-structure.md](plugin-structure.md) |
+| 1 hour | Full understanding | All documents in sequence below |
+
+## Reading Order (Full)
+
+1. [README.md](README.md) - TL;DR + conceptual model
+2. [path-resolution.md](path-resolution.md) - How paths are resolved at every layer
+3. [plugin-structure.md](plugin-structure.md) - Directory layout and what gets published
+4. [skills-and-hooks.md](skills-and-hooks.md) - Referencing files from skills, hooks, MCP/LSP configs
+5. [design-decisions.md](design-decisions.md) - Why it works this way
+6. [QUICK-REFERENCE.md](QUICK-REFERENCE.md) - Lookup table for daily use
+
+## Package Contents
+
+```
+claude-code-plugin/
+  00-START-HERE.md           # You are here
+  README.md                   # TL;DR + conceptual overview
+  path-resolution.md          # Complete path resolution mechanics
+  plugin-structure.md         # Directory layout + publishing rules
+  skills-and-hooks.md         # File references in plugin components
+  design-decisions.md         # Why: caching, security, env vars
+  QUICK-REFERENCE.md          # One-page lookup
+```

--- a/docs/implement/claude-code-plugin/00-START-HERE.md
+++ b/docs/implement/claude-code-plugin/00-START-HERE.md
@@ -26,7 +26,7 @@
 
 ## Package Contents
 
-```
+```text
 claude-code-plugin/
   00-START-HERE.md           # You are here
   README.md                   # TL;DR + conceptual overview

--- a/docs/implement/claude-code-plugin/QUICK-REFERENCE.md
+++ b/docs/implement/claude-code-plugin/QUICK-REFERENCE.md
@@ -86,7 +86,7 @@
 
 **Standard Claude Code:**
 
-```
+```text
 my-plugin/
   .claude-plugin/plugin.json     # Manifest (only this in .claude-plugin/)
   skills/{name}/SKILL.md         # Skills
@@ -102,7 +102,7 @@ my-plugin/
 
 > **Rundown Plugin** (additional directories):
 
-```
+```text
   runbooks/                      # Auto-discovered
   context/                       # Auto-discovered
   rundown-plugin.json            # Rundown plugin config

--- a/docs/implement/claude-code-plugin/QUICK-REFERENCE.md
+++ b/docs/implement/claude-code-plugin/QUICK-REFERENCE.md
@@ -1,0 +1,117 @@
+# Claude Code Plugin Paths: Quick Reference
+
+**Last Updated:** 2026-03-19
+
+> **Goal:** Find what you need in < 30 seconds
+
+---
+
+## Environment Variables
+
+| Variable | Scope | Use For | Persists? | Writable? |
+|----------|-------|---------|-----------|-----------|
+| `${CLAUDE_PLUGIN_ROOT}` | Plugin-wide | Bundled files (scripts, templates, configs) | No | No |
+| `${CLAUDE_PLUGIN_DATA}` | Plugin-wide | Persistent state (deps, caches) | Yes | Yes |
+| `${CLAUDE_SKILL_DIR}` | Skill-specific | Directory containing SKILL.md | — | No |
+| `${CLAUDE_SESSION_ID}` | Session-specific | Current session identifier | — | No |
+| `$ARGUMENTS` | Skill-specific | All arguments passed to skill | — | No |
+| `$ARGUMENTS[N]` / `$N` | Skill-specific | Nth argument (0-indexed) | — | No |
+
+---
+
+## How to Reference Files
+
+| Component | Pattern | Example |
+|-----------|---------|---------|
+| Skill frontmatter (Rundown Plugin) | `runbook: ${CLAUDE_PLUGIN_ROOT}path` | `runbook: ${CLAUDE_PLUGIN_ROOT}runbooks/plan.runbook.md` |
+| Skill body | Inline in markdown | `` Template: `${CLAUDE_PLUGIN_ROOT}templates/review.md` `` |
+| Hook command | In `command` string | `"${CLAUDE_PLUGIN_ROOT}/scripts/lint.sh"` |
+| MCP server | In `command`, `args`, `env`, `cwd` | `"command": "${CLAUDE_PLUGIN_ROOT}/servers/db"` |
+| LSP server | In `command`, `args`, `env` | `"env": { "PATH": "${CLAUDE_PLUGIN_DATA}/bin" }` |
+| Agent body | Inline in markdown | `Rules: ${CLAUDE_PLUGIN_ROOT}/rules/security.md` |
+
+---
+
+## Auto-Discovered vs Explicit
+
+**Standard Claude Code:**
+
+| Directory | Auto-discovered? | Override Location |
+|-----------|-------------------|-------------------|
+| `skills/` | Yes | — |
+| `commands/` | Yes (legacy; use `skills/`) | — |
+| `agents/` | Yes | — |
+| `hooks/hooks.json` | Yes | — |
+| `.mcp.json` | Yes | — |
+| `.lsp.json` | Yes | — |
+| `templates/` | No | Must use `${CLAUDE_PLUGIN_ROOT}templates/...` |
+| `scripts/` | No | Must use `${CLAUDE_PLUGIN_ROOT}scripts/...` |
+
+> **Rundown Plugin:**
+
+| Directory | Auto-discovered? | Override Location |
+|-----------|-------------------|-------------------|
+| `runbooks/` | Yes | `.claude/rundown/runbooks/` (project overrides plugin) |
+| `context/` | Yes | `.claude/context/` (project overrides plugin) |
+
+---
+
+## Quick Diagnosis
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| Path not found after install | External file not in plugin dir | Move file inside plugin root, or symlink it |
+| Path works locally, breaks installed | `--plugin-dir` doesn't cache | Ensure file is in `package.json` `files` array |
+| `${CLAUDE_PLUGIN_ROOT}` not substituted | Wrong context or wrong syntax | Use `${...}` braces; check it's in a supported context |
+| Written files disappear on update | Wrote to `${CLAUDE_PLUGIN_ROOT}` | Use `${CLAUDE_PLUGIN_DATA}` instead |
+| Plugin override not working | Project file missing or wrong name | Check `.claude/context/` or `.claude/rundown/runbooks/` (Rundown Plugin) |
+| MCP server fails to start | Missing `${CLAUDE_PLUGIN_ROOT}` | Use variable for all plugin paths |
+| Hook script not executing | Script not executable | `chmod +x scripts/your-script.sh` |
+| `CLAUDE_PLUGIN_ROOT` not set | Running outside Claude Code | Use `import.meta.url` fallback (see [path-resolution.md](path-resolution.md)) |
+
+---
+
+## Path Rules
+
+1. All paths relative to plugin root, starting with `./` in configs
+2. No `../` traversal outside plugin root
+3. `${CLAUDE_PLUGIN_ROOT}` for read-only bundled files
+4. `${CLAUDE_PLUGIN_DATA}` for persistent writable state
+5. Symlinks honored during cache copy
+6. Project-level overrides plugin-level for context/config/runbooks
+
+---
+
+## Directory Layout
+
+**Standard Claude Code:**
+
+```
+my-plugin/
+  .claude-plugin/plugin.json     # Manifest (only this in .claude-plugin/)
+  skills/{name}/SKILL.md         # Skills
+  commands/{name}.md             # Slash commands (legacy; use skills/)
+  agents/{name}.md               # Subagents
+  hooks/hooks.json               # Hook configuration
+  .mcp.json                      # MCP servers
+  .lsp.json                      # LSP servers
+  settings.json                  # Default settings
+  scripts/                       # Referenced via ${CLAUDE_PLUGIN_ROOT}
+  templates/                     # Referenced via ${CLAUDE_PLUGIN_ROOT}
+```
+
+> **Rundown Plugin** (additional directories):
+
+```
+  runbooks/                      # Auto-discovered
+  context/                       # Auto-discovered
+  rundown-plugin.json            # Rundown plugin config
+```
+
+---
+
+## See Also
+
+- [path-resolution.md](path-resolution.md) - Complete resolution mechanics
+- [skills-and-hooks.md](skills-and-hooks.md) - Detailed examples per component
+- [Official: Plugins reference](https://code.claude.com/docs/en/plugins-reference) - Canonical source

--- a/docs/implement/claude-code-plugin/README.md
+++ b/docs/implement/claude-code-plugin/README.md
@@ -1,0 +1,122 @@
+# Claude Code Plugin: File Path Handling
+
+**Status:** Verified against official docs + source code
+**Last Verified:** 2026-03-19
+
+---
+
+## TL;DR
+
+Claude Code plugins use two environment variables for all file references: `${CLAUDE_PLUGIN_ROOT}` (read-only, points to plugin installation, changes on update) and `${CLAUDE_PLUGIN_DATA}` (read-write, persists across updates). Both are substituted inline in skill content, agent content, hook commands, and MCP/LSP configs. Marketplace plugins are cached to `~/.claude/plugins/cache/`, so path traversal outside the plugin root breaks after installation.
+
+---
+
+## Reading Paths
+
+### Option A: "Just the rules" (2 minutes)
+1. Read [QUICK-REFERENCE.md](QUICK-REFERENCE.md)
+2. Done
+
+### Option B: "I need to build a plugin" (30 minutes)
+1. Read this README
+2. Read [path-resolution.md](path-resolution.md)
+3. Read [plugin-structure.md](plugin-structure.md)
+4. Reference [QUICK-REFERENCE.md](QUICK-REFERENCE.md) during implementation
+
+### Option C: "I'm debugging path issues" (15 minutes)
+1. Read [QUICK-REFERENCE.md](QUICK-REFERENCE.md) diagnosis table
+2. Read [path-resolution.md](path-resolution.md) for the resolution chain
+3. Check [design-decisions.md](design-decisions.md) for caching gotchas
+
+### Option D: "I need the full picture" (1 hour)
+1. Read all documents in sequence (see [00-START-HERE.md](00-START-HERE.md))
+
+---
+
+## Role-Based Paths
+
+### If You're Writing a New Plugin
+**Goal:** Structure files correctly so paths work after marketplace installation
+**Reading order:** [plugin-structure.md](plugin-structure.md) then [skills-and-hooks.md](skills-and-hooks.md) then [QUICK-REFERENCE.md](QUICK-REFERENCE.md)
+**Time:** ~20 minutes
+**Takeaway:** Every file reference must use `${CLAUDE_PLUGIN_ROOT}` or `${CLAUDE_PLUGIN_DATA}`. No `../`, no hardcoded paths.
+
+### If You're Extending an Existing Plugin
+**Goal:** Add skills/hooks that reference bundled files
+**Reading order:** [skills-and-hooks.md](skills-and-hooks.md) then [QUICK-REFERENCE.md](QUICK-REFERENCE.md)
+**Time:** ~10 minutes
+**Takeaway:** Use `${CLAUDE_PLUGIN_ROOT}` in frontmatter and content for bundled files. Use `${CLAUDE_PLUGIN_DATA}` for persistent state.
+
+### If You're Debugging Path Failures
+**Goal:** Understand why a path reference isn't working
+**Reading order:** [path-resolution.md](path-resolution.md) then [design-decisions.md](design-decisions.md)
+**Time:** ~15 minutes
+**Takeaway:** The plugin cache copies files but not external references. Check if your file is in the `files` array and inside the plugin root.
+
+---
+
+## Key Concepts
+
+### Two Environment Variables
+
+| Variable | Purpose | Persists? | Writable? |
+|----------|---------|-----------|-----------|
+| `${CLAUDE_PLUGIN_ROOT}` | Bundled files (scripts, templates, configs) | No (changes on update) | No |
+| `${CLAUDE_PLUGIN_DATA}` | Plugin state (deps, caches, generated files) | Yes (survives updates) | Yes |
+
+**See:** [path-resolution.md](path-resolution.md)
+
+### Plugin Caching
+
+Marketplace plugins are copied to `~/.claude/plugins/cache/`. This means:
+- Files outside the plugin directory are unreachable
+- `${CLAUDE_PLUGIN_ROOT}` changes on every update
+- Only files listed in `package.json` `files` array ship
+
+**See:** [design-decisions.md](design-decisions.md)
+
+### Discovery vs Explicit Reference
+
+Some file types are auto-discovered by convention. Others require explicit `${CLAUDE_PLUGIN_ROOT}` references.
+
+**Standard Claude Code:**
+
+| Type | Auto-discovered? | Reference Pattern |
+|------|-------------------|-------------------|
+| Skills | Yes (`skills/`) | By directory convention |
+| Commands | Yes (`commands/`) | By directory convention (legacy; use `skills/`) |
+| Agents | Yes (`agents/`) | By directory convention |
+| Hooks config | Yes (`hooks/`) | Also via path in `plugin.json` |
+| Templates | No | `${CLAUDE_PLUGIN_ROOT}templates/...` |
+| Scripts | No | `${CLAUDE_PLUGIN_ROOT}scripts/...` |
+
+> **Rundown Plugin:**
+
+| Type | Auto-discovered? | Reference Pattern |
+|------|-------------------|-------------------|
+| Runbooks | Yes (`runbooks/`) | Also via `${CLAUDE_PLUGIN_ROOT}runbooks/...` |
+| Context files | Yes (`context/`) | By naming convention only |
+| Config | No | `rundown-plugin.json` in plugin root or project |
+
+**See:** [plugin-structure.md](plugin-structure.md)
+
+---
+
+## Verification Status
+
+| Document | Status | Notes |
+|----------|--------|-------|
+| [path-resolution.md](path-resolution.md) | Verified | Cross-checked with source code + official docs |
+| [plugin-structure.md](plugin-structure.md) | Verified | Matches `package.json` `files` array and official layout |
+| [skills-and-hooks.md](skills-and-hooks.md) | Verified | Patterns confirmed in rundown plugin source |
+| [design-decisions.md](design-decisions.md) | Verified | Rationale from official docs |
+| [QUICK-REFERENCE.md](QUICK-REFERENCE.md) | Verified | Derived from above documents |
+
+---
+
+## Related Resources
+
+- **Official:** [Create plugins](https://code.claude.com/docs/en/plugins) - Plugin creation guide
+- **Official:** [Plugins reference](https://code.claude.com/docs/en/plugins-reference) - Complete technical spec
+- **Internal:** `packages/claude-code-plugin/` - This project's plugin implementation
+- **Internal:** `packages/cli/src/services/discovery.ts` - Runbook discovery chain

--- a/docs/implement/claude-code-plugin/design-decisions.md
+++ b/docs/implement/claude-code-plugin/design-decisions.md
@@ -1,0 +1,124 @@
+# Design Decisions
+
+Why Claude Code plugin path handling works this way.
+
+---
+
+## Why Two Variables Instead of One?
+
+**Decision:** Separate `${CLAUDE_PLUGIN_ROOT}` (read-only, ephemeral) from `${CLAUDE_PLUGIN_DATA}` (read-write, persistent).
+
+**Why:** Plugin updates replace the entire installation directory. If plugins stored state alongside their code, updates would destroy it. Separating concerns means:
+- Plugin code is always clean (no stale state from previous versions)
+- Plugin data survives updates (caches, installed dependencies, user config)
+- The update path is simple: copy new files, point `CLAUDE_PLUGIN_ROOT` to them
+
+**How to apply:** Never write files to `${CLAUDE_PLUGIN_ROOT}`. Use `${CLAUDE_PLUGIN_DATA}` for anything that should persist.
+
+---
+
+## Why Cache Marketplace Plugins?
+
+**Decision:** Copy marketplace plugins to `~/.claude/plugins/cache/` instead of running them in-place.
+
+**Why:**
+1. **Security:** Plugins are verified before installation. Caching ensures the verified version runs, not a later-modified version.
+2. **Isolation:** Plugins can't interfere with each other's files.
+3. **Reproducibility:** Every user runs the exact same files for a given version.
+
+**Consequence:** Path traversal (`../`) breaks after installation. Files outside the plugin root are not copied. This is intentional — it prevents accidental or malicious access to files beyond the plugin boundary.
+
+**How to apply:** Test with `--plugin-dir` during development, but always verify that paths work after marketplace installation too. If you need external files, use symlinks (they're honored during copy).
+
+---
+
+## Why Inline Variable Substitution?
+
+**Decision:** `${CLAUDE_PLUGIN_ROOT}` and `${CLAUDE_PLUGIN_DATA}` are replaced as literal text in all contexts (skill content, hook commands, MCP configs, etc.), not just as environment variables.
+
+**Why:**
+- Skills and agents are markdown content injected into Claude's context. Environment variables aren't accessible there.
+- Hook commands need the path before shell execution.
+- MCP/LSP configs are JSON — no shell expansion available.
+- A single substitution mechanism works uniformly across all contexts.
+
+**How to apply:** Use `${CLAUDE_PLUGIN_ROOT}` directly in any content string. `$CLAUDE_PLUGIN_ROOT` (without braces) also works in shell command contexts as an environment variable, but the `${}` form is preferred for consistency across all contexts (markdown content, JSON configs, shell commands).
+
+---
+
+## Why Project Overrides Plugin?
+
+**Decision:** For context files, config, and runbook discovery, project-level files take precedence over plugin-level files.
+
+**Why:**
+- Projects have specific needs that differ from plugin defaults
+- Teams should be able to customize plugin behavior per-project
+- Plugin defaults serve as sensible starting points
+
+**Configuration merge example:**
+
+> **Rundown Plugin:** This example uses `rundown-plugin.json`, which is specific to the rundown plugin.
+
+```
+rundown-plugin.json priority:
+1. .claude/rundown-plugin.json (project overrides)
+2. rundown-plugin.json (project root)
+3. ${CLAUDE_PLUGIN_ROOT}/rundown-plugin.json (plugin defaults)
+```
+
+**How to apply:** Ship sensible defaults in the plugin. Document which files can be overridden at the project level.
+
+---
+
+## Why Safe Path Utilities?
+
+**Decision:** All path operations use `safeJoin()`, `sanitizePathSegment()`, `isPathInside()`, and `isValidRunbookPath()`.
+
+**Why:** Plugins accept dynamic inputs (skill names, command names, agent types) that are used to construct file paths. Without validation:
+- A skill named `../../etc/passwd` could escape the plugin directory
+- A hook command could access arbitrary files
+- A namespace prefix could be crafted for path traversal
+
+**Implementation details:**
+- `safeJoin()` throws if the resulting path escapes the base directory
+- `sanitizePathSegment()` replaces `/`, `\` with `_` and `..` with `__`
+- `isValidRunbookPath()` only allows `[a-zA-Z0-9_./\-]` and rejects `..`
+- `resolvePluginPath()` rejects plugin names containing separators
+
+**How to apply:** Never construct paths from user input without sanitization. Use the utilities in `shared/utils.ts`.
+
+---
+
+## Why `execFileSync` for CLI Execution?
+
+**Decision:** Use `execFileSync` (array form) instead of `execSync` (string form) for running the rundown CLI.
+
+**Why:** `execSync` passes commands through a shell, enabling injection. `execFileSync` takes the command and arguments as separate values, preventing interpretation.
+
+```typescript
+// Safe: no shell interpretation
+execFileSyncImpl('node', [cliPath, ...args], options);
+
+// Unsafe: would allow injection via args
+execSync(`node ${cliPath} ${args.join(' ')}`, options);
+```
+
+**Source:** `packages/claude-code-plugin/src/workflow/hooks/rundown.ts`
+
+**How to apply:** Always use `execFileSync` (or equivalent) with array arguments when executing commands from plugin code.
+
+---
+
+## Why `import.meta.url` Fallback?
+
+**Decision:** When `CLAUDE_PLUGIN_ROOT` is not set, compute the plugin root from `import.meta.url`.
+
+**Why:** During development, tests, and some edge cases, Claude Code may not set the environment variable. The fallback ensures the plugin can still find its own files by navigating up from the script's location.
+
+```typescript
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// Traverse up from dist/gates/ to plugin root
+```
+
+**How to apply:** Always check `process.env.CLAUDE_PLUGIN_ROOT` first. Only fall back to `import.meta.url` computation when it's not set.

--- a/docs/implement/claude-code-plugin/design-decisions.md
+++ b/docs/implement/claude-code-plugin/design-decisions.md
@@ -59,7 +59,7 @@ Why Claude Code plugin path handling works this way.
 
 > **Rundown Plugin:** This example uses `rundown-plugin.json`, which is specific to the rundown plugin.
 
-```
+```text
 rundown-plugin.json priority:
 1. .claude/rundown-plugin.json (project overrides)
 2. rundown-plugin.json (project root)

--- a/docs/implement/claude-code-plugin/path-resolution.md
+++ b/docs/implement/claude-code-plugin/path-resolution.md
@@ -1,0 +1,247 @@
+# Path Resolution
+
+How Claude Code resolves file paths in plugins at every layer.
+
+---
+
+## The Two Environment Variables
+
+Claude Code sets two variables automatically when a plugin is loaded. Both are substituted inline wherever they appear — skill content, agent content, hook commands, and MCP/LSP server configs. Both are also exported as environment variables to hook processes and server subprocesses.
+
+### `${CLAUDE_PLUGIN_ROOT}`
+
+The absolute path to the plugin's installation directory.
+
+| Property | Value |
+|----------|-------|
+| **Set by** | Claude Code automatically |
+| **Points to** | Plugin installation directory |
+| **Persists across updates** | No (path changes on update) |
+| **Writable** | No (files written here don't survive updates) |
+| **Use for** | Scripts, templates, configs, binaries bundled with the plugin |
+
+**Example values:**
+- Local dev: `/Users/you/my-plugin` (when using `--plugin-dir`)
+- Installed: `~/.claude/plugins/cache/my-plugin@marketplace/1.0.0/my-plugin` (internal cache directory structure is observable but not officially documented and may change)
+
+### `${CLAUDE_PLUGIN_DATA}`
+
+A persistent directory for plugin state.
+
+| Property | Value |
+|----------|-------|
+| **Set by** | Claude Code automatically |
+| **Points to** | `~/.claude/plugins/data/{id}/` |
+| **Persists across updates** | Yes |
+| **Writable** | Yes |
+| **Use for** | `node_modules`, venvs, caches, generated files |
+| **Created** | Automatically on first reference |
+| **Cleaned up** | On uninstall from last scope (unless `--keep-data`) |
+
+The `{id}` is the plugin identifier with characters outside `a-z`, `A-Z`, `0-9`, `_`, `-` replaced by `-`. For `formatter@my-marketplace`, the directory is `~/.claude/plugins/data/formatter-my-marketplace/`.
+
+---
+
+## Variable Substitution
+
+Both variables are substituted as **literal text replacement** anywhere they appear:
+
+```json
+{
+  "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh",
+  "env": {
+    "CACHE_DIR": "${CLAUDE_PLUGIN_DATA}/cache"
+  }
+}
+```
+
+**All substitution variables:**
+
+| Variable | Scope | Description |
+|----------|-------|-------------|
+| `${CLAUDE_PLUGIN_ROOT}` | Plugin-wide | Plugin installation directory |
+| `${CLAUDE_PLUGIN_DATA}` | Plugin-wide | Persistent data directory |
+| `${CLAUDE_SKILL_DIR}` | Skill-specific | Directory containing SKILL.md |
+| `${CLAUDE_SESSION_ID}` | Session-specific | Current session identifier |
+| `$ARGUMENTS` | Skill-specific | All arguments passed to skill |
+| `$ARGUMENTS[N]` | Skill-specific | Nth argument (0-indexed) |
+| `$N` | Skill-specific | Shorthand for `$ARGUMENTS[N]` |
+
+**Substitution contexts:**
+- Skill `.md` content (body text)
+- Skill frontmatter fields (e.g., `runbook:`, `template:`)
+- Agent `.md` content
+- Hook `command` strings
+- MCP server `command`, `args`, `env`, `cwd` fields
+- LSP server `command`, `args`, `env` fields
+
+---
+
+## Fallback When `CLAUDE_PLUGIN_ROOT` Is Not Set
+
+In development or testing, `CLAUDE_PLUGIN_ROOT` might not be set. The rundown plugin computes it from the script's own location:
+
+```typescript
+// gates/plugin-path.ts
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function computePluginRoot(): string {
+  // File is at: dist/gates/plugin-path.js
+  // Go up 2 directories: gates/ -> dist/ -> plugin root
+  let pluginRoot = path.dirname(__dirname);
+  pluginRoot = path.dirname(pluginRoot);
+  return pluginRoot;
+}
+```
+
+**Source:** `packages/claude-code-plugin/src/gates/plugin-path.ts`
+
+This pattern (`import.meta.url` + directory traversal) is the standard fallback.
+
+Note: `context.ts` has its own independent `getPluginRoot()` fallback (separate from `plugin-path.ts`), using a similar directory traversal approach. Both produce correct results.
+
+---
+
+## Rundown Plugin: Runbook Discovery Chain
+
+> **Rundown Plugin:** Runbook discovery is a Rundown feature, not a standard Claude Code plugin capability.
+
+Runbooks are auto-discovered from multiple sources with priority:
+
+| Priority | Source | Location |
+|----------|--------|----------|
+| 1 (highest) | Project | `.claude/rundown/runbooks/` |
+| 2 | Plugin | `${CLAUDE_PLUGIN_ROOT}/runbooks/` |
+| 3 (lowest) | Bundled | CLI package `dist/runbooks/` |
+
+Directories are scanned recursively. Subdirectory structures like `planning/write-plan.runbook.md` are supported.
+
+### Namespace Syntax
+
+| Syntax | Resolution |
+|--------|------------|
+| `write-plan` | Priority chain: project, plugin, bundled |
+| `rundown:write-plan` | Explicit: plugin source only |
+
+The `findRunbookByName` resolver matches against both frontmatter `name` and filename-derived stem (slug-normalized).
+
+**Source:** `packages/cli/src/helpers/resolve-runbook.ts`, `packages/cli/src/services/discovery.ts`
+
+---
+
+## Rundown Plugin: Context File Discovery
+
+> **Rundown Plugin:** This section documents the rundown plugin's context injection system. This is NOT a standard Claude Code feature.
+
+Context files inject content based on hook events. Discovery follows a priority chain:
+
+### Standard Context (skills, commands, tools)
+
+| Priority | Location |
+|----------|----------|
+| 1 | `.claude/context/{name}-{stage}.md` (project) |
+| 2 | `.claude/context/slash-command/{name}-{stage}.md` |
+| 3 | `.claude/context/slash-command/{name}/{stage}.md` |
+| 4 | `.claude/context/skill/{name}-{stage}.md` |
+| 5 | `.claude/context/skill/{name}/{stage}.md` |
+| 6 | `${CLAUDE_PLUGIN_ROOT}/context/{name}-{stage}.md` (plugin, same variations) |
+
+### Agent-Command Context (SubagentStop)
+
+| Priority | Location |
+|----------|----------|
+| 1 | `.claude/context/{agent}-{command}-{stage}.md` (project, most specific) |
+| 2 | `.claude/context/{agent}-{stage}.md` (project, agent-specific) |
+| 3 | `${CLAUDE_PLUGIN_ROOT}/context/{agent}-{command}-{stage}.md` (plugin) |
+| 4 | `${CLAUDE_PLUGIN_ROOT}/context/{agent}-{stage}.md` (plugin) |
+| 5 | Standard discovery (backward compat) |
+
+### Supported Events
+
+The `extractNameAndStage` function maps the following hook events to context file lookups:
+
+| Event | Name | Stage |
+|-------|------|-------|
+| `SlashCommandStart` | command name | `start` |
+| `SlashCommandEnd` | command name | `end` |
+| `SkillStart` | skill name | `start` |
+| `SkillEnd` | skill name | `end` |
+| `PreToolUse` | tool name | `pre` |
+| `PostToolUse` | tool name | `post` |
+| `PostToolUseFailure` | tool name | `post` |
+| `SubagentStart` | agent type | `start` |
+| `SubagentStop` | (special handling) | — |
+| `UserPromptSubmit` | `prompt` | `submit` |
+| `Stop` | `agent` | `stop` |
+| `SessionStart` | `session` | `start` |
+| `SessionEnd` | `session` | `end` |
+| `Notification` | `notification` | `receive` |
+
+`SubagentStop` uses special agent-command context discovery rather than the standard name-stage pattern.
+
+**Source:** `packages/claude-code-plugin/src/context.ts`
+
+---
+
+## Rundown Plugin: Skill Runbook Resolution
+
+> **Rundown Plugin:** This section documents how the rundown plugin resolves runbook references from skill frontmatter. This is NOT a standard Claude Code feature.
+
+When a skill starts, the plugin:
+
+1. Receives skill name from hook event
+2. Strips namespace prefix (e.g., `rundown:writing-plans` becomes `writing-plans`)
+3. Sanitizes the name (path separators replaced with `_`)
+4. Searches for `SKILL.md` at:
+   - `${CLAUDE_PLUGIN_ROOT}/skills/{name}/SKILL.md` (plugin first)
+   - `.claude/skills/{name}/SKILL.md` (project second)
+5. Parses YAML frontmatter for `runbook:` field
+6. Validates the runbook path against `/^[\w./-]+$/` (rejects `..`)
+7. Executes via `rundown run <runbook>`
+
+Note: Skill SKILL.md resolution searches the plugin root first, then the project directory. This is the opposite of context and config resolution, which search the project first.
+
+**Source:** `packages/claude-code-plugin/src/gates/on-skill-start.ts`, `packages/claude-code-plugin/src/shared/find-runbook.ts`
+
+---
+
+## Rundown Plugin: Config File Resolution
+
+> **Rundown Plugin:** The `rundown-plugin.json` config is specific to the rundown plugin, not a standard Claude Code feature.
+
+Plugin configuration (`rundown-plugin.json`) is discovered from multiple locations:
+
+| Priority | Location |
+|----------|----------|
+| 1 (highest) | `.claude/rundown-plugin.json` (project) |
+| 2 | `rundown-plugin.json` (project root) |
+| 3 (lowest) | `${CLAUDE_PLUGIN_ROOT}/rundown-plugin.json` (plugin defaults) |
+
+Paths 1 and 2 are alternatives — the first project-level config found wins (the search breaks on first match). The winning project config is then merged with the plugin config (path 3), with project values overriding plugin defaults for the same keys.
+
+**Source:** `packages/claude-code-plugin/src/shared/config.ts`
+
+---
+
+## Security Constraints
+
+All path operations enforce boundaries:
+
+| Utility | Purpose | Location |
+|---------|---------|----------|
+| `isPathInside(base, target)` | Ensures target stays within base | `shared/utils.ts` |
+| `safeJoin(base, ...segments)` | Joins paths with boundary check, throws on escape | `shared/utils.ts` |
+| `sanitizePathSegment(segment)` | Replaces `/`, `\` with `_`, `..` with `__` | `shared/utils.ts` |
+| `isValidRunbookPath(path)` | Pattern `/^[\w./-]+$/`, rejects `..` | `shared/validate-runbook-path.ts` |
+| `shellEscape(str)` | Escapes `"`, `` ` ``, `\`, `$` | `shared/utils.ts` |
+
+### Plugin Name Validation
+
+`resolvePluginPath()` rejects names containing `/`, `\`, or `..`, and the exact names `.` and `..`. Single dots within compound names (e.g., `my.plugin`) are allowed.
+
+### CLI Execution Safety
+
+`rundown()` uses `execFileSync` (array form) to prevent shell injection. No shell interpretation occurs.
+
+**Source:** `packages/claude-code-plugin/src/shared/utils.ts`, `packages/claude-code-plugin/src/shared/validate-runbook-path.ts`, `packages/claude-code-plugin/src/shared/config.ts`, `packages/claude-code-plugin/src/workflow/hooks/rundown.ts`

--- a/docs/implement/claude-code-plugin/plugin-structure.md
+++ b/docs/implement/claude-code-plugin/plugin-structure.md
@@ -6,7 +6,7 @@ How to organize a Claude Code plugin so file references work correctly.
 
 ## Standard Layout
 
-```
+```text
 my-plugin/
   .claude-plugin/
     plugin.json              # Manifest (name, version, description)
@@ -35,7 +35,7 @@ my-plugin/
 
 > **Rundown Plugin:** The following directories are specific to the rundown plugin, not standard Claude Code components.
 
-```
+```text
 my-plugin/
   runbooks/                  # Auto-discovered runbooks
     planning/
@@ -94,7 +94,7 @@ For marketplace plugins, the entire plugin directory is copied to `~/.claude/plu
 
 Marketplace-installed plugins are copied to `~/.claude/plugins/cache/` rather than used in-place:
 
-```
+```text
 ~/.claude/plugins/cache/
   my-plugin@my-marketplace/
     1.0.0/
@@ -166,7 +166,7 @@ Full:
 
 The `@rundown-org/claude-code-plugin` uses this layout:
 
-```
+```text
 packages/claude-code-plugin/
   .claude-plugin/
     plugin.json                    # name: "rundown"

--- a/docs/implement/claude-code-plugin/plugin-structure.md
+++ b/docs/implement/claude-code-plugin/plugin-structure.md
@@ -1,0 +1,200 @@
+# Plugin Directory Structure
+
+How to organize a Claude Code plugin so file references work correctly.
+
+---
+
+## Standard Layout
+
+```
+my-plugin/
+  .claude-plugin/
+    plugin.json              # Manifest (name, version, description)
+  commands/                  # Slash commands (legacy; use skills/ for new skills)
+    status.md
+  agents/                    # Subagent definitions
+    reviewer.md
+  skills/                    # Skills (each subdirectory has SKILL.md)
+    code-review/
+      SKILL.md
+      scripts/               # Supporting files alongside SKILL.md
+  hooks/
+    hooks.json               # Hook configuration
+  .mcp.json                  # MCP server definitions
+  .lsp.json                  # LSP server configurations
+  settings.json              # Default settings (only "agent" key supported)
+  scripts/                   # Hook and utility scripts
+    format-code.sh
+  templates/                 # Templates referenced by skills
+    review.md
+  README.md
+  LICENSE
+```
+
+### Rundown Plugin: Additional Directories
+
+> **Rundown Plugin:** The following directories are specific to the rundown plugin, not standard Claude Code components.
+
+```
+my-plugin/
+  runbooks/                  # Auto-discovered runbooks
+    planning/
+      write-plan.runbook.md
+  context/                   # Auto-discovered context injection files
+    prompt-submit.md
+  rundown-plugin.json        # Rundown plugin configuration
+```
+
+Note: The `context/` directory is aspirational — no files currently ship with the rundown plugin, and it is not listed in the `package.json` `files` array.
+
+### Critical Rules
+
+1. **Only `plugin.json` goes inside `.claude-plugin/`**. All component directories (`commands/`, `agents/`, `skills/`, `hooks/`) must be at the plugin root.
+
+2. **Auto-discovered directories** are found by convention:
+   - `commands/` - Slash commands (legacy; use `skills/` for new skills)
+   - `agents/` - Subagent definitions
+   - `skills/` - Agent Skills
+   - `hooks/hooks.json` - Hook config
+   - `.mcp.json` - MCP servers
+   - `.lsp.json` - LSP servers
+
+3. **Custom paths supplement, not replace**. If you specify `"commands": "./custom/cmd.md"` in `plugin.json`, the default `commands/` directory is still scanned.
+
+---
+
+## What Gets Published
+
+For npm-based plugins, only files listed in `package.json` `files` array are included:
+
+```json
+{
+  "files": [
+    "dist",
+    ".claude-plugin",
+    "commands",
+    "hooks",
+    "runbooks",
+    "rundown-plugin.json",
+    "scripts",
+    "skills",
+    "templates",
+    "README.md"
+  ]
+}
+```
+
+**Source:** `packages/claude-code-plugin/package.json`
+
+For marketplace plugins, the entire plugin directory is copied to `~/.claude/plugins/cache/`. Only files physically inside the directory are included.
+
+---
+
+## Plugin Caching
+
+Marketplace-installed plugins are copied to `~/.claude/plugins/cache/` rather than used in-place:
+
+```
+~/.claude/plugins/cache/
+  my-plugin@my-marketplace/
+    1.0.0/
+      my-plugin/
+        .claude-plugin/
+        skills/
+        ...
+```
+
+### Implications
+
+| Behavior | Implication |
+|----------|-------------|
+| Files are copied | External references (`../shared/`) break |
+| `${CLAUDE_PLUGIN_ROOT}` changes on update | Don't write files there |
+| Symlinks are honored during copy | Use symlinks for shared dependencies |
+| Cache is local to the user | Different users have different absolute paths |
+
+### `--plugin-dir` Bypasses Caching
+
+During development, `--plugin-dir ./my-plugin` uses the directory in-place. No copying occurs. This means:
+- `../` references may work locally but break after installation
+- Changes are picked up immediately (use `/reload-plugins`)
+- This is the recommended development workflow
+- When a local plugin has the same name as a marketplace plugin, the local takes precedence. Exception: marketplace plugins force-enabled by managed settings cannot be overridden.
+
+---
+
+## Manifest (`plugin.json`)
+
+Minimal:
+```json
+{
+  "name": "my-plugin"
+}
+```
+
+Full:
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "description": "What this plugin does",
+  "author": { "name": "You", "email": "you@example.com" },
+  "homepage": "https://docs.example.com",
+  "repository": "https://github.com/you/plugin",
+  "license": "MIT",
+  "keywords": ["deployment", "ci-cd"],
+  "commands": ["./custom/commands/deploy.md"],
+  "agents": "./custom/agents/",
+  "skills": "./custom/skills/",
+  "hooks": "./config/hooks.json",
+  "mcpServers": "./mcp-config.json",
+  "lspServers": "./.lsp.json",
+  "outputStyles": "./styles/"
+}
+```
+
+### Path Rules in `plugin.json`
+
+- All paths must be relative to plugin root
+- All paths must start with `./`
+- Path traversal outside plugin root is rejected
+- Paths supplement default locations (don't replace them)
+
+---
+
+## Rundown Plugin: Concrete Example
+
+The `@rundown-org/claude-code-plugin` uses this layout:
+
+```
+packages/claude-code-plugin/
+  .claude-plugin/
+    plugin.json                    # name: "rundown"
+  dist/                            # Compiled TypeScript
+  skills/
+    writing-plans/SKILL.md         # runbook: ${CLAUDE_PLUGIN_ROOT}runbooks/planning/write-plan.runbook.md
+    verifying-by-consensus/SKILL.md
+    running-runbooks/SKILL.md
+    delegating-work/SKILL.md
+    writing-runbooks/SKILL.md
+  runbooks/
+    planning/write-plan.runbook.md
+    code-review/...
+    create-worktree.runbook.md
+  templates/
+    planning/plan.template.md      # Referenced via ${CLAUDE_PLUGIN_ROOT}templates/...
+    verify-review.md
+    verify-collation.md
+  hooks/
+    hooks.json
+  scripts/
+  commands/
+  context/
+  rundown-plugin.json              # Gate and hook configuration
+```
+
+Key patterns:
+- Skills reference runbooks and templates via `${CLAUDE_PLUGIN_ROOT}`
+- Runbooks are auto-discovered from the `runbooks/` directory
+- Context files are auto-discovered from the `context/` directory
+- Config merges plugin defaults with project overrides

--- a/docs/implement/claude-code-plugin/skills-and-hooks.md
+++ b/docs/implement/claude-code-plugin/skills-and-hooks.md
@@ -63,7 +63,7 @@ Claude Code substitutes the variable before the content reaches the model.
 
 Skills can include supporting files alongside `SKILL.md`:
 
-```
+```text
 skills/
   pdf-processor/
     SKILL.md

--- a/docs/implement/claude-code-plugin/skills-and-hooks.md
+++ b/docs/implement/claude-code-plugin/skills-and-hooks.md
@@ -1,0 +1,268 @@
+# Referencing Files from Skills, Hooks, and Configs
+
+Patterns for referencing bundled files from each plugin component.
+
+---
+
+## Skills
+
+### Standard Skill Frontmatter Fields
+
+All standard Claude Code skill frontmatter fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Skill name |
+| `description` | string | When to use this skill |
+| `argument-hint` | string | Placeholder text for arguments |
+| `disable-model-invocation` | boolean | Prevent model auto-invocation |
+| `user-invocable` | boolean | Whether users can invoke directly |
+| `allowed-tools` | string[] | Restrict available tools |
+| `model` | string | Override model for this skill |
+| `context` | string | Set to `fork` for subagent execution |
+| `agent` | string | Subagent type (when `context: fork`) |
+| `hooks` | object | Lifecycle hooks scoped to this skill |
+
+> **Rundown Plugin:** The `runbook:` and `template:` frontmatter fields are specific to the rundown plugin, not standard Claude Code features. See [Rundown-Specific: Runbook References in Frontmatter](#rundown-specific-runbook-references-in-frontmatter) below.
+
+### Frontmatter References
+
+Skills use `${CLAUDE_PLUGIN_ROOT}` in YAML frontmatter to declare associated files:
+
+```yaml
+---
+name: writing-plans
+description: Write implementation plans
+runbook: ${CLAUDE_PLUGIN_ROOT}runbooks/planning/write-plan.runbook.md
+template: ${CLAUDE_PLUGIN_ROOT}templates/planning/plan.template.md
+---
+```
+
+The `runbook:` field is special — the plugin parses it and auto-starts the runbook when the skill begins.
+
+Other frontmatter fields (like `template:`) are passed through as part of the skill content. Claude sees the substituted path and can read the file.
+
+**Source:** `packages/claude-code-plugin/skills/writing-plans/SKILL.md`
+
+### Body References
+
+Reference files anywhere in the skill body text:
+
+```markdown
+## Templates
+
+Review template: `${CLAUDE_PLUGIN_ROOT}templates/verify-review.md`
+Collation template: `${CLAUDE_PLUGIN_ROOT}templates/verify-collation.md`
+```
+
+Claude Code substitutes the variable before the content reaches the model.
+
+**Source:** `packages/claude-code-plugin/skills/verifying-by-consensus/SKILL.md`
+
+### Supporting Files
+
+Skills can include supporting files alongside `SKILL.md`:
+
+```
+skills/
+  pdf-processor/
+    SKILL.md
+    reference.md        # Supporting documentation
+    scripts/
+      process.sh        # Supporting scripts
+```
+
+Reference them via `${CLAUDE_PLUGIN_ROOT}skills/pdf-processor/reference.md`.
+
+---
+
+## Hooks
+
+### Hook Handler Types
+
+Claude Code supports four hook handler types:
+
+| Type | Description |
+|------|-------------|
+| `command` | Execute shell command/script |
+| `http` | POST event JSON to a URL |
+| `prompt` | Evaluate prompt with LLM (uses `$ARGUMENTS`) |
+| `agent` | Run agentic verifier with tools |
+
+Claude Code supports 22+ hook events. See the [official plugins reference](https://code.claude.com/docs/en/plugins-reference) for the full event list.
+
+> **Rundown Plugin:** The rundown plugin uses a single CLI dispatcher (`dist/cli.js`) for all events, rather than per-event scripts. The examples below show the general Claude Code pattern.
+
+### Command Hooks
+
+Hook commands use `${CLAUDE_PLUGIN_ROOT}` to reference scripts:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format-code.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The variable is substituted before the command is executed. Scripts must be executable (`chmod +x`).
+
+### Persistent Dependencies in Hooks
+
+Use `${CLAUDE_PLUGIN_DATA}` for dependencies that should survive plugin updates:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "diff -q \"${CLAUDE_PLUGIN_ROOT}/package.json\" \"${CLAUDE_PLUGIN_DATA}/package.json\" >/dev/null 2>&1 || (cd \"${CLAUDE_PLUGIN_DATA}\" && cp \"${CLAUDE_PLUGIN_ROOT}/package.json\" . && npm install) || rm -f \"${CLAUDE_PLUGIN_DATA}/package.json\""
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This pattern:
+1. Compares bundled `package.json` against stored copy
+2. Reinstalls on first run or when dependencies change
+3. Cleans up on failure so next session retries
+
+---
+
+## MCP Servers
+
+MCP server configs use both variables for commands, args, env, and cwd:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/servers/my-server",
+      "args": ["--config", "${CLAUDE_PLUGIN_ROOT}/config.json"],
+      "env": {
+        "DB_PATH": "${CLAUDE_PLUGIN_DATA}/data"
+      },
+      "cwd": "${CLAUDE_PLUGIN_ROOT}"
+    }
+  }
+}
+```
+
+For servers using persisted `node_modules`:
+
+```json
+{
+  "mcpServers": {
+    "routines": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server.js"],
+      "env": {
+        "NODE_PATH": "${CLAUDE_PLUGIN_DATA}/node_modules"
+      }
+    }
+  }
+}
+```
+
+---
+
+## LSP Servers
+
+LSP configs support the same variable substitution:
+
+```json
+{
+  "go": {
+    "command": "gopls",
+    "args": ["serve"],
+    "extensionToLanguage": {
+      ".go": "go"
+    },
+    "env": {
+      "GOPATH": "${CLAUDE_PLUGIN_DATA}/gopath"
+    }
+  }
+}
+```
+
+Note: LSP servers require the language server binary to be installed on the user's machine. The plugin configures the connection, not the server itself.
+
+Additional optional LSP fields include `transport`, `initializationOptions`, `settings`, `workspaceFolder`, `startupTimeout`, `shutdownTimeout`, `restartOnCrash`, and `maxRestarts`. See the [official plugins reference](https://code.claude.com/docs/en/plugins-reference) for details.
+
+---
+
+## Agents
+
+Agent content supports the same variable substitution:
+
+```markdown
+---
+name: security-reviewer
+description: Reviews code for security issues
+---
+
+Use the security rules at `${CLAUDE_PLUGIN_ROOT}/rules/security-rules.md` for reference.
+```
+
+See also: [official subagents documentation](https://code.claude.com/docs/en/plugins-reference#agents).
+
+---
+
+## Rundown Plugin: Context File Discovery
+
+> **Rundown Plugin:** Context file discovery is implemented by the rundown plugin's hook dispatcher. This is NOT a standard Claude Code feature.
+
+Context files are auto-discovered by naming convention. They do NOT use `${CLAUDE_PLUGIN_ROOT}` in their content — they are found by their location.
+
+**Plugin context files go in:** `<plugin-root>/context/`
+
+| File Pattern | Triggers On |
+|-------------|-------------|
+| `{name}-start.md` | Skill/command start |
+| `{name}-end.md` | Skill/command end |
+| `{tool}-pre.md` | Before tool use |
+| `{tool}-post.md` | After tool use |
+| `prompt-submit.md` | User prompt submission |
+| `session-start.md` | Session start |
+| `{agent}-{command}-end.md` | Agent-command scoped stop |
+
+Project-level context files (in `.claude/context/`) override plugin-level context files with the same name.
+
+---
+
+## Rundown-Specific: Runbook References in Frontmatter
+
+The rundown plugin's skill gate parses `runbook:` from SKILL.md frontmatter:
+
+```yaml
+runbook: ${CLAUDE_PLUGIN_ROOT}runbooks/planning/write-plan.runbook.md
+```
+
+Processing flow:
+1. `on-skill-start.ts` receives the SkillStart event
+2. `findRunbookByFrontmatter()` searches plugin then project for `SKILL.md`
+3. `parseRunbookFromFrontmatter()` extracts the `runbook:` field
+4. `isValidRunbookPath()` validates against `/^[\w./-]+$/` (rejects `..`)
+5. `rundown(['run', runbook], cwd)` executes via `execFileSync`
+
+**Source:** `packages/claude-code-plugin/src/gates/on-skill-start.ts`
+
+Note: The `runbook:` frontmatter field is specific to the rundown plugin, not a standard Claude Code feature. Standard skills use `${CLAUDE_PLUGIN_ROOT}` in the body text for file references.
+
+Note: The `verifying-by-consensus` skill uses `workflow:` instead of `runbook:` in its frontmatter. The `workflow:` field is NOT parsed by `parseRunbookFromFrontmatter()` — it serves as a documentation-only field, not an auto-start trigger.

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -462,6 +462,60 @@ describe('expandLoopVariablesForCommand', () => {
     };
     expect(expandLoopVariables('Index={{context.parent.index}}', variables)).toBe('Index=7');
   });
+
+  // Progressive prefix matching: flattened dotted keys with object values
+  it('resolves dotted path through flattened key holding an object', () => {
+    const variables: Record<string, unknown> = {
+      'context.vars.config': { host: 'localhost', port: 5432 },
+    };
+    expect(expandLoopVariables('Host: {{context.vars.config.host}}', variables)).toBe(
+      'Host: localhost',
+    );
+  });
+
+  it('resolves deep path through flattened key holding nested object', () => {
+    const variables: Record<string, unknown> = {
+      'context.vars.config': { db: { host: 'pg.local', port: 5432 } },
+    };
+    expect(expandLoopVariables('DB: {{context.vars.config.db.host}}', variables)).toBe(
+      'DB: pg.local',
+    );
+  });
+
+  it('resolves context.parent.vars through flattened key', () => {
+    const variables: Record<string, unknown> = {
+      'context.parent.vars.config': { host: 'parent-host' },
+    };
+    expect(
+      expandLoopVariables('Parent: {{context.parent.vars.config.host}}', variables),
+    ).toBe('Parent: parent-host');
+  });
+
+  it('prefers exact key over progressive prefix match', () => {
+    const variables: Record<string, unknown> = {
+      'context.vars.config.host': 'exact-match',
+      'context.vars.config': { host: 'from-object' },
+    };
+    expect(expandLoopVariables('{{context.vars.config.host}}', variables)).toBe('exact-match');
+  });
+
+  it('renders flattened object key as JSON when no remainder path', () => {
+    const variables: Record<string, unknown> = {
+      'context.vars.config': { host: 'localhost' },
+    };
+    expect(expandLoopVariables('{{context.vars.config}}', variables)).toBe(
+      '{"host":"localhost"}',
+    );
+  });
+
+  it('preserves placeholder when flattened key value lacks the remainder path', () => {
+    const variables: Record<string, unknown> = {
+      'context.vars.config': { host: 'localhost' },
+    };
+    expect(expandLoopVariables('{{context.vars.config.missing}}', variables)).toBe(
+      '{{context.vars.config.missing}}',
+    );
+  });
 });
 
 describe('collectUnresolvedVariables', () => {

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -486,9 +486,9 @@ describe('expandLoopVariablesForCommand', () => {
     const variables: Record<string, unknown> = {
       'context.parent.vars.config': { host: 'parent-host' },
     };
-    expect(
-      expandLoopVariables('Parent: {{context.parent.vars.config.host}}', variables),
-    ).toBe('Parent: parent-host');
+    expect(expandLoopVariables('Parent: {{context.parent.vars.config.host}}', variables)).toBe(
+      'Parent: parent-host',
+    );
   });
 
   it('prefers exact key over progressive prefix match', () => {
@@ -503,9 +503,7 @@ describe('expandLoopVariablesForCommand', () => {
     const variables: Record<string, unknown> = {
       'context.vars.config': { host: 'localhost' },
     };
-    expect(expandLoopVariables('{{context.vars.config}}', variables)).toBe(
-      '{"host":"localhost"}',
-    );
+    expect(expandLoopVariables('{{context.vars.config}}', variables)).toBe('{"host":"localhost"}');
   });
 
   it('preserves placeholder when flattened key value lacks the remainder path', () => {

--- a/packages/cli/src/services/renderers/text-renderer.ts
+++ b/packages/cli/src/services/renderers/text-renderer.ts
@@ -481,7 +481,8 @@ export class TextRenderer implements OutputRenderer {
       this.writer.writeLine('Variables:');
       const maxKeyLen = Math.max(...Object.keys(variables).map((k) => k.length));
       for (const [key, value] of Object.entries(variables)) {
-        this.writer.writeLine(`  ${key.padEnd(maxKeyLen + 2)}${value}`);
+        const display = typeof value === 'object' ? JSON.stringify(value) : String(value);
+        this.writer.writeLine(`  ${key.padEnd(maxKeyLen + 2)}${display}`);
       }
     }
 

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -118,9 +118,12 @@ function renderTemplateValue(value: unknown): string {
  *
  * Resolution order:
  * 1. Exact key match (supports flattened dotted keys like "context.parent.index")
- * 2. Dotted traversal from a root object key
+ * 2. Progressive prefix matching — tries each dotted prefix as a potential key,
+ *    then traverses the remainder via dotted path into the value. This handles
+ *    flattened dotted keys whose values are objects (e.g. `context.vars.config`
+ *    holding `{host: "localhost"}` resolves `context.vars.config.host`).
  *
- * @param path - Placeholder path (e.g. `item.name`, `context.ancestors.0.step`)
+ * @param path - Placeholder path (e.g. `item.name`, `context.vars.config.host`)
  * @param variables - Runtime/template variable map
  * @returns Rendered value string or undefined when unresolved
  */
@@ -133,17 +136,24 @@ function resolveTemplatePath(path: string, variables: Record<string, unknown>): 
     return undefined;
   }
 
-  const [rootVar, ...pathSegments] = path.split('.');
-  if (!Object.hasOwn(variables, rootVar)) {
-    return undefined;
+  // Try progressively longer key prefixes.
+  // For "context.vars.config.host", tries:
+  //   prefix="context"             remainder="vars.config.host"
+  //   prefix="context.vars"        remainder="config.host"
+  //   prefix="context.vars.config" remainder="host"
+  const segments = path.split('.');
+  for (let i = 1; i < segments.length; i++) {
+    const prefix = segments.slice(0, i).join('.');
+    if (!Object.hasOwn(variables, prefix)) continue;
+
+    const remainder = segments.slice(i).join('.');
+    const resolved = resolveDottedPath(variables[prefix], remainder);
+    if (resolved !== undefined) {
+      return renderTemplateValue(resolved);
+    }
   }
 
-  const resolved = resolveDottedPath(variables[rootVar], pathSegments.join('.'));
-  if (resolved === undefined) {
-    return undefined;
-  }
-
-  return renderTemplateValue(resolved);
+  return undefined;
 }
 
 /**

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -15,6 +15,7 @@
  */
 
 import { z } from 'zod';
+import { TemplateVarValueSchema } from '../schemas.js';
 
 // ============================================================================
 // CLI Error Codes
@@ -486,7 +487,10 @@ export const ResolveResponseSchema = z
     /** Runbook statistics (only present when structurally valid) */
     stats: RunbookStatsSchema.optional().describe('Runbook statistics'),
     /** Resolved template variables */
-    variables: z.record(z.string(), z.string()).optional().describe('Resolved template variables'),
+    variables: z
+      .record(z.string(), TemplateVarValueSchema)
+      .optional()
+      .describe('Resolved template variables'),
     /** Data sources for FOR loop iteration */
     sources: z
       .record(z.string(), ResolveSourceInfoSchema)


### PR DESCRIPTION
Separate Rundown-specific features from standard Claude Code plugin API with consistent blockquote markers. Fix factual inaccuracies (isValidRunbookPath location, resolvePluginPath behavior, config first-found-wins). Add missing standard features (CLAUDE_SKILL_DIR, $ARGUMENTS, hook handler types, LSP optional fields, outputStyles, settings.json). Add implementation nuances (skill resolution order, independent getPluginRoot fallback, dispatcher pattern).

Based on dual-verification review findings (30 issues: 6 common, 19 validated exclusive, 3 invalidated, 2 uncertain addressed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Claude Code Plugin docs suite covering getting-started, quick reference, README, design decisions, path resolution, plugin structure, skills & hooks, reading order, and package contents.

* **Bug Fix / Improvement**
  * Template rendering: improved dotted-placeholder resolution with progressive prefix matching and exact-match precedence.
  * Text output: structured variable values are now serialized (JSON) for clearer display.

* **Tests**
  * Added tests covering progressive prefix matching and precedence behavior.

* **Other**
  * Validation: response variables now accept structured template value types.
  * Spelling dictionary expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->