### PR TITLE
Run nested runbooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,9 @@ rundown run [file] --var key=value  # Set template variable (repeatable, omit =v
 rundown run [file] --var-json key=json  # Set variable with JSON value (repeatable)
 rundown run [file] --var-file path  # Load variables from YAML file (repeatable)
 rundown run [file] --prompted  # Show commands without auto-executing
-rundown run [file] --step <stepId>   # Jump to step after starting (requires --prompted)
-rundown run [file] --index <number>  # FOR loop iteration to target (requires --step)
+rundown run [file] --step <stepId>   # Link child to parent substep (inline nested execution)
+rundown run [file] --step <stepId> --prompted  # Jump to step after starting (goto)
+rundown run [file] --step <stepId> --index <number>  # FOR loop iteration to target
 rundown pass             # Mark current step as passed (aliases: yes, ok)
 rundown pass --step <stepId>         # Target specific substep
 rundown pass --index <number>        # FOR loop iteration (requires --step)

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -207,7 +207,7 @@ describe('delegate command', () => {
       );
 
       expect(result.exitCode).not.toBe(0);
-      expect(result.stdout + result.stderr).toContain('step not found');
+      expect(result.stdout + result.stderr).toContain('Step not found');
     });
 
     it('fails for duplicate delegation on same substep', async () => {

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -103,10 +103,10 @@ describe('start command', () => {
   });
 
   describe('option validation', () => {
-    it('rejects --step without --prompted', async () => {
+    it('rejects --step without active parent runbook', async () => {
       const result = await runCliInProcess('run runbooks/simple.runbook.md --step 1', workspace);
       expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain('--step requires --prompted');
+      expect(result.stderr).toContain('--step requires an active parent runbook');
     });
 
     it('rejects --index without --step', async () => {

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -41,6 +41,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   })),
   DelegationLock: jest.fn(),
   reconstituteContextVars: jest.fn().mockReturnValue({}),
+  extractInheritedUserVars: jest.fn().mockReturnValue({}),
   hashDelegationToken: jest.fn().mockReturnValue('sha256:mock'),
   truncateDelegationToken: jest.fn((token: string) => {
     const prefix = 'rdtk_';

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -769,7 +769,8 @@ describe('claimAndLaunch', () => {
       'child.md',
       expect.anything(),
       expect.objectContaining({
-        delegation: expect.objectContaining({
+        parentLinkage: expect.objectContaining({
+          kind: 'delegation',
           parentFrameKey: '1|3',
         }),
       }),

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -69,7 +69,9 @@ const { createBridgedEmitter } = await import('../../src/helpers/execution-emitt
 const { createPassTransitionConfig, createFailTransitionConfig } = await import(
   '../../src/helpers/transitions'
 );
-const { handleParentCompletion } = await import('../../src/helpers/delegation-completion');
+const { handleParentCompletion, extractParentLinkage } = await import(
+  '../../src/helpers/delegation-completion'
+);
 
 function makeState(id: string, overrides: Partial<RunbookState> = {}): RunbookState {
   return {
@@ -90,6 +92,7 @@ function makeState(id: string, overrides: Partial<RunbookState> = {}): RunbookSt
 
 function makeDelegationLinkage(overrides: Partial<DelegationLinkage> = {}): DelegationLinkage {
   return {
+    kind: 'delegation' as const,
     parentRunId: 'parent-run-id',
     parentStepId: '1',
     tokenHash: 'sha256:abc123',
@@ -208,7 +211,7 @@ describe('handleParentCompletion', () => {
 
   it('acquires delegation lock on parent run ID', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
     });
@@ -229,7 +232,7 @@ describe('handleParentCompletion', () => {
 
   it('returns not-applicable when parent no longer exists', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
 
     const states = new Map([['parent-run-id', null]]);
     const manager = makeManager(states);
@@ -245,9 +248,70 @@ describe('handleParentCompletion', () => {
     expect(lock.release).toHaveBeenCalled();
   });
 
+  it('does not block inline child when substep has cancelled delegation', async () => {
+    const childState = makeState('child-run-id', {
+      parentLinkage: {
+        kind: 'inline' as const,
+        parentRunId: 'parent-run-id',
+        parentStepId: '1',
+        parentStep: '1',
+        parentFrameKey: '1|' as any,
+        parentEntry: 1,
+      },
+    });
+    const parentState = makeState('parent-run-id', {
+      step: '1',
+      activeEntry: 1,
+      activeFrameKey: '1|',
+      substepStates: [
+        {
+          id: '1',
+          frameKey: '1|',
+          status: 'pending',
+          delegation: {
+            tokenHash: 'sha256:old-token',
+            childRunbookPath: 'old-child.md',
+            contextSnapshot: { vars: {}, ancestors: [] },
+            childRunId: 'old-child-run-id',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            cancelledAt: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      ],
+    });
+
+    const states = new Map([[parentState.id, parentState]]);
+    const manager = makeManager(states);
+    const _lock = makeLock();
+    const lifecycleService = makeLifecycleService();
+    const output = makeOutput();
+
+    wireMocks(manager, lifecycleService);
+
+    (drainResolvedCompletions as jest.Mock).mockResolvedValue({
+      status: 'continue',
+      applied: 0,
+      state: parentState,
+    });
+
+    const result = await handleParentCompletion(childState, 'pass', '/test', output);
+
+    // Inline child should NOT be blocked by the cancelled delegation
+    expect(result).not.toBe('not-applicable');
+    expect(lifecycleService.upsertResolvedCompletion).toHaveBeenCalledWith(
+      'parent-run-id',
+      expect.any(String),
+      expect.objectContaining({
+        agentId: 'inline',
+        result: 'pass',
+        targetSubstep: '1',
+      }),
+    );
+  });
+
   it('skips propagation when delegation was cancelled', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [
         {
@@ -282,7 +346,7 @@ describe('handleParentCompletion', () => {
 
   it('records resolved completion on parent', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       step: '1',
       activeEntry: 1,
@@ -319,7 +383,7 @@ describe('handleParentCompletion', () => {
 
   it('drains resolved completions on parent after recording', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
     });
@@ -350,7 +414,7 @@ describe('handleParentCompletion', () => {
 
   it('runs execution loop when completions were applied', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
     });
@@ -383,7 +447,7 @@ describe('handleParentCompletion', () => {
 
   it('returns stopped when drain results in stopped status', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
     });
@@ -409,14 +473,14 @@ describe('handleParentCompletion', () => {
 
   it('cascades to grandparent when parent completes', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const grandparentDelegation = makeDelegationLinkage({
       parentRunId: 'grandparent-run-id',
       parentStepId: '2',
     });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
-      delegation: grandparentDelegation,
+      parentLinkage: grandparentDelegation,
     });
     const grandparentState = makeState('grandparent-run-id', {
       substepStates: [{ id: '2', frameKey: '1|', status: 'pending', delegation: null }],
@@ -448,7 +512,7 @@ describe('handleParentCompletion', () => {
 
   it('respects maximum recursion depth', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const output = makeOutput();
 
     // Call with depth already at limit
@@ -462,7 +526,7 @@ describe('handleParentCompletion', () => {
 
   it('passes delegation-specific popRunbook:false policy to drain', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
     });
@@ -495,7 +559,7 @@ describe('handleParentCompletion', () => {
 
   it('explicitly pops session when drain returns done', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
     });
@@ -523,7 +587,7 @@ describe('handleParentCompletion', () => {
 
   it('explicitly pops session when drain returns stopped', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
     });
@@ -551,7 +615,7 @@ describe('handleParentCompletion', () => {
 
   it('uses fail transition config when result is fail', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
     });
@@ -578,7 +642,7 @@ describe('handleParentCompletion', () => {
 
   it('flushes output after handling', async () => {
     const delegation = makeDelegationLinkage();
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
     });
@@ -604,7 +668,7 @@ describe('handleParentCompletion', () => {
 
   it('passes parentFrameKey as frameKeyOverride to drain', async () => {
     const delegation = makeDelegationLinkage({ parentFrameKey: '1|3' as any });
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|3', status: 'pending', delegation: null }],
     });
@@ -634,7 +698,7 @@ describe('handleParentCompletion', () => {
 
   it('does not pass frameKeyOverride when parentFrameKey is undefined', async () => {
     const delegation = makeDelegationLinkage({ parentFrameKey: undefined });
-    const childState = makeState('child-run-id', { delegation });
+    const childState = makeState('child-run-id', { parentLinkage: delegation });
     const parentState = makeState('parent-run-id', {
       substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
     });
@@ -657,5 +721,68 @@ describe('handleParentCompletion', () => {
 
     const drainCall = (drainResolvedCompletions as jest.Mock).mock.calls[0][0];
     expect(drainCall.frameKeyOverride).toBeUndefined();
+  });
+});
+
+describe('inline linkage path', () => {
+  it('extractParentLinkage returns inline linkage from state', () => {
+    const state = makeState('child-run', {
+      parentLinkage: {
+        kind: 'inline' as const,
+        parentRunId: 'parent-run',
+        parentStepId: '1',
+        parentStep: '1',
+        parentFrameKey: '1|' as any,
+        parentEntry: 1,
+      },
+    });
+    const linkage = extractParentLinkage(state);
+    expect(linkage).toBeDefined();
+    expect(linkage!.parentRunId).toBe('parent-run');
+  });
+
+  it('agentId is inline for inline children', async () => {
+    const childState = makeState('child-run-id', {
+      parentLinkage: {
+        kind: 'inline' as const,
+        parentRunId: 'parent-run-id',
+        parentStepId: '1',
+        parentStep: '1',
+        parentFrameKey: '1|' as any,
+        parentEntry: 1,
+      },
+    });
+    const parentState = makeState('parent-run-id', {
+      step: '1',
+      activeEntry: 1,
+      activeFrameKey: '1|',
+      substepStates: [{ id: '1', frameKey: '1|', status: 'pending', delegation: null }],
+    });
+
+    const states = new Map([[parentState.id, parentState]]);
+    const manager = makeManager(states);
+    const _lock = makeLock();
+    const lifecycleService = makeLifecycleService();
+    const output = makeOutput();
+
+    wireMocks(manager, lifecycleService);
+
+    (drainResolvedCompletions as jest.Mock).mockResolvedValue({
+      status: 'continue',
+      applied: 0,
+      state: parentState,
+    });
+
+    await handleParentCompletion(childState, 'pass', '/test', output);
+
+    expect(lifecycleService.upsertResolvedCompletion).toHaveBeenCalledWith(
+      'parent-run-id',
+      expect.any(String),
+      expect.objectContaining({
+        agentId: 'inline',
+        result: 'pass',
+        targetSubstep: '1',
+      }),
+    );
   });
 });

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -105,6 +105,7 @@ function makeOutput(): any {
     flush: jest.fn(),
     status: jest.fn(),
     error: jest.fn(),
+    warning: jest.fn(),
   };
 }
 

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -69,7 +69,7 @@ const { createBridgedEmitter } = await import('../../src/helpers/execution-emitt
 const { createPassTransitionConfig, createFailTransitionConfig } = await import(
   '../../src/helpers/transitions'
 );
-const { handleDelegationCompletion } = await import('../../src/helpers/delegation-completion');
+const { handleParentCompletion } = await import('../../src/helpers/delegation-completion');
 
 function makeState(id: string, overrides: Partial<RunbookState> = {}): RunbookState {
   return {
@@ -195,12 +195,12 @@ beforeEach(() => {
   });
 });
 
-describe('handleDelegationCompletion', () => {
+describe('handleParentCompletion', () => {
   it('returns not-applicable when child has no delegation linkage', async () => {
     const childState = makeState('child-run-id');
     const output = makeOutput();
 
-    const result = await handleDelegationCompletion(childState, 'pass', '/test', output);
+    const result = await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(result).toBe('not-applicable');
   });
@@ -220,7 +220,7 @@ describe('handleDelegationCompletion', () => {
 
     wireMocks(manager, lifecycleService);
 
-    await handleDelegationCompletion(childState, 'pass', '/test', output);
+    await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(lock.acquire).toHaveBeenCalledWith('parent-run-id');
     expect(lock.release).toHaveBeenCalledWith('parent-run-id');
@@ -238,7 +238,7 @@ describe('handleDelegationCompletion', () => {
 
     wireMocks(manager, lifecycleService);
 
-    const result = await handleDelegationCompletion(childState, 'pass', '/test', output);
+    const result = await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(result).toBe('not-applicable');
     expect(lock.release).toHaveBeenCalled();
@@ -273,7 +273,7 @@ describe('handleDelegationCompletion', () => {
 
     wireMocks(manager, lifecycleService);
 
-    const result = await handleDelegationCompletion(childState, 'pass', '/test', output);
+    const result = await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(result).toBe('handled');
     expect(lifecycleService.upsertResolvedCompletion).not.toHaveBeenCalled();
@@ -303,7 +303,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'pass', '/test', output);
+    await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(lifecycleService.upsertResolvedCompletion).toHaveBeenCalledWith(
       'parent-run-id',
@@ -337,7 +337,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'pass', '/test', output);
+    await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(drainResolvedCompletions).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -368,7 +368,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'pass', '/test', output);
+    await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(runExecutionLoop).toHaveBeenCalledWith(
       manager,
@@ -401,7 +401,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    const result = await handleDelegationCompletion(childState, 'fail', '/test', output);
+    const result = await handleParentCompletion(childState, 'fail', '/test', output);
 
     expect(result).toBe('stopped');
   });
@@ -438,7 +438,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'pass', '/test', output);
+    await handleParentCompletion(childState, 'pass', '/test', output);
 
     // Should cascade - second acquire should be on grandparent
     expect(lock.acquire).toHaveBeenCalledWith('parent-run-id');
@@ -451,7 +451,7 @@ describe('handleDelegationCompletion', () => {
     const output = makeOutput();
 
     // Call with depth already at limit
-    const result = await handleDelegationCompletion(childState, 'pass', '/test', output, 32);
+    const result = await handleParentCompletion(childState, 'pass', '/test', output, 32);
 
     expect(result).toBe('handled');
     // Should not even acquire lock
@@ -480,7 +480,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'pass', '/test', output);
+    await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(drainResolvedCompletions).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -513,7 +513,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'pass', '/test', output);
+    await handleParentCompletion(childState, 'pass', '/test', output);
 
     const MockSession = core.SessionService as jest.MockedClass<typeof core.SessionService>;
     const sessionInstance = MockSession.mock.results[0]?.value;
@@ -541,7 +541,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'fail', '/test', output);
+    await handleParentCompletion(childState, 'fail', '/test', output);
 
     const MockSession = core.SessionService as jest.MockedClass<typeof core.SessionService>;
     const sessionInstance = MockSession.mock.results[0]?.value;
@@ -569,7 +569,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'fail', '/test', output);
+    await handleParentCompletion(childState, 'fail', '/test', output);
 
     expect(createFailTransitionConfig).toHaveBeenCalled();
     expect(createPassTransitionConfig).not.toHaveBeenCalled();
@@ -596,7 +596,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'pass', '/test', output);
+    await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(output.flush).toHaveBeenCalled();
   });
@@ -622,7 +622,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'pass', '/test', output);
+    await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(drainResolvedCompletions).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -652,7 +652,7 @@ describe('handleDelegationCompletion', () => {
       state: parentState,
     });
 
-    await handleDelegationCompletion(childState, 'pass', '/test', output);
+    await handleParentCompletion(childState, 'pass', '/test', output);
 
     const drainCall = (drainResolvedCompletions as jest.Mock).mock.calls[0][0];
     expect(drainCall.frameKeyOverride).toBeUndefined();

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -22,6 +22,17 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   findSubstepState: jest.fn((substepStates: any[], substepId: string, frameKey: string) =>
     substepStates.find((ss: any) => ss.id === substepId && ss.frameKey === frameKey),
   ),
+  upsertSubstepState: jest.fn(
+    (substepStates: any[], substepId: string, frameKey: string, patch: any) => {
+      const existing = substepStates.find(
+        (ss: any) => ss.id === substepId && ss.frameKey === frameKey,
+      );
+      if (existing) {
+        return substepStates.map((ss: any) => (ss === existing ? { ...ss, ...patch } : ss));
+      }
+      return [...substepStates, { id: substepId, frameKey, status: 'pending', ...patch }];
+    },
+  ),
   ...mockErrorHelpers,
 }));
 
@@ -115,6 +126,7 @@ function makeOutput(): any {
 function makeManager(states: Map<string, RunbookState | null>): any {
   return {
     load: jest.fn<any>().mockImplementation(async (id: string) => states.get(id) ?? null),
+    update: jest.fn<any>().mockResolvedValue(undefined),
   };
 }
 

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -927,7 +927,8 @@ describe('claimAndLaunch', () => {
       'child.md',
       expect.anything(),
       expect.objectContaining({
-        delegation: expect.objectContaining({
+        parentLinkage: expect.objectContaining({
+          kind: 'delegation',
           parentRunId: 'parent-id',
           tokenHash,
         }),

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -40,6 +40,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   DelegationScanService: jest.fn(),
   DelegationLock: jest.fn(),
   reconstituteContextVars: jest.fn().mockReturnValue({}),
+  extractInheritedUserVars: jest.fn(),
   hashDelegationToken: jest.fn().mockReturnValue('sha256:mock'),
   truncateDelegationToken: jest.fn((token: string) => {
     const prefix = 'rdtk_';
@@ -250,6 +251,7 @@ beforeEach(() => {
   ).mockReturnValue(mockParseResult());
   (core.hashDelegationToken as jest.Mock).mockReturnValue('sha256:mock');
   (core.reconstituteContextVars as jest.Mock).mockReturnValue({});
+  (core.extractInheritedUserVars as jest.Mock).mockReturnValue({});
   (core.deriveActiveFrame as jest.Mock).mockReturnValue({
     step: '1',
     substep: undefined,
@@ -1009,6 +1011,11 @@ describe('claimAndLaunch', () => {
       lifecycleService: makeLifecycle(),
       cwd: '/test',
     };
+
+    (core.extractInheritedUserVars as jest.Mock).mockReturnValue({
+      ContextId: 'ctx-parent',
+      Region: 'us-west',
+    });
 
     const { claimAndLaunch } = await import('../../src/helpers/runbook-pipeline');
     // cspell:disable-next-line

--- a/packages/cli/__tests__/integration/delegation-propagation.test.ts
+++ b/packages/cli/__tests__/integration/delegation-propagation.test.ts
@@ -100,11 +100,11 @@ describe('Delegation propagation integration', () => {
       result = await runCliInProcess(`claim ${token}`, workspace);
       expect(result.exitCode).toBe(0);
 
-      // Verify child state has delegation linkage
+      // Verify child state has delegation linkage via parentLinkage
       const childState = await getActiveState(workspace);
       expect(childState).not.toBeNull();
-      expect(childState!.delegation).toBeDefined();
-      expect((childState!.delegation as Record<string, unknown>).parentRunId).toBe(parentRunId);
+      expect(childState!.parentLinkage).toBeDefined();
+      expect((childState!.parentLinkage as Record<string, unknown>).parentRunId).toBe(parentRunId);
 
       // Pass the child step — propagates pass to parent substep 1.1
       // DEFER model: parent advances to 1.2
@@ -255,7 +255,7 @@ describe('Delegation propagation integration', () => {
 
       const parentState = await getActiveState(workspace);
       expect(parentState).not.toBeNull();
-      expect(parentState!.delegation).toBeDefined();
+      expect(parentState!.parentLinkage).toBeDefined();
       const parentRunId = parentState!.id as string;
 
       // Delegate parent substep 1.1 to child runbook

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -130,8 +130,9 @@ describe('Inline linkage integration (rd run --step)', () => {
       const parentState = await getActiveState(workspace);
       const parentRunId = parentState!.id as string;
 
-      // Run auto-executing child with inline linkage
-      result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      // Run auto-executing child with inline linkage to substep 1.2
+      // Using 1.2 (not 1.1) so parentStepId='2' is unambiguously the substep ID
+      result = await runCliInProcess('run child.runbook.md --step 1.2', workspace);
       expect(result.exitCode).toBe(0);
 
       // Child completed and was popped — parent is active again.
@@ -154,7 +155,7 @@ describe('Inline linkage integration (rd run --step)', () => {
       const linkage = childState!.inlineLinkage as Record<string, unknown>;
       expect(linkage.kind).toBe('inline');
       expect(linkage.parentRunId).toBe(parentRunId);
-      expect(linkage.parentStepId).toBe('1');
+      expect(linkage.parentStepId).toBe('2');
     });
   });
 

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  createTestWorkspace,
+  createRunbook,
+  runCliInProcess,
+  getActiveState,
+  readRunbookState,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+describe('Inline linkage integration (rd run --step)', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  /** Helper: write a parent runbook with two substeps. */
+  async function writeParentRunbook(): Promise<void> {
+    const content = createRunbook({
+      title: 'Parent',
+      steps: [
+        {
+          title: 'Review',
+          pass: 'CONTINUE',
+          substeps: [
+            { title: 'Code review', content: 'Do code review.' },
+            { title: 'Security review', content: 'Do security review.' },
+          ],
+        },
+        { title: 'Done', pass: 'COMPLETE', content: 'Final step.' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'parent.runbook.md'), content);
+  }
+
+  /** Helper: write a single-step auto-executing child that passes. */
+  async function writePassingChild(): Promise<void> {
+    const content = createRunbook({
+      title: 'Child',
+      steps: [{ title: 'Execute', pass: 'COMPLETE', command: 'rd echo --result pass' }],
+    });
+    await writeFile(join(workspace.cwd, 'child.runbook.md'), content);
+  }
+
+  /** Helper: write a single-step auto-executing child that fails and stops. */
+  async function writeFailingChild(): Promise<void> {
+    const content = createRunbook({
+      title: 'Child',
+      steps: [
+        { title: 'Execute', pass: 'COMPLETE', fail: 'STOP', command: 'rd echo --result fail' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'child.runbook.md'), content);
+  }
+
+  /** Helper: extract variables from parsed state. */
+  function getVariables(state: Record<string, unknown>): Record<string, unknown> {
+    return (state.variables ?? {}) as Record<string, unknown>;
+  }
+
+  describe('auto-executing child propagation', () => {
+    it('child pass propagates to parent substep and parent advances', async () => {
+      await writeParentRunbook();
+      await writePassingChild();
+
+      // Start parent in prompted mode
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      expect(parentState).not.toBeNull();
+      const parentRunId = parentState!.id as string;
+
+      // Run child with inline linkage to substep 1.1
+      result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Parent should now be at substep 1.2 (child pass resolved 1.1)
+      // Complete 1.2 to trigger aggregation
+      result = await runCliInProcess('pass', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const updatedParent = await readRunbookState(workspace, parentRunId);
+      expect(updatedParent).not.toBeNull();
+      expect(updatedParent!.step).toBe('2');
+    });
+
+    it('child stop propagates fail to parent substep', async () => {
+      await writeParentRunbook();
+      await writeFailingChild();
+
+      // Start parent in prompted mode
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      const parentRunId = parentState!.id as string;
+
+      // Run child with inline linkage — child will fail and stop
+      result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      // Child stopped → exit 1
+      expect(result.exitCode).toBe(1);
+
+      // Parent substep 1.1 should have a fail recorded.
+      // Complete 1.2 to trigger aggregation — FAIL ANY STOP
+      result = await runCliInProcess('pass', workspace);
+
+      const updatedParent = await readRunbookState(workspace, parentRunId);
+      expect(updatedParent).not.toBeNull();
+      expect(getVariables(updatedParent!).stopped).toBe(true);
+    });
+  });
+
+  describe('child state linkage', () => {
+    it('child state has inlineLinkage pointing to parent', async () => {
+      await writeParentRunbook();
+      await writePassingChild();
+
+      // Start parent in prompted mode
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      const parentRunId = parentState!.id as string;
+
+      // Run auto-executing child with inline linkage
+      result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Child completed and was popped — parent is active again.
+      // Load the child state by scanning runs directory for the non-parent state.
+      const { readdir, readFile: rf } = await import('node:fs/promises');
+      const runsDir = join(workspace.cwd, '.claude', 'rundown', 'runs');
+      const files = await readdir(runsDir);
+      const stateFiles = files.filter((f) => f.endsWith('.json') && f !== 'session.json');
+
+      let childState: Record<string, unknown> | null = null;
+      for (const f of stateFiles) {
+        const content = JSON.parse(await rf(join(runsDir, f), 'utf-8')) as Record<string, unknown>;
+        if (content.id !== parentRunId && content.inlineLinkage) {
+          childState = content;
+          break;
+        }
+      }
+
+      expect(childState).not.toBeNull();
+      const linkage = childState!.inlineLinkage as Record<string, unknown>;
+      expect(linkage.kind).toBe('inline');
+      expect(linkage.parentRunId).toBe(parentRunId);
+      expect(linkage.parentStepId).toBe('1');
+    });
+  });
+
+  describe('error cases', () => {
+    it('rejects --step without active parent runbook', async () => {
+      await writePassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('--step requires an active parent runbook');
+    });
+
+    it('rejects --step when step is not at frontier', async () => {
+      await writeParentRunbook();
+      await writePassingChild();
+
+      // Start parent — auto-executes past step 1
+      const result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Try to link to step 2.1 (step 2 has no substeps, and step 2 is not current)
+      const linkResult = await runCliInProcess('run child.runbook.md --step 2.1', workspace);
+      expect(linkResult.exitCode).toBe(1);
+    });
+
+    it('rejects --step when substep is already resolved', async () => {
+      await writeParentRunbook();
+      await writePassingChild();
+
+      // Start parent in prompted mode
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Manually resolve substep 1.1
+      result = await runCliInProcess('pass --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Try to run with inline linkage to already-resolved substep
+      result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('already resolved');
+    });
+  });
+});

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -7,7 +7,7 @@ import {
   readRunbookState,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
-import { writeFile } from 'node:fs/promises';
+import { writeFile, readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 describe('Inline linkage integration (rd run --step)', () => {
@@ -244,14 +244,17 @@ describe('Inline linkage integration (rd run --step)', () => {
 
       // Child completed and was popped — parent is active again.
       // Load the child state by scanning runs directory for the non-parent state.
-      const { readdir, readFile: rf } = await import('node:fs/promises');
+
       const runsDir = join(workspace.cwd, '.claude', 'rundown', 'runs');
       const files = await readdir(runsDir);
       const stateFiles = files.filter((f) => f.endsWith('.json') && f !== 'session.json');
 
       let childState: Record<string, unknown> | null = null;
       for (const f of stateFiles) {
-        const content = JSON.parse(await rf(join(runsDir, f), 'utf-8')) as Record<string, unknown>;
+        const content = JSON.parse(await readFile(join(runsDir, f), 'utf-8')) as Record<
+          string,
+          unknown
+        >;
         if (content.id !== parentRunId && content.parentLinkage) {
           childState = content;
           break;
@@ -302,14 +305,17 @@ describe('Inline linkage integration (rd run --step)', () => {
       expect(result.exitCode).toBe(0);
 
       // Scan runs directory for the child state
-      const { readdir, readFile: rf } = await import('node:fs/promises');
+
       const runsDir = join(workspace.cwd, '.claude', 'rundown', 'runs');
       const files = await readdir(runsDir);
       const stateFiles = files.filter((f) => f.endsWith('.json') && f !== 'session.json');
 
       let childState: Record<string, unknown> | null = null;
       for (const f of stateFiles) {
-        const content = JSON.parse(await rf(join(runsDir, f), 'utf-8')) as Record<string, unknown>;
+        const content = JSON.parse(await readFile(join(runsDir, f), 'utf-8')) as Record<
+          string,
+          unknown
+        >;
         if (content.id !== parentRunId && content.parentLinkage) {
           childState = content;
           break;
@@ -418,7 +424,7 @@ describe('Inline linkage integration (rd run --step)', () => {
       // code path where completeSubstep() is wired into the CLI (e.g., delegation
       // completion marking substeps done). The cursor has NOT advanced, so only
       // the status === 'done' guard catches this.
-      const { readFile } = await import('node:fs/promises');
+
       const statePath = join(workspace.cwd, '.claude', 'rundown', 'runs', `${parentRunId}.json`);
       const stateData = JSON.parse(await readFile(statePath, 'utf-8'));
       const substeps = stateData.substepStates as Array<Record<string, unknown>>;

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -65,13 +65,13 @@ describe('Inline linkage integration (rd run --step)', () => {
     return (state.variables ?? {}) as Record<string, unknown>;
   }
 
-  describe('afterInit fresh state reload (TOCTOU fix)', () => {
+  describe('afterInit fresh state reload (race condition fix)', () => {
     it('afterInit marks targeted substep as running in parent substepStates', async () => {
       // Behavioral test for the afterInit callback in `rd run --step`.
       //
       // The underlying fix (acquiring DelegationLock + fresh manager.load()
       // instead of closing over a stale parentState snapshot) prevents
-      // TOCTOU races when concurrent processes modify parent substepStates.
+      // race condition races when concurrent processes modify parent substepStates.
       // That race cannot be reproduced in single-process tests. This test
       // validates the observable contract: afterInit correctly marks the
       // targeted substep as 'running'.

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -66,15 +66,12 @@ describe('Inline linkage integration (rd run --step)', () => {
   }
 
   describe('afterInit fresh state reload (race condition fix)', () => {
-    it('afterInit marks targeted substep as running in parent substepStates', async () => {
-      // Behavioral test for the afterInit callback in `rd run --step`.
+    it('auto-completing child marks substep as done in parent substepStates', async () => {
+      // Behavioral test for the afterInit + completion propagation lifecycle.
       //
-      // The underlying fix (acquiring DelegationLock + fresh manager.load()
-      // instead of closing over a stale parentState snapshot) prevents
-      // race condition races when concurrent processes modify parent substepStates.
-      // That race cannot be reproduced in single-process tests. This test
-      // validates the observable contract: afterInit correctly marks the
-      // targeted substep as 'running'.
+      // afterInit marks the substep as 'running', then the child completes
+      // and handleParentCompletion marks it as 'done'. Since the child
+      // auto-completes synchronously, the final observable state is 'done'.
       await writeParentRunbook();
       await writePassingChild();
 
@@ -95,28 +92,29 @@ describe('Inline linkage integration (rd run --step)', () => {
       expect(initialSubsteps.every((ss) => ss.status === 'pending')).toBe(true);
 
       // Run child targeting substep 1.1 -- afterInit marks it 'running',
-      // then child completes and propagates pass
+      // then child completes and propagation marks it 'done'
       result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
       expect(result.exitCode).toBe(0);
 
-      // Load parent state and verify substep 1 was marked 'running'
+      // Load parent state and verify substep 1 reached 'done'
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
 
       const substepStates = (updatedParent!.substepStates ?? []) as Array<{
         id: string;
         status: string;
+        result?: string;
       }>;
 
       const ss1 = substepStates.find((ss) => ss.id === '1');
       expect(ss1).toBeDefined();
-      expect(ss1!.status).toBe('running');
+      expect(ss1!.status).toBe('done');
+      expect(ss1!.result).toBe('pass');
     });
 
-    it('sequential children both mark their respective substeps', async () => {
+    it('sequential children both mark their respective substeps as done', async () => {
       // Verify that two sequential inline children targeting different
-      // substeps both get their substep marked as 'running'. This exercises
-      // the afterInit code path with fresh state reload.
+      // substeps both get their substep marked as 'done' after completion.
       const parentContent = createRunbook({
         title: 'Parent',
         steps: [
@@ -166,8 +164,8 @@ describe('Inline linkage integration (rd run --step)', () => {
       expect(ss1).toBeDefined();
       expect(ss2).toBeDefined();
       expect(ss3).toBeDefined();
-      expect(ss1!.status).toBe('running');
-      expect(ss2!.status).toBe('running');
+      expect(ss1!.status).toBe('done');
+      expect(ss2!.status).toBe('done');
       expect(ss3!.status).toBe('pending');
     });
   });
@@ -367,16 +365,18 @@ describe('Inline linkage integration (rd run --step)', () => {
       result = await runCliInProcess('run child.runbook.md --step 1.1 --index 2', workspace);
       expect(result.exitCode).toBe(0);
 
-      // Parent state should have a SubstepState for frameKey "1|2"
+      // Parent state should have a SubstepState for frameKey "1|2" marked done
       const updated = await readRunbookState(workspace, parentRunId);
       const substepStates = (updated!.substepStates ?? []) as Array<{
         id: string;
         frameKey: string;
         status: string;
+        result?: string;
       }>;
       const targetEntry = substepStates.find((ss) => ss.id === '1' && ss.frameKey === '1|2');
       expect(targetEntry).toBeDefined();
-      expect(targetEntry!.status).toBe('running');
+      expect(targetEntry!.status).toBe('done');
+      expect(targetEntry!.result).toBe('pass');
     });
 
     it('inline child allowed when active cursor advanced but targeting different iteration', async () => {
@@ -398,6 +398,24 @@ describe('Inline linkage integration (rd run --step)', () => {
       // Targeting substep 1.1 in iteration 2 should succeed (different frame).
       result = await runCliInProcess('run child.runbook.md --step 1.1 --index 2', workspace);
       expect(result.exitCode).toBe(0);
+    });
+
+    it('rejects re-execution of completed non-active FOR substep', async () => {
+      await writeForParent();
+      await writePassingChild();
+
+      // Start parent in prompted mode — sits at step 1, iteration 1
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // First child targeting iteration 2, substep 1.1 — should succeed
+      result = await runCliInProcess('run child.runbook.md --step 1.1 --index 2', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Second child targeting the same iteration 2, substep 1.1 — should be rejected
+      result = await runCliInProcess('run child.runbook.md --step 1.1 --index 2', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('already resolved');
     });
 
     it('child inherits correct context.parent.index for non-active iteration', async () => {

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -384,7 +384,7 @@ describe('Inline linkage integration (rd run --step)', () => {
       expect(output).toContain('RD-801');
     });
 
-    it('rejects --step when substep is already resolved', async () => {
+    it('rejects --step when substep cursor has advanced (drain path)', async () => {
       await writeParentRunbook();
       await writePassingChild();
 
@@ -392,11 +392,43 @@ describe('Inline linkage integration (rd run --step)', () => {
       let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
       expect(result.exitCode).toBe(0);
 
-      // Manually resolve substep 1.1
+      // Manually resolve substep 1.1 — drain advances cursor past it
       result = await runCliInProcess('pass --step 1.1', workspace);
       expect(result.exitCode).toBe(0);
 
-      // Try to run with inline linkage to already-resolved substep
+      // Try to run with inline linkage to already-drained substep
+      result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('already resolved');
+    });
+
+    it('rejects --step when substep status is done (defensive path)', async () => {
+      await writeParentRunbook();
+      await writePassingChild();
+
+      // Start parent in prompted mode
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      expect(parentState).not.toBeNull();
+      const parentRunId = parentState!.id as string;
+
+      // Directly mark substep 1 as 'done' in persisted state — simulates a future
+      // code path where completeSubstep() is wired into the CLI (e.g., delegation
+      // completion marking substeps done). The cursor has NOT advanced, so only
+      // the status === 'done' guard catches this.
+      const { readFile } = await import('node:fs/promises');
+      const statePath = join(workspace.cwd, '.claude', 'rundown', 'runs', `${parentRunId}.json`);
+      const stateData = JSON.parse(await readFile(statePath, 'utf-8'));
+      const substeps = stateData.substepStates as Array<Record<string, unknown>>;
+      const target = substeps.find((ss) => ss.id === '1');
+      expect(target).toBeDefined();
+      target!.status = 'done';
+      target!.result = 'pass';
+      await writeFile(statePath, JSON.stringify(stateData, null, 2));
+
+      // Try to run with inline linkage to done substep
       result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('already resolved');

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -181,6 +181,44 @@ describe('Inline linkage integration (rd run --step)', () => {
       expect(linkResult.exitCode).toBe(1);
     });
 
+    it('rejects --step targeting a step with no substeps', async () => {
+      // Parent step 2 ("Done") has no substeps — inline linkage should be rejected
+      const parentContent = createRunbook({
+        title: 'Parent',
+        steps: [
+          { title: 'Setup', pass: 'CONTINUE', command: 'rd echo --result pass' },
+          { title: 'Done', pass: 'COMPLETE', content: 'Final step.' },
+        ],
+      });
+      await writeFile(join(workspace.cwd, 'parent.runbook.md'), parentContent);
+      await writePassingChild();
+
+      // Start parent in prompted mode — sits at step 1
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Advance parent to step 1 pass, then it should be at step 1
+      // Try to link to step 1 (no substep qualifier, step has no substeps)
+      result = await runCliInProcess('run child.runbook.md --step 1', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('RD-815');
+      expect(result.stderr).toContain('no substeps');
+    });
+
+    it('preserves RundownError codes for delegation errors', async () => {
+      await writePassingChild();
+      await writeParentRunbook();
+
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Target nonexistent step 9 — should get RD-801 (DELEGATION_STEP_NOT_FOUND)
+      result = await runCliInProcess('run child.runbook.md --step 9', workspace);
+      expect(result.exitCode).toBe(1);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain('RD-801');
+    });
+
     it('rejects --step when substep is already resolved', async () => {
       await writeParentRunbook();
       await writePassingChild();

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -330,6 +330,115 @@ describe('Inline linkage integration (rd run --step)', () => {
     });
   });
 
+  describe('FOR-loop frame-scoped fixes', () => {
+    /** Helper: write a FOR parent with substeps for frame-scoped tests. */
+    async function writeForParent(): Promise<void> {
+      const content = createRunbook({
+        title: 'Parent',
+        steps: [
+          {
+            title: 'Process',
+            for: { variable: 'i', start: 1, end: 3 },
+            pass: 'CONTINUE',
+            substeps: [
+              { title: 'Handle item', content: 'Handle item {{i}}.' },
+              { title: 'Verify item', content: 'Verify item {{i}}.' },
+              { title: 'Finish item', content: 'Finish item {{i}}.' },
+            ],
+          },
+          { title: 'Done', pass: 'COMPLETE', content: 'Final step.' },
+        ],
+      });
+      await writeFile(join(workspace.cwd, 'parent.runbook.md'), content);
+    }
+
+    it('inline child targeting non-active FOR iteration creates SubstepState entry', async () => {
+      await writeForParent();
+      await writePassingChild();
+
+      // Start parent in prompted mode — sits at step 1, iteration 1
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      const parentRunId = parentState!.id as string;
+
+      // Run child targeting iteration 2, substep 1.1 (non-active frame)
+      result = await runCliInProcess('run child.runbook.md --step 1.1 --index 2', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Parent state should have a SubstepState for frameKey "1|2"
+      const updated = await readRunbookState(workspace, parentRunId);
+      const substepStates = (updated!.substepStates ?? []) as Array<{
+        id: string;
+        frameKey: string;
+        status: string;
+      }>;
+      const targetEntry = substepStates.find((ss) => ss.id === '1' && ss.frameKey === '1|2');
+      expect(targetEntry).toBeDefined();
+      expect(targetEntry!.status).toBe('running');
+    });
+
+    it('inline child allowed when active cursor advanced but targeting different iteration', async () => {
+      await writeForParent();
+      await writePassingChild();
+
+      // Start parent in prompted mode — sits at step 1, iteration 1, substep 1
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Advance the cursor in the active iteration past substep 1
+      // by passing substep 1.1 and 1.2 in the active frame
+      result = await runCliInProcess('pass --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+      result = await runCliInProcess('pass --step 1.2', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Now cursor is at substep 3 in iteration 1.
+      // Targeting substep 1.1 in iteration 2 should succeed (different frame).
+      result = await runCliInProcess('run child.runbook.md --step 1.1 --index 2', workspace);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('child inherits correct context.parent.index for non-active iteration', async () => {
+      await writePassingChild();
+      await writeForParent();
+
+      // Start parent — sits at step 1, iteration 1
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      const parentRunId = parentState!.id as string;
+
+      // Run child targeting iteration 3 (parent is at iteration 1)
+      result = await runCliInProcess('run child.runbook.md --step 1.1 --index 3', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Find the child state and verify its templateVars
+      const runsDir = join(workspace.cwd, '.claude', 'rundown', 'runs');
+      const files = await readdir(runsDir);
+      const stateFiles = files.filter((f) => f.endsWith('.json') && f !== 'session.json');
+
+      let childState: Record<string, unknown> | null = null;
+      for (const f of stateFiles) {
+        const content = JSON.parse(await readFile(join(runsDir, f), 'utf-8')) as Record<
+          string,
+          unknown
+        >;
+        if (content.id !== parentRunId && content.parentLinkage) {
+          childState = content;
+          break;
+        }
+      }
+
+      expect(childState).not.toBeNull();
+      const templateVars = childState!.templateVars as Record<string, unknown>;
+      // context.parent.index should be "3" (the target iteration), not "1" (the active)
+      expect(templateVars['context.parent.index']).toBe('3');
+    });
+  });
+
   describe('error cases', () => {
     it('rejects --step without active parent runbook', async () => {
       await writePassingChild();

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -65,6 +65,113 @@ describe('Inline linkage integration (rd run --step)', () => {
     return (state.variables ?? {}) as Record<string, unknown>;
   }
 
+  describe('afterInit fresh state reload (TOCTOU fix)', () => {
+    it('afterInit marks targeted substep as running in parent substepStates', async () => {
+      // Behavioral test for the afterInit callback in `rd run --step`.
+      //
+      // The underlying fix (acquiring DelegationLock + fresh manager.load()
+      // instead of closing over a stale parentState snapshot) prevents
+      // TOCTOU races when concurrent processes modify parent substepStates.
+      // That race cannot be reproduced in single-process tests. This test
+      // validates the observable contract: afterInit correctly marks the
+      // targeted substep as 'running'.
+      await writeParentRunbook();
+      await writePassingChild();
+
+      // Start parent in prompted mode -- sits at step 1
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      expect(parentState).not.toBeNull();
+      const parentRunId = parentState!.id as string;
+
+      // Verify initial substepStates are all 'pending'
+      const initialSubsteps = (parentState!.substepStates ?? []) as Array<{
+        id: string;
+        status: string;
+      }>;
+      expect(initialSubsteps.length).toBe(2);
+      expect(initialSubsteps.every((ss) => ss.status === 'pending')).toBe(true);
+
+      // Run child targeting substep 1.1 -- afterInit marks it 'running',
+      // then child completes and propagates pass
+      result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Load parent state and verify substep 1 was marked 'running'
+      const updatedParent = await readRunbookState(workspace, parentRunId);
+      expect(updatedParent).not.toBeNull();
+
+      const substepStates = (updatedParent!.substepStates ?? []) as Array<{
+        id: string;
+        status: string;
+      }>;
+
+      const ss1 = substepStates.find((ss) => ss.id === '1');
+      expect(ss1).toBeDefined();
+      expect(ss1!.status).toBe('running');
+    });
+
+    it('sequential children both mark their respective substeps', async () => {
+      // Verify that two sequential inline children targeting different
+      // substeps both get their substep marked as 'running'. This exercises
+      // the afterInit code path with fresh state reload.
+      const parentContent = createRunbook({
+        title: 'Parent',
+        steps: [
+          {
+            title: 'Review',
+            pass: 'CONTINUE',
+            substeps: [
+              { title: 'Alpha review', content: 'Do alpha review.' },
+              { title: 'Beta review', content: 'Do beta review.' },
+              { title: 'Gamma review', content: 'Do gamma review.' },
+            ],
+          },
+          { title: 'Done', pass: 'COMPLETE', content: 'Final step.' },
+        ],
+      });
+      await writeFile(join(workspace.cwd, 'parent.runbook.md'), parentContent);
+      await writePassingChild();
+
+      // Start parent in prompted mode
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      expect(parentState).not.toBeNull();
+      const parentRunId = parentState!.id as string;
+
+      // Run first child targeting substep 1.1
+      result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Run second child targeting substep 1.2
+      result = await runCliInProcess('run child.runbook.md --step 1.2', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Load parent state and verify both substeps were marked
+      const updatedParent = await readRunbookState(workspace, parentRunId);
+      expect(updatedParent).not.toBeNull();
+
+      const substepStates = (updatedParent!.substepStates ?? []) as Array<{
+        id: string;
+        status: string;
+      }>;
+
+      const ss1 = substepStates.find((ss) => ss.id === '1');
+      const ss2 = substepStates.find((ss) => ss.id === '2');
+      const ss3 = substepStates.find((ss) => ss.id === '3');
+      expect(ss1).toBeDefined();
+      expect(ss2).toBeDefined();
+      expect(ss3).toBeDefined();
+      expect(ss1!.status).toBe('running');
+      expect(ss2!.status).toBe('running');
+      expect(ss3!.status).toBe('pending');
+    });
+  });
+
   describe('auto-executing child propagation', () => {
     it('child pass propagates to parent substep and parent advances', async () => {
       await writeParentRunbook();
@@ -145,17 +252,75 @@ describe('Inline linkage integration (rd run --step)', () => {
       let childState: Record<string, unknown> | null = null;
       for (const f of stateFiles) {
         const content = JSON.parse(await rf(join(runsDir, f), 'utf-8')) as Record<string, unknown>;
-        if (content.id !== parentRunId && content.inlineLinkage) {
+        if (content.id !== parentRunId && content.parentLinkage) {
           childState = content;
           break;
         }
       }
 
       expect(childState).not.toBeNull();
-      const linkage = childState!.inlineLinkage as Record<string, unknown>;
+      const linkage = childState!.parentLinkage as Record<string, unknown>;
       expect(linkage.kind).toBe('inline');
       expect(linkage.parentRunId).toBe(parentRunId);
       expect(linkage.parentStepId).toBe('2');
+      expect(linkage.parentFrameKey).toBeDefined();
+      expect(linkage.parentEntry).toBeDefined();
+    });
+  });
+
+  describe('FOR-loop inline linkage', () => {
+    it('child state carries iteration info in parentFrameKey', async () => {
+      // Parent runbook with a FOR loop step containing substeps
+      const parentContent = createRunbook({
+        title: 'Parent',
+        steps: [
+          {
+            title: 'Process',
+            for: { variable: 'i', start: 1, end: 3 },
+            pass: 'CONTINUE',
+            substeps: [
+              { title: 'Handle item', content: 'Handle item {{i}}.' },
+              { title: 'Verify item', content: 'Verify item {{i}}.' },
+            ],
+          },
+          { title: 'Done', pass: 'COMPLETE', content: 'Final step.' },
+        ],
+      });
+      await writeFile(join(workspace.cwd, 'parent.runbook.md'), parentContent);
+      await writePassingChild();
+
+      // Start parent in prompted mode
+      let result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      expect(parentState).not.toBeNull();
+      const parentRunId = parentState!.id as string;
+
+      // Run child with inline linkage targeting iteration 2 of substep 1.1
+      result = await runCliInProcess('run child.runbook.md --step 1.1 --index 2', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Scan runs directory for the child state
+      const { readdir, readFile: rf } = await import('node:fs/promises');
+      const runsDir = join(workspace.cwd, '.claude', 'rundown', 'runs');
+      const files = await readdir(runsDir);
+      const stateFiles = files.filter((f) => f.endsWith('.json') && f !== 'session.json');
+
+      let childState: Record<string, unknown> | null = null;
+      for (const f of stateFiles) {
+        const content = JSON.parse(await rf(join(runsDir, f), 'utf-8')) as Record<string, unknown>;
+        if (content.id !== parentRunId && content.parentLinkage) {
+          childState = content;
+          break;
+        }
+      }
+
+      expect(childState).not.toBeNull();
+      const linkage = childState!.parentLinkage as Record<string, unknown>;
+      expect(linkage.kind).toBe('inline');
+      expect(linkage.parentRunId).toBe(parentRunId);
+      expect(linkage.parentFrameKey).toBe('1|2');
     });
   });
 

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -23,7 +23,7 @@ import { getRunbookFromState } from '../helpers/runbook-loader.js';
 import { drainResolvedCompletions, runExecutionLoop } from '../services/execution.js';
 import { createBridgedEmitter } from '../helpers/execution-emitter.js';
 import { createFailTransitionConfig } from '../helpers/transitions.js';
-import { handleDelegationCompletion } from '../helpers/delegation-completion.js';
+import { handleParentCompletion, extractParentLinkage } from '../helpers/delegation-completion.js';
 import type { TransitionOrchestrationPolicy } from '../helpers/transition-orchestrator.js';
 
 /**
@@ -81,9 +81,9 @@ async function propagateForceAbort(
   if (drained.status === 'done' || drained.status === 'stopped') {
     await sessionService.popRunbook();
     const cascadeParent = await manager.load(parentRunId);
-    if (cascadeParent?.delegation) {
+    if (cascadeParent && extractParentLinkage(cascadeParent)) {
       const cascadeResult: 'pass' | 'fail' = drained.status === 'done' ? 'pass' : 'fail';
-      await handleDelegationCompletion(cascadeParent, cascadeResult, cwd, output);
+      await handleParentCompletion(cascadeParent, cascadeResult, cwd, output);
     }
   } else if (drained.applied > 0) {
     // Run execution loop to advance past resolved step
@@ -98,9 +98,9 @@ async function propagateForceAbort(
 
     if (loopResult === 'stopped' || loopResult === 'done') {
       const cascadeParent = await manager.load(parentRunId);
-      if (cascadeParent?.delegation) {
+      if (cascadeParent && extractParentLinkage(cascadeParent)) {
         const cascadeResult: 'pass' | 'fail' = loopResult === 'done' ? 'pass' : 'fail';
-        await handleDelegationCompletion(cascadeParent, cascadeResult, cwd, output);
+        await handleParentCompletion(cascadeParent, cascadeResult, cwd, output);
       }
     }
   }

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -11,7 +11,7 @@ import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { parseVarOption, parseVarJsonOption, collect } from '../helpers/option-utils.js';
 import { claimAndLaunch, type RunPipelineContext } from '../helpers/runbook-pipeline.js';
-import { handleParentCompletion } from '../helpers/delegation-completion.js';
+import { handleParentCompletion, extractParentLinkage } from '../helpers/delegation-completion.js';
 
 /**
  * Registers the 'claim' command for claiming delegation tokens.
@@ -87,7 +87,7 @@ export function registerClaimCommand(program: Command): void {
             let shouldExitWithError = result.loopResult === 'stopped';
             if (result.loopResult === 'done' || result.loopResult === 'stopped') {
               const childState = await manager.load(result.childRunId);
-              if (childState?.delegation) {
+              if (childState && extractParentLinkage(childState)) {
                 const propResult = childState.variables.completed ? 'pass' : 'fail';
                 const propagation = await handleParentCompletion(
                   childState,

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -11,7 +11,7 @@ import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { parseVarOption, parseVarJsonOption, collect } from '../helpers/option-utils.js';
 import { claimAndLaunch, type RunPipelineContext } from '../helpers/runbook-pipeline.js';
-import { handleDelegationCompletion } from '../helpers/delegation-completion.js';
+import { handleParentCompletion } from '../helpers/delegation-completion.js';
 
 /**
  * Registers the 'claim' command for claiming delegation tokens.
@@ -89,7 +89,7 @@ export function registerClaimCommand(program: Command): void {
               const childState = await manager.load(result.childRunId);
               if (childState?.delegation) {
                 const propResult = childState.variables.completed ? 'pass' : 'fail';
-                const propagation = await handleDelegationCompletion(
+                const propagation = await handleParentCompletion(
                   childState,
                   propResult,
                   cwd,

--- a/packages/cli/src/commands/fail.ts
+++ b/packages/cli/src/commands/fail.ts
@@ -10,7 +10,7 @@ import {
   executeTransition,
   type ExplicitTarget,
 } from '../helpers/transitions.js';
-import { handleDelegationCompletion } from '../helpers/delegation-completion.js';
+import { handleParentCompletion, extractParentLinkage } from '../helpers/delegation-completion.js';
 import { validateIndexRequiresStep } from '../helpers/index-option.js';
 
 /**
@@ -56,20 +56,20 @@ export function registerFailCommand(program: Command): void {
             const result = await executeTransition(ctx, failConfig, explicitTarget);
             if (result === 'stopped') shouldExitWithError = true;
 
-            // Delegation propagation — fires when child run reaches terminal state
+            // Parent propagation — fires when child run reaches terminal state
             const freshState = await ctx.manager.load(ctx.state.id);
-            if (freshState?.delegation) {
+            if (freshState && extractParentLinkage(freshState)) {
               const isTerminal =
                 freshState.variables.completed === true || freshState.variables.stopped === true;
               if (isTerminal) {
                 const propResult = freshState.variables.completed ? 'pass' : 'fail';
-                const delegationResult = await handleDelegationCompletion(
+                const propagationResult = await handleParentCompletion(
                   freshState,
                   propResult,
                   cwd,
                   output,
                 );
-                if (delegationResult === 'stopped') shouldExitWithError = true;
+                if (propagationResult === 'stopped') shouldExitWithError = true;
               }
             }
           } finally {

--- a/packages/cli/src/commands/pass.ts
+++ b/packages/cli/src/commands/pass.ts
@@ -10,7 +10,7 @@ import {
   executeTransition,
   type ExplicitTarget,
 } from '../helpers/transitions.js';
-import { handleDelegationCompletion } from '../helpers/delegation-completion.js';
+import { handleParentCompletion, extractParentLinkage } from '../helpers/delegation-completion.js';
 import { validateIndexRequiresStep } from '../helpers/index-option.js';
 
 /**
@@ -56,20 +56,20 @@ export function registerPassCommand(program: Command): void {
             const result = await executeTransition(ctx, passConfig, explicitTarget);
             if (result === 'stopped') shouldExitWithError = true;
 
-            // Delegation propagation — fires when child run reaches terminal state
+            // Parent propagation — fires when child run reaches terminal state
             const freshState = await ctx.manager.load(ctx.state.id);
-            if (freshState?.delegation) {
+            if (freshState && extractParentLinkage(freshState)) {
               const isTerminal =
                 freshState.variables.completed === true || freshState.variables.stopped === true;
               if (isTerminal) {
                 const propResult = freshState.variables.completed ? 'pass' : 'fail';
-                const delegationResult = await handleDelegationCompletion(
+                const propagationResult = await handleParentCompletion(
                   freshState,
                   propResult,
                   cwd,
                   output,
                 );
-                if (delegationResult === 'stopped') shouldExitWithError = true;
+                if (propagationResult === 'stopped') shouldExitWithError = true;
               }
             }
           } finally {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -14,6 +14,7 @@ import {
   deriveActiveFrame,
   buildFrameKey,
   findSubstepState,
+  upsertSubstepState,
   buildContextSnapshot,
   reconstituteContextVars,
   extractInheritedUserVars,
@@ -118,6 +119,8 @@ export function registerRunCommand(program: Command): void {
             let parentLinkage: ParentLinkage | undefined;
             let parentState: RunbookState | undefined;
 
+            let linkageIteration: number | undefined;
+
             if (options.step && !options.prompted) {
               const linkageResult = await buildInlineLinkage(
                 sessionService,
@@ -128,6 +131,7 @@ export function registerRunCommand(program: Command): void {
               );
               parentLinkage = linkageResult.linkage;
               parentState = linkageResult.parentState;
+              linkageIteration = linkageResult.explicitIteration;
             }
 
             // Build inherited vars from parent state (mirrors claimAndLaunch)
@@ -140,7 +144,9 @@ export function registerRunCommand(program: Command): void {
 
             if (parentState) {
               const parsed = parseStepIdFromString(options.step!);
-              const snapshot = buildContextSnapshot(parentState, parsed?.substep);
+              const snapshot = buildContextSnapshot(parentState, parsed?.substep, undefined, {
+                iterationOverride: linkageIteration,
+              });
               inheritedOptions = {
                 inheritedContextVars: reconstituteContextVars(snapshot),
                 inheritedUserVars: extractInheritedUserVars(snapshot),
@@ -178,10 +184,11 @@ export function registerRunCommand(program: Command): void {
                   const fresh = await manager.load(link.parentRunId);
                   if (!fresh) return;
                   const substeps = fresh.substepStates ?? [];
-                  const updated = substeps.map((ss) =>
-                    ss.id === link.parentStepId && ss.frameKey === link.parentFrameKey
-                      ? { ...ss, status: 'running' as const }
-                      : ss,
+                  const updated = upsertSubstepState(
+                    substeps,
+                    link.parentStepId,
+                    link.parentFrameKey!,
+                    { status: 'running' as const },
                   );
                   await manager.update(link.parentRunId, { substepStates: updated });
                 } finally {
@@ -308,7 +315,7 @@ async function buildInlineLinkage(
   output: OutputEmitter,
   stepId: string,
   indexOption?: string,
-): Promise<{ linkage: InlineLinkage; parentState: RunbookState }> {
+): Promise<{ linkage: InlineLinkage; parentState: RunbookState; explicitIteration?: number }> {
   // 1. Load active parent
   const parentState = await sessionService.getActive();
   if (!parentState) {
@@ -399,7 +406,13 @@ async function buildInlineLinkage(
   // Also check if the parent cursor has advanced past this substep (completion was drained).
   // Drain consumes the resolved completion and advances the cursor without marking
   // substepStates[].status as 'done', so the check above doesn't catch it.
-  if (parentState.substep && resolvedStepHasSubsteps(step)) {
+  // Only applies to the active frame — parentState.substep reflects the current iteration's
+  // cursor, not the target iteration, so this check is invalid for non-active frames.
+  if (
+    frameKey === parentState.activeFrameKey &&
+    parentState.substep &&
+    resolvedStepHasSubsteps(step)
+  ) {
     const orderedIds = step.substeps.map((ss) => ss.id);
     const cursorIndex = orderedIds.indexOf(parentState.substep);
     const targetIndex = orderedIds.indexOf(substepId);
@@ -432,5 +445,5 @@ async function buildInlineLinkage(
     parentEntry: inferEntryFromState(parentState, frameKey),
   };
 
-  return { linkage, parentState };
+  return { linkage, parentState, explicitIteration };
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -7,6 +7,7 @@ import {
   SessionService,
   ExecutionLifecycleService,
   RunbookSyntaxError,
+  RundownError,
   isNodeError,
   getErrorMessage,
   deriveActiveFrame,
@@ -242,6 +243,8 @@ export function registerRunCommand(program: Command): void {
             output.message("Try 'rd ls --all' to list available runbooks.", 'dim');
           } else if (error instanceof RunbookSyntaxError) {
             output.error(`Syntax error: ${error.message}`, 'INVALID_SYNTAX');
+          } else if (error instanceof RundownError) {
+            output.error(error.message, error.errorCode.code);
           } else {
             output.error(getErrorMessage(error), 'UNKNOWN_ERROR');
           }
@@ -299,6 +302,10 @@ async function buildInlineLinkage(
       parsed.step,
       step.substeps.map((ss) => ss.id),
     );
+  }
+
+  if (!resolvedStepHasSubsteps(step) && !parsed.substep) {
+    throw Errors.delegationStepNoSubsteps(parsed.step);
   }
 
   if (parsed.substep) {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -375,7 +375,9 @@ async function buildInlineLinkage(
     process.exit(1);
   }
 
-  // Also check if the parent cursor has advanced past this substep (completion was drained)
+  // Also check if the parent cursor has advanced past this substep (completion was drained).
+  // Drain consumes the resolved completion and advances the cursor without marking
+  // substepStates[].status as 'done', so the check above doesn't catch it.
   if (parentState.substep && Number(parentState.substep) > Number(substepId)) {
     output.error(`Substep ${substepId} is already resolved`, 'DELEGATION_ALREADY_RESOLVED');
     output.flush();

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -403,6 +403,7 @@ async function buildInlineLinkage(
     const orderedIds = step.substeps.map((ss) => ss.id);
     const cursorIndex = orderedIds.indexOf(parentState.substep);
     const targetIndex = orderedIds.indexOf(substepId);
+    // If either ID is not found (-1), skip — state may be corrupt or mid-transition.
     if (cursorIndex !== -1 && targetIndex !== -1 && cursorIndex > targetIndex) {
       output.error(`Substep ${substepId} is already resolved`, 'DELEGATION_ALREADY_RESOLVED');
       output.flush();

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -143,7 +143,7 @@ export function registerRunCommand(program: Command): void {
             let afterInit: ((stateId: string) => Promise<void>) | undefined;
             if (inlineLinkage && parentState) {
               const link = inlineLinkage;
-              afterInit = async () => {
+              afterInit = async (_stateId) => {
                 // Mark parent substep as 'running' (informational for rd status)
                 const substeps = parentState.substepStates ?? [];
                 const updated = substeps.map((ss) =>

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -399,10 +399,15 @@ async function buildInlineLinkage(
   // Also check if the parent cursor has advanced past this substep (completion was drained).
   // Drain consumes the resolved completion and advances the cursor without marking
   // substepStates[].status as 'done', so the check above doesn't catch it.
-  if (parentState.substep && Number(parentState.substep) > Number(substepId)) {
-    output.error(`Substep ${substepId} is already resolved`, 'DELEGATION_ALREADY_RESOLVED');
-    output.flush();
-    process.exit(1);
+  if (parentState.substep && resolvedStepHasSubsteps(step)) {
+    const orderedIds = step.substeps.map((ss) => ss.id);
+    const cursorIndex = orderedIds.indexOf(parentState.substep);
+    const targetIndex = orderedIds.indexOf(substepId);
+    if (cursorIndex !== -1 && targetIndex !== -1 && cursorIndex > targetIndex) {
+      output.error(`Substep ${substepId} is already resolved`, 'DELEGATION_ALREADY_RESOLVED');
+      output.flush();
+      process.exit(1);
+    }
   }
 
   // 8. Check no active delegation on substep

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -147,7 +147,7 @@ export function registerRunCommand(program: Command): void {
             if (parentLinkage && parentState) {
               const link = parentLinkage;
               afterInit = async (_stateId) => {
-                // Acquire lock and re-load fresh parent state to avoid TOCTOU:
+                // Acquire lock and re-load fresh parent state to avoid stale-read race:
                 // parentState was captured at buildInlineLinkage() time and may
                 // be stale by the time afterInit runs (another child may have
                 // modified substepStates in between).

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -9,17 +9,31 @@ import {
   RunbookSyntaxError,
   isNodeError,
   getErrorMessage,
+  deriveActiveFrame,
+  buildFrameKey,
+  findSubstepState,
+  Errors,
+  type InlineLinkage,
+  type RunbookState,
 } from '@rundown-org/core';
+import { parseStepIdFromString, resolvedStepHasSubsteps } from '@rundown-org/parser';
 import { getCwd } from '../helpers/context.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { parseVarOption, parseVarJsonOption, collect } from '../helpers/option-utils.js';
 import {
   prepareRunbook,
   startRunbook,
+  inferEntryFromState,
   type RunPipelineContext,
 } from '../helpers/runbook-pipeline.js';
 import { buildGotoContext, validateGotoTarget, executeGoto } from '../helpers/goto-workflow.js';
-import { validateIndexRequiresStep } from '../helpers/index-option.js';
+import {
+  validateIndexRequiresStep,
+  resolveIndexOption,
+  IndexOptionError,
+} from '../helpers/index-option.js';
+import { handleParentCompletion } from '../helpers/delegation-completion.js';
+import { getRunbookFromState } from '../helpers/runbook-loader.js';
 
 /**
  * Registers the 'run' command for starting runbooks.
@@ -30,7 +44,7 @@ export function registerRunCommand(program: Command): void {
     .command('run [file]')
     .description('Start a runbook')
     .option('--prompted', 'Prompted mode: show commands without auto-executing')
-    .option('--step <stepId>', 'Jump to step after starting (requires --prompted)')
+    .option('--step <stepId>', 'Link child to parent substep (or jump to step with --prompted)')
     .option('--index <number>', 'FOR loop iteration to target (requires --step)')
     .option('--json', 'Output execution events as JSON')
     .addOption(
@@ -82,12 +96,7 @@ export function registerRunCommand(program: Command): void {
             cwd,
           };
 
-          // Validate --step / --index option dependencies
-          if (options.step && !options.prompted) {
-            output.error('--step requires --prompted', 'INVALID_SYNTAX');
-            output.flush();
-            process.exit(1);
-          }
+          // Validate --index requires --step
           const depError = validateIndexRequiresStep(options.index, options.step);
           if (depError) {
             output.error(depError, 'INVALID_SYNTAX');
@@ -98,6 +107,22 @@ export function registerRunCommand(program: Command): void {
           const varOpts = { varFile: options.varFile, var: options.var, varJson: options.varJson };
 
           if (file) {
+            // Build inline linkage when --step is provided without --prompted
+            let inlineLinkage: InlineLinkage | undefined;
+            let parentState: RunbookState | undefined;
+
+            if (options.step && !options.prompted) {
+              const linkageResult = await buildInlineLinkage(
+                sessionService,
+                cwd,
+                output,
+                options.step,
+                options.index,
+              );
+              inlineLinkage = linkageResult.linkage;
+              parentState = linkageResult.parentState;
+            }
+
             const prepResult = await prepareRunbook(file, varOpts, cwd);
             if (!prepResult.ok) {
               output.error(prepResult.error, prepResult.code, prepResult.details);
@@ -114,9 +139,27 @@ export function registerRunCommand(program: Command): void {
               output.warning(`Undefined variable "{{${name}}}" preserved as literal text`);
             }
 
+            // Build afterInit callback outside the startRunbook call for clean captures
+            let afterInit: ((stateId: string) => Promise<void>) | undefined;
+            if (inlineLinkage && parentState) {
+              const link = inlineLinkage;
+              afterInit = async () => {
+                // Mark parent substep as 'running' (informational for rd status)
+                const substeps = parentState.substepStates ?? [];
+                const updated = substeps.map((ss) =>
+                  ss.id === link.parentStepId && ss.frameKey === link.parentFrameKey
+                    ? { ...ss, status: 'running' as const }
+                    : ss,
+                );
+                await manager.update(link.parentRunId, { substepStates: updated });
+              };
+            }
+
             const result = await startRunbook(ctx, prepResult.prepared, {
               file,
               prompted: options.prompted,
+              inlineLinkage,
+              afterInit,
             });
 
             if (!result.ok) {
@@ -125,8 +168,32 @@ export function registerRunCommand(program: Command): void {
               process.exit(1);
             }
 
-            // If --step provided and runbook is waiting (prompted mode), jump to the step
-            if (options.step && result.loopResult === 'waiting') {
+            // Inline linkage propagation — auto-record parent substep on child completion
+            if (inlineLinkage) {
+              const childState = await manager.load(result.stateId);
+              if (childState) {
+                const isTerminal =
+                  childState.variables.completed === true || childState.variables.stopped === true;
+                if (isTerminal) {
+                  const propResult: 'pass' | 'fail' = childState.variables.completed
+                    ? 'pass'
+                    : 'fail';
+                  const propOutcome = await handleParentCompletion(
+                    childState,
+                    propResult,
+                    cwd,
+                    output,
+                  );
+                  if (propOutcome === 'stopped') {
+                    output.flush();
+                    process.exit(1);
+                  }
+                }
+              }
+            }
+
+            // If --step provided with --prompted and runbook is waiting, jump to the step
+            if (options.step && options.prompted && result.loopResult === 'waiting') {
               const gotoCtx = await buildGotoContext(output, cwd);
               if (!gotoCtx) {
                 output.error('Failed to build goto context after start', 'ENGINE_INIT_FAILED');
@@ -153,10 +220,6 @@ export function registerRunCommand(program: Command): void {
                 process.exit(1);
               }
               return;
-            } else if (options.step) {
-              output.warning(
-                `--step ${options.step} ignored: runbook did not enter prompted mode (result: ${result.loopResult})`,
-              );
             }
 
             output.flush();
@@ -187,4 +250,131 @@ export function registerRunCommand(program: Command): void {
         }
       },
     );
+}
+
+/**
+ * Build inline linkage for `rd run --step` substep targeting.
+ *
+ * Validates the active parent runbook has the target substep at the execution
+ * frontier, and constructs an {@link InlineLinkage} for the child run.
+ *
+ * @param sessionService - Session service for loading active runbook
+ * @param cwd - Current working directory
+ * @param output - Output emitter for error reporting
+ * @param stepId - Target step ID (e.g., "1.1" for step 1, substep 1)
+ * @param indexOption - Optional --index flag value
+ * @returns The constructed linkage and parent state
+ */
+async function buildInlineLinkage(
+  sessionService: SessionService,
+  cwd: string,
+  output: OutputEmitter,
+  stepId: string,
+  indexOption?: string,
+): Promise<{ linkage: InlineLinkage; parentState: RunbookState }> {
+  // 1. Load active parent
+  const parentState = await sessionService.getActive();
+  if (!parentState) {
+    output.error('--step requires an active parent runbook', 'NO_ACTIVE_RUNBOOK');
+    output.flush();
+    process.exit(1);
+  }
+
+  // 2. Parse step ID
+  const parsed = parseStepIdFromString(stepId);
+  if (!parsed) {
+    throw Errors.delegationStepNotFound(stepId);
+  }
+
+  // 3. Load parent steps and validate
+  const steps = getRunbookFromState(parentState, cwd);
+  const step = steps.find((s) => s.name === parsed.step);
+  if (!step) {
+    throw Errors.delegationStepNotFound(parsed.step);
+  }
+
+  // 4. Validate step has substeps when needed
+  if (resolvedStepHasSubsteps(step) && !parsed.substep) {
+    throw Errors.delegationSubstepRequired(
+      parsed.step,
+      step.substeps.map((ss) => ss.id),
+    );
+  }
+
+  if (parsed.substep) {
+    if (!resolvedStepHasSubsteps(step)) {
+      throw Errors.delegationSubstepNotFound(parsed.substep, parsed.step, []);
+    }
+    const validIds = step.substeps.map((ss) => ss.id);
+    if (!validIds.includes(parsed.substep)) {
+      throw Errors.delegationSubstepNotFound(parsed.substep, parsed.step, validIds);
+    }
+  }
+
+  // 5. Verify step is at frontier
+  if (parentState.step !== parsed.step) {
+    throw Errors.delegationStepNotCurrent(parsed.step, parentState.step);
+  }
+
+  const substepId = parsed.substep ?? parsed.step;
+
+  // 6. Resolve frame key (following delegate.ts pattern)
+  let explicitIteration: number | undefined;
+  try {
+    explicitIteration = resolveIndexOption(indexOption, parsed.at);
+  } catch (error) {
+    if (error instanceof IndexOptionError) {
+      output.error(error.message, error.code);
+      output.flush();
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  if (explicitIteration !== undefined) {
+    if (step.kind !== 'for' && step.kind !== 'prompted-for') {
+      output.error(
+        `--index requires step "${parsed.step}" to be a FOR step, but it is "${step.kind}"`,
+        'INVALID_INDEX',
+      );
+      output.flush();
+      process.exit(1);
+    }
+  }
+
+  const frameKey =
+    explicitIteration !== undefined
+      ? buildFrameKey(parentState.step, explicitIteration)
+      : (parentState.activeFrameKey ?? deriveActiveFrame(parentState).frameKey);
+
+  // 7. Check substep not already done
+  const existingSubstep = findSubstepState(parentState.substepStates ?? [], substepId, frameKey);
+  if (existingSubstep?.status === 'done') {
+    output.error(`Substep ${substepId} is already resolved`, 'DELEGATION_ALREADY_RESOLVED');
+    output.flush();
+    process.exit(1);
+  }
+
+  // 8. Check no active delegation on substep
+  const existingDelegation = existingSubstep?.delegation;
+  if (existingDelegation?.cancelledAt === null && existingDelegation.childRunId === null) {
+    output.error(
+      `Substep ${substepId} already has an active delegation`,
+      'DELEGATION_ALREADY_EXISTS',
+    );
+    output.flush();
+    process.exit(1);
+  }
+
+  // 9. Build linkage
+  const linkage: InlineLinkage = {
+    kind: 'inline',
+    parentRunId: parentState.id,
+    parentStepId: substepId,
+    parentStep: parentState.step,
+    parentFrameKey: frameKey,
+    parentEntry: inferEntryFromState(parentState, frameKey),
+  };
+
+  return { linkage, parentState };
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -6,6 +6,7 @@ import {
   RunbookActorService,
   SessionService,
   ExecutionLifecycleService,
+  DelegationLock,
   RunbookSyntaxError,
   RundownError,
   isNodeError,
@@ -15,6 +16,7 @@ import {
   findSubstepState,
   Errors,
   type InlineLinkage,
+  type ParentLinkage,
   type RunbookState,
 } from '@rundown-org/core';
 import { parseStepIdFromString, resolvedStepHasSubsteps } from '@rundown-org/parser';
@@ -109,7 +111,7 @@ export function registerRunCommand(program: Command): void {
 
           if (file) {
             // Build inline linkage when --step is provided without --prompted
-            let inlineLinkage: InlineLinkage | undefined;
+            let parentLinkage: ParentLinkage | undefined;
             let parentState: RunbookState | undefined;
 
             if (options.step && !options.prompted) {
@@ -120,7 +122,7 @@ export function registerRunCommand(program: Command): void {
                 options.step,
                 options.index,
               );
-              inlineLinkage = linkageResult.linkage;
+              parentLinkage = linkageResult.linkage;
               parentState = linkageResult.parentState;
             }
 
@@ -142,24 +144,35 @@ export function registerRunCommand(program: Command): void {
 
             // Build afterInit callback outside the startRunbook call for clean captures
             let afterInit: ((stateId: string) => Promise<void>) | undefined;
-            if (inlineLinkage && parentState) {
-              const link = inlineLinkage;
+            if (parentLinkage && parentState) {
+              const link = parentLinkage;
               afterInit = async (_stateId) => {
-                // Mark parent substep as 'running' (informational for rd status)
-                const substeps = parentState.substepStates ?? [];
-                const updated = substeps.map((ss) =>
-                  ss.id === link.parentStepId && ss.frameKey === link.parentFrameKey
-                    ? { ...ss, status: 'running' as const }
-                    : ss,
-                );
-                await manager.update(link.parentRunId, { substepStates: updated });
+                // Acquire lock and re-load fresh parent state to avoid TOCTOU:
+                // parentState was captured at buildInlineLinkage() time and may
+                // be stale by the time afterInit runs (another child may have
+                // modified substepStates in between).
+                const lock = new DelegationLock(cwd);
+                await lock.acquire(link.parentRunId);
+                try {
+                  const fresh = await manager.load(link.parentRunId);
+                  if (!fresh) return;
+                  const substeps = fresh.substepStates ?? [];
+                  const updated = substeps.map((ss) =>
+                    ss.id === link.parentStepId && ss.frameKey === link.parentFrameKey
+                      ? { ...ss, status: 'running' as const }
+                      : ss,
+                  );
+                  await manager.update(link.parentRunId, { substepStates: updated });
+                } finally {
+                  await lock.release(link.parentRunId);
+                }
               };
             }
 
             const result = await startRunbook(ctx, prepResult.prepared, {
               file,
               prompted: options.prompted,
-              inlineLinkage,
+              parentLinkage,
               afterInit,
             });
 
@@ -170,7 +183,7 @@ export function registerRunCommand(program: Command): void {
             }
 
             // Inline linkage propagation — auto-record parent substep on child completion
-            if (inlineLinkage) {
+            if (parentLinkage) {
               const childState = await manager.load(result.stateId);
               if (childState) {
                 const isTerminal =

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -14,10 +14,14 @@ import {
   deriveActiveFrame,
   buildFrameKey,
   findSubstepState,
+  buildContextSnapshot,
+  reconstituteContextVars,
+  extractInheritedUserVars,
   Errors,
   type InlineLinkage,
   type ParentLinkage,
   type RunbookState,
+  type TemplateVarValue,
 } from '@rundown-org/core';
 import { parseStepIdFromString, resolvedStepHasSubsteps } from '@rundown-org/parser';
 import { getCwd } from '../helpers/context.js';
@@ -126,7 +130,24 @@ export function registerRunCommand(program: Command): void {
               parentState = linkageResult.parentState;
             }
 
-            const prepResult = await prepareRunbook(file, varOpts, cwd);
+            // Build inherited vars from parent state (mirrors claimAndLaunch)
+            let inheritedOptions:
+              | {
+                  inheritedContextVars?: Readonly<Record<string, TemplateVarValue>>;
+                  inheritedUserVars?: Readonly<Record<string, TemplateVarValue>>;
+                }
+              | undefined;
+
+            if (parentState) {
+              const parsed = parseStepIdFromString(options.step!);
+              const snapshot = buildContextSnapshot(parentState, parsed?.substep);
+              inheritedOptions = {
+                inheritedContextVars: reconstituteContextVars(snapshot),
+                inheritedUserVars: extractInheritedUserVars(snapshot),
+              };
+            }
+
+            const prepResult = await prepareRunbook(file, varOpts, cwd, inheritedOptions);
             if (!prepResult.ok) {
               output.error(prepResult.error, prepResult.code, prepResult.details);
               output.flush();
@@ -171,7 +192,7 @@ export function registerRunCommand(program: Command): void {
 
             const result = await startRunbook(ctx, prepResult.prepared, {
               file,
-              prompted: options.prompted,
+              prompted: options.prompted ?? false,
               parentLinkage,
               afterInit,
             });

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -347,9 +347,16 @@ async function buildInlineLinkage(
       ? buildFrameKey(parentState.step, explicitIteration)
       : (parentState.activeFrameKey ?? deriveActiveFrame(parentState).frameKey);
 
-  // 7. Check substep not already done
+  // 7. Check substep not already resolved
   const existingSubstep = findSubstepState(parentState.substepStates ?? [], substepId, frameKey);
   if (existingSubstep?.status === 'done') {
+    output.error(`Substep ${substepId} is already resolved`, 'DELEGATION_ALREADY_RESOLVED');
+    output.flush();
+    process.exit(1);
+  }
+
+  // Also check if the parent cursor has advanced past this substep (completion was drained)
+  if (parentState.substep && Number(parentState.substep) > Number(substepId)) {
     output.error(`Substep ${substepId} is already resolved`, 'DELEGATION_ALREADY_RESOLVED');
     output.flush();
     process.exit(1);

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -6,7 +6,7 @@ import { getCwd } from '../helpers/context.js';
 import { buildMetadata } from '../services/execution.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
-import { handleDelegationCompletion } from '../helpers/delegation-completion.js';
+import { handleParentCompletion, extractParentLinkage } from '../helpers/delegation-completion.js';
 
 /**
  * Registers the 'stop' command for aborting runbooks.
@@ -73,11 +73,11 @@ export function registerStopCommand(program: Command): void {
           output.metadata(buildMetadata(state));
           output.stopped(message ?? 'Runbook stopped');
 
-          // Propagate FAIL to parent if delegation exists.
+          // Propagate FAIL to parent if parent linkage exists.
           // The return value is intentionally ignored: a user-initiated stop
           // always succeeds (exit 0) even if the parent propagation itself stops.
-          if (updatedState.delegation) {
-            await handleDelegationCompletion(updatedState, 'fail', cwd, output);
+          if (extractParentLinkage(updatedState)) {
+            await handleParentCompletion(updatedState, 'fail', cwd, output);
           }
 
           output.flush();

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -1,13 +1,12 @@
 /**
- * Delegation completion propagation.
+ * Parent completion propagation.
  *
- * When a child run created via `rd delegate` / `rd claim` reaches a terminal
- * state (complete or stopped), its result must propagate back to the parent
- * substep. This module implements the propagation protocol described in
- * §6.3 of the delegation design.
+ * When a child run reaches a terminal state (complete or stopped), its result
+ * must propagate back to the parent substep. This applies to both delegation
+ * children (`rd delegate` / `rd claim`) and inline children (`rd run --step`).
  *
- * Uses {@link DelegationLinkage} to track and propagate completion results
- * through the delegation chain.
+ * Uses {@link ParentLinkageBase} to track and propagate completion results
+ * through the parent chain.
  *
  * @module helpers/delegation-completion
  */
@@ -23,6 +22,7 @@ import {
   deriveActiveFrame,
   findSubstepState,
   type RunbookState,
+  type ParentLinkageBase,
 } from '@rundown-org/core';
 import { getRunbookFromState } from './runbook-loader.js';
 import { drainResolvedCompletions, runExecutionLoop } from '../services/execution.js';
@@ -35,34 +35,51 @@ import type { TransitionOrchestrationPolicy } from './transition-orchestrator.js
 const MAX_PROPAGATION_DEPTH = 32;
 
 /**
- * Propagate a child run's terminal result to its parent delegation substep.
+ * Extract parent linkage from a child state.
  *
- * Follows the completion propagation protocol:
- * 1. Read delegation linkage from the child state
+ * Checks both inline linkage (`rd run --step`) and delegation linkage
+ * (`rd delegate`/`rd claim`), preferring inline when both are present.
+ *
+ * @param state - The child run's state
+ * @returns The parent linkage base fields, or undefined if no linkage exists
+ */
+export function extractParentLinkage(state: RunbookState): ParentLinkageBase | undefined {
+  if (state.inlineLinkage) return state.inlineLinkage;
+  if (state.delegation) return state.delegation;
+  return undefined;
+}
+
+/**
+ * Propagate a child run's terminal result to its parent substep.
+ *
+ * Works for both delegation children (`rd delegate`/`rd claim`) and inline
+ * children (`rd run --step`). Follows the completion propagation protocol:
+ * 1. Read parent linkage from the child state
  * 2. Acquire delegation lock on the parent
  * 3. Record a resolved completion on the parent substep
  * 4. Drain resolved completions on the parent
- * 5. If the parent itself reaches terminal state and has delegation linkage, recurse
+ * 5. If the parent itself reaches terminal state and has parent linkage, recurse
  *
- * @param childState - The child run's state (must have `delegation` linkage)
+ * @param childState - The child run's state (must have delegation or inline linkage)
  * @param result - Terminal result of the child ('pass' or 'fail')
  * @param cwd - Current working directory
  * @param output - Output emitter for CLI output
  * @param depth - Current recursion depth (default 0)
  * @returns 'handled' if propagation succeeded, 'stopped' if parent stopped,
- *          'not-applicable' if no delegation linkage exists
+ *          'not-applicable' if no parent linkage exists
  * @throws {Error} If delegation lock acquisition fails, parent state I/O errors,
  *         drain execution fails, or recursive propagation throws
  */
-export async function handleDelegationCompletion(
+export async function handleParentCompletion(
   childState: RunbookState,
   result: 'pass' | 'fail',
   cwd: string,
   output: OutputEmitter,
   depth = 0,
 ): Promise<'handled' | 'stopped' | 'not-applicable'> {
-  // Guard: no delegation linkage
-  if (!childState.delegation) {
+  // Guard: no parent linkage
+  const linkage = extractParentLinkage(childState);
+  if (!linkage) {
     return 'not-applicable';
   }
 
@@ -75,8 +92,7 @@ export async function handleDelegationCompletion(
     return 'handled';
   }
 
-  const { parentRunId, parentStepId, parentStep, parentFrameKey, parentEntry } =
-    childState.delegation;
+  const { parentRunId, parentStepId, parentStep, parentFrameKey, parentEntry } = linkage;
 
   const manager = new RunbookStateManager(cwd);
   const lock = new DelegationLock(cwd);
@@ -113,8 +129,9 @@ export async function handleDelegationCompletion(
     const lifecycleService = new ExecutionLifecycleService(manager);
     const existing = await lifecycleService.getResolvedCompletion(parentRunId, completionKey);
     if (!existing) {
+      const agentId = childState.inlineLinkage ? 'inline' : 'delegation';
       const completion = buildResolvedCompletion({
-        agentId: 'delegation',
+        agentId,
         result,
         targetStep: parentStep ?? parentState.step,
         targetSubstep: parentStepId,
@@ -132,7 +149,7 @@ export async function handleDelegationCompletion(
   const transitionConfig =
     result === 'pass' ? createPassTransitionConfig() : createFailTransitionConfig();
 
-  // Delegation-specific: never pop during drain.
+  // Parent completion: never pop during drain.
   // Session is managed explicitly below and by runExecutionLoop.
   const delegationPolicy: TransitionOrchestrationPolicy = {
     onComplete: { popRunbook: false },
@@ -167,12 +184,12 @@ export async function handleDelegationCompletion(
     ...(parentFrameKey ? { frameKeyOverride: parentFrameKey } : {}),
   });
 
-  // 8. Check if parent reached terminal state — cascade if it also has delegation linkage
+  // 8. Check if parent reached terminal state — cascade if it also has parent linkage
   if (drained.status === 'stopped') {
     await sessionService.popRunbook();
     const freshParent = await manager.load(parentRunId);
-    if (freshParent?.delegation) {
-      await handleDelegationCompletion(freshParent, 'fail', cwd, output, depth + 1);
+    if (freshParent && extractParentLinkage(freshParent)) {
+      await handleParentCompletion(freshParent, 'fail', cwd, output, depth + 1);
     }
     output.flush();
     return 'stopped';
@@ -181,8 +198,8 @@ export async function handleDelegationCompletion(
   if (drained.status === 'done') {
     await sessionService.popRunbook();
     const freshParent = await manager.load(parentRunId);
-    if (freshParent?.delegation) {
-      return handleDelegationCompletion(freshParent, 'pass', cwd, output, depth + 1);
+    if (freshParent && extractParentLinkage(freshParent)) {
+      return handleParentCompletion(freshParent, 'pass', cwd, output, depth + 1);
     }
     output.flush();
     return 'handled';
@@ -202,15 +219,15 @@ export async function handleDelegationCompletion(
 
     if (loopResult === 'stopped') {
       const freshParent = await manager.load(parentRunId);
-      if (freshParent?.delegation) {
-        await handleDelegationCompletion(freshParent, 'fail', cwd, output, depth + 1);
+      if (freshParent && extractParentLinkage(freshParent)) {
+        await handleParentCompletion(freshParent, 'fail', cwd, output, depth + 1);
       }
       return 'stopped';
     }
     if (loopResult === 'done') {
       const freshParent = await manager.load(parentRunId);
-      if (freshParent?.delegation) {
-        return handleDelegationCompletion(freshParent, 'pass', cwd, output, depth + 1);
+      if (freshParent && extractParentLinkage(freshParent)) {
+        return handleParentCompletion(freshParent, 'pass', cwd, output, depth + 1);
       }
     }
     return 'handled';
@@ -220,3 +237,6 @@ export async function handleDelegationCompletion(
   output.flush();
   return 'handled';
 }
+
+/** @deprecated Use {@link handleParentCompletion} instead. */
+export const handleDelegationCompletion = handleParentCompletion;

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -21,6 +21,7 @@ import {
   buildResolvedCompletion,
   deriveActiveFrame,
   findSubstepState,
+  upsertSubstepState,
   type RunbookState,
   type ParentLinkageBase,
 } from '@rundown-org/core';
@@ -137,6 +138,21 @@ export async function handleParentCompletion(
         targetEntry: entry,
       });
       await lifecycleService.upsertResolvedCompletion(parentRunId, completionKey, completion);
+    }
+
+    // 5b. Mark the SubstepState as done (frame-scoped).
+    // Drain consumes the resolved completion but does not update substepStates,
+    // so without this the status === 'done' guard in buildInlineLinkage would
+    // miss already-resolved non-active frame substeps and allow re-execution.
+    const freshParentForSubstep = await manager.load(parentRunId);
+    if (freshParentForSubstep) {
+      const updatedSubsteps = upsertSubstepState(
+        freshParentForSubstep.substepStates ?? [],
+        parentStepId,
+        frameKey,
+        { status: 'done' as const, result },
+      );
+      await manager.update(parentRunId, { substepStates: updatedSubsteps });
     }
   } finally {
     // 6. Release lock

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -44,9 +44,7 @@ const MAX_PROPAGATION_DEPTH = 32;
  * @returns The parent linkage base fields, or undefined if no linkage exists
  */
 export function extractParentLinkage(state: RunbookState): ParentLinkageBase | undefined {
-  if (state.inlineLinkage) return state.inlineLinkage;
-  if (state.delegation) return state.delegation;
-  return undefined;
+  return state.parentLinkage;
 }
 
 /**
@@ -112,8 +110,8 @@ export async function handleParentCompletion(
     // 3. Check if delegation was cancelled (frame-scoped lookup)
     const frameKey = parentFrameKey ?? deriveActiveFrame(parentState).frameKey;
     const substepState = findSubstepState(parentState.substepStates ?? [], parentStepId, frameKey);
-    if (substepState?.delegation?.cancelledAt) {
-      // Abort wins — skip propagation
+    if (childState.parentLinkage?.kind === 'delegation' && substepState?.delegation?.cancelledAt) {
+      // Abort wins — skip propagation (only for delegation children)
       return 'handled';
     }
 
@@ -129,7 +127,7 @@ export async function handleParentCompletion(
     const lifecycleService = new ExecutionLifecycleService(manager);
     const existing = await lifecycleService.getResolvedCompletion(parentRunId, completionKey);
     if (!existing) {
-      const agentId = childState.inlineLinkage ? 'inline' : 'delegation';
+      const agentId = childState.parentLinkage?.kind === 'inline' ? 'inline' : 'delegation';
       const completion = buildResolvedCompletion({
         agentId,
         result,

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -237,6 +237,3 @@ export async function handleParentCompletion(
   output.flush();
   return 'handled';
 }
-
-/** @deprecated Use {@link handleParentCompletion} instead. */
-export const handleDelegationCompletion = handleParentCompletion;

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -85,9 +85,9 @@ export async function handleParentCompletion(
 
   // Guard: recursion limit — likely a cycle or bug
   if (depth >= MAX_PROPAGATION_DEPTH) {
-    console.warn(
-      `Warning: Delegation propagation depth limit reached (${String(MAX_PROPAGATION_DEPTH)}). ` +
-        `Possible cycle in delegation chain starting from run ${childState.id}.`,
+    output.warning(
+      `Propagation depth limit reached (${String(MAX_PROPAGATION_DEPTH)}). ` +
+        `Possible cycle in parent chain starting from run ${childState.id}.`,
     );
     return 'handled';
   }

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -22,6 +22,7 @@ import {
   type ResolvedRunbook,
   type DelegationLinkage,
   type InlineLinkage,
+  type ParentLinkage,
   STATE_DIR,
   DelegationScanService,
   DelegationLock,
@@ -542,8 +543,7 @@ export async function prepareRunbook(
  * @param options - Launch options including optional parent context
  * @param options.runbookName - Name identifier for the runbook being launched
  * @param options.prompted - Whether to run in prompted mode (no auto-execution)
- * @param options.delegationLinkage - Optional parent delegation linkage for child runs
- * @param options.inlineLinkage - Optional inline parent linkage for `rd run --step` child runs
+ * @param options.parentLinkage - Optional parent linkage for child runs (delegation or inline)
  * @param options.afterInit - Optional callback invoked after state initialization with the new state ID
  * @returns RunbookStartResult
  */
@@ -553,8 +553,7 @@ async function launchRunbook(
   options: {
     runbookName: string;
     prompted: boolean;
-    delegationLinkage?: DelegationLinkage;
-    inlineLinkage?: InlineLinkage;
+    parentLinkage?: ParentLinkage;
     afterInit?: (stateId: string) => Promise<void>;
   },
 ): Promise<RunbookStartResult> {
@@ -565,8 +564,7 @@ async function launchRunbook(
   const state = await manager.create(options.runbookName, runbook, {
     runbookPath,
     prompted: options.prompted,
-    delegation: options.delegationLinkage,
-    inlineLinkage: options.inlineLinkage,
+    parentLinkage: options.parentLinkage,
     runbookSrc: rawContent,
     templateVars: mergedVariables,
   });
@@ -621,7 +619,7 @@ async function launchRunbook(
  * @param options - Start options
  * @param options.file - Runbook file path or name
  * @param options.prompted - Whether to run in prompted mode
- * @param options.inlineLinkage - Optional inline parent linkage for `rd run --step` child runs
+ * @param options.parentLinkage - Optional parent linkage for child runs (delegation or inline)
  * @param options.afterInit - Optional callback invoked after state initialization with the new state ID
  * @returns RunbookStartResult
  * @throws {Error} On state persistence or machine initialization failures
@@ -632,14 +630,14 @@ export async function startRunbook(
   options: {
     file: string;
     prompted?: boolean;
-    inlineLinkage?: InlineLinkage;
+    parentLinkage?: ParentLinkage;
     afterInit?: (stateId: string) => Promise<void>;
   },
 ): Promise<RunbookStartResult> {
   return launchRunbook(ctx, prepared, {
     runbookName: options.file,
     prompted: !!options.prompted,
-    inlineLinkage: options.inlineLinkage,
+    parentLinkage: options.parentLinkage,
     afterInit: options.afterInit,
   });
 }
@@ -883,6 +881,7 @@ export async function claimAndLaunch(
     // The parent may have advanced past the iteration where the delegation was created.
     const delegationFrameKey = freshSubstep.frameKey;
     const delegationLinkage: DelegationLinkage = {
+      kind: 'delegation' as const,
       parentRunId: freshParent.id,
       parentStepId: substepId ?? stepId,
       tokenHash,
@@ -899,7 +898,7 @@ export async function claimAndLaunch(
     const launchResult = await launchRunbook(ctx, prepResult.prepared, {
       runbookName: freshDelegation.childRunbookPath,
       prompted: parentPrompted,
-      delegationLinkage,
+      parentLinkage: delegationLinkage,
       afterInit: async (childStateId) => {
         // Set childRunId on parent delegation (tokenHash for precise matching)
         await updateStepDelegationChildRunId(

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -21,6 +21,7 @@ import {
   type ExecutionEventEmitter,
   type ResolvedRunbook,
   type DelegationLinkage,
+  type InlineLinkage,
   STATE_DIR,
   DelegationScanService,
   DelegationLock,
@@ -106,7 +107,7 @@ export interface PreparedRunbook {
 
 /** Result of starting a runbook execution loop via {@link startRunbook}. */
 export type RunbookStartResult =
-  | { ok: true; loopResult: 'done' | 'stopped' | 'waiting' }
+  | { ok: true; loopResult: 'done' | 'stopped' | 'waiting'; stateId: string }
   | { ok: false; error: string; code: string; details?: Record<string, unknown> };
 
 /**
@@ -542,6 +543,7 @@ export async function prepareRunbook(
  * @param options.runbookName - Name identifier for the runbook being launched
  * @param options.prompted - Whether to run in prompted mode (no auto-execution)
  * @param options.delegationLinkage - Optional parent delegation linkage for child runs
+ * @param options.inlineLinkage - Optional inline parent linkage for `rd run --step` child runs
  * @param options.afterInit - Optional callback invoked after state initialization with the new state ID
  * @returns RunbookStartResult
  */
@@ -552,6 +554,7 @@ async function launchRunbook(
     runbookName: string;
     prompted: boolean;
     delegationLinkage?: DelegationLinkage;
+    inlineLinkage?: InlineLinkage;
     afterInit?: (stateId: string) => Promise<void>;
   },
 ): Promise<RunbookStartResult> {
@@ -563,6 +566,7 @@ async function launchRunbook(
     runbookPath,
     prompted: options.prompted,
     delegation: options.delegationLinkage,
+    inlineLinkage: options.inlineLinkage,
     runbookSrc: rawContent,
     templateVars: mergedVariables,
   });
@@ -606,7 +610,7 @@ async function launchRunbook(
     emitter,
   );
 
-  return { ok: true, loopResult };
+  return { ok: true, loopResult, stateId: state.id };
 }
 
 /**
@@ -617,17 +621,26 @@ async function launchRunbook(
  * @param options - Start options
  * @param options.file - Runbook file path or name
  * @param options.prompted - Whether to run in prompted mode
+ * @param options.inlineLinkage - Optional inline parent linkage for `rd run --step` child runs
+ * @param options.afterInit - Optional callback invoked after state initialization with the new state ID
  * @returns RunbookStartResult
  * @throws {Error} On state persistence or machine initialization failures
  */
 export async function startRunbook(
   ctx: RunPipelineContext,
   prepared: PreparedRunbook,
-  options: { file: string; prompted?: boolean },
+  options: {
+    file: string;
+    prompted?: boolean;
+    inlineLinkage?: InlineLinkage;
+    afterInit?: (stateId: string) => Promise<void>;
+  },
 ): Promise<RunbookStartResult> {
   return launchRunbook(ctx, prepared, {
     runbookName: options.file,
     prompted: !!options.prompted,
+    inlineLinkage: options.inlineLinkage,
+    afterInit: options.afterInit,
   });
 }
 
@@ -638,7 +651,7 @@ export async function startRunbook(
  * @param frameKey - Frame key to look up (`step|iteration` format)
  * @returns The inferred entry number, or undefined if no history exists
  */
-function inferEntryFromState(state: RunbookState, frameKey: FrameKey): number | undefined {
+export function inferEntryFromState(state: RunbookState, frameKey: FrameKey): number | undefined {
   const known = state.frameEntries?.[frameKey];
   if (state.activeFrameKey === frameKey && state.activeEntry) return state.activeEntry;
   if (known && known > 0) return known;

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -26,6 +26,7 @@ import {
   DelegationScanService,
   DelegationLock,
   reconstituteContextVars,
+  extractInheritedUserVars,
   hashDelegationToken,
   truncateDelegationToken,
   DELEGATION_TOKEN_PREFIX,
@@ -843,14 +844,7 @@ export async function claimAndLaunch(
 
     // 4e. Reconstitute context vars from frozen snapshot
     const inheritedContextVars = reconstituteContextVars(freshDelegation.contextSnapshot);
-
-    // Extract parent user-level vars for top-level inheritance in child
-    const inheritedUserVars: Record<string, TemplateVarValue> = {};
-    for (const [key, value] of Object.entries(freshDelegation.contextSnapshot.vars)) {
-      if (!key.startsWith('context.') && key !== 'RunId') {
-        inheritedUserVars[key] = value;
-      }
-    }
+    const inheritedUserVars = extractInheritedUserVars(freshDelegation.contextSnapshot);
 
     // 4f. Prepare child runbook
     const prepResult = await prepareRunbook(freshDelegation.childRunbookPath, varOpts, cwd, {

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -21,7 +21,6 @@ import {
   type ExecutionEventEmitter,
   type ResolvedRunbook,
   type DelegationLinkage,
-  type InlineLinkage,
   type ParentLinkage,
   STATE_DIR,
   DelegationScanService,

--- a/packages/core/__tests__/runbook/delegation-propagation.test.ts
+++ b/packages/core/__tests__/runbook/delegation-propagation.test.ts
@@ -8,7 +8,7 @@ import {
 import type { DelegationLinkage, RunbookState } from '../../src/runbook/types.js';
 
 describe('DelegationLinkage extended fields', () => {
-  function makeSchemaState(delegation: Record<string, unknown>): Record<string, unknown> {
+  function makeSchemaState(parentLinkage: Record<string, unknown>): Record<string, unknown> {
     return {
       id: 'run-child',
       runbook: 'child.md',
@@ -21,12 +21,13 @@ describe('DelegationLinkage extended fields', () => {
       steps: [],
       startedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-      delegation,
+      parentLinkage,
     };
   }
 
-  it('schema accepts linkage with extended fields', () => {
+  it('schema accepts delegation linkage with extended fields', () => {
     const state = makeSchemaState({
+      kind: 'delegation',
       parentRunId: 'run-parent',
       parentStepId: '1',
       tokenHash: `sha256:${'a'.repeat(64)}`,
@@ -39,8 +40,9 @@ describe('DelegationLinkage extended fields', () => {
     expect(result.success).toBe(true);
   });
 
-  it('schema accepts linkage without extended fields (backward compat)', () => {
+  it('schema accepts delegation linkage without extended fields', () => {
     const state = makeSchemaState({
+      kind: 'delegation',
       parentRunId: 'run-parent',
       parentStepId: '1',
       tokenHash: `sha256:${'b'.repeat(64)}`,
@@ -52,6 +54,7 @@ describe('DelegationLinkage extended fields', () => {
 
   it('schema rejects non-positive parentEntry', () => {
     const state = makeSchemaState({
+      kind: 'delegation',
       parentRunId: 'run-parent',
       parentStepId: '1',
       tokenHash: `sha256:${'c'.repeat(64)}`,
@@ -64,19 +67,133 @@ describe('DelegationLinkage extended fields', () => {
 });
 
 describe('DelegationLinkage type shape', () => {
-  it('returns true when delegation field is present', () => {
+  it('returns true when parentLinkage field is present', () => {
     const linkage: DelegationLinkage = {
+      kind: 'delegation',
       parentRunId: 'run-parent',
       parentStepId: '1',
       tokenHash: `sha256:${'a'.repeat(64)}`,
     };
     expect(linkage).toBeDefined();
     expect(linkage.parentRunId).toBe('run-parent');
+    expect(linkage.kind).toBe('delegation');
   });
 
-  it('undefined delegation means no linkage', () => {
-    const state = { delegation: undefined };
-    expect(state.delegation).toBeUndefined();
+  it('undefined parentLinkage means no linkage', () => {
+    const state = { parentLinkage: undefined };
+    expect(state.parentLinkage).toBeUndefined();
+  });
+});
+
+describe('parentLinkage discriminated union schema', () => {
+  function makeBaseState(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      id: 'run-child',
+      runbook: 'child.md',
+      runbookPath: '/tmp/child.md',
+      runbookSrc: '## 1. Do\n- PASS COMPLETE\n\nDo it.',
+      step: '1',
+      stepName: 'Do',
+      retryCount: 0,
+      variables: {},
+      steps: [],
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      ...overrides,
+    };
+  }
+
+  it('accepts parentLinkage with kind: delegation', () => {
+    const state = makeBaseState({
+      parentLinkage: {
+        kind: 'delegation',
+        parentRunId: 'run-parent',
+        parentStepId: '1',
+        tokenHash: `sha256:${'a'.repeat(64)}`,
+        parentStep: '1',
+        parentFrameKey: '1|',
+        parentEntry: 1,
+      },
+    });
+
+    const result = RunbookStateSchema.safeParse(state);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const parsed = result.data as Record<string, unknown>;
+      expect(parsed).toHaveProperty('parentLinkage');
+      expect((parsed.parentLinkage as Record<string, unknown>).kind).toBe('delegation');
+    }
+  });
+
+  it('accepts parentLinkage with kind: inline', () => {
+    const state = makeBaseState({
+      parentLinkage: {
+        kind: 'inline',
+        parentRunId: 'run-parent',
+        parentStepId: '2',
+        parentStep: '1',
+        parentFrameKey: '1|',
+        parentEntry: 1,
+      },
+    });
+
+    const result = RunbookStateSchema.safeParse(state);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const parsed = result.data as Record<string, unknown>;
+      expect(parsed).toHaveProperty('parentLinkage');
+      expect((parsed.parentLinkage as Record<string, unknown>).kind).toBe('inline');
+    }
+  });
+
+  it('rejects parentLinkage with unknown kind', () => {
+    const state = makeBaseState({
+      parentLinkage: {
+        kind: 'bogus',
+        parentRunId: 'run-parent',
+        parentStepId: '1',
+      },
+    });
+
+    const result = RunbookStateSchema.safeParse(state);
+    expect(result.success).toBe(false);
+  });
+
+  it('does not recognize old delegation field as parentLinkage', () => {
+    // Old 'delegation' field is passthrough'd but NOT treated as parentLinkage.
+    // State with only the old field should have no parentLinkage in the typed result.
+    const state = makeBaseState({
+      delegation: {
+        parentRunId: 'run-parent',
+        parentStepId: '1',
+        tokenHash: `sha256:${'a'.repeat(64)}`,
+      },
+    });
+
+    const result = RunbookStateSchema.safeParse(state);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // The typed output should NOT have parentLinkage (it was never set)
+      expect(result.data.parentLinkage).toBeUndefined();
+    }
+  });
+
+  it('does not recognize old inlineLinkage field as parentLinkage', () => {
+    // Old 'inlineLinkage' field is passthrough'd but NOT treated as parentLinkage.
+    const state = makeBaseState({
+      inlineLinkage: {
+        kind: 'inline',
+        parentRunId: 'run-parent',
+        parentStepId: '1',
+      },
+    });
+
+    const result = RunbookStateSchema.safeParse(state);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // The typed output should NOT have parentLinkage (it was never set)
+      expect(result.data.parentLinkage).toBeUndefined();
+    }
   });
 });
 
@@ -135,6 +252,7 @@ describe('frame identity derivation for propagation', () => {
 
   it('uses stored parentFrameKey when available', () => {
     const linkage: DelegationLinkage = {
+      kind: 'delegation',
       parentRunId: 'run-parent',
       parentStepId: '1',
       tokenHash: `sha256:${'a'.repeat(64)}`,
@@ -153,6 +271,7 @@ describe('frame identity derivation for propagation', () => {
 
   it('falls back to deriveActiveFrame when parentFrameKey absent', () => {
     const linkage: DelegationLinkage = {
+      kind: 'delegation',
       parentRunId: 'run-parent',
       parentStepId: '2',
       tokenHash: `sha256:${'a'.repeat(64)}`,

--- a/packages/core/__tests__/runbook/delegation-scan.test.ts
+++ b/packages/core/__tests__/runbook/delegation-scan.test.ts
@@ -155,13 +155,14 @@ describe('DelegationScanService', () => {
       const tokenHash = hashDelegationToken(token);
 
       const linkage: DelegationLinkage = {
+        kind: 'delegation' as const,
         parentRunId: 'parent-run',
         parentStepId: '1',
         tokenHash,
       };
 
       const childState = makeState('child-run', {
-        delegation: linkage,
+        parentLinkage: linkage,
       });
       await writeState(childState);
 
@@ -187,19 +188,21 @@ describe('DelegationScanService', () => {
       const tokenHash = hashDelegationToken(token);
 
       const linkage1: DelegationLinkage = {
+        kind: 'delegation' as const,
         parentRunId: 'parent-run',
         parentStepId: '1',
         tokenHash,
       };
 
       const linkage2: DelegationLinkage = {
+        kind: 'delegation' as const,
         parentRunId: 'parent-run',
         parentStepId: '2',
         tokenHash,
       };
 
-      const child1 = makeState('child-1', { delegation: linkage1 });
-      const child2 = makeState('child-2', { delegation: linkage2 });
+      const child1 = makeState('child-1', { parentLinkage: linkage1 });
+      const child2 = makeState('child-2', { parentLinkage: linkage2 });
 
       await writeState(child1);
       await writeState(child2);

--- a/packages/core/__tests__/runbook/targeting.test.ts
+++ b/packages/core/__tests__/runbook/targeting.test.ts
@@ -9,10 +9,12 @@ import {
   deriveActiveFrame,
   deriveExecutionAt,
   derivePositionAt,
+  findSubstepState,
   getActiveForContext,
   parseCompletionKey,
+  upsertSubstepState,
 } from '../../src/runbook/targeting.js';
-import type { ForContext, RunbookState } from '../../src/runbook/types.js';
+import type { ForContext, RunbookState, SubstepState } from '../../src/runbook/types.js';
 
 describe('targeting helpers', () => {
   describe('deriveExecutionAt', () => {
@@ -381,6 +383,66 @@ describe('targeting helpers', () => {
         },
       });
       expect(position.for?.end).toBeUndefined();
+    });
+  });
+
+  describe('upsertSubstepState', () => {
+    const fk1 = buildFrameKey('1');
+    const fk1_2 = buildFrameKey('1', 2);
+    const fk1_3 = buildFrameKey('1', 3);
+
+    const pending = (id: string, frameKey: ReturnType<typeof buildFrameKey>): SubstepState => ({
+      id,
+      frameKey,
+      status: 'pending' as const,
+    });
+
+    it('appends new entry when no match exists', () => {
+      const result = upsertSubstepState([], '1', fk1, { status: 'running' });
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ id: '1', frameKey: fk1, status: 'running' });
+    });
+
+    it('appends new entry for non-initialized frame (FOR loop)', () => {
+      const existing = [pending('1', fk1_2)];
+      const result = upsertSubstepState(existing, '1', fk1_3, { status: 'running' });
+      expect(result).toHaveLength(2);
+      expect(findSubstepState(result, '1', fk1_2)?.status).toBe('pending');
+      expect(findSubstepState(result, '1', fk1_3)?.status).toBe('running');
+    });
+
+    it('updates existing entry when match is found', () => {
+      const existing = [pending('1', fk1), pending('2', fk1)];
+      const result = upsertSubstepState(existing, '1', fk1, { status: 'running' });
+      expect(result).toHaveLength(2);
+      expect(findSubstepState(result, '1', fk1)?.status).toBe('running');
+      expect(findSubstepState(result, '2', fk1)?.status).toBe('pending');
+    });
+
+    it('does not match same id with different frameKey', () => {
+      const existing = [pending('1', fk1_2)];
+      const result = upsertSubstepState(existing, '1', fk1_3, { status: 'running' });
+      expect(result).toHaveLength(2);
+      expect(findSubstepState(result, '1', fk1_2)?.status).toBe('pending');
+      expect(findSubstepState(result, '1', fk1_3)?.status).toBe('running');
+    });
+
+    it('preserves other fields when updating', () => {
+      const existing: readonly SubstepState[] = [
+        { id: '1', frameKey: fk1, status: 'pending', delegation: undefined },
+      ];
+      const result = upsertSubstepState(existing, '1', fk1, { status: 'running' });
+      expect(result[0]).toEqual({
+        id: '1',
+        frameKey: fk1,
+        status: 'running',
+        delegation: undefined,
+      });
+    });
+
+    it('defaults to pending status for new entries', () => {
+      const result = upsertSubstepState([], '1', fk1, { result: 'pass' });
+      expect(result[0]).toEqual({ id: '1', frameKey: fk1, status: 'pending', result: 'pass' });
     });
   });
 });

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -178,11 +178,11 @@ export const ErrorCodes = {
     docSlug: 'scenario-not-found',
   },
 
-  // Delegation Errors (8xx)
+  // Substep Targeting Errors (8xx) — shared by delegation and inline linkage
   DELEGATION_STEP_NOT_FOUND: {
     code: 'RD-801',
     category: ErrorCategory.DELEGATION,
-    title: 'Delegation step not found',
+    title: 'Step not found',
     description: 'The specified step does not exist in the active runbook.',
     docSlug: 'delegation-step-not-found',
   },
@@ -190,7 +190,7 @@ export const ErrorCodes = {
     code: 'RD-802',
     category: ErrorCategory.DELEGATION,
     title: 'Step not at execution frontier',
-    description: 'Delegation can only be created for the current step.',
+    description: 'The target step must be the current step.',
     docSlug: 'delegation-step-not-current',
   },
   DELEGATION_SUBSTEP_REQUIRED: {
@@ -204,7 +204,7 @@ export const ErrorCodes = {
     code: 'RD-804',
     category: ErrorCategory.DELEGATION,
     title: 'Active delegation exists',
-    description: 'This step already has an active (non-cancelled) delegation.',
+    description: 'This substep already has an active (non-cancelled) delegation.',
     docSlug: 'delegation-already-exists',
   },
   DELEGATION_RUNBOOK_NOT_FOUND: {

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -279,6 +279,14 @@ export const ErrorCodes = {
       'The specified substep does not have a runbook reference (e.g., "- child.runbook.md").',
     docSlug: 'delegation-substep-no-runbook',
   },
+  DELEGATION_STEP_NO_SUBSTEPS: {
+    code: 'RD-815',
+    category: ErrorCategory.DELEGATION,
+    title: 'Step has no substeps',
+    description:
+      'Inline linkage requires targeting a substep. The specified step has no substeps to target.',
+    docSlug: 'delegation-step-no-substeps',
+  },
 
   // Generic
   UNKNOWN_ERROR: {

--- a/packages/core/src/errors/factory.ts
+++ b/packages/core/src/errors/factory.ts
@@ -110,6 +110,9 @@ export const Errors = {
   delegationSubstepNoRunbook: (substep: string, step: string): RundownError =>
     new RundownError('DELEGATION_SUBSTEP_NO_RUNBOOK', { substep, step }),
 
+  delegationStepNoSubsteps: (step: string): RundownError =>
+    new RundownError('DELEGATION_STEP_NO_SUBSTEPS', { step }),
+
   // Generic
   unknown: (message: string, cause?: Error): RundownError =>
     new RundownError('UNKNOWN_ERROR', { message }, cause),

--- a/packages/core/src/runbook/delegation-context.ts
+++ b/packages/core/src/runbook/delegation-context.ts
@@ -1,4 +1,5 @@
-import type { ContextSnapshot, TemplateVarValue } from './types.js';
+import type { AncestorSnapshot, ContextSnapshot, RunbookState, TemplateVarValue } from './types.js';
+import { getActiveForContext, deriveExecutionAt } from './targeting.js';
 
 /** Maximum depth for parent context chain addressing. */
 export const MAX_ANCESTOR_DEPTH = 32;
@@ -109,5 +110,65 @@ export function reconstituteContextVars(
     chainPrefix += '.parent';
   }
 
+  return result;
+}
+
+/**
+ * Build a context snapshot from live runbook state.
+ *
+ * Captures the current execution position and template variables,
+ * suitable for passing to {@link reconstituteContextVars}.
+ *
+ * @param state - Current runbook state
+ * @param substep - Target substep identifier (e.g., "1")
+ * @param ancestors - Ancestor chain (defaults to empty)
+ * @param options - Optional overrides for extra variables and explicit iteration
+ * @param options.extraVars - Additional variables to merge into the snapshot
+ * @param options.iterationOverride - Explicit iteration number (overrides derived value)
+ * @returns Frozen context snapshot
+ */
+export function buildContextSnapshot(
+  state: RunbookState,
+  substep?: string,
+  ancestors?: readonly AncestorSnapshot[],
+  options?: {
+    extraVars?: Readonly<Record<string, TemplateVarValue>>;
+    iterationOverride?: number;
+  },
+): ContextSnapshot {
+  const baseVars = { ...(state.templateVars ?? {}) };
+  const vars = options?.extraVars ? { ...baseVars, ...options.extraVars } : baseVars;
+  const activeFor = getActiveForContext(state.forStack, state.step);
+  const iteration = options?.iterationOverride ?? activeFor?.iteration;
+  const at = deriveExecutionAt(state.step, substep, iteration);
+
+  return {
+    vars,
+    ancestors: ancestors ?? [],
+    step: state.step,
+    substep,
+    at,
+    ...(iteration !== undefined ? { index: iteration } : {}),
+  };
+}
+
+/**
+ * Extract parent user-level variables from a context snapshot.
+ *
+ * Filters out `context.*` namespace keys and `RunId` (which is per-execution),
+ * returning only user-defined variables suitable for child inheritance.
+ *
+ * @param snapshot - The context snapshot to extract user variables from
+ * @returns User-defined variables (excludes context.* and RunId)
+ */
+export function extractInheritedUserVars(
+  snapshot: ContextSnapshot,
+): Record<string, TemplateVarValue> {
+  const result: Record<string, TemplateVarValue> = {};
+  for (const [key, value] of Object.entries(snapshot.vars)) {
+    if (!key.startsWith('context.') && key !== 'RunId') {
+      result[key] = value;
+    }
+  }
   return result;
 }

--- a/packages/core/src/runbook/delegation-scan.ts
+++ b/packages/core/src/runbook/delegation-scan.ts
@@ -83,7 +83,10 @@ export class DelegationScanService {
     const states = await this.manager.list();
 
     for (const state of states) {
-      if (state.delegation?.tokenHash === tokenHash) {
+      if (
+        state.parentLinkage?.kind === 'delegation' &&
+        state.parentLinkage.tokenHash === tokenHash
+      ) {
         return state; // Early exit on first match — at most one orphan per token
       }
     }

--- a/packages/core/src/runbook/delegation-service.ts
+++ b/packages/core/src/runbook/delegation-service.ts
@@ -1,15 +1,10 @@
 import { parseStepIdFromString, resolvedStepHasSubsteps } from '@rundown-org/parser';
 import { Errors } from '../errors/factory.js';
+import { buildContextSnapshot } from './delegation-context.js';
 import { generateDelegationToken, hashDelegationToken } from './delegation-token.js';
-import {
-  deriveExecutionAt,
-  findSubstepState,
-  getActiveForContext,
-  type FrameKey,
-} from './targeting.js';
+import { findSubstepState, type FrameKey } from './targeting.js';
 import type {
   AncestorSnapshot,
-  ContextSnapshot,
   RunbookState,
   ResolvedStep,
   StepDelegation,
@@ -169,22 +164,11 @@ export function createDelegation(
   const tokenHash = hashDelegationToken(token);
 
   // 8. Build context snapshot
-  const baseVars = { ...(state.templateVars ?? {}) };
-  const mergedVars = extraVars ? { ...baseVars, ...extraVars } : baseVars;
-
-  // Capture structural fields from the delegation target, not the cursor
-  const activeFor = getActiveForContext(state.forStack, state.step);
-  const iteration = (typeof parsed.at === 'number' ? parsed.at : undefined) ?? activeFor?.iteration;
-  const at = deriveExecutionAt(state.step, parsed.substep, iteration);
-
-  const contextSnapshot: ContextSnapshot = {
-    vars: mergedVars,
-    ancestors: ancestors ?? [],
-    step: state.step,
-    substep: parsed.substep,
-    at,
-    ...(iteration !== undefined ? { index: iteration } : {}),
-  };
+  const explicitIteration = typeof parsed.at === 'number' ? parsed.at : undefined;
+  const contextSnapshot = buildContextSnapshot(state, parsed.substep, ancestors, {
+    extraVars,
+    iterationOverride: explicitIteration,
+  });
 
   // 9. Create delegation object
   const delegation: StepDelegation = {

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -59,4 +59,9 @@ export {
 } from './delegation-token.js';
 export { DelegationLock } from './delegation-lock.js';
 export { DelegationScanService, type TokenScanResult } from './delegation-scan.js';
-export { reconstituteContextVars, MAX_ANCESTOR_DEPTH } from './delegation-context.js';
+export {
+  reconstituteContextVars,
+  buildContextSnapshot,
+  extractInheritedUserVars,
+  MAX_ANCESTOR_DEPTH,
+} from './delegation-context.js';

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -10,6 +10,7 @@ import type {
   Runbook,
   ResolvedRunbook,
   DelegationLinkage,
+  InlineLinkage,
   TemplateVarValue,
 } from './types.js';
 import { RunbookStateSchema } from '../schemas.js';
@@ -43,6 +44,8 @@ interface CreateOptions {
   readonly prompted?: boolean;
   /** Delegation linkage when this run is created via `rd claim`. */
   readonly delegation?: DelegationLinkage;
+  /** Inline linkage when this run is created via `rd run --step`. */
+  readonly inlineLinkage?: InlineLinkage;
   readonly runbookSrc?: string;
   /** Optional record of template variable replacements to populate placeholders at run time. */
   readonly templateVars?: Record<string, TemplateVarValue>;
@@ -111,6 +114,7 @@ export class RunbookStateManager {
       resolvedCompletions: {},
       frameEntries: {},
       delegation: options.delegation,
+      inlineLinkage: options.inlineLinkage,
       startedAt: now,
       updatedAt: now,
       prompted: options.prompted,

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -9,8 +9,7 @@ import type {
   SubstepState,
   Runbook,
   ResolvedRunbook,
-  DelegationLinkage,
-  InlineLinkage,
+  ParentLinkage,
   TemplateVarValue,
 } from './types.js';
 import { RunbookStateSchema } from '../schemas.js';
@@ -42,10 +41,8 @@ export interface SessionData {
 interface CreateOptions {
   readonly runbookPath: string;
   readonly prompted?: boolean;
-  /** Delegation linkage when this run is created via `rd claim`. */
-  readonly delegation?: DelegationLinkage;
-  /** Inline linkage when this run is created via `rd run --step`. */
-  readonly inlineLinkage?: InlineLinkage;
+  /** Parent linkage when this run is a child (delegation or inline). */
+  readonly parentLinkage?: ParentLinkage;
   readonly runbookSrc?: string;
   /** Optional record of template variable replacements to populate placeholders at run time. */
   readonly templateVars?: Record<string, TemplateVarValue>;
@@ -113,8 +110,7 @@ export class RunbookStateManager {
       steps: [],
       resolvedCompletions: {},
       frameEntries: {},
-      delegation: options.delegation,
-      inlineLinkage: options.inlineLinkage,
+      parentLinkage: options.parentLinkage,
       startedAt: now,
       updatedAt: now,
       prompted: options.prompted,

--- a/packages/core/src/runbook/targeting.ts
+++ b/packages/core/src/runbook/targeting.ts
@@ -242,3 +242,28 @@ export function findSubstepState(
 ): SubstepState | undefined {
   return substepStates.find((ss) => ss.id === substepId && ss.frameKey === frameKey);
 }
+
+/**
+ * Update an existing SubstepState by `(id, frameKey)` or append a new entry.
+ *
+ * If a matching entry exists, applies `patch` to it. If no match is found,
+ * appends a new entry with `id`, `frameKey`, `status: 'pending'`, and the patch.
+ *
+ * @param substepStates - Existing substep states array
+ * @param substepId - Substep ID to match or create
+ * @param frameKey - Frame key to match or create
+ * @param patch - Fields to apply on the matched or new entry
+ * @returns New array with the updated or appended entry
+ */
+export function upsertSubstepState(
+  substepStates: readonly SubstepState[],
+  substepId: string,
+  frameKey: FrameKey,
+  patch: Partial<Pick<SubstepState, 'status' | 'result' | 'delegation'>>,
+): readonly SubstepState[] {
+  const existing = findSubstepState(substepStates, substepId, frameKey);
+  if (existing) {
+    return substepStates.map((ss) => (ss === existing ? { ...ss, ...patch } : ss));
+  }
+  return [...substepStates, { id: substepId, frameKey, status: 'pending' as const, ...patch }];
+}

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -412,17 +412,37 @@ export interface AncestorSnapshot {
   readonly index?: number;
 }
 
-/** Linkage data a child run carries to identify its parent delegation. */
-export interface DelegationLinkage {
+/**
+ * Fields shared by all parent-linkage variants (delegation and inline).
+ *
+ * Both {@link DelegationLinkage} and {@link InlineLinkage} carry the same
+ * parent identification fields needed by {@link handleParentCompletion} to
+ * propagate a child's terminal result back to the parent substep.
+ */
+export interface ParentLinkageBase {
   readonly parentRunId: string;
   readonly parentStepId: string;
-  readonly tokenHash: string;
-  /** Parent's step name at claim time (e.g., "1"). */
+  /** Parent's step name at link time (e.g., "1"). */
   readonly parentStep?: string;
-  /** Parent's frame key at claim time for completion key construction. */
+  /** Parent's frame key at link time for completion key construction. */
   readonly parentFrameKey?: FrameKey;
-  /** Parent's entry counter at claim time for completion key construction. */
+  /** Parent's entry counter at link time for completion key construction. */
   readonly parentEntry?: number;
+}
+
+/** Linkage data a child run carries to identify its parent delegation. */
+export interface DelegationLinkage extends ParentLinkageBase {
+  readonly tokenHash: string;
+}
+
+/**
+ * Linkage data for a child run created via `rd run --step` (inline execution).
+ *
+ * Unlike {@link DelegationLinkage}, no token is involved — the child executes
+ * inline in the same agent process and the result auto-propagates on completion.
+ */
+export interface InlineLinkage extends ParentLinkageBase {
+  readonly kind: 'inline';
 }
 
 /**
@@ -615,6 +635,9 @@ export interface RunbookState {
 
   /** Delegation linkage data when this run was created via `rd claim`. */
   readonly delegation?: DelegationLinkage;
+
+  /** Inline parent linkage when this run was created via `rd run --step`. */
+  readonly inlineLinkage?: InlineLinkage;
 
   readonly nested?: {
     readonly runbook: string;

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -432,6 +432,7 @@ export interface ParentLinkageBase {
 
 /** Linkage data a child run carries to identify its parent delegation. */
 export interface DelegationLinkage extends ParentLinkageBase {
+  readonly kind: 'delegation';
   readonly tokenHash: string;
 }
 
@@ -444,6 +445,15 @@ export interface DelegationLinkage extends ParentLinkageBase {
 export interface InlineLinkage extends ParentLinkageBase {
   readonly kind: 'inline';
 }
+
+/**
+ * Discriminated union of all parent linkage variants.
+ *
+ * A child run carries exactly one of these to identify how it was linked
+ * to its parent: either via delegation token (`rd delegate`/`rd claim`)
+ * or inline execution (`rd run --step`).
+ */
+export type ParentLinkage = DelegationLinkage | InlineLinkage;
 
 /**
  * Step state within a runbook
@@ -633,11 +643,8 @@ export interface RunbookState {
   // Substep tracking
   readonly substepStates?: readonly SubstepState[];
 
-  /** Delegation linkage data when this run was created via `rd claim`. */
-  readonly delegation?: DelegationLinkage;
-
-  /** Inline parent linkage when this run was created via `rd run --step`. */
-  readonly inlineLinkage?: InlineLinkage;
+  /** Parent linkage identifying how this child was linked to its parent. */
+  readonly parentLinkage?: ParentLinkage;
 
   readonly nested?: {
     readonly runbook: string;

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -308,25 +308,26 @@ export const RunbookStateSchema = z
     activeFrameKey: FrameKeySchema.optional(),
     activeEntry: z.number().int().positive().max(MAX_FOR_BOUND).optional(),
     substepStates: z.array(SubstepStateSchema).optional(),
-    delegation: z
-      .object({
-        parentRunId: z.string(),
-        parentStepId: z.string(),
-        tokenHash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
-        parentStep: z.string().optional(),
-        parentFrameKey: FrameKeySchema.optional(),
-        parentEntry: z.number().int().positive().optional(),
-      })
-      .optional(),
-    inlineLinkage: z
-      .object({
-        kind: z.literal('inline'),
-        parentRunId: z.string(),
-        parentStepId: z.string(),
-        parentStep: z.string().optional(),
-        parentFrameKey: FrameKeySchema.optional(),
-        parentEntry: z.number().int().positive().optional(),
-      })
+    parentLinkage: z
+      .discriminatedUnion('kind', [
+        z.object({
+          kind: z.literal('delegation'),
+          parentRunId: z.string(),
+          parentStepId: z.string(),
+          tokenHash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+          parentStep: z.string().optional(),
+          parentFrameKey: FrameKeySchema.optional(),
+          parentEntry: z.number().int().positive().optional(),
+        }),
+        z.object({
+          kind: z.literal('inline'),
+          parentRunId: z.string(),
+          parentStepId: z.string(),
+          parentStep: z.string().optional(),
+          parentFrameKey: FrameKeySchema.optional(),
+          parentEntry: z.number().int().positive().optional(),
+        }),
+      ])
       .optional(),
     nested: z
       .object({

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -318,6 +318,16 @@ export const RunbookStateSchema = z
         parentEntry: z.number().int().positive().optional(),
       })
       .optional(),
+    inlineLinkage: z
+      .object({
+        kind: z.literal('inline'),
+        parentRunId: z.string(),
+        parentStepId: z.string(),
+        parentStep: z.string().optional(),
+        parentFrameKey: FrameKeySchema.optional(),
+        parentEntry: z.number().int().positive().optional(),
+      })
+      .optional(),
     nested: z
       .object({
         runbook: z.string(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Link child runs directly to parent substeps via run --step (inline linkage with lifecycle propagation).

* **Improvements**
  * Parent-completion propagation now covers inline-linked children across CLI flows.
  * run: clarified --step/--index semantics, inline linkage sets parent state to running and propagates terminal outcomes.
  * Added new error for targeting steps without substeps (RD-815).

* **Documentation**
  * CLI docs updated for --step / --index semantics.

* **Tests**
  * Added and updated integration/unit tests for inline linkage and propagation.

* **Bug Fixes**
  * Standardized missing-target error text to "Step not found".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->