### PR TITLE
chore(jest): ignore .worktrees/ paths via shared base config

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,0 +1,5 @@
+export default {
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/../../.worktrees/'],
+  modulePathIgnorePatterns: ['<rootDir>/../../.worktrees/'],
+  watchPathIgnorePatterns: ['<rootDir>/../../.worktrees/'],
+};

--- a/packages/claude-code-plugin/jest.config.js
+++ b/packages/claude-code-plugin/jest.config.js
@@ -1,4 +1,7 @@
+import base from '../../jest.config.base.js';
+
 export default {
+  ...base,
   testEnvironment: 'node',
   testTimeout: 10000,
   roots: ['<rootDir>/__tests__'],

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,4 +1,7 @@
+import base from '../../jest.config.base.js';
+
 export default {
+  ...base,
   testEnvironment: 'node',
   roots: ['<rootDir>/__tests__'],
   testMatch: ['**/*.test.ts'],

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,4 +1,7 @@
+import base from '../../jest.config.base.js';
+
 export default {
+  ...base,
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/__tests__'],

--- a/packages/parser/jest.config.js
+++ b/packages/parser/jest.config.js
@@ -1,4 +1,7 @@
+import base from '../../jest.config.base.js';
+
 export default {
+  ...base,
   testEnvironment: 'node',
   roots: ['<rootDir>/__tests__'],
   testMatch: ['**/*.test.ts'],


### PR DESCRIPTION
@coderabbitai ignore

## Summary

- Adds `jest.config.base.js` at repo root with three ignore patterns pointing at `<rootDir>/../../.worktrees/` (`testPathIgnorePatterns`, `modulePathIgnorePatterns`, `watchPathIgnorePatterns`).
- Each per-package Jest config (`parser`, `core`, `cli`, `claude-code-plugin`) imports and spreads the base.
- Fixes haste-map duplicate-module collisions when tests run from the main checkout while git worktrees exist under `.worktrees/<branch>/`.

## Why

When running tests from the main checkout while a worktree like `.worktrees/feature-x/` exists, Jest's haste-map crawls that nested checkout and may surface duplicate-module errors. A subagent recently hit this and considered destructive cleanup. `modulePathIgnorePatterns` is the documented fix; the test/watch patterns prevent test discovery and watch-mode rebuilds inside worktrees as well.

`testPathIgnorePatterns` re-includes the default `/node_modules/` entry (otherwise clobbered when overriding the field).

## Test plan

- [x] `npm run test:unit` — all packages pass
- [x] `npm run check:format` clean
- [x] `npm run check:lint:fast` clean
- [ ] CI green