### PR TITLE
fix(parser): enforce ordering guard on INPUTS/OUTPUTS directives

### DIFF
--- a/packages/cli/__tests__/integration/context-passing.test.ts
+++ b/packages/cli/__tests__/integration/context-passing.test.ts
@@ -546,3 +546,31 @@ rd echo --result pass
     expect(result.stdout).toContain('COMPLETE');
   });
 });
+
+describe('INPUTS/OUTPUTS ordering enforcement via rd check', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('rejects INPUTS directive appearing after prompt text', async () => {
+    const content = `# Test\n\n## 1 Step\n\nSome text.\n\n- INPUTS\n  - Foo\n`;
+    await writeFile(join(workspace.cwd, 'late-inputs.runbook.md'), content);
+    const result = runCli('check late-inputs.runbook.md', workspace);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toMatch(/INPUTS.*must appear before/);
+  });
+
+  it('rejects OUTPUTS directive appearing after body content', async () => {
+    const content = `# Test\n\n## 1 Step\n\n\`\`\`bash\necho hi\n\`\`\`\n\n- OUTPUTS\n  - Foo {{ "bar" }}\n`;
+    await writeFile(join(workspace.cwd, 'late-outputs.runbook.md'), content);
+    const result = runCli('check late-outputs.runbook.md', workspace);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toMatch(/OUTPUTS.*must appear before/);
+  });
+});

--- a/packages/parser/__tests__/parser.test.ts
+++ b/packages/parser/__tests__/parser.test.ts
@@ -1342,6 +1342,16 @@ describe('INPUTS/OUTPUTS ordering violations', () => {
       const md = `## 1 Step\n\n### 1.1 Sub\n\n\`\`\`bash\necho hi\n\`\`\`\n\n- OUTPUTS\n  - Foo {{ "bar" }}\n`;
       expect(() => parseRunbook(md)).toThrow(/OUTPUTS.*must appear before/);
     });
+
+    it('rejects OUTPUTS after non-runbook bullet prose', () => {
+      const md = `## 1 Step\n- some note\n\n- OUTPUTS\n  - Foo {{ "bar" }}\n`;
+      expect(() => parseRunbook(md)).toThrow(/OUTPUTS.*must appear before/);
+    });
+
+    it('rejects OUTPUTS after non-runbook bullet prose in substep', () => {
+      const md = `## 1 Step\n\n### 1.1 Sub\n- some note\n\n- OUTPUTS\n  - Foo {{ "bar" }}\n`;
+      expect(() => parseRunbook(md)).toThrow(/OUTPUTS.*must appear before/);
+    });
   });
 
   describe('INPUTS after body content', () => {
@@ -1357,6 +1367,16 @@ describe('INPUTS/OUTPUTS ordering violations', () => {
 
     it('rejects INPUTS after fenced code block', () => {
       const md = `## 1 Step\n\n\`\`\`bash\necho hi\n\`\`\`\n\n- INPUTS\n  - Foo\n`;
+      expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
+    });
+
+    it('rejects INPUTS after non-runbook bullet prose', () => {
+      const md = `## 1 Step\n- some note\n\n- INPUTS\n  - Foo\n`;
+      expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
+    });
+
+    it('rejects INPUTS after non-runbook bullet prose in substep', () => {
+      const md = `## 1 Step\n\n### 1.1 Sub\n- some note\n\n- INPUTS\n  - Foo\n`;
       expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
     });
 

--- a/packages/parser/__tests__/parser.test.ts
+++ b/packages/parser/__tests__/parser.test.ts
@@ -1355,8 +1355,18 @@ describe('INPUTS/OUTPUTS ordering violations', () => {
       expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
     });
 
+    it('rejects INPUTS after fenced code block', () => {
+      const md = `## 1 Step\n\n\`\`\`bash\necho hi\n\`\`\`\n\n- INPUTS\n  - Foo\n`;
+      expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
+    });
+
     it('rejects INPUTS after prompt text in substep', () => {
       const md = `## 1 Step\n\n### 1.1 Sub\n\nSome text.\n\n- INPUTS\n  - Foo\n`;
+      expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
+    });
+
+    it('rejects INPUTS after fenced code block in substep', () => {
+      const md = `## 1 Step\n\n### 1.1 Sub\n\n\`\`\`bash\necho hi\n\`\`\`\n\n- INPUTS\n  - Foo\n`;
       expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
     });
 

--- a/packages/parser/__tests__/parser.test.ts
+++ b/packages/parser/__tests__/parser.test.ts
@@ -1321,6 +1321,69 @@ echo hi
   });
 });
 
+describe('INPUTS/OUTPUTS ordering violations', () => {
+  describe('OUTPUTS after body content', () => {
+    it('rejects OUTPUTS after prompt text', () => {
+      const md = `## 1 Step\n\nSome text.\n\n- OUTPUTS\n  - Foo {{ "bar" }}\n`;
+      expect(() => parseRunbook(md)).toThrow(/OUTPUTS.*must appear before/);
+    });
+
+    it('rejects OUTPUTS after fenced code block', () => {
+      const md = `## 1 Step\n\n\`\`\`bash\necho hi\n\`\`\`\n\n- OUTPUTS\n  - Foo {{ "bar" }}\n`;
+      expect(() => parseRunbook(md)).toThrow(/OUTPUTS.*must appear before/);
+    });
+
+    it('rejects OUTPUTS after prompt text in substep', () => {
+      const md = `## 1 Step\n\n### 1.1 Sub\n\nSome text.\n\n- OUTPUTS\n  - Foo {{ "bar" }}\n`;
+      expect(() => parseRunbook(md)).toThrow(/OUTPUTS.*must appear before/);
+    });
+
+    it('rejects OUTPUTS after code block in substep', () => {
+      const md = `## 1 Step\n\n### 1.1 Sub\n\n\`\`\`bash\necho hi\n\`\`\`\n\n- OUTPUTS\n  - Foo {{ "bar" }}\n`;
+      expect(() => parseRunbook(md)).toThrow(/OUTPUTS.*must appear before/);
+    });
+  });
+
+  describe('INPUTS after body content', () => {
+    it('rejects INPUTS after prompt text', () => {
+      const md = `## 1 Step\n\nSome text.\n\n- INPUTS\n  - Foo\n`;
+      expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
+    });
+
+    it('rejects INPUTS after runbook-list entry', () => {
+      const md = `## 1 Step\n- foo.runbook.md\n\n- INPUTS\n  - Foo\n`;
+      expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
+    });
+
+    it('rejects INPUTS after prompt text in substep', () => {
+      const md = `## 1 Step\n\n### 1.1 Sub\n\nSome text.\n\n- INPUTS\n  - Foo\n`;
+      expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
+    });
+
+    it('rejects INPUTS after runbook-list in substep', () => {
+      const md = `## 1 Step\n\n### 1.1 Sub\n- foo.runbook.md\n\n- INPUTS\n  - Foo\n`;
+      expect(() => parseRunbook(md)).toThrow(/INPUTS.*must appear before/);
+    });
+  });
+
+  describe('interchangeable with transitions (must not over-reach)', () => {
+    it('allows INPUTS before transitions', () => {
+      const md = `## 1 Step\n- INPUTS\n  - Foo\n- PASS CONTINUE\n`;
+      expect(() => parseRunbook(md)).not.toThrow();
+    });
+
+    it('allows OUTPUTS after transitions', () => {
+      const md = `## 1 Step\n- PASS CONTINUE\n- OUTPUTS\n  - Foo {{ "bar" }}\n`;
+      expect(() => parseRunbook(md)).not.toThrow();
+    });
+
+    it('allows interleaved transitions and directives', () => {
+      const md = `## 1 Step\n- PASS CONTINUE\n- OUTPUTS\n  - Foo {{ "bar" }}\n- FAIL CONTINUE\n- INPUTS\n  - Bar\n`;
+      expect(() => parseRunbook(md)).not.toThrow();
+    });
+  });
+});
+
 describe('substep content filtering', () => {
   it('filters runbook references from substep prompt, preserves text', () => {
     const md = `## 1 Step

--- a/packages/parser/fixtures/conformance/invalid/inputs-after-prompt.runbook.md
+++ b/packages/parser/fixtures/conformance/invalid/inputs-after-prompt.runbook.md
@@ -1,0 +1,8 @@
+# Invalid: INPUTS After Prompt Text
+
+## 1. Step with late INPUTS
+
+This prompt comes first.
+
+- INPUTS
+  - Foo

--- a/packages/parser/fixtures/conformance/invalid/outputs-after-body.runbook.md
+++ b/packages/parser/fixtures/conformance/invalid/outputs-after-body.runbook.md
@@ -1,0 +1,10 @@
+# Invalid: OUTPUTS After Body Content
+
+## 1. Step with late OUTPUTS
+
+```bash
+echo "This is body content"
+```
+
+- OUTPUTS
+  - Foo {{ "bar" }}

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -587,6 +587,11 @@ function handleListItemContent(
 function handleOutputsDirective(node: ListItem, ctx: ActiveStepContext): typeof SKIP {
   const target = getDirectiveTarget(ctx);
   const targetLabel = formatDirectiveTarget(ctx);
+  if (target.hasSeenContent || target.hasSeenPromptText) {
+    throw new RunbookSyntaxError(
+      `OUTPUTS directive in ${targetLabel}${formatLineNum(node)}: must appear before prompt text and body content`,
+    );
+  }
   const nestedList = node.children.find((c): c is List => c.type === 'list');
   if (!nestedList || nestedList.children.length === 0) {
     throw new RunbookSyntaxError(
@@ -648,6 +653,11 @@ function handleOutputsDirective(node: ListItem, ctx: ActiveStepContext): typeof 
 function handleInputsDirective(node: ListItem, ctx: ActiveStepContext): typeof SKIP {
   const target = getDirectiveTarget(ctx);
   const targetLabel = formatDirectiveTarget(ctx);
+  if (target.hasSeenContent || target.hasSeenPromptText) {
+    throw new RunbookSyntaxError(
+      `INPUTS directive in ${targetLabel}${formatLineNum(node)}: must appear before prompt text and body content`,
+    );
+  }
   const nestedList = node.children.find((c): c is List => c.type === 'list');
   if (!nestedList || nestedList.children.length === 0) {
     throw new RunbookSyntaxError(

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -550,9 +550,11 @@ function handleListItemContent(
     }
     // Only add content after validation passes
     ctx.currentStep.pendingSubstep.content += ` - ${text}\n`;
-    // Mark content seen if runbook list
+    // Mark content seen for runbook list entries; mark prompt seen for non-runbook bullets
     if (isRunbookListEntry) {
       ctx.currentStep.pendingSubstep.hasSeenContent = true;
+    } else {
+      ctx.currentStep.pendingSubstep.hasSeenPromptText = true;
     }
   } else {
     // Check ordering BEFORE adding content
@@ -566,6 +568,8 @@ function handleListItemContent(
     ctx.currentStep.content += itemText;
     if (!isRunbookListEntry) {
       ctx.implicitText += itemText;
+      // Non-runbook bullets are prompt text — mark so ordering guards fire correctly
+      ctx.currentStep.hasSeenPromptText = true;
     } else {
       // Mark content seen if runbook list
       ctx.currentStep.hasSeenContent = true;


### PR DESCRIPTION
INPUTS and OUTPUTS directives must appear in the header-adjacent region before prompt text and body content (SPEC.md §2.2, §8 conformance rule 3, FORMAT.md step/substep EBNF). The parser enforced this for transitions and FOR but not for INPUTS/OUTPUTS.

Adds a read-only hasSeenContent || hasSeenPromptText guard to handleOutputsDirective and handleInputsDirective, mirroring the pattern already used in handleListItemTransition. Neither handler mutates those flags, so the guard is purely additive with no stale-flag risk. getDirectiveTarget already resolves to the active substep (H3) or step (H2), so H3 substeps are covered without additional code.

Directives remain interchangeable with transitions within the header-adjacent region. The positive test suite confirms the guard does not over-reach: INPUTS before transitions, OUTPUTS after transitions, and interleaved orderings all parse correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * INPUTS directives must now appear before body/prompt text; violations are caught by the parser and CLI `check` command
  * OUTPUTS directives must now appear before body content; ordering violations are reported with line numbers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->