### PR TITLE
2026 04 16 sync docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,45 +101,11 @@ Schema validation is automatic when the JSON includes `"$schema": "https://rundo
 
 ## Template Variables
 
-Template variables use Handlebars syntax `{{variableName}}` and are expanded at run time.
+Template variables use Handlebars syntax `{{variableName}}` and are expanded at run time. The full precedence table, built-in variables list, and context-passing semantics live in the specification:
 
-**Variable Sources (Precedence: High to Low):**
-1. CLI flags (`--var-file`, `--var`, `--var-json`) — highest priority; within this layer: `--var-json` > `--var` > `--var-file` (all repeatable)
-2. `RD_VAR_*` environment variables (prefix stripped)
-3. `.rundown/config.yaml` (auto-discovered from cwd upward, stops at git root)
-4. Frontmatter `vars:` field
-5. Inherited delegation variables (parent context in delegation tree)
-6. Built-in defaults (lowest priority)
-
-**Built-in Variables:**
-| Variable | Example Value | Description |
-|----------|---------------|-------------|
-| `Date` | `2026-02-04` | Current date (YYYY-MM-DD) |
-| `DateTime` | `2026-02-04T10:30:00.000Z` | Full ISO 8601 timestamp |
-| `Year` | `2026` | Current year |
-| `Month` | `02` | Current month (01-12) |
-| `Day` | `04` | Current day (01-31) |
-| `Branch` | `feature/my-work` | Current git branch name (empty when not in git) |
-| `WorkPath` | `.rundown/work/feature-my-work` | Branch-isolated artifact directory (falls back to `.rundown/work` outside git) |
-| `RunId` | `4a7f0c3e` | Unique-per-execution identifier |
-| `ContextId` | `a3b8c1d2` | Shared identity across delegation tree |
-| `Step` | `3.1` | Current qualified step identifier |
-| `Index` | `3` | Current loop iteration number (inside FOR) |
-| `context.current.step` | `3.1` | Current qualified step identifier |
-| `context.current.substep` | `1` | Current substep number (when in substep) |
-| `context.current.index` | `3` | Current loop iteration (inside FOR) |
-| `context.current.at` | `3.3.1` | Full execution position (`STEP.INDEX.SUBSTEP` inside a FOR loop, `STEP.SUBSTEP` otherwise) |
-
-**Plugin Variables:**
-
-
-| Variable | Description |
-|----------|-------------|
-| `CLAUDE_PLUGIN_ROOT` | Plugin installation directory — auto-injected when running plugin-sourced runbooks |
-
-Plugin variables are automatically available when a runbook is resolved from a plugin source (e.g., `rundown:write-plan`). They use UPPER_SNAKE_CASE (not PascalCase) since they mirror host environment conventions. Plugin variables sit below CLI flags in precedence and can be overridden via `--var`.
-
-Built-in variables use PascalCase. Lowercase aliases `step` and `index` are also available. The date/time variables (`Date`, `DateTime`, `Year`, `Month`, `Day`), `Branch`, `WorkPath`, `RunId`, and `ContextId` are static run-time variables set once per execution and can be overridden via `--var`. `RunId` is a fresh 8-character hexadecimal identifier generated per execution; each child in a delegation tree gets its own RunId. `ContextId` is a fresh 8-character hexadecimal identifier generated per execution; children in a delegation tree inherit the parent's ContextId via `--var`, providing a shared identity across the tree. It can be overridden via `--var` to use a meaningful name (e.g., `--var ContextId=sprint-42`). The `Step` variable (and `Index` during FOR loops), `context.current.*` variables, and their lowercase aliases are dynamic per-step variables that reflect the current execution position and cannot be overridden via `--var`. The variable name `context` is reserved and cannot be used as a user variable name.
+- [docs/SPEC.md §6 Templating](docs/SPEC.md#6-templating) — precedence order, reserved keys, required variables
+- [docs/SPEC.md §6.1 Built-in Variables](docs/SPEC.md#61-built-in-variables) — `Date`, `Branch`, `WorkPath`, `RunId`, `ContextId`, `Step`, `Index`, `context.current.*`, plus plugin variables (`CLAUDE_PLUGIN_ROOT`)
+- [docs/SPEC.md §7 Context Passing](docs/SPEC.md#7-context-passing-inputs--outputs) — INPUTS / OUTPUTS directives and the `ContextId` delegation contract
 
 **CLI Example:**
 ```bash
@@ -413,7 +379,7 @@ Currently supported internally: `echo`, `prompt`. Unsupported commands fall back
 
 ## Documentation
 
-- [docs/SPEC.md](docs/SPEC.md) - Rundown specification
+- [docs/SPEC.md](docs/SPEC.md) - Rundown specification (includes §6.1 Built-in Variables and §7 Context Passing / INPUTS / OUTPUTS)
 - [docs/FORMAT.md](docs/FORMAT.md) - W3C EBNF grammar for runbook syntax
 - [docs/MCP.md](docs/MCP.md) - MCP server reference
 - [docs/SECURITY.md](docs/SECURITY.md) - Security policy configuration

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The `rd` command is an alias for `rundown`.
 
 ## Documentation
 
-- [SPEC.md](docs/SPEC.md) - Rundown format specification
+- [SPEC.md](docs/SPEC.md) - Rundown format specification (includes §6.1 Built-in Variables and §7 Context Passing / INPUTS / OUTPUTS)
 - [FORMAT.md](docs/FORMAT.md) - Formal BNF-style grammar
 - [MCP.md](docs/MCP.md) - MCP server reference
 - [SECURITY.md](docs/SECURITY.md) - Security policy configuration

--- a/docs/AGENT-ORCHESTRATION.md
+++ b/docs/AGENT-ORCHESTRATION.md
@@ -106,6 +106,8 @@ The plugin never destroys child runbook state. Incomplete delegations preserve t
 - Resolved completions drain in deterministic substep order. Aggregation waits for all DEFER'd results before evaluating the step-level transition.
 - When a completion arrives for a frontier substep that is not at the active cursor, it is **deferred** — stored and applied when the cursor reaches that substep.
 
+**Data flow between parent and child:** Delegated runbooks exchange values through context passing — a parent step's `- OUTPUTS` directive persists values after PASS; the child declares the same names via frontmatter `inputs:` or step-level `- INPUTS` and receives them at runtime. Children inherit the parent's `ContextId` via `--var`, so both sides read and write the same `.rundown/contexts/<ContextId>/outputs.json` store. See [SPEC.md §7 Context Passing](./SPEC.md#7-context-passing-inputs--outputs).
+
 See [Section 4: Control Flow](SPEC.md#4-control-flow) for transition semantics.
 
 ---

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -46,6 +46,7 @@ author_field   ::= "author:" ws text
 tags_field     ::= "tags:" newline tag_list
 vars_field     ::= "vars:" newline vars_map
 required_field ::= "required:" newline required_list
+inputs_field   ::= "inputs:" newline inputs_list
 
 name_string    ::= [a-zA-Z0-9_-] ( [a-zA-Z0-9_ -]* [a-zA-Z0-9_-] )?
 tag_list       ::= ( ws "- " tag newline )+
@@ -53,7 +54,10 @@ tag            ::= text
 vars_map       ::= ( ws variable_name ":" ws value newline )+
 value          ::= text
 required_list  ::= ( ws "- " variable_name newline )+
+inputs_list    ::= ( ws "- " variable_name newline )+
 ```
+
+The `inputs` field declares variable names to inject from the context outputs store at pipeline setup — see [SPEC.md §7 Context Passing](./SPEC.md#7-context-passing-inputs--outputs). Entries must not also appear in `vars` and must not be [reserved variable names](#reserved-variable-names).
 
 Additional fields beyond those listed are preserved (open schema). All fields are optional.
 
@@ -103,6 +107,8 @@ A step or substep may declare at most one INPUTS directive and at most one OUTPU
 INPUTS declares variable names that will be injected from context outputs before step rendering. OUTPUTS declares values to persist after a successful (PASS) transition. Output values may be Handlebars helper calls (`{{ path "file.json" }}`), template variable references (`{{ VarName }}`), quoted literals (`"value"`), or bare variable references (`VarName`).
 
 Variable names in INPUTS and OUTPUTS must match `variable_name` and must not be [reserved variable names](#reserved-variable-names).
+
+The `path` helper call `{{ path "file.json" }}` is syntactic sugar for the CLI form `rdpath --dir WorkPath --ctx ContextId --file file.json`. The optional `ctx=` argument (`{{ path "file.json" ctx=alt-ctx }}`) overrides the default `ContextId`. Filenames must match the [`filename`](#lexical-rules) production; context identifiers must match [`ctx_ref`](#lexical-rules). See [docs/RDPATH.md](./RDPATH.md) for the full path-assembly contract.
 
 ## Identifiers
 
@@ -180,7 +186,7 @@ Aggregation modifiers must pair complementarily: `PASS ALL` + `FAIL ANY` (pessim
 
 **Default transitions:** When no transitions are authored, the parser supplies `PASS CONTINUE`, `FAIL STOP`. Substeps under aggregation or with runbook delegation default to `PASS DEFER`, `FAIL DEFER`.
 
-**Disambiguation:** A `-`-prefixed bullet inside a step is resolved by priority: (1) FOR clause (`FOR` keyword), (2) transition (`PASS`, `FAIL`, `YES`, `NO`, or standalone `DEFER`), (3) runbook reference (`.runbook.md` suffix), (4) prompt text.
+**Disambiguation:** A `-`-prefixed bullet inside a step is resolved by priority: (1) context directive (`- INPUTS` or `- OUTPUTS` as exact, case-sensitive list-item text with no trailing content), (2) FOR clause (`FOR` keyword), (3) transition (`PASS`, `FAIL`, `YES`, `NO`, or standalone `DEFER`), (4) runbook reference (`.runbook.md` suffix), (5) prompt text. A bullet whose text merely contains `INPUTS` or `OUTPUTS` inside prose, or uses a different case (e.g., `inputs`, `Outputs`), falls through to normal list semantics.
 
 ## Actions
 
@@ -306,6 +312,8 @@ digit            ::= [0-9]
 text             ::= [^\n]+
 non_ws_char      ::= [^ \t\n]
 language_tag     ::= [a-zA-Z] [a-zA-Z0-9]*
+filename         ::= [A-Za-z0-9._-]+   /* rejected at runtime: "." and ".." */
+ctx_ref          ::= [A-Za-z0-9_-]+    /* must not be "." or ".." */
 ws               ::= ( " " | "\t" )+
 newline          ::= "\n"
 yaml_block       ::= (* opaque YAML content *)
@@ -314,3 +322,5 @@ content          ::= (* opaque code block content *)
 ```
 
 Upper bounds: step identifiers are capped at 999,999; FOR loop bounds at 10,000.
+
+`filename` and `ctx_ref` source from `VALID_FILE` and `VALID_CTX` in `packages/core/src/runbook/artifact-paths.ts`. They constrain the arguments of the [`path`](#context-directives) helper used in OUTPUTS and the underlying `rdpath` CLI.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -279,7 +279,7 @@ Start a runbook.
 
 **CLI Equivalent:** `rundown run [<file>] [--prompted] [--var key=value]... [--var-file path]`
 
-**Note:** The `--var` and `--var-file` options are CLI-only. The MCP `run` tool does not currently expose variable configuration parameters. Delegation to child runbooks uses the CLI `delegate`/`claim`/`abort` commands. See [CLI documentation](../CLAUDE.md#template-variables) for full variable configuration details.
+**Note:** The `--var` and `--var-file` options are CLI-only. The MCP `run` tool does not currently expose variable configuration parameters. Delegation to child runbooks uses the CLI `delegate`/`claim`/`abort` commands. See [SPEC.md §6 Templating](./SPEC.md#6-templating) for full variable configuration details.
 
 ---
 

--- a/docs/PROJECT-INTEGRATION.md
+++ b/docs/PROJECT-INTEGRATION.md
@@ -124,7 +124,7 @@ rd run pr-feedback --var pr_number=11 --var repo=myorg/myrepo
 
 Variables defined in frontmatter `vars:` serve as defaults. CLI `--var` flags take precedence.
 
-See CLAUDE.md for full variable source precedence.
+See [SPEC.md §6 Templating](./SPEC.md#6-templating) for the full variable source precedence.
 
 #### Data Sources in Configuration
 

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -529,7 +529,8 @@ Variables are collected from multiple sources with the following precedence (hig
 | `.rundown/config.yaml` | Auto-discovered from cwd upward, stops at git root |
 | Frontmatter `vars:` field | Variables defined in runbook frontmatter |
 | Inherited delegation variables | Parent context in delegation tree |
-| Built-in defaults | System-provided variables (`Date`, `RunId`, `WorkPath`, etc.) |
+| INPUTS (context passing) | Fill-gaps-only injection from `.rundown/contexts/<ContextId>/outputs.json` — see [SPEC.md §7](./SPEC.md#7-context-passing-inputs--outputs) |
+| Built-in defaults | System-provided variables — see [SPEC.md §6.1 Built-in Variables](./SPEC.md#61-built-in-variables) for the full table |
 
 ### Auto-Discovery
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -24,9 +24,11 @@ A Rundown document (`.runbook.md`) is a Markdown file with an optional YAML fron
 
 ### 1.2 Frontmatter
 
-Frontmatter fields beyond `name`, `description`, `version`, `author`, `tags`, `vars`, and `required` are preserved (open schema). This allows forward-compatible extensions and user-defined metadata.
+Frontmatter fields beyond `name`, `description`, `version`, `author`, `tags`, `vars`, `required`, and `inputs` are preserved (open schema). This allows forward-compatible extensions and user-defined metadata.
 
 The `required` field declares variable names that must be provided by the caller (via CLI flags, config, environment, or delegation). Each entry must be a valid template variable identifier matching `/^[a-zA-Z_][a-zA-Z0-9_]*$/`. Required variables must not appear in `vars` — they have no default. Missing required variables produce a hard error during resolution.
+
+The `inputs` field declares variable names to inject at pipeline setup from the context outputs store (see [§7 Context Passing](#7-context-passing-inputs--outputs)). Each entry must match the same identifier pattern as `required`. Entries must not also appear in `vars` — injection is gap-filling only; names already defined by `vars` would never receive an injected value. Reserved runtime names (`step`, `index`, `context`, matched case-insensitively) are rejected. Missing inputs at runtime are silently skipped; the declaration expresses intent rather than hard requirement.
 
 The frontmatter `description` field provides a summary for runbook discovery and listing (`rd ls --all`). The `Runbook.description` in the parsed AST is derived from preamble text between the H1 title and first H2 step. These are independent values.
 
@@ -266,7 +268,40 @@ Variables use Handlebars syntax: `{{variable}}`.
     3. `.rundown/config.yaml` (auto-discovered from cwd upward)
     4. Frontmatter `vars:` field
     5. Inherited delegation variables (parent context)
-    6. Built-in defaults (`Date`, `RunId`, `WorkPath`, etc.)
+    6. INPUTS injected from the context outputs store — fill gaps only, never override an existing variable. Silently skipped when `ContextId` is unset or the requested key is absent. See [§7 Context Passing](#7-context-passing-inputs--outputs).
+    7. Built-in defaults — see [§6.1 Built-in Variables](#61-built-in-variables).
+
+### 6.1 Built-in Variables
+
+Rundown sets the following built-in variables once per execution (unless marked dynamic per-step). PascalCase is canonical; lowercase aliases `step` and `index` are also accepted.
+
+| Variable | Example Value | Description |
+|----------|---------------|-------------|
+| `Date` | `2026-02-04` | Current date (YYYY-MM-DD) |
+| `DateTime` | `2026-02-04T10:30:00.000Z` | Full ISO 8601 timestamp |
+| `Year` | `2026` | Current year |
+| `Month` | `02` | Current month (01-12) |
+| `Day` | `04` | Current day (01-31) |
+| `Branch` | `feature/my-work` | Current git branch name (empty when not in git) |
+| `WorkPath` | `.rundown/work/feature-my-work` | Branch-isolated artifact directory (falls back to `.rundown/work` outside git). Default base directory for the `{{ path "..." }}` helper used in OUTPUTS expressions — see [§7.1 OUTPUTS](#71-outputs). |
+| `RunId` | `4a7f0c3e` | Unique-per-execution identifier (fresh 8-char hex per execution; each child in a delegation tree gets its own) |
+| `ContextId` | `a3b8c1d2` | Shared identity across a delegation tree. Indexes `.rundown/contexts/<ContextId>/outputs.json` for context passing — see [§7 Context Passing](#7-context-passing-inputs--outputs). Children inherit the parent's `ContextId` via `--var`. Overridable via `--var ContextId=<name>` for a meaningful identifier (e.g., `sprint-42`). |
+| `Step` | `3.1` | Current qualified step identifier (dynamic per step) |
+| `Index` | `3` | Current loop iteration number inside FOR (dynamic per iteration) |
+| `context.current.step` | `3.1` | Canonical current step identifier (dynamic) |
+| `context.current.substep` | `1` | Current substep number when in a substep (dynamic) |
+| `context.current.index` | `3` | Current loop iteration inside FOR (dynamic) |
+| `context.current.at` | `3.3.1` | Full execution position (`STEP.INDEX.SUBSTEP` inside a FOR loop, `STEP.SUBSTEP` otherwise) (dynamic) |
+
+Static variables (`Date`, `DateTime`, `Year`, `Month`, `Day`, `Branch`, `WorkPath`, `RunId`, `ContextId`) can be overridden via `--var`. Dynamic variables (`Step`, `Index`, `context.current.*` and their lowercase aliases) reflect the current execution position and cannot be overridden. The variable name `context` is reserved.
+
+**Plugin Variables:** When a runbook is resolved from a plugin source (e.g., `rundown:write-plan`), Rundown auto-injects additional variables using UPPER_SNAKE_CASE (mirroring host environment conventions):
+
+| Variable | Description |
+|----------|-------------|
+| `CLAUDE_PLUGIN_ROOT` | Plugin installation directory |
+
+Plugin variables sit in the precedence chain just below CLI flags and can be overridden via `--var`.
 
 ## 7. Context Passing (INPUTS / OUTPUTS)
 
@@ -276,20 +311,51 @@ Steps and substeps may declare INPUTS and OUTPUTS directives for passing data be
 
 OUTPUTS declares values to persist after a successful step execution.
 
+*   **Scope**: Supported on both H2 steps and H3 substeps. At most one OUTPUTS directive per step or substep (Conformance §8 rule 11).
 *   **Persistence trigger**: OUTPUTS are evaluated and stored only on PASS transitions. FAIL transitions skip OUTPUTS entirely.
 *   **Storage**: Values are written atomically to `.rundown/contexts/<ContextId>/outputs.json`. Writes are serialized with a file lock to prevent concurrent corruption.
-*   **Expressions**: Each output entry is evaluated against the step's resolved template variables. Supported forms: Handlebars expressions (`{{ path "file.json" }}`), quoted literals (`"value"`), bare variable references (`VarName`).
+*   **On-disk shape**: A flat JSON object `{ key: stringValue, ... }` — all keys and values are strings. Non-string values encountered during merge are dropped with a warning (not an error). The file is written by atomic temp-file-plus-rename. Writes are additive — new keys are added to the existing object; existing keys are overwritten; unrelated keys are preserved.
+*   **Expressions**: Each output entry is evaluated against the step's resolved template variables. Supported forms:
+    * `{{ path "file.json" }}` — path helper resolving to `<WorkPath>/.rd-<ContextId>/<Date>-file.json` (equivalent to `rdpath --dir WorkPath --ctx ContextId --file file.json`; see [docs/RDPATH.md](./RDPATH.md)).
+    * `{{ path "file.json" ctx=alt-ctx }}` — path helper with explicit context override.
+    * `{{ VarName }}` — template variable reference.
+    * `"literal value"` — quoted literal.
+    * `VarName` — bare variable reference (equivalent to `{{ VarName }}`).
+*   **Identifier constraints**: Context identifiers must match `[A-Za-z0-9_-]+` (not `.` or `..`); filenames must match `[A-Za-z0-9._-]+` (not `.` or `..`). Enforced by `VALID_CTX` and `VALID_FILE` at write time.
 *   **Best-effort**: OUTPUTS persistence is non-fatal. If storage fails (disk full, permissions, lock timeout), the step transition is not rolled back. An `ERROR_OCCURRED` event is emitted.
 *   **Merge semantics**: Outputs merge into the existing `outputs.json` — new keys are added, existing keys are overwritten.
 
 ### 7.2 INPUTS
 
-INPUTS declares template variable names to inject from context outputs before step rendering.
+INPUTS declares template variable names to inject from context outputs before step rendering. Two authoring channels exist — both read from the same `outputs.json` store and follow the same fill-gaps-only precedence.
 
-*   **Injection timing**: INPUTS are loaded from `.rundown/contexts/<ContextId>/outputs.json` and injected into the step's template variables before template expansion.
-*   **Precedence**: INPUTS sit below CLI flags, `RD_VAR_*`, config, and frontmatter `vars:` in the variable precedence chain. CLI `--var` always wins over context outputs.
-*   **Missing values**: If a declared input name is not found in context outputs, it is silently skipped (no error).
-*   **No ContextId**: If `ContextId` is not set, INPUTS injection is silently skipped.
+**Frontmatter `inputs:`** — declared at the runbook level. Validated at parse time (identifier pattern, reserved-name rejection, no-overlap with `vars:`). Injected at pipeline setup so values are available to every step that references them.
+
+```yaml
+---
+name: execute-plan
+inputs:
+  - PlanPath
+---
+```
+
+**Step-level `- INPUTS` directive** — declared on a specific H2 step or H3 substep (at most one per target; Conformance §8 rule 11). Injected at step execution time, immediately before template expansion for that step.
+
+```markdown
+## 3. Execute the plan
+- INPUTS
+  - PlanPath
+- PASS CONTINUE
+Run the plan at {{ PlanPath }}.
+```
+
+**Behaviour (common to both channels):**
+
+*   **Source**: `.rundown/contexts/<ContextId>/outputs.json`.
+*   **Fill-gaps-only**: INPUTS populate a variable only when it is not already defined by a higher-precedence source (CLI flags, `RD_VAR_*`, config, frontmatter `vars:`, inherited delegation). They never override an existing value.
+*   **Missing values**: Declared names absent from `outputs.json` are silently skipped (no error).
+*   **No ContextId**: If `ContextId` is unset, injection is silently skipped — a runbook can declare INPUTS safely without a context.
+*   **Malformed store**: `ENOENT` (file missing) is treated as an empty store. JSON parse errors and non-object top-level shapes throw. Non-string values encountered during load are dropped with a warning.
 
 ### 7.3 Delegation Inheritance
 
@@ -300,6 +366,46 @@ Children in a delegation tree inherit the parent's `ContextId` via `--var`, prov
 *   **Path traversal**: Context IDs are validated against a safe identifier pattern. `.` and `..` are rejected.
 *   **Symlink escape**: The contexts directory and output file paths are validated to stay within the project root. Symlink targets that escape the contexts directory are rejected.
 *   **File permissions**: Output files are written with restrictive permissions (mode 0o600 — owner read/write only).
+
+### 7.5 Example: write-plan / execute-plan
+
+A parent runbook produces a plan file and delegates to a child runbook that consumes it. Both share a `ContextId` through delegation inheritance.
+
+Parent (`write-plan.runbook.md`):
+
+```markdown
+## 1. Write the plan
+- OUTPUTS
+  - PlanPath {{ path "plan.md" }}
+- PASS CONTINUE
+
+Draft the plan and save it to `{{ path "plan.md" }}`.
+
+## 2. Hand off
+- ./execute-plan.runbook.md
+```
+
+Child (`execute-plan.runbook.md`):
+
+```markdown
+---
+name: execute-plan
+inputs:
+  - PlanPath
+---
+
+## 1. Execute
+- PASS COMPLETE
+
+Execute the plan stored at `{{ PlanPath }}`.
+```
+
+Flow:
+
+1. Parent step 1 runs and passes. `PlanPath` is resolved to e.g. `.rundown/work/feature-my-work/.rd-a3b8c1d2/2026-02-04-plan.md` via the `{{ path }}` helper and written to `.rundown/contexts/a3b8c1d2/outputs.json` as `{"PlanPath": "<resolved path>"}`.
+2. Parent step 2 delegates to the child. The child inherits `ContextId=a3b8c1d2` via `--var`.
+3. Child pipeline setup resolves the frontmatter `inputs:` list, reads `outputs.json`, and injects `PlanPath`.
+4. Child step 1 renders `{{ PlanPath }}` as the stored value and executes.
 
 ## 8. Conformance
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -268,8 +268,8 @@ Variables use Handlebars syntax: `{{variable}}`.
     3. `.rundown/config.yaml` (auto-discovered from cwd upward)
     4. Frontmatter `vars:` field
     5. Inherited delegation variables (parent context)
-    6. INPUTS injected from the context outputs store — fill gaps only, never override an existing variable. Silently skipped when `ContextId` is unset or the requested key is absent. See [§7 Context Passing](#7-context-passing-inputs--outputs).
-    7. Built-in defaults — see [§6.1 Built-in Variables](#61-built-in-variables).
+    6. Built-in defaults — see [§6.1 Built-in Variables](#61-built-in-variables).
+    7. INPUTS injected from the context outputs store — fill gaps only, never override an existing variable (including built-ins, which are always present). Silently skipped when `ContextId` is unset or the requested key is absent. See [§7 Context Passing](#7-context-passing-inputs--outputs).
 
 ### 6.1 Built-in Variables
 
@@ -311,19 +311,19 @@ Steps and substeps may declare INPUTS and OUTPUTS directives for passing data be
 
 OUTPUTS declares values to persist after a successful step execution.
 
-*   **Scope**: Supported on both H2 steps and H3 substeps. At most one OUTPUTS directive per step or substep (Conformance §8 rule 11).
-*   **Persistence trigger**: OUTPUTS are evaluated and stored only on PASS transitions. FAIL transitions skip OUTPUTS entirely.
-*   **Storage**: Values are written atomically to `.rundown/contexts/<ContextId>/outputs.json`. Writes are serialized with a file lock to prevent concurrent corruption.
-*   **On-disk shape**: A flat JSON object `{ key: stringValue, ... }` — all keys and values are strings. Non-string values encountered during merge are dropped with a warning (not an error). The file is written by atomic temp-file-plus-rename. Writes are additive — new keys are added to the existing object; existing keys are overwritten; unrelated keys are preserved.
-*   **Expressions**: Each output entry is evaluated against the step's resolved template variables. Supported forms:
+* **Scope**: Supported on both H2 steps and H3 substeps. At most one OUTPUTS directive per step or substep (Conformance §8 rule 11).
+* **Persistence trigger**: OUTPUTS are evaluated and stored only on PASS transitions. FAIL transitions skip OUTPUTS entirely.
+* **Storage**: Values are written atomically to `.rundown/contexts/<ContextId>/outputs.json`. Writes are serialized with a file lock to prevent concurrent corruption.
+* **On-disk shape**: A flat JSON object `{ key: stringValue, ... }` — all keys and values are strings. Non-string values encountered during merge are dropped with a warning (not an error). The file is written by atomic temp-file-plus-rename. Writes are additive — new keys are added to the existing object; existing keys are overwritten; unrelated keys are preserved.
+* **Expressions**: Each output entry is evaluated against the step's resolved template variables. Supported forms:
     * `{{ path "file.json" }}` — path helper resolving to `<WorkPath>/.rd-<ContextId>/<Date>-file.json` (equivalent to `rdpath --dir WorkPath --ctx ContextId --file file.json`; see [docs/RDPATH.md](./RDPATH.md)).
     * `{{ path "file.json" ctx=alt-ctx }}` — path helper with explicit context override.
     * `{{ VarName }}` — template variable reference.
     * `"literal value"` — quoted literal.
     * `VarName` — bare variable reference (equivalent to `{{ VarName }}`).
-*   **Identifier constraints**: Context identifiers must match `[A-Za-z0-9_-]+` (not `.` or `..`); filenames must match `[A-Za-z0-9._-]+` (not `.` or `..`). Enforced by `VALID_CTX` and `VALID_FILE` at write time.
-*   **Best-effort**: OUTPUTS persistence is non-fatal. If storage fails (disk full, permissions, lock timeout), the step transition is not rolled back. An `ERROR_OCCURRED` event is emitted.
-*   **Merge semantics**: Outputs merge into the existing `outputs.json` — new keys are added, existing keys are overwritten.
+* **Identifier constraints**: Context identifiers must match `[A-Za-z0-9_-]+` (not `.` or `..`); filenames must match `[A-Za-z0-9._-]+` (not `.` or `..`). Enforced by `VALID_CTX` and `VALID_FILE` at write time.
+* **Best-effort**: OUTPUTS persistence is non-fatal. If storage fails (disk full, permissions, lock timeout), the step transition is not rolled back. An `ERROR_OCCURRED` event is emitted.
+* **Merge semantics**: Outputs merge into the existing `outputs.json` — new keys are added, existing keys are overwritten.
 
 ### 7.2 INPUTS
 
@@ -351,11 +351,11 @@ Run the plan at {{ PlanPath }}.
 
 **Behaviour (common to both sites):**
 
-*   **Source**: `.rundown/contexts/<ContextId>/outputs.json`.
-*   **Fill-gaps-only**: INPUTS populate a variable only when it is not already defined by a higher-precedence source (CLI flags, `RD_VAR_*`, config, frontmatter `vars:`, inherited delegation). They never override an existing value.
-*   **Missing values**: Declared names absent from `outputs.json` are silently skipped (no error).
-*   **No ContextId**: If `ContextId` is unset, injection is silently skipped — a runbook can declare INPUTS safely without a context.
-*   **Malformed store**: `ENOENT` (file missing) is treated as an empty store. JSON parse errors and non-object top-level shapes throw. Non-string values encountered during load are dropped with a warning.
+* **Source**: `.rundown/contexts/<ContextId>/outputs.json`.
+* **Fill-gaps-only**: INPUTS populate a variable only when it is not already defined by a higher-precedence source (CLI flags, `RD_VAR_*`, config, frontmatter `vars:`, inherited delegation, built-in defaults). They never override an existing value.
+* **Missing values**: Declared names absent from `outputs.json` are silently skipped (no error).
+* **No ContextId**: If `ContextId` is unset, injection is silently skipped — a runbook can declare INPUTS safely without a context.
+* **Malformed store**: `ENOENT` (file missing) is treated as an empty store. JSON parse errors and non-object top-level shapes are caught at the injection site, logged as warnings, and INPUTS injection is skipped — the run is not aborted. Non-string values encountered during load are dropped with a warning.
 
 ### 7.3 Delegation Inheritance
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -327,7 +327,7 @@ OUTPUTS declares values to persist after a successful step execution.
 
 ### 7.2 INPUTS
 
-INPUTS declares template variable names to inject from context outputs before step rendering. Two authoring channels exist — both read from the same `outputs.json` store and follow the same fill-gaps-only precedence.
+INPUTS declares template variable names to inject from context outputs before step rendering. Two declaration sites exist — both read from the same `outputs.json` store and follow the same fill-gaps-only precedence.
 
 **Frontmatter `inputs:`** — declared at the runbook level. Validated at parse time (identifier pattern, reserved-name rejection, no-overlap with `vars:`). Injected at pipeline setup so values are available to every step that references them.
 
@@ -349,7 +349,7 @@ inputs:
 Run the plan at {{ PlanPath }}.
 ```
 
-**Behaviour (common to both channels):**
+**Behaviour (common to both sites):**
 
 *   **Source**: `.rundown/contexts/<ContextId>/outputs.json`.
 *   **Fill-gaps-only**: INPUTS populate a variable only when it is not already defined by a higher-precedence source (CLI flags, `RD_VAR_*`, config, frontmatter `vars:`, inherited delegation). They never override an existing value.
@@ -369,7 +369,7 @@ Children in a delegation tree inherit the parent's `ContextId` via `--var`, prov
 
 ### 7.5 Example: write-plan / execute-plan
 
-A parent runbook produces a plan file and delegates to a child runbook that consumes it. Both share a `ContextId` through delegation inheritance.
+A parent runbook produces a plan file and delegates to a child runbook that consumes it. Both share a `ContextId` through delegation inheritance (see [§7.3](#73-delegation-inheritance) for the hand-off contract — the child automatically inherits the parent's `ContextId` via `--var`).
 
 Parent (`write-plan.runbook.md`):
 

--- a/packages/claude-code-plugin/skills/writing-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-runbooks/SKILL.md
@@ -158,7 +158,7 @@ Process {{ item }}.
 
 ## Template Variables
 
-Use `{{ variableName }}` syntax. See [CLAUDE.md — Template Variables](../../CLAUDE.md#template-variables) for full reference.
+Use `{{ variableName }}` syntax. See [SPEC.md §6 Templating](../../../../docs/SPEC.md#6-templating) and [§6.1 Built-in Variables](../../../../docs/SPEC.md#61-built-in-variables) for the full reference.
 
 Key authoring notes:
 - Undefined variables preserved as literal `{{ variable }}` text
@@ -180,4 +180,5 @@ Key authoring notes:
 - [Rundown specification](../../../../docs/SPEC.md)
 - [Format grammar (EBNF)](../../../../docs/FORMAT.md)
 - [Runbook patterns and examples](../../../../runbooks/README.md)
-- [Template variables](../../../../CLAUDE.md#template-variables)
+- [Template variables](../../../../docs/SPEC.md#6-templating) — precedence, reserved keys, required variables
+- [Built-in variables](../../../../docs/SPEC.md#61-built-in-variables) — `Date`, `WorkPath`, `ContextId`, `Step`, `Index`, etc.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated and reorganized template variable, built-in variable, and context-passing documentation into the canonical specification (`SPEC.md`).
  * Clarified variable source precedence, including new context-driven variable injection capabilities.
  * Updated references across documentation to point to consolidated specification sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->