### PR TITLE
Handle subagent stop more good

### DIFF
--- a/docs/AGENT-ORCHESTRATION.md
+++ b/docs/AGENT-ORCHESTRATION.md
@@ -1,6 +1,6 @@
 # Agent Orchestration Models
 
-How Rundown orchestrates work through agents. This document covers the five orchestration models, when to use each, agent type conventions, and the status protocol.
+How Rundown orchestrates work through agents. This document covers the five orchestration models, when to use each, agent type conventions, and delegation completion.
 
 **Related docs:**
 - [RUNDOWN.md](./RUNDOWN.md) - CLI reference including subagent commands
@@ -22,7 +22,7 @@ How Rundown orchestrates work through agents. This document covers the five orch
   - [Naming](#naming)
   - [Namespaces](#namespaces)
   - [Context File Discovery](#context-file-discovery)
-- [Status Protocol](#status-protocol)
+- [Delegation Completion](#delegation-completion)
 - [Runbook Transitions for Agents](#runbook-transitions-for-agents)
 
 ---
@@ -270,37 +270,23 @@ This is how agent types get their instructions without a central registry — pl
 
 ---
 
-## Status Protocol
+## Delegation Completion
 
-Subagents signal completion via a `STATUS` line in their output:
+Subagents complete delegated work using `rd pass` or `rd fail`, which updates the child runbook state directly. The parent agent observes results via `rd status`.
 
-```
-STATUS: PASS
-```
+When a subagent stops, the plugin checks the child runbook state via `rd status --json`:
 
-or
+- **Child completed** (`rd pass`/`rd fail` was called): The child runbook has already been popped from the session stack and the result propagated to the parent. No action needed.
+- **Child still active** (subagent stopped without completing): The plugin surfaces context to the parent agent with the child's current position and step, so the parent can decide how to proceed (retry, complete manually, or fail the step).
 
-```
-STATUS: FAIL
-```
-
-**Supported values:**
-
-| Status | Meaning |
-|--------|---------|
-| `PASS` | Agent completed successfully |
-| `FAIL` | Agent encountered issues or rejected the work |
-| `BLOCKED` | Agent could not proceed (used in plan execution) |
-
-The plugin parses this from agent output and translates it to `rd pass` or `rd fail` within the child runbook context. See [Section 4: Control Flow](SPEC.md#4-control-flow) for transition semantics.
+The plugin never destroys child runbook state. Incomplete delegations preserve their context for inspection.
 
 Routing behavior:
-- Agent completion and plain `pass/fail` share one record-and-drain transition path.
 - Completion keys are scoped to `frame + entry + substep`; stale completions from previous entries are rejected.
 - Resolved completions drain in deterministic substep order. Aggregation waits for all DEFER'd results before evaluating the step-level transition.
-- When a completion arrives for a frontier substep that is not at the active cursor, it is **deferred** — stored and applied when the cursor reaches that substep. See [Section 4: Control Flow](SPEC.md#4-control-flow) for transition semantics.
+- When a completion arrives for a frontier substep that is not at the active cursor, it is **deferred** — stored and applied when the cursor reaches that substep.
 
-**Important:** The STATUS line should appear at the end of the agent's response. If no STATUS line is found, the plugin treats the result based on the agent's exit behaviour.
+See [Section 4: Control Flow](SPEC.md#4-control-flow) for transition semantics.
 
 ---
 

--- a/docs/AGENT-ORCHESTRATION.md
+++ b/docs/AGENT-ORCHESTRATION.md
@@ -200,7 +200,7 @@ Agent(description="1.1 - Review auth changes", subagent_type="code-review-agent"
 Agent(description="1.2 - Review auth changes", subagent_type="code-review-agent")
 ```
 
-Each agent writes its findings to `.work/{date}-verify-{agentId}.md`, ending with a `STATUS: PASS` or `STATUS: FAIL` line. The main agent then collates results.
+Each agent writes its findings to `.work/{date}-verify-{agentId}.md` and uses `rd pass` or `rd fail` to report the result. The main agent then collates results.
 
 ---
 

--- a/packages/claude-code-plugin/TESTING.md
+++ b/packages/claude-code-plugin/TESTING.md
@@ -122,9 +122,29 @@ echo '{"hook_event_name":"PreToolUse","cwd":"'$(pwd)'","tool_name":"Skill","tool
 
 ### SubagentStop
 
+**No-op path** (no active delegation — fast exit):
+
 ```bash
 echo '{"hook_event_name":"SubagentStop","cwd":"'$(pwd)'","agent_id":"test-agent","agent_type":"code-review-agent","last_assistant_message":"Agent completed successfully."}' | node dist/cli.js
 ```
+
+**Delegation correlation path** (exercises `rd status --json` flow):
+
+1. Start a runbook with a delegation substep and create a delegation token:
+   ```bash
+   rd run my-runbook.md
+   rd delegate --step 2.1
+   ```
+2. Claim the delegation token in a separate session (to seed `delegation_active_token`):
+   ```bash
+   rd claim <token>
+   ```
+3. Send SubagentStop with the same cwd so the handler finds the session token:
+   ```bash
+   echo '{"hook_event_name":"SubagentStop","cwd":"'$(pwd)'","agent_id":"test-agent","agent_type":"code-review-agent","last_assistant_message":"Agent completed successfully."}' | node dist/cli.js
+   ```
+
+The handler will call `rd status --json`, correlate the token hash against active delegations, and produce a context message based on the delegation state.
 
 ### UserPromptSubmit
 

--- a/packages/claude-code-plugin/TESTING.md
+++ b/packages/claude-code-plugin/TESTING.md
@@ -123,7 +123,7 @@ echo '{"hook_event_name":"PreToolUse","cwd":"'$(pwd)'","tool_name":"Skill","tool
 ### SubagentStop
 
 ```bash
-echo '{"hook_event_name":"SubagentStop","cwd":"'$(pwd)'","agent_id":"test-agent","agent_type":"code-review-agent","last_assistant_message":"STATUS: PASS"}' | node dist/cli.js
+echo '{"hook_event_name":"SubagentStop","cwd":"'$(pwd)'","agent_id":"test-agent","agent_type":"code-review-agent","last_assistant_message":"Agent completed successfully."}' | node dist/cli.js
 ```
 
 ### UserPromptSubmit

--- a/packages/claude-code-plugin/__tests__/helpers/test-utils.ts
+++ b/packages/claude-code-plugin/__tests__/helpers/test-utils.ts
@@ -106,7 +106,7 @@ export function createMockHookInput(
         ...base,
         agent_id: 'test-agent-123',
         agent_type: 'test-namespace:test-agent',
-        last_assistant_message: 'STATUS: PASS\nAgent completed successfully.',
+        last_assistant_message: 'Agent completed successfully.',
         ...rest,
       };
 

--- a/packages/claude-code-plugin/__tests__/integration/subagent-stop-contract.test.ts
+++ b/packages/claude-code-plugin/__tests__/integration/subagent-stop-contract.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Contract and lifecycle integration tests for the subagent-stop hook.
+ *
+ * These tests use the real CLI to create runbook state, capture `rd status --json`
+ * output, and feed it through the handler to validate the parsing contract between
+ * the plugin and CLI.
+ *
+ * Critical: Delegation tests must use REAL tokens extracted from `rd delegate` output.
+ * The handler hashes the token (SHA-256) and correlates against `tokenHash` in
+ * the status output. A fake token's hash won't match.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { setExecSync } from '../../src/workflow/hooks/rundown.js';
+import { runCli, createMockHookInput, createMockExecSync } from '../helpers/test-utils.js';
+
+// Mock Session to control delegation_active_token
+const mockGet = jest.fn();
+const mockSet = jest.fn();
+
+jest.unstable_mockModule('../../src/session.js', () => ({
+  Session: jest.fn().mockImplementation(() => ({
+    get: mockGet,
+    set: mockSet,
+  })),
+}));
+
+const { handleSubagentStop } = await import('../../src/workflow/hooks/subagent-stop.js');
+
+/** Fake token for non-delegation tests (hash won't match any real delegation). */
+const FAKE_TOKEN = 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+const SIMPLE_RUNBOOK = `---
+name: contract-test
+---
+# Contract Test
+
+## 1. First step
+- PASS CONTINUE
+
+Do something.
+
+## 2. Second step
+- PASS COMPLETE
+
+Do something else.
+`;
+
+const PARENT_RUNBOOK = `---
+name: parent-contract
+---
+# Parent Contract
+
+## 1. Delegated step
+
+### 1.1 Child task
+- PASS CONTINUE
+
+Delegate this.
+
+## 2. Final step
+- PASS COMPLETE
+
+Done.
+`;
+
+const CHILD_RUNBOOK = `---
+name: child-contract
+---
+# Child Contract
+
+## 1. Child work
+- PASS COMPLETE
+
+Do the child work.
+`;
+
+/** Extract delegation token from `rd delegate` stdout. */
+function extractToken(stdout: string): string {
+  const match = /Token:\s*(rdtk_\S+)/.exec(stdout);
+  if (!match) throw new Error(`No token found in delegate output:\n${stdout}`);
+  return match[1];
+}
+
+describe('subagent-stop contract tests', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSet.mockResolvedValue(undefined);
+    setExecSync(jest.fn() as never);
+
+    tempDir = mkdtempSync(join(tmpdir(), 'rd-subagent-stop-contract-'));
+    mkdirSync(join(tempDir, '.claude', 'rundown', 'runs'), { recursive: true });
+  });
+
+  afterEach(() => {
+    setExecSync(jest.fn() as never);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Capture real `rd status --json` output, inject it into the handler
+   * via setExecSync, and call handleSubagentStop.
+   *
+   * @param token - Delegation token to place in Session mock (use real token for delegation tests)
+   */
+  async function captureStatusAndHandle(token: string) {
+    mockGet.mockResolvedValue({ delegation_active_token: token });
+
+    const statusResult = runCli('status --json', tempDir);
+    expect(statusResult.exitCode).toBe(0);
+
+    setExecSync(createMockExecSync(statusResult.stdout) as never);
+
+    const input = createMockHookInput('SubagentStop', { cwd: tempDir });
+    return handleSubagentStop(input);
+  }
+
+  /** Write parent + child runbooks, start parent, delegate, return real token. */
+  function setupDelegation(): string {
+    writeFileSync(join(tempDir, 'parent.runbook.md'), PARENT_RUNBOOK);
+    writeFileSync(join(tempDir, 'child.runbook.md'), CHILD_RUNBOOK);
+
+    const runResult = runCli(['run', join(tempDir, 'parent.runbook.md'), '--prompted'], tempDir);
+    expect(runResult.exitCode).toBe(0);
+
+    const delegateResult = runCli('delegate child.runbook.md --step 1.1', tempDir);
+    expect(delegateResult.exitCode).toBe(0);
+
+    return extractToken(delegateResult.stdout);
+  }
+
+  describe('status shape contract', () => {
+    it('parses inactive status (no runbook running)', async () => {
+      const result = await captureStatusAndHandle(FAKE_TOKEN);
+      expect(result).toEqual({});
+    });
+
+    it('parses active status mid-execution', async () => {
+      writeFileSync(join(tempDir, 'test.runbook.md'), SIMPLE_RUNBOOK);
+      const runResult = runCli(['run', join(tempDir, 'test.runbook.md'), '--prompted'], tempDir);
+      expect(runResult.exitCode).toBe(0);
+
+      const result = await captureStatusAndHandle(FAKE_TOKEN);
+
+      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).toContain('First step');
+    });
+
+    it('parses stashed status', async () => {
+      writeFileSync(join(tempDir, 'test.runbook.md'), SIMPLE_RUNBOOK);
+      let cliResult = runCli(['run', join(tempDir, 'test.runbook.md'), '--prompted'], tempDir);
+      expect(cliResult.exitCode).toBe(0);
+
+      cliResult = runCli('stash', tempDir);
+      expect(cliResult.exitCode).toBe(0);
+
+      const result = await captureStatusAndHandle(FAKE_TOKEN);
+
+      expect(result.context).toContain('Delegation Incomplete');
+    });
+  });
+
+  describe('delegation contract', () => {
+    it('detects unclaimed delegation via tokenHash match', async () => {
+      const token = setupDelegation();
+
+      const result = await captureStatusAndHandle(token);
+
+      expect(result.context).toContain('Delegation Never Claimed');
+      expect(result.context).toContain('child.runbook.md');
+    });
+
+    it('detects child active after claim (no delegations visible)', async () => {
+      const token = setupDelegation();
+
+      const claimResult = runCli(`claim ${token}`, tempDir);
+      expect(claimResult.exitCode).toBe(0);
+
+      const result = await captureStatusAndHandle(token);
+
+      // After claim, child is active with no delegations → child_active
+      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).toContain('Child work');
+    });
+
+    it('reports parent active after child completes (no delegations)', async () => {
+      const token = setupDelegation();
+
+      let cliResult = runCli(`claim ${token}`, tempDir);
+      expect(cliResult.exitCode).toBe(0);
+
+      cliResult = runCli('pass', tempDir);
+      expect(cliResult.exitCode).toBe(0);
+
+      const result = await captureStatusAndHandle(token);
+
+      // Parent resumes at step 2, no delegations → child_active (conservative)
+      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).toContain('Final step');
+    });
+  });
+
+  describe('delegation lifecycle', () => {
+    it('unclaimed: delegate without claim', async () => {
+      const token = setupDelegation();
+
+      const result = await captureStatusAndHandle(token);
+
+      expect(result.context).toContain('Delegation Never Claimed');
+      expect(result.context).toContain('substep');
+    });
+
+    it('full lifecycle: delegate → claim → child active → pass', async () => {
+      const token = setupDelegation();
+
+      // Claim — child becomes active
+      let cliResult = runCli(`claim ${token}`, tempDir);
+      expect(cliResult.exitCode).toBe(0);
+
+      // Child still active
+      let result = await captureStatusAndHandle(token);
+      expect(result.context).toContain('Delegation Incomplete');
+
+      // Reset mock for second call (token consumed by first call)
+      // Complete child
+      cliResult = runCli('pass', tempDir);
+      expect(cliResult.exitCode).toBe(0);
+
+      // Parent active — handler still flags as incomplete (conservative)
+      result = await captureStatusAndHandle(token);
+      expect(result.context).toContain('Delegation Incomplete');
+    });
+  });
+});

--- a/packages/claude-code-plugin/__tests__/integration/subagent-stop-contract.test.ts
+++ b/packages/claude-code-plugin/__tests__/integration/subagent-stop-contract.test.ts
@@ -107,7 +107,9 @@ describe('subagent-stop contract tests', () => {
    *
    * @param token - Delegation token to place in Session mock (use real token for delegation tests)
    */
-  async function captureStatusAndHandle(token: string) {
+  async function captureStatusAndHandle(
+    token: string,
+  ): Promise<{ context?: string; violation?: string }> {
     mockGet.mockResolvedValue({ delegation_active_token: token });
 
     const statusResult = runCli('status --json', tempDir);
@@ -146,6 +148,7 @@ describe('subagent-stop contract tests', () => {
 
       const result = await captureStatusAndHandle(FAKE_TOKEN);
 
+      expect(result.context).toBeDefined();
       expect(result.context).toContain('Delegation Incomplete');
       expect(result.context).toContain('First step');
     });
@@ -160,6 +163,7 @@ describe('subagent-stop contract tests', () => {
 
       const result = await captureStatusAndHandle(FAKE_TOKEN);
 
+      expect(result.context).toBeDefined();
       expect(result.context).toContain('Delegation Incomplete');
     });
   });
@@ -170,6 +174,7 @@ describe('subagent-stop contract tests', () => {
 
       const result = await captureStatusAndHandle(token);
 
+      expect(result.context).toBeDefined();
       expect(result.context).toContain('Delegation Never Claimed');
       expect(result.context).toContain('child.runbook.md');
     });
@@ -183,6 +188,7 @@ describe('subagent-stop contract tests', () => {
       const result = await captureStatusAndHandle(token);
 
       // After claim, child is active with no delegations → child_active
+      expect(result.context).toBeDefined();
       expect(result.context).toContain('Delegation Incomplete');
       expect(result.context).toContain('Child work');
     });
@@ -199,21 +205,13 @@ describe('subagent-stop contract tests', () => {
       const result = await captureStatusAndHandle(token);
 
       // Parent resumes at step 2, no delegations → child_active (conservative)
+      expect(result.context).toBeDefined();
       expect(result.context).toContain('Delegation Incomplete');
       expect(result.context).toContain('Final step');
     });
   });
 
   describe('delegation lifecycle', () => {
-    it('unclaimed: delegate without claim', async () => {
-      const token = setupDelegation();
-
-      const result = await captureStatusAndHandle(token);
-
-      expect(result.context).toContain('Delegation Never Claimed');
-      expect(result.context).toContain('substep');
-    });
-
     it('full lifecycle: delegate → claim → child active → pass', async () => {
       const token = setupDelegation();
 
@@ -223,15 +221,16 @@ describe('subagent-stop contract tests', () => {
 
       // Child still active
       let result = await captureStatusAndHandle(token);
+      expect(result.context).toBeDefined();
       expect(result.context).toContain('Delegation Incomplete');
 
-      // Reset mock for second call (token consumed by first call)
       // Complete child
       cliResult = runCli('pass', tempDir);
       expect(cliResult.exitCode).toBe(0);
 
       // Parent active — handler still flags as incomplete (conservative)
       result = await captureStatusAndHandle(token);
+      expect(result.context).toBeDefined();
       expect(result.context).toContain('Delegation Incomplete');
     });
   });

--- a/packages/claude-code-plugin/__tests__/integration/subagent-stop-contract.test.ts
+++ b/packages/claude-code-plugin/__tests__/integration/subagent-stop-contract.test.ts
@@ -163,7 +163,8 @@ describe('subagent-stop contract tests', () => {
       const result = await captureStatusAndHandle(FAKE_TOKEN);
 
       expect(result.context).toBeDefined();
-      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).toContain('Delegation Stashed');
+      expect(result.context).toContain('stashed without being completed');
     });
   });
 

--- a/packages/claude-code-plugin/__tests__/integration/subagent-stop-contract.test.ts
+++ b/packages/claude-code-plugin/__tests__/integration/subagent-stop-contract.test.ts
@@ -141,16 +141,15 @@ describe('subagent-stop contract tests', () => {
       expect(result).toEqual({});
     });
 
-    it('parses active status mid-execution', async () => {
+    it('parses active status mid-execution (no delegations → completed)', async () => {
       writeFileSync(join(tempDir, 'test.runbook.md'), SIMPLE_RUNBOOK);
       const runResult = runCli(['run', join(tempDir, 'test.runbook.md'), '--prompted'], tempDir);
       expect(runResult.exitCode).toBe(0);
 
       const result = await captureStatusAndHandle(FAKE_TOKEN);
 
-      expect(result.context).toBeDefined();
-      expect(result.context).toContain('Delegation Incomplete');
-      expect(result.context).toContain('First step');
+      // Active with no delegations → treated as completed (parent resumed)
+      expect(result).toEqual({});
     });
 
     it('parses stashed status', async () => {
@@ -179,7 +178,7 @@ describe('subagent-stop contract tests', () => {
       expect(result.context).toContain('child.runbook.md');
     });
 
-    it('detects child active after claim (no delegations visible)', async () => {
+    it('treats claimed child with no delegations as completed', async () => {
       const token = setupDelegation();
 
       const claimResult = runCli(`claim ${token}`, tempDir);
@@ -187,13 +186,12 @@ describe('subagent-stop contract tests', () => {
 
       const result = await captureStatusAndHandle(token);
 
-      // After claim, child is active with no delegations → child_active
-      expect(result.context).toBeDefined();
-      expect(result.context).toContain('Delegation Incomplete');
-      expect(result.context).toContain('Child work');
+      // After claim, child is active with no delegations → completed
+      // (cannot distinguish from parent-resumed; no-delegations = completed)
+      expect(result).toEqual({});
     });
 
-    it('reports parent active after child completes (no delegations)', async () => {
+    it('treats parent resumed after child pass as completed', async () => {
       const token = setupDelegation();
 
       let cliResult = runCli(`claim ${token}`, tempDir);
@@ -204,34 +202,30 @@ describe('subagent-stop contract tests', () => {
 
       const result = await captureStatusAndHandle(token);
 
-      // Parent resumes at step 2, no delegations → child_active (conservative)
-      expect(result.context).toBeDefined();
-      expect(result.context).toContain('Delegation Incomplete');
-      expect(result.context).toContain('Final step');
+      // Parent resumes at step 2, no delegations → completed
+      expect(result).toEqual({});
     });
   });
 
   describe('delegation lifecycle', () => {
-    it('full lifecycle: delegate → claim → child active → pass', async () => {
+    it('full lifecycle: delegate → claim → pass → completed', async () => {
       const token = setupDelegation();
 
-      // Claim — child becomes active
+      // Claim — child becomes active (no delegations visible)
       let cliResult = runCli(`claim ${token}`, tempDir);
       expect(cliResult.exitCode).toBe(0);
 
-      // Child still active
+      // After claim: no delegations → treated as completed
       let result = await captureStatusAndHandle(token);
-      expect(result.context).toBeDefined();
-      expect(result.context).toContain('Delegation Incomplete');
+      expect(result).toEqual({});
 
       // Complete child
       cliResult = runCli('pass', tempDir);
       expect(cliResult.exitCode).toBe(0);
 
-      // Parent active — handler still flags as incomplete (conservative)
+      // After child pass: parent resumed, no delegations → completed
       result = await captureStatusAndHandle(token);
-      expect(result.context).toBeDefined();
-      expect(result.context).toContain('Delegation Incomplete');
+      expect(result).toEqual({});
     });
   });
 });

--- a/packages/claude-code-plugin/__tests__/integration/synthetic-gates.test.ts
+++ b/packages/claude-code-plugin/__tests__/integration/synthetic-gates.test.ts
@@ -175,7 +175,7 @@ runbook: ${runbook}
     const input: HookInput = {
       hook_event_name: 'SubagentStop',
       agent_id: 'test-agent-123',
-      last_assistant_message: 'STATUS: PASS',
+      last_assistant_message: 'Agent completed successfully.',
       cwd: testDir,
     };
 

--- a/packages/claude-code-plugin/__tests__/perf/hook-performance.test.ts
+++ b/packages/claude-code-plugin/__tests__/perf/hook-performance.test.ts
@@ -95,7 +95,7 @@ describe('Hook Performance Budget', () => {
       const input = createMockHookInput('SubagentStop', {
         cwd: testDir.path,
         agent_type: 'test-agent',
-        last_assistant_message: 'STATUS: PASS',
+        last_assistant_message: 'Agent completed successfully.',
       });
 
       // Warm up

--- a/packages/claude-code-plugin/__tests__/perf/hook-performance.test.ts
+++ b/packages/claude-code-plugin/__tests__/perf/hook-performance.test.ts
@@ -1,6 +1,7 @@
 // __tests__/perf/hook-performance.test.ts
 // Performance budget tests for hook processing
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
   dispatch,
@@ -18,6 +19,7 @@ import {
   createTempTestDir,
   writeTestConfig,
 } from '../helpers/test-utils.js';
+import { setExecSync } from '../../src/workflow/hooks/rundown.js';
 import type { GateConfig, HookConfig } from '../../src/shared/index.js';
 
 /**
@@ -103,6 +105,61 @@ describe('Hook Performance Budget', () => {
 
       const { durationMs } = await measureExecutionTime(() => dispatch(input));
       expect(durationMs).toBeLessThan(HOOK_BUDGET_MS);
+    });
+
+    it('processes SubagentStop with delegation under budget', async () => {
+      const config = createMockConfig({
+        hooks: {
+          SubagentStop: {
+            enabled_agents: ['test-agent'],
+            gates: [],
+          },
+        },
+        gates: {},
+      });
+      await writeTestConfig(testDir.path, config);
+
+      // Session expects token under metadata (SessionStateSchema)
+      const sessionDir = path.join(testDir.path, '.claude', 'session');
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const sessionFile = path.join(sessionDir, 'state.json');
+      const seedSession = () => {
+        fs.writeFileSync(
+          sessionFile,
+          JSON.stringify({
+            metadata: { delegation_active_token: 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567' },
+          }),
+        );
+      };
+
+      // Mock rd status --json to return a deterministic response
+      const statusJson = JSON.stringify({
+        active: true,
+        stashed: false,
+        file: 'parent.runbook.md',
+        delegations: [],
+      });
+      setExecSync((() => statusJson) as never);
+
+      try {
+        const input = createMockHookInput('SubagentStop', {
+          cwd: testDir.path,
+          agent_type: 'test-agent',
+          last_assistant_message: 'Agent completed successfully.',
+        });
+
+        // Warm up (consumes the one-shot token)
+        seedSession();
+        await dispatch(input);
+
+        // Re-seed so the timed run exercises the full delegation path
+        seedSession();
+        const { durationMs } = await measureExecutionTime(() => dispatch(input));
+        expect(durationMs).toBeLessThan(HOOK_BUDGET_MS);
+      } finally {
+        // Reset to a no-op to avoid leaking the mock
+        setExecSync((() => '') as never);
+      }
     });
 
     it('handles missing config gracefully and quickly', async () => {

--- a/packages/claude-code-plugin/__tests__/schemas.test.ts
+++ b/packages/claude-code-plugin/__tests__/schemas.test.ts
@@ -36,7 +36,7 @@ describe('HookInputSchema', () => {
       permission_mode: 'default',
       agent_id: 'agent-123',
       agent_type: 'code-review-agent',
-      last_assistant_message: 'STATUS: PASS',
+      last_assistant_message: 'Agent completed successfully.',
       tool_input: {
         file_path: '/Users/test/project/src/index.ts',
       },
@@ -83,7 +83,7 @@ describe('HookInputSchema', () => {
       {
         hook_event_name: 'SubagentStop',
         cwd: '/Users/test/project',
-        output: 'STATUS: PASS',
+        output: 'Agent completed successfully.',
       },
       {
         hook_event_name: 'PostToolUse',

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
@@ -133,17 +133,34 @@ describe('handleSubagentStop', () => {
       expect(result).toEqual({});
     });
 
-    it('returns empty when parent has delegations but ours is not found', async () => {
+    it('returns empty when no delegations remain (parent resumed)', async () => {
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
       setExecSync(
         createStatusMock({
           active: true,
           stashed: false,
           file: 'parent.runbook.md',
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      // No delegations and our token not found — parent resumed after completion
+      expect(result).toEqual({});
+    });
+
+    it('treats unrecognized delegations as child with nested delegations', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'child.runbook.md',
           delegations: [
             {
-              substep: '3.2',
-              runbook: 'other-child.runbook.md',
+              substep: '1.1',
+              runbook: 'grandchild.runbook.md',
               state: 'pending',
               tokenHash: OTHER_TOKEN_HASH,
             },
@@ -154,8 +171,9 @@ describe('handleSubagentStop', () => {
       const input = createMockHookInput('SubagentStop');
       const result = await handleSubagentStop(input);
 
-      // Our delegation isn't in the list — parent has sibling delegations only
-      expect(result).toEqual({});
+      // Delegations present but none match our token — child with nested delegations
+      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).toContain('child.runbook.md');
     });
   });
 
@@ -181,14 +199,29 @@ describe('handleSubagentStop', () => {
     });
   });
 
-  describe('child runbook still active', () => {
-    it('returns context when child is active (no delegations)', async () => {
+  describe('child runbook still active (nested delegations)', () => {
+    /** Status mock for a child runbook that has its own nested delegations. */
+    function childWithNestedDelegations(overrides: Record<string, unknown> = {}) {
+      return createStatusMock({
+        active: true,
+        stashed: false,
+        file: 'child.runbook.md',
+        delegations: [
+          {
+            substep: '1.1',
+            runbook: 'grandchild.runbook.md',
+            state: 'pending',
+            tokenHash: OTHER_TOKEN_HASH,
+          },
+        ],
+        ...overrides,
+      });
+    }
+
+    it('returns context when child has nested delegations', async () => {
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
       setExecSync(
-        createStatusMock({
-          active: true,
-          stashed: false,
-          file: 'child.runbook.md',
+        childWithNestedDelegations({
           step: { name: '2. Review changes' },
           position: { current: '2', total: 5 },
         }) as never,
@@ -205,13 +238,7 @@ describe('handleSubagentStop', () => {
 
     it('includes actionable instructions in context', async () => {
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
-      setExecSync(
-        createStatusMock({
-          active: true,
-          stashed: false,
-          file: 'child.runbook.md',
-        }) as never,
-      );
+      setExecSync(childWithNestedDelegations() as never);
 
       const input = createMockHookInput('SubagentStop');
       const result = await handleSubagentStop(input);
@@ -224,10 +251,7 @@ describe('handleSubagentStop', () => {
     it('includes step description when available', async () => {
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
       setExecSync(
-        createStatusMock({
-          active: true,
-          stashed: false,
-          file: 'child.runbook.md',
+        childWithNestedDelegations({
           step: { name: '3. Deploy', description: 'Deploy to staging' },
         }) as never,
       );

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
@@ -95,7 +95,7 @@ describe('handleSubagentStop', () => {
   });
 
   describe('child runbook completed', () => {
-    it('returns empty when child completed (not active)', async () => {
+    it('returns empty when child completed (not active, not stashed)', async () => {
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
       setExecSync(createStatusMock({ active: false, stashed: false }) as never);
 
@@ -103,6 +103,71 @@ describe('handleSubagentStop', () => {
       const result = await handleSubagentStop(input);
 
       expect(result).toEqual({});
+    });
+  });
+
+  describe('child runbook stashed', () => {
+    it('treats stashed runbook as incomplete', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: false,
+          stashed: true,
+          file: 'child.runbook.md',
+          step: { name: '2. Review' },
+          position: { current: '2', total: 4 },
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).toContain('child.runbook.md');
+      expect(result.context).toContain('2. Review');
+    });
+  });
+
+  describe('delegation never claimed', () => {
+    it('reports unclaimed when parent is active with pending delegation', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'parent.runbook.md',
+          step: { name: '3. Deploy' },
+          delegations: [{ substep: '3.1', runbook: 'child.runbook.md', state: 'pending' }],
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('Delegation Never Claimed');
+      expect(result.context).toContain('substep 3.1');
+      expect(result.context).toContain('child.runbook.md');
+      expect(result.context).not.toContain('parent.runbook.md');
+    });
+
+    it('treats claimed delegation as active child (not unclaimed)', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'child.runbook.md',
+          delegations: [
+            { substep: '3.1', runbook: 'child.runbook.md', state: 'claimed', childRunId: 'run-1' },
+          ],
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).not.toContain('Never Claimed');
     });
   });
 

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
@@ -14,11 +14,14 @@ jest.unstable_mockModule('../../../src/session.js', () => ({
   })),
 }));
 
-const { handleSubagentStop, parseAgentStatus } = await import(
-  '../../../src/workflow/hooks/subagent-stop.js'
-);
+const { handleSubagentStop } = await import('../../../src/workflow/hooks/subagent-stop.js');
 
 const VALID_TOKEN = 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+/** Helper to create a mock that returns `rd status --json` output. */
+function createStatusMock(status: Record<string, unknown>) {
+  return createMockExecSync(JSON.stringify(status));
+}
 
 describe('handleSubagentStop', () => {
   beforeEach(() => {
@@ -40,138 +43,166 @@ describe('handleSubagentStop', () => {
     });
   });
 
-  describe('delegation-aware abort', () => {
-    it('returns empty when status is pass (no abort needed)', async () => {
-      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
-
-      const input = createMockHookInput('SubagentStop', {
-        last_assistant_message: 'STATUS: PASS',
-      });
-
-      const result = await handleSubagentStop(input);
-      expect(result).toEqual({});
-    });
-
-    it('returns empty when status is fail but no delegation_active_token in session', async () => {
+  describe('no delegation token', () => {
+    it('returns empty when no delegation_active_token in session', async () => {
       mockGet.mockResolvedValue({});
-
-      const input = createMockHookInput('SubagentStop', {
-        last_assistant_message: 'STATUS: FAIL',
-      });
-
+      const input = createMockHookInput('SubagentStop');
       const result = await handleSubagentStop(input);
       expect(result).toEqual({});
     });
 
-    it('calls rd abort <token> --force when status is fail and token exists', async () => {
-      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
-      const mockExec = createMockExecSync('Delegation aborted');
+    it('does not call rd status when no token', async () => {
+      mockGet.mockResolvedValue({});
+      const mockExec = createMockExecSync('{}');
       setExecSync(mockExec as never);
 
-      const input = createMockHookInput('SubagentStop', {
-        last_assistant_message: 'STATUS: FAIL',
-        cwd: '/my/project',
-      });
-
+      const input = createMockHookInput('SubagentStop');
       await handleSubagentStop(input);
 
-      expect(mockExec).toHaveBeenCalledWith(
-        'node',
-        expect.arrayContaining(['abort', VALID_TOKEN, '--force']),
-        expect.objectContaining({ cwd: '/my/project' }),
-      );
+      expect(mockExec).not.toHaveBeenCalled();
     });
+  });
 
-    it('clears delegation_active_token from session after abort', async () => {
+  describe('token consumption', () => {
+    it('clears delegation_active_token from session (consume-once)', async () => {
       mockGet.mockResolvedValue({
         delegation_active_token: VALID_TOKEN,
         other_key: 'preserved',
       });
-      setExecSync(createMockExecSync('OK') as never);
+      setExecSync(createStatusMock({ active: false, stashed: false }) as never);
 
-      const input = createMockHookInput('SubagentStop', {
-        last_assistant_message: 'STATUS: FAIL',
-      });
-
+      const input = createMockHookInput('SubagentStop');
       await handleSubagentStop(input);
 
       expect(mockSet).toHaveBeenCalledWith('metadata', { other_key: 'preserved' });
     });
 
-    it('returns context describing abort on success', async () => {
+    it('clears token regardless of child runbook state', async () => {
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
-      setExecSync(createMockExecSync('OK') as never);
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'child.runbook.md',
+        }) as never,
+      );
 
-      const input = createMockHookInput('SubagentStop', {
-        last_assistant_message: 'STATUS: FAIL',
-      });
-
-      const result = await handleSubagentStop(input);
-      expect(result.context).toContain(VALID_TOKEN);
-      expect(result.context).toContain('aborted');
-    });
-
-    it('returns empty when abort call fails (best-effort)', async () => {
-      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
-      const mockExec = jest.fn().mockImplementation(() => {
-        throw new Error('abort failed');
-      });
-      setExecSync(mockExec as never);
-
-      const input = createMockHookInput('SubagentStop', {
-        last_assistant_message: 'STATUS: FAIL',
-      });
-
-      const result = await handleSubagentStop(input);
-      // Abort was attempted but failed gracefully
-      expect(mockExec).toHaveBeenCalled();
-      expect(result).toEqual({});
-    });
-
-    it('clears token even on pass (consume-once)', async () => {
-      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
-
-      const input = createMockHookInput('SubagentStop', {
-        last_assistant_message: 'STATUS: PASS',
-      });
-
+      const input = createMockHookInput('SubagentStop');
       await handleSubagentStop(input);
 
       expect(mockSet).toHaveBeenCalledWith('metadata', {});
     });
   });
-});
 
-describe('parseAgentStatus', () => {
-  it('returns pass for undefined output', () => {
-    expect(parseAgentStatus(undefined)).toBe('pass');
+  describe('child runbook completed', () => {
+    it('returns empty when child completed (not active)', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(createStatusMock({ active: false, stashed: false }) as never);
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result).toEqual({});
+    });
   });
 
-  it('returns pass for empty string', () => {
-    expect(parseAgentStatus('')).toBe('pass');
+  describe('child runbook still active', () => {
+    it('returns context when child runbook is still active', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'child.runbook.md',
+          step: { name: '2. Review changes' },
+          position: { current: '2', total: 5 },
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).toContain('child.runbook.md');
+      expect(result.context).toContain('2. Review changes');
+      expect(result.context).toContain('step 2 of 5');
+    });
+
+    it('includes actionable instructions in context', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'child.runbook.md',
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('rd status');
+      expect(result.context).toContain('retry');
+      expect(result.context).toContain('verify before proceeding');
+    });
+
+    it('includes step description when available', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'child.runbook.md',
+          step: { name: '3. Deploy', description: 'Deploy to staging' },
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('3. Deploy — Deploy to staging');
+    });
+
+    it('handles minimal status (active but no step/position info)', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(createStatusMock({ active: true, stashed: false }) as never);
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).toContain('child runbook was not completed');
+    });
   });
 
-  it('parses STATUS: OK as pass', () => {
-    expect(parseAgentStatus('STATUS: OK')).toBe('pass');
+  describe('status check failure', () => {
+    it('returns fallback context when rd status --json fails', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      const mockExec = jest.fn().mockImplementation(() => {
+        throw new Error('CLI error');
+      });
+      setExecSync(mockExec as never);
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('Unable to verify child runbook state');
+      expect(result.context).toContain('rd status');
+    });
   });
 
-  it('parses STATUS: PASS as pass', () => {
-    expect(parseAgentStatus('STATUS: PASS')).toBe('pass');
-  });
+  describe('last_assistant_message is not parsed', () => {
+    it('does not use agent output to determine result', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      // Child completed — should return empty regardless of message content
+      setExecSync(createStatusMock({ active: false, stashed: false }) as never);
 
-  it('parses STATUS: FAIL as fail', () => {
-    expect(parseAgentStatus('STATUS: FAIL')).toBe('fail');
-  });
+      const input = createMockHookInput('SubagentStop', {
+        last_assistant_message: 'STATUS: FAIL\nEverything broke',
+      });
+      const result = await handleSubagentStop(input);
 
-  it('parses STATUS: BLOCKED as fail', () => {
-    expect(parseAgentStatus('STATUS: BLOCKED')).toBe('fail');
-  });
-
-  it('is case-insensitive', () => {
-    expect(parseAgentStatus('status: blocked')).toBe('fail');
-  });
-
-  it('returns pass when no STATUS field found', () => {
-    expect(parseAgentStatus('Agent completed without status')).toBe('pass');
+      expect(result).toEqual({});
+    });
   });
 });

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
@@ -1,4 +1,5 @@
 // __tests__/workflow/hooks/subagent-stop.test.ts
+import { createHash } from 'node:crypto';
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { setExecSync } from '../../../src/workflow/hooks/rundown.js';
 import { createMockHookInput, createMockExecSync } from '../../helpers/test-utils.js';
@@ -17,6 +18,8 @@ jest.unstable_mockModule('../../../src/session.js', () => ({
 const { handleSubagentStop } = await import('../../../src/workflow/hooks/subagent-stop.js');
 
 const VALID_TOKEN = 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const VALID_TOKEN_HASH = `sha256:${createHash('sha256').update(VALID_TOKEN).digest('hex')}`;
+const OTHER_TOKEN_HASH = `sha256:${createHash('sha256').update('rdtk_OTHER00000000000000000000000').digest('hex')}`;
 
 /** Helper to create a mock that returns `rd status --json` output. */
 function createStatusMock(status: Record<string, unknown>) {
@@ -95,13 +98,63 @@ describe('handleSubagentStop', () => {
   });
 
   describe('child runbook completed', () => {
-    it('returns empty when child completed (not active, not stashed)', async () => {
+    it('returns empty when session is inactive (child popped)', async () => {
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
       setExecSync(createStatusMock({ active: false, stashed: false }) as never);
 
       const input = createMockHookInput('SubagentStop');
       const result = await handleSubagentStop(input);
 
+      expect(result).toEqual({});
+    });
+
+    it('returns empty when parent is active with our delegation claimed', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'parent.runbook.md',
+          delegations: [
+            {
+              substep: '3.1',
+              runbook: 'child.runbook.md',
+              state: 'claimed',
+              childRunId: 'run-1',
+              tokenHash: VALID_TOKEN_HASH,
+            },
+          ],
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result).toEqual({});
+    });
+
+    it('returns empty when parent has delegations but ours is not found', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'parent.runbook.md',
+          delegations: [
+            {
+              substep: '3.2',
+              runbook: 'other-child.runbook.md',
+              state: 'pending',
+              tokenHash: OTHER_TOKEN_HASH,
+            },
+          ],
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      // Our delegation isn't in the list — parent has sibling delegations only
       expect(result).toEqual({});
     });
   });
@@ -128,51 +181,8 @@ describe('handleSubagentStop', () => {
     });
   });
 
-  describe('delegation never claimed', () => {
-    it('reports unclaimed when parent is active with pending delegation', async () => {
-      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
-      setExecSync(
-        createStatusMock({
-          active: true,
-          stashed: false,
-          file: 'parent.runbook.md',
-          step: { name: '3. Deploy' },
-          delegations: [{ substep: '3.1', runbook: 'child.runbook.md', state: 'pending' }],
-        }) as never,
-      );
-
-      const input = createMockHookInput('SubagentStop');
-      const result = await handleSubagentStop(input);
-
-      expect(result.context).toContain('Delegation Never Claimed');
-      expect(result.context).toContain('substep 3.1');
-      expect(result.context).toContain('child.runbook.md');
-      expect(result.context).not.toContain('parent.runbook.md');
-    });
-
-    it('treats claimed delegation as active child (not unclaimed)', async () => {
-      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
-      setExecSync(
-        createStatusMock({
-          active: true,
-          stashed: false,
-          file: 'child.runbook.md',
-          delegations: [
-            { substep: '3.1', runbook: 'child.runbook.md', state: 'claimed', childRunId: 'run-1' },
-          ],
-        }) as never,
-      );
-
-      const input = createMockHookInput('SubagentStop');
-      const result = await handleSubagentStop(input);
-
-      expect(result.context).toContain('Delegation Incomplete');
-      expect(result.context).not.toContain('Never Claimed');
-    });
-  });
-
   describe('child runbook still active', () => {
-    it('returns context when child runbook is still active', async () => {
+    it('returns context when child is active (no delegations)', async () => {
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
       setExecSync(
         createStatusMock({
@@ -227,16 +237,66 @@ describe('handleSubagentStop', () => {
 
       expect(result.context).toContain('3. Deploy — Deploy to staging');
     });
+  });
 
-    it('handles minimal status (active but no step/position info)', async () => {
+  describe('delegation never claimed', () => {
+    it('reports unclaimed when our token matches a pending delegation', async () => {
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
-      setExecSync(createStatusMock({ active: true, stashed: false }) as never);
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'parent.runbook.md',
+          step: { name: '3. Deploy' },
+          delegations: [
+            {
+              substep: '3.1',
+              runbook: 'child.runbook.md',
+              state: 'pending',
+              tokenHash: VALID_TOKEN_HASH,
+            },
+          ],
+        }) as never,
+      );
 
       const input = createMockHookInput('SubagentStop');
       const result = await handleSubagentStop(input);
 
-      expect(result.context).toContain('Delegation Incomplete');
-      expect(result.context).toContain('child runbook was not completed');
+      expect(result.context).toContain('Delegation Never Claimed');
+      expect(result.context).toContain('substep 3.1');
+      expect(result.context).toContain('child.runbook.md');
+    });
+
+    it('does not report sibling pending delegation as unclaimed', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'parent.runbook.md',
+          delegations: [
+            {
+              substep: '3.1',
+              runbook: 'child-a.runbook.md',
+              state: 'claimed',
+              childRunId: 'run-1',
+              tokenHash: VALID_TOKEN_HASH,
+            },
+            {
+              substep: '3.2',
+              runbook: 'child-b.runbook.md',
+              state: 'pending',
+              tokenHash: OTHER_TOKEN_HASH,
+            },
+          ],
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      // Our delegation (3.1) is claimed — completed. Don't report 3.2 as unclaimed.
+      expect(result).toEqual({});
     });
   });
 

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
@@ -193,9 +193,40 @@ describe('handleSubagentStop', () => {
       const input = createMockHookInput('SubagentStop');
       const result = await handleSubagentStop(input);
 
-      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).toContain('Delegation Stashed');
+      expect(result.context).toContain('stashed without being completed');
       expect(result.context).toContain('child.runbook.md');
       expect(result.context).toContain('2. Review');
+      expect(result.context).toContain('rd pop');
+    });
+
+    it('preserves delegations when active+stashed (active child + stashed parent)', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: true,
+          file: 'child.runbook.md',
+          step: { name: '3. Deploy' },
+          position: { current: '3', total: 5 },
+          delegations: [
+            {
+              substep: '3.1',
+              runbook: 'grandchild.runbook.md',
+              state: 'claimed',
+              childRunId: 'run-gc-1',
+              tokenHash: OTHER_TOKEN_HASH,
+            },
+          ],
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      // Should be classified as active (preserving delegations), not stashed
+      expect(result.context).toContain('Delegation Incomplete');
+      expect(result.context).toContain('child.runbook.md');
     });
   });
 
@@ -321,6 +352,33 @@ describe('handleSubagentStop', () => {
 
       // Our delegation (3.1) is claimed — completed. Don't report 3.2 as unclaimed.
       expect(result).toEqual({});
+    });
+  });
+
+  describe('unverifiable delegations (missing tokenHash)', () => {
+    it('returns unknown when no delegations have tokenHash', async () => {
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'parent.runbook.md',
+          delegations: [
+            {
+              substep: '2.1',
+              runbook: 'child.runbook.md',
+              state: 'claimed',
+              childRunId: 'run-old',
+            },
+          ],
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('Unable to verify');
+      expect(result.context).toContain('rd status');
     });
   });
 

--- a/packages/claude-code-plugin/scripts/smoke-test.sh
+++ b/packages/claude-code-plugin/scripts/smoke-test.sh
@@ -73,7 +73,7 @@ else
 fi
 
 # Test 4: SubagentStop hook dispatch
-HOOK_INPUT='{"hook_event_name":"SubagentStop","cwd":"'"$TEMP_DIR"'","agent_id":"test-agent","agent_type":"general-purpose","last_assistant_message":"STATUS: PASS"}'
+HOOK_INPUT='{"hook_event_name":"SubagentStop","cwd":"'"$TEMP_DIR"'","agent_id":"test-agent","agent_type":"general-purpose","last_assistant_message":"Agent completed successfully."}'
 if echo "$HOOK_INPUT" | node "$PLUGIN_DIR/dist/cli.js" 2>/dev/null; then
     pass "SubagentStop hook dispatch"
 else

--- a/packages/claude-code-plugin/skills/verifying-by-consensus/SKILL.md
+++ b/packages/claude-code-plugin/skills/verifying-by-consensus/SKILL.md
@@ -54,7 +54,7 @@ Dispatch N agents to independently review the same subject. Collate findings:
 
 **Subagent protocol:**
 - Write findings to `.work/{date}-verify-{agentId}.md`
-- End response with `STATUS: PASS` or `STATUS: FAIL`
+- Use `rd pass` or `rd fail` to report the result
 
 ### Phase 2: Collate
 

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -17,41 +17,97 @@ export interface SubagentStopResult {
 }
 
 /**
- * Pattern for parsing STATUS field from agent output.
- * Expected format: STATUS: OK|PASS|BLOCKED|FAIL (case-insensitive)
+ * Minimal subset of `rd status --json` output needed by the subagent-stop hook.
  */
-const STATUS_PATTERN = /STATUS:\s*(OK|PASS|BLOCKED|FAIL)/i;
-
-/**
- * Determine whether a subagent STATUS in the given output indicates a pass or a fail.
- *
- * @param output - Raw subagent output text to search for a `STATUS:` field
- * @returns `pass` if `STATUS` is `OK` or `PASS` (case-insensitive) or if no `STATUS` is present; `fail` otherwise
- */
-export function parseAgentStatus(output?: string): 'pass' | 'fail' {
-  if (!output) return 'pass';
-
-  const match = STATUS_PATTERN.exec(output);
-  if (!match) return 'pass';
-
-  const status = match[1].toUpperCase();
-  return status === 'OK' || status === 'PASS' ? 'pass' : 'fail';
+interface StatusInfo {
+  /** Whether a runbook is currently active on the session stack. */
+  active: boolean;
+  /** Runbook file path. */
+  file?: string;
+  /** Current position in the runbook. */
+  position?: { current: string; total: number; substep?: string };
+  /** Current step details. */
+  step?: { name: string; description?: string };
 }
 
 /**
- * Handle a SubagentStop hook by consuming any active delegation token and aborting its delegation if the subagent failed.
+ * Query child runbook state via `rd status --json`.
  *
- * Consumes the session's `delegation_active_token` (if present). If the parsed agent status is a failure and a token was active, attempts a best-effort abort of the delegation and returns a context message; otherwise returns an empty result.
+ * Best-effort: returns undefined if the CLI call fails for any reason.
+ * Follows the same pattern as delegation-dispatch.ts.
+ *
+ * @param cwd - Working directory for the CLI call
+ * @returns Parsed status info, or undefined on failure
+ */
+function getChildRunbookStatus(cwd: string): StatusInfo | undefined {
+  try {
+    const output = rundown(['status', '--json'], cwd);
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    return {
+      active: parsed.active === true,
+      file: typeof parsed.file === 'string' ? parsed.file : undefined,
+      position: parsed.position as StatusInfo['position'],
+      step: parsed.step as StatusInfo['step'],
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Build a context message for the parent agent when a child runbook was not completed.
+ *
+ * @param status - Child runbook status info
+ * @returns Formatted context message with runbook position and actionable instructions
+ */
+function buildIncompleteRunbookContext(status: StatusInfo): string {
+  const lines: string[] = [
+    '## Delegation Incomplete',
+    '',
+    'The subagent stopped but the child runbook is still active.',
+    '',
+  ];
+
+  if (status.file) {
+    lines.push(`**Runbook:** ${status.file}`);
+  }
+  if (status.step) {
+    const stepDesc = status.step.description
+      ? `${status.step.name} — ${status.step.description}`
+      : status.step.name;
+    lines.push(`**Current step:** ${stepDesc}`);
+  }
+  if (status.position) {
+    lines.push(`**Position:** step ${status.position.current} of ${String(status.position.total)}`);
+  }
+
+  lines.push('');
+  lines.push('The child runbook was not completed by the subagent. You should:');
+  lines.push('1. Run `rd status` to inspect the current state');
+  lines.push(
+    '2. Decide whether to retry the delegation, complete the work yourself, or fail the step',
+  );
+  lines.push('3. Do NOT assume the work was completed — verify before proceeding');
+
+  return lines.join('\n');
+}
+
+/**
+ * Handle a SubagentStop hook by consuming any active delegation token and checking
+ * whether the child runbook was completed.
+ *
+ * If the child runbook is still active (the subagent stopped without calling
+ * `rd pass` or `rd fail`), returns a context message to the parent agent with
+ * the child's current position and actionable instructions. Never destroys
+ * child runbook state.
  *
  * @param input - Hook event payload (includes cwd, hook_event_name, and last_assistant_message)
- * @returns An object with `context` when an abort was attempted, or an empty object if no action was taken
+ * @returns An object with `context` when the child runbook is incomplete, or an empty object if no action was needed
  */
 export async function handleSubagentStop(input: HookInput): Promise<SubagentStopResult> {
   if (input.hook_event_name !== 'SubagentStop') {
     return {};
   }
-
-  const status = parseAgentStatus(input.last_assistant_message);
 
   // Read and consume delegation token from session metadata
   const session = new Session(input.cwd);
@@ -65,19 +121,29 @@ export async function handleSubagentStop(input: HookInput): Promise<SubagentStop
     await session.set('metadata', rest);
   }
 
-  // Successful delegations self-complete via child run
-  if (status === 'pass' || !token) {
+  // No delegation token — no action needed
+  if (!token) {
     return {};
   }
 
-  // Agent failed with an active delegation token — abort the delegation
-  try {
-    rundown(['abort', token, '--force'], input.cwd);
+  // Check child runbook state via rd status --json
+  const status = getChildRunbookStatus(input.cwd);
+
+  // Status check failed — return fallback context
+  if (!status) {
     return {
-      context: `Delegation ${token} aborted due to agent failure.`,
+      context:
+        'Subagent stopped with an active delegation. Unable to verify child runbook state — check with `rd status`.',
     };
-  } catch {
-    // Best-effort abort — continue without error
+  }
+
+  // Child completed (popped from session stack) — delegation already propagated
+  if (!status.active) {
     return {};
   }
+
+  // Child runbook still active — subagent didn't complete it
+  return {
+    context: buildIncompleteRunbookContext(status),
+  };
 }

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -17,17 +17,31 @@ export interface SubagentStopResult {
 }
 
 /**
+ * Delegation entry from `rd status --json` output.
+ */
+interface DelegationInfo {
+  substep: string;
+  runbook: string;
+  state: 'pending' | 'claimed' | 'cancelled';
+  childRunId?: string;
+}
+
+/**
  * Minimal subset of `rd status --json` output needed by the subagent-stop hook.
  */
 interface StatusInfo {
   /** Whether a runbook is currently active on the session stack. */
   active: boolean;
+  /** Whether the active runbook is stashed (enforcement paused). */
+  stashed: boolean;
   /** Runbook file path. */
   file?: string;
   /** Current position in the runbook. */
   position?: { current: string; total: number; substep?: string };
   /** Current step details. */
   step?: { name: string; description?: string };
+  /** Active delegations on substeps. */
+  delegations?: DelegationInfo[];
 }
 
 /**
@@ -45,6 +59,7 @@ function getChildRunbookStatus(cwd: string): StatusInfo | undefined {
     const parsed = JSON.parse(output) as Record<string, unknown>;
     return {
       active: parsed.active === true,
+      stashed: parsed.stashed === true,
       file: typeof parsed.file === 'string' ? parsed.file : undefined,
       position:
         parsed.position && typeof parsed.position === 'object'
@@ -54,6 +69,9 @@ function getChildRunbookStatus(cwd: string): StatusInfo | undefined {
         parsed.step && typeof parsed.step === 'object'
           ? (parsed.step as StatusInfo['step'])
           : undefined,
+      delegations: Array.isArray(parsed.delegations)
+        ? (parsed.delegations as DelegationInfo[])
+        : undefined,
     };
   } catch {
     return undefined;
@@ -99,13 +117,38 @@ function buildIncompleteRunbookContext(status: StatusInfo): string {
 }
 
 /**
+ * Build a context message when the delegation was never claimed by the subagent.
+ *
+ * @param delegation - The pending delegation info from the parent's status
+ * @returns Formatted context message explaining the unclaimed delegation
+ */
+function buildUnclaimedDelegationContext(delegation: DelegationInfo): string {
+  const lines: string[] = [
+    '## Delegation Never Claimed',
+    '',
+    `The subagent stopped without claiming delegation for substep ${delegation.substep}.`,
+    `**Child runbook:** ${delegation.runbook}`,
+    '',
+    'The delegation token was never claimed — no child runbook was started. You should:',
+    '1. Run `rd status` to inspect the current delegation state',
+    '2. Retry the delegation with a new subagent, or fail the step',
+  ];
+
+  return lines.join('\n');
+}
+
+/**
  * Handle a SubagentStop hook by consuming any active delegation token and checking
  * whether the child runbook was completed.
  *
- * If the child runbook is still active (the subagent stopped without calling
- * `rd pass` or `rd fail`), returns a context message to the parent agent with
- * the child's current position and actionable instructions. Never destroys
- * child runbook state.
+ * Distinguishes three incomplete states:
+ * - **Never claimed**: The subagent stopped before calling `rd claim`. The parent
+ *   runbook is still active with a pending delegation.
+ * - **Stashed**: The child runbook was stashed via `rd stash` but not completed.
+ * - **Still active**: The child runbook is running but the subagent stopped without
+ *   calling `rd pass` or `rd fail`.
+ *
+ * Never destroys child runbook state.
  *
  * @param input - Hook event payload (includes cwd, hook_event_name, and last_assistant_message)
  * @returns An object with `context` when the child runbook is incomplete, or an empty object if no action was needed
@@ -132,7 +175,7 @@ export async function handleSubagentStop(input: HookInput): Promise<SubagentStop
     return {};
   }
 
-  // Check child runbook state via rd status --json
+  // Check runbook state via rd status --json
   const status = getChildRunbookStatus(input.cwd);
 
   // Status check failed — return fallback context
@@ -143,9 +186,25 @@ export async function handleSubagentStop(input: HookInput): Promise<SubagentStop
     };
   }
 
-  // Child completed (popped from session stack) — delegation already propagated
+  // Stashed runbook is not completed — treat as incomplete
+  if (status.stashed) {
+    return {
+      context: buildIncompleteRunbookContext(status),
+    };
+  }
+
+  // Nothing active and not stashed — child completed and was popped from session stack
   if (!status.active) {
     return {};
+  }
+
+  // Active runbook has a pending delegation — subagent never claimed the token.
+  // The active runbook is the parent, not the child.
+  const pendingDelegation = status.delegations?.find((d) => d.state === 'pending');
+  if (pendingDelegation) {
+    return {
+      context: buildUnclaimedDelegationContext(pendingDelegation),
+    };
   }
 
   // Child runbook still active — subagent didn't complete it

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -46,8 +46,14 @@ function getChildRunbookStatus(cwd: string): StatusInfo | undefined {
     return {
       active: parsed.active === true,
       file: typeof parsed.file === 'string' ? parsed.file : undefined,
-      position: parsed.position as StatusInfo['position'],
-      step: parsed.step as StatusInfo['step'],
+      position:
+        parsed.position && typeof parsed.position === 'object'
+          ? (parsed.position as StatusInfo['position'])
+          : undefined,
+      step:
+        parsed.step && typeof parsed.step === 'object'
+          ? (parsed.step as StatusInfo['step'])
+          : undefined,
     };
   } catch {
     return undefined;

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -64,6 +64,9 @@ type DelegationOutcome =
 
 /**
  * Parse a validated position field from raw JSON.
+ *
+ * @param raw - Raw value from parsed JSON
+ * @returns Position info if the value is an object, otherwise undefined
  */
 function parsePosition(raw: unknown): RunbookPosition['position'] {
   if (!raw || typeof raw !== 'object') return undefined;
@@ -72,6 +75,9 @@ function parsePosition(raw: unknown): RunbookPosition['position'] {
 
 /**
  * Parse a validated step field from raw JSON.
+ *
+ * @param raw - Raw value from parsed JSON
+ * @returns Step info if the value is an object, otherwise undefined
  */
 function parseStep(raw: unknown): RunbookPosition['step'] {
   if (!raw || typeof raw !== 'object') return undefined;
@@ -79,18 +85,30 @@ function parseStep(raw: unknown): RunbookPosition['step'] {
 }
 
 /**
+ * Type guard for raw delegation objects from `rd status --json`.
+ *
+ * @param d - Raw value from the delegations array
+ * @returns True if the value is a valid DelegationStatus
+ */
+function isDelegationStatus(d: unknown): d is DelegationStatus {
+  if (d == null || typeof d !== 'object') return false;
+  const obj = d as Record<string, unknown>;
+  return (
+    typeof obj.substep === 'string' &&
+    typeof obj.runbook === 'string' &&
+    (obj.state === 'pending' || obj.state === 'claimed' || obj.state === 'cancelled')
+  );
+}
+
+/**
  * Parse delegation entries from raw JSON array.
+ *
+ * @param raw - Raw value from parsed JSON
+ * @returns Array of validated delegation status entries
  */
 function parseDelegations(raw: unknown): readonly DelegationStatus[] {
   if (!Array.isArray(raw)) return [];
-  return raw.filter(
-    (d): d is DelegationStatus =>
-      d != null &&
-      typeof d === 'object' &&
-      typeof d.substep === 'string' &&
-      typeof d.runbook === 'string' &&
-      (d.state === 'pending' || d.state === 'claimed' || d.state === 'cancelled'),
-  );
+  return raw.filter(isDelegationStatus);
 }
 
 /**
@@ -180,6 +198,9 @@ function classifyOutcome(status: RunbookStatus): DelegationOutcome {
 
 /**
  * Build position detail lines from runbook position info.
+ *
+ * @param pos - Runbook position info containing file, step, and position
+ * @returns Array of formatted markdown lines
  */
 function formatPositionLines(pos: RunbookPosition): string[] {
   const lines: string[] = [];

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -213,15 +213,16 @@ function classifyOutcome(status: RunbookStatus, tokenHash: string): DelegationOu
       const ours = status.delegations.find((d) => d.tokenHash === tokenHash);
 
       if (!ours) {
-        // Our delegation not found — either the active runbook is the child
-        // (children don't have delegations) or the parent is active and our
-        // delegation has already been fully resolved
+        // Our delegation not found — two possible scenarios:
+        // 1. Parent resumed after child completed (no delegations remain)
+        // 2. Child is active with its own nested delegations (grandchild)
         if (status.delegations.length > 0) {
-          // Parent is active with other delegations, but ours isn't here — completed
-          return { kind: 'completed' };
+          // Active runbook has delegations we don't recognize — likely a child
+          // with nested delegations still in progress
+          return { kind: 'child_active', status };
         }
-        // No delegations at all — active runbook is the child, still running
-        return { kind: 'child_active', status };
+        // No delegations — delegation was resolved and parent resumed
+        return { kind: 'completed' };
       }
 
       // Found our delegation — classify by its state

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -47,6 +47,7 @@ type DelegationStatus =
       readonly state: 'cancelled';
       readonly substep: string;
       readonly runbook: string;
+      readonly childRunId?: string;
       readonly tokenHash?: string;
     };
 
@@ -122,12 +123,21 @@ function parseStep(raw: unknown): RunbookPosition['step'] {
 function isDelegationStatus(d: unknown): d is DelegationStatus {
   if (d == null || typeof d !== 'object') return false;
   const obj = d as Record<string, unknown>;
-  return (
+  const shared =
     typeof obj.substep === 'string' &&
     typeof obj.runbook === 'string' &&
-    (obj.state === 'pending' || obj.state === 'claimed' || obj.state === 'cancelled') &&
-    (obj.tokenHash === undefined || typeof obj.tokenHash === 'string')
-  );
+    (obj.tokenHash === undefined || typeof obj.tokenHash === 'string');
+  if (!shared) return false;
+  switch (obj.state) {
+    case 'pending':
+      return obj.childRunId === undefined;
+    case 'claimed':
+      return typeof obj.childRunId === 'string';
+    case 'cancelled':
+      return obj.childRunId === undefined || typeof obj.childRunId === 'string';
+    default:
+      return false;
+  }
 }
 
 /**
@@ -158,8 +168,10 @@ function queryRunbookStatus(cwd: string): RunbookStatus | undefined {
     const stashed = parsed.stashed === true;
     const file = typeof parsed.file === 'string' ? parsed.file : undefined;
 
-    // Stashed: runbook paused via `rd stash`, not completed
-    if (stashed && file) {
+    // Stashed-only: runbook paused via `rd stash`, not completed.
+    // When both active and stashed are true (active child + stashed parent),
+    // fall through to the active branch which preserves delegations.
+    if (stashed && !active && file) {
       return {
         kind: 'stashed',
         file,
@@ -209,6 +221,14 @@ function classifyOutcome(status: RunbookStatus, tokenHash: string): DelegationOu
       return { kind: 'child_stashed', status };
 
     case 'active': {
+      // If no delegations carry token hashes, correlation is impossible (stale session state)
+      if (
+        status.delegations.length > 0 &&
+        !status.delegations.some((d) => d.tokenHash !== undefined)
+      ) {
+        return { kind: 'unknown' };
+      }
+
       // Find the delegation matching our token
       const ours = status.delegations.find((d) => d.tokenHash === tokenHash);
 
@@ -283,8 +303,7 @@ function buildContextMessage(outcome: DelegationOutcome): string | undefined {
     case 'unknown':
       return 'Subagent stopped with an active delegation. Unable to verify child runbook state — check with `rd status`.';
 
-    case 'child_active':
-    case 'child_stashed': {
+    case 'child_active': {
       const lines: string[] = [
         '## Delegation Incomplete',
         '',
@@ -296,6 +315,22 @@ function buildContextMessage(outcome: DelegationOutcome): string | undefined {
         '1. Run `rd status` to inspect the current state',
         '2. Decide whether to retry the delegation, complete the work yourself, or fail the step',
         '3. Do NOT assume the work was completed — verify before proceeding',
+      ];
+      return lines.join('\n');
+    }
+
+    case 'child_stashed': {
+      const lines: string[] = [
+        '## Delegation Stashed',
+        '',
+        'The subagent stopped and the child runbook was stashed without being completed.',
+        '',
+        ...formatPositionLines(outcome.status),
+        '',
+        'The stashed runbook needs to be resumed or resolved. You should:',
+        '1. Run `rd status` to inspect the current state',
+        '2. Run `rd pop` to resume the stashed runbook, or fail the step',
+        '3. Verify the runbook state before proceeding',
       ];
       return lines.join('\n');
     }

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -16,137 +16,251 @@ export interface SubagentStopResult {
   violation?: string;
 }
 
-/**
- * Delegation entry from `rd status --json` output.
- */
-interface DelegationInfo {
-  substep: string;
-  runbook: string;
-  state: 'pending' | 'claimed' | 'cancelled';
-  childRunId?: string;
-}
+// ---------------------------------------------------------------------------
+// Domain types — discriminated unions for runbook status and delegation state
+// ---------------------------------------------------------------------------
 
-/**
- * Minimal subset of `rd status --json` output needed by the subagent-stop hook.
- */
-interface StatusInfo {
-  /** Whether a runbook is currently active on the session stack. */
-  active: boolean;
-  /** Whether the active runbook is stashed (enforcement paused). */
-  stashed: boolean;
-  /** Runbook file path. */
-  file?: string;
-  /** Current position in the runbook. */
+/** Shared fields for runbook states that carry position information. */
+interface RunbookPosition {
+  file: string;
   position?: { current: string; total: number; substep?: string };
-  /** Current step details. */
   step?: { name: string; description?: string };
-  /** Active delegations on substeps. */
-  delegations?: DelegationInfo[];
+}
+
+/** Delegation status as a discriminated union — each state carries only its valid fields. */
+type DelegationStatus =
+  | { readonly state: 'pending'; readonly substep: string; readonly runbook: string }
+  | {
+      readonly state: 'claimed';
+      readonly substep: string;
+      readonly runbook: string;
+      readonly childRunId: string;
+    }
+  | { readonly state: 'cancelled'; readonly substep: string; readonly runbook: string };
+
+/** Runbook status as a discriminated union — impossible combinations are unrepresentable. */
+type RunbookStatus =
+  | { readonly kind: 'inactive' }
+  | ({ readonly kind: 'stashed' } & RunbookPosition)
+  | ({
+      readonly kind: 'active';
+      readonly delegations: readonly DelegationStatus[];
+    } & RunbookPosition);
+
+/**
+ * Delegation outcome — the hook's decision as a discriminated union.
+ * Each variant carries exactly the data needed for its context message.
+ */
+type DelegationOutcome =
+  | { readonly kind: 'completed' }
+  | { readonly kind: 'child_active'; readonly status: RunbookPosition }
+  | { readonly kind: 'child_stashed'; readonly status: RunbookPosition }
+  | { readonly kind: 'unclaimed'; readonly delegation: DelegationStatus & { state: 'pending' } }
+  | { readonly kind: 'unknown' };
+
+// ---------------------------------------------------------------------------
+// Parsing — raw JSON to discriminated union
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a validated position field from raw JSON.
+ */
+function parsePosition(raw: unknown): RunbookPosition['position'] {
+  if (!raw || typeof raw !== 'object') return undefined;
+  return raw as RunbookPosition['position'];
 }
 
 /**
- * Query child runbook state via `rd status --json`.
+ * Parse a validated step field from raw JSON.
+ */
+function parseStep(raw: unknown): RunbookPosition['step'] {
+  if (!raw || typeof raw !== 'object') return undefined;
+  return raw as RunbookPosition['step'];
+}
+
+/**
+ * Parse delegation entries from raw JSON array.
+ */
+function parseDelegations(raw: unknown): readonly DelegationStatus[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (d): d is DelegationStatus =>
+      d != null &&
+      typeof d === 'object' &&
+      typeof d.substep === 'string' &&
+      typeof d.runbook === 'string' &&
+      (d.state === 'pending' || d.state === 'claimed' || d.state === 'cancelled'),
+  );
+}
+
+/**
+ * Query runbook state via `rd status --json` and parse into a discriminated union.
  *
  * Best-effort: returns undefined if the CLI call fails for any reason.
- * Follows the same pattern as delegation-dispatch.ts.
  *
  * @param cwd - Working directory for the CLI call
- * @returns Parsed status info, or undefined on failure
+ * @returns Parsed runbook status, or undefined on failure
  */
-function getChildRunbookStatus(cwd: string): StatusInfo | undefined {
+function queryRunbookStatus(cwd: string): RunbookStatus | undefined {
   try {
     const output = rundown(['status', '--json'], cwd);
     const parsed = JSON.parse(output) as Record<string, unknown>;
+
+    const active = parsed.active === true;
+    const stashed = parsed.stashed === true;
+    const file = typeof parsed.file === 'string' ? parsed.file : undefined;
+
+    // Stashed: runbook paused via `rd stash`, not completed
+    if (stashed && file) {
+      return {
+        kind: 'stashed',
+        file,
+        position: parsePosition(parsed.position),
+        step: parseStep(parsed.step),
+      };
+    }
+
+    // Not active and not stashed: nothing running
+    if (!active) {
+      return { kind: 'inactive' };
+    }
+
+    // Active: runbook is running (could be parent or child)
     return {
-      active: parsed.active === true,
-      stashed: parsed.stashed === true,
-      file: typeof parsed.file === 'string' ? parsed.file : undefined,
-      position:
-        parsed.position && typeof parsed.position === 'object'
-          ? (parsed.position as StatusInfo['position'])
-          : undefined,
-      step:
-        parsed.step && typeof parsed.step === 'object'
-          ? (parsed.step as StatusInfo['step'])
-          : undefined,
-      delegations: Array.isArray(parsed.delegations)
-        ? (parsed.delegations as DelegationInfo[])
-        : undefined,
+      kind: 'active',
+      file: file ?? '(unknown)',
+      position: parsePosition(parsed.position),
+      step: parseStep(parsed.step),
+      delegations: parseDelegations(parsed.delegations),
     };
   } catch {
     return undefined;
   }
 }
 
-/**
- * Build a context message for the parent agent when a child runbook was not completed.
- *
- * @param status - Child runbook status info
- * @returns Formatted context message with runbook position and actionable instructions
- */
-function buildIncompleteRunbookContext(status: StatusInfo): string {
-  const lines: string[] = [
-    '## Delegation Incomplete',
-    '',
-    'The subagent stopped but the child runbook is still active.',
-    '',
-  ];
+// ---------------------------------------------------------------------------
+// Outcome classification
+// ---------------------------------------------------------------------------
 
-  if (status.file) {
-    lines.push(`**Runbook:** ${status.file}`);
+/**
+ * Classify the delegation outcome from the runbook status.
+ *
+ * @param status - Parsed runbook status from `rd status --json`
+ * @returns The delegation outcome determining which context message to produce
+ */
+function classifyOutcome(status: RunbookStatus): DelegationOutcome {
+  switch (status.kind) {
+    case 'inactive':
+      // Child completed and was popped from session stack
+      return { kind: 'completed' };
+
+    case 'stashed':
+      // Child was stashed, not completed
+      return { kind: 'child_stashed', status };
+
+    case 'active': {
+      // Check for pending (unclaimed) delegation — means the parent is active,
+      // not the child, because the child was never created
+      const pending = status.delegations.find(
+        (d): d is DelegationStatus & { state: 'pending' } => d.state === 'pending',
+      );
+      if (pending) {
+        return { kind: 'unclaimed', delegation: pending };
+      }
+
+      // Child runbook is active — subagent didn't complete it
+      return { kind: 'child_active', status };
+    }
   }
-  if (status.step) {
-    const stepDesc = status.step.description
-      ? `${status.step.name} — ${status.step.description}`
-      : status.step.name;
+}
+
+// ---------------------------------------------------------------------------
+// Context message builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build position detail lines from runbook position info.
+ */
+function formatPositionLines(pos: RunbookPosition): string[] {
+  const lines: string[] = [];
+
+  lines.push(`**Runbook:** ${pos.file}`);
+
+  if (pos.step) {
+    const stepDesc = pos.step.description
+      ? `${pos.step.name} — ${pos.step.description}`
+      : pos.step.name;
     lines.push(`**Current step:** ${stepDesc}`);
   }
-  if (status.position) {
-    lines.push(`**Position:** step ${status.position.current} of ${String(status.position.total)}`);
+  if (pos.position) {
+    lines.push(`**Position:** step ${pos.position.current} of ${String(pos.position.total)}`);
   }
 
-  lines.push('');
-  lines.push('The child runbook was not completed by the subagent. You should:');
-  lines.push('1. Run `rd status` to inspect the current state');
-  lines.push(
-    '2. Decide whether to retry the delegation, complete the work yourself, or fail the step',
-  );
-  lines.push('3. Do NOT assume the work was completed — verify before proceeding');
-
-  return lines.join('\n');
+  return lines;
 }
 
 /**
- * Build a context message when the delegation was never claimed by the subagent.
+ * Build a context message from a delegation outcome.
  *
- * @param delegation - The pending delegation info from the parent's status
- * @returns Formatted context message explaining the unclaimed delegation
+ * @param outcome - The classified delegation outcome
+ * @returns Formatted context message, or undefined if no context needed
  */
-function buildUnclaimedDelegationContext(delegation: DelegationInfo): string {
-  const lines: string[] = [
-    '## Delegation Never Claimed',
-    '',
-    `The subagent stopped without claiming delegation for substep ${delegation.substep}.`,
-    `**Child runbook:** ${delegation.runbook}`,
-    '',
-    'The delegation token was never claimed — no child runbook was started. You should:',
-    '1. Run `rd status` to inspect the current delegation state',
-    '2. Retry the delegation with a new subagent, or fail the step',
-  ];
+function buildContextMessage(outcome: DelegationOutcome): string | undefined {
+  switch (outcome.kind) {
+    case 'completed':
+      return undefined;
 
-  return lines.join('\n');
+    case 'unknown':
+      return 'Subagent stopped with an active delegation. Unable to verify child runbook state — check with `rd status`.';
+
+    case 'child_active':
+    case 'child_stashed': {
+      const lines: string[] = [
+        '## Delegation Incomplete',
+        '',
+        'The subagent stopped but the child runbook is still active.',
+        '',
+        ...formatPositionLines(outcome.status),
+        '',
+        'The child runbook was not completed by the subagent. You should:',
+        '1. Run `rd status` to inspect the current state',
+        '2. Decide whether to retry the delegation, complete the work yourself, or fail the step',
+        '3. Do NOT assume the work was completed — verify before proceeding',
+      ];
+      return lines.join('\n');
+    }
+
+    case 'unclaimed': {
+      const { delegation } = outcome;
+      const lines: string[] = [
+        '## Delegation Never Claimed',
+        '',
+        `The subagent stopped without claiming delegation for substep ${delegation.substep}.`,
+        `**Child runbook:** ${delegation.runbook}`,
+        '',
+        'The delegation token was never claimed — no child runbook was started. You should:',
+        '1. Run `rd status` to inspect the current delegation state',
+        '2. Retry the delegation with a new subagent, or fail the step',
+      ];
+      return lines.join('\n');
+    }
+  }
 }
+
+// ---------------------------------------------------------------------------
+// Hook handler
+// ---------------------------------------------------------------------------
 
 /**
  * Handle a SubagentStop hook by consuming any active delegation token and checking
  * whether the child runbook was completed.
  *
- * Distinguishes three incomplete states:
- * - **Never claimed**: The subagent stopped before calling `rd claim`. The parent
- *   runbook is still active with a pending delegation.
- * - **Stashed**: The child runbook was stashed via `rd stash` but not completed.
- * - **Still active**: The child runbook is running but the subagent stopped without
- *   calling `rd pass` or `rd fail`.
+ * Classifies the delegation state into one of five outcomes:
+ * - **completed**: Child runbook finished (`rd pass`/`rd fail`) and was popped.
+ * - **child_active**: Child runbook is running but subagent stopped without completing.
+ * - **child_stashed**: Child runbook was stashed via `rd stash` but not completed.
+ * - **unclaimed**: Subagent stopped before calling `rd claim`. Parent is still active.
+ * - **unknown**: Status check failed. Fallback context returned.
  *
  * Never destroys child runbook state.
  *
@@ -175,40 +289,10 @@ export async function handleSubagentStop(input: HookInput): Promise<SubagentStop
     return {};
   }
 
-  // Check runbook state via rd status --json
-  const status = getChildRunbookStatus(input.cwd);
+  // Query runbook state and classify the delegation outcome
+  const status = queryRunbookStatus(input.cwd);
+  const outcome: DelegationOutcome = status ? classifyOutcome(status) : { kind: 'unknown' };
+  const context = buildContextMessage(outcome);
 
-  // Status check failed — return fallback context
-  if (!status) {
-    return {
-      context:
-        'Subagent stopped with an active delegation. Unable to verify child runbook state — check with `rd status`.',
-    };
-  }
-
-  // Stashed runbook is not completed — treat as incomplete
-  if (status.stashed) {
-    return {
-      context: buildIncompleteRunbookContext(status),
-    };
-  }
-
-  // Nothing active and not stashed — child completed and was popped from session stack
-  if (!status.active) {
-    return {};
-  }
-
-  // Active runbook has a pending delegation — subagent never claimed the token.
-  // The active runbook is the parent, not the child.
-  const pendingDelegation = status.delegations?.find((d) => d.state === 'pending');
-  if (pendingDelegation) {
-    return {
-      context: buildUnclaimedDelegationContext(pendingDelegation),
-    };
-  }
-
-  // Child runbook still active — subagent didn't complete it
-  return {
-    context: buildIncompleteRunbookContext(status),
-  };
+  return context ? { context } : {};
 }

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -1,4 +1,5 @@
 // src/workflow/hooks/subagent-stop.ts
+import { createHash } from 'node:crypto';
 import type { HookInput } from '../../shared/index.js';
 import { Session } from '../../session.js';
 import { rundown } from './rundown.js';
@@ -29,14 +30,25 @@ interface RunbookPosition {
 
 /** Delegation status as a discriminated union — each state carries only its valid fields. */
 type DelegationStatus =
-  | { readonly state: 'pending'; readonly substep: string; readonly runbook: string }
+  | {
+      readonly state: 'pending';
+      readonly substep: string;
+      readonly runbook: string;
+      readonly tokenHash?: string;
+    }
   | {
       readonly state: 'claimed';
       readonly substep: string;
       readonly runbook: string;
       readonly childRunId: string;
+      readonly tokenHash?: string;
     }
-  | { readonly state: 'cancelled'; readonly substep: string; readonly runbook: string };
+  | {
+      readonly state: 'cancelled';
+      readonly substep: string;
+      readonly runbook: string;
+      readonly tokenHash?: string;
+    };
 
 /** Runbook status as a discriminated union — impossible combinations are unrepresentable. */
 type RunbookStatus =
@@ -57,6 +69,23 @@ type DelegationOutcome =
   | { readonly kind: 'child_stashed'; readonly status: RunbookPosition }
   | { readonly kind: 'unclaimed'; readonly delegation: DelegationStatus & { state: 'pending' } }
   | { readonly kind: 'unknown' };
+
+// ---------------------------------------------------------------------------
+// Token hashing
+// ---------------------------------------------------------------------------
+
+/**
+ * Hash a raw delegation token using SHA-256.
+ *
+ * Replicates the same algorithm as `hashDelegationToken` in `@rundown-org/core`
+ * to allow correlation without a direct core dependency.
+ *
+ * @param token - Raw delegation token string
+ * @returns Hash in `sha256:<hex>` format
+ */
+function hashToken(token: string): string {
+  return `sha256:${createHash('sha256').update(token).digest('hex')}`;
+}
 
 // ---------------------------------------------------------------------------
 // Parsing — raw JSON to discriminated union
@@ -96,7 +125,8 @@ function isDelegationStatus(d: unknown): d is DelegationStatus {
   return (
     typeof obj.substep === 'string' &&
     typeof obj.runbook === 'string' &&
-    (obj.state === 'pending' || obj.state === 'claimed' || obj.state === 'cancelled')
+    (obj.state === 'pending' || obj.state === 'claimed' || obj.state === 'cancelled') &&
+    (obj.tokenHash === undefined || typeof obj.tokenHash === 'string')
   );
 }
 
@@ -161,12 +191,14 @@ function queryRunbookStatus(cwd: string): RunbookStatus | undefined {
 // ---------------------------------------------------------------------------
 
 /**
- * Classify the delegation outcome from the runbook status.
+ * Classify the delegation outcome by correlating the token hash with the
+ * active runbook's delegation state.
  *
  * @param status - Parsed runbook status from `rd status --json`
+ * @param tokenHash - SHA-256 hash of the consumed delegation token
  * @returns The delegation outcome determining which context message to produce
  */
-function classifyOutcome(status: RunbookStatus): DelegationOutcome {
+function classifyOutcome(status: RunbookStatus, tokenHash: string): DelegationOutcome {
   switch (status.kind) {
     case 'inactive':
       // Child completed and was popped from session stack
@@ -177,17 +209,33 @@ function classifyOutcome(status: RunbookStatus): DelegationOutcome {
       return { kind: 'child_stashed', status };
 
     case 'active': {
-      // Check for pending (unclaimed) delegation — means the parent is active,
-      // not the child, because the child was never created
-      const pending = status.delegations.find(
-        (d): d is DelegationStatus & { state: 'pending' } => d.state === 'pending',
-      );
-      if (pending) {
-        return { kind: 'unclaimed', delegation: pending };
+      // Find the delegation matching our token
+      const ours = status.delegations.find((d) => d.tokenHash === tokenHash);
+
+      if (!ours) {
+        // Our delegation not found — either the active runbook is the child
+        // (children don't have delegations) or the parent is active and our
+        // delegation has already been fully resolved
+        if (status.delegations.length > 0) {
+          // Parent is active with other delegations, but ours isn't here — completed
+          return { kind: 'completed' };
+        }
+        // No delegations at all — active runbook is the child, still running
+        return { kind: 'child_active', status };
       }
 
-      // Child runbook is active — subagent didn't complete it
-      return { kind: 'child_active', status };
+      // Found our delegation — classify by its state
+      switch (ours.state) {
+        case 'pending':
+          // Never claimed — subagent stopped before calling rd claim
+          return { kind: 'unclaimed', delegation: ours };
+        case 'claimed':
+          // Claimed and parent is active — child completed and was popped
+          return { kind: 'completed' };
+        case 'cancelled':
+          // Already cancelled — treat as completed (nothing more to do)
+          return { kind: 'completed' };
+      }
     }
   }
 }
@@ -276,6 +324,9 @@ function buildContextMessage(outcome: DelegationOutcome): string | undefined {
  * Handle a SubagentStop hook by consuming any active delegation token and checking
  * whether the child runbook was completed.
  *
+ * Hashes the consumed token and correlates it with the delegation entries in
+ * `rd status --json` to identify the exact delegation belonging to this subagent.
+ *
  * Classifies the delegation state into one of five outcomes:
  * - **completed**: Child runbook finished (`rd pass`/`rd fail`) and was popped.
  * - **child_active**: Child runbook is running but subagent stopped without completing.
@@ -312,7 +363,8 @@ export async function handleSubagentStop(input: HookInput): Promise<SubagentStop
 
   // Query runbook state and classify the delegation outcome
   const status = queryRunbookStatus(input.cwd);
-  const outcome: DelegationOutcome = status ? classifyOutcome(status) : { kind: 'unknown' };
+  const hash = hashToken(token);
+  const outcome: DelegationOutcome = status ? classifyOutcome(status, hash) : { kind: 'unknown' };
   const context = buildContextMessage(outcome);
 
   return context ? { context } : {};

--- a/packages/claude-code-plugin/templates/verify-review.md
+++ b/packages/claude-code-plugin/templates/verify-review.md
@@ -36,4 +36,4 @@ Issues that should be considered but don't block.
 **BLOCKING count:** X
 **SUGGESTION count:** X
 
-STATUS: [PASS | FAIL]
+**Result:** [PASS | FAIL]

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -70,6 +70,7 @@ export interface StatusOutputData {
     runbook: string;
     state: 'pending' | 'claimed' | 'cancelled';
     childRunId?: string;
+    /** SHA-256 hash of the delegation token for cross-system correlation. */
     tokenHash?: string;
   }>;
 }

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -70,6 +70,7 @@ export interface StatusOutputData {
     runbook: string;
     state: 'pending' | 'claimed' | 'cancelled';
     childRunId?: string;
+    tokenHash?: string;
   }>;
 }
 
@@ -215,6 +216,7 @@ export function buildActiveStatus(
             ? ('claimed' as const)
             : ('pending' as const),
       ...(ss.delegation!.childRunId != null ? { childRunId: ss.delegation!.childRunId } : {}),
+      ...(ss.delegation!.tokenHash ? { tokenHash: ss.delegation!.tokenHash } : {}),
     }));
 
   return {

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -247,6 +247,8 @@ export const DelegationStatusEntrySchema = z
       .describe('Delegation state: pending, claimed, or cancelled'),
     /** Child run ID (when claimed) */
     childRunId: z.string().optional().describe('Child run ID when delegation is claimed'),
+    /** SHA-256 hash of the delegation token for correlation */
+    tokenHash: z.string().optional().describe('SHA-256 hash of the delegation token'),
   })
   .refine((entry) => entry.state !== 'claimed' || !!entry.childRunId, {
     message: 'childRunId is required when state is claimed',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the old status-line protocol with a "Delegation Completion" section; subagents should use explicit rd pass/rd fail commands and updated guidance/examples.

* **Improvements**
  * More robust delegation completion tracking and clearer parent/child runbook state handling; completed children treated as propagated, incomplete/stashed children surface contextual messages.

* **CLI**
  * Status output can include delegation correlation data (token hash) to enable token-based verification.

* **Tests**
  * Expanded integration, unit, perf, and smoke tests to validate the new delegation workflow and payload formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->