### PR TITLE
feat(cli)!: change default WorkPath to .rundown/work

### DIFF
--- a/.claude/rundown/runbooks/review/pr-feedback.runbook.md
+++ b/.claude/rundown/runbooks/review/pr-feedback.runbook.md
@@ -23,7 +23,7 @@ Fetch and triage review feedback from a pull request.
 - FAIL STOP
 
 ```bash
-WORK_PATH={{WorkPath}} .claude/rundown/runbooks/review/scripts/fetch-pr-comments.sh {{repo}} {{pr_number}}
+WORK_PATH="{{WorkPath}}" .claude/rundown/runbooks/review/scripts/fetch-pr-comments.sh {{repo}} {{pr_number}}
 ```
 
 ## 2 Review Summary
@@ -32,7 +32,7 @@ WORK_PATH={{WorkPath}} .claude/rundown/runbooks/review/scripts/fetch-pr-comments
 - FAIL STOP
 
 ```bash
-WORK_PATH={{WorkPath}} .claude/rundown/runbooks/review/scripts/summarize-findings.sh
+WORK_PATH="{{WorkPath}}" .claude/rundown/runbooks/review/scripts/summarize-findings.sh
 ```
 
 ## 3 Address Findings

--- a/.claude/rundown/runbooks/review/pr-feedback.runbook.md
+++ b/.claude/rundown/runbooks/review/pr-feedback.runbook.md
@@ -23,7 +23,7 @@ Fetch and triage review feedback from a pull request.
 - FAIL STOP
 
 ```bash
-.claude/rundown/runbooks/review/scripts/fetch-pr-comments.sh {{repo}} {{pr_number}}
+WORK_PATH={{WorkPath}} .claude/rundown/runbooks/review/scripts/fetch-pr-comments.sh {{repo}} {{pr_number}}
 ```
 
 ## 2 Review Summary
@@ -32,7 +32,7 @@ Fetch and triage review feedback from a pull request.
 - FAIL STOP
 
 ```bash
-.claude/rundown/runbooks/review/scripts/summarize-findings.sh
+WORK_PATH={{WorkPath}} .claude/rundown/runbooks/review/scripts/summarize-findings.sh
 ```
 
 ## 3 Address Findings
@@ -40,7 +40,7 @@ Fetch and triage review feedback from a pull request.
 - PASS CONTINUE
 - FAIL CONTINUE
 
-Work through each actionable finding from `.work/pr-feedback/findings.jsonl`.
+Work through each actionable finding from `{{WorkPath}}/pr-feedback/findings.jsonl`.
 For each finding, review the code at the specified path and line, then either
 address the feedback or note why it was skipped.
 

--- a/.claude/rundown/runbooks/review/scripts/fetch-pr-comments.sh
+++ b/.claude/rundown/runbooks/review/scripts/fetch-pr-comments.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fetch PR review comments and write structured JSON to .work/pr-feedback/
+# Fetch PR review comments and write structured JSON to the pr-feedback directory
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "$0")"
@@ -8,13 +8,20 @@ usage() {
   cat <<EOF
 Usage: $SCRIPT_NAME [options] <owner/repo> <pr_number>
 
-  Fetch PR review comments and write structured JSON to .work/pr-feedback/
+  Fetch PR review comments and write structured JSON to the pr-feedback directory.
+  Output directory defaults to \$OUTDIR or \$WORK_PATH/pr-feedback, falling back
+  to .rundown/work/pr-feedback.
 
 Options:
   -h, --help  Show this help
 
+Environment:
+  OUTDIR       Explicit output directory (overrides WORK_PATH).
+  WORK_PATH    Base work directory; pr-feedback is written under it.
+
 Examples:
   $SCRIPT_NAME tobyhede/rundown 11
+  WORK_PATH="\$(rd vars get WorkPath 2>/dev/null)" $SCRIPT_NAME tobyhede/rundown 11
 EOF
 }
 
@@ -36,7 +43,7 @@ fi
 
 REPO="$1"
 PR="$2"
-OUTDIR=".work/pr-feedback"
+OUTDIR="${OUTDIR:-${WORK_PATH:-.rundown/work}/pr-feedback}"
 mkdir -p "$OUTDIR"
 
 # Fetch all inline review comments

--- a/.claude/rundown/runbooks/review/scripts/summarize-findings.sh
+++ b/.claude/rundown/runbooks/review/scripts/summarize-findings.sh
@@ -9,10 +9,16 @@ usage() {
 Usage: $SCRIPT_NAME [options]
 
   Parse raw PR comments into structured findings with severity extraction.
-  Reads from .work/pr-feedback/raw-comments.jsonl (run fetch-pr-comments.sh first).
+  Reads from \$OUTDIR/raw-comments.jsonl (run fetch-pr-comments.sh first).
+  Output directory defaults to \$OUTDIR or \$WORK_PATH/pr-feedback, falling back
+  to .rundown/work/pr-feedback.
 
 Options:
   -h, --help  Show this help
+
+Environment:
+  OUTDIR       Explicit output directory (overrides WORK_PATH).
+  WORK_PATH    Base work directory; pr-feedback is read from it.
 EOF
 }
 
@@ -26,7 +32,7 @@ done
 
 command -v jq >/dev/null || { echo "Error: jq required" >&2; exit 2; }
 
-OUTDIR=".work/pr-feedback"
+OUTDIR="${OUTDIR:-${WORK_PATH:-.rundown/work}/pr-feedback}"
 RAW="$OUTDIR/raw-comments.jsonl"
 
 [ -f "$RAW" ] || { echo "Error: $RAW not found. Run fetch-pr-comments.sh first." >&2; exit 1; }

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,6 +26,7 @@ reviews:
     - "**"
     - "!.worktrees/**"
     - "!.work/**"
+    - "!.rundown/work/**"
     - "!site/node_modules/**"
     - "!site/.next/**"
     - "!**/*.snap"

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ node_modules/
 Thumbs.db
 .claude/
 .serena/
+.rundown/work/
 .work/
 .worktree/
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 coverage/
 .DS_Store
 *.log
+.rundown/work/
 .work/
 .worktree/
 .claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `Year` | `2026` | Current year |
 | `Month` | `02` | Current month (01-12) |
 | `Day` | `04` | Current day (01-31) |
-| `WorkPath` | `.work` | Default artifact directory |
+| `WorkPath` | `.rundown/work` | Default artifact directory |
 | `RunId` | `4a7f0c3e` | Unique-per-execution identifier |
 | `ContextId` | `a3b8c1d2` | Shared identity across delegation tree |
 | `Step` | `3.1` | Current qualified step identifier |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `Month` | `02` | Current month (01-12) |
 | `Day` | `04` | Current day (01-31) |
 | `Branch` | `feature/my-work` | Current git branch name (empty when not in git) |
-| `WorkPath` | `.work/feature-my-work` | Branch-isolated artifact directory (falls back to `.work` outside git) |
+| `WorkPath` | `.rundown/work/feature-my-work` | Branch-isolated artifact directory (falls back to `.rundown/work` outside git) |
 | `RunId` | `4a7f0c3e` | Unique-per-execution identifier |
 | `ContextId` | `a3b8c1d2` | Shared identity across delegation tree |
 | `Step` | `3.1` | Current qualified step identifier |

--- a/docs/PROJECT-INTEGRATION.md
+++ b/docs/PROJECT-INTEGRATION.md
@@ -220,6 +220,6 @@ review/
 Guidelines:
 - Use `#!/usr/bin/env bash` and `set -euo pipefail`
 - Accept parameters positionally with usage messages
-- Write output to `.rundown/work/<runbook-name>/` for intermediate artifacts
+- By default write output to `.rundown/work/<runbook-name>/` for intermediate artifacts; override via the `WorkPath` template variable (set with `--var WorkPath=...` or config) or the `WORK_PATH` environment variable read by scripts
 - Exit 0 for success (PASS), non-zero for failure (FAIL)
 - Keep scripts focused — one responsibility per script

--- a/docs/PROJECT-INTEGRATION.md
+++ b/docs/PROJECT-INTEGRATION.md
@@ -220,6 +220,6 @@ review/
 Guidelines:
 - Use `#!/usr/bin/env bash` and `set -euo pipefail`
 - Accept parameters positionally with usage messages
-- Write output to `.work/<runbook-name>/` for intermediate artifacts
+- Write output to `.rundown/work/<runbook-name>/` for intermediate artifacts
 - Exit 0 for success (PASS), non-zero for failure (FAIL)
 - Keep scripts focused — one responsibility per script

--- a/docs/RDPATH.md
+++ b/docs/RDPATH.md
@@ -17,29 +17,29 @@ rdpath --dir <path> --ctx <id> find <pattern> # Find within context scope
 
 ```bash
 # Base directory only
-rdpath --dir .work
-# → .work
+rdpath --dir .rundown/work
+# → .rundown/work
 
 # Context-scoped directory
-rdpath --dir .work --ctx sprint-42
-# → .work/.rd-sprint-42
+rdpath --dir .rundown/work --ctx sprint-42
+# → .rundown/work/.rd-sprint-42
 
 # Date-prefixed filename
-rdpath --dir .work --file plan.md
-# → .work/2026-03-27-plan.md
+rdpath --dir .rundown/work --file plan.md
+# → .rundown/work/2026-03-27-plan.md
 
 # Combined: context + date-prefixed file
-rdpath --dir .work --ctx sprint-42 --file review.md
-# → .work/.rd-sprint-42/2026-03-27-review.md
+rdpath --dir .rundown/work --ctx sprint-42 --file review.md
+# → .rundown/work/.rd-sprint-42/2026-03-27-review.md
 
 # Find files matching a glob
-rdpath --dir .work find '*.md'
+rdpath --dir .rundown/work find '*.md'
 
 # Find within a context scope
-rdpath --dir .work --ctx sprint-42 find '*-plan*.md'
+rdpath --dir .rundown/work --ctx sprint-42 find '*-plan*.md'
 
 # Recursive search
-rdpath --dir .work find '**/*.json'
+rdpath --dir .rundown/work find '**/*.json'
 ```
 
 ### Exit Codes
@@ -91,10 +91,10 @@ The `path` subcommand builds paths by composing three layers:
 
 | Input | Output |
 |-------|--------|
-| `--dir .work` | `.work` |
-| `--dir .work --ctx abc` | `.work/.rd-abc` |
-| `--dir .work --file plan.md` | `.work/2026-03-27-plan.md` |
-| `--dir .work --ctx abc --file plan.md` | `.work/.rd-abc/2026-03-27-plan.md` |
+| `--dir .rundown/work` | `.rundown/work` |
+| `--dir .rundown/work --ctx abc` | `.rundown/work/.rd-abc` |
+| `--dir .rundown/work --file plan.md` | `.rundown/work/2026-03-27-plan.md` |
+| `--dir .rundown/work --ctx abc --file plan.md` | `.rundown/work/.rd-abc/2026-03-27-plan.md` |
 
 The date prefix uses the current date in `YYYY-MM-DD` format (ISO 8601).
 
@@ -158,17 +158,17 @@ Resolve --dir
 
 ```bash
 # 1. Assemble a path for a new artifact
-ARTIFACT_DIR=$(rdpath --dir .work --ctx sprint-42)
+ARTIFACT_DIR=$(rdpath --dir .rundown/work --ctx sprint-42)
 mkdir -p "$ARTIFACT_DIR"
 
 # 2. Create a date-prefixed file
-PLAN_PATH=$(rdpath --dir .work --ctx sprint-42 --file plan.json)
+PLAN_PATH=$(rdpath --dir .rundown/work --ctx sprint-42 --file plan.json)
 echo '{"name": "my plan"}' > "$PLAN_PATH"
 
 # 3. Find artifacts later
-rdpath --dir .work --ctx sprint-42 find '*-plan*.json'
+rdpath --dir .rundown/work --ctx sprint-42 find '*-plan*.json'
 
 # 4. Combine with rdx for rendering
-PLAN=$(rdpath --dir .work --ctx sprint-42 find '*-plan.json')
-rdx "$PLAN" --output "$(rdpath --dir .work --ctx sprint-42 --file plan.md)"
+PLAN=$(rdpath --dir .rundown/work --ctx sprint-42 find '*-plan.json')
+rdx "$PLAN" --output "$(rdpath --dir .rundown/work --ctx sprint-42 --file plan.md)"
 ```

--- a/docs/RDX.md
+++ b/docs/RDX.md
@@ -382,5 +382,5 @@ cat plan.md
 
 The plan-writing skill and runbook use path conventions:
 ```bash
-rdx .work/feature-name/2026-03-26-plan.json --output .work/feature-name/2026-03-26-plan.md
+rdx .rundown/work/feature-name/2026-03-26-plan.json --output .rundown/work/feature-name/2026-03-26-plan.md
 ```

--- a/eslint.ignores.js
+++ b/eslint.ignores.js
@@ -9,6 +9,7 @@ export const ignores = [
   '**/stryker.config.mjs',
   '**/*.d.ts',
   'site/**',
+  '.rundown/work/**',
   '.work/**',
   '.worktree/**',
   '.worktrees/**',

--- a/packages/claude-code-plugin/scripts/walkthrough-verify.sh
+++ b/packages/claude-code-plugin/scripts/walkthrough-verify.sh
@@ -2,7 +2,8 @@
 # Verify walkthrough execution
 set -e
 
-LOG=".work/walkthrough.log"
+# Log path: override via $LOG or $WORK_PATH; falls back to .rundown/work/walkthrough.log
+LOG="${LOG:-${WORK_PATH:-.rundown/work}/walkthrough.log}"
 
 # Expected log entries (in order they should appear)
 EXPECTED=(

--- a/packages/cli/__tests__/commands/claim.test.ts
+++ b/packages/cli/__tests__/commands/claim.test.ts
@@ -455,7 +455,7 @@ rd echo --result fail
     it('child inherits parent context variables', async () => {
       // Parent with variables
       const parentWithVars = `---
-PlanPath: .work/plan.md
+PlanPath: .rundown/work/plan.md
 Region: us-west
 ---
 

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import {
+  DEFAULT_WORK_PATH,
   discoverVariables,
   FileSourcePolicyError,
   findConfigFile,
@@ -111,10 +112,10 @@ describe('getBuiltinVariables', () => {
     expect(builtins.Day).toMatch(/^(0[1-9]|[12]\d|3[01])$/);
   });
 
-  it('should return WorkPath starting with .work', () => {
+  it('should return WorkPath starting with DEFAULT_WORK_PATH', () => {
     const builtins = getBuiltinVariables();
 
-    expect(builtins.WorkPath).toMatch(/^\.work/);
+    expect(builtins.WorkPath.startsWith(DEFAULT_WORK_PATH)).toBe(true);
   });
 
   it('should return Branch property', () => {
@@ -127,25 +128,25 @@ describe('getBuiltinVariables', () => {
     setExecFileSyncImpl((() => 'feature/my-branch\n') as typeof nodeExecFileSync);
 
     const builtins = getBuiltinVariables();
-    expect(builtins.WorkPath).toBe('.work/feature-my-branch');
+    expect(builtins.WorkPath).toBe(`${DEFAULT_WORK_PATH}/feature-my-branch`);
     expect(builtins.Branch).toBe('feature/my-branch');
   });
 
-  it('should fall back to .work when not in git', () => {
+  it('should fall back to DEFAULT_WORK_PATH when not in git', () => {
     setExecFileSyncImpl((() => {
       throw new Error('not a git repo');
     }) as typeof nodeExecFileSync);
 
     const builtins = getBuiltinVariables();
-    expect(builtins.WorkPath).toBe('.work');
+    expect(builtins.WorkPath).toBe(DEFAULT_WORK_PATH);
     expect(builtins.Branch).toBe('');
   });
 
-  it('should fall back to .work on detached HEAD', () => {
+  it('should fall back to DEFAULT_WORK_PATH on detached HEAD', () => {
     setExecFileSyncImpl((() => 'HEAD\n') as typeof nodeExecFileSync);
 
     const builtins = getBuiltinVariables();
-    expect(builtins.WorkPath).toBe('.work');
+    expect(builtins.WorkPath).toBe(DEFAULT_WORK_PATH);
     expect(builtins.Branch).toBe('');
   });
 

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -238,6 +238,26 @@ function normalizeToStringVariables(
 }
 
 /**
+ * Default base directory for the `WorkPath` built-in variable.
+ *
+ * Sits alongside `.rundown/config.yaml` so all rundown-owned state lives
+ * under a single top-level directory. Branch-scoped subdirectories are
+ * appended by `computeWorkPath()`.
+ */
+export const DEFAULT_WORK_PATH = '.rundown/work';
+
+/**
+ * Compute the branch-scoped `WorkPath` value.
+ *
+ * @param branch - Raw git branch name, or `null` when not in a git repo
+ * @returns `.rundown/work/<sanitized-branch>` inside git, otherwise `.rundown/work`
+ */
+export function computeWorkPath(branch: string | null): string {
+  const sanitized = branch ? sanitizeBranchName(branch) : null;
+  return sanitized ? `${DEFAULT_WORK_PATH}/${sanitized}` : DEFAULT_WORK_PATH;
+}
+
+/**
  * Returns built-in default template variables.
  *
  * These have the lowest precedence and can be overridden by any other source
@@ -248,7 +268,6 @@ function normalizeToStringVariables(
 export function getBuiltinVariables(): Record<string, string> {
   const now = new Date();
   const branch = detectGitBranch();
-  const sanitized = branch ? sanitizeBranchName(branch) : null;
   return {
     Date: now.toISOString().slice(0, 10), // YYYY-MM-DD (UTC)
     DateTime: now.toISOString(), // Full ISO timestamp (UTC)
@@ -256,7 +275,7 @@ export function getBuiltinVariables(): Record<string, string> {
     Month: String(now.getUTCMonth() + 1).padStart(2, '0'), // MM (01-12, UTC)
     Day: String(now.getUTCDate()).padStart(2, '0'), // DD (01-31, UTC)
     Branch: branch ?? '', // Raw git branch name (empty when not in git)
-    WorkPath: sanitized ? `.work/${sanitized}` : '.work', // Branch-isolated artifact directory
+    WorkPath: computeWorkPath(branch), // Branch-isolated artifact directory
     RunId: randomBytes(4).toString('hex'), // 8-char hex
     ContextId: randomBytes(4).toString('hex'), // 8-char hex
   };

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -252,7 +252,7 @@ export const DEFAULT_WORK_PATH = '.rundown/work';
  * @param branch - Raw git branch name, or `null` when not in a git repo
  * @returns `.rundown/work/<sanitized-branch>` inside git, otherwise `.rundown/work`
  */
-export function computeWorkPath(branch: string | null): string {
+function computeWorkPath(branch: string | null): string {
   const sanitized = branch ? sanitizeBranchName(branch) : null;
   return sanitized ? `${DEFAULT_WORK_PATH}/${sanitized}` : DEFAULT_WORK_PATH;
 }

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -56,8 +56,8 @@ Runbooks must never hardcode artifact paths. Use the `rdpath` CLI tool to assemb
 
 | Category | Description | rdpath flags | Example output |
 |----------|-------------|--------------|----------------|
-| **Artifact** (durable) | Final deliverables kept long-term | `--dir <base> --file <name>` | `.work/feature/2026-03-16-plan.md` |
-| **Work product** (transient) | Intermediate files scoped to an execution | `--dir <base> --ctx <id> --file <name>` | `.work/feature/.rd-a3b8c1d2/2026-03-16-findings.md` |
+| **Artifact** (durable) | Final deliverables kept long-term | `--dir <base> --file <name>` | `.rundown/work/feature/2026-03-16-plan.md` |
+| **Work product** (transient) | Intermediate files scoped to an execution | `--dir <base> --ctx <id> --file <name>` | `.rundown/work/feature/.rd-a3b8c1d2/2026-03-16-findings.md` |
 
 ### Runbook Patterns
 

--- a/scripts/e2e-entrypoint.sh
+++ b/scripts/e2e-entrypoint.sh
@@ -132,14 +132,15 @@ log "Phase 5: Verifying runbook execution artifacts..."
 RUNBOOK_CONFIRMED=false
 
 # Check for plan JSON (write-plan runbook creates this via rdpath, date-prefixed).
-# Search .work/ recursively — rdpath uses context-scoped subdirs (.rd-<ctx>/).
+# Search the work directory recursively — rdpath uses context-scoped subdirs (.rd-<ctx>/).
+WORK_SEARCH_DIR="${WORK_PATH:-.rundown/work}"
 PLAN_FILE=""
-if [ -d ".work" ]; then
-  PLAN_FILE="$(find .work -name '*-plan.json' -type f 2>/dev/null | head -1 || true)"
+if [ -d "$WORK_SEARCH_DIR" ]; then
+  PLAN_FILE="$(find "$WORK_SEARCH_DIR" -name '*-plan.json' -type f 2>/dev/null | head -1 || true)"
 fi
 
 if [ -z "$PLAN_FILE" ]; then
-  log "No plan file found in .work/"
+  log "No plan file found in $WORK_SEARCH_DIR/"
 fi
 
 if [ -n "$PLAN_FILE" ]; then


### PR DESCRIPTION
## Summary
- Change default `WorkPath` built-in variable from `.work` to `.rundown/work` so rundown-owned state lives under a single top-level directory alongside `.rundown/config.yaml`.
- Export `DEFAULT_WORK_PATH` constant so tests and future callers reference a single source of truth.
- Parameterise bundled scripts (`fetch-pr-comments.sh`, `summarize-findings.sh`, `walkthrough-verify.sh`, `e2e-entrypoint.sh`) to honour `$WORK_PATH`, making them reusable under any `WorkPath` override.

## Breaking change
Default `WorkPath` changes. Users relying on the old default should set `--var WorkPath=.work` or add `WorkPath: .work` to their config. Old `.work/` entries retained in ignore files so pre-existing artifacts stay ignored during migration.

## Test plan
- [x] `packages/cli` unit tests pass (1707 tests)
- [x] `npm run check:spell` clean
- [x] Verified `.rundown/config.yaml` remains trackable — ignore files only match `.rundown/work/`, not `.rundown/` wholesale
- [ ] Manual: run a runbook on a branch and confirm artifacts land in `.rundown/work/<branch>/`
- [ ] Manual: run `pr-feedback.runbook.md` end-to-end to verify `WORK_PATH` forwarding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched the default work directory from `.work` to `.rundown/work`; scripts now resolve work/output paths via configurable environment variables.

* **Documentation**
  * Updated docs and runbooks to use the new `.rundown/work` paths in examples and guidance.

* **Tests**
  * Updated test fixtures and expectations to reference the new default work path.

* **Chores**
  * Added `.rundown/work/` to .gitignore, .dockerignore, lint ignores, and review filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->