### PR TITLE
Type hardening refactor

### DIFF
--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -28,7 +28,7 @@ interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 | Run | One active or persisted execution of a runbook. |
 | State file | JSON file under `.rundown/runs/` storing one run's state. |
 | Session | `.rundown/session.json`, which tracks active top-level runs, stashes, and claims. |
-| Frame | Internal execution scope key: `step|iteration`. |
+| Frame | Internal execution scope key: `step\|iteration`. |
 | Entry | Monotonic re-entry counter for a frame. |
 | Claim | `rdclm_...` handle that targets one delegated child run. |
 | Data source | Runtime value used by `FOR ... IN {{ source }}` iteration. |
@@ -174,7 +174,7 @@ Only `.json` and `.jsonl` file source extensions are supported.
 
 ### 6.2 File Source Rules
 
-File-backed data sources MUST satisfy all of the following rules:
+File-backed data sources MUST satisfy the following rules:
 
 | Rule | Requirement |
 | --- | --- |
@@ -467,7 +467,7 @@ Canonical runtime identity is `step + substep + iteration`.
 | Step | Top-level runbook step id. |
 | Substep | Nested substep id, if active. |
 | Iteration | Current `FOR` iteration, if active. |
-| Frame | Internal `step|iteration` scope key. |
+| Frame | Internal `step\|iteration` scope key. |
 | Entry | Monotonic re-entry counter for a frame. |
 | Completion key | `frame + entry + substep`. |
 

--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -1,271 +1,218 @@
-# Rundown Runtime Reference
+# Rundown Runtime Specification
 
-This document covers Rundown's execution model, state management, template variables, FOR loop semantics, security policy, and runtime identity. For the CLI command reference and user guide, see [docs/reference/cli.md](cli.md). For internal architecture, see [docs/internal/architecture.md](../internal/architecture.md).
+This document defines Rundown runtime behavior: execution state, iteration,
+data-source handling, variable resolution, persisted state, and runtime identity.
+For authoring syntax, see [docs/spec/language.md](../spec/language.md). For CLI
+usage, see [docs/reference/cli.md](cli.md). For the full security policy
+contract, see [docs/reference/security.md](security.md).
 
----
+## 1. Scope
 
-## Table of Contents
+This specification covers behavior after a runbook has been selected for
+execution. It defines how the runtime evaluates commands, advances steps,
+resolves variables, stores state, handles data sources, and targets nested or
+delegated work.
 
-- [Execution Model](#execution-model)
-- [Command Execution](#command-execution)
-- [FOR Loops](#for-loops)
-  - [FOR Clause Variants](#for-clause-variants)
-  - [Loop Variable Expansion](#loop-variable-expansion)
-  - [Iteration Semantics](#iteration-semantics)
-  - [GOTO AT Interaction](#goto-at-interaction)
-  - [Data Sources](#data-sources)
-- [State Persistence](#state-persistence)
-  - [File Locations](#file-locations)
-  - [Session Structure](#session-structure)
-  - [Runbook State Structure](#runbook-state-structure)
-- [Template Variables](#template-variables)
-  - [Variable Sources](#variable-sources)
-  - [Auto-Discovery](#auto-discovery)
-  - [Variable Name Requirements](#variable-name-requirements)
-  - [Runtime Context Model](#runtime-context-model)
-  - [Undefined Variables](#undefined-variables)
-  - [Template Variable Persistence](#template-variable-persistence)
-- [Security Policy](#security-policy)
-- [Runtime Identity Glossary](#runtime-identity-glossary)
+This specification does not define Rundown document syntax, CLI command-line
+parsing, JSON output shape, policy file format, or implementation architecture
+except where those topics affect runtime correctness.
 
----
+The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
-## Execution Model
-
-Rundown separates **runbook definition** from **state tracking**:
+## 2. Terminology
 
-| Component | Role |
-|-----------|------|
-| **Runbook file** | Markdown document defining steps, transitions, and conditions |
-| **CLI (`rundown`)** | Tracks runbook state: current step, retry count, variables |
-| **Agent (Claude)** | Executes work, uses CLI to report outcomes |
+| Term | Meaning |
+| --- | --- |
+| Runtime | The CLI-managed execution process for one or more runbooks. |
+| Run | One active or persisted execution of a runbook. |
+| State file | JSON file under `.rundown/runs/` storing one run's state. |
+| Session | `.rundown/session.json`, which tracks active top-level runs, stashes, and claims. |
+| Frame | Internal execution scope key: `step|iteration`. |
+| Entry | Monotonic re-entry counter for a frame. |
+| Claim | `rdclm_...` handle that targets one delegated child run. |
+| Data source | Runtime value used by `FOR ... IN {{ source }}` iteration. |
+| Static variable | Variable resolved once at run startup. |
+| Dynamic variable | Variable derived from the current step, substep, or iteration frame. |
 
-**Key concept:** The CLI tracks which step you are on and what happens when you report PASS or FAIL. For code blocks, it can execute commands automatically. Otherwise, the agent (or user) does the actual work.
+<a id="execution-model"></a>
 
----
+## 3. Runtime Model
 
-## Command Execution
+Rundown separates runbook definition from runtime state.
 
-| Behavior | Triggered By | What Happens |
-|----------|-------------|--------------|
-| **Automatic command** | Step has `bash`, `sh`, or `shell` code block | CLI runs command, exit code determines PASS/FAIL |
-| **Manual** | `--prompted` flag, display-only code block, or step has no executable code block | CLI waits for manual `rd pass` or `rd fail` |
+| Component | Runtime role |
+| --- | --- |
+| Runbook source | Defines steps, transitions, commands, inputs, outputs, and control flow. |
+| Runtime state | Tracks current position, variables, retries, loop state, child links, and persisted snapshot. |
+| Agent or user | Performs prompted work and reports `PASS` or `FAIL`. |
+| CLI | Evaluates transitions, persists state, runs executable command blocks, and enforces policy. |
 
-**Note:** A `prompt` code block is display-only. Rundown may render it through the `rd prompt` helper so the content appears wrapped in markdown fences, but it is not shell-executed and does not derive PASS/FAIL from a command exit code.
+The runtime MUST preserve the conceptual separation between result, handler, and
+action:
 
-Example of a step that auto-executes:
+| Layer | Runtime meaning |
+| --- | --- |
+| Result | Outcome signal: `PASS` or `FAIL`. |
+| Handler | Authored mapping from result to action. |
+| Action | Runtime control-flow effect such as `CONTINUE`, `GOTO`, `STOP`, or `DEFER`. |
 
-````markdown
-## 3. Run tests
-- PASS CONTINUE
-- FAIL RETRY 2 STOP
+Actions MUST propagate with their own semantics. The runtime MUST NOT silently
+map one action into another to simplify execution.
 
-```bash
-npm test
-```
-````
+<a id="command-execution"></a>
 
-Example of a prompted step:
+## 4. Command Execution
 
-````markdown
-## 4. Code review
-- PASS CONTINUE
-- FAIL STOP
-
-Review the implementation for issues.
-`rundown pass` if acceptable, `rundown fail` if blocked.
-````
+The runtime supports automatic and prompted execution.
 
----
+| Mode | Trigger | Runtime behavior |
+| --- | --- | --- |
+| Automatic command | Step or substep has `bash`, `sh`, or `shell` code block and execution is not prompted. | CLI executes the command from the project root; exit `0` signals `PASS`, non-zero signals `FAIL`. |
+| Prompted/manual | `--prompted`, display-only code block, or no executable code block. | CLI surfaces the prompt and waits for `rd pass` or `rd fail`. |
 
-## FOR Loops
+Executable command blocks inherit the parent process environment after policy
+filtering and Rundown environment injection. A `prompt` code block is
+display-only: it MUST NOT be shell-executed and MUST NOT derive a result from an
+exit code.
 
-Steps can iterate their substeps over a numeric range using a FOR annotation. FOR loops are defined in the runbook syntax and the CLI manages loop state automatically.
+The CLI MAY render display-only code blocks through `rd prompt` so the content
+appears as fenced Markdown.
 
-**Syntax (brief):**
+<a id="for-loops"></a>
 
-````markdown
-## 3. Process batches
-- FOR batch IN 1 TO 5
-- PASS ALL CONTINUE
-- FAIL ANY STOP
+## 5. Iteration Runtime
 
-### 1. Process item
-- PASS CONTINUE
-- FAIL BREAK
-````
+`FOR` syntax is defined in [docs/spec/language.md §8](../spec/language.md#8-iteration).
+At runtime, a `FOR` step repeats its substeps over a numeric range or data
+source.
 
-Step-level runbook lists are shorthand for implicit sequential substeps (`.1`, `.2`, ...), so FOR execution is equivalent across these forms:
+### 5.1 Loop State
 
-````markdown
-## 2. Review the plan
-- FOR pass IN 1 TO 2
-- PASS ALL CONTINUE
-- FAIL ANY GOTO Synthesize
+For an active loop, runtime state MUST track:
 
-- review-technical-accuracy.runbook.md
-- review-structural-integrity.runbook.md
-````
+| Field | Requirement |
+| --- | --- |
+| Current step | The parent `FOR` step id. |
+| Iteration | Current numeric iteration index. |
+| Direction | Ascending or descending range traversal. |
+| Loop variable | Optional named variable exposed to substeps. |
+| Current value | Current data element for array/file-backed sources. |
+| Iteration results | Recorded `PASS`/`FAIL` outcomes used for parent aggregation. |
 
-````markdown
-## 2. Review the plan
-- FOR pass IN 1 TO 2
-- PASS ALL CONTINUE
-- FAIL ANY GOTO Synthesize
+Numeric bounds and open-ended data-source iteration are capped at 10,000
+iterations.
 
-### 2.1
-- review-technical-accuracy.runbook.md
-### 2.2
-- review-structural-integrity.runbook.md
-````
+### 5.2 Dynamic Loop Variables
 
-See [docs/spec/language.md Iteration (FOR)](../spec/language.md#5-iteration-for) for the full grammar and all clause variants.
+The runtime MUST expand loop and location variables against the active frame.
 
-### FOR Clause Variants
+| Variable | Runtime value |
+| --- | --- |
+| `{{Index}}`, `{{index}}` | Current iteration number for this runbook context. |
+| `{{Step}}`, `{{step}}` | Current qualified step/substep position for this runbook context. |
+| `{{var}}` | Named loop variable; for ranges, the iteration index; for data sources, the current item. |
+| `{{context.current.*}}` | Canonical current structural context. |
 
-| Syntax | Description |
-|--------|-------------|
-| `FOR var IN 1 TO N` | Explicit range, named variable |
-| `FOR 1 TO N` | Explicit range, no variable |
-| `FOR var IN N` | Implicit start (1), named variable |
-| `FOR N` | Implicit start (1), no variable |
-| `FOR var IN {{ source }}` | All items from data source |
-| `FOR var IN 1 TO N OF {{ source }}` | Windowed data source |
-
-### Loop Variable Expansion
+Dynamic variables MUST NOT be overridden by user input, config, environment, or
+delegation inheritance.
 
-The named loop variable plus runtime step/index aliases are expanded per-iteration:
-- `{{Index}}` / `{{index}}` - Current iteration number (1-based), available inside all FOR substeps
-- `{{Step}}` / `{{step}}` - Qualified current runbook-context execution location (for shorthand runbook-list steps this is `N.1`, `N.2`, ...)
-- `{{var}}` - Named loop variable. For numeric ranges, equals the iteration index. For data sources (array/file), holds the current data element.
+### 5.3 Iteration Actions
 
-These are expanded per-iteration, unlike template variables which are expanded once at `rd run` time.
+Substep actions inside a `FOR` step affect the current iteration. Nested
+iteration-level transitions under `FOR` affect the loop after iteration
+aggregation.
 
-### Iteration Semantics
+| Action | Records current result | Parent step handler fires | Runtime effect |
+| --- | --- | --- | --- |
+| `DEFER` | Yes | After final recorded iteration | Record result and advance. |
+| `NEXT` | No | After final iteration | Skip remaining work and advance. |
+| `BREAK` | No | Yes | Exit loop immediately. |
+| `CONTINUE` | No | Yes | Exit loop and continue through step-level handler. |
+| `GOTO` | No | No | Jump immediately. |
+| `STOP` | No | No | Stop immediately. |
+| `COMPLETE` | No | No | Complete immediately. |
 
-FOR-level transitions (the bullets directly under the `FOR ...` clause) decide what happens after iteration results are aggregated. Substep handler actions inside a FOR loop control only the current iteration:
+Iteration-level `RETRY N action` MUST retry the current iteration before applying
+the exhausted fallback action. It applies to the iteration result, not to the
+specific substep action that produced that result.
 
-| Action | Effect |
-|--------|--------|
-| `DEFER` | Record the substep result for iteration aggregation |
-| `NEXT` | Skip remaining substeps, advance to next iteration |
-| `BREAK` | Exit the FOR loop; parent step transitions evaluate |
-| `STOP` | Halt runbook execution immediately |
-| `COMPLETE` | Complete runbook execution immediately |
-| `GOTO` | Jump to the target step or FOR iteration |
-| `RETRY` | Retry according to the configured retry wrapper |
+### 5.4 GOTO AT
 
-At FOR-transition scope, `CONTINUE` exits the loop without accumulating the current iteration result.
+When a `GOTO` targets a `FOR` step:
 
-FOR-level nested transitions (nested bullets directly under `- FOR ...`) run at **iteration scope**:
+| Form | Runtime target |
+| --- | --- |
+| `GOTO N` | Enters the target loop at that loop's start value. |
+| `GOTO N AT I` | Enters the target loop at iteration `I`. |
+| `GOTO N AT {{Index}}` | Re-enters at the current iteration value. |
 
-| Action | Effect |
-|--------|--------|
-| `DEFER` | Record the current iteration result; parent FOR aggregation runs after the final recorded iteration |
-| `NEXT` | Do not record the current iteration result; continue with the next iteration |
-| `CONTINUE` | Exit loop (current result NOT recorded) → step-level handler |
-| `BREAK` | Exit loop immediately (current result NOT recorded) → step-level handler |
-| `GOTO` | Jump immediately; bypass parent FOR aggregation |
-| `STOP` | Stop immediately; bypass parent FOR aggregation |
-| `COMPLETE` | Complete immediately; bypass parent FOR aggregation |
-| `RETRY N X` | Retry current iteration first, then execute exhausted action `X` |
+Status output MAY show display paths such as `STEP.INDEX.SUBSTEP`. Display paths
+are not authoring identifiers and are not canonical runtime identity.
 
-Parent FOR step transitions (`PASS ALL`, `FAIL ANY`, etc.) aggregate results across all iterations after normal loop completion, iteration-level `BREAK`, or iteration-level `CONTINUE`.
+<a id="data-sources"></a>
 
-### GOTO AT Interaction
+## 6. Data Sources
 
-The `AT` qualifier on GOTO targets specific iterations of a FOR step:
+Data sources are runtime values used by named `FOR` clauses. Data-source
+iteration MUST use a named loop variable.
 
-```bash
-rundown goto 3        # Jump to FOR step 3
-```
+### 6.1 Source Routing
 
-In runbook transitions, `GOTO N AT I` enters step N at iteration I. When `AT` is omitted for a FOR step, the default is defined in [docs/spec/language.md §4.2](../spec/language.md#42-actions). See [docs/reference/cli.md GOTO formats](cli.md#rundown-goto-step---jump-to-step) for the full valid-format table.
+Input values are routed into template variables and data sources based on their
+runtime type.
 
-**Status display during loops:**
+| Value pattern | Template rendering | Data-source routing |
+| --- | --- | --- |
+| JSON array from `--input-json` | Comma-joined string | Array source. |
+| YAML array from config/input file | Comma-joined string | Array source. |
+| `file:*.jsonl` | Source reference | Lazy JSON Lines stream. |
+| `file:*.json` | Source reference | JSON array/object; arrays are iterable. |
+| Scalar string/number/boolean | Scalar string value | Not a data source. |
 
-When a FOR loop is active, output includes explicit loop scope and expanded location:
-- `For: index/end` (or `index/?` for open-ended data sources)
-- `At: STEP.INDEX.SUBSTEP` (display path)
+Only `.json` and `.jsonl` file source extensions are supported.
 
-The display path is not an authoring identifier. Canonical runtime identity is `step + substep + iteration`.
+### 6.2 File Source Rules
 
-### Data Sources
+File-backed data sources MUST satisfy all of the following rules:
 
-FOR loops can iterate over arrays or files instead of numeric ranges.
+| Rule | Requirement |
+| --- | --- |
+| Containment | Resolved path MUST remain inside the project root after symlink resolution. |
+| Policy | Resolved path MUST be allowed by the active read policy before execution starts. |
+| Format | `.jsonl` is parsed as one JSON value per line; `.json` is parsed as JSON. |
+| Drift detection | Runtime MUST snapshot source metadata and detect modification on resume. |
+| Failure mode | Missing, denied, invalid, escaped, or drifted sources MUST fail visibly. |
 
-**Defining sources:**
+Blocked or invalid file sources MUST NOT silently become empty iteration sources.
 
-Sources are defined via `--input-json`, `.rundown/config.yaml`, `--input-file`, or `--input` flags. Values are routed based on type:
+For `.jsonl`, each line MAY contain any JSON value. When the current item is a
+JSON object, dotted field access is supported in templates. Rendering the whole
+item serializes it as JSON.
 
-| Value Pattern | Routing |
-|---------------|---------|
-| `--input-json items='["a","b"]'` | Comma-joined in vars, JsonArray for iteration |
-| `file:path/to/data.jsonl` | JsonArrayStream in vars (lazy streaming) |
-| `file:path/to/data.json` | JsonArray or JsonObject in vars (eager load) |
-| YAML array `[a, b, c]` | Comma-joined in vars, JsonArray for iteration |
-| Scalar string/number | Template vars only (no iteration source) |
+### 6.3 Windowed Sources
 
-**Example `.rundown/config.yaml`:**
+Windowed iteration reads only the requested inclusive item positions from the
+source. Open-ended data-source iteration reads until source exhaustion or the
+10,000-iteration cap.
 
-```yaml
-environment: staging
-items:
-  - alpha
-  - bravo
-  - charlie
-log_file: file:data/results.jsonl
-```
+<a id="state-persistence"></a>
 
-**Example runbook:**
+## 7. State Persistence
 
-````markdown
-## 2 Process items
-- FOR item IN {{ items }}
-- PASS ALL CONTINUE
-- FAIL ANY STOP
-### 1 Handle item
-- PASS CONTINUE
-- FAIL BREAK
-Handle {{item}} (iteration {{Index}}).
-````
+Runtime state persists across process exits and context clears.
 
-**File formats:**
-
-| Extension | Format | Parsing |
-|-----------|--------|---------|
-| `.jsonl` | JSON Lines | One JSON value per line (string, number, boolean, null, array, or object) |
-| `.json` | JSON | Eagerly loaded as JsonArray or JsonObject |
-
-Only `.json` and `.jsonl` extensions are supported for `file:` sources.
-
-`file:` sources are resolved to a canonical path, confined to the project root, and checked against the active security policy before execution starts. A denied source fails the runbook before the first step.
-
-**JSONL semantics:** Each `.jsonl` line is parsed as a JSON value. When the loop variable holds a parsed JSON object, dotted field access is supported in templates (e.g., `{{item.name}}`). Using `{{item}}` alone renders the serialized JSON string.
-
-**Open-ended iteration:** `FOR item IN {{ source }}` iterates until the source is exhausted, capped at 10,000 iterations.
-
-**Windowed iteration:** `FOR item IN 3 TO 7 OF {{ source }}` reads only items at positions 3 through 7.
-
-**Drift detection:** File sources record a snapshot (size, mtime, SHA-256 fingerprint) at first access. On resume, the snapshot is validated — if the file changed, execution fails with a drift error. Fingerprint comparison allows harmless mtime changes (e.g., backup tools) to pass.
-
-**Validation:** The CLI validates that all sourced FOR clauses reference defined data sources. Missing sources produce: `FOR loop references undefined data source "{{name}}"`.
-
----
-
-## State Persistence
-
-### File Locations
+### 7.1 File Locations
 
 | Path | Purpose |
-|------|---------|
-| `.rundown/runs/` | Runbook state files (`wf-YYYY-MM-DD-xxxxx.json`) |
-| `.rundown/session.json` | Active runbook tracking and stash state |
-| `.rundown/runbooks/` | Runbook source files (discovered for `rundown ls --all`) |
+| --- | --- |
+| `.rundown/runs/` | Runbook state files. |
+| `.rundown/session.json` | Active runbook stack, stash, and claim tracking. |
+| `.rundown/runbooks/` | Project-local runbook discovery source. |
 
-### Session Structure
+### 7.2 Session Structure
 
-The session tracks top-level runbooks with a default stack and delegated children with explicit claim ids:
+The session tracks top-level runs and delegated children separately.
 
 ```json
 {
@@ -288,27 +235,54 @@ The session tracks top-level runbooks with a default stack and delegated childre
 }
 ```
 
-- **defaultStack**: Legacy/default active runbook stack for top-level, inline, and unidentified/manual flows.
-- **stashedRunbookId**: Temporarily paused runbook (for `rundown stash`/`rundown pop`).
-- **claims**: Map of `rdclm_...` handles returned by `rd claim`, each pointing at exactly one delegated child runbook and its parent linkage.
+| Field | Requirement |
+| --- | --- |
+| `defaultStack` | Tracks active top-level, inline, and unidentified/manual flows. |
+| `stashedRunbookId` | Stores the default-stack run paused by plain `rd stash`. |
+| `claims` | Maps claim ids to exact delegated child runbooks and parent linkage. |
 
-Claimed delegated children are not pushed onto `defaultStack`. Commands that accept `--claim-id` (`status`, `pass`, `fail`, `collect`, `goto`, `stash`, `pop`, `stop`, and `complete`) resolve the exact child runbook for that claim and fail closed if the claim is missing, stale, terminal, or no longer linked to a live parent.
+Claimed delegated children MUST NOT be pushed onto `defaultStack`.
 
-`stash` and `pop` target either the default stack or a claim id:
-- Plain `stash` moves the default-stack active runbook into the single stash slot.
-- `stash --claim-id <id>` stashes the claimed child while preserving the claim record.
-- Plain `pop` restores only default-stack stashes.
-- `pop --claim-id <id>` restores the child for that claim id after verifying the delegated parent is still active.
+Commands that accept `--claim-id` MUST resolve the exact child run for that
+claim and MUST fail closed if the claim is missing, stale, terminal, or no
+longer linked to a live parent.
 
-### Stale persisted state / no-migration
+### 7.3 Stash Targeting
 
-Persisted state is not migrated between runtime versions. If a runbook state file (`wf-...json`), `.rundown/session.json`, `stashedRunbookId`, or `claims` entry is stale, structurally incompatible, or from a schema/runtime version the current CLI cannot safely resume, Rundown fails closed and refuses to continue that run.
+`stash` and `pop` target either the default stack or a specific claim.
 
-The user-facing recovery path is to finish or close the affected run if possible, or prune/clean persisted state and restart the runbook. Rundown must not silently migrate, shim, adapt, rewrite, or resume incompatible persisted state.
+| Command | Runtime target |
+| --- | --- |
+| `rd stash` | Moves the default-stack active run into the single default stash slot. |
+| `rd stash --claim-id <id>` | Stashes the claimed child and preserves its claim record. |
+| `rd pop` | Restores only default-stack stashes. |
+| `rd pop --claim-id <id>` | Restores the child for that claim after parent-link validation. |
 
-### Runbook State Structure
+Plain `rd pop` MUST NOT restore a claimed child.
 
-Each runbook state file contains:
+<a id="stale-persisted-state--no-migration"></a>
+
+### 7.4 Stale Persisted State / No Migration
+
+Persisted state MUST NOT be migrated between runtime versions. This applies to:
+
+| State | Covered data |
+| --- | --- |
+| Runbook state files | Structured fields and opaque `snapshot` blob. |
+| Session state | `defaultStack`, `stashedRunbookId`, and `claims`. |
+| Delegation state | Claim records, parent links, child links, tokens, and completion records. |
+
+If persisted state is stale, structurally incompatible, corrupt, unreadable, or
+from a schema/runtime version the current CLI cannot safely resume, Rundown MUST
+fail closed and refuse to continue that run.
+
+The recovery path is to finish or close the affected run if possible, or prune
+the incompatible state and restart from the source runbook. The runtime MUST NOT
+silently migrate, shim, adapt, rewrite, or resume incompatible persisted state.
+
+### 7.5 Runbook State Fields
+
+Each run state file stores enough information to resume deterministically.
 
 ```json
 {
@@ -319,42 +293,16 @@ Each runbook state file contains:
   "description": "Runbook description",
   "step": "2",
   "substep": "1",
-  "stepName": "Execute batch",
   "retryCount": 0,
   "variables": { "environment": "staging" },
   "templateVars": { "environment": "staging" },
-  "steps": [],
-  "substepStates": [
-    {
-      "id": "1",
-      "frameKey": "2|",
-      "status": "done",
-      "delegation": {
-        "tokenHash": "abc123...",
-        "childRunbookPath": ".rundown/runbooks/child.runbook.md",
-        "status": "claimed",
-        "childRunId": "wf-2024-01-07-child1"
-      }
-    }
-  ],
+  "substepStates": [],
   "resolvedCompletions": {},
   "frameEntries": { "2|2": 1 },
   "activeFrameKey": "2|2",
   "activeEntry": 1,
-  "forStack": [
-    {
-      "stepId": "2",
-      "iteration": 2,
-      "start": 1,
-      "variable": "item",
-      "source": { "kind": "array", "items": ["alpha", "bravo", "charlie"] },
-      "currentValue": "bravo"
-    }
-  ],
-  "iterationResults": ["pass", "pass"],
-  "startedAt": "2024-01-07T10:00:00.000Z",
-  "updatedAt": "2024-01-07T10:05:00.000Z",
-  "prompted": false,
+  "forStack": [],
+  "iterationResults": ["pass"],
   "lastResult": "pass",
   "lastAction": { "type": "CONTINUE" },
   "runbookSrc": "---\nname: my-runbook\n---\n# My Runbook\n...",
@@ -362,206 +310,198 @@ Each runbook state file contains:
 }
 ```
 
-Key fields:
-- `step`: Current step identifier (string: "1", "ErrorHandler")
-- `substep`: Current substep ID (e.g., "1", "2")
-- `retryCount`: Current retry attempt
-- `steps`: Array of step states for all runbook steps
-- `lastAction`: Most recent transition as a structured object (e.g., `{"type": "CONTINUE"}`, `{"type": "GOTO", "target": "3", "at": 2}`)
-- `lastResult`: Last PASS/FAIL signal (`pass` or `fail`)
-- `runbookPath`: Repo-relative resolved file path to the runbook source
-- `runbookSrc`: Raw runbook source content (template placeholders preserved)
-- `templateVars`: Frozen template variable map used for deterministic resume rendering
-- `forStack`: Active FOR loop stack (present during loop execution; see [FOR Loops](#for-loops))
-- `forStack[].source`: Resolved source for the active loop (range, array, or file with snapshot)
-- `forStack[].currentValue`: Data element at the current iteration (array/file sources)
-- `iterationResults`: Array of per-iteration outcomes (`"pass"` or `"fail"`) for the current loop
-- `substepStates[].id`: Substep identifier matching `Substep.id` (e.g., "1", "2")
-- `substepStates[].frameKey`: Scopes identity in FOR loops (e.g., "2|" or "2|3")
-- `substepStates[].status`: Substep lifecycle state (`pending`, `running`, `done`)
-- `substepStates[].delegation`: Delegation state for substeps (tokenHash, childRunbookPath, status, childRunId)
-- `resolvedCompletions`: Completion records keyed by `frame + entry + substep`
-- `frameEntries` / `activeFrameKey` / `activeEntry`: Re-entry-safe frame identity used to reject stale completions
-- `snapshot`: XState persisted snapshot for state restoration
+| Field | Runtime requirement |
+| --- | --- |
+| `step`, `substep` | Current structural position. |
+| `retryCount` | User-visible retry count across retry sites. |
+| `variables` | Live variable space, including accumulated outputs. |
+| `templateVars` | Frozen variable map used for deterministic resume rendering. |
+| `forStack` | Active loop frame and current source value. |
+| `iterationResults` | Results recorded for current loop aggregation. |
+| `substepStates` | Substep lifecycle and delegation state. |
+| `resolvedCompletions` | Completion records keyed by frame, entry, and substep. |
+| `frameEntries`, `activeFrameKey`, `activeEntry` | Re-entry-safe identity for stale-completion rejection. |
+| `lastResult`, `lastAction` | Last result signal and resolved action. |
+| `runbookSrc` | Raw source content with template placeholders preserved. |
+| `snapshot` | Opaque XState persisted snapshot. |
 
----
+The runtime MUST treat `snapshot` as persisted state subject to the no-migration
+rule.
 
-## Template Variables
+<a id="template-variables"></a>
 
-Rundown supports template variables using Handlebars syntax `{{variableName}}` for parameterizing runbooks.
+## 8. Variable Resolution
 
-### Syntax
+Rundown uses Handlebars syntax for template variables. Variable syntax is defined
+in [docs/spec/language.md §9](../spec/language.md#9-templating).
 
-````markdown
-## 1. Deploy to {{environment}}
-```bash
-npm run deploy --env={{environment}} --version={{version}}
-```
-````
+<a id="variable-sources"></a>
 
-### Variable Sources
+### 8.1 Variable Sources
 
-Variables are collected from multiple sources with the following precedence (highest to lowest):
+Variables are collected with this precedence, highest first:
 
-| Source | Description |
-|--------|-------------|
-| CLI flags (`--input-file`, `--input`, `--input-json`) | Repeatable, highest priority |
-| Plugin variables | Injected when resolving plugin runbooks, such as `rundown:write-plan` |
-| `RD_INPUT_*` environment variables | Prefix stripped (e.g., `RD_INPUT_environment` sets `environment`) |
-| Inherited delegation variables | Parent context in delegation tree |
-| `.rundown/config.yaml` | Auto-discovered from cwd upward, stops at git root |
-| Built-in defaults | System-provided variables — see [Built-in Variables](#built-in-variables) for the full table |
-| INPUTS (context passing) | Fill-gaps-only injection from the inherited live variable space / delegated `finalVars` — see [docs/spec/language.md §7](../spec/language.md#7-context-passing-outputs) |
+| Priority | Source | Rule |
+| --- | --- | --- |
+| 1 | Explicit invocation inputs | `--input-file`, `--input`, and `--input-json`; highest priority. |
+| 2 | Plugin variables | Injected only when resolving plugin runbooks. |
+| 3 | `RD_INPUT_*` environment variables | Prefix stripped. |
+| 4 | Inherited delegation variables | Parent runtime variable space passed to child. |
+| 5 | `.rundown/config.yaml` | Auto-discovered from cwd upward. |
+| 6 | Built-in defaults | Runtime-provided static defaults. |
+| 7 | Context-output inputs | Fill gaps only; MUST NOT override existing values. |
 
-### Auto-Discovery
+Frontmatter `inputs` declares accepted names only. It is not a value layer.
 
-The CLI automatically searches for `.rundown/config.yaml` starting from the current working directory and walking upward. The search stops at:
-- The first `.rundown/config.yaml` found
-- The git repository root (`.git` directory)
-- The filesystem root
+### 8.2 Config Auto-Discovery
 
-Example `.rundown/config.yaml`:
+The runtime searches for `.rundown/config.yaml` from the current working
+directory upward. Search stops at the first config file found, the git
+repository root, or the filesystem root.
 
-```yaml
-environment: staging
-version: 1.2.3
-db_host: localhost
-items:
-  - alpha
-  - bravo
-  - charlie
-log_file: file:data/results.jsonl
-```
+Arrays in config or input files become both comma-joined template values and
+array data sources. `file:` values become file-backed data sources. Scalars
+remain regular template variables.
 
-Arrays become data sources for `FOR item IN {{ items }}` — pass inline via `--input-json items='["a","b"]'` or define in YAML config. The `file:` prefix creates file-backed sources. Scalar values remain regular template variables. See [Data Sources](#data-sources) for details.
+### 8.3 Variable Name Requirements
 
-### Usage Examples
+User-provided variable names MUST match `/^[a-zA-Z_][a-zA-Z0-9_]*$/`.
 
-```bash
-# Set variables via CLI flags
-rundown run deploy.runbook.md --input environment=prod --input version=2.0.0
+The names `step`, `index`, and `context` are reserved case-insensitively.
+Reserved names MUST be rejected in frontmatter `inputs`, frontmatter `required`,
+explicit invocation inputs, input files, and config files. Reserved
+`RD_INPUT_*` variables are skipped with a warning.
 
-# Load variables from a file
-rundown run deploy.runbook.md --input-file production.yaml
+### 8.4 Undefined Variables
 
-# Combine sources (CLI flags override file values)
-rundown run deploy.runbook.md --input-file base.yaml --input environment=prod
-```
+Undefined variables and missing dotted paths are preserved as literal
+placeholders, such as `{{variable}}` or `{{context.parent.missing}}`. The runtime
+SHOULD emit one warning for each distinct undefined variable.
 
-### Built-in Variables
+### 8.5 Runtime Context Model
 
-Rundown sets the following built-in variables once per execution (unless marked dynamic per-step). PascalCase is canonical; lowercase aliases `step` and `index` are also accepted.
+The runtime exposes canonical namespaced context paths.
 
-| Variable | Example Value | Description |
-|----------|---------------|-------------|
-| `Date` | `2026-02-04` | Current date (YYYY-MM-DD) |
-| `DateTime` | `2026-02-04T10:30:00.000Z` | Full ISO 8601 timestamp |
-| `Year` | `2026` | Current year |
-| `Month` | `02` | Current month (01-12) |
-| `Day` | `04` | Current day (01-31) |
-| `Branch` | `feature/my-work` | Current git branch name (empty when not in git) |
-| `WorkPath` | `.rundown/work/feature-my-work` | Branch-isolated artifact directory (falls back to `.rundown/work` outside git). Default base directory for the `{{ path "..." }}` helper used in OUTPUTS expressions. |
-| `RunId` | `4a7f0c3e` | Unique-per-execution identifier (fresh 8-char hex per execution; each child in a delegation tree gets its own) |
-| `ContextId` | `a3b8c1d2` | Shared identity across a delegation tree. Scopes `{{ path "..." }}` helper output into `.rd-<ContextId>/` for context passing. Children inherit the parent's `ContextId` via `--input`. Overridable via `--input ContextId=<name>` for a meaningful identifier (e.g., `sprint-42`). |
-| `Step` | `3.1` | Current qualified step identifier (dynamic per step) |
-| `Index` | `3` | Current loop iteration number inside FOR (dynamic per iteration) |
-| `context.current.step` | `3.1` | Canonical current step identifier (dynamic) |
-| `context.current.substep` | `1` | Current substep number when in a substep (dynamic) |
-| `context.current.index` | `3` | Current loop iteration inside FOR (dynamic) |
-| `context.current.at` | `3.3.1` | Full execution position (`STEP.INDEX.SUBSTEP` inside a FOR loop, `STEP.SUBSTEP` otherwise) (dynamic) |
+| Path | Runtime meaning |
+| --- | --- |
+| `context.current.*` | Current step, substep, index, and display `at` path. |
+| `context.parent.*` | Nearest parent runbook structural context. |
+| `context.parent.vars.NAME` | Parent resolved variable. |
+| `context.ancestors.N.*` | Ancestor contexts; `0` is nearest parent. |
+| `context.vars.NAME` | Current variable namespace. |
 
-Static variables (`Date`, `DateTime`, `Year`, `Month`, `Day`, `Branch`, `WorkPath`, `RunId`, `ContextId`) can be overridden via `--input`. Dynamic variables (`Step`, `Index`, `context.current.*` and their lowercase aliases) reflect the current execution position and cannot be overridden. The variable name `context` is reserved.
+Parent context chain addressing is capped at 32 levels.
 
-**Plugin Variables:** When a runbook is resolved from a plugin source (e.g., `rundown:write-plan`), Rundown auto-injects additional variables using UPPER_SNAKE_CASE:
+<a id="built-in-variables"></a>
 
-| Variable | Description |
-|----------|-------------|
-| `CLAUDE_PLUGIN_ROOT` | Plugin installation directory |
+### 8.6 Built-In Variables
 
-Plugin variables sit in the precedence chain just below CLI flags and can be overridden via `--input`.
+PascalCase is canonical. Lowercase `step` and `index` aliases are accepted for
+dynamic current-frame values but remain reserved for user input.
 
-### Shell Environment
+| Variable | Rule |
+| --- | --- |
+| `Date`, `DateTime`, `Year`, `Month`, `Day` | Current date/time components. |
+| `Branch` | Current git branch, or empty outside git. |
+| `WorkPath` | Branch-isolated artifact directory; fallback `.rundown/work`; base for `{{ path "..." }}`. |
+| `RunId` | Fresh execution identifier for this runbook execution. |
+| `ContextId` | Shared identity across a delegation tree; scopes path helpers into `.rd-<ContextId>/`. |
+| `Step`, `Index` | Dynamic current step and iteration. |
+| `context.current.*` | Dynamic current structural context. |
+| `context.parent.*` | Parent structural context. |
+| `context.parent.vars.NAME` | Parent resolved variable. |
+| `context.ancestors.N.*` | Ancestor contexts. |
+| `context.vars.NAME` | Current variable namespace. |
 
-The built-in variables `WorkPath`, `ContextId`, and `RunId` are injected into each shell block's subprocess environment as `RD_WORK_PATH`, `RD_CONTEXT_ID`, and `RD_RUN_ID` respectively. These are injected after policy environment filtering using rundown-wins semantics (they are always present and cannot be blocked by user-supplied environment variables). The `RD_` prefix is reserved for rundown-injected environment variables; see also `RD_OUTPUTS_*` for file-backed output channels in [docs/spec/language.md §7](../spec/language.md#7-context-passing-outputs).
+Static built-ins MAY be overridden by higher-precedence sources. Dynamic
+built-ins MUST NOT be overridden. Plugin runbooks MAY receive upper-snake-case
+plugin variables such as `CLAUDE_PLUGIN_ROOT`.
 
-### Variable Name Requirements
+<a id="shell-environment"></a>
 
-Variable names must match the pattern `/^[a-zA-Z_][a-zA-Z0-9_]*$/`:
-- Must start with a letter or underscore
-- Can contain letters, digits, and underscores
-- Runtime-reserved names (`step`, `index`, `context`) are matched case-insensitively — any casing variant is reserved and cannot be overridden by user variables
+### 8.7 Shell Environment
 
-### Runtime Context Model
+Executable shell blocks receive Rundown environment variables after policy
+environment filtering.
 
-Runtime templating uses a canonical namespaced context model for nested runbooks:
-- `{{context.current.step}}`, `{{context.current.substep}}`, `{{context.current.index}}`, `{{context.current.at}}`
-- `{{context.parent.*}}` for nearest parent runbook context
-- `{{context.ancestors.0.*}}`, `{{context.ancestors.1.*}}`, ... for deeper ancestry (0 = nearest parent)
-- `{{context.vars.NAME}}` for user/config/frontmatter variables
+| Environment variable | Source variable |
+| --- | --- |
+| `RD_WORK_PATH` | `WorkPath` |
+| `RD_CONTEXT_ID` | `ContextId` |
+| `RD_RUN_ID` | `RunId` |
+| `RD_OUTPUTS_<VarName>` | Naked step/substep `OUTPUTS` entry. |
 
-Top-level aliases are retained for ergonomics:
-- `{{Step}}` / `{{step}}` always refer to the current runbook context
-- `{{Index}}` / `{{index}}` always refer to the current runbook context loop index
+Rundown-injected `RD_*` variables use Rundown-wins semantics: user-supplied
+environment variables MUST NOT block or override them.
 
-### Undefined Variables
+### 8.8 Template Persistence
 
-Undefined variables and missing dotted paths are preserved as literal placeholders (`{{variable}}`, `{{context.parent.missing}}`) rather than causing an error. A deduplicated warning is emitted to stderr for each undefined variable.
+`state.runbookSrc` stores raw runbook source, and `state.templateVars` stores the
+resolved static variable map. On resume, the runtime MUST re-apply FOR bounds
+and template placeholders from this frozen variable state so rendering remains
+deterministic.
 
-### Template Variable Persistence
+## 9. Security Integration
 
-`state.runbookSrc` stores raw runbook source, while `state.templateVars` stores the resolved variable map. On resume, FOR bounds and template placeholders are re-applied deterministically from this frozen variable state.
+The runtime delegates full policy semantics to
+[docs/reference/security.md](security.md). Runtime integration points are:
 
-Template variables are expanded before parsing and should not be confused with step identifiers:
-- `{{variable}}` - Template variable, expanded before parsing (e.g., `{{environment}}` becomes `production`)
-- Dotted paths are resolved consistently across startup substitution, runtime loop expansion, and runbook path expansion (for example `runbooks/focus-{{context.parent.index}}.runbook.md`). Runbook file paths use the same template variable expansion rules as step content.
+| Runtime action | Security requirement |
+| --- | --- |
+| Command execution | Command must pass run policy before spawning. |
+| File-backed data source load | Source path must pass containment and read-policy checks. |
+| Shell environment injection | User environment is filtered before Rundown `RD_*` injection. |
+| Sandbox execution | Supported OS sandbox applies read/write restrictions when enabled. |
 
----
+Security failures that affect execution MUST fail visibly. For data sources,
+policy denial MUST NOT produce silent zero-iteration success.
 
-## Security Policy
+<a id="runtime-identity-glossary"></a>
 
-Rundown enforces a security policy layer to control what commands runbooks can execute. See [docs/reference/security.md](security.md) for the full policy specification including default command allow/block/prompt behavior, sandbox enforcement, and the default write allowlist.
+## 10. Runtime Identity
 
-### Quick Reference
+Canonical runtime identity is `step + substep + iteration`.
 
-| Flag | Effect |
-|------|--------|
-| `--allow-run <cmds>` | Allow specific commands (comma-separated) |
-| `--allow-read <paths>` | Allow reading specific paths |
-| `--allow-write <paths>` | Allow writing to specific paths |
-| `--allow-env <vars>` | Allow specific environment variables |
-| `--allow-all` | Bypass all policy checks |
-| `--deny-all` | Block all commands not explicitly allowed |
-| `-y, --yes` | Auto-approve prompts |
-| `--non-interactive` | CI mode (auto-deny unlisted commands) |
-| `--policy <file>` | Use custom policy file |
-| `--trust-js-policy` | Trust an explicitly selected JS policy file and helper modules declared by policy config |
-| `--sandbox` | Enable OS-level filesystem sandbox |
-| `--no-sandbox` | Disable sandbox enforcement |
-| `--sandbox-strict` | Fail if sandbox is unavailable |
+| Identity component | Meaning |
+| --- | --- |
+| Step | Top-level runbook step id. |
+| Substep | Nested substep id, if active. |
+| Iteration | Current `FOR` iteration, if active. |
+| Frame | Internal `step|iteration` scope key. |
+| Entry | Monotonic re-entry counter for a frame. |
+| Completion key | `frame + entry + substep`. |
 
-Policy discovery is data-only by default: `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, or the `rundown` field in `package.json`. Executable `rundown.config.js/.cjs/.mjs` files are only loaded when passed via `--policy` together with `--trust-js-policy`. Helper modules declared by policy config are also executable code and are skipped unless `--trust-js-policy` is set; `--helpers` remains an explicit CLI opt-in.
+Re-entering a frame through `GOTO`, `RETRY`, or other control flow increments
+the entry counter. Completions from older entries MUST be rejected as stale.
 
-### Examples
+Claim ids are isolation-against-accident handles, not adversarial security
+capabilities. Any local process that can read workspace state or command output
+can observe and reuse them.
 
-```bash
-# Allow specific commands for this run
-rundown run deploy.runbook.md --allow-run docker,kubectl
+## 11. Conformance
 
-# Allow file operations
-rundown run backup.runbook.md --allow-read /var/log --allow-write /backup
+A conforming Rundown runtime MUST satisfy these requirements:
 
-# CI/CD: auto-approve with pre-approved commands
-rundown run test.runbook.md --yes --allow-run npm,jest
-
-# CI/CD: strict mode with no prompts
-rundown run test.runbook.md --non-interactive
-```
-
----
-
-## Runtime Identity Glossary
-
-- **Frame (internal):** Execution scope key `step|iteration` (for example `2|` or `2|3`).
-- **Entry (internal):** Monotonic re-entry counter for a frame (`1`, `2`, `3`, ...).
-- **Completion key (internal):** `frame + entry + substep`.
-- **Why both frame and entry:** Re-entering the same frame (for example via `GOTO` or `RETRY`) increments `entry`, so completions from older entries are rejected as stale.
+1. Preserve result, handler, and action as distinct runtime concepts.
+2. Execute shell code blocks only for executable info strings and derive results
+   from exit codes.
+3. Treat display-only prompts as non-executable.
+4. Track active loop state, current values, and iteration results explicitly.
+5. Enforce the 10,000-iteration cap for numeric and open-ended data-source loops.
+6. Record iteration results only for actions that specify accumulation.
+7. Preserve canonical runtime identity as `step + substep + iteration`.
+8. Reject stale frame-entry completions.
+9. Keep claimed delegated children out of `defaultStack`.
+10. Make claim-targeted commands fail closed when the claim cannot safely target
+    one live delegated child.
+11. Preserve variable source precedence exactly as specified.
+12. Reject or skip reserved variable names according to their source.
+13. Prevent user input from overriding dynamic variables.
+14. Inject Rundown `RD_*` environment variables with Rundown-wins semantics.
+15. Confine file-backed data sources to project-root-contained, policy-allowed
+    paths.
+16. Fail visibly for missing, denied, invalid, escaped, or drifted file-backed
+    data sources.
+17. Persist enough state to resume deterministically from `runbookSrc` and
+    `templateVars`.
+18. Never migrate, shim, adapt, rewrite, or resume incompatible persisted state.

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -1,390 +1,416 @@
-# Security Policy
-
-Rundown includes a Deno-inspired security policy layer that provides explicit allowlist-based permission control for runbook execution.
+# Security Policy Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in normative policy sections of this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
-## Security Model
+## 1. Scope
 
-Rundown provides **two layers of security**:
+This document specifies Rundown security policy behavior for command execution, file access, environment access, policy configuration, CLI overrides, JavaScript policy trust, data source files, prompts, session grants, and OS sandbox enforcement.
 
-### Layer 1: Command Policy (All Platforms)
+Sections marked "non-normative" provide explanation, examples, or troubleshooting. All other sections are normative.
 
-The policy engine checks which commands are allowed to run. This layer:
+<a id="security-model"></a>
+## 2. Terminology
 
-- Blocks denied executables (rm, sudo, curl, etc.)
-- Allows approved executables (git, npm, tsc, etc.)
-- Can prompt for unknown commands
-- Parses complex shell commands including pipes, subshells, and backticks
+An **operation** is a requested command execution, file read, file write, or environment variable access.
 
-### Layer 2: Filesystem Sandbox (Linux/macOS)
+A **policy document** is a data policy loaded from `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, the `rundown` field in `package.json`, or an explicitly selected policy file.
 
-When sandboxing is enabled (default on supported platforms), Rundown uses OS-level mechanisms to enforce file access:
+A **JavaScript policy** is a `.js`, `.cjs`, or `.mjs` policy file. JavaScript policies are executable code.
+
+A **configured list** is an `allow` or `deny` list loaded from a policy document.
+
+A **CLI grant** is a permission supplied by command-line flags such as `--allow-run`, `--allow-read`, `--allow-write`, or `--allow-env`.
+
+A **session grant** is a memory-only permission created by an interactive prompt decision.
+
+The **policy mode** is one of `prompted`, `execute`, or `deny`.
+
+The **sandbox** is the optional OS-level filesystem enforcement layer used on supported Linux and macOS hosts.
+
+## 3. Threat Model (non-normative)
+
+Rundown security policy is designed to reduce risk when executable runbooks are evaluated on a user's machine.
+
+| Threat | Protection |
+|--------|------------|
+| Arbitrary command execution | Command allow and deny lists control which executables may run. |
+| Sensitive file access | Path policy and, when available, OS sandboxing restrict file reads and writes. |
+| Credential leakage | Environment variable policy can block secret-bearing names. |
+| Runbook tampering | Runbook overrides allow different trust levels for different file patterns. |
+| Shell injection | The policy tokenizer extracts executables from compound shell syntax where possible. |
+
+Trust boundaries:
+
+```text
+User
+  -> Policy evaluator
+  -> OS sandbox, when enabled and available
+  -> Runbook command
+```
+
+The user is trusted to approve prompts, configure policy files, and choose CLI overrides. A runbook is not inherently trusted.
+
+<a id="sandbox-usage"></a>
+## 4. Security Layers
+
+Rundown has two security layers.
+
+### 4.1 Command Policy
+
+The command policy layer applies on all platforms. It MUST evaluate command execution before spawning a process, and it MUST filter environment variables before passing them to that process. It MUST evaluate file read and write paths when Rundown itself mediates those paths, such as file-backed data source loading or sandbox option assembly. File access performed inside an already allowed process is enforced only by the sandbox layer when sandboxing is enabled and available.
+
+The command policy layer MUST parse supported shell syntax and check each extracted executable. Supported compound forms include pipelines, logical operators, command substitutions, backticks, redirects, and here-documents. Executable words that depend on runtime expansion and cannot be parsed statically MUST be treated as unlisted executables, after which the effective policy mode determines whether to prompt, allow, or deny.
+
+### 4.2 Filesystem Sandbox
+
+When enabled, the sandbox layer SHOULD enforce policy-derived file access restrictions at the OS level.
 
 | Platform | Mechanism | Requirement |
 |----------|-----------|-------------|
 | Linux | Landlock LSM | Kernel 5.13+ with Landlock enabled |
-| macOS | Seatbelt (sandbox-exec) | macOS 10.5+ |
-| Windows | Not supported | Use WSL |
+| macOS | Seatbelt (`sandbox-exec`) | macOS 10.5+ |
+| Windows | Not supported | Use WSL for Linux sandbox behavior |
 
-The sandbox enforces:
-- Read-only access to allowed paths
-- Read-write access to specific directories
-- Blocking of denied paths at the kernel level
+macOS Seatbelt MUST allow only required system and runtime paths plus policy-derived read and write roots. It MUST NOT grant blanket reads of `$HOME`.
 
-Platform-specific behavior:
-- macOS Seatbelt allows only system/runtime paths plus policy-derived read/write roots. It no longer grants blanket reads of `$HOME`.
-- Linux allow-path enforcement is available, but deny-path policies fail closed when the current backend cannot represent them safely.
+Linux allow-path enforcement MAY be used when representable by the backend. Linux deny-path rules that cannot be safely represented MUST fail closed.
 
-## Sandbox Usage
+## 5. Policy Discovery
 
-```bash
-# Enable sandboxing (default on supported platforms)
-rundown run <file> --sandbox
+<a id="policy-configuration"></a>
+<a id="config-file-locations"></a>
+When `--policy <file>` is supplied, Rundown MUST load that file directly. Explicit policy loading MUST NOT search other policy locations first.
 
-# Disable sandboxing (trust mode)
-rundown run <file> --no-sandbox
+When `--policy` is not supplied, Rundown MUST search for policy configuration in this order:
 
-# Fail if sandbox unavailable (strict mode)
-rundown run <file> --sandbox-strict
-```
-
-### Sandbox Limitations
-
-**Without sandbox (`--no-sandbox` or unsupported platform):**
-- File read/write policies are NOT enforced
-- Commands can access any file the user can access
-- Use only with trusted runbooks
-
-**Interpreter bypass:**
-Allowing interpreters (python, node, sh) grants unrestricted code execution.
-The sandbox limits file access, but the interpreter can execute arbitrary logic.
-
-## Overview
-
-The security policy layer enforces a **default-deny** model:
-
-- Commands not in the allowlist require user confirmation
-- Deny lists take precedence over allow lists
-- Granular control over commands, file access, and environment variables
-- Session grants provide temporary permissions without modifying config
-- CLI flags can override policy for specific runs
-
-## Threat Model
-
-The policy layer protects against:
-
-| Threat | Protection |
-|--------|------------|
-| Arbitrary command execution | Allowlist controls which commands can run |
-| Sensitive file access | Path patterns + OS sandbox restrict read/write operations |
-| Credential leakage | Environment variable filtering blocks secrets |
-| Runbook tampering | Per-runbook overrides allow different trust levels |
-| Command injection via backticks | Parser extracts and checks commands in backticks |
-
-### Trust Boundaries
-
-```text
-┌─────────────────────────────────────────────────────┐
-│                     User                            │
-│  - Approves permission prompts                      │
-│  - Configures policy files                          │
-│  - Uses CLI flags for temporary overrides           │
-└─────────────────────────────────────────────────────┘
-                         │
-                         ▼
-┌─────────────────────────────────────────────────────┐
-│                Policy Evaluator                      │
-│  - Checks commands against allow/deny lists         │
-│  - Applies runbook-specific overrides               │
-│  - Manages session grants                           │
-│  - Extracts commands from backticks and $()         │
-└─────────────────────────────────────────────────────┘
-                         │
-                         ▼
-┌─────────────────────────────────────────────────────┐
-│              OS-Level Sandbox                        │
-│  (Linux: Landlock | macOS: Seatbelt)                │
-│  - Enforces file read/write restrictions            │
-│  - Kernel-level enforcement (cannot be bypassed)    │
-└─────────────────────────────────────────────────────┘
-                         │
-                         ▼
-┌─────────────────────────────────────────────────────┐
-│                   Runbook                           │
-│  - Defines steps and commands                       │
-│  - Subject to policy restrictions                   │
-└─────────────────────────────────────────────────────┘
-```
-
-### Data Source File Security
-
-File-backed data sources (`--input items=file:data.txt`) are subject to security controls:
-
-- **Symlink resolution:** `fs.realpath()` resolves symlinks before path validation
-- **Path containment:** Resolved paths must stay within the project root directory
-- **Policy enforcement:** The resolved path is checked against the active `read` policy before it becomes a FOR-loop source
-- **Prompt behavior:** Promptable reads ask for permission in interactive mode and fail startup in non-interactive mode
-- **Blocked sources:** Paths escaping the project are omitted from variable discovery with a warning. A FOR loop depending on that omitted variable fails closed when the loop starts with `ForResolutionError('undefined-variable')`; a `JsonArrayStream` that later resolves outside the project root fails with `policy-violation`, never zero silent iterations.
-- **Drift detection:** File snapshots (size, mtime, SHA-256 of first 64 KiB) detect modification between iterations
-- **Iteration cap:** `MAX_FILE_ITERATIONS` (10,000) prevents runaway loops from unbounded file sources
-
-These controls are always active, independent of the sandbox layer.
-
-## Policy Configuration
-
-### Config File Locations
-
-Policy configuration is discovered in the following order (highest to lowest priority):
-
-1. `.rundownrc` (JSON or YAML)
+1. `.rundownrc`
 2. `.rundownrc.json`
-3. `.rundownrc.yaml` / `.rundownrc.yml`
-4. `package.json` (`rundown` field)
+3. `.rundownrc.yaml`
+4. `.rundownrc.yml`
+5. `package.json` `rundown` field
 
-### Executable JavaScript Policies
+If no policy configuration is found, Rundown MUST use the built-in default policy.
 
-JavaScript policy files are executable code. They are **not** auto-discovered.
+If an auto-discovered configuration file is invalid, Rundown MUST warn and use the built-in default policy. If an explicitly selected policy file is missing or invalid, Rundown MUST fail closed.
 
-- Supported only when explicitly passed with `--policy`
-- Require `--trust-js-policy`
-- Supported extensions: `.js`, `.cjs`, `.mjs`
+JavaScript policy files MUST NOT be auto-discovered.
 
-Examples:
+## 6. Policy Document Model
 
-```bash
-# Data-only policy file (recommended)
-rundown run deploy.runbook.md --policy ./.rundownrc.yaml
+A policy document contains a default policy and MAY contain runbook-specific
+overrides, persisted grants, and helper module declarations.
 
-# Executable policy file (explicit trust required)
-rundown run deploy.runbook.md --policy ./rundown.config.cjs --trust-js-policy
-```
+| Key | Requirement |
+|-----|-------------|
+| `version` | Schema version. Missing value defaults to `1`. |
+| `default` | Default policy applied to every runbook unless an override changes the effective policy. |
+| `overrides` | Ordered list of runbook-specific policy fragments. Missing value defaults to an empty list. |
+| `grants` | Ordered list of persisted user grants. Missing value defaults to an empty list. |
+| `helpers` | Optional helper module paths. Loading these modules requires `--trust-js-policy`. |
 
-Migration from `rundown.config.js`:
-- Move the policy object into `.rundownrc.yaml`, `.rundownrc.json`, or `package.json`
-- Keep JavaScript only if you intentionally need executable policy logic
-- If you keep JavaScript, require `--policy ... --trust-js-policy` in your workflow
+The `default` policy object contains these fields:
 
-### Schema Reference
+| Key | Requirement |
+|-----|-------------|
+| `mode` | One of `prompted`, `execute`, or `deny`. Missing value defaults to `prompted`. |
+| `run` | Command permission rules. Missing value defaults to empty `allow` and `deny` lists. |
+| `read` | File-read permission rules. Missing value defaults to empty `allow` and `deny` lists. |
+| `write` | File-write permission rules. Missing value defaults to empty `allow` and `deny` lists. |
+| `env` | Environment-variable permission rules. Missing value defaults to empty `allow` and `deny` lists. |
 
-```yaml
-# .rundownrc.yaml
-version: 1
+Each permission rule object contains:
 
-default:
-  # Policy mode: 'prompted' | 'execute' | 'deny'
-  mode: prompted
+| Key | Requirement |
+|-----|-------------|
+| `allow` | Ordered list of glob patterns that may allow matching operations. Missing value defaults to an empty list. |
+| `deny` | Ordered list of glob patterns that may deny matching operations. Missing value defaults to an empty list. |
 
-  # Command execution rules
-  run:
-    allow:
-      - git
-      - npm
-      - node
-    deny:
-      - sudo
-      - rm
+Each override contains a `runbook` glob and MAY contain `mode`, `run`, `read`,
+`write`, or `env`. Each persisted grant contains `type`, `pattern`, optional
+`runbook`, optional `grantedAt`, and `scope`.
 
-  # File read rules (supports {repo}, {tmp} placeholders)
-  read:
-    allow:
-      - "{repo}/**"
-      - "{tmp}/**"
-    deny:
-      - "**/.env"
-      - "**/credentials.json"
+Pattern matching uses picomatch-compatible glob syntax.
 
-  # File write rules
-  write:
-    allow:
-      - "{repo}/.claude/**"
-      - "{repo}/dist/**"
-    deny:
-      - "**/.env"
+Path patterns MAY use these placeholders:
 
-  # Environment variable rules (supports glob patterns)
-  env:
-    allow:
-      - PATH
-      - HOME
-      - NODE_ENV
-      - npm_*
-    deny:
-      - "*_TOKEN"
-      - "*_SECRET"
-      - AWS_*
+| Placeholder | Resolves To |
+|-------------|-------------|
+| `{repo}` | Repository root, defaulting to `process.cwd()` |
+| `{tmp}` | System temporary directory, such as `/tmp` or `%TEMP%` |
 
-# Runbook-specific overrides
-overrides:
-  - runbook: "deploy/*.runbook.md"
-    mode: execute  # Trusted deployment scripts
-    run:
-      allow:
-        - docker
-        - kubectl
+Command `run` patterns match executable names. File `read` and `write` patterns match resolved paths. Environment `env` patterns match variable names.
 
-# Persisted grants
-grants:
-  - type: run
-    pattern: curl
-    scope: permanent
-```
+Runbook override patterns MUST be matched against runbook file paths. A matching override mode replaces the default mode for that runbook. Matching override permission rules are appended to the default permission rules for that runbook.
 
-### Default Policy
+## 7. Effective Policy Assembly
 
-When no configuration file is found, Rundown uses built-in defaults:
+The effective policy for a run MUST be assembled from:
 
-**Allowed commands:**
+1. The selected policy document, or the built-in default policy when no document is found.
+2. Any matching runbook overrides. Override modes replace the effective mode, and override permission lists are appended to the default permission lists.
+3. Persisted grants from the policy document. Persisted grants are appended to the effective allow lists for their permission type.
+4. CLI options for the current invocation.
+5. Session grants created during interactive prompts.
+
+The built-in policy mode is `prompted`.
+
+<a id="default-policy"></a>
+### 7.1 Built-In Default Policy
+
+When no configuration file is found, Rundown uses the built-in default policy.
+
+Allowed commands:
+
 - Version control: `git`
 - Node.js ecosystem: `node`, `npm`, `npx`, `pnpm`, `yarn`, `bun`
 - Build tools: `tsc`, `esbuild`, `vite`, `webpack`, `rollup`
 - Linting: `eslint`, `prettier`, `biome`
 - Testing: `jest`, `vitest`, `mocha`, `playwright`, `cypress`
 - Other languages: `python`, `python3`, `pip`, `pip3`, `go`, `cargo`, `rustc`, `make`, `cmake`
-- Rundown: `rd`, `rundown`
+- Rundown: `rd`, `rundown`, `rdpath`, `rdx`
 
-**Denied commands:**
+Denied commands:
+
 - System administration: `sudo`, `su`, `passwd`, `useradd`, `usermod`, `userdel`, `chown`, `chmod`
 - Network tools: `curl`, `wget`, `nc`, `netcat`, `ncat`, `ssh`, `scp`, `sftp`, `rsync`
 - Destructive operations: `rm`, `rmdir`, `mv`, `dd`, `mkfs`, `fdisk`, `parted`
 - Process control: `kill`, `killall`, `pkill`
 - Container tools: `docker`, `podman`, `kubectl`, `helm`
 
-**Default file access:**
+Default file access:
+
 - Read allow: `{repo}/**`, `{tmp}/**`
 - Read deny: `**/.env`, `**/.env.*`, `**/credentials.json`, `**/*secret*`, `**/*password*`, `**/id_rsa`, `**/id_ed25519`, `**/*.pem`, `**/*.key`
-- Write allow: `{repo}/.claude/**`, `{repo}/.rundown/contexts/**`, `{repo}/node_modules/**`, `{repo}/dist/**`, `{repo}/build/**`, `{repo}/.next/**`, `{tmp}/**`
-- Write deny: `**/.env`, `**/.env.*`, `**/credentials.json`, `**/*secret*`, `**/*password*`
+- Write allow: `{repo}/.claude/**`, `{repo}/.rundown/runs/**`, `{repo}/.rundown/locks/**`, `{repo}/.rundown/contexts/**`, `{repo}/.rundown/session.json`, `{repo}/.rundown/work/**`, `{repo}/node_modules/**`, `{repo}/dist/**`, `{repo}/build/**`, `{repo}/.next/**`, `{tmp}/**`
+- Write deny: `**/.env`, `**/.env.*`, `**/credentials.json`, `**/*secret*`, `**/*password*`, `{repo}/.rundown/config.yaml`
 
-**Note:** Read deny includes SSH keys and certificates (`id_rsa`, `id_ed25519`, `*.pem`, `*.key`) to prevent credential exfiltration, but write deny does not include these patterns to allow key generation workflows.
+Read deny includes SSH keys and certificates (`id_rsa`, `id_ed25519`, `*.pem`, `*.key`) to reduce credential exfiltration risk. Write deny does not include those patterns so key generation workflows can write new keys when otherwise allowed.
 
-**Allowed environment variables:**
+Allowed environment variables:
+
 - System: `PATH`, `HOME`, `USER`, `SHELL`, `TERM`, `LANG`, `LC_*`, `TMPDIR`, `TMP`, `TEMP`
 - Development: `CI`, `NODE_ENV`, `DEBUG`, `npm_*`, `RUNDOWN_*`
 
-**Denied environment variables:**
-- Tokens/secrets: `*_TOKEN`, `*_KEY`, `*_SECRET`, `*_PASSWORD`, `*_CREDENTIAL`
+Denied environment variables:
+
+- Tokens and secrets: `*_TOKEN`, `*_KEY`, `*_SECRET`, `*_PASSWORD`, `*_CREDENTIAL`
 - Cloud credentials: `AWS_*`, `GCP_*`, `AZURE_*`, `GOOGLE_*`
 - Infrastructure: `KUBECONFIG`, `DOCKER_*`, `SSH_*`, `GPG_*`
 - Specific tokens: `GITHUB_TOKEN`, `GITLAB_TOKEN`, `NPM_TOKEN`
 
-## Policy Modes
+<a id="allowdeny-lists"></a>
+## 8. Policy Decisions
+
+Policy decisions MUST use this precedence order:
+
+1. `--deny-all`
+2. `--allow-all`
+3. CLI grants
+4. Session grants
+5. Configured deny lists
+6. Configured allow lists
+7. Policy mode
+
+`--deny-all` MUST take precedence over `--allow-all` when both are supplied.
+
+CLI grants and session grants MUST be evaluated before configured deny and allow lists.
+
+Configured deny lists MUST take precedence over configured allow lists.
+
+The policy mode MUST be consulted only after no earlier rule decides the operation.
+
+<a id="policy-modes"></a>
+### 8.1 Policy Modes
 
 | Mode | Behavior |
 |------|----------|
-| `prompted` (default) | Ask user for permission on unlisted commands |
-| `execute` | Allow all commands without prompting |
-| `deny` | Block all unlisted commands without prompting |
+| `prompted` | Prompt for unlisted operations when interactive. |
+| `execute` | Allow unlisted operations. |
+| `deny` | Deny unlisted operations. |
 
-### Mode Selection
+The built-in default mode is `prompted`. In `prompted` mode, unlisted operations MUST prompt when the process is interactive. Prompt-required decisions MUST fail closed when the process is non-interactive.
 
-```bash
-# Use prompted mode (default)
-rundown run deploy.runbook.md
+## 9. CLI Overrides
 
-# Trust mode - skip all policy checks
-rundown run deploy.runbook.md --allow-all
-
-# Strict mode - block everything not explicitly allowed
-rundown run deploy.runbook.md --deny-all
-```
-
-## Allow/Deny Lists
-
-Pattern matching uses [picomatch](https://github.com/micromatch/picomatch) for glob syntax. Command parsing uses Rundown's policy tokenizer to extract executables from shell commands, including pipelines, redirects, command substitutions, and here-documents. Executable words that depend on runtime expansion are treated as dynamic and fail closed unless trust mode is enabled.
-
-### Command Execution (run)
-
-Commands are matched by their executable name:
-
-```yaml
-run:
-  allow:
-    - git        # Matches: git status, git push, etc.
-    - npm        # Matches: npm install, npm test
-  deny:
-    - sudo       # Blocks: sudo anything
-```
-
-For piped commands, shell wrappers, and logical operators, all executables are extracted and checked:
-
-```bash
-git log | grep fix        # Both 'git' and 'grep' must be allowed
-sh -c "npm install"       # 'sh' and 'npm' must be allowed
-npm test && npm build     # 'npm' must be allowed
-```
-
-### File Access (read/write)
-
-Path patterns support glob syntax with special placeholders:
-
-| Placeholder | Resolves To |
-|-------------|-------------|
-| `{repo}` | Repository root (defaults to `process.cwd()`) |
-| `{tmp}` | System temporary directory (e.g., `/tmp` on Unix, `%TEMP%` on Windows) |
-
-```yaml
-read:
-  allow:
-    - "{repo}/**"        # All files in repo
-    - "{tmp}/rundown-*"  # Temp files with prefix
-  deny:
-    - "**/.env"          # All .env files
-    - "**/secrets/**"    # Any secrets directory
-```
-
-### Environment Variables (env)
-
-Variable names support glob patterns:
-
-```yaml
-env:
-  allow:
-    - PATH
-    - NODE_ENV
-    - npm_*              # All npm_ prefixed vars
-    - RUNDOWN_*          # All Rundown vars
-  deny:
-    - "*_TOKEN"          # Any token
-    - "*_SECRET"         # Any secret
-    - AWS_*              # All AWS credentials
-```
-
-## CLI Options
+<a id="cli-options"></a>
+CLI overrides apply only to the current invocation unless they create a session grant through an interactive prompt.
 
 | Option | Description |
 |--------|-------------|
-| `--allow-run <cmds>` | Allow specific commands (comma-separated) |
-| `--allow-read <paths>` | Allow reading specific paths (comma-separated) |
-| `--allow-write <paths>` | Allow writing to specific paths (comma-separated) |
-| `--allow-env <vars>` | Allow specific environment variables (comma-separated) |
-| `--allow-all` | Bypass all policy checks (trust mode) |
-| `--deny-all` | Block all operations not explicitly allowed |
-| `--policy <file>` | Use a specific policy configuration file |
-| `--trust-js-policy` | Trust an explicitly selected executable JS policy file and helper modules declared by policy config |
-| `-y, --yes` | Skip confirmation prompts (auto-approve) |
-| `--non-interactive` | Non-interactive mode (auto-deny, CI-friendly) |
-| `--sandbox` | Enable OS-level sandbox (default on supported platforms) |
-| `--no-sandbox` | Disable sandbox enforcement |
-| `--sandbox-strict` | Fail if sandbox is unavailable |
+| `--allow-run <cmds>` | Allow specific commands, comma-separated. |
+| `--allow-read <paths>` | Allow reading specific paths, comma-separated. |
+| `--allow-write <paths>` | Allow writing specific paths, comma-separated. |
+| `--allow-env <vars>` | Allow specific environment variables, comma-separated. |
+| `--allow-all` | Bypass policy checks and disable sandboxing. |
+| `--deny-all` | Deny all operations; wins over `--allow-all` and all grants. |
+| `--policy <file>` | Load a specific policy file directly. |
+| `--trust-js-policy` | Trust an explicitly selected JavaScript policy and config-declared helper modules. |
+| `-y, --yes` | Skip confirmation prompts by approving promptable operations. |
+| `--non-interactive` | Disable prompts; prompt-required decisions fail closed. |
+| `--sandbox` | Enable OS-level sandboxing. |
+| `--no-sandbox` | Disable OS-level sandboxing. |
+| `--sandbox-strict` | Fail closed if sandboxing is unavailable. |
 
-**Note:** If both `--allow-all` and `--deny-all` are specified, `--deny-all` takes precedence.
+`--allow-all` MUST imply `--no-sandbox`.
 
-**Note:** `--allow-all` implies `--no-sandbox` (trust mode bypasses all enforcement).
+`--deny-all` MUST win over `--allow-all`.
 
-**Note:** Helper modules declared by `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, or `package.json` are executable JavaScript and are skipped unless `--trust-js-policy` is set. Helper modules passed directly with `--helpers` are treated as explicit CLI opt-in.
+`--helpers` is an explicit CLI opt-in for helper modules. Helper modules supplied through `--helpers` are not treated as auto-discovered configuration.
 
-### Precedence Order
+## 10. Sandbox Enforcement
 
-Permissions are evaluated in this order (first match wins):
+The sandbox MUST be enabled by default unless `--no-sandbox` or `--allow-all` is supplied.
 
-1. **CLI grants** (`--allow-run`, etc.) - highest priority
-2. **Session grants** (user-approved during prompts)
-3. **Deny list** - if matched, operation is blocked
-4. **Allow list** - if matched, operation is allowed
-5. **Policy mode** - `prompted`, `execute`, or `deny`
+`--allow-all` MUST disable sandboxing.
 
-### Examples
+If sandboxing is enabled but unavailable, Rundown MUST warn and execute unsandboxed unless `--sandbox-strict` is supplied.
+
+If `--sandbox-strict` is supplied and sandboxing is unavailable, Rundown MUST fail closed and MUST NOT execute the command.
+
+If the Linux sandbox backend cannot safely represent effective deny-path rules, Rundown MUST fail closed instead of silently weakening policy.
+
+When sandboxing is disabled with `--no-sandbox`, file read and write policy still applies in the policy evaluator, but OS-level enforcement does not apply. Commands can access any file the user account can access if the command itself bypasses or exceeds the evaluator's visibility.
+
+Allowing interpreters such as `python`, `node`, or `sh` grants broad code execution. The sandbox can restrict file access, but it does not make interpreter logic safe.
+
+## 11. Data Source File Security
+
+File-backed data sources use `file:` values, such as `--input items=file:data.jsonl`, and are used by `FOR variable IN {{ source }}` loops.
+
+File-backed data sources MUST resolve symlinks before validation.
+
+Resolved data source paths MUST remain inside the project root. Traversal or symlink escape outside the project root MUST fail visibly.
+
+Resolved data source paths MUST pass the active read policy before execution or iteration starts. Promptable reads MAY ask for permission in interactive mode and MUST fail closed in non-interactive mode.
+
+Rundown MUST detect data source drift between iterations. Drift includes material changes to the file snapshot, such as size, mtime, or sampled content hash changes. Drift MUST fail visibly.
+
+Missing, denied, invalid, escaped, or drifted data sources MUST NOT produce silent zero-iteration loops. They MUST fail visibly before or during loop execution.
+
+File-backed data source controls MUST apply independently of the sandbox layer.
+
+Implementations SHOULD cap file-backed iteration to prevent runaway loops. The current cap is `MAX_FILE_ITERATIONS` at 10,000 iterations.
+
+## 12. JavaScript Policy and Helper Trust
+
+<a id="executable-javascript-policies"></a>
+JavaScript, CommonJS, and ES module policy files are executable code. Files ending in `.js`, `.cjs`, or `.mjs` MUST be treated as JavaScript policies.
+
+JavaScript policies MUST NOT be auto-discovered.
+
+JavaScript policies MUST be loaded only when both conditions are true:
+
+1. The file is explicitly selected with `--policy <file>`.
+2. `--trust-js-policy` is supplied.
+
+If a JavaScript policy is explicitly selected without `--trust-js-policy`, Rundown MUST fail closed.
+
+Helper modules declared by policy configuration are executable code. Config-declared helper modules MUST be skipped unless `--trust-js-policy` is supplied.
+
+Helper modules passed directly through `--helpers` are allowed only because `--helpers` is an explicit CLI opt-in.
+
+## 13. Prompts, Session Grants, and Non-Interactive Mode
+
+In interactive prompted mode, unlisted operations MUST ask the user for a decision.
+
+Prompt decisions MAY create session grants with these scopes:
+
+| Option | Effect |
+|--------|--------|
+| Allow once | Allow one operation. |
+| Allow for this session | Remember the operation until the runbook or process ends. |
+| Allow all of this type for this session | Allow all operations of that type until the runbook or process ends. |
+| Deny once | Deny one operation. |
+| Deny all of this type for this session | Deny all operations of that type until the runbook or process ends. |
+
+Session grants MUST be memory-only. They MUST NOT persist to disk. They MUST be cleared when the runbook completes, the CLI process exits, or the user explicitly resets them.
+
+When `--non-interactive` is supplied, or when the process is detected as non-interactive, prompts MUST NOT be shown. Any decision that would require a prompt MUST fail closed unless allowed by an earlier precedence rule.
+
+`-y` or `--yes` MAY approve promptable operations without showing a prompt. It MUST NOT override `--deny-all`, configured deny rules, or other earlier denial decisions.
+
+<a id="fallback-behavior"></a>
+## 14. Failure Semantics
+
+| Case | Behavior |
+|------|----------|
+| No policy config found | Use built-in defaults. |
+| Invalid auto-discovered config | Warn and use built-in defaults. |
+| Missing or invalid explicit `--policy` config | Fail closed. |
+| JavaScript policy without `--trust-js-policy` | Fail closed. |
+| Config-declared helper without `--trust-js-policy` | Skip helper. |
+| Not parseable command | Fail closed unless `--allow-all` is active. |
+| Dynamic executable word | Treat as an unlisted operation; policy mode determines whether to prompt, allow, or deny. |
+| Unlisted operation in interactive prompted mode | Prompt. |
+| Unlisted operation requiring prompt in non-interactive mode | Fail closed. |
+| `--allow-all` and `--deny-all` both supplied | `--deny-all` wins. |
+| Sandbox unavailable with default sandboxing | Warn and run unsandboxed. |
+| Sandbox unavailable with `--sandbox-strict` | Fail closed. |
+| Linux deny-path rules cannot be safely represented | Fail closed. |
+| Missing data source file | Fail visibly. |
+| Denied data source file | Fail visibly. |
+| Invalid data source file | Fail visibly. |
+| Data source escapes project root | Fail visibly. |
+| Data source drift detected | Fail visibly. |
+
+## 15. Examples (non-normative)
+
+### 15.1 Policy Files
+
+```bash
+# Data-only policy file
+rundown run deploy.runbook.md --policy ./.rundownrc.yaml
+
+# Executable policy file
+rundown run deploy.runbook.md --policy ./rundown.config.cjs --trust-js-policy
+```
+
+Migration from `rundown.config.js`:
+
+- Move the policy object into `.rundownrc.yaml`, `.rundownrc.json`, or `package.json` when executable logic is not needed.
+- Keep JavaScript only when executable policy logic is intentional.
+- Require `--policy ... --trust-js-policy` in workflows that keep JavaScript policy files.
+
+### 15.2 Command, File, and Environment Rules
+
+```yaml
+version: 1
+default:
+  mode: prompted
+  run:
+    allow:
+      - git
+      - npm
+    deny:
+      - sudo
+  read:
+    allow:
+      - "{repo}/**"
+      - "{tmp}/rundown-*"
+    deny:
+      - "**/.env"
+      - "**/secrets/**"
+  env:
+    allow:
+      - PATH
+      - NODE_ENV
+      - npm_*
+      - RUNDOWN_*
+    deny:
+      - "*_TOKEN"
+      - "*_SECRET"
+      - AWS_*
+```
+
+For compound commands, every extracted executable must be allowed:
+
+```bash
+git log | grep fix
+sh -c "npm install"
+npm test && npm run build
+```
+
+### 15.3 CLI Overrides
 
 ```bash
 # Allow specific commands for this run
@@ -393,26 +419,20 @@ rundown run deploy.runbook.md --allow-run docker,kubectl
 # Allow file operations
 rundown run backup.runbook.md --allow-read /var/log --allow-write /backup
 
-# CI/CD: auto-approve with pre-approved commands
-rundown run test.runbook.md --yes --allow-run npm,jest
+# Prompted mode with default policy
+rundown run deploy.runbook.md
 
-# CI/CD: strict mode with no prompts
+# Strict mode with no prompts
 rundown run test.runbook.md --non-interactive
 
-# Use custom policy file
-rundown run deploy.runbook.md --policy ./ci-policy.yaml
-
-# Use executable JS policy file (explicit trust required)
-rundown run deploy.runbook.md --policy ./rundown.config.cjs --trust-js-policy
+# Trust mode for a controlled environment
+rundown run deploy.runbook.md --allow-all
 ```
 
-## Runbook Overrides
-
-Different runbooks can have different trust levels:
+### 15.4 Runbook Overrides
 
 ```yaml
 overrides:
-  # Trust deployment scripts
   - runbook: "deploy/**/*.runbook.md"
     mode: execute
     run:
@@ -421,11 +441,9 @@ overrides:
         - kubectl
         - helm
 
-  # Strict mode for untrusted runbooks
   - runbook: "community/**/*.runbook.md"
     mode: deny
 
-  # Additional permissions for specific runbook
   - runbook: "backup.runbook.md"
     run:
       allow:
@@ -433,70 +451,24 @@ overrides:
         - tar
 ```
 
-Override patterns use glob matching against runbook file paths.
-
-## Session Grants
-
-When prompted for permission, users can choose grant scope:
-
-| Option | Effect |
-|--------|--------|
-| Allow once | Single operation only |
-| Allow for this session | Remembered until runbook completes |
-| Allow all [type] for this session | Allow all operations of that type |
-| Deny once | Single denial |
-| Deny all [type] for this session | Block all operations of that type |
-
-Session grants are **memory-only** and do not persist to disk. They are cleared when:
-
-- The runbook completes
-- The CLI process exits
-- The user explicitly resets them
-
-## Best Practices
-
-### Principle of Least Privilege
-
-1. Start with the default policy and add specific permissions as needed
-2. Use `--allow-run` for one-off operations rather than modifying config
-3. Prefer `prompted` mode over `execute` for production runbooks
-
-### Repository-Specific Configurations
-
-Create `.rundownrc.yaml` in your repository with project-specific allowlists:
-
-```yaml
-version: 1
-default:
-  mode: prompted
-  run:
-    allow:
-      - turbo      # Project uses Turborepo
-      - prisma     # Database migrations
-```
-
-### CI/CD Considerations
-
-For CI environments:
+### 15.5 CI
 
 ```bash
-# Option 1: Pre-approve known commands
+# Pre-approve known commands
 rundown run test.runbook.md --yes --allow-run npm,jest,eslint
 
-# Option 2: Use non-interactive mode with policy file
+# Use non-interactive mode with a policy file
 rundown run test.runbook.md --non-interactive --policy ./ci-policy.yaml
 
-# Option 3: Trust mode for controlled CI environment
+# Trust mode for a controlled CI environment
 rundown run deploy.runbook.md --allow-all
 ```
-
-Create a dedicated CI policy file:
 
 ```yaml
 # ci-policy.yaml
 version: 1
 default:
-  mode: execute  # No prompts in CI
+  mode: execute
   run:
     allow:
       - npm
@@ -510,73 +482,51 @@ default:
       - wget
 ```
 
-### Auditing
+## 16. Troubleshooting (non-normative)
 
-Review your policy configuration periodically:
-
-1. Check for overly permissive `allow` patterns
-2. Ensure `deny` lists include sensitive operations
-3. Review runbook overrides for appropriate trust levels
-4. Monitor session grants during development
-
-## Sandbox Troubleshooting
-
-### Linux: Checking Landlock Availability
+<a id="sandbox-troubleshooting"></a>
+### 16.1 Linux Landlock
 
 ```bash
-# Check if Landlock is enabled in kernel
+# Check whether Landlock is enabled in the kernel
 cat /sys/kernel/security/lsm
-# Output should include 'landlock'
 
-# Check kernel version (requires 5.13+)
+# Check kernel version; Landlock requires 5.13+
 uname -r
 ```
 
-If Landlock is not available:
-- Upgrade to Linux kernel 5.13 or later
-- Ensure CONFIG_SECURITY_LANDLOCK is enabled in kernel config
-- Install a Landlock wrapper like [landrun](https://github.com/Zouuup/landrun) (v0.1.0 or later recommended)
+If Landlock is unavailable, upgrade to Linux kernel 5.13 or later, ensure `CONFIG_SECURITY_LANDLOCK` is enabled, or install a Landlock wrapper such as `landrun` v0.1.0 or later.
 
-### macOS: Seatbelt Permissions
-
-The `sandbox-exec` command is built into macOS but may require adjustments:
+### 16.2 macOS Seatbelt
 
 ```bash
-# Verify sandbox-exec exists
 which sandbox-exec
-# Should output: /usr/bin/sandbox-exec
 ```
 
-Common issues:
-- **SIP restrictions**: System Integrity Protection may block certain sandbox operations
-- **Entitlements**: Some apps may need specific entitlements for sandbox access
+`sandbox-exec` should resolve to `/usr/bin/sandbox-exec`. If sandbox-protected commands fail unexpectedly, check whether System Integrity Protection or application entitlements affect the command.
 
-### Fallback Behavior
-
-When sandbox is unavailable:
+### 16.3 Sandbox Fallbacks
 
 | Scenario | Behavior |
 |----------|----------|
-| `--sandbox` (default) | Falls back to unsandboxed with warning |
-| `--sandbox-strict` | Fails with error, command not executed |
-| `--no-sandbox` | Executes without sandbox, no warning |
+| `--sandbox` or default sandboxing | Falls back to unsandboxed execution with a warning when the sandbox is unavailable. |
+| `--sandbox-strict` | Fails with an error and does not execute the command when the sandbox is unavailable. |
+| `--no-sandbox` | Executes without sandboxing and does not warn about sandbox availability. |
 
-Linux deny-path note:
-- If the effective policy contains deny-path rules that the Linux backend cannot enforce safely, Rundown blocks execution instead of silently weakening policy.
-- To proceed in that case, disable sandboxing only for trusted runs with `--no-sandbox`.
+Linux deny-path note: if the effective policy contains deny-path rules that the Linux backend cannot enforce safely, Rundown blocks execution instead of silently weakening policy. For trusted runs only, disable sandboxing with `--no-sandbox`.
 
-### Debugging Sandbox Issues
-
-To debug sandbox-related issues:
+### 16.4 Debugging Sandbox Issues
 
 ```bash
-# Run with sandbox strict to see if sandbox is available
+# Require sandbox availability
 rundown run test.runbook.md --sandbox-strict
 
-# If it fails, check availability:
-# Linux: cat /sys/kernel/security/lsm
-# macOS: which sandbox-exec
-
-# Disable sandbox for trusted runbooks
+# Disable sandbox for a trusted runbook
 rundown run trusted.runbook.md --no-sandbox
 ```
+
+## 17. Conformance
+
+An implementation conforms to this specification when it follows the normative requirements in sections 1, 2, 4 through 14, and 17.
+
+Documentation, examples, and troubleshooting sections are non-normative and MUST NOT override normative requirements.

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -9,6 +9,7 @@ This document specifies Rundown security policy behavior for command execution, 
 Sections marked "non-normative" provide explanation, examples, or troubleshooting. All other sections are normative.
 
 <a id="security-model"></a>
+
 ## 2. Terminology
 
 An **operation** is a requested command execution, file read, file write, or environment variable access.
@@ -51,6 +52,7 @@ User
 The user is trusted to approve prompts, configure policy files, and choose CLI overrides. A runbook is not inherently trusted.
 
 <a id="sandbox-usage"></a>
+
 ## 4. Security Layers
 
 Rundown has two security layers.
@@ -89,9 +91,9 @@ When `--policy` is not supplied, Rundown MUST search for policy configuration in
 4. `.rundownrc.yml`
 5. `package.json` `rundown` field
 
-If no policy configuration is found, Rundown MUST use the built-in default policy.
+When no policy configuration is found, Rundown MUST use the built-in default policy.
 
-If an auto-discovered configuration file is invalid, Rundown MUST warn and use the built-in default policy. If an explicitly selected policy file is missing or invalid, Rundown MUST fail closed.
+Invalid auto-discovered configuration MUST trigger a warning and fall back to the built-in default policy. A missing or invalid explicitly selected policy file MUST fail closed.
 
 JavaScript policy files MUST NOT be auto-discovered.
 
@@ -155,6 +157,7 @@ The effective policy for a run MUST be assembled from:
 The built-in policy mode is `prompted`.
 
 <a id="default-policy"></a>
+
 ### 7.1 Built-In Default Policy
 
 When no configuration file is found, Rundown uses the built-in default policy.
@@ -199,6 +202,7 @@ Denied environment variables:
 - Specific tokens: `GITHUB_TOKEN`, `GITLAB_TOKEN`, `NPM_TOKEN`
 
 <a id="allowdeny-lists"></a>
+
 ## 8. Policy Decisions
 
 Policy decisions MUST use this precedence order:
@@ -220,6 +224,7 @@ Configured deny lists MUST take precedence over configured allow lists.
 The policy mode MUST be consulted only after no earlier rule decides the operation.
 
 <a id="policy-modes"></a>
+
 ### 8.1 Policy Modes
 
 | Mode | Behavior |
@@ -263,11 +268,11 @@ The sandbox MUST be enabled by default unless `--no-sandbox` or `--allow-all` is
 
 `--allow-all` MUST disable sandboxing.
 
-If sandboxing is enabled but unavailable, Rundown MUST warn and execute unsandboxed unless `--sandbox-strict` is supplied.
+When sandboxing is enabled but unavailable, Rundown MUST warn and execute unsandboxed unless `--sandbox-strict` is supplied.
 
-If `--sandbox-strict` is supplied and sandboxing is unavailable, Rundown MUST fail closed and MUST NOT execute the command.
+With `--sandbox-strict`, unavailable sandboxing MUST fail closed and MUST NOT execute the command.
 
-If the Linux sandbox backend cannot safely represent effective deny-path rules, Rundown MUST fail closed instead of silently weakening policy.
+When the Linux sandbox backend cannot safely represent effective deny-path rules, Rundown MUST fail closed instead of silently weakening policy.
 
 When sandboxing is disabled with `--no-sandbox`, file read and write policy still applies in the policy evaluator, but OS-level enforcement does not apply. Commands can access any file the user account can access if the command itself bypasses or exceeds the evaluator's visibility.
 
@@ -330,6 +335,7 @@ When `--non-interactive` is supplied, or when the process is detected as non-int
 `-y` or `--yes` MAY approve promptable operations without showing a prompt. It MUST NOT override `--deny-all`, configured deny rules, or other earlier denial decisions.
 
 <a id="fallback-behavior"></a>
+
 ## 14. Failure Semantics
 
 | Case | Behavior |
@@ -485,6 +491,7 @@ default:
 ## 16. Troubleshooting (non-normative)
 
 <a id="sandbox-troubleshooting"></a>
+
 ### 16.1 Linux Landlock
 
 ```bash

--- a/packages/claude-code-plugin/__tests__/dispatcher.coverage.test.ts
+++ b/packages/claude-code-plugin/__tests__/dispatcher.coverage.test.ts
@@ -105,13 +105,9 @@ describe('Dispatcher Coverage Extensions', () => {
     it('covers path jail and error handling', async () => {
       const config = { file_patterns: ['**/*.ts'] } satisfies GateConfig;
       expect(await gateMatchesFilePattern(config, '/outside/path.ts', testDir)).toBe(false);
-      expect(
-        await gateMatchesFilePattern(
-          malformedGateConfig([null]),
-          'test.ts',
-          testDir,
-        ),
-      ).toBe(false);
+      expect(await gateMatchesFilePattern(malformedGateConfig([null]), 'test.ts', testDir)).toBe(
+        false,
+      );
     });
   });
 
@@ -123,10 +119,7 @@ describe('Dispatcher Coverage Extensions', () => {
 
       // Config with missing hook
       const emptyConfig = { hooks: {}, gates: {} } satisfies RundownPluginConfig;
-      await fs.writeFile(
-        path.join(testDir, 'rundown-plugin.json'),
-        JSON.stringify(emptyConfig),
-      );
+      await fs.writeFile(path.join(testDir, 'rundown-plugin.json'), JSON.stringify(emptyConfig));
       const res2 = await dispatch({ hook_event_name: 'UserPromptSubmit', cwd: testDir });
       expect(res2.context).toBeDefined();
 

--- a/packages/claude-code-plugin/__tests__/dispatcher.coverage.test.ts
+++ b/packages/claude-code-plugin/__tests__/dispatcher.coverage.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import type { injectContext } from '../src/context.js';
 import type { executeGate } from '../src/gate-loader.js';
+import type { GateConfig, RundownPluginConfig } from '../src/shared/index.js';
 
 // Mock only what is necessary and external to the logic we want to test
 const mockInjectContext = jest.fn() as jest.MockedFunction<typeof injectContext>;
@@ -28,6 +29,10 @@ jest.unstable_mockModule('../src/workflow/context.js', () => ({
 const { dispatch, gateMatchesFilePattern } = await import('../src/dispatcher.js');
 const { Session } = await import('../src/session.js');
 const { detectSyntheticEvents } = await import('../src/synthetic-events/detector.js');
+
+function malformedGateConfig(filePatterns: unknown[]): GateConfig {
+  return { file_patterns: filePatterns as string[] };
+}
 
 describe('Dispatcher Coverage Extensions', () => {
   let testDir: string;
@@ -98,10 +103,14 @@ describe('Dispatcher Coverage Extensions', () => {
 
   describe('gateMatchesFilePattern coverage', () => {
     it('covers path jail and error handling', async () => {
-      const config = { file_patterns: ['**/*.ts'] } as any;
+      const config = { file_patterns: ['**/*.ts'] } satisfies GateConfig;
       expect(await gateMatchesFilePattern(config, '/outside/path.ts', testDir)).toBe(false);
       expect(
-        await gateMatchesFilePattern({ file_patterns: [null as any] }, 'test.ts', testDir),
+        await gateMatchesFilePattern(
+          malformedGateConfig([null]),
+          'test.ts',
+          testDir,
+        ),
       ).toBe(false);
     });
   });
@@ -113,9 +122,10 @@ describe('Dispatcher Coverage Extensions', () => {
       expect(res1.context).toBeDefined();
 
       // Config with missing hook
+      const emptyConfig = { hooks: {}, gates: {} } satisfies RundownPluginConfig;
       await fs.writeFile(
         path.join(testDir, 'rundown-plugin.json'),
-        JSON.stringify({ hooks: {}, gates: {} }),
+        JSON.stringify(emptyConfig),
       );
       const res2 = await dispatch({ hook_event_name: 'UserPromptSubmit', cwd: testDir });
       expect(res2.context).toBeDefined();
@@ -124,7 +134,7 @@ describe('Dispatcher Coverage Extensions', () => {
       const config3 = {
         hooks: { PostToolUse: { enabled_tools: ['Write'], gates: ['g1'] } },
         gates: { g1: { command: 'echo' } },
-      };
+      } satisfies RundownPluginConfig;
       await fs.writeFile(path.join(testDir, 'rundown-plugin.json'), JSON.stringify(config3));
       const res3 = await dispatch({
         hook_event_name: 'PostToolUse',
@@ -137,7 +147,7 @@ describe('Dispatcher Coverage Extensions', () => {
       const configKeyword = {
         hooks: { UserPromptSubmit: { gates: ['g1'] } },
         gates: { g1: { command: 'echo', keywords: ['important'] } },
-      };
+      } satisfies RundownPluginConfig;
       await fs.writeFile(path.join(testDir, 'rundown-plugin.json'), JSON.stringify(configKeyword));
       const resKeyword = await dispatch({
         hook_event_name: 'UserPromptSubmit',
@@ -150,7 +160,7 @@ describe('Dispatcher Coverage Extensions', () => {
       const configPattern = {
         hooks: { PostToolUse: { gates: ['g1'] } },
         gates: { g1: { command: 'echo', file_patterns: ['src/**'] } },
-      };
+      } satisfies RundownPluginConfig;
       await fs.writeFile(path.join(testDir, 'rundown-plugin.json'), JSON.stringify(configPattern));
       const resPattern = await dispatch({
         hook_event_name: 'PostToolUse',
@@ -163,7 +173,7 @@ describe('Dispatcher Coverage Extensions', () => {
       const config5 = {
         hooks: { UserPromptSubmit: { gates: ['g1'] } },
         gates: { g1: { command: 'echo', on_pass: 'g2' }, g2: { command: 'echo' } },
-      };
+      } satisfies RundownPluginConfig;
       await fs.writeFile(path.join(testDir, 'rundown-plugin.json'), JSON.stringify(config5));
       const res5 = await dispatch({ hook_event_name: 'UserPromptSubmit', cwd: testDir });
       expect(res5).toBeDefined();
@@ -175,7 +185,7 @@ describe('Dispatcher Coverage Extensions', () => {
         gates: {
           g1: { command: 'echo', on_pass: 'g1' }, // Self-chain
         },
-      };
+      } satisfies RundownPluginConfig;
       await fs.writeFile(path.join(testDir, 'rundown-plugin.json'), JSON.stringify(config));
       const res = await dispatch({ hook_event_name: 'UserPromptSubmit', cwd: testDir });
       expect(res.blockReason).toContain('Exceeded max gate chain depth');

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -4,6 +4,7 @@ import {
   brandDelegationTokenHashForTest,
   brandEffectiveVarsForTest,
   brandFrameKeyForTest,
+  brandStoredOutputsForTest,
 } from './brand-helpers.js';
 import { mockFn } from './typed-mocks.js';
 import type {
@@ -149,7 +150,7 @@ const { handleParentCompletion, extractParentLinkage } = await import(
 );
 
 function makeState(id: string, overrides: Partial<RunbookState> = {}): RunbookState {
-  return {
+  const base: RunbookState = {
     id,
     runbook: 'test.md',
     runbookPath: '/tmp/test.md',
@@ -157,12 +158,12 @@ function makeState(id: string, overrides: Partial<RunbookState> = {}): RunbookSt
     step: '1',
     stepName: 'Step',
     retryCount: 0,
-    variables: {},
+    variables: brandStoredOutputsForTest(),
     steps: [{ id: '1', status: 'running' }],
     startedAt: '2026-02-27T10:00:00.000Z',
     updatedAt: '2026-02-27T10:00:00.000Z',
-    ...overrides,
-  } as RunbookState;
+  };
+  return { ...base, ...overrides };
 }
 
 function makeDelegationLinkage(overrides: Partial<DelegationLinkage> = {}): DelegationLinkage {

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -792,6 +792,10 @@ function substituteCommand(
   variables: Record<string, unknown>,
 ): Command | undefined {
   if (!command) return undefined;
+  return substituteRequiredCommand(command, variables);
+}
+
+function substituteRequiredCommand(command: Command, variables: Record<string, unknown>): Command {
   return {
     ...command,
     code: substituteText(command.code, variables, shellEscapeValue),
@@ -835,40 +839,57 @@ function substituteSubstep(
  * @returns Step with all string fields expanded
  */
 function substituteStep(step: ResolvedStep, variables: Record<string, unknown>): ResolvedStep {
-  // Spread-first: preserve all fields (including aggregation, line, etc.)
-  // Override only the text fields that need substitution.
-  const substituted = {
-    ...step,
-    description: substituteText(step.description, variables),
-    prompt: step.prompt ? substituteText(step.prompt, variables) : step.prompt,
-  };
+  const description = substituteText(step.description, variables);
+  const prompt = step.prompt ? substituteText(step.prompt, variables) : step.prompt;
 
   // Handle kind-specific fields that contain text
   switch (step.kind) {
-    case 'base':
-      return substituted;
-    case 'command':
-      return {
-        ...substituted,
-        command: substituteCommand(step.command, variables)!,
-      } as ResolvedStep;
-    case 'substeps':
-      return {
-        ...substituted,
+    case 'base': {
+      const resolved = {
+        ...step,
+        description,
+        prompt,
+      } satisfies Extract<ResolvedStep, { kind: 'base' }>;
+      return resolved;
+    }
+    case 'command': {
+      const resolved = {
+        ...step,
+        description,
+        prompt,
+        command: substituteRequiredCommand(step.command, variables),
+      } satisfies Extract<ResolvedStep, { kind: 'command' }>;
+      return resolved;
+    }
+    case 'substeps': {
+      const resolved = {
+        ...step,
+        description,
+        prompt,
         substeps: step.substeps.map((ss) => substituteSubstep(ss, variables)),
-      } as ResolvedStep;
-    case 'for':
-      return {
-        ...substituted,
+      } satisfies Extract<ResolvedStep, { kind: 'substeps' }>;
+      return resolved;
+    }
+    case 'for': {
+      const resolved = {
+        ...step,
+        description,
+        prompt,
         substeps: step.substeps.map((ss) =>
           substituteSubstep(ss, variables, step.forClause.variable),
         ),
-      } as ResolvedStep;
-    case 'prompted-for':
-      return {
-        ...substituted,
+      } satisfies Extract<ResolvedStep, { kind: 'for' }>;
+      return resolved;
+    }
+    case 'prompted-for': {
+      const resolved = {
+        ...step,
+        description,
+        prompt,
         substeps: step.substeps.map((ss) => substituteSubstep(ss, variables, step.variable)),
-      } as ResolvedStep;
+      } satisfies Extract<ResolvedStep, { kind: 'prompted-for' }>;
+      return resolved;
+    }
   }
 }
 

--- a/packages/core/__tests__/cli/json-serialization.test.ts
+++ b/packages/core/__tests__/cli/json-serialization.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from '@jest/globals';
+import { serializeJsonForOutput } from '../../src/cli/json-serialization.js';
+
+describe('serializeJsonForOutput', () => {
+  it('serializes objects with pretty formatting by default', () => {
+    expect(serializeJsonForOutput({ key: 'value' })).toBe('{\n  "key": "value"\n}');
+  });
+
+  it('serializes compact objects when pretty is false', () => {
+    expect(serializeJsonForOutput({ key: 'value' }, false)).toBe('{"key":"value"}');
+  });
+
+  it('serializes root undefined as null', () => {
+    expect(serializeJsonForOutput(undefined)).toBe('null');
+  });
+
+  it('serializes root symbols as null', () => {
+    expect(serializeJsonForOutput(Symbol())).toBe('null');
+  });
+
+  it('serializes root functions as null', () => {
+    expect(
+      serializeJsonForOutput(() => {
+        /* noop */
+      }),
+    ).toBe('null');
+  });
+
+  it('throws the native JSON.stringify error for circular objects', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() => serializeJsonForOutput(circular)).toThrow(TypeError);
+  });
+
+  it('throws the native JSON.stringify error for bigint values', () => {
+    expect(() => serializeJsonForOutput(1n)).toThrow(TypeError);
+  });
+});

--- a/packages/core/__tests__/cli/writer.test.ts
+++ b/packages/core/__tests__/cli/writer.test.ts
@@ -50,6 +50,11 @@ describe('TestWriter', () => {
       writer.writeJson({ key: 'value' }, false);
       expect(writer.getOutput()).toBe('{"key":"value"}\n');
     });
+
+    it('appends exactly one newline', () => {
+      writer.writeJson({ key: 'value' }, false);
+      expect(writer.getOutput()).toBe(`${JSON.stringify({ key: 'value' })}\n`);
+    });
   });
 
   describe('clear', () => {

--- a/packages/core/__tests__/runbook/for-loop-design-invariants.test.ts
+++ b/packages/core/__tests__/runbook/for-loop-design-invariants.test.ts
@@ -21,6 +21,9 @@ import {
   makeTransitionObject,
   type ForLoopConfig,
   type EventType,
+  type IterationAction,
+  type ParentAction,
+  type SubstepAction,
 } from './for-loop-test-helpers.js';
 import type { ResolvedStep, Substep } from '../../src/runbook/types.js';
 
@@ -29,8 +32,8 @@ import type { ResolvedStep, Substep } from '../../src/runbook/types.js';
 // ---------------------------------------------------------------------------
 
 interface SubstepConfig {
-  passAction: string;
-  failAction: string;
+  passAction: SubstepAction;
+  failAction: SubstepAction;
   failRetry?: number;
 }
 
@@ -38,14 +41,14 @@ interface CustomForOpts {
   iterations: number;
   substeps: SubstepConfig[];
   iterationTransitions: {
-    passAction: string;
-    failAction: string;
+    passAction: IterationAction;
+    failAction: IterationAction;
     aggMode: 'ALL' | 'ANY' | 'none';
     failRetry?: number;
   };
   parentTransitions: {
-    passAction: string;
-    failAction: string;
+    passAction: ParentAction;
+    failAction: ParentAction;
     aggMode: 'ALL' | 'ANY' | 'none';
   };
 }

--- a/packages/core/__tests__/runbook/for-loop-design-invariants.test.ts
+++ b/packages/core/__tests__/runbook/for-loop-design-invariants.test.ts
@@ -107,6 +107,13 @@ function buildCustomSteps(opts: CustomForOpts): ResolvedStep[] {
 // ---------------------------------------------------------------------------
 
 describe('FOR loop design invariants', () => {
+  it('shared helper can represent GOTO actions', () => {
+    expect(makeTransitionObject('pass', 'GOTO').action).toEqual({
+      type: 'GOTO',
+      target: { step: '1' },
+    });
+  });
+
   // Property 1: RETRY is universal — fires for every substep action type
   //
   // Iteration-level RETRY fires based on iteration result, not substep action type.

--- a/packages/core/__tests__/runbook/for-loop-test-helpers.ts
+++ b/packages/core/__tests__/runbook/for-loop-test-helpers.ts
@@ -22,7 +22,34 @@ import type {
 // Config type — captures all 3 layers as data
 // ---------------------------------------------------------------------------
 
+/**
+ * Action literals valid for substep-level FOR-loop transitions in the shared
+ * test helper model.
+ *
+ * Literal values:
+ * - `CONTINUE` exits the current step scope through the step handler.
+ * - `DEFER` records the substep result for later aggregation.
+ * - `NEXT` skips remaining substeps and advances the loop.
+ * - `BREAK` exits the current loop without recording the current result.
+ * - `STOP` stops the runbook immediately.
+ * - `COMPLETE` completes the runbook immediately.
+ * - `GOTO` jumps to a target step.
+ */
 export type SubstepAction = 'CONTINUE' | 'DEFER' | 'NEXT' | 'BREAK' | 'STOP' | 'COMPLETE' | 'GOTO';
+
+/**
+ * Action literals valid for iteration-level transitions on a FOR clause in the
+ * shared test helper model.
+ *
+ * Literal values:
+ * - `CONTINUE` exits the loop and continues via the parent step handler.
+ * - `DEFER` records the iteration result for parent aggregation.
+ * - `NEXT` advances to the next iteration without recording the current result.
+ * - `BREAK` exits the current loop without recording the current result.
+ * - `STOP` stops the runbook immediately.
+ * - `COMPLETE` completes the runbook immediately.
+ * - `GOTO` jumps to a target step.
+ */
 export type IterationAction =
   | 'CONTINUE'
   | 'DEFER'
@@ -31,35 +58,74 @@ export type IterationAction =
   | 'STOP'
   | 'COMPLETE'
   | 'GOTO';
+
+/**
+ * Action literals valid for parent step transitions on a FOR step in the shared
+ * test helper model.
+ *
+ * Literal values:
+ * - `CONTINUE` advances through normal step control flow.
+ * - `DEFER` records a result for an outer aggregation scope.
+ * - `STOP` stops the runbook immediately.
+ * - `COMPLETE` completes the runbook immediately.
+ * - `GOTO` jumps to a target step.
+ */
 export type ParentAction = 'CONTINUE' | 'DEFER' | 'STOP' | 'COMPLETE' | 'GOTO';
+
+/**
+ * Union of all action literals supported by the shared FOR-loop test helper.
+ *
+ * Includes every literal from {@link SubstepAction}, {@link IterationAction},
+ * and {@link ParentAction}: `CONTINUE`, `DEFER`, `NEXT`, `BREAK`, `STOP`,
+ * `COMPLETE`, and `GOTO`.
+ */
 export type ForLoopAction = SubstepAction | IterationAction | ParentAction;
 
+/**
+ * Data-driven configuration for building a synthetic FOR-loop runbook in tests.
+ *
+ * Captures the loop shape plus all three transition layers:
+ * substep transitions, iteration transitions, and parent step aggregation.
+ */
 export interface ForLoopConfig {
-  iterations: number; // 1–5
-  numSubsteps: number; // 1–3
-
-  // Layer 1: substep transitions
+  /** Number of loop iterations to generate; property tests usually use 1–5. */
+  iterations: number;
+  /** Number of substeps to generate; property tests usually use 1–3. */
+  numSubsteps: number;
+  /** PASS action applied to each generated substep. */
   substepPassAction: SubstepAction;
+  /** FAIL action applied to each generated substep. */
   substepFailAction: SubstepAction;
-  substepFailRetry: number; // 0–2
-
-  // Layer 2: iteration transitions (forClause.transitions)
+  /** Retry count for generated substep FAIL transitions; usually 0–2. */
+  substepFailRetry: number;
+  /** PASS action applied by the FOR clause iteration transition layer. */
   iterationPassAction: IterationAction;
+  /** FAIL action applied by the FOR clause iteration transition layer. */
   iterationFailAction: IterationAction;
-  iterationAggMode: 'ALL' | 'ANY' | undefined; // aggregation discriminant
-  iterationFailRetry: number; // 0–2
-
-  // Layer 3: parent aggregation (step.transitions)
+  /** Aggregation mode for iteration results, or undefined for no aggregation. */
+  iterationAggMode: 'ALL' | 'ANY' | undefined;
+  /** Retry count for generated iteration FAIL transitions; usually 0–2. */
+  iterationFailRetry: number;
+  /** PASS action applied by the parent FOR step transition layer. */
   parentPassAction: ParentAction;
+  /** FAIL action applied by the parent FOR step transition layer. */
   parentFailAction: ParentAction;
-  parentAggMode: 'ALL' | 'ANY' | undefined; // aggregation discriminant
-  parentFailRetry: number; // 0–2
+  /** Aggregation mode for parent step results, or undefined for no aggregation. */
+  parentAggMode: 'ALL' | 'ANY' | undefined;
+  /** Retry count for generated parent FAIL transitions; usually 0–2. */
+  parentFailRetry: number;
 }
 
 // ---------------------------------------------------------------------------
 // Step builder — converts ForLoopConfig to parser Step[]
 // ---------------------------------------------------------------------------
 
+/**
+ * Convert a helper action literal into a parser action object.
+ *
+ * @param type - Helper action literal to convert.
+ * @returns Parser-compatible action object for the requested action literal.
+ */
 export function makeAction(type: ForLoopAction): Action {
   switch (type) {
     case 'CONTINUE':
@@ -81,6 +147,14 @@ export function makeAction(type: ForLoopAction): Action {
   return exhaustive;
 }
 
+/**
+ * Build a parser transition object for one pass/fail outcome.
+ *
+ * @param kind - Outcome kind that triggers the transition.
+ * @param action - Helper action literal to place on the transition.
+ * @param retry - Optional retry count to include on the transition.
+ * @returns Parser-compatible transition object.
+ */
 export function makeTransitionObject(
   kind: 'pass' | 'fail',
   action: ForLoopAction,
@@ -89,6 +163,14 @@ export function makeTransitionObject(
   return { kind, retry, action: makeAction(action) };
 }
 
+/**
+ * Build paired pass/fail transitions for generated runbook steps.
+ *
+ * @param passAction - Helper action literal for PASS outcomes.
+ * @param failAction - Helper action literal for FAIL outcomes.
+ * @param failRetry - Optional retry count for the FAIL transition.
+ * @returns Parser-compatible transitions object.
+ */
 export function makeTransitions(
   passAction: ForLoopAction,
   failAction: ForLoopAction,
@@ -100,6 +182,12 @@ export function makeTransitions(
   };
 }
 
+/**
+ * Convert an optional aggregation mode literal into a parser aggregation object.
+ *
+ * @param mode - Aggregation mode, or undefined when no aggregation should exist.
+ * @returns Parser-compatible aggregation object, or undefined.
+ */
 export function makeAggregation(mode: 'ALL' | 'ANY' | undefined): Aggregation | undefined {
   return mode ? { strategy: mode } : undefined;
 }
@@ -165,12 +253,26 @@ export function buildForLoopSteps(config: ForLoopConfig): ResolvedStep[] {
 // Runner — compiles machine, sends events, returns terminal state
 // ---------------------------------------------------------------------------
 
+/**
+ * Event literals used to drive compiled FOR-loop test machines.
+ *
+ * Literal values:
+ * - `PASS` reports a successful step or substep result.
+ * - `FAIL` reports a failed step or substep result.
+ */
 export type EventType = 'PASS' | 'FAIL';
 
+/**
+ * Observable execution result returned by FOR-loop helper runners.
+ */
 export interface RunResult {
-  terminalState: string; // 'COMPLETE' | 'STOPPED' | step state
+  /** Final XState state value, commonly `COMPLETE`, `STOPPED`, or a step state. */
+  terminalState: string;
+  /** Number of active FOR-loop frames remaining after execution. */
   forStackLength: number;
+  /** Iteration results accumulated by the compiled runbook machine. */
   iterationResults: readonly ('pass' | 'fail')[];
+  /** Number of events sent to the machine, including padding events. */
   eventsConsumed: number;
 }
 

--- a/packages/core/__tests__/runbook/for-loop-test-helpers.ts
+++ b/packages/core/__tests__/runbook/for-loop-test-helpers.ts
@@ -22,9 +22,16 @@ import type {
 // Config type — captures all 3 layers as data
 // ---------------------------------------------------------------------------
 
-export type SubstepAction = 'CONTINUE' | 'DEFER' | 'NEXT' | 'BREAK' | 'STOP' | 'COMPLETE';
-export type IterationAction = 'CONTINUE' | 'DEFER' | 'NEXT' | 'BREAK' | 'STOP' | 'COMPLETE';
-export type ParentAction = 'CONTINUE' | 'DEFER' | 'STOP' | 'COMPLETE';
+export type SubstepAction = 'CONTINUE' | 'DEFER' | 'NEXT' | 'BREAK' | 'STOP' | 'COMPLETE' | 'GOTO';
+export type IterationAction =
+  | 'CONTINUE'
+  | 'DEFER'
+  | 'NEXT'
+  | 'BREAK'
+  | 'STOP'
+  | 'COMPLETE'
+  | 'GOTO';
+export type ParentAction = 'CONTINUE' | 'DEFER' | 'STOP' | 'COMPLETE' | 'GOTO';
 export type ForLoopAction = SubstepAction | IterationAction | ParentAction;
 
 export interface ForLoopConfig {
@@ -67,6 +74,8 @@ export function makeAction(type: ForLoopAction): Action {
       return { type: 'STOP' };
     case 'COMPLETE':
       return { type: 'COMPLETE' };
+    case 'GOTO':
+      return { type: 'GOTO', target: { step: '1' } };
   }
   const exhaustive: never = type;
   return exhaustive;

--- a/packages/core/__tests__/runbook/for-loop-test-helpers.ts
+++ b/packages/core/__tests__/runbook/for-loop-test-helpers.ts
@@ -25,6 +25,7 @@ import type {
 export type SubstepAction = 'CONTINUE' | 'DEFER' | 'NEXT' | 'BREAK' | 'STOP' | 'COMPLETE';
 export type IterationAction = 'CONTINUE' | 'DEFER' | 'NEXT' | 'BREAK' | 'STOP' | 'COMPLETE';
 export type ParentAction = 'CONTINUE' | 'DEFER' | 'STOP' | 'COMPLETE';
+export type ForLoopAction = SubstepAction | IterationAction | ParentAction;
 
 export interface ForLoopConfig {
   iterations: number; // 1–5
@@ -52,7 +53,7 @@ export interface ForLoopConfig {
 // Step builder — converts ForLoopConfig to parser Step[]
 // ---------------------------------------------------------------------------
 
-export function makeAction(type: string): Action {
+export function makeAction(type: ForLoopAction): Action {
   switch (type) {
     case 'CONTINUE':
       return { type: 'CONTINUE' };
@@ -66,22 +67,22 @@ export function makeAction(type: string): Action {
       return { type: 'STOP' };
     case 'COMPLETE':
       return { type: 'COMPLETE' };
-    default:
-      return { type: 'CONTINUE' };
   }
+  const exhaustive: never = type;
+  return exhaustive;
 }
 
 export function makeTransitionObject(
   kind: 'pass' | 'fail',
-  action: string,
+  action: ForLoopAction,
   retry = 0,
 ): TransitionObject {
   return { kind, retry, action: makeAction(action) };
 }
 
 export function makeTransitions(
-  passAction: string,
-  failAction: string,
+  passAction: ForLoopAction,
+  failAction: ForLoopAction,
   failRetry = 0,
 ): Transitions {
   return {

--- a/packages/core/__tests__/runbook/for-loop-test-helpers.ts
+++ b/packages/core/__tests__/runbook/for-loop-test-helpers.ts
@@ -144,7 +144,7 @@ export function makeAction(type: ForLoopAction): Action {
       return { type: 'GOTO', target: { step: '1' } };
   }
   const exhaustive: never = type;
-  return exhaustive;
+  throw new Error(`Unexpected ForLoopAction type: ${String(exhaustive)}`);
 }
 
 /**

--- a/packages/core/src/cli/console-writer.ts
+++ b/packages/core/src/cli/console-writer.ts
@@ -1,4 +1,5 @@
 import type { OutputWriter, OutputStream } from './writer.js';
+import { serializeJsonForOutput } from './json-serialization.js';
 
 /**
  * Default OutputWriter implementation that writes to console.
@@ -59,14 +60,6 @@ export class ConsoleWriter implements OutputWriter {
    * @param pretty - Whether to pretty-print with indentation (defaults to true)
    */
   writeJson(data: unknown, pretty = true): void {
-    const stringify = JSON.stringify as (
-      value: unknown,
-      replacer?: null,
-      space?: string | number,
-    ) => string | undefined;
-    const json = pretty ? stringify(data, null, 2) : stringify(data);
-    // JSON.stringify can return undefined at runtime for functions/symbols,
-    // but TypeScript types it as string. Use a runtime-accurate signature here.
-    this.writeLine(json ?? 'null');
+    this.write(`${serializeJsonForOutput(data, pretty)}\n`);
   }
 }

--- a/packages/core/src/cli/json-serialization.ts
+++ b/packages/core/src/cli/json-serialization.ts
@@ -1,0 +1,22 @@
+/**
+ * Serialize a value for CLI JSON output.
+ *
+ * Preserves the existing writer behavior around formatting and root values that
+ * `JSON.stringify` cannot represent directly: `undefined`, symbols, and
+ * functions are emitted as `null`. Native `JSON.stringify` errors, including
+ * circular references and bigint values, are intentionally allowed to throw.
+ *
+ * @param data - Value to serialize for JSON output
+ * @param pretty - Whether to pretty-print with two-space indentation
+ * @returns Serialized JSON string, using `null` for non-serializable root values
+ * @throws {TypeError} When `JSON.stringify` throws for the provided value
+ */
+export function serializeJsonForOutput(data: unknown, pretty = true): string {
+  const stringify = JSON.stringify as (
+    value: unknown,
+    replacer?: null,
+    space?: string | number,
+  ) => string | undefined;
+  const json = pretty ? stringify(data, null, 2) : stringify(data);
+  return json ?? 'null';
+}

--- a/packages/core/src/cli/test-writer.ts
+++ b/packages/core/src/cli/test-writer.ts
@@ -1,4 +1,5 @@
 import type { OutputWriter, OutputStream } from './writer.js';
+import { serializeJsonForOutput } from './json-serialization.js';
 
 /**
  * Captured output entry for test assertions.
@@ -71,15 +72,7 @@ export class TestWriter implements OutputWriter {
    * @param pretty - Whether to pretty-print with indentation (defaults to true)
    */
   writeJson(data: unknown, pretty = true): void {
-    const stringify = JSON.stringify as (
-      value: unknown,
-      replacer?: null,
-      space?: string | number,
-    ) => string | undefined;
-    const json = pretty ? stringify(data, null, 2) : stringify(data);
-    // JSON.stringify can return undefined at runtime for functions/symbols,
-    // but TypeScript types it as string. Use a runtime-accurate signature here.
-    this.writeLine(json ?? 'null');
+    this.write(`${serializeJsonForOutput(data, pretty)}\n`);
   }
 
   // Test helper methods


### PR DESCRIPTION
# Summary

- Rewrite the runtime and security reference docs as normative specifications with explicit execution, iteration, state, variable, and policy semantics.
- Harden FOR-loop test helpers with typed action unions, exhaustive action construction, and typed property-test configuration.
- Extract shared JSON serialization for CLI writers and cover pretty, compact, null-fallback, and serialization-error behavior.
- Refactor template rendering to rebuild resolved step variants with `satisfies` instead of broad casts.
- Normalize delegation-completion test state variables with the branded stored-output helper.

## Testing

- [x] `npm run verify`

Targeted tests or checks:
- `npx markdownlint-cli2 "docs/reference/runtime.md" "docs/reference/security.md"` — targeted MD056/MD022 findings removed; command still reports pre-existing broad MD013/MD033/MD060 findings in these files.
- `npm run check:types -w packages/core`
- `npm run test:unit -w packages/core -- for-loop-design-invariants.test.ts`

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.

No Review Notes boxes apply: this PR updates reference documentation, tests, and internal type-hardening helpers, but does not change public CLI behavior, parser syntax, persisted state handling, security-policy execution, or GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced runtime reference with a detailed runtime specification covering execution layers, FOR-loop semantics, state persistence, variable resolution, data-source rules, and visible failure modes.
  * Rewrote security specification formalizing policy precedence, sandboxing, data-source protections, fail-closed semantics, and troubleshooting/conformance guidance.

* **Improvements**
  * Added a unified JSON serialization utility and standardized JSON output behavior.
  * Extended FOR-loop control-flow actions (including GOTO) and clarified iteration semantics.

* **Tests**
  * Expanded tests for JSON output, FOR-loop invariants, and delegation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->