### PR TITLE
Output state machine cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,18 +241,3 @@ jobs:
           name: playwright-report
           path: site/playwright-report/
           retention-days: 30
-
-  # Trigger turboshovel tests after successful CI on main
-  notify-dependents:
-    needs: [quality-checks, complexity-checks, lint-typed, test, scenarios, playwright]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger turboshovel CI
-        continue-on-error: true
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
-        with:
-          token: ${{ secrets.CROSS_REPO_PAT }}
-          repository: tobyhede/turboshovel
-          event-type: rundown-updated
-          client-payload: '{"sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "actor": "${{ github.actor }}"}'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,12 @@ This enables programmatic validation of CLI output against the schema.
 
 State persists in `.rundown/runs/` (execution state) and `.rundown/session.json` (active runbook tracking). Runbook source files are discovered from multiple locations (see [Runbook Discovery](#runbook-discovery)). State files persist across context clears.
 
-**Principle:** Never migrate persisted runbook state between versions. On schema changes, running runbooks should be completed/closed and restarted. The CLI should detect stale state and prompt the user rather than attempting silent migration.
+<important>
+**Principle:** NEVER migrate persisted runbook state between versions.
+On schema changes, any running runbooks should be completed/closed and restarted.
+The CLI should error and prompt the user if state is stale.
+Never attempt to migrate state.
+</important>
 
 ## Runbook Discovery
 

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -573,9 +573,9 @@ describe('RunbookActorService', () => {
   });
 
   describe('RunbookActorService — finalVars persistence', () => {
-    // Replaces the production-mirror probe in _scratch_production_mirror.test.ts.
-    // Verifies that updateFromActor reads snapshot.context.finalVars (Cause #4 in
-    // the handoff: the OLD updateFromActor never touched it).
+    // Verifies that updateFromActor reads snapshot.context.finalVars and writes
+    // it to RunbookState.finalVars on terminal sync. The earlier implementation
+    // wrote `variables` but never propagated `finalVars` out of the machine.
 
     it('persists context.finalVars to RunbookState.finalVars on STOPPED snapshot', async () => {
       const state = await manager.create('test.md', mockRunbook, {
@@ -612,6 +612,16 @@ describe('RunbookActorService', () => {
       });
 
       const result = await actorService.sendAndSync(state.id, mockSteps, { type: 'FAIL' });
+      expect(result!.state.finalVars).toBeUndefined();
+    });
+
+    it('leaves RunbookState.finalVars undefined when context.finalVars is empty on COMPLETE', async () => {
+      const state = await manager.create('test.md', mockRunbook, {
+        runbookPath: 'test.md',
+        // No frontmatterOutputs declared → context.finalVars stays {}
+      });
+
+      const result = await actorService.sendAndSync(state.id, mockSteps, { type: 'PASS' });
       expect(result!.state.finalVars).toBeUndefined();
     });
   });

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -618,7 +618,7 @@ describe('RunbookActorService', () => {
     it('leaves RunbookState.finalVars undefined when context.finalVars is empty on COMPLETE', async () => {
       const state = await manager.create('test.md', mockRunbook, {
         runbookPath: 'test.md',
-        // No frontmatterOutputs declared → context.finalVars stays {}
+        frontmatterOutputs: [],
       });
 
       const result = await actorService.sendAndSync(state.id, mockSteps, { type: 'PASS' });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -9817,5 +9817,56 @@ echo "processing"
       const assignPayload = getAssignPayload(stoppedEntry.actions);
       expect(assignPayload.lastAction).toEqual({ type: 'STOP' });
     });
+
+    it('records the parent declared PASS action on lastAction for unconditional FOR exit (Case C)', () => {
+      // Case C: FOR step, no parent-level aggregation, declared PASS COMPLETE.
+      // Omitting `aggregation` from the parent step (while keeping it inside forClause
+      // via DEFAULT_FOR_ITERATION) selects Case C in buildParentStateConfig.
+      const steps = inferSteps([
+        {
+          name: '1',
+          description: 'FOR parent, Case C — no aggregation',
+          forClause: { start: 1, end: 1, ...DEFAULT_FOR_ITERATION },
+          transitions: {
+            pass: { kind: 'pass' as const, retry: 0, action: { type: 'COMPLETE' as const } },
+            fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+          },
+          substeps: [
+            {
+              id: '1',
+              description: 'Iteration substep',
+              transitions: DEFAULT_TRANSITIONS,
+            },
+          ],
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const parentAlways = (machine.config.states as any)['step::1'].always as any[];
+
+      // Case C emits two COMPLETE-targeting entries: the BREAK/NEXT routing entry
+      // (no lastAction reassignment) and the normal PASS routing entry (sets
+      // lastAction to the parent's declared PASS action). We need the normal PASS
+      // routing entry — the one whose assign payload includes lastAction.
+      // It MUST record lastAction.type === 'COMPLETE', not CONTINUE (which was the
+      // bug before passLastAction was wired in).
+      const completeEntries = parentAlways.filter((entry: any) => entry.target === 'COMPLETE');
+      expect(completeEntries.length).toBeGreaterThanOrEqual(1);
+
+      const normalPassEntry = completeEntries.find((entry: any) => {
+        const arr = Array.isArray(entry.actions) ? entry.actions : [entry.actions];
+        return arr.some(
+          (a: any) =>
+            a.type === 'xstate.assign' &&
+            a.assignment &&
+            typeof a.assignment === 'object' &&
+            'lastAction' in a.assignment,
+        );
+      });
+      expect(normalPassEntry).toBeDefined();
+
+      const assignPayload = getAssignPayload(normalPassEntry.actions);
+      expect(assignPayload.lastAction).toEqual({ type: 'COMPLETE' });
+    });
   });
 });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -56,6 +56,7 @@ describe('runbook compiler', () => {
     return [...steps];
   }
 
+
   describe('static step compilation', () => {
     it('generates discrete states for substeps', () => {
       const steps = inferSteps([

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -56,7 +56,6 @@ describe('runbook compiler', () => {
     return [...steps];
   }
 
-
   describe('static step compilation', () => {
     it('generates discrete states for substeps', () => {
       const steps = inferSteps([

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -9844,19 +9844,20 @@ echo "processing"
       const machine = compileRunbookToMachine(steps);
       const parentAlways = (machine.config.states as any)['step::1'].always as any[];
 
-      // Case C emits two COMPLETE-targeting entries: the BREAK/NEXT routing entry
-      // (no lastAction reassignment) and the normal PASS routing entry (sets
-      // lastAction to the parent's declared PASS action). Guards are inline
-      // functions with no runtime name, so we assert over the aggregate set.
-      // The original bug was CONTINUE being recorded — assert that directly.
-      const completeEntries = parentAlways.filter((entry: any) => entry.target === 'COMPLETE');
-      const lastActions = completeEntries
-        .flatMap((entry: any) => (Array.isArray(entry.actions) ? entry.actions : [entry.actions]))
-        .filter((a: any) => a.type === 'xstate.assign' && 'lastAction' in (a.assignment ?? {}))
-        .map((a: any) => a.assignment.lastAction);
+      // Guards are now named in runbookSetup: entry.guard is a plain string at
+      // runtime, enabling unambiguous discriminants without inspecting payload content.
+      const passEntry = parentAlways.find((e: any) => e.guard === 'loopCompletedNormally');
+      expect(passEntry).toBeDefined();
+      const assignPayload = getAssignPayload(passEntry.actions);
+      expect(assignPayload.lastAction).toEqual({ type: 'COMPLETE' });
 
-      expect(lastActions).toContainEqual({ type: 'COMPLETE' });
-      expect(lastActions).not.toContainEqual({ type: 'CONTINUE' });
+      // BREAK/NEXT entry must NOT override lastAction — it preserves the iteration's own disposition.
+      const breakEntry = parentAlways.find((e: any) => e.guard === 'loopExitedViaControl');
+      expect(breakEntry).toBeDefined();
+      const breakActions = (
+        Array.isArray(breakEntry.actions) ? breakEntry.actions : [breakEntry.actions]
+      ) as any[];
+      expect(breakActions.some((a: any) => 'lastAction' in (a.assignment ?? {}))).toBe(false);
     });
   });
 });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -9846,27 +9846,17 @@ echo "processing"
 
       // Case C emits two COMPLETE-targeting entries: the BREAK/NEXT routing entry
       // (no lastAction reassignment) and the normal PASS routing entry (sets
-      // lastAction to the parent's declared PASS action). We need the normal PASS
-      // routing entry — the one whose assign payload includes lastAction.
-      // It MUST record lastAction.type === 'COMPLETE', not CONTINUE (which was the
-      // bug before passLastAction was wired in).
+      // lastAction to the parent's declared PASS action). Guards are inline
+      // functions with no runtime name, so we assert over the aggregate set.
+      // The original bug was CONTINUE being recorded — assert that directly.
       const completeEntries = parentAlways.filter((entry: any) => entry.target === 'COMPLETE');
-      expect(completeEntries.length).toBeGreaterThanOrEqual(1);
+      const lastActions = completeEntries
+        .flatMap((entry: any) => (Array.isArray(entry.actions) ? entry.actions : [entry.actions]))
+        .filter((a: any) => a.type === 'xstate.assign' && 'lastAction' in (a.assignment ?? {}))
+        .map((a: any) => a.assignment.lastAction);
 
-      const normalPassEntry = completeEntries.find((entry: any) => {
-        const arr = Array.isArray(entry.actions) ? entry.actions : [entry.actions];
-        return arr.some(
-          (a: any) =>
-            a.type === 'xstate.assign' &&
-            a.assignment &&
-            typeof a.assignment === 'object' &&
-            'lastAction' in a.assignment,
-        );
-      });
-      expect(normalPassEntry).toBeDefined();
-
-      const assignPayload = getAssignPayload(normalPassEntry.actions);
-      expect(assignPayload.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(lastActions).toContainEqual({ type: 'COMPLETE' });
+      expect(lastActions).not.toContainEqual({ type: 'CONTINUE' });
     });
   });
 });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -9783,7 +9783,7 @@ echo "processing"
 `);
 
       const machine = compileRunbookToMachine(steps);
-      const parentAlways = (machine.config.states as any)['step::1'].always as any[];
+      const parentAlways = getState(machine, 'step::1').always as any[];
 
       // Parent's declared PASS action is COMPLETE. The PASS-path exit entry
       // MUST record lastAction.type === 'COMPLETE', not CONTINUE.
@@ -9809,7 +9809,7 @@ echo "processing"
 `);
 
       const machine = compileRunbookToMachine(steps);
-      const parentAlways = (machine.config.states as any)['step::1'].always as any[];
+      const parentAlways = getState(machine, 'step::1').always as any[];
 
       const stoppedEntry = parentAlways.find((entry) => entry.target === 'STOPPED');
       expect(stoppedEntry).toBeDefined();
@@ -9842,7 +9842,7 @@ echo "processing"
       ]);
 
       const machine = compileRunbookToMachine(steps);
-      const parentAlways = (machine.config.states as any)['step::1'].always as any[];
+      const parentAlways = getState(machine, 'step::1').always as any[];
 
       // Guards are now named in runbookSetup: entry.guard is a plain string at
       // runtime, enabling unambiguous discriminants without inspecting payload content.

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -9544,6 +9544,17 @@ echo "processing"
       return (machine.config.states as Record<string, unknown>)[id] as any;
     }
 
+    function getAssignPayload(actions: unknown): Record<string, unknown> {
+      const arr = Array.isArray(actions) ? actions : [actions];
+      for (const action of arr) {
+        const a = action as { type?: string; assignment?: unknown };
+        if (a.type === 'xstate.assign' && a.assignment && typeof a.assignment === 'object') {
+          return a.assignment as Record<string, unknown>;
+        }
+      }
+      throw new Error(`No assign payload found in actions: ${JSON.stringify(actions)}`);
+    }
+
     it('emits a parent-level FAIL routing entry when parentStep.transitions.fail is STOP and there is no aggregation', () => {
       const steps = createRunbook(`## 1. Parent
 - PASS CONTINUE
@@ -9755,6 +9766,56 @@ echo "processing"
       expect(snapshot.value).toBe('COMPLETE');
       expect(snapshot.context.lastAction).toEqual({ type: 'COMPLETE' });
       expect(snapshot.context.lastMessage).toBe('all done');
+    });
+
+    it('records the parent declared PASS action on lastAction when the exit fires (not a forced CONTINUE)', () => {
+      const steps = createRunbook(`## 1. Parent
+- PASS COMPLETE
+- FAIL STOP
+
+### 1.1 First
+- PASS CONTINUE
+- FAIL CONTINUE
+
+### 1.2 Last
+- PASS CONTINUE
+- FAIL CONTINUE
+`);
+
+      const machine = compileRunbookToMachine(steps);
+      const parentAlways = (machine.config.states as any)['step::1'].always as any[];
+
+      // Parent's declared PASS action is COMPLETE. The PASS-path exit entry
+      // MUST record lastAction.type === 'COMPLETE', not CONTINUE.
+      const completeEntry = parentAlways.find((entry) => entry.target === 'COMPLETE');
+      expect(completeEntry).toBeDefined();
+
+      const assignPayload = getAssignPayload(completeEntry.actions);
+      expect(assignPayload.lastAction).toEqual({ type: 'COMPLETE' });
+    });
+
+    it('records the parent declared FAIL action on lastAction when the FAIL-path exit fires', () => {
+      const steps = createRunbook(`## 1. Parent
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.1 First
+- PASS CONTINUE
+- FAIL CONTINUE
+
+### 1.2 Last
+- PASS CONTINUE
+- FAIL CONTINUE
+`);
+
+      const machine = compileRunbookToMachine(steps);
+      const parentAlways = (machine.config.states as any)['step::1'].always as any[];
+
+      const stoppedEntry = parentAlways.find((entry) => entry.target === 'STOPPED');
+      expect(stoppedEntry).toBeDefined();
+
+      const assignPayload = getAssignPayload(stoppedEntry.actions);
+      expect(assignPayload.lastAction).toEqual({ type: 'STOP' });
     });
   });
 });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -8763,7 +8763,7 @@ echo "processing"
       expect(snapshot.context.finalVars).toEqual({ Result: 'failed-value' });
     });
 
-    it('decorates parent-step exit transitions with storeStepOutputs (no longer with storeFrontmatterOutputs)', () => {
+    it('decorates parent-step exit transitions with storeStepOutputs only (not storeFrontmatterOutputs)', () => {
       const steps = createRunbook(`## 1. Parent
 - PASS CONTINUE
 - FAIL STOP

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -9539,20 +9539,20 @@ echo "processing"
     });
   });
 
+  function getAssignPayload(actions: unknown): Record<string, unknown> {
+    const arr = Array.isArray(actions) ? actions : [actions];
+    for (const action of arr) {
+      const a = action as { type?: string; assignment?: unknown };
+      if (a.type === 'xstate.assign' && a.assignment && typeof a.assignment === 'object') {
+        return a.assignment as Record<string, unknown>;
+      }
+    }
+    throw new Error(`No assign payload found in actions: ${JSON.stringify(actions)}`);
+  }
+
   describe('parent-step unconditional-exit FAIL routing (Bug A)', () => {
     function getState(machine: ReturnType<typeof compileRunbookToMachine>, id: string): any {
       return (machine.config.states as Record<string, unknown>)[id] as any;
-    }
-
-    function getAssignPayload(actions: unknown): Record<string, unknown> {
-      const arr = Array.isArray(actions) ? actions : [actions];
-      for (const action of arr) {
-        const a = action as { type?: string; assignment?: unknown };
-        if (a.type === 'xstate.assign' && a.assignment && typeof a.assignment === 'object') {
-          return a.assignment as Record<string, unknown>;
-        }
-      }
-      throw new Error(`No assign payload found in actions: ${JSON.stringify(actions)}`);
     }
 
     it('emits a parent-level FAIL routing entry when parentStep.transitions.fail is STOP and there is no aggregation', () => {

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -179,10 +179,7 @@ export class RunbookActorService {
     // If the runbook is in a final state, don't try to parse a step number.
     // Just update the snapshot and variables, preserving the last step number.
     if (stateValue === 'COMPLETE' || stateValue === 'STOPPED') {
-      const variables = (snapshot.context?.variables ?? {}) as Record<
-        string,
-        boolean | number | string
-      >;
+      const variables = snapshot.context?.variables ?? {};
       const rawFinalVars = (snapshot.context?.finalVars ?? {}) as Record<string, string>;
       // Empty finalVars on terminal: explicitly write `undefined` so the persisted
       // state has no `finalVars` field. This matches the schema's optional contract
@@ -216,7 +213,7 @@ export class RunbookActorService {
     const match = primaryMatch ?? legacyMatch;
     const stepName = match ? match[1] : steps[0].name;
 
-    let substep = snapshot.context?.substep as string | undefined;
+    let substep = snapshot.context?.substep;
     if (!substep && match?.[2]) {
       substep = match[2];
     }
@@ -224,16 +221,13 @@ export class RunbookActorService {
     // Find step by name (unified lookup)
     const step = steps.find((s) => s.name === stepName) ?? steps[0];
 
-    const retryCount = (snapshot.context?.retryCount as number | undefined) ?? 0;
-    const variables = (snapshot.context?.variables ?? {}) as Record<
-      string,
-      boolean | number | string
-    >;
+    const retryCount = snapshot.context?.retryCount ?? 0;
+    const variables = snapshot.context?.variables ?? {};
 
     // FOR loop context
     const forStack = snapshot.context?.forStack as ForContext[] | undefined;
-    const iterationResults = snapshot.context?.iterationResults as ('pass' | 'fail')[] | undefined;
-    const lastAction = snapshot.context?.lastAction as RunbookState['lastAction'];
+    const iterationResults = snapshot.context?.iterationResults;
+    const lastAction = snapshot.context?.lastAction;
 
     // Filter implicit ForContext entries — don't persist synthetic loop state
     const realForStack = forStack?.filter((fc) => !fc.implicit);

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -13,7 +13,7 @@
  */
 
 import { createActor, type AnyActorRef } from 'xstate';
-import type { ResolvedStep, RunbookState, ForContext } from './types.js';
+import type { ResolvedStep, RunbookState } from './types.js';
 import type { RunbookStateManager } from './state.js';
 import { compileRunbookToMachine, type RunbookEvent, type RunbookContext } from './compiler.js';
 import { flattenTemplateVars } from './output-evaluator.js';
@@ -225,7 +225,7 @@ export class RunbookActorService {
     const variables = snapshot.context?.variables ?? {};
 
     // FOR loop context
-    const forStack = snapshot.context?.forStack as ForContext[] | undefined;
+    const forStack = snapshot.context?.forStack;
     const iterationResults = snapshot.context?.iterationResults;
     const lastAction = snapshot.context?.lastAction;
 

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -15,7 +15,7 @@
 import { createActor, type AnyActorRef } from 'xstate';
 import type { ResolvedStep, RunbookState, ForContext } from './types.js';
 import type { RunbookStateManager } from './state.js';
-import { compileRunbookToMachine, type RunbookEvent } from './compiler.js';
+import { compileRunbookToMachine, type RunbookEvent, type RunbookContext } from './compiler.js';
 import { flattenTemplateVars } from './output-evaluator.js';
 import { resolvedStepHasSubsteps } from '@rundown-org/parser';
 import { logger } from '../logger.js';
@@ -48,6 +48,16 @@ export interface ActorSyncResult {
  * after transitions, and convenience methods for the two dominant usage patterns:
  * initialisation (create + sync with no event) and transition (create + send + sync).
  */
+/**
+ * Typed shape of the persisted snapshot returned by `actor.getPersistedSnapshot()`
+ * within `updateFromActor`. Only the fields accessed in that method are declared;
+ * the full XState snapshot envelope is otherwise opaque.
+ */
+type PersistedRunbookSnapshot = {
+  value: unknown;
+  context?: Partial<RunbookContext>;
+};
+
 export class RunbookActorService {
   /**
    * Create a new RunbookActorService.
@@ -156,9 +166,7 @@ export class RunbookActorService {
     actor: AnyActorRef,
     steps: ResolvedStep[],
   ): Promise<{ state: RunbookState; snapshot: unknown }> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const snapshot = actor.getPersistedSnapshot() as any;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const snapshot = actor.getPersistedSnapshot() as unknown as PersistedRunbookSnapshot;
     const rawValue: unknown = snapshot.value;
 
     if (typeof rawValue !== 'string') {
@@ -171,12 +179,10 @@ export class RunbookActorService {
     // If the runbook is in a final state, don't try to parse a step number.
     // Just update the snapshot and variables, preserving the last step number.
     if (stateValue === 'COMPLETE' || stateValue === 'STOPPED') {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const variables = (snapshot.context?.variables ?? {}) as Record<
         string,
         boolean | number | string
       >;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const rawFinalVars = (snapshot.context?.finalVars ?? {}) as Record<string, string>;
       // Empty finalVars on terminal: explicitly write `undefined` so the persisted
       // state has no `finalVars` field. This matches the schema's optional contract
@@ -210,7 +216,6 @@ export class RunbookActorService {
     const match = primaryMatch ?? legacyMatch;
     const stepName = match ? match[1] : steps[0].name;
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     let substep = snapshot.context?.substep as string | undefined;
     if (!substep && match?.[2]) {
       substep = match[2];
@@ -219,20 +224,15 @@ export class RunbookActorService {
     // Find step by name (unified lookup)
     const step = steps.find((s) => s.name === stepName) ?? steps[0];
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const retryCount = (snapshot.context?.retryCount as number | undefined) ?? 0;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const variables = (snapshot.context?.variables ?? {}) as Record<
       string,
       boolean | number | string
     >;
 
     // FOR loop context
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const forStack = snapshot.context?.forStack as ForContext[] | undefined;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const iterationResults = snapshot.context?.iterationResults as ('pass' | 'fail')[] | undefined;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const lastAction = snapshot.context?.lastAction as RunbookState['lastAction'];
 
     // Filter implicit ForContext entries — don't persist synthetic loop state

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -180,7 +180,7 @@ export class RunbookActorService {
     // Just update the snapshot and variables, preserving the last step number.
     if (stateValue === 'COMPLETE' || stateValue === 'STOPPED') {
       const variables = snapshot.context?.variables ?? {};
-      const rawFinalVars = (snapshot.context?.finalVars ?? {}) as Readonly<Record<string, string>>;
+      const rawFinalVars = snapshot.context?.finalVars ?? {};
       // Empty finalVars on terminal: explicitly write `undefined` so the persisted
       // state has no `finalVars` field. This matches the schema's optional contract
       // and avoids storing a misleading empty object.

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -42,13 +42,6 @@ export interface ActorSyncResult {
 }
 
 /**
- * Manages XState actor lifecycle for runbooks.
- *
- * Encapsulates actor creation (with snapshot migration), state synchronisation
- * after transitions, and convenience methods for the two dominant usage patterns:
- * initialisation (create + sync with no event) and transition (create + send + sync).
- */
-/**
  * Typed shape of the persisted snapshot returned by `actor.getPersistedSnapshot()`
  * within `updateFromActor`. Only the fields accessed in that method are declared;
  * the full XState snapshot envelope is otherwise opaque.
@@ -58,6 +51,13 @@ type PersistedRunbookSnapshot = {
   context?: Partial<RunbookContext>;
 };
 
+/**
+ * Manages XState actor lifecycle for runbooks.
+ *
+ * Encapsulates actor creation (with snapshot migration), state synchronisation
+ * after transitions, and convenience methods for the two dominant usage patterns:
+ * initialisation (create + sync with no event) and transition (create + send + sync).
+ */
 export class RunbookActorService {
   /**
    * Create a new RunbookActorService.

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -180,7 +180,7 @@ export class RunbookActorService {
     // Just update the snapshot and variables, preserving the last step number.
     if (stateValue === 'COMPLETE' || stateValue === 'STOPPED') {
       const variables = snapshot.context?.variables ?? {};
-      const rawFinalVars = (snapshot.context?.finalVars ?? {}) as Record<string, string>;
+      const rawFinalVars = (snapshot.context?.finalVars ?? {}) as Readonly<Record<string, string>>;
       // Empty finalVars on terminal: explicitly write `undefined` so the persisted
       // state has no `finalVars` field. This matches the schema's optional contract
       // and avoids storing a misleading empty object.

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -126,13 +126,30 @@ export const runbookSetup = setup({
     }),
   },
   guards: {
-    /** Any FOR iteration recorded a fail result. */
-    anyIterationFailed: ({ context }) =>
-      (context.iterationResults ?? []).some((r) => r === 'fail'),
-    /** FOR loop exited early via a BREAK or NEXT loop-control action. */
+    /**
+     * Any FOR iteration recorded a fail result.
+     *
+     * @param root0 - XState guard argument
+     * @param root0.context - Current runbook context
+     * @returns True if any iteration result is 'fail'
+     */
+    anyIterationFailed: ({ context }) => (context.iterationResults ?? []).some((r) => r === 'fail'),
+    /**
+     * FOR loop exited early via a BREAK or NEXT loop-control action.
+     *
+     * @param root0 - XState guard argument
+     * @param root0.context - Current runbook context
+     * @returns True if the last action was BREAK or NEXT
+     */
     loopExitedViaControl: ({ context }) =>
       context.lastAction?.type === 'BREAK' || context.lastAction?.type === 'NEXT',
-    /** FOR loop completed normally: no failed iterations, no loop-control exit. */
+    /**
+     * FOR loop completed normally: no failed iterations, no loop-control exit.
+     *
+     * @param root0 - XState guard argument
+     * @param root0.context - Current runbook context
+     * @returns True if the loop ran to completion without failures or control exits
+     */
     loopCompletedNormally: ({ context }) =>
       !(context.iterationResults ?? []).some((r) => r === 'fail') &&
       context.lastAction?.type !== 'BREAK' &&

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -874,6 +874,14 @@ function buildParentStateConfig(
 ): { always: TransitionEntry[]; entry?: CompilerAction | CompilerAction[] } {
   const parentStep = config.parentStep;
   const stepName = config.stepName;
+
+  if (!parentStep.transitions) {
+    throw new Error(
+      `buildParentStateConfig invariant violated: parentStep "${parentStep.name}" has no transitions. ` +
+        `Parent steps require explicit pass/fail transitions (parser emits DEFAULT_TRANSITIONS when absent).`,
+    );
+  }
+
   const hasFor = parentStep.kind === 'for';
   const hasAggregation = !!parentStep.aggregation;
   const nextTarget = findNextStateId(stepName, undefined, steps);

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -125,6 +125,19 @@ export const runbookSetup = setup({
       },
     }),
   },
+  guards: {
+    /** Any FOR iteration recorded a fail result. */
+    anyIterationFailed: ({ context }) =>
+      (context.iterationResults ?? []).some((r) => r === 'fail'),
+    /** FOR loop exited early via a BREAK or NEXT loop-control action. */
+    loopExitedViaControl: ({ context }) =>
+      context.lastAction?.type === 'BREAK' || context.lastAction?.type === 'NEXT',
+    /** FOR loop completed normally: no failed iterations, no loop-control exit. */
+    loopCompletedNormally: ({ context }) =>
+      !(context.iterationResults ?? []).some((r) => r === 'fail') &&
+      context.lastAction?.type !== 'BREAK' &&
+      context.lastAction?.type !== 'NEXT',
+  },
 });
 
 /** Machine type produced by {@link compileRunbookToMachine}. */
@@ -145,6 +158,25 @@ type CompilerAction = ReturnType<typeof runbookSetup.assign> | CompilerActionRef
 
 /** XState state-node config type inferred from the runbook setup. */
 type RunbookStateConfig = Parameters<typeof runbookSetup.createStateConfig>[0];
+
+/**
+ * Guard type accepted by XState transitions in this machine: either an inline predicate
+ * function or a named guard string key registered in the `runbookSetup` guards block.
+ *
+ * Extracted from `RunbookStateConfig` so it stays in sync with the actual XState
+ * guard parameter type as the setup evolves.
+ */
+type RunbookGuard = NonNullable<
+  RunbookStateConfig['always'] extends infer A
+    ? A extends readonly (infer Entry)[]
+      ? Entry extends { guard?: infer G }
+        ? G
+        : never
+      : A extends { guard?: infer G }
+        ? G
+        : never
+    : never
+>;
 
 /**
  * Safety limit for file-backed data sources with open iteration windows.
@@ -232,12 +264,13 @@ export type RunbookEvent =
  * The `actions` field is typed as `unknown` because XState's internal action
  * types are deeply generic and incompatible with intermediate interfaces.
  * Type safety for actions comes from `runbookSetup.assign()` at call sites.
- * Guards and targets are properly typed.
+ * Guards accept either inline predicate functions or named guard string keys
+ * registered in the `runbookSetup` guards block (`RunbookGuard`).
  */
 interface TransitionEntry {
   target?: string;
   actions?: CompilerAction | CompilerAction[];
-  guard?: (args: { context: RunbookContext; event: RunbookEvent }) => boolean;
+  guard?: RunbookGuard;
 }
 
 type TransitionConfig = TransitionEntry | TransitionEntry[];
@@ -1455,23 +1488,15 @@ function buildParentStateConfig(
       // otherwise route to parent PASS target. BOTH entries must be guarded —
       // an unguarded earlier entry would shadow the guarded one (XState v5
       // evaluates `always` entries in order).
-      const anyIterationFail: GuardFn = ({ context }) =>
-        (context.iterationResults ?? []).some((r) => r === 'fail');
-      // BREAK/NEXT exits preserve their lastAction — exclude them from the normal routing guards.
-      const isBreakOrNext: GuardFn = ({ context }) =>
-        context.lastAction?.type === 'BREAK' || context.lastAction?.type === 'NEXT';
-      const noIterationFailNormal: GuardFn = ({ context }) =>
-        !(context.iterationResults ?? []).some((r) => r === 'fail') &&
-        context.lastAction?.type !== 'BREAK' &&
-        context.lastAction?.type !== 'NEXT';
+      // Guards: loopExitedViaControl, loopCompletedNormally, anyIterationFailed — registered in runbookSetup.
 
       // BREAK/NEXT PASS routing: exit was via BREAK or NEXT — preserve lastAction as-is.
       // lastMessage is cleared: BREAK/NEXT carry no message; any stale substep message must not leak.
       // Safety: in Case C (no aggregation), iterationResults is never populated by sequential guards,
-      // so anyIterationFail is always false when isBreakOrNext is true. If this invariant changes,
-      // revisit guard ordering — isBreakOrNext must either check for fails or be merged with anyIterationFail.
+      // so anyIterationFailed is always false when loopExitedViaControl is true. If this invariant changes,
+      // revisit guard ordering — loopExitedViaControl must either check for fails or be merged with anyIterationFailed.
       always.push({
-        guard: isBreakOrNext,
+        guard: 'loopExitedViaControl',
         target: parentPassTarget,
         actions: runbookSetup.assign({
           ...commonAssign,
@@ -1480,10 +1505,10 @@ function buildParentStateConfig(
         }),
       });
       // Normal PASS routing: no failed iterations and no BREAK/NEXT → parent's PASS action target.
-      // The BREAK/NEXT exclusion duplicates isBreakOrNext because XState evaluates guards
+      // The BREAK/NEXT exclusion duplicates loopExitedViaControl because XState evaluates guards
       // independently (not as an if-else chain) — both guards must be self-contained.
       always.push({
-        guard: noIterationFailNormal,
+        guard: 'loopCompletedNormally',
         target: parentPassTarget,
         actions: runbookSetup.assign({
           ...commonAssign,
@@ -1494,7 +1519,7 @@ function buildParentStateConfig(
       });
       // FAIL routing: any failed iteration → parent's FAIL action target.
       always.push({
-        guard: anyIterationFail,
+        guard: 'anyIterationFailed',
         target: parentFailTarget,
         actions: runbookSetup.assign({
           ...commonAssign,

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -126,30 +126,9 @@ export const runbookSetup = setup({
     }),
   },
   guards: {
-    /**
-     * Any FOR iteration recorded a fail result.
-     *
-     * @param root0 - XState guard argument
-     * @param root0.context - Current runbook context
-     * @returns True if any iteration result is 'fail'
-     */
     anyIterationFailed: ({ context }) => (context.iterationResults ?? []).some((r) => r === 'fail'),
-    /**
-     * FOR loop exited early via a BREAK or NEXT loop-control action.
-     *
-     * @param root0 - XState guard argument
-     * @param root0.context - Current runbook context
-     * @returns True if the last action was BREAK or NEXT
-     */
     loopExitedViaControl: ({ context }) =>
       context.lastAction?.type === 'BREAK' || context.lastAction?.type === 'NEXT',
-    /**
-     * FOR loop completed normally: no failed iterations, no loop-control exit.
-     *
-     * @param root0 - XState guard argument
-     * @param root0.context - Current runbook context
-     * @returns True if the loop ran to completion without failures or control exits
-     */
     loopCompletedNormally: ({ context }) =>
       !(context.iterationResults ?? []).some((r) => r === 'fail') &&
       context.lastAction?.type !== 'BREAK' &&

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -874,6 +874,7 @@ function buildParentStateConfig(
 ): { always: TransitionEntry[]; entry?: CompilerAction | CompilerAction[] } {
   const parentStep = config.parentStep;
   const stepName = config.stepName;
+  // parentStep.transitions is non-optional on ExecutionUnitFields — guaranteed by the parser.
 
   const hasFor = parentStep.kind === 'for';
   const hasAggregation = !!parentStep.aggregation;

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -875,13 +875,6 @@ function buildParentStateConfig(
   const parentStep = config.parentStep;
   const stepName = config.stepName;
 
-  if (!parentStep.transitions) {
-    throw new Error(
-      `buildParentStateConfig invariant violated: parentStep "${parentStep.name}" has no transitions. ` +
-        `Parent steps require explicit pass/fail transitions (parser emits DEFAULT_TRANSITIONS when absent).`,
-    );
-  }
-
   const hasFor = parentStep.kind === 'for';
   const hasAggregation = !!parentStep.aggregation;
   const nextTarget = findNextStateId(stepName, undefined, steps);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parent-step exit transitions to properly record the last action when transitioning to terminal states.

* **Tests**
  * Added test coverage validating `finalVars` propagation during terminal sync.
  * Enhanced test cases for parent-step exit transition behavior and action recording.

* **Chores**
  * Removed notify-dependents CI job from main branch workflows.
  * Improved type safety in actor service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->