### PR TITLE
Rdx plan schema

### DIFF
--- a/packages/claude-code-plugin/__tests__/fixtures/rdx/invalid-json.txt
+++ b/packages/claude-code-plugin/__tests__/fixtures/rdx/invalid-json.txt
@@ -1,0 +1,1 @@
+{ this is not valid json }

--- a/packages/claude-code-plugin/__tests__/fixtures/rdx/invalid-plan.json
+++ b/packages/claude-code-plugin/__tests__/fixtures/rdx/invalid-plan.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "plan",
+  "name": "Incomplete Plan"
+}

--- a/packages/claude-code-plugin/__tests__/fixtures/rdx/invalid-plan.json
+++ b/packages/claude-code-plugin/__tests__/fixtures/rdx/invalid-plan.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "plan",
+  "$schema": "https://rundown.org/schemas/plan.schema.json",
   "name": "Incomplete Plan"
 }

--- a/packages/claude-code-plugin/__tests__/fixtures/rdx/no-schema.json
+++ b/packages/claude-code-plugin/__tests__/fixtures/rdx/no-schema.json
@@ -1,0 +1,4 @@
+{
+  "name": "Simple Doc",
+  "summary": "A plain JSON document with no schema"
+}

--- a/packages/claude-code-plugin/__tests__/fixtures/rdx/unknown-schema.json
+++ b/packages/claude-code-plugin/__tests__/fixtures/rdx/unknown-schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://other.org/schemas/plan.schema.json",
+  "name": "Incomplete Plan"
+}

--- a/packages/claude-code-plugin/__tests__/fixtures/rdx/valid-plan.json
+++ b/packages/claude-code-plugin/__tests__/fixtures/rdx/valid-plan.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "plan",
+  "name": "Test Plan",
+  "meta": { "version": "1.0.0" },
+  "goal": "Test the rdx CLI",
+  "architecture_and_approach": "Simple approach",
+  "constraints_and_assumptions": "None",
+  "dependencies": null,
+  "context": null,
+  "files": [{ "path": "src/foo.ts", "action": "create" }],
+  "tasks": [
+    {
+      "name": "First Task",
+      "files": [{ "path": "src/foo.ts", "action": "create" }],
+      "subtasks": [{ "name": "Write test", "description": "Test it", "code": null }],
+      "commit": { "files": ["src/foo.ts"], "message": "feat: add foo" }
+    }
+  ]
+}

--- a/packages/claude-code-plugin/__tests__/fixtures/rdx/valid-plan.json
+++ b/packages/claude-code-plugin/__tests__/fixtures/rdx/valid-plan.json
@@ -5,14 +5,12 @@
   "goal": "Test the rdx CLI",
   "architecture_and_approach": "Simple approach",
   "constraints_and_assumptions": "None",
-  "dependencies": null,
-  "context": null,
   "files": [{ "path": "src/foo.ts", "action": "create" }],
   "tasks": [
     {
       "name": "First Task",
       "files": [{ "path": "src/foo.ts", "action": "create" }],
-      "subtasks": [{ "name": "Write test", "description": "Test it", "code": null }],
+      "subtasks": [{ "name": "Write test", "description": "Test it" }],
       "commit": { "files": ["src/foo.ts"], "message": "feat: add foo" }
     }
   ]

--- a/packages/claude-code-plugin/__tests__/fixtures/rdx/valid-plan.json
+++ b/packages/claude-code-plugin/__tests__/fixtures/rdx/valid-plan.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "plan",
+  "$schema": "https://rundown.org/schemas/plan.schema.json",
   "name": "Test Plan",
   "meta": { "version": "1.0.0" },
   "goal": "Test the rdx CLI",

--- a/packages/claude-code-plugin/__tests__/plan-schema.test.ts
+++ b/packages/claude-code-plugin/__tests__/plan-schema.test.ts
@@ -237,10 +237,7 @@ describe('plan.schema.json', () => {
   });
 
   it('has format: filepath on file path fields', () => {
-    const defs = (schema as Record<string, unknown>).$defs as Record<
-      string,
-      Record<string, unknown>
-    >;
+    const defs = (schema as Record<string, Record<string, unknown>>).$defs;
     const fileEntry = defs.FileEntry;
     const fileProps = fileEntry.properties as Record<string, Record<string, unknown>>;
     expect(fileProps.path.format).toBe('filepath');

--- a/packages/claude-code-plugin/__tests__/plan-schema.test.ts
+++ b/packages/claude-code-plugin/__tests__/plan-schema.test.ts
@@ -3,8 +3,8 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ZodError } from 'zod';
-import { PlanSchema, validatePlan } from '../src/plan-schema.js';
-import type { Plan } from '../src/plan-schema.js';
+import { PlanSchema, type validate, validatePlan } from '../src/plan-schema.js';
+import type { Plan, PlanTask, PlanSubtask, PlanFileEntry, PlanMeta } from '../src/plan-schema.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,14 +17,12 @@ function validPlan(overrides: Record<string, unknown> = {}): Record<string, unkn
     goal: 'Do the thing',
     architecture_and_approach: 'Simple approach',
     constraints_and_assumptions: 'None',
-    dependencies: null,
-    context: null,
     files: [{ path: 'src/foo.ts', action: 'create' }],
     tasks: [
       {
         name: 'First Task',
         files: [{ path: 'src/foo.ts', action: 'create' }],
-        subtasks: [{ name: 'Write test', description: 'Test it', code: null }],
+        subtasks: [{ name: 'Write test', description: 'Test it' }],
         commit: { files: ['src/foo.ts'], message: 'feat: add foo' },
       },
     ],
@@ -38,12 +36,16 @@ describe('PlanSchema', () => {
       expect(() => PlanSchema.parse(validPlan())).not.toThrow();
     });
 
-    it('accepts null dependencies', () => {
-      expect(() => PlanSchema.parse(validPlan({ dependencies: null }))).not.toThrow();
+    it('accepts absent dependencies', () => {
+      const plan = validPlan();
+      expect(plan).not.toHaveProperty('dependencies');
+      expect(() => PlanSchema.parse(plan)).not.toThrow();
     });
 
-    it('accepts null context', () => {
-      expect(() => PlanSchema.parse(validPlan({ context: null }))).not.toThrow();
+    it('accepts absent context', () => {
+      const plan = validPlan();
+      expect(plan).not.toHaveProperty('context');
+      expect(() => PlanSchema.parse(plan)).not.toThrow();
     });
 
     it('accepts string dependencies', () => {
@@ -138,13 +140,13 @@ describe('PlanSchema', () => {
       expect(plan.tasks[0].commit).toBeUndefined();
     });
 
-    it('accepts subtask with null description', () => {
+    it('accepts subtask without description', () => {
       const plan = validPlan({
         tasks: [
           {
             name: 'Task',
             files: [{ path: 'src/foo.ts', action: 'create' }],
-            subtasks: [{ name: 'Run tests', description: null }],
+            subtasks: [{ name: 'Run tests' }],
             commit: { files: ['src/foo.ts'], message: 'feat: add foo' },
           },
         ],
@@ -220,6 +222,14 @@ describe('PlanSchema', () => {
       ).toThrow(ZodError);
     });
 
+    it('rejects null dependencies', () => {
+      expect(() => PlanSchema.parse(validPlan({ dependencies: null }))).toThrow(ZodError);
+    });
+
+    it('rejects null context', () => {
+      expect(() => PlanSchema.parse(validPlan({ context: null }))).toThrow(ZodError);
+    });
+
     it('rejects task with empty subtasks', () => {
       expect(() =>
         PlanSchema.parse(
@@ -239,6 +249,12 @@ describe('PlanSchema', () => {
   });
 
   describe('strict mode', () => {
+    it('rejects plan with wrong $schema URI', () => {
+      expect(() =>
+        PlanSchema.parse(validPlan({ $schema: 'https://other.org/schemas/plan.schema.json' })),
+      ).toThrow(ZodError);
+    });
+
     it('rejects plan with extra root-level property', () => {
       expect(() => PlanSchema.parse(validPlan({ extra: 'nope' }))).toThrow(ZodError);
     });
@@ -313,17 +329,94 @@ describe('plan.schema.json', () => {
     expect(required).toContain('tasks');
   });
 
-  it('has format: markdown on prose fields', () => {
+  it('has description on prose fields', () => {
     const props = schema.properties as Record<string, Record<string, unknown>>;
-    expect(props.goal.format).toBe('markdown');
-    expect(props.architecture_and_approach.format).toBe('markdown');
-    expect(props.constraints_and_assumptions.format).toBe('markdown');
+    expect(props.goal.description).toEqual(expect.any(String));
+    expect(props.architecture_and_approach.description).toEqual(expect.any(String));
+    expect(props.constraints_and_assumptions.description).toEqual(expect.any(String));
   });
 
-  it('has format: filepath on file path fields', () => {
+  it('has description on file path fields', () => {
     const defs = (schema as Record<string, Record<string, unknown>>).$defs;
     const fileEntry = defs.FileEntry;
     const fileProps = fileEntry.properties as Record<string, Record<string, unknown>>;
-    expect(fileProps.path.format).toBe('filepath');
+    expect(fileProps.path.description).toEqual(expect.any(String));
+  });
+
+  it('does not use unsupported format values', () => {
+    const props = schema.properties as Record<string, Record<string, unknown>>;
+    expect(props.goal).not.toHaveProperty('format');
+    expect(props.architecture_and_approach).not.toHaveProperty('format');
+    expect(props.constraints_and_assumptions).not.toHaveProperty('format');
+  });
+});
+
+describe('type-level API', () => {
+  it('validate() returns Plan', () => {
+    const _check: Plan = null as unknown as ReturnType<typeof validate>;
+    expect(true).toBe(true);
+  });
+
+  it('validatePlan() returns Plan', () => {
+    const _check: Plan = null as unknown as ReturnType<typeof validatePlan>;
+    expect(true).toBe(true);
+  });
+
+  it('Plan has required fields', () => {
+    const plan = {} as Plan;
+    const _name: string = plan.name;
+    const _goal: string = plan.goal;
+    const _meta: PlanMeta = plan.meta;
+    const _tasks: PlanTask[] = plan.tasks;
+    const _files: PlanFileEntry[] = plan.files;
+    expect(true).toBe(true);
+  });
+
+  it('PlanTask has required fields', () => {
+    const task = {} as PlanTask;
+    const _name: string = task.name;
+    const _files: PlanFileEntry[] = task.files;
+    const _subtasks: PlanSubtask[] = task.subtasks;
+    expect(true).toBe(true);
+  });
+
+  it('PlanSubtask has required fields', () => {
+    const subtask = {} as PlanSubtask;
+    const _name: string = subtask.name;
+    const _description: string | undefined = subtask.description;
+    expect(true).toBe(true);
+  });
+
+  it('PlanFileEntry has required fields', () => {
+    const entry = {} as PlanFileEntry;
+    const _path: string = entry.path;
+    const _action: 'create' | 'edit' | 'delete' = entry.action;
+    expect(true).toBe(true);
+  });
+
+  it('PlanMeta has version literal', () => {
+    const meta = {} as PlanMeta;
+    const _version: '1.0.0' = meta.version;
+    expect(true).toBe(true);
+  });
+
+  it('validate() does not return string', () => {
+    // @ts-expect-error - validate returns Plan, not string
+    const _bad: string = null as unknown as ReturnType<typeof validate>;
+    expect(true).toBe(true);
+  });
+
+  it('PlanFileEntry action rejects invalid values', () => {
+    const entry = {} as PlanFileEntry;
+    // @ts-expect-error - action is 'create' | 'edit' | 'delete', not 'rename'
+    const _bad: 'rename' = entry.action;
+    expect(true).toBe(true);
+  });
+
+  it('PlanMeta version rejects non-literal', () => {
+    const meta = {} as PlanMeta;
+    // @ts-expect-error - version is '1.0.0', not '2.0.0'
+    const _bad: '2.0.0' = meta.version;
+    expect(true).toBe(true);
   });
 });

--- a/packages/claude-code-plugin/__tests__/plan-schema.test.ts
+++ b/packages/claude-code-plugin/__tests__/plan-schema.test.ts
@@ -143,13 +143,51 @@ describe('PlanSchema', () => {
             tasks: [
               {
                 name: 'Task',
-                files: [],
+                files: [{ path: 'src/foo.ts', action: 'create' }],
                 subtasks: [],
                 commit: { files: ['src/foo.ts'], message: 'feat: add foo' },
               },
             ],
           }),
         ),
+      ).toThrow(ZodError);
+    });
+  });
+
+  describe('strict mode', () => {
+    it('rejects plan with extra root-level property', () => {
+      expect(() => PlanSchema.parse(validPlan({ extra: 'nope' }))).toThrow(ZodError);
+    });
+
+    it('rejects task with extra property', () => {
+      expect(() =>
+        PlanSchema.parse(
+          validPlan({
+            tasks: [
+              {
+                name: 'Task',
+                files: [{ path: 'src/foo.ts', action: 'create' }],
+                subtasks: [{ name: 'Sub', description: 'desc' }],
+                commit: { files: ['src/foo.ts'], message: 'feat: add foo' },
+                priority: 'high',
+              },
+            ],
+          }),
+        ),
+      ).toThrow(ZodError);
+    });
+
+    it('rejects file entry with extra property', () => {
+      expect(() =>
+        PlanSchema.parse(
+          validPlan({ files: [{ path: 'src/foo.ts', action: 'create', size: 100 }] }),
+        ),
+      ).toThrow(ZodError);
+    });
+
+    it('rejects meta with extra property', () => {
+      expect(() =>
+        PlanSchema.parse(validPlan({ meta: { version: '1.0.0', draft: true } })),
       ).toThrow(ZodError);
     });
   });
@@ -199,9 +237,12 @@ describe('plan.schema.json', () => {
   });
 
   it('has format: filepath on file path fields', () => {
-    const props = schema.properties as Record<string, Record<string, unknown>>;
-    const filesItems = props.files.items as Record<string, unknown>;
-    const fileProps = filesItems.properties as Record<string, Record<string, unknown>>;
+    const defs = (schema as Record<string, unknown>).$defs as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const fileEntry = defs.FileEntry;
+    const fileProps = fileEntry.properties as Record<string, Record<string, unknown>>;
     expect(fileProps.path.format).toBe('filepath');
   });
 });

--- a/packages/claude-code-plugin/__tests__/plan-schema.test.ts
+++ b/packages/claude-code-plugin/__tests__/plan-schema.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ZodError } from 'zod';
+import { PlanSchema, validatePlan } from '../src/plan-schema.js';
+import type { Plan } from '../src/plan-schema.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/** Minimal valid plan for testing. Override fields as needed. */
+function validPlan(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'Test Plan',
+    meta: { version: '1.0.0' },
+    goal: 'Do the thing',
+    architecture_and_approach: 'Simple approach',
+    constraints_and_assumptions: 'None',
+    dependencies: null,
+    context: null,
+    files: [{ path: 'src/foo.ts', action: 'create' }],
+    tasks: [
+      {
+        name: 'First Task',
+        files: [{ path: 'src/foo.ts', action: 'create' }],
+        subtasks: [{ name: 'Write test', description: 'Test it', code: null }],
+        commit: { files: ['src/foo.ts'], message: 'feat: add foo' },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('PlanSchema', () => {
+  describe('valid plans', () => {
+    it('accepts a valid minimal plan', () => {
+      expect(() => PlanSchema.parse(validPlan())).not.toThrow();
+    });
+
+    it('accepts null dependencies', () => {
+      expect(() => PlanSchema.parse(validPlan({ dependencies: null }))).not.toThrow();
+    });
+
+    it('accepts null context', () => {
+      expect(() => PlanSchema.parse(validPlan({ context: null }))).not.toThrow();
+    });
+
+    it('accepts string dependencies', () => {
+      expect(() => PlanSchema.parse(validPlan({ dependencies: 'Some dep' }))).not.toThrow();
+    });
+
+    it('accepts optional scope_assessment', () => {
+      const plan = validPlan();
+      delete plan.scope_assessment;
+      expect(() => PlanSchema.parse(plan)).not.toThrow();
+    });
+
+    it('accepts scope_assessment when provided', () => {
+      expect(() => PlanSchema.parse(validPlan({ scope_assessment: 'Small' }))).not.toThrow();
+    });
+
+    it('accepts optional notes on file entries', () => {
+      expect(() =>
+        PlanSchema.parse(
+          validPlan({ files: [{ path: 'src/foo.ts', action: 'create', notes: 'Widget class' }] }),
+        ),
+      ).not.toThrow();
+    });
+
+    it('accepts subtask with code block', () => {
+      const plan = validPlan({
+        tasks: [
+          {
+            name: 'Task',
+            files: [{ path: 'src/foo.ts', action: 'create' }],
+            subtasks: [
+              {
+                name: 'Write test',
+                description: 'Test it',
+                code: { language: 'typescript', content: 'expect(true).toBe(true);' },
+              },
+            ],
+            commit: { files: ['src/foo.ts'], message: 'feat: add foo' },
+          },
+        ],
+      });
+      expect(() => PlanSchema.parse(plan)).not.toThrow();
+    });
+
+    it('accepts subtask with null description', () => {
+      const plan = validPlan({
+        tasks: [
+          {
+            name: 'Task',
+            files: [{ path: 'src/foo.ts', action: 'create' }],
+            subtasks: [{ name: 'Run tests', description: null }],
+            commit: { files: ['src/foo.ts'], message: 'feat: add foo' },
+          },
+        ],
+      });
+      expect(() => PlanSchema.parse(plan)).not.toThrow();
+    });
+  });
+
+  describe('invalid plans', () => {
+    it('rejects missing required fields', () => {
+      expect(() => PlanSchema.parse({ name: 'Incomplete' })).toThrow(ZodError);
+    });
+
+    it('rejects invalid version', () => {
+      expect(() => PlanSchema.parse(validPlan({ meta: { version: '2.0.0' } }))).toThrow(ZodError);
+    });
+
+    it('rejects invalid file action', () => {
+      expect(() =>
+        PlanSchema.parse(validPlan({ files: [{ path: 'foo.ts', action: 'rename' }] })),
+      ).toThrow(ZodError);
+    });
+
+    it('rejects empty tasks array', () => {
+      expect(() => PlanSchema.parse(validPlan({ tasks: [] }))).toThrow(ZodError);
+    });
+
+    it('rejects empty files array', () => {
+      expect(() => PlanSchema.parse(validPlan({ files: [] }))).toThrow(ZodError);
+    });
+
+    it('rejects empty name', () => {
+      expect(() => PlanSchema.parse(validPlan({ name: '' }))).toThrow(ZodError);
+    });
+
+    it('rejects empty file path', () => {
+      expect(() =>
+        PlanSchema.parse(validPlan({ files: [{ path: '', action: 'create' }] })),
+      ).toThrow(ZodError);
+    });
+
+    it('rejects task with empty subtasks', () => {
+      expect(() =>
+        PlanSchema.parse(
+          validPlan({
+            tasks: [
+              {
+                name: 'Task',
+                files: [],
+                subtasks: [],
+                commit: { files: ['src/foo.ts'], message: 'feat: add foo' },
+              },
+            ],
+          }),
+        ),
+      ).toThrow(ZodError);
+    });
+  });
+});
+
+describe('validatePlan', () => {
+  it('returns typed Plan on valid input', () => {
+    const result: Plan = validatePlan(validPlan());
+    expect(result.name).toBe('Test Plan');
+    expect(result.meta.version).toBe('1.0.0');
+    expect(result.tasks).toHaveLength(1);
+    expect(result.files).toHaveLength(1);
+  });
+
+  it('throws ZodError on invalid input', () => {
+    expect(() => validatePlan({ name: 'Incomplete' })).toThrow(ZodError);
+  });
+});
+
+describe('plan.schema.json', () => {
+  let schema: Record<string, unknown>;
+
+  beforeAll(async () => {
+    const schemaPath = path.resolve(__dirname, '..', 'schemas', 'plan.schema.json');
+    const raw = await fs.readFile(schemaPath, 'utf-8');
+    schema = JSON.parse(raw);
+  });
+
+  it('is valid JSON with object type at root', () => {
+    expect(schema.type).toBe('object');
+  });
+
+  it('has required array containing key fields', () => {
+    const required = schema.required as string[];
+    expect(required).toContain('name');
+    expect(required).toContain('meta');
+    expect(required).toContain('goal');
+    expect(required).toContain('files');
+    expect(required).toContain('tasks');
+  });
+
+  it('has format: markdown on prose fields', () => {
+    const props = schema.properties as Record<string, Record<string, unknown>>;
+    expect(props.goal.format).toBe('markdown');
+    expect(props.architecture_and_approach.format).toBe('markdown');
+    expect(props.constraints_and_assumptions.format).toBe('markdown');
+  });
+
+  it('has format: filepath on file path fields', () => {
+    const props = schema.properties as Record<string, Record<string, unknown>>;
+    const filesItems = props.files.items as Record<string, unknown>;
+    const fileProps = filesItems.properties as Record<string, Record<string, unknown>>;
+    expect(fileProps.path.format).toBe('filepath');
+  });
+});

--- a/packages/claude-code-plugin/__tests__/plan-schema.test.ts
+++ b/packages/claude-code-plugin/__tests__/plan-schema.test.ts
@@ -50,14 +50,16 @@ describe('PlanSchema', () => {
       expect(() => PlanSchema.parse(validPlan({ dependencies: 'Some dep' }))).not.toThrow();
     });
 
-    it('accepts optional scope_assessment', () => {
-      const plan = validPlan();
-      delete plan.scope_assessment;
-      expect(() => PlanSchema.parse(plan)).not.toThrow();
+    it('accepts plan with $schema URI', () => {
+      expect(() =>
+        PlanSchema.parse(validPlan({ $schema: 'https://rundown.org/schemas/plan.schema.json' })),
+      ).not.toThrow();
     });
 
-    it('accepts scope_assessment when provided', () => {
-      expect(() => PlanSchema.parse(validPlan({ scope_assessment: 'Small' }))).not.toThrow();
+    it('accepts plan without $schema', () => {
+      const plan = validPlan();
+      expect(plan).not.toHaveProperty('$schema');
+      expect(() => PlanSchema.parse(plan)).not.toThrow();
     });
 
     it('accepts optional notes on file entries', () => {

--- a/packages/claude-code-plugin/__tests__/plan-schema.test.ts
+++ b/packages/claude-code-plugin/__tests__/plan-schema.test.ts
@@ -88,6 +88,54 @@ describe('PlanSchema', () => {
       expect(() => PlanSchema.parse(plan)).not.toThrow();
     });
 
+    it('accepts task with files but no commit', () => {
+      const plan = PlanSchema.parse(
+        validPlan({
+          tasks: [
+            {
+              name: 'Review docs',
+              files: [{ path: 'docs/api.md', action: 'edit' }],
+              subtasks: [{ name: 'Check accuracy', description: 'Verify examples' }],
+            },
+          ],
+        }),
+      );
+      expect(plan.tasks[0].commit).toBeUndefined();
+    });
+
+    it('accepts task with empty files and commit', () => {
+      expect(() =>
+        PlanSchema.parse(
+          validPlan({
+            tasks: [
+              {
+                name: 'Config update',
+                files: [],
+                subtasks: [{ name: 'Update settings', description: 'Change config' }],
+                commit: { files: ['config.json'], message: 'chore: update config' },
+              },
+            ],
+          }),
+        ),
+      ).not.toThrow();
+    });
+
+    it('accepts task with empty files and no commit', () => {
+      const plan = PlanSchema.parse(
+        validPlan({
+          tasks: [
+            {
+              name: 'Research',
+              files: [],
+              subtasks: [{ name: 'Investigate', description: 'Review alternatives' }],
+            },
+          ],
+        }),
+      );
+      expect(plan.tasks[0].files).toHaveLength(0);
+      expect(plan.tasks[0].commit).toBeUndefined();
+    });
+
     it('accepts subtask with null description', () => {
       const plan = validPlan({
         tasks: [
@@ -146,6 +194,23 @@ describe('PlanSchema', () => {
                 files: [{ path: 'src/foo.ts', action: 'create' }],
                 subtasks: [{ name: 'Sub', description: 'Do it' }],
                 commit: { files: [], message: 'feat: add foo' },
+              },
+            ],
+          }),
+        ),
+      ).toThrow(ZodError);
+    });
+
+    it('rejects commit with empty message', () => {
+      expect(() =>
+        PlanSchema.parse(
+          validPlan({
+            tasks: [
+              {
+                name: 'Task',
+                files: [{ path: 'src/foo.ts', action: 'create' }],
+                subtasks: [{ name: 'Sub', description: 'Do it' }],
+                commit: { files: ['src/foo.ts'], message: '' },
               },
             ],
           }),

--- a/packages/claude-code-plugin/__tests__/plan-schema.test.ts
+++ b/packages/claude-code-plugin/__tests__/plan-schema.test.ts
@@ -136,6 +136,23 @@ describe('PlanSchema', () => {
       ).toThrow(ZodError);
     });
 
+    it('rejects commit with empty files array', () => {
+      expect(() =>
+        PlanSchema.parse(
+          validPlan({
+            tasks: [
+              {
+                name: 'Task',
+                files: [{ path: 'src/foo.ts', action: 'create' }],
+                subtasks: [{ name: 'Sub', description: 'Do it' }],
+                commit: { files: [], message: 'feat: add foo' },
+              },
+            ],
+          }),
+        ),
+      ).toThrow(ZodError);
+    });
+
     it('rejects task with empty subtasks', () => {
       expect(() =>
         PlanSchema.parse(

--- a/packages/claude-code-plugin/__tests__/rdx-core.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-core.test.ts
@@ -174,7 +174,7 @@ describe('renderToMarkdown', () => {
       expect(md).toContain('```typescript\nconst x = 1;\n```\n');
     });
 
-    it('renders code block shape with extra fields as fenced code block', () => {
+    it('preserves extra fields on code-like objects instead of treating as code block', () => {
       const md = renderToMarkdown({
         name: 'Root',
         tasks: [
@@ -184,7 +184,9 @@ describe('renderToMarkdown', () => {
           },
         ],
       });
-      expect(md).toContain('```typescript\nconst x = 1;\n```\n');
+      // Extra field means this is NOT a code block — all fields rendered
+      expect(md).not.toContain('```typescript\nconst x = 1;\n```\n');
+      expect(md).toContain('optional note');
     });
 
     it('renders nested object as subsection at depth+1', () => {

--- a/packages/claude-code-plugin/__tests__/rdx-core.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-core.test.ts
@@ -51,6 +51,12 @@ describe('renderToMarkdown', () => {
       expect(md).toContain('## Goal\n');
       expect(md).not.toContain('## Meta');
     });
+
+    it('skips fields with empty-string keys', () => {
+      const md = renderToMarkdown({ name: 'Root', '': 'hidden' });
+      // Empty key should not produce a bare "## \n" heading
+      expect(md).not.toMatch(/^##\s*$/m);
+    });
   });
 
   describe('arrays', () => {
@@ -100,6 +106,15 @@ describe('renderToMarkdown', () => {
         ],
       });
       expect(md).toContain('| A | B | C |');
+    });
+
+    it('escapes pipe characters in table cell values', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        items: [{ value: 'a|b', other: 'ok' }],
+      });
+      expect(md).toContain('| a\\|b | ok |');
+      expect(md).not.toMatch(/\| a\|b \|/);
     });
 
     it('renders nested named arrays with cascading numbers', () => {

--- a/packages/claude-code-plugin/__tests__/rdx-core.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-core.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from '@jest/globals';
+import { renderToMarkdown } from '../src/rdx-core.js';
+
+describe('renderToMarkdown', () => {
+  describe('primitives and headings', () => {
+    it('renders name as H1', () => {
+      const md = renderToMarkdown({ name: 'Title' });
+      expect(md).toBe('# Title\n');
+    });
+
+    it('renders name + string field as H1 + H2 section', () => {
+      const md = renderToMarkdown({ name: 'Title', goal: 'Do X' });
+      expect(md).toContain('# Title\n');
+      expect(md).toContain('## Goal\n\nDo X\n');
+    });
+
+    it('omits null fields entirely', () => {
+      const md = renderToMarkdown({ name: 'Title', dependencies: null });
+      expect(md).not.toContain('Dependencies');
+    });
+
+    it('renders number as string paragraph', () => {
+      const md = renderToMarkdown({ name: 'Root', count: 42 });
+      expect(md).toContain('## Count\n\n42\n');
+    });
+
+    it('renders boolean as string paragraph', () => {
+      const md = renderToMarkdown({ name: 'Root', enabled: true });
+      expect(md).toContain('## Enabled\n\ntrue\n');
+    });
+
+    it('converts underscore field names to Title Case headings', () => {
+      const md = renderToMarkdown({ name: 'Root', architecture_and_approach: 'Simple' });
+      expect(md).toContain('## Architecture And Approach\n');
+    });
+
+    it('renders meta as YAML frontmatter', () => {
+      const md = renderToMarkdown({ name: 'My Plan', meta: { version: '1.0.0' } });
+      expect(md).toMatch(/^---\nversion: ['"]?1\.0\.0['"]?\n---\n/);
+      expect(md).not.toContain('## Meta');
+    });
+
+    it('does not render meta in body', () => {
+      const md = renderToMarkdown({
+        name: 'Plan',
+        meta: { version: '1.0.0', tags: ['planning'] },
+        goal: 'Do it',
+      });
+      expect(md).toContain('---\n');
+      expect(md).toContain('# Plan\n');
+      expect(md).toContain('## Goal\n');
+      expect(md).not.toContain('## Meta');
+    });
+  });
+
+  describe('arrays', () => {
+    it('renders array of primitives as bullet list', () => {
+      const md = renderToMarkdown({ name: 'Root', items: ['a', 'b', 'c'] });
+      expect(md).toContain('## Items\n\n- a\n- b\n- c\n');
+    });
+
+    it('omits empty arrays', () => {
+      const md = renderToMarkdown({ name: 'Root', items: [] });
+      expect(md).not.toContain('Items');
+    });
+
+    it('renders named array elements at parent depth without container heading', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        tasks: [
+          { name: 'First Task', description: 'Do first thing' },
+          { name: 'Second Task', description: 'Do second thing' },
+        ],
+      });
+      expect(md).toContain('## 1. First Task\n');
+      expect(md).toContain('## 2. Second Task\n');
+      expect(md).not.toContain('## Tasks');
+    });
+
+    it('renders array of objects without name as pipe table', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        files: [
+          { path: 'src/widget.ts', action: 'create', notes: 'Widget class' },
+          { path: 'src/index.ts', action: 'edit' },
+        ],
+      });
+      expect(md).toContain('| Path | Action | Notes |');
+      expect(md).toMatch(/\|---+\|---+\|---+\|/); // separator row
+      expect(md).toContain('| src/widget.ts | create | Widget class |');
+      expect(md).toContain('| src/index.ts | edit |  |');
+    });
+
+    it('derives table column headers from union of all keys', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        items: [
+          { a: '1', b: '2' },
+          { a: '3', c: '4' },
+        ],
+      });
+      expect(md).toContain('| A | B | C |');
+    });
+
+    it('renders nested named arrays with cascading numbers', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        tasks: [
+          {
+            name: 'Task One',
+            subtasks: [
+              { name: 'Sub A', description: 'Do A' },
+              { name: 'Sub B', description: 'Do B' },
+            ],
+          },
+        ],
+      });
+      expect(md).toContain('## 1. Task One\n');
+      expect(md).toContain('### 1.1 Sub A\n');
+      expect(md).toContain('### 1.2 Sub B\n');
+    });
+  });
+
+  describe('code blocks', () => {
+    it('renders field named code as fenced code block', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        code: 'console.log("hello");',
+      });
+      expect(md).toContain('```\nconsole.log("hello");\n```\n');
+    });
+
+    it('renders object with language and content as fenced code block', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        tasks: [
+          {
+            name: 'Task',
+            code: { language: 'typescript', content: 'const x = 1;' },
+          },
+        ],
+      });
+      expect(md).toContain('```typescript\nconst x = 1;\n```\n');
+    });
+
+    it('renders nested object as subsection at depth+1', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        commit: { files: ['src/a.ts'], message: 'feat: add a' },
+      });
+      expect(md).toContain('## Commit\n');
+      expect(md).toContain('### Files\n');
+      expect(md).toContain('- src/a.ts\n');
+      expect(md).toContain('### Message\n');
+      expect(md).toContain('feat: add a\n');
+    });
+
+    it('caps heading depth at H6', () => {
+      // Deeply nested object: Root(H1) > a(H2) > b(H3) > c(H4) > d(H5) > e(H6) > f(H6, capped)
+      const md = renderToMarkdown({
+        name: 'Root',
+        a: { b: { c: { d: { e: { f: 'deep' } } } } },
+      });
+      // Count all headings — the deepest should be H6, not H7
+      expect(md).not.toContain('#######');
+      expect(md).toContain('###### F\n');
+    });
+  });
+
+  describe('integration', () => {
+    it('produces deterministic output (same input, same output)', () => {
+      const input = {
+        name: 'Add Widget',
+        meta: { version: '1.0.0' },
+        goal: 'Create a widget component.',
+        architecture_and_approach: 'Simple component following existing patterns.',
+        dependencies: null,
+        files: [{ path: 'src/widget.ts', action: 'create', notes: 'Widget class' }],
+        tasks: [
+          {
+            name: 'Implement Widget',
+            files: [{ path: 'src/widget.ts', action: 'create' }],
+            subtasks: [
+              {
+                name: 'Write failing test',
+                description: 'Test widget construction.',
+                code: { language: 'typescript', content: 'expect(new Widget()).toBeDefined();' },
+              },
+              {
+                name: 'Implement widget',
+                description: 'Create the widget class.',
+                code: { language: 'typescript', content: 'export class Widget {}' },
+              },
+            ],
+          },
+        ],
+      };
+      const first = renderToMarkdown(input);
+      const second = renderToMarkdown(input);
+      expect(first).toBe(second);
+    });
+
+    it('renders the design doc example correctly', () => {
+      const input = {
+        name: 'Add Widget',
+        meta: { version: '1.0.0' },
+        goal: 'Create a widget component.',
+        architecture_and_approach: 'Simple component following existing patterns.',
+        dependencies: null,
+        files: [{ path: 'src/widget.ts', action: 'create', notes: 'Widget class' }],
+        tasks: [
+          {
+            name: 'Implement Widget',
+            files: [{ path: 'src/widget.ts', action: 'create' }],
+            subtasks: [
+              {
+                name: 'Write failing test',
+                description: 'Test widget construction.',
+                code: { language: 'typescript', content: 'expect(new Widget()).toBeDefined();' },
+              },
+              {
+                name: 'Implement widget',
+                description: 'Create the widget class.',
+                code: { language: 'typescript', content: 'export class Widget {}' },
+              },
+            ],
+          },
+        ],
+      };
+      const md = renderToMarkdown(input);
+      // Frontmatter
+      expect(md).toMatch(/^---\n/);
+      // H1
+      expect(md).toContain('# Add Widget\n');
+      // Prose sections
+      expect(md).toContain('## Goal\n\nCreate a widget component.\n');
+      expect(md).toContain('## Architecture And Approach\n');
+      // Null omitted
+      expect(md).not.toContain('Dependencies');
+      // File table
+      expect(md).toContain('| Path | Action | Notes |');
+      expect(md).toContain('| src/widget.ts | create | Widget class |');
+      // Task heading (named array replaces parent)
+      expect(md).toContain('## 1. Implement Widget\n');
+      expect(md).not.toContain('## Tasks');
+      // Subtask headings
+      expect(md).toContain('### 1.1 Write Failing Test\n');
+      expect(md).toContain('### 1.2 Implement Widget\n');
+      // Code blocks
+      expect(md).toContain('```typescript\nexpect(new Widget()).toBeDefined();\n```');
+      expect(md).toContain('```typescript\nexport class Widget {}\n```');
+    });
+  });
+});

--- a/packages/claude-code-plugin/__tests__/rdx-core.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-core.test.ts
@@ -117,6 +117,14 @@ describe('renderToMarkdown', () => {
       expect(md).not.toMatch(/\| a\|b \|/);
     });
 
+    it('escapes backslash characters in table cell values', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        items: [{ value: 'a\\b', other: 'c\\|d' }],
+      });
+      expect(md).toContain('| a\\\\b | c\\\\\\|d |');
+    });
+
     it('renders nested named arrays with cascading numbers', () => {
       const md = renderToMarkdown({
         name: 'Root',

--- a/packages/claude-code-plugin/__tests__/rdx-core.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-core.test.ts
@@ -266,4 +266,66 @@ describe('renderToMarkdown', () => {
       expect(md).toContain('```typescript\nexport class Widget {}\n```');
     });
   });
+
+  describe('root-level arrays', () => {
+    it('renders primitive array as bullet list', () => {
+      const md = renderToMarkdown(['apple', 'banana', 'cherry']);
+      expect(md).toContain('- apple');
+      expect(md).toContain('- banana');
+      expect(md).toContain('- cherry');
+    });
+
+    it('renders named object array as numbered sections', () => {
+      const md = renderToMarkdown([
+        { name: 'First', description: 'One' },
+        { name: 'Second', description: 'Two' },
+      ]);
+      expect(md).toContain('# 1. First');
+      expect(md).toContain('# 2. Second');
+      expect(md).toContain('One');
+      expect(md).toContain('Two');
+    });
+
+    it('renders plain object array as pipe table', () => {
+      const md = renderToMarkdown([
+        { path: 'src/a.ts', action: 'create' },
+        { path: 'src/b.ts', action: 'edit' },
+      ]);
+      expect(md).toContain('| Path | Action |');
+      expect(md).toContain('| src/a.ts | create |');
+      expect(md).toContain('| src/b.ts | edit |');
+    });
+
+    it('renders empty array as empty string', () => {
+      expect(renderToMarkdown([])).toBe('');
+    });
+  });
+
+  describe('$schema stripping', () => {
+    it('omits $schema field from rendered output', () => {
+      const md = renderToMarkdown({
+        $schema: 'plan',
+        name: 'My Doc',
+        goal: 'Do stuff',
+      });
+      expect(md).toContain('# My Doc');
+      expect(md).toContain('Do stuff');
+      expect(md).not.toContain('$schema');
+      expect(md).not.toContain('plan');
+    });
+
+    it('renders all other fields normally alongside $schema', () => {
+      const md = renderToMarkdown({
+        $schema: 'plan',
+        name: 'Title',
+        meta: { version: '1.0.0' },
+        summary: 'A summary',
+      });
+      expect(md).toContain('# Title');
+      expect(md).toContain('---');
+      expect(md).toContain('version:');
+      expect(md).toContain('A summary');
+      expect(md).not.toContain('$schema');
+    });
+  });
 });

--- a/packages/claude-code-plugin/__tests__/rdx-core.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-core.test.ts
@@ -117,6 +117,14 @@ describe('renderToMarkdown', () => {
       expect(md).not.toMatch(/\| a\|b \|/);
     });
 
+    it('normalizes newlines in table cell values', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        items: [{ value: 'line1\nline2', other: 'a\r\nb' }],
+      });
+      expect(md).toContain('| line1 line2 | a b |');
+    });
+
     it('escapes backslash characters in table cell values', () => {
       const md = renderToMarkdown({
         name: 'Root',

--- a/packages/claude-code-plugin/__tests__/rdx-core.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-core.test.ts
@@ -174,6 +174,19 @@ describe('renderToMarkdown', () => {
       expect(md).toContain('```typescript\nconst x = 1;\n```\n');
     });
 
+    it('renders code block shape with extra fields as fenced code block', () => {
+      const md = renderToMarkdown({
+        name: 'Root',
+        tasks: [
+          {
+            name: 'Task',
+            code: { language: 'typescript', content: 'const x = 1;', description: 'optional note' },
+          },
+        ],
+      });
+      expect(md).toContain('```typescript\nconst x = 1;\n```\n');
+    });
+
     it('renders nested object as subsection at depth+1', () => {
       const md = renderToMarkdown({
         name: 'Root',

--- a/packages/claude-code-plugin/__tests__/rdx-validate.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-validate.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from '@jest/globals';
+import { type ZodError, z } from 'zod';
+import {
+  stripSchema,
+  resolveSchemaName,
+  loadValidator,
+  formatValidationErrors,
+} from '../src/rdx-validate.js';
+
+describe('stripSchema', () => {
+  it('extracts $schema field and returns clean data', () => {
+    const data = { $schema: 'plan', name: 'Test', goal: 'Do it' };
+    const { cleanData, schemaName } = stripSchema(data);
+    expect(schemaName).toBe('plan');
+    expect(cleanData).toEqual({ name: 'Test', goal: 'Do it' });
+  });
+
+  it('returns undefined schemaName when no $schema', () => {
+    const data = { name: 'Test' };
+    const { cleanData, schemaName } = stripSchema(data);
+    expect(schemaName).toBeUndefined();
+    expect(cleanData).toEqual({ name: 'Test' });
+  });
+
+  it('returns data unchanged when $schema is not a string', () => {
+    const data = { $schema: 42, name: 'Test' };
+    const { cleanData, schemaName } = stripSchema(data);
+    expect(schemaName).toBeUndefined();
+    expect(cleanData).toBe(data);
+  });
+
+  it('handles non-object data', () => {
+    expect(stripSchema('hello')).toEqual({ cleanData: 'hello', schemaName: undefined });
+    expect(stripSchema(null)).toEqual({ cleanData: null, schemaName: undefined });
+    expect(stripSchema([1, 2])).toEqual({ cleanData: [1, 2], schemaName: undefined });
+  });
+});
+
+describe('resolveSchemaName', () => {
+  it('returns explicit flag when both flag and data schema present', () => {
+    expect(resolveSchemaName('override', 'plan')).toBe('override');
+  });
+
+  it('returns data schema when no flag', () => {
+    expect(resolveSchemaName(undefined, 'plan')).toBe('plan');
+  });
+
+  it('returns undefined when neither provided', () => {
+    expect(resolveSchemaName(undefined, undefined)).toBeUndefined();
+  });
+
+  it('returns flag when data schema is undefined', () => {
+    expect(resolveSchemaName('plan', undefined)).toBe('plan');
+  });
+});
+
+describe('loadValidator', () => {
+  it('loads plan-schema validate function', async () => {
+    const validate = await loadValidator('plan');
+    expect(typeof validate).toBe('function');
+  });
+
+  it('throws for unknown schema name', async () => {
+    await expect(loadValidator('nonexistent')).rejects.toThrow('Unknown schema: nonexistent');
+  });
+
+  it('loaded validator rejects invalid data', async () => {
+    const validate = await loadValidator('plan');
+    expect(() => validate({ name: 'Incomplete' })).toThrow();
+  });
+
+  it('loaded validator accepts valid data', async () => {
+    const validate = await loadValidator('plan');
+    const result = validate({
+      name: 'Test Plan',
+      meta: { version: '1.0.0' },
+      goal: 'Do the thing',
+      architecture_and_approach: 'Simple approach',
+      constraints_and_assumptions: 'None',
+      dependencies: null,
+      context: null,
+      files: [{ path: 'src/foo.ts', action: 'create' }],
+      tasks: [
+        {
+          name: 'First Task',
+          files: [{ path: 'src/foo.ts', action: 'create' }],
+          subtasks: [{ name: 'Write test', description: 'Test it', code: null }],
+          commit: { files: ['src/foo.ts'], message: 'feat: add foo' },
+        },
+      ],
+    });
+    expect(result).toHaveProperty('name', 'Test Plan');
+  });
+});
+
+describe('formatValidationErrors', () => {
+  it('formats ZodError with paths', () => {
+    const schema = z.object({ name: z.string(), count: z.number() });
+    let error: ZodError | undefined;
+    try {
+      schema.parse({ name: 123, count: 'oops' });
+    } catch (e) {
+      error = e as ZodError;
+    }
+    expect(error).toBeDefined();
+    const output = formatValidationErrors(error!, 'test');
+    expect(output).toContain('error: schema validation failed (test)');
+    expect(output).toContain('/name:');
+    expect(output).toContain('/count:');
+  });
+
+  it('formats ZodError without schema name', () => {
+    const schema = z.object({ x: z.string() });
+    let error: ZodError | undefined;
+    try {
+      schema.parse({});
+    } catch (e) {
+      error = e as ZodError;
+    }
+    const output = formatValidationErrors(error!);
+    expect(output).toContain('error: schema validation failed\n');
+    expect(output).not.toContain('(');
+  });
+
+  it('formats non-ZodError', () => {
+    const output = formatValidationErrors(new Error('boom'), 'plan');
+    expect(output).toContain('error: schema validation failed (plan)');
+    expect(output).toContain('boom');
+  });
+
+  it('formats string error', () => {
+    const output = formatValidationErrors('something went wrong');
+    expect(output).toContain('something went wrong');
+  });
+});

--- a/packages/claude-code-plugin/__tests__/rdx-validate.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-validate.test.ts
@@ -64,6 +64,18 @@ describe('loadValidator', () => {
     await expect(loadValidator('nonexistent')).rejects.toThrow('Unknown schema: nonexistent');
   });
 
+  it('rejects path traversal in schema name', async () => {
+    await expect(loadValidator('../shared/errors')).rejects.toThrow('Invalid schema name');
+  });
+
+  it('rejects uppercase schema names', async () => {
+    await expect(loadValidator('PLAN')).rejects.toThrow('Invalid schema name');
+  });
+
+  it('rejects schema names with underscores', async () => {
+    await expect(loadValidator('plan_v2')).rejects.toThrow('Invalid schema name');
+  });
+
   it('loaded validator rejects invalid data', async () => {
     const validate = await loadValidator('plan');
     expect(() => validate({ name: 'Incomplete' })).toThrow();

--- a/packages/claude-code-plugin/__tests__/rdx-validate.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-validate.test.ts
@@ -39,36 +39,57 @@ describe('stripSchema', () => {
       name: 'Test',
       goal: 'Do it',
     };
-    const { cleanData, schemaName } = stripSchema(data);
+    const { cleanData, schemaName, rawSchema } = stripSchema(data);
     expect(schemaName).toBe('plan');
+    expect(rawSchema).toBe('https://rundown.org/schemas/plan.schema.json');
     expect(cleanData).toEqual({ name: 'Test', goal: 'Do it' });
   });
 
   it('extracts bare $schema name for backward compat', () => {
     const data = { $schema: 'plan', name: 'Test' };
-    const { cleanData, schemaName } = stripSchema(data);
+    const { cleanData, schemaName, rawSchema } = stripSchema(data);
     expect(schemaName).toBe('plan');
+    expect(rawSchema).toBe('plan');
     expect(cleanData).toEqual({ name: 'Test' });
   });
 
-  it('returns undefined schemaName when no $schema', () => {
-    const data = { name: 'Test' };
-    const { cleanData, schemaName } = stripSchema(data);
+  it('returns rawSchema but undefined schemaName for unrecognized URI', () => {
+    const data = { $schema: 'https://other.org/schemas/plan.schema.json', name: 'Test' };
+    const { cleanData, schemaName, rawSchema } = stripSchema(data);
     expect(schemaName).toBeUndefined();
+    expect(rawSchema).toBe('https://other.org/schemas/plan.schema.json');
+    expect(cleanData).toEqual({ name: 'Test' });
+  });
+
+  it('returns undefined schemaName and rawSchema when no $schema', () => {
+    const data = { name: 'Test' };
+    const { cleanData, schemaName, rawSchema } = stripSchema(data);
+    expect(schemaName).toBeUndefined();
+    expect(rawSchema).toBeUndefined();
     expect(cleanData).toEqual({ name: 'Test' });
   });
 
   it('returns data unchanged when $schema is not a string', () => {
     const data = { $schema: 42, name: 'Test' };
-    const { cleanData, schemaName } = stripSchema(data);
+    const { cleanData, schemaName, rawSchema } = stripSchema(data);
     expect(schemaName).toBeUndefined();
+    expect(rawSchema).toBeUndefined();
     expect(cleanData).toBe(data);
   });
 
   it('handles non-object data', () => {
-    expect(stripSchema('hello')).toEqual({ cleanData: 'hello', schemaName: undefined });
-    expect(stripSchema(null)).toEqual({ cleanData: null, schemaName: undefined });
-    expect(stripSchema([1, 2])).toEqual({ cleanData: [1, 2], schemaName: undefined });
+    const none = { cleanData: 'hello', schemaName: undefined, rawSchema: undefined };
+    expect(stripSchema('hello')).toEqual(none);
+    expect(stripSchema(null)).toEqual({
+      cleanData: null,
+      schemaName: undefined,
+      rawSchema: undefined,
+    });
+    expect(stripSchema([1, 2])).toEqual({
+      cleanData: [1, 2],
+      schemaName: undefined,
+      rawSchema: undefined,
+    });
   });
 });
 
@@ -125,14 +146,12 @@ describe('loadValidator', () => {
       goal: 'Do the thing',
       architecture_and_approach: 'Simple approach',
       constraints_and_assumptions: 'None',
-      dependencies: null,
-      context: null,
       files: [{ path: 'src/foo.ts', action: 'create' }],
       tasks: [
         {
           name: 'First Task',
           files: [{ path: 'src/foo.ts', action: 'create' }],
-          subtasks: [{ name: 'Write test', description: 'Test it', code: null }],
+          subtasks: [{ name: 'Write test', description: 'Test it' }],
           commit: { files: ['src/foo.ts'], message: 'feat: add foo' },
         },
       ],

--- a/packages/claude-code-plugin/__tests__/rdx-validate.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx-validate.test.ts
@@ -1,18 +1,54 @@
 import { describe, it, expect } from '@jest/globals';
 import { type ZodError, z } from 'zod';
 import {
+  parseSchemaName,
   stripSchema,
   resolveSchemaName,
   loadValidator,
   formatValidationErrors,
 } from '../src/rdx-validate.js';
 
+describe('parseSchemaName', () => {
+  it('extracts name from full URI', () => {
+    expect(parseSchemaName('https://rundown.org/schemas/plan.schema.json')).toBe('plan');
+  });
+
+  it('accepts bare name for backward compat', () => {
+    expect(parseSchemaName('plan')).toBe('plan');
+  });
+
+  it('accepts hyphenated names', () => {
+    expect(parseSchemaName('https://rundown.org/schemas/my-schema.schema.json')).toBe('my-schema');
+    expect(parseSchemaName('my-schema')).toBe('my-schema');
+  });
+
+  it('returns undefined for unrecognized URI', () => {
+    expect(parseSchemaName('https://other.org/schemas/plan.schema.json')).toBeUndefined();
+  });
+
+  it('returns undefined for invalid bare name', () => {
+    expect(parseSchemaName('PLAN')).toBeUndefined();
+    expect(parseSchemaName('../traversal')).toBeUndefined();
+  });
+});
+
 describe('stripSchema', () => {
-  it('extracts $schema field and returns clean data', () => {
-    const data = { $schema: 'plan', name: 'Test', goal: 'Do it' };
+  it('extracts $schema URI and returns clean data with resolved name', () => {
+    const data = {
+      $schema: 'https://rundown.org/schemas/plan.schema.json',
+      name: 'Test',
+      goal: 'Do it',
+    };
     const { cleanData, schemaName } = stripSchema(data);
     expect(schemaName).toBe('plan');
     expect(cleanData).toEqual({ name: 'Test', goal: 'Do it' });
+  });
+
+  it('extracts bare $schema name for backward compat', () => {
+    const data = { $schema: 'plan', name: 'Test' };
+    const { cleanData, schemaName } = stripSchema(data);
+    expect(schemaName).toBe('plan');
+    expect(cleanData).toEqual({ name: 'Test' });
   });
 
   it('returns undefined schemaName when no $schema', () => {

--- a/packages/claude-code-plugin/__tests__/rdx.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx.integration.test.ts
@@ -1,0 +1,121 @@
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturesDir = path.join(__dirname, 'fixtures', 'rdx');
+
+const runRdx = (args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['dist/rdx.js', ...args], {
+      cwd: path.resolve(__dirname, '..'),
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
+    });
+
+    proc.on('error', reject);
+  });
+};
+
+describe('rdx --check', () => {
+  test('valid JSON without schema prints Valid', async () => {
+    const result = await runRdx(['--check', path.join(fixturesDir, 'no-schema.json')]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('Valid.\n');
+  });
+
+  test('valid plan with $schema field prints Valid', async () => {
+    const result = await runRdx(['--check', path.join(fixturesDir, 'valid-plan.json')]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('Valid.\n');
+  });
+
+  test('invalid JSON syntax prints error and exits 1', async () => {
+    const result = await runRdx(['--check', path.join(fixturesDir, 'invalid-json.txt')]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('error:');
+  });
+
+  test('valid JSON failing schema prints validation errors and exits 1', async () => {
+    const result = await runRdx(['--check', path.join(fixturesDir, 'invalid-plan.json')]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('schema validation failed');
+    expect(result.stderr).toContain('plan');
+  });
+
+  test('--schema flag overrides $schema field', async () => {
+    // valid-plan.json has $schema: "plan", but --schema nonexistent should fail
+    const result = await runRdx([
+      '--check',
+      '--schema',
+      'nonexistent',
+      path.join(fixturesDir, 'valid-plan.json'),
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Unknown schema: nonexistent');
+  });
+
+  test('--schema flag validates file without $schema field', async () => {
+    // no-schema.json has no $schema, but --schema plan should validate (and fail)
+    const result = await runRdx([
+      '--check',
+      '--schema',
+      'plan',
+      path.join(fixturesDir, 'no-schema.json'),
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('schema validation failed');
+  });
+});
+
+describe('rdx render', () => {
+  test('valid JSON with $schema renders Markdown without $schema in output', async () => {
+    const result = await runRdx([path.join(fixturesDir, 'valid-plan.json')]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('# Test Plan');
+    expect(result.stdout).not.toContain('$schema');
+  });
+
+  test('invalid JSON with $schema prints errors and exits 1', async () => {
+    const result = await runRdx([path.join(fixturesDir, 'invalid-plan.json')]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('schema validation failed');
+  });
+
+  test('no schema renders without validation', async () => {
+    const result = await runRdx([path.join(fixturesDir, 'no-schema.json')]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('# Simple Doc');
+    expect(result.stdout).toContain('A plain JSON document with no schema');
+  });
+
+  test('--output writes to file', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'rdx-test-'));
+    const outPath = path.join(tmpDir, 'output.md');
+    try {
+      const result = await runRdx([path.join(fixturesDir, 'valid-plan.json'), '-o', outPath]);
+      expect(result.exitCode).toBe(0);
+      const content = await fs.readFile(outPath, 'utf-8');
+      expect(content).toContain('# Test Plan');
+      expect(content).not.toContain('$schema');
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/claude-code-plugin/__tests__/rdx.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx.integration.test.ts
@@ -71,6 +71,12 @@ describe('rdx --check', () => {
     expect(result.stderr).toContain('Unknown schema: nonexistent');
   });
 
+  test('unrecognized $schema URI prints error and exits 1', async () => {
+    const result = await runRdx(['--check', path.join(fixturesDir, 'unknown-schema.json')]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unrecognized schema');
+  });
+
   test('--schema flag validates file without $schema field', async () => {
     // no-schema.json has no $schema, but --schema plan should validate (and fail)
     const result = await runRdx([

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Claude Code plugin for runbook orchestration and workflow execution",
   "type": "module",
   "bin": {
-    "rdpath": "dist/rdpath.js"
+    "rdpath": "dist/rdpath.js",
+    "rdx": "dist/rdx.js"
   },
   "main": "dist/cli.js",
   "types": "dist/index.d.ts",
@@ -19,6 +20,7 @@
   },
   "files": [
     "dist",
+    "schemas",
     ".claude-plugin",
     "commands",
     "hooks",

--- a/packages/claude-code-plugin/runbooks/planning/write-plan.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/write-plan.runbook.md
@@ -16,7 +16,7 @@ Write a detailed implementation plan for a feature or task.
 
 ## 2. Write & save the plan
 
-Use the Writing Plans Skill. Output the plan as JSON conforming to the plan schema.
+Use the Writing Plans Skill. Output the plan as JSON conforming to the plan schema. Include `"$schema": "plan"` in the JSON for automatic validation.
 
 JSON path: `{{ WorkPath }}/{{ FeatureName }}/{{ Date }}-plan.json`
 

--- a/packages/claude-code-plugin/runbooks/planning/write-plan.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/write-plan.runbook.md
@@ -16,7 +16,7 @@ Write a detailed implementation plan for a feature or task.
 
 ## 2. Write & save the plan
 
-Use the Writing Plans Skill. Output the plan as JSON conforming to the plan schema. Include `"$schema": "plan"` in the JSON for automatic validation.
+Use the Writing Plans Skill. Output the plan as JSON conforming to the plan schema. Include `"$schema": "https://rundown.org/schemas/plan.schema.json"` in the JSON for automatic validation.
 
 JSON path: `{{ WorkPath }}/{{ FeatureName }}/{{ Date }}-plan.json`
 

--- a/packages/claude-code-plugin/runbooks/planning/write-plan.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/write-plan.runbook.md
@@ -16,9 +16,13 @@ Write a detailed implementation plan for a feature or task.
 
 ## 2. Write & save the plan
 
-Use the Writing Plans Skill.
+Use the Writing Plans Skill. Output the plan as JSON conforming to the plan schema.
 
-Path: `{{ WorkPath }}/{{ FeatureName }}/{{ Date }}-plan.md`
+JSON path: `{{ WorkPath }}/{{ FeatureName }}/{{ Date }}-plan.json`
+
+Validate: `rdx --check {{ WorkPath }}/{{ FeatureName }}/{{ Date }}-plan.json`
+
+Render: `rdx {{ WorkPath }}/{{ FeatureName }}/{{ Date }}-plan.json --output {{ WorkPath }}/{{ FeatureName }}/{{ Date }}-plan.md`
 
 ---
 

--- a/packages/claude-code-plugin/schemas/plan.schema.json
+++ b/packages/claude-code-plugin/schemas/plan.schema.json
@@ -82,7 +82,7 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["name", "files", "subtasks", "commit"],
+        "required": ["name", "files", "subtasks"],
         "properties": {
           "name": {
             "type": "string",

--- a/packages/claude-code-plugin/schemas/plan.schema.json
+++ b/packages/claude-code-plugin/schemas/plan.schema.json
@@ -130,6 +130,7 @@
             "properties": {
               "files": {
                 "type": "array",
+                "minItems": 1,
                 "items": {
                   "type": "string",
                   "minLength": 1,

--- a/packages/claude-code-plugin/schemas/plan.schema.json
+++ b/packages/claude-code-plugin/schemas/plan.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rundown.org/schemas/plan.schema.json",
+  "title": "Plan",
+  "description": "Implementation plan for the Rundown planning workflow.",
+  "type": "object",
+  "required": [
+    "name",
+    "meta",
+    "goal",
+    "architecture_and_approach",
+    "constraints_and_assumptions",
+    "dependencies",
+    "context",
+    "files",
+    "tasks"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "meta": {
+      "type": "object",
+      "required": ["version"],
+      "properties": {
+        "version": {
+          "const": "1.0.0"
+        }
+      },
+      "additionalProperties": false
+    },
+    "goal": {
+      "type": "string",
+      "format": "markdown"
+    },
+    "architecture_and_approach": {
+      "type": "string",
+      "format": "markdown"
+    },
+    "constraints_and_assumptions": {
+      "type": "string",
+      "format": "markdown"
+    },
+    "dependencies": {
+      "oneOf": [{ "type": "string", "format": "markdown" }, { "type": "null" }]
+    },
+    "context": {
+      "oneOf": [{ "type": "string", "format": "markdown" }, { "type": "null" }]
+    },
+    "scope_assessment": {
+      "type": "string"
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["path", "action"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "format": "filepath"
+          },
+          "action": {
+            "type": "string",
+            "enum": ["create", "edit", "delete"]
+          },
+          "notes": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "files", "subtasks", "commit"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["path", "action"],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "filepath"
+                },
+                "action": {
+                  "type": "string",
+                  "enum": ["create", "edit", "delete"]
+                },
+                "notes": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "subtasks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["name", "description"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "description": {
+                  "oneOf": [{ "type": "string", "format": "markdown" }, { "type": "null" }]
+                },
+                "code": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "required": ["language", "content"],
+                      "properties": {
+                        "language": { "type": "string" },
+                        "content": { "type": "string" }
+                      },
+                      "additionalProperties": false
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "commit": {
+            "type": "object",
+            "required": ["files", "message"],
+            "properties": {
+              "files": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "filepath"
+                }
+              },
+              "message": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/claude-code-plugin/schemas/plan.schema.json
+++ b/packages/claude-code-plugin/schemas/plan.schema.json
@@ -37,6 +37,12 @@
     "tasks"
   ],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "const": "https://rundown.org/schemas/plan.schema.json",
+      "description": "Schema URI for editor autocomplete and rdx validation dispatch."
+    },
     "name": {
       "type": "string",
       "minLength": 1
@@ -69,9 +75,6 @@
     "context": {
       "oneOf": [{ "type": "string", "format": "markdown" }, { "type": "null" }]
     },
-    "scope_assessment": {
-      "type": "string"
-    },
     "files": {
       "type": "array",
       "minItems": 1,
@@ -90,7 +93,8 @@
           },
           "files": {
             "type": "array",
-            "items": { "$ref": "#/$defs/FileEntry" }
+            "items": { "$ref": "#/$defs/FileEntry" },
+            "description": "Files affected by this task. May be empty for research or config-only tasks; commit.files independently enforces staged files."
           },
           "subtasks": {
             "type": "array",

--- a/packages/claude-code-plugin/schemas/plan.schema.json
+++ b/packages/claude-code-plugin/schemas/plan.schema.json
@@ -4,6 +4,27 @@
   "title": "Plan",
   "description": "Implementation plan for the Rundown planning workflow.",
   "type": "object",
+  "$defs": {
+    "FileEntry": {
+      "type": "object",
+      "required": ["path", "action"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "format": "filepath"
+        },
+        "action": {
+          "type": "string",
+          "enum": ["create", "edit", "delete"]
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
   "required": [
     "name",
     "meta",
@@ -54,25 +75,7 @@
     "files": {
       "type": "array",
       "minItems": 1,
-      "items": {
-        "type": "object",
-        "required": ["path", "action"],
-        "properties": {
-          "path": {
-            "type": "string",
-            "minLength": 1,
-            "format": "filepath"
-          },
-          "action": {
-            "type": "string",
-            "enum": ["create", "edit", "delete"]
-          },
-          "notes": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      }
+      "items": { "$ref": "#/$defs/FileEntry" }
     },
     "tasks": {
       "type": "array",
@@ -87,25 +90,7 @@
           },
           "files": {
             "type": "array",
-            "items": {
-              "type": "object",
-              "required": ["path", "action"],
-              "properties": {
-                "path": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "filepath"
-                },
-                "action": {
-                  "type": "string",
-                  "enum": ["create", "edit", "delete"]
-                },
-                "notes": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
+            "items": { "$ref": "#/$defs/FileEntry" }
           },
           "subtasks": {
             "type": "array",

--- a/packages/claude-code-plugin/schemas/plan.schema.json
+++ b/packages/claude-code-plugin/schemas/plan.schema.json
@@ -12,7 +12,7 @@
         "path": {
           "type": "string",
           "minLength": 1,
-          "format": "filepath"
+          "description": "Relative file path from project root (e.g. src/foo.ts)"
         },
         "action": {
           "type": "string",
@@ -31,8 +31,6 @@
     "goal",
     "architecture_and_approach",
     "constraints_and_assumptions",
-    "dependencies",
-    "context",
     "files",
     "tasks"
   ],
@@ -59,21 +57,23 @@
     },
     "goal": {
       "type": "string",
-      "format": "markdown"
+      "description": "Clear, concise description of the desired outcome"
     },
     "architecture_and_approach": {
       "type": "string",
-      "format": "markdown"
+      "description": "High-level solution design, critical components, data and integrations"
     },
     "constraints_and_assumptions": {
       "type": "string",
-      "format": "markdown"
+      "description": "Hard constraints and assumptions"
     },
     "dependencies": {
-      "oneOf": [{ "type": "string", "format": "markdown" }, { "type": "null" }]
+      "type": "string",
+      "description": "Required services, frameworks, libraries, or upstream changes"
     },
     "context": {
-      "oneOf": [{ "type": "string", "format": "markdown" }, { "type": "null" }]
+      "type": "string",
+      "description": "Additional context useful for implementation"
     },
     "files": {
       "type": "array",
@@ -101,28 +101,24 @@
             "minItems": 1,
             "items": {
               "type": "object",
-              "required": ["name", "description"],
+              "required": ["name"],
               "properties": {
                 "name": {
                   "type": "string",
                   "minLength": 1
                 },
                 "description": {
-                  "oneOf": [{ "type": "string", "format": "markdown" }, { "type": "null" }]
+                  "type": "string",
+                  "description": "What this subtask does and how"
                 },
                 "code": {
-                  "oneOf": [
-                    {
-                      "type": "object",
-                      "required": ["language", "content"],
-                      "properties": {
-                        "language": { "type": "string" },
-                        "content": { "type": "string" }
-                      },
-                      "additionalProperties": false
-                    },
-                    { "type": "null" }
-                  ]
+                  "type": "object",
+                  "required": ["language", "content"],
+                  "properties": {
+                    "language": { "type": "string" },
+                    "content": { "type": "string" }
+                  },
+                  "additionalProperties": false
                 }
               },
               "additionalProperties": false
@@ -138,7 +134,7 @@
                 "items": {
                   "type": "string",
                   "minLength": 1,
-                  "format": "filepath"
+                  "description": "File path to stage for commit"
                 }
               },
               "message": {

--- a/packages/claude-code-plugin/skills/writing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-plans/SKILL.md
@@ -93,14 +93,14 @@ Decompose the work into small, self-contained, granular tasks.
 The canonical plan format is **JSON** conforming to the plan schema. After writing the JSON plan, render it to Markdown with `rdx`.
 
 **Schema:** `${CLAUDE_PLUGIN_ROOT}schemas/plan.schema.json`
-**Validation:** Include `"$schema": "plan"` in the JSON — `rdx` auto-discovers and validates against the plan schema.
+**Validation:** Include `"$schema": "https://rundown.org/schemas/plan.schema.json"` in the JSON — `rdx` auto-discovers and validates against the plan schema.
 **Rendering:** `rdx <plan.json> --output <plan.md>`
 
 ### JSON Structure
 
 ```json
 {
-  "$schema": "plan",
+  "$schema": "https://rundown.org/schemas/plan.schema.json",
   "name": "Feature Name",
   "meta": { "version": "1.0.0" },
   "goal": "...",

--- a/packages/claude-code-plugin/skills/writing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-plans/SKILL.md
@@ -106,15 +106,14 @@ The canonical plan format is **JSON** conforming to the plan schema. After writi
   "goal": "...",
   "architecture_and_approach": "...",
   "constraints_and_assumptions": "...",
-  "dependencies": null,
-  "context": null,
+  "dependencies": "...",
   "files": [{ "path": "src/foo.ts", "action": "create", "notes": "..." }],
   "tasks": [{
     "name": "Task Name",
     "files": [{ "path": "src/foo.ts", "action": "create" }],
     "subtasks": [
       { "name": "Write failing test", "description": "...", "code": { "language": "typescript", "content": "..." } },
-      { "name": "Implement", "description": "...", "code": null }
+      { "name": "Implement", "description": "..." }
     ],
     "commit": { "files": ["src/foo.ts"], "message": "feat: add foo" }
   }]

--- a/packages/claude-code-plugin/skills/writing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-plans/SKILL.md
@@ -88,8 +88,47 @@ Decompose the work into small, self-contained, granular tasks.
 - Avoid exposition and verbosity
 
 
-## Template
+## Output Format
 
+The canonical plan format is **JSON** conforming to the plan schema. After writing the JSON plan, render it to Markdown with `rdx`.
+
+**Schema:** `${CLAUDE_PLUGIN_ROOT}schemas/plan.schema.json`
+**Validation:** `validatePlan()` from `plan-schema.ts`
+**Rendering:** `rdx <plan.json> --output <plan.md>`
+
+### JSON Structure
+
+```json
+{
+  "name": "Feature Name",
+  "meta": { "version": "1.0.0" },
+  "goal": "...",
+  "architecture_and_approach": "...",
+  "constraints_and_assumptions": "...",
+  "dependencies": null,
+  "context": null,
+  "files": [{ "path": "src/foo.ts", "action": "create", "notes": "..." }],
+  "tasks": [{
+    "name": "Task Name",
+    "files": [{ "path": "src/foo.ts", "action": "create" }],
+    "subtasks": [
+      { "name": "Write failing test", "description": "...", "code": { "language": "typescript", "content": "..." } },
+      { "name": "Implement", "description": "...", "code": null }
+    ],
+    "commit": { "files": ["src/foo.ts"], "message": "feat: add foo" }
+  }]
+}
+```
+
+### Workflow
+
+1. Write the plan as JSON
+2. Validate: `rdx --check <plan.json>`
+3. Render: `rdx <plan.json> --output <plan.md>`
+
+## Template (Reference)
+
+The rendered Markdown structure is shown in the template for reference:
 - `${CLAUDE_PLUGIN_ROOT}templates/planning/plan.template.md`
 
 ### Example Task Definition

--- a/packages/claude-code-plugin/skills/writing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-plans/SKILL.md
@@ -93,13 +93,14 @@ Decompose the work into small, self-contained, granular tasks.
 The canonical plan format is **JSON** conforming to the plan schema. After writing the JSON plan, render it to Markdown with `rdx`.
 
 **Schema:** `${CLAUDE_PLUGIN_ROOT}schemas/plan.schema.json`
-**Validation:** `validatePlan()` from `plan-schema.ts`
+**Validation:** Include `"$schema": "plan"` in the JSON — `rdx` auto-discovers and validates against the plan schema.
 **Rendering:** `rdx <plan.json> --output <plan.md>`
 
 ### JSON Structure
 
 ```json
 {
+  "$schema": "plan",
   "name": "Feature Name",
   "meta": { "version": "1.0.0" },
   "goal": "...",

--- a/packages/claude-code-plugin/src/plan-schema.ts
+++ b/packages/claude-code-plugin/src/plan-schema.ts
@@ -73,7 +73,7 @@ const Task = z
     name: z.string().min(1),
     files: z.array(FileEntry),
     subtasks: z.array(Subtask).min(1),
-    commit: CommitStep,
+    commit: CommitStep.optional(),
   })
   .strict();
 

--- a/packages/claude-code-plugin/src/plan-schema.ts
+++ b/packages/claude-code-plugin/src/plan-schema.ts
@@ -1,0 +1,122 @@
+/**
+ * Zod schema and validation for the JSON plan format.
+ *
+ * Defines the canonical structure for implementation plans. Plans are
+ * authored as JSON and rendered to Markdown by the generic `rdx` renderer.
+ *
+ * @module plan-schema
+ */
+
+import { z } from 'zod';
+
+/**
+ * String field that may contain markdown content.
+ *
+ * @returns Zod string schema with 'markdown' description
+ */
+const markdown = (): z.ZodString => z.string().describe('markdown');
+
+/**
+ * String field representing a file path.
+ *
+ * @returns Zod string schema with min(1) and 'filepath' description
+ */
+const filepath = (): z.ZodString => z.string().min(1).describe('filepath');
+
+/**
+ * A file entry describing a file affected by the plan.
+ */
+const FileEntry = z.object({
+  path: filepath(),
+  action: z.enum(['create', 'edit', 'delete']),
+  notes: z.string().optional(),
+});
+
+/**
+ * A fenced code block with language annotation.
+ */
+const CodeBlock = z.object({
+  language: z.string(),
+  content: z.string(),
+});
+
+/**
+ * A subtask within a task. Numbering is derived from ordinal position.
+ */
+const Subtask = z.object({
+  name: z.string().min(1),
+  description: markdown().nullable(),
+  code: CodeBlock.nullable().optional(),
+});
+
+/**
+ * Commit step specifying files to stage and commit message.
+ */
+const CommitStep = z.object({
+  files: z.array(filepath()),
+  message: z.string().min(1),
+});
+
+/**
+ * A task grouping related subtasks. Numbering is derived from ordinal position.
+ */
+const Task = z.object({
+  name: z.string().min(1),
+  files: z.array(FileEntry),
+  subtasks: z.array(Subtask).min(1),
+  commit: CommitStep,
+});
+
+/**
+ * Document metadata rendered as YAML frontmatter by the generic renderer.
+ * Named `Meta` (not `PlanMeta`) for reuse across document types.
+ */
+const Meta = z.object({
+  version: z.literal('1.0.0'),
+});
+
+/**
+ * Schema for a complete implementation plan.
+ *
+ * Validates the JSON structure used by the planning workflow.
+ * The `meta` field is rendered as YAML frontmatter by the generic renderer.
+ * The `name` field is rendered as the H1 heading.
+ */
+export const PlanSchema = z.object({
+  name: z.string().min(1),
+  meta: Meta,
+  goal: markdown(),
+  architecture_and_approach: markdown(),
+  constraints_and_assumptions: markdown(),
+  dependencies: markdown().nullable(),
+  context: markdown().nullable(),
+  scope_assessment: z.string().optional(),
+  files: z.array(FileEntry).min(1),
+  tasks: z.array(Task).min(1),
+});
+
+/** Validated plan type inferred from PlanSchema. */
+export type Plan = z.infer<typeof PlanSchema>;
+
+/** Validated task type inferred from Task schema. */
+export type PlanTask = z.infer<typeof Task>;
+
+/** Validated subtask type inferred from Subtask schema. */
+export type PlanSubtask = z.infer<typeof Subtask>;
+
+/** Validated file entry type inferred from FileEntry schema. */
+export type PlanFileEntry = z.infer<typeof FileEntry>;
+
+/** Document metadata type inferred from Meta schema. */
+export type Meta = z.infer<typeof Meta>;
+
+/**
+ * Validate unknown data against the plan schema.
+ *
+ * @param data - Unknown data to validate
+ * @returns Typed Plan object
+ * @throws {ZodError} If data does not conform to PlanSchema
+ */
+export function validatePlan(data: unknown): Plan {
+  return PlanSchema.parse(data);
+}

--- a/packages/claude-code-plugin/src/plan-schema.ts
+++ b/packages/claude-code-plugin/src/plan-schema.ts
@@ -10,25 +10,11 @@
 import { z } from 'zod';
 
 /**
- * String field that may contain markdown content.
- *
- * @returns Zod string schema with 'markdown' description
- */
-const markdown = (): z.ZodString => z.string().describe('markdown');
-
-/**
- * String field representing a file path.
- *
- * @returns Zod string schema with min(1) and 'filepath' description
- */
-const filepath = (): z.ZodString => z.string().min(1).describe('filepath');
-
-/**
  * A file entry describing a file affected by the plan.
  */
 const FileEntry = z
   .object({
-    path: filepath(),
+    path: z.string().min(1).describe('Relative file path from project root (e.g. src/foo.ts)'),
     action: z.enum(['create', 'edit', 'delete']),
     notes: z.string().optional(),
   })
@@ -50,8 +36,8 @@ const CodeBlock = z
 const Subtask = z
   .object({
     name: z.string().min(1),
-    description: markdown().nullable(),
-    code: CodeBlock.nullable().optional(),
+    description: z.string().describe('What this subtask does and how').optional(),
+    code: CodeBlock.optional(),
   })
   .strict();
 
@@ -60,7 +46,7 @@ const Subtask = z
  */
 const CommitStep = z
   .object({
-    files: z.array(filepath()).min(1),
+    files: z.array(z.string().min(1).describe('File path to stage for commit')).min(1),
     message: z.string().min(1),
   })
   .strict();
@@ -100,14 +86,19 @@ const Meta = z
  */
 export const PlanSchema = z
   .object({
-    $schema: z.string().url().optional(),
+    $schema: z.literal('https://rundown.org/schemas/plan.schema.json').optional(),
     name: z.string().min(1),
     meta: Meta,
-    goal: markdown(),
-    architecture_and_approach: markdown(),
-    constraints_and_assumptions: markdown(),
-    dependencies: markdown().nullable(),
-    context: markdown().nullable(),
+    goal: z.string().describe('Clear, concise description of the desired outcome'),
+    architecture_and_approach: z
+      .string()
+      .describe('High-level solution design, critical components, data and integrations'),
+    constraints_and_assumptions: z.string().describe('Hard constraints and assumptions'),
+    dependencies: z
+      .string()
+      .describe('Required services, frameworks, libraries, or upstream changes')
+      .optional(),
+    context: z.string().describe('Additional context useful for implementation').optional(),
     files: z.array(FileEntry).min(1),
     tasks: z.array(Task).min(1),
   })

--- a/packages/claude-code-plugin/src/plan-schema.ts
+++ b/packages/claude-code-plugin/src/plan-schema.ts
@@ -67,6 +67,10 @@ const CommitStep = z
 
 /**
  * A task grouping related subtasks. Numbering is derived from ordinal position.
+ *
+ * `files` intentionally allows an empty array — research or config-only tasks
+ * may not touch any files directly. `commit.files` independently enforces that
+ * commits stage at least one file.
  */
 const Task = z
   .object({
@@ -96,6 +100,7 @@ const Meta = z
  */
 export const PlanSchema = z
   .object({
+    $schema: z.string().url().optional(),
     name: z.string().min(1),
     meta: Meta,
     goal: markdown(),
@@ -103,7 +108,6 @@ export const PlanSchema = z
     constraints_and_assumptions: markdown(),
     dependencies: markdown().nullable(),
     context: markdown().nullable(),
-    scope_assessment: z.string().optional(),
     files: z.array(FileEntry).min(1),
     tasks: z.array(Task).min(1),
   })

--- a/packages/claude-code-plugin/src/plan-schema.ts
+++ b/packages/claude-code-plugin/src/plan-schema.ts
@@ -122,7 +122,7 @@ export type PlanSubtask = z.infer<typeof Subtask>;
 export type PlanFileEntry = z.infer<typeof FileEntry>;
 
 /** Document metadata type inferred from Meta schema. */
-export type Meta = z.infer<typeof Meta>;
+export type PlanMeta = z.infer<typeof Meta>;
 
 /**
  * Validate unknown data against the plan schema.

--- a/packages/claude-code-plugin/src/plan-schema.ts
+++ b/packages/claude-code-plugin/src/plan-schema.ts
@@ -26,54 +26,66 @@ const filepath = (): z.ZodString => z.string().min(1).describe('filepath');
 /**
  * A file entry describing a file affected by the plan.
  */
-const FileEntry = z.object({
-  path: filepath(),
-  action: z.enum(['create', 'edit', 'delete']),
-  notes: z.string().optional(),
-});
+const FileEntry = z
+  .object({
+    path: filepath(),
+    action: z.enum(['create', 'edit', 'delete']),
+    notes: z.string().optional(),
+  })
+  .strict();
 
 /**
  * A fenced code block with language annotation.
  */
-const CodeBlock = z.object({
-  language: z.string(),
-  content: z.string(),
-});
+const CodeBlock = z
+  .object({
+    language: z.string(),
+    content: z.string(),
+  })
+  .strict();
 
 /**
  * A subtask within a task. Numbering is derived from ordinal position.
  */
-const Subtask = z.object({
-  name: z.string().min(1),
-  description: markdown().nullable(),
-  code: CodeBlock.nullable().optional(),
-});
+const Subtask = z
+  .object({
+    name: z.string().min(1),
+    description: markdown().nullable(),
+    code: CodeBlock.nullable().optional(),
+  })
+  .strict();
 
 /**
  * Commit step specifying files to stage and commit message.
  */
-const CommitStep = z.object({
-  files: z.array(filepath()),
-  message: z.string().min(1),
-});
+const CommitStep = z
+  .object({
+    files: z.array(filepath()),
+    message: z.string().min(1),
+  })
+  .strict();
 
 /**
  * A task grouping related subtasks. Numbering is derived from ordinal position.
  */
-const Task = z.object({
-  name: z.string().min(1),
-  files: z.array(FileEntry),
-  subtasks: z.array(Subtask).min(1),
-  commit: CommitStep,
-});
+const Task = z
+  .object({
+    name: z.string().min(1),
+    files: z.array(FileEntry),
+    subtasks: z.array(Subtask).min(1),
+    commit: CommitStep,
+  })
+  .strict();
 
 /**
  * Document metadata rendered as YAML frontmatter by the generic renderer.
  * Named `Meta` (not `PlanMeta`) for reuse across document types.
  */
-const Meta = z.object({
-  version: z.literal('1.0.0'),
-});
+const Meta = z
+  .object({
+    version: z.literal('1.0.0'),
+  })
+  .strict();
 
 /**
  * Schema for a complete implementation plan.
@@ -82,18 +94,20 @@ const Meta = z.object({
  * The `meta` field is rendered as YAML frontmatter by the generic renderer.
  * The `name` field is rendered as the H1 heading.
  */
-export const PlanSchema = z.object({
-  name: z.string().min(1),
-  meta: Meta,
-  goal: markdown(),
-  architecture_and_approach: markdown(),
-  constraints_and_assumptions: markdown(),
-  dependencies: markdown().nullable(),
-  context: markdown().nullable(),
-  scope_assessment: z.string().optional(),
-  files: z.array(FileEntry).min(1),
-  tasks: z.array(Task).min(1),
-});
+export const PlanSchema = z
+  .object({
+    name: z.string().min(1),
+    meta: Meta,
+    goal: markdown(),
+    architecture_and_approach: markdown(),
+    constraints_and_assumptions: markdown(),
+    dependencies: markdown().nullable(),
+    context: markdown().nullable(),
+    scope_assessment: z.string().optional(),
+    files: z.array(FileEntry).min(1),
+    tasks: z.array(Task).min(1),
+  })
+  .strict();
 
 /** Validated plan type inferred from PlanSchema. */
 export type Plan = z.infer<typeof PlanSchema>;
@@ -113,10 +127,22 @@ export type Meta = z.infer<typeof Meta>;
 /**
  * Validate unknown data against the plan schema.
  *
+ * Convention export for generic rdx schema discovery.
+ * Schema modules export `validate(data)` so rdx can load them by name.
+ *
  * @param data - Unknown data to validate
  * @returns Typed Plan object
  * @throws {ZodError} If data does not conform to PlanSchema
  */
-export function validatePlan(data: unknown): Plan {
+export function validate(data: unknown): Plan {
   return PlanSchema.parse(data);
 }
+
+/**
+ * Alias for {@link validate} — retained for backward compatibility.
+ *
+ * @param data - Unknown data to validate
+ * @returns Typed Plan object
+ * @throws {ZodError} If data does not conform to PlanSchema
+ */
+export const validatePlan = validate;

--- a/packages/claude-code-plugin/src/plan-schema.ts
+++ b/packages/claude-code-plugin/src/plan-schema.ts
@@ -60,7 +60,7 @@ const Subtask = z
  */
 const CommitStep = z
   .object({
-    files: z.array(filepath()),
+    files: z.array(filepath()).min(1),
     message: z.string().min(1),
   })
   .strict();

--- a/packages/claude-code-plugin/src/rdx-core.ts
+++ b/packages/claude-code-plugin/src/rdx-core.ts
@@ -359,7 +359,9 @@ function renderObjectFields(obj: Record<string, unknown>, depth: number, prefix:
 export function renderToMarkdown(data: unknown): string {
   if (data === null || data === undefined) return '\n';
   if (Array.isArray(data)) return renderArray(data, 1, '').join('\n');
-  if (typeof data !== 'object') return `${String(data)}\n`;
+  if (typeof data === 'string') return `${data}\n`;
+  if (typeof data === 'number' || typeof data === 'boolean') return `${String(data)}\n`;
+  if (typeof data !== 'object') return '\n';
 
   const obj = data as Record<string, unknown>;
   const lines: string[] = [];

--- a/packages/claude-code-plugin/src/rdx-core.ts
+++ b/packages/claude-code-plugin/src/rdx-core.ts
@@ -16,15 +16,27 @@ const MAX_DEPTH = 6;
  * Convert a field name or value to a Title Case heading.
  *
  * Splits on underscores and spaces, capitalizes every word.
+ * Returns empty string for empty input.
  *
  * @param field - The field name (e.g. `architecture_and_approach`) or value (e.g. `Write failing test`)
- * @returns Title-cased heading text (e.g. `Architecture And Approach`)
+ * @returns Title-cased heading text (e.g. `Architecture And Approach`), or empty string
  */
 function toHeading(field: string): string {
+  if (!field) return '';
   return field
     .split(/[_ ]+/)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
+}
+
+/**
+ * Escape pipe characters in a string for use in Markdown table cells.
+ *
+ * @param s - Cell content
+ * @returns Escaped string safe for pipe tables
+ */
+function escapeCell(s: string): string {
+  return s.replace(/\|/g, '\\|');
 }
 
 /**
@@ -115,14 +127,14 @@ function renderTable(items: Array<Record<string, unknown>>): string {
     const cells = keys.map((k) => {
       const val = item[k];
       if (val === undefined || val === null) return '';
-      if (typeof val === 'string') return val;
+      if (typeof val === 'string') return escapeCell(val);
       if (typeof val === 'number' || typeof val === 'boolean') return String(val);
-      return JSON.stringify(val);
+      return escapeCell(JSON.stringify(val));
     });
     lines.push(`| ${cells.join(' | ')} |`);
   }
 
-  return lines.join('\n') + '\n';
+  return `${lines.join('\n')}\n`;
 }
 
 /**
@@ -299,6 +311,7 @@ function renderObjectFields(obj: Record<string, unknown>, depth: number, prefix:
   const lines: string[] = [];
 
   for (const [key, val] of Object.entries(obj)) {
+    if (!key) continue;
     if (val === null || val === undefined) continue;
     if (Array.isArray(val) && val.length === 0) continue;
 
@@ -345,7 +358,7 @@ function renderObjectFields(obj: Record<string, unknown>, depth: number, prefix:
  */
 export function renderToMarkdown(data: unknown): string {
   if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-    return String(data) + '\n';
+    return `${String(data)}\n`;
   }
 
   const obj = data as Record<string, unknown>;
@@ -366,7 +379,7 @@ export function renderToMarkdown(data: unknown): string {
 
   // Render remaining fields at depth 2
   for (const [key, val] of Object.entries(obj)) {
-    if (key === 'name' || key === 'meta') continue;
+    if (!key || key === 'name' || key === 'meta') continue;
     if (val === null || val === undefined) continue;
     if (Array.isArray(val) && val.length === 0) continue;
 

--- a/packages/claude-code-plugin/src/rdx-core.ts
+++ b/packages/claude-code-plugin/src/rdx-core.ts
@@ -55,21 +55,43 @@ function heading(text: string, depth: number): string {
 }
 
 /**
+ * Render a `code` field as a fenced code block.
+ *
+ * Strings render as bare fences. Objects with `{ language, content }` shape
+ * delegate to {@link renderValue} for language-annotated fences.
+ *
+ * @param val - The code field value
+ * @param depth - Current heading depth (for nested code block objects)
+ * @param prefix - Numbering prefix for nested arrays
+ * @returns Array of markdown lines
+ */
+function renderCodeField(val: unknown, depth: number, prefix: string): string[] {
+  if (typeof val === 'string') {
+    return ['```', val, '```', ''];
+  }
+  return renderValue(val, depth, prefix);
+}
+
+/**
+ * Check if an object has a string-valued property.
+ *
+ * @param obj - The object to check
+ * @param key - The property name to look for
+ * @returns True if `obj[key]` exists and is a string
+ */
+function hasStringProp<K extends string>(obj: object, key: K): obj is object & Record<K, string> {
+  return key in obj && typeof (obj as Record<string, unknown>)[key] === 'string';
+}
+
+/**
  * Check if a value is a code block shape: `{ language, content }`.
  *
  * @param value - The value to check
- * @returns True if value is an object with exactly `language` and `content` string fields
+ * @returns True if value is an object with `language` and `content` string fields
  */
 function isCodeBlockShape(value: unknown): value is { language: string; content: string } {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
-  const keys = Object.keys(value);
-  return (
-    keys.length === 2 &&
-    keys.includes('language') &&
-    keys.includes('content') &&
-    typeof (value as Record<string, unknown>).language === 'string' &&
-    typeof (value as Record<string, unknown>).content === 'string'
-  );
+  return hasStringProp(value, 'language') && hasStringProp(value, 'content');
 }
 
 /**
@@ -86,7 +108,7 @@ function isNamedObjectArray(
       typeof item === 'object' &&
       item !== null &&
       !Array.isArray(item) &&
-      typeof (item as Record<string, unknown>).name === 'string',
+      hasStringProp(item, 'name'),
   );
 }
 
@@ -262,14 +284,7 @@ function renderNamedArray(
 
       // Code field — fenced code block (no heading)
       if (key === 'code') {
-        if (typeof val === 'string') {
-          lines.push('```');
-          lines.push(val);
-          lines.push('```');
-          lines.push('');
-        } else {
-          lines.push(...renderValue(val, depth + 1, childPrefix));
-        }
+        lines.push(...renderCodeField(val, depth + 1, childPrefix));
         continue;
       }
 
@@ -320,14 +335,7 @@ function renderObjectFields(obj: Record<string, unknown>, depth: number, prefix:
 
     // Code field — fenced code block
     if (key === 'code') {
-      if (typeof val === 'string') {
-        lines.push('```');
-        lines.push(val);
-        lines.push('```');
-        lines.push('');
-      } else {
-        lines.push(...renderValue(val, depth, prefix));
-      }
+      lines.push(...renderCodeField(val, depth, prefix));
       continue;
     }
 
@@ -390,14 +398,7 @@ export function renderToMarkdown(data: unknown): string {
 
     // Code field at root
     if (key === 'code') {
-      if (typeof val === 'string') {
-        lines.push('```');
-        lines.push(val);
-        lines.push('```');
-        lines.push('');
-      } else {
-        lines.push(...renderValue(val, 2, ''));
-      }
+      lines.push(...renderCodeField(val, 2, ''));
       continue;
     }
 

--- a/packages/claude-code-plugin/src/rdx-core.ts
+++ b/packages/claude-code-plugin/src/rdx-core.ts
@@ -12,6 +12,25 @@ import * as yaml from 'js-yaml';
 /** Maximum heading depth (H6). */
 const MAX_DEPTH = 6;
 
+/** Scalar values that can appear in renderable JSON. */
+type RenderableScalar = string | number | boolean | null;
+
+/** Recursive type for any JSON-renderable value. */
+type RenderableValue = RenderableScalar | RenderableValue[] | RenderableObject;
+
+/** JSON object whose values are all renderable. */
+type RenderableObject = { [key: string]: RenderableValue };
+
+/**
+ * Check if a value is a non-null, non-array object (renderable JSON object).
+ *
+ * @param value - The value to check
+ * @returns True if value is a plain object
+ */
+function isRenderableObject(value: unknown): value is RenderableObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /**
  * Convert a field name or value to a Title Case heading.
  *
@@ -107,9 +126,7 @@ function isCodeBlockShape(value: unknown): value is { language: string; content:
  * @param arr - The array to check
  * @returns True if every element is an object with a string `name` field
  */
-function isNamedObjectArray(
-  arr: unknown[],
-): arr is Array<Record<string, unknown> & { name: string }> {
+function isNamedObjectArray(arr: unknown[]): arr is Array<RenderableObject & { name: string }> {
   return arr.every(
     (item) =>
       typeof item === 'object' &&
@@ -125,7 +142,7 @@ function isNamedObjectArray(
  * @param arr - The array to check
  * @returns True if every element is a plain object
  */
-function isObjectArray(arr: unknown[]): arr is Array<Record<string, unknown>> {
+function isObjectArray(arr: unknown[]): arr is Array<RenderableObject> {
   return arr.every((item) => typeof item === 'object' && item !== null && !Array.isArray(item));
 }
 
@@ -138,7 +155,7 @@ function isObjectArray(arr: unknown[]): arr is Array<Record<string, unknown>> {
  * @param items - Array of objects to render as a table
  * @returns Markdown pipe table string
  */
-function renderTable(items: Array<Record<string, unknown>>): string {
+function renderTable(items: Array<RenderableObject>): string {
   // Collect all unique keys in insertion order
   const keys: string[] = [];
   for (const item of items) {
@@ -157,8 +174,9 @@ function renderTable(items: Array<Record<string, unknown>>): string {
   // Data rows
   for (const item of items) {
     const cells = keys.map((k) => {
+      if (!(k in item)) return '';
       const val = item[k];
-      if (val === undefined || val === null) return '';
+      if (val === null) return '';
       if (typeof val === 'string') return escapeCell(val);
       if (typeof val === 'number' || typeof val === 'boolean') return String(val);
       return escapeCell(JSON.stringify(val));
@@ -214,8 +232,8 @@ function renderValue(value: unknown, depth: number, prefix: string): string[] {
   }
 
   // Object — render fields as subsections
-  if (typeof value === 'object') {
-    return renderObjectFields(value as Record<string, unknown>, depth, prefix);
+  if (isRenderableObject(value)) {
+    return renderObjectFields(value, depth, prefix);
   }
 
   return lines;
@@ -268,7 +286,7 @@ function renderArray(arr: unknown[], depth: number, prefix: string): string[] {
  * @returns Array of markdown lines
  */
 function renderNamedArray(
-  arr: Array<Record<string, unknown> & { name: string }>,
+  arr: Array<RenderableObject & { name: string }>,
   depth: number,
   prefix: string,
 ): string[] {
@@ -286,7 +304,7 @@ function renderNamedArray(
     const childPrefix = `${num}.`;
     for (const [key, val] of Object.entries(item)) {
       if (key === 'name') continue;
-      if (val === null || val === undefined) continue;
+      if (val === null) continue;
       if (Array.isArray(val) && val.length === 0) continue;
 
       // Code field — fenced code block (no heading)
@@ -332,12 +350,12 @@ function renderNamedArray(
  * @param prefix - Numbering prefix for nested arrays
  * @returns Array of markdown lines
  */
-function renderObjectFields(obj: Record<string, unknown>, depth: number, prefix: string): string[] {
+function renderObjectFields(obj: RenderableObject, depth: number, prefix: string): string[] {
   const lines: string[] = [];
 
   for (const [key, val] of Object.entries(obj)) {
     if (!key) continue;
-    if (val === null || val === undefined) continue;
+    if (val === null) continue;
     if (Array.isArray(val) && val.length === 0) continue;
 
     // Code field — fenced code block
@@ -379,13 +397,13 @@ export function renderToMarkdown(data: unknown): string {
   if (Array.isArray(data)) return renderArray(data, 1, '').join('\n');
   if (typeof data === 'string') return `${data}\n`;
   if (typeof data === 'number' || typeof data === 'boolean') return `${String(data)}\n`;
-  if (typeof data !== 'object') return '\n';
+  if (!isRenderableObject(data)) return '\n';
 
-  const obj = data as Record<string, unknown>;
+  const obj = data;
   const lines: string[] = [];
 
   // Extract meta → YAML frontmatter
-  if (obj.meta !== undefined && obj.meta !== null) {
+  if ('meta' in obj && obj.meta !== null) {
     lines.push('---');
     lines.push(yaml.dump(obj.meta, { lineWidth: -1 }).trimEnd());
     lines.push('---');
@@ -400,7 +418,7 @@ export function renderToMarkdown(data: unknown): string {
   // Render remaining fields at depth 2
   for (const [key, val] of Object.entries(obj)) {
     if (!key || key === 'name' || key === 'meta' || key === '$schema') continue;
-    if (val === null || val === undefined) continue;
+    if (val === null) continue;
     if (Array.isArray(val) && val.length === 0) continue;
 
     // Code field at root

--- a/packages/claude-code-plugin/src/rdx-core.ts
+++ b/packages/claude-code-plugin/src/rdx-core.ts
@@ -357,9 +357,9 @@ function renderObjectFields(obj: Record<string, unknown>, depth: number, prefix:
  * @returns Markdown string
  */
 export function renderToMarkdown(data: unknown): string {
-  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-    return `${String(data)}\n`;
-  }
+  if (data === null || data === undefined) return '\n';
+  if (Array.isArray(data)) return renderArray(data, 1, '').join('\n');
+  if (typeof data !== 'object') return `${String(data)}\n`;
 
   const obj = data as Record<string, unknown>;
   const lines: string[] = [];
@@ -379,7 +379,7 @@ export function renderToMarkdown(data: unknown): string {
 
   // Render remaining fields at depth 2
   for (const [key, val] of Object.entries(obj)) {
-    if (!key || key === 'name' || key === 'meta') continue;
+    if (!key || key === 'name' || key === 'meta' || key === '$schema') continue;
     if (val === null || val === undefined) continue;
     if (Array.isArray(val) && val.length === 0) continue;
 

--- a/packages/claude-code-plugin/src/rdx-core.ts
+++ b/packages/claude-code-plugin/src/rdx-core.ts
@@ -36,7 +36,10 @@ function toHeading(field: string): string {
  * @returns Escaped string safe for pipe tables
  */
 function escapeCell(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+  return s
+    .replace(/\r\n?|\n/g, ' ')
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|');
 }
 
 /**

--- a/packages/claude-code-plugin/src/rdx-core.ts
+++ b/packages/claude-code-plugin/src/rdx-core.ts
@@ -1,0 +1,398 @@
+/**
+ * Generic JSON-to-Markdown renderer.
+ *
+ * Converts any JSON structure to readable Markdown following structural
+ * conventions. Schema-unaware — rendering is driven by the JSON shape itself.
+ *
+ * @module rdx-core
+ */
+
+import * as yaml from 'js-yaml';
+
+/** Maximum heading depth (H6). */
+const MAX_DEPTH = 6;
+
+/**
+ * Convert a field name or value to a Title Case heading.
+ *
+ * Splits on underscores and spaces, capitalizes every word.
+ *
+ * @param field - The field name (e.g. `architecture_and_approach`) or value (e.g. `Write failing test`)
+ * @returns Title-cased heading text (e.g. `Architecture And Approach`)
+ */
+function toHeading(field: string): string {
+  return field
+    .split(/[_ ]+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Emit a markdown heading at the given depth, clamped to H6.
+ *
+ * @param text - Heading text
+ * @param depth - Heading depth (1 = H1, 6 = H6 max)
+ * @returns Markdown heading line
+ */
+function heading(text: string, depth: number): string {
+  const level = Math.min(depth, MAX_DEPTH);
+  return `${'#'.repeat(level)} ${text}\n`;
+}
+
+/**
+ * Check if a value is a code block shape: `{ language, content }`.
+ *
+ * @param value - The value to check
+ * @returns True if value is an object with exactly `language` and `content` string fields
+ */
+function isCodeBlockShape(value: unknown): value is { language: string; content: string } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length === 2 &&
+    keys.includes('language') &&
+    keys.includes('content') &&
+    typeof (value as Record<string, unknown>).language === 'string' &&
+    typeof (value as Record<string, unknown>).content === 'string'
+  );
+}
+
+/**
+ * Check if all objects in an array have a `name` string field.
+ *
+ * @param arr - The array to check
+ * @returns True if every element is an object with a string `name` field
+ */
+function isNamedObjectArray(
+  arr: unknown[],
+): arr is Array<Record<string, unknown> & { name: string }> {
+  return arr.every(
+    (item) =>
+      typeof item === 'object' &&
+      item !== null &&
+      !Array.isArray(item) &&
+      typeof (item as Record<string, unknown>).name === 'string',
+  );
+}
+
+/**
+ * Check if all items in an array are plain objects (not arrays, not null).
+ *
+ * @param arr - The array to check
+ * @returns True if every element is a plain object
+ */
+function isObjectArray(arr: unknown[]): arr is Array<Record<string, unknown>> {
+  return arr.every((item) => typeof item === 'object' && item !== null && !Array.isArray(item));
+}
+
+/**
+ * Render a pipe table from an array of objects.
+ *
+ * Column headers are the union of all keys across all elements.
+ * Column order follows first-appearance insertion order.
+ *
+ * @param items - Array of objects to render as a table
+ * @returns Markdown pipe table string
+ */
+function renderTable(items: Array<Record<string, unknown>>): string {
+  // Collect all unique keys in insertion order
+  const keys: string[] = [];
+  for (const item of items) {
+    for (const key of Object.keys(item)) {
+      if (!keys.includes(key)) keys.push(key);
+    }
+  }
+
+  const headers = keys.map(toHeading);
+  const lines: string[] = [];
+
+  // Header row
+  lines.push(`| ${headers.join(' | ')} |`);
+  // Separator row
+  lines.push(`|${keys.map(() => '------').join('|')}|`);
+  // Data rows
+  for (const item of items) {
+    const cells = keys.map((k) => {
+      const val = item[k];
+      if (val === undefined || val === null) return '';
+      if (typeof val === 'string') return val;
+      if (typeof val === 'number' || typeof val === 'boolean') return String(val);
+      return JSON.stringify(val);
+    });
+    lines.push(`| ${cells.join(' | ')} |`);
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Render a value to markdown lines.
+ *
+ * @param value - The value to render
+ * @param depth - Current heading depth
+ * @param prefix - Numbering prefix for nested arrays (e.g. "1.")
+ * @returns Array of markdown lines
+ */
+function renderValue(value: unknown, depth: number, prefix: string): string[] {
+  const lines: string[] = [];
+
+  // Null — omit entirely
+  if (value === null || value === undefined) {
+    return lines;
+  }
+
+  // String — paragraph
+  if (typeof value === 'string') {
+    lines.push(value);
+    lines.push('');
+    return lines;
+  }
+
+  // Number or boolean — string paragraph
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    lines.push(String(value));
+    lines.push('');
+    return lines;
+  }
+
+  // Array
+  if (Array.isArray(value)) {
+    return renderArray(value, depth, prefix);
+  }
+
+  // Code block shape: { language, content }
+  if (isCodeBlockShape(value)) {
+    lines.push(`\`\`\`${value.language}`);
+    lines.push(value.content);
+    lines.push('```');
+    lines.push('');
+    return lines;
+  }
+
+  // Object — render fields as subsections
+  if (typeof value === 'object') {
+    return renderObjectFields(value as Record<string, unknown>, depth, prefix);
+  }
+
+  return lines;
+}
+
+/**
+ * Render an array value to markdown lines.
+ *
+ * @param arr - The array to render
+ * @param depth - Current heading depth
+ * @param prefix - Numbering prefix for nested arrays
+ * @returns Array of markdown lines
+ */
+function renderArray(arr: unknown[], depth: number, prefix: string): string[] {
+  if (arr.length === 0) return [];
+
+  // Array of objects with name — numbered sections
+  if (isNamedObjectArray(arr)) {
+    return renderNamedArray(arr, depth, prefix);
+  }
+
+  // Array of objects without name — pipe table
+  if (isObjectArray(arr)) {
+    return renderTable(arr).split('\n');
+  }
+
+  // Array of primitives — bullet list
+  const lines: string[] = [];
+  for (const item of arr) {
+    lines.push(`- ${String(item)}`);
+  }
+  lines.push('');
+  return lines;
+}
+
+/**
+ * Render an array of named objects as numbered sections.
+ * Elements render at the current depth (replacing the parent heading).
+ *
+ * Number format:
+ * - Top-level (prefix=""): `1. Name` (dot after number)
+ * - Nested (prefix="1."): `1.1 Name` (no trailing dot)
+ *
+ * Within a named item, simple values (strings, code) render inline
+ * without field headings. Complex values (arrays, objects) get headings.
+ *
+ * @param arr - Array of objects with `name` fields
+ * @param depth - Current heading depth
+ * @param prefix - Numbering prefix (e.g. "1." for nested items)
+ * @returns Array of markdown lines
+ */
+function renderNamedArray(
+  arr: Array<Record<string, unknown> & { name: string }>,
+  depth: number,
+  prefix: string,
+): string[] {
+  const lines: string[] = [];
+
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
+    const num = `${prefix}${String(i + 1)}`;
+    const itemName = toHeading(item.name);
+    // Top-level: "1. Name", nested: "1.1 Name"
+    const separator = prefix ? ' ' : '. ';
+    lines.push(heading(`${num}${separator}${itemName}`, depth));
+
+    // Render remaining fields (excluding name) at depth + 1
+    const childPrefix = `${num}.`;
+    for (const [key, val] of Object.entries(item)) {
+      if (key === 'name') continue;
+      if (val === null || val === undefined) continue;
+      if (Array.isArray(val) && val.length === 0) continue;
+
+      // Code field — fenced code block (no heading)
+      if (key === 'code') {
+        if (typeof val === 'string') {
+          lines.push('```');
+          lines.push(val);
+          lines.push('```');
+          lines.push('');
+        } else {
+          lines.push(...renderValue(val, depth + 1, childPrefix));
+        }
+        continue;
+      }
+
+      // String — inline paragraph (no heading)
+      if (typeof val === 'string') {
+        lines.push(val);
+        lines.push('');
+        continue;
+      }
+
+      // Number/boolean — inline paragraph (no heading)
+      if (typeof val === 'number' || typeof val === 'boolean') {
+        lines.push(String(val));
+        lines.push('');
+        continue;
+      }
+
+      // Named array — replace heading
+      if (Array.isArray(val) && val.length > 0 && isNamedObjectArray(val)) {
+        lines.push(...renderNamedArray(val, depth + 1, childPrefix));
+        continue;
+      }
+
+      // Complex values (arrays, objects) — emit heading then value
+      lines.push(heading(toHeading(key), depth + 1));
+      lines.push(...renderValue(val, depth + 2, childPrefix));
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Render object fields at the given depth.
+ *
+ * @param obj - Object whose fields to render
+ * @param depth - Current heading depth
+ * @param prefix - Numbering prefix for nested arrays
+ * @returns Array of markdown lines
+ */
+function renderObjectFields(obj: Record<string, unknown>, depth: number, prefix: string): string[] {
+  const lines: string[] = [];
+
+  for (const [key, val] of Object.entries(obj)) {
+    if (val === null || val === undefined) continue;
+    if (Array.isArray(val) && val.length === 0) continue;
+
+    // Code field — fenced code block
+    if (key === 'code') {
+      if (typeof val === 'string') {
+        lines.push('```');
+        lines.push(val);
+        lines.push('```');
+        lines.push('');
+      } else {
+        lines.push(...renderValue(val, depth, prefix));
+      }
+      continue;
+    }
+
+    // Named array — elements replace the field heading
+    if (Array.isArray(val) && val.length > 0 && isNamedObjectArray(val)) {
+      lines.push(...renderNamedArray(val, depth, prefix));
+      continue;
+    }
+
+    // All other values — emit heading then value
+    lines.push(heading(toHeading(key), depth));
+    lines.push(...renderValue(val, depth + 1, prefix));
+  }
+
+  return lines;
+}
+
+/**
+ * Render a JSON value to Markdown.
+ *
+ * Follows structural conventions:
+ * - `name` field → H1 heading
+ * - `meta` field → YAML frontmatter
+ * - Named arrays → numbered sections (replacing parent heading)
+ * - Unnamed object arrays → pipe tables
+ * - Primitive arrays → bullet lists
+ * - Code blocks detected by field name or `{ language, content }` shape
+ *
+ * @param data - The JSON data to render
+ * @returns Markdown string
+ */
+export function renderToMarkdown(data: unknown): string {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return String(data) + '\n';
+  }
+
+  const obj = data as Record<string, unknown>;
+  const lines: string[] = [];
+
+  // Extract meta → YAML frontmatter
+  if (obj.meta !== undefined && obj.meta !== null) {
+    lines.push('---');
+    lines.push(yaml.dump(obj.meta, { lineWidth: -1 }).trimEnd());
+    lines.push('---');
+    lines.push('');
+  }
+
+  // Extract name → H1
+  if (typeof obj.name === 'string') {
+    lines.push(heading(obj.name, 1));
+  }
+
+  // Render remaining fields at depth 2
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === 'name' || key === 'meta') continue;
+    if (val === null || val === undefined) continue;
+    if (Array.isArray(val) && val.length === 0) continue;
+
+    // Code field at root
+    if (key === 'code') {
+      if (typeof val === 'string') {
+        lines.push('```');
+        lines.push(val);
+        lines.push('```');
+        lines.push('');
+      } else {
+        lines.push(...renderValue(val, 2, ''));
+      }
+      continue;
+    }
+
+    // Named array — elements replace the field heading
+    if (Array.isArray(val) && val.length > 0 && isNamedObjectArray(val)) {
+      lines.push(...renderNamedArray(val, 2, ''));
+      continue;
+    }
+
+    // All other values — emit H2 heading then value
+    lines.push(heading(toHeading(key), 2));
+    lines.push(...renderValue(val, 3, ''));
+  }
+
+  return lines.join('\n');
+}

--- a/packages/claude-code-plugin/src/rdx-core.ts
+++ b/packages/claude-code-plugin/src/rdx-core.ts
@@ -84,14 +84,21 @@ function hasStringProp<K extends string>(obj: object, key: K): obj is object & R
 }
 
 /**
- * Check if a value is a code block shape: `{ language, content }`.
+ * Check if a value is a code block shape: exactly `{ language, content }`.
+ *
+ * Requires exactly two keys to avoid silently dropping sibling fields
+ * on objects that happen to contain `language` and `content`.
  *
  * @param value - The value to check
- * @returns True if value is an object with `language` and `content` string fields
+ * @returns True if value is an object with exactly `language` and `content` string fields
  */
 function isCodeBlockShape(value: unknown): value is { language: string; content: string } {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
-  return hasStringProp(value, 'language') && hasStringProp(value, 'content');
+  return (
+    Object.keys(value).length === 2 &&
+    hasStringProp(value, 'language') &&
+    hasStringProp(value, 'content')
+  );
 }
 
 /**

--- a/packages/claude-code-plugin/src/rdx-core.ts
+++ b/packages/claude-code-plugin/src/rdx-core.ts
@@ -36,7 +36,7 @@ function toHeading(field: string): string {
  * @returns Escaped string safe for pipe tables
  */
 function escapeCell(s: string): string {
-  return s.replace(/\|/g, '\\|');
+  return s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
 }
 
 /**

--- a/packages/claude-code-plugin/src/rdx-validate.ts
+++ b/packages/claude-code-plugin/src/rdx-validate.ts
@@ -1,0 +1,95 @@
+/**
+ * Generic schema resolution and validation for the rdx CLI.
+ *
+ * Schema modules are discovered by convention: a schema name like "plan"
+ * resolves to a sibling module `./plan-schema.js` that exports a
+ * `validate(data: unknown): unknown` function.
+ *
+ * @module rdx-validate
+ */
+
+import { ZodError } from 'zod';
+import { getErrorMessage } from './shared/errors.js';
+
+/**
+ * Extract and strip the `$schema` field from parsed JSON data.
+ *
+ * @param data - Parsed JSON data (may or may not contain `$schema`)
+ * @returns Object with `cleanData` (data without `$schema`) and `schemaName` (extracted value or undefined)
+ */
+export function stripSchema(data: unknown): {
+  cleanData: unknown;
+  schemaName: string | undefined;
+} {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return { cleanData: data, schemaName: undefined };
+  }
+
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.$schema !== 'string') {
+    return { cleanData: data, schemaName: undefined };
+  }
+
+  const { $schema: schemaName, ...cleanData } = obj;
+  return { cleanData, schemaName };
+}
+
+/**
+ * Resolve the effective schema name from explicit flag and data field.
+ *
+ * @param explicit - Value from `--schema` CLI flag (highest priority)
+ * @param fromData - Value extracted from `$schema` field in data
+ * @returns Resolved schema name, or undefined if no schema specified
+ */
+export function resolveSchemaName(
+  explicit: string | undefined,
+  fromData: string | undefined,
+): string | undefined {
+  return explicit ?? fromData;
+}
+
+/**
+ * Dynamically load a schema validator by convention name.
+ *
+ * Resolves schema name to a sibling module: `<name>-schema.js`.
+ * The module must export a `validate(data: unknown): unknown` function.
+ *
+ * @param name - Schema name (e.g. "plan" resolves to "./plan-schema.js")
+ * @returns The validate function from the schema module
+ * @throws {Error} If the module is not found or does not export `validate`
+ */
+export async function loadValidator(name: string): Promise<(data: unknown) => unknown> {
+  let mod: Record<string, unknown>;
+  try {
+    mod = await import(`./${name}-schema.js`);
+  } catch {
+    throw new Error(`Unknown schema: ${name}`);
+  }
+  if (typeof mod.validate !== 'function') {
+    throw new Error(`Schema module '${name}-schema' does not export a validate() function`);
+  }
+  return mod.validate as (data: unknown) => unknown;
+}
+
+/**
+ * Format a validation error (typically ZodError) as human-readable lines.
+ *
+ * @param error - The caught error (ZodError or other)
+ * @param schemaName - Optional schema name for context in output
+ * @returns Formatted multi-line error string
+ */
+export function formatValidationErrors(error: unknown, schemaName?: string): string {
+  const label = schemaName ? ` (${schemaName})` : '';
+
+  if (error instanceof ZodError) {
+    const details = error.issues
+      .map((issue) => {
+        const path = issue.path.length > 0 ? `/${issue.path.join('/')}` : '(root)';
+        return `  ${path}: ${issue.message}`;
+      })
+      .join('\n');
+    return `error: schema validation failed${label}\n${details}\n`;
+  }
+
+  return `error: schema validation failed${label}\n  ${getErrorMessage(error)}\n`;
+}

--- a/packages/claude-code-plugin/src/rdx-validate.ts
+++ b/packages/claude-code-plugin/src/rdx-validate.ts
@@ -10,6 +10,26 @@
 
 import { getErrorMessage, isZodError } from './shared/errors.js';
 
+/** Type contract for schema modules loaded by the registry. */
+type ValidatorModule<T = unknown> = { validate(data: unknown): T };
+
+const schemaLoaders = {
+  plan: () => import('./plan-schema.js') as Promise<ValidatorModule>,
+} as const;
+
+/** Known schema names from the registry. */
+type SchemaName = keyof typeof schemaLoaders;
+
+/**
+ * Check if a name is a known schema in the registry.
+ *
+ * @param name - The schema name to check
+ * @returns True if name is a registered schema
+ */
+function isSchemaName(name: string): name is SchemaName {
+  return name in schemaLoaders;
+}
+
 /** URI prefix for Rundown schema identifiers. */
 const SCHEMA_URI_PREFIX = 'https://rundown.org/schemas/';
 
@@ -37,24 +57,29 @@ export function parseSchemaName(raw: string): string | undefined {
 /**
  * Extract and strip the `$schema` field from parsed JSON data.
  *
+ * Always strips `$schema` from `cleanData`. Returns `schemaName` when
+ * parseable, plus `rawSchema` so callers can detect and reject
+ * unrecognized `$schema` values (rawSchema present but schemaName undefined).
+ *
  * @param data - Parsed JSON data (may or may not contain `$schema`)
- * @returns Object with `cleanData` (data without `$schema`) and `schemaName` (extracted name or undefined)
+ * @returns Object with `cleanData`, resolved `schemaName`, and `rawSchema`
  */
 export function stripSchema(data: unknown): {
   cleanData: unknown;
   schemaName: string | undefined;
+  rawSchema: string | undefined;
 } {
   if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-    return { cleanData: data, schemaName: undefined };
+    return { cleanData: data, schemaName: undefined, rawSchema: undefined };
   }
 
   const obj = data as Record<string, unknown>;
   if (typeof obj.$schema !== 'string') {
-    return { cleanData: data, schemaName: undefined };
+    return { cleanData: data, schemaName: undefined, rawSchema: undefined };
   }
 
   const { $schema: rawSchema, ...cleanData } = obj;
-  return { cleanData, schemaName: parseSchemaName(rawSchema) };
+  return { cleanData, schemaName: parseSchemaName(rawSchema), rawSchema };
 }
 
 /**
@@ -72,29 +97,24 @@ export function resolveSchemaName(
 }
 
 /**
- * Dynamically load a schema validator by convention name.
+ * Load a schema validator by name from the typed registry.
  *
- * Resolves schema name to a sibling module: `<name>-schema.js`.
- * The module must export a `validate(data: unknown): unknown` function.
+ * Schema modules are registered in `schemaLoaders`. The name must pass
+ * a format check (security boundary) and exist in the registry.
  *
- * @param name - Schema name (e.g. "plan" resolves to "./plan-schema.js")
+ * @param name - Schema name (e.g. "plan")
  * @returns The validate function from the schema module
- * @throws {Error} If the module is not found or does not export `validate`
+ * @throws {Error} If the name is invalid or not in the registry
  */
 export async function loadValidator(name: string): Promise<(data: unknown) => unknown> {
   if (!/^[a-z][a-z0-9-]*$/.test(name)) {
     throw new Error(`Invalid schema name: ${name}`);
   }
-  let mod: Record<string, unknown>;
-  try {
-    mod = (await import(`./${name}-schema.js`)) as Record<string, unknown>;
-  } catch {
+  if (!isSchemaName(name)) {
     throw new Error(`Unknown schema: ${name}`);
   }
-  if (typeof mod.validate !== 'function') {
-    throw new Error(`Schema module '${name}-schema' does not export a validate() function`);
-  }
-  return mod.validate as (data: unknown) => unknown;
+  const mod = await schemaLoaders[name]();
+  return (data: unknown) => mod.validate(data);
 }
 
 /**

--- a/packages/claude-code-plugin/src/rdx-validate.ts
+++ b/packages/claude-code-plugin/src/rdx-validate.ts
@@ -61,7 +61,7 @@ export function resolveSchemaName(
 export async function loadValidator(name: string): Promise<(data: unknown) => unknown> {
   let mod: Record<string, unknown>;
   try {
-    mod = await import(`./${name}-schema.js`);
+    mod = (await import(`./${name}-schema.js`)) as Record<string, unknown>;
   } catch {
     throw new Error(`Unknown schema: ${name}`);
   }

--- a/packages/claude-code-plugin/src/rdx-validate.ts
+++ b/packages/claude-code-plugin/src/rdx-validate.ts
@@ -10,11 +10,35 @@
 
 import { getErrorMessage, isZodError } from './shared/errors.js';
 
+/** URI prefix for Rundown schema identifiers. */
+const SCHEMA_URI_PREFIX = 'https://rundown.org/schemas/';
+
+/** Suffix for schema URI filenames. */
+const SCHEMA_URI_SUFFIX = '.schema.json';
+
+/**
+ * Extract a schema name from a `$schema` value.
+ *
+ * Accepts both full URIs (`https://rundown.org/schemas/plan.schema.json` → `"plan"`)
+ * and bare names (`"plan"` → `"plan"`) for backward compatibility with the `--schema` flag.
+ *
+ * @param raw - The raw `$schema` string value
+ * @returns The extracted schema name, or undefined if the value is unrecognized
+ */
+export function parseSchemaName(raw: string): string | undefined {
+  if (raw.startsWith(SCHEMA_URI_PREFIX) && raw.endsWith(SCHEMA_URI_SUFFIX)) {
+    const name = raw.slice(SCHEMA_URI_PREFIX.length, -SCHEMA_URI_SUFFIX.length);
+    return /^[a-z][a-z0-9-]*$/.test(name) ? name : undefined;
+  }
+  // Bare name fallback (e.g. --schema plan)
+  return /^[a-z][a-z0-9-]*$/.test(raw) ? raw : undefined;
+}
+
 /**
  * Extract and strip the `$schema` field from parsed JSON data.
  *
  * @param data - Parsed JSON data (may or may not contain `$schema`)
- * @returns Object with `cleanData` (data without `$schema`) and `schemaName` (extracted value or undefined)
+ * @returns Object with `cleanData` (data without `$schema`) and `schemaName` (extracted name or undefined)
  */
 export function stripSchema(data: unknown): {
   cleanData: unknown;
@@ -29,8 +53,8 @@ export function stripSchema(data: unknown): {
     return { cleanData: data, schemaName: undefined };
   }
 
-  const { $schema: schemaName, ...cleanData } = obj;
-  return { cleanData, schemaName };
+  const { $schema: rawSchema, ...cleanData } = obj;
+  return { cleanData, schemaName: parseSchemaName(rawSchema) };
 }
 
 /**

--- a/packages/claude-code-plugin/src/rdx-validate.ts
+++ b/packages/claude-code-plugin/src/rdx-validate.ts
@@ -8,8 +8,7 @@
  * @module rdx-validate
  */
 
-import { ZodError } from 'zod';
-import { getErrorMessage } from './shared/errors.js';
+import { getErrorMessage, isZodError } from './shared/errors.js';
 
 /**
  * Extract and strip the `$schema` field from parsed JSON data.
@@ -59,6 +58,9 @@ export function resolveSchemaName(
  * @throws {Error} If the module is not found or does not export `validate`
  */
 export async function loadValidator(name: string): Promise<(data: unknown) => unknown> {
+  if (!/^[a-z][a-z0-9-]*$/.test(name)) {
+    throw new Error(`Invalid schema name: ${name}`);
+  }
   let mod: Record<string, unknown>;
   try {
     mod = (await import(`./${name}-schema.js`)) as Record<string, unknown>;
@@ -81,7 +83,7 @@ export async function loadValidator(name: string): Promise<(data: unknown) => un
 export function formatValidationErrors(error: unknown, schemaName?: string): string {
   const label = schemaName ? ` (${schemaName})` : '';
 
-  if (error instanceof ZodError) {
+  if (isZodError(error)) {
     const details = error.issues
       .map((issue) => {
         const path = issue.path.length > 0 ? `/${issue.path.join('/')}` : '(root)';

--- a/packages/claude-code-plugin/src/rdx.ts
+++ b/packages/claude-code-plugin/src/rdx.ts
@@ -37,11 +37,12 @@ program
       const { cleanData, schemaName: dataSchema } = stripSchema(data);
       const schema = resolveSchemaName(options.schema, dataSchema);
 
-      // Validate against schema when available
+      // Validate against schema when available, capturing typed result
+      let dataToRender: unknown = cleanData;
       if (schema) {
         try {
           const validate = await loadValidator(schema);
-          validate(cleanData);
+          dataToRender = validate(cleanData);
         } catch (error) {
           process.stderr.write(formatValidationErrors(error, schema));
           process.exitCode = 1;
@@ -54,7 +55,7 @@ program
         return;
       }
 
-      const md = renderToMarkdown(cleanData);
+      const md = renderToMarkdown(dataToRender);
       if (options.output) {
         await fs.writeFile(options.output, md);
       } else {

--- a/packages/claude-code-plugin/src/rdx.ts
+++ b/packages/claude-code-plugin/src/rdx.ts
@@ -34,8 +34,15 @@ program
       const data: unknown = JSON.parse(raw);
 
       // Extract $schema and prepare clean data
-      const { cleanData, schemaName: dataSchema } = stripSchema(data);
+      const { cleanData, schemaName: dataSchema, rawSchema } = stripSchema(data);
       const schema = resolveSchemaName(options.schema, dataSchema);
+
+      // Reject unrecognized $schema URIs — don't silently skip validation
+      if (rawSchema && !schema) {
+        process.stderr.write(`error: unrecognized schema: ${rawSchema}\n`);
+        process.exitCode = 1;
+        return;
+      }
 
       // Validate against schema when available, capturing typed result
       let dataToRender: unknown = cleanData;

--- a/packages/claude-code-plugin/src/rdx.ts
+++ b/packages/claude-code-plugin/src/rdx.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * CLI entry point for the rdx JSON-to-Markdown tool.
+ *
+ * Renders any JSON file to readable Markdown following structural conventions.
+ * Optionally validates JSON parse-ability without rendering.
+ *
+ * @module
+ */
+
+import { Command } from 'commander';
+import * as fs from 'node:fs/promises';
+import { renderToMarkdown } from './rdx-core.js';
+import { getErrorMessage } from './shared/errors.js';
+
+const program = new Command();
+program
+  .name('rdx')
+  .description('Transform JSON to Markdown')
+  .argument('<file>', 'JSON file to process')
+  .option('--check', 'Validate JSON without rendering')
+  .option('-o, --output <path>', 'Write to file instead of stdout')
+  .action(async (file: string, options: { check?: boolean; output?: string }) => {
+    try {
+      const raw = await fs.readFile(file, 'utf-8');
+      const data: unknown = JSON.parse(raw);
+      if (options.check) {
+        process.stdout.write('Valid.\n');
+        return;
+      }
+      const md = renderToMarkdown(data);
+      if (options.output) {
+        await fs.writeFile(options.output, md);
+      } else {
+        process.stdout.write(md);
+      }
+    } catch (error) {
+      process.stderr.write(`error: ${getErrorMessage(error)}\n`);
+      process.exitCode = 1;
+    }
+  });
+
+program.parse();

--- a/packages/claude-code-plugin/src/rdx.ts
+++ b/packages/claude-code-plugin/src/rdx.ts
@@ -3,7 +3,8 @@
  * CLI entry point for the rdx JSON-to-Markdown tool.
  *
  * Renders any JSON file to readable Markdown following structural conventions.
- * Optionally validates JSON parse-ability without rendering.
+ * Validates against a schema when one is discoverable (via `--schema` flag
+ * or `$schema` field in the JSON data).
  *
  * @module
  */
@@ -11,6 +12,12 @@
 import { Command } from 'commander';
 import * as fs from 'node:fs/promises';
 import { renderToMarkdown } from './rdx-core.js';
+import {
+  stripSchema,
+  resolveSchemaName,
+  loadValidator,
+  formatValidationErrors,
+} from './rdx-validate.js';
 import { getErrorMessage } from './shared/errors.js';
 
 const program = new Command();
@@ -18,17 +25,36 @@ program
   .name('rdx')
   .description('Transform JSON to Markdown')
   .argument('<file>', 'JSON file to process')
-  .option('--check', 'Validate JSON without rendering')
+  .option('--check', 'Validate without rendering')
+  .option('--schema <name>', 'Schema name for validation (e.g. "plan")')
   .option('-o, --output <path>', 'Write to file instead of stdout')
-  .action(async (file: string, options: { check?: boolean; output?: string }) => {
+  .action(async (file: string, options: { check?: boolean; schema?: string; output?: string }) => {
     try {
       const raw = await fs.readFile(file, 'utf-8');
       const data: unknown = JSON.parse(raw);
+
+      // Extract $schema and prepare clean data
+      const { cleanData, schemaName: dataSchema } = stripSchema(data);
+      const schema = resolveSchemaName(options.schema, dataSchema);
+
+      // Validate against schema when available
+      if (schema) {
+        try {
+          const validate = await loadValidator(schema);
+          validate(cleanData);
+        } catch (error) {
+          process.stderr.write(formatValidationErrors(error, schema));
+          process.exitCode = 1;
+          return;
+        }
+      }
+
       if (options.check) {
         process.stdout.write('Valid.\n');
         return;
       }
-      const md = renderToMarkdown(data);
+
+      const md = renderToMarkdown(cleanData);
       if (options.output) {
         await fs.writeFile(options.output, md);
       } else {

--- a/packages/claude-code-plugin/src/shared/errors.ts
+++ b/packages/claude-code-plugin/src/shared/errors.ts
@@ -48,11 +48,17 @@ export function getErrorMessage(error: unknown): string {
 export function isZodError(
   error: unknown,
 ): error is { issues: Array<{ path: Array<string | number>; message: string }> } {
+  if (typeof error !== 'object' || error === null || !('issues' in error)) return false;
+  const issues = (error as { issues: unknown }).issues;
+  if (!Array.isArray(issues) || issues.length === 0) return false;
+  const first: unknown = issues[0];
   return (
-    typeof error === 'object' &&
-    error !== null &&
-    'issues' in error &&
-    Array.isArray((error as { issues: unknown }).issues)
+    typeof first === 'object' &&
+    first !== null &&
+    'path' in first &&
+    Array.isArray((first as { path: unknown }).path) &&
+    'message' in first &&
+    typeof (first as { message: unknown }).message === 'string'
   );
 }
 

--- a/packages/claude-code-plugin/src/shared/errors.ts
+++ b/packages/claude-code-plugin/src/shared/errors.ts
@@ -39,6 +39,24 @@ export function getErrorMessage(error: unknown): string {
 }
 
 /**
+ * Structural type guard for ZodError.
+ * Uses property checking instead of `instanceof` to work across ESM realm boundaries.
+ *
+ * @param error - The unknown value to check
+ * @returns True if error has a ZodError-shaped `issues` array
+ */
+export function isZodError(
+  error: unknown,
+): error is { issues: Array<{ path: Array<string | number>; message: string }> } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'issues' in error &&
+    Array.isArray((error as { issues: unknown }).issues)
+  );
+}
+
+/**
  * Discriminated union for session load errors
  * Allows callers to handle each error type appropriately
  */

--- a/packages/claude-code-plugin/src/shared/errors.ts
+++ b/packages/claude-code-plugin/src/shared/errors.ts
@@ -39,6 +39,25 @@ export function getErrorMessage(error: unknown): string {
 }
 
 /**
+ * Check if a value looks like a single Zod issue entry.
+ *
+ * @param value - The value to check
+ * @returns True if value has `path` (array) and `message` (string) fields
+ */
+function isZodIssueLike(
+  value: unknown,
+): value is { path: Array<string | number>; message: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'path' in value &&
+    Array.isArray((value as { path: unknown }).path) &&
+    'message' in value &&
+    typeof (value as { message: unknown }).message === 'string'
+  );
+}
+
+/**
  * Structural type guard for ZodError.
  * Uses property checking instead of `instanceof` to work across ESM realm boundaries.
  *
@@ -51,15 +70,7 @@ export function isZodError(
   if (typeof error !== 'object' || error === null || !('issues' in error)) return false;
   const issues = (error as { issues: unknown }).issues;
   if (!Array.isArray(issues) || issues.length === 0) return false;
-  const first: unknown = issues[0];
-  return (
-    typeof first === 'object' &&
-    first !== null &&
-    'path' in first &&
-    Array.isArray((first as { path: unknown }).path) &&
-    'message' in first &&
-    typeof (first as { message: unknown }).message === 'string'
-  );
+  return issues.every(isZodIssueLike);
 }
 
 /**

--- a/packages/claude-code-plugin/templates/planning/plan.template.md
+++ b/packages/claude-code-plugin/templates/planning/plan.template.md
@@ -1,6 +1,6 @@
 ---
 name: Implementation Plan Template
-description: Template for writing detailed plans structured into small, self-contained, granular tasks and subtasks.
+description: Template showing the rendered Markdown structure for implementation plans. The canonical format is JSON validated against schemas/plan.schema.json.
 use_when: Writing detailed implementation plans.
 version: 1.0.0
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an rdx CLI to validate plan JSON (--check) and render to Markdown with output file support; introduced an official strict plan JSON schema and a JSON→Markdown renderer.

* **Tests**
  * Added comprehensive tests and fixtures covering schema validation, renderer output, CLI behavior, and error cases (including strict-mode validation).

* **Documentation**
  * Updated Writing Plans docs and templates to require JSON plan output, include schema identifier, and show validation + render commands.

* **Chore**
  * Package metadata updated to include schemas in published files and expose the rdx executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->