### PR TITLE
docs: sync SPEC, FORMAT, RUNDOWN, and CLAUDE.md against codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Template variables use Handlebars syntax `{{variableName}}` and are expanded at 
 | `context.current.step` | `3.1` | Current qualified step identifier |
 | `context.current.substep` | `1` | Current substep number (when in substep) |
 | `context.current.index` | `3` | Current loop iteration (inside FOR) |
-| `context.current.at` | `3.1[3]` | Full execution position |
+| `context.current.at` | `3.3.1` | Full execution position (`STEP.INDEX.SUBSTEP` inside a FOR loop, `STEP.SUBSTEP` otherwise) |
 
 **Plugin Variables:**
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -102,7 +102,7 @@ Unicode escapes: `\u2014` is em dash (—), `\u2192` is right arrow (→).
 
 Separators are matched greedily — the longest sequence of separator characters between identifier and description text is consumed.
 
-**Note:** Two distinct separator sets apply at different parse phases. Only space, dash (`-`), and colon (`:`) may terminate a step identifier inside the header (the in-header step-ID terminator set). The broader set listed in the production above (`.` `:` `—` `→` `-` `)` space) is stripped from the leading edge of the description text after the identifier has been parsed. Authors writing `## 1. Foo` rely on the trailing-strip behavior; the `.` is not itself a valid in-header terminator.
+**Note:** The full separator set (`.` `:` `—` `→` `-` `)` plus whitespace) is applied in two places during header parsing: trailing separator characters are stripped from the extracted step-identifier token, and leading separators are stripped from the remainder before it becomes the description. This makes headers like `## 1.`, `## 1. Foo`, `## Rollback)`, and `## Rollback — clean up` all valid with the same set of punctuation.
 
 ## FOR Clauses
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -78,7 +78,7 @@ substep ::= "### " substep_id separator? text? newline
             ( code_block | runbook_list )?
 ```
 
-Substeps cannot contain nested substeps.
+Substeps cannot contain nested substeps. See [SPEC.md §1.1](./SPEC.md) for the heading hierarchy rules.
 
 ## Identifiers
 
@@ -101,6 +101,8 @@ separator ::= ( "." | ":" | "\u2014" | "\u2192" | "-" | ")" | " " )+
 Unicode escapes: `\u2014` is em dash (—), `\u2192` is right arrow (→).
 
 Separators are matched greedily — the longest sequence of separator characters between identifier and description text is consumed.
+
+**Note:** Two distinct separator sets apply at different parse phases. Only space, dash (`-`), and colon (`:`) may terminate a step identifier inside the header (the in-header step-ID terminator set). The broader set listed in the production above (`.` `:` `—` `→` `-` `)` space) is stripped from the leading edge of the description text after the identifier has been parsed. Authors writing `## 1. Foo` rely on the trailing-strip behavior; the `.` is not itself a valid in-header terminator.
 
 ## FOR Clauses
 
@@ -177,6 +179,8 @@ Context constraints:
 | `DEFER` | Substeps, FOR nested transitions |
 | `NEXT` | FOR substeps, FOR nested transitions |
 | `BREAK` | FOR substeps, FOR nested transitions |
+
+Note: `- DEFER` on its own line is a shorthand transition equivalent to `PASS DEFER` + `FAIL DEFER` (see [Transitions](#transitions)). The `DEFER` action listed here is the target of that shorthand and of explicit `PASS DEFER` / `FAIL DEFER` transitions.
 
 FOR nested transitions allow: `CONTINUE`, `DEFER`, `NEXT`, `BREAK`, `GOTO`, `STOP`, `COMPLETE` (with optional `RETRY` wrapper).
 

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -606,7 +606,7 @@ Rundown enforces a security policy layer to control what commands runbooks can e
 
 ### Default Behavior
 
-See [SECURITY.md](./SECURITY.md) for full default policy details, including command allow/block/prompt behavior, sandbox-on-by-default enforcement, and the default write restriction to `.rundown` subpaths.
+See [SECURITY.md](./SECURITY.md) for full default policy details, including command allow/block/prompt behavior, sandbox-on-by-default enforcement, and the default write allowlist (Rundown state paths under `.rundown/`, plus `.claude/**`, `node_modules/**`, `dist/**`, `build/**`, `.next/**`, and `{tmp}/**`).
 
 ### Quick Reference
 

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -33,6 +33,7 @@ This document provides a comprehensive guide and reference for the Rundown CLI (
   - [Enforcement Control](#enforcement-control)
   - [Validation](#validation)
   - [Maintenance](#maintenance)
+  - [Testing and Utilities](#testing-and-utilities)
   - [Delegation Commands](#delegation-commands)
 - [Common Tasks](#common-tasks)
 - [Delegation Patterns](#delegation-patterns)
@@ -108,6 +109,25 @@ The CLI resolves runbook paths in this order:
 2. Relative to current working directory
 3. Relative to `.rundown/runbooks/` in the project root
 
+### Runbook Discovery
+
+When a runbook is referenced by name (rather than an explicit path), the CLI searches multiple sources in priority order:
+
+| Priority | Source | Location |
+|----------|--------|----------|
+| 1 (highest) | Project | `.rundown/runbooks/` |
+| 2 | Plugin | `$CLAUDE_PLUGIN_ROOT/runbooks/` |
+| 3 | Bundled | CLI package `dist/runbooks/` |
+
+Directories are scanned recursively, so nested layouts like `planning/write-plan.runbook.md` are supported.
+
+**Namespace syntax** — Use `namespace:name` to target a specific source explicitly:
+
+- `write-plan` — resolves via the priority chain above
+- `rundown:write-plan` — explicit: from the plugin source only
+
+`rd ls --all` lists discoverable runbooks with a `SOURCE` column indicating where each was found (`project`, `plugin`, or `bundled`).
+
 **Check status:**
 ```bash
 rundown status
@@ -152,11 +172,13 @@ Runbooks compile to XState machines at runtime. Steps become states:
 | `## 1. Title` | `step::1` |
 | `## 2. Title` | `step::2` |
 | `### 2.1 Substep` | `step::2::1` |
+| `## Cleanup` | `step::Cleanup` |
+| `### Cleanup.verify` | `step::Cleanup::verify` |
 
 Terminal states: `COMPLETE`, `STOPPED`
 
-#### Events
-The state machine responds to these events:
+#### Input Events
+The state machine responds to these input events:
 
 | Event | Trigger | Effect |
 |-------|---------|--------|
@@ -164,6 +186,8 @@ The state machine responds to these events:
 | `FAIL` | `rundown fail` or command exit non-0 | Evaluate FAIL transition |
 | `GOTO` | `rundown goto N` or GOTO action | Jump to step N |
 | `RETRY` | FAIL + RETRY action | Increment retryCount, stay in state |
+
+These input events are distinct from the action output recorded as `lastAction.type` after a transition resolves. The full `LastAction` union has nine variants: `START`, `CONTINUE`, `DEFER`, `GOTO`, `COMPLETE`, `STOP`, `RETRY`, `NEXT`, `BREAK` (see `packages/core/src/runbook/types.ts`).
 
 #### Transitions
 Default transitions when none specified:
@@ -182,7 +206,7 @@ Transition evaluation:
 | Behavior | Triggered By | What Happens |
 |----------|-------------|--------------|
 | **Automatic** | Step has `bash` or `prompt` code block | CLI runs command, exit code determines PASS/FAIL |
-| **Manual** | `--prompted` flag or no code block | CLI waits for manual `rd pass` or `rd fail` |
+| **Manual** | `--prompted` flag, or step has neither a bash nor prompt code block | CLI waits for manual `rd pass` or `rd fail` |
 
 **Note:** A `prompt` code block becomes an `rd prompt '...'` command that outputs the content wrapped in markdown fences. It executes automatically like `bash` blocks.
 
@@ -422,10 +446,7 @@ Each runbook state file contains:
   "stepName": "Execute batch",
   "retryCount": 0,
   "variables": { "environment": "staging" },
-  "sources": {
-    "items": { "kind": "array", "items": ["alpha", "bravo", "charlie"] },
-    "log_file": { "kind": "file", "path": "data/results.jsonl", "format": "jsonl" }
-  },
+  "templateVars": { "environment": "staging" },
   "steps": [],
   "substepStates": [
     {
@@ -473,7 +494,6 @@ Key fields:
 - `runbookPath`: Repo-relative resolved file path to the runbook source
 - `runbookSrc`: Raw runbook source content (template placeholders preserved)
 - `templateVars`: Frozen template variable map used for deterministic resume rendering
-- `sources`: Data source definitions for FOR loops (arrays and file references)
 - `forStack`: Active FOR loop stack (present during loop execution; see [FOR Loops](#for-loops))
 - `forStack[].source`: Resolved source for the active loop (range, array, or file with snapshot)
 - `forStack[].currentValue`: Data element at the current iteration (array/file sources)
@@ -504,11 +524,12 @@ Variables are collected from multiple sources with the following precedence (hig
 
 | Source | Description |
 |--------|-------------|
-| `--var key=value` | CLI flags (repeatable, highest priority) |
-| `--var-file path` | YAML file specified on command line |
+| CLI flags (`--var-file`, `--var`, `--var-json`) | Repeatable, highest priority |
+| `RD_VAR_*` environment variables | Prefix stripped (e.g., `RD_VAR_environment` sets `environment`) |
 | `.rundown/config.yaml` | Auto-discovered from cwd upward, stops at git root |
 | Frontmatter `vars:` field | Variables defined in runbook frontmatter |
-| Built-in defaults | System-provided variables (Date, DateTime, Year, etc.) |
+| Inherited delegation variables | Parent context in delegation tree |
+| Built-in defaults | System-provided variables (`Date`, `RunId`, `WorkPath`, etc.) |
 
 ### Auto-Discovery
 
@@ -549,7 +570,7 @@ rundown run deploy.runbook.md --var-file base.yaml --var environment=prod
 Variable names must match the pattern `/^[a-zA-Z_][a-zA-Z0-9_]*$/`:
 - Must start with a letter or underscore
 - Can contain letters, digits, and underscores
-- Runtime-reserved names cannot be overridden by user variables: `step`, `index`, `context`, `Step`, `Index`
+- Runtime-reserved names (`step`, `index`, `context`) are matched case-insensitively — any casing variant is reserved and cannot be overridden by user variables
 
 ### Runtime Context Model
 
@@ -585,10 +606,7 @@ Rundown enforces a security policy layer to control what commands runbooks can e
 
 ### Default Behavior
 
-In `prompted` mode (default), Rundown:
-- Allows common safe commands: git, npm, node, pnpm, yarn, etc.
-- Blocks dangerous commands: sudo, rm, curl, wget, etc.
-- Prompts for unlisted commands
+See [SECURITY.md](./SECURITY.md) for full default policy details, including command allow/block/prompt behavior, sandbox-on-by-default enforcement, and the default write restriction to `.rundown` subpaths.
 
 ### Quick Reference
 
@@ -700,9 +718,15 @@ Signal successful step completion.
 
 ```bash
 rundown pass
+rundown pass --step 2.1              # Target a specific substep
+rundown pass --step 2.1 --index 3    # Target substep at FOR iteration 3
 ```
 
 **Aliases:** `rundown yes`, `rundown ok`
+
+**Flags:**
+- `--step <stepId>` — Target a specific substep (not the currently active one).
+- `--index <number>` — FOR loop iteration to target (requires `--step`).
 
 **Behavior:**
 1. Send PASS event to XState
@@ -716,9 +740,15 @@ Signal step failure.
 
 ```bash
 rundown fail
+rundown fail --step 2.1              # Target a specific substep
+rundown fail --step 2.1 --index 3    # Target substep at FOR iteration 3
 ```
 
 **Alias:** `rundown no`
+
+**Flags:**
+- `--step <stepId>` — Target a specific substep (not the currently active one).
+- `--index <number>` — FOR loop iteration to target (requires `--step`).
 
 **Behavior:**
 1. Send FAIL event to XState
@@ -735,9 +765,13 @@ For RETRY transitions:
 Navigate directly to a step.
 
 ```bash
-rundown goto 3       # Jump to step 3
-rundown goto 3.1     # Jump to substep 3.1
+rundown goto 3                # Jump to step 3
+rundown goto 3.1              # Jump to substep 3.1
+rundown goto 3 --index 2      # Jump to step 3 and enter FOR iteration 2
 ```
+
+**Flags:**
+- `--index <number>` — For FOR-annotated targets, enter the loop at the specified iteration.
 
 **Restrictions:**
 - Target must exist
@@ -799,6 +833,8 @@ rundown ls --all --tags review  # Filter by tag
 - `stopped` - Terminated with failure
 - `inactive` - In session but not active
 
+**Columns (for `--all`):** `NAME`, `SOURCE`, `DESCRIPTION`, `TAGS`. The `SOURCE` column indicates where each runbook was discovered (`project`, `plugin`, or `bundled`) — see [Runbook Discovery](#runbook-discovery) and [Table Output](#table-output) for the column layout.
+
 ### Enforcement Control
 
 #### `rundown stash` - Pause Enforcement
@@ -857,6 +893,71 @@ rundown prune --completed   # Only completed
 rundown prune --inactive    # Only inactive
 rundown prune --active      # Only active (careful!)
 ```
+
+### Testing and Utilities
+
+#### `rundown echo` - Test Helper
+
+Echo command for runbook testing. Supports configurable pass/fail result sequences (useful for exercising retry logic).
+
+```bash
+rundown echo [command...]
+rundown echo -r pass                # Configure result (repeatable)
+rundown echo -r fail -r pass        # Sequence: fail first, then pass
+rundown echo --json                 # JSON output
+```
+
+#### `rundown resolve <file>` - Resolve Variables
+
+Resolve and validate template variables and data sources for a runbook without executing it.
+
+```bash
+rundown resolve my-runbook.runbook.md
+rundown resolve my-runbook.runbook.md --var environment=staging
+rundown resolve my-runbook.runbook.md --json
+```
+
+Useful for verifying that required variables are satisfied and data sources resolve before running.
+
+#### `rundown prompt <content>` - Emit Prompt Content
+
+Output content wrapped in markdown fences. Used by the runtime to render `prompt` code blocks; can also be invoked directly.
+
+```bash
+rundown prompt 'Review the implementation'
+rundown prompt 'Review the implementation' --json
+```
+
+#### `rundown scenario` - Runbook Scenarios
+
+List, show, or execute scenarios declared in a runbook's frontmatter (see [SCENARIOS.md](./SCENARIOS.md)).
+
+```bash
+rundown scenario ls <file>                  # List scenarios
+rundown scenario show <file> <name>         # Show scenario details
+rundown scenario run <file> <name>          # Execute and verify
+rundown scenario run <file> <name> --quiet  # Suppress command output
+rundown scenario ls <file> --json           # JSON output (also on show/run)
+```
+
+#### `rundown scenario-suite` - Scenario Suites
+
+List, show, or execute cases from a scenario suite file.
+
+```bash
+rundown scenario-suite ls <suite-file>
+rundown scenario-suite show <suite-file> <case>
+rundown scenario-suite run <suite-file> <case>
+rundown scenario-suite run <suite-file> --all      # Run all cases
+rundown scenario-suite run <suite-file> --quiet    # Suppress output
+```
+
+#### Sibling CLIs: `rdpath` and `rdx`
+
+Two companion CLIs ship alongside `rundown`:
+
+- **`rdpath`** — Path assembly tool for date-prefixed filenames and context-scoped paths. See [RDPATH.md](./RDPATH.md).
+- **`rdx`** — JSON-to-Markdown renderer with optional schema validation. See [RDX.md](./RDX.md).
 
 ### Delegation Commands
 
@@ -1201,7 +1302,21 @@ rundown pop                  # Resume enforcement
 
 # Maintenance
 rundown check <file>         # Validate runbook
+rundown resolve <file>       # Resolve and validate variables/data sources
 rundown prune                # Clean up state
+
+# Testing and utilities
+rundown echo [command...]              # Test helper (configurable pass/fail)
+rundown prompt <content>               # Output content in markdown fences
+rundown scenario ls <file>             # List runbook scenarios
+rundown scenario show <file> <name>    # Show scenario details
+rundown scenario run <file> <name>     # Execute a scenario
+rundown scenario-suite ls <suite>      # List scenario-suite cases
+rundown scenario-suite run <suite>     # Execute suite case(s)
+
+# Sibling CLIs
+rdpath --dir <path>          # Path assembly tool (see RDPATH.md)
+rdx <file>                   # Render JSON to Markdown (see RDX.md)
 
 # Delegation
 rd delegate <runbook> --step <id>  # Delegate substep to child runbook

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -245,7 +245,7 @@ Variables use Handlebars syntax: `{{variable}}`.
 | CLI (`--var`) | Global | Expanded at startup. |
 | `{{Step}}`, `{{step}}` | Step | Current execution identifier for this runbook context (e.g., `1`, `1.2`). |
 | `{{Index}}`, `{{index}}` | Loop | Current iteration number for this runbook context. |
-| `{{context.current.*}}` | Step/Loop | Canonical current runbook context: `step` (e.g., `3`), `substep` (e.g., `1`), `index` (e.g., `3`), `at` (e.g., `3.1[3]`). |
+| `{{context.current.*}}` | Step/Loop | Canonical current runbook context: `step` (e.g., `3`), `substep` (e.g., `1`), `index` (e.g., `3`), `at` (e.g., `3.3.1` — `STEP.INDEX.SUBSTEP` inside a FOR loop, `STEP.SUBSTEP` otherwise). |
 | `{{context.parent.*}}` | Nested | Parent runbook structural context and template variables (`vars.*`). |
 | `{{context.ancestors.N.*}}` | Nested | Ancestor runbook contexts (`0` is nearest parent). |
 | `{{context.vars.NAME}}` | Global | User/config/frontmatter variable namespace. |
@@ -273,7 +273,7 @@ Variables use Handlebars syntax: `{{variable}}`.
 3.  **Strict Ordering**: FOR -> Transitions -> Prompt -> Body.
 4.  **Exclusivity**: Only one body type (Code OR Substeps). Step-level runbook lists are shorthand for Substeps.
 5.  **Single Code Block**: Max one code block per step (executable or display-only).
-6.  **Loop Safety**: `NEXT` and `BREAK` are valid in FOR substeps and FOR iteration-level transitions.
+6.  **Loop Safety**: `NEXT` and `BREAK` are valid **only** in FOR substeps and FOR iteration-level transitions. Using them at step level outside any FOR loop is rejected by the validator.
 7.  **Source Validation**: FOR clauses referencing a data source must reference a defined source. Named variable required.
 8.  **FOR Requires Substeps**: A FOR-annotated step must contain substeps.
 9.  **No Nested RETRY**: RETRY fallback actions cannot be RETRY.


### PR DESCRIPTION
## Summary

Documentation accuracy pass driven by dual-verification review of `docs/SPEC.md`, `docs/FORMAT.md`, and `docs/RUNDOWN.md` against the current implementation. 20 verified findings implemented.

**Two factual errors corrected:**
- Removed non-existent `sources` top-level field from `RunbookState` JSON example (`forStack[].source` is the real location)
- Fixed `context.current.at` example from `3.1[3]` (bracket notation that does not exist) to `3.3.1` (`STEP.INDEX.SUBSTEP` as produced by `deriveExecutionAt`)

**Completeness fixes (RUNDOWN.md):**
- Variable Sources table expanded to all 6 tiers (was missing `RD_VAR_*` and inherited delegation variables)
- New Runbook Discovery section (project → plugin → bundled priority chain, `namespace:name` syntax)
- New Testing and Utilities section (`echo`, `resolve`, `prompt`, `scenario`, `scenario-suite`, `rdpath`/`rdx`)
- CLI Quick Reference extended with missing commands
- `pass`/`fail` `--step`/`--index` flag docs; `goto --index` flag docs
- `templateVars` added to `RunbookState` JSON example
- Named-step state ID examples (`step::Cleanup`)
- Events table retitled as Input Events; `LastAction` variants documented
- Reserved-keys wording updated (case-insensitive matching)
- Manual-mode trigger description clarified
- Default Behavior section replaced with pointer to `SECURITY.md`
- `rundown ls` SOURCE column documented

**SPEC.md:** Conformance point 6 tightened (NEXT/BREAK only valid in FOR context); `context.current.at` format description corrected

**FORMAT.md:** Separator note (in-header terminator set vs trailing-strip set); DEFER action/shorthand cross-reference; `SPEC.md §1.1` cross-reference for nested-substep restriction

## Test plan

- [ ] Read through `docs/RUNDOWN.md` Variable Sources table — should show 6 tiers
- [ ] Read through new Runbook Discovery section — should describe project → plugin → bundled chain
- [ ] Check `docs/SPEC.md` §7 conformance point 6 — should say NEXT/BREAK are *only* valid in FOR context
- [ ] Check `docs/SPEC.md` and `CLAUDE.md` `context.current.at` example — should show `3.3.1` not `3.1[3]`
- [ ] Check `docs/FORMAT.md` §Actions table — DEFER note should appear *after* the table, not inside it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified template variable format specifications with detailed encoding rules.
  * Documented new CLI commands including `rundown resolve`, `echo`, `prompt`, and scenario utilities.
  * Added "Testing and Utilities" section with runbook discovery details and namespace syntax.
  * Enhanced parsing behavior, state machine, and command execution documentation.
  * Introduced new targeting flags (`--step`, `--index`) for command operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->