### PR TITLE
refactor(plugin): require tokenHash in delegation status guard

### DIFF
--- a/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
@@ -596,8 +596,15 @@ describe('handleSubagentStop', () => {
     });
   });
 
-  describe('unverifiable delegations (missing tokenHash)', () => {
-    it('returns unknown when no delegations have tokenHash', async () => {
+  describe('stale delegations filtered by type guard', () => {
+    // `isDelegationStatus` rejects entries without a string `tokenHash`.
+    // Such entries come only from pre-tokenHash session state (unsupported
+    // per the no-migration principle in CLAUDE.md). The hook must route
+    // these to `unknown` rather than drop them silently and misreport the
+    // parent as cleanly resumed — the `hadInvalidDelegations` flag carries
+    // that signal from parsing into classification.
+
+    it('returns unknown when all delegations lack tokenHash', async () => {
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
       setExecSync(
         createStatusMock({
@@ -610,6 +617,40 @@ describe('handleSubagentStop', () => {
               runbook: 'child.runbook.md',
               state: 'claimed',
               childRunId: 'run-old',
+            },
+          ],
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('Unable to verify');
+      expect(result.context).toContain('rd status');
+    });
+
+    it('returns unknown when a mixed array contains any invalid entry', async () => {
+      // Valid sibling plus a stale entry missing tokenHash. The valid entry
+      // survives the filter; the stale one flips `hadInvalidDelegations`,
+      // forcing the classifier to `unknown` instead of `completed`.
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'parent.runbook.md',
+          delegations: [
+            {
+              substep: '3.1',
+              runbook: 'child-a.runbook.md',
+              state: 'pending',
+              tokenHash: OTHER_TOKEN_HASH,
+            },
+            {
+              substep: '3.2',
+              runbook: 'child-stale.runbook.md',
+              state: 'claimed',
+              childRunId: 'run-stale',
             },
           ],
         }) as never,

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
@@ -662,6 +662,82 @@ describe('handleSubagentStop', () => {
       expect(result.context).toContain('Unable to verify');
       expect(result.context).toContain('rd status');
     });
+
+    it('routes to completed when our token matches despite invalid siblings', async () => {
+      // Pins branch ordering in classifyOutcome: a successful `ours` match
+      // must win over hadInvalidDelegations. Regression guard — would fail
+      // if the flag check were reordered to shadow a matched token.
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'parent.runbook.md',
+          delegations: [
+            {
+              substep: '3.1',
+              runbook: 'child-ours.runbook.md',
+              state: 'claimed',
+              childRunId: 'run-ours',
+              tokenHash: VALID_TOKEN_HASH,
+            },
+            {
+              substep: '3.2',
+              runbook: 'child-stale.runbook.md',
+              state: 'claimed',
+              childRunId: 'run-stale',
+              // Missing tokenHash — flips hadInvalidDelegations=true.
+            },
+          ],
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).not.toContain('Unable to verify');
+      expect(result.context).toContain('Delegation Step Complete');
+    });
+
+    it('treats non-array delegations as absent, not invalid', async () => {
+      // Raw `delegations` is not an array → parseDelegations returns
+      // hadInvalid=false. No match → fall through to completed.
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'parent.runbook.md',
+          delegations: 'not-an-array',
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).not.toContain('Unable to verify');
+      expect(result.context).toContain('Delegation Step Complete');
+    });
+
+    it('rejects non-object delegation entries and routes to unknown', async () => {
+      // Primitive entries (null, number, string) fail isDelegationStatus →
+      // hadInvalidDelegations=true → unknown.
+      mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
+      setExecSync(
+        createStatusMock({
+          active: true,
+          stashed: false,
+          file: 'parent.runbook.md',
+          delegations: [null, 42, 'bogus'],
+        }) as never,
+      );
+
+      const input = createMockHookInput('SubagentStop');
+      const result = await handleSubagentStop(input);
+
+      expect(result.context).toContain('Unable to verify');
+      expect(result.context).toContain('rd status');
+    });
   });
 
   describe('status check failure', () => {

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
@@ -21,6 +21,21 @@ const VALID_TOKEN = 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 const VALID_TOKEN_HASH = `sha256:${createHash('sha256').update(VALID_TOKEN).digest('hex')}`;
 const OTHER_TOKEN_HASH = `sha256:${createHash('sha256').update('rdtk_OTHER00000000000000000000000').digest('hex')}`;
 
+/**
+ * Outcome-distinguishing markers from {@link buildContextMessage}.
+ *
+ * These substrings are the test seam — `handleSubagentStop` returns only
+ * `{ context: string | undefined }`, so outcome discrimination at the
+ * public boundary must go through user-visible banner text. Centralized
+ * here so banner wording changes only need updating in one place.
+ *
+ * - {@link BANNER_COMPLETED_NO_SIBLINGS}: `completed` outcome with no
+ *   unresolved sibling delegations (H2 heading).
+ * - {@link BANNER_UNKNOWN}: `unknown` outcome fallback message.
+ */
+const BANNER_COMPLETED_NO_SIBLINGS = 'Delegation Step Complete';
+const BANNER_UNKNOWN = 'Unable to verify';
+
 /** Helper to create a mock that returns `rd status --json` output. */
 function createStatusMock(status: Record<string, unknown>) {
   return createMockExecSync(JSON.stringify(status));
@@ -659,14 +674,17 @@ describe('handleSubagentStop', () => {
       const input = createMockHookInput('SubagentStop');
       const result = await handleSubagentStop(input);
 
-      expect(result.context).toContain('Unable to verify');
+      expect(result.context).toContain(BANNER_UNKNOWN);
       expect(result.context).toContain('rd status');
     });
 
     it('routes to completed when our token matches despite invalid siblings', async () => {
-      // Pins branch ordering in classifyOutcome: a successful `ours` match
-      // must win over hadInvalidDelegations. Regression guard — would fail
-      // if the flag check were reordered to shadow a matched token.
+      // Narrow regression guard: catches reorderings that hoist the
+      // `hadInvalidDelegations` check above the `ours = find(...)` step in
+      // classifyOutcome. Does NOT cover every conceivable reordering — a
+      // direct exported-function test would be needed for that. Today this
+      // is the strongest assertion available at the `handleSubagentStop`
+      // public boundary.
       mockGet.mockResolvedValue({ delegation_active_token: VALID_TOKEN });
       setExecSync(
         createStatusMock({
@@ -695,8 +713,8 @@ describe('handleSubagentStop', () => {
       const input = createMockHookInput('SubagentStop');
       const result = await handleSubagentStop(input);
 
-      expect(result.context).not.toContain('Unable to verify');
-      expect(result.context).toContain('Delegation Step Complete');
+      expect(result.context).not.toContain(BANNER_UNKNOWN);
+      expect(result.context).toContain(BANNER_COMPLETED_NO_SIBLINGS);
     });
 
     it('treats non-array delegations as absent, not invalid', async () => {
@@ -715,8 +733,8 @@ describe('handleSubagentStop', () => {
       const input = createMockHookInput('SubagentStop');
       const result = await handleSubagentStop(input);
 
-      expect(result.context).not.toContain('Unable to verify');
-      expect(result.context).toContain('Delegation Step Complete');
+      expect(result.context).not.toContain(BANNER_UNKNOWN);
+      expect(result.context).toContain(BANNER_COMPLETED_NO_SIBLINGS);
     });
 
     it('rejects non-object delegation entries and routes to unknown', async () => {
@@ -735,7 +753,7 @@ describe('handleSubagentStop', () => {
       const input = createMockHookInput('SubagentStop');
       const result = await handleSubagentStop(input);
 
-      expect(result.context).toContain('Unable to verify');
+      expect(result.context).toContain(BANNER_UNKNOWN);
       expect(result.context).toContain('rd status');
     });
   });

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -70,21 +70,21 @@ type DelegationStatus =
       readonly state: 'pending';
       readonly substep: string;
       readonly runbook: string;
-      readonly tokenHash?: string;
+      readonly tokenHash: string;
     }
   | {
       readonly state: 'claimed';
       readonly substep: string;
       readonly runbook: string;
       readonly childRunId: string;
-      readonly tokenHash?: string;
+      readonly tokenHash: string;
     }
   | {
       readonly state: 'cancelled';
       readonly substep: string;
       readonly runbook: string;
       readonly childRunId?: string;
-      readonly tokenHash?: string;
+      readonly tokenHash: string;
     };
 
 /** Runbook status as a discriminated union — impossible combinations are unrepresentable. */
@@ -94,6 +94,14 @@ type RunbookStatus =
   | ({
       readonly kind: 'active';
       readonly delegations: readonly DelegationStatus[];
+      /**
+       * True when the raw delegations array contained entries that failed
+       * {@link isDelegationStatus} validation (e.g. stale pre-tokenHash state).
+       * Such entries are filtered out of `delegations`, but the flag preserves
+       * the signal so classification can route to `unknown` rather than
+       * fall through to a confidently-wrong `completed` banner.
+       */
+      readonly hadInvalidDelegations: boolean;
     } & RunbookPosition);
 
 /** Parent state carried on a completed outcome when the parent runbook is still active. */
@@ -230,7 +238,7 @@ function isDelegationStatus(d: unknown): d is DelegationStatus {
   const shared =
     typeof obj.substep === 'string' &&
     typeof obj.runbook === 'string' &&
-    (obj.tokenHash === undefined || typeof obj.tokenHash === 'string');
+    typeof obj.tokenHash === 'string';
   if (!shared) return false;
   switch (obj.state) {
     case 'pending':
@@ -247,12 +255,22 @@ function isDelegationStatus(d: unknown): d is DelegationStatus {
 /**
  * Parse delegation entries from raw JSON array.
  *
+ * Separates valid entries from invalid ones so the caller can distinguish
+ * "no delegations" from "delegations present but unverifiable" (e.g. stale
+ * session state lacking tokenHash). Invalid entries are dropped from
+ * `entries` but counted in `hadInvalid`.
+ *
  * @param raw - Raw value from parsed JSON
- * @returns Array of validated delegation status entries
+ * @returns Struct with validated entries and a flag indicating whether any
+ *   raw entries failed validation
  */
-function parseDelegations(raw: unknown): readonly DelegationStatus[] {
-  if (!Array.isArray(raw)) return [];
-  return raw.filter(isDelegationStatus);
+function parseDelegations(raw: unknown): {
+  readonly entries: readonly DelegationStatus[];
+  readonly hadInvalid: boolean;
+} {
+  if (!Array.isArray(raw)) return { entries: [], hadInvalid: false };
+  const entries = raw.filter(isDelegationStatus);
+  return { entries, hadInvalid: entries.length !== raw.length };
 }
 
 /**
@@ -293,12 +311,16 @@ function queryRunbookStatus(cwd: string): RunbookStatus | undefined {
     }
 
     // Active: runbook is running (could be parent or child)
+    const { entries: delegations, hadInvalid: hadInvalidDelegations } = parseDelegations(
+      parsed.delegations,
+    );
     return {
       kind: 'active',
       file: file ?? '(unknown)',
       position: parsePosition(parsed.position),
       step: parseStep(parsed.step),
-      delegations: parseDelegations(parsed.delegations),
+      delegations,
+      hadInvalidDelegations,
       ...(parentLinkage ? { parentLinkage } : {}),
     };
   } catch {
@@ -360,12 +382,11 @@ function classifyOutcome(status: RunbookStatus, tokenHash: string): DelegationOu
       const ours = status.delegations.find((d) => d.tokenHash === tokenHash);
 
       if (!ours) {
-        // No match on either signal. If delegations exist but none carry a
-        // tokenHash, correlation is impossible (stale session state).
-        if (
-          status.delegations.length > 0 &&
-          !status.delegations.some((d) => d.tokenHash !== undefined)
-        ) {
+        // If the raw status payload carried delegation entries that failed
+        // validation (e.g. stale pre-tokenHash session state), correlation
+        // is impossible — route to `unknown` rather than fall through and
+        // misreport the parent as cleanly resumed.
+        if (status.hadInvalidDelegations) {
           return { kind: 'unknown' };
         }
         // Otherwise: parent resumed after child completion. Any delegations

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -71,7 +71,7 @@ export interface StatusOutputData {
     state: 'pending' | 'claimed' | 'cancelled';
     childRunId?: string;
     /** SHA-256 hash of the delegation token for cross-system correlation. */
-    tokenHash?: string;
+    tokenHash: string;
   }>;
   /**
    * Parent linkage projection when this runbook was launched as a child.
@@ -259,7 +259,7 @@ export function buildActiveStatus(
             ? ('claimed' as const)
             : ('pending' as const),
       ...(ss.delegation!.childRunId != null ? { childRunId: ss.delegation!.childRunId } : {}),
-      ...(ss.delegation!.tokenHash ? { tokenHash: ss.delegation!.tokenHash } : {}),
+      tokenHash: ss.delegation!.tokenHash,
     }));
 
   return {

--- a/packages/core/__tests__/runbook/delegation-schemas.test.ts
+++ b/packages/core/__tests__/runbook/delegation-schemas.test.ts
@@ -327,8 +327,15 @@ describe('RunbookStateSchema round-trip with delegation', () => {
 });
 
 describe('DelegationStatusEntrySchema', () => {
+  const TOKEN_HASH = 'sha256:0000000000000000000000000000000000000000000000000000000000000000';
+
   it('validates a pending entry', () => {
-    const entry = { substep: '1.1', runbook: 'child.md', state: 'pending' };
+    const entry = {
+      substep: '1.1',
+      runbook: 'child.md',
+      state: 'pending',
+      tokenHash: TOKEN_HASH,
+    };
     expect(() => DelegationStatusEntrySchema.parse(entry)).not.toThrow();
   });
 
@@ -338,34 +345,59 @@ describe('DelegationStatusEntrySchema', () => {
       runbook: 'child.md',
       state: 'claimed',
       childRunId: 'run_abc123',
+      tokenHash: TOKEN_HASH,
     };
     expect(() => DelegationStatusEntrySchema.parse(entry)).not.toThrow();
   });
 
   it('validates a cancelled entry', () => {
-    const entry = { substep: '1.1', runbook: 'child.md', state: 'cancelled' };
+    const entry = {
+      substep: '1.1',
+      runbook: 'child.md',
+      state: 'cancelled',
+      tokenHash: TOKEN_HASH,
+    };
     expect(() => DelegationStatusEntrySchema.parse(entry)).not.toThrow();
   });
 
   it('rejects invalid state', () => {
-    const entry = { substep: '1.1', runbook: 'child.md', state: 'resolved' };
+    const entry = {
+      substep: '1.1',
+      runbook: 'child.md',
+      state: 'resolved',
+      tokenHash: TOKEN_HASH,
+    };
     expect(() => DelegationStatusEntrySchema.parse(entry)).toThrow();
   });
 
   it('rejects missing required fields', () => {
     expect(() => DelegationStatusEntrySchema.parse({})).toThrow();
   });
+
+  it('rejects entry missing tokenHash', () => {
+    const entry = { substep: '1.1', runbook: 'child.md', state: 'pending' };
+    expect(() => DelegationStatusEntrySchema.parse(entry)).toThrow();
+  });
 });
 
 describe('StatusResponseSchema with delegations', () => {
+  const TOKEN_HASH_A = 'sha256:1111111111111111111111111111111111111111111111111111111111111111';
+  const TOKEN_HASH_B = 'sha256:2222222222222222222222222222222222222222222222222222222222222222';
+
   it('accepts delegations field', () => {
     const status = {
       kind: 'status',
       active: true,
       stashed: false,
       delegations: [
-        { substep: '1.1', runbook: 'review.md', state: 'pending' },
-        { substep: '1.2', runbook: 'test.md', state: 'claimed', childRunId: 'run_xyz' },
+        { substep: '1.1', runbook: 'review.md', state: 'pending', tokenHash: TOKEN_HASH_A },
+        {
+          substep: '1.2',
+          runbook: 'test.md',
+          state: 'claimed',
+          childRunId: 'run_xyz',
+          tokenHash: TOKEN_HASH_B,
+        },
       ],
     };
     expect(() => StatusResponseSchema.parse(status)).not.toThrow();

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -248,7 +248,7 @@ export const DelegationStatusEntrySchema = z
     /** Child run ID (when claimed) */
     childRunId: z.string().optional().describe('Child run ID when delegation is claimed'),
     /** SHA-256 hash of the delegation token for correlation */
-    tokenHash: z.string().optional().describe('SHA-256 hash of the delegation token'),
+    tokenHash: z.string().describe('SHA-256 hash of the delegation token'),
   })
   .refine((entry) => entry.state !== 'claimed' || !!entry.childRunId, {
     message: 'childRunId is required when state is claimed',


### PR DESCRIPTION
Narrow DelegationStatus variants so tokenHash is required (matching the core StepDelegation type). Tighten isDelegationStatus to reject entries without a string tokenHash — such entries come only from pre-tokenHash session state, which we do not migrate.

Add hadInvalidDelegations flag to the active RunbookStatus variant so parseDelegations can signal filtered entries to classifyOutcome. Replace the post-filter "all entries lack tokenHash" stale-state check with a pre-filter flag check, preventing stale entries from silently falling through to a confidently-wrong 'completed' banner.

Add a mixed-array test where one valid sibling plus one stale entry still routes to 'unknown' via the new flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rejects invalid or stale delegation entries and returns "unknown" when verification can't be performed (covers mixed valid/invalid lists and primitive entries).
  * Treats non-array or absent delegations as not invalidating progress.

* **Refactor**
  * Delegation identifiers are now required and the system tracks filtered-out invalid entries to influence outcome.

* **Tests**
  * Added scenarios for mixed arrays, token-matching success despite invalid siblings, non-array delegations, and primitive-entry rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->