### PR TITLE
docs: sync scenario and rundown docs

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -44,18 +44,30 @@ desc_field     ::= "description:" ws text
 version_field  ::= "version:" ws text
 author_field   ::= "author:" ws text
 tags_field     ::= "tags:" newline tag_list
-inputs_fm_field ::= "inputs:" newline inputs_map
+inputs_fm_field ::= "inputs:" newline input_list
 required_field  ::= "required:" newline required_list
+outputs_fm_field ::= "outputs:" newline output_fm_list
 
 name_string    ::= [a-zA-Z0-9_-] ( [a-zA-Z0-9_ -]* [a-zA-Z0-9_-] )?
 tag_list       ::= ( ws "- " tag newline )+
 tag            ::= text
-inputs_map     ::= ( ws variable_name ":" ws value newline )+
-value          ::= text
+input_list     ::= ( ws "- " variable_name newline )+
 required_list  ::= ( ws "- " variable_name newline )+
+output_fm_list ::= ( ws "- " quoted_output_entry newline
+                   | ws "- " output_entry newline )+
 ```
 
-Additional fields beyond those listed are preserved (open schema). All fields are optional.
+Public frontmatter keys are case-insensitive (`inputs:`, `INPUTS:`, and `Inputs:` are equivalent); unknown keys are preserved with their original casing. All fields are optional.
+
+`inputs:` declares variable names only. Runtime values come from CLI flags, config, environment bridge variables, or delegation inheritance. Each name must match `variable_name` and must not be [reserved](#reserved-variable-names). `required:` entries must also be declared in `inputs:`.
+
+`outputs:` uses the same entry grammar as [OUTPUTS directives](#context-directives). Quote entries that contain template expressions in YAML:
+
+```yaml
+outputs:
+  - Result
+  - 'PlanPath {{ path "plan.json" }}'
+```
 
 ## Steps
 
@@ -90,12 +102,13 @@ Substeps cannot contain nested substeps. See [SPEC.md §1.1](./SPEC.md) for the 
 outputs_directive ::= "- OUTPUTS" newline output_list
 output_list       ::= ( ws "- " output_entry newline )+
 output_entry      ::= variable_name ( ws output_value )?
+quoted_output_entry ::= quoted_string
 output_value      ::= helper_call | template_variable | quoted_string | variable_name
 helper_call       ::= "{{" ws? variable_name ( ws argument )+ ws? "}}"
 argument          ::= quoted_string | variable_path
 ```
 
-A step or substep may declare at most one OUTPUTS directive. Duplicate directives on the same target are rejected. The `- INPUTS` directive has been removed — use the frontmatter `inputs:` field to declare default variable values.
+A step or substep may declare at most one OUTPUTS directive. Duplicate directives on the same target are rejected. The `- INPUTS` directive has been removed — use the frontmatter `inputs:` field to declare variable names.
 
 OUTPUTS declares values to inject into the runbook's live variable space
 after step completion. An entry may be a **naked declaration** (name only)

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -45,7 +45,9 @@ version_field  ::= "version:" ws text
 author_field   ::= "author:" ws text
 tags_field     ::= "tags:" newline tag_list
 inputs_fm_field ::= "inputs:" newline input_list
+                  | "inputs:" ws inline_sequence
 required_field  ::= "required:" newline required_list
+                  | "required:" ws inline_sequence
 outputs_fm_field ::= "outputs:" newline output_fm_list
 
 name_string    ::= [a-zA-Z0-9_-] ( [a-zA-Z0-9_ -]* [a-zA-Z0-9_-] )?
@@ -53,13 +55,14 @@ tag_list       ::= ( ws "- " tag newline )+
 tag            ::= text
 input_list     ::= ( ws "- " variable_name newline )+
 required_list  ::= ( ws "- " variable_name newline )+
+inline_sequence ::= "[" variable_name ( "," variable_name )* "]"
 output_fm_list ::= ( ws "- " quoted_output_entry newline
                    | ws "- " output_entry newline )+
 ```
 
 Public frontmatter keys are case-insensitive (`inputs:`, `INPUTS:`, and `Inputs:` are equivalent); unknown keys are preserved with their original casing. All fields are optional.
 
-`inputs:` declares variable names only. Runtime values come from CLI flags, config, environment bridge variables, or delegation inheritance. Each name must match `variable_name` and must not be [reserved](#reserved-variable-names). `required:` entries must also be declared in `inputs:`.
+`inputs:` declares variable names only. Runtime values come from CLI flags, config, environment bridge variables, or delegation inheritance. Each name must match `variable_name` and must not be [reserved](#reserved-variable-names). `required:` entries must also be declared in `inputs:`. Both block YAML sequences and inline YAML sequences such as `inputs: [PlanPath]` are valid.
 
 `outputs:` uses the same entry grammar as [OUTPUTS directives](#context-directives). Quote entries that contain template expressions in YAML:
 

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -425,27 +425,40 @@ The session tracks which runbooks are active using a **stack-based model**:
   "defaultStack": ["wf-2026-04-28-parent"],
   "stashedRunbookId": null,
   "ownedRunbooks": {
-    "agent:agent-a:session:session-a": {
-      "kind": "agent-owned-runbook",
-      "ownerKey": "agent:agent-a:session:session-a",
-      "agent_id": "agent-a",
-      "session_id": "session-a",
-      "childRunId": "wf-2026-04-28-child",
-      "tokenHash": "sha256:...",
-      "parentRunId": "wf-2026-04-28-parent",
-      "parentStepId": "1",
-      "claimedAt": "2026-04-28T00:00:00.000Z",
-      "updatedAt": "2026-04-28T00:00:00.000Z"
-    }
+    "agent:agent-a:session:session-a": [
+      {
+        "kind": "agent-owned-runbook",
+        "ownerKey": "agent:agent-a:session:session-a",
+        "agent_id": "agent-a",
+        "session_id": "session-a",
+        "childRunId": "wf-2026-04-28-child",
+        "tokenHash": "sha256:...",
+        "parentRunId": "wf-2026-04-28-parent",
+        "parentStepId": "1",
+        "parentFrameKey": "1|",
+        "parentEntry": 1,
+        "claimedAt": "2026-04-28T00:00:00.000Z",
+        "updatedAt": "2026-04-28T00:00:00.000Z"
+      }
+    ]
   }
 }
 ```
 
 - **defaultStack**: Legacy/default active runbook stack for top-level, inline, and unidentified/manual flows.
 - **stashedRunbookId**: Temporarily paused runbook (for `rundown stash`/`rundown pop`).
-- **ownedRunbooks**: Per-agent/session ownership map for delegated child runs claimed by subagents. Identified callers resolve this map before falling back to `defaultStack`.
+- **stashedRunbookOwnership**: Ownership record captured when an agent-owned child is stashed.
+- **ownedRunbooks**: Per-agent/session ownership stacks for delegated child runs claimed by subagents. Identified callers resolve the top entry for their owner key and do not fall back to `defaultStack`.
+
+Agent identity is read from `RD_AGENT_ID` and optional `RD_SESSION_ID`. This is an isolation mechanism for cooperating local agents, not a security boundary; any process can set those environment variables. Owner keys are `agent:<agent_id>` or `agent:<agent_id>:session:<session_id>` with key segments percent-encoded.
 
 Terminal cleanup commands (`rundown stop` and `rundown complete`) remove stale owned child references when the target state is already missing or unusable. Step-result commands (`rundown pass` and `rundown fail`) fail closed in that case because they cannot safely apply a result to a missing delegated child.
+
+`stash` and `pop` are ownership-aware:
+- Anonymous `stash` moves the default-stack active runbook into the single stash slot.
+- Identified `stash` resolves the caller-owned child, removes it from that owner's stack, and stores the ownership record in `stashedRunbookOwnership`.
+- Anonymous `pop` refuses an agent-owned stash; identified `pop` refuses anonymous stashes and stashes owned by another caller.
+- Owned `pop` also verifies the delegated parent still exists and is not terminal before restoring the child to the owner's stack.
 
 ### Runbook State Structure
 
@@ -973,6 +986,14 @@ rundown scenario run <file> <name>          # Execute and verify
 rundown scenario run <file> <name> --quiet  # Suppress command output
 ```
 
+Implementation notes:
+- `scenario run` creates an isolated temp workspace, copies the scenario runbook into `.rundown/runbooks/`, copies referenced `*.runbook.md` children found in commands, and executes commands through `executeCommandSequence`.
+- `rd`/`rundown` commands are spawned directly as `node <cliPath> ...` so JSON output can be captured; non-`rd` commands run through the shell.
+- Leading command-scoped env assignments are supported for `rd` commands, for example `RD_AGENT_ID=a RD_SESSION_ID=s rd pass`. Shell operators in an `rd` command are rejected; split those commands into separate scenario entries.
+- Prefix a command with `! ` when a non-zero exit is expected. If an expected-failure command exits 0, the scenario fails; otherwise the failed command is allowed to continue.
+- Delegation tokens are captured from `rd delegate` JSON responses and from `step_entered.delegateFrontier` auto-issued tokens. `${TOKEN}` expands to the first captured token, `${TOKEN_2}` to the second, and so on.
+- `--input-file` dependencies are copied by directory. Scenario execution copies the entire containing directory for each relative `--input-file` path so YAML files that contain sibling `file:` references keep working. Absolute paths and `..` traversal are rejected.
+
 #### `rundown scenario-suite` - Scenario Suites
 
 List, show, or execute cases from a scenario suite file.
@@ -1008,8 +1029,9 @@ Delegation semantics:
 - `claim` uses the delegation token (printed by `delegate`) to launch the child runbook.
 - Child runbook uses plain `rd pass` / `rd fail` to report its outcome.
 - Completion routing is frame + entry aware (`frame + entry + substep`) to prevent stale re-entry completions from being applied.
-- Identified subagents are routed by ownership, not by the shared stack. `rd claim <token>` records the claimed child run id under the caller's `agent_id`/`session_id`; later plain ownership-routed commands (`rd status`, `rd pass`, `rd fail`, `rd stash`, `rd pop`, and `rd stop`) resolve that owned child first.
-- The shared `defaultStack` is not a safe targeting mechanism for parallel delegated siblings because the most recently claimed child is not necessarily the caller's child.
+- Identified subagents are routed by ownership, not by the shared stack. `rd claim <token>` records the claimed child run id under the caller's `RD_AGENT_ID`/`RD_SESSION_ID`; later plain ownership-routed commands (`rd status`, `rd pass`, `rd fail`, `rd stash`, `rd pop`, `rd stop`, and `rd complete`) resolve that owned child.
+- Ownership is stored as a stack per owner key. Re-claim by the same owner refreshes/moves the existing entry to the top; claim by a different owner for the same child is rejected with `DELEGATION_OWNER_CONFLICT`.
+- Anonymous claims still use `defaultStack`; identified claims use `ownedRunbooks`. The shared `defaultStack` is not a safe targeting mechanism for parallel delegated siblings because the most recently claimed child is not necessarily the caller's child.
 - If an ownership record points at missing or terminal state, commands fail closed instead of falling back to the shared stack in the same invocation.
 
 ### Runtime Identity Glossary

--- a/docs/RUNDOWN.md
+++ b/docs/RUNDOWN.md
@@ -990,7 +990,7 @@ Implementation notes:
 - `scenario run` creates an isolated temp workspace, copies the scenario runbook into `.rundown/runbooks/`, copies referenced `*.runbook.md` children found in commands, and executes commands through `executeCommandSequence`.
 - `rd`/`rundown` commands are spawned directly as `node <cliPath> ...` so JSON output can be captured; non-`rd` commands run through the shell.
 - Leading command-scoped env assignments are supported for `rd` commands, for example `RD_AGENT_ID=a RD_SESSION_ID=s rd pass`. Shell operators in an `rd` command are rejected; split those commands into separate scenario entries.
-- Prefix a command with `! ` when a non-zero exit is expected. If an expected-failure command exits 0, the scenario fails; otherwise the failed command is allowed to continue.
+- Prefix a command with `!` followed by a literal space when a non-zero exit is expected. If an expected-failure command exits 0, the scenario fails; otherwise the failed command is allowed to continue.
 - Delegation tokens are captured from `rd delegate` JSON responses and from `step_entered.delegateFrontier` auto-issued tokens. `${TOKEN}` expands to the first captured token, `${TOKEN_2}` to the second, and so on.
 - `--input-file` dependencies are copied by directory. Scenario execution copies the entire containing directory for each relative `--input-file` path so YAML files that contain sibling `file:` references keep working. Absolute paths and `..` traversal are rejected.
 

--- a/docs/SCENARIOS.md
+++ b/docs/SCENARIOS.md
@@ -185,7 +185,7 @@ commands:
 
 Shell operators in an `rd`/`rundown` command are rejected (`&&`, `||`, `|`, etc.). Split those into separate `commands` entries. Non-`rd` commands run through the user's shell.
 
-Prefix a command with `! ` when a non-zero exit is the expected outcome:
+Prefix a command with `!` followed by a literal space when a non-zero exit is the expected outcome:
 
 ```yaml
 commands:
@@ -193,7 +193,7 @@ commands:
   - "! rd claim rdtk_invalid"
 ```
 
-For `! ` commands, exit code `0` is an error. For normal commands, a non-zero exit is an error unless the command output still produced a parsed terminal runbook result.
+For `!` commands, exit code `0` is an error. The `!` token must be followed by a space. For normal commands, a non-zero exit is an error unless the command output still produced a parsed terminal runbook result.
 
 ### Naming Convention
 
@@ -433,6 +433,6 @@ Scenarios and suite cases run in isolated temporary workspaces.
 
 For runbook-frontmatter scenarios, the runner copies the scenario's source runbook into the temp workspace's `.rundown/runbooks/` directory. It also scans commands for `*.runbook.md` references and copies those referenced runbooks from the source runbook's directory. Missing referenced runbooks fail before command execution.
 
-For `--input-file` arguments in frontmatter scenarios, both `--input-file path.yaml` and `--input-file=path.yaml` are detected, including inside `! ` expected-failure commands and env-prefixed `rd` commands. The runner copies the entire containing input-file directory because YAML input files may refer to sibling `file:` data sources. Absolute input-file paths and `..` traversal are rejected, and source and destination paths are resolved to ensure they stay inside the source directory and temp workspace.
+For `--input-file` arguments in frontmatter scenarios, both `--input-file` followed by `path.yaml` and `--input-file=path.yaml` are detected, including inside `!` expected-failure commands and env-prefixed `rd` commands. The `!` token must be followed by a space. The runner copies the entire containing input-file directory because YAML input files may refer to sibling `file:` data sources. Absolute input-file paths and `..` traversal are rejected, and source and destination paths are resolved to ensure they stay inside the source directory and temp workspace.
 
 For scenario suites, each case's `file` path is resolved relative to the suite file. The runner rejects absolute paths and `..` traversal, preserves the case file's subdirectory structure under `.rundown/runbooks/`, and also copies the main runbook flat by basename so bare-filename commands resolve. Referenced child runbooks are copied from the main runbook's directory first, then the suite directory, with path traversal rejected.

--- a/docs/SCENARIOS.md
+++ b/docs/SCENARIOS.md
@@ -40,10 +40,34 @@ expect_block =
   [ "steps:" step_assertion { step_assertion } ]
 
 step_assertion =
-  "- " [ "at:" text ] [ "from:" text ] [ "action:" text ] [ "result:" ( "PASS" | "FAIL" ) ] [ "command:" text ] [ "aggregated:" boolean ]
+  "- " [ "runbook:" text ] [ "at:" text ] [ "from:" text ] [ "action:" text ] [ "result:" ( "PASS" | "FAIL" ) ] [ "command:" text ] [ "aggregated:" boolean ]
 ```
 
 At least one of top-level `result:` or `expect.result` must be specified. If both are present, they must match.
+
+External scenario suites use the same command and assertion model in standalone `*.scenario-suite.yaml` files:
+
+```yaml
+version: 1
+name: Regression Suite
+description: Optional suite description
+tags: [regression]
+cases:
+  happy-path:
+    description: Optional case description
+    file: path/to/example.runbook.md
+    commands:
+      - rd run --prompted example.runbook.md
+      - rd pass
+    expect:
+      result: COMPLETE
+      steps:
+        - runbook: example.runbook.md
+          at: "1"
+          action: COMPLETE
+```
+
+Suite `version` must be `1`, `name` is required, `cases` must be non-empty, and each case `file` must end in `.runbook.md`. Each case requires `commands` plus either top-level `result` or `expect.result`.
 
 ## Design Principles
 
@@ -149,7 +173,27 @@ scenarios:
       result: STOP
 ```
 
-Commands output JSON by default. The scenario runner parses JSON output when `expect.steps` is present or when running `rd delegate` (for token capture). Use `--text` for human-readable terminal output in demo scenarios.
+Commands output JSON by default. The scenario runner parses every `rd`/`rundown` command's stdout to collect terminal state, step transitions, and delegation tokens. Use `--text` for human-readable terminal output in demo scenarios; `--text` output is not useful for `expect.steps` or token capture.
+
+The runner executes plain `rd` and `rundown` commands directly through the current CLI entry point instead of through a shell. Leading command-scoped environment assignments are supported:
+
+```yaml
+commands:
+  - RD_AGENT_ID=agent-a RD_SESSION_ID=session-a rd claim ${TOKEN}
+  - RD_AGENT_ID=agent-a RD_SESSION_ID=session-a rundown pass
+```
+
+Shell operators in an `rd`/`rundown` command are rejected (`&&`, `||`, `|`, etc.). Split those into separate `commands` entries. Non-`rd` commands run through the user's shell.
+
+Prefix a command with `! ` when a non-zero exit is the expected outcome:
+
+```yaml
+commands:
+  - rd run --prompted validation.runbook.md
+  - "! rd claim rdtk_invalid"
+```
+
+For `! ` commands, exit code `0` is an error. For normal commands, a non-zero exit is an error unless the command output still produced a parsed terminal runbook result.
 
 ### Naming Convention
 
@@ -177,7 +221,12 @@ Scenario names describe the execution path:
 
 ### Token Capture
 
-The scenario runner extracts delegation tokens from parsed JSON output. When `rd delegate` runs, the JSON response includes a `token` field. These tokens are captured in order and available for substitution in subsequent commands:
+The scenario runner extracts delegation tokens from parsed JSON output. Tokens are captured in order from:
+
+- `rd delegate` JSON responses with `action: "delegated"` and a string `token`
+- `step_entered` events whose `delegateFrontier` array contains string `token` values
+
+Captured tokens are available for substitution in subsequent commands:
 
 - First token captured: `${TOKEN}`
 - Second token: `${TOKEN_2}`
@@ -193,7 +242,7 @@ commands:
   - rd claim ${TOKEN}
 ```
 
-The runner substitutes `${TOKEN}` with the actual token value extracted from the delegate command's JSON `token` field. For multi-delegation scenarios:
+The runner substitutes `${TOKEN}` with the actual captured token value. For multi-delegation scenarios:
 
 ```yaml
 commands:
@@ -203,6 +252,8 @@ commands:
   - rd delegate child-b.runbook.md --step 1.2
   - rd claim ${TOKEN_2}     # claims child-b token
 ```
+
+For `DELEGATE`-annotated steps, `rd run` can auto-issue frontier tokens as soon as the delegate step is entered. In that case, a later `rd claim ${TOKEN}` can use the token captured from the `step_entered.delegateFrontier` event without an explicit `rd delegate` command.
 
 ### Auto-Execution Scenarios
 
@@ -227,8 +278,11 @@ Assertion field names align with both the `StepTransitionedPayload` event fields
 |-------|---------|--------|
 | `at` | Step position after transition | Qualified ID: `1`, `1.1`, `1.3.1`, `ErrorHandler` |
 | `from` | Step position before transition | Same as `at` |
-| `action` | Transition type | `CONTINUE`, `GOTO`, `STOP`, `COMPLETE`, `RETRY`, `BREAK`, `NEXT` |
+| `action` | Transition type | `CONTINUE`, `DEFER`, `GOTO`, `STOP`, `COMPLETE`, `RETRY`, `BREAK`, `NEXT` |
 | `result` | Step outcome that triggered transition | `PASS`, `FAIL` |
+| `command` | Command associated with the transition | Exact command string |
+| `aggregated` | Whether the transition came from deferred aggregation | `true`, `false` |
+| `runbook` | Runbook that emitted the transition | Suffix match against event `runbook.path`, falling back to `runbook.name` |
 
 ### Action Semantics: NEXT vs CONTINUE
 
@@ -276,7 +330,8 @@ expect:
   result: COMPLETE              # Terminal outcome (optional if top-level result: present)
 
   steps:                        # Transition assertions (optional, ordered)
-    - at: "1.1"
+    - runbook: child.runbook.md  # Optional runbook filter for delegated/nested runs
+      at: "1.1"
       from: "1"
       action: CONTINUE
       result: PASS
@@ -288,6 +343,8 @@ expect:
 All fields within `steps` entries are optional. Assert only what matters for the test.
 
 There is no separate `final` block. The last `steps` entry serves as the terminal assertion when needed. The `result` field at the top level (`COMPLETE`/`STOP`) captures the terminal outcome from `RUNBOOK_COMPLETED`/`RUNBOOK_STOPPED` events.
+
+Terminal results are parsed from JSON event streams (`type: "runbook_completed"` or `type: "runbook_stopped"`) and from flushed JSON command responses with `complete: true` or `stopped: true`. Step assertions are matched only against streamed `step_transitioned` events, not flushed summary objects.
 
 ### Matching Semantics
 
@@ -355,3 +412,27 @@ expect:
     - action: GOTO
       at: ErrorHandler
 ```
+
+**Delegated child transition:**
+
+```yaml
+expect:
+  result: COMPLETE
+  steps:
+    - runbook: child.runbook.md
+      from: "1"
+      action: COMPLETE
+      result: PASS
+    - runbook: parent.runbook.md
+      action: COMPLETE
+```
+
+## Dependency Copying and Path Safety
+
+Scenarios and suite cases run in isolated temporary workspaces.
+
+For runbook-frontmatter scenarios, the runner copies the scenario's source runbook into the temp workspace's `.rundown/runbooks/` directory. It also scans commands for `*.runbook.md` references and copies those referenced runbooks from the source runbook's directory. Missing referenced runbooks fail before command execution.
+
+For `--input-file` arguments in frontmatter scenarios, both `--input-file path.yaml` and `--input-file=path.yaml` are detected, including inside `! ` expected-failure commands and env-prefixed `rd` commands. The runner copies the entire containing input-file directory because YAML input files may refer to sibling `file:` data sources. Absolute input-file paths and `..` traversal are rejected, and source and destination paths are resolved to ensure they stay inside the source directory and temp workspace.
+
+For scenario suites, each case's `file` path is resolved relative to the suite file. The runner rejects absolute paths and `..` traversal, preserves the case file's subdirectory structure under `.rundown/runbooks/`, and also copies the main runbook flat by basename so bare-filename commands resolve. Referenced child runbooks are copied from the main runbook's directory first, then the suite directory, with path traversal rejected.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -242,7 +242,7 @@ Steps annotated with `FOR` execute their substeps repeatedly.
 *   **Source references**: `{{ source }}` in FOR clauses is NOT template-expanded. It is a data source identifier resolved at runtime. Template-variable bounds (`{{ Max }}`) ARE expanded before parsing.
 *   **Unresolved bounds**: When a template-variable bound in a FOR clause cannot be resolved (undefined variable), the step is demoted to `kind: 'prompted-for'` — a substeps-only step with no executable `forClause`. The original FOR text is preserved as prompt text. This allows an orchestrating agent to handle unresolved FOR bounds manually.
 *   **Named variable required**: Data source FOR clauses require a named variable. Unnamed syntax (`FOR {{source}}`) is invalid.
-*   **Data sources**: Provided at runtime as arrays or file-backed JSON/JSONL sources. `file:` source values must stay within the project root after symlink resolution.
+* **Data sources**: Provided at runtime as arrays or file-backed JSON/JSONL sources. `file:` source values must stay within the project root after symlink resolution.
 *   **Constraint**: FOR steps MUST have substeps. Step-level runbook-list shorthand qualifies because it is canonicalized to implicit substeps.
 *   **Scope**: Loop variable available in substeps as `{{var}}`.
 *   **Aggregation**: Transitions on the parent FOR step evaluate the aggregate result of all iterations.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -242,7 +242,7 @@ Steps annotated with `FOR` execute their substeps repeatedly.
 *   **Source references**: `{{ source }}` in FOR clauses is NOT template-expanded. It is a data source identifier resolved at runtime. Template-variable bounds (`{{ Max }}`) ARE expanded before parsing.
 *   **Unresolved bounds**: When a template-variable bound in a FOR clause cannot be resolved (undefined variable), the step is demoted to `kind: 'prompted-for'` — a substeps-only step with no executable `forClause`. The original FOR text is preserved as prompt text. This allows an orchestrating agent to handle unresolved FOR bounds manually.
 *   **Named variable required**: Data source FOR clauses require a named variable. Unnamed syntax (`FOR {{source}}`) is invalid.
-*   **Data sources**: Provided at runtime as arrays (in-memory) or files (text or JSONL). Resolved against a sources map. See [RUNDOWN.md](./RUNDOWN.md#data-sources) for configuration.
+*   **Data sources**: Provided at runtime as arrays or file-backed JSON/JSONL sources. `file:` source values must stay within the project root after symlink resolution.
 *   **Constraint**: FOR steps MUST have substeps. Step-level runbook-list shorthand qualifies because it is canonicalized to implicit substeps.
 *   **Scope**: Loop variable available in substeps as `{{var}}`.
 *   **Aggregation**: Transitions on the parent FOR step evaluate the aggregate result of all iterations.


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Frontmatter inputs now declare names (block or inline); required entries must appear in inputs; outputs frontmatter added (YAML template entries must be quoted); public frontmatter keys are case-insensitive.
  * Clarified session ownership semantics, stash/pop rules, and delegation conflict handling.
  * Expanded scenario/spec guidance: runbook filtering, external suite format, runner execution/token capture rules, `!` command semantics, and safer dependency/path copying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/SPEC.md`, `docs/FORMAT.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
