### PR TITLE
feat(cli): auto-inject CLAUDE_PLUGIN_ROOT for plugin-sourced runbooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `context.current.at` | `3.1[3]` | Full execution position |
 
 **Plugin Variables:**
+
 | Variable | Description |
 |----------|-------------|
 | `CLAUDE_PLUGIN_ROOT` | Plugin installation directory — auto-injected when running plugin-sourced runbooks |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,13 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `context.current.index` | `3` | Current loop iteration (inside FOR) |
 | `context.current.at` | `3.1[3]` | Full execution position |
 
+**Plugin Variables:**
+| Variable | Description |
+|----------|-------------|
+| `CLAUDE_PLUGIN_ROOT` | Plugin installation directory — auto-injected when running plugin-sourced runbooks |
+
+Plugin variables are automatically available when a runbook is resolved from a plugin source (e.g., `rundown:write-plan`). They use UPPER_SNAKE_CASE (not PascalCase) since they mirror host environment conventions. Plugin variables sit below CLI flags in precedence and can be overridden via `--var`.
+
 Built-in variables use PascalCase. Lowercase aliases `step` and `index` are also available. The date/time variables (`Date`, `DateTime`, `Year`, `Month`, `Day`), `Branch`, `WorkPath`, `RunId`, and `ContextId` are static run-time variables set once per execution and can be overridden via `--var`. `RunId` is a fresh 8-character hexadecimal identifier generated per execution; each child in a delegation tree gets its own RunId. `ContextId` is a fresh 8-character hexadecimal identifier generated per execution; children in a delegation tree inherit the parent's ContextId via `--var`, providing a shared identity across the tree. It can be overridden via `--var` to use a meaningful name (e.g., `--var ContextId=sprint-42`). The `Step` variable (and `Index` during FOR loops), `context.current.*` variables, and their lowercase aliases are dynamic per-step variables that reflect the current execution position and cannot be overridden via `--var`. The variable name `context` is reserved and cannot be used as a user variable name.
 
 **CLI Example:**

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -716,7 +716,10 @@ describe('claimAndLaunch', () => {
     });
 
     // Set up prepareRunbook mocks (resetAllMocks clears these)
-    (resolveRunbookFile as jest.Mock).mockResolvedValue('/test/child.md');
+    (resolveRunbookFile as jest.Mock).mockResolvedValue({
+      path: '/test/child.md',
+      source: 'project',
+    });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue({

--- a/packages/cli/__tests__/helpers/resolve-runbook.test.ts
+++ b/packages/cli/__tests__/helpers/resolve-runbook.test.ts
@@ -27,7 +27,8 @@ describe('resolveRunbookFile', () => {
 
     const result = await resolveRunbookFile(testDir, 'test.runbook.md');
 
-    expect(result).toBe(path.join(claudeDir, 'test.runbook.md'));
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe(path.join(claudeDir, 'test.runbook.md'));
   });
 
   it('should find runbook in plugin runbooks directory', async () => {
@@ -39,7 +40,8 @@ describe('resolveRunbookFile', () => {
     process.env.CLAUDE_PLUGIN_ROOT = path.join(testDir, 'plugin');
 
     const result = await resolveRunbookFile(testDir, 'plugin.runbook.md');
-    expect(result).toBe(path.join(pluginDir, 'plugin.runbook.md'));
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe(path.join(pluginDir, 'plugin.runbook.md'));
     // afterEach restores originalPluginRoot
   });
 
@@ -48,7 +50,8 @@ describe('resolveRunbookFile', () => {
 
     const result = await resolveRunbookFile(testDir, 'relative.runbook.md');
 
-    expect(result).toBe(path.join(testDir, 'relative.runbook.md'));
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe(path.join(testDir, 'relative.runbook.md'));
   });
 
   it('should return null if runbook not found', async () => {
@@ -66,7 +69,8 @@ describe('resolveRunbookFile', () => {
 
     const result = await resolveRunbookFile(testDir, 'test.runbook.md');
 
-    expect(result).toBe(path.join(claudeDir, 'test.runbook.md'));
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe(path.join(claudeDir, 'test.runbook.md'));
   });
 
   describe('resolution precedence', () => {
@@ -81,7 +85,8 @@ describe('resolveRunbookFile', () => {
 
       const result = await resolveRunbookFile(testDir, 'retry-success.runbook.md');
 
-      expect(result).toBe(path.join(claudeDir, 'retry-success.runbook.md'));
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(path.join(claudeDir, 'retry-success.runbook.md'));
     });
   });
 
@@ -94,8 +99,8 @@ describe('resolveRunbookFile', () => {
       const result = await resolveRunbookFile(testDir, 'retry-success.runbook.md');
 
       expect(result).not.toBeNull();
-      expect(result).toContain('runbooks');
-      expect(result).toContain('retry-success.runbook.md');
+      expect(result!.path).toContain('runbooks');
+      expect(result!.path).toContain('retry-success.runbook.md');
     });
   });
 
@@ -117,11 +122,13 @@ describe('resolveRunbookFile', () => {
 
       // Without namespace - should resolve to project (higher priority)
       const withoutNamespace = await resolveRunbookFile(testDir, 'write-plan');
-      expect(withoutNamespace).toBe(path.join(claudeDir, 'write-plan.runbook.md'));
+      expect(withoutNamespace).not.toBeNull();
+      expect(withoutNamespace!.path).toBe(path.join(claudeDir, 'write-plan.runbook.md'));
 
       // With rundown: namespace - should resolve to plugin only
       const withNamespace = await resolveRunbookFile(testDir, 'rundown:write-plan');
-      expect(withNamespace).toBe(path.join(pluginDir, 'write-plan.runbook.md'));
+      expect(withNamespace).not.toBeNull();
+      expect(withNamespace!.path).toBe(path.join(pluginDir, 'write-plan.runbook.md'));
     });
 
     it('returns null for unknown namespace', async () => {
@@ -147,7 +154,8 @@ describe('resolveRunbookFile', () => {
       process.env.CLAUDE_PLUGIN_ROOT = path.join(testDir, 'plugin');
 
       const result = await resolveRunbookFile(testDir, 'rundown:review-plan');
-      expect(result).toBe(path.join(planningDir, 'review-plan.runbook.md'));
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(path.join(planningDir, 'review-plan.runbook.md'));
     });
 
     it('returns null when namespaced runbook not found in target source', async () => {
@@ -167,6 +175,86 @@ describe('resolveRunbookFile', () => {
       // Should not find it with rundown: namespace (which looks in plugin only)
       const result = await resolveRunbookFile(testDir, 'rundown:project-only');
       expect(result).toBeNull();
+    });
+  });
+
+  describe('source metadata', () => {
+    it('returns source "project" for runbook in .claude/rundown/runbooks/', async () => {
+      const claudeDir = path.join(testDir, '.claude/rundown/runbooks');
+      await fs.mkdir(claudeDir, { recursive: true });
+      await fs.writeFile(path.join(claudeDir, 'test.runbook.md'), '# Test');
+
+      const result = await resolveRunbookFile(testDir, 'test.runbook.md');
+
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(path.join(claudeDir, 'test.runbook.md'));
+      expect(result!.source).toBe('project');
+    });
+
+    it('returns source "plugin" for runbook in plugin directory', async () => {
+      const pluginDir = path.join(testDir, 'plugin/runbooks');
+      await fs.mkdir(pluginDir, { recursive: true });
+      await fs.writeFile(path.join(pluginDir, 'plugin.runbook.md'), '# Plugin');
+
+      process.env.CLAUDE_PLUGIN_ROOT = path.join(testDir, 'plugin');
+
+      const result = await resolveRunbookFile(testDir, 'plugin.runbook.md');
+
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(path.join(pluginDir, 'plugin.runbook.md'));
+      expect(result!.source).toBe('plugin');
+    });
+
+    it('returns source "project" for runbook relative to cwd', async () => {
+      await fs.writeFile(path.join(testDir, 'relative.runbook.md'), '# Relative');
+
+      const result = await resolveRunbookFile(testDir, 'relative.runbook.md');
+
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(path.join(testDir, 'relative.runbook.md'));
+      expect(result!.source).toBe('project');
+    });
+
+    it('returns source "bundled" for bundled runbook', async () => {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+
+      const result = await resolveRunbookFile(testDir, 'retry-success.runbook.md');
+
+      expect(result).not.toBeNull();
+      expect(result!.source).toBe('bundled');
+    });
+
+    it('returns source "plugin" for namespaced resolution', async () => {
+      const pluginDir = path.join(testDir, 'plugin/runbooks');
+      await fs.mkdir(pluginDir, { recursive: true });
+      await fs.writeFile(
+        path.join(pluginDir, 'write-plan.runbook.md'),
+        '---\nname: write-plan\n---\n# Plugin Version',
+      );
+
+      process.env.CLAUDE_PLUGIN_ROOT = path.join(testDir, 'plugin');
+
+      const result = await resolveRunbookFile(testDir, 'rundown:write-plan');
+
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(path.join(pluginDir, 'write-plan.runbook.md'));
+      expect(result!.source).toBe('plugin');
+    });
+
+    it('returns source from discovery service for name-based lookup', async () => {
+      const pluginDir = path.join(testDir, 'plugin/runbooks');
+      await fs.mkdir(pluginDir, { recursive: true });
+      await fs.writeFile(
+        path.join(pluginDir, 'my-runbook.runbook.md'),
+        '---\nname: my-runbook\n---\n# Test',
+      );
+
+      process.env.CLAUDE_PLUGIN_ROOT = path.join(testDir, 'plugin');
+
+      const result = await resolveRunbookFile(testDir, 'my-runbook');
+
+      expect(result).not.toBeNull();
+      expect(result!.source).toBe('plugin');
     });
   });
 });

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -276,7 +276,7 @@ describe('prepareRunbook', () => {
   });
 
   it('returns error when runbook has no steps', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/empty.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/empty.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(mockParseResult({ runbook: { steps: [] } }));
@@ -291,7 +291,7 @@ describe('prepareRunbook', () => {
   });
 
   it('returns prepared runbook on success', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/good.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/good.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(mockParseResult());
@@ -306,7 +306,7 @@ describe('prepareRunbook', () => {
   });
 
   it('adds context.vars aliases to merged template variables', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/good.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/good.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(mockParseResult());
@@ -329,7 +329,7 @@ describe('prepareRunbook', () => {
   });
 
   it('adds context.vars.* aliases for inherited user vars', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/child.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/child.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(mockParseResult());
@@ -354,7 +354,7 @@ describe('prepareRunbook', () => {
   });
 
   it('child vars override inherited in context.vars.* aliases', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/child.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/child.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(mockParseResult());
@@ -379,7 +379,7 @@ describe('prepareRunbook', () => {
   });
 
   it('passes parser frontmatter vars into variable resolution', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/good.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/good.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(
@@ -400,7 +400,7 @@ describe('prepareRunbook', () => {
   });
 
   it('returns VALIDATION_ERROR when frontmatter vars use reserved names', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/reserved.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/reserved.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(
@@ -427,7 +427,7 @@ describe('prepareRunbook', () => {
   });
 
   it('returns error when validateSources throws', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/sourced.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/sourced.md', source: 'project' });
     (parser.isSourced as jest.MockedFunction<typeof parser.isSourced>).mockReturnValue(true);
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -449,7 +449,7 @@ describe('prepareRunbook', () => {
   });
 
   it('returns VALIDATION_ERROR when parser diagnostics contain errors', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/bad-for.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/bad-for.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(
@@ -470,7 +470,7 @@ describe('prepareRunbook', () => {
   });
 
   it('returns PrepareFailure when resolveForBounds throws for invalid value', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/for-bounds.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/for-bounds.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(
@@ -500,7 +500,7 @@ describe('prepareRunbook', () => {
   });
 
   it('returns POLICY_DENIED when file-backed variable resolution is blocked by policy', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/good.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/good.md', source: 'project' });
     (resolveVariables as jest.Mock).mockRejectedValue(
       new FileSourcePolicyError('items', '/test/.env', 'Path blocked by policy'),
     );
@@ -518,6 +518,73 @@ describe('prepareRunbook', () => {
         reason: 'Path blocked by policy',
       });
     }
+  });
+
+  it('injects CLAUDE_PLUGIN_ROOT when runbook resolves from plugin source', async () => {
+    resolveRunbookFile.mockResolvedValue({
+      path: '/home/user/.claude/extensions/rundown-plugin/runbooks/write-plan.runbook.md',
+      source: 'plugin' as const,
+    });
+    (
+      parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
+    ).mockReturnValue(mockParseResult());
+
+    const result = await prepareRunbook('rundown:write-plan', {}, '/test');
+
+    expect(result.ok).toBe(true);
+    // CLAUDE_PLUGIN_ROOT should be derived from the resolved path (everything before /runbooks/)
+    expect(substituteRunbookVariables).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        CLAUDE_PLUGIN_ROOT: '/home/user/.claude/extensions/rundown-plugin/',
+      }),
+    );
+  });
+
+  it('does not inject CLAUDE_PLUGIN_ROOT when runbook resolves from project source', async () => {
+    resolveRunbookFile.mockResolvedValue({
+      path: '/test/.claude/rundown/runbooks/my-runbook.runbook.md',
+      source: 'project' as const,
+    });
+    (
+      parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
+    ).mockReturnValue(mockParseResult());
+
+    const result = await prepareRunbook('my-runbook', {}, '/test');
+
+    expect(result.ok).toBe(true);
+    expect(substituteRunbookVariables).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({
+        CLAUDE_PLUGIN_ROOT: expect.anything(),
+      }),
+    );
+  });
+
+  it('allows --var to override CLAUDE_PLUGIN_ROOT', async () => {
+    resolveRunbookFile.mockResolvedValue({
+      path: '/home/user/.claude/extensions/rundown-plugin/runbooks/write-plan.runbook.md',
+      source: 'plugin' as const,
+    });
+    (
+      parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
+    ).mockReturnValue(mockParseResult());
+    (resolveVariables as jest.Mock).mockResolvedValue({
+      vars: { CLAUDE_PLUGIN_ROOT: '/custom/override' },
+      sources: {},
+      warnings: [],
+    });
+
+    const result = await prepareRunbook('rundown:write-plan', {}, '/test');
+
+    expect(result.ok).toBe(true);
+    // The user's --var override should win over auto-injected value
+    expect(substituteRunbookVariables).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        CLAUDE_PLUGIN_ROOT: '/custom/override',
+      }),
+    );
   });
 });
 
@@ -879,7 +946,7 @@ describe('claimAndLaunch', () => {
     };
     (core.DelegationScanService as jest.Mock).mockImplementation(() => mockScanner);
 
-    resolveRunbookFile.mockResolvedValue('/test/child.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/child.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(mockParseResult());
@@ -975,7 +1042,7 @@ describe('claimAndLaunch', () => {
     };
     (core.DelegationScanService as jest.Mock).mockImplementation(() => mockScanner);
 
-    resolveRunbookFile.mockResolvedValue('/test/child.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/child.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(mockParseResult());
@@ -1127,7 +1194,7 @@ describe('claimAndLaunch', () => {
     };
     (core.DelegationScanService as jest.Mock).mockImplementation(() => mockScanner);
 
-    resolveRunbookFile.mockResolvedValue('/test/child.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/child.md', source: 'project' });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(mockParseResult());

--- a/packages/cli/__tests__/helpers/scenario-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/scenario-workflow.test.ts
@@ -84,7 +84,7 @@ describe('loadScenarios', () => {
   });
 
   it('returns error when no frontmatter', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/runbook.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/runbook.md', source: 'project' });
     (readFile as jest.MockedFunction<typeof readFile>).mockResolvedValue('# No frontmatter' as any);
     extractFrontmatter.mockReturnValue({ frontmatter: null, content: '# No frontmatter' });
 
@@ -98,7 +98,7 @@ describe('loadScenarios', () => {
   });
 
   it('returns error with validation details', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/runbook.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/runbook.md', source: 'project' });
     (readFile as jest.MockedFunction<typeof readFile>).mockResolvedValue(
       '---\nscenarios: bad\n---' as any,
     );
@@ -114,7 +114,7 @@ describe('loadScenarios', () => {
   });
 
   it('returns error when no scenarios defined', async () => {
-    resolveRunbookFile.mockResolvedValue('/test/runbook.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/runbook.md', source: 'project' });
     (readFile as jest.MockedFunction<typeof readFile>).mockResolvedValue(
       '---\nname: test\n---' as any,
     );
@@ -138,7 +138,7 @@ describe('loadScenarios', () => {
       },
     };
 
-    resolveRunbookFile.mockResolvedValue('/test/runbook.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/runbook.md', source: 'project' });
     (readFile as jest.MockedFunction<typeof readFile>).mockResolvedValue(
       '---\nname: my-runbook\n---' as any,
     );
@@ -163,7 +163,7 @@ describe('loadScenarios', () => {
       test: { result: 'COMPLETE', commands: ['rd run x.md'] },
     };
 
-    resolveRunbookFile.mockResolvedValue('/test/runbook.md');
+    resolveRunbookFile.mockResolvedValue({ path: '/test/runbook.md', source: 'project' });
     (readFile as jest.MockedFunction<typeof readFile>).mockResolvedValue(
       '---\nscenarios:\n---' as any,
     );

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -122,10 +122,11 @@ export function registerDelegateCommand(program: Command): void {
             }
 
             // Resolve child runbook path
-            const childPath = await resolveRunbookFile(cwd, resolvedRunbook);
-            if (!childPath) {
+            const childResolved = await resolveRunbookFile(cwd, resolvedRunbook);
+            if (!childResolved) {
               throw Errors.delegationRunbookNotFound(resolvedRunbook);
             }
+            const childPath = childResolved.path;
 
             // Parse extra vars through the standard normalization pipeline
             const rawVars = await collectCliFlags(

--- a/packages/cli/src/helpers/context.ts
+++ b/packages/cli/src/helpers/context.ts
@@ -23,9 +23,9 @@ export function getCwd(): string {
  */
 export async function getStepTotal(cwd: string, runbookPath: string): Promise<number> {
   try {
-    const fullPath = await resolveRunbookFile(cwd, runbookPath);
-    if (!fullPath) return 0;
-    const content = await fs.readFile(fullPath, 'utf8');
+    const resolved = await resolveRunbookFile(cwd, runbookPath);
+    if (!resolved) return 0;
+    const content = await fs.readFile(resolved.path, 'utf8');
     const steps = parseRunbook(content);
     return countNumberedSteps(steps);
   } catch {

--- a/packages/cli/src/helpers/resolve-runbook.ts
+++ b/packages/cli/src/helpers/resolve-runbook.ts
@@ -4,6 +4,20 @@ import { findRunbookByName, findRunbookByNameInSource } from '../services/discov
 import { getBundledRunbooksPath } from './bundled-runbooks.js';
 
 /**
+ * Result of resolving a runbook file, including its source.
+ *
+ * Provides the absolute filesystem path alongside the source that
+ * the runbook was discovered from, enabling downstream consumers
+ * to derive source-specific context (e.g., plugin root directory).
+ */
+export interface ResolvedRunbook {
+  /** Absolute path to the resolved runbook file */
+  path: string;
+  /** Source directory where the runbook was found */
+  source: 'project' | 'plugin' | 'bundled';
+}
+
+/**
  * Parsed runbook identifier with optional namespace.
  */
 export interface ParsedIdentifier {
@@ -55,14 +69,14 @@ function namespaceToSource(namespace: string): 'project' | 'plugin' | 'bundled' 
  *
  * @param cwd - Current working directory
  * @param filename - Runbook filename to find
- * @returns Absolute path to runbook file, or null if not found
+ * @returns Resolved runbook with path and source, or null if not found
  */
-async function resolveByPath(cwd: string, filename: string): Promise<string | null> {
+async function resolveByPath(cwd: string, filename: string): Promise<ResolvedRunbook | null> {
   // 1. Check project-local .claude/rundown/runbooks/
   const localPath = path.join(cwd, '.claude/rundown/runbooks', filename);
   try {
     await fs.access(localPath);
-    return localPath;
+    return { path: localPath, source: 'project' };
   } catch {
     /* not found */
   }
@@ -73,7 +87,7 @@ async function resolveByPath(cwd: string, filename: string): Promise<string | nu
     const pluginPath = path.join(pluginRoot, 'runbooks', filename);
     try {
       await fs.access(pluginPath);
-      return pluginPath;
+      return { path: pluginPath, source: 'plugin' };
     } catch {
       /* not found */
     }
@@ -83,7 +97,7 @@ async function resolveByPath(cwd: string, filename: string): Promise<string | nu
   const relativePath = path.resolve(cwd, filename);
   try {
     await fs.access(relativePath);
-    return relativePath;
+    return { path: relativePath, source: 'project' };
   } catch {
     /* not found */
   }
@@ -92,7 +106,7 @@ async function resolveByPath(cwd: string, filename: string): Promise<string | nu
   const bundledPath = path.join(getBundledRunbooksPath(), filename);
   try {
     await fs.access(bundledPath);
-    return bundledPath;
+    return { path: bundledPath, source: 'bundled' };
   } catch {
     /* not found */
   }
@@ -135,10 +149,13 @@ function isPathIdentifier(identifier: string): boolean {
  *
  * @param cwd - Current working directory
  * @param identifier - Runbook filename, name, or namespaced name to find
- * @returns Absolute path to runbook file, or null if not found
+ * @returns Resolved runbook with path and source, or null if not found
  * @throws {Error} May throw filesystem errors if directory access fails unexpectedly
  */
-export async function resolveRunbookFile(cwd: string, identifier: string): Promise<string | null> {
+export async function resolveRunbookFile(
+  cwd: string,
+  identifier: string,
+): Promise<ResolvedRunbook | null> {
   // Parse namespace from identifier
   const { namespace, name } = parseIdentifier(identifier);
 
@@ -150,7 +167,7 @@ export async function resolveRunbookFile(cwd: string, identifier: string): Promi
       return null;
     }
     const discovered = await findRunbookByNameInSource(cwd, name, source);
-    return discovered ? discovered.path : null;
+    return discovered ? { path: discovered.path, source: discovered.source } : null;
   }
 
   // Detect if identifier is path-based or name-based
@@ -164,12 +181,12 @@ export async function resolveRunbookFile(cwd: string, identifier: string): Promi
     if (!name.includes('/') && name.endsWith('.runbook.md')) {
       const stem = name.replace(/\.runbook\.md$/, '');
       const discovered = await findRunbookByName(cwd, stem);
-      return discovered ? discovered.path : null;
+      return discovered ? { path: discovered.path, source: discovered.source } : null;
     }
     return null;
   } else {
     // Name-based resolution: use discovery service
     const discovered = await findRunbookByName(cwd, name);
-    return discovered ? discovered.path : null;
+    return discovered ? { path: discovered.path, source: discovered.source } : null;
   }
 }

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -297,6 +297,8 @@ export interface LoadAndParseSuccess {
   ok: true;
   /** Absolute path to the resolved runbook file */
   filePath: string;
+  /** Source where the runbook was discovered from */
+  source: 'project' | 'plugin' | 'bundled';
   /** Raw markdown content */
   rawContent: string;
   /** Parsed runbook AST (before variable substitution) */
@@ -339,9 +341,9 @@ export type LoadAndParseResult = LoadAndParseSuccess | LoadAndParseFailure;
  * @returns Discriminated union: ok with loaded data, or error with message
  */
 export async function loadAndParseRunbook(file: string, cwd: string): Promise<LoadAndParseResult> {
-  const filePath = await resolveRunbookFile(cwd, file);
+  const resolved = await resolveRunbookFile(cwd, file);
 
-  if (!filePath) {
+  if (!resolved) {
     return {
       ok: false,
       error: `Runbook not found: ${file}. Try 'rd ls --all' to list available runbooks.`,
@@ -349,6 +351,8 @@ export async function loadAndParseRunbook(file: string, cwd: string): Promise<Lo
       details: { runbook: file },
     };
   }
+
+  const { path: filePath, source } = resolved;
 
   try {
     const rawContent = await fs.readFile(filePath, 'utf8');
@@ -366,7 +370,7 @@ export async function loadAndParseRunbook(file: string, cwd: string): Promise<Lo
       substeps: countSubsteps(runbook.steps),
     };
 
-    return { ok: true, filePath, rawContent, runbook, frontmatter, diagnostics, stats };
+    return { ok: true, filePath, source, rawContent, runbook, frontmatter, diagnostics, stats };
   } catch (error: unknown) {
     return {
       ok: false,
@@ -406,7 +410,24 @@ export async function prepareRunbook(
   // Phase 1-2: Parse + Validate
   const parsed = await loadAndParseRunbook(file, cwd);
   if (!parsed.ok) return parsed;
-  const { filePath, rawContent, runbook: rawRunbook, frontmatter, diagnostics, stats } = parsed;
+  const {
+    filePath,
+    source,
+    rawContent,
+    runbook: rawRunbook,
+    frontmatter,
+    diagnostics,
+    stats,
+  } = parsed;
+
+  // Derive CLAUDE_PLUGIN_ROOT from resolved path when source is plugin
+  let pluginRoot: string | undefined;
+  if (source === 'plugin') {
+    const runbooksIdx = filePath.indexOf('/runbooks/');
+    if (runbooksIdx !== -1) {
+      pluginRoot = filePath.slice(0, runbooksIdx + 1); // include trailing slash
+    }
+  }
 
   // Variable resolution
   let mergedVariables: Record<string, TemplateVarValue>;
@@ -427,6 +448,10 @@ export async function prepareRunbook(
       },
     );
     mergedVariables = { ...resolvedVariables.vars };
+    // Inject CLAUDE_PLUGIN_ROOT for plugin-sourced runbooks (below CLI flags in precedence)
+    if (pluginRoot && !('CLAUDE_PLUGIN_ROOT' in mergedVariables)) {
+      mergedVariables.CLAUDE_PLUGIN_ROOT = pluginRoot;
+    }
     allWarnings.push(...resolvedVariables.warnings);
   } catch (error) {
     if (error instanceof FileSourcePolicyError) {

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -423,9 +423,10 @@ export async function prepareRunbook(
   // Derive CLAUDE_PLUGIN_ROOT from resolved path when source is plugin
   let pluginRoot: string | undefined;
   if (source === 'plugin') {
-    const runbooksIdx = filePath.indexOf('/runbooks/');
+    const runbooksSep = `${path.sep}runbooks${path.sep}`;
+    const runbooksIdx = filePath.indexOf(runbooksSep);
     if (runbooksIdx !== -1) {
-      pluginRoot = filePath.slice(0, runbooksIdx + 1); // include trailing slash
+      pluginRoot = filePath.slice(0, runbooksIdx + 1); // include trailing separator
     }
   }
 

--- a/packages/cli/src/helpers/scenario-workflow.ts
+++ b/packages/cli/src/helpers/scenario-workflow.ts
@@ -76,12 +76,13 @@ export interface ScenarioRunResult {
  * @returns ScenarioLoadResult with loaded data or error details
  */
 export async function loadScenarios(file: string, cwd: string): Promise<ScenarioLoadResult> {
-  const filePath = await resolveRunbookFile(cwd, file);
+  const resolved = await resolveRunbookFile(cwd, file);
 
-  if (!filePath) {
+  if (!resolved) {
     return { ok: false, error: `Runbook file not found: ${file}`, code: 'RUNBOOK_NOT_FOUND' };
   }
 
+  const filePath = resolved.path;
   const content = await readFile(filePath, 'utf-8');
   const { frontmatter } = extractFrontmatter(content);
 


### PR DESCRIPTION
When a runbook resolves from a plugin source, derive the plugin root directory from the file path and inject it as a template variable. This enables plugin runbooks to reference bundled assets (schemas, etc.) via {{ CLAUDE_PLUGIN_ROOT }} without relying on environment variables.

- Add ResolvedRunbook interface with source metadata tracking
- Derive plugin root by finding /runbooks/ in resolved path
- Include trailing slash for clean path concatenation
- Inject below CLI flags in variable precedence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically injects CLAUDE_PLUGIN_ROOT when a runbook is resolved from a plugin source; user-provided --var can override it.
  * Improved detection of plugin-sourced runbooks so plugin-scoped variables are applied reliably.

* **Documentation**
  * Added "Plugin Variables" section describing CLAUDE_PLUGIN_ROOT, naming convention, precedence, and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->