### PR TITLE
Lifecycle flags cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,12 @@ rundown ls --all --tags <tags>  # Filter by comma-separated tags
 rundown check <file>     # Check runbook for errors
 rundown resolve <file>   # Resolve and validate variables and data sources
 rundown echo             # Test helper: echo with configurable result
-rundown prune            # Remove runbook state (default: completed)
+rundown prune            # Remove runbook state (default: completed + stopped)
 rundown prune --dry-run  # Show what would be removed without deleting
-rundown prune --completed # Prune completed runbook state
+rundown prune --completed # Prune successfully completed runbook state
+rundown prune --stopped  # Prune stopped (aborted/failed) runbook state
 rundown prune --active   # Prune active runbook state
-rundown prune --inactive # Prune inactive runbook state
+rundown prune --inactive # Prune inactive (orphaned) runbook state
 rundown prune --all      # Prune all runbook state
 rundown scenario ls <file>           # List scenarios in a runbook
 rundown scenario show <file> <name>  # Show scenario details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,10 +183,11 @@ State persists in `.rundown/runs/` (execution state) and `.rundown/session.json`
 
 <important>
 **Principle:** NEVER migrate persisted runbook state between versions.
-On schema changes, any running runbooks should be completed/closed and restarted.
-The CLI should error and prompt the user if state is stale.
-Never attempt to migrate state.
 </important>
+
+**Principle:** Never migrate persisted runbook state between versions. This applies to all data written to `.rundown/runs/`: structured `RunbookState` fields (step, variables, lifecycle, etc.) and the opaque `state.snapshot` blob stored inside `RunbookState`. Neither is exempt. On schema changes, running runbooks should be completed/closed and restarted. The CLI should detect stale state (via schema version or structural guard) and prompt the user to finish or prune — never silently adapt, rewrite, or shim the data.
+
+There is no in-memory migration scenario. In-memory state does not survive process restarts. Any state that reaches `createActor` originates from disk and is subject to the same no-migration rule.
 
 ## Runbook Discovery
 

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -886,10 +886,11 @@ Line 22: Invalid transition: GOTO 10 (step does not exist)
 Clean up runbook state files (not runbook source files).
 
 ```bash
-rundown prune               # Remove completed runbooks (default)
+rundown prune               # Remove completed + stopped runbooks (default)
 rundown prune --all         # Remove all runbook state
 rundown prune --dry-run     # Preview what would be removed
 rundown prune --completed   # Only completed
+rundown prune --stopped     # Only stopped (aborted/failed)
 rundown prune --inactive    # Only inactive
 rundown prune --active      # Only active (careful!)
 ```
@@ -1056,8 +1057,14 @@ Output: `PASS: N steps` or `FAIL: error details`
 # Preview what would be removed
 rundown prune --dry-run
 
-# Remove completed runbook state
+# Remove completed + stopped runbook state (default)
+rundown prune
+
+# Remove only completed runbook state
 rundown prune --completed
+
+# Remove only stopped (aborted/failed) runbook state
+rundown prune --stopped
 
 # Remove all state
 rundown prune --all

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:coverage:mcp": "npm run test:coverage -w packages/mcp",
     "format": "biome format --write .",
     "check:format": "biome check --formatter-enabled=true --linter-enabled=false .",
-    "check:spell": "cspell --no-progress .",
+    "check:spell": "cspell --no-progress --no-must-find-files .",
     "check:lint:fast": "biome lint .",
     "check:lint:typed": "eslint .",
     "check:types:core": "npm run check:types -w packages/core",

--- a/packages/claude-code-plugin/jest.config.js
+++ b/packages/claude-code-plugin/jest.config.js
@@ -23,6 +23,8 @@ export default {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@rundown-org/core$': '<rootDir>/../core/src/index.ts',
+    '^@rundown-org/parser$': '<rootDir>/../parser/src/index.ts',
   },
   transform: {
     '^.+\\.tsx?$': [

--- a/packages/cli/__tests__/commands/claim.test.ts
+++ b/packages/cli/__tests__/commands/claim.test.ts
@@ -354,7 +354,7 @@ rd echo --result fail
       // Parent should be stopped
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(updatedParent!.lifecycle).toBe('stopped');
     });
   });
 

--- a/packages/cli/__tests__/commands/claim.test.ts
+++ b/packages/cli/__tests__/commands/claim.test.ts
@@ -354,8 +354,7 @@ rd echo --result fail
       // Parent should be stopped
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      const vars = updatedParent!.variables as Record<string, unknown>;
-      expect(vars.stopped).toBe(true);
+      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
     });
   });
 

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -59,7 +59,7 @@ describe('fail command', () => {
       expect(result.stdout).toContain('STOP');
     });
 
-    it('should set variables.stopped=true when STOP action triggered', async () => {
+    it('should set lifecycle to stopped when STOP action triggered', async () => {
       // runbook already started by beforeEach
       await runCliInProcess('fail --text', workspace);
 

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -67,7 +67,7 @@ describe('fail command', () => {
       // Retrieve from all states
       const states = await getAllStates(workspace);
       const state = states.find((s) => s.runbook === 'runbooks/simple.runbook.md');
-      expect(state?.variables.stopped).toBe(true);
+      expect(state?.lifecycle).toBe('stopped');
     });
   });
 
@@ -252,7 +252,7 @@ Final step.
       expect(result.exitCode).toBe(1);
       const states = await getAllStates(workspace);
       const state = states.find((s) => s.runbook === 'runbooks/substep-fail-any.md');
-      expect(state?.variables.stopped).toBe(true);
+      expect(state?.lifecycle).toBe('stopped');
     });
 
     it('consecutive fail commands maintain state consistency', async () => {

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -61,7 +61,7 @@ describe('pass command', () => {
 
       const states = await getAllStates(workspace);
       const state = states.find((s) => s.runbook === 'runbooks/simple.runbook.md');
-      expect(state?.variables.completed).toBe(true);
+      expect(state?.lifecycle).toBe('completed');
     });
   });
 
@@ -147,7 +147,7 @@ This step stops on pass.
 
       const states = await getAllStates(workspace);
       const state = states.find((s) => s.runbook === 'runbooks/stop-on-pass.md');
-      expect(state?.variables.stopped).toBe(true);
+      expect(state?.lifecycle).toBe('stopped');
     });
   });
 

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -56,7 +56,7 @@ describe('pass command', () => {
       expect(session.active).toBeNull();
     });
 
-    it('should set variables.completed=true when completing runbook', async () => {
+    it('should set lifecycle to completed when runbook completes', async () => {
       await runCliInProcess('pass --text', workspace);
 
       const states = await getAllStates(workspace);
@@ -142,7 +142,7 @@ This step stops on pass.
       expect(result.stdout).toContain('STOP');
     });
 
-    it('should set variables.stopped=true when STOP action triggered', async () => {
+    it('should set lifecycle to stopped when STOP action triggered', async () => {
       await runCliInProcess('pass --text', workspace);
 
       const states = await getAllStates(workspace);

--- a/packages/cli/__tests__/commands/prune.test.ts
+++ b/packages/cli/__tests__/commands/prune.test.ts
@@ -37,13 +37,45 @@ describe('prune command', () => {
     });
   });
 
-  describe('default behavior (--completed)', () => {
+  describe('default behavior (--completed + --stopped)', () => {
     it('prunes completed runbook state by default', async () => {
       // Auto-run completes the runbook (both steps pass), leaving state with completed=true
       await runCliInProcess('run runbooks/simple.runbook.md --text', workspace);
 
       const statesBefore = await listRunbookStates(workspace);
       expect(statesBefore.length).toBe(1);
+
+      const result = await runCliInProcess('prune --text', workspace);
+
+      expect(result.exitCode).toBe(0);
+      const statesAfter = await listRunbookStates(workspace);
+      expect(statesAfter.length).toBe(0);
+    });
+
+    it('prunes stopped runbook state by default', async () => {
+      // Start runbook then stop it — leaves state with lifecycle=stopped
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      await runCliInProcess('stop --text', workspace);
+
+      const statesBefore = await listRunbookStates(workspace);
+      expect(statesBefore.length).toBe(1);
+
+      const result = await runCliInProcess('prune --text', workspace);
+
+      expect(result.exitCode).toBe(0);
+      const statesAfter = await listRunbookStates(workspace);
+      expect(statesAfter.length).toBe(0);
+    });
+
+    it('prunes both completed and stopped runbook state by default', async () => {
+      // Create completed state
+      await runCliInProcess('run runbooks/simple.runbook.md --text', workspace);
+      // Create stopped state
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      await runCliInProcess('stop --text', workspace);
+
+      const statesBefore = await listRunbookStates(workspace);
+      expect(statesBefore.length).toBe(2);
 
       const result = await runCliInProcess('prune --text', workspace);
 
@@ -93,6 +125,40 @@ describe('prune command', () => {
       // Remaining state should be the active one
       const session = await readSession(workspace);
       expect(session.active).not.toBeNull();
+    });
+  });
+
+  describe('--stopped flag', () => {
+    it('prunes only stopped runbook state', async () => {
+      // Create stopped state
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      await runCliInProcess('stop --text', workspace);
+
+      const statesBefore = await listRunbookStates(workspace);
+      expect(statesBefore.length).toBe(1);
+
+      const result = await runCliInProcess('prune --stopped --text', workspace);
+
+      expect(result.exitCode).toBe(0);
+      const statesAfter = await listRunbookStates(workspace);
+      expect(statesAfter.length).toBe(0);
+    });
+
+    it('does not prune completed state when only --stopped specified', async () => {
+      // Create completed state
+      await runCliInProcess('run runbooks/simple.runbook.md --text', workspace);
+      // Create stopped state
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      await runCliInProcess('stop --text', workspace);
+
+      const statesBefore = await listRunbookStates(workspace);
+      expect(statesBefore.length).toBe(2);
+
+      await runCliInProcess('prune --stopped --text', workspace);
+
+      // Only the completed state should remain
+      const statesAfter = await listRunbookStates(workspace);
+      expect(statesAfter.length).toBe(1);
     });
   });
 

--- a/packages/cli/__tests__/commands/prune.test.ts
+++ b/packages/cli/__tests__/commands/prune.test.ts
@@ -6,6 +6,7 @@ import {
   runCliInProcess,
   readSession,
   listRunbookStates,
+  readRunbookState,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
 
@@ -159,6 +160,8 @@ describe('prune command', () => {
       // Only the completed state should remain
       const statesAfter = await listRunbookStates(workspace);
       expect(statesAfter.length).toBe(1);
+      const remainingState = await readRunbookState(workspace, statesAfter[0].replace('.json', ''));
+      expect(remainingState?.lifecycle).toBe('completed');
     });
   });
 

--- a/packages/cli/__tests__/commands/stash-pop.test.ts
+++ b/packages/cli/__tests__/commands/stash-pop.test.ts
@@ -172,6 +172,8 @@ rd echo "hello"
       startedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       runbookSrc, // Include runbookSrc so pop can read steps
+      lifecycle: 'running',
+      schemaVersion: 2,
     };
     await writeFile(stateFile, JSON.stringify(state, null, 2));
 

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -107,6 +107,25 @@ describe('stop command', () => {
       expect(session.active).toBeNull();
       expect(session.defaultStack).toHaveLength(0);
     });
+
+    it('cleans up stale state with wrong schemaVersion instead of propagating error', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const state = await getActiveState(workspace);
+      const stateId = state!.id as string;
+      const stateDir = workspace.statePath();
+
+      // Write a state with the wrong schemaVersion to trigger StaleRunbookStateError
+      const staleState = { ...state, schemaVersion: 1 };
+      await writeFile(join(stateDir, `${stateId}.json`), JSON.stringify(staleState));
+
+      // stop is a cleanup command — StaleRunbookStateError must not propagate
+      const result = await runCliInProcess('stop --text', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const session = await readSession(workspace);
+      expect(session.active).toBeNull();
+      expect(session.defaultStack).toHaveLength(0);
+    });
   });
 
   describe('stop with message', () => {

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -254,7 +254,7 @@ Run the child task.
       // Aggregation: FAIL ANY (1.1 failed) triggers STOP
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(updatedParent!.lifecycle).toBe('stopped');
     });
 
     it('stop with custom message propagates to parent', async () => {
@@ -282,7 +282,7 @@ Run the child task.
       // Parent should be stopped (FAIL ANY: STOP)
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(updatedParent!.lifecycle).toBe('stopped');
     });
 
     it('stop with outputs structured data and propagates', async () => {
@@ -322,7 +322,7 @@ Run the child task.
       // Verify parent is stopped
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(updatedParent!.lifecycle).toBe('stopped');
     });
 
     it('stop without delegation linkage does not propagate', async () => {
@@ -398,7 +398,7 @@ Approve the deployment.
       // Verify parent is stopped
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(updatedParent!.lifecycle).toBe('stopped');
 
       // Grandparent is now active at substep 1.2 — complete it
       // Aggregation: FAIL ANY triggers STOP
@@ -407,7 +407,7 @@ Approve the deployment.
       // Verify grandparent is stopped
       const updatedGrandparent = await readRunbookState(workspace, grandparentRunId);
       expect(updatedGrandparent).not.toBeNull();
-      expect((updatedGrandparent! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(updatedGrandparent!.lifecycle).toBe('stopped');
     });
   });
 });

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -254,7 +254,7 @@ Run the child task.
       // Aggregation: FAIL ANY (1.1 failed) triggers STOP
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent!.variables as Record<string, unknown>).stopped).toBe(true);
+      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
     });
 
     it('stop with custom message propagates to parent', async () => {
@@ -282,7 +282,7 @@ Run the child task.
       // Parent should be stopped (FAIL ANY: STOP)
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent!.variables as Record<string, unknown>).stopped).toBe(true);
+      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
     });
 
     it('stop with outputs structured data and propagates', async () => {
@@ -322,7 +322,7 @@ Run the child task.
       // Verify parent is stopped
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent!.variables as Record<string, unknown>).stopped).toBe(true);
+      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
     });
 
     it('stop without delegation linkage does not propagate', async () => {
@@ -398,7 +398,7 @@ Approve the deployment.
       // Verify parent is stopped
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent!.variables as Record<string, unknown>).stopped).toBe(true);
+      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
 
       // Grandparent is now active at substep 1.2 — complete it
       // Aggregation: FAIL ANY triggers STOP
@@ -407,7 +407,7 @@ Approve the deployment.
       // Verify grandparent is stopped
       const updatedGrandparent = await readRunbookState(workspace, grandparentRunId);
       expect(updatedGrandparent).not.toBeNull();
-      expect((updatedGrandparent!.variables as Record<string, unknown>).stopped).toBe(true);
+      expect((updatedGrandparent! as Record<string, unknown>).lifecycle).toBe('stopped');
     });
   });
 });

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -47,7 +47,7 @@ describe('stop command', () => {
       expect(stateAfter).not.toBeNull();
       expect(stateAfter!.lastAction).toEqual({ type: 'STOP' });
       expect(stateAfter!.lastResult).toBe('fail');
-      expect(stateAfter!.variables.stopped).toBe(true);
+      expect(stateAfter!.lifecycle).toBe('stopped');
     });
   });
 

--- a/packages/cli/__tests__/helpers/status.test.ts
+++ b/packages/cli/__tests__/helpers/status.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from '@jest/globals';
 import { getStatus } from '../../src/helpers/status.js';
+import type { Lifecycle } from '@rundown-org/core';
 
 describe('getStatus', () => {
-  const makeState = (id: string, opts: { completed?: boolean; stopped?: boolean } = {}) => ({
+  const makeState = (id: string, lifecycle?: Lifecycle) => ({
     id,
-    variables: { completed: opts.completed, stopped: opts.stopped },
+    lifecycle,
   });
 
   it('returns "active" when state matches active runbook', () => {
@@ -18,12 +19,12 @@ describe('getStatus', () => {
   });
 
   it('returns "complete" when state is completed', () => {
-    const state = makeState('run-3', { completed: true });
+    const state = makeState('run-3', 'completed');
     expect(getStatus(state, null, null)).toBe('complete');
   });
 
   it('returns "stopped" when state is stopped', () => {
-    const state = makeState('run-4', { stopped: true });
+    const state = makeState('run-4', 'stopped');
     expect(getStatus(state, null, null)).toBe('stopped');
   });
 
@@ -38,17 +39,17 @@ describe('getStatus', () => {
   });
 
   it('prioritizes stashed over completed', () => {
-    const state = makeState('run-7', { completed: true });
+    const state = makeState('run-7', 'completed');
     expect(getStatus(state, null, 'run-7')).toBe('stashed');
   });
 
   it('prioritizes stashed over stopped', () => {
-    const state = makeState('run-X', { stopped: true });
+    const state = makeState('run-X', 'stopped');
     expect(getStatus(state, null, 'run-X')).toBe('stashed');
   });
 
-  it('prioritizes completed over stopped', () => {
-    const state = makeState('run-8', { completed: true, stopped: true });
+  it('prioritizes completed over stopped (lifecycle field is canonical)', () => {
+    const state = makeState('run-8', 'completed');
     expect(getStatus(state, null, null)).toBe('complete');
   });
 });

--- a/packages/cli/__tests__/integration/delegation-claim.test.ts
+++ b/packages/cli/__tests__/integration/delegation-claim.test.ts
@@ -306,7 +306,7 @@ rd echo --result fail
       // Parent should be stopped
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(updatedParent!.lifecycle).toBe('stopped');
     });
   });
 });

--- a/packages/cli/__tests__/integration/delegation-claim.test.ts
+++ b/packages/cli/__tests__/integration/delegation-claim.test.ts
@@ -306,8 +306,7 @@ rd echo --result fail
       // Parent should be stopped
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      const vars = updatedParent!.variables as Record<string, unknown>;
-      expect(vars.stopped).toBe(true);
+      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
     });
   });
 });

--- a/packages/cli/__tests__/integration/delegation-propagation.test.ts
+++ b/packages/cli/__tests__/integration/delegation-propagation.test.ts
@@ -112,7 +112,7 @@ describe('Delegation propagation integration', () => {
       const childId = childState!.id as string;
       const finalChildState = await readRunbookState(workspace, childId);
       expect(finalChildState).not.toBeNull();
-      expect((finalChildState! as Record<string, unknown>).lifecycle).toBe('completed');
+      expect(finalChildState!.lifecycle).toBe('completed');
 
       // Parent is now at substep 1.2 — complete it to trigger aggregation
       // PASS ALL (both passed) → CONTINUE → step 2
@@ -157,7 +157,7 @@ describe('Delegation propagation integration', () => {
 
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(updatedParent!.lifecycle).toBe('stopped');
     });
   });
 
@@ -193,7 +193,7 @@ describe('Delegation propagation integration', () => {
 
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(updatedParent!.lifecycle).toBe('stopped');
     });
   });
 
@@ -274,7 +274,7 @@ describe('Delegation propagation integration', () => {
       // Verify parent completed
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('completed');
+      expect(updatedParent!.lifecycle).toBe('completed');
 
       // Grandparent is at substep 1.2 — complete it
       // PASS ALL (both passed) → COMPLETE
@@ -283,7 +283,7 @@ describe('Delegation propagation integration', () => {
       // Verify grandparent completed
       const updatedGrandparent = await readRunbookState(workspace, grandparentRunId);
       expect(updatedGrandparent).not.toBeNull();
-      expect((updatedGrandparent! as Record<string, unknown>).lifecycle).toBe('completed');
+      expect(updatedGrandparent!.lifecycle).toBe('completed');
     });
   });
 
@@ -342,7 +342,7 @@ describe('Delegation propagation integration', () => {
       // Parent should have moved to step 2 or completed
       // (PASS ALL: CONTINUE means it should advance to step 2)
       const step = finalParent!.step as string;
-      const lifecycle = (finalParent! as Record<string, unknown>).lifecycle;
+      const lifecycle = finalParent!.lifecycle;
       // Either on step 2 or completed
       expect(step === '2' || lifecycle === 'completed').toBe(true);
     });
@@ -420,7 +420,7 @@ describe('Delegation propagation integration', () => {
       // After all 3 resolve, parent should complete (PASS ALL: COMPLETE)
       const finalParent = await readRunbookState(workspace, parentRunId);
       expect(finalParent).not.toBeNull();
-      expect((finalParent! as Record<string, unknown>).lifecycle).toBe('completed');
+      expect(finalParent!.lifecycle).toBe('completed');
     });
   });
 
@@ -525,7 +525,7 @@ describe('Delegation propagation integration', () => {
       // Runbook completed and was deactivated — read state by ID
       const finalState = await readRunbookState(workspace, childRunId);
       expect(finalState).not.toBeNull();
-      expect((finalState! as Record<string, unknown>).lifecycle).toBe('completed');
+      expect(finalState!.lifecycle).toBe('completed');
     });
 
     it('handles fail command without delegation linkage', async () => {
@@ -546,7 +546,7 @@ describe('Delegation propagation integration', () => {
       // Runbook stopped and was deactivated — read state by ID
       const finalState = await readRunbookState(workspace, childRunId);
       expect(finalState).not.toBeNull();
-      expect((finalState! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(finalState!.lifecycle).toBe('stopped');
     });
 
     it('handles stop command without delegation linkage', async () => {

--- a/packages/cli/__tests__/integration/delegation-propagation.test.ts
+++ b/packages/cli/__tests__/integration/delegation-propagation.test.ts
@@ -72,11 +72,6 @@ describe('Delegation propagation integration', () => {
     }
   }
 
-  /** Helper: extract variables from parsed state. */
-  function getVariables(state: Record<string, unknown>): Record<string, unknown> {
-    return (state.variables ?? {}) as Record<string, unknown>;
-  }
-
   describe('2-level pass propagation', () => {
     it('child pass resolves parent substep and parent advances', async () => {
       await writeParentRunbook();
@@ -113,11 +108,11 @@ describe('Delegation propagation integration', () => {
         throw new Error(`rd pass failed: ${result.stdout}\n${result.stderr}`);
       }
 
-      // After child completes, it should have variables.completed = true
+      // After child completes, it should have lifecycle = 'completed'
       const childId = childState!.id as string;
       const finalChildState = await readRunbookState(workspace, childId);
       expect(finalChildState).not.toBeNull();
-      expect(getVariables(finalChildState!).completed).toBe(true);
+      expect((finalChildState! as Record<string, unknown>).lifecycle).toBe('completed');
 
       // Parent is now at substep 1.2 — complete it to trigger aggregation
       // PASS ALL (both passed) → CONTINUE → step 2
@@ -162,7 +157,7 @@ describe('Delegation propagation integration', () => {
 
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect(getVariables(updatedParent!).stopped).toBe(true);
+      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
     });
   });
 
@@ -198,7 +193,7 @@ describe('Delegation propagation integration', () => {
 
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect(getVariables(updatedParent!).stopped).toBe(true);
+      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
     });
   });
 
@@ -279,7 +274,7 @@ describe('Delegation propagation integration', () => {
       // Verify parent completed
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect(getVariables(updatedParent!).completed).toBe(true);
+      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('completed');
 
       // Grandparent is at substep 1.2 — complete it
       // PASS ALL (both passed) → COMPLETE
@@ -288,8 +283,7 @@ describe('Delegation propagation integration', () => {
       // Verify grandparent completed
       const updatedGrandparent = await readRunbookState(workspace, grandparentRunId);
       expect(updatedGrandparent).not.toBeNull();
-      const gpCompleted = getVariables(updatedGrandparent!).completed === true;
-      expect(gpCompleted).toBe(true);
+      expect((updatedGrandparent! as Record<string, unknown>).lifecycle).toBe('completed');
     });
   });
 
@@ -348,9 +342,9 @@ describe('Delegation propagation integration', () => {
       // Parent should have moved to step 2 or completed
       // (PASS ALL: CONTINUE means it should advance to step 2)
       const step = finalParent!.step as string;
-      const completed = getVariables(finalParent!).completed;
+      const lifecycle = (finalParent! as Record<string, unknown>).lifecycle;
       // Either on step 2 or completed
-      expect(step === '2' || completed === true).toBe(true);
+      expect(step === '2' || lifecycle === 'completed').toBe(true);
     });
   });
 
@@ -426,7 +420,7 @@ describe('Delegation propagation integration', () => {
       // After all 3 resolve, parent should complete (PASS ALL: COMPLETE)
       const finalParent = await readRunbookState(workspace, parentRunId);
       expect(finalParent).not.toBeNull();
-      expect(getVariables(finalParent!).completed).toBe(true);
+      expect((finalParent! as Record<string, unknown>).lifecycle).toBe('completed');
     });
   });
 
@@ -531,7 +525,7 @@ describe('Delegation propagation integration', () => {
       // Runbook completed and was deactivated — read state by ID
       const finalState = await readRunbookState(workspace, childRunId);
       expect(finalState).not.toBeNull();
-      expect(getVariables(finalState!).completed).toBe(true);
+      expect((finalState! as Record<string, unknown>).lifecycle).toBe('completed');
     });
 
     it('handles fail command without delegation linkage', async () => {
@@ -552,7 +546,7 @@ describe('Delegation propagation integration', () => {
       // Runbook stopped and was deactivated — read state by ID
       const finalState = await readRunbookState(workspace, childRunId);
       expect(finalState).not.toBeNull();
-      expect(getVariables(finalState!).stopped).toBe(true);
+      expect((finalState! as Record<string, unknown>).lifecycle).toBe('stopped');
     });
 
     it('handles stop command without delegation linkage', async () => {

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -235,7 +235,7 @@ describe('Inline linkage integration (rd run --step)', () => {
 
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
+      expect(updatedParent!.lifecycle).toBe('stopped');
     });
   });
 

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -63,11 +63,6 @@ describe('Inline linkage integration (rd run --step)', () => {
     await writeFile(join(workspace.cwd, 'child.runbook.md'), content);
   }
 
-  /** Helper: extract variables from parsed state. */
-  function getVariables(state: Record<string, unknown>): Record<string, unknown> {
-    return (state.variables ?? {}) as Record<string, unknown>;
-  }
-
   /** Helper: find child state in runs directory by scanning for parentLinkage. */
   async function findChildState(parentRunId: string): Promise<Record<string, unknown> | null> {
     const runsDir = workspace.statePath();
@@ -240,7 +235,7 @@ describe('Inline linkage integration (rd run --step)', () => {
 
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
-      expect(getVariables(updatedParent!).stopped).toBe(true);
+      expect((updatedParent! as Record<string, unknown>).lifecycle).toBe('stopped');
     });
   });
 
@@ -579,8 +574,7 @@ describe('Inline linkage integration (rd run --step)', () => {
 
       const childState = await findChildState(parentRunId);
       expect(childState).not.toBeNull();
-      const variables = (childState!.variables ?? {}) as Record<string, unknown>;
-      expect(variables.completed).toBe(true);
+      expect(childState!.lifecycle).toBe('completed');
     });
 
     it('inline child state has context.parent vars', async () => {

--- a/packages/cli/__tests__/integration/scenario-runner.test.ts
+++ b/packages/cli/__tests__/integration/scenario-runner.test.ts
@@ -278,20 +278,19 @@ async function executeScenario(
   }
 
   const state = matchingStates.find((s) => {
-    const variables = s.variables as Record<string, unknown> | undefined;
+    const lc = (s as Record<string, unknown>).lifecycle;
     if (expectedResult === 'COMPLETE') {
-      return variables?.completed === true;
+      return lc === 'completed';
     } else {
-      return variables?.stopped === true;
+      return lc === 'stopped';
     }
   });
 
   if (!state) {
     const statesSummary = matchingStates
       .map((s) => {
-        const vars = s.variables as Record<string, unknown> | undefined;
-        const varsStr = vars ? JSON.stringify(vars) : 'undefined';
-        return `ID=${String(s.id).slice(0, 8)}, vars=${varsStr}`;
+        const lc = (s as Record<string, unknown>).lifecycle;
+        return `ID=${String(s.id).slice(0, 8)}, lifecycle=${String(lc)}`;
       })
       .join('; ');
     throw new Error(
@@ -299,12 +298,12 @@ async function executeScenario(
     );
   }
 
-  const variables = state.variables as Record<string, unknown> | undefined;
+  const lc = (state as Record<string, unknown>).lifecycle;
 
   if (expectedResult === 'COMPLETE') {
-    expect(variables?.completed).toBe(true);
+    expect(lc).toBe('completed');
   } else {
-    expect(variables?.stopped).toBe(true);
+    expect(lc).toBe('stopped');
   }
 }
 

--- a/packages/cli/__tests__/integration/scenario-runner.test.ts
+++ b/packages/cli/__tests__/integration/scenario-runner.test.ts
@@ -278,7 +278,7 @@ async function executeScenario(
   }
 
   const state = matchingStates.find((s) => {
-    const lc = (s as Record<string, unknown>).lifecycle;
+    const lc = s.lifecycle;
     if (expectedResult === 'COMPLETE') {
       return lc === 'completed';
     } else {
@@ -289,7 +289,7 @@ async function executeScenario(
   if (!state) {
     const statesSummary = matchingStates
       .map((s) => {
-        const lc = (s as Record<string, unknown>).lifecycle;
+        const lc = s.lifecycle;
         return `ID=${String(s.id).slice(0, 8)}, lifecycle=${String(lc)}`;
       })
       .join('; ');
@@ -298,7 +298,7 @@ async function executeScenario(
     );
   }
 
-  const lc = (state as Record<string, unknown>).lifecycle;
+  const lc = state.lifecycle;
 
   if (expectedResult === 'COMPLETE') {
     expect(lc).toBe('completed');

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -29,6 +29,8 @@ export default {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@rundown-org/core$': '<rootDir>/../core/src/index.ts',
+    '^@rundown-org/parser$': '<rootDir>/../parser/src/index.ts',
   },
   transform: {
     '^.+\\.tsx?$': [

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -88,7 +88,7 @@ export function registerClaimCommand(program: Command): void {
             if (result.loopResult === 'done' || result.loopResult === 'stopped') {
               const childState = await manager.load(result.childRunId);
               if (childState && extractParentLinkage(childState)) {
-                const propResult = childState.variables.completed ? 'pass' : 'fail';
+                const propResult = childState.lifecycle === 'completed' ? 'pass' : 'fail';
                 const propagation = await handleParentCompletion(
                   childState,
                   propResult,

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -47,7 +47,7 @@ export function registerCompleteCommand(program: Command): void {
           const steps = getRunbookFromState(state, cwd);
           await manager.update(state.id, {
             step: steps[steps.length - 1].name,
-            variables: { completed: true },
+            lifecycle: 'completed',
           });
           await sessionService.popRunbook();
 

--- a/packages/cli/src/commands/fail.ts
+++ b/packages/cli/src/commands/fail.ts
@@ -60,9 +60,9 @@ export function registerFailCommand(program: Command): void {
             const freshState = await ctx.manager.load(ctx.state.id);
             if (freshState && extractParentLinkage(freshState)) {
               const isTerminal =
-                freshState.variables.completed === true || freshState.variables.stopped === true;
+                freshState.lifecycle === 'completed' || freshState.lifecycle === 'stopped';
               if (isTerminal) {
-                const propResult = freshState.variables.completed ? 'pass' : 'fail';
+                const propResult = freshState.lifecycle === 'completed' ? 'pass' : 'fail';
                 const propagationResult = await handleParentCompletion(
                   freshState,
                   propResult,

--- a/packages/cli/src/commands/pass.ts
+++ b/packages/cli/src/commands/pass.ts
@@ -60,9 +60,9 @@ export function registerPassCommand(program: Command): void {
             const freshState = await ctx.manager.load(ctx.state.id);
             if (freshState && extractParentLinkage(freshState)) {
               const isTerminal =
-                freshState.variables.completed === true || freshState.variables.stopped === true;
+                freshState.lifecycle === 'completed' || freshState.lifecycle === 'stopped';
               if (isTerminal) {
-                const propResult = freshState.variables.completed ? 'pass' : 'fail';
+                const propResult = freshState.lifecycle === 'completed' ? 'pass' : 'fail';
                 const propagationResult = await handleParentCompletion(
                   freshState,
                   propResult,

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -76,7 +76,7 @@ export function registerPruneCommand(program: Command): void {
             return false;
           });
 
-          // Stale files (unloadable due to schema version mismatch) are invisible to
+          // Stale files (skipped by list() due to schema version mismatch) are invisible to
           // list() but can still be deleted. Treat them as inactive: prune with
           // --inactive or --all.
           const loadedIds = new Set(states.map((s) => s.id));

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -22,6 +22,7 @@ async function listAllRunIds(cwd: string): Promise<string[]> {
 interface PruneOptions {
   dryRun?: boolean;
   completed?: boolean;
+  stopped?: boolean;
   active?: boolean;
   inactive?: boolean;
   all?: boolean;
@@ -37,12 +38,10 @@ export function registerPruneCommand(program: Command): void {
     .command('prune')
     .description('Remove runbook state (does not delete runbook files)')
     .option('--dry-run', 'Show what would be removed without deleting')
-    .option(
-      '--completed',
-      'Prune successfully completed runbook state (stopped runs use --inactive)',
-    )
+    .option('--completed', 'Prune successfully completed runbook state')
+    .option('--stopped', 'Prune stopped (aborted/failed) runbook state')
     .option('--active', 'Prune active runbook state')
-    .option('--inactive', 'Prune inactive runbook state')
+    .option('--inactive', 'Prune inactive (orphaned) runbook state')
     .option('--all', 'Prune all runbook state')
     .option('--text', 'Output as human-readable text')
     .action(async (options: PruneOptions) => {
@@ -55,12 +54,23 @@ export function registerPruneCommand(program: Command): void {
           const sessionService = new SessionService(manager);
           const states = await manager.list();
           const allIds = await listAllRunIds(cwd);
-          const activeState = await sessionService.getActive();
+          let activeState: Awaited<ReturnType<typeof sessionService.getActive>>;
+          try {
+            activeState = await sessionService.getActive();
+          } catch {
+            activeState = null;
+          }
           const stashedId = await sessionService.getStashedRunbookId();
 
-          // Default to --completed if no filter flags provided
-          const hasFilter = options.completed ?? options.active ?? options.inactive ?? options.all;
+          // Default to --completed --stopped (all terminal runs) if no filter flags provided
+          const hasFilter =
+            options.completed ??
+            options.stopped ??
+            options.active ??
+            options.inactive ??
+            options.all;
           const pruneCompleted = options.all ?? options.completed ?? !hasFilter;
+          const pruneStopped = options.all ?? options.stopped ?? !hasFilter;
           const pruneActive = options.all ?? options.active;
           const pruneInactive = options.all ?? options.inactive;
 
@@ -68,9 +78,11 @@ export function registerPruneCommand(program: Command): void {
             const isActive = activeState?.id === state.id;
             const isStashed = state.id === stashedId;
             const isCompleted = state.lifecycle === 'completed';
-            const isInactive = !isActive && !isStashed && !isCompleted;
+            const isStopped = state.lifecycle === 'stopped';
+            const isInactive = !isActive && !isStashed && !isCompleted && !isStopped;
 
             if (pruneCompleted && isCompleted) return true;
+            if (pruneStopped && isStopped) return true;
             if (pruneActive && isActive) return true;
             if (pruneInactive && isInactive) return true;
             return false;

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -101,34 +101,37 @@ export function registerPruneCommand(program: Command): void {
             _status: getStatus(state, activeState, stashedId),
           }));
 
-          // Stale items satisfy the display columns (id, runbook, title, _status)
-          const staleEnrichedItems = staleToDelete.map((id) => ({
+          type LoadedRow = (typeof enrichedItems)[0];
+          type StaleRow = {
+            id: string;
+            runbook: string;
+            title: string | undefined;
+            _status: string;
+          };
+          type PruneRow = LoadedRow | StaleRow;
+
+          // Stale items carry only the fields needed for display and JSON output
+          const staleEnrichedItems: StaleRow[] = staleToDelete.map((id) => ({
             id,
             runbook: '(stale)',
-            title: undefined as string | undefined,
+            title: undefined,
             _status: 'stale',
           }));
 
-          const allItems = [
-            ...enrichedItems,
-            ...(staleEnrichedItems as unknown as typeof enrichedItems),
-          ];
+          const allItems: PruneRow[] = [...enrichedItems, ...staleEnrichedItems];
 
           // Define columns once for reuse
           const columns = [
             { header: 'ID', key: 'id' as const },
-            { header: 'STATUS', key: (item: (typeof enrichedItems)[0]) => item._status },
+            { header: 'STATUS', key: (item: PruneRow) => item._status },
             { header: 'RUNBOOK', key: 'runbook' as const },
-            {
-              header: 'TITLE',
-              key: (item: (typeof enrichedItems)[0]) => (item.title ? `[${item.title}]` : ''),
-            },
+            { header: 'TITLE', key: (item: PruneRow) => (item.title ? `[${item.title}]` : '') },
           ];
 
           // JSON mapper to clean internal fields
-          const jsonMapper = (item: (typeof enrichedItems)[0]): Record<string, unknown> => {
-            const { _status: _, ...rest } = item;
-            return { ...rest, status: item._status };
+          const jsonMapper = (item: PruneRow): Record<string, unknown> => {
+            const { _status, ...rest } = item as Record<string, unknown>;
+            return { ...rest, status: _status };
           };
 
           if (allItems.length === 0) {

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -1,11 +1,23 @@
 // packages/cli/src/commands/prune.ts
 
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { Command } from 'commander';
 import { RunbookStateManager, SessionService } from '@rundown-org/core';
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { getStatus } from '../helpers/status.js';
+
+async function listAllRunIds(cwd: string): Promise<string[]> {
+  try {
+    const runsDir = join(cwd, '.rundown', 'runs');
+    const files = await readdir(runsDir);
+    return files.filter((f) => f.endsWith('.json')).map((f) => f.replace('.json', ''));
+  } catch {
+    return [];
+  }
+}
 
 interface PruneOptions {
   dryRun?: boolean;
@@ -25,7 +37,10 @@ export function registerPruneCommand(program: Command): void {
     .command('prune')
     .description('Remove runbook state (does not delete runbook files)')
     .option('--dry-run', 'Show what would be removed without deleting')
-    .option('--completed', 'Prune completed runbook state')
+    .option(
+      '--completed',
+      'Prune successfully completed runbook state (stopped runs use --inactive)',
+    )
     .option('--active', 'Prune active runbook state')
     .option('--inactive', 'Prune inactive runbook state')
     .option('--all', 'Prune all runbook state')
@@ -39,6 +54,7 @@ export function registerPruneCommand(program: Command): void {
           const manager = new RunbookStateManager(cwd);
           const sessionService = new SessionService(manager);
           const states = await manager.list();
+          const allIds = await listAllRunIds(cwd);
           const activeState = await sessionService.getActive();
           const stashedId = await sessionService.getStashedRunbookId();
 
@@ -60,11 +76,31 @@ export function registerPruneCommand(program: Command): void {
             return false;
           });
 
+          // Stale files (unloadable due to schema version mismatch) are invisible to
+          // list() but can still be deleted. Treat them as inactive: prune with
+          // --inactive or --all.
+          const loadedIds = new Set(states.map((s) => s.id));
+          const staleIds = allIds.filter((id) => !loadedIds.has(id));
+          const staleToDelete = (pruneInactive ?? options.all) ? staleIds : [];
+
           // Enrich items with status string for display
           const enrichedItems = toDelete.map((state) => ({
             ...state,
             _status: getStatus(state, activeState, stashedId),
           }));
+
+          // Stale items satisfy the display columns (id, runbook, title, _status)
+          const staleEnrichedItems = staleToDelete.map((id) => ({
+            id,
+            runbook: '(stale)',
+            title: undefined as string | undefined,
+            _status: 'stale',
+          }));
+
+          const allItems = [
+            ...enrichedItems,
+            ...(staleEnrichedItems as unknown as typeof enrichedItems),
+          ];
 
           // Define columns once for reuse
           const columns = [
@@ -83,7 +119,7 @@ export function registerPruneCommand(program: Command): void {
             return { ...rest, status: item._status };
           };
 
-          if (toDelete.length === 0) {
+          if (allItems.length === 0) {
             // Use output.list() for consistency - outputs raw array in JSON mode
             output.list([], columns as Parameters<typeof output.list>[1], {
               emptyMessage: 'No runbook state to prune.',
@@ -94,7 +130,7 @@ export function registerPruneCommand(program: Command): void {
           }
 
           if (options.dryRun) {
-            output.list(enrichedItems, columns as Parameters<typeof output.list>[1], {
+            output.list(allItems, columns as Parameters<typeof output.list>[1], {
               jsonMapper,
             });
             output.flush();
@@ -105,8 +141,11 @@ export function registerPruneCommand(program: Command): void {
           for (const state of toDelete) {
             await manager.delete(state.id);
           }
+          for (const id of staleToDelete) {
+            await manager.delete(id);
+          }
 
-          output.list(enrichedItems, columns as Parameters<typeof output.list>[1], { jsonMapper });
+          output.list(allItems, columns as Parameters<typeof output.list>[1], { jsonMapper });
           output.flush();
         },
         { text: options.text },

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -51,7 +51,7 @@ export function registerPruneCommand(program: Command): void {
           const toDelete = states.filter((state) => {
             const isActive = activeState?.id === state.id;
             const isStashed = state.id === stashedId;
-            const isCompleted = state.variables.completed === true;
+            const isCompleted = state.lifecycle === 'completed';
             const isInactive = !isActive && !isStashed && !isCompleted;
 
             if (pruneCompleted && isCompleted) return true;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -215,9 +215,9 @@ export function registerRunCommand(program: Command): void {
               const childState = await manager.load(result.stateId);
               if (childState) {
                 const isTerminal =
-                  childState.variables.completed === true || childState.variables.stopped === true;
+                  childState.lifecycle === 'completed' || childState.lifecycle === 'stopped';
                 if (isTerminal) {
-                  const propResult: 'pass' | 'fail' = childState.variables.completed
+                  const propResult: 'pass' | 'fail' = childState.lifecycle === 'completed'
                     ? 'pass'
                     : 'fail';
                   const propOutcome = await handleParentCompletion(

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -217,9 +217,8 @@ export function registerRunCommand(program: Command): void {
                 const isTerminal =
                   childState.lifecycle === 'completed' || childState.lifecycle === 'stopped';
                 if (isTerminal) {
-                  const propResult: 'pass' | 'fail' = childState.lifecycle === 'completed'
-                    ? 'pass'
-                    : 'fail';
+                  const propResult: 'pass' | 'fail' =
+                    childState.lifecycle === 'completed' ? 'pass' : 'fail';
                   const propOutcome = await handleParentCompletion(
                     childState,
                     propResult,

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -65,7 +65,7 @@ export function registerStopCommand(program: Command): void {
           const updatedState = await manager.update(state.id, {
             lastAction: { type: 'STOP' },
             lastResult: 'fail',
-            variables: { stopped: true },
+            lifecycle: 'stopped',
           });
           await sessionService.popRunbook();
 

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,7 +1,13 @@
 // packages/cli/src/commands/stop.ts
 
 import type { Command } from 'commander';
-import { RunbookStateManager, SessionService, isError, type RunbookState } from '@rundown-org/core';
+import {
+  RunbookStateManager,
+  SessionService,
+  StaleRunbookStateError,
+  isError,
+  type RunbookState,
+} from '@rundown-org/core';
 import { getCwd } from '../helpers/context.js';
 import { buildMetadata } from '../services/execution.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
@@ -39,7 +45,7 @@ export function registerStopCommand(program: Command): void {
             // fall through to the orphan cleanup path since stop is a cleanup command.
             if (
               getActiveError &&
-              !getActiveError.message.includes('Stale runbook state') &&
+              !(getActiveError instanceof StaleRunbookStateError) &&
               !getActiveError.message.includes('dynamic-step snapshots') &&
               !(isError(getActiveError) && getActiveError.name === 'SyntaxError')
             ) {

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -190,9 +190,10 @@ export async function handleParentCompletion(
   // state.snapshot, so a direct manager.update({ variables }) is invisible to the next actor.
   if (childState.finalVars && Object.keys(childState.finalVars).length > 0) {
     try {
+      const vars: Record<string, string> = { ...childState.finalVars };
       await parentActorService.sendAndSync(parentRunId, parentSteps, {
         type: 'SET_VARIABLES',
-        vars: childState.finalVars,
+        vars,
       });
     } catch (err) {
       const errMsg = getErrorMessage(err);

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -874,8 +874,8 @@ export async function claimAndLaunch(
       };
     }
 
-    // Reject claims against stopped parents — the run has been aborted
-    if (freshParent.lifecycle === 'stopped') {
+    // Reject claims against stopped or completed parents — the run has ended
+    if (freshParent.lifecycle === 'stopped' || freshParent.lifecycle === 'completed') {
       return {
         ok: false,
         error: 'Parent run has been stopped. Delegation cannot be claimed.',

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -875,7 +875,7 @@ export async function claimAndLaunch(
     }
 
     // Reject claims against stopped parents — the run has been aborted
-    if (freshParent.variables.stopped) {
+    if (freshParent.lifecycle === 'stopped') {
       return {
         ok: false,
         error: 'Parent run has been stopped. Delegation cannot be claimed.',

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -876,9 +876,10 @@ export async function claimAndLaunch(
 
     // Reject claims against stopped or completed parents — the run has ended
     if (freshParent.lifecycle === 'stopped' || freshParent.lifecycle === 'completed') {
+      const reason = freshParent.lifecycle === 'completed' ? 'completed' : 'stopped';
       return {
         ok: false,
-        error: 'Parent run has been stopped. Delegation cannot be claimed.',
+        error: `Parent run has been ${reason}. Delegation cannot be claimed.`,
         code: ErrorCodes.TOKEN_NOT_FOUND.code,
         details: { parentRunId: freshParent.id },
       };

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -109,9 +109,7 @@ function buildVars(state: RunbookState): Record<string, string> | undefined {
       .filter(([, v]) => typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
       .map(([k, v]) => [k, String(v as string | number | boolean)]),
   );
-  const fromStateVars = Object.fromEntries(
-    Object.entries(state.variables).map(([k, v]) => [k, String(v)]),
-  );
+  const fromStateVars = Object.fromEntries(Object.entries(state.variables));
   const merged = { ...fromTemplateVars, ...fromStateVars };
   return Object.keys(merged).length > 0 ? merged : undefined;
 }

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -98,7 +98,9 @@ export interface StatusOutputData {
  * Build the effective variable space for status output.
  *
  * Merges templateVars (CLI/config/frontmatter) with state.variables (step OUTPUTS).
- * Only scalar values (string, number, boolean) are included; arrays and streams are excluded.
+ * From templateVars, only scalar values (string, number, boolean) are included;
+ * arrays and streams are excluded. state.variables is already Record<string, string>
+ * and is merged as-is; step outputs win over templateVars on key collision.
  *
  * @param state - Runbook state with templateVars and variables
  * @returns Stringified key-value map, or undefined if empty
@@ -109,8 +111,7 @@ function buildVars(state: RunbookState): Record<string, string> | undefined {
       .filter(([, v]) => typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
       .map(([k, v]) => [k, String(v as string | number | boolean)]),
   );
-  const fromStateVars = Object.fromEntries(Object.entries(state.variables));
-  const merged = { ...fromTemplateVars, ...fromStateVars };
+  const merged = { ...fromTemplateVars, ...state.variables } as Record<string, string>;
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 

--- a/packages/cli/src/helpers/status.ts
+++ b/packages/cli/src/helpers/status.ts
@@ -1,23 +1,23 @@
+import type { Lifecycle } from '@rundown-org/core';
+
 /**
  * Get the display status string for a runbook state.
  *
  * @param state - The runbook state object
  * @param state.id - Unique identifier for this runbook state
- * @param state.variables - Runbook state variables
- * @param state.variables.completed - Whether the runbook has completed
- * @param state.variables.stopped - Whether the runbook was stopped
+ * @param state.lifecycle - Lifecycle state of the runbook
  * @param activeState - The currently active runbook state (if any)
  * @param stashedId - The ID of the stashed runbook (if any)
  * @returns Status string: 'active', 'stashed', 'complete', 'stopped', or 'inactive'
  */
 export function getStatus(
-  state: { id: string; variables: { completed?: boolean; stopped?: boolean } },
+  state: { id: string; lifecycle?: Lifecycle },
   activeState: { id: string } | null,
   stashedId: string | null,
 ): string {
   if (activeState?.id === state.id) return 'active';
   if (state.id === stashedId) return 'stashed';
-  if (state.variables.completed) return 'complete';
-  if (state.variables.stopped) return 'stopped';
+  if (state.lifecycle === 'completed') return 'complete';
+  if (state.lifecycle === 'stopped') return 'stopped';
   return 'inactive';
 }

--- a/packages/cli/src/helpers/transition-orchestrator.ts
+++ b/packages/cli/src/helpers/transition-orchestrator.ts
@@ -212,7 +212,7 @@ export async function orchestrateTransition(
       deriveTransitionMessage(result, currentStep, previousState.retryCount);
 
     await manager.update(runbookId, {
-      variables: { completed: true },
+      lifecycle: 'completed',
     });
     sink.onRunbookCompleted({
       message,
@@ -229,7 +229,7 @@ export async function orchestrateTransition(
       deriveTransitionMessage(result, currentStep, previousState.retryCount);
 
     await manager.update(runbookId, {
-      variables: { stopped: true },
+      lifecycle: 'stopped',
     });
     sink.onRunbookStopped({
       message,

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -663,12 +663,16 @@ export async function runExecutionLoop(
         reason: execResult.denialReason ?? 'Permission denied',
         position: policyPosition,
       });
+      await manager.update(runbookId, {
+        lifecycle: 'stopped',
+      });
       // Emit RUNBOOK_STOPPED so JSON output shows correct terminal state
       emitter.emit('RUNBOOK_STOPPED', {
         position: policyPosition,
         reason: 'policy_denied',
         message: `Command blocked by policy: ${execResult.denialReason ?? 'Permission denied'}`,
       });
+      await sessionService.popRunbook();
       return 'stopped';
     }
 

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -474,7 +474,7 @@ export async function runExecutionLoop(
         const completionMessage = extractLastMessage(iterResult.state.snapshot);
 
         await manager.update(runbookId, {
-          variables: { completed: true },
+          lifecycle: 'completed',
         });
 
         emitter.emit('RUNBOOK_COMPLETED', {
@@ -493,7 +493,7 @@ export async function runExecutionLoop(
         const stopMessage = extractLastMessage(iterResult.state.snapshot);
 
         await manager.update(runbookId, {
-          variables: { stopped: true },
+          lifecycle: 'stopped',
         });
 
         const stopPos = buildStepPosition(

--- a/packages/core/__tests__/runbook/__snapshots__/compiler-machine-structural-snapshot.test.ts.snap
+++ b/packages/core/__tests__/runbook/__snapshots__/compiler-machine-structural-snapshot.test.ts.snap
@@ -1,0 +1,364 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produces a stable structural config for GOTO construct 1`] = `
+{
+  "context": {
+    "finalVars": {},
+    "forStack": [],
+    "frontmatterOutputs": [],
+    "iterationRetryCount": 0,
+    "lifecycle": "running",
+    "parentRetryCount": 0,
+    "retryCount": 0,
+    "substepCompletedCount": 0,
+    "templateVars": {},
+    "variables": {},
+  },
+  "id": "runbook",
+  "initial": "step::1",
+  "on": {
+    "SET_VARIABLES": {
+      "actions": "[fn]",
+    },
+  },
+  "states": {
+    "COMPLETE": {
+      "entry": [
+        {
+          "params": {},
+          "type": "storeFrontmatterOutputs",
+        },
+        "[fn]",
+      ],
+      "output": "[fn]",
+      "type": "final",
+    },
+    "STOPPED": {
+      "entry": [
+        {
+          "params": {},
+          "type": "storeFrontmatterOutputs",
+        },
+        "[fn]",
+      ],
+      "output": "[fn]",
+      "type": "final",
+    },
+    "step::1": {
+      "on": {
+        "FAIL": {
+          "actions": {
+            "params": {
+              "action": {
+                "type": "STOP",
+              },
+            },
+            "type": "setLastAction",
+          },
+          "target": "STOPPED",
+        },
+        "GOTO": [
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::1",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::2",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::3",
+          },
+        ],
+        "PASS": {
+          "actions": "[fn]",
+          "target": "step::3",
+        },
+        "RETRY": {
+          "actions": "[fn]",
+          "target": "step::1",
+        },
+      },
+    },
+    "step::2": {
+      "on": {
+        "FAIL": {
+          "actions": {
+            "params": {
+              "action": {
+                "type": "STOP",
+              },
+            },
+            "type": "setLastAction",
+          },
+          "target": "STOPPED",
+        },
+        "GOTO": [
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::1",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::2",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::3",
+          },
+        ],
+        "PASS": {
+          "actions": "[fn]",
+          "target": "step::3",
+        },
+        "RETRY": {
+          "actions": "[fn]",
+          "target": "step::2",
+        },
+      },
+    },
+    "step::3": {
+      "on": {
+        "FAIL": {
+          "actions": {
+            "params": {
+              "action": {
+                "type": "STOP",
+              },
+            },
+            "type": "setLastAction",
+          },
+          "target": "STOPPED",
+        },
+        "GOTO": [
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::1",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::2",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::3",
+          },
+        ],
+        "PASS": {
+          "actions": {
+            "params": {
+              "action": {
+                "type": "COMPLETE",
+              },
+            },
+            "type": "setLastAction",
+          },
+          "target": "COMPLETE",
+        },
+        "RETRY": {
+          "actions": "[fn]",
+          "target": "step::3",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produces a stable structural config for a representative runbook 1`] = `
+{
+  "context": {
+    "finalVars": {},
+    "forStack": [],
+    "frontmatterOutputs": [],
+    "iterationRetryCount": 0,
+    "lifecycle": "running",
+    "parentRetryCount": 0,
+    "retryCount": 0,
+    "substepCompletedCount": 0,
+    "templateVars": {},
+    "variables": {},
+  },
+  "id": "runbook",
+  "initial": "step::1::1",
+  "on": {
+    "SET_VARIABLES": {
+      "actions": "[fn]",
+    },
+  },
+  "states": {
+    "COMPLETE": {
+      "entry": [
+        {
+          "params": {},
+          "type": "storeFrontmatterOutputs",
+        },
+        "[fn]",
+      ],
+      "output": "[fn]",
+      "type": "final",
+    },
+    "STOPPED": {
+      "entry": [
+        {
+          "params": {},
+          "type": "storeFrontmatterOutputs",
+        },
+        "[fn]",
+      ],
+      "output": "[fn]",
+      "type": "final",
+    },
+    "step::1": {
+      "always": [
+        {
+          "actions": "[fn]",
+          "guard": "[fn]",
+          "target": "step::1::2",
+        },
+        {
+          "actions": "[fn]",
+          "guard": "[fn]",
+          "target": "step::2",
+        },
+        {
+          "actions": "[fn]",
+          "guard": "[fn]",
+          "target": "STOPPED",
+        },
+      ],
+    },
+    "step::1::1": {
+      "entry": "[fn]",
+      "on": {
+        "FAIL": {
+          "actions": "[fn]",
+          "target": "step::1::2",
+        },
+        "GOTO": [
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::1::1",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::1::2",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::2",
+          },
+        ],
+        "PASS": {
+          "actions": "[fn]",
+          "target": "step::1::2",
+        },
+        "RETRY": {
+          "actions": "[fn]",
+          "target": "step::1::1",
+        },
+      },
+    },
+    "step::1::2": {
+      "on": {
+        "FAIL": {
+          "actions": {
+            "params": {
+              "action": {
+                "type": "STOP",
+              },
+            },
+            "type": "setLastAction",
+          },
+          "target": "STOPPED",
+        },
+        "GOTO": [
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::1::1",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::1::2",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::2",
+          },
+        ],
+        "PASS": {
+          "actions": "[fn]",
+          "target": "step::1",
+        },
+        "RETRY": {
+          "actions": "[fn]",
+          "target": "step::1::2",
+        },
+      },
+    },
+    "step::2": {
+      "on": {
+        "FAIL": {
+          "actions": {
+            "params": {
+              "action": {
+                "type": "STOP",
+              },
+            },
+            "type": "setLastAction",
+          },
+          "target": "STOPPED",
+        },
+        "GOTO": [
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::1::1",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::1::2",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+            "target": "step::2",
+          },
+        ],
+        "PASS": {
+          "actions": {
+            "params": {
+              "action": {
+                "type": "COMPLETE",
+              },
+            },
+            "type": "setLastAction",
+          },
+          "target": "COMPLETE",
+        },
+        "RETRY": {
+          "actions": "[fn]",
+          "target": "step::2",
+        },
+      },
+    },
+  },
+}
+`;

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -17,6 +17,7 @@ interface LifecycleHarness {
   service: RunbookActorService;
   runbookId: string;
   steps: ResolvedStep[];
+  testDir: string;
 }
 
 async function createLifecycleHarness(markdown: string): Promise<LifecycleHarness> {
@@ -38,7 +39,7 @@ async function createLifecycleHarness(markdown: string): Promise<LifecycleHarnes
   const actor = await service.createActor(state.id, steps);
   if (!actor) throw new Error('createLifecycleHarness: actor creation failed');
 
-  return { actor, service, runbookId: state.id, steps };
+  return { actor, service, runbookId: state.id, steps, testDir };
 }
 
 describe('RunbookActorService', () => {
@@ -613,6 +614,8 @@ describe('RunbookActorService', () => {
         harness.steps,
       );
       expect(state.lifecycle).toBe('completed');
+      harness.actor.stop();
+      await rm(harness.testDir, { recursive: true, force: true });
     });
 
     it('persists lifecycle = "stopped" when machine reaches STOPPED', async () => {
@@ -624,6 +627,8 @@ describe('RunbookActorService', () => {
         harness.steps,
       );
       expect(state.lifecycle).toBe('stopped');
+      harness.actor.stop();
+      await rm(harness.testDir, { recursive: true, force: true });
     });
 
     it('persists lifecycle = "running" for non-terminal snapshots', async () => {
@@ -637,6 +642,8 @@ describe('RunbookActorService', () => {
         harness.steps,
       );
       expect(state.lifecycle).toBe('running');
+      harness.actor.stop();
+      await rm(harness.testDir, { recursive: true, force: true });
     });
   });
 

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -4,10 +4,41 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { RunbookStateManager } from '../../src/runbook/state.js';
 import { RunbookActorService } from '../../src/runbook/actor-service.js';
-import type { Step, Runbook } from '../../src/runbook/types.js';
+import type { AnyActorRef } from '../../src/runbook/actor-service.js';
+import type { Step, Runbook, ResolvedStep } from '../../src/runbook/types.js';
+import { createRunbook } from './fixtures.js';
 
 function mockActor(snapshot: { value: string; context: Record<string, unknown> }) {
   return { getPersistedSnapshot: () => snapshot } as any;
+}
+
+interface LifecycleHarness {
+  actor: AnyActorRef;
+  service: RunbookActorService;
+  runbookId: string;
+  steps: ResolvedStep[];
+}
+
+async function createLifecycleHarness(markdown: string): Promise<LifecycleHarness> {
+  const steps = createRunbook(markdown);
+  const testDir = await mkdtemp(join(tmpdir(), 'lifecycle-harness-'));
+  const manager = new RunbookStateManager(testDir);
+  const service = new RunbookActorService(manager);
+
+  const mockRunbookDef = {
+    title: 'Lifecycle Test',
+    description: 'Lifecycle test runbook',
+    steps: steps as unknown as Step[],
+  };
+  const state = await manager.create('lifecycle-test.md', mockRunbookDef, {
+    runbookPath: 'lifecycle-test.md',
+    frontmatterOutputs: [],
+  });
+
+  const actor = await service.createActor(state.id, steps);
+  if (!actor) throw new Error('createLifecycleHarness: actor creation failed');
+
+  return { actor, service, runbookId: state.id, steps };
 }
 
 describe('RunbookActorService', () => {
@@ -569,6 +600,43 @@ describe('RunbookActorService', () => {
         Items: ['a', 'b'], // flattenTemplateVars: array passes through as array
       });
       actor!.stop();
+    });
+  });
+
+  describe('lifecycle surfacing from actor snapshot', () => {
+    it('persists lifecycle = "completed" when machine reaches COMPLETE', async () => {
+      const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n');
+      harness.actor.send({ type: 'PASS' });
+      const { state } = await harness.service.updateFromActor(
+        harness.runbookId,
+        harness.actor,
+        harness.steps,
+      );
+      expect(state.lifecycle).toBe('completed');
+    });
+
+    it('persists lifecycle = "stopped" when machine reaches STOPPED', async () => {
+      const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n');
+      harness.actor.send({ type: 'FAIL' });
+      const { state } = await harness.service.updateFromActor(
+        harness.runbookId,
+        harness.actor,
+        harness.steps,
+      );
+      expect(state.lifecycle).toBe('stopped');
+    });
+
+    it('persists lifecycle = "running" for non-terminal snapshots', async () => {
+      const harness = await createLifecycleHarness(
+        '## 1. First\n- PASS CONTINUE\n- FAIL STOP\n\n## 2. Last\n- PASS COMPLETE\n- FAIL STOP\n',
+      );
+      harness.actor.send({ type: 'PASS' });
+      const { state } = await harness.service.updateFromActor(
+        harness.runbookId,
+        harness.actor,
+        harness.steps,
+      );
+      expect(state.lifecycle).toBe('running');
     });
   });
 

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -618,7 +618,7 @@ describe('RunbookActorService', () => {
     it('leaves RunbookState.finalVars undefined when context.finalVars is empty on COMPLETE', async () => {
       const state = await manager.create('test.md', mockRunbook, {
         runbookPath: 'test.md',
-        frontmatterOutputs: [],
+        frontmatterOutputs: [], // No frontmatterOutputs declared → context.finalVars stays {}
       });
 
       const result = await actorService.sendAndSync(state.id, mockSteps, { type: 'PASS' });

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -555,43 +555,52 @@ describe('RunbookActorService', () => {
   describe('lifecycle surfacing from actor snapshot', () => {
     it('persists lifecycle = "completed" when machine reaches COMPLETE', async () => {
       const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n');
-      harness.actor.send({ type: 'PASS' });
-      const { state } = await harness.service.updateFromActor(
-        harness.runbookId,
-        harness.actor,
-        harness.steps,
-      );
-      expect(state.lifecycle).toBe('completed');
-      harness.actor.stop();
-      await rm(harness.testDir, { recursive: true, force: true });
+      try {
+        harness.actor.send({ type: 'PASS' });
+        const { state } = await harness.service.updateFromActor(
+          harness.runbookId,
+          harness.actor,
+          harness.steps,
+        );
+        expect(state.lifecycle).toBe('completed');
+      } finally {
+        harness.actor.stop();
+        await rm(harness.testDir, { recursive: true, force: true });
+      }
     });
 
     it('persists lifecycle = "stopped" when machine reaches STOPPED', async () => {
       const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n');
-      harness.actor.send({ type: 'FAIL' });
-      const { state } = await harness.service.updateFromActor(
-        harness.runbookId,
-        harness.actor,
-        harness.steps,
-      );
-      expect(state.lifecycle).toBe('stopped');
-      harness.actor.stop();
-      await rm(harness.testDir, { recursive: true, force: true });
+      try {
+        harness.actor.send({ type: 'FAIL' });
+        const { state } = await harness.service.updateFromActor(
+          harness.runbookId,
+          harness.actor,
+          harness.steps,
+        );
+        expect(state.lifecycle).toBe('stopped');
+      } finally {
+        harness.actor.stop();
+        await rm(harness.testDir, { recursive: true, force: true });
+      }
     });
 
     it('persists lifecycle = "running" for non-terminal snapshots', async () => {
       const harness = await createLifecycleHarness(
         '## 1. First\n- PASS CONTINUE\n- FAIL STOP\n\n## 2. Last\n- PASS COMPLETE\n- FAIL STOP\n',
       );
-      harness.actor.send({ type: 'PASS' });
-      const { state } = await harness.service.updateFromActor(
-        harness.runbookId,
-        harness.actor,
-        harness.steps,
-      );
-      expect(state.lifecycle).toBe('running');
-      harness.actor.stop();
-      await rm(harness.testDir, { recursive: true, force: true });
+      try {
+        harness.actor.send({ type: 'PASS' });
+        const { state } = await harness.service.updateFromActor(
+          harness.runbookId,
+          harness.actor,
+          harness.steps,
+        );
+        expect(state.lifecycle).toBe('running');
+      } finally {
+        harness.actor.stop();
+        await rm(harness.testDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -233,59 +233,6 @@ describe('RunbookActorService', () => {
       expect(completed.forStack).toBeUndefined();
       expect(completed.iterationResults).toBeUndefined();
     });
-
-    it('migrates old snapshot context on createActor', async () => {
-      // Test the createActor migration path directly
-      // Start with a normal actor that has been running
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
-      const actor1 = await actorService.createActor(state.id, mockSteps);
-      expect(actor1).not.toBeNull();
-
-      // Get its snapshot
-      const snapshot1 = actor1!.getPersistedSnapshot() as any;
-
-      // Now manually modify the snapshot to have old-style flat fields
-      const oldSnapshot = {
-        ...snapshot1,
-        context: {
-          ...snapshot1.context,
-          forIteration: 2,
-          forStart: 1,
-          forEnd: 3,
-          forVariable: 'item',
-          // Remove forStack to simulate old state
-          forStack: undefined,
-        },
-      };
-
-      // Save this old snapshot
-      await manager.update(state.id, { snapshot: oldSnapshot });
-
-      // Create a new actor - should trigger migration
-      const actor2 = await actorService.createActor(state.id, mockSteps);
-      expect(actor2).not.toBeNull();
-
-      // Get the migrated snapshot
-      const snapshot2 = actor2!.getPersistedSnapshot() as any;
-      const context = snapshot2.context;
-
-      // Should have forStack, not flat fields
-      expect(context.forStack).toEqual([
-        {
-          stepId: '1',
-          iteration: 2,
-          start: 1,
-          end: 3,
-          variable: 'item',
-          implicit: false,
-          source: { kind: 'range' },
-        },
-      ]);
-      expect(context.forIteration).toBeUndefined();
-      expect(context.forStart).toBeUndefined();
-      expect(context.forEnd).toBeUndefined();
-      expect(context.forVariable).toBeUndefined();
-    });
   });
 
   describe('implicit ForContext filtering', () => {

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -217,7 +217,8 @@ describe('RunbookActorService', () => {
       const completeActor = mockActor({
         value: 'COMPLETE',
         context: {
-          variables: { completed: true },
+          variables: {},
+          lifecycle: 'completed',
           retryCount: 0,
         },
       });

--- a/packages/core/__tests__/runbook/compiler-machine-structural-snapshot.test.ts
+++ b/packages/core/__tests__/runbook/compiler-machine-structural-snapshot.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from '@jest/globals';
+import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
+import { createRunbook } from './fixtures.js';
+
+function snapshotConfig(machine: ReturnType<typeof compileRunbookToMachine>): unknown {
+  return JSON.parse(
+    JSON.stringify(machine.config, (_key, value) => {
+      if (typeof value === 'function') return '[fn]';
+      return value;
+    }),
+  );
+}
+
+describe('compileRunbookToMachine (lifecycle cleanup structural snapshot)', () => {
+  it('produces a stable structural config for a representative runbook', () => {
+    const steps = createRunbook(`## 1. Parent
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.1 First
+- PASS CONTINUE
+- FAIL CONTINUE
+
+### 1.2 Last
+- PASS CONTINUE
+- FAIL STOP
+
+## 2. Done
+- PASS COMPLETE
+- FAIL STOP
+`);
+
+    const machine = compileRunbookToMachine(steps);
+    expect(snapshotConfig(machine)).toMatchSnapshot();
+  });
+
+  it('produces a stable structural config for GOTO construct', () => {
+    const steps = createRunbook(`## 1. Redirect
+- PASS GOTO 3
+- FAIL STOP
+
+## 2. Skipped
+- PASS CONTINUE
+- FAIL STOP
+
+## 3. Target
+- PASS COMPLETE
+- FAIL STOP
+`);
+
+    const machine = compileRunbookToMachine(steps);
+    expect(snapshotConfig(machine)).toMatchSnapshot();
+  });
+
+  it('lifecycle is initialized in the machine context', () => {
+    const steps = createRunbook(`## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n`);
+    const machine = compileRunbookToMachine(steps);
+    const ctx = machine.config.context as unknown as { lifecycle?: string };
+    expect(ctx.lifecycle).toBe('running');
+  });
+});

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -56,6 +56,7 @@ describe('runbook compiler', () => {
     return [...steps];
   }
 
+
   describe('static step compilation', () => {
     it('generates discrete states for substeps', () => {
       const steps = inferSteps([

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -9530,17 +9530,6 @@ echo "processing"
     });
   });
 
-  function getAssignPayload(actions: unknown): Record<string, unknown> {
-    const arr = Array.isArray(actions) ? actions : [actions];
-    for (const action of arr) {
-      const a = action as { type?: string; assignment?: unknown };
-      if (a.type === 'xstate.assign' && a.assignment && typeof a.assignment === 'object') {
-        return a.assignment as Record<string, unknown>;
-      }
-    }
-    throw new Error(`No assign payload found in actions: ${JSON.stringify(actions)}`);
-  }
-
   describe('parent-step unconditional-exit FAIL routing (Bug A)', () => {
     function getState(machine: ReturnType<typeof compileRunbookToMachine>, id: string): any {
       return (machine.config.states as Record<string, unknown>)[id] as any;

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -47,8 +47,6 @@ describe('runbook compiler', () => {
     });
   }
 
-
-
   describe('static step compilation', () => {
     it('generates discrete states for substeps', () => {
       const steps = inferSteps([

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -9555,6 +9555,17 @@ echo "processing"
       return (machine.config.states as Record<string, unknown>)[id] as any;
     }
 
+    function getAssignPayload(actions: unknown): Record<string, unknown> {
+      const arr = Array.isArray(actions) ? actions : [actions];
+      for (const action of arr) {
+        const a = action as { type?: string; assignment?: unknown };
+        if (a.type === 'xstate.assign' && a.assignment && typeof a.assignment === 'object') {
+          return a.assignment as Record<string, unknown>;
+        }
+      }
+      throw new Error(`No assign payload found in actions: ${JSON.stringify(actions)}`);
+    }
+
     it('emits a parent-level FAIL routing entry when parentStep.transitions.fail is STOP and there is no aggregation', () => {
       const steps = createRunbook(`## 1. Parent
 - PASS CONTINUE

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -9,7 +9,7 @@ import type {
   StepWithSubsteps,
   ResolvedStepWithFor,
 } from '../../src/runbook/types.js';
-import { areAllStepsResolved } from '@rundown-org/parser';
+import { createRunbook } from './fixtures.js';
 
 describe('runbook compiler', () => {
   /** Input type: Resolved step variants without the `kind` discriminant. */
@@ -47,14 +47,6 @@ describe('runbook compiler', () => {
     });
   }
 
-  function createRunbook(markdown: string): ResolvedStep[] {
-    const { runbook } = parseRunbookDocument(markdown);
-    const steps = [...runbook.steps];
-    if (!areAllStepsResolved(steps)) {
-      throw new Error('Test runbook has unresolved FOR bounds or runbook references');
-    }
-    return [...steps];
-  }
 
 
   describe('static step compilation', () => {

--- a/packages/core/__tests__/runbook/delegation-scan.test.ts
+++ b/packages/core/__tests__/runbook/delegation-scan.test.ts
@@ -48,6 +48,8 @@ describe('DelegationScanService', () => {
       steps: [{ id: '1', status: 'running' }],
       startedAt: '2026-02-27T10:00:00.000Z',
       updatedAt: '2026-02-27T10:00:00.000Z',
+      lifecycle: 'running',
+      schemaVersion: 2,
       ...overrides,
     } as RunbookState;
   }

--- a/packages/core/__tests__/runbook/fixtures.ts
+++ b/packages/core/__tests__/runbook/fixtures.ts
@@ -1,0 +1,18 @@
+import { parseRunbookDocument, areAllStepsResolved } from '@rundown-org/parser';
+import type { ResolvedStep } from '../../src/runbook/types.js';
+
+/**
+ * Parse a markdown runbook string and return its resolved steps.
+ * Throws if the runbook contains unresolved FOR bounds or runbook references.
+ *
+ * @param markdown - Runbook markdown content
+ * @returns Array of resolved steps suitable for `compileRunbookToMachine`
+ */
+export function createRunbook(markdown: string): ResolvedStep[] {
+  const { runbook } = parseRunbookDocument(markdown);
+  const steps = [...runbook.steps];
+  if (!areAllStepsResolved(steps)) {
+    throw new Error('Test runbook has unresolved FOR bounds or runbook references');
+  }
+  return [...steps];
+}

--- a/packages/core/__tests__/runbook/fixtures.ts
+++ b/packages/core/__tests__/runbook/fixtures.ts
@@ -10,9 +10,9 @@ import type { ResolvedStep } from '../../src/runbook/types.js';
  */
 export function createRunbook(markdown: string): ResolvedStep[] {
   const { runbook } = parseRunbookDocument(markdown);
-  const steps = [...runbook.steps];
+  const steps = runbook.steps;
   if (!areAllStepsResolved(steps)) {
     throw new Error('Test runbook has unresolved FOR bounds or runbook references');
   }
-  return [...steps];
+  return steps as ResolvedStep[];
 }

--- a/packages/core/__tests__/runbook/lifecycle-context.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-context.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from '@jest/globals';
+import { createActor } from 'xstate';
+import { parseRunbookDocument, areAllStepsResolved } from '@rundown-org/parser';
+import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
+import type { ResolvedStep } from '../../src/runbook/types.js';
+
+function createRunbook(markdown: string): ResolvedStep[] {
+  const { runbook } = parseRunbookDocument(markdown);
+  const steps = [...runbook.steps];
+  if (!areAllStepsResolved(steps)) {
+    throw new Error('Test runbook has unresolved FOR bounds or runbook references');
+  }
+  return [...steps];
+}
+
+describe('lifecycle context field', () => {
+  it('initializes context.lifecycle to "running"', () => {
+    const steps = createRunbook(`## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n`);
+    const machine = compileRunbookToMachine(steps);
+    const actor = createActor(machine);
+    actor.start();
+    const ctx = actor.getSnapshot().context;
+    expect(ctx.lifecycle).toBe('running');
+    actor.stop();
+  });
+
+  it('sets context.lifecycle to "completed" on COMPLETE final entry', () => {
+    const steps = createRunbook(`## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n`);
+    const machine = compileRunbookToMachine(steps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'PASS' });
+    expect(actor.getSnapshot().context.lifecycle).toBe('completed');
+    actor.stop();
+  });
+
+  it('sets context.lifecycle to "stopped" on STOPPED final entry', () => {
+    const steps = createRunbook(`## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n`);
+    const machine = compileRunbookToMachine(steps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'FAIL' });
+    expect(actor.getSnapshot().context.lifecycle).toBe('stopped');
+    actor.stop();
+  });
+
+  it('still writes the legacy variables.completed flag (coexistence phase)', () => {
+    const steps = createRunbook(`## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n`);
+    const machine = compileRunbookToMachine(steps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'PASS' });
+    // Backward-compat assertion — removed in Task 5.
+    expect(actor.getSnapshot().context.variables.completed).toBe(true);
+    actor.stop();
+  });
+});

--- a/packages/core/__tests__/runbook/lifecycle-context.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-context.test.ts
@@ -34,14 +34,15 @@ describe('lifecycle context field', () => {
     actor.stop();
   });
 
-  it('still writes the legacy variables.completed flag (coexistence phase)', () => {
+  it('no longer writes legacy variables.completed/stopped flags', () => {
     const steps = createRunbook(`## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n`);
     const machine = compileRunbookToMachine(steps);
     const actor = createActor(machine);
     actor.start();
     actor.send({ type: 'PASS' });
-    // Backward-compat assertion — removed in Task 5.
-    expect(actor.getSnapshot().context.variables.completed).toBe(true);
+    const vars = actor.getSnapshot().context.variables;
+    expect(vars.completed).toBeUndefined();
+    expect(vars.stopped).toBeUndefined();
     actor.stop();
   });
 });

--- a/packages/core/__tests__/runbook/lifecycle-context.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-context.test.ts
@@ -47,4 +47,17 @@ describe('lifecycle context field', () => {
     expect(vars.stopped).toBeUndefined();
     actor.stop();
   });
+
+  it('no longer writes legacy variables.completed/stopped flags on FAIL → stopped path', () => {
+    const steps = createRunbook(`## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n`);
+    const machine = compileRunbookToMachine(steps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'FAIL' });
+    expect(actor.getSnapshot().context.lifecycle).toBe('stopped');
+    const vars = actor.getSnapshot().context.variables;
+    expect(vars.completed).toBeUndefined();
+    expect(vars.stopped).toBeUndefined();
+    actor.stop();
+  });
 });

--- a/packages/core/__tests__/runbook/lifecycle-context.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-context.test.ts
@@ -21,6 +21,7 @@ describe('lifecycle context field', () => {
     actor.start();
     actor.send({ type: 'PASS' });
     expect(actor.getSnapshot().context.lifecycle).toBe('completed');
+    expect(actor.getSnapshot().context.lifecycle).not.toBe('stopped');
     actor.stop();
   });
 
@@ -31,6 +32,7 @@ describe('lifecycle context field', () => {
     actor.start();
     actor.send({ type: 'FAIL' });
     expect(actor.getSnapshot().context.lifecycle).toBe('stopped');
+    expect(actor.getSnapshot().context.lifecycle).not.toBe('completed');
     actor.stop();
   });
 

--- a/packages/core/__tests__/runbook/lifecycle-context.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-context.test.ts
@@ -1,17 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import { createActor } from 'xstate';
-import { parseRunbookDocument, areAllStepsResolved } from '@rundown-org/parser';
 import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
-import type { ResolvedStep } from '../../src/runbook/types.js';
-
-function createRunbook(markdown: string): ResolvedStep[] {
-  const { runbook } = parseRunbookDocument(markdown);
-  const steps = [...runbook.steps];
-  if (!areAllStepsResolved(steps)) {
-    throw new Error('Test runbook has unresolved FOR bounds or runbook references');
-  }
-  return [...steps];
-}
+import { createRunbook } from './fixtures.js';
 
 describe('lifecycle context field', () => {
   it('initializes context.lifecycle to "running"', () => {

--- a/packages/core/__tests__/runbook/state-schema-version.test.ts
+++ b/packages/core/__tests__/runbook/state-schema-version.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { RunbookStateSchema } from '../../src/schemas.js';
+import { RunbookStateManager, StaleRunbookStateError } from '../../src/runbook/index.js';
 
-const BASE_STATE = {
+const BASE_SCHEMA_STATE = {
   id: 'r1',
   runbook: 'x.md',
   runbookPath: 'x.md',
@@ -16,7 +20,7 @@ const BASE_STATE = {
 describe('RunbookStateSchema — schema version and lifecycle fields', () => {
   it('accepts state with schemaVersion 2 and lifecycle field', () => {
     const parsed = RunbookStateSchema.parse({
-      ...BASE_STATE,
+      ...BASE_SCHEMA_STATE,
       variables: {},
       lifecycle: 'running',
       schemaVersion: 2,
@@ -26,9 +30,9 @@ describe('RunbookStateSchema — schema version and lifecycle fields', () => {
   });
 
   it('accepts all lifecycle enum values', () => {
-    for (const lc of ['running', 'completed', 'stopped'] as const) {
+    for (const lc of ['running', 'completed', 'stopped']) {
       const parsed = RunbookStateSchema.parse({
-        ...BASE_STATE,
+        ...BASE_SCHEMA_STATE,
         variables: {},
         lifecycle: lc,
         schemaVersion: 2,
@@ -40,7 +44,7 @@ describe('RunbookStateSchema — schema version and lifecycle fields', () => {
   it('rejects boolean values inside variables (narrow shape enforced)', () => {
     expect(() =>
       RunbookStateSchema.parse({
-        ...BASE_STATE,
+        ...BASE_SCHEMA_STATE,
         variables: { completed: true },
         lifecycle: 'running',
         schemaVersion: 2,
@@ -51,7 +55,7 @@ describe('RunbookStateSchema — schema version and lifecycle fields', () => {
   it('rejects number values inside variables', () => {
     expect(() =>
       RunbookStateSchema.parse({
-        ...BASE_STATE,
+        ...BASE_SCHEMA_STATE,
         variables: { count: 42 },
         lifecycle: 'running',
         schemaVersion: 2,
@@ -61,7 +65,7 @@ describe('RunbookStateSchema — schema version and lifecycle fields', () => {
 
   it('accepts empty variables map', () => {
     const parsed = RunbookStateSchema.parse({
-      ...BASE_STATE,
+      ...BASE_SCHEMA_STATE,
       variables: {},
       lifecycle: 'running',
       schemaVersion: 2,
@@ -71,11 +75,81 @@ describe('RunbookStateSchema — schema version and lifecycle fields', () => {
 
   it('accepts string-only variables map', () => {
     const parsed = RunbookStateSchema.parse({
-      ...BASE_STATE,
+      ...BASE_SCHEMA_STATE,
       variables: { env: 'staging', version: '1.2.3' },
       lifecycle: 'running',
       schemaVersion: 2,
     });
     expect(parsed.variables).toEqual({ env: 'staging', version: '1.2.3' });
+  });
+});
+
+describe('RunbookStateManager.load() — stale state enforcement', () => {
+  let tmpDir: string;
+  let manager: RunbookStateManager;
+
+  const V1_STATE = {
+    id: 'wf-stale-test',
+    runbook: 'x.md',
+    runbookPath: 'x.md',
+    step: '1',
+    stepName: 'x',
+    retryCount: 0,
+    variables: {},
+    steps: [],
+    startedAt: '2026-04-19T00:00:00.000Z',
+    updatedAt: '2026-04-19T00:00:00.000Z',
+    lifecycle: 'running',
+    schemaVersion: 1, // old version
+  };
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'rundown-test-'));
+    manager = new RunbookStateManager(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('throws StaleRunbookStateError when loading v1 state', async () => {
+    const runsDir = path.join(tmpDir, '.rundown', 'runs');
+    await fs.mkdir(runsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(runsDir, `${V1_STATE.id}.json`),
+      JSON.stringify(V1_STATE, null, 2),
+    );
+
+    await expect(manager.load(V1_STATE.id)).rejects.toBeInstanceOf(StaleRunbookStateError);
+  });
+
+  it('throws StaleRunbookStateError with helpful message', async () => {
+    const runsDir = path.join(tmpDir, '.rundown', 'runs');
+    await fs.mkdir(runsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(runsDir, `${V1_STATE.id}.json`),
+      JSON.stringify(V1_STATE, null, 2),
+    );
+
+    await expect(manager.load(V1_STATE.id)).rejects.toThrow('rd prune --all');
+  });
+
+  it('returns null for missing state file', async () => {
+    const result = await manager.load('wf-does-not-exist');
+    expect(result).toBeNull();
+  });
+
+  it('loads valid v2 state successfully', async () => {
+    const runsDir = path.join(tmpDir, '.rundown', 'runs');
+    await fs.mkdir(runsDir, { recursive: true });
+    const v2State = { ...V1_STATE, schemaVersion: 2 };
+    await fs.writeFile(
+      path.join(runsDir, `${v2State.id}.json`),
+      JSON.stringify(v2State, null, 2),
+    );
+
+    const result = await manager.load(v2State.id);
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(v2State.id);
   });
 });

--- a/packages/core/__tests__/runbook/state-schema-version.test.ts
+++ b/packages/core/__tests__/runbook/state-schema-version.test.ts
@@ -143,10 +143,7 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
     const runsDir = path.join(tmpDir, '.rundown', 'runs');
     await fs.mkdir(runsDir, { recursive: true });
     const v2State = { ...V1_STATE, schemaVersion: 2 };
-    await fs.writeFile(
-      path.join(runsDir, `${v2State.id}.json`),
-      JSON.stringify(v2State, null, 2),
-    );
+    await fs.writeFile(path.join(runsDir, `${v2State.id}.json`), JSON.stringify(v2State, null, 2));
 
     const result = await manager.load(v2State.id);
     expect(result).not.toBeNull();

--- a/packages/core/__tests__/runbook/state-schema-version.test.ts
+++ b/packages/core/__tests__/runbook/state-schema-version.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from '@jest/globals';
+import { RunbookStateSchema } from '../../src/schemas.js';
+
+const BASE_STATE = {
+  id: 'r1',
+  runbook: 'x.md',
+  runbookPath: 'x.md',
+  step: '1',
+  stepName: 'x',
+  retryCount: 0,
+  steps: [],
+  startedAt: '2026-04-19T00:00:00.000Z',
+  updatedAt: '2026-04-19T00:00:00.000Z',
+};
+
+describe('RunbookStateSchema — schema version and lifecycle fields', () => {
+  it('accepts state with schemaVersion 2 and lifecycle field', () => {
+    const parsed = RunbookStateSchema.parse({
+      ...BASE_STATE,
+      variables: {},
+      lifecycle: 'running',
+      schemaVersion: 2,
+    });
+    expect(parsed.lifecycle).toBe('running');
+    expect(parsed.schemaVersion).toBe(2);
+  });
+
+  it('accepts all lifecycle enum values', () => {
+    for (const lc of ['running', 'completed', 'stopped'] as const) {
+      const parsed = RunbookStateSchema.parse({
+        ...BASE_STATE,
+        variables: {},
+        lifecycle: lc,
+        schemaVersion: 2,
+      });
+      expect(parsed.lifecycle).toBe(lc);
+    }
+  });
+
+  it('rejects boolean values inside variables (narrow shape enforced)', () => {
+    expect(() =>
+      RunbookStateSchema.parse({
+        ...BASE_STATE,
+        variables: { completed: true },
+        lifecycle: 'running',
+        schemaVersion: 2,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects number values inside variables', () => {
+    expect(() =>
+      RunbookStateSchema.parse({
+        ...BASE_STATE,
+        variables: { count: 42 },
+        lifecycle: 'running',
+        schemaVersion: 2,
+      }),
+    ).toThrow();
+  });
+
+  it('accepts empty variables map', () => {
+    const parsed = RunbookStateSchema.parse({
+      ...BASE_STATE,
+      variables: {},
+      lifecycle: 'running',
+      schemaVersion: 2,
+    });
+    expect(parsed.variables).toEqual({});
+  });
+
+  it('accepts string-only variables map', () => {
+    const parsed = RunbookStateSchema.parse({
+      ...BASE_STATE,
+      variables: { env: 'staging', version: '1.2.3' },
+      lifecycle: 'running',
+      schemaVersion: 2,
+    });
+    expect(parsed.variables).toEqual({ env: 'staging', version: '1.2.3' });
+  });
+});

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -39,21 +39,21 @@ describe('RunbookStateManager', () => {
   });
 
   describe('getChildRunbookResult', () => {
-    it('should return pass when child has completed=true', async () => {
+    it('should return pass when child has lifecycle completed', async () => {
       const child = await manager.create('child.runbook.md', mockRunbook, {
         runbookPath: 'child.runbook.md',
       });
-      await manager.update(child.id, { variables: { completed: true } });
+      await manager.update(child.id, { lifecycle: 'completed' });
 
       const result = await lifecycleService.getChildRunbookResult(child.id);
       expect(result).toBe('pass');
     });
 
-    it('should return fail when child has stopped=true', async () => {
+    it('should return fail when child has lifecycle stopped', async () => {
       const child = await manager.create('child.runbook.md', mockRunbook, {
         runbookPath: 'child.runbook.md',
       });
-      await manager.update(child.id, { variables: { stopped: true } });
+      await manager.update(child.id, { lifecycle: 'stopped' });
 
       const result = await lifecycleService.getChildRunbookResult(child.id);
       expect(result).toBe('fail');

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -17,6 +17,7 @@ export default {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@rundown-org/parser$': '<rootDir>/../parser/src/index.ts',
   },
   transform: {
     '^.+\\.tsx?$': [

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -58,6 +58,7 @@ type PersistedRunbookSnapshot = {
  * after transitions, and convenience methods for the two dominant usage patterns:
  * initialisation (create + sync with no event) and transition (create + send + sync).
  */
+
 export class RunbookActorService {
   /**
    * Create a new RunbookActorService.
@@ -179,8 +180,11 @@ export class RunbookActorService {
     // If the runbook is in a final state, don't try to parse a step number.
     // Just update the snapshot and variables, preserving the last step number.
     if (stateValue === 'COMPLETE' || stateValue === 'STOPPED') {
-      const variables = snapshot.context?.variables ?? {};
-      const rawFinalVars = snapshot.context?.finalVars ?? {};
+      const variables = (snapshot.context?.variables ?? {}) as Record<
+        string,
+        boolean | number | string
+      >;
+      const rawFinalVars = (snapshot.context?.finalVars ?? {}) as Record<string, string>;
       // Empty finalVars on terminal: explicitly write `undefined` so the persisted
       // state has no `finalVars` field. This matches the schema's optional contract
       // and avoids storing a misleading empty object.
@@ -213,7 +217,7 @@ export class RunbookActorService {
     const match = primaryMatch ?? legacyMatch;
     const stepName = match ? match[1] : steps[0].name;
 
-    let substep = snapshot.context?.substep;
+    let substep = snapshot.context?.substep as string | undefined;
     if (!substep && match?.[2]) {
       substep = match[2];
     }
@@ -221,13 +225,16 @@ export class RunbookActorService {
     // Find step by name (unified lookup)
     const step = steps.find((s) => s.name === stepName) ?? steps[0];
 
-    const retryCount = snapshot.context?.retryCount ?? 0;
-    const variables = snapshot.context?.variables ?? {};
+    const retryCount = (snapshot.context?.retryCount as number | undefined) ?? 0;
+    const variables = (snapshot.context?.variables ?? {}) as Record<
+      string,
+      boolean | number | string
+    >;
 
     // FOR loop context
-    const forStack = snapshot.context?.forStack;
-    const iterationResults = snapshot.context?.iterationResults;
-    const lastAction = snapshot.context?.lastAction;
+    const forStack = snapshot.context?.forStack as ForContext[] | undefined;
+    const iterationResults = snapshot.context?.iterationResults as ('pass' | 'fail')[] | undefined;
+    const lastAction = snapshot.context?.lastAction as RunbookState['lastAction'];
 
     // Filter implicit ForContext entries — don't persist synthetic loop state
     const realForStack = forStack?.filter((fc) => !fc.implicit);

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -179,7 +179,7 @@ export class RunbookActorService {
     // If the runbook is in a final state, don't try to parse a step number.
     // Just update the snapshot and variables, preserving the last step number.
     if (stateValue === 'COMPLETE' || stateValue === 'STOPPED') {
-      const variables = (snapshot.context?.variables ?? {}) as Record<string, string>;
+      const variables = snapshot.context?.variables ?? {};
       const rawFinalVars = (snapshot.context?.finalVars ?? {}) as Record<string, string>;
       // Empty finalVars on terminal: explicitly write `undefined` so the persisted
       // state has no `finalVars` field. This matches the schema's optional contract
@@ -225,7 +225,7 @@ export class RunbookActorService {
     const step = steps.find((s) => s.name === stepName) ?? steps[0];
 
     const retryCount = snapshot.context?.retryCount ?? 0;
-    const variables = (snapshot.context?.variables ?? {}) as Record<string, string>;
+    const variables = snapshot.context?.variables ?? {};
 
     // FOR loop context
     const forStack = snapshot.context?.forStack as ForContext[] | undefined;

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -179,10 +179,7 @@ export class RunbookActorService {
     // If the runbook is in a final state, don't try to parse a step number.
     // Just update the snapshot and variables, preserving the last step number.
     if (stateValue === 'COMPLETE' || stateValue === 'STOPPED') {
-      const variables = (snapshot.context?.variables ?? {}) as Record<
-        string,
-        boolean | number | string
-      >;
+      const variables = snapshot.context?.variables ?? {};
       const rawFinalVars = (snapshot.context?.finalVars ?? {}) as Record<string, string>;
       // Empty finalVars on terminal: explicitly write `undefined` so the persisted
       // state has no `finalVars` field. This matches the schema's optional contract
@@ -216,7 +213,7 @@ export class RunbookActorService {
     const match = primaryMatch ?? legacyMatch;
     const stepName = match ? match[1] : steps[0].name;
 
-    let substep = snapshot.context?.substep as string | undefined;
+    let substep = snapshot.context?.substep;
     if (!substep && match?.[2]) {
       substep = match[2];
     }
@@ -224,16 +221,13 @@ export class RunbookActorService {
     // Find step by name (unified lookup)
     const step = steps.find((s) => s.name === stepName) ?? steps[0];
 
-    const retryCount = (snapshot.context?.retryCount as number | undefined) ?? 0;
-    const variables = (snapshot.context?.variables ?? {}) as Record<
-      string,
-      boolean | number | string
-    >;
+    const retryCount = snapshot.context?.retryCount ?? 0;
+    const variables = snapshot.context?.variables ?? {};
 
     // FOR loop context
     const forStack = snapshot.context?.forStack as ForContext[] | undefined;
-    const iterationResults = snapshot.context?.iterationResults as ('pass' | 'fail')[] | undefined;
-    const lastAction = snapshot.context?.lastAction as RunbookState['lastAction'];
+    const iterationResults = snapshot.context?.iterationResults;
+    const lastAction = snapshot.context?.lastAction;
 
     // Filter implicit ForContext entries — don't persist synthetic loop state
     const realForStack = forStack?.filter((fc) => !fc.implicit);

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -3,16 +3,16 @@
 /**
  * XState actor lifecycle service for runbooks.
  *
- * Owns actor creation (with snapshot migration), state synchronisation
- * after transitions, and convenience methods for the two dominant patterns:
- * initialisation (create + sync, no event) and transition (create + send + sync).
+ * Owns actor creation, state synchronisation after transitions, and convenience
+ * methods for the two dominant patterns: initialisation (create + sync, no event)
+ * and transition (create + send + sync).
  *
  * Composes RunbookStateManager for persistence — does not own disk I/O.
  *
  * @module
  */
 
-import { createActor, type AnyActorRef } from 'xstate';
+import { createActor, type AnyActorRef, type Snapshot } from 'xstate';
 import type { ResolvedStep, RunbookState, ForContext } from './types.js';
 import type { RunbookStateManager } from './state.js';
 import { compileRunbookToMachine, type RunbookEvent, type RunbookContext } from './compiler.js';
@@ -69,8 +69,7 @@ export class RunbookActorService {
   /**
    * Create and start an XState actor from persisted state.
    *
-   * Loads the persisted snapshot, applies migration from flat FOR fields
-   * to forStack array if needed, compiles the machine, and starts the actor.
+   * Loads the persisted snapshot, compiles the machine, and starts the actor.
    * The compiler is seeded with `state.templateVars` (flattened) and
    * `state.frontmatterOutputs` so OUTPUTS evaluation works identically on
    * resume as on initial start.
@@ -95,54 +94,8 @@ export class RunbookActorService {
       frontmatterOutputs: state.frontmatterOutputs,
     });
 
-    // Migrate old snapshot context: flat FOR fields → forStack
-    // Intentionally shallow copy — only snapshot.context is replaced during
-    // migration, so other nested properties (e.g. snapshot.children) remain
-    // aliased to the original. This is safe because we never mutate them.
-    // Snapshot migration deals with untyped persisted data — any is unavoidable
-    /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unnecessary-type-assertion */
-    const rawSnapshot = state.snapshot as any;
-    let snapshot = rawSnapshot;
-    if (rawSnapshot?.context && !rawSnapshot.context.forStack) {
-      // Only copy when migration is needed — preserve original otherwise
-      snapshot = { ...rawSnapshot };
-      const ctx = { ...(rawSnapshot.context as any) };
-      if (ctx.forIteration !== undefined) {
-        // Derive stepId from snapshot.value (authoritative) with state.step fallback
-        const stateValue = rawSnapshot.value as string | undefined;
-        const stepMatch = stateValue
-          ? (/^step::([^:]+)/.exec(stateValue) ?? /^step_([^_]+)/.exec(stateValue))
-          : null;
-        const stepId = stepMatch?.[1] ?? state.step;
-
-        snapshot.context = {
-          ...ctx,
-          forStack: [
-            {
-              stepId,
-              iteration: ctx.forIteration,
-              start: ctx.forStart ?? 1,
-              end: ctx.forEnd ?? ctx.forIteration,
-              variable: ctx.forVariable,
-              implicit: false,
-              source: { kind: 'range' as const },
-            },
-          ],
-          forIteration: undefined,
-          forStart: undefined,
-          forEnd: undefined,
-          forVariable: undefined,
-        };
-      } else {
-        // No active loop — just ensure forStack exists
-        snapshot.context = { ...ctx, forStack: [] };
-      }
-    }
-    /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unnecessary-type-assertion */
-
     const actor = createActor(machine, {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      snapshot,
+      snapshot: state.snapshot as Snapshot<unknown> | undefined,
     });
     actor.start();
     return actor;

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -13,7 +13,7 @@
  */
 
 import { createActor, type AnyActorRef } from 'xstate';
-import type { ResolvedStep, RunbookState } from './types.js';
+import type { ResolvedStep, RunbookState, ForContext, Lifecycle } from './types.js';
 import type { RunbookStateManager } from './state.js';
 import { compileRunbookToMachine, type RunbookEvent, type RunbookContext } from './compiler.js';
 import { flattenTemplateVars } from './output-evaluator.js';
@@ -185,9 +185,13 @@ export class RunbookActorService {
       // state has no `finalVars` field. This matches the schema's optional contract
       // and avoids storing a misleading empty object.
       const finalVars = Object.keys(rawFinalVars).length > 0 ? rawFinalVars : undefined;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const lifecycle = (snapshot.context?.lifecycle ??
+        (stateValue === 'COMPLETE' ? 'completed' : 'stopped')) as Lifecycle;
       const state = await this.manager.update(id, {
         variables,
         finalVars,
+        lifecycle,
         snapshot,
         // Clear FOR loop state on completion
         forStack: undefined,
@@ -245,6 +249,8 @@ export class RunbookActorService {
       stepName: step.description,
       retryCount,
       variables,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      lifecycle: (snapshot.context?.lifecycle ?? 'running') as Lifecycle,
       snapshot,
       forStack: computedForStack,
       iterationResults: computedIterationResults,

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -179,7 +179,7 @@ export class RunbookActorService {
     // If the runbook is in a final state, don't try to parse a step number.
     // Just update the snapshot and variables, preserving the last step number.
     if (stateValue === 'COMPLETE' || stateValue === 'STOPPED') {
-      const variables = snapshot.context?.variables ?? {};
+      const variables = (snapshot.context?.variables ?? {}) as Record<string, string>;
       const rawFinalVars = (snapshot.context?.finalVars ?? {}) as Record<string, string>;
       // Empty finalVars on terminal: explicitly write `undefined` so the persisted
       // state has no `finalVars` field. This matches the schema's optional contract
@@ -225,7 +225,7 @@ export class RunbookActorService {
     const step = steps.find((s) => s.name === stepName) ?? steps[0];
 
     const retryCount = snapshot.context?.retryCount ?? 0;
-    const variables = snapshot.context?.variables ?? {};
+    const variables = (snapshot.context?.variables ?? {}) as Record<string, string>;
 
     // FOR loop context
     const forStack = snapshot.context?.forStack as ForContext[] | undefined;

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -58,7 +58,6 @@ type PersistedRunbookSnapshot = {
  * after transitions, and convenience methods for the two dominant usage patterns:
  * initialisation (create + sync with no event) and transition (create + send + sync).
  */
-
 export class RunbookActorService {
   /**
    * Create a new RunbookActorService.

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -13,7 +13,7 @@
  */
 
 import { createActor, type AnyActorRef } from 'xstate';
-import type { ResolvedStep, RunbookState, ForContext, Lifecycle } from './types.js';
+import type { ResolvedStep, RunbookState, ForContext } from './types.js';
 import type { RunbookStateManager } from './state.js';
 import { compileRunbookToMachine, type RunbookEvent, type RunbookContext } from './compiler.js';
 import { flattenTemplateVars } from './output-evaluator.js';
@@ -185,9 +185,8 @@ export class RunbookActorService {
       // state has no `finalVars` field. This matches the schema's optional contract
       // and avoids storing a misleading empty object.
       const finalVars = Object.keys(rawFinalVars).length > 0 ? rawFinalVars : undefined;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const lifecycle = (snapshot.context?.lifecycle ??
-        (stateValue === 'COMPLETE' ? 'completed' : 'stopped')) as Lifecycle;
+      const lifecycle =
+        snapshot.context?.lifecycle ?? (stateValue === 'COMPLETE' ? 'completed' : 'stopped');
       const state = await this.manager.update(id, {
         variables,
         finalVars,
@@ -249,8 +248,7 @@ export class RunbookActorService {
       stepName: step.description,
       retryCount,
       variables,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      lifecycle: (snapshot.context?.lifecycle ?? 'running') as Lifecycle,
+      lifecycle: snapshot.context?.lifecycle ?? 'running',
       snapshot,
       forStack: computedForStack,
       iterationResults: computedIterationResults,

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -27,10 +27,8 @@ import {
   buildExecutionFrame,
   evaluateFrontmatterOutputDeclarations,
   evaluateStepOutputDeclarations,
-  type OutputFrameState,
   type OutputVars,
 } from './output-evaluator.js';
-
 
 /**
  * Module-level XState setup with typed context, events, and named actions.

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -7,6 +7,7 @@ import type {
   ForContext,
   ResolvedStep,
   ResolvedStepHavingSubsteps,
+  Lifecycle,
 } from './types.js';
 import { isResolvedVariableForContext } from './types.js';
 import type { StepId } from './step-id.js';
@@ -236,6 +237,8 @@ export interface RunbookContext {
   readonly frontmatterOutputs: readonly OutputDeclaration[];
   /** Final OUTPUTS snapshot persisted at terminal entry. Exposed via machine output. */
   readonly finalVars: RunbookMachineOutput['finalVars'];
+  /** Machine-owned lifecycle flag. 'running' during execution; 'completed' or 'stopped' on final entry. */
+  lifecycle: Lifecycle;
 }
 
 /**
@@ -2566,6 +2569,7 @@ export function compileRunbookToMachine(
       templateVars: options?.templateVars ?? {},
       frontmatterOutputs: options?.frontmatterOutputs ?? [],
       finalVars: {},
+      lifecycle: 'running',
     },
     states: {
       ...states,
@@ -2575,6 +2579,7 @@ export function compileRunbookToMachine(
           actionRef('storeFrontmatterOutputs', {}),
           runbookSetup.assign({
             variables: ({ context }) => ({ ...context.variables, completed: true }),
+            lifecycle: () => 'completed' as const,
           }),
         ],
         output: ({ context }) => ({ finalVars: context.finalVars }),
@@ -2585,6 +2590,7 @@ export function compileRunbookToMachine(
           actionRef('storeFrontmatterOutputs', {}),
           runbookSetup.assign({
             variables: ({ context }) => ({ ...context.variables, stopped: true }),
+            lifecycle: () => 'stopped' as const,
           }),
         ],
         output: ({ context }) => ({ finalVars: context.finalVars }),

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -31,26 +31,6 @@ import {
   type OutputVars,
 } from './output-evaluator.js';
 
-/**
- * Coerce {@link RunbookContext} into the {@link OutputFrameState} shape expected
- * by {@link buildExecutionFrame}. The latter requires `variables` to be a string
- * map; the runbook context allows scalar booleans/numbers, so we stringify them
- * for the frame snapshot used during OUTPUTS expression evaluation.
- *
- * @param context - The runbook machine context
- * @returns A frame state suitable for output evaluation
- */
-function toFrameState(context: RunbookContext): OutputFrameState {
-  const stringified: Record<string, string> = {};
-  for (const [key, value] of Object.entries(context.variables)) {
-    stringified[key] = typeof value === 'string' ? value : String(value);
-  }
-  return {
-    templateVars: context.templateVars,
-    variables: stringified,
-    forStack: context.forStack,
-  };
-}
 
 /**
  * Module-level XState setup with typed context, events, and named actions.
@@ -88,7 +68,7 @@ export const runbookSetup = setup({
       variables: ({ context }, params: ActionDefs['storeStepOutputs']) => {
         const substepId =
           params.substepId ?? (params.useCompletedSubstep ? context.completedSubstep : undefined);
-        const baseFrameState = toFrameState(context);
+        const baseFrameState = context;
         const activeFor = baseFrameState.forStack.at(-1);
         const completedFor = context.completedForContext;
         const frameState =
@@ -118,7 +98,7 @@ export const runbookSetup = setup({
         if (context.frontmatterOutputs.length === 0) {
           return context.finalVars;
         }
-        const frame = buildExecutionFrame(toFrameState(context), {
+        const frame = buildExecutionFrame(context, {
           stepName: params.stepName ?? '',
           substepId: params.substepId,
         });
@@ -217,8 +197,8 @@ export interface RunbookContext {
    * evaluating step; the step-id check in storeStepOutputs guards against stale values.
    */
   completedForContext?: ForContext;
-  /** User-defined runbook variables */
-  variables: Record<string, boolean | number | string>;
+  /** User-defined runbook variables. String-only after lifecycle flags moved out. */
+  variables: Record<string, string>;
   /** Last action taken by the state machine (source of truth for transition type) */
   lastAction?: LastAction;
   /** Message from STOP/COMPLETE actions */
@@ -255,7 +235,7 @@ export type RunbookEvent =
   | { type: 'FAIL' }
   | { type: 'RETRY' }
   | { type: 'GOTO'; target: StepId }
-  | { type: 'SET_VARIABLES'; vars: Record<string, boolean | number | string> };
+  | { type: 'SET_VARIABLES'; vars: Record<string, string> };
 
 /**
  * XState transition configuration returned by transition builder functions.

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -2578,7 +2578,6 @@ export function compileRunbookToMachine(
         entry: [
           actionRef('storeFrontmatterOutputs', {}),
           runbookSetup.assign({
-            variables: ({ context }) => ({ ...context.variables, completed: true }),
             lifecycle: () => 'completed' as const,
           }),
         ],
@@ -2589,7 +2588,6 @@ export function compileRunbookToMachine(
         entry: [
           actionRef('storeFrontmatterOutputs', {}),
           runbookSetup.assign({
-            variables: ({ context }) => ({ ...context.variables, stopped: true }),
             lifecycle: () => 'stopped' as const,
           }),
         ],

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -238,7 +238,7 @@ export interface RunbookContext {
   /** Final OUTPUTS snapshot persisted at terminal entry. Exposed via machine output. */
   readonly finalVars: RunbookMachineOutput['finalVars'];
   /** Machine-owned lifecycle flag. 'running' during execution; 'completed' or 'stopped' on final entry. */
-  lifecycle: Lifecycle;
+  readonly lifecycle: Lifecycle;
 }
 
 /**

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -903,7 +903,6 @@ function buildParentStateConfig(
 ): { always: TransitionEntry[]; entry?: CompilerAction | CompilerAction[] } {
   const parentStep = config.parentStep;
   const stepName = config.stepName;
-  // parentStep.transitions is non-optional on ExecutionUnitFields — guaranteed by the parser.
 
   const hasFor = parentStep.kind === 'for';
   const hasAggregation = !!parentStep.aggregation;

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -266,9 +266,9 @@ export class ExecutionLifecycleService {
   /**
    * Get the result of a child runbook execution.
    *
-   * Determines the result based on the child runbook's variables:
-   * - Returns 'fail' if stopped is true
-   * - Returns 'pass' if completed is true or runbook not found
+   * Determines the result based on the child runbook's lifecycle field:
+   * - Returns 'fail' if lifecycle is 'stopped'
+   * - Returns 'pass' if lifecycle is 'completed' or runbook not found
    * - Returns null if the runbook is still in progress
    *
    * @param childId - The child runbook state ID
@@ -278,8 +278,8 @@ export class ExecutionLifecycleService {
     const child = await this.manager.load(childId);
     if (!child) return 'pass';
 
-    if (child.variables.stopped === true) return 'fail';
-    if (child.variables.completed === true) return 'pass';
+    if (child.lifecycle === 'stopped') return 'fail';
+    if (child.lifecycle === 'completed') return 'pass';
 
     return null;
   }

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -11,7 +11,7 @@ export * from './step-id.js';
 export * from './step-utils.js';
 export * from './targeting.js';
 export * from './transition-kernel.js';
-export { RunbookStateManager, type SessionData } from './state.js';
+export { RunbookStateManager, StaleRunbookStateError, type SessionData } from './state.js';
 export { SessionService } from './session-service.js';
 export { ExecutionLifecycleService } from './execution-lifecycle-service.js';
 export { compileRunbookToMachine, runbookSetup, MAX_FILE_ITERATIONS } from './compiler.js';

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -22,6 +22,9 @@ import {
   LEGACY_SESSION_FILE,
 } from '../paths.js';
 
+/** Current persisted state schema version. Bump whenever RunbookState shape changes incompatibly. */
+const CURRENT_SCHEMA_VERSION = 2;
+
 function generateId(): string {
   const now = new Date();
   const date = now.toISOString().slice(0, 10);
@@ -143,6 +146,8 @@ export class RunbookStateManager {
       runbookSrc: options.runbookSrc,
       templateVars: options.templateVars,
       frontmatterOutputs: options.frontmatterOutputs ?? [],
+      lifecycle: 'running',
+      schemaVersion: CURRENT_SCHEMA_VERSION,
     };
 
     await this.save(state);
@@ -192,6 +197,17 @@ export class RunbookStateManager {
       }
     }
 
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      (parsed as Record<string, unknown>).schemaVersion !== CURRENT_SCHEMA_VERSION
+    ) {
+      throw new Error(
+        `Runbook state for "${id}" was persisted under a previous schema version. ` +
+          'Run `rd prune --all` to clear stale state before continuing.',
+      );
+    }
+
     const result = RunbookStateSchema.safeParse(parsed);
     if (!result.success) {
       throw new Error(
@@ -216,6 +232,7 @@ export class RunbookStateManager {
     await fs.mkdir(this.stateDir, { recursive: true });
     const updated: RunbookState = {
       ...state,
+      schemaVersion: CURRENT_SCHEMA_VERSION,
       updatedAt: new Date().toISOString(),
     };
     const content = JSON.stringify(updated, null, 2);

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -25,6 +25,22 @@ import {
 /** Current persisted state schema version. Bump whenever RunbookState shape changes incompatibly. */
 const CURRENT_SCHEMA_VERSION = 2;
 
+/**
+ * Thrown when a persisted state file was written by an older schema version.
+ * Callers should surface this to the user with a prompt to run `rd prune --all`.
+ */
+export class StaleRunbookStateError extends Error {
+  /**
+   * Create a new StaleRunbookStateError.
+   *
+   * @param message - Human-readable description of why the state is stale
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = 'StaleRunbookStateError';
+  }
+}
+
 function generateId(): string {
   const now = new Date();
   const date = now.toISOString().slice(0, 10);
@@ -202,7 +218,7 @@ export class RunbookStateManager {
       parsed !== null &&
       (parsed as Record<string, unknown>).schemaVersion !== CURRENT_SCHEMA_VERSION
     ) {
-      throw new Error(
+      throw new StaleRunbookStateError(
         `Runbook state for "${id}" was persisted under a previous schema version. ` +
           'Run `rd prune --all` to clear stale state before continuing.',
       );
@@ -303,8 +319,11 @@ export class RunbookStateManager {
           try {
             const state = await this.load(id);
             if (state) states.push(state);
-          } catch {
-            // Stale/corrupt state — skip, handled by `rundown prune`
+          } catch (err) {
+            if (err instanceof StaleRunbookStateError) {
+              process.stderr.write(`[rundown] Warning: ${err.message}\n`);
+            }
+            // Other errors (corrupt JSON, missing files) — skip silently
           }
         }
       }

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -640,7 +640,7 @@ export interface RunbookState {
   readonly substep?: string;
   readonly stepName: string; // Human-readable description
   readonly retryCount: number;
-  readonly variables: Record<string, boolean | number | string>;
+  readonly variables: Record<string, string>;
   readonly steps: readonly StepState[];
 
   // Orchestration fields
@@ -699,4 +699,7 @@ export interface RunbookState {
 
   /** Lifecycle state. 'running' during execution; 'completed' or 'stopped' once terminal. */
   readonly lifecycle?: Lifecycle;
+
+  /** Schema version for stale-state detection. Present on all states written after schema v2. */
+  readonly schemaVersion?: number;
 }

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -620,6 +620,14 @@ export function assertResolvedVariableForContext(
 }
 
 /**
+ * Runbook lifecycle state. `'running'` covers the entire active lifetime (including
+ * paused/stashed). Reaching a final state transitions to `'completed'` (COMPLETE)
+ * or `'stopped'` (STOPPED). Replaces the previous lifecycle booleans inside
+ * `state.variables`.
+ */
+export type Lifecycle = 'running' | 'completed' | 'stopped';
+
+/**
  * Runbook execution state (persisted)
  */
 export interface RunbookState {

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -696,4 +696,7 @@ export interface RunbookState {
 
   /** Evaluated frontmatter outputs: values at runbook termination. Read by parent delegation completion. */
   readonly finalVars?: Readonly<Record<string, string>>;
+
+  /** Lifecycle state. 'running' during execution; 'completed' or 'stopped' once terminal. */
+  readonly lifecycle?: Lifecycle;
 }

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -294,7 +294,7 @@ export const RunbookStateSchema = z
     substep: z.string().optional(),
     stepName: z.string(),
     retryCount: z.number().nonnegative().int(),
-    variables: z.record(z.string(), z.union([z.boolean(), z.number(), z.string()])),
+    variables: z.record(z.string(), z.string()),
     steps: z.array(
       z.object({
         id: z.string(),
@@ -368,6 +368,8 @@ export const RunbookStateSchema = z
     templateVars: z.record(z.string(), TemplateVarValueSchema).optional(),
     frontmatterOutputs: z.array(OutputDeclarationSchema).optional(),
     finalVars: z.record(z.string(), z.string()).optional(),
+    lifecycle: z.enum(['running', 'completed', 'stopped']).optional(),
+    schemaVersion: z.number().int().nonnegative().optional(),
   })
   // passthrough() allows unknown fields (e.g., legacy pendingSteps, agentBindings,
   // agentId, parentRunbookId) to survive schema validation without breaking existing

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -368,6 +368,10 @@ export const RunbookStateSchema = z
     templateVars: z.record(z.string(), TemplateVarValueSchema).optional(),
     frontmatterOutputs: z.array(OutputDeclarationSchema).optional(),
     finalVars: z.record(z.string(), z.string()).optional(),
+    // Optional by design: state.create() always writes these fields, but
+    // state.load() must parse legacy files (which lack them) far enough to
+    // reach the schemaVersion check and throw StaleRunbookStateError.
+    // Making them required would bypass stale-state detection. Do not tighten.
     lifecycle: z.enum(['running', 'completed', 'stopped']).optional(),
     schemaVersion: z.number().int().nonnegative().optional(),
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runbook states now include explicit lifecycle statuses: running, completed, stopped.
  * Added state schema versioning (v2) to detect incompatible persisted state.
  * `prune` now defaults to removing completed + stopped runs and adds a `--stopped` selector; stale entries are discovered and shown.

* **Bug Fixes**
  * Stale/corrupted state detection tightened; CLI prompts to finish or prune outdated state (no silent migration).
  * Terminal state persistence unified to lifecycle field for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->