### PR TITLE
feat(cli): add Branch built-in variable and branch-isolated WorkPath

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,8 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `Year` | `2026` | Current year |
 | `Month` | `02` | Current month (01-12) |
 | `Day` | `04` | Current day (01-31) |
-| `WorkPath` | `.work` | Default artifact directory |
+| `Branch` | `feature/my-work` | Current git branch name (empty when not in git) |
+| `WorkPath` | `.work/feature-my-work` | Branch-isolated artifact directory (falls back to `.work` outside git) |
 | `RunId` | `4a7f0c3e` | Unique-per-execution identifier |
 | `ContextId` | `a3b8c1d2` | Shared identity across delegation tree |
 | `Step` | `3.1` | Current qualified step identifier |
@@ -120,7 +121,7 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `context.current.index` | `3` | Current loop iteration (inside FOR) |
 | `context.current.at` | `3.1[3]` | Full execution position |
 
-Built-in variables use PascalCase. Lowercase aliases `step` and `index` are also available. The date/time variables (`Date`, `DateTime`, `Year`, `Month`, `Day`), `WorkPath`, `RunId`, and `ContextId` are static run-time variables set once per execution and can be overridden via `--var`. `RunId` is a fresh 8-character hexadecimal identifier generated per execution; each child in a delegation tree gets its own RunId. `ContextId` is a fresh 8-character hexadecimal identifier generated per execution; children in a delegation tree inherit the parent's ContextId via `--var`, providing a shared identity across the tree. It can be overridden via `--var` to use a meaningful name (e.g., `--var ContextId=sprint-42`). The `Step` variable (and `Index` during FOR loops), `context.current.*` variables, and their lowercase aliases are dynamic per-step variables that reflect the current execution position and cannot be overridden via `--var`. The variable name `context` is reserved and cannot be used as a user variable name.
+Built-in variables use PascalCase. Lowercase aliases `step` and `index` are also available. The date/time variables (`Date`, `DateTime`, `Year`, `Month`, `Day`), `Branch`, `WorkPath`, `RunId`, and `ContextId` are static run-time variables set once per execution and can be overridden via `--var`. `RunId` is a fresh 8-character hexadecimal identifier generated per execution; each child in a delegation tree gets its own RunId. `ContextId` is a fresh 8-character hexadecimal identifier generated per execution; children in a delegation tree inherit the parent's ContextId via `--var`, providing a shared identity across the tree. It can be overridden via `--var` to use a meaningful name (e.g., `--var ContextId=sprint-42`). The `Step` variable (and `Index` during FOR loops), `context.current.*` variables, and their lowercase aliases are dynamic per-step variables that reflect the current execution position and cannot be overridden via `--var`. The variable name `context` is reserved and cannot be used as a user variable name.
 
 **CLI Example:**
 ```bash

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -56,6 +56,7 @@ gopls
 Eventless
 exfiltration
 fdisk
+featurebranch
 frontmatter
 gitdir
 handlebars
@@ -83,6 +84,7 @@ monorepo
 msg
 mutants
 mutator
+mybranch
 myorg
 myrepo
 myrunbook
@@ -143,6 +145,7 @@ stryker
 Subcategorize
 subcommand
 subcommands
+subdirs
 subshell
 subshells
 substep

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -62,6 +62,10 @@ describe('parseVarFlag', () => {
 });
 
 describe('getBuiltinVariables', () => {
+  afterEach(() => {
+    setExecFileSyncImpl(nodeExecFileSync);
+  });
+
   it('should return all expected built-in variables', () => {
     const builtins = getBuiltinVariables();
 
@@ -122,13 +126,9 @@ describe('getBuiltinVariables', () => {
   it('should include sanitized branch in WorkPath when in git repo', () => {
     setExecFileSyncImpl((() => 'feature/my-branch\n') as typeof nodeExecFileSync);
 
-    try {
-      const builtins = getBuiltinVariables();
-      expect(builtins.WorkPath).toBe('.work/feature-my-branch');
-      expect(builtins.Branch).toBe('feature/my-branch');
-    } finally {
-      setExecFileSyncImpl(nodeExecFileSync);
-    }
+    const builtins = getBuiltinVariables();
+    expect(builtins.WorkPath).toBe('.work/feature-my-branch');
+    expect(builtins.Branch).toBe('feature/my-branch');
   });
 
   it('should fall back to .work when not in git', () => {
@@ -136,25 +136,17 @@ describe('getBuiltinVariables', () => {
       throw new Error('not a git repo');
     }) as typeof nodeExecFileSync);
 
-    try {
-      const builtins = getBuiltinVariables();
-      expect(builtins.WorkPath).toBe('.work');
-      expect(builtins.Branch).toBe('');
-    } finally {
-      setExecFileSyncImpl(nodeExecFileSync);
-    }
+    const builtins = getBuiltinVariables();
+    expect(builtins.WorkPath).toBe('.work');
+    expect(builtins.Branch).toBe('');
   });
 
   it('should fall back to .work on detached HEAD', () => {
     setExecFileSyncImpl((() => 'HEAD\n') as typeof nodeExecFileSync);
 
-    try {
-      const builtins = getBuiltinVariables();
-      expect(builtins.WorkPath).toBe('.work');
-      expect(builtins.Branch).toBe('');
-    } finally {
-      setExecFileSyncImpl(nodeExecFileSync);
-    }
+    const builtins = getBuiltinVariables();
+    expect(builtins.WorkPath).toBe('.work');
+    expect(builtins.Branch).toBe('');
   });
 
   it('should return RunId as alphanumeric string', () => {
@@ -1224,9 +1216,14 @@ describe('sanitizeBranchName', () => {
     expect(sanitizeBranchName('fix/bug/nested')).toBe('fix-bug-nested');
   });
 
-  it('should strip invalid characters', () => {
-    expect(sanitizeBranchName('feature@branch!')).toBe('featurebranch');
-    expect(sanitizeBranchName('my..branch')).toBe('mybranch');
+  it('should strip invalid characters and append hash when lossy', () => {
+    const result = sanitizeBranchName('feature@branch!');
+    expect(result).toMatch(/^featurebranch-[a-f0-9]{8}$/);
+  });
+
+  it('should preserve dots in branch names', () => {
+    expect(sanitizeBranchName('my..branch')).toBe('my..branch');
+    expect(sanitizeBranchName('release/1.2.3')).toBe('release-1.2.3');
   });
 
   it('should collapse consecutive hyphens', () => {
@@ -1238,5 +1235,26 @@ describe('sanitizeBranchName', () => {
     expect(sanitizeBranchName('-leading')).toBe('leading');
     expect(sanitizeBranchName('trailing-')).toBe('trailing');
     expect(sanitizeBranchName('/scoped/')).toBe('scoped');
+  });
+
+  it('should produce distinct results for branches that previously collided', () => {
+    const a = sanitizeBranchName('release/1.2');
+    const b = sanitizeBranchName('release/12');
+    expect(a).not.toBe(b);
+    expect(a).toBe('release-1.2');
+    expect(b).toBe('release-12');
+  });
+
+  it('should return hash-only for non-ASCII-only branches', () => {
+    const a = sanitizeBranchName('功能');
+    const b = sanitizeBranchName('特性');
+    expect(a).toMatch(/^[a-f0-9]{8}$/);
+    expect(b).toMatch(/^[a-f0-9]{8}$/);
+    expect(a).not.toBe(b);
+  });
+
+  it('should produce deterministic output', () => {
+    expect(sanitizeBranchName('feature@branch')).toBe(sanitizeBranchName('feature@branch'));
+    expect(sanitizeBranchName('功能')).toBe(sanitizeBranchName('功能'));
   });
 });

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -9,7 +9,10 @@ import {
   resolveVariables,
   routeExtraVars,
   collectCliFlags,
+  sanitizeBranchName,
+  setExecFileSyncImpl,
 } from '../../src/services/variable-discovery.js';
+import { execFileSync as nodeExecFileSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -67,6 +70,7 @@ describe('getBuiltinVariables', () => {
     expect(builtins).toHaveProperty('Year');
     expect(builtins).toHaveProperty('Month');
     expect(builtins).toHaveProperty('Day');
+    expect(builtins).toHaveProperty('Branch');
     expect(builtins).toHaveProperty('WorkPath');
     expect(builtins).toHaveProperty('RunId');
     expect(builtins).toHaveProperty('ContextId');
@@ -103,10 +107,54 @@ describe('getBuiltinVariables', () => {
     expect(builtins.Day).toMatch(/^(0[1-9]|[12]\d|3[01])$/);
   });
 
-  it('should return WorkPath as .work', () => {
+  it('should return WorkPath starting with .work', () => {
     const builtins = getBuiltinVariables();
 
-    expect(builtins.WorkPath).toBe('.work');
+    expect(builtins.WorkPath).toMatch(/^\.work/);
+  });
+
+  it('should return Branch property', () => {
+    const builtins = getBuiltinVariables();
+
+    expect(builtins).toHaveProperty('Branch');
+  });
+
+  it('should include sanitized branch in WorkPath when in git repo', () => {
+    setExecFileSyncImpl((() => 'feature/my-branch\n') as typeof nodeExecFileSync);
+
+    try {
+      const builtins = getBuiltinVariables();
+      expect(builtins.WorkPath).toBe('.work/feature-my-branch');
+      expect(builtins.Branch).toBe('feature/my-branch');
+    } finally {
+      setExecFileSyncImpl(nodeExecFileSync);
+    }
+  });
+
+  it('should fall back to .work when not in git', () => {
+    setExecFileSyncImpl((() => {
+      throw new Error('not a git repo');
+    }) as typeof nodeExecFileSync);
+
+    try {
+      const builtins = getBuiltinVariables();
+      expect(builtins.WorkPath).toBe('.work');
+      expect(builtins.Branch).toBe('');
+    } finally {
+      setExecFileSyncImpl(nodeExecFileSync);
+    }
+  });
+
+  it('should fall back to .work on detached HEAD', () => {
+    setExecFileSyncImpl((() => 'HEAD\n') as typeof nodeExecFileSync);
+
+    try {
+      const builtins = getBuiltinVariables();
+      expect(builtins.WorkPath).toBe('.work');
+      expect(builtins.Branch).toBe('');
+    } finally {
+      setExecFileSyncImpl(nodeExecFileSync);
+    }
   });
 
   it('should return RunId as alphanumeric string', () => {
@@ -1158,5 +1206,37 @@ describe('collectCliFlags', () => {
   it('returns empty object when no flags provided', async () => {
     const result = await collectCliFlags({}, tmpDir);
     expect(result).toEqual({});
+  });
+});
+
+describe('sanitizeBranchName', () => {
+  it('should return empty string for empty input', () => {
+    expect(sanitizeBranchName('')).toBe('');
+  });
+
+  it('should pass through simple names unchanged', () => {
+    expect(sanitizeBranchName('main')).toBe('main');
+    expect(sanitizeBranchName('develop')).toBe('develop');
+  });
+
+  it('should replace slashes with hyphens', () => {
+    expect(sanitizeBranchName('feature/add-login')).toBe('feature-add-login');
+    expect(sanitizeBranchName('fix/bug/nested')).toBe('fix-bug-nested');
+  });
+
+  it('should strip invalid characters', () => {
+    expect(sanitizeBranchName('feature@branch!')).toBe('featurebranch');
+    expect(sanitizeBranchName('my..branch')).toBe('mybranch');
+  });
+
+  it('should collapse consecutive hyphens', () => {
+    expect(sanitizeBranchName('a//b')).toBe('a-b');
+    expect(sanitizeBranchName('a---b')).toBe('a-b');
+  });
+
+  it('should trim leading and trailing hyphens', () => {
+    expect(sanitizeBranchName('-leading')).toBe('leading');
+    expect(sanitizeBranchName('trailing-')).toBe('trailing');
+    expect(sanitizeBranchName('/scoped/')).toBe('scoped');
   });
 });

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -13,6 +13,7 @@
 import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { execFileSync as nodeExecFileSync } from 'node:child_process';
 import * as yaml from 'js-yaml';
 import {
   isJsonValue,
@@ -23,6 +24,57 @@ import {
   type PolicyPrompter,
   type TemplateVarValue,
 } from '@rundown-org/core';
+
+// Allow injection for testing
+let execFileSyncImpl: typeof nodeExecFileSync = nodeExecFileSync;
+
+/**
+ * Replace the execFileSync implementation (for testing).
+ *
+ * @param fn - Replacement function matching the execFileSync signature
+ */
+export function setExecFileSyncImpl(fn: typeof nodeExecFileSync): void {
+  execFileSyncImpl = fn;
+}
+
+/**
+ * Sanitize a git branch name for use in filesystem paths.
+ *
+ * Replaces `/` with `-`, strips characters not in `[a-zA-Z0-9_-]`,
+ * collapses consecutive hyphens, and trims leading/trailing hyphens.
+ *
+ * @param branch - Raw git branch name
+ * @returns Sanitized branch name safe for filesystem paths
+ */
+export function sanitizeBranchName(branch: string): string {
+  return branch
+    .replace(/\//g, '-')
+    .replace(/[^a-zA-Z0-9_-]/g, '')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Detect the current git branch name.
+ *
+ * Runs `git rev-parse --abbrev-ref HEAD` and returns the branch name,
+ * or `null` if not in a git repo, on a detached HEAD, or git is unavailable.
+ *
+ * @returns Branch name or null
+ */
+function detectGitBranch(): string | null {
+  try {
+    const result = execFileSyncImpl('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const branch = result.trim();
+    if (!branch || branch === 'HEAD') return null;
+    return branch;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Valid identifier pattern for variable names.
@@ -175,13 +227,16 @@ function normalizeToStringVariables(
  */
 export function getBuiltinVariables(): Record<string, string> {
   const now = new Date();
+  const branch = detectGitBranch();
+  const sanitized = branch ? sanitizeBranchName(branch) : null;
   return {
     Date: now.toISOString().slice(0, 10), // YYYY-MM-DD (UTC)
     DateTime: now.toISOString(), // Full ISO timestamp (UTC)
     Year: String(now.getUTCFullYear()), // YYYY (UTC)
     Month: String(now.getUTCMonth() + 1).padStart(2, '0'), // MM (01-12, UTC)
     Day: String(now.getUTCDate()).padStart(2, '0'), // DD (01-31, UTC)
-    WorkPath: '.work', // Default artifact directory
+    Branch: branch ?? '', // Raw git branch name (empty when not in git)
+    WorkPath: sanitized ? `.work/${sanitized}` : '.work', // Branch-isolated artifact directory
     RunId: randomBytes(4).toString('hex'), // 8-char hex
     ContextId: randomBytes(4).toString('hex'), // 8-char hex
   };
@@ -564,7 +619,7 @@ function collectEnvBridgeVars(warnings?: string[]): Record<string, unknown> {
  * earlier ones for the same key during processing in `resolveVariables`.
  *
  * ```
- * Layer 0: builtins        ← Date, WorkPath, RunId, ContextId (fresh)
+ * Layer 0: builtins        ← Date, Branch, WorkPath, RunId, ContextId (fresh)
  * Layer 1: inheritedVars   ← parent delegation vars (overrides builtins)
  * Layer 2: frontmatter     ← runbook YAML frontmatter vars:
  * Layer 3: discovered      ← .rundown/config.yaml (auto-discovered)
@@ -669,7 +724,7 @@ async function enforceFileSourcePolicy(
  * Resolve variables into the unified template variable map.
  *
  * Processes variable layers in precedence order (lowest to highest):
- * 1. Built-in defaults (Date, DateTime, Year, Month, Day, WorkPath, RunId, ContextId)
+ * 1. Built-in defaults (Date, DateTime, Year, Month, Day, Branch, WorkPath, RunId, ContextId)
  * 1b. Inherited vars from parent delegation (overrides builtins)
  * 2. Frontmatter vars
  * 3. Auto-discovered .rundown/config.yaml

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -10,7 +10,7 @@
  * @module
  */
 
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { execFileSync as nodeExecFileSync } from 'node:child_process';
@@ -40,18 +40,31 @@ export function setExecFileSyncImpl(fn: typeof nodeExecFileSync): void {
 /**
  * Sanitize a git branch name for use in filesystem paths.
  *
- * Replaces `/` with `-`, strips characters not in `[a-zA-Z0-9_-]`,
+ * Replaces `/` with `-`, strips characters not in `[a-zA-Z0-9._-]`,
  * collapses consecutive hyphens, and trims leading/trailing hyphens.
+ *
+ * When sanitization is lossy (characters were stripped), an 8-character SHA-256
+ * hash of the original branch name is appended to prevent collisions (e.g.
+ * `release/1.2` vs `release/12` producing distinct paths). If all characters
+ * are stripped (e.g. non-ASCII-only names), the hash alone is returned.
  *
  * @param branch - Raw git branch name
  * @returns Sanitized branch name safe for filesystem paths
  */
 export function sanitizeBranchName(branch: string): string {
-  return branch
-    .replace(/\//g, '-')
-    .replace(/[^a-zA-Z0-9_-]/g, '')
-    .replace(/-{2,}/g, '-')
-    .replace(/^-+|-+$/g, '');
+  const slashNormalized = branch.replace(/\//g, '-');
+  const charStripped = slashNormalized.replace(/[^a-zA-Z0-9._-]/g, '');
+  const isLossy = charStripped !== slashNormalized;
+  const sanitized = charStripped.replace(/-{2,}/g, '-').replace(/^-+|-+$/g, '');
+
+  if (!sanitized) {
+    return isLossy ? createHash('sha256').update(branch).digest('hex').slice(0, 8) : '';
+  }
+  if (isLossy) {
+    const hash = createHash('sha256').update(branch).digest('hex').slice(0, 8);
+    return `${sanitized}-${hash}`;
+  }
+  return sanitized;
 }
 
 /**


### PR DESCRIPTION
Add git branch detection to template variable discovery:
- `Branch` variable: current git branch name (empty outside git/detached HEAD)
- `WorkPath` now resolves to `.work/<sanitized-branch>` for branch isolation
- `sanitizeBranchName()` converts branch names to filesystem-safe paths
- Graceful fallback to `.work` when git unavailable or detached HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added `Branch` built-in template variable that provides the current git branch name in templates.

* **Improved Behavior**
  - `WorkPath` directory structure now branches per git repository state (`.work/<branch>`) instead of a single `.work`, with automatic fallback to `.work` when outside a git repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->