### PR TITLE
2026 04 06 sync docs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,8 @@
       "Bash(git checkout:*)",
       "Bash(git worktree add:*)",
       "Bash(git worktree list:*)",
-      "Bash(git worktree remove:*)"
+      "Bash(git worktree remove:*)",
+      "Bash(gh pr:*)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Schema validation is automatic when the JSON includes `"$schema": "https://rundo
 Template variables use Handlebars syntax `{{variableName}}` and are expanded at run time.
 
 **Variable Sources (Precedence: High to Low):**
-1. CLI flags (`--var-file`, `--var`, `--var-json`) — highest priority; within this layer: `--var-json` > `--var` > `--var-file` (repeatable)
+1. CLI flags (`--var-file`, `--var`, `--var-json`) — highest priority; within this layer: `--var-json` > `--var` > `--var-file` (all repeatable)
 2. `RD_VAR_*` environment variables (prefix stripped)
 3. `.rundown/config.yaml` (auto-discovered from cwd upward, stops at git root)
 4. Frontmatter `vars:` field
@@ -125,7 +125,7 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `ContextId` | `a3b8c1d2` | Shared identity across delegation tree |
 | `Step` | `3.1` | Current qualified step identifier |
 | `Index` | `3` | Current loop iteration number (inside FOR) |
-| `context.current.step` | `3` | Current step number |
+| `context.current.step` | `3.1` | Current qualified step identifier |
 | `context.current.substep` | `1` | Current substep number (when in substep) |
 | `context.current.index` | `3` | Current loop iteration (inside FOR) |
 | `context.current.at` | `3.1[3]` | Full execution position |
@@ -299,7 +299,7 @@ npm run test:unit     # Same as npm test
 npm run test:integration  # Integration tests in parallel
 npm run test:all      # Full suite: unit → integration → property → perf
 npm run test:coverage # Test coverage across all packages
-npm run verify        # Pre-PR: format, spell, lint, test (MUST run before push)
+npm run verify        # Pre-PR: check format, spell, lint, test (MUST run before push)
 npm run lint          # Lint all packages (biome + eslint)
 npm run check:lint:fast   # Fast lint (biome only)
 npm run check:lint:typed  # Typed lint (eslint only)
@@ -321,6 +321,7 @@ npm run verify:claude    # Docker: verify CLI+plugin install (local build)
 npm run verify:claude:npm  # Docker: verify install from npm registry
 npm run test:e2e         # Docker: E2E plugin workflow test
 npm run test:e2e:shell   # Docker: interactive shell in E2E container
+npm run test:e2e:build   # Docker: build E2E test image
 ```
 
 ## Testing Conventions
@@ -427,7 +428,7 @@ Three distinct concepts govern step execution. Never conflate them:
 |---------|--------|----------|
 | **RESULT** | Outcome of execution | `pass`, `fail` |
 | **HANDLER** | Configured mapping from result to action | `PASS CONTINUE`, `FAIL DEFER` |
-| **ACTION** | What to do next | `CONTINUE`, `NEXT`, `BREAK`, `DEFER`, `STOP`, `COMPLETE` |
+| **ACTION** | What to do next | `CONTINUE`, `NEXT`, `BREAK`, `DEFER`, `STOP`, `COMPLETE`, `GOTO` |
 
 A step produces a **result** (pass/fail). The runbook's **handler** for that result determines the **action** to take. These are separate layers — a result is not an action, and a handler is not a result.
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -210,7 +210,7 @@ executable_lang ::= "bash" | "sh" | "shell"
 display_lang    ::= language_tag
 ```
 
-Opening fence is 3 or more backticks. Closing fence must use at least as many backticks as the opening fence (CommonMark §4.5). Language tag is required — bare code fences are invalid. Tags are matched case-insensitively. Non-executable tags (e.g., `json`, `yaml`) are display-only. The `prompt` suffix on non-executable tags is accepted but redundant — all non-executable code blocks are prompt blocks.
+Opening fence is 3 or more backticks. Closing fence must use at least as many backticks as the opening fence (CommonMark §4.5). Language tag is required — bare code fences are invalid. Tags are matched case-insensitively. Non-executable tags (e.g., `json`, `yaml`) are display-only. When `prompt` follows an executable language tag (e.g., `bash prompt`), the block is demoted to display-only — it is not executed. The `prompt` suffix on non-executable tags is accepted but redundant — all non-executable code blocks are prompt blocks.
 
 ## Template Variables
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -57,7 +57,7 @@ Step content must appear in this strict order:
 
 A step must contain exactly one type of body content.
 
-Steps are represented as a discriminated union on `kind`: `'base'` (prompt-only), `'command'` (executable code block), `'substeps'` (nested H3 steps), `'for'` (loop with substeps), `'prompted-for'` (resolved only; unresolved FOR demoted to prompt-only).
+Steps are represented as a discriminated union on `kind`: `'base'` (prompt-only), `'command'` (executable code block), `'substeps'` (nested H3 steps), `'for'` (loop with substeps), `'prompted-for'` (unresolved FOR demoted to prompt-only).
 
 ### 3.1 Code Blocks
 Executes a command or displays a prompt. Max one code block per step.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -28,8 +28,6 @@ Frontmatter fields beyond `name`, `description`, `version`, `author`, `tags`, an
 
 The frontmatter `description` field provides a summary for runbook discovery and listing (`rd ls --all`). The `Runbook.description` in the parsed AST is derived from preamble text between the H1 title and first H2 step. These are independent values.
 
-*Note: A follow-up task will rename `Runbook.description` → `Runbook.preamble` to eliminate this naming ambiguity.*
-
 ## 2. Steps
 
 Steps are the fundamental units of execution defined by H2 headers.
@@ -59,7 +57,7 @@ Step content must appear in this strict order:
 
 A step must contain exactly one type of body content.
 
-Steps are represented as a discriminated union on `kind`: `'base'` (prompt-only), `'command'` (executable code block), `'substeps'` (nested H3 steps), `'for'` (loop with substeps), `'prompted-for'` (unresolved FOR, prompt-only).
+Steps are represented as a discriminated union on `kind`: `'base'` (prompt-only), `'command'` (executable code block), `'substeps'` (nested H3 steps), `'for'` (loop with substeps), `'prompted-for'` (resolved only; unresolved FOR demoted to prompt-only).
 
 ### 3.1 Code Blocks
 Executes a command or displays a prompt. Max one code block per step.
@@ -142,8 +140,9 @@ Transition keywords (`PASS`, `YES`, `FAIL`, `NO`) are matched as whole words in 
 *   If only `PASS` defined: `FAIL` -> `STOP`.
 *   If only `FAIL` defined: `PASS` -> `CONTINUE`.
 *   If neither is defined: `PASS CONTINUE`, `FAIL STOP`.
+*   Substeps under aggregation or with runbook delegation default to `PASS DEFER`, `FAIL DEFER`.
 
-When only one transition side specifies an aggregation modifier, the defaulted side receives its complement (`PASS ALL` defaults `FAIL ANY`, and vice versa).
+One-sided aggregation modifiers are rejected — both sides must be explicitly authored (e.g., `PASS ALL ... FAIL ANY ...`).
 
 ### 4.2 Actions
 
@@ -171,7 +170,7 @@ GOTO targeting the containing step (self-reference) without an AT qualifier may 
 *   `GOTO 3 AT 1`: Jump to Step 3, iteration 1 (if FOR step).
 *   `GOTO 3 AT {{Index}}`: Re-enter Step 3 at current iteration.
 
-> **Internal:** The compiler uses a `GOTO NEXT` representation internally to advance to the next step. This cannot be written in markdown syntax — `NEXT` is rejected as a GOTO target by the parser.
+> **Internal:** The compiler resolves step-to-step advancement using `CONTINUE` actions mapped to concrete next-step state IDs at compile time. `NEXT` is rejected as a GOTO target by the parser.
 
 ## 5. Iteration (FOR)
 
@@ -255,7 +254,7 @@ Variables use Handlebars syntax: `{{variable}}`.
 *   **Parent variables**: `{{context.parent.vars.NAME}}` exposes the parent's resolved template variables. Only non-context keys propagate. Available via both chain (`context.parent.parent.vars.*`) and array (`context.ancestors.N.vars.*`) addressing.
 *   **Depth limit**: Parent context chain addressing is capped at 32 levels (enforced on the delegation ancestor chain depth). Exceeding this limit produces an error.
 *   **Path resolution**: Dotted paths are supported consistently (for example `{{context.parent.index}}`).
-*   **Reserved keys**: Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive — any case variant such as `STEP`, `Step`, `INDEX` is also reserved) and cannot be overridden by user variables. The CLI rejects these names in frontmatter `vars:`, `--var` flags, `--var-file` contents, and `.rundown/config.yaml` with an error diagnostic.
+*   **Reserved keys**: Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive — any case variant such as `STEP`, `Step`, `INDEX` is also reserved) and cannot be overridden by user variables. The CLI rejects these names in frontmatter `vars:`, `--var` flags, `--var-file` contents, `.rundown/config.yaml`, and `RD_VAR_*` environment variables (silently skipped with a warning) with an error diagnostic.
 *   **Precedence** (highest to lowest):
     1. CLI flags (`--var-file`, `--var`, `--var-json`) — highest priority
     2. `RD_VAR_*` environment variables (prefix stripped)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -254,7 +254,7 @@ Variables use Handlebars syntax: `{{variable}}`.
 *   **Parent variables**: `{{context.parent.vars.NAME}}` exposes the parent's resolved template variables. Only non-context keys propagate. Available via both chain (`context.parent.parent.vars.*`) and array (`context.ancestors.N.vars.*`) addressing.
 *   **Depth limit**: Parent context chain addressing is capped at 32 levels (enforced on the delegation ancestor chain depth). Exceeding this limit produces an error.
 *   **Path resolution**: Dotted paths are supported consistently (for example `{{context.parent.index}}`).
-*   **Reserved keys**: Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive — any case variant such as `STEP`, `Step`, `INDEX` is also reserved) and cannot be overridden by user variables. The CLI rejects these names in frontmatter `vars:`, `--var` flags, `--var-file` contents, `.rundown/config.yaml`, and `RD_VAR_*` environment variables (silently skipped with a warning) with an error diagnostic.
+*   **Reserved keys**: Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive — any case variant such as `STEP`, `Step`, `INDEX` is also reserved) and cannot be overridden by user variables. The CLI rejects these names in frontmatter `vars:`, `--var` flags, `--var-file` contents, and `.rundown/config.yaml` with an error diagnostic. Reserved names in `RD_VAR_*` environment variables are silently skipped with a warning.
 *   **Precedence** (highest to lowest):
     1. CLI flags (`--var-file`, `--var`, `--var-json`) — highest priority
     2. `RD_VAR_*` environment variables (prefix stripped)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI variable repeatability and step variable formatting (qualified step identifiers).
  * Refined code-block rules to treat executable-tag blocks with "prompt" as display-only.
  * Removed a planned rename note; clarified `prompted-for` semantics and transition/aggregation defaults.
  * Added a new dev command for building the E2E test image and tweaked pre-PR check wording.

* **New Features**
  * Added `GOTO` as a step action.

* **Changes**
  * Require explicit `PASS`/`FAIL` outcomes for aggregation modifiers.
  * Expanded reserved-variable enforcement to include RD_VAR_* environment keys.

* **Chores**
  * Extended local permissions allowlist to permit GitHub-PR CLI bash commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->