### PR TITLE
test(cli): add --var-json integration tests and scenario runbooks

### DIFF
--- a/packages/cli/__tests__/integration/for-loop-data-sources.test.ts
+++ b/packages/cli/__tests__/integration/for-loop-data-sources.test.ts
@@ -760,6 +760,160 @@ rd echo host={{ host }}
     expect(allText).not.toContain("host=''");
   });
 
+  it('iterates over --var-json array', async () => {
+    await writeFile(
+      join(workspace.cwd, 'json-array.runbook.md'),
+      `---
+name: JSON Array
+---
+# JSON Array
+
+## 1. Process items
+- FOR item IN {{ items }}
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Handle item
+- PASS CONTINUE
+
+\`\`\`bash
+rd echo item={{ item }}
+\`\`\`
+`,
+    );
+
+    const result = runCli(
+      'run --json --var-json items=["alpha","bravo","charlie"] json-array.runbook.md',
+      workspace,
+    );
+    expect(result.exitCode).toBe(0);
+
+    const events = parseJsonEvents(result.stdout);
+    const commandStartedEvents = events.filter((e) => e.type === 'command_started');
+
+    expect(commandStartedEvents).toHaveLength(3);
+    expect(commandStartedEvents[0].command).toContain('item=alpha');
+    expect(commandStartedEvents[1].command).toContain('item=bravo');
+    expect(commandStartedEvents[2].command).toContain('item=charlie');
+  });
+
+  it('iterates over --var-json array of objects with dotted access', async () => {
+    await writeFile(
+      join(workspace.cwd, 'json-objects.runbook.md'),
+      `---
+name: JSON Objects
+---
+# JSON Objects
+
+## 1. Process items
+- FOR item IN {{ items }}
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Handle item
+- PASS CONTINUE
+
+\`\`\`bash
+rd echo name={{ item.name }} count={{ item.count }}
+\`\`\`
+`,
+    );
+
+    const result = runCli(
+      'run --json --var-json items=[{"name":"alice","count":10},{"name":"bob","count":20}] json-objects.runbook.md',
+      workspace,
+    );
+    expect(result.exitCode).toBe(0);
+
+    const events = parseJsonEvents(result.stdout);
+    const commandStartedEvents = events.filter((e) => e.type === 'command_started');
+
+    expect(commandStartedEvents).toHaveLength(2);
+    expect(commandStartedEvents[0].command).toContain('name=alice');
+    expect(commandStartedEvents[0].command).toContain('count=10');
+    expect(commandStartedEvents[1].command).toContain('name=bob');
+    expect(commandStartedEvents[1].command).toContain('count=20');
+  });
+
+  it('handles empty --var-json array with 0 iterations', async () => {
+    await writeFile(
+      join(workspace.cwd, 'json-empty.runbook.md'),
+      `---
+name: JSON Empty
+---
+# JSON Empty
+
+## 1. Process items
+- FOR item IN {{ items }}
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Handle item
+- PASS CONTINUE
+
+\`\`\`bash
+rd echo item={{ item }}
+\`\`\`
+
+## 2. Done
+\`\`\`bash
+rd echo done
+\`\`\`
+`,
+    );
+
+    const result = runCli('run --json --var-json items=[] json-empty.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    const events = parseJsonEvents(result.stdout);
+    const stepEnteredEvents = events.filter((e) => e.type === 'step_entered');
+    const commandStartedEvents = events.filter((e) => e.type === 'command_started');
+
+    // Empty array: 0 iterations, only the "Done" step runs
+    expect(stepEnteredEvents).toHaveLength(1);
+    expect(commandStartedEvents).toHaveLength(1);
+    expect(stepEnteredEvents[0].description).toContain('Done');
+    expect(commandStartedEvents[0].command).toContain('done');
+  });
+
+  it('iterates over windowed --var-json array', async () => {
+    await writeFile(
+      join(workspace.cwd, 'json-windowed.runbook.md'),
+      `---
+name: JSON Windowed
+---
+# JSON Windowed
+
+## 1. Process items
+- FOR item IN 2 TO 4 OF {{ items }}
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Handle item
+- PASS CONTINUE
+
+\`\`\`bash
+rd echo item={{ item }}
+\`\`\`
+`,
+    );
+
+    const result = runCli(
+      'run --json --var-json items=["a","b","c","d","e"] json-windowed.runbook.md',
+      workspace,
+    );
+    expect(result.exitCode).toBe(0);
+
+    const events = parseJsonEvents(result.stdout);
+    const commandStartedEvents = events.filter((e) => e.type === 'command_started');
+
+    // Positions 2-4 map to items[1], items[2], items[3]
+    expect(commandStartedEvents).toHaveLength(3);
+    expect(commandStartedEvents[0].command).toContain('item=b');
+    expect(commandStartedEvents[1].command).toContain('item=c');
+    expect(commandStartedEvents[2].command).toContain('item=d');
+  });
+
   it('resolves JSONL file values before template expansion (protocol proof)', async () => {
     await writeFile(join(workspace.cwd, 'items.jsonl'), '"first"\n"second"\n');
 

--- a/packages/cli/__tests__/integration/template-variables.test.ts
+++ b/packages/cli/__tests__/integration/template-variables.test.ts
@@ -267,6 +267,166 @@ describe('Template Variables Integration', () => {
     });
   });
 
+  describe('--var-json integration', () => {
+    it('scalar number renders in template', async () => {
+      const runbookContent = createRunbook({
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{count}}' }],
+      });
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+
+      const result = runCli('run test.runbook.md --var-json count=42 --json', workspace);
+
+      expect(result.exitCode).toBe(0);
+      const events = parseJsonlEvents(result.stdout);
+      const commandStartedEvent = events.find((e) => e.type === 'command_started');
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toBe('rd echo 42');
+    });
+
+    it('boolean value stringified in template', async () => {
+      const runbookContent = createRunbook({
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{debug}}' }],
+      });
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+
+      const result = runCli('run test.runbook.md --var-json debug=true --json', workspace);
+
+      expect(result.exitCode).toBe(0);
+      const events = parseJsonlEvents(result.stdout);
+      const commandStartedEvent = events.find((e) => e.type === 'command_started');
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toBe('rd echo true');
+    });
+
+    it('null value stringified in template', async () => {
+      const runbookContent = createRunbook({
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{val}}' }],
+      });
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+
+      const result = runCli('run test.runbook.md --var-json val=null --json', workspace);
+
+      expect(result.exitCode).toBe(0);
+      const events = parseJsonlEvents(result.stdout);
+      const commandStartedEvent = events.find((e) => e.type === 'command_started');
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toBe('rd echo null');
+    });
+
+    it('object with dotted field access in template', async () => {
+      await writeFile(
+        join(workspace.cwd, 'test.runbook.md'),
+        `---
+name: dotted-access
+---
+# Dotted Access
+
+## 1. Echo config
+- PASS COMPLETE
+
+\`\`\`bash
+rd echo host={{config.host}} port={{config.port}}
+\`\`\`
+`,
+      );
+
+      const result = runCli(
+        'run test.runbook.md --var-json config={"host":"localhost","port":3000} --json',
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const events = parseJsonlEvents(result.stdout);
+      const commandStartedEvent = events.find((e) => e.type === 'command_started');
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toContain('host=localhost');
+      expect(commandStartedEvent.command).toContain('port=3000');
+    });
+
+    it('object renders as serialized JSON when used directly', async () => {
+      const runbookContent = createRunbook({
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{config}}' }],
+      });
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+
+      const result = runCli(
+        'run test.runbook.md --var-json config={"host":"localhost"} --json',
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const events = parseJsonlEvents(result.stdout);
+      const commandStartedEvent = events.find((e) => e.type === 'command_started');
+      expect(commandStartedEvent).toBeDefined();
+      // Object is JSON-stringified and shell-escaped
+      expect(commandStartedEvent.command).toContain('"host":"localhost"');
+    });
+
+    it('--var-json overrides --var for same key', async () => {
+      const runbookContent = createRunbook({
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{count}}' }],
+      });
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+
+      const result = runCli(
+        'run test.runbook.md --var count=10 --var-json count=99 --json',
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const events = parseJsonlEvents(result.stdout);
+      const commandStartedEvent = events.find((e) => e.type === 'command_started');
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toBe('rd echo 99');
+    });
+
+    it('--var-json overrides --var-file for same key', async () => {
+      const runbookContent = createRunbook({
+        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{count}}' }],
+      });
+      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+      await writeFile(join(workspace.cwd, 'vars.yaml'), 'count: 10');
+
+      const result = runCli(
+        'run test.runbook.md --var-file vars.yaml --var-json count=99 --json',
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const events = parseJsonlEvents(result.stdout);
+      const commandStartedEvent = events.find((e) => e.type === 'command_started');
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toBe('rd echo 99');
+    });
+
+    it('multiple --var-json flags', async () => {
+      await writeFile(
+        join(workspace.cwd, 'test.runbook.md'),
+        `---
+name: multi-json
+---
+# Multi JSON
+
+## 1. Echo values
+- PASS COMPLETE
+
+\`\`\`bash
+rd echo a={{a}} b={{b}}
+\`\`\`
+`,
+      );
+
+      const result = runCli('run test.runbook.md --var-json a=1 --var-json b=2 --json', workspace);
+
+      expect(result.exitCode).toBe(0);
+      const events = parseJsonlEvents(result.stdout);
+      const commandStartedEvent = events.find((e) => e.type === 'command_started');
+      expect(commandStartedEvent).toBeDefined();
+      expect(commandStartedEvent.command).toContain('a=1');
+      expect(commandStartedEvent.command).toContain('b=2');
+    });
+  });
+
   describe('missing variables', () => {
     it('preserves undefined variables as literal text', async () => {
       const runbookContent = createRunbook({

--- a/runbooks/variables/var-json-array.runbook.md
+++ b/runbooks/variables/var-json-array.runbook.md
@@ -1,0 +1,27 @@
+---
+name: var-json-array
+description: Inline JSON array via --var-json drives FOR loop iteration
+tags:
+  - variables
+  - for-loops
+scenarios:
+  completed:
+    description: JSON array passed via --var-json drives FOR loop
+    commands:
+      - rd run --var-json 'items=["alpha","bravo","charlie"]' var-json-array.runbook.md
+    result: COMPLETE
+---
+
+# JSON Array Source
+
+## 1. Process items
+
+- FOR item IN {{ items }}
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Handle {{item}}
+
+```bash
+rd echo "item={{item}}"
+```

--- a/runbooks/variables/var-json-precedence.runbook.md
+++ b/runbooks/variables/var-json-precedence.runbook.md
@@ -1,0 +1,22 @@
+---
+name: var-json-precedence
+description: --var-json overrides --var for same key
+tags:
+  - variables
+scenarios:
+  override:
+    description: --var-json wins over --var for same key
+    commands:
+      - rd run --var count=10 --var-json count=99 var-json-precedence.runbook.md
+    result: COMPLETE
+---
+
+# JSON Precedence
+
+## 1. Echo count
+
+- PASS COMPLETE
+
+```bash
+rd echo "count={{count}}"
+```

--- a/runbooks/variables/var-json-scalar.runbook.md
+++ b/runbooks/variables/var-json-scalar.runbook.md
@@ -1,0 +1,22 @@
+---
+name: var-json-scalar
+description: Inline JSON scalar via --var-json sets template variable
+tags:
+  - variables
+scenarios:
+  completed:
+    description: JSON number passed via --var-json is used as template variable
+    commands:
+      - rd run --var-json count=42 var-json-scalar.runbook.md
+    result: COMPLETE
+---
+
+# JSON Scalar
+
+## 1. Echo count
+
+- PASS COMPLETE
+
+```bash
+rd echo "count={{count}}"
+```


### PR DESCRIPTION
Add E2E integration tests for the --var-json CLI flag covering:
- Scalar rendering (number, boolean, null)
- JSON object dotted field access and serialized rendering
- Precedence: --var-json overrides --var and --var-file
- Multiple --var-json flags
- JSON array as FOR loop data source (full, empty, windowed, objects)

Add scenario runbooks for --var-json:
- var-json-scalar: inline JSON number template variable
- var-json-array: inline JSON array drives FOR loop
- var-json-precedence: --var-json wins over --var for same key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--var-json` option to pass JSON variables (arrays, objects, scalars) with dotted property access support.
  * Enabled FOR loop iteration directly over JSON arrays via `--var-json`.
  * JSON variables take precedence over `--var` and `--var-file`.

* **Tests**
  * Added integration tests for FOR loop iteration with JSON data and template variable substitution.

* **Documentation**
  * Added runbooks demonstrating `--var-json` usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->