### PR TITLE
Simplify frontmatter inputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,9 +130,10 @@ RD_INPUT_environment=staging rundown run deploy.md                 # Environment
 ---
 name: my-runbook
 inputs:
-  environment: development
-  port: 3000
-  debug: true
+  - environment
+  - port
+  - debug
+  - PlanPath
 required:
   - PlanPath
 ---
@@ -143,12 +144,12 @@ Server running on port {{ port }} in {{ environment }} mode.
 Deploy plan at {{ PlanPath }}.
 ```
 
-The `required` field declares variables the caller must provide. Required variables must not appear in `inputs:` (they have no default). Missing required variables produce a hard error at resolution time. Provide them via `--input`, `--input-file`, config, `RD_INPUT_*` env vars, or delegation inheritance.
+The `inputs` field is a list of names — declarations only, with no values. The `required` field declares which of those variables the caller must provide; names listed in `required` must also appear in `inputs`. Missing required variables produce a hard error at resolution time. Provide values via `--input`, `--input-file`, config, `RD_INPUT_*` env vars, or delegation inheritance.
 
 **Notes:**
 - Variable names must match pattern `/^[a-zA-Z_][a-zA-Z0-9_]*$/`
 - Undefined variables are preserved as literal `{{variable}}` text
-- Frontmatter inputs support string, number, and boolean values (converted to strings). For arrays, use `--input-json` inline or `.rundown/config.yaml` / `--input-file`. For `file:` data sources, use `.rundown/config.yaml` or `--input-file`
+- Frontmatter `inputs:` declares names only — values come from `--input`, `--input-file`, `RD_INPUT_*` env vars, `.rundown/config.yaml`, or delegation inheritance. Use `--input-json`, `.rundown/config.yaml`, or `--input-file` for arrays and `file:` data sources
 - `--input KEY` (without `=`) inherits the value of environment variable `KEY`
 
 ### Data Sources
@@ -168,7 +169,7 @@ Data sources are referenced in FOR clauses: `FOR item IN {{ items }}`.
 **File formats:** Only `.json` and `.jsonl` extensions are supported. `.jsonl` files are parsed as JSON Lines (one JSON value per line). Each line may contain any JSON value (string, number, boolean, null, array, or object). When the loop variable holds a parsed JSON object, dotted field access is supported in templates (e.g., `{{item.name}}`). Using `{{item}}` alone renders the serialized JSON string. `.json` files are eagerly loaded as a `JsonObject` or `JsonArray` value.
 
 **Notes:**
-- Arrays can be passed inline via `--input-json` or in `.rundown/config.yaml` and `--input-file` (not in frontmatter `inputs:`). `file:` values are supported in `.rundown/config.yaml` and `--input-file` only
+- Arrays can be passed via `--input-json` (inline), `.rundown/config.yaml`, or `--input-file`. `file:` values are supported in `.rundown/config.yaml` and `--input-file` only. Frontmatter `inputs:` declares names only and does not carry values
 - File paths must stay within the project root (symlinks resolved, traversal blocked)
 - `file:` values are routed into the internal variable store as typed values (`JsonArrayStream` for `.jsonl`, `JsonArray`/`JsonObject` for `.json`)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -26,9 +26,9 @@ A Rundown document (`.runbook.md`) is a Markdown file with an optional YAML fron
 
 Frontmatter fields beyond `name`, `description`, `version`, `author`, `tags`, `inputs`, `outputs`, and `required` are preserved (open schema). This allows forward-compatible extensions and user-defined metadata.
 
-The `required` field declares variable names that must be provided by the caller (via CLI flags, config, environment, or delegation). Each entry must be a valid template variable identifier matching `/^[a-zA-Z_][a-zA-Z0-9_]*$/`. Required variables must not appear in `inputs` — they have no default. Missing required variables produce a hard error during resolution.
+The `required` field declares variable names that must be provided by the caller (via CLI flags, config, environment, or delegation). Each entry must be a valid template variable identifier matching `/^[a-zA-Z_][a-zA-Z0-9_]*$/`. Names listed in `required` must also be declared in `inputs`. Missing required variables produce a hard error during resolution.
 
-The `inputs` field declares default values for template variables. Each key must match the identifier pattern `/^[a-zA-Z_][a-zA-Z0-9_]*$/`. Entries must not also appear in `required`. Reserved runtime names (`step`, `index`, `context`, matched case-insensitively) are rejected. At runtime, declared defaults are overridden by higher-precedence sources (CLI flags, environment, config files). As the lowest-priority runtime layer, `inputs:` values also fill gaps from the context outputs store when a `ContextId` is available (see [§7 Context Passing](#7-context-passing-outputs)).
+The `inputs` field declares the names of template variables the runbook accepts. It is a list of identifiers; entries do not carry values. Each name must match the identifier pattern `/^[a-zA-Z_][a-zA-Z0-9_]*$/`. Reserved runtime names (`step`, `index`, `context`, matched case-insensitively) are rejected. Values for declared inputs are supplied at runtime via CLI flags, environment, config files, delegation inheritance, or context outputs (see [§7 Context Passing](#7-context-passing-outputs)).
 
 The frontmatter `description` field provides a summary for runbook discovery and listing (`rd ls --all`). The `Runbook.description` in the parsed AST is derived from preamble text between the H1 title and first H2 step. These are independent values.
 
@@ -303,16 +303,16 @@ Variables use Handlebars syntax: `{{variable}}`.
 *   **Parent variables**: `{{context.parent.vars.NAME}}` exposes the parent's resolved template variables. Only non-context keys propagate. Available via both chain (`context.parent.parent.vars.*`) and array (`context.ancestors.N.vars.*`) addressing.
 *   **Depth limit**: Parent context chain addressing is capped at 32 levels (enforced on the delegation ancestor chain depth). Exceeding this limit produces an error.
 *   **Path resolution**: Dotted paths are supported consistently (for example `{{context.parent.index}}`).
-*   **Required variables**: The frontmatter `required` field declares variables that must be provided by the caller via CLI flags, config, environment bridge, or delegation inheritance. Required variables must not appear in `inputs:`. Missing required variables produce a hard error (`MISSING_REQUIRED_VARS`) during resolution. Reserved runtime names are also rejected in `required`.
+*   **Required variables**: The frontmatter `required` field declares variables that must be provided by the caller via CLI flags, config, environment bridge, or delegation inheritance. Names listed in `required` must also appear in `inputs:`. Missing required variables produce a hard error (`MISSING_REQUIRED_VARS`) during resolution. Reserved runtime names are also rejected in `required`.
 * **Reserved keys**: Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive — any case variant such as `STEP`, `Step`, `INDEX` is also reserved) and cannot be overridden by user variables. The CLI rejects these names in frontmatter `inputs:`, `required`, `--input` flags, `--input-file` contents, and `.rundown/config.yaml` with an error diagnostic. Reserved names in `RD_INPUT_*` environment variables are silently skipped with a warning.
 * **Precedence** (highest to lowest):
     1. CLI flags (`--input-file`, `--input`, `--input-json`) — highest priority
     2. `RD_INPUT_*` environment variables (prefix stripped)
-    3. `.rundown/config.yaml` (auto-discovered from cwd upward)
-    4. Frontmatter `inputs:` field
-    5. Inherited delegation variables (parent context)
-    6. Built-in defaults — see [§6.1 Built-in Variables](#61-built-in-variables).
-    7. INPUTS injected from the context outputs store — fill gaps only, never override an existing variable (including built-ins, which are always present). Silently skipped when `ContextId` is unset or the requested key is absent. See [§7 Context Passing](#7-context-passing-outputs).
+    3. Inherited delegation variables (parent context)
+    4. `.rundown/config.yaml` (auto-discovered from cwd upward)
+    5. Built-in defaults — see [§6.1 Built-in Variables](#61-built-in-variables).
+    6. INPUTS injected from the context outputs store — fill gaps only, never override an existing variable (including built-ins, which are always present). Silently skipped when `ContextId` is unset or the requested key is absent. See [§7 Context Passing](#7-context-passing-outputs).
+    Frontmatter `inputs:` only declares which names the runbook accepts; it is not a runtime value layer.
 
 ### 6.1 Built-in Variables
 
@@ -423,6 +423,8 @@ Child (`execute-plan.runbook.md`):
 ```markdown
 ---
 name: execute-plan
+inputs:
+  - PlanPath
 required:
   - PlanPath
 ---
@@ -437,7 +439,7 @@ Flow:
 
 1. Parent step 1 runs and its transition completes. The machine evaluates the step's `OUTPUTS`, resolves `PlanPath` via the `{{ path }}` helper (e.g. `.rundown/work/feature-my-work/.rd-a3b8c1d2/2026-02-04-plan.md`), and merges `{ PlanPath: "<resolved path>" }` into the live `context.variables`.
 2. Parent step 2 delegates to the child. The child inherits `ContextId=a3b8c1d2` via `--input`, and the plugin forwards the parent's live variable space (including `PlanPath`) as `--input` flags on the child's `rd claim` invocation.
-3. Child pipeline setup resolves variables: `--input PlanPath=...` satisfies `required: PlanPath`, and frontmatter `inputs:` defaults fill any gaps.
+3. Child pipeline setup resolves variables: `--input PlanPath=...` binds the value to the declared `inputs:` entry and satisfies `required: PlanPath`.
 4. Child step 1 renders `{{ PlanPath }}` as the forwarded value and executes.
 
 ## 8. Conformance
@@ -454,7 +456,7 @@ Flow:
 10. **FOR Iteration Action Set**: FOR-level nested transitions only allow `CONTINUE`, `DEFER`, `NEXT`, `BREAK`, `GOTO`, `STOP`, `COMPLETE` (plus RETRY wrappers).
 11. **Single Directives**: At most one OUTPUTS directive per step or substep.
 12. **Reserved Names in Directives**: OUTPUTS variable names must not be reserved names (case-insensitive).
-13. **No INPUTS Directive**: The `- INPUTS` step directive has been removed. Use the frontmatter `inputs:` field to declare default variable values; variables are injected via `--input` flags at invocation time.
+13. **No INPUTS Directive**: The `- INPUTS` step directive has been removed. Use the frontmatter `inputs:` field to declare the variable names the runbook accepts; values are supplied via `--input` flags or other runtime sources at invocation time.
 14. **DELEGATE Ordering**: The `- DELEGATE` annotation must appear after `- FOR` (when present) and before transitions, prompt, and body. Misordered DELEGATE is a parse error. (See §4.3.)
 15. **DELEGATE Requires Runbook Target**: Every substep marked `delegate: true` must declare at least one runbook target. A bare DELEGATE substep (no runbook bullet) is rejected at parse time. Step-level DELEGATE propagates to all substeps and the same target requirement applies to every propagated child.
 16. **RETRY on DELEGATE is Result-Agnostic**: `rd delegate --retry` succeeds regardless of the substep's prior result. Retry re-issues a fresh token by cancelling the current delegation and re-creating one with a new token; the retry hook propagates the canonical FOR-iteration location through `contextSnapshot.at`.

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/delegation-dispatch.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/delegation-dispatch.test.ts
@@ -184,8 +184,8 @@ describe('handleDelegationDispatch', () => {
     const tokenHash = hashToken(VALID_TOKEN);
     const childRunbook = `---
 inputs:
-  PlanPath: ''
-  environment: staging
+  - PlanPath
+  - environment
 ---
 # Child Runbook
 
@@ -214,6 +214,38 @@ PASS COMPLETE
     expect(result.context).not.toContain('unrelated');
   });
 
+  it('falls back to plain rd claim when child frontmatter validation fails', async () => {
+    const tokenHash = hashToken(VALID_TOKEN);
+    const childRunbook = `---
+inputs:
+  PlanPath: /work/plan.json
+---
+# Child Runbook
+
+## 1. Step
+PASS COMPLETE
+`;
+    mockReadFile.mockResolvedValue(childRunbook);
+
+    const status = {
+      file: 'parent.md',
+      step: { name: '3' },
+      vars: { PlanPath: '/work/plan.json' },
+      delegations: [{ state: 'pending', runbook: 'child.runbook.md', tokenHash }],
+    };
+    setExecSync(mockExecFileSync(JSON.stringify(status)));
+
+    const input = createMockHookInput('PreToolUse', {
+      tool_name: 'Task',
+      tool_input: { prompt: `RD_CLAIM_TOKEN=${VALID_TOKEN}` },
+    });
+
+    const result = await handleDelegationDispatch(input);
+    expect(result.context).toContain(`rd claim ${VALID_TOKEN}`);
+    expect(result.context).not.toContain('--input');
+    expect(result.context).not.toContain('PlanPath=');
+  });
+
   it('does not inject --input flags when no delegation matches the detected token', async () => {
     const differentTokenHash = hashToken('rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ999999');
     const status = {
@@ -236,7 +268,7 @@ PASS COMPLETE
   });
 
   it('passes numeric parent var as --input-json flag', async () => {
-    const childRunbook = `---\ninputs:\n  port: 3000\n---\n# Child\n\n## 1. Step\n- PASS COMPLETE\n`;
+    const childRunbook = `---\ninputs:\n  - port\n---\n# Child\n\n## 1. Step\n- PASS COMPLETE\n`;
     mockReadFile.mockResolvedValue(childRunbook);
     const flags = await buildChildInputFlags('child.runbook.md', { port: 3000 }, '/test/project');
     expect(flags).toBe("--input-json port='3000'");
@@ -247,10 +279,10 @@ PASS COMPLETE
     const childRunbook = `---
 name: child
 inputs:
-  DollarVar: ''
-  BacktickVar: ''
-  QuoteVar: ''
-  SpaceVar: ''
+  - DollarVar
+  - BacktickVar
+  - QuoteVar
+  - SpaceVar
 ---
 # Child
 

--- a/packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts
@@ -56,9 +56,9 @@ export interface DelegationDispatchResult {
 /**
  * Build `--input key=value` flags for a child runbook from parent's live variable space.
  *
- * Reads the child runbook's frontmatter `inputs:` keys and, for each key that
- * exists in the parent's vars, produces a `--input key=value` flag. Non-fatal:
- * returns empty string on any error.
+ * Reads the child runbook's frontmatter `inputs:` declarations and, for each
+ * declared name that exists in the parent's vars, produces a `--input key=value`
+ * flag. Non-fatal: returns empty string on any error.
  *
  * @param childRunbookPath - Absolute or cwd-relative path to the child runbook
  * @param parentVars - Parent's live variable space from `rd status --json`
@@ -78,7 +78,7 @@ export async function buildChildInputFlags(
       : path.resolve(cwd, childRunbookPath);
     const src = await fs.readFile(resolved, 'utf-8');
     const { frontmatter } = parseRunbookDocument(src);
-    const inputKeys = Object.keys(frontmatter?.inputs ?? {});
+    const inputKeys = frontmatter?.inputs ?? [];
     // Shell-quote values so spaces and special characters are preserved when the
     // claim command string is executed by Claude Code's task/agent tool.
     // Non-string values (numbers, booleans, objects) are serialized as JSON and
@@ -152,7 +152,7 @@ export async function handleDelegationDispatch(
     if (file) statusLines.push(`Active runbook: ${file}`);
     if (step) statusLines.push(`Current step: ${step}`);
 
-    // Inject --input flags from child runbook's inputs: keys using parent's live vars.
+    // Inject --input flags from the child runbook's declared inputs using the parent's live vars.
     // Match the delegation entry by tokenHash to correctly identify the child runbook
     // when multiple delegations are pending simultaneously.
     const parentVars = (status as { vars?: Record<string, unknown> }).vars;

--- a/packages/cli/__tests__/check.test.ts
+++ b/packages/cli/__tests__/check.test.ts
@@ -122,7 +122,7 @@ Do something.
       runbookPath,
       `---
 inputs:
-  Step: custom
+  - Step
 ---
 ## 1. Do something
 - PASS COMPLETE
@@ -145,7 +145,7 @@ Hello.
       runbookPath,
       `---
 inputs:
-  Index: 5
+  - Index
 ---
 ## 1. Do something
 - PASS COMPLETE
@@ -168,7 +168,7 @@ Hello.
       runbookPath,
       `---
 inputs:
-  Date: "2025-01-01"
+  - Date
 ---
 ## 1. Do something
 - PASS COMPLETE

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -306,11 +306,23 @@ Do child work.
 
       let result = await runCliInProcess(`claim ${token1!}`, workspace);
       expect(result.exitCode).toBe(0);
-      const child1Id = String(findActionOutput(result.stdout)?.run_id);
+      const child1Output = findActionOutput(result.stdout);
+      expect(child1Output).toBeDefined();
+      if (!child1Output) {
+        throw new Error('Expected claim output to include run metadata');
+      }
+      expect(typeof child1Output.run_id).toBe('string');
+      const child1Id = child1Output.run_id;
 
       result = await runCliInProcess(`claim ${token2!}`, workspace);
       expect(result.exitCode).toBe(0);
-      const child2Id = String(findActionOutput(result.stdout)?.run_id);
+      const child2Output = findActionOutput(result.stdout);
+      expect(child2Output).toBeDefined();
+      if (!child2Output) {
+        throw new Error('Expected claim output to include run metadata');
+      }
+      expect(typeof child2Output.run_id).toBe('string');
+      const child2Id = child2Output.run_id;
 
       const activeBefore = await getActiveState(workspace);
       expect(activeBefore?.id).toBe(child2Id);

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -3,11 +3,12 @@ import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   createTestWorkspace,
+  findActionOutput,
   runCliInProcess,
   getActiveState,
+  readRunbookState,
   readSession,
   getAllStates,
-  findActionOutput,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
 import { ActionResponseSchema } from '../helpers/schema-validator.js';
@@ -186,6 +187,143 @@ Do child work.
       const session3 = await readSession(workspace);
       expect(session3.active).toBe(parentId);
     });
+  });
+
+  describe('sibling fan-out isolation', () => {
+    interface FrontierEntry {
+      id: string;
+      runbook: string;
+      token: string;
+    }
+
+    function parseConcatenatedJson(raw: string): unknown[] {
+      const results: unknown[] = [];
+      let i = 0;
+      while (i < raw.length) {
+        while (i < raw.length && /\s/.test(raw[i])) i++;
+        if (i >= raw.length) break;
+        const start = i;
+        let depth = 0;
+        let inString = false;
+        let escaped = false;
+        for (; i < raw.length; i++) {
+          const ch = raw[i];
+          if (inString) {
+            if (escaped) {
+              escaped = false;
+            } else if (ch === '\\') {
+              escaped = true;
+            } else if (ch === '"') {
+              inString = false;
+            }
+          } else if (ch === '"') {
+            inString = true;
+          } else if (ch === '{' || ch === '[') {
+            depth++;
+          } else if (ch === '}' || ch === ']') {
+            depth--;
+            if (depth === 0) {
+              i++;
+              break;
+            }
+          }
+        }
+        const chunk = raw.slice(start, i);
+        try {
+          results.push(JSON.parse(chunk));
+        } catch {
+          // skip malformed chunk
+        }
+      }
+      return results;
+    }
+
+    function findFrontierInEvents(events: unknown[]): FrontierEntry[] | undefined {
+      for (const ev of events) {
+        if (Array.isArray(ev)) {
+          const nested = findFrontierInEvents(ev);
+          if (nested) return nested;
+        } else if (ev && typeof ev === 'object') {
+          const e = ev as { type?: string; delegateFrontier?: FrontierEntry[] };
+          if (e.type === 'step_entered' && e.delegateFrontier) {
+            return e.delegateFrontier;
+          }
+        }
+      }
+      return undefined;
+    }
+
+    it('does not let the later claimed sibling steal the first child pass', async () => {
+      const childRunbook = [
+        '# Child',
+        '',
+        '## 1. Work',
+        '',
+        '- PASS COMPLETE',
+        '- FAIL STOP',
+        '',
+        'Do child work.',
+        '',
+      ].join('\n');
+      const parentRunbook = [
+        '# Parent',
+        '',
+        '## 1. Fan out',
+        '',
+        '- DELEGATE',
+        '- PASS ALL CONTINUE',
+        '- FAIL ANY STOP',
+        '',
+        '### 1.1 First child',
+        '',
+        '- child.runbook.md',
+        '',
+        '### 1.2 Second child',
+        '',
+        '- child.runbook.md',
+        '',
+        '## 2. Done',
+        '',
+        '- PASS COMPLETE',
+        '',
+        'Finished.',
+        '',
+      ].join('\n');
+
+      await mkdir(join(workspace.cwd, 'runbooks'), { recursive: true });
+      await writeFile(join(workspace.cwd, 'runbooks', 'child.runbook.md'), childRunbook);
+      await writeFile(join(workspace.cwd, 'runbooks', 'parent.runbook.md'), parentRunbook);
+      await writeFile(join(workspace.runbooksDir(), 'child.runbook.md'), childRunbook);
+
+      const start = await runCliInProcess('run --prompted runbooks/parent.runbook.md', workspace);
+      expect(start.exitCode).toBe(0);
+      const frontier = findFrontierInEvents(parseConcatenatedJson(start.stdout)) ?? [];
+      expect(frontier).toHaveLength(2);
+      const token1 = frontier.find((entry) => entry.id === '1.1')?.token;
+      const token2 = frontier.find((entry) => entry.id === '1.2')?.token;
+      expect(token1).toBeDefined();
+      expect(token2).toBeDefined();
+
+      let result = await runCliInProcess(`claim ${token1!}`, workspace);
+      expect(result.exitCode).toBe(0);
+      const child1Id = String(findActionOutput(result.stdout)?.run_id);
+
+      result = await runCliInProcess(`claim ${token2!}`, workspace);
+      expect(result.exitCode).toBe(0);
+      const child2Id = String(findActionOutput(result.stdout)?.run_id);
+
+      const activeBefore = await getActiveState(workspace);
+      expect(activeBefore?.id).toBe(child2Id);
+
+      result = await runCliInProcess('pass --text', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const child1 = await readRunbookState(workspace, child1Id);
+      const child2 = await readRunbookState(workspace, child2Id);
+
+      expect(child1?.lifecycle).toBe('running');
+      expect(child2?.lifecycle).toBe('completed');
+    }, 30_000);
   });
 
   describe('runbook completion with stack', () => {

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -308,20 +308,18 @@ Do child work.
       expect(result.exitCode).toBe(0);
       const child1Output = findActionOutput(result.stdout);
       expect(child1Output).toBeDefined();
-      if (!child1Output) {
-        throw new Error('Expected claim output to include run metadata');
+      if (!child1Output || typeof child1Output.run_id !== 'string') {
+        throw new Error('Expected claim output to include run_id string');
       }
-      expect(typeof child1Output.run_id).toBe('string');
       const child1Id = child1Output.run_id;
 
       result = await runCliInProcess(`claim ${token2!}`, workspace);
       expect(result.exitCode).toBe(0);
       const child2Output = findActionOutput(result.stdout);
       expect(child2Output).toBeDefined();
-      if (!child2Output) {
-        throw new Error('Expected claim output to include run metadata');
+      if (!child2Output || typeof child2Output.run_id !== 'string') {
+        throw new Error('Expected claim output to include run_id string');
       }
-      expect(typeof child2Output.run_id).toBe('string');
       const child2Id = child2Output.run_id;
 
       const activeBefore = await getActiveState(workspace);

--- a/packages/cli/__tests__/commands/resolve.test.ts
+++ b/packages/cli/__tests__/commands/resolve.test.ts
@@ -52,37 +52,40 @@ echo hello
     expect(output.variables).toHaveProperty('WorkPath');
   });
 
-  it('resolves valid runbook with frontmatter vars — shows resolved variables', async () => {
+  it('resolves declared inputs from CLI — shows resolved variables', async () => {
     const runbookPath = path.join(workspace.cwd, 'vars.runbook.md');
     fs.writeFileSync(
       runbookPath,
       `---
 name: test-runbook
 inputs:
-  environment: development
-  port: 3000
+  - environment
+  - port
 ---
 ## Step 1
 Server on port {{ port }} in {{ environment }} mode.
 `,
     );
 
-    const result = await runCliInProcess(`resolve ${runbookPath}`, workspace);
+    const result = await runCliInProcess(
+      `resolve ${runbookPath} --input environment=development --input port=3000`,
+      workspace,
+    );
     const output = JSON.parse(result.stdout);
 
     expect(output.valid).toBe(true);
     expect(output.variables).toHaveProperty('environment', 'development');
-    expect(output.variables).toHaveProperty('port', 3000);
+    expect(output.variables).toHaveProperty('port', '3000');
   });
 
-  it('resolves with --input flags — CLI vars override frontmatter', async () => {
+  it('resolves with --input flags for declared inputs', async () => {
     const runbookPath = path.join(workspace.cwd, 'override.runbook.md');
     fs.writeFileSync(
       runbookPath,
       `---
 name: test-runbook
 inputs:
-  environment: development
+  - environment
 ---
 ## Step 1
 Deploy to {{ environment }}.
@@ -129,14 +132,17 @@ Deploy to {{ missingVar }}.
       runbookPath,
       `---
 inputs:
-  environment: staging
+  - environment
 ---
 ## 3. Deploy
 Deploy to {{ environment }}.
 `,
     );
 
-    const result = await runCliInProcess(`resolve ${runbookPath}`, workspace);
+    const result = await runCliInProcess(
+      `resolve ${runbookPath} --input environment=staging`,
+      workspace,
+    );
     const output = JSON.parse(result.stdout);
 
     expect(output.valid).toBe(false);
@@ -267,20 +273,20 @@ echo {{ server }}
     expect(output.sources.servers.items).toBe(2);
   });
 
-  it('outputs valid JSON matching schema by default', async () => {
+  it('outputs valid JSON matching schema with declared inputs', async () => {
     const runbookPath = path.join(workspace.cwd, 'schema-test.runbook.md');
     fs.writeFileSync(
       runbookPath,
       `---
 inputs:
-  name: world
+  - name
 ---
 ## Step 1
 Hello {{ name }}.
 `,
     );
 
-    const result = await runCliInProcess(`resolve ${runbookPath}`, workspace);
+    const result = await runCliInProcess(`resolve ${runbookPath} --input name=world`, workspace);
     const output = JSON.parse(result.stdout);
 
     // Validate against Zod schema (single source of truth)
@@ -349,7 +355,7 @@ echo hello
       runbookPath,
       `---
 inputs:
-  greeting: hello
+  - greeting
 ---
 ## Step 1
 Say {{ greeting }} to {{ recipient }}.
@@ -454,13 +460,13 @@ echo hello
     }
   });
 
-  it('resolves FOR clause with template variable bounds', async () => {
+  it('resolves FOR clause with declared template variable bounds', async () => {
     const runbookPath = path.join(workspace.cwd, 'for-var-bounds.runbook.md');
     fs.writeFileSync(
       runbookPath,
       `---
 inputs:
-  Max: 5
+  - Max
 ---
 ## 1. Process batches
 - FOR batch IN 1 TO {{Max}}
@@ -476,7 +482,7 @@ echo batch
 `,
     );
 
-    const result = await runCliInProcess(`resolve ${runbookPath}`, workspace);
+    const result = await runCliInProcess(`resolve ${runbookPath} --input Max=5`, workspace);
     const output = JSON.parse(result.stdout);
 
     expect(output.valid).toBe(true);
@@ -490,14 +496,17 @@ echo batch
       runbookPath,
       `---
 inputs:
-  greeting: hello
+  - greeting
 ---
 ## Step 1
 Say {{ greeting }}.
 `,
     );
 
-    const result = await runCliInProcess(`resolve ${runbookPath} --text`, workspace);
+    const result = await runCliInProcess(
+      `resolve ${runbookPath} --input greeting=hello --text`,
+      workspace,
+    );
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('PASS');
     expect(result.stdout).toContain('Variables:');
@@ -512,7 +521,7 @@ Say {{ greeting }}.
         `---
 name: meta
 inputs:
-  Target: ""
+  - Target
 ---
 ## 1. Execute
 - {{ Target }}

--- a/packages/cli/__tests__/fixtures/snapshots/snapshot-child.runbook.md
+++ b/packages/cli/__tests__/fixtures/snapshots/snapshot-child.runbook.md
@@ -1,7 +1,7 @@
 ---
 name: snapshot-child
 description: Child runbook that consumes Message from parent delegation
-required:
+inputs:
   - Message
 ---
 # Snapshot Child

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -153,8 +153,6 @@ jest.unstable_mockModule('../../src/services/template-renderer', () => ({
 
 // Mock validate-frontmatter-vars
 jest.unstable_mockModule('../../src/helpers/validate-frontmatter-vars', () => ({
-  validateFrontmatterVars: mockFn<() => string[]>().mockReturnValue([]),
-  validateRequiredVars: mockFn<() => string[]>().mockReturnValue([]),
   validateOutputsDeclarations: mockFn<() => string[]>().mockReturnValue([]),
 }));
 
@@ -175,7 +173,7 @@ const { resolveRunbookFile } = await import('../../src/helpers/resolve-runbook.j
 const { resolveVariables } = await import('../../src/services/variable-discovery.js');
 const { substituteRunbookVariables, resolveForBounds, collectUnresolvedRunbookVariables } =
   await import('../../src/services/template-renderer.js');
-const { validateFrontmatterVars, validateRequiredVars, validateOutputsDeclarations } = await import(
+const { validateOutputsDeclarations } = await import(
   '../../src/helpers/validate-frontmatter-vars.js'
 );
 const { createBridgedEmitter } = await import('../../src/helpers/execution-emitter.js');
@@ -839,8 +837,6 @@ describe('claimAndLaunch', () => {
       frontmatter: null,
       diagnostics: [],
     } as unknown as ReturnType<typeof parser.parseRunbookDocument>);
-    jest.mocked(validateFrontmatterVars).mockReturnValue([]);
-    jest.mocked(validateRequiredVars).mockReturnValue([]);
     jest.mocked(validateOutputsDeclarations).mockReturnValue([]);
     // Cast through unknown: ResolvedVariables uses a branded vars map
     // and tracks more fields than this fixture provides.
@@ -968,8 +964,6 @@ describe('claimAndLaunch', () => {
       frontmatter: null,
       diagnostics: [],
     } as unknown as ReturnType<typeof parser.parseRunbookDocument>);
-    jest.mocked(validateFrontmatterVars).mockReturnValue([]);
-    jest.mocked(validateRequiredVars).mockReturnValue([]);
     jest.mocked(validateOutputsDeclarations).mockReturnValue([]);
     jest.mocked(resolveVariables).mockResolvedValue({
       vars: {},

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -519,14 +519,14 @@ describe('prepareRunbook', () => {
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(
       mockParseResult({
-        frontmatter: { inputs: ['Region'] },
+        frontmatter: { inputs: ['Region'] } as NonNullable<ParseResult['frontmatter']>,
       }),
     );
 
     await prepareRunbook('good.md', {}, '/test');
 
     const call = jest.mocked(resolveVariables).mock.calls[0];
-    expect(call?.[0]).not.toHaveProperty('frontmatterVars');
+    expect(call[0]).not.toHaveProperty('frontmatterVars');
   });
 
   it('returns VALIDATION_ERROR when required names are not declared in inputs', async () => {
@@ -538,7 +538,10 @@ describe('prepareRunbook', () => {
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(
       mockParseResult({
-        frontmatter: { inputs: ['PlanPath'], required: ['Region'] },
+        frontmatter: {
+          inputs: ['PlanPath'],
+          required: ['Region'],
+        } as NonNullable<ParseResult['frontmatter']>,
         diagnostics: [
           {
             severity: 'error',
@@ -566,7 +569,7 @@ describe('prepareRunbook', () => {
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(
       mockParseResult({
-        frontmatter: { inputs: ['context'] },
+        frontmatter: { inputs: ['context'] } as NonNullable<ParseResult['frontmatter']>,
         diagnostics: [
           {
             severity: 'error',

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -175,8 +175,6 @@ jest.unstable_mockModule('../../src/services/template-renderer', () => ({
 
 // Mock validate-frontmatter-vars
 jest.unstable_mockModule('../../src/helpers/validate-frontmatter-vars', () => ({
-  validateFrontmatterVars: mockFn<(...args: unknown[]) => unknown[]>().mockReturnValue([]),
-  validateRequiredVars: mockFn<(...args: unknown[]) => unknown[]>().mockReturnValue([]),
   validateOutputsDeclarations: mockFn<(...args: unknown[]) => unknown[]>().mockReturnValue([]),
 }));
 
@@ -205,7 +203,7 @@ const {
   warnUnresolvedRunbookVariables,
   collectUnresolvedRunbookVariables,
 } = await import('../../src/services/template-renderer.js');
-const { validateFrontmatterVars, validateRequiredVars, validateOutputsDeclarations } = await import(
+const { validateOutputsDeclarations } = await import(
   '../../src/helpers/validate-frontmatter-vars.js'
 );
 const fsPromises = await import('node:fs/promises');
@@ -360,8 +358,6 @@ beforeEach(() => {
   jest.mocked(expandLoopVariables).mockImplementation((text: string) => text);
   jest.mocked(warnUnresolvedRunbookVariables).mockReturnValue([]);
   jest.mocked(collectUnresolvedRunbookVariables).mockReturnValue(new Set());
-  jest.mocked(validateFrontmatterVars).mockReturnValue([]);
-  jest.mocked(validateRequiredVars).mockReturnValue([]);
   jest.mocked(validateOutputsDeclarations).mockReturnValue([]);
   // readFile is overloaded; jest.mocked picks the Buffer-returning overload, but we need to
   // resolve a string. Cast through unknown to a typed mock returning string.
@@ -514,7 +510,7 @@ describe('prepareRunbook', () => {
     );
   });
 
-  it('passes parser frontmatter inputs into variable resolution', async () => {
+  it('does not pass frontmatter inputs into variable resolution', async () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/good.md',
       source: 'project',
@@ -523,52 +519,45 @@ describe('prepareRunbook', () => {
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(
       mockParseResult({
-        frontmatter: { inputs: { Region: '' } },
+        frontmatter: { inputs: ['Region'] },
       }),
     );
 
     await prepareRunbook('good.md', {}, '/test');
 
-    expect(resolveVariables).toHaveBeenCalledWith(
-      expect.objectContaining({
-        frontmatterVars: { Region: '' },
-      }),
-      '/test',
-      expect.anything(),
-    );
+    const call = jest.mocked(resolveVariables).mock.calls[0];
+    expect(call?.[0]).not.toHaveProperty('frontmatterVars');
   });
 
-  it('returns VALIDATION_ERROR when frontmatter inputs use reserved names', async () => {
+  it('returns VALIDATION_ERROR when required names are not declared in inputs', async () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
-      path: '/test/reserved.md',
+      path: '/test/missing-input.md',
       source: 'project',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(
       mockParseResult({
-        frontmatter: { inputs: { context: '' } },
+        frontmatter: { inputs: ['PlanPath'], required: ['Region'] },
+        diagnostics: [
+          {
+            severity: 'error',
+            message: 'Frontmatter "required" variable "Region" must also be declared in "inputs"',
+          },
+        ],
       }),
     );
-    jest.mocked(validateFrontmatterVars).mockReturnValue([
-      {
-        severity: 'error',
-        message:
-          'Frontmatter input "context" uses reserved runtime variable name. Reserved names (case-insensitive): step, index, context',
-      },
-    ]);
 
-    const result = await prepareRunbook('reserved.md', {}, '/test');
+    const result = await prepareRunbook('missing-input.md', {}, '/test');
 
-    expect(validateFrontmatterVars).toHaveBeenCalledWith({ context: '' });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe('VALIDATION_ERROR');
-      expect(result.error).toContain('reserved runtime variable name');
+      expect(result.error).toContain('must also be declared in "inputs"');
     }
   });
 
-  it('omits helper-collision warnings when bailing on early VALIDATION_ERROR', async () => {
+  it('bails before helper-collision warnings when frontmatter validation fails', async () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/reserved.md',
       source: 'project',
@@ -577,16 +566,17 @@ describe('prepareRunbook', () => {
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
     ).mockReturnValue(
       mockParseResult({
-        frontmatter: { inputs: { context: '' } },
+        frontmatter: { inputs: ['context'] },
+        diagnostics: [
+          {
+            severity: 'error',
+            message:
+              'Frontmatter "inputs[0]" — "context" is a reserved variable name (step, index, context — case-insensitive)',
+          },
+        ],
       }),
     );
-    jest.mocked(validateFrontmatterVars).mockReturnValue([
-      {
-        severity: 'error',
-        message:
-          'Frontmatter input "context" uses reserved runtime variable name. Reserved names (case-insensitive): step, index, context',
-      },
-    ]);
+    jest.mocked(validateOutputsDeclarations).mockReturnValue([]);
     // Provide a variable named `Region` that collides with a registered helper.
     jest.mocked(resolveVariables).mockResolvedValue({
       vars: { Region: 'us-west' },
@@ -604,8 +594,7 @@ describe('prepareRunbook', () => {
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.code).toBe('VALIDATION_ERROR');
-        // The early-error bailout must NOT include helper-collision warnings,
-        // because the user can't act on them while structural errors exist.
+        expect(result.error).toContain('reserved variable name');
         const warnings = result.warnings ?? [];
         const hasHelperWarning = warnings.some((w) =>
           w.includes('shadowed by a registered helper'),
@@ -688,64 +677,6 @@ describe('prepareRunbook', () => {
     if (!result.ok) {
       expect(result.code).toBe('MISSING_REQUIRED_VARS');
       expect(result.details).toEqual(expect.objectContaining({ missing: ['Date'] }));
-    }
-  });
-
-  it('returns VALIDATION_ERROR (not MISSING_REQUIRED_VARS) for invalid identifier in required', async () => {
-    jest.mocked(resolveRunbookFile).mockResolvedValue({
-      path: '/test/bad-req.md',
-      source: 'project',
-    });
-    (
-      parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
-    ).mockReturnValue(
-      mockParseResult({
-        frontmatter: { required: ['123bad'] },
-      }),
-    );
-    // validateRequiredVars returns an error diagnostic for the invalid identifier
-    jest
-      .mocked(validateRequiredVars)
-      .mockReturnValue([
-        { severity: 'error', message: 'Required variable "123bad" is not a valid identifier' },
-      ]);
-
-    const result = await prepareRunbook('bad-req.md', {}, '/test');
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe('VALIDATION_ERROR');
-      expect(result.error).toContain('123bad');
-    }
-  });
-
-  it('returns VALIDATION_ERROR (not MISSING_REQUIRED_VARS) for reserved name in required', async () => {
-    jest.mocked(resolveRunbookFile).mockResolvedValue({
-      path: '/test/reserved-req.md',
-      source: 'project',
-    });
-    (
-      parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
-    ).mockReturnValue(
-      mockParseResult({
-        frontmatter: { required: ['Step'] },
-      }),
-    );
-    // validateRequiredVars returns an error diagnostic for the reserved name
-    jest.mocked(validateRequiredVars).mockReturnValue([
-      {
-        severity: 'error',
-        message:
-          'Required variable "Step" uses reserved runtime variable name. Reserved names (case-insensitive): step, index, context',
-      },
-    ]);
-
-    const result = await prepareRunbook('reserved-req.md', {}, '/test');
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe('VALIDATION_ERROR');
-      expect(result.error).toContain('Step');
     }
   });
 

--- a/packages/cli/__tests__/helpers/test-utils.test.ts
+++ b/packages/cli/__tests__/helpers/test-utils.test.ts
@@ -27,8 +27,9 @@ describe('createRunbook', () => {
       });
       expect(md).toContain('---');
       expect(md).toContain('name: my-runbook');
-      expect(md).toContain('  env: staging');
-      expect(md).toContain('  port: 3000');
+      expect(md).toContain('inputs:');
+      expect(md).toContain('  - env');
+      expect(md).toContain('  - port');
     });
 
     it('renders custom title', () => {

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -804,7 +804,7 @@ export interface CreateRunbookOptions {
  */
 export function createRunbook(options: CreateRunbookOptions): string {
   const { name, vars, steps, title = 'Test' } = options;
-  const declaredInputs = Array.isArray(vars) ? vars : Object.keys(vars ?? {});
+  const declaredInputs: string[] = Array.isArray(vars) ? [...vars] : Object.keys(vars ?? {});
 
   const lines: string[] = [];
 

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -780,8 +780,8 @@ export interface StepConfig {
 export interface CreateRunbookOptions {
   /** Runbook name (appears in frontmatter) */
   name?: string;
-  /** Template variable declarations (appears in frontmatter inputs:) */
-  vars?: Record<string, string | number | boolean>;
+  /** Declared input names (appears in frontmatter inputs:) */
+  vars?: readonly string[] | Record<string, unknown>;
   /** Runbook steps */
   steps: StepConfig[];
   /** Custom title (defaults to 'Test') */
@@ -797,23 +797,24 @@ export interface CreateRunbookOptions {
  * @example
  * ```typescript
  * const content = createRunbook({
- *   vars: { message: 'hello' },
+ *   vars: ['message'],
  *   steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }]
  * });
  * ```
  */
 export function createRunbook(options: CreateRunbookOptions): string {
   const { name, vars, steps, title = 'Test' } = options;
+  const declaredInputs = Array.isArray(vars) ? vars : Object.keys(vars ?? {});
 
   const lines: string[] = [];
 
   // Frontmatter (only if name or vars present)
-  if (name || vars) {
+  if (name || declaredInputs.length > 0) {
     lines.push('---');
     if (name) lines.push(`name: ${name}`);
-    if (vars && Object.keys(vars).length > 0) {
+    if (declaredInputs.length > 0) {
       lines.push('inputs:');
-      for (const [key] of Object.entries(vars)) {
+      for (const key of declaredInputs) {
         lines.push(`  - ${key}`);
       }
     }

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -780,7 +780,7 @@ export interface StepConfig {
 export interface CreateRunbookOptions {
   /** Runbook name (appears in frontmatter) */
   name?: string;
-  /** Template variables (appears in frontmatter inputs:) */
+  /** Template variable declarations (appears in frontmatter inputs:) */
   vars?: Record<string, string | number | boolean>;
   /** Runbook steps */
   steps: StepConfig[];
@@ -813,8 +813,8 @@ export function createRunbook(options: CreateRunbookOptions): string {
     if (name) lines.push(`name: ${name}`);
     if (vars && Object.keys(vars).length > 0) {
       lines.push('inputs:');
-      for (const [key, value] of Object.entries(vars)) {
-        lines.push(`  ${key}: ${String(value)}`);
+      for (const [key] of Object.entries(vars)) {
+        lines.push(`  - ${key}`);
       }
     }
     lines.push('---');

--- a/packages/cli/__tests__/helpers/validate-frontmatter-vars.test.ts
+++ b/packages/cli/__tests__/helpers/validate-frontmatter-vars.test.ts
@@ -1,158 +1,5 @@
-import {
-  validateFrontmatterVars,
-  validateOutputsDeclarations,
-  validateRequiredVars,
-} from '../../src/helpers/validate-frontmatter-vars.js';
-
-describe('validateFrontmatterVars', () => {
-  it('returns empty array for undefined vars', () => {
-    expect(validateFrontmatterVars(undefined)).toEqual([]);
-  });
-
-  it('returns empty array for empty vars', () => {
-    expect(validateFrontmatterVars({})).toEqual([]);
-  });
-
-  it('returns empty array for non-reserved vars', () => {
-    expect(validateFrontmatterVars({ name: 'test', port: 3000 })).toEqual([]);
-  });
-
-  it('returns error for Step (case-insensitive)', () => {
-    const result = validateFrontmatterVars({ Step: 'custom' });
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('error');
-    expect(result[0].message).toContain('"Step"');
-    expect(result[0].message).toContain('reserved');
-  });
-
-  it('returns error for index (lowercase)', () => {
-    const result = validateFrontmatterVars({ index: 5 });
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('error');
-    expect(result[0].message).toContain('"index"');
-  });
-
-  it('returns error for CONTEXT (uppercase)', () => {
-    const result = validateFrontmatterVars({ CONTEXT: 'value' });
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('error');
-    expect(result[0].message).toContain('"CONTEXT"');
-  });
-
-  it('returns multiple errors for multiple reserved vars', () => {
-    const result = validateFrontmatterVars({ Step: 'a', Index: 'b', Context: 'c' });
-    expect(result).toHaveLength(3);
-    expect(result.every((d) => d.severity === 'error')).toBe(true);
-  });
-
-  it('allows built-in overridable vars (Date, Year, WorkPath)', () => {
-    const result = validateFrontmatterVars({
-      Date: '2025-01-01',
-      Year: '2025',
-      WorkPath: '.artifacts',
-    });
-    expect(result).toEqual([]);
-  });
-
-  it('returns errors only for reserved vars in a mixed set', () => {
-    const result = validateFrontmatterVars({
-      name: 'test',
-      Step: 'custom',
-      port: 3000,
-      Index: 5,
-    });
-    expect(result).toHaveLength(2);
-    const messages = result.map((d) => d.message);
-    expect(messages).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('"Step"'),
-        expect.stringContaining('"Index"'),
-      ]),
-    );
-  });
-
-  it('diagnostics have no line field', () => {
-    const result = validateFrontmatterVars({ Step: 'custom' });
-    expect(result[0]).not.toHaveProperty('line');
-  });
-});
-
-describe('validateRequiredVars', () => {
-  it('returns empty for undefined required', () => {
-    expect(validateRequiredVars(undefined, undefined)).toEqual([]);
-  });
-
-  it('returns empty for empty required array', () => {
-    expect(validateRequiredVars([], undefined)).toEqual([]);
-  });
-
-  it('returns empty for valid required with no overlap', () => {
-    expect(validateRequiredVars(['PlanPath'], { port: 3000 })).toEqual([]);
-  });
-
-  it('returns empty for valid required with no vars', () => {
-    expect(validateRequiredVars(['PlanPath', 'Target'], undefined)).toEqual([]);
-  });
-
-  it('returns error when name appears in both required and vars', () => {
-    const result = validateRequiredVars(['PlanPath'], { PlanPath: '' });
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('error');
-    expect(result[0].message).toContain('"PlanPath"');
-    expect(result[0].message).toContain('required');
-    expect(result[0].message).toContain('vars');
-  });
-
-  it('returns error for reserved runtime names', () => {
-    const result = validateRequiredVars(['Step'], undefined);
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('error');
-    expect(result[0].message).toContain('"Step"');
-    expect(result[0].message).toContain('reserved');
-  });
-
-  it('returns error for reserved names case-insensitively', () => {
-    const result = validateRequiredVars(['INDEX'], undefined);
-    expect(result).toHaveLength(1);
-    expect(result[0].message).toContain('"INDEX"');
-  });
-
-  it('returns error for invalid identifiers', () => {
-    const result = validateRequiredVars(['123invalid'], undefined);
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('error');
-    expect(result[0].message).toContain('not a valid identifier');
-  });
-
-  it('returns multiple errors for multiple violations', () => {
-    const result = validateRequiredVars(['Step', 'PlanPath', '123bad'], { PlanPath: '' });
-    expect(result).toHaveLength(3); // reserved + overlap + invalid
-  });
-
-  it('skips overlap check for invalid identifiers', () => {
-    // Invalid identifier gets only the invalid-id error, not also an overlap error
-    const result = validateRequiredVars(['123bad'], { '123bad': 'val' });
-    expect(result).toHaveLength(1);
-    expect(result[0].message).toContain('not a valid identifier');
-  });
-
-  it('returns error for duplicate entries', () => {
-    const result = validateRequiredVars(['PlanPath', 'PlanPath'], undefined);
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe('error');
-    expect(result[0].message).toContain('Duplicate');
-    expect(result[0].message).toContain('"PlanPath"');
-  });
-
-  it('skips further validation for duplicate entries', () => {
-    // Second occurrence only gets the duplicate error, not also overlap/reserved
-    const result = validateRequiredVars(['PlanPath', 'PlanPath'], { PlanPath: '' });
-    // First: overlap error. Second: duplicate error.
-    expect(result).toHaveLength(2);
-    expect(result[0].message).toContain('cannot be both');
-    expect(result[1].message).toContain('Duplicate');
-  });
-});
+import { describe, it, expect } from '@jest/globals';
+import { validateOutputsDeclarations } from '../../src/helpers/validate-frontmatter-vars.js';
 
 describe('validateOutputsDeclarations', () => {
   it('returns empty array for undefined outputs', () => {
@@ -179,30 +26,6 @@ describe('validateOutputsDeclarations', () => {
     expect(result[0].message.toLowerCase()).toContain('duplicate');
   });
 
-  it('allows output that references an existing input (pass-through use-case)', () => {
-    const result = validateOutputsDeclarations([{ name: 'PlanPath' }], {
-      PlanPath: '/default/plan.json',
-    });
-    expect(result).toEqual([]);
-  });
-
-  it('allows output that shares a name with an input (no conflict)', () => {
-    const result = validateOutputsDeclarations([{ name: 'PlanPath' }], {
-      PlanPath: 'default.json',
-    });
-    expect(result).toEqual([]);
-  });
-
-  it('flags only the duplicate error for repeated output names even when input name matches', () => {
-    // Both entries share a name with an input. First entry: no error (input overlap allowed).
-    // Second entry: duplicate error only.
-    const result = validateOutputsDeclarations([{ name: 'PlanPath' }, { name: 'PlanPath' }], {
-      PlanPath: 'default.json',
-    });
-    expect(result).toHaveLength(1);
-    expect(result[0].message.toLowerCase()).toContain('duplicate');
-  });
-
   it('returns error for reserved runtime names', () => {
     const result = validateOutputsDeclarations([{ name: 'Step' }]);
     expect(result).toHaveLength(1);
@@ -220,7 +43,6 @@ describe('validateOutputsDeclarations', () => {
   });
 
   it('reports both reserved error and duplicate error when same reserved name repeated', () => {
-    // First occurrence: reserved error. Second occurrence: duplicate error (seen set short-circuits).
     const result = validateOutputsDeclarations([{ name: 'Step' }, { name: 'Step' }]);
     expect(result).toHaveLength(2);
     const messages = result.map((d) => d.message);

--- a/packages/cli/__tests__/helpers/validate-frontmatter-vars.test.ts
+++ b/packages/cli/__tests__/helpers/validate-frontmatter-vars.test.ts
@@ -21,6 +21,18 @@ describe('validateFrontmatterVars', () => {
     expect(result[0].message).toContain('"Step"');
     expect(result[1].message).toContain('"Context"');
   });
+
+  it('returns error for reserved runtime names case-insensitively', () => {
+    const result = validateFrontmatterVars({ sTeP: '1', cOnTeXt: 'ctx' });
+    expect(result).toHaveLength(2);
+    expect(result.every((diagnostic) => diagnostic.severity === 'error')).toBe(true);
+    expect(result.map((diagnostic) => diagnostic.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('"sTeP"'),
+        expect.stringContaining('"cOnTeXt"'),
+      ]),
+    );
+  });
 });
 
 describe('validateRequiredVars', () => {
@@ -43,14 +55,17 @@ describe('validateRequiredVars', () => {
 
   it('returns error for reserved names and vars overlap', () => {
     const result = validateRequiredVars(['Step', 'PlanPath'], { PlanPath: 'value' });
-    expect(result).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ message: expect.stringContaining('reserved runtime variable') }),
-        expect.objectContaining({
-          message: expect.stringContaining('cannot be both in "required" and "vars"'),
-        }),
-      ]),
-    );
+    expect(result).toHaveLength(2);
+    expect(result).toEqual([
+      expect.objectContaining({
+        severity: 'error',
+        message: expect.stringContaining('reserved runtime variable'),
+      }),
+      expect.objectContaining({
+        severity: 'error',
+        message: expect.stringContaining('cannot be both in "required" and "vars"'),
+      }),
+    ]);
   });
 });
 

--- a/packages/cli/__tests__/helpers/validate-frontmatter-vars.test.ts
+++ b/packages/cli/__tests__/helpers/validate-frontmatter-vars.test.ts
@@ -1,5 +1,58 @@
 import { describe, it, expect } from '@jest/globals';
-import { validateOutputsDeclarations } from '../../src/helpers/validate-frontmatter-vars.js';
+import {
+  validateFrontmatterVars,
+  validateRequiredVars,
+  validateOutputsDeclarations,
+} from '../../src/helpers/validate-frontmatter-vars.js';
+
+describe('validateFrontmatterVars', () => {
+  it('returns empty array for undefined vars', () => {
+    expect(validateFrontmatterVars(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for non-reserved vars', () => {
+    expect(validateFrontmatterVars({ PlanPath: 'value', Region: 'us-west' })).toEqual([]);
+  });
+
+  it('returns error for reserved runtime names', () => {
+    const result = validateFrontmatterVars({ Step: '1', Context: 'ctx' });
+    expect(result).toHaveLength(2);
+    expect(result[0].severity).toBe('error');
+    expect(result[0].message).toContain('"Step"');
+    expect(result[1].message).toContain('"Context"');
+  });
+});
+
+describe('validateRequiredVars', () => {
+  it('returns empty array for undefined required list', () => {
+    expect(validateRequiredVars(undefined, undefined)).toEqual([]);
+  });
+
+  it('returns error for duplicate required names', () => {
+    const result = validateRequiredVars(['PlanPath', 'PlanPath'], undefined);
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toContain('Duplicate entry "PlanPath"');
+  });
+
+  it('returns error for poisoned or invalid identifiers', () => {
+    const result = validateRequiredVars(['__proto__', 'bad-name'], undefined);
+    expect(result).toHaveLength(2);
+    expect(result[0].message).toContain('not a valid identifier');
+    expect(result[1].message).toContain('not a valid identifier');
+  });
+
+  it('returns error for reserved names and vars overlap', () => {
+    const result = validateRequiredVars(['Step', 'PlanPath'], { PlanPath: 'value' });
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining('reserved runtime variable') }),
+        expect.objectContaining({
+          message: expect.stringContaining('cannot be both in "required" and "vars"'),
+        }),
+      ]),
+    );
+  });
+});
 
 describe('validateOutputsDeclarations', () => {
   it('returns empty array for undefined outputs', () => {

--- a/packages/cli/__tests__/integration/for-loop-variables.test.ts
+++ b/packages/cli/__tests__/integration/for-loop-variables.test.ts
@@ -394,7 +394,7 @@ describe('Per-step variable expansion ({{Step}}, {{Index}}, FOR loop variables)'
     });
     await writeFile(join(workspace.cwd, 'for-var-bounds.runbook.md'), content);
 
-    const result = runCli('run for-var-bounds.runbook.md', workspace);
+    const result = runCli('run for-var-bounds.runbook.md --input Max=3', workspace);
     expect(result.exitCode).toBe(0);
 
     const events = result.stdout

--- a/packages/cli/__tests__/integration/frontmatter-outputs.test.ts
+++ b/packages/cli/__tests__/integration/frontmatter-outputs.test.ts
@@ -219,7 +219,7 @@ describe('frontmatter outputs — rd status includes vars field', () => {
     const RUNBOOK = `---
 name: fm-status-vars-test
 inputs:
-  environment: staging
+  - environment
 ---
 # Status Vars Test
 
@@ -229,10 +229,10 @@ Waiting for manual pass.
     await writeFile(join(workspace.cwd, 'status-vars.runbook.md'), RUNBOOK);
 
     // Start runbook — pauses at step 1 (no command block).
-    const startResult = runCli('run status-vars.runbook.md', workspace);
+    const startResult = runCli('run status-vars.runbook.md --input environment=staging', workspace);
     expect(startResult.exitCode).toBe(0);
 
-    // Check that rd status includes vars field with frontmatter defaults.
+    // Check that rd status includes vars field with resolved inputs.
     const statusResult = runCli('status', workspace);
     expect(statusResult.exitCode).toBe(0);
 

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -528,7 +528,10 @@ describe('Inline linkage integration (rd run --step)', () => {
       await writeParentRunbook({ Region: 'us-west' });
       await writePassingChild();
 
-      let result = await runCliInProcess('run --prompted parent.runbook.md --text', workspace);
+      let result = await runCliInProcess(
+        'run --prompted parent.runbook.md --input Region=us-west --text',
+        workspace,
+      );
       expect(result.exitCode).toBe(0);
 
       const parentState = await getActiveState(workspace);
@@ -568,7 +571,10 @@ describe('Inline linkage integration (rd run --step)', () => {
       await writeParentRunbook({ AppName: 'rundown' });
       await writePassingChild();
 
-      let result = await runCliInProcess('run --prompted parent.runbook.md --text', workspace);
+      let result = await runCliInProcess(
+        'run --prompted parent.runbook.md --input AppName=rundown --text',
+        workspace,
+      );
       expect(result.exitCode).toBe(0);
 
       const parentState = await getActiveState(workspace);
@@ -588,7 +594,10 @@ describe('Inline linkage integration (rd run --step)', () => {
       await writeParentRunbook({ Region: 'us-west' });
       await writePassingChild();
 
-      let result = await runCliInProcess('run --prompted parent.runbook.md --text', workspace);
+      let result = await runCliInProcess(
+        'run --prompted parent.runbook.md --input Region=us-west --text',
+        workspace,
+      );
       expect(result.exitCode).toBe(0);
 
       const parentState = await getActiveState(workspace);

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -160,6 +160,9 @@ name: policy-enforced-capture
 ---
 # Policy Enforced Capture
 
+inputs:
+  - Captured
+
 ## 1. Capture
 - OUTPUTS
   - Captured
@@ -201,6 +204,9 @@ printf 'policy-captured' > "$RD_OUTPUTS_Captured"
 name: policy-enforced-capture
 ---
 # Policy Enforced Capture
+
+inputs:
+  - Captured
 
 ## 1. Capture
 - OUTPUTS
@@ -404,6 +410,8 @@ printf 'inner-value' > "$RD_OUTPUTS_Inner"
 name: substep-in-for-capture
 required:
   - items
+inputs:
+  - items
 ---
 # Substep In FOR Capture
 
@@ -463,6 +471,8 @@ printf "%s" "{{ item }}" > "$RD_OUTPUTS_Inner"
     const RUNBOOK = `---
 name: step-for-single-substep
 required:
+  - items
+inputs:
   - items
 ---
 # Step FOR Single Substep
@@ -559,6 +569,8 @@ printf 'should-not-capture' > "$RD_OUTPUTS_Blocked"
     const RUNBOOK = `---
 name: for-fail-midway
 required:
+  - items
+inputs:
   - items
 ---
 # FOR Fail Midway

--- a/packages/cli/__tests__/integration/template-variables.test.ts
+++ b/packages/cli/__tests__/integration/template-variables.test.ts
@@ -105,16 +105,16 @@ describe('Template Variables Integration', () => {
     });
   });
 
-  describe('frontmatter vars precedence', () => {
-    it('uses frontmatter vars when no other source provides value', async () => {
+  describe('frontmatter inputs precedence', () => {
+    it('uses declared inputs when supplied via --input', async () => {
       const runbookContent = createRunbook({
         name: 'test-runbook',
-        vars: { message: 'from-frontmatter' },
+        vars: { message: 'from-input' },
         steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }],
       });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
 
-      const result = runCli('run test.runbook.md', workspace);
+      const result = runCli('run test.runbook.md --input message=from-input', workspace);
 
       expect(result.exitCode).toBe(0);
 
@@ -122,32 +122,13 @@ describe('Template Variables Integration', () => {
       const commandStartedEvent = events.find((e) => e.type === 'command_started');
 
       expect(commandStartedEvent).toBeDefined();
-      expect(commandStartedEvent!.command).toBe('rd echo from-frontmatter');
+      expect(commandStartedEvent!.command).toBe('rd echo from-input');
     });
 
-    it('--input overrides frontmatter vars', async () => {
+    it('--input-file overrides declared inputs', async () => {
       const runbookContent = createRunbook({
         name: 'test-runbook',
-        vars: { message: 'from-frontmatter' },
-        steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }],
-      });
-      await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
-
-      const result = runCli('run test.runbook.md --input message=from-flag', workspace);
-
-      expect(result.exitCode).toBe(0);
-
-      const events = parseJsonlEvents(result.stdout);
-      const commandStartedEvent = events.find((e) => e.type === 'command_started');
-
-      expect(commandStartedEvent).toBeDefined();
-      expect(commandStartedEvent!.command).toBe('rd echo from-flag');
-    });
-
-    it('--input-file overrides frontmatter vars', async () => {
-      const runbookContent = createRunbook({
-        name: 'test-runbook',
-        vars: { message: 'from-frontmatter' },
+        vars: { message: 'from-input' },
         steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }],
       });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
@@ -164,10 +145,10 @@ describe('Template Variables Integration', () => {
       expect(commandStartedEvent!.command).toBe('rd echo from-file');
     });
 
-    it('config.yaml overrides frontmatter vars', async () => {
+    it('config.yaml overrides declared inputs', async () => {
       const runbookContent = createRunbook({
         name: 'test-runbook',
-        vars: { message: 'from-frontmatter' },
+        vars: { message: 'from-input' },
         steps: [{ title: 'Echo', pass: 'COMPLETE', command: 'rd echo {{message}}' }],
       });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
@@ -187,7 +168,7 @@ describe('Template Variables Integration', () => {
       expect(commandStartedEvent!.command).toBe('rd echo from-config');
     });
 
-    it('frontmatter vars work with multiple variables', async () => {
+    it('declared inputs work with multiple variables', async () => {
       const runbookContent = createRunbook({
         name: 'test-runbook',
         vars: { greeting: 'Hello', name: 'World', count: 42 },
@@ -197,7 +178,10 @@ describe('Template Variables Integration', () => {
       });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
 
-      const result = runCli('run test.runbook.md', workspace);
+      const result = runCli(
+        'run test.runbook.md --input greeting=Hello --input name=World --input count=42',
+        workspace,
+      );
 
       expect(result.exitCode).toBe(0);
 
@@ -208,7 +192,7 @@ describe('Template Variables Integration', () => {
       expect(commandStartedEvent!.command).toBe('rd echo "Hello World 42"');
     });
 
-    it('--input partially overrides frontmatter vars (other vars use defaults)', async () => {
+    it('--input partially overrides values from --input-file', async () => {
       const runbookContent = createRunbook({
         name: 'test-runbook',
         vars: { greeting: 'Hello', count: 42 },
@@ -221,8 +205,12 @@ describe('Template Variables Integration', () => {
         ],
       });
       await writeFile(join(workspace.cwd, 'test.runbook.md'), runbookContent);
+      await writeFile(join(workspace.cwd, 'vars.yaml'), 'greeting: Hello\ncount: 42');
 
-      const result = runCli('run test.runbook.md --input greeting=Hi', workspace);
+      const result = runCli(
+        'run test.runbook.md --input-file vars.yaml --input greeting=Hi',
+        workspace,
+      );
 
       expect(result.exitCode).toBe(0);
 
@@ -230,13 +218,10 @@ describe('Template Variables Integration', () => {
       const commandStartedEvent = events.find((e) => e.type === 'command_started');
 
       expect(commandStartedEvent).toBeDefined();
-      // greeting overridden to "Hi", count stays at frontmatter default "42"
       expect(commandStartedEvent!.command).toBe('rd echo "Hi, count is 42"');
     });
 
-    it('frontmatter vars work in child runbooks', async () => {
-      // Test frontmatter vars by running child runbook directly (not via Mode 3)
-      // This verifies the vars are extracted and applied during run
+    it('declared inputs work in child runbooks', async () => {
       const childRunbook = createRunbook({
         name: 'child-runbook',
         vars: { task_name: 'DefaultTask' },
@@ -246,11 +231,9 @@ describe('Template Variables Integration', () => {
 
       await writeFile(join(workspace.cwd, 'child.runbook.md'), childRunbook);
 
-      // Run child runbook directly (JSON is default) to capture JSONL events
-      const result = runCli('run child.runbook.md', workspace);
+      const result = runCli('run child.runbook.md --input task_name=DefaultTask', workspace);
       expect(result.exitCode).toBe(0);
 
-      // Verify the command was expanded with the frontmatter default variable
       const events = parseJsonlEvents(result.stdout);
       const commandStartedEvent = events.find((e) => e.type === 'command_started');
       expect(commandStartedEvent).toBeDefined();

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -478,31 +478,6 @@ describe('resolveVariables', () => {
     });
   });
 
-  describe('frontmatter vars', () => {
-    it('uses pre-extracted frontmatterVars', async () => {
-      const result = await resolveVariables(
-        { frontmatterVars: { greeting: 'Hello', count: 42 } },
-        tmpDir,
-      );
-      expect(result.vars.greeting).toBe('Hello');
-      expect(result.vars.count).toBe(42);
-    });
-
-    it('returns no frontmatter vars when frontmatterVars is undefined', async () => {
-      const result = await resolveVariables({}, tmpDir);
-      // Only built-in vars should be present
-      expect(result.vars.greeting).toBeUndefined();
-    });
-
-    it('CLI --input overrides frontmatter vars', async () => {
-      const result = await resolveVariables(
-        { frontmatterVars: { env: 'development' }, input: ['env=production'] },
-        tmpDir,
-      );
-      expect(result.vars.env).toBe('production');
-    });
-  });
-
   describe('reserved runtime keys', () => {
     it('rejects reserved keys with an error', async () => {
       await expect(resolveVariables({ input: ['Step=shadow'] }, tmpDir)).rejects.toThrow(
@@ -660,38 +635,30 @@ describe('resolveVariables', () => {
     });
   });
 
-  describe('frontmatter routing', () => {
-    // Frontmatter vars are typed Record<string, string | number | boolean> by the
-    // parser's Zod schema — arrays are intentionally excluded. Array routing is
-    // tested via config/var-file layers in the YAML array/multiline tests above.
-    it('routes frontmatter scalar to vars only', async () => {
-      const result = await resolveVariables({ frontmatterVars: { env: 'staging' } }, tmpDir);
-      expect(result.vars.env).toBe('staging');
-    });
-  });
-
   describe('inherited vars', () => {
     it('inherited vars override builtins', async () => {
       const result = await resolveVariables({ inheritedVars: { ContextId: 'parent123' } }, tmpDir);
       expect(result.vars.ContextId).toBe('parent123');
     });
 
-    it('frontmatter overrides inherited vars', async () => {
+    it('config overrides inherited vars', async () => {
+      const configDir = path.join(tmpDir, RUNDOWN_DIR);
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(path.join(configDir, 'config.yaml'), 'myVar: config\n');
+
       const result = await resolveVariables(
         {
           inheritedVars: { myVar: 'inherited' },
-          frontmatterVars: { myVar: 'frontmatter' },
         },
         tmpDir,
       );
-      expect(result.vars.myVar).toBe('frontmatter');
+      expect(result.vars.myVar).toBe('config');
     });
 
     it('inherited ContextId survives when child has no override', async () => {
       const result = await resolveVariables(
         {
           inheritedVars: { ContextId: 'parent123' },
-          frontmatterVars: { otherVar: 'value' },
         },
         tmpDir,
       );
@@ -750,14 +717,15 @@ describe('resolveVariables', () => {
       });
     });
 
-    it('input-file array overrides frontmatter scalar', async () => {
+    it('input-file array overrides discovered config scalar', async () => {
       const varFile = path.join(tmpDir, 'vars.yaml');
       await fs.writeFile(varFile, 'servers:\n  - a\n  - b\n');
 
-      const result = await resolveVariables(
-        { frontmatterVars: { servers: 'single' }, inputFile: [varFile] },
-        tmpDir,
-      );
+      const configDir = path.join(tmpDir, RUNDOWN_DIR);
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(path.join(configDir, 'config.yaml'), 'servers: single\n');
+
+      const result = await resolveVariables({ inputFile: [varFile] }, tmpDir);
       expect(result.vars.servers).toEqual(['a', 'b']);
     });
 

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -815,6 +815,18 @@ describe('resolveVariables', () => {
       expect(result.providedKeys.has('data')).toBe(false);
     });
 
+    it('does not count a rejected external value when a builtin already exists', async () => {
+      const nested = path.join(tmpDir, 'project');
+      await fs.mkdir(nested, { recursive: true });
+
+      const result = await resolveVariables({ input: ['Date=file:../escape.txt'] }, nested);
+      expect(result.vars).toHaveProperty('Date');
+      expect(result.providedKeys.has('Date')).toBe(false);
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([expect.stringContaining('path escapes project directory')]),
+      );
+    });
+
     it('includes accepted file source in providedKeys', async () => {
       const file = path.join(tmpDir, 'data.json');
       await fs.writeFile(file, '["ok"]');

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -641,7 +641,7 @@ describe('resolveVariables', () => {
       expect(result.vars.ContextId).toBe('parent123');
     });
 
-    it('config overrides inherited vars', async () => {
+    it('inherited vars override discovered config', async () => {
       const configDir = path.join(tmpDir, RUNDOWN_DIR);
       await fs.mkdir(configDir, { recursive: true });
       await fs.writeFile(path.join(configDir, 'config.yaml'), 'myVar: config\n');
@@ -652,7 +652,21 @@ describe('resolveVariables', () => {
         },
         tmpDir,
       );
-      expect(result.vars.myVar).toBe('config');
+      expect(result.vars.myVar).toBe('inherited');
+    });
+
+    it('inherited ContextId survives discovered config override', async () => {
+      const configDir = path.join(tmpDir, RUNDOWN_DIR);
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(path.join(configDir, 'config.yaml'), 'ContextId: config123\n');
+
+      const result = await resolveVariables(
+        {
+          inheritedVars: { ContextId: 'parent123' },
+        },
+        tmpDir,
+      );
+      expect(result.vars.ContextId).toBe('parent123');
     });
 
     it('inherited ContextId survives when child has no override', async () => {

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -59,11 +59,7 @@ import {
   collectUnresolvedRunbookVariables,
 } from '../services/template-renderer.js';
 import { getPolicyEvaluator, getPolicyPrompter } from '../services/policy-context.js';
-import {
-  validateFrontmatterVars,
-  validateRequiredVars,
-  validateOutputsDeclarations,
-} from './validate-frontmatter-vars.js';
+import { validateOutputsDeclarations } from './validate-frontmatter-vars.js';
 import { getHelperRegistry, detectHelperCollisions } from '../services/helper-registry.js';
 
 /**
@@ -370,15 +366,10 @@ export async function loadAndParseRunbook(file: string, cwd: string): Promise<Lo
       diagnostics: parseDiagnostics,
     } = parseRunbookDocument(rawContent, path.basename(filePath));
 
-    const varDiagnostics = validateFrontmatterVars(frontmatter?.inputs);
-    const fmRequired = frontmatter?.required;
     const fmOutputs = frontmatter?.outputs;
-    const requiredDiagnostics = validateRequiredVars(fmRequired, frontmatter?.inputs);
-    const outputsDiagnostics = validateOutputsDeclarations(fmOutputs, frontmatter?.inputs);
+    const outputsDiagnostics = validateOutputsDeclarations(fmOutputs);
     const diagnostics: readonly ValidationDiagnostic[] = [
       ...parseDiagnostics,
-      ...varDiagnostics,
-      ...requiredDiagnostics,
       ...outputsDiagnostics,
     ];
 
@@ -465,7 +456,6 @@ export async function prepareRunbook(
         inputFile: inputOpts.inputFile,
         input: inputOpts.input,
         inputJson: inputOpts.inputJson,
-        frontmatterVars: frontmatter?.inputs,
         inheritedVars: inheritedUserVars,
       },
       cwd,

--- a/packages/cli/src/helpers/validate-frontmatter-vars.ts
+++ b/packages/cli/src/helpers/validate-frontmatter-vars.ts
@@ -1,8 +1,87 @@
 import type { OutputDeclaration, ValidationDiagnostic } from '@rundown-org/parser';
 import {
   isRuntimeReservedVariable,
+  isValidVariableName,
   RUNTIME_RESERVED_VARIABLES,
 } from '../services/variable-discovery.js';
+
+/**
+ * Validate frontmatter vars against runtime-reserved variable names.
+ *
+ * Returns error diagnostics for any vars that collide with reserved names
+ * like `Step`, `Index`, or `Context` (case-insensitive).
+ *
+ * @param vars - The frontmatter `vars` object, or undefined if absent
+ * @returns Array of validation diagnostics (errors only)
+ */
+export function validateFrontmatterVars(
+  vars: Record<string, string | number | boolean> | undefined,
+): ValidationDiagnostic[] {
+  if (!vars) return [];
+  const diagnostics: ValidationDiagnostic[] = [];
+  for (const key of Object.keys(vars)) {
+    if (isRuntimeReservedVariable(key)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Frontmatter var "${key}" uses reserved runtime variable name. Reserved names (case-insensitive): ${[...RUNTIME_RESERVED_VARIABLES].join(', ')}`,
+      });
+    }
+  }
+  return diagnostics;
+}
+
+/**
+ * Validate frontmatter `required` field against vars and reserved names.
+ *
+ * Returns error diagnostics for:
+ * - Names appearing in both `required` and `vars` (required vars must not have defaults)
+ * - Reserved runtime names (step, index, context — case-insensitive)
+ * - Invalid variable identifiers
+ *
+ * @param required - The frontmatter `required` array, or undefined if absent
+ * @param vars - The frontmatter `vars` object, or undefined if absent
+ * @returns Array of validation diagnostics (errors only)
+ */
+export function validateRequiredVars(
+  required: string[] | undefined,
+  vars: Record<string, string | number | boolean> | undefined,
+): ValidationDiagnostic[] {
+  if (!required || required.length === 0) return [];
+  const diagnostics: ValidationDiagnostic[] = [];
+  const varsKeys = new Set(Object.keys(vars ?? {}));
+  const seen = new Set<string>();
+
+  for (const name of required) {
+    if (seen.has(name)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Duplicate entry "${name}" in "required" — each variable should be listed once`,
+      });
+      continue;
+    }
+    seen.add(name);
+    if (!isValidVariableName(name)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Required variable "${name}" is not a valid identifier`,
+      });
+      continue;
+    }
+    if (isRuntimeReservedVariable(name)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Required variable "${name}" uses reserved runtime variable name. Reserved names (case-insensitive): ${[...RUNTIME_RESERVED_VARIABLES].join(', ')}`,
+      });
+    }
+    if (varsKeys.has(name)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Variable "${name}" cannot be both in "required" and "vars" — required variables must not have defaults`,
+      });
+    }
+  }
+  return diagnostics;
+}
 
 /**
  * Validate frontmatter `outputs` field against reserved names.
@@ -12,10 +91,12 @@ import {
  * - Reserved runtime names (step, index, context — case-insensitive)
  *
  * @param outputs - Parsed output declarations from frontmatter, or undefined if absent
+ * @param _vars - The frontmatter `vars` object, or undefined if absent (reserved for future use)
  * @returns Array of validation diagnostics (errors only)
  */
 export function validateOutputsDeclarations(
   outputs: OutputDeclaration[] | undefined,
+  _vars?: Record<string, string | number | boolean>,
 ): ValidationDiagnostic[] {
   if (!outputs || outputs.length === 0) return [];
 

--- a/packages/cli/src/helpers/validate-frontmatter-vars.ts
+++ b/packages/cli/src/helpers/validate-frontmatter-vars.ts
@@ -1,87 +1,8 @@
 import type { OutputDeclaration, ValidationDiagnostic } from '@rundown-org/parser';
 import {
   isRuntimeReservedVariable,
-  isValidVariableName,
   RUNTIME_RESERVED_VARIABLES,
 } from '../services/variable-discovery.js';
-
-/**
- * Validate frontmatter vars against runtime-reserved variable names.
- *
- * Returns error diagnostics for any vars that collide with reserved names
- * like `Step`, `Index`, or `Context` (case-insensitive).
- *
- * @param vars - The frontmatter `vars` object, or undefined if absent
- * @returns Array of validation diagnostics (errors only)
- */
-export function validateFrontmatterVars(
-  vars: Record<string, string | number | boolean> | undefined,
-): ValidationDiagnostic[] {
-  if (!vars) return [];
-  const diagnostics: ValidationDiagnostic[] = [];
-  for (const key of Object.keys(vars)) {
-    if (isRuntimeReservedVariable(key)) {
-      diagnostics.push({
-        severity: 'error',
-        message: `Frontmatter var "${key}" uses reserved runtime variable name. Reserved names (case-insensitive): ${[...RUNTIME_RESERVED_VARIABLES].join(', ')}`,
-      });
-    }
-  }
-  return diagnostics;
-}
-
-/**
- * Validate frontmatter `required` field against vars and reserved names.
- *
- * Returns error diagnostics for:
- * - Names appearing in both `required` and `vars` (required vars must not have defaults)
- * - Reserved runtime names (step, index, context — case-insensitive)
- * - Invalid variable identifiers
- *
- * @param required - The frontmatter `required` array, or undefined if absent
- * @param vars - The frontmatter `vars` object, or undefined if absent
- * @returns Array of validation diagnostics (errors only)
- */
-export function validateRequiredVars(
-  required: string[] | undefined,
-  vars: Record<string, string | number | boolean> | undefined,
-): ValidationDiagnostic[] {
-  if (!required || required.length === 0) return [];
-  const diagnostics: ValidationDiagnostic[] = [];
-  const varsKeys = new Set(Object.keys(vars ?? {}));
-  const seen = new Set<string>();
-
-  for (const name of required) {
-    if (seen.has(name)) {
-      diagnostics.push({
-        severity: 'error',
-        message: `Duplicate entry "${name}" in "required" — each variable should be listed once`,
-      });
-      continue;
-    }
-    seen.add(name);
-    if (!isValidVariableName(name)) {
-      diagnostics.push({
-        severity: 'error',
-        message: `Required variable "${name}" is not a valid identifier`,
-      });
-      continue;
-    }
-    if (isRuntimeReservedVariable(name)) {
-      diagnostics.push({
-        severity: 'error',
-        message: `Required variable "${name}" uses reserved runtime variable name. Reserved names (case-insensitive): ${[...RUNTIME_RESERVED_VARIABLES].join(', ')}`,
-      });
-    }
-    if (varsKeys.has(name)) {
-      diagnostics.push({
-        severity: 'error',
-        message: `Variable "${name}" cannot be both in "required" and "vars" — required variables must not have defaults`,
-      });
-    }
-  }
-  return diagnostics;
-}
 
 /**
  * Validate frontmatter `outputs` field against reserved names.
@@ -91,12 +12,10 @@ export function validateRequiredVars(
  * - Reserved runtime names (step, index, context — case-insensitive)
  *
  * @param outputs - Parsed output declarations from frontmatter, or undefined if absent
- * @param _vars - The frontmatter `vars` object, or undefined if absent (reserved for future use)
  * @returns Array of validation diagnostics (errors only)
  */
 export function validateOutputsDeclarations(
   outputs: OutputDeclaration[] | undefined,
-  _vars?: Record<string, string | number | boolean>,
 ): ValidationDiagnostic[] {
   if (!outputs || outputs.length === 0) return [];
 

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -541,6 +541,7 @@ async function loadJsonFile(canonical: string): Promise<JsonObject | JsonArray> 
  * @param projectRoot - Canonical project root path (pre-resolved)
  * @param security - Optional security context for file source policy enforcement
  * @param warnings - Optional array to collect routing warnings
+ * @returns `true` if the value was routed into `vars`; `false` if skipped (e.g., file path escapes project root)
  */
 async function routeVariable(
   key: string,

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -692,20 +692,18 @@ function collectEnvBridgeVars(warnings?: string[]): Record<string, unknown> {
  * ```
  * Layer 0: builtins        ← Date, Branch, WorkPath, RunId, ContextId (fresh)
  * Layer 1: inheritedVars   ← parent delegation vars (overrides builtins)
- * Layer 2: frontmatter     ← runbook YAML frontmatter vars:
- * Layer 3: discovered      ← .rundown/config.yaml (auto-discovered)
- * Layer 4: envBridge        ← RD_INPUT_* environment variables
- * Layer 5: cliFlags        ← --input-file, --input, --input-json (highest precedence)
+ * Layer 2: discovered      ← .rundown/config.yaml (auto-discovered)
+ * Layer 3: envBridge       ← RD_INPUT_* environment variables
+ * Layer 4: cliFlags        ← --input-file, --input, --input-json (highest precedence)
  * ```
  *
  * The inherited layer ensures that parent ContextId survives into child
  * runbooks during delegation, rather than being replaced by a fresh builtin.
  *
- * @param options - Variable sources from CLI flags, input-file, frontmatter vars, and inherited vars
+ * @param options - Variable sources from CLI flags, input-file, and inherited vars
  * @param options.inputFile - Array of paths to YAML files containing variable definitions (repeatable)
  * @param options.input - Array of key=value flag strings from CLI
  * @param options.inputJson - Array of key=json flag strings from CLI for structured values
- * @param options.frontmatterVars - Pre-extracted frontmatter vars (from parser's validated RunbookFrontmatter)
  * @param options.inheritedVars - Variables inherited from parent delegation
  * @param cwd - Current working directory for resolving relative paths
  * @param warnings - Optional array to collect discovery warnings
@@ -716,7 +714,6 @@ async function collectRawLayers(
     inputFile?: string[];
     input?: string[];
     inputJson?: string[];
-    frontmatterVars?: Record<string, string | number | boolean>;
     inheritedVars?: Record<string, TemplateVarValue>;
   },
   cwd: string,
@@ -728,19 +725,16 @@ async function collectRawLayers(
   // Layer 1: Inherited vars from parent delegation (overrides builtins)
   const inherited: Record<string, unknown> = options.inheritedVars ?? {};
 
-  // Layer 2: Frontmatter vars — pre-extracted from parser's validated RunbookFrontmatter
-  const frontmatter: Record<string, unknown> = options.frontmatterVars ?? {};
-
-  // Layer 3: Auto-discovered config
+  // Layer 2: Auto-discovered config
   const discovered: Record<string, unknown> = await discoverRawVariables(cwd);
 
-  // Layer 4: Environment bridge (RD_INPUT_* env vars)
+  // Layer 3: Environment bridge (RD_INPUT_* env vars)
   const envBridge = collectEnvBridgeVars(warnings);
 
-  // Layer 5: CLI flags (--input-file, --input, --input-json merged)
+  // Layer 4: CLI flags (--input-file, --input, --input-json merged)
   const cliFlags = await collectCliFlags(options, cwd);
 
-  return [builtins, inherited, frontmatter, discovered, envBridge, cliFlags];
+  return [builtins, inherited, discovered, envBridge, cliFlags];
 }
 
 /**
@@ -797,12 +791,11 @@ async function enforceFileSourcePolicy(
  * Processes variable layers in precedence order (lowest to highest):
  * 1. Built-in defaults (Date, DateTime, Year, Month, Day, Branch, WorkPath, RunId, ContextId)
  * 1b. Inherited vars from parent delegation (overrides builtins)
- * 2. Frontmatter vars
- * 3. Auto-discovered .rundown/config.yaml
- * 3b. Environment bridge (RD_INPUT_* env vars)
- * 4. --input-file contents (repeatable, later overrides earlier)
- * 5. --input flags
- * 6. --input-json flags (highest precedence)
+ * 2. Auto-discovered .rundown/config.yaml
+ * 2b. Environment bridge (RD_INPUT_* env vars)
+ * 3. --input-file contents (repeatable, later overrides earlier)
+ * 4. --input flags
+ * 5. --input-json flags (highest precedence)
  *
  * Each variable value is routed into `vars` based on its type:
  * - String with `file:` prefix → JsonArrayStream (.jsonl) or JsonArray/JsonObject (.json)
@@ -811,11 +804,10 @@ async function enforceFileSourcePolicy(
  * - Number → preserved, not stringified
  * - Other scalar (boolean, null, plain string) → stringified
  *
- * @param options - Variable sources from CLI flags, input-file, frontmatter vars, and inherited vars
+ * @param options - Variable sources from CLI flags, input-file, and inherited vars
  * @param options.inputFile - Array of paths to YAML files containing variable definitions (repeatable)
  * @param options.input - Array of key=value flag strings from CLI
  * @param options.inputJson - Array of key=json flag strings from CLI for structured values
- * @param options.frontmatterVars - Pre-extracted frontmatter vars (from parser's validated RunbookFrontmatter)
  * @param options.inheritedVars - Variables inherited from parent delegation (overrides builtins)
  * @param cwd - Current working directory for resolving relative paths
  * @param security - Optional security context for file source policy enforcement
@@ -828,7 +820,6 @@ export async function resolveVariables(
     inputFile?: string[];
     input?: string[];
     inputJson?: string[];
-    frontmatterVars?: Record<string, string | number | boolean>;
     inheritedVars?: Record<string, TemplateVarValue>;
   },
   cwd: string,
@@ -843,10 +834,10 @@ export async function resolveVariables(
   // Collect raw inputs at each precedence level
   const layers = await collectRawLayers(options, cwd, warnings);
 
-  // External provider layer indices — excludes builtins (0) and frontmatter (2).
+  // External provider layer indices — excludes builtins (0).
   // Used to track which keys were actually accepted via routing for `required` var validation.
-  // Indices must match collectRawLayers ordering: 1=inherited, 3=config, 4=env, 5=CLI.
-  const EXTERNAL_PROVIDER_INDICES = new Set([1, 3, 4, 5]);
+  // Indices must match collectRawLayers ordering: 1=inherited, 2=config, 3=env, 4=CLI.
+  const EXTERNAL_PROVIDER_INDICES = new Set([1, 2, 3, 4]);
   const providedKeys = new Set<string>();
 
   // Process each layer in precedence order (lowest to highest)

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -550,7 +550,7 @@ async function routeVariable(
   projectRoot: string,
   security?: VariableSecurityContext,
   warnings?: string[],
-): Promise<void> {
+): Promise<boolean> {
   // String with file: prefix → load into vars based on extension
   if (typeof value === 'string' && value.startsWith('file:')) {
     const rawPath = value.slice(5);
@@ -568,7 +568,7 @@ async function routeVariable(
     const rel = path.relative(projectRoot, canonical);
     if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
       warnings?.push(`Ignoring file source "${key}" — path escapes project directory`);
-      return;
+      return false;
     }
 
     await enforceFileSourcePolicy(key, canonical, security);
@@ -586,7 +586,7 @@ async function routeVariable(
       );
     }
 
-    return;
+    return true;
   }
 
   // Array → vars as JsonArray (type-preserving, not comma-joined)
@@ -599,7 +599,7 @@ async function routeVariable(
       );
       vars[key] = value.map(String) as unknown as JsonArray;
     }
-    return;
+    return true;
   }
 
   // Non-array object → vars only as JsonObject (for dotted template access)
@@ -611,7 +611,7 @@ async function routeVariable(
       warnings?.push(`Variable "${key}" contains non-JSON values; converting to string`);
       vars[key] = JSON.stringify(value);
     }
-    return;
+    return true;
   }
 
   // Number → vars only (preserved, not stringified)
@@ -625,11 +625,12 @@ async function routeVariable(
     } else {
       vars[key] = value;
     }
-    return;
+    return true;
   }
 
   // Other scalar (string, boolean, null) → vars only (stringified)
   vars[key] = String(value);
+  return true;
 }
 
 /**
@@ -868,11 +869,11 @@ export async function resolveVariables(
         warnings.push(`Ignoring variable with invalid key: ${key}`);
         continue;
       }
-      await routeVariable(key, value, vars, cwd, projectRoot, security, warnings);
+      const accepted = await routeVariable(key, value, vars, cwd, projectRoot, security, warnings);
       // Track keys from external provider layers that were actually accepted by routing.
       // routeVariable() may silently reject values (e.g., path traversal in file: sources)
       // without writing to vars — only count keys that made it through.
-      if (EXTERNAL_PROVIDER_INDICES.has(layerIndex) && key in vars) {
+      if (EXTERNAL_PROVIDER_INDICES.has(layerIndex) && accepted) {
         providedKeys.add(key);
       }
     }

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -691,14 +691,15 @@ function collectEnvBridgeVars(warnings?: string[]): Record<string, unknown> {
  *
  * ```
  * Layer 0: builtins        ← Date, Branch, WorkPath, RunId, ContextId (fresh)
- * Layer 1: inheritedVars   ← parent delegation vars (overrides builtins)
- * Layer 2: discovered      ← .rundown/config.yaml (auto-discovered)
+ * Layer 1: discovered      ← .rundown/config.yaml (auto-discovered)
+ * Layer 2: inheritedVars   ← parent delegation vars (overrides builtins/config)
  * Layer 3: envBridge       ← RD_INPUT_* environment variables
  * Layer 4: cliFlags        ← --input-file, --input, --input-json (highest precedence)
  * ```
  *
  * The inherited layer ensures that parent ContextId survives into child
- * runbooks during delegation, rather than being replaced by a fresh builtin.
+ * runbooks during delegation, rather than being replaced by a fresh builtin
+ * or shadowed by project-local config.
  *
  * @param options - Variable sources from CLI flags, input-file, and inherited vars
  * @param options.inputFile - Array of paths to YAML files containing variable definitions (repeatable)
@@ -722,11 +723,11 @@ async function collectRawLayers(
   // Layer 0: Built-ins (lowest)
   const builtins: Record<string, unknown> = getBuiltinVariables();
 
-  // Layer 1: Inherited vars from parent delegation (overrides builtins)
-  const inherited: Record<string, unknown> = options.inheritedVars ?? {};
-
-  // Layer 2: Auto-discovered config
+  // Layer 1: Auto-discovered config
   const discovered: Record<string, unknown> = await discoverRawVariables(cwd);
+
+  // Layer 2: Inherited vars from parent delegation (overrides builtins/config)
+  const inherited: Record<string, unknown> = options.inheritedVars ?? {};
 
   // Layer 3: Environment bridge (RD_INPUT_* env vars)
   const envBridge = collectEnvBridgeVars(warnings);
@@ -734,7 +735,7 @@ async function collectRawLayers(
   // Layer 4: CLI flags (--input-file, --input, --input-json merged)
   const cliFlags = await collectCliFlags(options, cwd);
 
-  return [builtins, inherited, discovered, envBridge, cliFlags];
+  return [builtins, discovered, inherited, envBridge, cliFlags];
 }
 
 /**
@@ -836,7 +837,7 @@ export async function resolveVariables(
 
   // External provider layer indices — excludes builtins (0).
   // Used to track which keys were actually accepted via routing for `required` var validation.
-  // Indices must match collectRawLayers ordering: 1=inherited, 2=config, 3=env, 4=CLI.
+  // Indices must match collectRawLayers ordering: 1=config, 2=inherited, 3=env, 4=CLI.
   const EXTERNAL_PROVIDER_INDICES = new Set([1, 2, 3, 4]);
   const providedKeys = new Set<string>();
 

--- a/packages/core/__tests__/sandbox/macos.test.ts
+++ b/packages/core/__tests__/sandbox/macos.test.ts
@@ -6,6 +6,7 @@ const actualChildProcess = await import('node:child_process');
 jest.unstable_mockModule('node:child_process', () => ({
   ...actualChildProcess,
   spawn: jest.fn(),
+  spawnSync: jest.fn(),
 }));
 
 // Mock fs
@@ -20,7 +21,7 @@ jest.unstable_mockModule('node:fs', () => ({
 
 // Import after mocking
 const { SeatbeltSandbox } = await import('../../src/sandbox/macos.js');
-const { spawn } = await import('node:child_process');
+const { spawn, spawnSync } = await import('node:child_process');
 const { existsSync, writeFileSync, unlinkSync } = await import('node:fs');
 
 describe('SeatbeltSandbox', () => {
@@ -66,6 +67,7 @@ describe('SeatbeltSandbox', () => {
     it('returns available when on darwin and sandbox-exec exists', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
       (existsSync as jest.Mock).mockReturnValue(true);
+      (spawnSync as jest.Mock).mockReturnValue({ status: 0, error: undefined });
 
       const sandbox = new SeatbeltSandbox();
       const availability = await sandbox.getAvailability();
@@ -81,6 +83,7 @@ describe('SeatbeltSandbox', () => {
     it('caches availability result', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
       (existsSync as jest.Mock).mockReturnValue(true);
+      (spawnSync as jest.Mock).mockReturnValue({ status: 0, error: undefined });
 
       const sandbox = new SeatbeltSandbox();
       await sandbox.getAvailability();
@@ -95,6 +98,7 @@ describe('SeatbeltSandbox', () => {
     it('returns true when available', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
       (existsSync as jest.Mock).mockReturnValue(true);
+      (spawnSync as jest.Mock).mockReturnValue({ status: 0, error: undefined });
 
       const sandbox = new SeatbeltSandbox();
       const result = await sandbox.isAvailable();

--- a/packages/core/__tests__/sandbox/macos.test.ts
+++ b/packages/core/__tests__/sandbox/macos.test.ts
@@ -80,6 +80,64 @@ describe('SeatbeltSandbox', () => {
       expect(availability.supportsDenyPaths).toBe(true);
     });
 
+    it('returns unavailable when the probe profile cannot be written', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      (existsSync as jest.Mock).mockReturnValue(true);
+      (writeFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error('disk full');
+      });
+
+      const sandbox = new SeatbeltSandbox();
+      const availability = await sandbox.getAvailability();
+
+      expect(availability).toEqual(
+        expect.objectContaining({
+          available: false,
+          mechanism: 'none',
+          platform: 'darwin',
+          supportsReadRestrictions: false,
+          supportsWriteRestrictions: false,
+          supportsDenyPaths: false,
+          reason: expect.stringContaining('disk full'),
+        }),
+      );
+      expect(spawnSync).not.toHaveBeenCalled();
+    });
+
+    it('returns unavailable when the probe spawn fails and uses a timeout', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      (existsSync as jest.Mock).mockReturnValue(true);
+      (writeFileSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+      (spawnSync as jest.Mock).mockImplementation(() => {
+        throw new Error('probe timed out');
+      });
+
+      const sandbox = new SeatbeltSandbox();
+      const availability = await sandbox.getAvailability();
+
+      expect(spawnSync).toHaveBeenCalledWith(
+        '/usr/bin/sandbox-exec',
+        ['-f', expect.stringContaining('.sb'), '/bin/true'],
+        expect.objectContaining({
+          stdio: 'ignore',
+          timeout: 5000,
+        }),
+      );
+      expect(availability).toEqual(
+        expect.objectContaining({
+          available: false,
+          mechanism: 'none',
+          platform: 'darwin',
+          supportsReadRestrictions: false,
+          supportsWriteRestrictions: false,
+          supportsDenyPaths: false,
+          reason: expect.stringContaining('probe timed out'),
+        }),
+      );
+    });
+
     it('caches availability result', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
       (existsSync as jest.Mock).mockReturnValue(true);

--- a/packages/core/src/sandbox/macos.ts
+++ b/packages/core/src/sandbox/macos.ts
@@ -312,8 +312,9 @@ export class SeatbeltSandbox implements SandboxImplementation {
       writeFileSync(profilePath, '(version 1)\n(allow default)\n', { mode: 0o600 });
       const probe = spawnSync('/usr/bin/sandbox-exec', ['-f', profilePath, '/bin/true'], {
         stdio: 'ignore',
+        timeout: 5000,
       });
-      const available = probe.status === 0 && probe.error == null;
+      const available: boolean = probe.status === 0 && probe.error == null;
       this.availabilityCache = available
         ? {
             available: true,
@@ -332,6 +333,18 @@ export class SeatbeltSandbox implements SandboxImplementation {
             supportsWriteRestrictions: false,
             supportsDenyPaths: false,
           };
+      return Promise.resolve(this.availabilityCache);
+    } catch (error: unknown) {
+      const reason = Error.isError(error) ? error.message : String(error);
+      this.availabilityCache = {
+        available: false,
+        mechanism: 'none',
+        reason: `sandbox-exec probe failed: ${reason}`,
+        platform: process.platform,
+        supportsReadRestrictions: false,
+        supportsWriteRestrictions: false,
+        supportsDenyPaths: false,
+      };
       return Promise.resolve(this.availabilityCache);
     } finally {
       try {

--- a/packages/core/src/sandbox/macos.ts
+++ b/packages/core/src/sandbox/macos.ts
@@ -8,7 +8,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { writeFileSync, unlinkSync, existsSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -303,15 +303,43 @@ export class SeatbeltSandbox implements SandboxImplementation {
       return Promise.resolve(this.availabilityCache);
     }
 
-    this.availabilityCache = {
-      available: true,
-      mechanism: 'seatbelt',
-      platform: process.platform,
-      supportsReadRestrictions: true,
-      supportsWriteRestrictions: true,
-      supportsDenyPaths: true,
-    };
-    return Promise.resolve(this.availabilityCache);
+    // Verify that sandbox-exec can actually apply a profile in this
+    // environment, not just that the binary exists. Some CI/container
+    // configurations expose /usr/bin/sandbox-exec but deny profile
+    // application with EPERM.
+    const profilePath = join(tmpdir(), `rundown-sandbox-probe-${randomUUID()}.sb`);
+    try {
+      writeFileSync(profilePath, '(version 1)\n(allow default)\n', { mode: 0o600 });
+      const probe = spawnSync('/usr/bin/sandbox-exec', ['-f', profilePath, '/bin/true'], {
+        stdio: 'ignore',
+      });
+      const available = probe.status === 0 && probe.error == null;
+      this.availabilityCache = available
+        ? {
+            available: true,
+            mechanism: 'seatbelt',
+            platform: process.platform,
+            supportsReadRestrictions: true,
+            supportsWriteRestrictions: true,
+            supportsDenyPaths: true,
+          }
+        : {
+            available: false,
+            mechanism: 'none',
+            reason: `sandbox-exec could not run in this environment${probe.error ? `: ${probe.error.message}` : ''}`,
+            platform: process.platform,
+            supportsReadRestrictions: false,
+            supportsWriteRestrictions: false,
+            supportsDenyPaths: false,
+          };
+      return Promise.resolve(this.availabilityCache);
+    } finally {
+      try {
+        unlinkSync(profilePath);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
   }
 
   /**

--- a/packages/parser/__tests__/frontmatter.test.ts
+++ b/packages/parser/__tests__/frontmatter.test.ts
@@ -541,6 +541,22 @@ describe('required field', () => {
       ]),
     );
   });
+
+  it('rejects duplicate required names before subset validation', () => {
+    const md = `---\nname: test\ninputs:\n  - PlanPath\nrequired:\n  - PlanPath\n  - PlanPath\n---\n# Content`;
+    const { frontmatter, diagnostics } = extractFrontmatter(md);
+    expect(frontmatter?.required).toEqual(['PlanPath']);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toMatch(/duplicate entry "PlanPath".*"required"/i);
+  });
+
+  it('rejects poisoned required identifiers', () => {
+    const md = `---\nname: test\nrequired:\n  - constructor\n---\n# Content`;
+    const { frontmatter, diagnostics } = extractFrontmatter(md);
+    expect(frontmatter?.required).toBeUndefined();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toMatch(/constructor.*not a valid identifier/i);
+  });
 });
 
 describe('extractFrontmatter() — case-insensitive keys', () => {
@@ -609,6 +625,19 @@ inputs:
     expect(diagnostics).toHaveLength(1);
     expect(frontmatter?.inputs).toEqual(['environment']);
     expect(diagnostics[0].message).toContain('must be a string identifier');
+  });
+
+  it('rejects poisoned identifiers in inputs', () => {
+    const markdown = `---
+inputs:
+  - __proto__
+  - environment
+---
+# Test`;
+    const { frontmatter, diagnostics } = extractFrontmatter(markdown);
+    expect(frontmatter?.inputs).toEqual(['environment']);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toMatch(/__proto__.*not a valid identifier/i);
   });
 
   it('treats vars: as unknown passthrough (not a known field)', () => {

--- a/packages/parser/__tests__/frontmatter.test.ts
+++ b/packages/parser/__tests__/frontmatter.test.ts
@@ -96,85 +96,54 @@ description: Test
     expect(result.content.trim()).toBe('');
   });
 
-  it('extracts frontmatter with inputs field containing strings', () => {
+  it('extracts frontmatter with inputs field as a declaration list', () => {
+    const markdown = `---
+name: my-runbook
+inputs:
+  - greeting
+  - name
+---
+# Content`;
+
+    const result = extractFrontmatter(markdown);
+
+    expect(result.frontmatter).not.toBeNull();
+    expect(result.frontmatter?.name).toBe('my-runbook');
+    expect(result.frontmatter?.inputs).toEqual(['greeting', 'name']);
+  });
+
+  it('extracts frontmatter with uppercase INPUTS: as a declaration list', () => {
+    const markdown = `---
+INPUTS:
+  - environment
+  - port
+---
+# Content`;
+
+    const result = extractFrontmatter(markdown);
+
+    expect(result.frontmatter?.inputs).toEqual(['environment', 'port']);
+  });
+
+  it('returns undefined for an explicit empty INPUTS list', () => {
+    const markdown = `---
+name: my-runbook
+INPUTS: []
+---
+# Content`;
+
+    const result = extractFrontmatter(markdown);
+
+    expect(result.frontmatter).not.toBeNull();
+    expect(result.frontmatter?.inputs).toBeUndefined();
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('rejects legacy map-style inputs', () => {
     const markdown = `---
 name: my-runbook
 inputs:
   greeting: Hello
-  name: World
----
-# Content`;
-
-    const result = extractFrontmatter(markdown);
-
-    expect(result.frontmatter).not.toBeNull();
-    expect(result.frontmatter?.name).toBe('my-runbook');
-    expect(result.frontmatter?.inputs).toEqual({
-      greeting: 'Hello',
-      name: 'World',
-    });
-  });
-
-  it('extracts frontmatter with inputs field containing numbers', () => {
-    const markdown = `---
-name: my-runbook
-inputs:
-  port: 3000
-  ratio: 1.618
----
-# Content`;
-
-    const result = extractFrontmatter(markdown);
-
-    expect(result.frontmatter).not.toBeNull();
-    expect(result.frontmatter?.inputs).toEqual({
-      port: 3000,
-      ratio: 1.618,
-    });
-  });
-
-  it('extracts frontmatter with inputs field containing booleans', () => {
-    const markdown = `---
-name: my-runbook
-inputs:
-  debug: true
-  production: false
----
-# Content`;
-
-    const result = extractFrontmatter(markdown);
-
-    expect(result.frontmatter).not.toBeNull();
-    expect(result.frontmatter?.inputs).toEqual({
-      debug: true,
-      production: false,
-    });
-  });
-
-  it('extracts frontmatter with inputs field containing mixed types', () => {
-    const markdown = `---
-name: my-runbook
-inputs:
-  name: test-app
-  port: 8080
-  debug: true
----
-# Content`;
-
-    const result = extractFrontmatter(markdown);
-
-    expect(result.frontmatter).not.toBeNull();
-    expect(result.frontmatter?.inputs).toEqual({
-      name: 'test-app',
-      port: 8080,
-      debug: true,
-    });
-  });
-
-  it('extracts frontmatter with empty inputs object', () => {
-    const markdown = `---
-name: my-runbook
-inputs: {}
 ---
 # Content`;
 
@@ -182,43 +151,7 @@ inputs: {}
 
     expect(result.frontmatter).not.toBeNull();
     expect(result.frontmatter?.inputs).toBeUndefined();
-  });
-
-  it('collapses entire inputs: field to undefined when values are invalid types (arrays)', () => {
-    const markdown = `---
-name: my-runbook
-inputs:
-  items:
-    - one
-    - two
----
-# Content`;
-
-    const result = extractFrontmatter(markdown);
-
-    // inputs: fails Zod record validation entirely when values are non-scalar — whole field collapses to undefined via .catch(undefined)
-    expect(result.frontmatter).not.toBeNull();
-    expect(result.frontmatter?.name).toBe('my-runbook');
-    expect(result.frontmatter?.inputs).toBeUndefined();
-    expect(result.content.trim()).toBe('# Content');
-  });
-
-  it('collapses entire inputs: field to undefined when values are invalid types (nested objects)', () => {
-    const markdown = `---
-name: my-runbook
-inputs:
-  config:
-    nested: value
----
-# Content`;
-
-    const result = extractFrontmatter(markdown);
-
-    // inputs: fails Zod record validation entirely when values are non-scalar — whole field collapses to undefined via .catch(undefined)
-    expect(result.frontmatter).not.toBeNull();
-    expect(result.frontmatter?.name).toBe('my-runbook');
-    expect(result.frontmatter?.inputs).toBeUndefined();
-    expect(result.content.trim()).toBe('# Content');
+    expect(result.diagnostics.some((d) => d.message.includes('YAML sequence'))).toBe(true);
   });
 
   // New tests for gray-matter specific behavior
@@ -242,11 +175,11 @@ another_field: 123
     expect(result.content.trim()).toBe('# Content');
   });
 
-  it('preserves typed inputs and required alongside unknown passthrough fields', () => {
+  it('preserves declarations and required alongside unknown passthrough fields', () => {
     const markdown = `---
 name: test-runbook
 inputs:
-  PlanPath: /default/path
+  - PlanPath
 required:
   - Region
 skill: my-skill
@@ -255,7 +188,7 @@ skill: my-skill
 
     const result = extractFrontmatter(markdown);
 
-    expect(result.frontmatter?.inputs).toEqual({ PlanPath: '/default/path' });
+    expect(result.frontmatter?.inputs).toEqual(['PlanPath']);
     expect(result.frontmatter?.required).toEqual(['Region']);
     expect(result.frontmatter).toHaveProperty('skill', 'my-skill');
   });
@@ -563,14 +496,15 @@ describe('required field', () => {
     const md = `---\nname: test\nrequired:\n  - ""\n  - VarA\n---\n# Content`;
     const { frontmatter, diagnostics } = extractFrontmatter(md);
     expect(frontmatter?.required).toEqual(['VarA']);
-    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics).toHaveLength(2);
     expect(diagnostics[0].message).toMatch(/required\[0\].*not a valid identifier/);
+    expect(diagnostics[1].message).toMatch(/must also be declared in "inputs"/);
   });
 
   it('coexists with inputs', () => {
-    const md = `---\nname: test\ninputs:\n  port: 3000\nrequired:\n  - PlanPath\n---\n# Content`;
+    const md = `---\nname: test\ninputs:\n  - port\nrequired:\n  - PlanPath\n---\n# Content`;
     const { frontmatter } = extractFrontmatter(md);
-    expect(frontmatter?.inputs).toEqual({ port: 3000 });
+    expect(frontmatter?.inputs).toEqual(['port']);
     expect(frontmatter?.required).toEqual(['PlanPath']);
   });
 
@@ -593,27 +527,34 @@ describe('required field', () => {
     const md = `---\nname: test\nrequired:\n  - GoodName\n  - "bad-name"\n---\n# Content`;
     const { frontmatter, diagnostics } = extractFrontmatter(md);
     expect(frontmatter?.required).toEqual(['GoodName']);
-    expect(diagnostics).toEqual([
-      expect.objectContaining({
-        severity: 'error',
-        message: expect.stringMatching(/bad-name.*not a valid identifier/),
-      }),
-    ]);
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          message: expect.stringMatching(/bad-name.*not a valid identifier/),
+        }),
+        expect.objectContaining({
+          severity: 'error',
+          message: expect.stringMatching(/must also be declared in "inputs"/),
+        }),
+      ]),
+    );
   });
 });
 
 describe('extractFrontmatter() — case-insensitive keys', () => {
   it('parses INPUTS: (uppercase) identically to inputs:', () => {
-    const md = `---\nINPUTS:\n  env: staging\n---\n# Content`;
+    const md = `---\nINPUTS:\n  - env\n---\n# Content`;
     const { frontmatter, diagnostics } = extractFrontmatter(md);
     expect(diagnostics).toHaveLength(0);
-    expect(frontmatter?.inputs).toEqual({ env: 'staging' });
+    expect(frontmatter?.inputs).toEqual(['env']);
   });
 
   it('parses Inputs: (mixed case) identically to inputs:', () => {
-    const md = `---\nInputs:\n  region: us-east-1\n---\n# Content`;
+    const md = `---\nInputs:\n  - region\n---\n# Content`;
     const { frontmatter } = extractFrontmatter(md);
-    expect(frontmatter?.inputs).toEqual({ region: 'us-east-1' });
+    expect(frontmatter?.inputs).toEqual(['region']);
   });
 
   it('parses REQUIRED: (uppercase) identically to required:', () => {
@@ -629,10 +570,11 @@ describe('extractFrontmatter() — case-insensitive keys', () => {
   });
 
   it('first-occurrence wins on key collision (inputs: + INPUTS:)', () => {
-    const md = `---\ninputs:\n  env: first\nINPUTS:\n  env: second\n---\n# Content`;
-    const { frontmatter } = extractFrontmatter(md);
+    const md = `---\ninputs:\n  - first\nINPUTS:\n  - second\n---\n# Content`;
+    const { frontmatter, diagnostics } = extractFrontmatter(md);
     // YAML preserves the first key; second is dropped
-    expect(frontmatter?.inputs).toEqual({ env: 'first' });
+    expect(diagnostics).toHaveLength(0);
+    expect(frontmatter?.inputs).toEqual(['first']);
   });
 
   it('preserves unknown passthrough keys unchanged', () => {
@@ -642,37 +584,31 @@ describe('extractFrontmatter() — case-insensitive keys', () => {
   });
 });
 
-describe('inputs: field (new — default variable values)', () => {
-  it('parses inputs: as Record<string, string|number|boolean>', () => {
+describe('inputs: field (declaration list)', () => {
+  it('parses inputs: as a string array', () => {
     const markdown = `---
 inputs:
-  environment: staging
-  port: 3000
-  debug: true
+  - environment
+  - port
+  - debug
 ---
 # Test`;
     const { frontmatter, diagnostics } = extractFrontmatter(markdown);
     expect(diagnostics).toHaveLength(0);
-    expect(frontmatter?.inputs).toEqual({
-      environment: 'staging',
-      port: 3000,
-      debug: true,
-    });
+    expect(frontmatter?.inputs).toEqual(['environment', 'port', 'debug']);
   });
 
-  it('filters null values per-entry (PlanPath: with no value = null in YAML)', () => {
+  it('rejects map-style entries inside the list', () => {
     const markdown = `---
 inputs:
-  environment: staging
-  PlanPath:
+  - environment
+  - PlanPath: staging
 ---
 # Test`;
     const { frontmatter, diagnostics } = extractFrontmatter(markdown);
-    expect(diagnostics).toHaveLength(0);
-    // null value filtered; scalar value kept
-    expect(frontmatter?.inputs).toEqual({ environment: 'staging' });
-    // PlanPath key is absent (filtered), not present as null
-    expect((frontmatter?.inputs as Record<string, unknown>).PlanPath).toBeUndefined();
+    expect(diagnostics).toHaveLength(1);
+    expect(frontmatter?.inputs).toEqual(['environment']);
+    expect(diagnostics[0].message).toContain('must be a string identifier');
   });
 
   it('treats vars: as unknown passthrough (not a known field)', () => {
@@ -687,11 +623,10 @@ vars:
     expect(frontmatter?.inputs).toBeUndefined();
   });
 
-  it('returns undefined when all inputs: values are null (all keys with no value)', () => {
+  it('returns undefined when the inputs list is empty', () => {
     const markdown = `---
 inputs:
-  PlanPath:
-  OtherVar:
+  []
 ---
 # Test`;
     const { frontmatter, diagnostics } = extractFrontmatter(markdown);

--- a/packages/parser/__tests__/outputs-inputs.test.ts
+++ b/packages/parser/__tests__/outputs-inputs.test.ts
@@ -325,7 +325,7 @@ describe('parseRunbookDocument - INPUTS step directive removal', () => {
   it('emits a parse error when - INPUTS directive appears in a step', () => {
     const markdown = `---
 inputs:
-  Message: hello
+  - Message
 ---
 # My Runbook
 

--- a/packages/parser/__tests__/parser.test.ts
+++ b/packages/parser/__tests__/parser.test.ts
@@ -1976,8 +1976,8 @@ This is the preamble description.
     const md = `---
 name: my-runbook
 inputs:
-  greeting: Hello
-  count: 42
+  - greeting
+  - count
 ---
 ## 1 Step
 - PASS COMPLETE
@@ -1985,7 +1985,7 @@ inputs:
     const { frontmatter } = parseRunbookDocument(md);
     expect(frontmatter).not.toBeNull();
     expect(frontmatter?.name).toBe('my-runbook');
-    expect(frontmatter?.inputs).toEqual({ greeting: 'Hello', count: 42 });
+    expect(frontmatter?.inputs).toEqual(['greeting', 'count']);
   });
 
   it('preserves extension fields in frontmatter via passthrough', () => {

--- a/packages/parser/src/frontmatter.ts
+++ b/packages/parser/src/frontmatter.ts
@@ -66,7 +66,7 @@ export interface RunbookFrontmatter {
   version?: string; // Optional: semantic version
   author?: string; // Optional
   tags?: string[]; // Optional: categorization
-  inputs?: Record<string, string | number | boolean>; // Optional: default template variables
+  inputs?: string[]; // Optional: declared template variable names
   required?: string[]; // Optional: variables that must be provided by caller
   outputs?: OutputDeclaration[]; // Optional: variables to publish to context OUTPUTS at completion
   [key: string]: unknown; // Passthrough fields preserved verbatim
@@ -91,19 +91,7 @@ export const RunbookFrontmatterSchema = z
     version: z.string().optional().catch(undefined),
     author: z.string().optional().catch(undefined),
     tags: z.array(z.string()).optional().catch(undefined),
-    // Note: null values (e.g., `PlanPath:` with no value in YAML) are silently filtered
-    // per-entry rather than dropping the entire record via .catch(undefined).
-    inputs: z
-      .record(z.union([z.string(), z.number(), z.boolean()]).nullable())
-      .optional()
-      .transform((val) => {
-        if (!val) return undefined;
-        const filtered = Object.fromEntries(
-          Object.entries(val).filter(([, v]) => v !== null),
-        ) as Record<string, string | number | boolean>;
-        return Object.keys(filtered).length > 0 ? filtered : undefined;
-      })
-      .catch(undefined),
+    inputs: z.unknown().optional().catch(undefined),
     // Defer per-element validation of `required`/`outputs` to a post-zod pass
     // so we can preserve valid entries and emit per-index diagnostics
     // (rather than silently dropping the whole array on any single failure).
@@ -181,19 +169,22 @@ export function extractFrontmatter(markdown: string): {
   // Invalid fields become undefined; valid fields and unknown passthrough fields are preserved.
   const parsed = RunbookFrontmatterSchema.parse(normalized);
 
-  // Per-element validation of `required` / `outputs` (zod accepts unknown[] for
+  // Per-element validation of `inputs` / `required` / `outputs` (zod accepts unknown[] for
   // these and we filter here so we can preserve valid entries and emit
   // diagnostics for each invalid one — instead of silently dropping the whole
   // array on the first bad element).
-  // Note: `inputs` is no longer listed — it comes through `...parsed` already
-  // validated by Zod as Record<string, string|number|boolean> | undefined.
   const diagnostics: ValidationDiagnostic[] = [];
+  const inputs =
+    parsed.inputs !== undefined ? filterInputDeclarations(parsed.inputs, diagnostics) : undefined;
+  const required =
+    parsed.required !== undefined
+      ? filterIdentifierArray(parsed.required, 'required', diagnostics)
+      : undefined;
+  validateRequiredSubset(required, inputs, diagnostics);
   const frontmatter: RunbookFrontmatter = {
     ...parsed,
-    required:
-      parsed.required !== undefined
-        ? filterIdentifierArray(parsed.required, 'required', diagnostics)
-        : undefined,
+    inputs,
+    required,
     outputs:
       parsed.outputs !== undefined
         ? filterOutputDeclarationArray(parsed.outputs, diagnostics)
@@ -201,6 +192,71 @@ export function extractFrontmatter(markdown: string): {
   };
 
   return { frontmatter, content, diagnostics };
+}
+
+/**
+ * Validate frontmatter `inputs` declarations.
+ *
+ * Accepts a YAML sequence of bare identifier strings. Any non-sequence input
+ * or non-string entry is rejected with a diagnostic. Valid entries are kept in
+ * author order and duplicates are reported as errors.
+ *
+ * @param raw - Raw `inputs` value from frontmatter
+ * @param diagnostics - Output array; validation errors are appended in-place
+ * @returns The valid input names, or `undefined` when the field is absent,
+ *   empty, or invalid
+ */
+function filterInputDeclarations(
+  raw: unknown,
+  diagnostics: ValidationDiagnostic[],
+): string[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) {
+    diagnostics.push({
+      severity: 'error',
+      message:
+        'Frontmatter "inputs" must be a YAML sequence of variable names (for example: inputs: [PlanPath] or inputs:\n  - PlanPath)',
+    });
+    return undefined;
+  }
+
+  if (raw.length === 0) return undefined;
+
+  const kept: string[] = [];
+  const seen = new Set<string>();
+  raw.forEach((entry, index) => {
+    if (typeof entry !== 'string') {
+      diagnostics.push({
+        severity: 'error',
+        message: `Frontmatter "inputs[${String(index)}]" must be a string identifier (got ${typeof entry})`,
+      });
+      return;
+    }
+    if (!IDENTIFIER_PATTERN.test(entry)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Frontmatter "inputs[${String(index)}]" — "${entry}" is not a valid identifier`,
+      });
+      return;
+    }
+    if (isReservedTemplateName(entry)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Frontmatter "inputs[${String(index)}]" — "${entry}" is a reserved variable name (step, index, context — case-insensitive)`,
+      });
+      return;
+    }
+    if (seen.has(entry)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Frontmatter "inputs[${String(index)}]" — duplicate entry "${entry}" in "inputs" — each variable should be listed once`,
+      });
+      return;
+    }
+    seen.add(entry);
+    kept.push(entry);
+  });
+  return kept.length > 0 ? kept : undefined;
 }
 
 /**
@@ -249,6 +305,30 @@ function filterIdentifierArray(
     kept.push(entry);
   });
   return kept.length > 0 ? kept : undefined;
+}
+
+/**
+ * Validate that required variables are declared in frontmatter inputs.
+ *
+ * @param required - Filtered required names from frontmatter
+ * @param inputs - Filtered input declarations from frontmatter
+ * @param diagnostics - Output array; validation errors are appended in-place
+ */
+function validateRequiredSubset(
+  required: string[] | undefined,
+  inputs: string[] | undefined,
+  diagnostics: ValidationDiagnostic[],
+): void {
+  if (!required || required.length === 0) return;
+  const declared = new Set(inputs ?? []);
+  for (const name of required) {
+    if (!declared.has(name)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Frontmatter "required" variable "${name}" must also be declared in "inputs"`,
+      });
+    }
+  }
 }
 
 /**

--- a/packages/parser/src/frontmatter.ts
+++ b/packages/parser/src/frontmatter.ts
@@ -6,6 +6,17 @@ import type { OutputDeclaration } from './ast.js';
 import { parseFrontmatterOutputDeclaration } from './helpers.js';
 
 const IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const POISONED_IDENTIFIER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Check whether a frontmatter identifier is syntactically valid and safe.
+ *
+ * @param name - Candidate identifier to validate
+ * @returns True when the identifier matches the allowed pattern and is not a poisoned key
+ */
+function isSafeIdentifier(name: string): boolean {
+  return IDENTIFIER_PATTERN.test(name) && !POISONED_IDENTIFIER_KEYS.has(name);
+}
 
 /**
  * Known frontmatter keys whose casing is normalized before Zod parsing.
@@ -232,7 +243,7 @@ function filterInputDeclarations(
       });
       return;
     }
-    if (!IDENTIFIER_PATTERN.test(entry)) {
+    if (!isSafeIdentifier(entry)) {
       diagnostics.push({
         severity: 'error',
         message: `Frontmatter "inputs[${String(index)}]" — "${entry}" is not a valid identifier`,
@@ -264,7 +275,7 @@ function filterInputDeclarations(
  * entries and emitting an error diagnostic for each invalid one. Returns
  * `undefined` if no valid entries remain (so downstream code sees the same
  * "field absent" signal as before). An explicitly-empty input is preserved
- * as `[]` (no diagnostics emitted).
+ * as `[]` (no diagnostics emitted). Duplicate entries are rejected.
  *
  * @param raw         - Raw array elements from the parsed frontmatter
  * @param field       - Field name (`required`) used in diagnostic messages
@@ -280,6 +291,7 @@ function filterIdentifierArray(
   if (raw.length === 0) return [];
 
   const kept: string[] = [];
+  const seen = new Set<string>();
   raw.forEach((entry, index) => {
     if (typeof entry !== 'string') {
       diagnostics.push({
@@ -288,7 +300,7 @@ function filterIdentifierArray(
       });
       return;
     }
-    if (!IDENTIFIER_PATTERN.test(entry)) {
+    if (!isSafeIdentifier(entry)) {
       diagnostics.push({
         severity: 'error',
         message: `Frontmatter "${field}[${String(index)}]" — "${entry}" is not a valid identifier`,
@@ -302,6 +314,14 @@ function filterIdentifierArray(
       });
       return;
     }
+    if (seen.has(entry)) {
+      diagnostics.push({
+        severity: 'error',
+        message: `Frontmatter "${field}[${String(index)}]" — duplicate entry "${entry}" in "${field}" — each variable should be listed once`,
+      });
+      return;
+    }
+    seen.add(entry);
     kept.push(entry);
   });
   return kept.length > 0 ? kept : undefined;

--- a/runbooks/transitions/metadata-full.runbook.md
+++ b/runbooks/transitions/metadata-full.runbook.md
@@ -5,14 +5,14 @@ version: 1.0.0
 author: Rundown Team
 tags:
   - transitions
-inputs:
-  greeting: hello
-  port: 3000
+INPUTS:
+  - greeting
+  - port
 scenarios:
   completed:
-    description: Exercises every metadata field with variable expansion
+    description: Exercises every metadata field with explicit variable inputs
     commands:
-      - rd run metadata-full.runbook.md
+      - rd run --input greeting=hello --input port=3000 metadata-full.runbook.md
     result: COMPLETE
 ---
 

--- a/runbooks/variables/variable-precedence.runbook.md
+++ b/runbooks/variables/variable-precedence.runbook.md
@@ -3,18 +3,18 @@ name: variable-precedence
 description: Variable resolution precedence from frontmatter and CLI
 tags:
   - variables
-inputs:
-  greeting: hello
+INPUTS:
+  - greeting
 scenarios:
   override:
-    description: CLI --input overrides frontmatter default
+    description: CLI --input overrides declared input
     commands:
       - rd run --input greeting=overridden variable-precedence.runbook.md
     result: COMPLETE
   default:
-    description: Frontmatter default used when no CLI override
+    description: Declared input provided explicitly
     commands:
-      - rd run variable-precedence.runbook.md
+      - rd run --input greeting=hello variable-precedence.runbook.md
     result: COMPLETE
 ---
 


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Frontmatter `inputs` is now a declaration list of names (no defaults); pass values via `--input`/`--input-file`. Frontmatter no longer supplies template variables into resolution.

* **Validation Improvements**
  * Stronger frontmatter checks: reject reserved names, duplicates, poisoned/unsafe identifiers; `required` must appear in `inputs`.

* **Behavior**
  * Variable precedence updated: discovered/inherited sources take new precedence over former frontmatter layer.

* **Tests**
  * Updated and new tests reflect list-style inputs, explicit CLI inputs, and sibling isolation scenarios.

* **Bug Fixes**
  * macOS sandbox availability now probes runtime behavior for more accurate detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/SPEC.md`, `docs/FORMAT.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
