### PR TITLE
test: add agent dispatch coverage

### DIFF
--- a/packages/claude-code-plugin/__tests__/workflow/hooks/delegation-dispatch.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/delegation-dispatch.test.ts
@@ -24,6 +24,7 @@ jest.unstable_mockModule('node:fs/promises', () => ({
 const { handleDelegationDispatch, buildChildInputFlags } = await import(
   '../../../src/workflow/hooks/delegation-dispatch.js'
 );
+const { handleSubagentStop } = await import('../../../src/workflow/hooks/subagent-stop.js');
 
 function hashToken(token: string): string {
   return `sha256:${createHash('sha256').update(token).digest('hex')}`;
@@ -35,7 +36,6 @@ describe('handleDelegationDispatch', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setGet(session, 'metadata', {});
-    mockSet.mockResolvedValue(undefined);
     // Default: rd status --json fails (no active runbook)
     setExecSync(mockExecFileSyncError({ message: 'no active runbook' }));
   });
@@ -123,6 +123,65 @@ describe('handleDelegationDispatch', () => {
     expect(DelegationActiveTokensMetadataSchema.parse(written.delegation_active_tokens)).toEqual(
       written.delegation_active_tokens,
     );
+  });
+
+  it('round-trips per-agent token metadata from dispatch to SubagentStop', async () => {
+    // cspell:disable-next-line
+    const siblingToken = 'rdtk_BBCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+    setGet(session, 'metadata', {
+      delegation_active_tokens: {
+        'sibling-agent': {
+          kind: 'delegation-active-token',
+          agent_id: 'sibling-agent',
+          session_id: 'session-abc',
+          tokenHash: hashToken(siblingToken),
+          createdAt: '2026-04-28T00:00:00.000Z',
+        },
+      },
+    });
+
+    const dispatchInput = createMockHookInput('PreToolUse', {
+      agent_id: 'agent-123',
+      session_id: 'session-abc',
+      tool_name: 'Task',
+      tool_input: {
+        prompt: `Do the delegated work\nRD_CLAIM_TOKEN=${VALID_TOKEN}`,
+      },
+    });
+
+    await handleDelegationDispatch(dispatchInput);
+
+    const written = mockSet.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+    expect(written.delegation_active_tokens).toMatchObject({
+      'agent-123': {
+        kind: 'delegation-active-token',
+        agent_id: 'agent-123',
+        session_id: 'session-abc',
+        tokenHash: hashToken(VALID_TOKEN),
+      },
+      'sibling-agent': {
+        agent_id: 'sibling-agent',
+        tokenHash: hashToken(siblingToken),
+      },
+    });
+    expect(JSON.stringify(written.delegation_active_tokens)).not.toContain(VALID_TOKEN);
+
+    setExecSync(mockExecFileSync(JSON.stringify({ active: false, stashed: false })));
+    const stopInput = createMockHookInput('SubagentStop', {
+      agent_id: 'agent-123',
+      session_id: 'session-abc',
+    });
+
+    await handleSubagentStop(stopInput);
+
+    expect(mockSet).toHaveBeenLastCalledWith('metadata', {
+      delegation_active_tokens: {
+        'sibling-agent': expect.objectContaining({
+          agent_id: 'sibling-agent',
+          tokenHash: hashToken(siblingToken),
+        }),
+      },
+    });
   });
 
   it('rejects write-side delegation_active_tokens schema drift', async () => {

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -249,6 +249,9 @@ Do work.
         'run --prompted runbooks/parent-fail.runbook.md',
         workspace,
       );
+      expect(start.exitCode).toBe(0);
+      const parentId = (await getActiveState(workspace))?.id;
+      expect(parentId).toBeDefined();
       const frontier = findFrontierInEvents(parseConcatenatedJson(start.stdout)) ?? [];
       const token = frontier.find((entry) => entry.id === '1.1')?.token;
       expect(token).toBeDefined();
@@ -257,10 +260,14 @@ Do work.
       const claim = await runCliInProcess(`claim ${token!}`, workspace, agent);
       const childId = String(findActionOutput(claim.stdout)?.run_id);
 
-      // Anonymous fail — must not stop the agent-owned child.
-      await runCliInProcess('fail --text', workspace);
+      // Anonymous fail — must stop the default-stack parent, not the
+      // agent-owned child.
+      const failResult = await runCliInProcess('fail --text', workspace);
+      expect(failResult.exitCode).toBe(1);
 
+      const parent = await readRunbookState(workspace, parentId!);
       const child = await readRunbookState(workspace, childId);
+      expect(parent?.lifecycle).toBe('stopped');
       expect(child?.lifecycle).toBe('running');
     }, 30_000);
   });

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -345,6 +345,8 @@ Do child work.
 
       const start = await runCliInProcess('run --prompted runbooks/parent.runbook.md', workspace);
       expect(start.exitCode).toBe(0);
+      const parentId = (await getActiveState(workspace))?.id;
+      expect(parentId).toBeDefined();
       const frontier = findFrontierInEvents(parseConcatenatedJson(start.stdout)) ?? [];
       const token = frontier.find((entry) => entry.id === '1.1')?.token;
       expect(token).toBeDefined();
@@ -354,12 +356,15 @@ Do child work.
       expect(claim.exitCode).toBe(0);
       const childId = String(findActionOutput(claim.stdout)?.run_id);
 
-      // Anonymous pass — the resolver must not route to the agent-owned child.
-      // Whether it succeeds or errors on the parent is not the regression we're guarding;
-      // the invariant is that the agent's child remains untouched.
-      await runCliInProcess('pass --text', workspace);
+      // Anonymous pass — the resolver must route to the default-stack parent,
+      // never to the agent-owned child.
+      const passResult = await runCliInProcess('pass --text', workspace);
+      expect(passResult.exitCode).toBe(0);
 
+      const parent = await readRunbookState(workspace, parentId!);
       const child = await readRunbookState(workspace, childId);
+      expect(parent?.step).toBe('2');
+      expect(parent?.lifecycle).toBe('running');
       expect(child?.lifecycle).toBe('running');
     }, 30_000);
   });

--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -550,4 +550,10 @@ describe('extractInputFileReferences', () => {
     const result = extractInputFileReferences(commands);
     expect(result).toEqual(['data/sources.yaml']);
   });
+
+  it('extracts --input-file from expected-failure rd commands', () => {
+    const commands = ['! rd run my.runbook.md --input-file data/sources.yaml'];
+    const result = extractInputFileReferences(commands);
+    expect(result).toEqual(['data/sources.yaml']);
+  });
 });

--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -519,6 +519,12 @@ describe('parseRdCommandWithEnv', () => {
       /Unsupported shell operators/,
     );
   });
+
+  it('rejects rd tokens after shell operators', () => {
+    expect(() => parseRdCommandWithEnv('echo setup && rd pass')).toThrow(
+      /Unsupported shell operators/,
+    );
+  });
 });
 
 describe('extractRunbookReferences', () => {

--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -4,6 +4,7 @@ import {
   matchStepAssertions,
   formatStepAssertionDescription,
   substituteTokens,
+  parseRdCommandWithEnv,
   extractRunbookReferences,
   extractInputFileReferences,
 } from '../../src/helpers/command-sequence.js';
@@ -482,6 +483,41 @@ describe('substituteTokens', () => {
 
   it('returns original string unchanged when no placeholders', () => {
     expect(substituteTokens('rd pass', [])).toBe('rd pass');
+  });
+});
+
+describe('parseRdCommandWithEnv', () => {
+  it('parses plain rd commands', () => {
+    expect(parseRdCommandWithEnv('rd pass --text')).toEqual({
+      args: ['pass', '--text'],
+      env: {},
+    });
+  });
+
+  it('parses leading environment assignments for rd commands', () => {
+    expect(
+      parseRdCommandWithEnv("RD_AGENT_ID=agent-a RD_SESSION_ID='session a' rd claim rdtk_abc123"),
+    ).toEqual({
+      args: ['claim', 'rdtk_abc123'],
+      env: {
+        RD_AGENT_ID: 'agent-a',
+        RD_SESSION_ID: 'session a',
+      },
+    });
+  });
+
+  it('returns null for non-rd shell commands', () => {
+    expect(parseRdCommandWithEnv('echo hello')).toBeNull();
+  });
+
+  it('returns null for env-prefixed non-rd shell commands with operators', () => {
+    expect(parseRdCommandWithEnv('FOO=bar echo ok && echo done')).toBeNull();
+  });
+
+  it('rejects env-prefixed rd commands with operators', () => {
+    expect(() => parseRdCommandWithEnv('RD_AGENT_ID=agent-a rd pass && echo done')).toThrow(
+      /Unsupported shell operators/,
+    );
   });
 });
 

--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -514,6 +514,10 @@ describe('parseRdCommandWithEnv', () => {
     expect(parseRdCommandWithEnv('FOO=bar echo ok && echo done')).toBeNull();
   });
 
+  it('returns null when rd is a shell command argument before an operator', () => {
+    expect(parseRdCommandWithEnv('echo rd && echo done')).toBeNull();
+  });
+
   it('rejects env-prefixed rd commands with operators', () => {
     expect(() => parseRdCommandWithEnv('RD_AGENT_ID=agent-a rd pass && echo done')).toThrow(
       /Unsupported shell operators/,
@@ -522,6 +526,12 @@ describe('parseRdCommandWithEnv', () => {
 
   it('rejects rd tokens after shell operators', () => {
     expect(() => parseRdCommandWithEnv('echo setup && rd pass')).toThrow(
+      /Unsupported shell operators/,
+    );
+  });
+
+  it('rejects env-prefixed rd commands after shell operators', () => {
+    expect(() => parseRdCommandWithEnv('echo setup && RD_AGENT_ID=agent-a rd pass')).toThrow(
       /Unsupported shell operators/,
     );
   });

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -103,7 +103,8 @@ export function parseRdCommandWithEnv(cmd: string): ParsedRdCommand | null {
   const hasOperators = shellArgs.some((entry) => typeof entry !== 'string');
   if (hasOperators) {
     const executable = findExecutableAfterEnvAssignments(shellArgs);
-    if (executable === 'rd' || executable === 'rundown') {
+    const hasRdToken = shellArgs.some((entry) => entry === 'rd' || entry === 'rundown');
+    if (executable === 'rd' || executable === 'rundown' || hasRdToken) {
       throw new Error(
         `Unsupported shell operators in scenario command: ${cmd}. ` +
           'Split into separate commands instead of using &&, ||, |, etc.',

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -67,6 +67,70 @@ export interface CommandSequenceOptions {
   env?: Record<string, string | undefined>;
 }
 
+/** Parsed `rd` command with command-scoped environment assignments. */
+export interface ParsedRdCommand {
+  /** Arguments passed to the Rundown CLI, excluding the `rd` executable. */
+  args: string[];
+  /** Environment assignments that apply only to this command. */
+  env: Record<string, string>;
+}
+
+const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=.*/;
+
+function findExecutableAfterEnvAssignments(shellArgs: Array<string | object>): string | null {
+  for (const entry of shellArgs) {
+    if (typeof entry !== 'string') {
+      return null;
+    }
+    if (ENV_ASSIGNMENT_PATTERN.test(entry)) {
+      continue;
+    }
+    return entry;
+  }
+  return null;
+}
+
+/**
+ * Parse a scenario command as an `rd` command, allowing leading environment
+ * assignments such as `RD_AGENT_ID=a RD_SESSION_ID=s rd pass`.
+ *
+ * @param cmd - Scenario command string after token substitution
+ * @returns Parsed args/env for `rd`/`rundown`, or null for non-`rd` shell commands
+ * @throws {Error} When shell operators are present in an `rd` command
+ */
+export function parseRdCommandWithEnv(cmd: string): ParsedRdCommand | null {
+  const shellArgs = shellParse(cmd);
+  const hasOperators = shellArgs.some((entry) => typeof entry !== 'string');
+  if (hasOperators) {
+    const executable = findExecutableAfterEnvAssignments(shellArgs);
+    if (executable === 'rd' || executable === 'rundown') {
+      throw new Error(
+        `Unsupported shell operators in scenario command: ${cmd}. ` +
+          'Split into separate commands instead of using &&, ||, |, etc.',
+      );
+    }
+    return null;
+  }
+
+  const args = shellArgs as string[];
+  const env: Record<string, string> = {};
+  let commandIndex = 0;
+
+  while (commandIndex < args.length && ENV_ASSIGNMENT_PATTERN.test(args[commandIndex])) {
+    const assignment = args[commandIndex];
+    const equalsIndex = assignment.indexOf('=');
+    env[assignment.slice(0, equalsIndex)] = assignment.slice(equalsIndex + 1);
+    commandIndex++;
+  }
+
+  const executable = args[commandIndex];
+  if (executable !== 'rd' && executable !== 'rundown') {
+    return null;
+  }
+
+  return { args: args.slice(commandIndex + 1), env };
+}
+
 /**
  * Substitute captured token placeholders in a command string.
  *
@@ -402,9 +466,9 @@ export function extractInputFileReferences(commands: string[]): string[] {
   const result: string[] = [];
 
   for (const cmd of commands) {
-    const rdMatch = /^rd\s+(.*)$/.exec(cmd);
-    if (!rdMatch) continue;
-    const args = shellParse(rdMatch[1]).filter((a): a is string => typeof a === 'string');
+    const parsed = parseRdCommandWithEnv(cmd);
+    if (!parsed) continue;
+    const args = parsed.args;
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
       let filePath: string | undefined;
@@ -428,9 +492,10 @@ export function extractInputFileReferences(commands: string[]): string[] {
  * Execute a sequence of commands in order, accumulating transitions and tokens.
  *
  * Handles `rd` commands (JSON is the default output format) and generic
- * shell commands. Token placeholders (`${TOKEN}`, `${TOKEN_2}`, etc.) are
- * substituted with previously captured delegation tokens before each
- * command runs. Tokens are extracted from parsed JSON `delegate` responses.
+ * shell commands. Prefix a command with `! ` when a non-zero exit is the
+ * expected outcome. Token placeholders (`${TOKEN}`, `${TOKEN_2}`, etc.) are
+ * substituted with previously captured delegation tokens before each command
+ * runs. Tokens are extracted from parsed JSON `delegate` responses.
  *
  * @param options - Execution options including commands, working directory, CLI path, and quiet flag
  * @returns Promise resolving to the terminal result, all transitions, and captured tokens
@@ -447,27 +512,25 @@ export async function executeCommandSequence(
   const { commands, cwd, cliPath, quiet, env } = options;
 
   for (const rawCmd of commands) {
+    const trimmedRaw = rawCmd.trimStart();
+    const expectsFailure = trimmedRaw.startsWith('! ');
+    const commandText = expectsFailure ? trimmedRaw.slice(2).trimStart() : rawCmd;
     // Token substitution — replace ${TOKEN}, ${TOKEN_2}, etc. with captured values
-    const cmd = substituteTokens(rawCmd, capturedTokens);
+    const cmd = substituteTokens(commandText, capturedTokens);
 
-    options.onCommandStart?.(cmd);
+    options.onCommandStart?.(expectsFailure ? `! ${cmd}` : cmd);
 
-    const rdMatch = /^rd\s+(.*)$/.exec(cmd);
+    const rdCommand = parseRdCommandWithEnv(cmd);
 
     let stdout: string;
 
-    if (rdMatch) {
+    if (rdCommand) {
       // rd command — parse args (JSON is the default output format)
-      const shellArgs = shellParse(rdMatch[1]);
-      const hasOperators = shellArgs.some((entry) => typeof entry !== 'string');
-      if (hasOperators) {
-        throw new Error(
-          `Unsupported shell operators in scenario command: ${cmd}. ` +
-            'Split into separate commands instead of using &&, ||, |, etc.',
-        );
-      }
-      const args = shellArgs as string[];
-      const result = await runCommandWithTee({ kind: 'rd', args }, { cwd, quiet, cliPath, env });
+      const commandEnv = { ...env, ...rdCommand.env };
+      const result = await runCommandWithTee(
+        { kind: 'rd', args: rdCommand.args },
+        { cwd, quiet, cliPath, env: commandEnv },
+      );
       stdout = result.stdout;
 
       // Parse JSON output to extract transitions, terminal state, and tokens
@@ -483,14 +546,20 @@ export async function executeCommandSequence(
       }
 
       // If the command failed and no terminal result was parsed, propagate the failure
-      if (result.exitCode !== 0 && jsonResult.terminal === null) {
+      if (expectsFailure && result.exitCode === 0) {
+        throw new Error(`Command was expected to fail but exited 0: ${cmd}`);
+      }
+      if (!expectsFailure && result.exitCode !== 0 && jsonResult.terminal === null) {
         throw new Error(`Command failed with exit code ${String(result.exitCode)}: ${cmd}`);
       }
     } else {
       // Shell command — execute directly
       const result = await runCommandWithTee({ kind: 'shell', cmd }, { cwd, quiet, cliPath, env });
       stdout = result.stdout;
-      if (result.exitCode !== 0) {
+      if (expectsFailure && result.exitCode === 0) {
+        throw new Error(`Shell command was expected to fail but exited 0: ${cmd}`);
+      }
+      if (!expectsFailure && result.exitCode !== 0) {
         throw new Error(`Shell command failed with exit code ${String(result.exitCode)}: ${cmd}`);
       }
     }

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -90,6 +90,26 @@ function findExecutableAfterEnvAssignments(shellArgs: Array<string | object>): s
   return null;
 }
 
+function hasRdExecutableInOperatorSeparatedSegment(shellArgs: Array<string | object>): boolean {
+  let segment: Array<string | object> = [];
+
+  for (const entry of shellArgs) {
+    if (typeof entry !== 'string') {
+      const executable = findExecutableAfterEnvAssignments(segment);
+      if (executable === 'rd' || executable === 'rundown') {
+        return true;
+      }
+      segment = [];
+      continue;
+    }
+
+    segment.push(entry);
+  }
+
+  const executable = findExecutableAfterEnvAssignments(segment);
+  return executable === 'rd' || executable === 'rundown';
+}
+
 /**
  * Parse a scenario command as an `rd` command, allowing leading environment
  * assignments such as `RD_AGENT_ID=a RD_SESSION_ID=s rd pass`.
@@ -102,9 +122,7 @@ export function parseRdCommandWithEnv(cmd: string): ParsedRdCommand | null {
   const shellArgs = shellParse(cmd);
   const hasOperators = shellArgs.some((entry) => typeof entry !== 'string');
   if (hasOperators) {
-    const executable = findExecutableAfterEnvAssignments(shellArgs);
-    const hasRdToken = shellArgs.some((entry) => entry === 'rd' || entry === 'rundown');
-    if (executable === 'rd' || executable === 'rundown' || hasRdToken) {
+    if (hasRdExecutableInOperatorSeparatedSegment(shellArgs)) {
       throw new Error(
         `Unsupported shell operators in scenario command: ${cmd}. ` +
           'Split into separate commands instead of using &&, ||, |, etc.',

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -466,7 +466,9 @@ export function extractInputFileReferences(commands: string[]): string[] {
   const result: string[] = [];
 
   for (const cmd of commands) {
-    const parsed = parseRdCommandWithEnv(cmd);
+    const trimmed = cmd.trimStart();
+    const commandText = trimmed.startsWith('! ') ? trimmed.slice(2).trimStart() : cmd;
+    const parsed = parseRdCommandWithEnv(commandText);
     if (!parsed) continue;
     const args = parsed.args;
     for (let i = 0; i < args.length; i++) {

--- a/packages/core/__tests__/runbook/session-service.test.ts
+++ b/packages/core/__tests__/runbook/session-service.test.ts
@@ -462,6 +462,49 @@ describe('SessionService', () => {
       }
     });
 
+    it('restores a stashed middle child on top of an in-progress owner stack', async () => {
+      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const childA = await manager.create('child-a.md', mockRunbook, {
+        runbookPath: 'child-a.md',
+      });
+      const childB = await manager.create('child-b.md', mockRunbook, {
+        runbookPath: 'child-b.md',
+      });
+      const childC = await manager.create('child-c.md', mockRunbook, {
+        runbookPath: 'child-c.md',
+      });
+      const linkageA = linkageFor(parent.id, '1');
+      const linkageB = linkageFor(parent.id, '2');
+      const linkageC = linkageFor(parent.id, '3');
+
+      await sessionService.claimRunbookForOwner(identity, childA.id, linkageA);
+      const claimedB = await sessionService.claimRunbookForOwner(identity, childB.id, linkageB);
+      expect(claimedB.status).toBe('claimed');
+      if (claimedB.status !== 'claimed') return;
+
+      await sessionService.stashRunbook(childB.id);
+      await sessionService.claimRunbookForOwner(identity, childC.id, linkageC);
+      await sessionService.unstashForOwner(identity);
+
+      const session = await manager.loadSession();
+      const ownerStack = Object.values(session.ownedRunbooks).flat();
+      expect(ownerStack.map((ownership) => ownership.childRunId)).toEqual([
+        childA.id,
+        childC.id,
+        childB.id,
+      ]);
+
+      const active = await sessionService.getActiveForOwner(identity);
+      expect(active.status).toBe('owned');
+      if (active.status === 'owned') {
+        expect(active.state.id).toBe(childB.id);
+        expect(active.ownership.claimedAt).toBe(claimedB.ownership.claimedAt);
+        expect(active.ownership.tokenHash).toBe(claimedB.ownership.tokenHash);
+        expect(active.ownership.parentRunId).toBe(parent.id);
+        expect(active.ownership.parentStepId).toBe('1');
+      }
+    });
+
     it('rejects same-owner re-claim of a stashed child with conflict', async () => {
       const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
       const child = await manager.create('child.md', mockRunbook, { runbookPath: 'child.md' });

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { isError } from '../../src/errors.js';
@@ -271,6 +271,20 @@ describe('RunbookStateManager', () => {
   });
 
   describe('Load and save operations', () => {
+    it('rejects legacy per-agent stacks session shape', async () => {
+      await mkdir(join(testDir, '.rundown'), { recursive: true });
+      await writeFile(
+        join(testDir, '.rundown', 'session.json'),
+        JSON.stringify({
+          stacks: {
+            'agent:legacy-agent:session:legacy-session': ['legacy-run-id'],
+          },
+        }),
+      );
+
+      await expect(manager.loadSession()).rejects.toThrow(/Legacy per-agent session format/);
+    });
+
     it('load returns null for nonexistent runbook', async () => {
       const result = await manager.load('nonexistent-id');
       expect(result).toBeNull();

--- a/runbooks/agent-dispatch/agent-child-prompted.runbook.md
+++ b/runbooks/agent-dispatch/agent-child-prompted.runbook.md
@@ -1,0 +1,25 @@
+---
+name: agent-child-prompted
+description: Prompted child runbook for agent-dispatch ownership scenarios
+tags:
+  - test
+  - agent-dispatch
+
+scenarios:
+  pass:
+    description: Child can be completed manually
+    commands:
+      - rd run --prompted agent-child-prompted.runbook.md
+      - rd pass
+    result: COMPLETE
+---
+
+# Agent-dispatch child stays active until its owning agent passes it
+
+## 1. Agent-owned work
+
+- PASS COMPLETE
+- FAIL STOP
+
+The child intentionally has no command block so ownership scenarios can claim it
+and then complete it with the agent-scoped `rd pass` command.

--- a/runbooks/agent-dispatch/orchestrator.runbook.md
+++ b/runbooks/agent-dispatch/orchestrator.runbook.md
@@ -1,0 +1,36 @@
+---
+name: agent-dispatch-orchestrator
+description: One agent claims and completes multiple delegated child runbooks
+tags:
+  - test
+  - agent-dispatch
+
+scenarios:
+  same-agent-two-claims:
+    description: Same agent claims two children, completes stack top first, then returns to the earlier child
+    commands:
+      - rd run --prompted orchestrator.runbook.md
+      - rd delegate agent-child-prompted.runbook.md --step 1.1
+      - rd delegate agent-child-prompted.runbook.md --step 1.2
+      - RD_AGENT_ID=orchestrator RD_SESSION_ID=agent-dispatch rd claim ${TOKEN}
+      - RD_AGENT_ID=orchestrator RD_SESSION_ID=agent-dispatch rd claim ${TOKEN_2}
+      - RD_AGENT_ID=orchestrator RD_SESSION_ID=agent-dispatch rd pass
+      - RD_AGENT_ID=orchestrator RD_SESSION_ID=agent-dispatch rd pass
+      - rd collect
+    result: COMPLETE
+---
+
+# One orchestrator agent owns multiple delegated children as a stack
+
+## 1. Fan out to agent-owned children
+
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 First child
+
+- agent-child-prompted.runbook.md
+
+### 1.2 Second child
+
+- agent-child-prompted.runbook.md

--- a/runbooks/agent-dispatch/ownership-refusal.runbook.md
+++ b/runbooks/agent-dispatch/ownership-refusal.runbook.md
@@ -1,0 +1,33 @@
+---
+name: agent-dispatch-ownership-refusal
+description: Agent-owned delegated children refuse anonymous or cross-agent control
+tags:
+  - test
+  - agent-dispatch
+
+scenarios:
+  owned-stash-refuses-anonymous-pop:
+    description: Anonymous pop and cross-agent claim fail while the owning agent can restore and complete the child
+    commands:
+      - rd run --prompted ownership-refusal.runbook.md
+      - rd delegate agent-child-prompted.runbook.md --step 1.1
+      - RD_AGENT_ID=agent-a RD_SESSION_ID=refusal-session rd claim ${TOKEN}
+      - RD_AGENT_ID=agent-a RD_SESSION_ID=refusal-session rd stash
+      - "! rd pop"
+      - "! RD_AGENT_ID=agent-b RD_SESSION_ID=refusal-session rd claim ${TOKEN}"
+      - RD_AGENT_ID=agent-a RD_SESSION_ID=refusal-session rd pop
+      - RD_AGENT_ID=agent-a RD_SESSION_ID=refusal-session rd pass
+      - rd collect
+    result: COMPLETE
+---
+
+# Agent-owned children reject anonymous and cross-agent control
+
+## 1. Delegate one owned child
+
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Owned child
+
+- agent-child-prompted.runbook.md

--- a/runbooks/agent-dispatch/sibling-fan-out.runbook.md
+++ b/runbooks/agent-dispatch/sibling-fan-out.runbook.md
@@ -1,0 +1,36 @@
+---
+name: agent-dispatch-sibling-fan-out
+description: Two different agents claim sibling delegated child runbooks
+tags:
+  - test
+  - agent-dispatch
+
+scenarios:
+  distinct-agents-complete-siblings:
+    description: Two sibling agents complete their own children without crossing ownership
+    commands:
+      - rd run --prompted sibling-fan-out.runbook.md
+      - rd delegate agent-child-prompted.runbook.md --step 1.1
+      - rd delegate agent-child-prompted.runbook.md --step 1.2
+      - RD_AGENT_ID=agent-one RD_SESSION_ID=sibling-session rd claim ${TOKEN}
+      - RD_AGENT_ID=agent-two RD_SESSION_ID=sibling-session rd claim ${TOKEN_2}
+      - RD_AGENT_ID=agent-one RD_SESSION_ID=sibling-session rd pass
+      - RD_AGENT_ID=agent-two RD_SESSION_ID=sibling-session rd pass
+      - rd collect
+    result: COMPLETE
+---
+
+# Sibling agents own separate delegated children
+
+## 1. Fan out to sibling agents
+
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Agent one child
+
+- agent-child-prompted.runbook.md
+
+### 1.2 Agent two child
+
+- agent-child-prompted.runbook.md

--- a/runbooks/scenario-suite.yaml
+++ b/runbooks/scenario-suite.yaml
@@ -138,6 +138,50 @@ cases:
       - rd pass
     result: COMPLETE
 
+  # agent-dispatch/
+  agent-dispatch-orchestrator-completed:
+    description: Same agent claims two children and completes them as an owner stack
+    file: agent-dispatch/orchestrator.runbook.md
+    commands:
+      - rd run --prompted orchestrator.runbook.md
+      - rd delegate agent-child-prompted.runbook.md --step 1.1
+      - rd delegate agent-child-prompted.runbook.md --step 1.2
+      - RD_AGENT_ID=orchestrator RD_SESSION_ID=agent-dispatch rd claim ${TOKEN}
+      - RD_AGENT_ID=orchestrator RD_SESSION_ID=agent-dispatch rd claim ${TOKEN_2}
+      - RD_AGENT_ID=orchestrator RD_SESSION_ID=agent-dispatch rd pass
+      - RD_AGENT_ID=orchestrator RD_SESSION_ID=agent-dispatch rd pass
+      - rd collect
+    result: COMPLETE
+
+  agent-dispatch-sibling-fan-out-completed:
+    description: Two sibling agents claim and complete separate delegated children
+    file: agent-dispatch/sibling-fan-out.runbook.md
+    commands:
+      - rd run --prompted sibling-fan-out.runbook.md
+      - rd delegate agent-child-prompted.runbook.md --step 1.1
+      - rd delegate agent-child-prompted.runbook.md --step 1.2
+      - RD_AGENT_ID=agent-one RD_SESSION_ID=sibling-session rd claim ${TOKEN}
+      - RD_AGENT_ID=agent-two RD_SESSION_ID=sibling-session rd claim ${TOKEN_2}
+      - RD_AGENT_ID=agent-one RD_SESSION_ID=sibling-session rd pass
+      - RD_AGENT_ID=agent-two RD_SESSION_ID=sibling-session rd pass
+      - rd collect
+    result: COMPLETE
+
+  agent-dispatch-ownership-refusal-completed:
+    description: Owned stash refuses anonymous pop and cross-agent claim before owner restores it
+    file: agent-dispatch/ownership-refusal.runbook.md
+    commands:
+      - rd run --prompted ownership-refusal.runbook.md
+      - rd delegate agent-child-prompted.runbook.md --step 1.1
+      - RD_AGENT_ID=agent-a RD_SESSION_ID=refusal-session rd claim ${TOKEN}
+      - RD_AGENT_ID=agent-a RD_SESSION_ID=refusal-session rd stash
+      - "! rd pop"
+      - "! RD_AGENT_ID=agent-b RD_SESSION_ID=refusal-session rd claim ${TOKEN}"
+      - RD_AGENT_ID=agent-a RD_SESSION_ID=refusal-session rd pop
+      - RD_AGENT_ID=agent-a RD_SESSION_ID=refusal-session rd pass
+      - rd collect
+    result: COMPLETE
+
   # for-loops/ (new coverage)
   for-descending-completed:
     description: Descending range iterates 3, 2, 1


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runbooks/scenarios for multi-agent delegation: orchestrator LIFO, sibling fan-out, and ownership-refusal flows.
  * Command parsing/execution now supports KEY=VALUE env prefixes, a leading "!" to invert expected exit semantics, and merges command-scoped env into execution.

* **Tests**
  * Strengthened end-to-end tests for delegation, per-agent token handling, and lifecycle transitions.
  * Added unit tests for env-aware command parsing, input-file extraction, and legacy session-format detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/SPEC.md`, `docs/FORMAT.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
