### PR TITLE
Rdpath doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ The `rd` command is an alias for `rundown`.
 ```bash
 rdpath --dir <path>                           # Assemble base path (default subcommand)
 rdpath --dir <path> --ctx <id>                # With context scope (.rd-<id>/)
-rdpath --dir <path> --ctx <id> --file <name>  # With date-prefixed filename
+rdpath --dir <path> --file <name>             # With date-prefixed filename
+rdpath --dir <path> --ctx <id> --file <name>  # With date-prefixed filename in context
 rdpath --dir <path> find <pattern>            # Find files matching glob pattern
 rdpath --dir <path> --ctx <id> find <pattern> # Find within context scope
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,6 +388,7 @@ Currently supported internally: `echo`, `prompt`. Unsupported commands fall back
 - [docs/DOCKER.md](docs/DOCKER.md) - Docker verification pipeline
 - [docs/SCENARIOS.md](docs/SCENARIOS.md) - Scenarios and test runbook standard
 - [docs/RDX.md](docs/RDX.md) - RDX JSON-to-Markdown CLI reference
+- [docs/RDPATH.md](docs/RDPATH.md) - rdpath path assembly CLI reference
 
 ## Conceptual Model
 

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -41,7 +41,11 @@ delegatable
 deps
 deserialized
 dotdot
+EACCES
 EBNF
+ELOOP
+ENOENT
+EPERM
 émoji
 env
 esac

--- a/docs/RDPATH.md
+++ b/docs/RDPATH.md
@@ -127,6 +127,32 @@ The `find` subcommand resolves symlinks via `realpath()` and verifies that resol
 
 ---
 
+## Execution Flow
+
+### path (default)
+
+```text
+Resolve --dir
+  → If --ctx → validate, append .rd-<ctx>/
+  → If --file → validate, prepend YYYY-MM-DD-
+  → Output assembled path
+```
+
+### find
+
+```text
+Resolve --dir
+  → If --ctx → validate, append .rd-<ctx>/
+  → Verify directory exists
+  → Resolve realpath for symlink safety
+  → Glob match pattern within directory
+  → Filter: files only, inside search dir
+  → Sort lexicographically
+  → Output one path per line
+```
+
+---
+
 ## Typical Workflow
 
 ```bash

--- a/docs/RDPATH.md
+++ b/docs/RDPATH.md
@@ -143,6 +143,7 @@ Resolve --dir
 ```text
 Resolve --dir
   → If --ctx → validate, append .rd-<ctx>/
+  → Validate pattern (reject absolute paths and .. traversal)
   → Verify directory exists
   → Resolve realpath for symlink safety
   → Glob match pattern within directory

--- a/docs/RDPATH.md
+++ b/docs/RDPATH.md
@@ -1,0 +1,147 @@
+# rdpath — Path Assembly CLI
+
+`rdpath` is a path assembly and file discovery tool shipped with `@rundown-org/claude-code-plugin`. It builds artifact paths with optional context scoping and date-prefixed filenames, and provides glob-based file discovery within artifact directories.
+
+## Usage
+
+```bash
+rdpath --dir <path>                           # Assemble base path (default subcommand)
+rdpath --dir <path> --ctx <id>                # With context scope (.rd-<id>/)
+rdpath --dir <path> --file <name>             # With date-prefixed filename
+rdpath --dir <path> --ctx <id> --file <name>  # Combined context + filename
+rdpath --dir <path> find <pattern>            # Find files matching glob pattern
+rdpath --dir <path> --ctx <id> find <pattern> # Find within context scope
+```
+
+### Examples
+
+```bash
+# Base directory only
+rdpath --dir .work
+# → .work
+
+# Context-scoped directory
+rdpath --dir .work --ctx sprint-42
+# → .work/.rd-sprint-42
+
+# Date-prefixed filename
+rdpath --dir .work --file plan.md
+# → .work/2026-03-27-plan.md
+
+# Combined: context + date-prefixed file
+rdpath --dir .work --ctx sprint-42 --file review.md
+# → .work/.rd-sprint-42/2026-03-27-review.md
+
+# Find files matching a glob
+rdpath --dir .work find '*.md'
+
+# Find within a context scope
+rdpath --dir .work --ctx sprint-42 find '*-plan*.md'
+
+# Recursive search
+rdpath --dir .work find '**/*.json'
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Error (invalid input, directory not found, traversal attempt) |
+
+Errors are written to stderr with an `error:` prefix.
+
+---
+
+## Subcommands
+
+### `path` (default)
+
+Assembles an artifact path from `--dir`, optional `--ctx`, and optional `--file`. This is the default subcommand — invoked when no subcommand is specified.
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--dir <path>` | Yes | Base directory |
+| `--ctx <id>` | No | Context scope — appends `.rd-<id>/` subdirectory |
+| `--file <name>` | No | Filename — prepends today's date (`YYYY-MM-DD-<name>`) |
+
+Output is the assembled path, written to stdout with a trailing newline.
+
+### `find`
+
+Discovers files matching a glob pattern within an artifact directory.
+
+| Option/Argument | Required | Description |
+|-----------------|----------|-------------|
+| `--dir <path>` | Yes | Base directory to search |
+| `--ctx <id>` | No | Context scope — searches within `.rd-<id>/` subdirectory |
+| `<pattern>` | Yes | Glob pattern (relative to target directory) |
+
+Output is one matching file path per line, sorted lexicographically. Empty output (exit 0) when no files match. Only regular files are returned — directories matching the pattern are excluded.
+
+---
+
+## Path Assembly
+
+The `path` subcommand builds paths by composing three layers:
+
+```text
+<dir> / [.rd-<ctx>/] [YYYY-MM-DD-<file>]
+```
+
+| Input | Output |
+|-------|--------|
+| `--dir .work` | `.work` |
+| `--dir .work --ctx abc` | `.work/.rd-abc` |
+| `--dir .work --file plan.md` | `.work/2026-03-27-plan.md` |
+| `--dir .work --ctx abc --file plan.md` | `.work/.rd-abc/2026-03-27-plan.md` |
+
+The date prefix uses the current date in `YYYY-MM-DD` format (ISO 8601).
+
+---
+
+## Security
+
+### Input Validation
+
+| Input | Constraint | Regex |
+|-------|-----------|-------|
+| `--ctx` | Alphanumeric, hyphens, underscores | `^[a-zA-Z0-9_-]+$` |
+| `--file` | Alphanumeric, dots, hyphens, underscores | `^[a-zA-Z0-9._-]+$` |
+| `<pattern>` | Must be relative, no `..` segments | Rejects absolute paths and `..` traversal |
+
+### Directory Traversal Prevention
+
+- `--ctx` and `--file` values are validated against strict character sets — path separators (`/`, `\`) and `..` are rejected
+- Glob patterns must be relative to the target directory — absolute patterns and `..` segments are rejected
+- Pattern: `(?:^|[/\\])\.\.(?:$|[/\\])` catches traversal in any position
+
+### Symlink Safety
+
+The `find` subcommand resolves symlinks via `realpath()` and verifies that resolved targets remain within the search directory:
+
+- Symlinks resolving **inside** the search directory are included
+- Symlinks resolving **outside** the search directory are silently excluded
+- Dangling symlinks (broken targets) are silently skipped
+- Permission errors (`EACCES`, `EPERM`) and symlink loops (`ELOOP`) are silently skipped
+
+---
+
+## Typical Workflow
+
+```bash
+# 1. Assemble a path for a new artifact
+ARTIFACT_DIR=$(rdpath --dir .work --ctx sprint-42)
+mkdir -p "$ARTIFACT_DIR"
+
+# 2. Create a date-prefixed file
+PLAN_PATH=$(rdpath --dir .work --ctx sprint-42 --file plan.json)
+echo '{"name": "my plan"}' > "$PLAN_PATH"
+
+# 3. Find artifacts later
+rdpath --dir .work --ctx sprint-42 find '*-plan*.json'
+
+# 4. Combine with rdx for rendering
+PLAN=$(rdpath --dir .work --ctx sprint-42 find '*-plan.json')
+rdx "$PLAN" --output "$(rdpath --dir .work --ctx sprint-42 --file plan.md)"
+```

--- a/docs/RDX.md
+++ b/docs/RDX.md
@@ -272,7 +272,7 @@ Given this plan JSON:
 
 Renders to:
 
-```markdown
+````markdown
 ---
 version: 1.0.0
 ---
@@ -320,7 +320,7 @@ Create the widget class.
 ```typescript
 export class Widget {}
 ```
-```
+````
 
 Note: The task-level `### Files` table appears between the task heading and subtasks when the task has a non-empty `files` array.
 

--- a/docs/RDX.md
+++ b/docs/RDX.md
@@ -1,4 +1,4 @@
-# RDX — JSON-to-Markdown CLI
+# rdx — JSON-to-Markdown CLI
 
 `rdx` is a schema-aware JSON-to-Markdown transformation tool shipped with `@rundown-org/claude-code-plugin`. It renders arbitrary JSON to readable Markdown following structural conventions and optionally validates against discoverable schemas.
 
@@ -55,7 +55,7 @@ The renderer is **schema-unaware** — output is driven entirely by the JSON sha
 
 | JSON Type | Rendered As |
 |-----------|-------------|
-| `null` / `undefined` | Omitted |
+| `null` | Omitted |
 | `string` | Paragraph |
 | `number` / `boolean` | Stringified paragraph |
 | Array of primitives | Bullet list (`- item`) |
@@ -189,7 +189,7 @@ The plan schema validates implementation plans. Include `"$schema": "https://run
 
 ```typescript
 {
-  $schema?: string,                          // Optional schema URI
+  $schema?: "https://rundown.org/schemas/plan.schema.json",  // Optional schema URI (literal)
   name: string,                              // Plan name (min 1 char)
   meta: { version: "1.0.0" },               // Must be exactly "1.0.0"
   goal: string,                              // Desired outcome
@@ -237,35 +237,68 @@ All objects use strict mode — no additional properties are allowed.
 
 #### Example Rendered Output
 
-Given a plan JSON:
+Given this plan JSON:
+
+```json
+{
+  "name": "Add Widget",
+  "meta": { "version": "1.0.0" },
+  "goal": "Create a widget component.",
+  "architecture_and_approach": "Simple component following existing patterns.",
+  "files": [
+    { "path": "src/widget.ts", "action": "create", "notes": "Widget class" }
+  ],
+  "tasks": [
+    {
+      "name": "Implement Widget",
+      "files": [{ "path": "src/widget.ts", "action": "create" }],
+      "subtasks": [
+        {
+          "name": "Write failing test",
+          "description": "Test widget construction.",
+          "code": { "language": "typescript", "content": "expect(new Widget()).toBeDefined();" }
+        },
+        {
+          "name": "Implement widget",
+          "description": "Create the widget class.",
+          "code": { "language": "typescript", "content": "export class Widget {}" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Renders to:
 
 ```markdown
 ---
 version: 1.0.0
 ---
 
-# Add Widget Component
+# Add Widget
 
 ## Goal
 
-Create a reusable widget component.
+Create a widget component.
 
 ## Architecture And Approach
 
 Simple component following existing patterns.
-
-## Constraints And Assumptions
-
-Must support dark mode.
 
 ## Files
 
 | Path | Action | Notes |
 |------|------|------|
 | src/widget.ts | create | Widget class |
-| src/widget.test.ts | create | Unit tests |
 
 ## 1. Implement Widget
+
+### Files
+
+| Path | Action |
+|------|------|
+| src/widget.ts | create |
 
 ### 1.1 Write Failing Test
 
@@ -275,24 +308,16 @@ Test widget construction.
 expect(new Widget()).toBeDefined();
 ```
 
-### 1.2 Create Widget Class
+### 1.2 Implement Widget
 
-Implement the widget.
+Create the widget class.
 
 ```typescript
 export class Widget {}
 ```
-
-### Commit
-
-#### Files
-
-- src/widget.ts
-
-#### Message
-
-feat: add widget component
 ```
+
+Note: The task-level `### Files` table appears between the task heading and subtasks when the task has a non-empty `files` array.
 
 ---
 
@@ -326,7 +351,7 @@ Read JSON file
   → Resolve schema (--schema flag > $schema field)
   → If rawSchema present but unresolvable → error, exit 1
   → If schema resolved → validate cleanData → dataToRender (or cleanData if no schema)
-  → If --check → output "Valid.", exit 0
+  → If --check → output "Valid.", exit 0 (schema validation only if schema resolved; otherwise confirms valid JSON only)
   → renderToMarkdown(dataToRender)
   → Output to --output file or stdout
 ```

--- a/docs/RDX.md
+++ b/docs/RDX.md
@@ -194,11 +194,11 @@ The plan schema validates implementation plans. Include `"$schema": "https://run
   meta: { version: "1.0.0" },               // Must be exactly "1.0.0"
   goal: string,                              // Desired outcome
   architecture_and_approach: string,          // Solution design
-  constraints_and_assumptions: string,        // Boundaries and assumptions
+  constraints_and_assumptions: string,        // Hard constraints and assumptions
+  dependencies?: string,                      // Optional dependencies
+  context?: string,                          // Optional context
   files: FileEntry[],                        // Files affected (min 1)
   tasks: Task[],                             // Implementation tasks (min 1)
-  dependencies?: string,                      // Optional dependencies
-  context?: string                           // Optional context
 }
 ```
 
@@ -245,6 +245,7 @@ Given this plan JSON:
   "meta": { "version": "1.0.0" },
   "goal": "Create a widget component.",
   "architecture_and_approach": "Simple component following existing patterns.",
+  "constraints_and_assumptions": "Must support dark mode.",
   "files": [
     { "path": "src/widget.ts", "action": "create", "notes": "Widget class" }
   ],
@@ -285,6 +286,10 @@ Create a widget component.
 ## Architecture And Approach
 
 Simple component following existing patterns.
+
+## Constraints And Assumptions
+
+Must support dark mode.
 
 ## Files
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive rdpath Path Assembly CLI reference, including usage, subcommands, context scoping, file-name variants, output/exit behavior, security/validation rules, symlink handling, and examples.
  * Clarified rdpath command usage to support explicit --file variants with and without context.
  * Updated rdx CLI docs with tighter schema, rendering rules, examples, and validation behavior.
  * Expanded spellcheck dictionary with common syscall error terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->