### PR TITLE
Json template vars

### DIFF
--- a/packages/cli/__tests__/commands/resolve.test.ts
+++ b/packages/cli/__tests__/commands/resolve.test.ts
@@ -71,7 +71,7 @@ Server on port {{ port }} in {{ environment }} mode.
 
     expect(output.valid).toBe(true);
     expect(output.variables).toHaveProperty('environment', 'development');
-    expect(output.variables).toHaveProperty('port', '3000');
+    expect(output.variables).toHaveProperty('port', 3000);
   });
 
   it('resolves with --var flags — CLI vars override frontmatter', async () => {

--- a/packages/cli/__tests__/helpers/option-utils.test.ts
+++ b/packages/cli/__tests__/helpers/option-utils.test.ts
@@ -87,13 +87,9 @@ describe('parseVarJsonOption', () => {
     expect(result).toEqual(['items=["a","b"]']);
   });
 
-  it('throws InvalidArgumentError for JSON objects', () => {
-    expect(() => parseVarJsonOption('config={"host":"localhost"}', [])).toThrow(
-      InvalidArgumentError,
-    );
-    expect(() => parseVarJsonOption('config={"host":"localhost"}', [])).toThrow(
-      /must be scalars or arrays, not objects/,
-    );
+  it('accepts JSON objects (passthrough for downstream routing)', () => {
+    const result = parseVarJsonOption('config={"host":"localhost"}', []);
+    expect(result).toEqual(['config={"host":"localhost"}']);
   });
 
   it('accepts valid JSON number', () => {

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -142,9 +142,8 @@ const {
 } = await import('../../src/services/template-renderer');
 const { validateFrontmatterVars } = await import('../../src/helpers/validate-frontmatter-vars');
 const fsPromises = await import('node:fs/promises');
-const { validateSources, prepareRunbook, startRunbook } = await import(
-  '../../src/helpers/runbook-pipeline'
-);
+const { validateSources, prepareRunbook, startRunbook, buildContextVars, buildTemplateVars } =
+  await import('../../src/helpers/runbook-pipeline');
 
 function makeState(id: string, overrides: Record<string, unknown> = {}): any {
   return {
@@ -1188,5 +1187,63 @@ describe('claimAndLaunch', () => {
         prompted: true,
       }),
     );
+  });
+});
+
+describe('buildContextVars', () => {
+  it('creates context.vars.* aliases for string values', () => {
+    const result = buildContextVars({ env: 'prod', version: '1.0' });
+    expect(result['context.vars.env']).toBe('prod');
+    expect(result['context.vars.version']).toBe('1.0');
+  });
+
+  it('preserves JsonObject values in context.vars.*', () => {
+    const result = buildContextVars({ config: { host: 'localhost', port: 3000 } });
+    expect(result['context.vars.config']).toEqual({ host: 'localhost', port: 3000 });
+  });
+
+  it('preserves number values in context.vars.*', () => {
+    const result = buildContextVars({ port: 8080 });
+    expect(result['context.vars.port']).toBe(8080);
+  });
+});
+
+describe('buildTemplateVars', () => {
+  it('merges inherited and local vars', () => {
+    const result = buildTemplateVars({ env: 'staging' }, { inheritedUserVars: { region: 'us' } });
+    expect(result.env).toBe('staging');
+    expect(result.region).toBe('us');
+  });
+
+  it('local vars override inherited', () => {
+    const result = buildTemplateVars({ env: 'prod' }, { inheritedUserVars: { env: 'staging' } });
+    expect(result.env).toBe('prod');
+  });
+
+  it('preserves JsonObject values through merge', () => {
+    const result = buildTemplateVars(
+      { name: 'child' },
+      { inheritedUserVars: { config: { host: 'localhost' } } },
+    );
+    expect(result.config).toEqual({ host: 'localhost' });
+    expect(result['context.vars.config']).toEqual({ host: 'localhost' });
+  });
+
+  it('preserves number values through merge', () => {
+    const result = buildTemplateVars({ port: 8080 });
+    expect(result.port).toBe(8080);
+    expect(result['context.vars.port']).toBe(8080);
+  });
+
+  it('preserves inherited context vars with object values', () => {
+    const result = buildTemplateVars(
+      { env: 'staging' },
+      {
+        inheritedContextVars: {
+          'context.parent.vars.config': { host: 'parent-host' },
+        },
+      },
+    );
+    expect(result['context.parent.vars.config']).toEqual({ host: 'parent-host' });
   });
 });

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -153,6 +153,40 @@ describe('substituteText', () => {
   it('should handle spaces in braces', () => {
     expect(substituteText('{{ name }}', { name: 'test' })).toBe('test');
   });
+
+  it('should resolve dotted access on object values', () => {
+    expect(substituteText('{{config.host}}', { config: { host: 'localhost' } })).toBe('localhost');
+  });
+
+  it('should serialize object to JSON when accessed directly', () => {
+    expect(substituteText('{{config}}', { config: { host: 'localhost' } })).toBe(
+      '{"host":"localhost"}',
+    );
+  });
+
+  it('should resolve deeply nested dotted access', () => {
+    expect(substituteText('{{config.db.host}}', { config: { db: { host: 'localhost' } } })).toBe(
+      'localhost',
+    );
+  });
+
+  it('should resolve number values from objects', () => {
+    expect(substituteText('port={{config.port}}', { config: { port: 3000 } })).toBe('port=3000');
+  });
+
+  it('should resolve null-in-object as "null"', () => {
+    expect(substituteText('{{config.host}}', { config: { host: null } })).toBe('null');
+  });
+
+  it('should preserve literal for nonexistent dotted path', () => {
+    expect(substituteText('{{config.nonexistent}}', { config: { host: 'localhost' } })).toBe(
+      '{{config.nonexistent}}',
+    );
+  });
+
+  it('should handle number template variable values', () => {
+    expect(substituteText('port={{port}}', { port: 42 })).toBe('port=42');
+  });
 });
 
 describe('substituteRunbookVariables', () => {

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -554,6 +554,17 @@ describe('resolveVariables', () => {
     });
   });
 
+  describe('YAML object routing', () => {
+    it('preserves object values from --var-file', async () => {
+      const tmpFile = path.join(tmpDir, 'objects.yaml');
+      await fs.writeFile(tmpFile, 'config:\n  host: localhost\n  port: 3000\n');
+
+      const result = await resolveVariables({ varFile: [tmpFile] }, tmpDir);
+
+      expect(result.vars.config).toEqual({ host: 'localhost', port: 3000 });
+    });
+  });
+
   describe('YAML file: prefix routing', () => {
     it('routes YAML file: value to sources only', async () => {
       const dataFile = path.join(tmpDir, 'data.txt');

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -435,7 +435,7 @@ describe('resolveVariables', () => {
         tmpDir,
       );
       expect(result.vars.greeting).toBe('Hello');
-      expect(result.vars.count).toBe('42');
+      expect(result.vars.count).toBe(42);
     });
 
     it('returns no frontmatter vars when frontmatterVars is undefined', async () => {
@@ -947,17 +947,17 @@ describe('resolveVariables', () => {
       });
     });
 
-    it('object value produces warning and is ignored', async () => {
+    it('object value is preserved as JsonObject', async () => {
       const result = await resolveVariables({ varJson: ['config={"host":"localhost"}'] }, tmpDir);
 
-      expect(result.vars.config).toBeUndefined();
-      expect(result.warnings.some((w) => w.includes('config') && w.includes('complex'))).toBe(true);
+      expect(result.vars.config).toEqual({ host: 'localhost' });
+      expect(result.warnings).toHaveLength(0);
     });
 
-    it('number value produces string var', async () => {
+    it('number value is preserved as number', async () => {
       const result = await resolveVariables({ varJson: ['count=42'] }, tmpDir);
 
-      expect(result.vars.count).toBe('42');
+      expect(result.vars.count).toBe(42);
       expect(result.sources.count).toBeUndefined();
     });
 
@@ -977,7 +977,32 @@ describe('resolveVariables', () => {
       const result = await resolveVariables({ var: ['count=10'], varJson: ['count=99'] }, tmpDir);
 
       // varJson is processed after var in collectRawLayers, so it wins
-      expect(result.vars.count).toBe('99');
+      expect(result.vars.count).toBe(99);
+    });
+
+    it('empty object is preserved', async () => {
+      const result = await resolveVariables({ varJson: ['config={}'] }, tmpDir);
+
+      expect(result.vars.config).toEqual({});
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('deeply nested object is preserved', async () => {
+      const result = await resolveVariables({ varJson: ['config={"a":{"b":{"c":1}}}'] }, tmpDir);
+
+      expect(result.vars.config).toEqual({ a: { b: { c: 1 } } });
+    });
+
+    it('object with array field is preserved', async () => {
+      const result = await resolveVariables({ varJson: ['config={"items":["a","b"]}'] }, tmpDir);
+
+      expect(result.vars.config).toEqual({ items: ['a', 'b'] });
+    });
+
+    it('null value is stringified', async () => {
+      const result = await resolveVariables({ varJson: ['val=null'] }, tmpDir);
+
+      expect(result.vars.val).toBe('null');
     });
   });
 });
@@ -1000,17 +1025,16 @@ describe('routeExtraVars', () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  it('warns and drops object values', async () => {
+  it('preserves object values as JsonObject', async () => {
     const result = await routeExtraVars({ config: { nested: true } }, tmpDir);
-    expect(result.vars.config).toBeUndefined();
+    expect(result.vars.config).toEqual({ nested: true });
     expect(result.sources.config).toBeUndefined();
-    expect(result.warnings).toHaveLength(1);
-    expect(result.warnings[0]).toContain('complex value');
+    expect(result.warnings).toHaveLength(0);
   });
 
-  it('converts scalar values to strings', async () => {
+  it('preserves numbers and stringifies booleans', async () => {
     const result = await routeExtraVars({ port: 8080, debug: true, name: 'test' }, tmpDir);
-    expect(result.vars.port).toBe('8080');
+    expect(result.vars.port).toBe(8080);
     expect(result.vars.debug).toBe('true');
     expect(result.vars.name).toBe('test');
     expect(result.warnings).toHaveLength(0);

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -1004,6 +1004,24 @@ describe('resolveVariables', () => {
 
       expect(result.vars.val).toBe('null');
     });
+
+    it('non-finite numbers are stringified with warning', async () => {
+      // YAML .inf/-.inf/.nan produce non-finite JS numbers that break JSON.stringify
+      const configPath = path.join(tmpDir, '.rundown', 'config.yaml');
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, 'timeout: .inf\nretries: .nan\n');
+
+      const result = await resolveVariables({}, tmpDir);
+
+      expect(result.vars.timeout).toBe('Infinity');
+      expect(result.vars.retries).toBe('NaN');
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('non-finite'),
+          expect.stringContaining('non-finite'),
+        ]),
+      );
+    });
   });
 });
 

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -563,6 +563,31 @@ describe('resolveVariables', () => {
 
       expect(result.vars.config).toEqual({ host: 'localhost', port: 3000 });
     });
+
+    it('stringifies YAML object with Date value and warns', async () => {
+      const tmpFile = path.join(tmpDir, 'date-obj.yaml');
+      // YAML parses unquoted timestamps as Date objects
+      await fs.writeFile(tmpFile, 'event:\n  name: launch\n  date: 2026-03-20\n');
+
+      const result = await resolveVariables({ varFile: [tmpFile] }, tmpDir);
+
+      // Date gets parsed by yaml.load() as a JS Date, failing isJsonValue
+      expect(typeof result.vars.event).toBe('string');
+      expect(result.warnings).toContain(
+        'Variable "event" contains non-JSON values; converting to string',
+      );
+    });
+
+    it('preserves normal YAML object as JsonObject', async () => {
+      const tmpFile = path.join(tmpDir, 'normal-obj.yaml');
+      // Quoted strings prevent YAML date parsing
+      await fs.writeFile(tmpFile, 'config:\n  host: localhost\n  port: 3000\n  debug: true\n');
+
+      const result = await resolveVariables({ varFile: [tmpFile] }, tmpDir);
+
+      expect(result.vars.config).toEqual({ host: 'localhost', port: 3000, debug: true });
+      expect(result.warnings).toHaveLength(0);
+    });
   });
 
   describe('YAML file: prefix routing', () => {

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -21,7 +21,7 @@ import {
 } from '../helpers/index-option.js';
 import { collectCliFlags, routeExtraVars } from '../services/variable-discovery.js';
 import { parseVarOption, parseVarJsonOption, collect } from '../helpers/option-utils.js';
-import type { DataSource } from '@rundown-org/core';
+import type { DataSource, TemplateVarValue } from '@rundown-org/core';
 
 /**
  * Registers the 'delegate' command for creating delegation tokens.
@@ -133,7 +133,7 @@ export function registerDelegateCommand(program: Command): void {
               cwd,
             );
 
-            let extraVars: Record<string, string> | undefined;
+            let extraVars: Record<string, TemplateVarValue> | undefined;
             let extraSources: Record<string, DataSource> | undefined;
             if (Object.keys(rawVars).length > 0) {
               const routed = await routeExtraVars(rawVars, cwd);

--- a/packages/cli/src/helpers/option-utils.ts
+++ b/packages/cli/src/helpers/option-utils.ts
@@ -87,16 +87,10 @@ export function parseVarJsonOption(value: string, previous: string[]): string[] 
     throw new InvalidArgumentError(msg);
   }
   const jsonStr = value.slice(eqIndex + 1);
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(jsonStr);
+    JSON.parse(jsonStr);
   } catch {
     throw new InvalidArgumentError(`Invalid JSON for "${key}": ${jsonStr}`);
-  }
-  if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-    throw new InvalidArgumentError(
-      `--var-json values must be scalars or arrays, not objects (got "${key}")`,
-    );
   }
   return [...previous, value];
 }

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -31,6 +31,7 @@ import {
   DELEGATION_TOKEN_PREFIX,
   ErrorCodes,
   getErrorMessage,
+  type TemplateVarValue,
 } from '@rundown-org/core';
 import {
   parseRunbookDocument,
@@ -97,7 +98,7 @@ export interface PreparedRunbook {
   /** Parsed and variable-substituted runbook AST (all FOR bounds resolved) */
   runbook: ResolvedRunbook;
   /** Merged template variables from all sources */
-  mergedVariables: Record<string, string>;
+  mergedVariables: Record<string, TemplateVarValue>;
   /** Resolved data sources for FOR loop iteration */
   sources: Record<string, DataSource>;
   /** Step and substep counts */
@@ -198,8 +199,10 @@ function emitRunbookStarted(
  * @param vars - User/config template variables to namespace under `context.vars.*`
  * @returns Record mapping `context.vars.{key}` to corresponding values
  */
-export function buildContextVars(vars: Readonly<Record<string, string>>): Record<string, string> {
-  const contextVars: Record<string, string> = {};
+export function buildContextVars(
+  vars: Readonly<Record<string, TemplateVarValue>>,
+): Record<string, TemplateVarValue> {
+  const contextVars: Record<string, TemplateVarValue> = {};
   for (const [key, value] of Object.entries(vars)) {
     contextVars[`context.vars.${key}`] = value;
   }
@@ -219,13 +222,13 @@ export function buildContextVars(vars: Readonly<Record<string, string>>): Record
  * @returns Complete template variable map ready for substitution
  */
 export function buildTemplateVars(
-  localVars: Readonly<Record<string, string>>,
+  localVars: Readonly<Record<string, TemplateVarValue>>,
   options?: {
-    inheritedUserVars?: Readonly<Record<string, string>>;
-    inheritedContextVars?: Readonly<Record<string, string>>;
+    inheritedUserVars?: Readonly<Record<string, TemplateVarValue>>;
+    inheritedContextVars?: Readonly<Record<string, TemplateVarValue>>;
   },
-): Record<string, string> {
-  const effectiveUserVars: Record<string, string> = {
+): Record<string, TemplateVarValue> {
+  const effectiveUserVars: Record<string, TemplateVarValue> = {
     ...(options?.inheritedUserVars ?? {}), // parent --var (overridable)
     ...localVars, // child frontmatter + claim --var (overrides)
   };
@@ -254,7 +257,7 @@ export interface PrepareFailure {
   code: string;
   details?: Record<string, unknown>;
   /** Partial results — available when pipeline progressed past parse */
-  variables?: Record<string, string>;
+  variables?: Record<string, TemplateVarValue>;
   sources?: Record<string, DataSource>;
   stats?: { steps: number; substeps: number };
   diagnostics?: readonly ValidationDiagnostic[];
@@ -390,8 +393,8 @@ export async function prepareRunbook(
   varOpts: VarOptions,
   cwd: string,
   options?: {
-    inheritedContextVars?: Readonly<Record<string, string>>;
-    inheritedUserVars?: Readonly<Record<string, string>>;
+    inheritedContextVars?: Readonly<Record<string, TemplateVarValue>>;
+    inheritedUserVars?: Readonly<Record<string, TemplateVarValue>>;
     inheritedSources?: Readonly<Record<string, DataSource>>;
   },
 ): Promise<PrepareResult> {
@@ -401,7 +404,7 @@ export async function prepareRunbook(
   const { filePath, rawContent, runbook: rawRunbook, frontmatter, diagnostics, stats } = parsed;
 
   // Variable resolution
-  let mergedVariables: Record<string, string>;
+  let mergedVariables: Record<string, TemplateVarValue>;
   let sources: Record<string, DataSource>;
   const allWarnings: string[] = [];
   try {
@@ -838,7 +841,7 @@ export async function claimAndLaunch(
     const inheritedContextVars = reconstituteContextVars(freshDelegation.contextSnapshot);
 
     // Extract parent user-level vars for top-level inheritance in child
-    const inheritedUserVars: Record<string, string> = {};
+    const inheritedUserVars: Record<string, TemplateVarValue> = {};
     for (const [key, value] of Object.entries(freshDelegation.contextSnapshot.vars)) {
       if (!key.startsWith('context.') && key !== 'RunId') {
         inheritedUserVars[key] = value;

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -32,6 +32,7 @@ import {
   type ForContext,
   type DataSource,
   type FrameKey,
+  type TemplateVarValue,
 } from '@rundown-org/core';
 import { isSourced, resolvedStepHasSubsteps, type ForClause } from '@rundown-org/parser';
 import { isInternalRdCommand, executeRdCommandInternal } from './internal-commands.js';
@@ -61,7 +62,7 @@ export type StepVariables = Record<string, unknown>;
  * Template variables for AST-level substitution (e.g., `environment`, `port`).
  * Sourced from frontmatter, CLI flags, or config files.
  */
-export type TemplateVariables = Record<string, string>;
+export type TemplateVariables = Record<string, TemplateVarValue>;
 
 /**
  * Build per-step dynamic variables for Phase 2 expansion.
@@ -89,7 +90,7 @@ export function buildStepVariables(
   forStack?: readonly ForContext[],
   forClause?: ForClause,
   sources?: Readonly<Record<string, DataSource>>,
-  templateVars?: Readonly<Record<string, string>>,
+  templateVars?: Readonly<Record<string, TemplateVarValue>>,
 ): StepVariables {
   const step = substepId ? `${stepId}.${substepId}` : stepId;
   const vars: StepVariables = {

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -471,6 +471,7 @@ async function routeVariable(
   }
 
   // Non-array object → vars only as JsonObject (for dotted template access)
+  // Safe cast: values originate from yaml.load() or JSON.parse(), which produce JSON-compatible objects
   if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
     vars[key] = value as JsonObject;
     delete sources[key];
@@ -478,8 +479,16 @@ async function routeVariable(
   }
 
   // Number → vars only (preserved, not stringified)
+  // Guard against YAML .inf/-.inf/.nan which produce non-finite JS numbers
   if (typeof value === 'number') {
-    vars[key] = value;
+    if (!Number.isFinite(value)) {
+      warnings?.push(
+        `Variable "${key}" has non-finite numeric value (${String(value)}); converting to string`,
+      );
+      vars[key] = String(value);
+    } else {
+      vars[key] = value;
+    }
     delete sources[key];
     return;
   }

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -17,6 +17,7 @@ import * as yaml from 'js-yaml';
 import type {
   DataSource,
   FileFormat,
+  JsonObject,
   PolicyEvaluator,
   PolicyPrompter,
   TemplateVarValue,
@@ -470,8 +471,8 @@ async function routeVariable(
   }
 
   // Non-array object → vars only as JsonObject (for dotted template access)
-  if (typeof value === 'object' && value !== null) {
-    vars[key] = value as TemplateVarValue;
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    vars[key] = value as JsonObject;
     delete sources[key];
     return;
   }
@@ -661,10 +662,12 @@ async function enforceFileSourcePolicy(
  * 5. --var flags (highest precedence)
  *
  * Each variable value is routed based on its type:
- * - String with file: prefix → file source only
- * - Array → both vars (comma-joined) and sources (array)
+ * - String with `file:` prefix → file source only (not in vars)
+ * - Array → both vars (comma-joined) and sources (array of items)
  * - Multiline string → both vars and sources (array of lines)
- * - Scalar → vars only
+ * - Non-array object (JsonObject) → vars only (for dotted template access)
+ * - Number → vars only (preserved, not stringified)
+ * - Other scalar (boolean, null, plain string) → vars only (stringified)
  *
  * @param options - Variable sources from CLI flags, var-file, frontmatter vars, and inherited vars
  * @param options.varFile - Array of paths to YAML files containing variable definitions (repeatable)

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -14,7 +14,13 @@ import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as yaml from 'js-yaml';
-import type { DataSource, FileFormat, PolicyEvaluator, PolicyPrompter } from '@rundown-org/core';
+import type {
+  DataSource,
+  FileFormat,
+  PolicyEvaluator,
+  PolicyPrompter,
+  TemplateVarValue,
+} from '@rundown-org/core';
 
 /**
  * Valid identifier pattern for variable names.
@@ -65,13 +71,15 @@ export function isRuntimeReservedVariable(name: string): boolean {
  */
 export interface ResolvedVariables {
   /**
-   * Readonly map of string values used for template substitution.
+   * Readonly map of template variable values used for template substitution.
    *
    * Feeds the Handlebars template rendering pipeline — every entry is
-   * substituted into `{{key}}` placeholders at render time.  The map is
-   * immutable for the lifetime of a single resolution pass.
+   * substituted into `{{key}}` placeholders at render time. Values are
+   * strings, numbers (preserved from `--var-json`), or JSON objects
+   * (for dotted field access like `{{config.host}}`).
+   * The map is immutable for the lifetime of a single resolution pass.
    */
-  readonly vars: Readonly<Record<string, string>>;
+  readonly vars: Readonly<Record<string, TemplateVarValue>>;
   /**
    * Readonly map of {@link DataSource} objects consumed only at FOR loop
    * entry time.
@@ -393,11 +401,13 @@ function inferFileFormat(filePath: string): FileFormat {
  * - String with file: prefix → file source only (not in vars)
  * - Array → both maps (comma-joined in vars, array DataSource in sources)
  * - Multiline string → both maps (raw in vars, split lines as array DataSource in sources)
- * - Other scalar → vars only
+ * - Non-array object → vars only as JsonObject (for dotted template access)
+ * - Number → vars only (preserved, not stringified)
+ * - Other scalar (boolean, null) → vars only (stringified)
  *
  * @param key - Variable name
  * @param value - Variable value (unknown type)
- * @param vars - Accumulator for string variables
+ * @param vars - Accumulator for template variable values
  * @param sources - Accumulator for data sources
  * @param cwd - Current working directory for resolving relative paths
  * @param projectRoot - Canonical project root path (pre-resolved)
@@ -407,7 +417,7 @@ function inferFileFormat(filePath: string): FileFormat {
 async function routeVariable(
   key: string,
   value: unknown,
-  vars: Record<string, string>,
+  vars: Record<string, TemplateVarValue>,
   sources: Record<string, DataSource>,
   cwd: string,
   projectRoot: string,
@@ -459,11 +469,21 @@ async function routeVariable(
     return;
   }
 
-  // Scalar → vars only (clear any stale source from lower-precedence layer)
+  // Non-array object → vars only as JsonObject (for dotted template access)
   if (typeof value === 'object' && value !== null) {
-    warnings?.push(`Ignoring variable "${key}" with complex value`);
+    vars[key] = value as TemplateVarValue;
+    delete sources[key];
     return;
   }
+
+  // Number → vars only (preserved, not stringified)
+  if (typeof value === 'number') {
+    vars[key] = value;
+    delete sources[key];
+    return;
+  }
+
+  // Other scalar (string, boolean, null) → vars only (stringified)
   vars[key] = String(value);
 
   delete sources[key];
@@ -554,7 +574,7 @@ async function collectRawLayers(
     var?: string[];
     varJson?: string[];
     frontmatterVars?: Record<string, string | number | boolean>;
-    inheritedVars?: Record<string, string>;
+    inheritedVars?: Record<string, TemplateVarValue>;
   },
   cwd: string,
   warnings?: string[],
@@ -664,12 +684,12 @@ export async function resolveVariables(
     var?: string[];
     varJson?: string[];
     frontmatterVars?: Record<string, string | number | boolean>;
-    inheritedVars?: Record<string, string>;
+    inheritedVars?: Record<string, TemplateVarValue>;
   },
   cwd: string,
   security?: VariableSecurityContext,
 ): Promise<ResolvedVariables> {
-  const vars: Record<string, string> = {};
+  const vars: Record<string, TemplateVarValue> = {};
   const sources: Record<string, DataSource> = {};
   const warnings: string[] = [];
 
@@ -730,11 +750,11 @@ export async function routeExtraVars(
   cwd: string,
   security?: VariableSecurityContext,
 ): Promise<{
-  vars: Record<string, string>;
+  vars: Record<string, TemplateVarValue>;
   sources: Record<string, DataSource>;
   warnings: string[];
 }> {
-  const vars: Record<string, string> = {};
+  const vars: Record<string, TemplateVarValue> = {};
   const sources: Record<string, DataSource> = {};
   const warnings: string[] = [];
 

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -142,10 +142,11 @@ export class FileSourcePolicyError extends Error {
 }
 
 /**
- * Normalize a raw variables object to Record<string, string>.
+ * Normalize raw variable values to string-only records.
  *
- * Validates keys match identifier pattern, converts values to strings,
- * and warns on invalid keys or complex values.
+ * @deprecated Used only by the default `loadVariablesFromFile` overload for legacy
+ * frontmatter normalization. Do NOT use for `--var-file`, config, or any path where
+ * structured values (arrays, objects) should be preserved. Use `routeVariable` instead.
  *
  * @param vars - Raw variables object with unknown value types
  * @param source - Label for warning messages (e.g., "frontmatter var", "variable")
@@ -310,6 +311,7 @@ export async function loadVariablesFromFile(
     if (options?.normalize === false) {
       return raw;
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- legacy frontmatter path
     return normalizeVariables(raw);
   } catch (error) {
     if (options?.optional === false) {

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -14,13 +14,14 @@ import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as yaml from 'js-yaml';
-import type {
-  DataSource,
-  FileFormat,
-  JsonObject,
-  PolicyEvaluator,
-  PolicyPrompter,
-  TemplateVarValue,
+import {
+  isJsonValue,
+  type DataSource,
+  type FileFormat,
+  type JsonObject,
+  type PolicyEvaluator,
+  type PolicyPrompter,
+  type TemplateVarValue,
 } from '@rundown-org/core';
 
 /**
@@ -153,7 +154,7 @@ export class FileSourcePolicyError extends Error {
  * @param warnings - Optional array to collect normalization warnings
  * @returns Normalized variables with string values only
  */
-function normalizeVariables(
+function normalizeToStringVariables(
   vars: Record<string, unknown>,
   source = 'variable',
   warnings?: string[],
@@ -312,7 +313,7 @@ export async function loadVariablesFromFile(
       return raw;
     }
     // eslint-disable-next-line @typescript-eslint/no-deprecated -- legacy frontmatter path
-    return normalizeVariables(raw);
+    return normalizeToStringVariables(raw);
   } catch (error) {
     if (options?.optional === false) {
       throw error;
@@ -473,9 +474,14 @@ async function routeVariable(
   }
 
   // Non-array object → vars only as JsonObject (for dotted template access)
-  // Safe cast: values originate from yaml.load() or JSON.parse(), which produce JSON-compatible objects
+  // Validate recursively: yaml.load() can produce Date, undefined, etc.
   if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-    vars[key] = value as JsonObject;
+    if (isJsonValue(value)) {
+      vars[key] = value as JsonObject;
+    } else {
+      warnings?.push(`Variable "${key}" contains non-JSON values; converting to string`);
+      vars[key] = JSON.stringify(value);
+    }
     delete sources[key];
     return;
   }

--- a/packages/core/__tests__/runbook/delegation-context.test.ts
+++ b/packages/core/__tests__/runbook/delegation-context.test.ts
@@ -422,4 +422,49 @@ describe('reconstituteContextVars', () => {
     );
     expect(contextKeys).toHaveLength(0);
   });
+
+  it('preserves JsonObject values in parent vars', () => {
+    const snapshot: ContextSnapshot = {
+      vars: { config: { host: 'localhost', port: 3000 } },
+      ancestors: [],
+    };
+
+    const result = reconstituteContextVars(snapshot);
+
+    expect(result['context.parent.vars.config']).toEqual({ host: 'localhost', port: 3000 });
+    expect(result['context.ancestors.0.vars.config']).toEqual({ host: 'localhost', port: 3000 });
+  });
+
+  it('preserves JsonObject values in ancestor vars', () => {
+    const ancestor: AncestorSnapshot = {
+      runId: 'gp-1',
+      runbook: 'grandparent.md',
+      step: '1',
+      substep: null,
+      vars: { db: { host: 'db.example.com', port: 5432 } },
+    };
+    const snapshot: ContextSnapshot = {
+      vars: { env: 'prod' },
+      ancestors: [ancestor],
+    };
+
+    const result = reconstituteContextVars(snapshot);
+
+    expect(result['context.ancestors.1.vars.db']).toEqual({ host: 'db.example.com', port: 5432 });
+    expect(result['context.parent.parent.vars.db']).toEqual({
+      host: 'db.example.com',
+      port: 5432,
+    });
+  });
+
+  it('preserves number values in parent vars', () => {
+    const snapshot: ContextSnapshot = {
+      vars: { port: 8080 },
+      ancestors: [],
+    };
+
+    const result = reconstituteContextVars(snapshot);
+
+    expect(result['context.parent.vars.port']).toBe(8080);
+  });
 });

--- a/packages/core/__tests__/runbook/delegation-schemas.test.ts
+++ b/packages/core/__tests__/runbook/delegation-schemas.test.ts
@@ -120,9 +120,52 @@ describe('ContextSnapshotSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects non-string vars values', () => {
+  it('rejects array vars values', () => {
     const result = ContextSnapshotSchema.safeParse({
       vars: { env: 'prod', items: ['a', 'b'] },
+      ancestors: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts number vars values', () => {
+    const result = ContextSnapshotSchema.safeParse({
+      vars: { env: 'prod', port: 3000 },
+      ancestors: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts object vars values', () => {
+    const result = ContextSnapshotSchema.safeParse({
+      vars: { config: { host: 'localhost', port: 3000 } },
+      ancestors: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts deeply nested object vars values', () => {
+    const result = ContextSnapshotSchema.safeParse({
+      vars: { config: { db: { host: 'localhost', port: 5432 } } },
+      ancestors: [],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.vars.config).toEqual({ db: { host: 'localhost', port: 5432 } });
+    }
+  });
+
+  it('rejects boolean vars values', () => {
+    const result = ContextSnapshotSchema.safeParse({
+      vars: { debug: true },
+      ancestors: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects null vars values', () => {
+    const result = ContextSnapshotSchema.safeParse({
+      vars: { val: null },
       ancestors: [],
     });
     expect(result.success).toBe(false);

--- a/packages/core/__tests__/runbook/types.test.ts
+++ b/packages/core/__tests__/runbook/types.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import type { Action, SubstepState, Substep, RunbookState } from '../../src/runbook/types.js';
+import { isJsonValue } from '../../src/runbook/types.js';
 import { buildFrameKey } from '../../src/runbook/targeting.js';
 
 describe('SubstepState type', () => {
@@ -111,5 +112,68 @@ describe('RunbookState runbookSrc field', () => {
       runbookSrc: '# Test Runbook\n\n## 1. Test Step',
     };
     expect(state.runbookSrc).toBe('# Test Runbook\n\n## 1. Test Step');
+  });
+});
+
+describe('isJsonValue', () => {
+  it('accepts null', () => {
+    expect(isJsonValue(null)).toBe(true);
+  });
+
+  it('accepts string', () => {
+    expect(isJsonValue('hello')).toBe(true);
+  });
+
+  it('accepts number', () => {
+    expect(isJsonValue(42)).toBe(true);
+  });
+
+  it('accepts boolean', () => {
+    expect(isJsonValue(true)).toBe(true);
+    expect(isJsonValue(false)).toBe(true);
+  });
+
+  it('accepts empty array', () => {
+    expect(isJsonValue([])).toBe(true);
+  });
+
+  it('accepts nested array', () => {
+    expect(isJsonValue(['a', 1, [true, null]])).toBe(true);
+  });
+
+  it('accepts plain object', () => {
+    expect(isJsonValue({ host: 'localhost', port: 8080 })).toBe(true);
+  });
+
+  it('accepts deeply nested object', () => {
+    expect(isJsonValue({ a: { b: { c: [1, 'x', null] } } })).toBe(true);
+  });
+
+  it('rejects undefined', () => {
+    expect(isJsonValue(undefined)).toBe(false);
+  });
+
+  it('rejects function', () => {
+    expect(isJsonValue(() => {})).toBe(false);
+  });
+
+  it('rejects Date', () => {
+    expect(isJsonValue(new Date())).toBe(false);
+  });
+
+  it('rejects RegExp', () => {
+    expect(isJsonValue(/foo/)).toBe(false);
+  });
+
+  it('rejects object containing Date value', () => {
+    expect(isJsonValue({ created: new Date() })).toBe(false);
+  });
+
+  it('rejects object containing undefined value', () => {
+    expect(isJsonValue({ key: undefined })).toBe(false);
+  });
+
+  it('rejects array containing undefined', () => {
+    expect(isJsonValue([1, undefined, 'a'])).toBe(false);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export {
   StepDelegationSchema,
   ContextSnapshotSchema,
   AncestorSnapshotSchema,
+  TemplateVarValueSchema,
 } from './schemas.js';
 
 // Errors

--- a/packages/core/src/runbook/delegation-context.ts
+++ b/packages/core/src/runbook/delegation-context.ts
@@ -19,7 +19,8 @@ export const MAX_ANCESTOR_DEPTH = 32;
  * recursive nesting.
  *
  * @param snapshot - The frozen context snapshot from delegation metadata
- * @returns Variable map keyed by `context.parent.vars.*`, `context.ancestors.N.*`, etc.
+ * @returns Variable map with string values for structural fields (step, substep, at, index)
+ *          and TemplateVarValue entries (strings, numbers, or objects) from snapshot.vars
  * @throws {Error} When the ancestor chain exceeds {@link MAX_ANCESTOR_DEPTH} levels
  */
 export function reconstituteContextVars(

--- a/packages/core/src/runbook/delegation-context.ts
+++ b/packages/core/src/runbook/delegation-context.ts
@@ -1,4 +1,4 @@
-import type { ContextSnapshot } from './types.js';
+import type { ContextSnapshot, TemplateVarValue } from './types.js';
 
 /** Maximum depth for parent context chain addressing. */
 export const MAX_ANCESTOR_DEPTH = 32;
@@ -22,14 +22,16 @@ export const MAX_ANCESTOR_DEPTH = 32;
  * @returns Variable map keyed by `context.parent.vars.*`, `context.ancestors.N.*`, etc.
  * @throws {Error} When the ancestor chain exceeds {@link MAX_ANCESTOR_DEPTH} levels
  */
-export function reconstituteContextVars(snapshot: ContextSnapshot): Record<string, string> {
+export function reconstituteContextVars(
+  snapshot: ContextSnapshot,
+): Record<string, TemplateVarValue> {
   if (snapshot.ancestors.length > MAX_ANCESTOR_DEPTH) {
     throw new Error(
       `Parent context chain depth (${String(snapshot.ancestors.length)}) exceeds maximum of ${String(MAX_ANCESTOR_DEPTH)} levels`,
     );
   }
 
-  const result: Record<string, string> = {};
+  const result: Record<string, TemplateVarValue> = {};
 
   // Parent structural fields: step, substep, at, index
   if (snapshot.step) {

--- a/packages/core/src/runbook/delegation-service.ts
+++ b/packages/core/src/runbook/delegation-service.ts
@@ -15,6 +15,7 @@ import type {
   ResolvedStep,
   StepDelegation,
   SubstepState,
+  TemplateVarValue,
 } from './types.js';
 
 /**
@@ -69,7 +70,7 @@ export interface DelegateOptions {
   /** Path to the child runbook to delegate to. */
   readonly childRunbookPath: string;
   /** Extra variables to merge into the context snapshot. */
-  readonly extraVars?: Readonly<Record<string, string>>;
+  readonly extraVars?: Readonly<Record<string, TemplateVarValue>>;
   /** Extra data sources to include in the context snapshot for FOR loop iteration. */
   readonly extraSources?: Readonly<Record<string, DataSource>>;
   /** Ancestor chain built by the caller. */

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -1,4 +1,5 @@
 export type * from './types.js';
+export { isJsonObject } from './types.js';
 export * from './step-id.js';
 export * from './step-utils.js';
 export * from './targeting.js';

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -1,5 +1,5 @@
 export type * from './types.js';
-export { isJsonObject } from './types.js';
+export { isJsonObject, isJsonValue } from './types.js';
 export * from './step-id.js';
 export * from './step-utils.js';
 export * from './targeting.js';

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -11,6 +11,7 @@ import type {
   ResolvedRunbook,
   DataSource,
   DelegationLinkage,
+  TemplateVarValue,
 } from './types.js';
 import { RunbookStateSchema } from '../schemas.js';
 
@@ -44,7 +45,7 @@ interface CreateOptions {
   readonly delegation?: DelegationLinkage;
   readonly runbookSrc?: string;
   /** Optional record of template variable replacements to populate placeholders at run time. */
-  readonly templateVars?: Record<string, string>;
+  readonly templateVars?: Record<string, TemplateVarValue>;
   /** Data source bindings for FOR loop iteration (arrays and file references). */
   readonly sources?: Readonly<Record<string, DataSource>>;
 }

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -154,7 +154,9 @@ export type TemplateVarValue = string | number | JsonObject;
  * @returns True if the value is a structured JSON object (not a string or number)
  */
 export function isJsonObject(value: TemplateVarValue): value is JsonObject {
-  return typeof value === 'object';
+  // Defensive: null check guards against untyped callers even though TemplateVarValue excludes null
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  return value !== null && typeof value === 'object';
 }
 
 /**

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -128,6 +128,36 @@ export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonValue[] | { readonly [key: string]: JsonValue };
 
 /**
+ * JSON object with arbitrary nested JSON values.
+ *
+ * Used for structured template variable values that support dotted field access
+ * in templates (e.g., `{{config.host}}`).
+ */
+export type JsonObject = { readonly [key: string]: JsonValue };
+
+/**
+ * Values that can appear in the template variable map.
+ *
+ * - `string`: the dominant case (CLI vars, env, builtins, stringified booleans/nulls)
+ * - `number`: preserved from `--var-json` and YAML config (not stringified)
+ * - `JsonObject`: structured values for dotted template access (`{{config.host}}`)
+ *
+ * Top-level arrays are routed to DataSources, not stored in vars.
+ * Top-level booleans and nulls are stringified at routing time.
+ */
+export type TemplateVarValue = string | number | JsonObject;
+
+/**
+ * Type guard for JSON object values within the template variable map.
+ *
+ * @param value - Template variable value to check
+ * @returns True if the value is a structured JSON object (not a string or number)
+ */
+export function isJsonObject(value: TemplateVarValue): value is JsonObject {
+  return typeof value === 'object';
+}
+
+/**
  * Structured discriminated union for the last action taken by the state machine.
  *
  * Replaces the previous string-based representation to preserve full transition
@@ -214,7 +244,7 @@ export interface StepDelegation {
 
 /** Snapshot of execution context at delegation time. */
 export interface ContextSnapshot {
-  readonly vars: Readonly<Record<string, string>>;
+  readonly vars: Readonly<Record<string, TemplateVarValue>>;
   /** Data source bindings for FOR loop iteration in delegated runbooks. */
   readonly sources?: Readonly<Record<string, DataSource>>;
   readonly ancestors: readonly AncestorSnapshot[];
@@ -234,7 +264,7 @@ export interface AncestorSnapshot {
   readonly runbook: string;
   readonly step: string;
   readonly substep: string | null;
-  readonly vars: Readonly<Record<string, string>>;
+  readonly vars: Readonly<Record<string, TemplateVarValue>>;
   /** Qualified execution location at delegation time (e.g., "1.2.1"). */
   readonly at?: string;
   /** FOR loop iteration number at delegation time (1-based). */
@@ -476,7 +506,7 @@ export interface RunbookState {
   readonly runbookSrc?: string;
 
   /** Template variables used for AST-level substitution, frozen at run time */
-  readonly templateVars?: Readonly<Record<string, string>>;
+  readonly templateVars?: Readonly<Record<string, TemplateVarValue>>;
 
   /** Data source bindings for FOR loop iteration (arrays and file references) */
   readonly sources?: Readonly<Record<string, DataSource>>;

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -160,6 +160,36 @@ export function isJsonObject(value: TemplateVarValue): value is JsonObject {
 }
 
 /**
+ * Recursive type guard that validates an unknown value is a valid JSON value.
+ *
+ * Walks objects and arrays recursively, checking that all primitives are
+ * string, number, boolean, or null. Rejects Date, undefined, functions,
+ * and other non-JSON types that `yaml.load()` can produce.
+ *
+ * @param value - The value to validate
+ * @returns True if the value is a valid JSON value (primitives, arrays, or plain objects)
+ */
+export function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null) return true;
+  switch (typeof value) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+      return true;
+    case 'object': {
+      if (Array.isArray(value)) {
+        return value.every(isJsonValue);
+      }
+      // Reject Date, RegExp, etc. — only plain objects are valid
+      if (Object.getPrototypeOf(value) !== Object.prototype) return false;
+      return Object.values(value as Record<string, unknown>).every(isJsonValue);
+    }
+    default:
+      return false;
+  }
+}
+
+/**
  * Structured discriminated union for the last action taken by the state machine.
  *
  * Replaces the previous string-based representation to preserve full transition

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -134,10 +134,11 @@ export { StepIdSchema, ActionSchema, TransitionsSchema };
 const RunbookStepSchema = z.string().min(1);
 
 /**
- * Recursive JSON value schema for loop iteration values.
+ * Recursive JSON value schema for loop iteration values and template variable objects.
  *
  * Supports arbitrary JSON structures: primitives, arrays, and objects.
- * Used to validate currentValue in ForStackEntry when iterating over JSONL files.
+ * Used to validate currentValue in ForStackEntry when iterating over JSONL files,
+ * and as the basis for TemplateVarValueSchema for template variable validation.
  * Uses z.lazy() for recursive reference handling.
  *
  * When used with .optional(), allows either a JSON value or absence (undefined),

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { FrameKey } from './runbook/targeting.js';
-import type { JsonValue } from './runbook/types.js';
+import type { JsonValue, TemplateVarValue } from './runbook/types.js';
 import { getErrorMessage } from './errors.js';
 
 /** Zod schema that parses strings and brands them as {@link FrameKey}. */
@@ -134,6 +134,39 @@ export { StepIdSchema, ActionSchema, TransitionsSchema };
 const RunbookStepSchema = z.string().min(1);
 
 /**
+ * Recursive JSON value schema for loop iteration values.
+ *
+ * Supports arbitrary JSON structures: primitives, arrays, and objects.
+ * Used to validate currentValue in ForStackEntry when iterating over JSONL files.
+ * Uses z.lazy() for recursive reference handling.
+ *
+ * When used with .optional(), allows either a JSON value or absence (undefined),
+ * but explicitly rejects undefined values that are passed through objects.
+ */
+const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(z.string(), JsonValueSchema),
+  ]),
+);
+
+/**
+ * Schema for template variable values: string, number, or JSON object.
+ *
+ * Matches the {@link TemplateVarValue} type — excludes top-level arrays,
+ * booleans, and nulls which are routed/stringified at variable resolution time.
+ */
+export const TemplateVarValueSchema: z.ZodType<TemplateVarValue> = z.union([
+  z.string(),
+  z.number(),
+  z.record(z.string(), JsonValueSchema),
+]);
+
+/**
  * Zod schema for a single ancestor in the runbook lineage snapshot.
  */
 export const AncestorSnapshotSchema = z.object({
@@ -141,7 +174,7 @@ export const AncestorSnapshotSchema = z.object({
   runbook: z.string(),
   step: z.string(),
   substep: z.string().nullable(),
-  vars: z.record(z.string(), z.string()),
+  vars: z.record(z.string(), TemplateVarValueSchema),
   at: z.string().optional(),
   index: z.number().int().positive().optional(),
 });
@@ -162,7 +195,7 @@ export const DataSourceSchema = z.discriminatedUnion('kind', [
  * Zod schema for execution context snapshot at delegation time.
  */
 export const ContextSnapshotSchema = z.object({
-  vars: z.record(z.string(), z.string()),
+  vars: z.record(z.string(), TemplateVarValueSchema),
   sources: z.record(z.string(), DataSourceSchema).optional(),
   ancestors: z.array(AncestorSnapshotSchema).readonly(),
   step: z.string().optional(),
@@ -229,27 +262,6 @@ const ResolvedSourceSchema = z.discriminatedUnion('kind', [
       .nullable(),
   }),
 ]);
-
-/**
- * Recursive JSON value schema for loop iteration values.
- *
- * Supports arbitrary JSON structures: primitives, arrays, and objects.
- * Used to validate currentValue in ForStackEntry when iterating over JSONL files.
- * Uses z.lazy() for recursive reference handling.
- *
- * When used with .optional(), allows either a JSON value or absence (undefined),
- * but explicitly rejects undefined values that are passed through objects.
- */
-const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
-  z.union([
-    z.string(),
-    z.number(),
-    z.boolean(),
-    z.null(),
-    z.array(JsonValueSchema),
-    z.record(z.string(), JsonValueSchema),
-  ]),
-);
 
 /**
  * Zod schema for ForStack entry with optional source field for backward compat
@@ -344,7 +356,7 @@ export const RunbookStateSchema = z
       ])
       .optional(),
     runbookSrc: z.string().optional(),
-    templateVars: z.record(z.string(), z.string()).optional(),
+    templateVars: z.record(z.string(), TemplateVarValueSchema).optional(),
     /** Data source bindings for sourced FOR loops (array or file-backed). */
     sources: z.record(z.string(), DataSourceSchema).optional(),
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template variables can now be numbers or objects (not only strings); dotted-path access into nested object values is supported. CLI/delegation flows accept and propagate non-string template values. Library exports now include JSON-value helpers and a TemplateVarValue schema.

* **Bug Fixes**
  * Numeric frontmatter/JSON vars preserved as numbers; non-finite numbers stringified with warnings; null serialized as "null". YAML-native non-JSON types (e.g., timestamps) are stringified with warnings. Object JSON var inputs are accepted.

* **Tests**
  * Added coverage for non-string values, dotted-path resolution, merging/overrides, routing, and context preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->