### PR TITLE
Feat/output capture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,12 +255,12 @@ rundown run [file] --policy ./policy.yaml # Custom policy file
 rundown run [file] --sandbox              # Enable OS-level sandbox (default)
 rundown run [file] --no-sandbox           # Disable sandbox (trust mode)
 rundown run [file] --sandbox-strict       # Fail if sandbox unavailable
-rundown run [file] --trust-js-policy      # Trust executable JS policy configs
+rundown run [file] --trust-js-policy      # Trust executable JS policy configs and config-declared helpers
 ```
 
 ## Policy Configuration
 
-Policy files are auto-discovered from: `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, `package.json` (rundown field). JavaScript config files (`.js`, `.cjs`, `.mjs`) are not auto-discovered — they require explicit `--policy <path>` with `--trust-js-policy`.
+Policy files are auto-discovered from: `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, `package.json` (rundown field). JavaScript config files (`.js`, `.cjs`, `.mjs`) are not auto-discovered — they require explicit `--policy <path>` with `--trust-js-policy`. Helper modules declared by policy config are skipped unless `--trust-js-policy` is set; `--helpers` remains an explicit CLI opt-in.
 
 See [docs/SECURITY.md](docs/SECURITY.md) for full security policy documentation.
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -103,13 +103,12 @@ or carry a value expression. Naked entries at step / substep level activate
 a file-backed channel: Rundown creates an empty file whose path is composed
 from the active scope tiers (step id, optional substep id, optional FOR
 iteration index) followed by `<VarName>` and exports its absolute path as
-`RD_OUTPUTS_<VarName>` to the spawned command. The four possible paths are:
+`RD_OUTPUTS_<VarName>` to the spawned command. The three possible paths are:
 
 | Scope | Path |
 |---|---|
 | Step | `.rundown/runs/<runId>/outputs/<stepId>/<VarName>` |
 | Substep | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<VarName>` |
-| FOR iteration (in step) | `.rundown/runs/<runId>/outputs/<stepId>/<iteration>/<VarName>` |
 | FOR iteration (in substep) | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<iteration>/<VarName>` |
 
 See [docs/SPEC.md §7.1](./SPEC.md#71-outputs). Expression-form output values

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -89,7 +89,7 @@ Substeps cannot contain nested substeps. See [SPEC.md §1.1](./SPEC.md) for the 
 ```ebnf
 outputs_directive ::= "- OUTPUTS" newline output_list
 output_list       ::= ( ws "- " output_entry newline )+
-output_entry      ::= variable_name ws output_value
+output_entry      ::= variable_name ( ws output_value )?
 output_value      ::= helper_call | template_variable | quoted_string | variable_name
 helper_call       ::= "{{" ws? variable_name ( ws argument )+ ws? "}}"
 argument          ::= quoted_string | variable_path
@@ -97,7 +97,25 @@ argument          ::= quoted_string | variable_path
 
 A step or substep may declare at most one OUTPUTS directive. Duplicate directives on the same target are rejected. The `- INPUTS` directive has been removed — use the frontmatter `inputs:` field to declare default variable values.
 
-OUTPUTS declares values to inject into the runbook's live variable space after step completion. Output values may be Handlebars helper calls (`{{ path "file.json" }}`), template variable references (`{{ VarName }}`), quoted literals (`"value"`), or bare variable references (`VarName`).
+OUTPUTS declares values to inject into the runbook's live variable space
+after step completion. An entry may be a **naked declaration** (name only)
+or carry a value expression. Naked entries at step / substep level activate
+a file-backed channel: Rundown creates an empty file whose path is composed
+from the active scope tiers (step id, optional substep id, optional FOR
+iteration index) followed by `<VarName>` and exports its absolute path as
+`RD_OUTPUTS_<VarName>` to the spawned command. The four possible paths are:
+
+| Scope | Path |
+|---|---|
+| Step | `.rundown/runs/<runId>/outputs/<stepId>/<VarName>` |
+| Substep | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<VarName>` |
+| FOR iteration (in step) | `.rundown/runs/<runId>/outputs/<stepId>/<iteration>/<VarName>` |
+| FOR iteration (in substep) | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<iteration>/<VarName>` |
+
+See [docs/SPEC.md §7.1](./SPEC.md#71-outputs). Expression-form output values
+may be Handlebars helper calls (`{{ path "file.json" }}`), template variable
+references (`{{ VarName }}`), quoted literals (`"value"`), or bare variable
+references (`VarName`).
 
 Variable names in OUTPUTS must match `variable_name` and must not be [reserved variable names](#reserved-variable-names).
 

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -627,12 +627,12 @@ See [SECURITY.md](./SECURITY.md) for full default policy details, including comm
 | `-y, --yes` | Auto-approve prompts |
 | `--non-interactive` | CI mode (auto-deny unlisted commands) |
 | `--policy <file>` | Use custom policy file |
-| `--trust-js-policy` | Trust an explicitly selected JS policy file |
+| `--trust-js-policy` | Trust an explicitly selected JS policy file and helper modules declared by policy config |
 | `--sandbox` | Enable OS-level filesystem sandbox |
 | `--no-sandbox` | Disable sandbox enforcement |
 | `--sandbox-strict` | Fail if sandbox is unavailable |
 
-Policy discovery is data-only by default: `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, or the `rundown` field in `package.json`. Executable `rundown.config.js/.cjs/.mjs` files are only loaded when passed via `--policy` together with `--trust-js-policy`.
+Policy discovery is data-only by default: `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, or the `rundown` field in `package.json`. Executable `rundown.config.js/.cjs/.mjs` files are only loaded when passed via `--policy` together with `--trust-js-policy`. Helper modules declared by policy config are also executable code and are skipped unless `--trust-js-policy` is set; `--helpers` remains an explicit CLI opt-in.
 
 ### Examples
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -359,7 +359,7 @@ env:
 | `--allow-all` | Bypass all policy checks (trust mode) |
 | `--deny-all` | Block all operations not explicitly allowed |
 | `--policy <file>` | Use a specific policy configuration file |
-| `--trust-js-policy` | Trust an explicitly selected executable JS policy file |
+| `--trust-js-policy` | Trust an explicitly selected executable JS policy file and helper modules declared by policy config |
 | `-y, --yes` | Skip confirmation prompts (auto-approve) |
 | `--non-interactive` | Non-interactive mode (auto-deny, CI-friendly) |
 | `--sandbox` | Enable OS-level sandbox (default on supported platforms) |
@@ -369,6 +369,8 @@ env:
 **Note:** If both `--allow-all` and `--deny-all` are specified, `--deny-all` takes precedence.
 
 **Note:** `--allow-all` implies `--no-sandbox` (trust mode bypasses all enforcement).
+
+**Note:** Helper modules declared by `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, or `package.json` are executable JavaScript and are skipped unless `--trust-js-policy` is set. Helper modules passed directly with `--helpers` are treated as explicit CLI opt-in.
 
 ### Precedence Order
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -365,14 +365,13 @@ OUTPUTS declares values to inject into the runbook's live variable space after s
   (just the name) at step or substep level activates a file-backed output
   channel. Before the step's command spawns, Rundown creates an empty file
   whose path includes the active scope tiers in this order: step id, optional
-  substep id, optional FOR iteration index, then `<VarName>`. The four
+  substep id, optional FOR iteration index, then `<VarName>`. The three
   resulting paths are:
 
   | Scope | Path |
   |---|---|
   | Step | `.rundown/runs/<runId>/outputs/<stepId>/<VarName>` |
   | Substep | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<VarName>` |
-  | FOR iteration (in step) | `.rundown/runs/<runId>/outputs/<stepId>/<iteration>/<VarName>` |
   | FOR iteration (in substep) | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<iteration>/<VarName>` |
 
   Rundown injects `RD_OUTPUTS_<VarName>=<absolute-path>` into the command's

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -356,7 +356,31 @@ OUTPUTS declares values to inject into the runbook's live variable space after s
 
 * **Evaluation trigger**: OUTPUTS are evaluated by the XState machine on both PASS and FAIL transitions when the completing step or substep declares outputs.
 * **Storage**: Step-level outputs merge into the machine's live `context.variables`; terminal frontmatter outputs are written to `context.finalVars` and persisted to `RunbookState.finalVars`.
-* **Expressions**: Each output entry is evaluated against the step's resolved runtime frame. Supported forms: Handlebars expressions (`{{ path "file.json" }}`), quoted literals (`"value"` — may embed Handlebars templates, e.g. `"{{ Index }}"`), bare variable references (`VarName`).
+* **Expressions**: Each entry is evaluated against the step's resolved
+  runtime frame. Supported forms: naked file-backed channel (`VarName` only —
+  see "Naked form" below), Handlebars expressions (`{{ path "file.json" }}`),
+  quoted literals (`"value"` — may embed Handlebars templates, e.g.
+  `"{{ Index }}"`), and bare variable references (`VarName value`).
+* **Naked form (file-backed channel)**: An OUTPUTS entry with no expression
+  (just the name) at step or substep level activates a file-backed output
+  channel. Before the step's command spawns, Rundown creates an empty file
+  whose path includes the active scope tiers in this order: step id, optional
+  substep id, optional FOR iteration index, then `<VarName>`. The four
+  resulting paths are:
+
+  | Scope | Path |
+  |---|---|
+  | Step | `.rundown/runs/<runId>/outputs/<stepId>/<VarName>` |
+  | Substep | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<VarName>` |
+  | FOR iteration (in step) | `.rundown/runs/<runId>/outputs/<stepId>/<iteration>/<VarName>` |
+  | FOR iteration (in substep) | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<iteration>/<VarName>` |
+
+  Rundown injects `RD_OUTPUTS_<VarName>=<absolute-path>` into the command's
+  environment (after policy filtering, rundown-wins). When the command exits,
+  Rundown reads the file, trims trailing whitespace and newlines, and merges
+  the value into `context.variables` using the same precedence as
+  expression-form outputs. UTF-8 only; missing, empty, or non-UTF-8 content
+  is logged and omitted (best-effort, transition not rolled back).
 * **Best-effort**: OUTPUTS evaluation is non-fatal. Failed expressions are omitted from the stored result and logged; the step transition is not rolled back.
 * **Merge semantics**: Outputs merge into the existing live variable space — new keys are added, existing keys are overwritten.
 * **Status visibility**: The `rd status` command includes a `vars` field that exposes the current merged variable space (template vars + step outputs).
@@ -432,6 +456,19 @@ Flow:
 15. **DELEGATE Requires Runbook Target**: Every substep marked `delegate: true` must declare at least one runbook target. A bare DELEGATE substep (no runbook bullet) is rejected at parse time. Step-level DELEGATE propagates to all substeps and the same target requirement applies to every propagated child.
 16. **RETRY on DELEGATE is Result-Agnostic**: `rd delegate --retry` succeeds regardless of the substep's prior result. Retry re-issues a fresh token by cancelling the current delegation and re-creating one with a new token; the retry hook propagates the canonical FOR-iteration location through `contextSnapshot.at`.
 17. **Parent Orchestration Supersedes Child Lifecycle for Exit Codes**: When a delegated child runbook reaches a terminal lifecycle (e.g. `FAIL STOP` on the child) and a parent absorbs the outcome non-terminally (e.g. `FAIL RETRY`), the child's CLI invocation (`rd pass` / `rd fail`) exits 0. Exit 1 is reserved for cases where the orchestrated workflow has actually halted: no parent linkage exists and the local lifecycle is `stopped`, or the parent's propagation also resolves to `stopped` (e.g. RETRY exhaustion → `STOP` fallback). This lets scripted orchestrators use exit codes as flow control without mistaking an in-progress retry for a terminal failure.
+18. **File-Backed Naked OUTPUTS**: A naked OUTPUTS entry (name only) at step
+    or substep level activates a file-backed channel. `RD_OUTPUTS_<VarName>`
+    is injected only for naked-form entries; expression-form entries produce
+    no file and no env var.
+19. **Mixed OUTPUTS Forms**: A step or substep may mix naked and expression
+    OUTPUTS entries within a single OUTPUTS block.
+20. **`RD_OUTPUTS_*` is Rundown-Wins**: `RD_OUTPUTS_<VarName>` is always a
+    valid writable absolute path when the command starts. These env vars are
+    injected by Rundown after policy environment filtering and cannot be
+    blocked or overridden by user-supplied environment variables.
+21. **Captured Output Merge Precedence**: Captured naked outputs merge into
+    `context.variables` using the same precedence as expression-form
+    outputs — same-name keys overwrite existing values.
 
 ## 9. Compatibility
 

--- a/packages/cli/__tests__/integration/helper-extensibility.test.ts
+++ b/packages/cli/__tests__/integration/helper-extensibility.test.ts
@@ -61,8 +61,24 @@ describe('Helper extensibility — end-to-end (helper registered via .rundownrc)
     await workspace.cleanup();
   });
 
-  it('resolve reports no unresolved variables when helper transforms the placeholder', async () => {
-    const result = runCli('resolve demo.runbook.md --input Name=world', workspace);
+  it('run --prompted preserves helper placeholders from config unless JS policy is trusted', async () => {
+    const result = runCli('run --prompted demo.runbook.md --input Name=world', workspace);
+
+    expect(result.exitCode).toBe(0);
+
+    const events = parseJsonEvents(result.stdout) as Array<Record<string, unknown>>;
+    const stepEntered = events.find((e) => e.type === 'step_entered');
+
+    expect(stepEntered).toBeDefined();
+    expect(stepEntered!.prompt).toContain('{{ upper Name }}');
+    expect(stepEntered!.prompt).not.toContain('WORLD');
+  });
+
+  it('resolve reports no unresolved variables when trusted config helper transforms the placeholder', async () => {
+    const result = runCli(
+      'resolve demo.runbook.md --input Name=world --trust-js-policy',
+      workspace,
+    );
 
     expect(result.exitCode).toBe(0);
 
@@ -74,8 +90,11 @@ describe('Helper extensibility — end-to-end (helper registered via .rundownrc)
     expect(unresolved ?? []).toHaveLength(0);
   });
 
-  it('run --prompted renders {{ upper Name }} as WORLD in the step_entered prompt', async () => {
-    const result = runCli('run --prompted demo.runbook.md --input Name=world', workspace);
+  it('run --prompted renders {{ upper Name }} as WORLD with trusted config helper', async () => {
+    const result = runCli(
+      'run --prompted demo.runbook.md --input Name=world --trust-js-policy',
+      workspace,
+    );
 
     expect(result.exitCode).toBe(0);
 
@@ -113,7 +132,7 @@ describe('Helper extensibility — collision warning when variable name matches 
   it('resolve emits a collision warning when a variable shares a name with a registered helper', async () => {
     // Passing --input upper=... creates a variable named "upper", which collides with the helper
     const result = runCli(
-      'resolve demo.runbook.md --input Name=world --input upper=custom',
+      'resolve demo.runbook.md --input Name=world --input upper=custom --trust-js-policy',
       workspace,
     );
 
@@ -131,6 +150,39 @@ describe('Helper extensibility — collision warning when variable name matches 
     );
     expect(collisionWarning).toBeDefined();
     expect(collisionWarning!.message).toContain('{{ ./upper }}');
+  });
+});
+
+describe('Helper extensibility — end-to-end (helper registered via --helpers)', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+
+    const helperDir = join(workspace.cwd, '.rundown', 'helpers');
+    await mkdir(helperDir, { recursive: true });
+    await writeFile(join(helperDir, 'fmt.mjs'), HELPER_MODULE_CONTENT);
+    await writeFile(join(workspace.cwd, 'demo.runbook.md'), HELPER_RUNBOOK);
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('run --prompted renders helper output without --trust-js-policy for explicit --helpers', async () => {
+    const result = runCli(
+      'run --prompted demo.runbook.md --input Name=world --helpers .rundown/helpers/fmt.mjs',
+      workspace,
+    );
+
+    expect(result.exitCode).toBe(0);
+
+    const events = parseJsonEvents(result.stdout) as Array<Record<string, unknown>>;
+    const stepEntered = events.find((e) => e.type === 'step_entered');
+
+    expect(stepEntered).toBeDefined();
+    expect(stepEntered!.prompt).toContain('WORLD');
+    expect(stepEntered!.prompt).not.toContain('{{ upper Name }}');
   });
 });
 

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -276,4 +276,81 @@ printf "%s" "{{ item }}" > "$RD_OUTPUTS_Inner"
     expect(await readFile(iter1, 'utf-8')).toBe('alpha');
     expect(await readFile(iter2, 'utf-8')).toBe('beta');
   });
+
+  // NOTE: The three-segment path <stepId>/<iteration>/<VarName> (iteration-only, no substep)
+  // documented in outputChannelPath is not reachable via a valid runbook. FOR steps require
+  // at least one substep (validated by the parser), and commands always execute inside
+  // substeps (isSubstep=true). The iteration tier is therefore always combined with the
+  // substep tier, producing the four-segment path. The unit test for outputChannelPath in
+  // packages/core/__tests__/runbook/output-channels.test.ts covers the three-segment scope
+  // directly. This integration test covers the closest achievable scenario: a FOR loop at
+  // step level with naked OUTPUTS on the substep (single substep), verifying that each
+  // iteration produces an isolated capture file at <stepId>/<substepId>/<iteration>/<VarName>.
+  it('creates per-iteration capture files for a single-substep FOR loop (adapts three-segment intent)', async () => {
+    const RUNBOOK = `---
+name: step-for-single-substep
+required:
+  - items
+---
+# Step FOR Single Substep
+
+## 1. Capture each item
+- FOR item IN {{ items }}
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Write item
+- OUTPUTS
+  - Inner
+- PASS CONTINUE
+- FAIL STOP
+
+\`\`\`sh
+printf "%s" "{{ item }}" > "$RD_OUTPUTS_Inner"
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'step-for-single.runbook.md'), RUNBOOK);
+    const result = runCli(
+      [
+        'run',
+        'step-for-single.runbook.md',
+        '--allow-all',
+        '--input-json',
+        'items=["alpha","beta"]',
+      ],
+      workspace,
+    );
+    expect(result.exitCode).toBe(0);
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { id: string; variables?: Record<string, unknown> };
+    // Last iteration's value wins via SET_VARIABLES merge precedence.
+    expect(state.variables?.Inner).toBe('beta');
+    // Iteration paths: <stepId>/<substepId>/<iteration>/<VarName> (four-segment)
+    const iter1 = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      '1',
+      '1',
+      'Inner',
+    );
+    const iter2 = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      '1',
+      '2',
+      'Inner',
+    );
+    expect((await stat(iter1)).isFile()).toBe(true);
+    expect((await stat(iter2)).isFile()).toBe(true);
+    expect(await readFile(iter1, 'utf-8')).toBe('alpha');
+    expect(await readFile(iter2, 'utf-8')).toBe('beta');
+  });
 });

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -81,6 +81,114 @@ describe('output capture — file-backed naked OUTPUTS at step level', () => {
     const content = await readFile(channelPath, 'utf-8');
     expect(content).toBe('v1.2.3');
   });
+
+  it('captures output from intercepted rd echo commands', async () => {
+    const RUNBOOK = `---
+name: internal-rd-capture
+---
+# Internal rd Capture
+
+## 1. Capture
+- OUTPUTS
+  - Message
+- PASS CONTINUE
+- FAIL STOP
+
+\`\`\`sh
+rd echo internal-value
+\`\`\`
+
+## 2. Echo captured
+- OUTPUTS
+  - Echoed {{ Message }}
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`sh
+rd echo --result pass
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'internal-rd.runbook.md'), RUNBOOK);
+
+    const result = runCli('run internal-rd.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    const states = await getAllRunbookStates(workspace);
+    expect(states).toHaveLength(1);
+    const state = states[0] as { id: string; variables?: Record<string, unknown> };
+    expect(state.variables?.Message).toBe('internal-value');
+    expect(state.variables?.Echoed).toBe('internal-value');
+
+    const channelPath = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      'Message',
+    );
+    expect(await readFile(channelPath, 'utf-8')).toBe('internal-value');
+  });
+});
+
+describe('output capture — policy-enforced path', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('captures when the command is allowed by policy', async () => {
+    const RUNBOOK = `---
+name: policy-enforced-capture
+---
+# Policy Enforced Capture
+
+## 1. Capture
+- OUTPUTS
+  - Blocked
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`sh
+printf 'should-not-capture' > "$RD_OUTPUTS_Blocked"
+\`\`\`
+`;
+    await writeFile(
+      join(workspace.cwd, '.rundownrc.yaml'),
+      `default:
+  mode: execute
+  run:
+    allow:
+      - printf
+`,
+    );
+    await writeFile(join(workspace.cwd, 'allowed.runbook.md'), RUNBOOK);
+
+    const result = runCli('run allowed.runbook.md --no-sandbox', workspace);
+    expect(result.exitCode).toBe(0);
+
+    const states = await getAllRunbookStates(workspace);
+    expect(states).toHaveLength(1);
+    const state = states[0] as { id: string; variables?: Record<string, unknown> };
+    expect(state.variables?.Blocked).toBe('should-not-capture');
+
+    const channelPath = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      'Blocked',
+    );
+    expect(await readFile(channelPath, 'utf-8')).toBe('should-not-capture');
+  });
 });
 
 describe('output capture — best-effort behaviour', () => {
@@ -244,8 +352,7 @@ printf 'inner-value' > "$RD_OUTPUTS_Inner"
       '1',
       'Inner',
     );
-    const fileStat = await stat(expected);
-    expect(fileStat.isFile()).toBe(true);
+    expect(await readFile(expected, 'utf-8')).toBe('inner-value');
   });
 
   it('creates a four-segment path when a substep with naked OUTPUTS is inside a FOR loop', async () => {
@@ -304,8 +411,6 @@ printf "%s" "{{ item }}" > "$RD_OUTPUTS_Inner"
       '2',
       'Inner',
     );
-    expect((await stat(iter1)).isFile()).toBe(true);
-    expect((await stat(iter2)).isFile()).toBe(true);
     expect(await readFile(iter1, 'utf-8')).toBe('alpha');
     expect(await readFile(iter2, 'utf-8')).toBe('beta');
   });
@@ -372,8 +477,6 @@ printf "%s" "{{ item }}" > "$RD_OUTPUTS_Inner"
       '2',
       'Inner',
     );
-    expect((await stat(iter1)).isFile()).toBe(true);
-    expect((await stat(iter2)).isFile()).toBe(true);
     expect(await readFile(iter1, 'utf-8')).toBe('alpha');
     expect(await readFile(iter2, 'utf-8')).toBe('beta');
   });

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -1,7 +1,7 @@
 // packages/cli/__tests__/integration/output-capture.test.ts
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { writeFile, readFile, stat } from 'node:fs/promises';
+import { writeFile, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   createTestWorkspace,

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -173,6 +173,39 @@ printf 'https://example.test' > "$RD_OUTPUTS_DeployUrl"
     expect(state.variables?.Tag as string).toMatch(/-staging$/);
   });
 
+  it('does not publish captured outputs before a retry transition completes', async () => {
+    const RUNBOOK = `---
+name: retry-capture
+---
+# Retry Capture
+
+## 1. Capture during a failing attempt
+- OUTPUTS
+  - Token
+- PASS COMPLETE
+- FAIL RETRY 1 STOP
+
+\`\`\`sh
+if [ ! -f marker ]; then
+  printf 'stale' > "$RD_OUTPUTS_Token"
+  touch marker
+  exit 1
+fi
+
+if [ "{{ Token }}" = "stale" ]; then
+  exit 2
+fi
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'retry-capture.runbook.md'), RUNBOOK);
+    const result = runCli('run retry-capture.runbook.md --allow-all', workspace);
+    expect(result.exitCode).toBe(0);
+
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { variables?: Record<string, unknown> };
+    expect(state.variables?.Token).toBeUndefined();
+  });
+
   it('creates a per-substep directory when the OUTPUTS lives on a substep', async () => {
     // Parent uses PASS ALL aggregation, so substep must DEFER to participate
     // (PASS CONTINUE would prevent aggregation from accumulating a result).

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -344,4 +344,159 @@ printf "%s" "{{ item }}" > "$RD_OUTPUTS_Inner"
     expect(await readFile(iter1, 'utf-8')).toBe('alpha');
     expect(await readFile(iter2, 'utf-8')).toBe('beta');
   });
+
+  // Gap #2: Policy-denied command skips capture
+  it('does not capture when the command is blocked by policy', async () => {
+    const RUNBOOK = `---
+name: policy-denied-capture
+---
+# Policy Denied Capture
+
+## 1. Blocked write
+- OUTPUTS
+  - Blocked
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`sh
+printf 'should-not-capture' > "$RD_OUTPUTS_Blocked"
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'denied.runbook.md'), RUNBOOK);
+    // --deny-all blocks the shell command execution, causing the step to fail → STOP.
+    // This is deterministic and avoids any interactive prompt.
+    const result = runCli('run denied.runbook.md --deny-all', workspace);
+    // The runbook should fail (policy denial → step fails → STOP)
+    expect(result.exitCode).not.toBe(0);
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { variables?: Record<string, unknown> };
+    // Variable was never set (no merge happened because the command was blocked)
+    expect(state.variables?.Blocked).toBeUndefined();
+  });
+
+  // Gap #3: FOR iteration that fails mid-sequence
+  it('preserves capture from iteration 1 when iteration 2 fails', async () => {
+    const RUNBOOK = `---
+name: for-fail-midway
+required:
+  - items
+---
+# FOR Fail Midway
+
+## 1. Parent
+- FOR item IN {{ items }}
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Capture
+- OUTPUTS
+  - Inner
+- PASS DEFER
+- FAIL DEFER
+
+\`\`\`sh
+if [ "{{ item }}" = "good" ]; then
+  printf "good-value" > "$RD_OUTPUTS_Inner"
+else
+  exit 1
+fi
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'for-fail.runbook.md'), RUNBOOK);
+    const result = runCli(
+      `run for-fail.runbook.md --allow-all --input-json items=["good","bad"]`,
+      workspace,
+    );
+    // Runbook stops on iteration 2's failure
+    expect(result.exitCode).not.toBe(0);
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { id: string; variables?: Record<string, unknown> };
+    // Iteration 1's captured value should be in state (the SET_VARIABLES dispatch ran before
+    // iteration 2's failure).
+    // NOTE: If this assertion fails, check result.stdout/stderr — the actual behaviour may differ
+    // from expectation (e.g. SET_VARIABLES from iteration 1 may be rolled back on STOP).
+    expect(state.variables?.Inner).toBe('good-value');
+    // Iteration 1's channel file persisted
+    const iter1 = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      '1',
+      '1',
+      'Inner',
+    );
+    const iter2 = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      '1',
+      '2',
+      'Inner',
+    );
+    expect(await readFile(iter1, 'utf-8')).toBe('good-value');
+    // iter2 file may exist (pre-created empty) or may not (depending on whether
+    // prepareOutputChannels ran for iteration 2 before the abort)
+    try {
+      const iter2Content = await readFile(iter2, 'utf-8');
+      expect(iter2Content).toBe('');
+    } catch (err) {
+      // ENOENT is also acceptable — channel file may not have been created if iteration aborted early
+      expect((err as { code?: string }).code).toBe('ENOENT');
+    }
+  });
+
+  // Gap #5: Multiple naked OUTPUTS in one step (end-to-end)
+  it('captures multiple naked OUTPUTS from a single step', async () => {
+    const RUNBOOK = `---
+name: multi-naked-capture
+---
+# Multi Naked Capture
+
+## 1. Capture two values
+- OUTPUTS
+  - Version
+  - DeployUrl
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`sh
+printf 'v1.2.3' > "$RD_OUTPUTS_Version"
+printf 'https://example.test/v1' > "$RD_OUTPUTS_DeployUrl"
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'multi.runbook.md'), RUNBOOK);
+    const result = runCli('run multi.runbook.md --allow-all', workspace);
+    expect(result.exitCode).toBe(0);
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { id: string; variables?: Record<string, unknown> };
+    expect(state.variables?.Version).toBe('v1.2.3');
+    expect(state.variables?.DeployUrl).toBe('https://example.test/v1');
+    // Both channel files persist on disk for audit
+    const versionPath = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      'Version',
+    );
+    const deployPath = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      'DeployUrl',
+    );
+    expect(await readFile(versionPath, 'utf-8')).toBe('v1.2.3');
+    expect(await readFile(deployPath, 'utf-8')).toBe('https://example.test/v1');
+  });
 });

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { writeFile, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { isNodeError, isSandboxAvailable } from '@rundown-org/core';
 import {
   createTestWorkspace,
   runCli,
@@ -35,6 +36,16 @@ printf 'v1.2.3' > "$RD_OUTPUTS_Version"
 rd echo --result pass
 \`\`\`
 `;
+
+async function assertCapturedChannel(
+  workspace: TestWorkspace,
+  stateId: string,
+  channelName: string,
+  expectedValue: string,
+): Promise<void> {
+  const channelPath = join(workspace.cwd, '.rundown', 'runs', stateId, 'outputs', '1', channelName);
+  expect(await readFile(channelPath, 'utf-8')).toBe(expectedValue);
+}
 
 describe('output capture — file-backed naked OUTPUTS at step level', () => {
   let workspace: TestWorkspace;
@@ -132,7 +143,7 @@ rd echo --result pass
   });
 });
 
-describe('output capture — policy-enforced path', () => {
+describe('output capture — policy-enforced capture', () => {
   let workspace: TestWorkspace;
 
   beforeEach(async () => {
@@ -143,7 +154,7 @@ describe('output capture — policy-enforced path', () => {
     await workspace.cleanup();
   });
 
-  it('captures when the command is allowed by policy', async () => {
+  it('captures when policy allows the command without sandbox', async () => {
     const RUNBOOK = `---
 name: policy-enforced-capture
 ---
@@ -151,12 +162,12 @@ name: policy-enforced-capture
 
 ## 1. Capture
 - OUTPUTS
-  - Blocked
+  - Captured
 - PASS COMPLETE
 - FAIL STOP
 
 \`\`\`sh
-printf 'should-not-capture' > "$RD_OUTPUTS_Blocked"
+printf 'policy-captured' > "$RD_OUTPUTS_Captured"
 \`\`\`
 `;
     await writeFile(
@@ -176,18 +187,51 @@ printf 'should-not-capture' > "$RD_OUTPUTS_Blocked"
     const states = await getAllRunbookStates(workspace);
     expect(states).toHaveLength(1);
     const state = states[0] as { id: string; variables?: Record<string, unknown> };
-    expect(state.variables?.Blocked).toBe('should-not-capture');
+    expect(state.variables?.Captured).toBe('policy-captured');
 
-    const channelPath = join(
-      workspace.cwd,
-      '.rundown',
-      'runs',
-      state.id,
-      'outputs',
-      '1',
-      'Blocked',
+    await assertCapturedChannel(workspace, state.id, 'Captured', 'policy-captured');
+  });
+
+  it('captures when policy allows the command with sandbox enabled', async () => {
+    if (!(await isSandboxAvailable())) {
+      return;
+    }
+
+    const RUNBOOK = `---
+name: policy-enforced-capture
+---
+# Policy Enforced Capture
+
+## 1. Capture
+- OUTPUTS
+  - Captured
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`sh
+printf 'policy-captured' > "$RD_OUTPUTS_Captured"
+\`\`\`
+`;
+    await writeFile(
+      join(workspace.cwd, '.rundownrc.yaml'),
+      `default:
+  mode: execute
+  run:
+    allow:
+      - printf
+`,
     );
-    expect(await readFile(channelPath, 'utf-8')).toBe('should-not-capture');
+    await writeFile(join(workspace.cwd, 'allowed.runbook.md'), RUNBOOK);
+
+    const result = runCli('run allowed.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+
+    const states = await getAllRunbookStates(workspace);
+    expect(states).toHaveLength(1);
+    const state = states[0] as { id: string; variables?: Record<string, unknown> };
+    expect(state.variables?.Captured).toBe('policy-captured');
+
+    await assertCapturedChannel(workspace, state.id, 'Captured', 'policy-captured');
   });
 });
 
@@ -583,7 +627,11 @@ fi
       expect(iter2Content).toBe('');
     } catch (err) {
       // ENOENT is also acceptable — channel file may not have been created if iteration aborted early
-      expect((err as { code?: string }).code).toBe('ENOENT');
+      if (Error.isError(err) && isNodeError(err)) {
+        expect(err.code).toBe('ENOENT');
+      } else {
+        throw err;
+      }
     }
   });
 

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -48,6 +48,9 @@ describe('output capture — file-backed naked OUTPUTS at step level', () => {
     await workspace.cleanup();
   });
 
+  // `printf`/`echo` are not in the default policy allow list and the default
+  // mode is `prompted` — `--allow-all` bypasses policy so the shell can write
+  // to $RD_OUTPUTS_*.
   it('captures the shell-written value and exposes it to the next step', async () => {
     const result = runCli('run capture.runbook.md --allow-all', workspace);
     expect(result.exitCode).toBe(0);
@@ -91,6 +94,9 @@ describe('output capture — best-effort behaviour', () => {
     await workspace.cleanup();
   });
 
+  // `printf`/`echo` are not in the default policy allow list and the default
+  // mode is `prompted` — `--allow-all` bypasses policy so the shell can write
+  // to $RD_OUTPUTS_*.
   it('omits an output the shell never wrote (empty file)', async () => {
     const RUNBOOK = `---
 name: empty-capture
@@ -168,6 +174,8 @@ printf 'https://example.test' > "$RD_OUTPUTS_DeployUrl"
   });
 
   it('creates a per-substep directory when the OUTPUTS lives on a substep', async () => {
+    // Parent uses PASS ALL aggregation, so substep must DEFER to participate
+    // (PASS CONTINUE would prevent aggregation from accumulating a result).
     const RUNBOOK = `---
 name: substep-capture
 ---

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -1,0 +1,271 @@
+// packages/cli/__tests__/integration/output-capture.test.ts
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { writeFile, readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  createTestWorkspace,
+  runCli,
+  getAllRunbookStates,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
+
+const CAPTURE_RUNBOOK = `---
+name: output-capture-test
+---
+# Output Capture Test
+
+## 1. Capture
+- OUTPUTS
+  - Version
+- PASS CONTINUE
+- FAIL STOP
+
+\`\`\`sh
+printf 'v1.2.3' > "$RD_OUTPUTS_Version"
+\`\`\`
+
+## 2. Echo captured
+- OUTPUTS
+  - Echoed {{ Version }}
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`sh
+rd echo --result pass
+\`\`\`
+`;
+
+describe('output capture — file-backed naked OUTPUTS at step level', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+    await writeFile(join(workspace.cwd, 'capture.runbook.md'), CAPTURE_RUNBOOK);
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('captures the shell-written value and exposes it to the next step', async () => {
+    const result = runCli('run capture.runbook.md --allow-all', workspace);
+    expect(result.exitCode).toBe(0);
+
+    const states = await getAllRunbookStates(workspace);
+    expect(states).toHaveLength(1);
+    const state = states[0] as { id: string; variables?: Record<string, unknown> };
+    expect(state.variables?.Version).toBe('v1.2.3');
+    // Step 2's expression-form OUTPUTS pulls the captured value through
+    expect(state.variables?.Echoed).toBe('v1.2.3');
+  });
+
+  it('persists the channel file on disk for audit', async () => {
+    const result = runCli('run capture.runbook.md --allow-all', workspace);
+    expect(result.exitCode).toBe(0);
+
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { id: string };
+    const channelPath = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      'Version',
+    );
+    const content = await readFile(channelPath, 'utf-8');
+    expect(content).toBe('v1.2.3');
+  });
+});
+
+describe('output capture — best-effort behaviour', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('omits an output the shell never wrote (empty file)', async () => {
+    const RUNBOOK = `---
+name: empty-capture
+---
+# Empty Capture
+
+## 1. Skip the write
+- OUTPUTS
+  - Maybe
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`sh
+rd echo --result pass
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'empty.runbook.md'), RUNBOOK);
+    const result = runCli('run empty.runbook.md --allow-all', workspace);
+    expect(result.exitCode).toBe(0);
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { variables?: Record<string, unknown> };
+    expect(state.variables?.Maybe).toBeUndefined();
+  });
+
+  it('trims trailing newline from echo without -n', async () => {
+    const RUNBOOK = `---
+name: trim-capture
+---
+# Trim Capture
+
+## 1. Capture with newline
+- OUTPUTS
+  - Greeting
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`sh
+echo "hello" > "$RD_OUTPUTS_Greeting"
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'trim.runbook.md'), RUNBOOK);
+    const result = runCli('run trim.runbook.md --allow-all', workspace);
+    expect(result.exitCode).toBe(0);
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { variables?: Record<string, unknown> };
+    expect(state.variables?.Greeting).toBe('hello');
+  });
+
+  it('mixes naked and expression forms in a single OUTPUTS block', async () => {
+    const RUNBOOK = `---
+name: mixed-capture
+---
+# Mixed Capture
+
+## 1. Capture and tag
+- OUTPUTS
+  - DeployUrl
+  - Tag "{{ RunId }}-staging"
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`sh
+printf 'https://example.test' > "$RD_OUTPUTS_DeployUrl"
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'mixed.runbook.md'), RUNBOOK);
+    const result = runCli('run mixed.runbook.md --allow-all', workspace);
+    expect(result.exitCode).toBe(0);
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { variables?: Record<string, unknown> };
+    expect(state.variables?.DeployUrl).toBe('https://example.test');
+    // Tag is expression-form; RunId is an 8-hex generated id
+    expect(typeof state.variables?.Tag).toBe('string');
+    expect(state.variables?.Tag as string).toMatch(/-staging$/);
+  });
+
+  it('creates a per-substep directory when the OUTPUTS lives on a substep', async () => {
+    const RUNBOOK = `---
+name: substep-capture
+---
+# Substep Capture
+
+## 1. Parent
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Capture
+- OUTPUTS
+  - Inner
+- PASS DEFER
+- FAIL DEFER
+
+\`\`\`sh
+printf 'inner-value' > "$RD_OUTPUTS_Inner"
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'substep.runbook.md'), RUNBOOK);
+    const result = runCli('run substep.runbook.md --allow-all', workspace);
+    expect(result.exitCode).toBe(0);
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { id: string; variables?: Record<string, unknown> };
+    expect(state.variables?.Inner).toBe('inner-value');
+    const expected = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      '1',
+      'Inner',
+    );
+    const fileStat = await stat(expected);
+    expect(fileStat.isFile()).toBe(true);
+  });
+
+  it('creates a four-segment path when a substep with naked OUTPUTS is inside a FOR loop', async () => {
+    const RUNBOOK = `---
+name: substep-in-for-capture
+required:
+  - items
+---
+# Substep In FOR Capture
+
+## 1. Parent
+- FOR item IN {{ items }}
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Capture
+- OUTPUTS
+  - Inner
+- PASS CONTINUE
+- FAIL STOP
+
+\`\`\`sh
+printf "%s" "{{ item }}" > "$RD_OUTPUTS_Inner"
+\`\`\`
+`;
+    await writeFile(join(workspace.cwd, 'substep-in-for.runbook.md'), RUNBOOK);
+    const result = runCli(
+      ['run', 'substep-in-for.runbook.md', '--allow-all', '--input-json', 'items=["alpha","beta"]'],
+      workspace,
+    );
+    expect(result.exitCode).toBe(0);
+    const states = await getAllRunbookStates(workspace);
+    const state = states[0] as { id: string; variables?: Record<string, unknown> };
+    // Last iteration's value wins via SET_VARIABLES merge precedence.
+    expect(state.variables?.Inner).toBe('beta');
+    // Iteration 1: <stepId>/<substepId>/<iteration>/<VarName>
+    const iter1 = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      '1',
+      '1',
+      'Inner',
+    );
+    const iter2 = join(
+      workspace.cwd,
+      '.rundown',
+      'runs',
+      state.id,
+      'outputs',
+      '1',
+      '1',
+      '2',
+      'Inner',
+    );
+    expect((await stat(iter1)).isFile()).toBe(true);
+    expect((await stat(iter2)).isFile()).toBe(true);
+    expect(await readFile(iter1, 'utf-8')).toBe('alpha');
+    expect(await readFile(iter2, 'utf-8')).toBe('beta');
+  });
+});

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -277,16 +277,7 @@ printf "%s" "{{ item }}" > "$RD_OUTPUTS_Inner"
     expect(await readFile(iter2, 'utf-8')).toBe('beta');
   });
 
-  // NOTE: The three-segment path <stepId>/<iteration>/<VarName> (iteration-only, no substep)
-  // documented in outputChannelPath is not reachable via a valid runbook. FOR steps require
-  // at least one substep (validated by the parser), and commands always execute inside
-  // substeps (isSubstep=true). The iteration tier is therefore always combined with the
-  // substep tier, producing the four-segment path. The unit test for outputChannelPath in
-  // packages/core/__tests__/runbook/output-channels.test.ts covers the three-segment scope
-  // directly. This integration test covers the closest achievable scenario: a FOR loop at
-  // step level with naked OUTPUTS on the substep (single substep), verifying that each
-  // iteration produces an isolated capture file at <stepId>/<substepId>/<iteration>/<VarName>.
-  it('creates per-iteration capture files for a single-substep FOR loop (adapts three-segment intent)', async () => {
+  it('creates per-iteration capture files for a single-substep FOR loop', async () => {
     const RUNBOOK = `---
 name: step-for-single-substep
 required:

--- a/packages/cli/__tests__/services/execution-helpers.test.ts
+++ b/packages/cli/__tests__/services/execution-helpers.test.ts
@@ -1,0 +1,299 @@
+// packages/cli/__tests__/services/execution-helpers.test.ts
+//
+// Unit tests for the scope-tier derivation helpers exported from execution.ts:
+//   - deriveOutputScope(currentState, isSubstep, substepId?)
+//   - extractUnitOutputs(currentStep, isSubstep, substepId?)
+//
+// Both helpers are pure (no I/O), so they are tested directly without mocking
+// the full execution loop.
+
+import { describe, it, expect } from '@jest/globals';
+import { deriveOutputScope, extractUnitOutputs } from '../../src/services/execution.js';
+import type { RunbookState, ForContext } from '@rundown-org/core';
+import type { ResolvedStep, OutputDeclaration } from '@rundown-org/parser';
+
+// ---------------------------------------------------------------------------
+// Minimal RunbookState factory
+// ---------------------------------------------------------------------------
+
+function makeState(step: string, forStack: readonly ForContext[] = []): RunbookState {
+  return {
+    id: 'test-run',
+    runbook: 'test.md',
+    runbookPath: '/test.md',
+    step,
+    stepName: `Step ${step}`,
+    retryCount: 0,
+    variables: {} as RunbookState['variables'],
+    steps: [],
+    forStack,
+    startedAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Minimal ResolvedStep factories
+// ---------------------------------------------------------------------------
+
+function makeOutputDecl(name: string, value?: string): OutputDeclaration {
+  return value !== undefined ? { name, value } : { name };
+}
+
+function makeCommandStep(name: string, outputs?: readonly OutputDeclaration[]): ResolvedStep {
+  return {
+    kind: 'command',
+    name,
+    description: `Step ${name}`,
+    command: { code: 'echo hello', lang: 'sh' },
+    transitions: {
+      pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+      fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+    },
+    ...(outputs !== undefined ? { outputs } : {}),
+  } as ResolvedStep;
+}
+
+function makeSubstepsStep(
+  name: string,
+  substeps: Array<{ id: string; outputs?: readonly OutputDeclaration[] }>,
+  stepOutputs?: readonly OutputDeclaration[],
+): ResolvedStep {
+  const resolvedSubsteps = substeps.map((sub) => ({
+    id: sub.id,
+    description: `Substep ${sub.id}`,
+    transitions: {
+      pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+      fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+    },
+    ...(sub.outputs !== undefined ? { outputs: sub.outputs } : {}),
+  }));
+
+  return {
+    kind: 'substeps',
+    name,
+    description: `Step ${name}`,
+    substeps: resolvedSubsteps,
+    transitions: {
+      pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+      fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+    },
+    ...(stepOutputs !== undefined ? { outputs: stepOutputs } : {}),
+  } as unknown as ResolvedStep;
+}
+
+// ---------------------------------------------------------------------------
+// deriveOutputScope tests
+// ---------------------------------------------------------------------------
+
+describe('deriveOutputScope', () => {
+  describe('step only (isSubstep=false)', () => {
+    it('returns only stepId when no substep and no FOR stack', () => {
+      const state = makeState('1');
+      const scope = deriveOutputScope(state, false);
+      expect(scope).toEqual({ stepId: '1' });
+    });
+
+    it('ignores substepId argument when isSubstep=false', () => {
+      const state = makeState('1');
+      const scope = deriveOutputScope(state, false, '2');
+      expect(scope).toEqual({ stepId: '1' });
+      expect(scope).not.toHaveProperty('substepId');
+    });
+
+    it('uses state.step as stepId for named steps', () => {
+      const state = makeState('ErrorHandler');
+      const scope = deriveOutputScope(state, false);
+      expect(scope).toEqual({ stepId: 'ErrorHandler' });
+    });
+  });
+
+  describe('substep tier', () => {
+    it('includes substepId when isSubstep=true and substepId is provided', () => {
+      const state = makeState('1');
+      const scope = deriveOutputScope(state, true, '2');
+      expect(scope).toEqual({ stepId: '1', substepId: '2' });
+    });
+
+    it('omits substepId when isSubstep=true but substepId is undefined', () => {
+      const state = makeState('1');
+      const scope = deriveOutputScope(state, true, undefined);
+      expect(scope).toEqual({ stepId: '1' });
+      expect(scope).not.toHaveProperty('substepId');
+    });
+  });
+
+  describe('iteration tier', () => {
+    it('includes iteration from top FOR frame when non-implicit and stepId matches', () => {
+      const forStack: readonly ForContext[] = [
+        {
+          stepId: '1',
+          iteration: 3,
+          start: 1,
+          end: 5,
+          implicit: false,
+          source: { kind: 'range' },
+        },
+      ];
+      const state = makeState('1', forStack);
+      const scope = deriveOutputScope(state, true, '2');
+      expect(scope).toEqual({ stepId: '1', substepId: '2', iteration: 3 });
+    });
+
+    it('omits iteration when the top FOR frame is implicit', () => {
+      const forStack: readonly ForContext[] = [
+        {
+          stepId: '1',
+          iteration: 3,
+          start: 1,
+          end: 1,
+          implicit: true,
+          source: { kind: 'range' },
+        },
+      ];
+      const state = makeState('1', forStack);
+      const scope = deriveOutputScope(state, true, '2');
+      expect(scope).toEqual({ stepId: '1', substepId: '2' });
+      expect(scope).not.toHaveProperty('iteration');
+    });
+
+    it('omits iteration when the top FOR frame is for a different step', () => {
+      const forStack: readonly ForContext[] = [
+        {
+          stepId: '99',
+          iteration: 3,
+          start: 1,
+          end: 5,
+          implicit: false,
+          source: { kind: 'range' },
+        },
+      ];
+      const state = makeState('1', forStack);
+      const scope = deriveOutputScope(state, true, '2');
+      expect(scope).toEqual({ stepId: '1', substepId: '2' });
+      expect(scope).not.toHaveProperty('iteration');
+    });
+
+    it('omits iteration for step-level scope (isSubstep=false) even with a matching FOR frame', () => {
+      // FOR loops always execute inside substeps, so step-level scope never
+      // exposes an iteration tier in practice; but the helper's contract is
+      // determined by isSubstep — when false, substepId is also omitted.
+      const forStack: readonly ForContext[] = [
+        {
+          stepId: '1',
+          iteration: 2,
+          start: 1,
+          end: 3,
+          implicit: false,
+          source: { kind: 'range' },
+        },
+      ];
+      const state = makeState('1', forStack);
+      const scope = deriveOutputScope(state, false);
+      // stepId is always present; iteration is included even for step-level scope
+      // when the FOR frame matches — the helper only gates on implicit and stepId match.
+      expect(scope.stepId).toBe('1');
+      expect(scope).not.toHaveProperty('substepId');
+      // iteration IS included (the helper does not gate on isSubstep for the
+      // iteration tier — it only gates the substep tier on isSubstep).
+      expect(scope.iteration).toBe(2);
+    });
+
+    it('uses the last (top) frame when multiple frames are stacked', () => {
+      const forStack: readonly ForContext[] = [
+        {
+          stepId: '1',
+          iteration: 1,
+          start: 1,
+          end: 3,
+          implicit: false,
+          source: { kind: 'range' },
+        },
+        {
+          stepId: '1',
+          iteration: 5,
+          start: 1,
+          end: 10,
+          implicit: false,
+          source: { kind: 'range' },
+        },
+      ];
+      const state = makeState('1', forStack);
+      const scope = deriveOutputScope(state, true, '2');
+      expect(scope.iteration).toBe(5);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractUnitOutputs tests
+// ---------------------------------------------------------------------------
+
+describe('extractUnitOutputs', () => {
+  describe('step-level outputs (isSubstep=false)', () => {
+    it('returns step outputs when step has outputs and isSubstep=false', () => {
+      const outputs: readonly OutputDeclaration[] = [makeOutputDecl('Result')];
+      const step = makeCommandStep('1', outputs);
+      const result = extractUnitOutputs(step, false);
+      expect(result).toEqual(outputs);
+    });
+
+    it('returns empty array when step has no outputs field and isSubstep=false', () => {
+      const step = makeCommandStep('1');
+      const result = extractUnitOutputs(step, false);
+      expect(result).toEqual([]);
+    });
+
+    it('ignores substepId when isSubstep=false, returns step outputs', () => {
+      const stepOutputs: readonly OutputDeclaration[] = [makeOutputDecl('StepOut')];
+      const step = makeSubstepsStep(
+        '1',
+        [{ id: '1.1', outputs: [makeOutputDecl('SubOut')] }],
+        stepOutputs,
+      );
+      // Even if substepId is provided, isSubstep=false routes to step.outputs
+      const result = extractUnitOutputs(step, false, '1.1');
+      expect(result).toEqual(stepOutputs);
+    });
+  });
+
+  describe('substep-level outputs (isSubstep=true)', () => {
+    it('returns the matching substep outputs when isSubstep=true', () => {
+      const substepOutputs: readonly OutputDeclaration[] = [makeOutputDecl('SubResult')];
+      const step = makeSubstepsStep('1', [{ id: '1.1', outputs: substepOutputs }]);
+      const result = extractUnitOutputs(step, true, '1.1');
+      expect(result).toEqual(substepOutputs);
+    });
+
+    it('does NOT return step-level outputs when routing to a substep', () => {
+      const stepOutputs: readonly OutputDeclaration[] = [makeOutputDecl('StepOut')];
+      const substepOutputs: readonly OutputDeclaration[] = [makeOutputDecl('SubOut')];
+      const step = makeSubstepsStep('1', [{ id: '1.1', outputs: substepOutputs }], stepOutputs);
+      const result = extractUnitOutputs(step, true, '1.1');
+      expect(result).toEqual(substepOutputs);
+      expect(result).not.toEqual(stepOutputs);
+    });
+
+    it('returns empty array when substep id does not match any substep', () => {
+      const step = makeSubstepsStep('1', [{ id: '1.1', outputs: [makeOutputDecl('Sub')] }]);
+      const result = extractUnitOutputs(step, true, '9.9');
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when the matching substep has no outputs field', () => {
+      // substep without outputs key
+      const step = makeSubstepsStep('1', [{ id: '1.1' }]);
+      const result = extractUnitOutputs(step, true, '1.1');
+      expect(result).toEqual([]);
+    });
+
+    it('returns step outputs when isSubstep=true but step has no substeps (falls back to step.outputs)', () => {
+      // A command step (no substeps) — resolvedStepHasSubsteps returns false,
+      // so the helper falls through to return currentStep.outputs.
+      const stepOutputs: readonly OutputDeclaration[] = [makeOutputDecl('StepOut')];
+      const step = makeCommandStep('1', stepOutputs);
+      const result = extractUnitOutputs(step, true, '1.1');
+      expect(result).toEqual(stepOutputs);
+    });
+  });
+});

--- a/packages/cli/__tests__/services/execution-helpers.test.ts
+++ b/packages/cli/__tests__/services/execution-helpers.test.ts
@@ -98,7 +98,7 @@ describe('deriveOutputScope', () => {
       const state = makeState('1');
       const scope = deriveOutputScope(state, false, '2');
       expect(scope).toEqual({ stepId: '1' });
-      expect(scope).not.toHaveProperty('substepId');
+      expect(scope).not.toHaveProperty('substep');
     });
 
     it('uses state.step as stepId for named steps', () => {
@@ -109,22 +109,22 @@ describe('deriveOutputScope', () => {
   });
 
   describe('substep tier', () => {
-    it('includes substepId when isSubstep=true and substepId is provided', () => {
+    it('includes substep when isSubstep=true and substepId is provided', () => {
       const state = makeState('1');
       const scope = deriveOutputScope(state, true, '2');
-      expect(scope).toEqual({ stepId: '1', substepId: '2' });
+      expect(scope).toEqual({ stepId: '1', substep: { id: '2' } });
     });
 
-    it('omits substepId when isSubstep=true but substepId is undefined', () => {
+    it('omits substep when isSubstep=true but substepId is undefined', () => {
       const state = makeState('1');
       const scope = deriveOutputScope(state, true, undefined);
       expect(scope).toEqual({ stepId: '1' });
-      expect(scope).not.toHaveProperty('substepId');
+      expect(scope).not.toHaveProperty('substep');
     });
   });
 
   describe('iteration tier', () => {
-    it('includes iteration from top FOR frame when non-implicit and stepId matches', () => {
+    it('includes iteration nested inside substep when non-implicit FOR frame matches', () => {
       const forStack: readonly ForContext[] = [
         {
           stepId: '1',
@@ -137,7 +137,7 @@ describe('deriveOutputScope', () => {
       ];
       const state = makeState('1', forStack);
       const scope = deriveOutputScope(state, true, '2');
-      expect(scope).toEqual({ stepId: '1', substepId: '2', iteration: 3 });
+      expect(scope).toEqual({ stepId: '1', substep: { id: '2', iteration: 3 } });
     });
 
     it('omits iteration when the top FOR frame is implicit', () => {
@@ -153,8 +153,8 @@ describe('deriveOutputScope', () => {
       ];
       const state = makeState('1', forStack);
       const scope = deriveOutputScope(state, true, '2');
-      expect(scope).toEqual({ stepId: '1', substepId: '2' });
-      expect(scope).not.toHaveProperty('iteration');
+      expect(scope).toEqual({ stepId: '1', substep: { id: '2' } });
+      expect(scope.substep).not.toHaveProperty('iteration');
     });
 
     it('omits iteration when the top FOR frame is for a different step', () => {
@@ -170,14 +170,14 @@ describe('deriveOutputScope', () => {
       ];
       const state = makeState('1', forStack);
       const scope = deriveOutputScope(state, true, '2');
-      expect(scope).toEqual({ stepId: '1', substepId: '2' });
-      expect(scope).not.toHaveProperty('iteration');
+      expect(scope).toEqual({ stepId: '1', substep: { id: '2' } });
+      expect(scope.substep).not.toHaveProperty('iteration');
     });
 
-    it('omits iteration for step-level scope (isSubstep=false) even with a matching FOR frame', () => {
-      // FOR loops always execute inside substeps, so step-level scope never
-      // exposes an iteration tier in practice; but the helper's contract is
-      // determined by isSubstep — when false, substepId is also omitted.
+    it('omits substep and iteration when isSubstep=false even with a matching FOR frame', () => {
+      // FOR loops always execute inside substeps. With isSubstep=false, the
+      // helper returns only { stepId } — iteration is gated on the isSubstep
+      // precondition, making { stepId, iteration } unrepresentable at runtime.
       const forStack: readonly ForContext[] = [
         {
           stepId: '1',
@@ -190,13 +190,8 @@ describe('deriveOutputScope', () => {
       ];
       const state = makeState('1', forStack);
       const scope = deriveOutputScope(state, false);
-      // stepId is always present; iteration is included even for step-level scope
-      // when the FOR frame matches — the helper only gates on implicit and stepId match.
-      expect(scope.stepId).toBe('1');
-      expect(scope).not.toHaveProperty('substepId');
-      // iteration IS included (the helper does not gate on isSubstep for the
-      // iteration tier — it only gates the substep tier on isSubstep).
-      expect(scope.iteration).toBe(2);
+      expect(scope).toEqual({ stepId: '1' });
+      expect(scope).not.toHaveProperty('substep');
     });
 
     it('uses the last (top) frame when multiple frames are stacked', () => {
@@ -220,7 +215,7 @@ describe('deriveOutputScope', () => {
       ];
       const state = makeState('1', forStack);
       const scope = deriveOutputScope(state, true, '2');
-      expect(scope.iteration).toBe(5);
+      expect(scope.substep?.iteration).toBe(5);
     });
   });
 });

--- a/packages/cli/__tests__/services/execution-helpers.test.ts
+++ b/packages/cli/__tests__/services/execution-helpers.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect } from '@jest/globals';
 import { deriveOutputScope, extractUnitOutputs } from '../../src/services/execution.js';
 import type { RunbookState, ForContext } from '@rundown-org/core';
-import type { ResolvedStep, OutputDeclaration } from '@rundown-org/parser';
+import type { ResolvedStep, OutputDeclaration, Substep } from '@rundown-org/parser';
 
 // ---------------------------------------------------------------------------
 // Minimal RunbookState factory
@@ -41,7 +41,7 @@ function makeOutputDecl(name: string, value?: string): OutputDeclaration {
 }
 
 function makeCommandStep(name: string, outputs?: readonly OutputDeclaration[]): ResolvedStep {
-  return {
+  const step = {
     kind: 'command',
     name,
     description: `Step ${name}`,
@@ -51,7 +51,9 @@ function makeCommandStep(name: string, outputs?: readonly OutputDeclaration[]): 
       fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
     },
     ...(outputs !== undefined ? { outputs } : {}),
-  } as ResolvedStep;
+  } satisfies ResolvedStep;
+
+  return step;
 }
 
 function makeSubstepsStep(
@@ -59,7 +61,7 @@ function makeSubstepsStep(
   substeps: Array<{ id: string; outputs?: readonly OutputDeclaration[] }>,
   stepOutputs?: readonly OutputDeclaration[],
 ): ResolvedStep {
-  const resolvedSubsteps = substeps.map((sub) => ({
+  const resolvedSubsteps: readonly Substep[] = substeps.map((sub) => ({
     id: sub.id,
     description: `Substep ${sub.id}`,
     transitions: {
@@ -69,7 +71,7 @@ function makeSubstepsStep(
     ...(sub.outputs !== undefined ? { outputs: sub.outputs } : {}),
   }));
 
-  return {
+  const step = {
     kind: 'substeps',
     name,
     description: `Step ${name}`,
@@ -79,7 +81,9 @@ function makeSubstepsStep(
       fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
     },
     ...(stepOutputs !== undefined ? { outputs: stepOutputs } : {}),
-  } as unknown as ResolvedStep;
+  } satisfies ResolvedStep;
+
+  return step;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -253,7 +253,7 @@ jest.unstable_mockModule('@rundown-org/core', () => {
     ),
     resetHelperInvokeWarnings: jest.fn(),
     partitionOutputDeclarations: jest.fn().mockReturnValue({ naked: [], expression: [] }),
-    prepareOutputChannels: jest.fn().mockResolvedValue({ env: {}, createdPaths: [] }),
+    prepareOutputChannels: jest.fn().mockResolvedValue({ env: {}, prepared: [] }),
     readCapturedOutputs: jest.fn().mockResolvedValue({}),
   };
 });

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -87,6 +87,7 @@ jest.unstable_mockModule('@rundown-org/core', () => {
     printRunbookStoppedAtStep: jest.fn(),
     printPolicyDenied: jest.fn(),
     executeCommand: jest.fn(),
+    executeCommandWithEnv: jest.fn().mockResolvedValue({ success: true, exitCode: 0 }),
     executeCommandWithPolicy: jest.fn(),
     evaluatePassCondition: jest.fn(),
     evaluateFailCondition: jest.fn(),

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -252,6 +252,9 @@ jest.unstable_mockModule('@rundown-org/core', () => {
       },
     ),
     resetHelperInvokeWarnings: jest.fn(),
+    partitionOutputDeclarations: jest.fn().mockReturnValue({ naked: [], expression: [] }),
+    prepareOutputChannels: jest.fn().mockResolvedValue({ env: {}, createdPaths: [] }),
+    readCapturedOutputs: jest.fn().mockResolvedValue({}),
   };
 });
 

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -17,14 +17,16 @@ type LifecycleStateLike = {
 
 // Mock dependencies
 const mockActorService = {
-  sendAndSync:
-    mockFn<(id: string, steps: unknown, event: unknown) => Promise<Record<string, unknown>>>(),
-  getContextSnapshot:
-    mockFn<(id: string, steps: unknown) => Promise<Record<string, unknown> | null>>(),
+  sendAndSync: mockFn<
+    (id: string, steps: unknown, event: unknown) => Promise<Record<string, unknown>>
+  >() as any,
+  getContextSnapshot: mockFn<
+    (id: string, steps: unknown) => Promise<Record<string, unknown> | null>
+  >() as any,
 };
 
 const mockSessionService = {
-  popRunbook: mockFn<(id: string) => Promise<void>>(),
+  popRunbook: mockFn<(id: string) => Promise<void>>() as any,
 };
 
 const ensureActiveEntryFn =
@@ -50,7 +52,7 @@ const consumeResolvedCompletionFn = mockFn<(id: string) => Promise<unknown>>();
 consumeResolvedCompletionFn.mockResolvedValue(null);
 
 const mockLifecycleService = {
-  setLastResult: jest.fn(),
+  setLastResult: jest.fn() as any,
   ensureActiveEntry: ensureActiveEntryFn,
   listResolvedCompletions: listResolvedCompletionsFn,
   consumeResolvedCompletion: consumeResolvedCompletionFn,
@@ -87,7 +89,7 @@ jest.unstable_mockModule('@rundown-org/core', () => {
     printRunbookStoppedAtStep: jest.fn(),
     printPolicyDenied: jest.fn(),
     executeCommand: jest.fn(),
-    executeCommandWithEnv: jest.fn().mockResolvedValue({ success: true, exitCode: 0 }),
+    executeCommandWithEnv: (jest.fn() as any).mockResolvedValue({ success: true, exitCode: 0 }),
     executeCommandWithPolicy: jest.fn(),
     evaluatePassCondition: jest.fn(),
     evaluateFailCondition: jest.fn(),
@@ -153,7 +155,7 @@ jest.unstable_mockModule('@rundown-org/core', () => {
     SessionService: jest.fn(() => mockSessionService),
     ExecutionLifecycleService: jest.fn(() => mockLifecycleService),
     ForIterationService: jest.fn(() => {
-      const prepareIteration = mockFn<(...args: unknown[]) => Promise<{ status: string }>>();
+      const prepareIteration = mockFn<(...args: unknown[]) => Promise<{ status: string }>>() as any;
       prepareIteration.mockResolvedValue({ status: 'no-resolution-needed' });
       return { prepareIteration };
     }),
@@ -165,42 +167,42 @@ jest.unstable_mockModule('@rundown-org/core', () => {
     }),
     logger: {
       debug: (() => {
-        const fn = mockFn<(...args: unknown[]) => Promise<void>>();
+        const fn = mockFn<(...args: unknown[]) => Promise<void>>() as any;
         fn.mockResolvedValue(undefined);
         return fn;
       })(),
       info: (() => {
-        const fn = mockFn<(...args: unknown[]) => Promise<void>>();
+        const fn = mockFn<(...args: unknown[]) => Promise<void>>() as any;
         fn.mockResolvedValue(undefined);
         return fn;
       })(),
       warn: (() => {
-        const fn = mockFn<(...args: unknown[]) => Promise<void>>();
+        const fn = mockFn<(...args: unknown[]) => Promise<void>>() as any;
         fn.mockResolvedValue(undefined);
         return fn;
       })(),
       error: (() => {
-        const fn = mockFn<(...args: unknown[]) => Promise<void>>();
+        const fn = mockFn<(...args: unknown[]) => Promise<void>>() as any;
         fn.mockResolvedValue(undefined);
         return fn;
       })(),
       always: (() => {
-        const fn = mockFn<(...args: unknown[]) => Promise<void>>();
+        const fn = mockFn<(...args: unknown[]) => Promise<void>>() as any;
         fn.mockResolvedValue(undefined);
         return fn;
       })(),
       event: (() => {
-        const fn = mockFn<(...args: unknown[]) => Promise<void>>();
+        const fn = mockFn<(...args: unknown[]) => Promise<void>>() as any;
         fn.mockResolvedValue(undefined);
         return fn;
       })(),
       getLogFilePath: (() => {
-        const fn = mockFn<() => string>();
+        const fn = mockFn<() => string>() as any;
         fn.mockReturnValue('/tmp/rundown-test.log');
         return fn;
       })(),
       getLogDir: (() => {
-        const fn = mockFn<() => string>();
+        const fn = mockFn<() => string>() as any;
         fn.mockReturnValue('/tmp');
         return fn;
       })(),
@@ -253,47 +255,31 @@ jest.unstable_mockModule('@rundown-org/core', () => {
       },
     ),
     resetHelperInvokeWarnings: jest.fn(),
-    partitionOutputDeclarations: jest.fn().mockReturnValue({ naked: [], expression: [] }),
-    prepareOutputChannels: jest.fn().mockResolvedValue({ env: {}, prepared: [] }),
-    readCapturedOutputs: jest.fn().mockResolvedValue({}),
+    partitionOutputDeclarations: (jest.fn() as any).mockReturnValue({ naked: [], expression: [] }),
+    prepareOutputChannels: (jest.fn() as any).mockResolvedValue({ env: {}, prepared: [] }),
+    readCapturedOutputs: (jest.fn() as any).mockResolvedValue({}),
   };
 });
 
-jest.unstable_mockModule('../../src/helpers/delegate-inference', () => {
-  const inferAllDelegateSubsteps =
-    mockFn<(...args: unknown[]) => { runbookRef: string; stepId: string }[]>();
-  inferAllDelegateSubsteps.mockReturnValue([]);
-  return { inferAllDelegateSubsteps };
-});
+jest.unstable_mockModule('../../src/helpers/delegate-inference', () => ({
+  inferAllDelegateSubsteps: (jest.fn() as any).mockReturnValue([]),
+}));
 
-jest.unstable_mockModule('../../src/helpers/resolve-runbook', () => {
-  const resolveRunbookFile =
-    mockFn<(...args: unknown[]) => Promise<{ path: string; source: string } | null>>();
-  resolveRunbookFile.mockResolvedValue(null);
-  return { resolveRunbookFile };
-});
+jest.unstable_mockModule('../../src/helpers/resolve-runbook', () => ({
+  resolveRunbookFile: (jest.fn() as any).mockResolvedValue(null),
+}));
 
-jest.unstable_mockModule('../../src/services/internal-commands', () => {
-  const isInternalRdCommand = mockFn<(command: string) => boolean>();
-  isInternalRdCommand.mockReturnValue(false);
-  return {
-    isInternalRdCommand,
-    executeRdCommandInternal: jest.fn(),
-  };
-});
+jest.unstable_mockModule('../../src/services/internal-commands', () => ({
+  isInternalRdCommand: (jest.fn() as any).mockReturnValue(false),
+  executeRdCommandInternal: jest.fn(),
+}));
 
-jest.unstable_mockModule('../../src/services/policy-context', () => {
-  const isPolicyEnforced = mockFn<() => boolean>();
-  isPolicyEnforced.mockReturnValue(false);
-  const getSandboxOptions = mockFn<() => { sandbox: boolean; sandboxStrict: boolean }>();
-  getSandboxOptions.mockReturnValue({ sandbox: true, sandboxStrict: false });
-  return {
-    getPolicyEvaluator: jest.fn(),
-    getPolicyPrompter: jest.fn(),
-    isPolicyEnforced,
-    getSandboxOptions,
-  };
-});
+jest.unstable_mockModule('../../src/services/policy-context', () => ({
+  getPolicyEvaluator: jest.fn(),
+  getPolicyPrompter: jest.fn(),
+  isPolicyEnforced: (jest.fn() as any).mockReturnValue(false),
+  getSandboxOptions: (jest.fn() as any).mockReturnValue({ sandbox: true, sandboxStrict: false }),
+}));
 
 // Import after mocking
 const core = await import('@rundown-org/core');
@@ -303,6 +289,7 @@ const resolveRunbook = await import('../../src/helpers/resolve-runbook.js');
 const { runExecutionLoop, executeCommandWithPolicyCheck } = await import(
   '../../src/services/execution.js'
 );
+const mockedPolicyContext = jest.mocked(policyContext);
 
 // Production types — used solely for the `as unknown as` casts below.
 type RunbookStateManagerType = RunbookStateManager;
@@ -371,24 +358,15 @@ describe('runExecutionLoop', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // Restore default ForIterationService mock (tests may override).
-    // ForIterationService is a class (jest.Mock constructor) so we cast
-    // through `unknown` to a mock-instance type — `jest.mocked` infers
-    // the class signature here and refuses simple `mockImplementation`
-    // calls because of the constructor overloads.
-    (core.ForIterationService as unknown as jest.Mock).mockImplementation(() => {
-      const prepareIteration = mockFn<(...args: unknown[]) => Promise<{ status: string }>>();
-      prepareIteration.mockResolvedValue({ status: 'no-resolution-needed' });
-      return { prepareIteration };
-    });
+    // Restore default ForIterationService mock (tests may override)
+    (core.ForIterationService as any).mockImplementation(() => ({
+      prepareIteration: jest.fn(async () => ({ status: 'no-resolution-needed' as const })) as any,
+    }));
 
-    jest.mocked(policyContext.isPolicyEnforced).mockReturnValue(false);
-    jest.mocked(policyContext.getSandboxOptions).mockReturnValue({
-      sandbox: true,
-      sandboxStrict: false,
-    });
-    jest.mocked(core.executeCommand).mockReset();
-    jest.mocked(core.executeCommandWithPolicy).mockReset();
+    mockedPolicyContext.isPolicyEnforced.mockReturnValue(false);
+    mockedPolicyContext.getSandboxOptions.mockReturnValue({ sandbox: true, sandboxStrict: false });
+    (core.executeCommand as any).mockReset();
+    (core.executeCommandWithPolicy as any).mockReset();
 
     mockManager = {
       load: mockFn<(id: string) => Promise<Record<string, unknown> | null>>(),
@@ -1285,7 +1263,7 @@ describe('runExecutionLoop', () => {
     });
 
     // PENDING_FRONTIER_CONSUMED must NOT be sent when no frontier was consumed
-    const consumedCall = mockActorService.sendAndSync.mock.calls.find((call) => {
+    const consumedCall = mockActorService.sendAndSync.mock.calls.find((call: unknown[]) => {
       const event = call[2] as { type?: string } | undefined;
       return call[1] === delegateSteps && event?.type === 'PENDING_FRONTIER_CONSUMED';
     });
@@ -1357,7 +1335,7 @@ describe('executeCommandWithPolicyCheck', () => {
   });
 
   it('calls executeCommandWithEnv when policy is not enforced but rdInjected is non-empty', async () => {
-    policyContext.isPolicyEnforced.mockReturnValue(false);
+    mockedPolicyContext.isPolicyEnforced.mockReturnValue(false);
     const rdInjected = { RD_OUTPUTS_Foo: '/tmp/foo' };
     (core.executeCommandWithEnv as any).mockResolvedValue({ success: true, exitCode: 0 });
 

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -1311,7 +1311,8 @@ describe('executeCommandWithPolicyCheck', () => {
 
     await executeCommandWithPolicyCheck(command, cwd);
 
-    expect(core.executeCommand).toHaveBeenCalledWith(command, cwd, undefined);
+    expect(core.executeCommand).toHaveBeenCalledWith(command, cwd);
+    expect(core.executeCommandWithEnv).not.toHaveBeenCalled();
     expect(core.executeCommandWithPolicy).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -1354,4 +1354,20 @@ describe('executeCommandWithPolicyCheck', () => {
       }),
     );
   });
+
+  it('calls executeCommandWithEnv when policy is not enforced but rdInjected is non-empty', async () => {
+    policyContext.isPolicyEnforced.mockReturnValue(false);
+    const rdInjected = { RD_OUTPUTS_Foo: '/tmp/foo' };
+    (core.executeCommandWithEnv as any).mockResolvedValue({ success: true, exitCode: 0 });
+
+    await executeCommandWithPolicyCheck(command, cwd, undefined, rdInjected);
+
+    expect(core.executeCommandWithEnv).toHaveBeenCalledWith(
+      command,
+      cwd,
+      expect.objectContaining({ RD_OUTPUTS_Foo: '/tmp/foo' }),
+    );
+    expect(core.executeCommand).not.toHaveBeenCalled();
+    expect(core.executeCommandWithPolicy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -159,7 +159,13 @@ export function createProgram(): Command {
     await initializePolicyContext(policyOpts, cwd);
     const configHelpers = getPolicyContext().policy.helpers ?? [];
     const cliHelpers = policyOpts.helpers ?? [];
-    const allHelperPaths = [...configHelpers, ...cliHelpers];
+    const trustedConfigHelpers = policyOpts.trustJsPolicy ? configHelpers : [];
+    if (configHelpers.length > 0 && !policyOpts.trustJsPolicy) {
+      console.warn(
+        'Warning: Policy-configured helper modules require --trust-js-policy and were skipped.',
+      );
+    }
+    const allHelperPaths = [...trustedConfigHelpers, ...cliHelpers];
     // Always reset both registries so in-process re-entry (tests, hosts that
     // boot the CLI multiple times) cannot leak helpers from a prior invocation.
     // When no helpers are configured, install an empty registry rather than

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -47,6 +47,7 @@ import {
   prepareOutputChannels,
   readCapturedOutputs,
   type OutputScope,
+  type PreparedChannel,
 } from '@rundown-org/core';
 import {
   isSourced,
@@ -888,26 +889,21 @@ export async function runExecutionLoop(
     const expandedCommandCode = expandLoopVariablesForCommand(command.code, stepVars);
 
     // --- Output capture: pre-spawn ---------------------------------------
-    const unitOutputs = extractUnitOutputs(
-      currentStep,
-      isSubstep,
-      isSubstep ? itemToRender.id : undefined,
-    );
+    const substepId = isSubstep ? itemToRender.id : undefined;
+    const unitOutputs = extractUnitOutputs(currentStep, isSubstep, substepId);
     const { naked: nakedOutputs } = partitionOutputDeclarations(unitOutputs);
-    const outputScope = deriveOutputScope(
-      currentState,
-      isSubstep,
-      isSubstep ? itemToRender.id : undefined,
-    );
-    const channels =
-      nakedOutputs.length > 0
-        ? await prepareOutputChannels({
-            cwd,
-            runId: currentState.id,
-            scope: outputScope,
-            naked: nakedOutputs,
-          })
-        : { env: {} as Record<string, string>, createdPaths: [] as readonly string[] };
+    let channels: { env: Record<string, string>; prepared: readonly PreparedChannel[] };
+    if (nakedOutputs.length > 0) {
+      const outputScope = deriveOutputScope(currentState, isSubstep, substepId);
+      channels = await prepareOutputChannels({
+        cwd,
+        runId: currentState.id,
+        scope: outputScope,
+        naked: nakedOutputs,
+      });
+    } else {
+      channels = { env: {}, prepared: [] };
+    }
     // --------------------------------------------------------------------
 
     // Build rundown-injected environment variables (RD_WORK_PATH, RD_RUN_ID, etc.)
@@ -963,9 +959,9 @@ export async function runExecutionLoop(
       sandboxed: execResult.sandboxed,
     });
 
-    // --- Output capture: post-spawn --------------------------------------
-    if (channels.createdPaths.length > 0) {
-      const captured = await readCapturedOutputs(channels.createdPaths, nakedOutputs);
+    // --- Output capture: post-spawn ---------------------------------------
+    if (!execResult.policyDenied && channels.prepared.length > 0) {
+      const captured = await readCapturedOutputs(channels.prepared);
       if (Object.keys(captured).length > 0) {
         const setSync = await actorService.sendAndSync(runbookId, steps, {
           type: 'SET_VARIABLES',

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -223,7 +223,7 @@ export function findStepOrThrow(steps: ResolvedStep[], stepName: string): Resolv
  * @param substepId - The substep id when isSubstep is true
  * @returns OutputScope suitable for `outputChannelPath` / `prepareOutputChannels`
  */
-function deriveOutputScope(
+export function deriveOutputScope(
   currentState: RunbookState,
   isSubstep: boolean,
   substepId?: string,
@@ -250,7 +250,7 @@ function deriveOutputScope(
  * @param substepId - The substep id when isSubstep is true
  * @returns Output declarations or empty array
  */
-function extractUnitOutputs(
+export function extractUnitOutputs(
   currentStep: ResolvedStep,
   isSubstep: boolean,
   substepId?: string,

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -954,7 +954,7 @@ export async function runExecutionLoop(
     let execResult: ExecutionResult;
 
     if (isInternalRdCommand(expandedCommandCode)) {
-      const internalResult = await executeRdCommandInternal(expandedCommandCode, cwd);
+      const internalResult = await executeRdCommandInternal(expandedCommandCode, cwd, rdInjected);
       if (internalResult !== null) {
         execResult = internalResult;
       } else {

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -264,6 +264,29 @@ export function extractUnitOutputs(
   return currentStep.outputs ?? [];
 }
 
+/**
+ * Determine whether the current PASS/FAIL result will be consumed by a retry
+ * transition before the authored exhausted action runs.
+ *
+ * File-backed OUTPUTS must follow expression OUTPUTS semantics: a retrying
+ * attempt does not publish outputs to `context.variables`. The state machine
+ * tracks the active retry budget in `retryCount` for command execution, so the
+ * CLI can avoid pre-transition `SET_VARIABLES` while a retry is still pending.
+ *
+ * @param item - The step or substep currently executing
+ * @param result - Command result that will be sent to the state machine
+ * @param state - Current persisted runbook state
+ * @returns True when the next transition is a retry, false otherwise
+ */
+function resultWillRetry(
+  item: Step | ResolvedStep | Substep,
+  result: 'pass' | 'fail',
+  state: RunbookState,
+): boolean {
+  const transition = item.transitions[result];
+  return transition.retry > 0 && state.retryCount < transition.retry;
+}
+
 interface ApplyResultTransitionArgs {
   manager: RunbookStateManager;
   actorService: RunbookActorService;
@@ -962,8 +985,11 @@ export async function runExecutionLoop(
       sandboxed: execResult.sandboxed,
     });
 
+    const lastResult = execResult.success ? 'pass' : 'fail';
+    const publishCapturedOutputs = !resultWillRetry(itemToRender, lastResult, currentState);
+
     // --- Output capture: post-spawn ---------------------------------------
-    if (!execResult.policyDenied && channels.prepared.length > 0) {
+    if (!execResult.policyDenied && publishCapturedOutputs && channels.prepared.length > 0) {
       const captured = await readCapturedOutputs(channels.prepared);
       if (Object.keys(captured).length > 0) {
         const setSync = await actorService.sendAndSync(runbookId, steps, {
@@ -1005,7 +1031,6 @@ export async function runExecutionLoop(
     }
 
     // Store result
-    const lastResult = execResult.success ? 'pass' : 'fail';
     await lifecycleService.setLastResult(runbookId, lastResult);
     const transitionResult = await applyResultTransition({
       manager,

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -1087,7 +1087,7 @@ export function buildMetadata(state: RunbookState): RunbookMetadata {
  * @param command - The shell command to execute
  * @param cwd - Working directory for execution
  * @param runbookPath - Optional runbook file path for override matching
- * @param rdInjected - Optional extra environment variables injected by Rundown (e.g. RD_WORK_PATH)
+ * @param rdInjected - Optional rundown-injected env vars (`RD_OUTPUTS_*`, `RD_WORK_PATH`, etc.) merged into the child process environment
  * @returns Execution result
  */
 export async function executeCommandWithPolicyCheck(

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -43,8 +43,17 @@ import {
   Errors,
   isError,
   type DelegateFrontierEntry,
+  partitionOutputDeclarations,
+  prepareOutputChannels,
+  readCapturedOutputs,
+  type OutputScope,
 } from '@rundown-org/core';
-import { isSourced, resolvedStepHasSubsteps, type ForClause } from '@rundown-org/parser';
+import {
+  isSourced,
+  resolvedStepHasSubsteps,
+  type ForClause,
+  type OutputDeclaration,
+} from '@rundown-org/parser';
 import { isInternalRdCommand, executeRdCommandInternal } from './internal-commands.js';
 import type { StepVariables } from './execution-vars.js';
 import { inferAllDelegateSubsteps } from '../helpers/delegate-inference.js';
@@ -189,6 +198,66 @@ export function findStepOrThrow(steps: ResolvedStep[], stepName: string): Resolv
   const step = steps.find((s) => s.name === stepName);
   if (!step) throw new Error(`Step '${stepName}' not found — possible state corruption`);
   return step;
+}
+
+/**
+ * Derive the output-channel scope for the unit currently being executed.
+ *
+ * `substepId` and `iteration` are independent optional path tiers and compose
+ * when both apply — a naked OUTPUTS on a substep inside a FOR loop produces
+ * `{ stepId, substepId, iteration }`, which `outputChannelPath` renders as
+ * `<stepId>/<substepId>/<iteration>/<VarName>`.
+ *
+ * Tier population:
+ * - substep tier: set from `substepId` whenever `isSubstep` is true
+ * - iteration tier: set from `top.iteration` whenever the top FOR frame is
+ *   non-implicit and its `stepId` matches `currentState.step`
+ *
+ * Implicit FOR frames contribute no iteration tier — implicit frames have no
+ * user-visible counter to segment the path with.
+ *
+ * @param currentState - The runbook state at the moment of execution
+ * @param isSubstep - Whether the current execution unit is a substep
+ * @param substepId - The substep id when isSubstep is true
+ * @returns OutputScope suitable for `outputChannelPath` / `prepareOutputChannels`
+ */
+function deriveOutputScope(
+  currentState: RunbookState,
+  isSubstep: boolean,
+  substepId?: string,
+): OutputScope {
+  const stepId = currentState.step;
+  const scope: { stepId: string; substepId?: string; iteration?: number } = { stepId };
+  if (isSubstep && substepId !== undefined) {
+    scope.substepId = substepId;
+  }
+  const top = currentState.forStack?.at(-1);
+  if (top && !top.implicit && top.stepId === stepId) {
+    scope.iteration = top.iteration;
+  }
+  return scope;
+}
+
+/**
+ * Extract the OUTPUTS declarations attached to the execution unit currently
+ * being run. For a substep, return the substep's OUTPUTS; for a step-level
+ * command, return the parent step's OUTPUTS.
+ *
+ * @param currentStep - The resolved parent step
+ * @param isSubstep - Whether a substep is being executed
+ * @param substepId - The substep id when isSubstep is true
+ * @returns Output declarations or empty array
+ */
+function extractUnitOutputs(
+  currentStep: ResolvedStep,
+  isSubstep: boolean,
+  substepId?: string,
+): readonly OutputDeclaration[] {
+  if (isSubstep && substepId !== undefined && resolvedStepHasSubsteps(currentStep)) {
+    const sub = currentStep.substeps.find((s) => s.id === substepId);
+    return sub?.outputs ?? [];
+  }
+  return currentStep.outputs ?? [];
 }
 
 interface ApplyResultTransitionArgs {
@@ -818,10 +887,33 @@ export async function runExecutionLoop(
     // Expand command code for execution (after guard — command is guaranteed)
     const expandedCommandCode = expandLoopVariablesForCommand(command.code, stepVars);
 
+    // --- Output capture: pre-spawn ---------------------------------------
+    const unitOutputs = extractUnitOutputs(
+      currentStep,
+      isSubstep,
+      isSubstep ? itemToRender.id : undefined,
+    );
+    const { naked: nakedOutputs } = partitionOutputDeclarations(unitOutputs);
+    const outputScope = deriveOutputScope(
+      currentState,
+      isSubstep,
+      isSubstep ? itemToRender.id : undefined,
+    );
+    const channels =
+      nakedOutputs.length > 0
+        ? await prepareOutputChannels({
+            cwd,
+            runId: currentState.id,
+            scope: outputScope,
+            naked: nakedOutputs,
+          })
+        : { env: {} as Record<string, string>, createdPaths: [] as readonly string[] };
+    // --------------------------------------------------------------------
+
     // Build rundown-injected environment variables (RD_WORK_PATH, RD_RUN_ID, etc.)
     // Keys come from BUILTIN_VARIABLES so a rename in variable-discovery.ts
     // surfaces here as a typecheck error instead of silently breaking injection.
-    const rdInjected: Record<string, string> = {};
+    const rdInjected: Record<string, string> = { ...channels.env };
     const workPath = stepVars[BUILTIN_VARIABLES.WorkPath];
     const contextId = stepVars[BUILTIN_VARIABLES.ContextId];
     const runId = stepVars[BUILTIN_VARIABLES.RunId];
@@ -829,10 +921,7 @@ export async function runExecutionLoop(
     if (typeof contextId === 'string') rdInjected.RD_CONTEXT_ID = contextId;
     if (typeof runId === 'string') rdInjected.RD_RUN_ID = runId;
 
-    // Execute command
-    // For rd commands, try internal execution first (avoids nested spawn issues in WebContainer)
-    // Use display command (with rd echo wrapper stripped) for cleaner output
-    // Fall back to original command if extractDisplayCommand returns empty (e.g., "rd echo --result pass")
+    // Execute command (unchanged — still routed via internal vs spawn)
     const extracted = extractDisplayCommand(expandedCommandCode);
     const displayCommand = extracted || expandedCommandCode;
     emitter.emit('COMMAND_STARTED', {
@@ -847,7 +936,6 @@ export async function runExecutionLoop(
       if (internalResult !== null) {
         execResult = internalResult;
       } else {
-        // Fallback to spawn if internal execution not supported for this subcommand
         execResult = await executeCommandWithPolicyCheck(
           expandedCommandCode,
           cwd,
@@ -864,7 +952,7 @@ export async function runExecutionLoop(
       );
     }
 
-    // Emit COMMAND_COMPLETED event
+    // Emit COMMAND_COMPLETED event (unchanged)
     emitter.emit('COMMAND_COMPLETED', {
       command: expandedCommandCode,
       success: execResult.success,
@@ -874,6 +962,27 @@ export async function runExecutionLoop(
       denialReason: execResult.denialReason,
       sandboxed: execResult.sandboxed,
     });
+
+    // --- Output capture: post-spawn --------------------------------------
+    if (channels.createdPaths.length > 0) {
+      const captured = await readCapturedOutputs(channels.createdPaths, nakedOutputs);
+      if (Object.keys(captured).length > 0) {
+        const setSync = await actorService.sendAndSync(runbookId, steps, {
+          type: 'SET_VARIABLES',
+          vars: captured,
+        });
+        if (setSync) {
+          currentState = setSync.state;
+        } else {
+          void logger.warn('output-capture: SET_VARIABLES sync returned null', {
+            runbookId,
+            stepId: currentState.step,
+            captured: Object.keys(captured),
+          });
+        }
+      }
+    }
+    // --------------------------------------------------------------------
 
     // Handle policy denial
     if (execResult.policyDenied) {

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -205,15 +205,18 @@ export function findStepOrThrow(steps: ResolvedStep[], stepName: string): Resolv
 /**
  * Derive the output-channel scope for the unit currently being executed.
  *
- * `substepId` and `iteration` are independent optional path tiers and compose
- * when both apply — a naked OUTPUTS on a substep inside a FOR loop produces
- * `{ stepId, substepId, iteration }`, which `outputChannelPath` renders as
- * `<stepId>/<substepId>/<iteration>/<VarName>`.
+ * Produces one of three tier compositions:
+ * - `{ stepId }` — step-level (no substep, no iteration)
+ * - `{ stepId, substep: { id } }` — substep-level, no FOR loop
+ * - `{ stepId, substep: { id, iteration } }` — substep inside a FOR loop
  *
  * Tier population:
- * - substep tier: set from `substepId` whenever `isSubstep` is true
- * - iteration tier: set from `top.iteration` whenever the top FOR frame is
- *   non-implicit and its `stepId` matches `currentState.step`
+ * - substep tier: set from `substepId` when both `isSubstep` is true and
+ *   `substepId` is defined — the `isSubstep` guard is a belt-and-suspenders
+ *   check; the nested type makes iteration-without-substep unrepresentable
+ * - iteration tier: set from `top.iteration` when `isSubstep` is true AND
+ *   the top FOR frame is non-implicit and its `stepId` matches
+ *   `currentState.step`
  *
  * Implicit FOR frames contribute no iteration tier — implicit frames have no
  * user-visible counter to segment the path with.
@@ -229,15 +232,14 @@ export function deriveOutputScope(
   substepId?: string,
 ): OutputScope {
   const stepId = currentState.step;
-  const scope: { stepId: string; substepId?: string; iteration?: number } = { stepId };
-  if (isSubstep && substepId !== undefined) {
-    scope.substepId = substepId;
+  if (!isSubstep || substepId === undefined) {
+    return { stepId };
   }
   const top = currentState.forStack?.at(-1);
   if (top && !top.implicit && top.stepId === stepId) {
-    scope.iteration = top.iteration;
+    return { stepId, substep: { id: substepId, iteration: top.iteration } };
   }
-  return scope;
+  return { stepId, substep: { id: substepId } };
 }
 
 /**

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -27,6 +27,7 @@ import {
   type RunbookState,
   type ExecutionResult,
   executeCommand,
+  executeCommandWithEnv,
   executeCommandWithPolicy,
   countNumberedSteps,
   extractDisplayCommand,
@@ -1097,7 +1098,14 @@ export async function executeCommandWithPolicyCheck(
 ): Promise<ExecutionResult> {
   // Check if policy enforcement is active
   if (!isPolicyEnforced()) {
-    return executeCommand(command, cwd, rdInjected);
+    // When policy is bypassed (--allow-all / trust mode), still inject
+    // rundown-specific env vars (RD_OUTPUTS_*, RD_WORK_PATH, etc.) so
+    // file-backed OUTPUTS channels are visible to the subprocess.
+    if (rdInjected && Object.keys(rdInjected).length > 0) {
+      const env = { ...process.env, ...rdInjected } as Record<string, string>;
+      return executeCommandWithEnv(command, cwd, env);
+    }
+    return executeCommand(command, cwd);
   }
 
   // Get evaluator and set runbook path for override matching

--- a/packages/cli/src/services/internal-commands.ts
+++ b/packages/cli/src/services/internal-commands.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ExecutionResult } from '@rundown-org/core';
+import { promises as fs } from 'node:fs';
 import { executeEchoLogic, toExecutionResult } from '../helpers/echo-command.js';
 
 /**
@@ -125,9 +126,14 @@ function executePromptInternal(args: string[]): ExecutionResult {
  *
  * @param args - Command arguments after 'echo'
  * @param cwd - Current working directory
+ * @param rdInjected - Rundown-injected env vars, including any `RD_OUTPUTS_*` file paths
  * @returns ExecutionResult with success/failure
  */
-async function executeEchoInternal(args: string[], cwd: string): Promise<ExecutionResult> {
+async function executeEchoInternal(
+  args: string[],
+  cwd: string,
+  rdInjected?: Record<string, string>,
+): Promise<ExecutionResult> {
   // Parse --result options from args
   const { results, remaining } = parseResultOptions(args);
 
@@ -138,12 +144,25 @@ async function executeEchoInternal(args: string[], cwd: string): Promise<Executi
 
   // Use shared echo logic
   const result = await executeEchoLogic(results, commandArgs, cwd);
+  const output = result.output;
+
+  if (output && rdInjected) {
+    try {
+      const outputPaths = Object.entries(rdInjected)
+        .filter(([key, value]) => key.startsWith('RD_OUTPUTS_') && value.length > 0)
+        .map(([, value]) => value);
+      await Promise.all(outputPaths.map((filePath) => fs.writeFile(filePath, output)));
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      return { success: false, exitCode: 1 };
+    }
+  }
 
   // Output error or result message
   if (result.error) {
     console.error(result.error);
-  } else if (result.output) {
-    console.log(result.output);
+  } else if (output) {
+    console.log(output);
   }
 
   return toExecutionResult(result);
@@ -158,6 +177,7 @@ async function executeEchoInternal(args: string[], cwd: string): Promise<Executi
  *
  * @param command - The full command string (e.g., "rd echo --result pass")
  * @param cwd - Current working directory
+ * @param rdInjected - Optional Rundown-injected env vars to pass through to handlers
  * @returns ExecutionResult if command was handled internally, or null if
  *          the command is not supported and should fall back to spawn
  *
@@ -175,12 +195,13 @@ async function executeEchoInternal(args: string[], cwd: string): Promise<Executi
 export async function executeRdCommandInternal(
   command: string,
   cwd: string,
+  rdInjected?: Record<string, string>,
 ): Promise<ExecutionResult | null> {
   const { subcommand, args } = parseRdCommand(command);
 
   switch (subcommand) {
     case 'echo':
-      return executeEchoInternal(args, cwd);
+      return executeEchoInternal(args, cwd, rdInjected);
 
     case 'prompt':
       return executePromptInternal(args);

--- a/packages/core/__tests__/runbook/output-channels.test.ts
+++ b/packages/core/__tests__/runbook/output-channels.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from '@jest/globals';
 import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
 import {
   partitionOutputDeclarations,
   outputsDirForRun,
   outputChannelPath,
   buildOutputChannelEnv,
+  prepareOutputChannels,
+  readCapturedOutputs,
   type OutputScope,
 } from '../../src/runbook/output-channels.js';
 
@@ -151,5 +155,146 @@ describe('buildOutputChannelEnv', () => {
   it('returns an empty record when no naked outputs are declared', () => {
     const env = buildOutputChannelEnv('/repo', 'wf-x', { stepId: '1' }, []);
     expect(env).toEqual({});
+  });
+});
+
+describe('prepareOutputChannels', () => {
+  it('creates one zero-byte file per naked output and returns absolute env paths', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const result = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-1',
+        scope: { stepId: '1' },
+        naked: [{ name: 'DeployUrl' }, { name: 'Version' }],
+      });
+      expect(Object.keys(result.env).sort()).toEqual([
+        'RD_OUTPUTS_DeployUrl',
+        'RD_OUTPUTS_Version',
+      ]);
+      for (const p of result.createdPaths) {
+        const stat = await fs.stat(p);
+        expect(stat.isFile()).toBe(true);
+        expect(stat.size).toBe(0);
+      }
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('truncates an existing channel file to zero bytes', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const channelPath = path.join(
+        cwd,
+        '.rundown',
+        'runs',
+        'wf-test-2',
+        'outputs',
+        '1',
+        'Version',
+      );
+      await fs.mkdir(path.dirname(channelPath), { recursive: true });
+      await fs.writeFile(channelPath, 'stale-value\n');
+      await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-2',
+        scope: { stepId: '1' },
+        naked: [{ name: 'Version' }],
+      });
+      const after = await fs.readFile(channelPath, 'utf-8');
+      expect(after).toBe('');
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips an entry with an invalid name and continues with the rest', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const result = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-3',
+        scope: { stepId: '1' },
+        // 'step' is reserved → should be dropped; 'Version' should still be created
+        naked: [{ name: 'step' }, { name: 'Version' }],
+      });
+      expect(Object.keys(result.env)).toEqual(['RD_OUTPUTS_Version']);
+      expect(result.createdPaths).toHaveLength(1);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('readCapturedOutputs', () => {
+  it('reads UTF-8 content and trims trailing whitespace + newlines', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const prepared = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-4',
+        scope: { stepId: '1' },
+        naked: [{ name: 'A' }, { name: 'B' }],
+      });
+      await fs.writeFile(prepared.createdPaths[0], 'value-a\n');
+      await fs.writeFile(prepared.createdPaths[1], 'value-b   \n\n');
+      const captured = await readCapturedOutputs(prepared.createdPaths, [
+        { name: 'A' },
+        { name: 'B' },
+      ]);
+      expect(captured).toEqual({ A: 'value-a', B: 'value-b' });
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('omits empty files (post-trim) with a warning', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const prepared = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-5',
+        scope: { stepId: '1' },
+        naked: [{ name: 'Empty' }, { name: 'Filled' }],
+      });
+      await fs.writeFile(prepared.createdPaths[0], '   \n');
+      await fs.writeFile(prepared.createdPaths[1], 'kept');
+      const captured = await readCapturedOutputs(prepared.createdPaths, [
+        { name: 'Empty' },
+        { name: 'Filled' },
+      ]);
+      expect(captured).toEqual({ Filled: 'kept' });
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('omits files containing a NUL byte (treated as non-UTF-8)', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const prepared = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-6',
+        scope: { stepId: '1' },
+        naked: [{ name: 'Bin' }],
+      });
+      await fs.writeFile(prepared.createdPaths[0], Buffer.from([0x68, 0x00, 0x69]));
+      const captured = await readCapturedOutputs(prepared.createdPaths, [{ name: 'Bin' }]);
+      expect(captured).toEqual({});
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('omits files that are missing on disk', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const ghostPath = path.join(cwd, '.rundown', 'runs', 'wf-test-7', 'outputs', '1', 'Ghost');
+      const captured = await readCapturedOutputs([ghostPath], [{ name: 'Ghost' }]);
+      expect(captured).toEqual({});
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/__tests__/runbook/output-channels.test.ts
+++ b/packages/core/__tests__/runbook/output-channels.test.ts
@@ -80,13 +80,6 @@ describe('outputChannelPath', () => {
     );
   });
 
-  it('assembles a FOR-iteration-in-step path (iteration, no substep)', () => {
-    const scope: OutputScope = { stepId: '3', iteration: 2 };
-    expect(outputChannelPath(cwd, runId, scope, 'Tag')).toBe(
-      path.join(cwd, '.rundown', 'runs', runId, 'outputs', '3', '2', 'Tag'),
-    );
-  });
-
   it('assembles a FOR-iteration-in-substep path with all four segments', () => {
     const scope: OutputScope = { stepId: '3', substepId: '1', iteration: 2 };
     expect(outputChannelPath(cwd, runId, scope, 'Tag')).toBe(

--- a/packages/core/__tests__/runbook/output-channels.test.ts
+++ b/packages/core/__tests__/runbook/output-channels.test.ts
@@ -175,6 +175,24 @@ describe('prepareOutputChannels', () => {
     }
   });
 
+  it('creates newly prepared channel files with owner-only permissions', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    const originalUmask = process.umask(0);
+    try {
+      const result = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-1c',
+        scope: { stepId: '1' },
+        naked: [{ name: 'Version' }],
+      });
+      const stat = await fs.stat(result.prepared[0].path);
+      expect(stat.mode & 0o777).toBe(0o600);
+    } finally {
+      process.umask(originalUmask);
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('prepared channels carry the correct name for each entry', async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
     try {
@@ -217,6 +235,36 @@ describe('prepareOutputChannels', () => {
     }
   });
 
+  it('tightens permissions again when reusing an existing channel file', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const channelPath = path.join(
+        cwd,
+        '.rundown',
+        'runs',
+        'wf-test-2b',
+        'outputs',
+        '1',
+        'Version',
+      );
+      await fs.mkdir(path.dirname(channelPath), { recursive: true });
+      await fs.writeFile(channelPath, 'stale-value\n');
+      await fs.chmod(channelPath, 0o644);
+
+      await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-2b',
+        scope: { stepId: '1' },
+        naked: [{ name: 'Version' }],
+      });
+
+      const stat = await fs.stat(channelPath);
+      expect(stat.mode & 0o777).toBe(0o600);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('skips an entry with an invalid name and continues with the rest', async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
     try {
@@ -229,6 +277,46 @@ describe('prepareOutputChannels', () => {
       });
       expect(Object.keys(result.env)).toEqual(['RD_OUTPUTS_Version']);
       expect(result.prepared).toHaveLength(1);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('omits symlinked channel files during readback', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const prepared = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-8',
+        scope: { stepId: '1' },
+        naked: [{ name: 'Symlinked' }],
+      });
+      const targetPath = path.join(cwd, 'target.txt');
+      await fs.writeFile(targetPath, 'linked-value');
+      await fs.rm(prepared.prepared[0].path);
+      await fs.symlink(targetPath, prepared.prepared[0].path);
+
+      const captured = await readCapturedOutputs(prepared.prepared);
+      expect(captured).toEqual({});
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('omits non-regular channel files during readback', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const prepared = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-9',
+        scope: { stepId: '1' },
+        naked: [{ name: 'Directory' }],
+      });
+      await fs.rm(prepared.prepared[0].path);
+      await fs.mkdir(prepared.prepared[0].path);
+
+      const captured = await readCapturedOutputs(prepared.prepared);
+      expect(captured).toEqual({});
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }

--- a/packages/core/__tests__/runbook/output-channels.test.ts
+++ b/packages/core/__tests__/runbook/output-channels.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from '@jest/globals';
+import * as path from 'node:path';
+import {
+  partitionOutputDeclarations,
+  outputsDirForRun,
+  outputChannelPath,
+  buildOutputChannelEnv,
+  type OutputScope,
+} from '../../src/runbook/output-channels.js';
+
+describe('partitionOutputDeclarations', () => {
+  it('separates naked and expression entries preserving order', () => {
+    const result = partitionOutputDeclarations([
+      { name: 'DeployUrl' },
+      { name: 'Tag', value: '"{{ RunId }}-staging"' },
+      { name: 'Version' },
+    ]);
+    expect(result.naked).toEqual([{ name: 'DeployUrl' }, { name: 'Version' }]);
+    expect(result.expression).toEqual([{ name: 'Tag', value: '"{{ RunId }}-staging"' }]);
+  });
+
+  it('returns empty arrays for an empty input', () => {
+    const result = partitionOutputDeclarations([]);
+    expect(result.naked).toEqual([]);
+    expect(result.expression).toEqual([]);
+  });
+});
+
+describe('outputsDirForRun', () => {
+  it('joins to .rundown/runs/<runId>/outputs', () => {
+    const cwd = '/repo';
+    expect(outputsDirForRun(cwd, 'wf-2026-04-25-abc123')).toBe(
+      path.join('/repo', '.rundown', 'runs', 'wf-2026-04-25-abc123', 'outputs'),
+    );
+  });
+
+  it('rejects an unsafe runId', () => {
+    expect(() => outputsDirForRun('/repo', '..')).toThrow(/Invalid runId/);
+    expect(() => outputsDirForRun('/repo', 'a/b')).toThrow(/Invalid runId/);
+  });
+});
+
+describe('outputChannelPath', () => {
+  const cwd = '/repo';
+  const runId = 'wf-2026-04-25-abc123';
+
+  it('assembles a step-scoped path (no substep, no iteration)', () => {
+    const scope: OutputScope = { stepId: '1' };
+    expect(outputChannelPath(cwd, runId, scope, 'Version')).toBe(
+      path.join(cwd, '.rundown', 'runs', runId, 'outputs', '1', 'Version'),
+    );
+  });
+
+  it('assembles a substep-scoped path (substep, no iteration)', () => {
+    const scope: OutputScope = { stepId: '1', substepId: '2' };
+    expect(outputChannelPath(cwd, runId, scope, 'DeployUrl')).toBe(
+      path.join(cwd, '.rundown', 'runs', runId, 'outputs', '1', '2', 'DeployUrl'),
+    );
+  });
+
+  it('assembles a FOR-iteration-in-step path (iteration, no substep)', () => {
+    const scope: OutputScope = { stepId: '3', iteration: 2 };
+    expect(outputChannelPath(cwd, runId, scope, 'Tag')).toBe(
+      path.join(cwd, '.rundown', 'runs', runId, 'outputs', '3', '2', 'Tag'),
+    );
+  });
+
+  it('assembles a FOR-iteration-in-substep path with all four segments', () => {
+    const scope: OutputScope = { stepId: '3', substepId: '1', iteration: 2 };
+    expect(outputChannelPath(cwd, runId, scope, 'Tag')).toBe(
+      path.join(cwd, '.rundown', 'runs', runId, 'outputs', '3', '1', '2', 'Tag'),
+    );
+  });
+
+  it('rejects an invalid VarName', () => {
+    const scope: OutputScope = { stepId: '1' };
+    expect(() => outputChannelPath(cwd, runId, scope, '../escape')).toThrow(/Invalid output name/);
+    expect(() => outputChannelPath(cwd, runId, scope, '1bad')).toThrow(/Invalid output name/);
+  });
+
+  it('rejects a reserved name (case-insensitive)', () => {
+    const scope: OutputScope = { stepId: '1' };
+    expect(() => outputChannelPath(cwd, runId, scope, 'Step')).toThrow(/reserved/);
+  });
+});
+
+describe('buildOutputChannelEnv', () => {
+  it('emits one RD_OUTPUTS_<Name> entry per naked output, all absolute paths', () => {
+    const cwd = '/repo';
+    const runId = 'wf-2026-04-25-abc123';
+    const scope: OutputScope = { stepId: '1' };
+    const env = buildOutputChannelEnv(cwd, runId, scope, [
+      { name: 'DeployUrl' },
+      { name: 'Version' },
+    ]);
+    expect(Object.keys(env).sort()).toEqual(['RD_OUTPUTS_DeployUrl', 'RD_OUTPUTS_Version']);
+    expect(env.RD_OUTPUTS_DeployUrl).toBe(
+      path.join(cwd, '.rundown', 'runs', runId, 'outputs', '1', 'DeployUrl'),
+    );
+    expect(path.isAbsolute(env.RD_OUTPUTS_Version)).toBe(true);
+  });
+
+  it('routes scope substepId + iteration into a four-segment env value', () => {
+    const cwd = '/repo';
+    const runId = 'wf-2026-04-25-abc123';
+    const scope: OutputScope = { stepId: '1', substepId: '2', iteration: 3 };
+    const env = buildOutputChannelEnv(cwd, runId, scope, [{ name: 'DeployUrl' }]);
+    expect(env.RD_OUTPUTS_DeployUrl).toBe(
+      path.join(cwd, '.rundown', 'runs', runId, 'outputs', '1', '2', '3', 'DeployUrl'),
+    );
+  });
+
+  it('returns an empty record when no naked outputs are declared', () => {
+    const env = buildOutputChannelEnv('/repo', 'wf-x', { stepId: '1' }, []);
+    expect(env).toEqual({});
+  });
+});

--- a/packages/core/__tests__/runbook/output-channels.test.ts
+++ b/packages/core/__tests__/runbook/output-channels.test.ts
@@ -172,11 +172,26 @@ describe('prepareOutputChannels', () => {
         'RD_OUTPUTS_DeployUrl',
         'RD_OUTPUTS_Version',
       ]);
-      for (const p of result.createdPaths) {
+      for (const p of result.prepared.map((c) => c.path)) {
         const stat = await fs.stat(p);
         expect(stat.isFile()).toBe(true);
         expect(stat.size).toBe(0);
       }
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('prepared channels carry the correct name for each entry', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const result = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-1b',
+        scope: { stepId: '1' },
+        naked: [{ name: 'DeployUrl' }, { name: 'Version' }],
+      });
+      expect(result.prepared.map((c) => c.name)).toEqual(['DeployUrl', 'Version']);
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }
@@ -220,7 +235,7 @@ describe('prepareOutputChannels', () => {
         naked: [{ name: 'step' }, { name: 'Version' }],
       });
       expect(Object.keys(result.env)).toEqual(['RD_OUTPUTS_Version']);
-      expect(result.createdPaths).toHaveLength(1);
+      expect(result.prepared).toHaveLength(1);
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }
@@ -237,12 +252,9 @@ describe('readCapturedOutputs', () => {
         scope: { stepId: '1' },
         naked: [{ name: 'A' }, { name: 'B' }],
       });
-      await fs.writeFile(prepared.createdPaths[0], 'value-a\n');
-      await fs.writeFile(prepared.createdPaths[1], 'value-b   \n\n');
-      const captured = await readCapturedOutputs(prepared.createdPaths, [
-        { name: 'A' },
-        { name: 'B' },
-      ]);
+      await fs.writeFile(prepared.prepared[0].path, 'value-a\n');
+      await fs.writeFile(prepared.prepared[1].path, 'value-b   \n\n');
+      const captured = await readCapturedOutputs(prepared.prepared);
       expect(captured).toEqual({ A: 'value-a', B: 'value-b' });
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
@@ -258,12 +270,9 @@ describe('readCapturedOutputs', () => {
         scope: { stepId: '1' },
         naked: [{ name: 'Empty' }, { name: 'Filled' }],
       });
-      await fs.writeFile(prepared.createdPaths[0], '   \n');
-      await fs.writeFile(prepared.createdPaths[1], 'kept');
-      const captured = await readCapturedOutputs(prepared.createdPaths, [
-        { name: 'Empty' },
-        { name: 'Filled' },
-      ]);
+      await fs.writeFile(prepared.prepared[0].path, '   \n');
+      await fs.writeFile(prepared.prepared[1].path, 'kept');
+      const captured = await readCapturedOutputs(prepared.prepared);
       expect(captured).toEqual({ Filled: 'kept' });
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
@@ -279,8 +288,8 @@ describe('readCapturedOutputs', () => {
         scope: { stepId: '1' },
         naked: [{ name: 'Bin' }],
       });
-      await fs.writeFile(prepared.createdPaths[0], Buffer.from([0x68, 0x00, 0x69]));
-      const captured = await readCapturedOutputs(prepared.createdPaths, [{ name: 'Bin' }]);
+      await fs.writeFile(prepared.prepared[0].path, Buffer.from([0x68, 0x00, 0x69]));
+      const captured = await readCapturedOutputs(prepared.prepared);
       expect(captured).toEqual({});
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
@@ -291,7 +300,7 @@ describe('readCapturedOutputs', () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
     try {
       const ghostPath = path.join(cwd, '.rundown', 'runs', 'wf-test-7', 'outputs', '1', 'Ghost');
-      const captured = await readCapturedOutputs([ghostPath], [{ name: 'Ghost' }]);
+      const captured = await readCapturedOutputs([{ name: 'Ghost', path: ghostPath }]);
       expect(captured).toEqual({});
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });

--- a/packages/core/__tests__/runbook/output-channels.test.ts
+++ b/packages/core/__tests__/runbook/output-channels.test.ts
@@ -282,6 +282,38 @@ describe('prepareOutputChannels', () => {
     }
   });
 
+  it('skips symlinked channel targets when preparing files', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const targetPath = path.join(cwd, 'target.txt');
+      const channelPath = path.join(
+        cwd,
+        '.rundown',
+        'runs',
+        'wf-test-8b',
+        'outputs',
+        '1',
+        'Symlinked',
+      );
+      await fs.mkdir(path.dirname(channelPath), { recursive: true });
+      await fs.writeFile(targetPath, 'linked-value');
+      await fs.symlink(targetPath, channelPath);
+
+      const result = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-8b',
+        scope: { stepId: '1' },
+        naked: [{ name: 'Symlinked' }],
+      });
+
+      expect(result.env).toEqual({});
+      expect(result.prepared).toEqual([]);
+      expect(await fs.readFile(targetPath, 'utf-8')).toBe('linked-value');
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('omits symlinked channel files during read-back', async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
     try {
@@ -370,6 +402,23 @@ describe('readCapturedOutputs', () => {
         naked: [{ name: 'Bin' }],
       });
       await fs.writeFile(prepared.prepared[0].path, Buffer.from([0x68, 0x00, 0x69]));
+      const captured = await readCapturedOutputs(prepared.prepared);
+      expect(captured).toEqual({});
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('omits files containing invalid UTF-8 byte sequences', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
+    try {
+      const prepared = await prepareOutputChannels({
+        cwd,
+        runId: 'wf-test-6b',
+        scope: { stepId: '1' },
+        naked: [{ name: 'Invalid' }],
+      });
+      await fs.writeFile(prepared.prepared[0].path, Buffer.from([0xc3, 0x28]));
       const captured = await readCapturedOutputs(prepared.prepared);
       expect(captured).toEqual({});
     } finally {

--- a/packages/core/__tests__/runbook/output-channels.test.ts
+++ b/packages/core/__tests__/runbook/output-channels.test.ts
@@ -74,14 +74,14 @@ describe('outputChannelPath', () => {
   });
 
   it('assembles a substep-scoped path (substep, no iteration)', () => {
-    const scope: OutputScope = { stepId: '1', substepId: '2' };
+    const scope: OutputScope = { stepId: '1', substep: { id: '2' } };
     expect(outputChannelPath(cwd, runId, scope, 'DeployUrl')).toBe(
       path.join(cwd, '.rundown', 'runs', runId, 'outputs', '1', '2', 'DeployUrl'),
     );
   });
 
   it('assembles a FOR-iteration-in-substep path with all four segments', () => {
-    const scope: OutputScope = { stepId: '3', substepId: '1', iteration: 2 };
+    const scope: OutputScope = { stepId: '3', substep: { id: '1', iteration: 2 } };
     expect(outputChannelPath(cwd, runId, scope, 'Tag')).toBe(
       path.join(cwd, '.rundown', 'runs', runId, 'outputs', '3', '1', '2', 'Tag'),
     );
@@ -105,17 +105,17 @@ describe('outputChannelPath', () => {
 
   it('rejects an unsafe substepId', () => {
     expect(() =>
-      outputChannelPath(cwd, runId, { stepId: '1', substepId: '../escape' }, 'Var'),
+      outputChannelPath(cwd, runId, { stepId: '1', substep: { id: '../escape' } }, 'Var'),
     ).toThrow(/Invalid substepId/);
   });
 
-  it('rejects iteration <= 0', () => {
-    expect(() => outputChannelPath(cwd, runId, { stepId: '1', iteration: 0 }, 'Var')).toThrow(
-      /Invalid iteration/,
-    );
-    expect(() => outputChannelPath(cwd, runId, { stepId: '1', iteration: -1 }, 'Var')).toThrow(
-      /Invalid iteration/,
-    );
+  it('rejects iteration <= 0 (must be via substep tier — unrepresentable without substep)', () => {
+    expect(() =>
+      outputChannelPath(cwd, runId, { stepId: '1', substep: { id: '2', iteration: 0 } }, 'Var'),
+    ).toThrow(/Invalid iteration/);
+    expect(() =>
+      outputChannelPath(cwd, runId, { stepId: '1', substep: { id: '2', iteration: -1 } }, 'Var'),
+    ).toThrow(/Invalid iteration/);
   });
 });
 
@@ -135,10 +135,10 @@ describe('buildOutputChannelEnv', () => {
     expect(path.isAbsolute(env.RD_OUTPUTS_Version)).toBe(true);
   });
 
-  it('routes scope substepId + iteration into a four-segment env value', () => {
+  it('routes scope substep + iteration into a four-segment env value', () => {
     const cwd = '/repo';
     const runId = 'wf-2026-04-25-abc123';
-    const scope: OutputScope = { stepId: '1', substepId: '2', iteration: 3 };
+    const scope: OutputScope = { stepId: '1', substep: { id: '2', iteration: 3 } };
     const env = buildOutputChannelEnv(cwd, runId, scope, [{ name: 'DeployUrl' }]);
     expect(env.RD_OUTPUTS_DeployUrl).toBe(
       path.join(cwd, '.rundown', 'runs', runId, 'outputs', '1', '2', '3', 'DeployUrl'),

--- a/packages/core/__tests__/runbook/output-channels.test.ts
+++ b/packages/core/__tests__/runbook/output-channels.test.ts
@@ -282,7 +282,7 @@ describe('prepareOutputChannels', () => {
     }
   });
 
-  it('omits symlinked channel files during readback', async () => {
+  it('omits symlinked channel files during read-back', async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
     try {
       const prepared = await prepareOutputChannels({
@@ -303,7 +303,7 @@ describe('prepareOutputChannels', () => {
     }
   });
 
-  it('omits non-regular channel files during readback', async () => {
+  it('omits non-regular channel files during read-back', async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'rd-outputs-'));
     try {
       const prepared = await prepareOutputChannels({

--- a/packages/core/__tests__/runbook/output-channels.test.ts
+++ b/packages/core/__tests__/runbook/output-channels.test.ts
@@ -24,6 +24,24 @@ describe('partitionOutputDeclarations', () => {
     expect(result.naked).toEqual([]);
     expect(result.expression).toEqual([]);
   });
+
+  it('returns all entries as naked when no expressions are present', () => {
+    const result = partitionOutputDeclarations([{ name: 'Foo' }, { name: 'Bar' }]);
+    expect(result.naked).toEqual([{ name: 'Foo' }, { name: 'Bar' }]);
+    expect(result.expression).toEqual([]);
+  });
+
+  it('returns all entries as expression when no naked entries are present', () => {
+    const result = partitionOutputDeclarations([
+      { name: 'Foo', value: '"literal"' },
+      { name: 'Bar', value: '"{{ RunId }}"' },
+    ]);
+    expect(result.naked).toEqual([]);
+    expect(result.expression).toEqual([
+      { name: 'Foo', value: '"literal"' },
+      { name: 'Bar', value: '"{{ RunId }}"' },
+    ]);
+  });
 });
 
 describe('outputsDirForRun', () => {
@@ -81,6 +99,26 @@ describe('outputChannelPath', () => {
   it('rejects a reserved name (case-insensitive)', () => {
     const scope: OutputScope = { stepId: '1' };
     expect(() => outputChannelPath(cwd, runId, scope, 'Step')).toThrow(/reserved/);
+  });
+
+  it('rejects an unsafe stepId', () => {
+    expect(() => outputChannelPath(cwd, runId, { stepId: '..' }, 'Var')).toThrow(/Invalid stepId/);
+    expect(() => outputChannelPath(cwd, runId, { stepId: 'a/b' }, 'Var')).toThrow(/Invalid stepId/);
+  });
+
+  it('rejects an unsafe substepId', () => {
+    expect(() =>
+      outputChannelPath(cwd, runId, { stepId: '1', substepId: '../escape' }, 'Var'),
+    ).toThrow(/Invalid substepId/);
+  });
+
+  it('rejects iteration <= 0', () => {
+    expect(() => outputChannelPath(cwd, runId, { stepId: '1', iteration: 0 }, 'Var')).toThrow(
+      /Invalid iteration/,
+    );
+    expect(() => outputChannelPath(cwd, runId, { stepId: '1', iteration: -1 }, 'Var')).toThrow(
+      /Invalid iteration/,
+    );
   });
 });
 

--- a/packages/core/__tests__/runbook/output-evaluator.test.ts
+++ b/packages/core/__tests__/runbook/output-evaluator.test.ts
@@ -103,12 +103,12 @@ describe('evaluateStepOutputDeclarations', () => {
     expect(evaluateStepOutputDeclarations([], {})).toEqual({});
   });
 
-  it('skips naked-form step outputs and leaves the value out of the result', () => {
-    const outputs: OutputDeclaration[] = [{ name: 'Literal', value: '"value"' }, { name: 'Naked' }];
-
-    expect(evaluateStepOutputDeclarations(outputs, {})).toEqual({
-      Literal: 'value',
-    });
+  it('silently ignores naked entries (file-backed at executor)', () => {
+    const result = evaluateStepOutputDeclarations(
+      [{ name: 'Version' }, { name: 'Tag', value: '"v1"' }],
+      {},
+    );
+    expect(result).toEqual({ Tag: 'v1' });
   });
 
   it('omits entries whose template reference is unresolved (variable absent from frame)', () => {

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -576,4 +576,37 @@ describe('RunbookStateManager', () => {
       expect(loaded?.templateVars?.items).toEqual(['a', 'b']);
     });
   });
+
+  describe('RunbookStateManager.delete — output capture cleanup', () => {
+    it('removes the per-run outputs directory alongside the state JSON', async () => {
+      const state = await manager.create('demo.runbook.md', mockRunbook, {
+        runbookPath: '/abs/demo.runbook.md',
+      });
+      // Simulate captured output files written during a run
+      const outDir = join(testDir, '.rundown', 'runs', state.id, 'outputs', '1');
+      await (await import('node:fs/promises')).mkdir(outDir, { recursive: true });
+      await (await import('node:fs/promises')).writeFile(join(outDir, 'Version'), 'v1.2.3');
+
+      await manager.delete(state.id);
+
+      // Both the state file and the outputs dir should be gone
+      const { stat: fsStat } = await import('node:fs/promises');
+      await expect(
+        fsStat(join(testDir, '.rundown', 'runs', `${state.id}.json`)),
+      ).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+      await expect(fsStat(join(testDir, '.rundown', 'runs', state.id))).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+    });
+
+    it('is a no-op when the outputs directory does not exist', async () => {
+      const state = await manager.create('demo.runbook.md', mockRunbook, {
+        runbookPath: '/abs/demo.runbook.md',
+      });
+      // No outputs dir created — delete must still succeed
+      await expect(manager.delete(state.id)).resolves.toBeUndefined();
+    });
+  });
 });

--- a/packages/core/__tests__/sandbox/policy-mapper.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.test.ts
@@ -192,6 +192,26 @@ describe('policyToSandboxOptions', () => {
     expect(options.allowUnsandboxed).toBe(true);
   });
 
+  it('adds Rundown-owned write grants to readWritePaths', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: [] },
+        write: { allow: [], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy);
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+      extraReadWritePaths: ['/repo/.rundown/runs/run-1/outputs/1/Token'],
+    });
+
+    expect(options.readWritePaths).toContain('/repo/.rundown/runs/run-1/outputs/1/Token');
+  });
+
   it('deduplicates paths', () => {
     const policy: PolicyConfig = {
       ...DEFAULT_POLICY,

--- a/packages/core/__tests__/sandbox/policy-mapper.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.test.ts
@@ -409,6 +409,8 @@ describe('policyToSandboxOptions', () => {
     try {
       const capturePath = join(repoRoot, 'output.txt');
       const actualFs = await import('node:fs');
+      // Reset modules and re-import so this test binds the mocked `node:fs` inside the fresh module.
+      // The outer mapper reference keeps the original import for the branch check.
       jest.resetModules();
       jest.unstable_mockModule('node:fs', () => ({
         ...actualFs,
@@ -448,6 +450,8 @@ describe('policyToSandboxOptions', () => {
     try {
       const capturePath = join(repoRoot, 'output.txt');
       const actualFs = await import('node:fs');
+      // Reset modules and re-import so this test binds the mocked `node:fs` inside the fresh module.
+      // The outer mapper reference keeps the original import for the branch check.
       jest.resetModules();
       jest.unstable_mockModule('node:fs', () => ({
         ...actualFs,

--- a/packages/core/__tests__/sandbox/policy-mapper.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.test.ts
@@ -351,10 +351,7 @@ describe('policyToSandboxOptions', () => {
     expect(options.readOnlyPaths).toContain('/repo/granted');
   });
 
-  it.each([
-    ['policyToSandboxOptions', policyToSandboxOptions],
-    ['policyConfigToSandboxOptions', policyConfigToSandboxOptions],
-  ])('rejects out-of-root extra read-write paths in %s', async (_, mapper) => {
+  it('rejects out-of-root extra read-write paths in policyToSandboxOptions', async () => {
     const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
     const outsidePath = join(dirname(repoRoot), 'outside.txt');
     try {
@@ -373,22 +370,41 @@ describe('policyToSandboxOptions', () => {
         extraReadWritePaths: [outsidePath],
       };
 
-      if (mapper === policyToSandboxOptions) {
-        const evaluator = new PolicyEvaluator(policy);
-        expect(() => mapper(evaluator, options)).toThrow(/escapes trusted roots/);
-      } else {
-        expect(() => mapper(policy, options)).toThrow(/escapes trusted roots/);
-      }
+      const evaluator = new PolicyEvaluator(policy);
+      expect(() => policyToSandboxOptions(evaluator, options)).toThrow(/escapes trusted roots/);
     } finally {
       await rm(repoRoot, { recursive: true, force: true });
       await rm(outsidePath, { force: true });
     }
   });
 
-  it.each([
-    ['policyToSandboxOptions', policyToSandboxOptions],
-    ['policyConfigToSandboxOptions', policyConfigToSandboxOptions],
-  ])('rejects wrong-device extra read-write paths in %s', async (_, mapper) => {
+  it('rejects out-of-root extra read-write paths in policyConfigToSandboxOptions', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const outsidePath = join(dirname(repoRoot), 'outside.txt');
+    try {
+      await writeFile(outsidePath, 'outside');
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [], deny: [] },
+          write: { allow: [], deny: [] },
+        },
+      };
+      const options = {
+        cwd: repoRoot,
+        repoRoot,
+        extraReadWritePaths: [outsidePath],
+      };
+
+      expect(() => policyConfigToSandboxOptions(policy, options)).toThrow(/escapes trusted roots/);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(outsidePath, { force: true });
+    }
+  });
+
+  it('rejects wrong-device extra read-write paths in policyToSandboxOptions', async () => {
     const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
     try {
       const capturePath = join(repoRoot, 'output.txt');
@@ -402,10 +418,9 @@ describe('policyToSandboxOptions', () => {
           return { dev } as unknown as Stats;
         }),
       }));
-      const {
-        policyToSandboxOptions: mockedPolicyToSandboxOptions,
-        policyConfigToSandboxOptions: mockedPolicyConfigToSandboxOptions,
-      } = await import('../../src/sandbox/policy-mapper.js');
+      const { policyToSandboxOptions: mockedPolicyToSandboxOptions } = await import(
+        '../../src/sandbox/policy-mapper.js'
+      );
       const policy: PolicyConfig = {
         ...DEFAULT_POLICY,
         default: {
@@ -420,17 +435,49 @@ describe('policyToSandboxOptions', () => {
         extraReadWritePaths: [capturePath],
       };
 
-      if (mapper === policyToSandboxOptions) {
-        const evaluator = new PolicyEvaluator(policy);
-        expect(() => mockedPolicyToSandboxOptions(evaluator, options)).toThrow(/different device/);
-      } else {
-        expect(() => mockedPolicyConfigToSandboxOptions(policy, options)).toThrow(
-          /different device/,
-        );
-      }
+      const evaluator = new PolicyEvaluator(policy);
+      expect(() => mockedPolicyToSandboxOptions(evaluator, options)).toThrow(/different device/);
     } finally {
       await rm(repoRoot, { recursive: true, force: true });
       jest.resetModules();
+    }
+  });
+
+  it('rejects wrong-device extra read-write paths in policyConfigToSandboxOptions', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    try {
+      const capturePath = join(repoRoot, 'output.txt');
+      const actualFs = await import('node:fs');
+      jest.resetModules();
+      jest.unstable_mockModule('node:fs', () => ({
+        ...actualFs,
+        realpathSync: jest.fn((value: string) => value),
+        statSync: jest.fn((value: string) => {
+          const dev = value.includes('output.txt') ? 2 : 1;
+          return { dev } as unknown as Stats;
+        }),
+      }));
+      const { policyConfigToSandboxOptions: mockedPolicyConfigToSandboxOptions } = await import(
+        '../../src/sandbox/policy-mapper.js'
+      );
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [], deny: [] },
+          write: { allow: [], deny: [] },
+        },
+      };
+      const options = {
+        cwd: repoRoot,
+        repoRoot,
+        extraReadWritePaths: [capturePath],
+      };
+
+      expect(() => mockedPolicyConfigToSandboxOptions(policy, options)).toThrow(/different device/);
+    } finally {
+      jest.resetModules();
+      await rm(repoRoot, { recursive: true, force: true });
     }
   });
 });

--- a/packages/core/__tests__/sandbox/policy-mapper.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
+import { join, dirname } from 'node:path';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import type { Stats } from 'node:fs';
 import {
   policyToSandboxOptions,
   policyConfigToSandboxOptions,
@@ -192,24 +195,69 @@ describe('policyToSandboxOptions', () => {
     expect(options.allowUnsandboxed).toBe(true);
   });
 
-  it('adds Rundown-owned write grants to readWritePaths', () => {
-    const policy: PolicyConfig = {
-      ...DEFAULT_POLICY,
-      default: {
-        ...DEFAULT_POLICY.default,
-        read: { allow: [], deny: [] },
-        write: { allow: [], deny: [] },
-      },
-    };
-    const evaluator = new PolicyEvaluator(policy);
+  it('adds Rundown-owned write grants to readWritePaths', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const capturePath = join(repoRoot, '.rundown', 'runs', 'run-1', 'outputs', '1', 'Token');
+    try {
+      await mkdir(dirname(capturePath), { recursive: true });
+      await writeFile(capturePath, 'token');
 
-    const options = policyToSandboxOptions(evaluator, {
-      cwd: '/repo',
-      repoRoot: '/repo',
-      extraReadWritePaths: ['/repo/.rundown/runs/run-1/outputs/1/Token'],
-    });
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [], deny: [] },
+          write: { allow: [], deny: [] },
+        },
+      };
+      const evaluator = new PolicyEvaluator(policy);
 
-    expect(options.readWritePaths).toContain('/repo/.rundown/runs/run-1/outputs/1/Token');
+      const options = policyToSandboxOptions(evaluator, {
+        cwd: repoRoot,
+        repoRoot,
+        extraReadWritePaths: [capturePath],
+      });
+
+      expect(options.readWritePaths).toContain(capturePath);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('excludes extra read-write paths from readOnlyPaths', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    try {
+      const capturePath = join(repoRoot, '.rundown', 'runs', 'run-1', 'outputs', '1', 'Token');
+      await mkdir(dirname(capturePath), { recursive: true });
+      await writeFile(capturePath, 'token');
+
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: {
+            allow: [capturePath],
+            deny: [],
+          },
+          write: {
+            allow: [],
+            deny: [],
+          },
+        },
+      };
+      const evaluator = new PolicyEvaluator(policy);
+
+      const options = policyToSandboxOptions(evaluator, {
+        cwd: repoRoot,
+        repoRoot,
+        extraReadWritePaths: [capturePath],
+      });
+
+      expect(options.readWritePaths).toContain(capturePath);
+      expect(options.readOnlyPaths).not.toContain(capturePath);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
   });
 
   it('deduplicates paths', () => {
@@ -301,6 +349,89 @@ describe('policyToSandboxOptions', () => {
     });
 
     expect(options.readOnlyPaths).toContain('/repo/granted');
+  });
+
+  it.each([
+    ['policyToSandboxOptions', policyToSandboxOptions],
+    ['policyConfigToSandboxOptions', policyConfigToSandboxOptions],
+  ])('rejects out-of-root extra read-write paths in %s', async (_, mapper) => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const outsidePath = join(dirname(repoRoot), 'outside.txt');
+    try {
+      await writeFile(outsidePath, 'outside');
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [], deny: [] },
+          write: { allow: [], deny: [] },
+        },
+      };
+      const options = {
+        cwd: repoRoot,
+        repoRoot,
+        extraReadWritePaths: [outsidePath],
+      };
+
+      if (mapper === policyToSandboxOptions) {
+        const evaluator = new PolicyEvaluator(policy);
+        expect(() => mapper(evaluator, options)).toThrow(/escapes trusted roots/);
+      } else {
+        expect(() => mapper(policy, options)).toThrow(/escapes trusted roots/);
+      }
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(outsidePath, { force: true });
+    }
+  });
+
+  it.each([
+    ['policyToSandboxOptions', policyToSandboxOptions],
+    ['policyConfigToSandboxOptions', policyConfigToSandboxOptions],
+  ])('rejects wrong-device extra read-write paths in %s', async (_, mapper) => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    try {
+      const capturePath = join(repoRoot, 'output.txt');
+      const actualFs = await import('node:fs');
+      jest.resetModules();
+      jest.unstable_mockModule('node:fs', () => ({
+        ...actualFs,
+        realpathSync: jest.fn((value: string) => value),
+        statSync: jest.fn((value: string) => {
+          const dev = value.includes('output.txt') ? 2 : 1;
+          return { dev } as unknown as Stats;
+        }),
+      }));
+      const {
+        policyToSandboxOptions: mockedPolicyToSandboxOptions,
+        policyConfigToSandboxOptions: mockedPolicyConfigToSandboxOptions,
+      } = await import('../../src/sandbox/policy-mapper.js');
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [], deny: [] },
+          write: { allow: [], deny: [] },
+        },
+      };
+      const options = {
+        cwd: repoRoot,
+        repoRoot,
+        extraReadWritePaths: [capturePath],
+      };
+
+      if (mapper === policyToSandboxOptions) {
+        const evaluator = new PolicyEvaluator(policy);
+        expect(() => mockedPolicyToSandboxOptions(evaluator, options)).toThrow(/different device/);
+      } else {
+        expect(() => mockedPolicyConfigToSandboxOptions(policy, options)).toThrow(
+          /different device/,
+        );
+      }
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      jest.resetModules();
+    }
   });
 });
 

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -15,17 +15,22 @@ export const RUNDOWN_DIR = '.rundown';
  * inputs like `../outside` or absolute paths from escaping `.rundown/`
  * when joined via `path.join`.
  */
-const SAFE_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+export const SAFE_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 /**
  * Validate that a user-supplied id is safe to interpolate into a filename.
  *
+ * Rejects empty strings, `.`, `..`, and any value containing characters
+ * outside `[A-Za-z0-9._-]`. The `field` label appears verbatim in the error
+ * message so callers can produce domain-specific messages such as
+ * `Invalid runId: "..."` or `Invalid stepId: "..."`.
+ *
  * @param value - The id to validate
- * @param field - Field name used in the error message (for debuggability)
- * @throws {Error} If the id is empty, contains path separators, `..`, or any
- *         character outside the safe set
+ * @param field - Field label used in the error message (e.g. `'runId'`, `'stepId'`)
+ * @throws {Error} If the id is empty, equals `.` or `..`, contains path
+ *         separators, or any character outside the safe set
  */
-function assertSafeId(value: string, field: 'id' | 'runId'): void {
+export function assertSafeId(value: string, field: string): void {
   // Reject `.` and `..` explicitly: both match SAFE_ID_PATTERN but resolve to
   // parent/current directory under path.join, enabling traversal out of the
   // intended `.rundown/` subtree.

--- a/packages/core/src/runbook/executor.ts
+++ b/packages/core/src/runbook/executor.ts
@@ -41,6 +41,23 @@ export interface PolicyExecutionOptions {
 }
 
 /**
+ * Extract Rundown-owned file paths that must be writable inside the OS sandbox.
+ *
+ * These variables are injected after policy environment filtering and are not
+ * user grants. Without a matching sandbox grant, commands can see
+ * `RD_OUTPUTS_*` but still be blocked from writing the prepared channel file.
+ *
+ * @param rdInjected - Rundown-injected environment variables
+ * @returns Absolute or caller-provided paths that should be granted read/write
+ */
+function extractRundownSandboxWritePaths(rdInjected?: Record<string, string>): string[] {
+  if (!rdInjected) return [];
+  return Object.entries(rdInjected)
+    .filter(([key, value]) => key.startsWith('RD_OUTPUTS_') && value.length > 0)
+    .map(([, value]) => value);
+}
+
+/**
  * Execute a shell command with inherited stdio.
  *
  * Spawns a shell process to run the command, inheriting stdin/stdout/stderr
@@ -205,6 +222,7 @@ export async function executeCommandWithPolicy(
         repoRoot: evaluator.getRepoRoot(),
         tmpDir: evaluator.getTmpDir(),
         allowUnsandboxed: !sandboxStrict,
+        extraReadWritePaths: extractRundownSandboxWritePaths(rdInjected),
       });
       sandboxOptions.env = finalEnv;
 

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -126,4 +126,5 @@ export {
   type NakedOutput,
   type OutputScope,
   type PrepareOutputChannelsArgs,
+  type PreparedChannel,
 } from './output-channels.js';

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -125,4 +125,5 @@ export {
   readCapturedOutputs,
   type NakedOutput,
   type OutputScope,
+  type PrepareOutputChannelsArgs,
 } from './output-channels.js';

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -116,3 +116,13 @@ export {
   type InitialTemplateVars,
   type StoredOutputs,
 } from './effective-vars.js';
+export {
+  partitionOutputDeclarations,
+  outputsDirForRun,
+  outputChannelPath,
+  buildOutputChannelEnv,
+  prepareOutputChannels,
+  readCapturedOutputs,
+  type NakedOutput,
+  type OutputScope,
+} from './output-channels.js';

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -16,6 +16,18 @@ export interface NakedOutput {
 }
 
 /**
+ * A single output channel that was successfully pre-created.
+ *
+ * Used as the input to {@link readCapturedOutputs}. The pairing of `name` to
+ * `path` is established by {@link prepareOutputChannels}, removing the need
+ * for the caller to track parallel arrays.
+ */
+export interface PreparedChannel {
+  readonly name: string;
+  readonly path: string;
+}
+
+/**
  * Scope at which a captured output is collected.
  *
  * `substepId` and `iteration` are independent optional path tiers and compose
@@ -176,13 +188,16 @@ export function buildOutputChannelEnv(
  * couldn't actually back with a file.
  *
  * @param args - Project root + run id + scope + naked declarations
- * @returns The injectable env map and the absolute paths that were created
+ * @returns The injectable env map and the list of successfully-prepared channels (each carrying its name and absolute path)
  */
 export async function prepareOutputChannels(
   args: PrepareOutputChannelsArgs,
-): Promise<{ readonly env: Record<string, string>; readonly createdPaths: readonly string[] }> {
+): Promise<{
+  readonly env: Record<string, string>;
+  readonly prepared: readonly PreparedChannel[];
+}> {
   const env: Record<string, string> = {};
-  const createdPaths: string[] = [];
+  const prepared: PreparedChannel[] = [];
   for (const entry of args.naked) {
     let filePath: string;
     try {
@@ -199,7 +214,7 @@ export async function prepareOutputChannels(
       // Truncate to zero bytes so re-runs do not see stale content.
       await fs.writeFile(filePath, '');
       env[`RD_OUTPUTS_${entry.name}`] = filePath;
-      createdPaths.push(filePath);
+      prepared.push({ name: entry.name, path: filePath });
     } catch (err) {
       void logger.warn('prepareOutputChannels: failed to create channel file, skipping', {
         name: entry.name,
@@ -208,7 +223,7 @@ export async function prepareOutputChannels(
       });
     }
   }
-  return { env, createdPaths };
+  return { env, prepared };
 }
 
 /**
@@ -219,25 +234,15 @@ export async function prepareOutputChannels(
  * from the result. The caller decides what to do with the returned record;
  * the spec mandates merging into `context.variables` via `SET_VARIABLES`.
  *
- * @param createdPaths - Absolute paths returned by `prepareOutputChannels`
- * @param naked - The naked declarations whose names map 1:1 to `createdPaths`
+ * @param prepared - Channels returned by `prepareOutputChannels`, each carrying its name and absolute path
  * @returns Record `{ <VarName>: <trimmedValue> }` for every successful read
  */
 export async function readCapturedOutputs(
-  createdPaths: readonly string[],
-  naked: readonly NakedOutput[],
+  prepared: readonly PreparedChannel[],
 ): Promise<Record<string, string>> {
-  if (createdPaths.length !== naked.length) {
-    // prepareOutputChannels guarantees pairwise correspondence; a mismatch
-    // means a caller composed paths and naked from different sources.
-    throw new Error(
-      `readCapturedOutputs: paths length (${createdPaths.length}) does not match naked length (${naked.length})`,
-    );
-  }
   const captured: Record<string, string> = {};
-  for (let i = 0; i < createdPaths.length; i++) {
-    const filePath = createdPaths[i];
-    const name = naked[i].name;
+  for (const channel of prepared) {
+    const { name, path: filePath } = channel;
     let raw: string;
     try {
       raw = await fs.readFile(filePath, 'utf-8');

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -30,16 +30,14 @@ export interface PreparedChannel {
 /**
  * Scope at which a captured output is collected.
  *
- * `substepId` and `iteration` are independent optional path tiers and compose
- * when both are present. The path layout matches the spec:
- *
+ * Path tiers:
  * - `{ stepId }` → `<stepId>/<VarName>`
  * - `{ stepId, substepId }` → `<stepId>/<substepId>/<VarName>`
- * - `{ stepId, iteration }` → `<stepId>/<iteration>/<VarName>`
  * - `{ stepId, substepId, iteration }` → `<stepId>/<substepId>/<iteration>/<VarName>`
  *
- * The four-segment form is used when a substep with naked OUTPUTS sits inside
- * a FOR loop — the iteration index preserves the per-iteration audit trail.
+ * `iteration` is only set in conjunction with `substepId` — FOR loops
+ * always execute their commands inside substeps, so an iteration tier
+ * without a substep tier is not a producible scope.
  */
 export interface OutputScope {
   readonly stepId: string;
@@ -115,7 +113,6 @@ export function outputsDirForRun(cwd: string, runId: string): string {
  * Composes optional `substepId` and `iteration` tiers from the scope:
  * - bare step: `<outputsDir>/<stepId>/<varName>`
  * - substep only: `<outputsDir>/<stepId>/<substepId>/<varName>`
- * - iteration only: `<outputsDir>/<stepId>/<iteration>/<varName>`
  * - substep + iteration: `<outputsDir>/<stepId>/<substepId>/<iteration>/<varName>`
  *
  * @param cwd - Project root

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -1,9 +1,10 @@
 import * as path from 'node:path';
-import { promises as fs } from 'node:fs';
+import { promises as fs, constants as fsConstants } from 'node:fs';
 import type { OutputDeclaration } from '@rundown-org/parser';
 import { isReservedTemplateName, NAMED_IDENTIFIER_PATTERN } from '@rundown-org/parser';
 import { RUNDOWN_DIR, assertSafeId } from '../paths.js';
 import { logger } from '../logger.js';
+import { isNodeError } from '../errors.js';
 
 /**
  * Naked OUTPUTS entry — the name-only form that activates a file-backed
@@ -217,6 +218,8 @@ export async function prepareOutputChannels(args: PrepareOutputChannelsArgs): Pr
       await fs.mkdir(path.dirname(filePath), { recursive: true });
       // Truncate to zero bytes so re-runs do not see stale content.
       await fs.writeFile(filePath, '');
+      // Explicitly lock channel files down to owner-read/write only, regardless of umask.
+      await fs.chmod(filePath, 0o600);
       env[`RD_OUTPUTS_${entry.name}`] = filePath;
       prepared.push({ name: entry.name, path: filePath });
     } catch (err) {
@@ -247,12 +250,21 @@ export async function readCapturedOutputs(
   const captured: Record<string, string> = {};
   for (const channel of prepared) {
     const { name, path: filePath } = channel;
-    let raw: string;
+    let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+    let raw: string | undefined;
     try {
-      raw = await fs.readFile(filePath, 'utf-8');
+      handle = await fs.open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+      const stat = await handle.stat();
+      if (!stat.isFile()) {
+        void logger.warn('readCapturedOutputs: non-regular channel file, omitting', {
+          name,
+          path: filePath,
+        });
+        continue;
+      }
+      raw = await handle.readFile('utf-8');
     } catch (err) {
-      const code = (err as { code?: string }).code;
-      if (code === 'ENOENT') {
+      if (isNodeError(err) && err.code === 'ENOENT') {
         void logger.warn('readCapturedOutputs: channel file missing', { name, path: filePath });
       } else {
         void logger.warn('readCapturedOutputs: read failed', {
@@ -262,6 +274,10 @@ export async function readCapturedOutputs(
         });
       }
       continue;
+    } finally {
+      if (handle !== undefined) {
+        await handle.close().catch(() => undefined);
+      }
     }
     if (raw.includes('\0')) {
       // NUL byte → treat as non-UTF-8 per spec

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -30,19 +30,22 @@ export interface PreparedChannel {
 /**
  * Scope at which a captured output is collected.
  *
- * Path tiers:
+ * Three valid tier compositions:
  * - `{ stepId }` → `<stepId>/<VarName>`
- * - `{ stepId, substepId }` → `<stepId>/<substepId>/<VarName>`
- * - `{ stepId, substepId, iteration }` → `<stepId>/<substepId>/<iteration>/<VarName>`
+ * - `{ stepId, substep: { id } }` → `<stepId>/<substepId>/<VarName>`
+ * - `{ stepId, substep: { id, iteration } }` → `<stepId>/<substepId>/<iteration>/<VarName>`
  *
- * `iteration` is only set in conjunction with `substepId` — FOR loops
- * always execute their commands inside substeps, so an iteration tier
- * without a substep tier is not a producible scope.
+ * By construction, iteration cannot appear without a substep tier — the
+ * impossible `<stepId>/<iteration>/<VarName>` shape is unrepresentable.
+ * FOR loops always execute their commands inside substeps, so nesting
+ * `iteration` inside `substep` is the correct structural encoding.
  */
 export interface OutputScope {
   readonly stepId: string;
-  readonly substepId?: string;
-  readonly iteration?: number;
+  readonly substep?: {
+    readonly id: string;
+    readonly iteration?: number;
+  };
 }
 
 /**
@@ -110,14 +113,14 @@ export function outputsDirForRun(cwd: string, runId: string): string {
 /**
  * Assemble the absolute path of a single output channel file.
  *
- * Composes optional `substepId` and `iteration` tiers from the scope:
+ * Composes optional `substep` and `iteration` tiers from the scope:
  * - bare step: `<outputsDir>/<stepId>/<varName>`
  * - substep only: `<outputsDir>/<stepId>/<substepId>/<varName>`
  * - substep + iteration: `<outputsDir>/<stepId>/<substepId>/<iteration>/<varName>`
  *
  * @param cwd - Project root
  * @param runId - Validated run id
- * @param scope - Step + optional substep + optional iteration tiers
+ * @param scope - Step + optional substep (with optional iteration) tiers
  * @param varName - Output variable name (`NAMED_IDENTIFIER_PATTERN`, non-reserved)
  * @returns Absolute file path
  * @throws {Error} when any segment fails its safety / identifier validation
@@ -132,15 +135,15 @@ export function outputChannelPath(
   assertSafeId(scope.stepId, 'stepId');
   const base = outputsDirForRun(cwd, runId);
   const segments: string[] = [base, scope.stepId];
-  if (scope.substepId !== undefined) {
-    assertSafeId(scope.substepId, 'substepId');
-    segments.push(scope.substepId);
-  }
-  if (scope.iteration !== undefined) {
-    if (!Number.isInteger(scope.iteration) || scope.iteration <= 0) {
-      throw new Error(`Invalid iteration index: ${String(scope.iteration)}`);
+  if (scope.substep !== undefined) {
+    assertSafeId(scope.substep.id, 'substepId');
+    segments.push(scope.substep.id);
+    if (scope.substep.iteration !== undefined) {
+      if (!Number.isInteger(scope.substep.iteration) || scope.substep.iteration <= 0) {
+        throw new Error(`Invalid iteration index: ${String(scope.substep.iteration)}`);
+      }
+      segments.push(String(scope.substep.iteration));
     }
-    segments.push(String(scope.iteration));
   }
   segments.push(varName);
   return path.join(...segments);
@@ -154,7 +157,7 @@ export function outputChannelPath(
  *
  * @param cwd - Project root
  * @param runId - Validated run id
- * @param scope - Step + optional substep + optional iteration tiers
+ * @param scope - Step + optional substep (with optional iteration) tiers
  * @param naked - Naked OUTPUTS entries from `partitionOutputDeclarations`
  * @returns Record suitable for merging into the rundown-injected env
  * @throws {Error} when a naked entry fails safety validation (propagated from

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -203,6 +203,7 @@ export async function prepareOutputChannels(args: PrepareOutputChannelsArgs): Pr
 }> {
   const env: Record<string, string> = {};
   const prepared: PreparedChannel[] = [];
+  const noFollow = fsConstants.O_NOFOLLOW;
   for (const entry of args.naked) {
     let filePath: string;
     try {
@@ -216,13 +217,34 @@ export async function prepareOutputChannels(args: PrepareOutputChannelsArgs): Pr
     }
     try {
       await fs.mkdir(path.dirname(filePath), { recursive: true });
-      // Truncate to zero bytes so re-runs do not see stale content.
-      await fs.writeFile(filePath, '');
-      // Explicitly lock channel files down to owner-read/write only, regardless of umask.
-      await fs.chmod(filePath, 0o600);
+      const handle = await fs.open(
+        filePath,
+        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | noFollow,
+        0o600,
+      );
+      try {
+        const stat = await handle.stat();
+        if (!stat.isFile()) {
+          void logger.warn('prepareOutputChannels: non-regular channel target, skipping', {
+            name: entry.name,
+            path: filePath,
+          });
+          continue;
+        }
+        await handle.chmod(0o600);
+      } finally {
+        await handle.close().catch(() => undefined);
+      }
       env[`RD_OUTPUTS_${entry.name}`] = filePath;
       prepared.push({ name: entry.name, path: filePath });
     } catch (err) {
+      if (isNodeError(err) && err.code === 'ELOOP') {
+        void logger.warn('prepareOutputChannels: symlinked channel file, skipping', {
+          name: entry.name,
+          path: filePath,
+        });
+        continue;
+      }
       void logger.warn('prepareOutputChannels: failed to create channel file, skipping', {
         name: entry.name,
         path: filePath,
@@ -262,7 +284,16 @@ export async function readCapturedOutputs(
         });
         continue;
       }
-      raw = await handle.readFile('utf-8');
+      const bytes = await handle.readFile();
+      try {
+        raw = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+      } catch {
+        void logger.warn('readCapturedOutputs: non-UTF-8 content, omitting', {
+          name,
+          path: filePath,
+        });
+        continue;
+      }
     } catch (err) {
       if (isNodeError(err) && err.code === 'ENOENT') {
         void logger.warn('readCapturedOutputs: channel file missing', { name, path: filePath });

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -190,9 +190,7 @@ export function buildOutputChannelEnv(
  * @param args - Project root + run id + scope + naked declarations
  * @returns The injectable env map and the list of successfully-prepared channels (each carrying its name and absolute path)
  */
-export async function prepareOutputChannels(
-  args: PrepareOutputChannelsArgs,
-): Promise<{
+export async function prepareOutputChannels(args: PrepareOutputChannelsArgs): Promise<{
   readonly env: Record<string, string>;
   readonly prepared: readonly PreparedChannel[];
 }> {

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 import { promises as fs } from 'node:fs';
 import type { OutputDeclaration } from '@rundown-org/parser';
 import { isReservedTemplateName, NAMED_IDENTIFIER_PATTERN } from '@rundown-org/parser';
-import { RUNDOWN_DIR } from '../paths.js';
+import { RUNDOWN_DIR, assertSafeId } from '../paths.js';
 import { logger } from '../logger.js';
 
 /**
@@ -35,18 +35,18 @@ export interface OutputScope {
   readonly iteration?: number;
 }
 
-const SAFE_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
-
-function assertSafeRunId(value: string): void {
-  if (!value || value === '.' || value === '..' || !SAFE_ID_PATTERN.test(value)) {
-    throw new Error(`Invalid runId: ${JSON.stringify(value)}`);
-  }
-}
-
-function assertSafeStepSegment(value: string, field: 'stepId' | 'substepId'): void {
-  if (!value || value === '.' || value === '..' || !SAFE_ID_PATTERN.test(value)) {
-    throw new Error(`Invalid ${field}: ${JSON.stringify(value)}`);
-  }
+/**
+ * Arguments for {@link prepareOutputChannels}.
+ */
+export interface PrepareOutputChannelsArgs {
+  /** Project root directory. */
+  readonly cwd: string;
+  /** Validated run identifier (matches the `assertSafeId` rules in `paths.ts`). */
+  readonly runId: string;
+  /** Step + optional substep + optional iteration tiers. */
+  readonly scope: OutputScope;
+  /** Naked OUTPUTS entries from {@link partitionOutputDeclarations}. */
+  readonly naked: readonly NakedOutput[];
 }
 
 function assertSafeOutputName(value: string): void {
@@ -93,7 +93,7 @@ export function partitionOutputDeclarations(outputs: readonly OutputDeclaration[
  * @throws {Error} when `runId` is empty, `..`, or contains unsafe characters
  */
 export function outputsDirForRun(cwd: string, runId: string): string {
-  assertSafeRunId(runId);
+  assertSafeId(runId, 'runId');
   return path.join(cwd, RUNDOWN_DIR, 'runs', runId, 'outputs');
 }
 
@@ -120,11 +120,11 @@ export function outputChannelPath(
   varName: string,
 ): string {
   assertSafeOutputName(varName);
-  assertSafeStepSegment(scope.stepId, 'stepId');
+  assertSafeId(scope.stepId, 'stepId');
   const base = outputsDirForRun(cwd, runId);
   const segments: string[] = [base, scope.stepId];
   if (scope.substepId !== undefined) {
-    assertSafeStepSegment(scope.substepId, 'substepId');
+    assertSafeId(scope.substepId, 'substepId');
     segments.push(scope.substepId);
   }
   if (scope.iteration !== undefined) {
@@ -148,6 +148,8 @@ export function outputChannelPath(
  * @param scope - Step + optional substep + optional iteration tiers
  * @param naked - Naked OUTPUTS entries from `partitionOutputDeclarations`
  * @returns Record suitable for merging into the rundown-injected env
+ * @throws {Error} when a naked entry fails safety validation (propagated from
+ *         {@link outputChannelPath})
  */
 export function buildOutputChannelEnv(
   cwd: string,
@@ -176,12 +178,9 @@ export function buildOutputChannelEnv(
  * @param args - Project root + run id + scope + naked declarations
  * @returns The injectable env map and the absolute paths that were created
  */
-export async function prepareOutputChannels(args: {
-  readonly cwd: string;
-  readonly runId: string;
-  readonly scope: OutputScope;
-  readonly naked: readonly NakedOutput[];
-}): Promise<{ readonly env: Record<string, string>; readonly createdPaths: readonly string[] }> {
+export async function prepareOutputChannels(
+  args: PrepareOutputChannelsArgs,
+): Promise<{ readonly env: Record<string, string>; readonly createdPaths: readonly string[] }> {
   const env: Record<string, string> = {};
   const createdPaths: string[] = [];
   for (const entry of args.naked) {

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -23,7 +23,9 @@ export interface NakedOutput {
  * for the caller to track parallel arrays.
  */
 export interface PreparedChannel {
+  /** Stable output name, used to map the channel back to a runbook variable. */
   readonly name: string;
+  /** Absolute file path for the channel, e.g. `.rundown/runs/<id>/outputs/<step>/<VarName>`. */
   readonly path: string;
 }
 
@@ -41,9 +43,13 @@ export interface PreparedChannel {
  * `iteration` inside `substep` is the correct structural encoding.
  */
 export interface OutputScope {
+  /** Owning step identifier, such as `1` or `Cleanup`. */
   readonly stepId: string;
+  /** Optional nested substep scope. */
   readonly substep?: {
+    /** Substep identifier, such as `1` or `Validate`. */
     readonly id: string;
+    /** Optional FOR-loop iteration index for the nested substep. */
     readonly iteration?: number;
   };
 }

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -1,0 +1,275 @@
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+import type { OutputDeclaration } from '@rundown-org/parser';
+import { isReservedTemplateName, NAMED_IDENTIFIER_PATTERN } from '@rundown-org/parser';
+import { RUNDOWN_DIR } from '../paths.js';
+import { logger } from '../logger.js';
+
+/**
+ * Naked OUTPUTS entry — the name-only form that activates a file-backed
+ * output channel. Distinct from the full {@link OutputDeclaration} so naked
+ * vs expression intent is encoded in the type.
+ */
+export interface NakedOutput {
+  /** Variable name to capture (must match `NAMED_IDENTIFIER_PATTERN`). */
+  readonly name: string;
+}
+
+/**
+ * Scope at which a captured output is collected.
+ *
+ * `substepId` and `iteration` are independent optional path tiers and compose
+ * when both are present. The path layout matches the spec:
+ *
+ * - `{ stepId }` → `<stepId>/<VarName>`
+ * - `{ stepId, substepId }` → `<stepId>/<substepId>/<VarName>`
+ * - `{ stepId, iteration }` → `<stepId>/<iteration>/<VarName>`
+ * - `{ stepId, substepId, iteration }` → `<stepId>/<substepId>/<iteration>/<VarName>`
+ *
+ * The four-segment form is used when a substep with naked OUTPUTS sits inside
+ * a FOR loop — the iteration index preserves the per-iteration audit trail.
+ */
+export interface OutputScope {
+  readonly stepId: string;
+  readonly substepId?: string;
+  readonly iteration?: number;
+}
+
+const SAFE_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+function assertSafeRunId(value: string): void {
+  if (!value || value === '.' || value === '..' || !SAFE_ID_PATTERN.test(value)) {
+    throw new Error(`Invalid runId: ${JSON.stringify(value)}`);
+  }
+}
+
+function assertSafeStepSegment(value: string, field: 'stepId' | 'substepId'): void {
+  if (!value || value === '.' || value === '..' || !SAFE_ID_PATTERN.test(value)) {
+    throw new Error(`Invalid ${field}: ${JSON.stringify(value)}`);
+  }
+}
+
+function assertSafeOutputName(value: string): void {
+  if (!NAMED_IDENTIFIER_PATTERN.test(value)) {
+    throw new Error(`Invalid output name: ${JSON.stringify(value)}`);
+  }
+  if (isReservedTemplateName(value)) {
+    throw new Error(`Invalid output name: ${JSON.stringify(value)} is a reserved variable name`);
+  }
+}
+
+/**
+ * Partition an OUTPUTS list into naked (file-backed) and expression entries.
+ *
+ * Order is preserved within each partition. Naked entries (no `value`) drive
+ * `RD_OUTPUTS_*` env injection; expression entries flow through the existing
+ * `evaluateStepOutputDeclarations` path unchanged.
+ *
+ * @param outputs - Parsed declarations from a step or substep
+ * @returns Object with `naked` and `expression` arrays
+ */
+export function partitionOutputDeclarations(outputs: readonly OutputDeclaration[]): {
+  readonly naked: readonly NakedOutput[];
+  readonly expression: readonly OutputDeclaration[];
+} {
+  const naked: NakedOutput[] = [];
+  const expression: OutputDeclaration[] = [];
+  for (const decl of outputs) {
+    if (decl.value === undefined) {
+      naked.push({ name: decl.name });
+    } else {
+      expression.push(decl);
+    }
+  }
+  return { naked, expression };
+}
+
+/**
+ * Absolute path to the per-run outputs directory: `.rundown/runs/<runId>/outputs`.
+ *
+ * @param cwd - Project root
+ * @param runId - Validated run identifier (matches the `assertSafeId` rules in `paths.ts`)
+ * @returns Absolute directory path
+ * @throws {Error} when `runId` is empty, `..`, or contains unsafe characters
+ */
+export function outputsDirForRun(cwd: string, runId: string): string {
+  assertSafeRunId(runId);
+  return path.join(cwd, RUNDOWN_DIR, 'runs', runId, 'outputs');
+}
+
+/**
+ * Assemble the absolute path of a single output channel file.
+ *
+ * Composes optional `substepId` and `iteration` tiers from the scope:
+ * - bare step: `<outputsDir>/<stepId>/<varName>`
+ * - substep only: `<outputsDir>/<stepId>/<substepId>/<varName>`
+ * - iteration only: `<outputsDir>/<stepId>/<iteration>/<varName>`
+ * - substep + iteration: `<outputsDir>/<stepId>/<substepId>/<iteration>/<varName>`
+ *
+ * @param cwd - Project root
+ * @param runId - Validated run id
+ * @param scope - Step + optional substep + optional iteration tiers
+ * @param varName - Output variable name (`NAMED_IDENTIFIER_PATTERN`, non-reserved)
+ * @returns Absolute file path
+ * @throws {Error} when any segment fails its safety / identifier validation
+ */
+export function outputChannelPath(
+  cwd: string,
+  runId: string,
+  scope: OutputScope,
+  varName: string,
+): string {
+  assertSafeOutputName(varName);
+  assertSafeStepSegment(scope.stepId, 'stepId');
+  const base = outputsDirForRun(cwd, runId);
+  const segments: string[] = [base, scope.stepId];
+  if (scope.substepId !== undefined) {
+    assertSafeStepSegment(scope.substepId, 'substepId');
+    segments.push(scope.substepId);
+  }
+  if (scope.iteration !== undefined) {
+    if (!Number.isInteger(scope.iteration) || scope.iteration <= 0) {
+      throw new Error(`Invalid iteration index: ${String(scope.iteration)}`);
+    }
+    segments.push(String(scope.iteration));
+  }
+  segments.push(varName);
+  return path.join(...segments);
+}
+
+/**
+ * Build the `RD_OUTPUTS_*` env-var map for a set of naked outputs.
+ *
+ * Each entry maps `RD_OUTPUTS_<VarName>` → absolute file path. The caller is
+ * responsible for actually creating the files (see `prepareOutputChannels`).
+ *
+ * @param cwd - Project root
+ * @param runId - Validated run id
+ * @param scope - Step + optional substep + optional iteration tiers
+ * @param naked - Naked OUTPUTS entries from `partitionOutputDeclarations`
+ * @returns Record suitable for merging into the rundown-injected env
+ */
+export function buildOutputChannelEnv(
+  cwd: string,
+  runId: string,
+  scope: OutputScope,
+  naked: readonly NakedOutput[],
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const entry of naked) {
+    env[`RD_OUTPUTS_${entry.name}`] = outputChannelPath(cwd, runId, scope, entry.name);
+  }
+  return env;
+}
+
+/**
+ * Pre-create empty output-channel files and return the env-var map.
+ *
+ * Creates the directory tree and writes a zero-byte file per naked output.
+ * Idempotent: existing files are truncated to zero bytes so a re-execution
+ * doesn't carry forward stale captures from a prior attempt.
+ *
+ * Best-effort: per-file failures are logged and the entry is dropped from
+ * the returned env so the shell sees no `RD_OUTPUTS_<X>` for an output we
+ * couldn't actually back with a file.
+ *
+ * @param args - Project root + run id + scope + naked declarations
+ * @returns The injectable env map and the absolute paths that were created
+ */
+export async function prepareOutputChannels(args: {
+  readonly cwd: string;
+  readonly runId: string;
+  readonly scope: OutputScope;
+  readonly naked: readonly NakedOutput[];
+}): Promise<{ readonly env: Record<string, string>; readonly createdPaths: readonly string[] }> {
+  const env: Record<string, string> = {};
+  const createdPaths: string[] = [];
+  for (const entry of args.naked) {
+    let filePath: string;
+    try {
+      filePath = outputChannelPath(args.cwd, args.runId, args.scope, entry.name);
+    } catch (err) {
+      void logger.warn('prepareOutputChannels: invalid output declaration, skipping', {
+        name: entry.name,
+        error: String(err),
+      });
+      continue;
+    }
+    try {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      // Truncate to zero bytes so re-runs do not see stale content.
+      await fs.writeFile(filePath, '');
+      env[`RD_OUTPUTS_${entry.name}`] = filePath;
+      createdPaths.push(filePath);
+    } catch (err) {
+      void logger.warn('prepareOutputChannels: failed to create channel file, skipping', {
+        name: entry.name,
+        path: filePath,
+        error: String(err),
+      });
+    }
+  }
+  return { env, createdPaths };
+}
+
+/**
+ * Read captured outputs from previously-created channel files.
+ *
+ * UTF-8 only, trailing whitespace and newlines trimmed. Files that are
+ * missing, empty after trim, non-UTF-8, or unreadable are logged and omitted
+ * from the result. The caller decides what to do with the returned record;
+ * the spec mandates merging into `context.variables` via `SET_VARIABLES`.
+ *
+ * @param createdPaths - Absolute paths returned by `prepareOutputChannels`
+ * @param naked - The naked declarations whose names map 1:1 to `createdPaths`
+ * @returns Record `{ <VarName>: <trimmedValue> }` for every successful read
+ */
+export async function readCapturedOutputs(
+  createdPaths: readonly string[],
+  naked: readonly NakedOutput[],
+): Promise<Record<string, string>> {
+  if (createdPaths.length !== naked.length) {
+    // prepareOutputChannels guarantees pairwise correspondence; a mismatch
+    // means a caller composed paths and naked from different sources.
+    throw new Error(
+      `readCapturedOutputs: paths length (${createdPaths.length}) does not match naked length (${naked.length})`,
+    );
+  }
+  const captured: Record<string, string> = {};
+  for (let i = 0; i < createdPaths.length; i++) {
+    const filePath = createdPaths[i];
+    const name = naked[i].name;
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, 'utf-8');
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code === 'ENOENT') {
+        void logger.warn('readCapturedOutputs: channel file missing', { name, path: filePath });
+      } else {
+        void logger.warn('readCapturedOutputs: read failed', {
+          name,
+          path: filePath,
+          error: String(err),
+        });
+      }
+      continue;
+    }
+    if (raw.includes('\0')) {
+      // NUL byte → treat as non-UTF-8 per spec
+      void logger.warn('readCapturedOutputs: non-UTF-8 content, omitting', {
+        name,
+        path: filePath,
+      });
+      continue;
+    }
+    // Trim trailing whitespace + newlines (`\s` covers space, tab, \r, \n, etc.)
+    const trimmed = raw.replace(/\s+$/u, '');
+    if (trimmed.length === 0) {
+      void logger.warn('readCapturedOutputs: empty value, omitting', { name, path: filePath });
+      continue;
+    }
+    captured[name] = trimmed;
+  }
+  return captured;
+}

--- a/packages/core/src/runbook/output-evaluator.ts
+++ b/packages/core/src/runbook/output-evaluator.ts
@@ -363,12 +363,16 @@ export function evaluateOutputExpression(expr: string, variables: OutputVars): s
 }
 
 /**
- * Evaluate step-level OUTPUTS declarations, skipping naked entries and logging
- * (but not throwing on) individual expression failures.
+ * Evaluate step-level OUTPUTS declarations.
+ *
+ * Expression-form entries are evaluated against the provided variable frame.
+ * Naked-form entries (no `value`) are silently skipped — they declare a
+ * file-backed output channel handled by the executor, not the evaluator.
  *
  * @param outputs - Declarations parsed from the step's OUTPUTS block
  * @param vars - Variable frame for expression evaluation
- * @returns Map of output name to rendered value; failed or naked entries are omitted
+ * @returns Map of output name to rendered value; failed expression entries
+ *   are omitted with a warning, naked entries are omitted silently
  */
 export function evaluateStepOutputDeclarations(
   outputs: readonly OutputDeclaration[],
@@ -378,9 +382,8 @@ export function evaluateStepOutputDeclarations(
 
   for (const output of outputs) {
     if (output.value === undefined) {
-      void logger.warn('evaluateStepOutputDeclarations: naked form invalid at step level', {
-        name: output.name,
-      });
+      // Naked form is valid at step level — handled by the executor as a
+      // file-backed RD_OUTPUTS_<Name> channel. Skip silently here.
       continue;
     }
     try {

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -344,15 +344,25 @@ export class RunbookStateManager {
   }
 
   /**
-   * Delete a runbook state file from disk.
+   * Delete a runbook state file and its per-run outputs directory from disk.
    *
-   * Silently ignores errors if the file does not exist.
+   * Removes both `.rundown/runs/<id>.json` and the captured-output directory
+   * `.rundown/runs/<id>/` if it exists. Silently ignores errors when either
+   * path is absent — `delete` must be idempotent.
    *
    * @param id - The runbook state ID to delete
    */
   async delete(id: string): Promise<void> {
     try {
       await fs.unlink(this.statePath(id));
+    } catch {
+      /* intentionally ignored */
+    }
+    try {
+      // The per-run outputs directory shares the run id with the state file.
+      // Use rm -rf semantics so a non-empty directory is removed cleanly.
+      const runDir = this.statePath(id).replace(/\.json$/, '');
+      await fs.rm(runDir, { recursive: true, force: true });
     } catch {
       /* intentionally ignored */
     }

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -355,16 +355,20 @@ export class RunbookStateManager {
   async delete(id: string): Promise<void> {
     try {
       await fs.unlink(this.statePath(id));
-    } catch {
-      /* intentionally ignored */
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== 'ENOENT') {
+        throw error;
+      }
     }
     try {
       // The per-run outputs directory shares the run id with the state file.
       // Use rm -rf semantics so a non-empty directory is removed cleanly.
       const runDir = this.statePath(id).replace(/\.json$/, '');
       await fs.rm(runDir, { recursive: true, force: true });
-    } catch {
-      /* intentionally ignored */
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== 'ENOENT') {
+        throw error;
+      }
     }
   }
 

--- a/packages/core/src/sandbox/policy-mapper.ts
+++ b/packages/core/src/sandbox/policy-mapper.ts
@@ -31,6 +31,9 @@ export interface PolicyMapperOptions {
 
   /** Whether to allow execution without sandbox if unavailable */
   allowUnsandboxed?: boolean;
+
+  /** Additional Rundown-owned paths that must be writable regardless of user policy */
+  extraReadWritePaths?: readonly string[];
 }
 
 /**
@@ -240,12 +243,15 @@ export function policyToSandboxOptions(
   // Resolve read-only paths (from read.allow minus write.allow)
   const readAllowPaths = resolvePathPatterns(readRules.allow, repoRoot, tmpDir);
   const writeAllowPaths = resolvePathPatterns(writeRules.allow, repoRoot, tmpDir);
+  const extraReadWritePaths = (options.extraReadWritePaths ?? []).map((p) =>
+    path.isAbsolute(p) ? p : path.resolve(repoRoot, p),
+  );
 
   // Read-only: paths in read.allow but not in write.allow
   const readOnlyPaths = readAllowPaths.filter((p) => !writeAllowPaths.includes(p));
 
   // Read-write: paths in write.allow (implies read as well)
-  const readWritePaths = writeAllowPaths;
+  const readWritePaths = [...writeAllowPaths, ...extraReadWritePaths];
 
   const denyPatterns = [...readRules.deny, ...writeRules.deny].map((pattern) =>
     resolvePlaceholders(pattern, repoRoot, tmpDir),
@@ -287,9 +293,12 @@ export function policyConfigToSandboxOptions(
 
   const readAllowPaths = resolvePathPatterns(policy.default.read.allow, repoRoot, tmpDir);
   const writeAllowPaths = resolvePathPatterns(policy.default.write.allow, repoRoot, tmpDir);
+  const extraReadWritePaths = (options.extraReadWritePaths ?? []).map((p) =>
+    path.isAbsolute(p) ? p : path.resolve(repoRoot, p),
+  );
 
   const readOnlyPaths = readAllowPaths.filter((p) => !writeAllowPaths.includes(p));
-  const readWritePaths = writeAllowPaths;
+  const readWritePaths = [...writeAllowPaths, ...extraReadWritePaths];
 
   const denyPatterns = [...policy.default.read.deny, ...policy.default.write.deny].map((pattern) =>
     resolvePlaceholders(pattern, repoRoot, tmpDir),

--- a/packages/core/src/sandbox/policy-mapper.ts
+++ b/packages/core/src/sandbox/policy-mapper.ts
@@ -133,7 +133,7 @@ function normalizeExtraReadWritePath(candidate: string, repoRoot: string, cwd: s
   const absoluteCandidate = path.isAbsolute(candidate)
     ? candidate
     : path.resolve(repoRoot, candidate);
-  const canonicalCandidate = fs.realpathSync(absoluteCandidate);
+  const canonicalCandidate = resolveCanonicalPath(absoluteCandidate);
   const canonicalRoots = [...new Set([resolveCanonicalPath(repoRoot), resolveCanonicalPath(cwd)])];
   const trustedRoot = canonicalRoots.find((root) => isWithinRoot(canonicalCandidate, root));
 

--- a/packages/core/src/sandbox/policy-mapper.ts
+++ b/packages/core/src/sandbox/policy-mapper.ts
@@ -258,7 +258,7 @@ export function policyToSandboxOptions(
   );
   const denyPaths = collectConcreteDenyPaths(
     denyPatterns,
-    [...readAllowPaths, ...writeAllowPaths],
+    [...readAllowPaths, ...writeAllowPaths, ...extraReadWritePaths],
     repoRoot,
     options.cwd,
   );
@@ -305,7 +305,7 @@ export function policyConfigToSandboxOptions(
   );
   const denyPaths = collectConcreteDenyPaths(
     denyPatterns,
-    [...readAllowPaths, ...writeAllowPaths],
+    [...readAllowPaths, ...writeAllowPaths, ...extraReadWritePaths],
     repoRoot,
     options.cwd,
   );

--- a/packages/core/src/sandbox/policy-mapper.ts
+++ b/packages/core/src/sandbox/policy-mapper.ts
@@ -121,6 +121,71 @@ function isWithinRoot(candidate: string, root: string): boolean {
   return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..');
 }
 
+function resolveCanonicalPath(value: string): string {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
+}
+
+function normalizeExtraReadWritePath(candidate: string, repoRoot: string, cwd: string): string {
+  const absoluteCandidate = path.isAbsolute(candidate)
+    ? candidate
+    : path.resolve(repoRoot, candidate);
+  const canonicalCandidate = fs.realpathSync(absoluteCandidate);
+  const canonicalRoots = [...new Set([resolveCanonicalPath(repoRoot), resolveCanonicalPath(cwd)])];
+  const trustedRoot = canonicalRoots.find((root) => isWithinRoot(canonicalCandidate, root));
+
+  if (trustedRoot === undefined) {
+    throw new Error(
+      `extraReadWritePaths entry "${candidate}" escapes trusted roots "${repoRoot}" and "${cwd}"`,
+    );
+  }
+
+  const candidateStat = fs.statSync(canonicalCandidate);
+  const trustedRootStat = fs.statSync(trustedRoot);
+  if (candidateStat.dev !== trustedRootStat.dev) {
+    throw new Error(
+      `extraReadWritePaths entry "${candidate}" is on a different device than trusted root "${trustedRoot}"`,
+    );
+  }
+
+  return canonicalCandidate;
+}
+
+function normalizeExtraReadWritePaths(
+  extraReadWritePaths: readonly string[] | undefined,
+  repoRoot: string,
+  cwd: string,
+): string[] {
+  const normalized: string[] = [];
+  for (const candidate of extraReadWritePaths ?? []) {
+    const canonicalCandidate = normalizeExtraReadWritePath(candidate, repoRoot, cwd);
+    if (!normalized.includes(canonicalCandidate)) {
+      normalized.push(canonicalCandidate);
+    }
+  }
+  return normalized;
+}
+
+function buildSandboxPathSets(
+  readAllowPaths: readonly string[],
+  writeAllowPaths: readonly string[],
+  extraReadWritePaths: readonly string[],
+): {
+  readOnlyPaths: string[];
+  readWritePaths: string[];
+} {
+  const readWriteSet = new Set<string>([...writeAllowPaths, ...extraReadWritePaths]);
+  const readOnlyPaths = readAllowPaths.filter((p) => !readWriteSet.has(p));
+  const readWritePaths = [...readWriteSet];
+  return {
+    readOnlyPaths: [...new Set(readOnlyPaths)],
+    readWritePaths,
+  };
+}
+
 function selectExpansionRoots(roots: string[], repoRoot: string, cwd: string): string[] {
   return [...new Set(roots)].filter((root) => {
     return isWithinRoot(root, repoRoot) || isWithinRoot(root, cwd);
@@ -243,15 +308,16 @@ export function policyToSandboxOptions(
   // Resolve read-only paths (from read.allow minus write.allow)
   const readAllowPaths = resolvePathPatterns(readRules.allow, repoRoot, tmpDir);
   const writeAllowPaths = resolvePathPatterns(writeRules.allow, repoRoot, tmpDir);
-  const extraReadWritePaths = (options.extraReadWritePaths ?? []).map((p) =>
-    path.isAbsolute(p) ? p : path.resolve(repoRoot, p),
+  const extraReadWritePaths = normalizeExtraReadWritePaths(
+    options.extraReadWritePaths,
+    repoRoot,
+    options.cwd,
   );
-
-  // Read-only: paths in read.allow but not in write.allow
-  const readOnlyPaths = readAllowPaths.filter((p) => !writeAllowPaths.includes(p));
-
-  // Read-write: paths in write.allow (implies read as well)
-  const readWritePaths = [...writeAllowPaths, ...extraReadWritePaths];
+  const { readOnlyPaths, readWritePaths } = buildSandboxPathSets(
+    readAllowPaths,
+    writeAllowPaths,
+    extraReadWritePaths,
+  );
 
   const denyPatterns = [...readRules.deny, ...writeRules.deny].map((pattern) =>
     resolvePlaceholders(pattern, repoRoot, tmpDir),
@@ -266,8 +332,8 @@ export function policyToSandboxOptions(
   return {
     cwd: options.cwd,
     repoRoot,
-    readOnlyPaths: [...new Set(readOnlyPaths)],
-    readWritePaths: [...new Set(readWritePaths)],
+    readOnlyPaths,
+    readWritePaths,
     denyPatterns: [...new Set(denyPatterns)],
     denyPaths: [...new Set(denyPaths)],
     env: {},
@@ -293,12 +359,16 @@ export function policyConfigToSandboxOptions(
 
   const readAllowPaths = resolvePathPatterns(policy.default.read.allow, repoRoot, tmpDir);
   const writeAllowPaths = resolvePathPatterns(policy.default.write.allow, repoRoot, tmpDir);
-  const extraReadWritePaths = (options.extraReadWritePaths ?? []).map((p) =>
-    path.isAbsolute(p) ? p : path.resolve(repoRoot, p),
+  const extraReadWritePaths = normalizeExtraReadWritePaths(
+    options.extraReadWritePaths,
+    repoRoot,
+    options.cwd,
   );
-
-  const readOnlyPaths = readAllowPaths.filter((p) => !writeAllowPaths.includes(p));
-  const readWritePaths = [...writeAllowPaths, ...extraReadWritePaths];
+  const { readOnlyPaths, readWritePaths } = buildSandboxPathSets(
+    readAllowPaths,
+    writeAllowPaths,
+    extraReadWritePaths,
+  );
 
   const denyPatterns = [...policy.default.read.deny, ...policy.default.write.deny].map((pattern) =>
     resolvePlaceholders(pattern, repoRoot, tmpDir),
@@ -313,8 +383,8 @@ export function policyConfigToSandboxOptions(
   return {
     cwd: options.cwd,
     repoRoot,
-    readOnlyPaths: [...new Set(readOnlyPaths)],
-    readWritePaths: [...new Set(readWritePaths)],
+    readOnlyPaths,
+    readWritePaths,
     denyPatterns: [...new Set(denyPatterns)],
     denyPaths: [...new Set(denyPaths)],
     env: {},

--- a/packages/parser/__tests__/__snapshots__/outputs-ast-snapshot.test.ts.snap
+++ b/packages/parser/__tests__/__snapshots__/outputs-ast-snapshot.test.ts.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`OUTPUTS AST shape — snapshot locks the AST for naked-form OUTPUTS at step level 1`] = `
+[
+  {
+    "kind": "base",
+    "outputs": [
+      {
+        "name": "Version",
+      },
+      {
+        "name": "Tag",
+        "value": ""{{ RunId }}-staging"",
+      },
+    ],
+  },
+  {
+    "kind": "substeps",
+    "outputs": undefined,
+    "substepOutputs": [
+      {
+        "outputs": [
+          {
+            "name": "Inner",
+          },
+        ],
+      },
+    ],
+  },
+]
+`;
+
+exports[`OUTPUTS AST shape — snapshot locks the full step AST for a step bearing mixed naked + expression OUTPUTS 1`] = `
+[
+  {
+    "name": "DeployUrl",
+  },
+  {
+    "name": "Version",
+  },
+]
+`;

--- a/packages/parser/__tests__/conformance.test.ts
+++ b/packages/parser/__tests__/conformance.test.ts
@@ -144,4 +144,25 @@ describe('Rundown Conformance (Fixture Driven)', () => {
       expect(errors.length).toBeGreaterThan(0);
     });
   });
+
+  describe('Conformance — step-level naked OUTPUTS', () => {
+    it('accepts the design-spec example (DeployUrl + Version naked)', () => {
+      const md = `## 1. Deploy
+- OUTPUTS
+  - DeployUrl
+  - Version
+- PASS CONTINUE
+- FAIL STOP
+
+\`\`\`sh
+./deploy.sh --env staging
+echo -n "$(./get-version.sh)" > $RD_OUTPUTS_Version
+\`\`\`
+`;
+      const { runbook, diagnostics } = parseRunbookDocument(md);
+      const errors = diagnostics.filter((d) => d.severity === 'error');
+      expect(errors).toEqual([]);
+      expect(runbook.steps[0].outputs).toEqual([{ name: 'DeployUrl' }, { name: 'Version' }]);
+    });
+  });
 });

--- a/packages/parser/__tests__/conformance.test.ts
+++ b/packages/parser/__tests__/conformance.test.ts
@@ -165,4 +165,28 @@ echo -n "$(./get-version.sh)" > $RD_OUTPUTS_Version
       expect(runbook.steps[0].outputs).toEqual([{ name: 'DeployUrl' }, { name: 'Version' }]);
     });
   });
+
+  describe('Conformance — substep-level naked OUTPUTS', () => {
+    it('accepts naked OUTPUTS on a substep', () => {
+      const md = `## 1. Parent
+
+### 1.1 Capture
+- OUTPUTS
+  - Inner
+- PASS DEFER
+- FAIL DEFER
+
+\`\`\`sh
+printf 'inner-value' > $RD_OUTPUTS_Inner
+\`\`\`
+`;
+      const { runbook, diagnostics } = parseRunbookDocument(md);
+      const errors = diagnostics.filter((d) => d.severity === 'error');
+      expect(errors).toEqual([]);
+      const step = runbook.steps[0];
+      expect('substeps' in step ? step.substeps[0].outputs : undefined).toEqual([
+        { name: 'Inner' },
+      ]);
+    });
+  });
 });

--- a/packages/parser/__tests__/outputs-ast-snapshot.test.ts
+++ b/packages/parser/__tests__/outputs-ast-snapshot.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Snapshot tests locking the parsed AST shape for runbooks that use
+ * naked-form and expression-form OUTPUTS at both step and substep level.
+ *
+ * These snapshots serve as a regression guard: any change to how the parser
+ * handles OUTPUTS declarations will produce a snapshot diff, forcing explicit
+ * review before acceptance.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { parseRunbookDocument } from '../src/index.js';
+
+describe('OUTPUTS AST shape — snapshot', () => {
+  it('locks the AST for naked-form OUTPUTS at step level', () => {
+    const md = `## 1. Capture
+- OUTPUTS
+  - Version
+  - Tag "{{ RunId }}-staging"
+- PASS CONTINUE
+- FAIL STOP
+
+## 2. Parent
+### 2.1 Inner capture
+- OUTPUTS
+  - Inner
+- PASS DEFER
+- FAIL DEFER
+`;
+    const { runbook, diagnostics } = parseRunbookDocument(md);
+    expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    // Snapshot the relevant outputs fields only — avoiding volatile fields
+    // (prompt text, command, etc.) that are orthogonal to this feature.
+    const outputs = runbook.steps.map((step) => {
+      const entry: Record<string, unknown> = {
+        kind: step.kind,
+        outputs: step.outputs,
+      };
+      if (step.kind === 'substeps') {
+        entry.substepOutputs = step.substeps.map((ss) => ({
+          outputs: ss.outputs,
+        }));
+      }
+      return entry;
+    });
+    expect(outputs).toMatchSnapshot();
+  });
+
+  it('locks the full step AST for a step bearing mixed naked + expression OUTPUTS', () => {
+    const md = `## 1. Deploy
+- OUTPUTS
+  - DeployUrl
+  - Version
+- PASS CONTINUE
+- FAIL STOP
+`;
+    const { runbook } = parseRunbookDocument(md);
+    // Snapshot only the outputs field for this step.
+    expect(runbook.steps[0].outputs).toMatchSnapshot();
+  });
+});

--- a/packages/parser/__tests__/outputs-inputs.test.ts
+++ b/packages/parser/__tests__/outputs-inputs.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from '@jest/globals';
-import { parseOutputDeclaration, parseRunbookDocument, RunbookSyntaxError } from '../src/index.js';
+import {
+  parseOutputDeclaration,
+  parseRunbookDocument,
+  parseStepOutputDeclaration,
+  RunbookSyntaxError,
+} from '../src/index.js';
 
 // Regex-escape a dynamic segment before interpolating it into a `RegExp`
 // constructor — avoids the static-analysis ReDoS warning and is defensive
@@ -369,5 +374,87 @@ describe('parseRunbookDocument OUTPUTS directive — reserved-name guard', () =>
   - context {{ path "x.json" }}
 `;
     expect(() => parseRunbookDocument(md)).toThrow(RunbookSyntaxError);
+  });
+});
+
+describe('parseStepOutputDeclaration', () => {
+  it('accepts naked form (name only) and returns { name }', () => {
+    expect(parseStepOutputDeclaration('Version')).toEqual({ name: 'Version' });
+  });
+
+  it('rejects an invalid identifier in naked form', () => {
+    expect(parseStepOutputDeclaration('123bad')).toBeNull();
+  });
+
+  it('preserves expression-form parsing', () => {
+    expect(parseStepOutputDeclaration('PlanPath {{ path "plan.json" }}')).toEqual({
+      name: 'PlanPath',
+      value: '{{ path "plan.json" }}',
+    });
+  });
+
+  it('returns null for empty / whitespace-only input', () => {
+    expect(parseStepOutputDeclaration('')).toBeNull();
+    expect(parseStepOutputDeclaration('   ')).toBeNull();
+  });
+});
+
+describe('parseRunbookDocument step OUTPUTS naked form', () => {
+  it('accepts a naked OUTPUTS entry on a step', () => {
+    const md = `## 1. Capture
+- OUTPUTS
+  - Version
+- PASS CONTINUE
+- FAIL STOP
+`;
+    const { runbook, diagnostics } = parseRunbookDocument(md);
+    const errors = diagnostics.filter((d) => d.severity === 'error');
+    expect(errors).toEqual([]);
+    expect(runbook.steps[0].outputs).toEqual([{ name: 'Version' }]);
+  });
+
+  it('accepts a naked OUTPUTS entry on a substep', () => {
+    const md = `## 1. Parent
+### 1.1 Child
+- OUTPUTS
+  - DeployUrl
+- PASS CONTINUE
+- FAIL STOP
+`;
+    const { runbook, diagnostics } = parseRunbookDocument(md);
+    const errors = diagnostics.filter((d) => d.severity === 'error');
+    expect(errors).toEqual([]);
+    const step = runbook.steps[0];
+    expect('substeps' in step ? step.substeps[0].outputs : undefined).toEqual([
+      { name: 'DeployUrl' },
+    ]);
+  });
+
+  it('accepts mixed naked + expression entries in a single OUTPUTS block', () => {
+    const md = `## 1. Capture
+- OUTPUTS
+  - DeployUrl
+  - Tag "{{ RunId }}-staging"
+- PASS CONTINUE
+- FAIL STOP
+`;
+    const { runbook, diagnostics } = parseRunbookDocument(md);
+    const errors = diagnostics.filter((d) => d.severity === 'error');
+    expect(errors).toEqual([]);
+    expect(runbook.steps[0].outputs).toEqual([
+      { name: 'DeployUrl' },
+      { name: 'Tag', value: '"{{ RunId }}-staging"' },
+    ]);
+  });
+
+  it('still rejects reserved names in naked form', () => {
+    const md = `## 1. Capture
+- OUTPUTS
+  - step
+- PASS CONTINUE
+- FAIL STOP
+`;
+    expect(() => parseRunbookDocument(md)).toThrow(RunbookSyntaxError);
+    expect(() => parseRunbookDocument(md)).toThrow(/reserved variable name/);
   });
 });

--- a/packages/parser/__tests__/outputs-inputs.test.ts
+++ b/packages/parser/__tests__/outputs-inputs.test.ts
@@ -397,6 +397,10 @@ describe('parseStepOutputDeclaration', () => {
     expect(parseStepOutputDeclaration('')).toBeNull();
     expect(parseStepOutputDeclaration('   ')).toBeNull();
   });
+
+  it('parses a reserved-name naked entry without rejecting (caller enforces reserved-name policy)', () => {
+    expect(parseStepOutputDeclaration('step')).toEqual({ name: 'step' });
+  });
 });
 
 describe('parseRunbookDocument step OUTPUTS naked form', () => {

--- a/packages/parser/src/ast.ts
+++ b/packages/parser/src/ast.ts
@@ -257,8 +257,10 @@ export interface OutputDeclaration {
   readonly name: string;
   /**
    * Raw value expression — template variable, `{{ path "file" }}`, or quoted literal.
-   * Absent for the naked form used in frontmatter OUTPUTS (`PlanPath` with no expression),
-   * which resolves the value from context template vars by name at completion time.
+   * Absent for the naked form. Semantics depend on context:
+   * - Frontmatter OUTPUTS: resolves the value from context template vars by name at completion time.
+   * - Step / substep OUTPUTS: activates a file-backed channel — the executor pre-creates a file and
+   *   exports its path as `RD_OUTPUTS_<VarName>` for the spawned shell.
    */
   readonly value?: string;
 }

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -1067,14 +1067,47 @@ export function parseOutputDeclaration(text: string): OutputDeclaration | null {
 }
 
 /**
+ * Parse a step or substep OUTPUTS declaration entry.
+ *
+ * Accepts both naked form (name only — declares a file-backed output channel)
+ * and expression form (`PlanPath {{ path "plan.json" }}`). Step-level naked
+ * outputs are activated by the executor: a file is pre-created at
+ * `.rundown/runs/<runId>/outputs/<stepId>/<VarName>` and the path is exported
+ * as `RD_OUTPUTS_<VarName>` to the spawned shell.
+ *
+ * Mirrors {@link parseFrontmatterOutputDeclaration}. The two functions
+ * intentionally diverge in semantics (frontmatter naked = export by name from
+ * live vars; step naked = file-backed channel) but share grammar.
+ *
+ * @param text - Raw declaration text from the OUTPUTS block list item
+ * @returns Parsed OutputDeclaration, or null when the text is empty / invalid
+ */
+export function parseStepOutputDeclaration(text: string): OutputDeclaration | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  const spaceIdx = trimmed.search(/\s/);
+  if (spaceIdx === -1) {
+    // Naked form: just a name, no value expression
+    const name = trimmed;
+    if (!NAMED_IDENTIFIER_PATTERN.test(name)) return null;
+    return { name };
+  }
+
+  // With-value form: delegate to the existing expression-form parser
+  return parseOutputDeclaration(text);
+}
+
+/**
  * Parse a frontmatter OUTPUTS declaration entry.
  *
  * Extends the step-level format by supporting naked form (name only, no value expression):
  * - Naked: `PlanPath` → `{ name: 'PlanPath' }` (value absent — resolved from template vars at completion)
  * - With value: `PlanPath {{ path "plan.json" }}` → delegates to {@link parseOutputDeclaration}
  *
- * Step-level OUTPUTS use {@link parseOutputDeclaration} directly, which rejects naked form.
- * Frontmatter OUTPUTS use this function to accept both forms.
+ * Step-level OUTPUTS use {@link parseStepOutputDeclaration}, which also accepts naked form for
+ * file-backed output channels. Frontmatter OUTPUTS use this function where naked form means
+ * "export by name from live vars at completion".
  *
  * @param text - Raw declaration text from the frontmatter outputs array
  * @returns Parsed OutputDeclaration, or null if the text is empty or invalid

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -34,6 +34,7 @@ export {
   isStepExitAction,
   isTerminalAction,
   parseOutputDeclaration,
+  parseStepOutputDeclaration,
   parseFrontmatterOutputDeclaration,
 } from './helpers.js';
 export type { ConvertedTransitions, ParsedStepHeader, ParsedSubstepHeader } from './helpers.js';

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -26,7 +26,7 @@ import {
   validateLoopControlUsage,
   validateDEFERUsage,
   parseForClause,
-  parseOutputDeclaration,
+  parseStepOutputDeclaration,
 } from './helpers.js';
 import { isReservedTemplateName } from './reserved.js';
 import { validateRunbook } from './validator.js';
@@ -677,7 +677,7 @@ function handleOutputsDirective(node: ListItem, ctx: ActiveStepContext): typeof 
       );
     }
     const text = extractText(paragraph as PhrasingContent | Heading | Paragraph | ListItem);
-    const decl = parseOutputDeclaration(text);
+    const decl = parseStepOutputDeclaration(text);
     if (!decl) {
       throw new RunbookSyntaxError(
         `Invalid OUTPUTS declaration in ${targetLabel}${formatLineNum(item)}: "${text.trim()}" — expected "Name value" (e.g., "PlanPath {{ path \\"plan.json\\" }}")`,

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -680,7 +680,7 @@ function handleOutputsDirective(node: ListItem, ctx: ActiveStepContext): typeof 
     const decl = parseStepOutputDeclaration(text);
     if (!decl) {
       throw new RunbookSyntaxError(
-        `Invalid OUTPUTS declaration in ${targetLabel}${formatLineNum(item)}: "${text.trim()}" — expected "Name value" (e.g., "PlanPath {{ path \\"plan.json\\" }}")`,
+        `Invalid OUTPUTS declaration in ${targetLabel}${formatLineNum(item)}: "${text.trim()}" — expected a name (e.g., "Version") or "Name value" (e.g., "PlanPath {{ path \\"plan.json\\" }}")`,
       );
     }
     if (isReservedTemplateName(decl.name)) {

--- a/runbooks/context-passing/outputs-naked-capture.runbook.md
+++ b/runbooks/context-passing/outputs-naked-capture.runbook.md
@@ -1,0 +1,47 @@
+---
+name: outputs-naked-capture
+description: Naked OUTPUTS entry lets the shell write a value; the captured value flows into the next step
+tags:
+  - context-passing
+scenarios:
+  completed:
+    description: Shell writes to $RD_OUTPUTS_Version; step 2 asserts the value was captured
+    commands:
+      - rd run --allow-all outputs-naked-capture.runbook.md
+    expect:
+      result: COMPLETE
+      steps:
+        - from: "1"
+          at: "2"
+          result: PASS
+          action: CONTINUE
+        - from: "2"
+          at: "2"
+          result: PASS
+          action: COMPLETE
+---
+
+# Naked OUTPUTS Capture
+
+Shell writes a value to the file path provided via `$RD_OUTPUTS_<Name>`;
+the runtime reads the file after the step completes and stores the value in
+the runbook variable store. The next step verifies the value was captured
+by asserting it matches the expected string.
+
+## 1. Capture version
+- OUTPUTS
+  - Version
+- PASS CONTINUE
+- FAIL STOP
+
+```sh
+printf 'v1.0.0' > "$RD_OUTPUTS_Version"
+```
+
+## 2. Assert captured value
+- PASS COMPLETE
+- FAIL STOP
+
+```sh
+test "{{ Version }}" = "v1.0.0"
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Name-only ("naked") OUTPUTS now create file-backed output channels; commands receive RD_OUTPUTS_<VarName> env vars, captured values are published to run state and persisted on disk.

* **New Behavior**
  * CLI `--trust-js-policy` now also enables executing helper modules declared by a trusted JS policy; helpers passed via `--helpers` remain an explicit opt-in.

* **Documentation**
  * Clarified OUTPUTS semantics, capture paths, merge precedence, and `--trust-js-policy` vs `--helpers` behavior.

* **Tests**
  * Expanded integration and unit coverage for OUTPUTS capture, CLI helper handling, sandbox/policy mapping, and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->