### PR TITLE
test: add H3 substep aggregation and runbook-list parser coverage

### DIFF
--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -172,7 +172,12 @@ describe('runbook compiler', () => {
 
       // 1.2 passes — all results in, PASS ALL: COMPLETE
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('COMPLETE');
+      const passAllSnapshot = actor.getSnapshot();
+      expect(passAllSnapshot.value).toBe('COMPLETE');
+      expect(passAllSnapshot.context.deferredResults).toEqual(['pass', 'pass']);
+      expect(passAllSnapshot.context.lastAction).toEqual(
+        expect.objectContaining({ type: 'COMPLETE' }),
+      );
     });
 
     it('H3 runbook substeps under aggregating parent FAIL ANY triggers STOP', () => {
@@ -197,7 +202,10 @@ describe('runbook compiler', () => {
 
       // 1.2 passes — all results in, FAIL ANY has a fail → STOPPED
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('STOPPED');
+      const failAnySnapshot = actor.getSnapshot();
+      expect(failAnySnapshot.value).toBe('STOPPED');
+      expect(failAnySnapshot.context.deferredResults).toEqual(['fail', 'pass']);
+      expect(failAnySnapshot.context.lastAction).toEqual(expect.objectContaining({ type: 'STOP' }));
     });
 
     it('mixed H3 substeps: prose and runbook-list both DEFER under aggregating parent', () => {
@@ -223,7 +231,9 @@ Write the plan manually.
 
       // 1.2 (runbook list) passes → DEFER → PASS ALL: COMPLETE
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('COMPLETE');
+      const mixedSnapshot = actor.getSnapshot();
+      expect(mixedSnapshot.value).toBe('COMPLETE');
+      expect(mixedSnapshot.context.deferredResults).toEqual(['pass', 'pass']);
     });
 
     it('non-aggregating substeps with sequential flow (Case D)', () => {

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -150,6 +150,82 @@ describe('runbook compiler', () => {
       expect(actor.getSnapshot().value).toBe('step::2');
     });
 
+    it('H3 runbook substeps under aggregating parent DEFER and aggregate on PASS ALL', () => {
+      const steps = createRunbook(`## 1. Review
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Code review
+- code-review.runbook.md
+
+### 1.2 Security review
+- security-review.runbook.md
+`);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // 1.1 passes — DEFER advances to 1.2, aggregation waits
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('step::1::2');
+
+      // 1.2 passes — all results in, PASS ALL: COMPLETE
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('COMPLETE');
+    });
+
+    it('H3 runbook substeps under aggregating parent FAIL ANY triggers STOP', () => {
+      const steps = createRunbook(`## 1. Review
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Code review
+- code-review.runbook.md
+
+### 1.2 Security review
+- security-review.runbook.md
+`);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // 1.1 fails — DEFER collects result, advances to 1.2
+      actor.send({ type: 'FAIL' });
+      expect(actor.getSnapshot().value).toBe('step::1::2');
+
+      // 1.2 passes — all results in, FAIL ANY has a fail → STOPPED
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('STOPPED');
+    });
+
+    it('mixed H3 substeps: prose and runbook-list both DEFER under aggregating parent', () => {
+      const steps = createRunbook(`## 1. Plan and review
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Write plan
+Write the plan manually.
+
+### 1.2 Review plan
+- review-plan.runbook.md
+`);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Both substeps get DEFER under aggregating parent
+      // 1.1 (prose) passes → DEFER → advances to 1.2
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('step::1::2');
+
+      // 1.2 (runbook list) passes → DEFER → PASS ALL: COMPLETE
+      actor.send({ type: 'PASS' });
+      expect(actor.getSnapshot().value).toBe('COMPLETE');
+    });
+
     it('non-aggregating substeps with sequential flow (Case D)', () => {
       const steps = inferSteps([
         {

--- a/packages/parser/__tests__/parser.test.ts
+++ b/packages/parser/__tests__/parser.test.ts
@@ -74,6 +74,84 @@ describe('parseRunbook with substep runbooks', () => {
   });
 });
 
+describe('H3 substep with runbook list — variations', () => {
+  it('parses mixed H3 substeps: prose sibling and runbook-list sibling in same parent', () => {
+    const markdown = `## 1. Execute
+
+### 1.1 Analyze
+- PASS CONTINUE
+- FAIL STOP
+
+Do analysis work.
+
+### 1.2 Run child
+- PASS CONTINUE
+- FAIL STOP
+
+- child.runbook.md
+`;
+    const steps = parseRunbook(markdown);
+    expect(steps[0].substeps).toHaveLength(2);
+    expect(steps[0].substeps![0].prompt).toBe('Do analysis work.');
+    expect(steps[0].substeps![0].runbooks).toBeUndefined();
+    expect(steps[0].substeps![1].prompt).toBeUndefined();
+    expect(steps[0].substeps![1].runbooks).toEqual(['child.runbook.md']);
+  });
+
+  it('parses template variable reference in H3 runbook list path', () => {
+    const markdown = `## 1. Execute
+
+### 1.1 Run plan
+- PASS CONTINUE
+- FAIL STOP
+
+- {{ PlanPath }}
+`;
+    const steps = parseRunbook(markdown);
+    const substep = steps[0].substeps![0];
+    expect(substep.runbooks).toEqual([{ ref: 'PlanPath' }]);
+  });
+
+  it('preserves H3 header description when substep body is runbook list only', () => {
+    const markdown = `## 1. Execute
+
+### 1.1 Review plan
+- PASS CONTINUE
+- FAIL STOP
+
+- review-plan.runbook.md
+`;
+    const steps = parseRunbook(markdown);
+    const substep = steps[0].substeps![0];
+    expect(substep.id).toBe('1');
+    expect(substep.description).toBe('Review plan');
+    expect(substep.runbooks).toEqual(['review-plan.runbook.md']);
+    expect(substep.prompt).toBeUndefined();
+  });
+
+  it('parses two H3 runbook-list substeps preserving both descriptions', () => {
+    const markdown = `## 1. Execute
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Write plan
+- write-plan.runbook.md
+
+### 1.2 Review plan
+- review-plan.runbook.md
+`;
+    const steps = parseRunbook(markdown);
+    expect(steps[0].substeps).toHaveLength(2);
+    const [sub1, sub2] = steps[0].substeps!;
+    expect(sub1.description).toBe('Write plan');
+    expect(sub1.runbooks).toEqual(['write-plan.runbook.md']);
+    expect(sub1.prompt).toBeUndefined();
+    expect(sub2.description).toBe('Review plan');
+    expect(sub2.runbooks).toEqual(['review-plan.runbook.md']);
+    expect(sub2.prompt).toBeUndefined();
+  });
+});
+
 describe('inline code preservation', () => {
   it('preserves inline code in step description', () => {
     const md = `## 1. Path: \`/some/path\`


### PR DESCRIPTION
## Summary

- Add 3 compiler tests for H3 substep aggregation: PASS ALL → COMPLETE, FAIL ANY → STOPPED, and mixed prose + runbook-list siblings under an aggregating parent
- Add 4 parser tests for H3 runbook-list variations: template variable in path, description preservation, and mixed sibling types

## Notes

Pure test additions — no source changes. Tests cover existing behavior that was previously untested.

## Test plan

- [ ] `cd packages/core && npx jest compiler.test.ts`
- [ ] `cd packages/parser && npx jest parser.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for H3 substep deferred aggregation covering pass, fail, and mixed-content scenarios, verifying state progression, aggregated deferred results, and stop behavior on failure.
  * Added parsing tests for H3 substeps with runbook lists, including template-variable references, preservation of substep descriptions, and correct assignment of prompt vs runbooks fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->