### PR TITLE
fix(core): symbol-brand JsonArrayStream to block --var-json spoofing

### DIFF
--- a/docs/superpowers/specs/2026-04-21-cli-var-to-input-rename-design.md
+++ b/docs/superpowers/specs/2026-04-21-cli-var-to-input-rename-design.md
@@ -39,6 +39,7 @@ The old name `--var` was accurate (it sets template variables) but generic. `--i
 All changes are mechanical string/identifier replacements. No logic changes.
 
 ### packages/cli/src — 9 files
+
 - `commands/run.ts` — option definitions, options interface, varOpts assignment
 - `commands/claim.ts` — option definitions, options interface, varOpts passthrough
 - `commands/delegate.ts` — option definitions, options interface, varOpts passthrough
@@ -50,20 +51,25 @@ All changes are mechanical string/identifier replacements. No logic changes.
 - `services/variable-discovery.ts` — `ENV_VAR_PREFIX` constant → `ENV_INPUT_PREFIX`, interfaces, comments, error messages
 
 ### packages/claude-code-plugin/src — 1 file (live code)
+
 - `workflow/hooks/delegation-dispatch.ts:86` — generates `--var key=value` flag strings passed to the CLI
 
 ### packages/core/src — 1 file (comments only)
+
 - `runbook/types.ts` — JSDoc comments referencing `--var-json`
 
 ### packages/parser/src — 1 file (comments only)
+
 - `reserved.ts` — JSDoc comment referencing `--var`
 
 ### Tests — 14 files (~200+ touch points)
+
 - CLI argument strings in invocations
 - `RD_VAR_*` → `RD_INPUT_*` env assignments in test setup/teardown
 - `varFile`/`varJson` property names in option objects passed to service functions
 
 ### Documentation — 29 files (~175+ references)
+
 - `CLAUDE.md` — command reference tables and examples
 - `README.md` — quick-start examples
 - `docs/SPEC.md`, `docs/RUNDOWN.md`, `docs/FORMAT.md`, `docs/SECURITY.md`, `docs/MCP.md`, `docs/PROJECT-INTEGRATION.md`, `docs/AGENT-ORCHESTRATION.md`

--- a/docs/superpowers/specs/2026-04-21-cli-var-to-input-rename-design.md
+++ b/docs/superpowers/specs/2026-04-21-cli-var-to-input-rename-design.md
@@ -1,0 +1,87 @@
+# Design: Rename `--var` → `--input` CLI Flags
+
+**Date:** 2026-04-21
+**Status:** Approved
+
+## Summary
+
+Rename the CLI variable-passing flags (`--var`, `--var-json`, `--var-file`) and the `RD_VAR_*` environment bridge to `--input`, `--input-json`, `--input-file`, and `RD_INPUT_*`. Rename internal TypeScript property names to match. No aliases, no deprecation — clean lift and shift.
+
+## Motivation
+
+The recent addition of `inputs:` and `outputs:` frontmatter fields establishes a runbook's declared interface. The CLI flags that provide values to that interface should use the same vocabulary. `--input` aligns with `inputs:`, making the mental model explicit:
+
+- Frontmatter `inputs:` declares defaults and the runbook's variable interface
+- `--input` provides values for that interface at invocation time
+- `required:` declares which inputs the caller must provide
+
+The old name `--var` was accurate (it sets template variables) but generic. `--input` is more precise about the role: you are providing inputs to a runbook. This also applies to built-in overrides (`--input ContextId=sprint-42`) — those are still inputs to the execution context.
+
+## Rename Map
+
+| Old (CLI) | New (CLI) |
+|---|---|
+| `--var <key=value>` | `--input <key=value>` |
+| `--var-json <key=json>` | `--input-json <key=json>` |
+| `--var-file <path>` | `--input-file <path>` |
+| `RD_VAR_*` | `RD_INPUT_*` |
+
+| Old (TypeScript) | New (TypeScript) |
+|---|---|
+| `varFile` | `inputFile` |
+| `varJson` | `inputJson` |
+| `var` (property) | `input` |
+| `varOpts` | `inputOpts` |
+| `ENV_VAR_PREFIX` | `ENV_INPUT_PREFIX` (value `'RD_INPUT_'`) |
+
+## Scope
+
+All changes are mechanical string/identifier replacements. No logic changes.
+
+### packages/cli/src — 9 files
+- `commands/run.ts` — option definitions, options interface, varOpts assignment
+- `commands/claim.ts` — option definitions, options interface, varOpts passthrough
+- `commands/delegate.ts` — option definitions, options interface, varOpts passthrough
+- `commands/resolve.ts` — option definitions, options interface, varOpts passthrough
+- `helpers/option-utils.ts` — comments, error messages referencing flag names
+- `helpers/runbook-pipeline.ts` — VarOpts interface, error messages, comments
+- `helpers/command-sequence.ts` — string literal `'--var-file'` used to scan scenario commands
+- `helpers/scenario-workflow.ts` — `varFiles`/`varFileDirs` local variable names
+- `services/variable-discovery.ts` — `ENV_VAR_PREFIX` constant → `ENV_INPUT_PREFIX`, interfaces, comments, error messages
+
+### packages/claude-code-plugin/src — 1 file (live code)
+- `workflow/hooks/delegation-dispatch.ts:86` — generates `--var key=value` flag strings passed to the CLI
+
+### packages/core/src — 1 file (comments only)
+- `runbook/types.ts` — JSDoc comments referencing `--var-json`
+
+### packages/parser/src — 1 file (comments only)
+- `reserved.ts` — JSDoc comment referencing `--var`
+
+### Tests — 14 files (~200+ touch points)
+- CLI argument strings in invocations
+- `RD_VAR_*` → `RD_INPUT_*` env assignments in test setup/teardown
+- `varFile`/`varJson` property names in option objects passed to service functions
+
+### Documentation — 29 files (~175+ references)
+- `CLAUDE.md` — command reference tables and examples
+- `README.md` — quick-start examples
+- `docs/SPEC.md`, `docs/RUNDOWN.md`, `docs/FORMAT.md`, `docs/SECURITY.md`, `docs/MCP.md`, `docs/PROJECT-INTEGRATION.md`, `docs/AGENT-ORCHESTRATION.md`
+- `runbooks/` — 15+ example runbook files with `rd run --var` invocations
+- `packages/claude-code-plugin/skills/` — `running-runbooks`, `writing-runbooks`, `delegating-runbooks` SKILL.md files
+- Prior spec doc in `docs/cipherpowers/specs/`
+
+**Total: ~55 files, ~400 references.**
+
+## Decisions
+
+- **No aliases.** No `--var` fallback, no `RD_VAR_*` fallback. Existing scripts will break and must update.
+- **Internal props renamed.** `varFile`, `varJson`, `var` (property) renamed to `inputFile`, `inputJson`, `input` for full consistency. `var` as a property key is also a reserved word in JS, so renaming is a minor cleanup.
+- **`RD_INPUT_*` renamed.** The env bridge prefix mirrors the flag name directly; inconsistency here would be confusing.
+- **Stryker sandbox files excluded.** `.stryker-tmp/` directories are ephemeral mutation testing artifacts and will be regenerated; they do not need manual updates.
+
+## Out of Scope
+
+- Renaming `vars` field in `rd status` JSON output (`state.vars`, `context.vars.*`) — these are different concepts (the resolved variable space, not the CLI input mechanism) and are not affected by this rename.
+- Renaming `vars:` frontmatter field (there is none — frontmatter uses `inputs:` already).
+- Any logic changes. This is purely a naming change.

--- a/docs/superpowers/specs/2026-04-21-scenario-snapshot-tests-design.md
+++ b/docs/superpowers/specs/2026-04-21-scenario-snapshot-tests-design.md
@@ -65,6 +65,7 @@ JSON and text variants are separate `it()` blocks with distinct names.
 Two files required:
 
 **`snapshot-delegation-outputs.runbook.md`** (parent):
+
 ```yaml
 ---
 name: snapshot-delegation-outputs
@@ -88,6 +89,7 @@ Delegated to child runbook.
 ```
 
 **`snapshot-child.runbook.md`** (child):
+
 ```yaml
 ---
 name: snapshot-child
@@ -160,7 +162,7 @@ Review the diff in `.snap` files carefully before committing — snapshot update
 
 ## File Layout
 
-```
+```text
 packages/cli/
   __tests__/
     fixtures/

--- a/docs/superpowers/specs/2026-04-21-scenario-snapshot-tests-design.md
+++ b/docs/superpowers/specs/2026-04-21-scenario-snapshot-tests-design.md
@@ -1,0 +1,179 @@
+# Scenario Snapshot Tests Design
+
+**Date:** 2026-04-21
+**Status:** Approved
+
+## Summary
+
+Add snapshot test coverage for runbook scenario CLI output. Tests capture raw CLI output in both JSON (NDJSON) and `--text` format from a curated set of purpose-built fixture runbooks, normalise volatile values, and compare against Jest `.snap` files. MVP is a small curated set; the structure is designed to expand to comprehensive coverage later.
+
+## Goals
+
+- Detect regressions in CLI output shape and content across both output modes
+- Cover the core output patterns (simple flows, retries, multi-level delegation + outputs)
+- Establish the infrastructure for expanding to full scenario coverage later
+
+## Non-Goals
+
+- Comprehensive coverage of all runbooks in `runbooks/` (that's the long-term target)
+- Testing business logic correctness (that's already handled by `scenario-runner.test.ts`)
+
+## Architecture
+
+Three components:
+
+### 1. `normalizeCliOutput(output: string, cwd: string): string`
+
+A helper function added to `packages/cli/__tests__/helpers/test-utils.ts`. Applied to all CLI output before snapshotting. Replaces volatile values with stable placeholders:
+
+| Pattern | Placeholder |
+|---|---|
+| Run IDs (8-char hex) | `<runId>` |
+| ISO 8601 timestamps | `<timestamp>` |
+| `cwd` (temp workspace path) | `<workdir>` |
+| Any other `/tmp/...` path | `<tmpdir>` |
+
+For JSON output: applied to the raw NDJSON string (after `NO_COLOR=1` is already stripping ANSI). For text output: applied to the rendered string directly.
+
+### 2. Fixture runbooks — `packages/cli/__tests__/fixtures/snapshots/`
+
+Purpose-built minimal `.runbook.md` files. Each has exactly the steps needed for the scenario being snapshotted — no extra noise. Each carries a `scenarios:` frontmatter block so `rd scenario run` can drive it.
+
+### 3. `packages/cli/__tests__/integration/scenario-snapshots.test.ts`
+
+Explicit `it()` blocks — one per scenario per output format. Each test:
+1. Creates an isolated test workspace (via existing `createTestWorkspace()`)
+2. Runs `rd scenario run <fixture> <scenario>` via `runCliInProcess()`
+3. Calls `normalizeCliOutput(result.stdout, workspace.cwd)`
+4. Calls `expect(normalised).toMatchSnapshot()`
+
+JSON and text variants are separate `it()` blocks with distinct names.
+
+## MVP Fixture Set
+
+### Simple fixtures
+
+| File | Scenario | Covers |
+|---|---|---|
+| `snapshot-simple-complete.runbook.md` | `pass` | Single step → PASS → COMPLETE |
+| `snapshot-simple-stop.runbook.md` | `fail` | Single step → FAIL → STOP |
+| `snapshot-multi-step.runbook.md` | `all-pass` | Three steps, all PASS → COMPLETE |
+| `snapshot-retry.runbook.md` | `retry-pass` | Step fails, retries, passes on second attempt |
+
+### Complex fixture — delegation with outputs
+
+Two files required:
+
+**`snapshot-delegation-outputs.runbook.md`** (parent):
+```yaml
+---
+name: snapshot-delegation-outputs
+description: Parent delegates to child; parent OUTPUTS consumed by child via INPUTS
+scenarios:
+  complete:
+    commands:
+      - rd run snapshot-delegation-outputs.runbook.md
+      - rd delegate snapshot-child.runbook.md --step 1.1
+      - rd claim ${TOKEN}
+    result: COMPLETE
+---
+# Delegation with Outputs
+## 1. Parent step
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+- OUTPUTS
+  - Message "hello from snapshot parent"
+### 1.1 Child task
+Delegated to child runbook.
+```
+
+**`snapshot-child.runbook.md`** (child):
+```yaml
+---
+name: snapshot-child
+description: Child runbook that consumes INPUTS from parent delegation
+---
+# Snapshot Child
+## 1. Child step
+- PASS COMPLETE
+- FAIL STOP
+- INPUTS
+  - Message
+The message is: {{Message}}
+```
+
+Scenario command sequence uses `${TOKEN}` variable substitution (existing infrastructure in `executeScenario()`). The snapshot captures the full multi-level event stream: parent steps, delegation event, child execution, claim resolution.
+
+## Test File Structure
+
+```typescript
+// packages/cli/__tests__/integration/scenario-snapshots.test.ts
+
+describe('scenario output snapshots', () => {
+  let workspace: TestWorkspace;
+
+  beforeAll(async () => {
+    workspace = await createTestWorkspace([
+      'snapshot-simple-complete.runbook.md',
+      'snapshot-simple-stop.runbook.md',
+      'snapshot-multi-step.runbook.md',
+      'snapshot-retry.runbook.md',
+      'snapshot-delegation-outputs.runbook.md',
+      'snapshot-child.runbook.md',
+    ]);
+  });
+
+  afterAll(() => workspace.cleanup());
+
+  it('simple-complete — JSON', async () => { ... });
+  it('simple-complete — text', async () => { ... });
+  it('simple-stop — JSON', async () => { ... });
+  it('simple-stop — text', async () => { ... });
+  it('multi-step — JSON', async () => { ... });
+  it('multi-step — text', async () => { ... });
+  it('retry-pass — JSON', async () => { ... });
+  it('retry-pass — text', async () => { ... });
+  it('delegation-outputs — JSON', async () => { ... });
+  it('delegation-outputs — text', async () => { ... });
+});
+```
+
+## Expansion Path
+
+When expanding to comprehensive coverage:
+
+1. Add fixture runbooks to `__tests__/fixtures/snapshots/` — one per scenario shape
+2. Add a data-driven loop in a sibling test file (`scenario-snapshots-full.test.ts`) that auto-discovers all fixtures and generates snapshot tests — same normalisation helper, same `toMatchSnapshot()` call
+3. The explicit MVP tests in `scenario-snapshots.test.ts` remain as documented regression anchors for the key patterns
+
+## Updating Snapshots
+
+Use Jest's standard flag:
+
+```bash
+npx jest scenario-snapshots --updateSnapshot
+# or
+npx jest scenario-snapshots -u
+```
+
+Review the diff in `.snap` files carefully before committing — snapshot updates are the signal that output has changed.
+
+## File Layout
+
+```
+packages/cli/
+  __tests__/
+    fixtures/
+      snapshots/                          ← new
+        snapshot-simple-complete.runbook.md
+        snapshot-simple-stop.runbook.md
+        snapshot-multi-step.runbook.md
+        snapshot-retry.runbook.md
+        snapshot-delegation-outputs.runbook.md
+        snapshot-child.runbook.md
+    helpers/
+      test-utils.ts                       ← add normalizeCliOutput()
+    integration/
+      scenario-snapshots.test.ts          ← new
+      scenario-runner.test.ts             ← unchanged
+```

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { mockErrorHelpers } from './mock-error-helpers';
 
-// Import actual @rundown-org/core before mocking to capture real implementations
-const actualCore = await import('@rundown-org/core');
+// Capture the real isJsonArrayStream before the mock is registered.
+// jest.unstable_mockModule does NOT hoist (unlike jest.mock), so this top-level
+// await executes first and always captures the real branded implementation.
+const { isJsonArrayStream: realIsJsonArrayStream } = await import('@rundown-org/core');
 
 // Mock @rundown-org/core
 jest.unstable_mockModule('@rundown-org/core', () => ({
@@ -78,7 +80,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
     LAUNCH_FAILED: { code: 'RD-816' },
   },
   isJsonArray: jest.fn((v: unknown) => Array.isArray(v)),
-  isJsonArrayStream: jest.fn(actualCore.isJsonArrayStream),
+  isJsonArrayStream: jest.fn(realIsJsonArrayStream),
   logger: { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() },
   ...mockErrorHelpers,
 }));

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { mockErrorHelpers } from './mock-error-helpers';
 
+// Import actual @rundown-org/core before mocking to capture real implementations
+const actualCore = await import('@rundown-org/core');
+
 // Mock @rundown-org/core
 jest.unstable_mockModule('@rundown-org/core', () => ({
   stepIdToString: jest.fn((id: { step: string; substep?: string }) =>
@@ -75,12 +78,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
     LAUNCH_FAILED: { code: 'RD-816' },
   },
   isJsonArray: jest.fn((v: unknown) => Array.isArray(v)),
-  isJsonArrayStream: jest.fn(
-    (v: unknown) =>
-      typeof v === 'object' &&
-      v !== null &&
-      (v as Record<string, unknown>).kind === 'json-array-stream',
-  ),
+  isJsonArrayStream: jest.fn(actualCore.isJsonArrayStream),
   logger: { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() },
   ...mockErrorHelpers,
 }));

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { mockErrorHelpers } from './mock-error-helpers.js';
 
-// Import actual @rundown-org/core before mocking to capture real implementations
-const actualCore = await import('@rundown-org/core');
+// Capture the real isJsonArrayStream before the mock is registered.
+// jest.unstable_mockModule does NOT hoist (unlike jest.mock), so this top-level
+// await executes first and always captures the real branded implementation.
+const { isJsonArrayStream: realIsJsonArrayStream } = await import('@rundown-org/core');
 
 // Mock @rundown-org/core
 jest.unstable_mockModule('@rundown-org/core', () => ({
@@ -77,7 +79,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
     LAUNCH_FAILED: { code: 'RD-816' },
   },
   isJsonArray: jest.fn((v: unknown) => Array.isArray(v)),
-  isJsonArrayStream: jest.fn(actualCore.isJsonArrayStream),
+  isJsonArrayStream: jest.fn(realIsJsonArrayStream),
   logger: { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() },
   ...mockErrorHelpers,
 }));

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -291,6 +291,8 @@ beforeEach(() => {
     iteration: undefined,
     frameKey: '1',
   });
+  (core.isJsonArray as jest.Mock).mockImplementation((v: unknown) => Array.isArray(v));
+  (core.isJsonArrayStream as jest.Mock).mockImplementation(realIsJsonArrayStream);
 });
 
 // validateSources was removed in the unified variable model refactoring.

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { mockErrorHelpers } from './mock-error-helpers.js';
 
+// Import actual @rundown-org/core before mocking to capture real implementations
+const actualCore = await import('@rundown-org/core');
+
 // Mock @rundown-org/core
 jest.unstable_mockModule('@rundown-org/core', () => ({
   stepIdToString: jest.fn((id: { step: string; substep?: string }) =>
@@ -74,12 +77,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
     LAUNCH_FAILED: { code: 'RD-816' },
   },
   isJsonArray: jest.fn((v: unknown) => Array.isArray(v)),
-  isJsonArrayStream: jest.fn(
-    (v: unknown) =>
-      typeof v === 'object' &&
-      v !== null &&
-      (v as Record<string, unknown>).kind === 'json-array-stream',
-  ),
+  isJsonArrayStream: jest.fn(actualCore.isJsonArrayStream),
   logger: { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() },
   ...mockErrorHelpers,
 }));

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -27,6 +27,9 @@ const mockLifecycleService = {
   consumeResolvedCompletion: jest.fn().mockResolvedValue(null),
 };
 
+// Import actual @rundown-org/core before mocking to capture real implementations
+const actualCore = await import('@rundown-org/core');
+
 jest.unstable_mockModule('@rundown-org/core', () => {
   const asTerminalSnapshot = jest.fn((snapshot: unknown) => {
     if (
@@ -128,12 +131,7 @@ jest.unstable_mockModule('@rundown-org/core', () => {
       getLogDir: jest.fn().mockReturnValue('/tmp'),
     },
     isJsonArray: jest.fn((v: unknown) => Array.isArray(v)),
-    isJsonArrayStream: jest.fn(
-      (v: unknown) =>
-        typeof v === 'object' &&
-        v !== null &&
-        (v as Record<string, unknown>).kind === 'json-array-stream',
-    ),
+    isJsonArrayStream: jest.fn(actualCore.isJsonArrayStream),
     assertResolvedVariableForContext: jest.fn(
       (fc: {
         currentValue?: unknown;

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -27,8 +27,10 @@ const mockLifecycleService = {
   consumeResolvedCompletion: jest.fn().mockResolvedValue(null),
 };
 
-// Import actual @rundown-org/core before mocking to capture real implementations
-const actualCore = await import('@rundown-org/core');
+// Capture the real isJsonArrayStream before the mock is registered.
+// jest.unstable_mockModule does NOT hoist (unlike jest.mock), so this top-level
+// await executes first and always captures the real branded implementation.
+const { isJsonArrayStream: realIsJsonArrayStream } = await import('@rundown-org/core');
 
 jest.unstable_mockModule('@rundown-org/core', () => {
   const asTerminalSnapshot = jest.fn((snapshot: unknown) => {
@@ -131,7 +133,7 @@ jest.unstable_mockModule('@rundown-org/core', () => {
       getLogDir: jest.fn().mockReturnValue('/tmp'),
     },
     isJsonArray: jest.fn((v: unknown) => Array.isArray(v)),
-    isJsonArrayStream: jest.fn(actualCore.isJsonArrayStream),
+    isJsonArrayStream: jest.fn(realIsJsonArrayStream),
     assertResolvedVariableForContext: jest.fn(
       (fc: {
         currentValue?: unknown;

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -31,6 +31,7 @@ const mockLifecycleService = {
 // jest.unstable_mockModule does NOT hoist (unlike jest.mock), so this top-level
 // await executes first and always captures the real branded implementation.
 const { isJsonArrayStream: realIsJsonArrayStream } = await import('@rundown-org/core');
+const { ForResolutionError: RealForResolutionError } = await import('@rundown-org/core');
 
 jest.unstable_mockModule('@rundown-org/core', () => {
   const asTerminalSnapshot = jest.fn((snapshot: unknown) => {
@@ -134,6 +135,7 @@ jest.unstable_mockModule('@rundown-org/core', () => {
     },
     isJsonArray: jest.fn((v: unknown) => Array.isArray(v)),
     isJsonArrayStream: jest.fn(realIsJsonArrayStream),
+    ForResolutionError: RealForResolutionError,
     assertResolvedVariableForContext: jest.fn(
       (fc: {
         currentValue?: unknown;
@@ -373,6 +375,44 @@ describe('runExecutionLoop', () => {
       'POLICY_DENIED',
       expect.objectContaining({
         reason: 'Not allowed',
+      }),
+    );
+  });
+
+  it('stops with policy-denied when prepareIteration throws ForResolutionError policy-violation', async () => {
+    mockManager.load.mockResolvedValue({ id: runbookId, step: '1', status: 'running' });
+
+    (core.ForIterationService as any).mockImplementation(() => ({
+      prepareIteration: jest
+        .fn()
+        .mockRejectedValue(
+          new RealForResolutionError(
+            'JsonArrayStream path "/etc/passwd" escapes project root "/project"',
+            'policy-violation',
+          ),
+        ),
+    }));
+
+    const result = await runExecutionLoop(
+      mockManager,
+      runbookId,
+      steps,
+      '/tmp',
+      false,
+      mockEmitter,
+    );
+
+    expect(result).toBe('stopped');
+    expect(mockEmitter.emit).toHaveBeenCalledWith(
+      'POLICY_DENIED',
+      expect.objectContaining({
+        reason: expect.stringContaining('escapes project root'),
+      }),
+    );
+    expect(mockEmitter.emit).toHaveBeenCalledWith(
+      'RUNBOOK_STOPPED',
+      expect.objectContaining({
+        reason: 'policy_denied',
       }),
     );
   });

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -30,8 +30,10 @@ const mockLifecycleService = {
 // Capture the real isJsonArrayStream before the mock is registered.
 // jest.unstable_mockModule does NOT hoist (unlike jest.mock), so this top-level
 // await executes first and always captures the real branded implementation.
-const { isJsonArrayStream: realIsJsonArrayStream } = await import('@rundown-org/core');
-const { ForResolutionError: RealForResolutionError } = await import('@rundown-org/core');
+const {
+  isJsonArrayStream: realIsJsonArrayStream,
+  ForResolutionError: RealForResolutionError,
+} = await import('@rundown-org/core');
 
 jest.unstable_mockModule('@rundown-org/core', () => {
   const asTerminalSnapshot = jest.fn((snapshot: unknown) => {

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -415,6 +415,14 @@ describe('runExecutionLoop', () => {
         reason: 'policy_denied',
       }),
     );
+
+    const emittedEvents = mockEmitter.emit.mock.calls.map(
+      ([event]: [string, ...unknown[]]) => event,
+    );
+    expect(emittedEvents.indexOf('POLICY_DENIED')).toBeGreaterThanOrEqual(0);
+    expect(emittedEvents.indexOf('RUNBOOK_STOPPED')).toBeGreaterThan(
+      emittedEvents.indexOf('POLICY_DENIED'),
+    );
   });
 
   it('completes the runbook', async () => {

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -30,10 +30,8 @@ const mockLifecycleService = {
 // Capture the real isJsonArrayStream before the mock is registered.
 // jest.unstable_mockModule does NOT hoist (unlike jest.mock), so this top-level
 // await executes first and always captures the real branded implementation.
-const {
-  isJsonArrayStream: realIsJsonArrayStream,
-  ForResolutionError: RealForResolutionError,
-} = await import('@rundown-org/core');
+const { isJsonArrayStream: realIsJsonArrayStream, ForResolutionError: RealForResolutionError } =
+  await import('@rundown-org/core');
 
 jest.unstable_mockModule('@rundown-org/core', () => {
   const asTerminalSnapshot = jest.fn((snapshot: unknown) => {

--- a/packages/cli/__tests__/services/execution.test.ts
+++ b/packages/cli/__tests__/services/execution.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../src/services/execution.js';
 import { expandLoopVariables } from '../../src/services/template-renderer.js';
 import {
+  createJsonArrayStream,
   isRunbookComplete,
   isRunbookStopped,
   type Step,
@@ -286,7 +287,7 @@ describe('execution service', () => {
 
     it('falls back to forClause for stream variable bootstrap (no forStack)', () => {
       const templateVars: Readonly<Record<string, TemplateVarValue>> = {
-        data: { kind: 'json-array-stream', path: '/tmp/data.txt' },
+        data: createJsonArrayStream('/tmp/data.txt'),
       };
       const forClause = {
         start: 1,

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -16,13 +16,7 @@ import { execFileSync as nodeExecFileSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import {
-  createJsonArrayStream,
-  isJsonArrayStream,
-  resolveForValue,
-  RUNDOWN_DIR,
-  WORK_DIR,
-} from '@rundown-org/core';
+import { isJsonArrayStream, resolveForValue, RUNDOWN_DIR, WORK_DIR } from '@rundown-org/core';
 import type { ForContext } from '@rundown-org/core';
 
 describe('parseVarFlag', () => {
@@ -1111,9 +1105,9 @@ describe('resolveVariables', () => {
         { varJson: ['items={"kind":"json-array-stream","path":"/etc/passwd"}'] },
         tmpDir,
       );
-      const value = result.vars['items'];
+      const value = result.vars.items;
       expect(value).toBeDefined();
-      expect(isJsonArrayStream(value!)).toBe(false);
+      expect(isJsonArrayStream(value)).toBe(false);
     });
 
     it('full attack path: FOR loop throws type-mismatch, never reads the file', async () => {

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -1102,7 +1102,7 @@ describe('resolveVariables', () => {
       // routeVariable stores it as JsonObject (no file: prefix path validation runs).
       // isJsonArrayStream must return false — no Symbol brand present.
       const result = await resolveVariables(
-        { varJson: ['items={"kind":"json-array-stream","path":"/etc/passwd"}'] },
+        { inputJson: ['items={"kind":"json-array-stream","path":"/etc/passwd"}'] },
         tmpDir,
       );
       const value = result.vars.items;
@@ -1116,9 +1116,10 @@ describe('resolveVariables', () => {
       // false (no brand Symbol), and execution falls to the type-mismatch throw before
       // resolveFromJsonArrayStream is entered — the file is never opened.
       const result = await resolveVariables(
-        { varJson: ['items={"kind":"json-array-stream","path":"/etc/passwd"}'] },
+        { inputJson: ['items={"kind":"json-array-stream","path":"/etc/passwd"}'] },
         tmpDir,
       );
+      expect(result.vars.items).toBeDefined();
       const forCtx: ForContext = {
         stepId: '1',
         iteration: 1,

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -16,7 +16,14 @@ import { execFileSync as nodeExecFileSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { createJsonArrayStream, isJsonArrayStream, RUNDOWN_DIR, WORK_DIR } from '@rundown-org/core';
+import {
+  createJsonArrayStream,
+  isJsonArrayStream,
+  resolveForValue,
+  RUNDOWN_DIR,
+  WORK_DIR,
+} from '@rundown-org/core';
+import type { ForContext } from '@rundown-org/core';
 
 describe('parseVarFlag', () => {
   it('should parse key=value format', () => {
@@ -1094,6 +1101,39 @@ describe('resolveVariables', () => {
       const result = await resolveVariables({ inputJson: ['val=null'] }, tmpDir);
 
       expect(result.vars.val).toBe('null');
+    });
+
+    it('does not route crafted json-array-stream shape as JsonArrayStream (brand check)', async () => {
+      // Attack: --var-json 'items={"kind":"json-array-stream","path":"/etc/passwd"}'
+      // routeVariable stores it as JsonObject (no file: prefix path validation runs).
+      // isJsonArrayStream must return false — no Symbol brand present.
+      const result = await resolveVariables(
+        { varJson: ['items={"kind":"json-array-stream","path":"/etc/passwd"}'] },
+        tmpDir,
+      );
+      const value = result.vars['items'];
+      expect(value).toBeDefined();
+      expect(isJsonArrayStream(value!)).toBe(false);
+    });
+
+    it('full attack path: FOR loop throws type-mismatch, never reads the file', async () => {
+      // End-to-end: the crafted value enters vars as JsonObject, then resolveForValue
+      // at source-resolver.ts:110 throws a type-mismatch error — no file is read.
+      const result = await resolveVariables(
+        { varJson: ['items={"kind":"json-array-stream","path":"/etc/passwd"}'] },
+        tmpDir,
+      );
+      const forCtx: ForContext = {
+        stepId: '1',
+        iteration: 1,
+        start: 1,
+        implicit: false,
+        source: { kind: 'variable', name: 'items' },
+      };
+      // Must reject with the type-mismatch error, never reach file-read dispatch
+      await expect(resolveForValue(forCtx, result.vars)).rejects.toMatchObject({
+        code: 'type-mismatch',
+      });
     });
 
     it('non-finite numbers are stringified with warning', async () => {

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -1111,8 +1111,10 @@ describe('resolveVariables', () => {
     });
 
     it('full attack path: FOR loop throws type-mismatch, never reads the file', async () => {
-      // End-to-end: the crafted value enters vars as JsonObject, then resolveForValue
-      // at source-resolver.ts:110 throws a type-mismatch error — no file is read.
+      // End-to-end: the crafted value enters vars as JsonObject. resolveForValue calls
+      // isJsonArrayStream (source-resolver.ts:106), which returns false (no brand Symbol),
+      // and execution falls to the type-mismatch throw (line 111) before
+      // resolveFromJsonArrayStream (line 157) is entered — the file is never opened.
       const result = await resolveVariables(
         { varJson: ['items={"kind":"json-array-stream","path":"/etc/passwd"}'] },
         tmpDir,

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -16,7 +16,7 @@ import { execFileSync as nodeExecFileSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { RUNDOWN_DIR, WORK_DIR } from '@rundown-org/core';
+import { createJsonArrayStream, isJsonArrayStream, RUNDOWN_DIR, WORK_DIR } from '@rundown-org/core';
 
 describe('parseVarFlag', () => {
   it('should parse key=value format', () => {
@@ -551,7 +551,8 @@ describe('resolveVariables', () => {
       await fs.writeFile(file, '{"a":1}\n');
 
       const result = await resolveVariables({ input: [`data=file:${file}`] }, tmpDir);
-      expect(result.vars.data).toEqual({
+      expect(isJsonArrayStream(result.vars.data)).toBe(true);
+      expect(result.vars.data).toMatchObject({
         kind: 'json-array-stream',
         path: await fs.realpath(file),
       });
@@ -641,7 +642,8 @@ describe('resolveVariables', () => {
       await fs.writeFile(varFile, `items: "file:${dataFile}"\n`);
 
       const result = await resolveVariables({ inputFile: [varFile] }, tmpDir);
-      expect(result.vars.items).toEqual({
+      expect(isJsonArrayStream(result.vars.items)).toBe(true);
+      expect(result.vars.items).toMatchObject({
         kind: 'json-array-stream',
         path: await fs.realpath(dataFile),
       });
@@ -701,7 +703,8 @@ describe('resolveVariables', () => {
         { inputFile: [varFile], input: [`items=file:${fileB}`] },
         tmpDir,
       );
-      expect(result.vars.items).toEqual({
+      expect(isJsonArrayStream(result.vars.items)).toBe(true);
+      expect(result.vars.items).toMatchObject({
         kind: 'json-array-stream',
         path: await fs.realpath(fileB),
       });
@@ -730,7 +733,8 @@ describe('resolveVariables', () => {
         { inputFile: [varFile], input: [`items=file:${dataFile}`] },
         tmpDir,
       );
-      expect(result.vars.items).toEqual({
+      expect(isJsonArrayStream(result.vars.items)).toBe(true);
+      expect(result.vars.items).toMatchObject({
         kind: 'json-array-stream',
         path: await fs.realpath(dataFile),
       });
@@ -879,7 +883,8 @@ describe('resolveVariables', () => {
         await fs.realpath(file),
         'Prompt before read',
       );
-      expect(result.vars.data).toEqual({
+      expect(isJsonArrayStream(result.vars.data)).toBe(true);
+      expect(result.vars.data).toMatchObject({
         kind: 'json-array-stream',
         path: await fs.realpath(file),
       });
@@ -1155,7 +1160,8 @@ describe('routeExtraVars', () => {
     await fs.writeFile(dataFile, '{"a":1}\n{"b":2}\n');
 
     const result = await routeExtraVars({ items: `file:${dataFile}` }, tmpDir);
-    expect(result.vars.items).toEqual({
+    expect(isJsonArrayStream(result.vars.items)).toBe(true);
+    expect(result.vars.items).toMatchObject({
       kind: 'json-array-stream',
       path: expect.any(String),
     });

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -1112,9 +1112,9 @@ describe('resolveVariables', () => {
 
     it('full attack path: FOR loop throws type-mismatch, never reads the file', async () => {
       // End-to-end: the crafted value enters vars as JsonObject. resolveForValue calls
-      // isJsonArrayStream (source-resolver.ts:106), which returns false (no brand Symbol),
-      // and execution falls to the type-mismatch throw (line 111) before
-      // resolveFromJsonArrayStream (line 157) is entered — the file is never opened.
+      // the isJsonArrayStream guard in resolveForValue's 'variable' case, which returns
+      // false (no brand Symbol), and execution falls to the type-mismatch throw before
+      // resolveFromJsonArrayStream is entered — the file is never opened.
       const result = await resolveVariables(
         { varJson: ['items={"kind":"json-array-stream","path":"/etc/passwd"}'] },
         tmpDir,

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -35,7 +35,7 @@ import {
   isJsonArray,
   isJsonArrayStream,
   assertResolvedVariableForContext,
-  isError,
+  ForResolutionError,
   RUNS_DIR,
 } from '@rundown-org/core';
 import { isSourced, resolvedStepHasSubsteps, type ForClause } from '@rundown-org/parser';
@@ -472,11 +472,7 @@ export async function runExecutionLoop(
     try {
       iterResult = await iterationService.prepareIteration(runbookId, steps);
     } catch (err) {
-      if (
-        isError(err) &&
-        err.name === 'ForResolutionError' &&
-        (err as { code?: string }).code === 'policy-violation'
-      ) {
+      if (err instanceof ForResolutionError && err.code === 'policy-violation') {
         const policyPosition = buildStepPosition(
           currentState.step,
           countNumberedSteps(steps),

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -453,7 +453,12 @@ export async function runExecutionLoop(
   const actorService = new RunbookActorService(manager);
   const sessionService = new SessionService(manager);
   const lifecycleService = new ExecutionLifecycleService(manager);
-  const projectRoot = await fs.realpath(cwd).catch(() => cwd);
+  const projectRoot = await fs.realpath(cwd).catch((err: unknown) => {
+    void logger.warn(
+      `runExecutionLoop: fs.realpath("${cwd}") failed, using raw path: ${Error.isError(err) ? err.message : String(err)}`,
+    );
+    return cwd;
+  });
   const iterationService = new ForIterationService(manager, actorService, projectRoot);
   const ensuredInitial = await lifecycleService.ensureActiveEntry(runbookId, undefined, state);
   let currentState: RunbookState = ensuredInitial.state;

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -1,5 +1,6 @@
 // packages/cli/src/services/execution.ts
 
+import * as fs from 'node:fs/promises';
 import {
   buildStepPosition,
   deriveExecutionAt,
@@ -452,7 +453,8 @@ export async function runExecutionLoop(
   const actorService = new RunbookActorService(manager);
   const sessionService = new SessionService(manager);
   const lifecycleService = new ExecutionLifecycleService(manager);
-  const iterationService = new ForIterationService(manager, actorService, cwd);
+  const projectRoot = await fs.realpath(cwd).catch(() => cwd);
+  const iterationService = new ForIterationService(manager, actorService, projectRoot);
   const ensuredInitial = await lifecycleService.ensureActiveEntry(runbookId, undefined, state);
   let currentState: RunbookState = ensuredInitial.state;
 

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -451,7 +451,7 @@ export async function runExecutionLoop(
   const actorService = new RunbookActorService(manager);
   const sessionService = new SessionService(manager);
   const lifecycleService = new ExecutionLifecycleService(manager);
-  const iterationService = new ForIterationService(manager, actorService);
+  const iterationService = new ForIterationService(manager, actorService, cwd);
   const ensuredInitial = await lifecycleService.ensureActiveEntry(runbookId, undefined, state);
   let currentState: RunbookState = ensuredInitial.state;
 

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -453,12 +453,15 @@ export async function runExecutionLoop(
   const actorService = new RunbookActorService(manager);
   const sessionService = new SessionService(manager);
   const lifecycleService = new ExecutionLifecycleService(manager);
-  const projectRoot = await fs.realpath(cwd).catch((err: unknown) => {
+  let projectRoot: string;
+  try {
+    projectRoot = await fs.realpath(cwd);
+  } catch (err: unknown) {
     void logger.warn(
       `runExecutionLoop: fs.realpath("${cwd}") failed, using raw path: ${Error.isError(err) ? err.message : String(err)}`,
     );
-    return cwd;
-  });
+    projectRoot = cwd;
+  }
   const iterationService = new ForIterationService(manager, actorService, projectRoot);
   const ensuredInitial = await lifecycleService.ensureActiveEntry(runbookId, undefined, state);
   let currentState: RunbookState = ensuredInitial.state;

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -35,6 +35,7 @@ import {
   isJsonArray,
   isJsonArrayStream,
   assertResolvedVariableForContext,
+  isError,
   RUNS_DIR,
 } from '@rundown-org/core';
 import { isSourced, resolvedStepHasSubsteps, type ForClause } from '@rundown-org/parser';
@@ -467,7 +468,37 @@ export async function runExecutionLoop(
     // Resolve dynamic values for all data sources (array, file, range).
     // The ForIterationService resolves currentValue before each iteration,
     // replacing the previous file-only inline resolution.
-    const iterResult = await iterationService.prepareIteration(runbookId, steps);
+    let iterResult: Awaited<ReturnType<typeof iterationService.prepareIteration>>;
+    try {
+      iterResult = await iterationService.prepareIteration(runbookId, steps);
+    } catch (err) {
+      if (
+        isError(err) &&
+        err.name === 'ForResolutionError' &&
+        (err as { code?: string }).code === 'policy-violation'
+      ) {
+        const policyPosition = buildStepPosition(
+          currentState.step,
+          countNumberedSteps(steps),
+          currentState.substep,
+          currentState.forStack,
+        );
+        emitter.emit('POLICY_DENIED', {
+          command: `JsonArrayStream variable access`,
+          reason: err.message,
+          position: policyPosition,
+        });
+        await manager.update(runbookId, { lifecycle: 'stopped' });
+        emitter.emit('RUNBOOK_STOPPED', {
+          position: policyPosition,
+          reason: 'policy_denied',
+          message: `FOR loop data source blocked by policy: ${err.message}`,
+        });
+        await sessionService.popRunbook();
+        return 'stopped';
+      }
+      throw err;
+    }
 
     if (iterResult.status === 'exhausted') {
       if (iterResult.terminal === 'complete') {

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -16,6 +16,7 @@ import * as path from 'node:path';
 import { execFileSync as nodeExecFileSync } from 'node:child_process';
 import * as yaml from 'js-yaml';
 import {
+  createJsonArrayStream,
   isJsonValue,
   type JsonArray,
   type JsonArrayStream,
@@ -555,7 +556,7 @@ async function routeVariable(
 
     if (canonical.endsWith('.jsonl')) {
       // JSONL → lazy stream (file read at iteration time)
-      vars[key] = { kind: 'json-array-stream', path: canonical } satisfies JsonArrayStream;
+      vars[key] = createJsonArrayStream(canonical);
     } else if (canonical.endsWith('.json')) {
       // JSON → eager load as JsonObject or JsonArray
       vars[key] = await loadJsonFile(canonical);

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -19,7 +19,6 @@ import {
   createJsonArrayStream,
   isJsonValue,
   type JsonArray,
-  type JsonArrayStream,
   type JsonObject,
   type PolicyEvaluator,
   type PolicyPrompter,

--- a/packages/core/__tests__/runbook/for-iteration-service.test.ts
+++ b/packages/core/__tests__/runbook/for-iteration-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import type { RunbookState, ForContext, Step, TemplateVarValue } from '../../src/runbook/types.js';
+import { createJsonArrayStream } from '../../src/runbook/types.js';
 
 // Capture the real ForResolutionError before the mock is installed.
 // jest.unstable_mockModule does NOT hoist, so this top-level await executes
@@ -306,11 +307,11 @@ describe('ForIterationService', () => {
         implicit: false,
         source: { kind: 'variable', name: 'items' },
       };
-      const stream = { kind: 'json-array-stream' as const, path: '/etc/passwd' };
+      const stream = createJsonArrayStream('/etc/passwd');
       const state = makeState({
         forStack: [fc],
         templateVars: {
-          items: stream as unknown as TemplateVarValue,
+          items: stream,
         },
       });
 
@@ -329,6 +330,13 @@ describe('ForIterationService', () => {
         code: 'policy-violation',
         message: expect.stringContaining('escapes project root'),
       });
+
+      // Verify projectRoot was forwarded as the third argument to resolveForValue
+      expect(mockedResolveForValue).toHaveBeenCalledWith(
+        expect.objectContaining({ stepId: '1', variable: 'items' }),
+        expect.objectContaining({ items: stream }),
+        '/safe',
+      );
     });
   });
 });

--- a/packages/core/__tests__/runbook/for-iteration-service.test.ts
+++ b/packages/core/__tests__/runbook/for-iteration-service.test.ts
@@ -85,7 +85,7 @@ describe('ForIterationService', () => {
     it('throws when load returns null', async () => {
       mockManager.load.mockResolvedValue(null);
 
-      const service = new ForIterationService(mockManager, mockActorService);
+      const service = new ForIterationService(mockManager, mockActorService, undefined);
       await expect(service.prepareIteration('missing-id', steps)).rejects.toThrow(
         'Runbook missing-id not found',
       );
@@ -95,7 +95,7 @@ describe('ForIterationService', () => {
       const state = makeState();
       mockManager.load.mockResolvedValue(state);
 
-      const service = new ForIterationService(mockManager, mockActorService);
+      const service = new ForIterationService(mockManager, mockActorService, undefined);
       const result = await service.prepareIteration('test-123', steps);
 
       expect(result.status).toBe('no-resolution-needed');
@@ -114,7 +114,7 @@ describe('ForIterationService', () => {
       const state = makeState({ forStack: [fc] });
       mockManager.load.mockResolvedValue(state);
 
-      const service = new ForIterationService(mockManager, mockActorService);
+      const service = new ForIterationService(mockManager, mockActorService, undefined);
       const result = await service.prepareIteration('test-123', steps);
 
       expect(result.status).toBe('no-resolution-needed');
@@ -133,7 +133,7 @@ describe('ForIterationService', () => {
       const state = makeState({ forStack: [fc] });
       mockManager.load.mockResolvedValue(state);
 
-      const service = new ForIterationService(mockManager, mockActorService);
+      const service = new ForIterationService(mockManager, mockActorService, undefined);
       const result = await service.prepareIteration('test-123', steps);
 
       expect(result.status).toBe('no-resolution-needed');
@@ -155,7 +155,7 @@ describe('ForIterationService', () => {
       const state = makeState({ forStack: [fc] });
       mockManager.load.mockResolvedValue(state);
 
-      const service = new ForIterationService(mockManager, mockActorService);
+      const service = new ForIterationService(mockManager, mockActorService, undefined);
       const result = await service.prepareIteration('test-123', steps);
 
       expect(result.status).toBe('no-resolution-needed');
@@ -182,7 +182,7 @@ describe('ForIterationService', () => {
       });
       mockManager.updateForContext.mockResolvedValue(updatedState);
 
-      const service = new ForIterationService(mockManager, mockActorService);
+      const service = new ForIterationService(mockManager, mockActorService, undefined);
       const result = await service.prepareIteration('test-123', steps);
 
       expect(result.status).toBe('ready');
@@ -224,7 +224,7 @@ describe('ForIterationService', () => {
       mockedIsComplete.mockReturnValue(true);
       mockedIsStopped.mockReturnValue(false);
 
-      const service = new ForIterationService(mockManager, mockActorService);
+      const service = new ForIterationService(mockManager, mockActorService, undefined);
       const result = await service.prepareIteration('test-123', steps);
 
       expect(result.status).toBe('exhausted');
@@ -258,7 +258,7 @@ describe('ForIterationService', () => {
       mockManager.updateForContext.mockResolvedValue(undefined);
       mockActorService.sendAndSync.mockResolvedValue(null);
 
-      const service = new ForIterationService(mockManager, mockActorService);
+      const service = new ForIterationService(mockManager, mockActorService, undefined);
       await expect(service.prepareIteration('test-123', steps)).rejects.toThrow(
         'Runbook test-123 not found after capping',
       );
@@ -287,7 +287,7 @@ describe('ForIterationService', () => {
       mockManager.updateForContext.mockResolvedValue(undefined);
       mockActorService.sendAndSync.mockResolvedValue(null);
 
-      const service = new ForIterationService(mockManager, mockActorService);
+      const service = new ForIterationService(mockManager, mockActorService, undefined);
       const result = await service.prepareIteration('test-123', steps);
 
       expect(result.status).toBe('exhausted');

--- a/packages/core/__tests__/runbook/for-iteration-service.test.ts
+++ b/packages/core/__tests__/runbook/for-iteration-service.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import type { RunbookState, ForContext, Step } from '../../src/runbook/types.js';
 
+// Capture the real ForResolutionError before the mock is installed.
+// jest.unstable_mockModule does NOT hoist, so this top-level await executes
+// first and always captures the real class.
+const { ForResolutionError: RealForResolutionError } = await import(
+  '../../src/runbook/source-resolver.js'
+);
+
 // Mock source-resolver to avoid file I/O in unit tests
 jest.unstable_mockModule('../../src/runbook/source-resolver.js', () => ({
   resolveForValue: jest.fn(),
@@ -287,6 +294,41 @@ describe('ForIterationService', () => {
         expect(result.state).toBe(cappedState);
         expect(result.terminal).toBe('stopped');
       }
+    });
+
+    it('propagates ForResolutionError with code policy-violation from resolveForValue', async () => {
+      const fc: ForContext = {
+        stepId: '1',
+        iteration: 1,
+        start: 1,
+        end: undefined,
+        variable: 'items',
+        implicit: false,
+        source: { kind: 'variable', name: 'items' },
+      };
+      const stream = { kind: 'json-array-stream' as const, path: '/etc/passwd' };
+      const state = makeState({
+        forStack: [fc],
+        templateVars: {
+          items: stream as unknown as import('../../src/runbook/types.js').TemplateVarValue,
+        },
+      });
+
+      mockManager.load.mockResolvedValue(state);
+      mockedResolveForValue.mockRejectedValue(
+        new RealForResolutionError(
+          'JsonArrayStream path "/etc/passwd" escapes project root "/safe"',
+          'policy-violation',
+        ),
+      );
+
+      const service = new ForIterationService(mockManager, mockActorService, '/safe');
+
+      await expect(service.prepareIteration('test-123', steps)).rejects.toMatchObject({
+        name: 'ForResolutionError',
+        code: 'policy-violation',
+        message: expect.stringContaining('escapes project root'),
+      });
     });
   });
 });

--- a/packages/core/__tests__/runbook/for-iteration-service.test.ts
+++ b/packages/core/__tests__/runbook/for-iteration-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import type { RunbookState, ForContext, Step, TemplateVarValue } from '../../src/runbook/types.js';
+import type { RunbookState, ForContext, Step } from '../../src/runbook/types.js';
 import { createJsonArrayStream } from '../../src/runbook/types.js';
 
 // Capture the real ForResolutionError before the mock is installed.

--- a/packages/core/__tests__/runbook/for-iteration-service.test.ts
+++ b/packages/core/__tests__/runbook/for-iteration-service.test.ts
@@ -334,7 +334,7 @@ describe('ForIterationService', () => {
       // Verify projectRoot was forwarded as the third argument to resolveForValue
       expect(mockedResolveForValue).toHaveBeenCalledWith(
         expect.objectContaining({ stepId: '1', variable: 'items' }),
-        expect.objectContaining({ items: stream }),
+        { items: stream },
         '/safe',
       );
     });

--- a/packages/core/__tests__/runbook/for-iteration-service.test.ts
+++ b/packages/core/__tests__/runbook/for-iteration-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import type { RunbookState, ForContext, Step } from '../../src/runbook/types.js';
+import type { RunbookState, ForContext, Step, TemplateVarValue } from '../../src/runbook/types.js';
 
 // Capture the real ForResolutionError before the mock is installed.
 // jest.unstable_mockModule does NOT hoist, so this top-level await executes
@@ -310,7 +310,7 @@ describe('ForIterationService', () => {
       const state = makeState({
         forStack: [fc],
         templateVars: {
-          items: stream as unknown as import('../../src/runbook/types.js').TemplateVarValue,
+          items: stream as unknown as TemplateVarValue,
         },
       });
 

--- a/packages/core/__tests__/runbook/output-evaluator.test.ts
+++ b/packages/core/__tests__/runbook/output-evaluator.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import type { OutputDeclaration } from '@rundown-org/parser';
+import { createJsonArrayStream } from '../../src/runbook/types.js';
 import type { ForContext, TemplateVarValue } from '../../src/runbook/types.js';
 import {
   buildExecutionFrame,
@@ -194,7 +195,7 @@ describe('flattenTemplateVars', () => {
       Port: 3000,
       Items: ['a', 'b', 'c'],
       Config: { host: 'localhost', debug: true },
-      Stream: { kind: 'json-array-stream', path: '/tmp/items.jsonl' },
+      Stream: createJsonArrayStream('/tmp/items.jsonl'),
     };
 
     expect(flattenTemplateVars(vars)).toEqual({
@@ -248,7 +249,7 @@ describe('flattenTemplateVars', () => {
     // flattenTemplateVars drops JsonArrayStream keys. evaluateOutputExpression('items', {})
     // currently falls back to `trimmed` → stores the string "items". Must skip instead.
     const vars = flattenTemplateVars({
-      items: { kind: 'json-array-stream' as const, path: '/tmp/data.jsonl' },
+      items: createJsonArrayStream('/tmp/data.jsonl'),
       Region: 'us-east-1',
     });
     const result = evaluateStepOutputDeclarations(
@@ -266,7 +267,7 @@ describe('flattenTemplateVars', () => {
     // evaluateOutputExpression('{{ items }}', {}) returns '{{ items }}' (unresolved braces).
     // Storing that string as an output value silently corrupts the result.
     const vars = flattenTemplateVars({
-      items: { kind: 'json-array-stream' as const, path: '/tmp/data.jsonl' },
+      items: createJsonArrayStream('/tmp/data.jsonl'),
       Region: 'us-east-1',
     });
     const result = evaluateStepOutputDeclarations(

--- a/packages/core/__tests__/runbook/source-resolver.test.ts
+++ b/packages/core/__tests__/runbook/source-resolver.test.ts
@@ -258,6 +258,26 @@ describe('resolveForValue', () => {
       expect(result.kind).toBe('resolved');
     });
 
+    it('throws policy-violation for sibling-prefix path (e.g. /base/project-evil)', async () => {
+      // /base/project-evil/data.jsonl starts with the same string as projectRoot
+      // (/base/project) but is NOT inside it. path.relative() returns
+      // '../project-evil/data.jsonl' — the dotdot prefix is caught correctly.
+      // This test documents and regression-guards that behaviour.
+      const base = path.dirname(projectRoot); // e.g. /tmp/rundown-sr-sec-xxxxx
+      const siblingDir = path.join(base, 'project-evil');
+      await fs.mkdir(siblingDir, { recursive: true });
+      const siblingFile = path.join(siblingDir, 'data.jsonl');
+      await fs.writeFile(siblingFile, '"secret"\n');
+
+      const vars: Record<string, TemplateVarValue> = {
+        data: createJsonArrayStream(siblingFile),
+      };
+
+      await expect(resolveForValue(makeContext(), vars, projectRoot)).rejects.toMatchObject({
+        code: 'policy-violation',
+      });
+    });
+
     it('skips boundary check when projectRoot is omitted', async () => {
       const vars: Record<string, TemplateVarValue> = {
         data: createJsonArrayStream(outsideFile),

--- a/packages/core/__tests__/runbook/source-resolver.test.ts
+++ b/packages/core/__tests__/runbook/source-resolver.test.ts
@@ -1,4 +1,5 @@
 import { resolveForValue } from '../../src/runbook/source-resolver.js';
+import { createJsonArrayStream } from '../../src/runbook/types.js';
 import type { ForContext, JsonArrayStream, TemplateVarValue } from '../../src/runbook/types.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -122,7 +123,7 @@ describe('resolveForValue', () => {
     it('returns resolved with value and snapshot for JSONL file', async () => {
       const file = path.join(tmpDir, 'data.jsonl');
       await fs.writeFile(file, '{"id": 1, "name": "Alice"}\n{"id": 2, "name": "Bob"}\n');
-      const stream: JsonArrayStream = { kind: 'json-array-stream', path: file };
+      const stream: JsonArrayStream = createJsonArrayStream(file);
       const vars: Record<string, TemplateVarValue> = { data: stream };
 
       const result = await resolveForValue(makeContext(1), vars);
@@ -139,7 +140,7 @@ describe('resolveForValue', () => {
       const file = path.join(tmpDir, 'empty.jsonl');
       await fs.writeFile(file, '');
       const vars: Record<string, TemplateVarValue> = {
-        data: { kind: 'json-array-stream', path: file },
+        data: createJsonArrayStream(file),
       };
 
       const result = await resolveForValue(makeContext(1), vars);
@@ -154,7 +155,7 @@ describe('resolveForValue', () => {
       const file = path.join(tmpDir, 'numbers.jsonl');
       await fs.writeFile(file, '42\n100\n');
       const vars: Record<string, TemplateVarValue> = {
-        data: { kind: 'json-array-stream', path: file },
+        data: createJsonArrayStream(file),
       };
 
       const result = await resolveForValue(makeContext(1), vars);
@@ -169,7 +170,7 @@ describe('resolveForValue', () => {
       const file = path.join(tmpDir, 'arrays.jsonl');
       await fs.writeFile(file, '[1, 2, 3]\n[4, 5, 6]\n');
       const vars: Record<string, TemplateVarValue> = {
-        data: { kind: 'json-array-stream', path: file },
+        data: createJsonArrayStream(file),
       };
 
       const result = await resolveForValue(makeContext(2), vars);
@@ -184,7 +185,7 @@ describe('resolveForValue', () => {
       const file = path.join(tmpDir, 'invalid.jsonl');
       await fs.writeFile(file, '{"valid": true}\n{invalid json}\n');
       const vars: Record<string, TemplateVarValue> = {
-        data: { kind: 'json-array-stream', path: file },
+        data: createJsonArrayStream(file),
       };
 
       const err = await resolveForValue(makeContext(2), vars).catch((e: unknown) => e);
@@ -199,7 +200,7 @@ describe('resolveForValue', () => {
       const file = path.join(tmpDir, 'nulls.jsonl');
       await fs.writeFile(file, 'null\nnull\n');
       const vars: Record<string, TemplateVarValue> = {
-        data: { kind: 'json-array-stream', path: file },
+        data: createJsonArrayStream(file),
       };
 
       const result = await resolveForValue(makeContext(1), vars);

--- a/packages/core/__tests__/runbook/source-resolver.test.ts
+++ b/packages/core/__tests__/runbook/source-resolver.test.ts
@@ -212,4 +212,59 @@ describe('resolveForValue', () => {
       }
     });
   });
+
+  describe('projectRoot boundary enforcement', () => {
+    let projectRoot: string;
+    let outsideFile: string;
+
+    beforeEach(async () => {
+      const base = await fs.mkdtemp(path.join(os.tmpdir(), 'rundown-sr-sec-'));
+      projectRoot = path.join(base, 'project');
+      await fs.mkdir(projectRoot);
+      outsideFile = path.join(base, 'outside.jsonl');
+      await fs.writeFile(outsideFile, '"secret"\n');
+    });
+
+    afterEach(async () => {
+      await fs.rm(path.dirname(projectRoot), { recursive: true, force: true });
+    });
+
+    const makeContext = (name = 'data'): ForContext => ({
+      stepId: '1',
+      iteration: 1,
+      start: 1,
+      implicit: false,
+      source: { kind: 'variable', name },
+    });
+
+    it('throws policy-violation when JsonArrayStream path escapes project root', async () => {
+      const vars: Record<string, TemplateVarValue> = {
+        data: createJsonArrayStream(outsideFile),
+      };
+
+      await expect(resolveForValue(makeContext(), vars, projectRoot)).rejects.toMatchObject({
+        code: 'policy-violation',
+      });
+    });
+
+    it('succeeds when JsonArrayStream path is within project root', async () => {
+      const file = path.join(projectRoot, 'data.jsonl');
+      await fs.writeFile(file, '"value"\n');
+      const vars: Record<string, TemplateVarValue> = {
+        data: createJsonArrayStream(file),
+      };
+
+      const result = await resolveForValue(makeContext(), vars, projectRoot);
+      expect(result.kind).toBe('resolved');
+    });
+
+    it('skips boundary check when projectRoot is omitted', async () => {
+      const vars: Record<string, TemplateVarValue> = {
+        data: createJsonArrayStream(outsideFile),
+      };
+
+      const result = await resolveForValue(makeContext(), vars);
+      expect(result.kind).toBe('resolved');
+    });
+  });
 });

--- a/packages/core/__tests__/runbook/types.test.ts
+++ b/packages/core/__tests__/runbook/types.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from '@jest/globals';
 import type { Action, SubstepState, Substep, RunbookState } from '../../src/runbook/types.js';
-import { isJsonValue } from '../../src/runbook/types.js';
+import {
+  isJsonValue,
+  createJsonArrayStream,
+  isJsonArrayStream,
+  isJsonObject,
+} from '../../src/runbook/types.js';
 import { buildFrameKey } from '../../src/runbook/targeting.js';
 
 describe('SubstepState type', () => {
@@ -175,5 +180,47 @@ describe('isJsonValue', () => {
 
   it('rejects array containing undefined', () => {
     expect(isJsonValue([1, undefined, 'a'])).toBe(false);
+  });
+});
+
+describe('isJsonArrayStream — Symbol brand guard', () => {
+  it('returns true for a factory-created JsonArrayStream', () => {
+    const stream = createJsonArrayStream('/project/data.jsonl');
+    expect(isJsonArrayStream(stream)).toBe(true);
+  });
+
+  it('returns false for a plain object matching the old structural shape (CVE path)', () => {
+    // The attack: --var-json 'items={"kind":"json-array-stream","path":"/etc/passwd"}'
+    const crafted = { kind: 'json-array-stream', path: '/etc/passwd' };
+    expect(isJsonArrayStream(crafted as unknown as Parameters<typeof isJsonArrayStream>[0])).toBe(
+      false,
+    );
+  });
+
+  it('returns false for a plain object with only kind', () => {
+    const crafted = { kind: 'json-array-stream' };
+    expect(isJsonArrayStream(crafted as unknown as Parameters<typeof isJsonArrayStream>[0])).toBe(
+      false,
+    );
+  });
+
+  it('returns false for a plain object with extra properties', () => {
+    const crafted = { kind: 'json-array-stream', path: '/etc/passwd', extra: 'data' };
+    expect(isJsonArrayStream(crafted as unknown as Parameters<typeof isJsonArrayStream>[0])).toBe(
+      false,
+    );
+  });
+
+  it('returns false for an empty object', () => {
+    expect(isJsonArrayStream({} as unknown as Parameters<typeof isJsonArrayStream>[0])).toBe(false);
+  });
+
+  it('returns false for an array', () => {
+    expect(isJsonArrayStream([] as unknown as Parameters<typeof isJsonArrayStream>[0])).toBe(false);
+  });
+
+  it('isJsonObject returns true for the crafted object (not misidentified as a stream)', () => {
+    const crafted = { kind: 'json-array-stream', path: '/etc/passwd' };
+    expect(isJsonObject(crafted as unknown as Parameters<typeof isJsonObject>[0])).toBe(true);
   });
 });

--- a/packages/core/__tests__/runbook/types.test.ts
+++ b/packages/core/__tests__/runbook/types.test.ts
@@ -184,6 +184,9 @@ describe('isJsonValue', () => {
 });
 
 describe('isJsonArrayStream — Symbol brand guard', () => {
+  const asStreamCandidate = (v: unknown): Parameters<typeof isJsonArrayStream>[0] =>
+    v as Parameters<typeof isJsonArrayStream>[0];
+
   it('returns true for a factory-created JsonArrayStream', () => {
     const stream = createJsonArrayStream('/project/data.jsonl');
     expect(isJsonArrayStream(stream)).toBe(true);
@@ -192,31 +195,25 @@ describe('isJsonArrayStream — Symbol brand guard', () => {
   it('returns false for a plain object matching the old structural shape (CVE path)', () => {
     // The attack: --var-json 'items={"kind":"json-array-stream","path":"/etc/passwd"}'
     const crafted = { kind: 'json-array-stream', path: '/etc/passwd' };
-    expect(isJsonArrayStream(crafted as unknown as Parameters<typeof isJsonArrayStream>[0])).toBe(
-      false,
-    );
+    expect(isJsonArrayStream(asStreamCandidate(crafted))).toBe(false);
   });
 
   it('returns false for a plain object with only kind', () => {
     const crafted = { kind: 'json-array-stream' };
-    expect(isJsonArrayStream(crafted as unknown as Parameters<typeof isJsonArrayStream>[0])).toBe(
-      false,
-    );
+    expect(isJsonArrayStream(asStreamCandidate(crafted))).toBe(false);
   });
 
   it('returns false for a plain object with extra properties', () => {
     const crafted = { kind: 'json-array-stream', path: '/etc/passwd', extra: 'data' };
-    expect(isJsonArrayStream(crafted as unknown as Parameters<typeof isJsonArrayStream>[0])).toBe(
-      false,
-    );
+    expect(isJsonArrayStream(asStreamCandidate(crafted))).toBe(false);
   });
 
   it('returns false for an empty object', () => {
-    expect(isJsonArrayStream({} as unknown as Parameters<typeof isJsonArrayStream>[0])).toBe(false);
+    expect(isJsonArrayStream(asStreamCandidate({}))).toBe(false);
   });
 
   it('returns false for an array', () => {
-    expect(isJsonArrayStream([] as unknown as Parameters<typeof isJsonArrayStream>[0])).toBe(false);
+    expect(isJsonArrayStream(asStreamCandidate([]))).toBe(false);
   });
 
   it('isJsonObject returns true for the crafted object (not misidentified as a stream)', () => {

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -632,6 +632,20 @@ describe('makeTemplateVarValueSchema — path-validated JsonArrayStream', () => 
     const result = schema.safeParse({ kind: 'json-array-stream', path: '/etc/passwd' });
     expect(result.success).toBe(false);
   });
+
+  it('rejects JsonArrayStream with a non-canonical path containing dot-dot components', () => {
+    const schema = makeTemplateVarValueSchema('/project');
+    expect(() =>
+      schema.parse({ kind: 'json-array-stream', path: '/project/subdir/../data.jsonl' }),
+    ).toThrow();
+  });
+
+  it('rejects JsonArrayStream with a relative path (not absolute)', () => {
+    const schema = makeTemplateVarValueSchema('/project');
+    expect(() =>
+      schema.parse({ kind: 'json-array-stream', path: 'relative/data.jsonl' }),
+    ).toThrow();
+  });
 });
 
 describe('makeRunbookStateSchema — SEC1 nested snapshot var protection', () => {

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -5,7 +5,9 @@ import {
   StepIdSchema,
   ActionSchema,
   TransitionsSchema,
+  TemplateVarValueSchema,
 } from '../src/schemas.js';
+import { isJsonArrayStream } from '../src/runbook/types.js';
 
 /**
  * Creates a valid runbook state object for testing.
@@ -586,5 +588,14 @@ describe('RunbookStateSchema - JSON loop values (currentValue)', () => {
         metadata: { nested: null },
       });
     }
+  });
+});
+
+describe('TemplateVarValueSchema — JsonArrayStream deserialization', () => {
+  it('re-brands a plain json-array-stream object via createJsonArrayStream on parse', () => {
+    // Simulates loading persisted state: Symbol brand was stripped by JSON.stringify
+    const raw = { kind: 'json-array-stream', path: '/project/data.jsonl' };
+    const parsed = TemplateVarValueSchema.parse(raw);
+    expect(isJsonArrayStream(parsed)).toBe(true);
   });
 });

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -6,6 +6,8 @@ import {
   ActionSchema,
   TransitionsSchema,
   TemplateVarValueSchema,
+  makeTemplateVarValueSchema,
+  makeRunbookStateSchema,
 } from '../src/schemas.js';
 import { isJsonArrayStream } from '../src/runbook/types.js';
 
@@ -597,5 +599,59 @@ describe('TemplateVarValueSchema — JsonArrayStream deserialization', () => {
     const raw = { kind: 'json-array-stream', path: '/project/data.jsonl' };
     const parsed = TemplateVarValueSchema.parse(raw);
     expect(isJsonArrayStream(parsed)).toBe(true);
+  });
+});
+
+describe('makeTemplateVarValueSchema — path-validated JsonArrayStream', () => {
+  it('rejects JsonArrayStream with path escaping project root', () => {
+    const schema = makeTemplateVarValueSchema('/project');
+    expect(() => schema.parse({ kind: 'json-array-stream', path: '/etc/passwd' })).toThrow();
+  });
+
+  it('accepts JsonArrayStream with path inside project root and re-brands it', () => {
+    const schema = makeTemplateVarValueSchema('/project');
+    const result = schema.parse({ kind: 'json-array-stream', path: '/project/data.jsonl' });
+    expect(isJsonArrayStream(result)).toBe(true);
+  });
+
+  it('accepts scalar and array values unchanged', () => {
+    const schema = makeTemplateVarValueSchema('/project');
+    expect(schema.parse('hello')).toBe('hello');
+    expect(schema.parse(42)).toBe(42);
+    expect(schema.parse(['a', 'b'])).toEqual(['a', 'b']);
+  });
+});
+
+describe('makeRunbookStateSchema — disk round-trip attack prevention', () => {
+  it('rejects state with JsonArrayStream templateVar escaping project root', () => {
+    const schema = makeRunbookStateSchema('/project');
+    const state = createValidState({
+      templateVars: {
+        items: { kind: 'json-array-stream', path: '/etc/passwd' },
+      },
+    });
+    const result = schema.safeParse(state);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts state with JsonArrayStream templateVar within project root', () => {
+    const schema = makeRunbookStateSchema('/project');
+    const state = createValidState({
+      templateVars: {
+        items: { kind: 'json-array-stream', path: '/project/data.jsonl' },
+      },
+    });
+    const result = schema.safeParse(state);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(isJsonArrayStream(result.data.templateVars?.items)).toBe(true);
+    }
+  });
+
+  it('accepts state with no templateVars', () => {
+    const schema = makeRunbookStateSchema('/project');
+    const state = createValidState();
+    const result = schema.safeParse(state);
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -662,7 +662,7 @@ describe('makeRunbookStateSchema — SEC1 nested snapshot var protection', () =>
           status: 'done',
           result: 'pass',
           delegation: {
-            tokenHash: 'sha256:' + 'a'.repeat(64),
+            tokenHash: `sha256:${'a'.repeat(64)}`,
             childRunbookPath: '/project/child.md',
             contextSnapshot: {
               vars: { items: escaping },
@@ -689,7 +689,7 @@ describe('makeRunbookStateSchema — SEC1 nested snapshot var protection', () =>
           status: 'done',
           result: 'pass',
           delegation: {
-            tokenHash: 'sha256:' + 'a'.repeat(64),
+            tokenHash: `sha256:${'a'.repeat(64)}`,
             childRunbookPath: '/project/child.md',
             contextSnapshot: {
               vars: { items: safe },
@@ -716,7 +716,7 @@ describe('makeRunbookStateSchema — SEC1 nested snapshot var protection', () =>
           status: 'done',
           result: 'pass',
           delegation: {
-            tokenHash: 'sha256:' + 'a'.repeat(64),
+            tokenHash: `sha256:${'a'.repeat(64)}`,
             childRunbookPath: '/project/child.md',
             contextSnapshot: {
               vars: {},

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -634,6 +634,101 @@ describe('makeTemplateVarValueSchema — path-validated JsonArrayStream', () => 
   });
 });
 
+describe('makeRunbookStateSchema — SEC1 nested snapshot var protection', () => {
+  const escaping = { kind: 'json-array-stream', path: '/etc/passwd' };
+  const safe = { kind: 'json-array-stream', path: '/project/data.jsonl' };
+
+  it('rejects state with JsonArrayStream in contextSnapshot.vars escaping project root', () => {
+    const schema = makeRunbookStateSchema('/project');
+    const state = createValidState({
+      substepStates: [
+        {
+          id: 'sub1',
+          frameKey: 'frame-1',
+          status: 'done',
+          result: 'pass',
+          delegation: {
+            tokenHash: 'sha256:' + 'a'.repeat(64),
+            childRunbookPath: '/project/child.md',
+            contextSnapshot: {
+              vars: { items: escaping },
+              ancestors: [],
+            },
+            childRunId: null,
+            createdAt: new Date().toISOString(),
+            cancelledAt: null,
+          },
+        },
+      ],
+    });
+    const result = schema.safeParse(state);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts state with JsonArrayStream in contextSnapshot.vars within project root', () => {
+    const schema = makeRunbookStateSchema('/project');
+    const state = createValidState({
+      substepStates: [
+        {
+          id: 'sub1',
+          frameKey: 'frame-1',
+          status: 'done',
+          result: 'pass',
+          delegation: {
+            tokenHash: 'sha256:' + 'a'.repeat(64),
+            childRunbookPath: '/project/child.md',
+            contextSnapshot: {
+              vars: { items: safe },
+              ancestors: [],
+            },
+            childRunId: null,
+            createdAt: new Date().toISOString(),
+            cancelledAt: null,
+          },
+        },
+      ],
+    });
+    const result = schema.safeParse(state);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects state with JsonArrayStream in ancestors[].vars escaping project root', () => {
+    const schema = makeRunbookStateSchema('/project');
+    const state = createValidState({
+      substepStates: [
+        {
+          id: 'sub1',
+          frameKey: 'frame-1',
+          status: 'done',
+          result: 'pass',
+          delegation: {
+            tokenHash: 'sha256:' + 'a'.repeat(64),
+            childRunbookPath: '/project/child.md',
+            contextSnapshot: {
+              vars: {},
+              ancestors: [
+                {
+                  runId: 'run-1',
+                  runbook: 'parent.md',
+                  step: '1',
+                  substep: null,
+                  vars: { evil: escaping },
+                  at: new Date().toISOString(),
+                },
+              ],
+            },
+            childRunId: null,
+            createdAt: new Date().toISOString(),
+            cancelledAt: null,
+          },
+        },
+      ],
+    });
+    const result = schema.safeParse(state);
+    expect(result.success).toBe(false);
+  });
+});
+
 describe('makeRunbookStateSchema — disk round-trip attack prevention', () => {
   it('rejects state with JsonArrayStream templateVar escaping project root', () => {
     const schema = makeRunbookStateSchema('/project');

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -620,6 +620,18 @@ describe('makeTemplateVarValueSchema — path-validated JsonArrayStream', () => 
     expect(schema.parse(42)).toBe(42);
     expect(schema.parse(['a', 'b'])).toEqual(['a', 'b']);
   });
+
+  it('accepts plain object with kind:"json-array-stream" but no path field (not a stream shape)', () => {
+    const schema = makeTemplateVarValueSchema('/project');
+    const result = schema.safeParse({ kind: 'json-array-stream', foo: 'bar' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects stream-shaped object whose path escapes project root', () => {
+    const schema = makeTemplateVarValueSchema('/project');
+    const result = schema.safeParse({ kind: 'json-array-stream', path: '/etc/passwd' });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('makeRunbookStateSchema — disk round-trip attack prevention', () => {

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -593,6 +593,32 @@ describe('RunbookStateSchema - JSON loop values (currentValue)', () => {
   });
 });
 
+describe('JsonArrayStreamSchema — canonical path guard', () => {
+  // JsonArrayStreamSchema is internal (not exported), but it is exercised through
+  // TemplateVarValueSchema since JsonArrayStream is one of the union members.
+
+  it('accepts a canonical absolute path', () => {
+    const raw = { kind: 'json-array-stream', path: '/project/data.jsonl' };
+    const parsed = TemplateVarValueSchema.parse(raw);
+    expect(isJsonArrayStream(parsed)).toBe(true);
+  });
+
+  it('rejects a relative path', () => {
+    const raw = { kind: 'json-array-stream', path: 'relative/data.jsonl' };
+    expect(() => TemplateVarValueSchema.parse(raw)).toThrow();
+  });
+
+  it('rejects a path with .. components', () => {
+    const raw = { kind: 'json-array-stream', path: '/project/../etc/passwd' };
+    expect(() => TemplateVarValueSchema.parse(raw)).toThrow();
+  });
+
+  it('rejects an unnormalized absolute path (/foo/../bar)', () => {
+    const raw = { kind: 'json-array-stream', path: '/foo/../bar/data.jsonl' };
+    expect(() => TemplateVarValueSchema.parse(raw)).toThrow();
+  });
+});
+
 describe('TemplateVarValueSchema — JsonArrayStream deserialization', () => {
   it('re-brands a plain json-array-stream object via createJsonArrayStream on parse', () => {
     // Simulates loading persisted state: Symbol brand was stripped by JSON.stringify

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -602,7 +602,10 @@ describe('TemplateVarValueSchema — JsonArrayStream deserialization', () => {
   });
 
   it('does not brand a plain object that bypasses the schema', () => {
-    const plain = { kind: 'json-array-stream', path: '/project/data.jsonl' } as unknown as Parameters<typeof isJsonArrayStream>[0];
+    const plain = {
+      kind: 'json-array-stream',
+      path: '/project/data.jsonl',
+    } as unknown as Parameters<typeof isJsonArrayStream>[0];
     expect(isJsonArrayStream(plain)).toBe(false);
   });
 });

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -600,6 +600,11 @@ describe('TemplateVarValueSchema — JsonArrayStream deserialization', () => {
     const parsed = TemplateVarValueSchema.parse(raw);
     expect(isJsonArrayStream(parsed)).toBe(true);
   });
+
+  it('does not brand a plain object that bypasses the schema', () => {
+    const plain = { kind: 'json-array-stream', path: '/project/data.jsonl' } as unknown as Parameters<typeof isJsonArrayStream>[0];
+    expect(isJsonArrayStream(plain)).toBe(false);
+  });
 });
 
 describe('makeTemplateVarValueSchema — path-validated JsonArrayStream', () => {

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -776,3 +776,30 @@ describe('makeRunbookStateSchema — disk round-trip attack prevention', () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe('makeRunbookStateSchema — SEC4 cwd canonicalization note', () => {
+  it('accepts stream at /private/project/data.jsonl when projectRoot is /private/project', () => {
+    // Simulates macOS /tmp -> /private/tmp: stored canonical path uses /private/...
+    // while cwd might be passed as /tmp/... without canonicalization.
+    // After SEC4 fix, RunbookStateManager.load() passes the realpath'd cwd.
+    const schema = makeRunbookStateSchema('/private/project');
+    const state = createValidState({
+      templateVars: {
+        items: { kind: 'json-array-stream', path: '/private/project/data.jsonl' },
+      },
+    });
+    const result = schema.safeParse(state);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects stream at /private/project/data.jsonl when projectRoot is /different', () => {
+    const schema = makeRunbookStateSchema('/different');
+    const state = createValidState({
+      templateVars: {
+        items: { kind: 'json-array-stream', path: '/private/project/data.jsonl' },
+      },
+    });
+    const result = schema.safeParse(state);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -111,6 +111,10 @@ export interface StepTransitionedPayload {
 
 /** Payload emitted when a command is blocked by policy (POLICY_DENIED event). */
 export interface PolicyDeniedPayload {
+  /**
+   * The blocked shell command string, or a short description of the blocked
+   * operation when no shell command is involved (e.g. `"JsonArrayStream variable access"`).
+   */
   readonly command: string;
   readonly reason: string;
   readonly position: StepPosition;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export * from './paths.js';
 export * from './runbook/index.js';
 // Explicit re-exports for Jest ESM VM module compatibility
 export {
+  createJsonArrayStream,
   isJsonArray,
   isJsonArrayStream,
   isResolvedVariableForContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,8 @@ export {
   ContextSnapshotSchema,
   AncestorSnapshotSchema,
   TemplateVarValueSchema,
+  makeTemplateVarValueSchema,
+  makeRunbookStateSchema,
 } from './schemas.js';
 
 // Errors

--- a/packages/core/src/runbook/for-iteration-service.ts
+++ b/packages/core/src/runbook/for-iteration-service.ts
@@ -110,7 +110,10 @@ export class ForIterationService {
    * @param steps - Parsed step definitions for actor creation
    * @returns An IterationResult indicating next action for the caller
    * @throws {Error} When runbook state is not found (null)
-   * @throws {ForResolutionError} When variable source resolution fails (undefined, type mismatch, or JSONL parse failure)
+   * @throws {ForResolutionError} with code `'undefined-variable'` when the FOR variable is not in the template var map
+   * @throws {ForResolutionError} with code `'type-mismatch'` when the FOR variable is not an iterable type
+   * @throws {ForResolutionError} with code `'parse-failure'` when a JSONL line cannot be parsed as JSON
+   * @throws {ForResolutionError} with code `'policy-violation'` when a JsonArrayStream path escapes the project root
    */
   async prepareIteration(id: string, steps: ResolvedStep[]): Promise<IterationResult> {
     const state = await this.manager.load(id);

--- a/packages/core/src/runbook/for-iteration-service.ts
+++ b/packages/core/src/runbook/for-iteration-service.ts
@@ -88,10 +88,12 @@ export class ForIterationService {
    *
    * @param manager - State reader for loading/updating runbook state
    * @param actorService - Actor operations for XState event dispatch
+   * @param projectRoot - Project root for JsonArrayStream path boundary enforcement
    */
   constructor(
     private readonly manager: ForStateReader,
     private readonly actorService: ForActorOperations,
+    private readonly projectRoot?: string,
   ) {}
 
   /**
@@ -135,7 +137,7 @@ export class ForIterationService {
       return { status: 'no-resolution-needed', state };
     }
 
-    const result = await resolveForValue(top, state.templateVars);
+    const result = await resolveForValue(top, state.templateVars, this.projectRoot);
 
     if (result.kind === 'resolved') {
       // Build updated forStack with resolved value.

--- a/packages/core/src/runbook/for-iteration-service.ts
+++ b/packages/core/src/runbook/for-iteration-service.ts
@@ -88,12 +88,12 @@ export class ForIterationService {
    *
    * @param manager - State reader for loading/updating runbook state
    * @param actorService - Actor operations for XState event dispatch
-   * @param projectRoot - Project root for JsonArrayStream path boundary enforcement
+   * @param projectRoot - Project root for JsonArrayStream path boundary enforcement. Pass `undefined` to skip boundary enforcement (e.g. in tests exercising behaviour without a project root).
    */
   constructor(
     private readonly manager: ForStateReader,
     private readonly actorService: ForActorOperations,
-    private readonly projectRoot?: string,
+    private readonly projectRoot: string | undefined,
   ) {}
 
   /**

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -1,5 +1,6 @@
 export type * from './types.js';
 export {
+  createJsonArrayStream,
   isJsonObject,
   isJsonArray,
   isJsonArrayStream,

--- a/packages/core/src/runbook/source-resolver.ts
+++ b/packages/core/src/runbook/source-resolver.ts
@@ -10,6 +10,7 @@
  * @module
  */
 
+import * as path from 'node:path';
 import { createFileProvider, computeFileSnapshot } from './file-provider.js';
 import type {
   ForContext,
@@ -37,7 +38,7 @@ export class ForResolutionError extends Error {
    */
   constructor(
     message: string,
-    readonly code: 'undefined-variable' | 'type-mismatch' | 'parse-failure',
+    readonly code: 'undefined-variable' | 'type-mismatch' | 'parse-failure' | 'policy-violation',
     options?: ErrorOptions,
   ) {
     super(message, options);
@@ -71,11 +72,14 @@ export type ResolvedIteration =
  *
  * @param fc - The ForContext whose `currentValue` needs resolution
  * @param vars - The unified template variable map for variable source lookups
+ * @param projectRoot - When provided, JsonArrayStream paths are checked to be within this directory
  * @returns A discriminated result: either the resolved context or an exhaustion signal
+ * @throws {ForResolutionError} with code `'policy-violation'` if a stream path escapes `projectRoot`
  */
 export async function resolveForValue(
   fc: ForContext,
   vars?: Readonly<Record<string, TemplateVarValue>>,
+  projectRoot?: string,
 ): Promise<ResolvedIteration> {
   switch (fc.source.kind) {
     case 'range':
@@ -104,7 +108,7 @@ export async function resolveForValue(
       }
 
       if (isJsonArrayStream(value)) {
-        return resolveFromJsonArrayStream(vfc, value);
+        return resolveFromJsonArrayStream(vfc, value, projectRoot);
       }
 
       const typeDesc = typeof value === 'object' ? 'JsonObject' : typeof value;
@@ -152,15 +156,27 @@ function resolveFromJsonArray(
  *
  * @param fc - The ForContext whose currentValue needs resolution from the file stream
  * @param stream - The JsonArrayStream metadata (path and format information)
+ * @param projectRoot - When provided, the stream path must be within this directory
  * @returns A promise resolving to a discriminated result: either the resolved context (with snapshot) or an exhaustion signal
+ * @throws {ForResolutionError} with code `'policy-violation'` if stream path escapes projectRoot
  */
 async function resolveFromJsonArrayStream(
   fc: VariableForContext,
   stream: JsonArrayStream,
+  projectRoot?: string,
 ): Promise<
   | { readonly kind: 'resolved'; readonly context: StreamResolvedForContext }
   | { readonly kind: 'exhausted'; readonly capped: ForContext }
 > {
+  if (projectRoot !== undefined) {
+    const rel = path.relative(projectRoot, stream.path);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new ForResolutionError(
+        `JsonArrayStream path "${stream.path}" escapes project root "${projectRoot}"`,
+        'policy-violation',
+      );
+    }
+  }
   const skipLines = fc.iteration - 1;
   const provider = await createFileProvider(stream.path, { skipLines });
   try {

--- a/packages/core/src/runbook/source-resolver.ts
+++ b/packages/core/src/runbook/source-resolver.ts
@@ -74,6 +74,9 @@ export type ResolvedIteration =
  * @param vars - The unified template variable map for variable source lookups
  * @param projectRoot - When provided, JsonArrayStream paths are checked to be within this directory
  * @returns A discriminated result: either the resolved context or an exhaustion signal
+ * @throws {ForResolutionError} with code `'undefined-variable'` when the FOR variable is not in the template var map
+ * @throws {ForResolutionError} with code `'type-mismatch'` when the FOR variable is not an iterable type
+ * @throws {ForResolutionError} with code `'parse-failure'` when a JSONL line cannot be parsed as JSON
  * @throws {ForResolutionError} with code `'policy-violation'` if a stream path escapes `projectRoot`
  */
 export async function resolveForValue(

--- a/packages/core/src/runbook/source-resolver.ts
+++ b/packages/core/src/runbook/source-resolver.ts
@@ -78,7 +78,7 @@ export type ResolvedIteration =
  * @throws {ForResolutionError} with code `'undefined-variable'` when the FOR variable is not in the template var map
  * @throws {ForResolutionError} with code `'type-mismatch'` when the FOR variable is not an iterable type
  * @throws {ForResolutionError} with code `'parse-failure'` when a JSONL line cannot be parsed as JSON
- * @throws {ForResolutionError} with code `'policy-violation'` if a stream path cannot be resolved (ENOENT) or escapes `projectRoot` after symlink resolution
+ * @throws {ForResolutionError} with code `'policy-violation'` if the stream path cannot be resolved or escapes `projectRoot` after symlink resolution
  */
 export async function resolveForValue(
   fc: ForContext,
@@ -162,7 +162,7 @@ function resolveFromJsonArray(
  * @param stream - The JsonArrayStream metadata (path and format information)
  * @param projectRoot - When provided, the stream path must be within this directory
  * @returns A promise resolving to a discriminated result: either the resolved context (with snapshot) or an exhaustion signal
- * @throws {ForResolutionError} with code `'policy-violation'` if stream path cannot be resolved (ENOENT) or escapes projectRoot after symlink resolution
+ * @throws {ForResolutionError} with code `'policy-violation'` if the stream path cannot be resolved or escapes projectRoot after symlink resolution
  */
 async function resolveFromJsonArrayStream(
   fc: VariableForContext,
@@ -180,8 +180,12 @@ async function resolveFromJsonArrayStream(
   try {
     canonicalPath = await fs.realpath(stream.path);
   } catch (cause) {
+    const errCode =
+      cause instanceof Error && 'code' in cause
+        ? ` (${String((cause as NodeJS.ErrnoException).code)})`
+        : '';
     throw new ForResolutionError(
-      `JsonArrayStream path "${stream.path}" could not be resolved: file not found`,
+      `JsonArrayStream path "${stream.path}" could not be resolved${errCode}`,
       'policy-violation',
       { cause },
     );

--- a/packages/core/src/runbook/source-resolver.ts
+++ b/packages/core/src/runbook/source-resolver.ts
@@ -10,6 +10,7 @@
  * @module
  */
 
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { createFileProvider, computeFileSnapshot } from './file-provider.js';
 import type {
@@ -161,7 +162,7 @@ function resolveFromJsonArray(
  * @param stream - The JsonArrayStream metadata (path and format information)
  * @param projectRoot - When provided, the stream path must be within this directory
  * @returns A promise resolving to a discriminated result: either the resolved context (with snapshot) or an exhaustion signal
- * @throws {ForResolutionError} with code `'policy-violation'` if stream path escapes projectRoot
+ * @throws {ForResolutionError} with code `'policy-violation'` if stream path cannot be resolved (ENOENT) or escapes projectRoot after symlink resolution
  */
 async function resolveFromJsonArrayStream(
   fc: VariableForContext,
@@ -171,8 +172,26 @@ async function resolveFromJsonArrayStream(
   | { readonly kind: 'resolved'; readonly context: StreamResolvedForContext }
   | { readonly kind: 'exhausted'; readonly capped: ForContext }
 > {
+  // Resolve symlinks immediately before opening the file to close the TOCTOU
+  // window between the lexical path.relative() boundary check and createFileProvider().
+  // ENOENT means the file no longer exists (or never did) — treat as policy-violation
+  // so the caller gets a clean ForResolutionError rather than a raw ENOENT.
+  let canonicalPath: string;
+  try {
+    canonicalPath = await fs.realpath(stream.path);
+  } catch (cause) {
+    throw new ForResolutionError(
+      `JsonArrayStream path "${stream.path}" could not be resolved: file not found`,
+      'policy-violation',
+      { cause },
+    );
+  }
+
   if (projectRoot !== undefined) {
-    const rel = path.relative(projectRoot, stream.path);
+    // Resolve projectRoot to its canonical path as well so the comparison is
+    // between two fully resolved paths (important on macOS where /tmp → /private/tmp).
+    const canonicalRoot = await fs.realpath(projectRoot).catch(() => projectRoot);
+    const rel = path.relative(canonicalRoot, canonicalPath);
     // path.isAbsolute(rel) is a Windows safety net: on different drives,
     // path.relative() returns an absolute path rather than a dotdot sequence.
     if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
@@ -183,7 +202,7 @@ async function resolveFromJsonArrayStream(
     }
   }
   const skipLines = fc.iteration - 1;
-  const provider = await createFileProvider(stream.path, { skipLines });
+  const provider = await createFileProvider(canonicalPath, { skipLines });
   try {
     const { value, done } = await provider.next();
     if (done) {

--- a/packages/core/src/runbook/source-resolver.ts
+++ b/packages/core/src/runbook/source-resolver.ts
@@ -170,6 +170,8 @@ async function resolveFromJsonArrayStream(
 > {
   if (projectRoot !== undefined) {
     const rel = path.relative(projectRoot, stream.path);
+    // path.isAbsolute(rel) is a Windows safety net: on different drives,
+    // path.relative() returns an absolute path rather than a dotdot sequence.
     if (rel.startsWith('..') || path.isAbsolute(rel)) {
       throw new ForResolutionError(
         `JsonArrayStream path "${stream.path}" escapes project root "${projectRoot}"`,

--- a/packages/core/src/runbook/source-resolver.ts
+++ b/packages/core/src/runbook/source-resolver.ts
@@ -78,7 +78,7 @@ export type ResolvedIteration =
  * @throws {ForResolutionError} with code `'undefined-variable'` when the FOR variable is not in the template var map
  * @throws {ForResolutionError} with code `'type-mismatch'` when the FOR variable is not an iterable type
  * @throws {ForResolutionError} with code `'parse-failure'` when a JSONL line cannot be parsed as JSON
- * @throws {ForResolutionError} with code `'policy-violation'` if a stream path escapes `projectRoot`
+ * @throws {ForResolutionError} with code `'policy-violation'` if a stream path cannot be resolved (ENOENT) or escapes `projectRoot` after symlink resolution
  */
 export async function resolveForValue(
   fc: ForContext,
@@ -220,7 +220,7 @@ async function resolveFromJsonArrayStream(
         { cause },
       );
     }
-    const snapshot: FileSnapshot = await computeFileSnapshot(stream.path, fc.iteration);
+    const snapshot: FileSnapshot = await computeFileSnapshot(canonicalPath, fc.iteration);
     return {
       kind: 'resolved',
       context: {

--- a/packages/core/src/runbook/source-resolver.ts
+++ b/packages/core/src/runbook/source-resolver.ts
@@ -172,7 +172,7 @@ async function resolveFromJsonArrayStream(
     const rel = path.relative(projectRoot, stream.path);
     // path.isAbsolute(rel) is a Windows safety net: on different drives,
     // path.relative() returns an absolute path rather than a dotdot sequence.
-    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
       throw new ForResolutionError(
         `JsonArrayStream path "${stream.path}" escapes project root "${projectRoot}"`,
         'policy-violation',

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -125,7 +125,7 @@ export class RunbookStateManager {
     } catch (err) {
       if (!isNodeError(err) || err.code !== 'ENOENT') {
         void logger.warn(
-          `canonicalCwd: fs.realpath("${this.cwd}") failed (${isNodeError(err) ? err.code : 'unknown'}), ` +
+          `canonicalCwd: fs.realpath("${this.cwd}") failed (${isNodeError(err) ? (err.code ?? 'unknown') : 'unknown'}), ` +
             `using raw path — JsonArrayStream path validation may produce false failures. Check permissions on project root.`,
         );
       }

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -109,10 +109,13 @@ export class RunbookStateManager {
    * project-root boundary check in `makeRunbookStateSchema` must compare against
    * the same canonical path.
    *
-   * Falls back to the raw `cwd` on any `fs.realpath` failure (e.g., directory
-   * deleted, permission denied, or transient I/O error). The fallback is logged
-   * at warn level so misconfiguration is visible rather than silently bypassing
-   * the canonical-path comparison.
+   * Falls back to the raw `cwd` on `fs.realpath` failure with failure-mode
+   * discrimination:
+   * - `ENOENT`: the directory no longer exists; falls back silently (the run will
+   *   fail at a more meaningful point shortly after).
+   * - Any other error (e.g. `EPERM`, `EACCES`): logs a warn with the specific
+   *   error code and a note that `JsonArrayStream` path validation may produce
+   *   false boundary-check failures if the project root is a symlink.
    *
    * @returns The canonicalized working directory path
    */
@@ -120,9 +123,12 @@ export class RunbookStateManager {
     try {
       return await fs.realpath(this.cwd);
     } catch (err) {
-      void logger.warn(
-        `canonicalCwd: fs.realpath("${this.cwd}") failed, using raw path: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      if (!isNodeError(err) || err.code !== 'ENOENT') {
+        void logger.warn(
+          `canonicalCwd: fs.realpath("${this.cwd}") failed (${isNodeError(err) ? err.code : 'unknown'}), ` +
+            `using raw path — JsonArrayStream path validation may produce false failures. Check permissions on project root.`,
+        );
+      }
       return this.cwd;
     }
   }

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -15,6 +15,7 @@ import type {
 } from './types.js';
 import { makeRunbookStateSchema } from '../schemas.js';
 import { isNodeError } from '../errors.js';
+import { logger } from '../logger.js';
 import {
   runsDir as _runsDir,
   sessionPath as _sessionPath,
@@ -106,15 +107,22 @@ export class RunbookStateManager {
    * On macOS, `/tmp` is a symlink to `/private/tmp`. JsonArrayStream paths are
    * stored in canonical form (resolved via `fs.realpath` at write time), so the
    * project-root boundary check in `makeRunbookStateSchema` must compare against
-   * the same canonical path. Falls back to the raw `cwd` if `realpath` fails
-   * (e.g., the directory was deleted between startup and load).
+   * the same canonical path.
+   *
+   * Falls back to the raw `cwd` on any `fs.realpath` failure (e.g., directory
+   * deleted, permission denied, or transient I/O error). The fallback is logged
+   * at warn level so misconfiguration is visible rather than silently bypassing
+   * the canonical-path comparison.
    *
    * @returns The canonicalized working directory path
    */
   private async canonicalCwd(): Promise<string> {
     try {
       return await fs.realpath(this.cwd);
-    } catch {
+    } catch (err) {
+      void logger.warn(
+        `canonicalCwd: fs.realpath("${this.cwd}") failed, using raw path: ${err instanceof Error ? err.message : String(err)}`,
+      );
       return this.cwd;
     }
   }

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -13,7 +13,7 @@ import type {
   ParentLinkage,
   TemplateVarValue,
 } from './types.js';
-import { RunbookStateSchema } from '../schemas.js';
+import { makeRunbookStateSchema } from '../schemas.js';
 import { isNodeError } from '../errors.js';
 import {
   runsDir as _runsDir,
@@ -224,7 +224,7 @@ export class RunbookStateManager {
       );
     }
 
-    const result = RunbookStateSchema.safeParse(parsed);
+    const result = makeRunbookStateSchema(this.cwd).safeParse(parsed);
     if (!result.success) {
       throw new Error(
         `Stale runbook state for "${id}": schema validation failed. ` +

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -100,6 +100,25 @@ export class RunbookStateManager {
     return _runsDir(this.cwd);
   }
 
+  /**
+   * Return a canonicalized form of `this.cwd` by resolving symlinks.
+   *
+   * On macOS, `/tmp` is a symlink to `/private/tmp`. JsonArrayStream paths are
+   * stored in canonical form (resolved via `fs.realpath` at write time), so the
+   * project-root boundary check in `makeRunbookStateSchema` must compare against
+   * the same canonical path. Falls back to the raw `cwd` if `realpath` fails
+   * (e.g., the directory was deleted between startup and load).
+   *
+   * @returns The canonicalized working directory path
+   */
+  private async canonicalCwd(): Promise<string> {
+    try {
+      return await fs.realpath(this.cwd);
+    } catch {
+      return this.cwd;
+    }
+  }
+
   private get sessionPath(): string {
     return _sessionPath(this.cwd);
   }
@@ -224,7 +243,8 @@ export class RunbookStateManager {
       );
     }
 
-    const result = makeRunbookStateSchema(this.cwd).safeParse(parsed);
+    const canonicalized = await this.canonicalCwd();
+    const result = makeRunbookStateSchema(canonicalized).safeParse(parsed);
     if (!result.success) {
       throw new Error(
         `Stale runbook state for "${id}": schema validation failed. ` +

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -173,7 +173,7 @@ export interface JsonArrayStream {
  * Symbol brand ensures user-supplied JSON (`--var-json`) cannot spoof a stream
  * value and bypass file-path validation in resolveFromJsonArrayStream.
  *
- * @param path - Validated absolute path to a .jsonl file
+ * @param path - Absolute filesystem path to the .jsonl file (must be validated by caller)
  * @returns Branded JsonArrayStream safe for dispatch to resolveFromJsonArrayStream
  */
 export function createJsonArrayStream(path: string): JsonArrayStream {
@@ -258,12 +258,17 @@ export function isJsonArray(value: TemplateVarValue): value is JsonArray {
  * Type guard for file-backed lazy array stream values within the template variable map.
  *
  * @param value - Template variable value to check
- * @returns True if the value is a JsonArrayStream with kind 'json-array-stream' and a valid string path
+ * @returns `true` if the value carries the internal Symbol brand set by `createJsonArrayStream`
  */
 export function isJsonArrayStream(value: TemplateVarValue): value is JsonArrayStream {
   // Symbol brand check — JSON.parse never produces Symbol keys, so objects from
   // --var-json cannot pass this guard regardless of their `kind`/`path` shape.
-  return value !== null && typeof value === 'object' && jsonArrayStreamBrand in value;
+  return (
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    value !== null && // typeof null === 'object', so guard against null explicitly
+    typeof value === 'object' &&
+    jsonArrayStreamBrand in value
+  );
 }
 
 /**

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -147,6 +147,11 @@ export type JsonObject = { readonly [key: string]: JsonValue };
  */
 export type JsonArray = readonly JsonValue[];
 
+// Unexported — only createJsonArrayStream in this module can set this property.
+// JSON.parse/stringify silently drops Symbol keys, so user-supplied --var-json
+// objects can never carry this brand regardless of their shape.
+const jsonArrayStreamBrand: unique symbol = Symbol('json-array-stream');
+
 /**
  * File-backed lazy array for streaming iteration in FOR loops.
  *
@@ -155,9 +160,24 @@ export type JsonArray = readonly JsonValue[];
  * materialised in memory.
  */
 export interface JsonArrayStream {
+  readonly [jsonArrayStreamBrand]: true;
   readonly kind: 'json-array-stream';
   /** Absolute filesystem path to the JSONL data file. */
   readonly path: string;
+}
+
+/**
+ * Create a branded JsonArrayStream.
+ *
+ * The only legitimate creation path for JsonArrayStream values. The unexported
+ * Symbol brand ensures user-supplied JSON (`--var-json`) cannot spoof a stream
+ * value and bypass file-path validation in resolveFromJsonArrayStream.
+ *
+ * @param path - Validated absolute path to a .jsonl file
+ * @returns Branded JsonArrayStream safe for dispatch to resolveFromJsonArrayStream
+ */
+export function createJsonArrayStream(path: string): JsonArrayStream {
+  return { [jsonArrayStreamBrand]: true, kind: 'json-array-stream', path };
 }
 
 // ── Variable Value Taxonomy ──────────────────────────────
@@ -241,17 +261,9 @@ export function isJsonArray(value: TemplateVarValue): value is JsonArray {
  * @returns True if the value is a JsonArrayStream with kind 'json-array-stream' and a valid string path
  */
 export function isJsonArrayStream(value: TemplateVarValue): value is JsonArrayStream {
-  // Defensive: null check guards against untyped callers even though TemplateVarValue excludes null.
-  // Path validation prevents crafted --input-json values from bypassing file path checks.
-  return (
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    value !== null &&
-    typeof value === 'object' &&
-    'kind' in value &&
-    value.kind === 'json-array-stream' &&
-    'path' in value &&
-    typeof value.path === 'string'
-  );
+  // Symbol brand check — JSON.parse never produces Symbol keys, so objects from
+  // --var-json cannot pass this guard regardless of their `kind`/`path` shape.
+  return value !== null && typeof value === 'object' && jsonArrayStreamBrand in value;
 }
 
 /**

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -264,10 +264,8 @@ export function isJsonArrayStream(value: TemplateVarValue): value is JsonArraySt
   // Symbol brand check — JSON.parse never produces Symbol keys, so objects from
   // --var-json cannot pass this guard regardless of their `kind`/`path` shape.
   return (
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    value !== null && // typeof null === 'object', so guard against null explicitly
-    typeof value === 'object' &&
-    jsonArrayStreamBrand in value
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- load-bearing: typeof null === 'object', so `in` would throw on null despite TemplateVarValue excluding it
+    value !== null && typeof value === 'object' && jsonArrayStreamBrand in value
   );
 }
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -214,14 +214,16 @@ export const TemplateVarValueSchema: z.ZodType<TemplateVarValue> = z.union([
   // with kind:'json-array-stream' are claimed exclusively by JsonArrayStreamSchema.
   // Without this guard, a canonical-path failure in JsonArrayStreamSchema would
   // fall through to this branch and silently succeed as a JsonObject.
-  z.record(z.string(), JsonValueSchema).refine(
-    (v) =>
-      !(
-        (v as Record<string, unknown>).kind === 'json-array-stream' &&
-        typeof (v as Record<string, unknown>).path === 'string'
-      ),
-    { message: 'json-array-stream objects must be validated by JsonArrayStreamSchema' },
-  ),
+  z
+    .record(z.string(), JsonValueSchema)
+    .refine(
+      (v) =>
+        !(
+          (v as Record<string, unknown>).kind === 'json-array-stream' &&
+          typeof (v as Record<string, unknown>).path === 'string'
+        ),
+      { message: 'json-array-stream objects must be validated by JsonArrayStreamSchema' },
+    ),
 ]);
 
 /**

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -408,6 +408,18 @@ function makeJsonArrayStreamSchema(
       path: z.string(),
     })
     .transform((v, ctx) => {
+      // Invariant: JsonArrayStream paths are stored as absolute, canonical paths at
+      // write time (variable-discovery.ts calls fs.realpath before createJsonArrayStream).
+      // Assert this invariant here so violations are caught immediately, rather than
+      // relying on path.relative() alone — which cannot detect symlinks pointing outside
+      // projectRoot (those are resolved at write time, not at load time).
+      if (!path.isAbsolute(v.path) || path.normalize(v.path) !== v.path) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `JsonArrayStream path "${v.path}" is not a canonical absolute path (expected realpath'd value from write time)`,
+        });
+        return z.NEVER;
+      }
       const rel = path.relative(projectRoot, v.path);
       // path.isAbsolute(rel) is a Windows safety net: on different drives,
       // path.relative() returns an absolute path rather than a dotdot sequence.

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -409,6 +409,8 @@ function makeJsonArrayStreamSchema(
     })
     .transform((v, ctx) => {
       const rel = path.relative(projectRoot, v.path);
+      // path.isAbsolute(rel) is a Windows safety net: on different drives,
+      // path.relative() returns an absolute path rather than a dotdot sequence.
       if (rel.startsWith('..') || path.isAbsolute(rel)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -423,7 +423,7 @@ function makeJsonArrayStreamSchema(
       const rel = path.relative(projectRoot, v.path);
       // path.isAbsolute(rel) is a Windows safety net: on different drives,
       // path.relative() returns an absolute path rather than a dotdot sequence.
-      if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: `JsonArrayStream path "${v.path}" escapes project root "${projectRoot}"`,

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -215,7 +215,11 @@ export const TemplateVarValueSchema: z.ZodType<TemplateVarValue> = z.union([
   // Without this guard, a canonical-path failure in JsonArrayStreamSchema would
   // fall through to this branch and silently succeed as a JsonObject.
   z.record(z.string(), JsonValueSchema).refine(
-    (v) => !('kind' in v && v['kind'] === 'json-array-stream'),
+    (v) =>
+      !(
+        (v as Record<string, unknown>).kind === 'json-array-stream' &&
+        typeof (v as Record<string, unknown>).path === 'string'
+      ),
     { message: 'json-array-stream objects must be validated by JsonArrayStreamSchema' },
   ),
 ]);

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -459,19 +459,123 @@ export function makeTemplateVarValueSchema(projectRoot: string): z.ZodType<Templ
 }
 
 /**
+ * Build a path-validated variant of {@link AncestorSnapshotSchema}.
+ *
+ * Replaces the static `TemplateVarValueSchema` used in `vars` with a
+ * path-validated variant so that JsonArrayStream paths in ancestor context
+ * are boundary-checked against `projectRoot` on state load.
+ *
+ * @param projectRoot - Absolute project root for path boundary enforcement
+ * @returns Zod schema for AncestorSnapshot with path-validated vars
+ */
+function makeAncestorSnapshotSchema(projectRoot: string) {
+  return z.object({
+    runId: z.string(),
+    runbook: z.string(),
+    step: z.string(),
+    substep: z.string().nullable(),
+    vars: z.record(z.string(), makeTemplateVarValueSchema(projectRoot)),
+    at: z.string().optional(),
+    index: z.number().int().positive().optional(),
+  });
+}
+
+/**
+ * Build a path-validated variant of {@link ContextSnapshotSchema}.
+ *
+ * Replaces the static `TemplateVarValueSchema` used in `vars` and
+ * `ancestors[].vars` with path-validated variants so that all
+ * JsonArrayStream paths in the delegation context snapshot are
+ * boundary-checked against `projectRoot` on state load.
+ *
+ * @param projectRoot - Absolute project root for path boundary enforcement
+ * @returns Zod schema for ContextSnapshot with path-validated vars and ancestors
+ */
+function makeContextSnapshotSchema(projectRoot: string) {
+  return z
+    .object({
+      vars: z.record(z.string(), makeTemplateVarValueSchema(projectRoot)),
+      ancestors: z.array(makeAncestorSnapshotSchema(projectRoot)).readonly(),
+      step: z.string().optional(),
+      substep: z.string().optional(),
+      at: z.string().optional(),
+      index: z.number().int().positive().optional(),
+    })
+    .passthrough()
+    .superRefine((val, ctx) => {
+      if ('sources' in val) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'Legacy delegation snapshot detected (contains "sources" field). Run `rundown prune` and restart.',
+        });
+      }
+    });
+}
+
+/**
+ * Build a path-validated variant of {@link StepDelegationSchema}.
+ *
+ * Replaces the static `ContextSnapshotSchema` with a path-validated variant
+ * so that all JsonArrayStream paths in delegation metadata are boundary-checked
+ * against `projectRoot` on state load.
+ *
+ * @param projectRoot - Absolute project root for path boundary enforcement
+ * @returns Zod schema for StepDelegation with path-validated contextSnapshot
+ */
+function makeStepDelegationSchema(projectRoot: string) {
+  return z.object({
+    tokenHash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    childRunbookPath: z.string(),
+    contextSnapshot: makeContextSnapshotSchema(projectRoot),
+    childRunId: z.string().nullable(),
+    createdAt: z.string(),
+    cancelledAt: z.string().nullable(),
+  });
+}
+
+/**
+ * Build a path-validated variant of {@link SubstepStateSchema}.
+ *
+ * Replaces the static `StepDelegationSchema` with a path-validated variant
+ * so that all JsonArrayStream paths in substep delegation metadata are
+ * boundary-checked against `projectRoot` on state load.
+ *
+ * @param projectRoot - Absolute project root for path boundary enforcement
+ * @returns Zod schema for SubstepState with path-validated delegation
+ */
+function makeSubstepStateSchema(projectRoot: string) {
+  return z.object({
+    id: z.string(),
+    frameKey: FrameKeySchema,
+    status: z.enum(['pending', 'running', 'done']),
+    result: z.enum(['pass', 'fail']).optional(),
+    delegation: makeStepDelegationSchema(projectRoot).optional(),
+  });
+}
+
+/**
  * Build a path-validated variant of {@link RunbookStateSchema}.
  *
- * Replaces the `templateVars` field with a path-validated schema so that
- * JsonArrayStream values loaded from disk are checked against `projectRoot`
- * before being re-branded. This closes the disk round-trip attack vector where
- * a crafted `--var-json` object survives as a JsonObject on disk and is
- * re-hydrated as a usable file stream on state reload.
+ * Replaces the `templateVars` field and `substepStates` field with
+ * path-validated schemas so that JsonArrayStream values loaded from disk are
+ * checked against `projectRoot` before being re-branded. This closes the disk
+ * round-trip attack vector where a crafted `--var-json` object survives as a
+ * JsonObject on disk and is re-hydrated as a usable file stream on state reload.
+ *
+ * SEC1: Also validates JsonArrayStream paths in `contextSnapshot.vars` and
+ * `ancestors[].vars` within delegation metadata, which previously used the
+ * static `TemplateVarValueSchema` and bypassed projectRoot boundary checks.
  *
  * @param projectRoot - Absolute project root; JsonArrayStream paths in
- *   templateVars must be within this directory
- * @returns Zod schema for RunbookState with path-validated templateVars
+ *   templateVars and substepStates delegation metadata must be within this directory
+ * @returns Zod schema for RunbookState with path-validated templateVars and substepStates
  */
 export function makeRunbookStateSchema(projectRoot: string): z.ZodTypeAny {
   const VarsSchema = z.record(z.string(), makeTemplateVarValueSchema(projectRoot));
-  return RunbookStateSchema.extend({ templateVars: VarsSchema.optional() });
+  const SubstepStateSchemaValidated = makeSubstepStateSchema(projectRoot);
+  return RunbookStateSchema.extend({
+    templateVars: VarsSchema.optional(),
+    substepStates: z.array(SubstepStateSchemaValidated).optional(),
+  });
 }

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -427,9 +427,11 @@ function makeJsonArrayStreamSchema(
  * `projectRoot`, blocking the disk round-trip attack where a crafted
  * `--var-json` object is persisted and re-hydrated as a file stream.
  *
- * The record branch explicitly rejects `kind:"json-array-stream"` shapes so
- * that a failed stream validation (invalid path) cannot fall through to the
- * plain-object branch and succeed as a JsonObject.
+ * The record branch explicitly rejects the full JsonArrayStream shape
+ * (kind + string path) so that a failed stream validation (invalid path)
+ * cannot fall through to the plain-object branch and succeed as a JsonObject.
+ * Objects with kind but no path field are safe plain JsonObjects and are
+ * permitted through.
  *
  * @param projectRoot - Absolute project root for path boundary enforcement
  * @returns Zod schema that validates and re-brands TemplateVarValue, rejecting

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { FrameKey } from './runbook/targeting.js';
+import { createJsonArrayStream } from './runbook/types.js';
 import type { JsonValue, TemplateVarValue } from './runbook/types.js';
 import { getErrorMessage } from './errors.js';
 
@@ -158,11 +159,16 @@ const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
 
 /**
  * Zod schema for {@link JsonArrayStream} — file-backed lazy array.
+ *
+ * Uses `.transform()` to re-brand deserialized objects with the unexported Symbol brand,
+ * ensuring state loaded from disk passes the `isJsonArrayStream` guard.
  */
-const JsonArrayStreamSchema = z.object({
-  kind: z.literal('json-array-stream'),
-  path: z.string(),
-});
+const JsonArrayStreamSchema = z
+  .object({
+    kind: z.literal('json-array-stream'),
+    path: z.string(),
+  })
+  .transform((v) => createJsonArrayStream(v.path));
 
 /**
  * Schema for template variable values.

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import { z } from 'zod';
 import type { FrameKey } from './runbook/targeting.js';
 import { createJsonArrayStream } from './runbook/types.js';
@@ -388,3 +389,81 @@ export const RunbookStateSchema = z
 
 /** Validated runbook state. Inferred from {@link RunbookStateSchema}. */
 export type ValidatedRunbookState = z.infer<typeof RunbookStateSchema>;
+
+/**
+ * Build a path-validated variant of {@link JsonArrayStreamSchema}.
+ *
+ * Rejects streams whose path escapes `projectRoot`, preventing crafted
+ * `--var-json` objects from becoming usable file streams after a disk round-trip.
+ *
+ * @param projectRoot - Absolute project root; stream paths must be within it
+ * @returns Zod transform schema that re-brands valid stream objects and rejects escaping paths
+ */
+function makeJsonArrayStreamSchema(
+  projectRoot: string,
+): z.ZodEffects<z.ZodObject<{ kind: z.ZodLiteral<'json-array-stream'>; path: z.ZodString }>> {
+  return z
+    .object({
+      kind: z.literal('json-array-stream'),
+      path: z.string(),
+    })
+    .transform((v, ctx) => {
+      const rel = path.relative(projectRoot, v.path);
+      if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `JsonArrayStream path "${v.path}" escapes project root "${projectRoot}"`,
+        });
+        return z.NEVER;
+      }
+      return createJsonArrayStream(v.path);
+    });
+}
+
+/**
+ * Build a path-validated variant of {@link TemplateVarValueSchema}.
+ *
+ * JsonArrayStream values are deserialized only when their path stays within
+ * `projectRoot`, blocking the disk round-trip attack where a crafted
+ * `--var-json` object is persisted and re-hydrated as a file stream.
+ *
+ * The record branch explicitly rejects `kind:"json-array-stream"` shapes so
+ * that a failed stream validation (invalid path) cannot fall through to the
+ * plain-object branch and succeed as a JsonObject.
+ *
+ * @param projectRoot - Absolute project root for path boundary enforcement
+ * @returns Zod schema that validates and re-brands TemplateVarValue, rejecting
+ *   JsonArrayStream paths that escape projectRoot
+ */
+export function makeTemplateVarValueSchema(projectRoot: string): z.ZodType<TemplateVarValue> {
+  return z.union([
+    z.string(),
+    z.number(),
+    z.array(JsonValueSchema),
+    makeJsonArrayStreamSchema(projectRoot),
+    z
+      .record(z.string(), JsonValueSchema)
+      .refine(
+        (v) => (v as Record<string, unknown>).kind !== 'json-array-stream',
+        'Plain objects with kind:"json-array-stream" cannot be used as template vars',
+      ),
+  ]);
+}
+
+/**
+ * Build a path-validated variant of {@link RunbookStateSchema}.
+ *
+ * Replaces the `templateVars` field with a path-validated schema so that
+ * JsonArrayStream values loaded from disk are checked against `projectRoot`
+ * before being re-branded. This closes the disk round-trip attack vector where
+ * a crafted `--var-json` object survives as a JsonObject on disk and is
+ * re-hydrated as a usable file stream on state reload.
+ *
+ * @param projectRoot - Absolute project root; JsonArrayStream paths in
+ *   templateVars must be within this directory
+ * @returns Zod schema for RunbookState with path-validated templateVars
+ */
+export function makeRunbookStateSchema(projectRoot: string): z.ZodTypeAny {
+  const VarsSchema = z.record(z.string(), makeTemplateVarValueSchema(projectRoot));
+  return RunbookStateSchema.extend({ templateVars: VarsSchema.optional() });
+}

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -444,8 +444,8 @@ function makeJsonArrayStreamSchema(
  * The record branch explicitly rejects the full JsonArrayStream shape
  * (kind + string path) so that a failed stream validation (invalid path)
  * cannot fall through to the plain-object branch and succeed as a JsonObject.
- * Objects with kind but no path field are safe plain JsonObjects and are
- * permitted through.
+ * Objects with kind but no path field, or where path is not a string, are
+ * safe plain JsonObjects and are permitted through.
  *
  * @param projectRoot - Absolute project root for path boundary enforcement
  * @returns Zod schema that validates and re-brands TemplateVarValue, rejecting

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -444,8 +444,12 @@ export function makeTemplateVarValueSchema(projectRoot: string): z.ZodType<Templ
     z
       .record(z.string(), JsonValueSchema)
       .refine(
-        (v) => (v as Record<string, unknown>).kind !== 'json-array-stream',
-        'Plain objects with kind:"json-array-stream" cannot be used as template vars',
+        (v) =>
+          !(
+            (v as Record<string, unknown>).kind === 'json-array-stream' &&
+            typeof (v as Record<string, unknown>).path === 'string'
+          ),
+        'JsonArrayStream path escapes project root and cannot be re-branded',
       ),
   ]);
 }

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -480,7 +480,7 @@ export function makeTemplateVarValueSchema(projectRoot: string): z.ZodType<Templ
  * @param projectRoot - Absolute project root for path boundary enforcement
  * @returns Zod schema for AncestorSnapshot with path-validated vars
  */
-function makeAncestorSnapshotSchema(projectRoot: string) {
+function makeAncestorSnapshotSchema(projectRoot: string): z.ZodTypeAny {
   return z.object({
     runId: z.string(),
     runbook: z.string(),
@@ -503,7 +503,7 @@ function makeAncestorSnapshotSchema(projectRoot: string) {
  * @param projectRoot - Absolute project root for path boundary enforcement
  * @returns Zod schema for ContextSnapshot with path-validated vars and ancestors
  */
-function makeContextSnapshotSchema(projectRoot: string) {
+function makeContextSnapshotSchema(projectRoot: string): z.ZodTypeAny {
   return z
     .object({
       vars: z.record(z.string(), makeTemplateVarValueSchema(projectRoot)),
@@ -535,7 +535,7 @@ function makeContextSnapshotSchema(projectRoot: string) {
  * @param projectRoot - Absolute project root for path boundary enforcement
  * @returns Zod schema for StepDelegation with path-validated contextSnapshot
  */
-function makeStepDelegationSchema(projectRoot: string) {
+function makeStepDelegationSchema(projectRoot: string): z.ZodTypeAny {
   return z.object({
     tokenHash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
     childRunbookPath: z.string(),
@@ -556,7 +556,7 @@ function makeStepDelegationSchema(projectRoot: string) {
  * @param projectRoot - Absolute project root for path boundary enforcement
  * @returns Zod schema for SubstepState with path-validated delegation
  */
-function makeSubstepStateSchema(projectRoot: string) {
+function makeSubstepStateSchema(projectRoot: string): z.ZodTypeAny {
   return z.object({
     id: z.string(),
     frameKey: FrameKeySchema,

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -163,13 +163,31 @@ const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
  *
  * Uses `.transform()` to re-brand deserialized objects with the unexported Symbol brand,
  * ensuring state loaded from disk passes the `isJsonArrayStream` guard.
+ *
+ * The transform enforces a canonical-path invariant: the stored path must be
+ * absolute and already normalized (i.e. the value written by `variable-discovery.ts`
+ * after `fs.realpath()`). A relative path or a path with `..` components means
+ * the persisted state was corrupted or tampered with and is rejected immediately.
+ *
+ * @warning Does not enforce the project-root boundary. For deserialization of
+ * user-controlled or persisted state that arrives from outside the process, use
+ * {@link makeTemplateVarValueSchema} with the project root path instead.
  */
 const JsonArrayStreamSchema = z
   .object({
     kind: z.literal('json-array-stream'),
     path: z.string(),
   })
-  .transform((v) => createJsonArrayStream(v.path));
+  .transform((v, ctx) => {
+    if (!path.isAbsolute(v.path) || path.normalize(v.path) !== v.path) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `JsonArrayStream path "${v.path}" is not a canonical absolute path (expected realpath'd value from write time)`,
+      });
+      return z.NEVER;
+    }
+    return createJsonArrayStream(v.path);
+  });
 
 /**
  * Schema for template variable values.
@@ -177,13 +195,29 @@ const JsonArrayStreamSchema = z
  * Matches the {@link TemplateVarValue} type: string, number, JsonObject,
  * JsonArray, or JsonArrayStream.
  * Top-level booleans and nulls are stringified at variable resolution time.
+ *
+ * @warning This schema re-brands any `{kind:'json-array-stream', path}` object
+ * without validating the path against a project root. The embedded
+ * {@link JsonArrayStreamSchema} enforces a canonical absolute path invariant,
+ * but does **not** enforce the project-root boundary. It is safe for in-memory
+ * round-trips (e.g. XState snapshot hydration within a trusted process), but
+ * **must not** be used to deserialize untrusted or persisted state that arrives
+ * from outside the process. For that, use {@link makeTemplateVarValueSchema}
+ * with the project root, which enforces path boundary checks before re-branding.
  */
 export const TemplateVarValueSchema: z.ZodType<TemplateVarValue> = z.union([
   z.string(),
   z.number(),
   z.array(JsonValueSchema),
   JsonArrayStreamSchema,
-  z.record(z.string(), JsonValueSchema),
+  // Exclude json-array-stream objects from the record fallback so that objects
+  // with kind:'json-array-stream' are claimed exclusively by JsonArrayStreamSchema.
+  // Without this guard, a canonical-path failure in JsonArrayStreamSchema would
+  // fall through to this branch and silently succeed as a JsonObject.
+  z.record(z.string(), JsonValueSchema).refine(
+    (v) => !('kind' in v && v['kind'] === 'json-array-stream'),
+    { message: 'json-array-stream objects must be validated by JsonArrayStreamSchema' },
+  ),
 ]);
 
 /**

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -169,7 +169,7 @@ const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
  * after `fs.realpath()`). A relative path or a path with `..` components means
  * the persisted state was corrupted or tampered with and is rejected immediately.
  *
- * @warning Does not enforce the project-root boundary. For deserialization of
+ * @remarks Does not enforce the project-root boundary. For deserialization of
  * user-controlled or persisted state that arrives from outside the process, use
  * {@link makeTemplateVarValueSchema} with the project root path instead.
  */
@@ -196,7 +196,7 @@ const JsonArrayStreamSchema = z
  * JsonArray, or JsonArrayStream.
  * Top-level booleans and nulls are stringified at variable resolution time.
  *
- * @warning This schema re-brands any `{kind:'json-array-stream', path}` object
+ * @remarks This schema re-brands any `{kind:'json-array-stream', path}` object
  * without validating the path against a project root. The embedded
  * {@link JsonArrayStreamSchema} enforces a canonical absolute path invariant,
  * but does **not** enforce the project-root boundary. It is safe for in-memory


### PR DESCRIPTION
## Summary

- Closes a path-traversal attack where `--var-json 'items={"kind":"json-array-stream","path":"/etc/passwd"}'` bypassed file-path validation and reached `resolveFromJsonArrayStream` with arbitrary paths
- Introduces an unexported `unique symbol` brand on `JsonArrayStream` and a `createJsonArrayStream` factory as its sole creation path — `JSON.parse` cannot produce Symbol keys, making the guard unspoofable from user-controlled JSON input
- Zod deserialization schema re-attaches the brand via the factory on state load, so persisted streams continue to work
- Updates all test module mocks that re-implemented the old structural guard to delegate to the real branded implementation

## Attack Vector (closed)

```
--var-json 'items={"kind":"json-array-stream","path":"/etc/passwd"}'
```

1. `JSON.parse` produces `{kind:'json-array-stream', path:'/etc/passwd'}` — a plain object
2. `routeVariable()` stores it as `JsonObject` (the `file:` path-validation branch never runs)
3. `isJsonArrayStream()` previously returned `true` (structural match on `kind` + `path`)
4. `resolveFromJsonArrayStream()` called `createFileProvider('/etc/passwd', ...)` — arbitrary file read

## Test Plan

- [ ] `isJsonArrayStream` returns `false` for a crafted `{ kind: 'json-array-stream', path: '/etc/passwd' }` plain object
- [ ] `resolveForValue` throws `type-mismatch` for a crafted `--var-json` value — `createFileProvider` is never reached
- [ ] State deserialization re-brands via Zod `.transform()` — legitimate stored streams continue to work
- [ ] `npm run verify` passes clean across all packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public helpers to create/brand JSONL stream inputs and new schema builders to validate template values and runbook state against a project root.

* **Bug Fixes / Security**
  * Enforces project-root boundary for JSONL sources; offending runs emit a policy-denied event and stop.

* **API Surface**
  * Added explicit exports for the stream factory and new schema builders.

* **Tests**
  * Expanded coverage for stream branding, boundary checks, and policy-violation flows.

* **Documentation**
  * Added CLI rename and snapshot-testing design specs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->