### PR TITLE
[codex] sync SPEC and FORMAT with parser behavior

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -17,6 +17,7 @@ A Rundown document (`.runbook.md`) is a Markdown file with an optional YAML fron
 | **Steps** | `## ID Title` | 1..N | Top-level execution units. |
 
 ### 1.1 Hierarchy
+
 * **H1**: Metadata (Title).
 * **H2**: Step.
 * **H3**: Substep.
@@ -37,6 +38,7 @@ The frontmatter `description` field provides a summary for runbook discovery and
 Steps are the fundamental units of execution defined by H2 headers.
 
 ### 2.1 Identifiers
+
 Steps must be identified sequentially or by name.
 
 | Format | Type | Usage |
@@ -66,6 +68,7 @@ A step must contain exactly one type of body content.
 Steps are represented as a discriminated union on `kind`: `'base'` (prompt-only), `'command'` (executable code block), `'substeps'` (nested H3 steps), `'for'` (loop with substeps), `'prompted-for'` (unresolved FOR demoted to prompt-only).
 
 ### 3.1 Code Blocks
+
 Executes a command or displays a prompt. Max one code block per step.
 
 | Tag | Type | Behavior |
@@ -77,13 +80,14 @@ Executes a command or displays a prompt. Max one code block per step.
 
 Code block info string tags are matched case-insensitively. `BASH`, `Bash`, and `bash` are all treated as executable.
 
-*   **Environment**: Inherits parent environment.
-*   **CWD**: Project root.
-*   **Stdio**: Inherited.
+* **Environment**: Inherits parent environment.
+* **CWD**: Project root.
+* **Stdio**: Inherited.
 
 ### 3.2 Substeps
 
 Nested steps defined by H3 (`###`) headers.
+
 * **Identifiers**: `### 1` (bare numeric), `### Name` (bare named), `### 1.1` (qualified numeric), or `### Step.Name` (qualified named). Bare forms inherit their parent step from document position — they belong to the H2 step they appear under. Qualified forms explicitly specify their parent.
 * **Strict H3 rule**: When a step contains any valid substep, all H3 headers within that step must be valid substep identifiers.
 * **Aggregation**: Parent step outcome is derived from substeps via transitions (`ALL`/`ANY`).
@@ -120,6 +124,7 @@ Runbook list entries may use template variable references (`{{ VarName }}`) inst
 A runbook-list entry may carry a nested `- DELEGATE` bullet to mark that entry for delegation; see [§4.3 DELEGATE](#43-delegate).
 
 ### 3.4 Runtime Target Identity
+
 Runtime dispatch/completion identity is canonicalized as:
 
 `step + substep + iteration`
@@ -132,6 +137,7 @@ Control flow is defined by **Transitions** (conditions) and **Actions** (effects
 
 ### 4.1 Transitions
 Syntax: `- {RESULT} [{AGGREGATION}]: {ACTION}`
+Syntax: `- {RESULT} [{AGGREGATION}] {ACTION}`
 
 | Component | Values | Description |
 | :--- | :--- | :--- |
@@ -145,10 +151,11 @@ Transition keywords (`PASS`, `YES`, `FAIL`, `NO`) are matched as whole words in 
 **Aggregation semantics:** Aggregation always waits for all DEFER'd results before evaluating. `ALL`/`ANY` evaluates over the count of DEFER'd results, not total substeps/iterations. This mirrors `Promise.allSettled` semantics — all results are collected before the outcome is determined.
 
 **Defaults**:
-*   If only `PASS` defined: `FAIL` -> `STOP`.
-*   If only `FAIL` defined: `PASS` -> `CONTINUE`.
-*   If neither is defined: `PASS CONTINUE`, `FAIL STOP`.
-*   Substeps under aggregation or with runbook delegation default to `PASS DEFER`, `FAIL DEFER`.
+
+* If only `PASS` defined: `FAIL` -> `STOP`.
+* If only `FAIL` defined: `PASS` -> `CONTINUE`.
+* If neither is defined: `PASS CONTINUE`, `FAIL STOP`.
+* Substeps under aggregation or with runbook delegation default to `PASS DEFER`, `FAIL DEFER`.
 
 One-sided aggregation modifiers are rejected — both sides must be explicitly authored (e.g., `PASS ALL ... FAIL ANY ...`).
 
@@ -173,10 +180,11 @@ One-sided aggregation modifiers are rejected — both sides must be explicitly a
 GOTO targeting the containing step (self-reference) without an AT qualifier may create an infinite loop. Use RETRY for bounded re-execution.
 
 **GOTO Syntax**:
-*   `GOTO 3`: Jump to Step 3.
-*   `GOTO 3` (FOR step, no AT): Defaults to the loop's start value (e.g., `1` for `FOR 1 TO 10`, `5` for `FOR 5 TO 1`).
-*   `GOTO 3 AT 1`: Jump to Step 3, iteration 1 (if FOR step).
-*   `GOTO 3 AT {{Index}}`: Re-enter Step 3 at current iteration.
+* `GOTO 3`: Jump to Step 3.
+* `GOTO 3` (FOR step, no AT): Defaults to the loop's start value (e.g., `1` for `FOR 1 TO 10`, `5` for `FOR 5 TO 1`).
+* `GOTO 3 AT 1`: Jump to Step 3, iteration 1 (if FOR step).
+* `GOTO 3 AT {{Index}}`: Re-enter Step 3 at current iteration.
+* `GOTO 3.2.1`: Accepted shorthand for `GOTO 3.1 AT 2` (`STEP.INDEX.SUBSTEP`).
 
 > **Internal:** The compiler resolves step-to-step advancement using `CONTINUE` actions mapped to concrete next-step state IDs at compile time. `NEXT` is rejected as a GOTO target by the parser.
 
@@ -187,6 +195,7 @@ GOTO targeting the containing step (self-reference) without an AT qualifier may 
 **Syntax.** The annotation is bare — `DELEGATE foo` is a syntax error. DELEGATE accepts three equivalent forms:
 
 * **Step-level** — on the H2 step, propagates to all H3 substeps:
+
     ```markdown
     ## 1. Delegated work
     - DELEGATE
@@ -196,13 +205,17 @@ GOTO targeting the containing step (self-reference) without an AT qualifier may 
     ### 1.1 First task
     - child-a.runbook.md
     ```
+
 * **Per-substep** — on individual H3 substeps, applies only to the annotated substeps:
+
     ```markdown
     ### 1.1 First task
     - DELEGATE
     - child-a.runbook.md
     ```
+
 * **Runbook-list shorthand** — nested under runbook-list entries (no H3 headers):
+
     ```markdown
     ## 1. Delegated work
     - child-a.runbook.md
@@ -233,22 +246,22 @@ Steps annotated with `FOR` execute their substeps repeatedly.
 | `FOR var IN {{source}}` | Named variable, data source (all items). |
 | `FOR var IN 1 TO N OF {{source}}` | Named variable, windowed data source. |
 
-*   **Direction**: When `start > end`, iteration descends (step −1). When `start <= end`, it ascends (step +1). Single-number shorthand (`FOR N`) always ascends from 1.
-*   **Limits**: Open-ended data source iteration is capped at 10,000 iterations. Numeric bounds are capped at 10,000 at parse time.
-*   **Source references**: `{{ source }}` in FOR clauses is NOT template-expanded. It is a data source identifier resolved at runtime. Template-variable bounds (`{{ Max }}`) ARE expanded before parsing.
-*   **Unresolved bounds**: When a template-variable bound in a FOR clause cannot be resolved (undefined variable), the step is demoted to `kind: 'prompted-for'` — a substeps-only step with no executable `forClause`. The original FOR text is preserved as prompt text. This allows an orchestrating agent to handle unresolved FOR bounds manually.
-*   **Named variable required**: Data source FOR clauses require a named variable. Unnamed syntax (`FOR {{source}}`) is invalid.
-*   **Data sources**: Provided at runtime as arrays (in-memory) or files (text or JSONL). Resolved against a sources map. See [RUNDOWN.md](./RUNDOWN.md#data-sources) for configuration.
-*   **Constraint**: FOR steps MUST have substeps. Step-level runbook-list shorthand qualifies because it is canonicalized to implicit substeps.
-*   **Scope**: Loop variable available in substeps as `{{var}}`.
-*   **Aggregation**: Transitions on the parent FOR step evaluate the aggregate result of all iterations.
-*   **Iteration-level transitions**: Nested `PASS`/`FAIL` transitions under a `FOR` clause are stored on the `forClause.transitions` field and execute per iteration. Allowed actions: `DEFER` (default, loop back with accumulation), `NEXT` (loop back without accumulation), `CONTINUE` (exit loop), `BREAK` (exit loop), `GOTO`, `STOP`, `COMPLETE` (optionally wrapped by `RETRY`).
+* **Direction**: When `start > end`, iteration descends (step −1). When `start <= end`, it ascends (step +1). Single-number shorthand (`FOR N`) always ascends from 1.
+* **Limits**: Open-ended data source iteration is capped at 10,000 iterations. Numeric bounds are capped at 10,000 at parse time.
+* **Source references**: `{{ source }}` in FOR clauses is NOT template-expanded. It is a data source identifier resolved at runtime. Template-variable bounds (`{{ Max }}`) ARE expanded before parsing.
+* **Unresolved bounds**: When a template-variable bound in a FOR clause cannot be resolved (undefined variable), the step is demoted to `kind: 'prompted-for'` — a substeps-only step with no executable `forClause`. The original FOR text is preserved as prompt text. This allows an orchestrating agent to handle unresolved FOR bounds manually.
+* **Named variable required**: Data source FOR clauses require a named variable. Unnamed syntax (`FOR {{source}}`) is invalid.
+* **Data sources**: Provided at runtime as arrays (in-memory) or files (`.json` or `.jsonl`). Resolved against a sources map. See [RUNDOWN.md](./RUNDOWN.md#data-sources) for configuration.
+* **Constraint**: FOR steps MUST have substeps. Step-level runbook-list shorthand qualifies because it is canonicalized to implicit substeps.
+* **Scope**: Loop variable available in substeps as `{{var}}`.
+* **Aggregation**: Transitions on the parent FOR step evaluate the aggregate result of all iterations.
+* **Iteration-level transitions**: Nested `PASS`/`FAIL` transitions under a `FOR` clause are stored on the `forClause.transitions` field and execute per iteration. Allowed actions: `DEFER` (default, loop back with accumulation), `NEXT` (loop back without accumulation), `CONTINUE` (exit loop), `BREAK` (exit loop), `GOTO`, `STOP`, `COMPLETE` (optionally wrapped by `RETRY`).
 * **CONTINUE at iteration scope**: At step level, CONTINUE proceeds to the next step. At FOR iteration level, CONTINUE exits the loop — the current iteration result is NOT accumulated (same as NEXT/BREAK), and execution continues with the step after the FOR step.
-*   **Nested bullet rule**: Nested bullets under `FOR` must be transition bullets; non-transition nested bullets are invalid and fail parse.
-*   **Retry order**: Iteration-level `RETRY` semantics are deterministic: retry first, then execute the exhausted action. RETRY is universal — it fires for ALL substep actions (including `BREAK` and `NEXT`) based on the iteration result, not the substep action. After retries are exhausted, the substep's action takes effect:
-    *   `BREAK` → exit loop (non-accumulating, same as NEXT)
-    *   `NEXT` → skip to next iteration (or aggregation at end, non-accumulating)
-    *   `DEFER`/`CONTINUE` → configured iteration-level transition applies
+* **Nested bullet rule**: Nested bullets under `FOR` must be transition bullets; non-transition nested bullets are invalid and fail parse.
+* **Retry order**: Iteration-level `RETRY` semantics are deterministic: retry first, then execute the exhausted action. RETRY is universal — it fires for ALL substep actions (including `BREAK` and `NEXT`) based on the iteration result, not the substep action. After retries are exhausted, the substep's action takes effect:
+  * `BREAK` → exit loop (non-accumulating, same as NEXT)
+  * `NEXT` → skip to next iteration (or aggregation at end, non-accumulating)
+  * `DEFER`/`CONTINUE` → configured iteration-level transition applies
 * **Execution model**: Each iteration executes its substeps. Each substep produces a **result** (pass/fail). Substep **handlers** map results to **actions**. Only two actions are loop control: `NEXT` (advance to next iteration) and `BREAK` (exit loop). All other actions (`CONTINUE`, `GOTO`, `STOP`, `COMPLETE`) are general flow control that exit the loop as a side effect.
 
 **Iteration execution flow:**
@@ -294,12 +307,12 @@ Variables use Handlebars syntax: `{{variable}}`.
 | `{{context.vars.NAME}}` | Global | User/config/frontmatter variable namespace. |
 | Loop Var | Loop | Current item/index (e.g., `{{batch}}`). |
 
-*   **Undefined**: Preserved as literal text. A warning is emitted to stderr for each undefined variable.
-*   **Evaluation**: Global vars expanded once; Step/Loop vars expanded per iteration.
-*   **Parent variables**: `{{context.parent.vars.NAME}}` exposes the parent's resolved template variables. Only non-context keys propagate. Available via both chain (`context.parent.parent.vars.*`) and array (`context.ancestors.N.vars.*`) addressing.
-*   **Depth limit**: Parent context chain addressing is capped at 32 levels (enforced on the delegation ancestor chain depth). Exceeding this limit produces an error.
-*   **Path resolution**: Dotted paths are supported consistently (for example `{{context.parent.index}}`).
-*   **Required variables**: The frontmatter `required` field declares variables that must be provided by the caller via CLI flags, config, environment bridge, or delegation inheritance. Required variables must not appear in `inputs:`. Missing required variables produce a hard error (`MISSING_REQUIRED_VARS`) during resolution. Reserved runtime names are also rejected in `required`.
+* **Undefined**: Preserved as literal text. A warning is emitted to stderr for each undefined variable.
+* **Evaluation**: Global vars expanded once; Step/Loop vars expanded per iteration.
+* **Parent variables**: `{{context.parent.vars.NAME}}` exposes the parent's resolved template variables. Only non-context keys propagate. Available via both chain (`context.parent.parent.vars.*`) and array (`context.ancestors.N.vars.*`) addressing.
+* **Depth limit**: Parent context chain addressing is capped at 32 levels (enforced on the delegation ancestor chain depth). Exceeding this limit produces an error.
+* **Path resolution**: Dotted paths are supported consistently (for example `{{context.parent.index}}`).
+* **Required variables**: The frontmatter `required` field declares variables that must be provided by the caller via CLI flags, config, environment bridge, or delegation inheritance. Required variables must not appear in `inputs:`. Missing required variables produce a hard error (`MISSING_REQUIRED_VARS`) during resolution. Reserved runtime names are also rejected in `required`.
 * **Reserved keys**: Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive — any case variant such as `STEP`, `Step`, `INDEX` is also reserved) and cannot be overridden by user variables. The CLI rejects these names in frontmatter `inputs:`, `required`, `--input` flags, `--input-file` contents, and `.rundown/config.yaml` with an error diagnostic. Reserved names in `RD_INPUT_*` environment variables are silently skipped with a warning.
 * **Precedence** (highest to lowest):
     1. CLI flags (`--input-file`, `--input`, `--input-json`) — highest priority
@@ -388,9 +401,9 @@ OUTPUTS declares values to inject into the runbook's live variable space after s
 
 The frontmatter `outputs:` field declares variables to capture at run completion and write to `state.finalVars`.
 
-*   **Evaluation timing**: Evaluated when the runbook reaches a terminal machine transition (`COMPLETE` or `STOPPED`).
-*   **Variable space**: Evaluated against the full merged variable space at termination time (template vars + accumulated step outputs + active step/index frame).
-*   **Cross-runbook forwarding**: When a child runbook completes, its `state.finalVars` are forwarded to the parent's live variable space via `SET_VARIABLES`, making the child's outputs available to subsequent parent steps.
+* **Evaluation timing**: Evaluated when the runbook reaches a terminal machine transition (`COMPLETE` or `STOPPED`).
+* **Variable space**: Evaluated against the full merged variable space at termination time (template vars + accumulated step outputs + active step/index frame).
+* **Cross-runbook forwarding**: When a child runbook completes, its `state.finalVars` are forwarded to the parent's live variable space via `SET_VARIABLES`, making the child's outputs available to subsequent parent steps.
 
 ### 7.3 Delegation Inheritance
 
@@ -438,15 +451,15 @@ Flow:
 
 ## 8. Conformance
 
-1.  **Strict Hierarchy**: H2 -> H3. No H4.
-2.  **Sequential IDs**: Numeric steps must be sequential (1, 2, 3...; gaps invalid). Named steps do not participate in sequential numbering.
-3.  **Strict Ordering**: OUTPUTS -> FOR -> Transitions -> Prompt -> Body.
-4.  **Exclusivity**: Only one body type (Code OR Substeps). Step-level runbook lists are shorthand for Substeps.
-5.  **Single Code Block**: Max one code block per step (executable or display-only).
-6.  **Loop Safety**: `NEXT` and `BREAK` are valid **only** in FOR substeps and FOR iteration-level transitions. Using them at step level outside any FOR loop is rejected by the validator.
-7.  **Source Validation**: FOR clauses referencing a data source must reference a defined source. Named variable required.
-8.  **FOR Requires Substeps**: A FOR-annotated step must contain substeps.
-9.  **No Nested RETRY**: RETRY fallback actions cannot be RETRY.
+1. **Strict Hierarchy**: H2 -> H3. No H4.
+2. **Sequential IDs**: Numeric steps must be sequential (1, 2, 3...; gaps invalid). Named steps do not participate in sequential numbering.
+3. **Structural Bullet Ordering**: Structural bullets must appear before prompt/body content. `FOR` precedes `DELEGATE` when both are present. `OUTPUTS` may appear anywhere in the structural bullet block before prompt/body content.
+4. **Exclusivity**: Only one body type (Code OR Substeps). Step-level runbook lists are shorthand for Substeps.
+5. **Single Code Block**: Max one code block per step (executable or display-only).
+6. **Loop Safety**: `NEXT` and `BREAK` are valid **only** in FOR substeps and FOR iteration-level transitions. Using them at step level outside any FOR loop is rejected by the validator.
+7. **Source Validation**: FOR clauses referencing a data source must reference a defined source. Named variable required.
+8. **FOR Requires Substeps**: A FOR-annotated step must contain substeps.
+9. **No Nested RETRY**: RETRY fallback actions cannot be RETRY.
 10. **FOR Iteration Action Set**: FOR-level nested transitions only allow `CONTINUE`, `DEFER`, `NEXT`, `BREAK`, `GOTO`, `STOP`, `COMPLETE` (plus RETRY wrappers).
 11. **Single Directives**: At most one OUTPUTS directive per step or substep.
 12. **Reserved Names in Directives**: OUTPUTS variable names must not be reserved names (case-insensitive).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -53,11 +53,11 @@ Reserved word matching is case-sensitive. `NEXT` is reserved; `Next` and `NextSt
 Named identifiers must match `/^[A-Za-z_][A-Za-z0-9_]*$/`.
 
 ### 2.2 Content Order
-Step content must appear in this strict order:
-1.  **OUTPUTS**: Context output declarations (optional). Must appear as a bullet item immediately after the step header.
-2.  **FOR Annotation**: Loop definition (optional). Must appear as a bullet item after directives.
-3.  **DELEGATE Annotation**: Delegation marker (optional). See [§4.3 DELEGATE](#43-delegate).
-4.  **Transitions**: Control flow rules (optional). Must appear as bullet items immediately after DELEGATE / FOR (or after directives if neither is present). Transitions must appear before any prompt text or body content.
+Step content must follow these ordering rules:
+1.  **Structural Bullets**: All structural bullets (`OUTPUTS`, `FOR`, `DELEGATE`, transitions) must appear before prompt text or body content.
+2.  **FOR before DELEGATE**: When both `FOR` and `DELEGATE` are present, `FOR` must precede `DELEGATE`.
+3.  **OUTPUTS Placement**: `OUTPUTS` directives may appear anywhere within the structural bullet block (before prompt/body content).
+4.  **Transitions**: Control flow rules (optional). Must appear as bullet items before any prompt text or body content.
 5.  **Prompt**: Text instructions.
 6.  **Body**: One of: Code Block or Substeps. A step-level runbook list is shorthand for implicit sequential substeps (`.1`, `.2`, ...).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17917,7 +17917,7 @@
         "@webcontainer/api": "^1.6.4",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
-        "astro": "^6.1.8",
+        "astro": "^6.1.6",
         "clsx": "^2.1.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",

--- a/packages/parser/__tests__/helpers.test.ts
+++ b/packages/parser/__tests__/helpers.test.ts
@@ -592,6 +592,13 @@ describe('extractStepHeader with named steps', () => {
         description: 'Rollback',
       });
     });
+
+    it('strips spaced em dash separator from named step description', () => {
+      expect(extractStepHeader('Rollback — clean up')).toEqual({
+        name: 'Rollback',
+        description: 'clean up',
+      });
+    });
   });
 });
 
@@ -1351,6 +1358,14 @@ describe('extractSubstepHeader edge cases', () => {
     expect(extractSubstepHeader('1.')).toEqual({
       id: '1',
       description: '',
+    });
+  });
+
+  it('treats trailing dot after qualified numeric substep as separator', () => {
+    expect(extractSubstepHeader('1.2. Restart service')).toEqual({
+      stepRef: '1',
+      id: '2',
+      description: 'Restart service',
     });
   });
 
@@ -2307,6 +2322,10 @@ describe('C2: substep short form (bare numeric)', () => {
     expect(extractSubstepHeader('0')).toBeNull();
   });
 
+  it('returns null for leading-zero numeric substep id', () => {
+    expect(extractSubstepHeader('01')).toBeNull();
+  });
+
   it('still parses dot form "1.1 Description"', () => {
     expect(extractSubstepHeader('1.1 Description')).toEqual({
       stepRef: '1',
@@ -2322,6 +2341,10 @@ describe('E3: bare numeric step headers', () => {
       name: '1',
       description: 'Step 1',
     });
+  });
+
+  it('rejects leading-zero numeric step headers', () => {
+    expect(extractStepHeader('01')).toBeNull();
   });
 
   it('parses "1." as step with default description', () => {
@@ -2562,10 +2585,13 @@ describe('extractSubstepHeader mutation killing', () => {
     expect(result).toEqual({ id: '1', description: '' });
   });
 
-  it('returns null for dot-qualified pattern not matching expected format', () => {
+  it('treats trailing dot after qualified named substep as separator', () => {
     const result = extractSubstepHeader('1.Cleanup. Description');
-    // This doesn't parse as expected pattern - returns null
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      stepRef: '1',
+      id: 'Cleanup',
+      description: 'Description',
+    });
   });
 
   it('returns null for string starting with dot', () => {

--- a/packages/parser/__tests__/outputs-inputs.test.ts
+++ b/packages/parser/__tests__/outputs-inputs.test.ts
@@ -120,6 +120,17 @@ describe('parseRunbookDocument with OUTPUTS directive', () => {
     ]);
   });
 
+  it('attaches naked parsed outputs to step when OUTPUTS directive is present', () => {
+    const md = `## 1. Write plan
+- PASS CONTINUE
+- FAIL STOP
+- OUTPUTS
+  - PlanPath
+`;
+    const { runbook } = parseRunbookDocument(md);
+    expect(runbook.steps[0].outputs).toEqual([{ name: 'PlanPath' }]);
+  });
+
   it('leaves outputs undefined when no OUTPUTS directive is present', () => {
     const md = `## 1. Simple step
 - PASS CONTINUE
@@ -174,6 +185,21 @@ describe('parseRunbookDocument with OUTPUTS directive', () => {
     expect(step.substeps[0].outputs).toEqual([
       { name: 'ChildPath', value: '{{ path "child.json" }}' },
     ]);
+  });
+
+  it('attaches naked parsed outputs to a substep when OUTPUTS directive is present', () => {
+    const md = `## 1. Parent step
+### 1.1 Child substep
+- OUTPUTS
+  - ChildPath
+`;
+    const { runbook } = parseRunbookDocument(md);
+    const step = runbook.steps[0];
+    expect(step.kind).toBe('substeps');
+    if (step.kind !== 'substeps') {
+      throw new Error('expected substeps step');
+    }
+    expect(step.substeps[0].outputs).toEqual([{ name: 'ChildPath' }]);
   });
 
   it('throws RunbookSyntaxError when OUTPUTS block contains duplicate names', () => {

--- a/packages/parser/__tests__/schemas.test.ts
+++ b/packages/parser/__tests__/schemas.test.ts
@@ -193,6 +193,32 @@ describe('StepIdSchema with named steps', () => {
     expect(StepIdSchema.safeParse({ step: 'ErrorHandler', substep: 'Recover' }).success).toBe(true);
   });
 
+  it('rejects leading-zero numeric step', () => {
+    expect(StepIdSchema.safeParse({ step: '01' }).success).toBe(false);
+  });
+
+  it('rejects leading-zero numeric substep', () => {
+    expect(StepIdSchema.safeParse({ step: 'ErrorHandler', substep: '01' }).success).toBe(false);
+  });
+
+  it('rejects leading-zero numeric qualifier step', () => {
+    expect(
+      StepIdSchema.safeParse({
+        step: 'NEXT',
+        qualifier: { step: '01' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects leading-zero numeric qualifier substep', () => {
+    expect(
+      StepIdSchema.safeParse({
+        step: 'NEXT',
+        qualifier: { step: 'Cleanup', substep: '01' },
+      }).success,
+    ).toBe(false);
+  });
+
   it('rejects NEXT with substep', () => {
     expect(StepIdSchema.safeParse({ step: 'NEXT', substep: '1' }).success).toBe(false);
   });
@@ -265,6 +291,11 @@ describe('unified naming schemas', () => {
   it('StepNameSchema accepts numeric strings', () => {
     const result = StepIdSchema.safeParse({ step: '1' });
     expect(result.success).toBe(true);
+  });
+
+  it('StepNameSchema rejects leading-zero numeric strings', () => {
+    const result = StepNameSchema.safeParse('01');
+    expect(result.success).toBe(false);
   });
 
   it('StepNameSchema accepts identifiers', () => {

--- a/packages/parser/__tests__/step-id.test.ts
+++ b/packages/parser/__tests__/step-id.test.ts
@@ -354,6 +354,18 @@ describe('parseStepIdFromString reserved word substep checks mutation killing', 
   it('rejects multi-digit zero substep (named)', () => {
     expect(parseStepIdFromString('deploy.00')).toBeNull();
   });
+
+  it('rejects leading-zero numeric step target', () => {
+    expect(parseStepIdFromString('01')).toBeNull();
+  });
+
+  it('rejects leading-zero numeric step in substep target', () => {
+    expect(parseStepIdFromString('01.2')).toBeNull();
+  });
+
+  it('rejects leading-zero iteration in three-part shorthand', () => {
+    expect(parseStepIdFromString('1.02.3')).toBeNull();
+  });
 });
 
 describe('parseStepIdFromString two-part step ID mutation killing', () => {

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -4,6 +4,11 @@ import {
   type ParseConditionalResult,
   type AggregationModifier,
 } from './types.js';
+import {
+  isCanonicalPositiveInteger,
+  isReservedWord,
+  NAMED_IDENTIFIER_PATTERN,
+} from './identifiers.js';
 import type {
   Action,
   AccumulatingAction,
@@ -15,12 +20,7 @@ import type {
   Transitions,
 } from './schemas.js';
 import { MAX_STEP_NUMBER, MAX_FOR_BOUND } from './schemas.js';
-import {
-  parseStepIdFromString,
-  stepIdToString,
-  isReservedWord,
-  NAMED_IDENTIFIER_PATTERN,
-} from './step-id.js';
+import { parseStepIdFromString, stepIdToString } from './step-id.js';
 import type { ParsedForClause, Bound, RunbookEntry, RunbookRef, OutputDeclaration } from './ast.js';
 import { isBoundRef } from './guards.js';
 import { TEMPLATE_VAR_PATH_PATTERN } from './schemas.js';
@@ -140,10 +140,6 @@ export interface ParsedSubstepHeader {
 
 /** Characters to strip from trailing position of named step identifiers. */
 const TRAILING_SEPARATORS = new Set(['.', ':', '\u2014', '\u2192', ')', '-']);
-
-function isCanonicalPositiveInteger(value: string): boolean {
-  return /^[1-9]\d*$/.test(value);
-}
 
 /**
  * Strip common separators and whitespace from the beginning of text.
@@ -1136,6 +1132,8 @@ export function parseFrontmatterOutputDeclaration(text: string): OutputDeclarati
   // With-value form: delegate to existing step-level parser
   return parseOutputDeclaration(text);
 }
+
+export { isCanonicalPositiveInteger } from './identifiers.js';
 
 /**
  * Format an action as its canonical string representation.

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -141,6 +141,10 @@ export interface ParsedSubstepHeader {
 /** Characters to strip from trailing position of named step identifiers. */
 const TRAILING_SEPARATORS = new Set(['.', ':', '\u2014', '\u2192', ')', '-']);
 
+function isCanonicalPositiveInteger(value: string): boolean {
+  return /^[1-9]\d*$/.test(value);
+}
+
 /**
  * Strip common separators and whitespace from the beginning of text.
  *
@@ -199,6 +203,7 @@ export function extractStepHeader(text: string): ParsedStepHeader | null {
 
   if (numEnd > 0) {
     const numberStr = trimmed.slice(0, numEnd);
+    if (!isCanonicalPositiveInteger(numberStr)) return null;
     const number = parseInt(numberStr, 10);
     if (number <= 0 || number > MAX_STEP_NUMBER) return null;
 
@@ -221,7 +226,7 @@ export function extractStepHeader(text: string): ParsedStepHeader | null {
   if (isReservedWord(strippedName)) return null;
 
   const restWords = words.slice(1);
-  const description = restWords.length > 0 ? restWords.join(' ') : strippedName;
+  const description = restWords.length > 0 ? stripSeparator(restWords.join(' ')) : strippedName;
 
   return { name: strippedName, description };
 }
@@ -237,7 +242,7 @@ export function extractStepHeader(text: string): ParsedStepHeader | null {
  * @returns True if the string is a valid step reference, false otherwise
  */
 function isValidStepRef(s: string): boolean {
-  if (/^\d+$/.test(s)) return parseInt(s, 10) > 0;
+  if (/^\d+$/.test(s)) return isCanonicalPositiveInteger(s);
   if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(s)) return !isReservedWord(s);
   return false;
 }
@@ -253,7 +258,7 @@ function isValidStepRef(s: string): boolean {
  * @returns True if the string is a valid substep identifier, false otherwise
  */
 function isValidSubstepId(s: string): boolean {
-  if (/^\d+$/.test(s)) return parseInt(s, 10) > 0;
+  if (/^\d+$/.test(s)) return isCanonicalPositiveInteger(s);
   if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(s)) return !isReservedWord(s);
   return false;
 }
@@ -286,8 +291,7 @@ export function extractSubstepHeader(text: string): ParsedSubstepHeader | null {
 
   // Branch 1: Bare positive integer (e.g., "1", "2 Description", "1. Title", "3) Title")
   if (/^\d+$/.test(firstToken)) {
-    const num = parseInt(firstToken, 10);
-    if (num > 0) {
+    if (isCanonicalPositiveInteger(firstToken)) {
       const afterFirstToken = trimmed.slice(firstTokenRaw.length);
       const description = stripSeparator(afterFirstToken);
       return { id: firstToken, description };
@@ -303,7 +307,12 @@ export function extractSubstepHeader(text: string): ParsedSubstepHeader | null {
       if (!afterDot) return null;
 
       const spaceIndex = afterDot.indexOf(' ');
-      const substepId = spaceIndex === -1 ? afterDot : afterDot.slice(0, spaceIndex);
+      const substepIdRaw = spaceIndex === -1 ? afterDot : afterDot.slice(0, spaceIndex);
+      let substepIdEnd = substepIdRaw.length;
+      while (substepIdEnd > 0 && TRAILING_SEPARATORS.has(substepIdRaw[substepIdEnd - 1])) {
+        substepIdEnd--;
+      }
+      const substepId = substepIdRaw.slice(0, substepIdEnd);
       if (!isValidSubstepId(substepId)) return null;
 
       const remainder = spaceIndex !== -1 ? afterDot.slice(spaceIndex) : '';

--- a/packages/parser/src/identifiers.ts
+++ b/packages/parser/src/identifiers.ts
@@ -3,7 +3,7 @@
  *
  * These keywords have special meaning in the Rundown runbook syntax.
  */
-export const RESERVED_WORDS = new Set([
+export const RESERVED_WORDS: ReadonlySet<string> = new Set([
   'NEXT',
   'CONTINUE',
   'COMPLETE',

--- a/packages/parser/src/identifiers.ts
+++ b/packages/parser/src/identifiers.ts
@@ -1,0 +1,44 @@
+/**
+ * Reserved words that cannot be used as named step or substep identifiers.
+ *
+ * These keywords have special meaning in the Rundown runbook syntax.
+ */
+export const RESERVED_WORDS = new Set([
+  'NEXT',
+  'CONTINUE',
+  'COMPLETE',
+  'STOP',
+  'GOTO',
+  'RETRY',
+  'PASS',
+  'FAIL',
+  'YES',
+  'NO',
+  'ALL',
+  'ANY',
+  'BREAK',
+  'DEFER',
+  'FOR',
+  'IN',
+  'TO',
+  'AT',
+  'DELEGATE',
+]);
+
+/**
+ * Check if a string is a reserved word.
+ *
+ * @param word - The string to check against reserved words
+ * @returns True if the word is reserved and cannot be used as an identifier
+ */
+export function isReservedWord(word: string): boolean {
+  return RESERVED_WORDS.has(word);
+}
+
+/**
+ * Valid identifier pattern for named steps and substeps.
+ *
+ * Matches identifiers that start with a letter or underscore,
+ * followed by zero or more letters, digits, or underscores.
+ */
+export const NAMED_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;

--- a/packages/parser/src/identifiers.ts
+++ b/packages/parser/src/identifiers.ts
@@ -42,3 +42,15 @@ export function isReservedWord(word: string): boolean {
  * followed by zero or more letters, digits, or underscores.
  */
 export const NAMED_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Check whether a string is a canonical positive integer.
+ *
+ * Canonical values have no leading zeroes and contain only decimal digits.
+ *
+ * @param value - The string to check
+ * @returns True if the string is a positive integer in canonical form
+ */
+export function isCanonicalPositiveInteger(value: string): boolean {
+  return /^[1-9]\d*$/.test(value);
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -33,6 +33,7 @@ export {
   isLoopControlAction,
   isStepExitAction,
   isTerminalAction,
+  isCanonicalPositiveInteger,
   parseOutputDeclaration,
   parseStepOutputDeclaration,
   parseFrontmatterOutputDeclaration,

--- a/packages/parser/src/schemas.ts
+++ b/packages/parser/src/schemas.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { isReservedWord, NAMED_IDENTIFIER_PATTERN } from './identifiers.js';
+import {
+  isCanonicalPositiveInteger,
+  isReservedWord,
+  NAMED_IDENTIFIER_PATTERN,
+} from './identifiers.js';
 
 /**
  * Maximum valid step number.
@@ -169,7 +173,7 @@ export const StepNameSchema = z.string().refine(
   (s) => {
     if (/^\d+$/.test(s)) {
       const num = parseInt(s, 10);
-      return num > 0 && num <= MAX_STEP_NUMBER;
+      return isCanonicalPositiveInteger(s) && num <= MAX_STEP_NUMBER;
     }
     return NAMED_IDENTIFIER_PATTERN.test(s) && !isReservedWord(s);
   },
@@ -184,11 +188,26 @@ export const StepNameSchema = z.string().refine(
 export const StepIdSchema = z
   .object({
     step: z.union([z.literal('NEXT'), StepNameSchema]),
-    substep: z.string().optional(),
+    substep: z
+      .string()
+      .refine(
+        (s) =>
+          isCanonicalPositiveInteger(s) || (NAMED_IDENTIFIER_PATTERN.test(s) && !isReservedWord(s)),
+        { message: 'Substep must be a positive integer or valid identifier' },
+      )
+      .optional(),
     qualifier: z
       .object({
         step: StepNameSchema,
-        substep: z.string().optional(),
+        substep: z
+          .string()
+          .refine(
+            (s) =>
+              isCanonicalPositiveInteger(s) ||
+              (NAMED_IDENTIFIER_PATTERN.test(s) && !isReservedWord(s)),
+            { message: 'Substep must be a positive integer or valid identifier' },
+          )
+          .optional(),
       })
       .optional(),
     at: z.union([z.number().int().positive(), z.string().regex(TEMPLATE_VAR_PATTERN)]).optional(),

--- a/packages/parser/src/schemas.ts
+++ b/packages/parser/src/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { isReservedWord, NAMED_IDENTIFIER_PATTERN } from './step-id.js';
+import { isReservedWord, NAMED_IDENTIFIER_PATTERN } from './identifiers.js';
 
 /**
  * Maximum valid step number.

--- a/packages/parser/src/step-id.ts
+++ b/packages/parser/src/step-id.ts
@@ -1,7 +1,11 @@
 import type { StepId } from './schemas.js';
-import { isCanonicalPositiveInteger } from './helpers.js';
+import {
+  isCanonicalPositiveInteger,
+  isReservedWord,
+  NAMED_IDENTIFIER_PATTERN,
+} from './identifiers.js';
+
 export { RESERVED_WORDS, isReservedWord, NAMED_IDENTIFIER_PATTERN } from './identifiers.js';
-import { isReservedWord, NAMED_IDENTIFIER_PATTERN } from './identifiers.js';
 
 /**
  * Options for controlling step ID parsing behavior.

--- a/packages/parser/src/step-id.ts
+++ b/packages/parser/src/step-id.ts
@@ -1,61 +1,7 @@
 import type { StepId } from './schemas.js';
-
-/**
- * Reserved words that cannot be used as named step or substep identifiers.
- *
- * These keywords have special meaning in the Rundown runbook syntax:
- * - Flow control: NEXT, CONTINUE, DEFER, COMPLETE, STOP, GOTO, RETRY
- * - FOR loop: FOR, IN, TO, AT, BREAK
- * - Conditionals: PASS, FAIL, YES, NO
- * - Aggregation: ALL, ANY
- * - Delegation: DELEGATE
- *
- * Using these as step names would create parsing ambiguity.
- */
-export const RESERVED_WORDS = new Set([
-  'NEXT',
-  'CONTINUE',
-  'COMPLETE',
-  'STOP',
-  'GOTO',
-  'RETRY',
-  'PASS',
-  'FAIL',
-  'YES',
-  'NO',
-  'ALL',
-  'ANY',
-  'BREAK',
-  'DEFER',
-  'FOR',
-  'IN',
-  'TO',
-  'AT',
-  'DELEGATE',
-]);
-
-/**
- * Check if a string is a reserved word.
- *
- * @param word - The string to check against reserved words
- * @returns True if the word is reserved and cannot be used as an identifier
- */
-export function isReservedWord(word: string): boolean {
-  return RESERVED_WORDS.has(word);
-}
-
-/**
- * Valid identifier pattern for named steps and substeps.
- *
- * Matches identifiers that start with a letter or underscore,
- * followed by zero or more letters, digits, or underscores.
- * Examples: "ErrorHandler", "cleanup_task", "_internal", "Step1"
- */
-export const NAMED_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
-
-function isCanonicalPositiveInteger(value: string): boolean {
-  return /^[1-9]\d*$/.test(value);
-}
+import { isCanonicalPositiveInteger } from './helpers.js';
+export { RESERVED_WORDS, isReservedWord, NAMED_IDENTIFIER_PATTERN } from './identifiers.js';
+import { isReservedWord, NAMED_IDENTIFIER_PATTERN } from './identifiers.js';
 
 /**
  * Options for controlling step ID parsing behavior.

--- a/packages/parser/src/step-id.ts
+++ b/packages/parser/src/step-id.ts
@@ -53,6 +53,10 @@ export function isReservedWord(word: string): boolean {
  */
 export const NAMED_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
+function isCanonicalPositiveInteger(value: string): boolean {
+  return /^[1-9]\d*$/.test(value);
+}
+
 /**
  * Options for controlling step ID parsing behavior.
  */
@@ -72,8 +76,7 @@ function isValidSubstepInStepId(substep: string): boolean {
     return false;
   }
   if (/^\d+$/.test(substep)) {
-    const substepNum = parseInt(substep, 10);
-    if (substepNum < 1) return false;
+    if (!isCanonicalPositiveInteger(substep)) return false;
   }
   return true;
 }
@@ -130,10 +133,10 @@ function parseThreeLevelNumeric(
   const substep = match[3];
 
   const stepNum = parseInt(stepStr, 10);
-  if (stepNum <= 0) return null;
+  if (!isCanonicalPositiveInteger(stepStr) || stepNum <= 0) return null;
 
   const iterationNum = parseInt(iterationStr, 10);
-  if (iterationNum < 1) return null;
+  if (!isCanonicalPositiveInteger(iterationStr) || iterationNum < 1) return null;
 
   if (substep && !isValidSubstepInStepId(substep)) return null;
 
@@ -164,7 +167,7 @@ function parseTwoLevelNumeric(
   const stepNum = parseInt(stepStr, 10);
 
   // Validate step number is positive
-  if (stepNum <= 0) return null;
+  if (!isCanonicalPositiveInteger(stepStr) || stepNum <= 0) return null;
 
   const substep = match[2];
 


### PR DESCRIPTION
## Summary

- Reconcile SPEC/FORMAT docs with current parser/runtime behavior for structural bullets, transition syntax, data sources, runbook-list annotations, `GOTO` shorthand, status vars, and file-backed naked `OUTPUTS`.
- Tighten parser identifier handling to reject leading-zero numeric IDs and targets.
- Fix header parsing for documented separator cases like qualified substeps and spaced named-heading separators.

## Why

The docs and implementation had drifted in both directions: some tested behavior was under-documented, while a few parser paths did not match the documented heading/identifier contract. This PR documents deliberate behavior and fixes the parser cases that create ambiguous or surprising authoring syntax.

## Validation

- `npm test --workspace @rundown-org/parser -- --runInBand`
- `npm run check:types --workspace @rundown-org/parser`
- `npm run check:lint:fast`
- `npm run check:format`
- `npm run check:spell`
- `git diff --cached --check` before commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated specification with new syntax variants for Transition and GOTO commands
  * Clarified supported file formats (.json, .jsonl) and structural validation ordering
  * Enhanced conformance requirements for step directives and naming constraints

* **Improvements**
  * Strengthened parser validation for numeric identifiers
  * Refined step/substep structure conformance rules
  * Improved validation for OUTPUTS directives
<!-- end of auto-generated comment: release notes by coderabbit.ai -->