### PR TITLE
fix: expose pending delegation recovery tokens

### DIFF
--- a/packages/cli/__tests__/commands/abort.test.ts
+++ b/packages/cli/__tests__/commands/abort.test.ts
@@ -6,7 +6,7 @@ import {
   getActiveState,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 describe('abort command - unit tests', () => {
@@ -61,6 +61,37 @@ describe('abort command - unit tests', () => {
     return tokenMatch![1];
   }
 
+  async function mirrorActiveSubstepStatesIntoSnapshot(): Promise<void> {
+    const state = await getActiveState(workspace);
+    if (!state) throw new Error('Expected active state');
+    const snapshot =
+      state.snapshot && typeof state.snapshot === 'object'
+        ? (state.snapshot as Record<string, unknown>)
+        : {};
+    const context =
+      snapshot.context && typeof snapshot.context === 'object'
+        ? (snapshot.context as Record<string, unknown>)
+        : {};
+    const stateFile = join(workspace.statePath(), `${state.id}.json`);
+    await writeFile(
+      stateFile,
+      JSON.stringify(
+        {
+          ...state,
+          snapshot: {
+            ...snapshot,
+            context: {
+              ...context,
+              substepStates: state.substepStates,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
   describe('token validation', () => {
     it('rejects token with incorrect prefix', async () => {
       const result = await runCliInProcess('abort invalid_token_without_prefix --text', workspace);
@@ -98,6 +129,28 @@ describe('abort command - unit tests', () => {
       const result = await runCliInProcess(`abort ${token} --text`, workspace);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toMatch(/CANCELLED/i);
+    });
+
+    it('pending → cancelled removes raw recovery token from persisted snapshot', async () => {
+      const token = await setupDelegation();
+      await mirrorActiveSubstepStatesIntoSnapshot();
+
+      const result = await runCliInProcess(`abort ${token} --text`, workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parent = await getActiveState(workspace);
+      if (!parent) throw new Error('Expected parent state');
+      const persisted = JSON.parse(
+        await readFile(join(workspace.statePath(), `${parent.id}.json`), 'utf-8'),
+      ) as {
+        snapshot?: {
+          context?: { substepStates?: Array<{ delegation?: Record<string, unknown> }> };
+        };
+      };
+      const snapshotDelegation = persisted.snapshot?.context?.substepStates?.[0]?.delegation;
+      expect(snapshotDelegation?.cancelledAt).toEqual(expect.any(String));
+      expect(snapshotDelegation?.tokenHash).toEqual(expect.stringMatching(/^sha256:[a-f0-9]{64}$/));
+      expect(snapshotDelegation?.token).toBeUndefined();
     });
 
     it('pending → cancelled is idempotent', async () => {

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   createTestWorkspace,
@@ -19,6 +19,37 @@ describe('delegate command', () => {
   afterEach(async () => {
     await workspace.cleanup();
   });
+
+  async function mirrorActiveSubstepStatesIntoSnapshot(): Promise<void> {
+    const state = await getActiveState(workspace);
+    if (!state) throw new Error('Expected active state');
+    const snapshot =
+      state.snapshot && typeof state.snapshot === 'object'
+        ? (state.snapshot as Record<string, unknown>)
+        : {};
+    const context =
+      snapshot.context && typeof snapshot.context === 'object'
+        ? (snapshot.context as Record<string, unknown>)
+        : {};
+    const stateFile = join(workspace.statePath(), `${state.id}.json`);
+    await writeFile(
+      stateFile,
+      JSON.stringify(
+        {
+          ...state,
+          snapshot: {
+            ...snapshot,
+            context: {
+              ...context,
+              substepStates: state.substepStates,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  }
 
   /** Start a prompted runbook with substeps and create a child runbook. */
   async function setupDelegation(): Promise<void> {
@@ -139,6 +170,35 @@ describe('delegate command', () => {
       const delegations = statusOutput.delegations as Array<Record<string, unknown>>;
       expect(delegations[0]?.state).toBe('claimed');
       expect(delegations[0]?.token).toBeUndefined();
+    });
+
+    it('removes the raw recovery token from persisted snapshot after claim', async () => {
+      await setupDelegation();
+
+      const delegated = await runCliInProcess(
+        'delegate runbooks/child.runbook.md --step 1.1',
+        workspace,
+      );
+      const token = JSON.parse(delegated.stdout).token as string;
+      await mirrorActiveSubstepStatesIntoSnapshot();
+
+      const claimed = await runCliInProcess(`claim ${token}`, workspace, {
+        env: { RD_AGENT_ID: 'snapshot-agent', RD_SESSION_ID: 'snapshot-session' },
+      });
+      expect(claimed.exitCode).toBe(0);
+
+      const parent = await getActiveState(workspace);
+      if (!parent) throw new Error('Expected parent state');
+      const persisted = JSON.parse(
+        await readFile(join(workspace.statePath(), `${parent.id}.json`), 'utf-8'),
+      ) as {
+        snapshot?: {
+          context?: { substepStates?: Array<{ delegation?: Record<string, unknown> }> };
+        };
+      };
+      const snapshotDelegation = persisted.snapshot?.context?.substepStates?.[0]?.delegation;
+      expect(snapshotDelegation?.tokenHash).toEqual(expect.stringMatching(/^sha256:[a-f0-9]{64}$/));
+      expect(snapshotDelegation?.token).toBeUndefined();
     });
 
     it('JSON output has snake_case keys', async () => {

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -70,7 +70,11 @@ describe('delegate command', () => {
     it('updates state with delegation on substep', async () => {
       await setupDelegation();
 
-      await runCliInProcess('delegate runbooks/child.runbook.md --step 1.1', workspace);
+      const result = await runCliInProcess(
+        'delegate runbooks/child.runbook.md --step 1.1',
+        workspace,
+      );
+      const output = JSON.parse(result.stdout) as Record<string, unknown>;
 
       const state = await getActiveState(workspace);
       const substepStates = state?.substepStates as Array<Record<string, unknown>> | undefined;
@@ -82,13 +86,18 @@ describe('delegate command', () => {
       const delegation = ss1?.delegation as Record<string, unknown>;
       expect(delegation.tokenHash).toBeDefined();
       expect((delegation.tokenHash as string).startsWith('sha256:')).toBe(true);
+      expect(delegation.token).toBe(output.token);
       expect(delegation.childRunId).toBeNull();
     });
 
     it('status shows delegation info', async () => {
       await setupDelegation();
 
-      await runCliInProcess('delegate runbooks/child.runbook.md --step 1.1', workspace);
+      const delegated = await runCliInProcess(
+        'delegate runbooks/child.runbook.md --step 1.1',
+        workspace,
+      );
+      const token = JSON.parse(delegated.stdout).token as string;
 
       const statusResult = await runCliInProcess('status', workspace);
       expect(statusResult.exitCode).toBe(0);
@@ -99,6 +108,37 @@ describe('delegate command', () => {
       expect(delegations).toHaveLength(1);
       expect(delegations?.[0]?.substep).toBe('1');
       expect(delegations?.[0]?.state).toBe('pending');
+      expect(delegations?.[0]?.token).toBe(token);
+      expect(delegations?.[0]?.tokenHash).toEqual(expect.stringMatching(/^sha256:[a-f0-9]{64}$/));
+    });
+
+    it('removes the raw recovery token after claim', async () => {
+      await setupDelegation();
+
+      const delegated = await runCliInProcess(
+        'delegate runbooks/child.runbook.md --step 1.1',
+        workspace,
+      );
+      const token = JSON.parse(delegated.stdout).token as string;
+
+      const claimed = await runCliInProcess(`claim ${token}`, workspace, {
+        env: { RD_AGENT_ID: 'delegate-agent', RD_SESSION_ID: 'delegate-session' },
+      });
+      expect(claimed.exitCode).toBe(0);
+
+      const state = await getActiveState(workspace);
+      const substepStates = state?.substepStates as Array<Record<string, unknown>> | undefined;
+      const ss1 = substepStates?.find((ss) => ss.id === '1');
+      const delegation = ss1?.delegation as Record<string, unknown>;
+      expect(delegation.childRunId).toEqual(expect.stringMatching(/^wf-/));
+      expect(delegation.tokenHash).toEqual(expect.stringMatching(/^sha256:[a-f0-9]{64}$/));
+      expect(delegation.token).toBeUndefined();
+
+      const statusResult = await runCliInProcess('status', workspace);
+      const statusOutput = JSON.parse(statusResult.stdout) as Record<string, unknown>;
+      const delegations = statusOutput.delegations as Array<Record<string, unknown>>;
+      expect(delegations[0]?.state).toBe('claimed');
+      expect(delegations[0]?.token).toBeUndefined();
     });
 
     it('JSON output has snake_case keys', async () => {

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -105,6 +105,7 @@ describe('delegate command', () => {
         'delegate runbooks/child.runbook.md --step 1.1',
         workspace,
       );
+      expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout) as Record<string, unknown>;
 
       const state = await getActiveState(workspace);
@@ -128,6 +129,7 @@ describe('delegate command', () => {
         'delegate runbooks/child.runbook.md --step 1.1',
         workspace,
       );
+      expect(delegated.exitCode).toBe(0);
       const token = JSON.parse(delegated.stdout).token as string;
 
       const statusResult = await runCliInProcess('status', workspace);
@@ -150,6 +152,7 @@ describe('delegate command', () => {
         'delegate runbooks/child.runbook.md --step 1.1',
         workspace,
       );
+      expect(delegated.exitCode).toBe(0);
       const token = JSON.parse(delegated.stdout).token as string;
 
       const claimed = await runCliInProcess(`claim ${token}`, workspace, {
@@ -166,6 +169,7 @@ describe('delegate command', () => {
       expect(delegation.token).toBeUndefined();
 
       const statusResult = await runCliInProcess('status', workspace);
+      expect(statusResult.exitCode).toBe(0);
       const statusOutput = JSON.parse(statusResult.stdout) as Record<string, unknown>;
       const delegations = statusOutput.delegations as Array<Record<string, unknown>>;
       expect(delegations[0]?.state).toBe('claimed');
@@ -179,6 +183,7 @@ describe('delegate command', () => {
         'delegate runbooks/child.runbook.md --step 1.1',
         workspace,
       );
+      expect(delegated.exitCode).toBe(0);
       const token = JSON.parse(delegated.stdout).token as string;
       await mirrorActiveSubstepStatesIntoSnapshot();
 

--- a/packages/cli/__tests__/services/renderers/text-renderer.test.ts
+++ b/packages/cli/__tests__/services/renderers/text-renderer.test.ts
@@ -801,8 +801,19 @@ describe('TextRenderer', () => {
           position: { current: '1', total: 2 },
           step: { name: '1', description: 'Review' },
           delegations: [
-            { substep: '1.1', runbook: 'review-code.md', state: 'pending' },
-            { substep: '1.2', runbook: 'review-tests.md', state: 'claimed', childRunId: 'run_abc' },
+            {
+              substep: '1.1',
+              runbook: 'review-code.md',
+              state: 'pending',
+              token: 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+            },
+            {
+              substep: '1.2',
+              runbook: 'review-tests.md',
+              state: 'claimed',
+              childRunId: 'run_abc',
+              token: 'rdtk_ZYXWVUTSRQPONMLKJIHGFEDCBA765432',
+            },
             { substep: '1.3', runbook: 'review-security.md', state: 'cancelled' },
           ],
         },
@@ -815,9 +826,11 @@ describe('TextRenderer', () => {
       expect(output).toContain('Delegations:');
       expect(output).toContain('1.1');
       expect(output).toContain('review-code.md');
-      expect(output).toContain('(pending claim)');
+      expect(output).toContain('(pending claim: rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567)');
+      expect(output).toContain('rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
       expect(output).toContain('1.2');
       expect(output).toContain('(claimed: run_abc)');
+      expect(output).not.toContain('rdtk_ZYXWVUTSRQPONMLKJIHGFEDCBA765432');
       expect(output).toContain('1.3');
       expect(output).toContain('(cancelled)');
     });

--- a/packages/cli/__tests__/services/renderers/text-renderer.test.ts
+++ b/packages/cli/__tests__/services/renderers/text-renderer.test.ts
@@ -790,6 +790,8 @@ describe('TextRenderer', () => {
     it('renders delegations section when present', () => {
       const writer = createMockWriter();
       const renderer = new TextRenderer({ writer });
+      const pendingToken = 'rdtk_TEST_PENDING_TOKEN';
+      const claimedToken = 'rdtk_TEST_CLAIMED_TOKEN';
 
       const event: DetailOutput = {
         type: 'detail',
@@ -805,15 +807,14 @@ describe('TextRenderer', () => {
               substep: '1.1',
               runbook: 'review-code.md',
               state: 'pending',
-              token: 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+              token: pendingToken,
             },
             {
               substep: '1.2',
               runbook: 'review-tests.md',
               state: 'claimed',
               childRunId: 'run_abc',
-              // cspell:disable-next-line
-              token: 'rdtk_ZYXWVUTSRQPONMLKJIHGFEDCBA765432',
+              token: claimedToken,
             },
             { substep: '1.3', runbook: 'review-security.md', state: 'cancelled' },
           ],
@@ -827,12 +828,11 @@ describe('TextRenderer', () => {
       expect(output).toContain('Delegations:');
       expect(output).toContain('1.1');
       expect(output).toContain('review-code.md');
-      expect(output).toContain('(pending claim: rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567)');
-      expect(output).toContain('rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
+      expect(output).toContain(`(pending claim: ${pendingToken})`);
+      expect(output).toContain(pendingToken);
       expect(output).toContain('1.2');
       expect(output).toContain('(claimed: run_abc)');
-      // cspell:disable-next-line
-      expect(output).not.toContain('rdtk_ZYXWVUTSRQPONMLKJIHGFEDCBA765432');
+      expect(output).not.toContain(claimedToken);
       expect(output).toContain('1.3');
       expect(output).toContain('(cancelled)');
     });

--- a/packages/cli/__tests__/services/renderers/text-renderer.test.ts
+++ b/packages/cli/__tests__/services/renderers/text-renderer.test.ts
@@ -812,6 +812,7 @@ describe('TextRenderer', () => {
               runbook: 'review-tests.md',
               state: 'claimed',
               childRunId: 'run_abc',
+              // cspell:disable-next-line
               token: 'rdtk_ZYXWVUTSRQPONMLKJIHGFEDCBA765432',
             },
             { substep: '1.3', runbook: 'review-security.md', state: 'cancelled' },
@@ -830,6 +831,7 @@ describe('TextRenderer', () => {
       expect(output).toContain('rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
       expect(output).toContain('1.2');
       expect(output).toContain('(claimed: run_abc)');
+      // cspell:disable-next-line
       expect(output).not.toContain('rdtk_ZYXWVUTSRQPONMLKJIHGFEDCBA765432');
       expect(output).toContain('1.3');
       expect(output).toContain('(cancelled)');

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -877,9 +877,10 @@ async function updateStepDelegationChildRunId(
     if (ss.id === substepId && ss.delegation) {
       // When tokenHash is provided, match precisely; otherwise fall back to id match
       if (tokenHash && ss.delegation.tokenHash !== tokenHash) return ss;
+      const { token: _claimedToken, ...claimedDelegation } = ss.delegation;
       return {
         ...ss,
-        delegation: { ...ss.delegation, childRunId },
+        delegation: { ...claimedDelegation, childRunId },
       };
     }
     return ss;

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -73,6 +73,8 @@ export interface StatusOutputData {
     childRunId?: string;
     /** SHA-256 hash of the delegation token for cross-system correlation. */
     tokenHash: string;
+    /** Raw claim token, present only while the delegation is pending. */
+    token?: string;
   }>;
   /**
    * Parent linkage projection when this runbook was launched as a child.
@@ -295,6 +297,11 @@ export function buildActiveStatus(
             : ('pending' as const),
       ...(ss.delegation!.childRunId != null ? { childRunId: ss.delegation!.childRunId } : {}),
       tokenHash: ss.delegation!.tokenHash,
+      ...(ss.delegation!.childRunId == null &&
+      ss.delegation!.cancelledAt == null &&
+      ss.delegation!.token != null
+        ? { token: ss.delegation!.token }
+        : {}),
     }));
 
   return {

--- a/packages/cli/src/services/renderers/text-renderer.ts
+++ b/packages/cli/src/services/renderers/text-renderer.ts
@@ -58,7 +58,13 @@ interface StatusDetailData {
   step?: { name: string; description?: string };
   lastAction?: { action: string; result?: 'PASS' | 'FAIL' };
   pending?: string[];
-  delegations?: { substep: string; runbook: string; state: string; childRunId?: string }[];
+  delegations?: {
+    substep: string;
+    runbook: string;
+    state: string;
+    childRunId?: string;
+    token?: string;
+  }[];
 }
 
 /**
@@ -292,7 +298,7 @@ export class TextRenderer implements OutputRenderer {
         } else if (d.state === 'cancelled') {
           stateLabel = '(cancelled)';
         } else {
-          stateLabel = '(pending claim)';
+          stateLabel = d.token ? `(pending claim: ${d.token})` : '(pending claim)';
         }
         this.writer.writeLine(`  ${d.substep}  ${d.runbook}  DELEGATED  ${stateLabel}`);
       }

--- a/packages/core/__tests__/runbook/delegation-schemas.test.ts
+++ b/packages/core/__tests__/runbook/delegation-schemas.test.ts
@@ -612,13 +612,15 @@ describe('RunbookStateSchema round-trip with delegation', () => {
 
 describe('DelegationStatusEntrySchema', () => {
   const TOKEN_HASH = 'sha256:0000000000000000000000000000000000000000000000000000000000000000';
+  const TOKEN = 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
-  it('validates a pending entry', () => {
+  it('validates a pending entry with a recovery token', () => {
     const entry = {
       substep: '1.1',
       runbook: 'child.md',
       state: 'pending',
       tokenHash: TOKEN_HASH,
+      token: TOKEN,
     };
     expect(() => DelegationStatusEntrySchema.parse(entry)).not.toThrow();
   });
@@ -660,6 +662,29 @@ describe('DelegationStatusEntrySchema', () => {
 
   it('rejects entry missing tokenHash', () => {
     const entry = { substep: '1.1', runbook: 'child.md', state: 'pending' };
+    expect(() => DelegationStatusEntrySchema.parse(entry)).toThrow();
+  });
+
+  it('rejects malformed recovery tokens', () => {
+    const entry = {
+      substep: '1.1',
+      runbook: 'child.md',
+      state: 'pending',
+      tokenHash: TOKEN_HASH,
+      token: 'bad-token',
+    };
+    expect(() => DelegationStatusEntrySchema.parse(entry)).toThrow();
+  });
+
+  it('rejects recovery tokens on claimed entries', () => {
+    const entry = {
+      substep: '1.1',
+      runbook: 'child.md',
+      state: 'claimed',
+      childRunId: 'run_abc123',
+      tokenHash: TOKEN_HASH,
+      token: TOKEN,
+    };
     expect(() => DelegationStatusEntrySchema.parse(entry)).toThrow();
   });
 });

--- a/packages/core/__tests__/runbook/delegation-schemas.test.ts
+++ b/packages/core/__tests__/runbook/delegation-schemas.test.ts
@@ -218,12 +218,30 @@ describe('StepDelegationSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('rejects a token on a claimed delegation', () => {
+    const result = StepDelegationSchema.safeParse({
+      ...validDelegation,
+      token: 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+      childRunId: 'child-run-456',
+    });
+    expect(result.success).toBe(false);
+  });
+
   it('accepts non-null cancelledAt', () => {
     const result = StepDelegationSchema.safeParse({
       ...validDelegation,
       cancelledAt: '2026-02-27T11:00:00.000Z',
     });
     expect(result.success).toBe(true);
+  });
+
+  it('rejects a token on a cancelled delegation', () => {
+    const result = StepDelegationSchema.safeParse({
+      ...validDelegation,
+      token: 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+      cancelledAt: '2026-02-27T11:00:00.000Z',
+    });
+    expect(result.success).toBe(false);
   });
 
   it('preserves extraVars through parse (round-trip)', () => {

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -16,6 +16,7 @@
 
 import { z } from 'zod';
 import { TemplateVarValueSchema } from '../schemas.js';
+import { DELEGATION_TOKEN_PATTERN } from '../runbook/delegation-token.js';
 
 // ============================================================================
 // CLI Error Codes
@@ -273,10 +274,20 @@ export const DelegationStatusEntrySchema = z
     childRunId: z.string().optional().describe('Child run ID when delegation is claimed'),
     /** SHA-256 hash of the delegation token for correlation */
     tokenHash: z.string().describe('SHA-256 hash of the delegation token'),
+    /** Raw delegation token for pending-token recovery */
+    token: z
+      .string()
+      .regex(DELEGATION_TOKEN_PATTERN)
+      .optional()
+      .describe('Raw delegation token, present only while the delegation is pending'),
   })
   .refine((entry) => entry.state !== 'claimed' || !!entry.childRunId, {
     message: 'childRunId is required when state is claimed',
     path: ['childRunId'],
+  })
+  .refine((entry) => entry.state === 'pending' || entry.token === undefined, {
+    message: 'token is only available while state is pending',
+    path: ['token'],
   })
   .describe('Delegation status entry');
 

--- a/packages/core/src/runbook/delegation-service.ts
+++ b/packages/core/src/runbook/delegation-service.ts
@@ -297,6 +297,7 @@ export function createDelegation(
 
   // 9. Create delegation object
   const delegation: StepDelegation = {
+    token,
     tokenHash,
     childRunbookPath,
     contextSnapshot,
@@ -373,6 +374,7 @@ export function abortDelegation(options: AbortDelegationOptions): AbortDelegatio
   // 4. Set cancelledAt
   const updatedDelegation: StepDelegation = {
     ...delegation,
+    token: undefined,
     cancelledAt: new Date().toISOString(),
   };
 

--- a/packages/core/src/runbook/delegation-token.ts
+++ b/packages/core/src/runbook/delegation-token.ts
@@ -14,6 +14,9 @@ export type DelegationTokenHash = string & { readonly [delegationTokenHashBrand]
 /** Canonical persisted delegation token hash pattern. */
 export const DELEGATION_TOKEN_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
 
+/** Canonical raw delegation token pattern. */
+export const DELEGATION_TOKEN_PATTERN = /^rdtk_[A-Z2-7]{32}$/;
+
 /**
  * Encode a buffer as RFC 4648 base32 (no padding).
  *
@@ -106,8 +109,8 @@ export function assertDelegationTokenHash(value: string): DelegationTokenHash {
 /**
  * Compute a SHA-256 hash of a delegation token.
  *
- * The hash is stored in state instead of the raw token to prevent
- * token leakage through persisted state files.
+ * The hash is stored in state for stable correlation after the raw pending
+ * token is claimed or cancelled.
  *
  * @param token - The raw delegation token to hash
  * @returns Hash string in format `sha256:<64 hex chars>`

--- a/packages/core/src/runbook/delegation-token.ts
+++ b/packages/core/src/runbook/delegation-token.ts
@@ -6,6 +6,10 @@ export const TOKEN_PREFIX = 'rdtk_';
 /** RFC 4648 base32 alphabet. */
 const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
+function escapeRegExpLiteral(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+}
+
 export declare const delegationTokenHashBrand: unique symbol;
 
 /** SHA-256 hash of a delegation token in persisted state format. */
@@ -15,7 +19,9 @@ export type DelegationTokenHash = string & { readonly [delegationTokenHashBrand]
 export const DELEGATION_TOKEN_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
 
 /** Canonical raw delegation token pattern. */
-export const DELEGATION_TOKEN_PATTERN = /^rdtk_[A-Z2-7]{32}$/;
+export const DELEGATION_TOKEN_PATTERN = new RegExp(
+  `^${escapeRegExpLiteral(TOKEN_PREFIX)}[A-Z2-7]{32}$`,
+);
 
 /**
  * Encode a buffer as RFC 4648 base32 (no padding).

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -28,6 +28,26 @@ import {
 /** Current persisted state schema version. Bump whenever RunbookState shape changes incompatibly. */
 const CURRENT_SCHEMA_VERSION = 2;
 
+function patchSnapshotSubstepStates(
+  snapshot: unknown,
+  substepStates: readonly SubstepState[] | undefined,
+): unknown {
+  if (!snapshot || typeof snapshot !== 'object' || !('context' in snapshot)) {
+    return snapshot;
+  }
+  const context = (snapshot as { context?: unknown }).context;
+  if (!context || typeof context !== 'object') {
+    return snapshot;
+  }
+  return {
+    ...(snapshot as Record<string, unknown>),
+    context: {
+      ...(context as Record<string, unknown>),
+      substepStates,
+    },
+  };
+}
+
 /**
  * Thrown when a persisted state file was written by an older schema version.
  * Callers should surface this to the user with a prompt to run `rd prune --all`.
@@ -342,10 +362,18 @@ export class RunbookStateManager {
       templateVars: updatesTemplateVars,
       ...restUpdates
     } = updates;
+    const shouldPatchSnapshotSubstepStates =
+      restUpdates.substepStates !== undefined && restUpdates.snapshot === undefined;
+    const patchedRestUpdates = shouldPatchSnapshotSubstepStates
+      ? {
+          ...restUpdates,
+          snapshot: patchSnapshotSubstepStates(existing.snapshot, restUpdates.substepStates),
+        }
+      : restUpdates;
 
     const updated: RunbookState = {
       ...existing,
-      ...restUpdates,
+      ...patchedRestUpdates,
       variables: brandStoredOutputs({ ...existing.variables, ...(updatesVariables ?? {}) }),
       ...(updatesTemplateVars !== undefined
         ? { templateVars: brandInitialTemplateVars(updatesTemplateVars) }

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -429,6 +429,13 @@ export interface ResolvedCompletion {
 
 /** Delegation metadata attached to a parent step's substep state. */
 export interface StepDelegation {
+  /**
+   * Raw delegation token while the delegation is pending.
+   *
+   * Present only until the token is claimed or cancelled, so operators can
+   * recover the `rd claim <token>` command from `rd status`.
+   */
+  readonly token?: string;
   readonly tokenHash: DelegationTokenHash;
   readonly childRunbookPath: string;
   readonly contextSnapshot: ContextSnapshot;

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -288,19 +288,31 @@ export const ContextSnapshotSchema = z
     }
   });
 
+function isPendingDelegation(delegation: {
+  readonly childRunId: string | null;
+  readonly cancelledAt: string | null;
+}): boolean {
+  return delegation.childRunId === null && delegation.cancelledAt === null;
+}
+
 /**
  * Zod schema for delegation metadata attached to a substep.
  */
-export const StepDelegationSchema = z.object({
-  token: z.string().regex(DELEGATION_TOKEN_PATTERN).optional(),
-  tokenHash: DelegationTokenHashSchema,
-  childRunbookPath: z.string(),
-  contextSnapshot: ContextSnapshotSchema,
-  childRunId: z.string().nullable(),
-  createdAt: z.string(),
-  cancelledAt: z.string().nullable(),
-  extraVars: z.record(z.string(), TemplateVarValueSchema).optional(),
-});
+export const StepDelegationSchema = z
+  .object({
+    token: z.string().regex(DELEGATION_TOKEN_PATTERN).optional(),
+    tokenHash: DelegationTokenHashSchema,
+    childRunbookPath: z.string(),
+    contextSnapshot: ContextSnapshotSchema,
+    childRunId: z.string().nullable(),
+    createdAt: z.string(),
+    cancelledAt: z.string().nullable(),
+    extraVars: z.record(z.string(), TemplateVarValueSchema).optional(),
+  })
+  .refine((delegation) => delegation.token === undefined || isPendingDelegation(delegation), {
+    message: 'token is only allowed while delegation is pending',
+    path: ['token'],
+  });
 
 /**
  * Zod schema for SubstepState
@@ -764,16 +776,21 @@ function makeContextSnapshotSchema(projectRoot: string): z.ZodTypeAny {
  * @returns Zod schema for StepDelegation with path-validated contextSnapshot
  */
 function makeStepDelegationSchema(projectRoot: string): z.ZodTypeAny {
-  return z.object({
-    token: z.string().regex(DELEGATION_TOKEN_PATTERN).optional(),
-    tokenHash: DelegationTokenHashSchema,
-    childRunbookPath: z.string(),
-    contextSnapshot: makeContextSnapshotSchema(projectRoot),
-    childRunId: z.string().nullable(),
-    createdAt: z.string(),
-    cancelledAt: z.string().nullable(),
-    extraVars: z.record(z.string(), TemplateVarValueSchema).optional(),
-  });
+  return z
+    .object({
+      token: z.string().regex(DELEGATION_TOKEN_PATTERN).optional(),
+      tokenHash: DelegationTokenHashSchema,
+      childRunbookPath: z.string(),
+      contextSnapshot: makeContextSnapshotSchema(projectRoot),
+      childRunId: z.string().nullable(),
+      createdAt: z.string(),
+      cancelledAt: z.string().nullable(),
+      extraVars: z.record(z.string(), TemplateVarValueSchema).optional(),
+    })
+    .refine((delegation) => delegation.token === undefined || isPendingDelegation(delegation), {
+      message: 'token is only allowed while delegation is pending',
+      path: ['token'],
+    });
 }
 
 /**

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 import { z } from 'zod';
 import {
+  DELEGATION_TOKEN_PATTERN,
   DELEGATION_TOKEN_HASH_PATTERN,
   type delegationTokenHashBrand,
   type DelegationTokenHash,
@@ -291,6 +292,7 @@ export const ContextSnapshotSchema = z
  * Zod schema for delegation metadata attached to a substep.
  */
 export const StepDelegationSchema = z.object({
+  token: z.string().regex(DELEGATION_TOKEN_PATTERN).optional(),
   tokenHash: DelegationTokenHashSchema,
   childRunbookPath: z.string(),
   contextSnapshot: ContextSnapshotSchema,
@@ -763,6 +765,7 @@ function makeContextSnapshotSchema(projectRoot: string): z.ZodTypeAny {
  */
 function makeStepDelegationSchema(projectRoot: string): z.ZodTypeAny {
   return z.object({
+    token: z.string().regex(DELEGATION_TOKEN_PATTERN).optional(),
     tokenHash: DelegationTokenHashSchema,
     childRunbookPath: z.string(),
     contextSnapshot: makeContextSnapshotSchema(projectRoot),


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status now exposes a raw recovery token for pending delegations to enable one-step claiming.
* **Bug Fixes**
  * Raw recovery tokens are stripped from status and persisted snapshots when a delegation is claimed or cancelled; a hashed token remains for correlation.
  * Persisted snapshot substep state is kept in sync with active state during updates.
* **Tests**
  * Added coverage for token display, validation, removal on claim/abort, and persisted-state consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/SPEC.md`, `docs/FORMAT.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
