### PR TITLE
feat: add runbook field to step assertions for delegation filtering

### DIFF
--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -136,6 +136,28 @@ describe('parseJsonLines', () => {
     expect(result.transitions).toHaveLength(0);
     expect(result.terminal).toBeNull();
   });
+
+  it('captures runbook envelope field from step_transitioned event', () => {
+    const stdout =
+      '{"type":"step_transitioned","action":"COMPLETE","from":"1","at":"1","result":"PASS","runbook":{"path":"/abs/child.runbook.md","name":"child"}}\n';
+    const result = parseJsonLines(stdout);
+    expect(result.transitions[0].runbook).toEqual({ path: '/abs/child.runbook.md', name: 'child' });
+  });
+
+  it('captures parentStepId envelope field from step_transitioned event', () => {
+    const stdout =
+      '{"type":"step_transitioned","action":"COMPLETE","from":"1","at":"1","result":"PASS","parentStepId":"1.1"}\n';
+    const result = parseJsonLines(stdout);
+    expect(result.transitions[0].parentStepId).toBe('1.1');
+  });
+
+  it('leaves runbook and parentStepId undefined when absent', () => {
+    const stdout =
+      '{"type":"step_transitioned","action":"CONTINUE","from":"1","at":"2","result":"PASS"}\n';
+    const result = parseJsonLines(stdout);
+    expect(result.transitions[0].runbook).toBeUndefined();
+    expect(result.transitions[0].parentStepId).toBeUndefined();
+  });
 });
 
 describe('matchStepAssertions', () => {
@@ -209,6 +231,98 @@ describe('matchStepAssertions', () => {
     expect(results[0].matched).toBe(true); // GOTO matches second event
     expect(results[1].matched).toBe(false); // CONTINUE at position 2 already consumed
   });
+
+  it('matches runbook filter by path suffix', () => {
+    const events = [
+      {
+        action: 'COMPLETE',
+        from: '1',
+        result: 'PASS' as const,
+        runbook: { path: '/abs/child.runbook.md' },
+      },
+    ];
+    const results = matchStepAssertions(
+      [{ runbook: 'child.runbook.md', action: 'COMPLETE' }],
+      events,
+    );
+    expect(results[0].matched).toBe(true);
+  });
+
+  it('matches runbook filter by name suffix when path absent', () => {
+    const events = [
+      {
+        action: 'COMPLETE',
+        from: '1',
+        result: 'PASS' as const,
+        runbook: { name: 'child.runbook.md' },
+      },
+    ];
+    const results = matchStepAssertions([{ runbook: 'child.runbook.md' }], events);
+    expect(results[0].matched).toBe(true);
+  });
+
+  it('rejects runbook filter when path does not match', () => {
+    const events = [
+      {
+        action: 'COMPLETE',
+        from: '1',
+        result: 'PASS' as const,
+        runbook: { path: '/abs/parent.runbook.md' },
+      },
+    ];
+    const results = matchStepAssertions([{ runbook: 'child.runbook.md' }], events);
+    expect(results[0].matched).toBe(false);
+  });
+
+  it('runbook filter is a suffix match — handles subdirectory paths', () => {
+    const events = [
+      {
+        action: 'COMPLETE',
+        from: '1',
+        result: 'PASS' as const,
+        runbook: { path: '/abs/delegation/child.runbook.md' },
+      },
+    ];
+    const results = matchStepAssertions([{ runbook: 'child.runbook.md' }], events);
+    expect(results[0].matched).toBe(true);
+  });
+
+  it('assertion without runbook matches events regardless of their runbook field', () => {
+    const events = [
+      {
+        action: 'COMPLETE',
+        from: '1',
+        result: 'PASS' as const,
+        runbook: { path: '/abs/anything.runbook.md' },
+      },
+    ];
+    const results = matchStepAssertions([{ action: 'COMPLETE' }], events);
+    expect(results[0].matched).toBe(true);
+  });
+
+  it('runbook filter distinguishes child from parent when both at same step position', () => {
+    const events = [
+      {
+        action: 'COMPLETE',
+        from: '1',
+        result: 'PASS' as const,
+        runbook: { path: '/abs/child.runbook.md' },
+      },
+      {
+        action: 'COMPLETE',
+        from: '1',
+        result: 'PASS' as const,
+        runbook: { path: '/abs/parent.runbook.md' },
+      },
+    ];
+    const assertions = [
+      { runbook: 'child.runbook.md', from: '1', action: 'COMPLETE' as const },
+      { runbook: 'parent.runbook.md', from: '1', action: 'COMPLETE' as const },
+    ];
+    const results = matchStepAssertions(assertions, events);
+    expect(results[0].matched).toBe(true);
+    expect(results[1].matched).toBe(true);
+  });
 });
 
 describe('formatStepAssertionDescription', () => {
@@ -234,6 +348,14 @@ describe('formatStepAssertionDescription', () => {
       matched: true,
     });
     expect(result).toBe('step (empty assertion): matched');
+  });
+
+  it('includes runbook first when present', () => {
+    const result = formatStepAssertionDescription({
+      assertion: { runbook: 'child.runbook.md', from: '1', action: 'COMPLETE' },
+      matched: true,
+    });
+    expect(result).toBe('step runbook=child.runbook.md from=1 action=COMPLETE: matched');
   });
 });
 

--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -274,6 +274,20 @@ describe('matchStepAssertions', () => {
     expect(results[0].matched).toBe(false);
   });
 
+  it('rejects runbook filter when path does not match even if name matches', () => {
+    // path takes precedence when present — name is not a fallback matcher alongside path
+    const events = [
+      {
+        action: 'COMPLETE',
+        from: '1',
+        result: 'PASS' as const,
+        runbook: { path: '/abs/parent.runbook.md', name: 'child.runbook.md' },
+      },
+    ];
+    const results = matchStepAssertions([{ runbook: 'child.runbook.md' }], events);
+    expect(results[0].matched).toBe(false);
+  });
+
   it('runbook filter is a suffix match — handles subdirectory paths', () => {
     const events = [
       {

--- a/packages/cli/__tests__/integration/delegation-h3-runbook-substep.test.ts
+++ b/packages/cli/__tests__/integration/delegation-h3-runbook-substep.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Integration tests for delegation from H3 substeps defined as runbook lists.
+ *
+ * Tests the form:
+ * ```markdown
+ * ### 1.1 Child task
+ * - child.runbook.md
+ * ```
+ *
+ * Where the substep body IS the runbook reference — no prose. Delegation
+ * can then infer the runbook path from the substep's `runbooks` field.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { createTestWorkspace, runCli, type TestWorkspace } from '../helpers/test-utils.js';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+describe('H3 runbook-list substep delegation integration', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  /** Simple auto-completing child runbook. */
+  async function writeChildRunbook(name = 'child.runbook.md'): Promise<void> {
+    await writeFile(
+      join(workspace.cwd, name),
+      `## 1. Execute
+- PASS COMPLETE
+
+\`\`\`bash
+rd echo "child completed"
+\`\`\`
+`,
+    );
+  }
+
+  /** Parent runbook: aggregating step with one H3 runbook-list substep (no prose). */
+  async function writeParentSingle(): Promise<void> {
+    await writeFile(
+      join(workspace.cwd, 'parent.runbook.md'),
+      `## 1. Execute workflow
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Child task
+- child.runbook.md
+`,
+    );
+  }
+
+  /** Parent runbook: aggregating step with two H3 runbook-list substeps. */
+  async function writeParentTwo(): Promise<void> {
+    await writeFile(
+      join(workspace.cwd, 'parent.runbook.md'),
+      `## 1. Execute workflow
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 First task
+- child1.runbook.md
+
+### 1.2 Second task
+- child2.runbook.md
+`,
+    );
+  }
+
+  it('delegates substep using runbook inferred from H3 runbook list (--step only)', async () => {
+    await writeChildRunbook();
+    await writeParentSingle();
+
+    let result = runCli('run --prompted parent.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    // Provide --step but omit runbook path — inferred from substep.runbooks[0]
+    result = runCli('delegate --step 1.1', workspace);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('DELEGATED');
+
+    const tokenMatch = /Token:\s*(rdtk_\S+)/.exec(result.stdout);
+    expect(tokenMatch).not.toBeNull();
+  });
+
+  it('delegates substep using fully inferred step and runbook (no args)', async () => {
+    await writeChildRunbook();
+    await writeParentSingle();
+
+    let result = runCli('run --prompted parent.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    // No args — infers step (1.1) and runbook (child.runbook.md) from state
+    result = runCli('delegate', workspace);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('DELEGATED');
+
+    const tokenMatch = /Token:\s*(rdtk_\S+)/.exec(result.stdout);
+    expect(tokenMatch).not.toBeNull();
+  });
+
+  it('completes parent after delegate → claim for single H3 runbook-list substep', async () => {
+    await writeChildRunbook();
+    await writeParentSingle();
+
+    let result = runCli('run --prompted parent.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    result = runCli('delegate', workspace);
+    expect(result.exitCode).toBe(0);
+
+    const tokenMatch = /Token:\s*(rdtk_\S+)/.exec(result.stdout);
+    expect(tokenMatch).not.toBeNull();
+    const token = tokenMatch![1];
+
+    result = runCli(`claim ${token}`, workspace);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('sequential delegation of two H3 runbook-list substeps completes parent', async () => {
+    await writeChildRunbook('child1.runbook.md');
+    await writeChildRunbook('child2.runbook.md');
+    await writeParentTwo();
+
+    // Run WITHOUT --prompted so children also run without --prompted and auto-complete
+    let result = runCli('run parent.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    // Delegate first substep (inferred → child1.runbook.md)
+    result = runCli('delegate', workspace);
+    expect(result.exitCode).toBe(0);
+    const token1Match = /Token:\s*(rdtk_\S+)/.exec(result.stdout);
+    expect(token1Match).not.toBeNull();
+    const token1 = token1Match![1];
+
+    // Child1 auto-executes rd echo and completes; propagates pass to parent substep 1.1
+    result = runCli(`claim ${token1}`, workspace);
+    expect(result.exitCode).toBe(0);
+
+    // Delegate second substep (inferred → child2.runbook.md); parent is now active again
+    result = runCli('delegate', workspace);
+    expect(result.exitCode).toBe(0);
+    const token2Match = /Token:\s*(rdtk_\S+)/.exec(result.stdout);
+    expect(token2Match).not.toBeNull();
+    const token2 = token2Match![1];
+
+    result = runCli(`claim ${token2}`, workspace);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('delegate --step 1.1 with explicit runbook overrides inferred runbook', async () => {
+    await writeChildRunbook();
+    await writeChildRunbook('explicit-child.runbook.md');
+    await writeParentSingle();
+
+    let result = runCli('run --prompted parent.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    // Pass explicit runbook path even though substep has one — explicit wins
+    result = runCli('delegate explicit-child.runbook.md --step 1.1', workspace);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('DELEGATED');
+
+    const tokenMatch = /Token:\s*(rdtk_\S+)/.exec(result.stdout);
+    expect(tokenMatch).not.toBeNull();
+    const token = tokenMatch![1];
+
+    result = runCli(`claim ${token}`, workspace);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('mixed H3 substeps: prose substep passed manually, runbook substep delegated', async () => {
+    await writeChildRunbook();
+    await writeFile(
+      join(workspace.cwd, 'parent.runbook.md'),
+      `## 1. Execute workflow
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Manual step
+Do some manual work here.
+
+### 1.2 Automated step
+- child.runbook.md
+`,
+    );
+
+    let result = runCli('run --prompted parent.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    // Step 1.1 is prose — pass it directly
+    result = runCli('pass --step 1.1', workspace);
+    expect(result.exitCode).toBe(0);
+
+    // Step 1.2 is runbook list — delegate and claim
+    result = runCli('delegate', workspace);
+    expect(result.exitCode).toBe(0);
+    const tokenMatch = /Token:\s*(rdtk_\S+)/.exec(result.stdout);
+    expect(tokenMatch).not.toBeNull();
+    const token = tokenMatch![1];
+
+    result = runCli(`claim ${token}`, workspace);
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/cli/__tests__/schemas/scenarios.test.ts
+++ b/packages/cli/__tests__/schemas/scenarios.test.ts
@@ -177,6 +177,32 @@ describe('StepAssertionSchema', () => {
     const result = StepAssertionSchema.safeParse({ result: 'pass' }); // lowercase
     expect(result.success).toBe(false);
   });
+
+  it('accepts runbook as a string', () => {
+    const result = StepAssertionSchema.safeParse({ runbook: 'child.runbook.md' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.runbook).toBe('child.runbook.md');
+    }
+  });
+
+  it('runbook is optional — absent from parsed data when not provided', () => {
+    const result = StepAssertionSchema.safeParse({ action: 'COMPLETE' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.runbook).toBeUndefined();
+    }
+  });
+
+  it('validates full assertion including runbook', () => {
+    const result = StepAssertionSchema.safeParse({
+      runbook: 'delegation-child-pass.runbook.md',
+      from: '1',
+      action: 'COMPLETE',
+      result: 'PASS',
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('getEffectiveResult', () => {

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -25,6 +25,10 @@ export interface CapturedTransition {
   command?: string;
   /** Whether this transition resulted from aggregation (deferred result evaluation). */
   aggregated?: boolean;
+  /** Runbook that produced this transition (from event envelope). */
+  runbook?: { name?: string; path?: string };
+  /** Present for delegated/nested child runs — identifies the delegating parent step. */
+  parentStepId?: string;
 }
 
 /** Result of matching a single step assertion against the event stream. */
@@ -183,6 +187,8 @@ function processJsonObject(
       result: obj.result as 'PASS' | 'FAIL',
       command: obj.command as string | undefined,
       aggregated: obj.aggregated === true ? true : undefined,
+      runbook: obj.runbook as { name?: string; path?: string } | undefined,
+      parentStepId: typeof obj.parentStepId === 'string' ? obj.parentStepId : undefined,
     });
   } else if (obj.type === 'runbook_completed') {
     terminal = 'COMPLETE';
@@ -209,12 +215,12 @@ function processJsonObject(
  *
  * Handles two output formats:
  * - NDJSON: Multiple compact JSON objects, one per line (execution events + flushed object)
- * - Pretty-printed: A single multi-line JSON object (flushed object only, e.g., from `rd pass --json`)
+ * - Pretty-printed: A single multi-line JSON object (flushed object only, e.g., from `rd pass`)
  *
  * Transitions are extracted ONLY from streamed `step_transitioned` events.
  * The flushed JSON object (without a `type` field) is used ONLY for terminal detection.
  *
- * @param stdout - Raw stdout string from an rd command run with `--json`
+ * @param stdout - Raw stdout string from an rd command (JSON is the default format)
  * @returns Object with extracted transitions and terminal result (or null if not determined)
  */
 export function parseJsonLines(stdout: string): {
@@ -277,6 +283,12 @@ function eventMatchesAssertion(event: CapturedTransition, assertion: StepAsserti
   if (assertion.result !== undefined && event.result !== assertion.result) return false;
   if (assertion.command !== undefined && event.command !== assertion.command) return false;
   if (assertion.aggregated !== undefined && event.aggregated !== assertion.aggregated) return false;
+  if (assertion.runbook !== undefined) {
+    const rb = event.runbook;
+    const pathMatch = rb?.path !== undefined && rb.path.endsWith(assertion.runbook);
+    const nameMatch = rb?.name !== undefined && rb.name.endsWith(assertion.runbook);
+    if (!pathMatch && !nameMatch) return false;
+  }
   return true;
 }
 
@@ -326,6 +338,7 @@ export function matchStepAssertions(
  */
 export function formatStepAssertionDescription(sa: StepAssertionResult): string {
   const parts: string[] = [];
+  if (sa.assertion.runbook !== undefined) parts.push(`runbook=${sa.assertion.runbook}`);
   if (sa.assertion.at !== undefined) parts.push(`at=${sa.assertion.at}`);
   if (sa.assertion.from !== undefined) parts.push(`from=${sa.assertion.from}`);
   if (sa.assertion.action !== undefined) parts.push(`action=${sa.assertion.action}`);
@@ -399,7 +412,7 @@ export function extractVarFileReferences(commands: string[]): string[] {
 /**
  * Execute a sequence of commands in order, accumulating transitions and tokens.
  *
- * Handles `rd` commands (routed through the CLI with `--json`) and generic
+ * Handles `rd` commands (routed through the CLI with JSON output) and generic
  * shell commands. Token placeholders (`${TOKEN}`, `${TOKEN_2}`, etc.) are
  * substituted with previously captured delegation tokens before each
  * command runs. Tokens are extracted from parsed JSON `delegate` responses.
@@ -429,7 +442,7 @@ export async function executeCommandSequence(
     let stdout: string;
 
     if (rdMatch) {
-      // rd command — parse args and inject --json
+      // rd command — parse args (JSON output is the default)
       const shellArgs = shellParse(rdMatch[1]);
       const hasOperators = shellArgs.some((entry) => typeof entry !== 'string');
       if (hasOperators) {
@@ -438,7 +451,7 @@ export async function executeCommandSequence(
             'Split into separate commands instead of using &&, ||, |, etc.',
         );
       }
-      const args = injectJsonFlag(shellArgs as string[]);
+      const args = shellArgs as string[];
       const result = await runCommandWithTee({ kind: 'rd', args }, { cwd, quiet, cliPath, env });
       stdout = result.stdout;
 

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -215,12 +215,12 @@ function processJsonObject(
  *
  * Handles two output formats:
  * - NDJSON: Multiple compact JSON objects, one per line (execution events + flushed object)
- * - Pretty-printed: A single multi-line JSON object (flushed object only, e.g., from `rd pass`)
+ * - Pretty-printed: A single multi-line JSON object (flushed object only, e.g., from `rd pass --json`)
  *
  * Transitions are extracted ONLY from streamed `step_transitioned` events.
  * The flushed JSON object (without a `type` field) is used ONLY for terminal detection.
  *
- * @param stdout - Raw stdout string from an rd command (JSON is the default format)
+ * @param stdout - Raw stdout string from an rd command run with `--json`
  * @returns Object with extracted transitions and terminal result (or null if not determined)
  */
 export function parseJsonLines(stdout: string): {
@@ -285,9 +285,13 @@ function eventMatchesAssertion(event: CapturedTransition, assertion: StepAsserti
   if (assertion.aggregated !== undefined && event.aggregated !== assertion.aggregated) return false;
   if (assertion.runbook !== undefined) {
     const rb = event.runbook;
-    const pathMatch = rb?.path !== undefined && rb.path.endsWith(assertion.runbook);
-    const nameMatch = rb?.name !== undefined && rb.name.endsWith(assertion.runbook);
-    if (!pathMatch && !nameMatch) return false;
+    if (rb?.path !== undefined) {
+      if (!rb.path.endsWith(assertion.runbook)) return false;
+    } else if (rb?.name !== undefined) {
+      if (!rb.name.endsWith(assertion.runbook)) return false;
+    } else {
+      return false;
+    }
   }
   return true;
 }
@@ -412,7 +416,7 @@ export function extractVarFileReferences(commands: string[]): string[] {
 /**
  * Execute a sequence of commands in order, accumulating transitions and tokens.
  *
- * Handles `rd` commands (routed through the CLI with JSON output) and generic
+ * Handles `rd` commands (routed through the CLI with `--json`) and generic
  * shell commands. Token placeholders (`${TOKEN}`, `${TOKEN_2}`, etc.) are
  * substituted with previously captured delegation tokens before each
  * command runs. Tokens are extracted from parsed JSON `delegate` responses.
@@ -442,7 +446,7 @@ export async function executeCommandSequence(
     let stdout: string;
 
     if (rdMatch) {
-      // rd command — parse args (JSON output is the default)
+      // rd command — parse args and inject --json
       const shellArgs = shellParse(rdMatch[1]);
       const hasOperators = shellArgs.some((entry) => typeof entry !== 'string');
       if (hasOperators) {
@@ -451,7 +455,7 @@ export async function executeCommandSequence(
             'Split into separate commands instead of using &&, ||, |, etc.',
         );
       }
-      const args = shellArgs as string[];
+      const args = injectJsonFlag(shellArgs as string[]);
       const result = await runCommandWithTee({ kind: 'rd', args }, { cwd, quiet, cliPath, env });
       stdout = result.stdout;
 

--- a/packages/cli/src/schemas/scenarios.ts
+++ b/packages/cli/src/schemas/scenarios.ts
@@ -6,6 +6,10 @@ import { z } from 'zod';
  * All fields are optional — only specified fields are matched against
  * the transition event. String/number union on `at`/`from` handles
  * YAML's tendency to parse `1.10` as a float.
+ *
+ * The `runbook` field is matched as a suffix against the transition's
+ * `runbook.path` (falling back to `runbook.name`). For example,
+ * `"child.runbook.md"` matches `"/abs/path/child.runbook.md"`.
  */
 export const StepAssertionSchema = z.object({
   at: z.union([z.string(), z.number()]).transform(String).optional(),
@@ -16,6 +20,7 @@ export const StepAssertionSchema = z.object({
   result: z.enum(['PASS', 'FAIL']).optional(),
   command: z.string().optional(),
   aggregated: z.boolean().optional(),
+  runbook: z.string().optional(),
 });
 
 /** A parsed step assertion used to match against captured transition events. */

--- a/runbooks/delegation/delegate-substep-list.runbook.md
+++ b/runbooks/delegation/delegate-substep-list.runbook.md
@@ -1,0 +1,66 @@
+---
+name: delegate-substep-list
+description: Delegation from H3 substeps defined as pure runbook list bodies (no prose)
+tags:
+  - delegation
+
+scenarios:
+  single-pass:
+    description: Single H3 runbook-list substep delegated via full inference; child step passed explicitly
+    commands:
+      - rd run --prompted delegate-substep-list.runbook.md
+      - rd delegate
+      - rd claim ${TOKEN}
+      - rd pass
+    expect:
+      result: COMPLETE
+      steps:
+        - runbook: delegate-substep-list.runbook.md
+          from: "1.1"
+          action: COMPLETE
+          result: PASS
+
+  step-inferred-runbook:
+    description: Delegate with --step only; runbook inferred from substep body; child step passed explicitly
+    commands:
+      - rd run --prompted delegate-substep-list.runbook.md
+      - rd delegate --step 1.1
+      - rd claim ${TOKEN}
+      - rd pass
+    expect:
+      result: COMPLETE
+      steps:
+        - runbook: delegate-substep-list.runbook.md
+          from: "1.1"
+          action: COMPLETE
+          result: PASS
+
+  child-fails:
+    description: Child runbook fails, parent stops; child step failed explicitly
+    commands:
+      - rd run --prompted delegate-substep-list.runbook.md
+      - rd delegate --step 1.1 delegation-child-fail.runbook.md
+      - rd claim ${TOKEN}
+      - rd fail
+    expect:
+      result: STOP
+      steps:
+        - runbook: delegate-substep-list.runbook.md
+          from: "1.1"
+          action: STOP
+          result: FAIL
+---
+
+# Delegate Substep List
+
+Parent runbook whose substep is defined as a pure runbook list body (no prose body text).
+The substep's runbook reference is inferred by `rd delegate` from the substep's `runbooks` field.
+
+## 1. Execute workflow
+
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Child task
+
+- delegation-child-pass.runbook.md


### PR DESCRIPTION
## Summary

- Add `runbook` field to `CapturedTransition` and `StepAssertionSchema`, matched as a suffix against the transition's `runbook.path` (falling back to `runbook.name`) — e.g. `"child.runbook.md"` matches `"/abs/path/child.runbook.md"`
- Add `parentStepId` field to `CapturedTransition` for delegated/nested child runs
- Remove `--json` flag injection from `executeCommandSequence` (JSON is now the CLI default output format)
- Add 8 integration tests for H3 substep delegation inference: auto-infer runbook path from substep metadata, explicit `--step`, and child failure handling
- Add `delegate-substep-list.runbook.md` test fixture with 3 scenarios

## Test plan

- [ ] `cd packages/cli && npx jest command-sequence.test.ts scenarios.test.ts`
- [ ] `npm run test:integration` — `delegation-h3-runbook-substep` integration tests