### PR TITLE
Convert task to agent

### DIFF
--- a/docs/AGENT-ORCHESTRATION.md
+++ b/docs/AGENT-ORCHESTRATION.md
@@ -179,7 +179,7 @@ Multiple independent agents are dispatched in parallel, their results collected 
 
 | Phase | Description |
 |-------|-------------|
-| **Dispatch** | Launch N agents with `Step(subagent_type="...")` (`Task` is accepted as an alias for `Step` for backward compatibility) |
+| **Dispatch** | Launch N agents with `Agent(subagent_type="...")` (`Task` and `Step` are accepted as aliases for backward compatibility) |
 | **Execute** | Each agent works independently, writes findings to `.work/` |
 | **Collate** | Main agent reads all findings, categorises as Common (N/N agreement) vs Exclusive |
 | **Cross-check** | Optional: dispatch agent to validate exclusive findings |
@@ -196,8 +196,8 @@ Multiple independent agents are dispatched in parallel, their results collected 
 
 **Example** (from `verifying-by-consensus`):
 ```text
-Step(description="1.1 - Review auth changes", subagent_type="code-review-agent")
-Step(description="1.2 - Review auth changes", subagent_type="code-review-agent")
+Agent(description="1.1 - Review auth changes", subagent_type="code-review-agent")
+Agent(description="1.2 - Review auth changes", subagent_type="code-review-agent")
 ```
 
 Each agent writes its findings to `.work/{date}-verify-{agentId}.md`, ending with a `STATUS: PASS` or `STATUS: FAIL` line. The main agent then collates results.

--- a/packages/claude-code-plugin/__tests__/gates/on-delegation-dispatch.test.ts
+++ b/packages/claude-code-plugin/__tests__/gates/on-delegation-dispatch.test.ts
@@ -44,6 +44,20 @@ describe('on-delegation-dispatch gate', () => {
     });
   });
 
+  it('passes Agent tool through to handler', async () => {
+    mockHandleDelegationDispatch.mockResolvedValue({});
+
+    const input: HookInput = {
+      hook_event_name: 'PreToolUse',
+      cwd: '/test',
+      tool_name: 'Agent',
+    };
+
+    const result = await execute(input);
+    expect(result).toEqual({});
+    expect(mockHandleDelegationDispatch).toHaveBeenCalledWith(input);
+  });
+
   it('returns block decision when handler returns violation', async () => {
     mockHandleDelegationDispatch.mockResolvedValue({
       violation: 'Token expired',

--- a/packages/claude-code-plugin/__tests__/gates/on-step-tracker.test.ts
+++ b/packages/claude-code-plugin/__tests__/gates/on-step-tracker.test.ts
@@ -32,6 +32,20 @@ describe('on-step-tracker gate', () => {
     expect(mockTrackStepDispatch).toHaveBeenCalledWith(input);
   });
 
+  it('passes Agent tool through to handler', () => {
+    mockTrackStepDispatch.mockReturnValue({});
+
+    const input: HookInput = {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Agent',
+      cwd: '/test',
+    };
+
+    const result = execute(input);
+    expect(result).toEqual({});
+    expect(mockTrackStepDispatch).toHaveBeenCalledWith(input);
+  });
+
   it('returns block decision when violation occurs', async () => {
     mockTrackStepDispatch.mockReturnValue({
       violation: 'Step description must start with StepId',

--- a/packages/claude-code-plugin/__tests__/integration/synthetic-gates.test.ts
+++ b/packages/claude-code-plugin/__tests__/integration/synthetic-gates.test.ts
@@ -157,6 +157,20 @@ runbook: ${runbook}
     expect(result.blockReason).toBeUndefined();
   });
 
+  it('dispatches PreToolUse(Agent) through on-delegation-dispatch gate', async () => {
+    const input: HookInput = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Agent',
+      tool_input: { prompt: 'No delegation marker here', description: 'Just an agent' },
+      cwd: testDir,
+    };
+
+    // Should not block - no delegation marker means gate passes through
+    const result = await dispatch(input);
+
+    expect(result.blockReason).toBeUndefined();
+  });
+
   it('dispatches SubagentStop through on-subagent-stop gate', async () => {
     const input: HookInput = {
       hook_event_name: 'SubagentStop',

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/delegation-detector.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/delegation-detector.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import {
   detectDelegationMarker,
-  detectDelegationInTaskInput,
+  detectDelegationInToolInput,
 } from '../../../src/workflow/hooks/delegation-detector.js';
 
 describe('detectDelegationMarker', () => {
@@ -58,13 +58,13 @@ describe('detectDelegationMarker', () => {
   });
 });
 
-describe('detectDelegationInTaskInput', () => {
+describe('detectDelegationInToolInput', () => {
   const VALID_TOKEN = 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
   it('checks prompt before description', () => {
     const promptToken = 'rdtk_PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP';
     const descToken = 'rdtk_DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
-    const result = detectDelegationInTaskInput(
+    const result = detectDelegationInToolInput(
       `RD_CLAIM_TOKEN=${promptToken}`,
       `RD_CLAIM_TOKEN=${descToken}`,
     );
@@ -72,22 +72,22 @@ describe('detectDelegationInTaskInput', () => {
   });
 
   it('falls back to description when prompt has no marker', () => {
-    const result = detectDelegationInTaskInput('No marker here', `RD_CLAIM_TOKEN=${VALID_TOKEN}`);
+    const result = detectDelegationInToolInput('No marker here', `RD_CLAIM_TOKEN=${VALID_TOKEN}`);
     expect(result).toEqual({ token: VALID_TOKEN });
   });
 
   it('returns null when both undefined', () => {
-    const result = detectDelegationInTaskInput(undefined, undefined);
+    const result = detectDelegationInToolInput(undefined, undefined);
     expect(result).toBeNull();
   });
 
   it('returns null when both empty', () => {
-    const result = detectDelegationInTaskInput('', '');
+    const result = detectDelegationInToolInput('', '');
     expect(result).toBeNull();
   });
 
   it('returns null when prompt is undefined and description has no marker', () => {
-    const result = detectDelegationInTaskInput(undefined, 'Just a description');
+    const result = detectDelegationInToolInput(undefined, 'Just a description');
     expect(result).toBeNull();
   });
 });

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/delegation-dispatch.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/delegation-dispatch.test.ts
@@ -42,7 +42,7 @@ describe('handleDelegationDispatch', () => {
     expect(result).toEqual({});
   });
 
-  it('returns empty for PreToolUse where tool_name !== Task', async () => {
+  it('returns empty for PreToolUse where tool_name is neither Agent nor Task', async () => {
     const input = createMockHookInput('PreToolUse', {
       tool_name: 'Edit',
       tool_input: { file_path: '/test/file.ts' },

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/delegation-dispatch.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/delegation-dispatch.test.ts
@@ -103,6 +103,49 @@ describe('handleDelegationDispatch', () => {
     });
   });
 
+  it('returns context for Agent tool with marker in prompt', async () => {
+    const input = createMockHookInput('PreToolUse', {
+      tool_name: 'Agent',
+      tool_input: {
+        prompt: `Do the work\nRD_CLAIM_TOKEN=${VALID_TOKEN}\nThen report`,
+        description: 'A description',
+      },
+    });
+    const result = await handleDelegationDispatch(input);
+    expect(result.context).toContain(`rd claim ${VALID_TOKEN}`);
+    expect(result.context).toContain('Delegation Context');
+  });
+
+  it('returns context for Agent tool with marker in description', async () => {
+    const input = createMockHookInput('PreToolUse', {
+      tool_name: 'Agent',
+      tool_input: {
+        prompt: 'No marker here',
+        description: `Delegated agent\nRD_CLAIM_TOKEN=${VALID_TOKEN}`,
+      },
+    });
+    const result = await handleDelegationDispatch(input);
+    expect(result.context).toContain(`rd claim ${VALID_TOKEN}`);
+  });
+
+  it('stores token in session metadata on Agent tool detection', async () => {
+    mockGet.mockResolvedValue({ existing_key: 'value' });
+
+    const input = createMockHookInput('PreToolUse', {
+      tool_name: 'Agent',
+      tool_input: {
+        prompt: `RD_CLAIM_TOKEN=${VALID_TOKEN}`,
+      },
+    });
+
+    await handleDelegationDispatch(input);
+
+    expect(mockSet).toHaveBeenCalledWith('metadata', {
+      existing_key: 'value',
+      delegation_active_token: VALID_TOKEN,
+    });
+  });
+
   it('returns context even when rd status --json fails (best-effort)', async () => {
     setExecSync(
       jest.fn().mockImplementation(() => {

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/step-tracker.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/step-tracker.test.ts
@@ -49,6 +49,20 @@ describe('trackStepDispatch', () => {
       expect(result).toEqual({});
       expect(mockExec).toHaveBeenCalled();
     });
+
+    it('processes Agent tool name', () => {
+      const mockExec = jest.fn().mockReturnValue('ok');
+      setExecSync(mockExec as never);
+
+      const input = createMockHookInput('PostToolUse', {
+        tool_name: 'Agent',
+        tool_input: { description: '2.1 - Run integration tests' },
+      });
+
+      const result = trackStepDispatch(input);
+      expect(result).toEqual({});
+      expect(mockExec).toHaveBeenCalled();
+    });
   });
 
   describe('description validation', () => {

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/step-tracker.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/step-tracker.test.ts
@@ -67,7 +67,7 @@ describe('trackStepDispatch', () => {
 
   describe('description validation', () => {
     const expectedViolation =
-      'Step description must include a valid step identifier (e.g. "1.1 - Do work" or "ErrorHandler: Recover").';
+      'Tool description must include a valid step identifier (e.g. "1.1 - Do work" or "ErrorHandler: Recover").';
 
     it('returns violation when description is empty', () => {
       const input = createMockHookInput('PostToolUse', {

--- a/packages/claude-code-plugin/rundown-plugin.json
+++ b/packages/claude-code-plugin/rundown-plugin.json
@@ -12,14 +12,14 @@
   },
   "hooks": {
     "PreToolUse": {
-      "enabled_tools": ["Task"],
+      "enabled_tools": ["Agent", "Task"],
       "gates": ["on-delegation-dispatch"]
     },
     "SubagentStop": {
       "gates": ["on-subagent-stop"]
     },
     "PostToolUse": {
-      "enabled_tools": ["Edit", "Write", "Step", "Task"],
+      "enabled_tools": ["Agent", "Edit", "Write", "Step", "Task"],
       "gates": ["check"]
     },
     "SlashCommandStart": {

--- a/packages/claude-code-plugin/skills/verifying-by-consensus/SKILL.md
+++ b/packages/claude-code-plugin/skills/verifying-by-consensus/SKILL.md
@@ -41,15 +41,15 @@ Dispatch N agents to independently review the same subject. Collate findings:
 3. Start workflow: `rundown run runbooks/verify.runbook.md`
 4. Dispatch agents with StepId prefix in description:
    ```
-   Step(description="1.1 - Review [subject]", prompt="...", subagent_type="...")
-   Step(description="1.2 - Review [subject]", prompt="...", subagent_type="...")
+   Agent(description="1.1 - Review [subject]", prompt="...", subagent_type="...")
+   Agent(description="1.2 - Review [subject]", prompt="...", subagent_type="...")
    ```
 
 **Hooks automate step binding:**
 
 | Manual command | Hook trigger | When |
 |----------------|--------------|------|
-| `rundown run --step 1.1` | PostToolUse (Step) | StepId detected in description |
+| `rundown run --step 1.1` | PostToolUse (Agent/Step) | StepId detected in description |
 | `rundown run --agent {id}` | SubagentStart | Agent spawns |
 
 **Subagent protocol:**

--- a/packages/claude-code-plugin/src/gates/on-delegation-dispatch.ts
+++ b/packages/claude-code-plugin/src/gates/on-delegation-dispatch.ts
@@ -4,10 +4,10 @@ import { handleDelegationDispatch } from '../workflow/hooks/delegation-dispatch.
 /**
  * Delegation Dispatch Gate
  *
- * Detects delegation markers in PreToolUse(Task) events and enriches
+ * Detects delegation markers in PreToolUse(Agent/Task) events and enriches
  * subagent prompts with claim instructions.
  *
- * @param input - Hook input containing Task tool metadata
+ * @param input - Hook input containing Agent/Task tool metadata
  * @returns Gate result: block on violation, context on marker detection, or empty
  * @throws {Error} Propagates errors from handleDelegationDispatch if session I/O fails
  */

--- a/packages/claude-code-plugin/src/gates/on-step-tracker.ts
+++ b/packages/claude-code-plugin/src/gates/on-step-tracker.ts
@@ -5,7 +5,7 @@ import { trackStepDispatch } from '../workflow/hooks/step-tracker.js';
  * Workflow Step Tracker Gate
  *
  * Wraps trackStepDispatch logic as a configurable gate.
- * Validates that Step/Task tool descriptions are non-empty and forwards
+ * Validates that Agent/Step/Task tool descriptions are non-empty and forwards
  * them to the rundown CLI for workflow state tracking.
  * @param input - Hook input containing tool name and description
  * @returns Gate result with block decision on violation, or empty on success

--- a/packages/claude-code-plugin/src/workflow/hooks/delegation-detector.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/delegation-detector.ts
@@ -41,11 +41,11 @@ export function detectDelegationMarker(text: string): DelegationDetection | null
 }
 
 /**
- * Detect a delegation marker in Task tool input fields.
+ * Detect a delegation marker in Agent/Task tool input fields.
  * Scans prompt first, then falls back to description.
  *
- * @param prompt - Task prompt field
- * @param description - Task description field
+ * @param prompt - Agent/Task prompt field
+ * @param description - Agent/Task description field
  * @returns Detection result with token, or null if no marker found
  */
 export function detectDelegationInTaskInput(

--- a/packages/claude-code-plugin/src/workflow/hooks/delegation-detector.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/delegation-detector.ts
@@ -48,7 +48,7 @@ export function detectDelegationMarker(text: string): DelegationDetection | null
  * @param description - Agent/Task description field
  * @returns Detection result with token, or null if no marker found
  */
-export function detectDelegationInTaskInput(
+export function detectDelegationInToolInput(
   prompt?: string,
   description?: string,
 ): DelegationDetection | null {

--- a/packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts
@@ -5,6 +5,18 @@ import { Session } from '../../session.js';
 import { detectDelegationInToolInput } from './delegation-detector.js';
 import { rundown } from './rundown.js';
 
+/** Tool names that carry delegation context. */
+type DelegationToolName = 'Agent' | 'Task';
+
+/**
+ * Type guard for tool names that support delegation dispatch.
+ * @param toolName - Tool name from hook input
+ * @returns True when the tool is Agent or Task
+ */
+function isDelegationToolName(toolName: HookInput['tool_name']): toolName is DelegationToolName {
+  return toolName === 'Agent' || toolName === 'Task';
+}
+
 /**
  * Result from delegation dispatch handling.
  */
@@ -26,14 +38,12 @@ export interface DelegationDispatchResult {
  * @param input - Hook input received from Claude Code for the event
  * @returns A Dispatch result containing `context` with the delegation instructions when a token
  *          is found; an empty object when no delegation is detected or the event is not applicable.
+ * @throws {Error} When session metadata cannot be read or written
  */
 export async function handleDelegationDispatch(
   input: HookInput,
 ): Promise<DelegationDispatchResult> {
-  if (
-    input.hook_event_name !== 'PreToolUse' ||
-    (input.tool_name !== 'Agent' && input.tool_name !== 'Task')
-  ) {
+  if (input.hook_event_name !== 'PreToolUse' || !isDelegationToolName(input.tool_name)) {
     return {};
   }
 

--- a/packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts
@@ -2,7 +2,7 @@
 
 import type { HookInput } from '../../shared/index.js';
 import { Session } from '../../session.js';
-import { detectDelegationInTaskInput } from './delegation-detector.js';
+import { detectDelegationInToolInput } from './delegation-detector.js';
 import { rundown } from './rundown.js';
 
 /**
@@ -37,7 +37,7 @@ export async function handleDelegationDispatch(
     return {};
   }
 
-  const detection = detectDelegationInTaskInput(
+  const detection = detectDelegationInToolInput(
     input.tool_input?.prompt,
     input.tool_input?.description,
   );

--- a/packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts
@@ -16,7 +16,7 @@ export interface DelegationDispatchResult {
 }
 
 /**
- * Detect delegation markers in a PreToolUse Task event, persist the delegation token in
+ * Detect delegation markers in a PreToolUse Agent/Task event, persist the delegation token in
  * session metadata for abort correlation, and produce a Markdown context instructing
  * the subagent to claim the token and report results.
  *
@@ -30,7 +30,10 @@ export interface DelegationDispatchResult {
 export async function handleDelegationDispatch(
   input: HookInput,
 ): Promise<DelegationDispatchResult> {
-  if (input.hook_event_name !== 'PreToolUse' || input.tool_name !== 'Task') {
+  if (
+    input.hook_event_name !== 'PreToolUse' ||
+    (input.tool_name !== 'Agent' && input.tool_name !== 'Task')
+  ) {
     return {};
   }
 

--- a/packages/claude-code-plugin/src/workflow/hooks/index.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/index.ts
@@ -6,7 +6,7 @@ export {
 } from './delegation-dispatch.js';
 export {
   detectDelegationMarker,
-  detectDelegationInTaskInput,
+  detectDelegationInToolInput,
   type DelegationDetection,
 } from './delegation-detector.js';
 export { handleSubagentStop, type SubagentStopResult } from './subagent-stop.js';

--- a/packages/claude-code-plugin/src/workflow/hooks/step-tracker.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/step-tracker.ts
@@ -16,14 +16,14 @@ const EXACT_STEP_ID = new RegExp(`^${STEP_ID_PATTERN}$`);
 const PREFIXED_STEP_ID = new RegExp(`^\\s*(${STEP_ID_PATTERN})\\s*[-–—:]\\s+`);
 
 /**
- * Extract a normalized step identifier from a Step/Task description.
+ * Extract a normalized step identifier from an Agent/Step/Task description.
  *
  * Accepted forms:
  * - "1.1"
  * - "NamedStep"
  * - "1.1 - Description"
  * - "NamedStep: Description"
- * @param description - Raw Step/Task tool description text
+ * @param description - Raw Agent/Step/Task tool description text
  * @returns Normalized step identifier, or null if no valid identifier found
  */
 function extractStepId(description: string): string | null {
@@ -43,7 +43,7 @@ function extractStepId(description: string): string | null {
 }
 
 /**
- * Track Step tool dispatches in workflow state
+ * Track Agent/Step/Task tool dispatches in workflow state
  * @param input - Hook input containing tool name and description
  * @returns Result with optional violation message if step identifier is invalid
  */

--- a/packages/claude-code-plugin/src/workflow/hooks/step-tracker.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/step-tracker.ts
@@ -3,7 +3,7 @@ import type { HookInput } from '../../shared/index.js';
 import { rundown } from './rundown.js';
 
 /**
- * Result of processing a Step/Task tool dispatch for workflow tracking.
+ * Result of processing an Agent/Step/Task tool dispatch for workflow tracking.
  */
 export interface StepDispatchResult {
   violation?: string;
@@ -48,8 +48,8 @@ function extractStepId(description: string): string | null {
  * @returns Result with optional violation message if step identifier is invalid
  */
 export function trackStepDispatch(input: HookInput): StepDispatchResult {
-  // Handle both Step and Task tool (Task for backward compatibility/LLM training)
-  if (input.tool_name !== 'Step' && input.tool_name !== 'Task') {
+  // Handle Agent, Step, and Task tools (Task/Step for backward compatibility)
+  if (input.tool_name !== 'Agent' && input.tool_name !== 'Step' && input.tool_name !== 'Task') {
     return {};
   }
 

--- a/packages/claude-code-plugin/src/workflow/hooks/step-tracker.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/step-tracker.ts
@@ -2,6 +2,18 @@
 import type { HookInput } from '../../shared/index.js';
 import { rundown } from './rundown.js';
 
+/** Tool names that are tracked as workflow step dispatches. */
+type TrackableToolName = 'Agent' | 'Step' | 'Task';
+
+/**
+ * Determine whether a tool name should be tracked as a workflow step dispatch.
+ * @param toolName - Tool name from hook input
+ * @returns True when the tool is Agent, Step, or Task
+ */
+function isTrackableToolName(toolName: HookInput['tool_name']): toolName is TrackableToolName {
+  return toolName === 'Agent' || toolName === 'Step' || toolName === 'Task';
+}
+
 /**
  * Result of processing an Agent/Step/Task tool dispatch for workflow tracking.
  */
@@ -49,7 +61,7 @@ function extractStepId(description: string): string | null {
  */
 export function trackStepDispatch(input: HookInput): StepDispatchResult {
   // Handle Agent, Step, and Task tools (Task/Step for backward compatibility)
-  if (input.tool_name !== 'Agent' && input.tool_name !== 'Step' && input.tool_name !== 'Task') {
+  if (!isTrackableToolName(input.tool_name)) {
     return {};
   }
 

--- a/packages/claude-code-plugin/src/workflow/hooks/step-tracker.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/step-tracker.ts
@@ -60,7 +60,7 @@ export function trackStepDispatch(input: HookInput): StepDispatchResult {
     if (!stepId) {
       return {
         violation:
-          'Step description must include a valid step identifier (e.g. "1.1 - Do work" or "ErrorHandler: Recover").',
+          'Tool description must include a valid step identifier (e.g. "1.1 - Do work" or "ErrorHandler: Recover").',
       };
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated orchestration and workflow docs and examples to use Agent(...) instead of Step(...); clarified Task and Step are accepted aliases; changed validation wording to "Tool description" where applicable.

* **Tests**
  * Added unit and integration tests ensuring Agent tool paths for delegation dispatch and step tracking behave consistently.

* **Chores**
  * Enabled Agent in PreToolUse and PostToolUse hook configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->