### PR TITLE
Implement canonical runtime run identity

### DIFF
--- a/docs/spec/cli-output.md
+++ b/docs/spec/cli-output.md
@@ -33,8 +33,11 @@ Authoritative TypeScript types: `packages/core/src/output/schema.ts`
 ```json
 {
   "id": "string",      // State file identifier
-  "runbook": "string", // Runbook filename
-  "status": "string",  // active, stashed, completed, stale, orphaned
+  "runbook": {         // Canonical runbook reference
+    "source": "project",
+    "path": "runbooks/deploy.runbook.md"
+  },
+  "status": "string",  // active, stashed, complete, stopped, inactive
   "step": "string",    // (optional) Current step position
   "total": number,     // (optional) Total steps
   "title": "string"    // (optional) Runbook title
@@ -470,15 +473,16 @@ No stashed runbook to restore.
 
 ## prune
 
-Prune uses the same `Runbook` format as `ls`, with status values like "stale" or "orphaned".
+Prune uses the same loaded `Runbook` format as `ls`. Raw state files that cannot
+be loaded as current v1 run state are ignored.
 
 ### `rd prune --dry-run`
 
 **Text:**
 ```text
 ID        STATUS     RUNBOOK                    TITLE
-abc123    stale      old-deploy.runbook.md      Old Deploy
-def456    orphaned   missing.runbook.md
+abc123    complete   deploy.runbook.md          Deploy
+def456    inactive   audit.runbook.md           Audit
 ```
 
 **JSON:**
@@ -486,14 +490,21 @@ def456    orphaned   missing.runbook.md
 [
   {
     "id": "abc123",
-    "status": "stale",
-    "runbook": "old-deploy.runbook.md",
-    "title": "Old Deploy"
+    "status": "complete",
+    "runbook": {
+      "source": "project",
+      "path": "runbooks/deploy.runbook.md"
+    },
+    "title": "Deploy"
   },
   {
     "id": "def456",
-    "status": "orphaned",
-    "runbook": "missing.runbook.md"
+    "status": "inactive",
+    "runbook": {
+      "source": "project",
+      "path": "runbooks/audit.runbook.md"
+    },
+    "title": "Audit"
   }
 ]
 ```
@@ -504,7 +515,9 @@ Both dry-run and actual prune output the same format.
 
 **Text:**
 ```text
-Pruned 2 stale state files.
+ID        STATUS     RUNBOOK                    TITLE
+abc123    complete   deploy.runbook.md          Deploy
+def456    inactive   audit.runbook.md           Audit
 ```
 
 **JSON:**
@@ -512,14 +525,21 @@ Pruned 2 stale state files.
 [
   {
     "id": "abc123",
-    "status": "stale",
-    "runbook": "old-deploy.runbook.md",
-    "title": "Old Deploy"
+    "status": "complete",
+    "runbook": {
+      "source": "project",
+      "path": "runbooks/deploy.runbook.md"
+    },
+    "title": "Deploy"
   },
   {
     "id": "def456",
-    "status": "orphaned",
-    "runbook": "missing.runbook.md"
+    "status": "inactive",
+    "runbook": {
+      "source": "project",
+      "path": "runbooks/audit.runbook.md"
+    },
+    "title": "Audit"
   }
 ]
 ```

--- a/packages/claude-code-plugin/__tests__/rdpath-find-integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdpath-find-integration.test.ts
@@ -84,8 +84,7 @@ Active step.
       steps,
     };
 
-    const state = await manager.create('active.runbook.md', runbook, {
-      runbookPath: 'active.runbook.md',
+    const state = await manager.create({ source: 'project', path: 'active.runbook.md' }, runbook, {
       prompted: true,
       templateVars: vars,
     });
@@ -97,10 +96,10 @@ Active step.
     await fs.mkdir(runsDir, { recursive: true });
     await fs.writeFile(
       path.join(cwd, '.rundown', 'session.json'),
-      JSON.stringify({ defaultStack: ['wf-stale-1'] }, null, 2),
+      JSON.stringify({ defaultStack: ['wf_11111111111111111111111111111111'] }, null, 2),
     );
     await fs.writeFile(
-      path.join(runsDir, 'wf-stale-1.json'),
+      path.join(runsDir, 'wf_11111111111111111111111111111111.json'),
       JSON.stringify({ schemaVersion: 1 }, null, 2),
     );
   }

--- a/packages/claude-code-plugin/src/rdpath.ts
+++ b/packages/claude-code-plugin/src/rdpath.ts
@@ -69,6 +69,7 @@ function isRecoverableActiveStateLookupError(error: unknown): boolean {
     message.includes('schema validation failed') ||
     message.includes('previous schema version') ||
     message.includes('Legacy per-agent session format detected') ||
+    message.includes('Session file contains invalid runbook targeting data') ||
     message.includes('Session file contains invalid entries')
   ) {
     return true;

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -162,7 +162,7 @@ describe('delegate command', () => {
       const substepStates = state?.substepStates as Array<Record<string, unknown>> | undefined;
       const ss1 = substepStates?.find((ss) => ss.id === '1');
       const delegation = ss1?.delegation as Record<string, unknown>;
-      expect(delegation.childRunId).toEqual(expect.stringMatching(/^wf-/));
+      expect(delegation.childRunId).toEqual(expect.stringMatching(/^wf_[a-f0-9]{32}$/));
       expect(delegation.tokenHash).toEqual(expect.stringMatching(/^sha256:[a-f0-9]{64}$/));
       expect(delegation.token).toBeUndefined();
 
@@ -371,7 +371,7 @@ describe('delegate command', () => {
             ...state,
             parentLinkage: {
               kind: 'delegation',
-              parentRunId: 'parent-run-id',
+              parentRunId: 'wf_00000000000000000000000000000031',
               parentStepId: '1',
               tokenHash: `sha256:${'a'.repeat(64)}`,
             },

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -68,8 +68,9 @@ describe('fail command', () => {
       // After blocking, the runbook is saved but no longer active
       // Retrieve from all states
       const states = await getAllStates(workspace);
-      const state = states.find((s) => s.runbook === 'runbooks/simple.runbook.md');
+      const state = states.find((s) => s.runbook.path === 'runbooks/simple.runbook.md');
       expect(state?.lifecycle).toBe('stopped');
+      expect(state?.terminalAt).toEqual(expect.any(String));
     });
   });
 
@@ -118,7 +119,7 @@ Do work.
 
       // Should now be on parent
       const statusResult = await runCliInProcess('status --text', workspace);
-      expect(statusResult.stdout).toContain('parent-fail.md');
+      expect(statusResult.stdout).toContain('parent-fail.runbook.md');
     });
   });
 
@@ -416,7 +417,7 @@ Final step.
 
       expect(result.exitCode).toBe(1);
       const states = await getAllStates(workspace);
-      const state = states.find((s) => s.runbook === 'runbooks/substep-fail-any.md');
+      const state = states.find((s) => s.runbook.path === 'runbooks/substep-fail-any.runbook.md');
       expect(state?.lifecycle).toBe('stopped');
     });
 

--- a/packages/cli/__tests__/commands/json-output.test.ts
+++ b/packages/cli/__tests__/commands/json-output.test.ts
@@ -43,7 +43,7 @@ prompt: Wait
       expect(Array.isArray(output)).toBe(true);
       expect(output).toHaveLength(1);
       expect(output[0]).toHaveProperty('id');
-      expect(output[0]).toHaveProperty('runbook', 'test.runbook.md');
+      expect(output[0]).toHaveProperty('runbook', { source: 'project', path: 'test.runbook.md' });
       expect(output[0]).toHaveProperty('step', 'Step');
       // Should not contain internal props like _status
       expect(output[0]).not.toHaveProperty('_status');

--- a/packages/cli/__tests__/commands/output-format.test.ts
+++ b/packages/cli/__tests__/commands/output-format.test.ts
@@ -34,7 +34,7 @@ describe('output format integration tests', () => {
         workspace,
       );
 
-      expect(result.stdout).toMatch(/wf-\d{4}-\d{2}-\d{2}/);
+      expect(result.stdout).toMatch(/wf_[a-f0-9]{32}/);
     });
 
     it('shows first step details in action block', async () => {
@@ -164,7 +164,7 @@ describe('output format integration tests', () => {
       const result = await runCliInProcess('status --text', workspace);
 
       expect(result.stdout).toContain('State:');
-      expect(result.stdout).toMatch(/wf-\d{4}-\d{2}-\d{2}/);
+      expect(result.stdout).toMatch(/wf_[a-f0-9]{32}/);
     });
 
     it('shows current step block', async () => {
@@ -191,7 +191,7 @@ describe('output format integration tests', () => {
     it('includes runbook ID in output', async () => {
       const result = await runCliInProcess('stop --text', workspace);
 
-      expect(result.stdout).toMatch(/wf-\d{4}-\d{2}-\d{2}/);
+      expect(result.stdout).toMatch(/wf_[a-f0-9]{32}/);
     });
 
     it('shows confirmation message', async () => {

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -62,8 +62,9 @@ describe('pass command', () => {
       await runCliInProcess('pass --text', workspace);
 
       const states = await getAllStates(workspace);
-      const state = states.find((s) => s.runbook === 'runbooks/simple.runbook.md');
+      const state = states.find((s) => s.runbook.path === 'runbooks/simple.runbook.md');
       expect(state?.lifecycle).toBe('completed');
+      expect(state?.terminalAt).toEqual(expect.any(String));
     });
   });
 
@@ -148,8 +149,9 @@ This step stops on pass.
       await runCliInProcess('pass --text', workspace);
 
       const states = await getAllStates(workspace);
-      const state = states.find((s) => s.runbook === 'runbooks/stop-on-pass.md');
+      const state = states.find((s) => s.runbook.path === 'runbooks/stop-on-pass.runbook.md');
       expect(state?.lifecycle).toBe('stopped');
+      expect(state?.terminalAt).toEqual(expect.any(String));
     });
   });
 
@@ -292,7 +294,7 @@ Do child work.
       const claimId2 = child2Output.claim_id;
 
       const anonymousActive = await getActiveState(workspace);
-      expect(anonymousActive?.runbook).toBe('runbooks/parent.runbook.md');
+      expect(anonymousActive?.runbook.path).toBe('runbooks/parent.runbook.md');
 
       let status = await runCliInProcess(['status', '--claim-id', claimId1], workspace);
       expect(JSON.parse(status.stdout).state).toContain(child1Id);
@@ -404,7 +406,7 @@ Do work.
 
       // Should now be on parent
       result = await runCliInProcess('status --text', workspace);
-      expect(result.stdout).toContain('parent.md');
+      expect(result.stdout).toContain('parent.runbook.md');
     });
   });
 
@@ -424,7 +426,7 @@ This step stops on pass.
       await runCliInProcess('pass --text', workspace);
 
       const states = await getAllStates(workspace);
-      const state = states.find((s) => s.runbook === 'runbooks/stop-on-pass.md');
+      const state = states.find((s) => s.runbook.path === 'runbooks/stop-on-pass.runbook.md');
 
       // lastResult should reflect user's choice (pass), not transition outcome
       expect(state?.lastResult).toBe('pass');

--- a/packages/cli/__tests__/commands/prune.test.ts
+++ b/packages/cli/__tests__/commands/prune.test.ts
@@ -263,6 +263,21 @@ describe('prune command', () => {
       const statesAfter = await listRunbookStates(workspace);
       expect(statesAfter.length).toBe(0);
     });
+
+    it('skips raw state files that cannot be loaded', async () => {
+      const canonicalCorruptId = 'wf_00000000000000000000000000000000';
+      const nonCanonicalId = 'wf-legacy-local-dev';
+      await writeFile(join(workspace.statePath(), `${canonicalCorruptId}.json`), '{');
+      await writeFile(join(workspace.statePath(), `${nonCanonicalId}.json`), '{');
+
+      const result = await runCliInProcess('prune --all', workspace);
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual([]);
+      await expect(listRunbookStates(workspace)).resolves.toEqual(
+        expect.arrayContaining([`${canonicalCorruptId}.json`, `${nonCanonicalId}.json`]),
+      );
+    });
   });
 
   describe('--dry-run flag', () => {

--- a/packages/cli/__tests__/commands/prune.test.ts
+++ b/packages/cli/__tests__/commands/prune.test.ts
@@ -300,7 +300,10 @@ describe('prune command', () => {
       const output = JSON.parse(result.stdout) as Record<string, unknown>[];
       expect(Array.isArray(output)).toBe(true);
       expect(output.length).toBe(1);
-      expect(output[0].runbook).toBe('runbooks/simple.runbook.md');
+      expect(output[0].runbook).toEqual({
+        source: 'project',
+        path: 'runbooks/simple.runbook.md',
+      });
       expect(output[0].status).toBe('complete');
     });
 
@@ -334,7 +337,10 @@ describe('prune command', () => {
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout) as Record<string, unknown>[];
       expect(output.length).toBe(1);
-      expect(output[0].runbook).toBe('runbooks/simple.runbook.md');
+      expect(output[0].runbook).toEqual({
+        source: 'project',
+        path: 'runbooks/simple.runbook.md',
+      });
 
       // State should still exist (dry-run)
       const statesAfter = await listRunbookStates(workspace);

--- a/packages/cli/__tests__/commands/run-prompted.test.ts
+++ b/packages/cli/__tests__/commands/run-prompted.test.ts
@@ -90,7 +90,7 @@ Second step.
 
       expect(result.exitCode).toBe(0);
       const state = await getActiveState(workspace);
-      expect(state?.runbook).toBe('goto-start.runbook.md');
+      expect(state?.runbook).toEqual({ source: 'project', path: 'goto-start.runbook.md' });
       expect(state?.step).toBe('2');
     });
 
@@ -129,7 +129,7 @@ Second step.
       // Child should inherit prompted flag from parent
       const state = await readRunbookState(workspace, String(childRunId));
       expect(state?.prompted).toBe(true);
-      expect(state?.runbook).toContain('with-commands');
+      expect(state?.runbook.path).toContain('with-commands');
     });
   });
 

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -49,7 +49,7 @@ describe('start command', () => {
 
       const state = await getActiveState(workspace);
       expect(state).not.toBeNull();
-      expect(state?.runbook).toBe('runbooks/simple.runbook.md');
+      expect(state?.runbook).toEqual({ source: 'project', path: 'runbooks/simple.runbook.md' });
     });
 
     it('initializes step=1 and retryCount=0', async () => {

--- a/packages/cli/__tests__/commands/stash-pop.test.ts
+++ b/packages/cli/__tests__/commands/stash-pop.test.ts
@@ -69,7 +69,7 @@ describe('stash command', () => {
 
     const afterState = await getActiveState(workspace);
     expect(afterState?.step).toBe(beforeState?.step);
-    expect(afterState?.runbook).toBe(beforeState?.runbook);
+    expect(afterState?.runbook).toEqual(beforeState?.runbook);
   });
 
   it('returns non-zero when another runbook is already stashed', async () => {
@@ -450,7 +450,7 @@ describe('pop command', () => {
   it('outputs error when step not found in runbook', async () => {
     // Create a state file with a step that doesn't exist in the runbook
     // runbookSrc must be present for pop to read from stored content
-    const runbookId = 'wf-2025-01-28-test01';
+    const runbookId = 'wf_00000000000000000000000000000011';
     const stateFile = join(workspace.statePath(), `${runbookId}.json`);
     const runbookSrc = `# Test Runbook
 
@@ -463,8 +463,7 @@ rd echo "hello"
 `;
     const state = {
       id: runbookId,
-      runbook: 'runbooks/simple.runbook.md',
-      runbookPath: join(workspace.cwd, 'runbooks', 'simple.runbook.md'),
+      runbook: { source: 'project', path: 'runbooks/simple.runbook.md' },
       title: 'Test Runbook',
       step: 'NonExistentStep', // Step that doesn't exist in runbookSrc
       stepName: 'A step that does not exist',
@@ -490,15 +489,14 @@ rd echo "hello"
   });
 
   it('restores a claimed stash using captured claim provenance', async () => {
-    const runbookId = 'wf-2025-01-28-owned01';
-    const parentRunId = 'wf-2025-01-28-parent01';
+    const runbookId = 'wf_00000000000000000000000000000012';
+    const parentRunId = 'wf_00000000000000000000000000000013';
     await writeFile(
       join(workspace.statePath(), `${parentRunId}.json`),
       JSON.stringify(
         {
           id: parentRunId,
-          runbook: 'parent.runbook.md',
-          runbookPath: 'parent.runbook.md',
+          runbook: { source: 'project', path: 'parent.runbook.md' },
           title: 'Parent Runbook',
           step: '1',
           stepName: 'Parent step',
@@ -530,8 +528,7 @@ rd echo "hello"
       JSON.stringify(
         {
           id: runbookId,
-          runbook: 'owned.runbook.md',
-          runbookPath: 'owned.runbook.md',
+          runbook: { source: 'project', path: 'owned.runbook.md' },
           title: 'Test Runbook',
           step: '1',
           stepName: 'First step',

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -57,7 +57,7 @@ describe('status command', () => {
     const result = await runCliInProcess('status --text', workspace);
 
     expect(result.stdout).toContain('State:');
-    expect(result.stdout).toMatch(/wf-\d{4}-\d{2}-\d{2}/);
+    expect(result.stdout).toMatch(/wf_[a-f0-9]{32}/);
   });
 
   it('outputs "No active runbook" when none', async () => {
@@ -241,7 +241,7 @@ describe('claim-id delegated children', () => {
     expect(JSON.parse(status.stdout)).toEqual(
       expect.objectContaining({ active: false, stashed: true }),
     );
-    expect(status.stdout).toContain('child-secret.md');
+    expect(status.stdout).toContain('child-secret.runbook.md');
     // Plain status must not leak claim-scoped variables: only `--claim-id`
     // callers see them (asserted positively in the next test).
     expect(status.stdout).not.toContain('top-secret-input');
@@ -257,7 +257,7 @@ describe('claim-id delegated children', () => {
     expect(status.exitCode).toBe(0);
     expect(output.active).toBe(true);
     expect(output.stashed).toBe(true);
-    expect(output.file).toContain('child-secret.md');
+    expect(output.file).toContain('child-secret.runbook.md');
     expect(output.state).toContain(childRunId);
     expect(output.parentLinkage).toEqual(
       expect.objectContaining({
@@ -403,10 +403,14 @@ describe('complete command', () => {
 
   it('marks runbook as complete', async () => {
     await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+    const stateBefore = await getActiveState(workspace);
 
     const result = await runCliInProcess('complete --text', workspace);
 
     expect(result.stdout).toContain('COMPLETE');
+    const stateAfter = await readRunbookState(workspace, stateBefore!.id);
+    expect(stateAfter!.lifecycle).toBe('completed');
+    expect(stateAfter!.terminalAt).toEqual(expect.any(String));
   });
 
   it('clears active runbook', async () => {
@@ -529,6 +533,7 @@ Do work.
 
     const childState = await readRunbookState(workspace, String(childRunId));
     expect(childState?.lifecycle).toBe('completed');
+    expect(childState?.terminalAt).toEqual(expect.any(String));
 
     const updatedParent = await readRunbookState(workspace, parentState!.id);
     expect(updatedParent?.step).toBe('2');

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -50,6 +50,7 @@ describe('stop command', () => {
       expect(stateAfter!.lastAction).toEqual({ type: 'STOP' });
       expect(stateAfter!.lastResult).toBe('fail');
       expect(stateAfter!.lifecycle).toBe('stopped');
+      expect(stateAfter!.terminalAt).toEqual(expect.any(String));
     });
   });
 

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -1010,6 +1010,7 @@ describe('claimAndLaunch', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/tmp/test/child.md',
       source: 'project',
+      sourceRoot: '/tmp/test',
     });
     // Cast through unknown: the parser fixture is a minimal stand-in
     // (real Runbook type carries many more fields than this test reads).
@@ -1096,7 +1097,7 @@ describe('claimAndLaunch', () => {
     // Critical assertion: delegation linkage should use the delegation's stored
     // frameKey ('1|3'), NOT the parent's current frame ('1|5')
     expect(mockCreate).toHaveBeenCalledWith(
-      'child.md',
+      { source: 'project', path: 'child.runbook.md' },
       expect.anything(),
       expect.objectContaining({
         parentLinkage: expect.objectContaining({
@@ -1160,6 +1161,7 @@ describe('claimAndLaunch', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/tmp/test/child.md',
       source: 'project',
+      sourceRoot: '/tmp/test',
     });
     // Cast through unknown: minimal parser fixture (see frameKey linkage test).
     jest.mocked(parser.parseRunbookDocument).mockReturnValue({

--- a/packages/cli/__tests__/helpers/delegate-inference.test.ts
+++ b/packages/cli/__tests__/helpers/delegate-inference.test.ts
@@ -45,8 +45,7 @@ function makeStepWithSubsteps(name: string, substeps: Substep[]): ResolvedStepWi
 function makeState(overrides: Partial<RunbookState> = {}): RunbookState {
   return {
     id: 'test-run-id',
-    runbook: 'test.runbook.md',
-    runbookPath: 'test.runbook.md',
+    runbook: { source: 'project', path: 'test.runbook.md' },
     step: '1',
     stepName: 'Step 1',
     retryCount: 0,

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -152,8 +152,7 @@ const { handleParentCompletion, extractParentLinkage } = await import(
 function makeState(id: string, overrides: Partial<RunbookState> = {}): RunbookState {
   const base: RunbookState = {
     id,
-    runbook: 'test.md',
-    runbookPath: '/tmp/test.md',
+    runbook: { source: 'project', path: 'test.runbook.md' },
     runbookSrc: '## 1. Step\n- PASS COMPLETE',
     step: '1',
     stepName: 'Step',

--- a/packages/cli/__tests__/helpers/execution-emitter.test.ts
+++ b/packages/cli/__tests__/helpers/execution-emitter.test.ts
@@ -10,9 +10,8 @@ type ExecutionEvent = Parameters<OutputEmitter['executionEvent']>[0];
 describe('createBridgedEmitter', () => {
   function makeState(overrides: Partial<RunbookState> = {}): RunbookState {
     return {
-      id: 'wf-test',
-      runbook: 'test-runbook',
-      runbookPath: 'test-runbook.runbook.md',
+      id: 'wf_0123456789abcdef0123456789abcdef',
+      runbook: { source: 'project', path: 'test-runbook.runbook.md' },
       step: '1',
       stepName: 'Step 1',
       retryCount: 0,
@@ -48,88 +47,32 @@ describe('createBridgedEmitter', () => {
     emitter.emit('RUNBOOK_STARTED', {
       title: 'Test',
       prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+      statePath: '.rundown/runs/wf_0123456789abcdef0123456789abcdef.json',
     });
 
     expect(executionEventFn).toHaveBeenCalledTimes(1);
     const event = executionEventFn.mock.calls[0]?.[0];
     expect(event.type).toBe('RUNBOOK_STARTED');
-    expect(event.runbookId).toBe('wf-test');
+    expect(event.runbookId).toBe('wf_0123456789abcdef0123456789abcdef');
   });
 
-  it('adapts state runbook path into a canonical project runbook reference', () => {
-    const { output, executionEventFn } = makeOutput();
-    const state = makeState({ runbook: 'my-book', runbookPath: 'path/to/my-book.runbook.md' });
-    const emitter = createBridgedEmitter(state, output as unknown as OutputEmitter);
-
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
-    });
-
-    const event = executionEventFn.mock.calls[0]?.[0];
-    expect(event.runbook).toEqual({ source: 'project', path: 'path/to/my-book.runbook.md' });
-  });
-
-  it('uses an explicit canonical runbook reference when provided', () => {
+  it('passes the canonical runbook ref from state', () => {
     const { output, executionEventFn } = makeOutput();
     const state = makeState({
-      runbook: 'rundown:write-plan',
-      runbookPath: '../../plugin/runbooks/planning/write-plan.runbook.md',
-    });
-    const emitter = createBridgedEmitter(state, output as unknown as OutputEmitter, {
-      source: 'plugin',
-      path: 'planning/write-plan.runbook.md',
-    });
-
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
-    });
-
-    const event = executionEventFn.mock.calls[0]?.[0];
-    expect(event.runbook).toEqual({ source: 'plugin', path: 'planning/write-plan.runbook.md' });
-  });
-
-  it('uses a persisted canonical runbook reference when no explicit reference is provided', () => {
-    const { output, executionEventFn } = makeOutput();
-    const state = makeState({
-      runbook: 'rundown:write-plan',
-      runbookPath: '../../plugin/runbooks/planning/write-plan.runbook.md',
-      runbookRef: { source: 'plugin', path: 'planning/write-plan.runbook.md' },
+      runbook: { source: 'plugin', path: 'planning/review/review-plan.runbook.md' },
     });
     const emitter = createBridgedEmitter(state, output as unknown as OutputEmitter);
 
     emitter.emit('RUNBOOK_STARTED', {
       title: 'Test',
       prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
-    });
-
-    const event = executionEventFn.mock.calls[0]?.[0];
-    expect(event.runbook).toEqual({ source: 'plugin', path: 'planning/write-plan.runbook.md' });
-  });
-
-  it('falls back to the launch argument when persisted runbook path is not canonical', () => {
-    const { output, executionEventFn } = makeOutput();
-    const state = makeState({
-      runbook: 'runbooks/substep-fail-any.md',
-      runbookPath: '../../var/folders/test/runbooks/substep-fail-any.md',
-    });
-    const emitter = createBridgedEmitter(state, output as unknown as OutputEmitter);
-
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+      statePath: '.rundown/runs/wf_0123456789abcdef0123456789abcdef.json',
     });
 
     const event = executionEventFn.mock.calls[0]?.[0];
     expect(event.runbook).toEqual({
-      source: 'project',
-      path: 'runbooks/substep-fail-any.runbook.md',
+      source: 'plugin',
+      path: 'planning/review/review-plan.runbook.md',
     });
   });
 });

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -374,8 +374,7 @@ describe('executeGoto', () => {
   function makeState(overrides: Partial<RunbookState> = {}): RunbookState {
     return {
       id: 'test-id',
-      runbook: 'test.md',
-      runbookPath: 'test.md',
+      runbook: { source: 'project', path: 'test.runbook.md' },
       step: '1',
       stepName: 'Step 1',
       retryCount: 0,

--- a/packages/cli/__tests__/helpers/normalize-cli-output.test.ts
+++ b/packages/cli/__tests__/helpers/normalize-cli-output.test.ts
@@ -9,7 +9,7 @@ function makeWorkspace(cwd: string): TestWorkspace {
   return {
     cwd,
     cleanup: async () => undefined,
-    runbookPath: () => '',
+    runbookFilePath: () => '',
     statePath: () => '',
     sessionPath: () => '',
     runbooksDir: () => '',

--- a/packages/cli/__tests__/helpers/resolve-runbook.test.ts
+++ b/packages/cli/__tests__/helpers/resolve-runbook.test.ts
@@ -222,6 +222,7 @@ describe('resolveRunbookFile', () => {
       expect(result).not.toBeNull();
       expect(result!.path).toBe(runbookPath);
       expect(result!.source).toBe('plugin');
+      expect(result!.sourceRoot).toBe(path.join(testDir, 'plugin/runbooks'));
     });
 
     it('returns source "project" for runbook relative to cwd', async () => {
@@ -257,6 +258,7 @@ describe('resolveRunbookFile', () => {
       expect(result).not.toBeNull();
       expect(result!.path).toBe(runbookPath);
       expect(result!.source).toBe('bundled');
+      expect(result!.sourceRoot).toBe(bundledDir);
     });
 
     it('keeps an absolute bundled path even when a project runbook has the same basename', async () => {
@@ -277,6 +279,7 @@ describe('resolveRunbookFile', () => {
       expect(result).not.toBeNull();
       expect(result!.path).toBe(bundledPath);
       expect(result!.source).toBe('bundled');
+      expect(result!.sourceRoot).toBe(bundledDir);
     });
 
     it('returns source "plugin" for namespaced resolution', async () => {

--- a/packages/cli/__tests__/helpers/runbook-loader.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-loader.test.ts
@@ -23,7 +23,7 @@ echo done
 `;
     const state: Partial<RunbookState> = {
       id: 'test-id',
-      runbook: 'test.runbook.md',
+      runbook: { source: 'project', path: 'test.runbook.md' },
       runbookSrc,
     };
 
@@ -37,7 +37,7 @@ echo done
   it('should throw when runbookSrc is missing (corrupted state)', () => {
     const state: Partial<RunbookState> = {
       id: 'corrupted-id',
-      runbook: 'test.runbook.md',
+      runbook: { source: 'project', path: 'test.runbook.md' },
       // runbookSrc is undefined
     };
 
@@ -56,7 +56,7 @@ Deploy to {{ env }}.
 `;
     const state: Partial<RunbookState> = {
       id: 'template-id',
-      runbook: 'template.runbook.md',
+      runbook: { source: 'project', path: 'template.runbook.md' },
       runbookSrc,
       templateVars: brandInitialTemplateVarsForTest({ env: 'staging' }),
     };
@@ -71,7 +71,7 @@ Deploy to {{ env }}.
   it('should not attempt disk fallback', () => {
     const state: Partial<RunbookState> = {
       id: 'missing-src-id',
-      runbook: 'nonexistent.runbook.md',
+      runbook: { source: 'project', path: 'nonexistent.runbook.md' },
       // runbookSrc is undefined
     };
 

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -227,8 +227,7 @@ const { setHelperRegistry, resetHelperRegistry } = await import(
 function makeState(id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     id,
-    runbook: 'test.md',
-    runbookPath: '/tmp/test.md',
+    runbook: { source: 'project', path: 'test.runbook.md' },
     runbookSrc: '## 1. Step\n- PASS COMPLETE',
     step: '1',
     stepName: 'Step',
@@ -409,6 +408,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/empty.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -427,6 +427,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/good.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -445,6 +446,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/good.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -471,6 +473,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/child.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -499,6 +502,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/child.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -527,6 +531,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/good.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -546,6 +551,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/missing-input.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -577,6 +583,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/reserved.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -626,6 +633,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/needs-var.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -649,6 +657,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/needs-var.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -672,6 +681,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/needs-date.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -700,6 +710,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/sourced.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (parser.isSourced as jest.MockedFunction<typeof parser.isSourced>).mockReturnValue(true);
     (
@@ -730,6 +741,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/bad-for.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -754,6 +766,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/for-bounds.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -787,6 +800,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/good.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     jest
       .mocked(resolveVariables)
@@ -813,6 +827,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/home/user/.claude/extensions/rundown-plugin/not-runbooks/child.runbook.md',
       source: 'plugin' as const,
+      sourceRoot: '/home/user/.claude/extensions/rundown-plugin/runbooks',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -823,7 +838,7 @@ describe('prepareRunbook', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe('RUNBOOK_REF_RESOLUTION_ERROR');
-      expect(result.error).toContain('not beneath a runbooks directory');
+      expect(result.error).toContain('outside');
       expect(result.details).toEqual({ runbook: 'rundown:child' });
     }
     expect(resolveVariables).not.toHaveBeenCalled();
@@ -833,6 +848,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/home/user/.claude/extensions/rundown-plugin/runbooks/write-plan.runbook.md',
       source: 'plugin' as const,
+      sourceRoot: '/home/user/.claude/extensions/rundown-plugin/runbooks',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -845,7 +861,7 @@ describe('prepareRunbook', () => {
     expect(substituteRunbookVariables).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        CLAUDE_PLUGIN_ROOT: '/home/user/.claude/extensions/rundown-plugin/',
+        CLAUDE_PLUGIN_ROOT: '/home/user/.claude/extensions/rundown-plugin',
       }),
     );
   });
@@ -854,6 +870,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/.rundown/runbooks/my-runbook.runbook.md',
       source: 'project' as const,
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -874,6 +891,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/home/user/.claude/extensions/rundown-plugin/runbooks/write-plan.runbook.md',
       source: 'plugin' as const,
+      sourceRoot: '/home/user/.claude/extensions/rundown-plugin/runbooks',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -900,6 +918,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/.rundown/runbooks/ops/deploy.runbook.md',
       source: 'project' as const,
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -911,7 +930,7 @@ describe('prepareRunbook', () => {
     if (result.ok) {
       expect(result.prepared.runbookRef).toEqual({
         source: 'project',
-        path: 'ops/deploy.runbook.md',
+        path: '.rundown/runbooks/ops/deploy.runbook.md',
       });
     }
   });
@@ -920,6 +939,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/ops/direct.runbook.md',
       source: 'project' as const,
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -940,6 +960,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/ops/legacy.md',
       source: 'project' as const,
+      sourceRoot: '/test',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -960,6 +981,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/home/user/.claude/extensions/rundown-plugin/runbooks/planning/write-plan.runbook.md',
       source: 'plugin' as const,
+      sourceRoot: '/home/user/.claude/extensions/rundown-plugin/runbooks',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -980,6 +1002,7 @@ describe('prepareRunbook', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/home/user/.claude/extensions/rundown-plugin/runbooks/team/runbooks/child.runbook.md',
       source: 'plugin' as const,
+      sourceRoot: '/home/user/.claude/extensions/rundown-plugin/runbooks',
     });
     (
       parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
@@ -997,27 +1020,16 @@ describe('prepareRunbook', () => {
   });
 
   it('prepares source-root-relative bundled runbook refs', async () => {
-    const originalBundledPath = process.env.BUNDLED_RUNBOOKS_PATH;
-    process.env.BUNDLED_RUNBOOKS_PATH = '/repo/packages/cli/dist/runbooks';
-    const result = await (async (): ReturnType<typeof prepareRunbook> => {
-      try {
-        jest.mocked(resolveRunbookFile).mockResolvedValue({
-          path: '/repo/packages/cli/dist/runbooks/planning/review.runbook.md',
-          source: 'bundled' as const,
-        });
-        (
-          parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
-        ).mockReturnValue(mockParseResult());
+    jest.mocked(resolveRunbookFile).mockResolvedValue({
+      path: '/repo/packages/cli/dist/runbooks/planning/review.runbook.md',
+      source: 'bundled' as const,
+      sourceRoot: '/repo/packages/cli/dist/runbooks',
+    });
+    (
+      parser.parseRunbookDocument as jest.MockedFunction<typeof parser.parseRunbookDocument>
+    ).mockReturnValue(mockParseResult());
 
-        return await prepareRunbook('review', {}, '/test');
-      } finally {
-        if (originalBundledPath === undefined) {
-          delete process.env.BUNDLED_RUNBOOKS_PATH;
-        } else {
-          process.env.BUNDLED_RUNBOOKS_PATH = originalBundledPath;
-        }
-      }
-    })();
+    const result = await prepareRunbook('review', {}, '/test');
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -1064,6 +1076,8 @@ describe('startRunbook', () => {
 
     const prepared: PreparedRunbook = {
       filePath: '/test/runbook.md',
+      source: 'project',
+      sourceRoot: '/test',
       runbookRef: { source: 'project', path: 'runbook.runbook.md' },
       rawContent: '# Test',
       runbook: { steps: [makeStep() as PreparedRunbook['runbook']['steps'][number]] },
@@ -1079,25 +1093,16 @@ describe('startRunbook', () => {
       expect(result.loopResult).toBe('done');
     }
     expect(mockCreate).toHaveBeenCalledWith(
-      'runbook.md',
+      prepared.runbookRef,
       prepared.runbook,
       expect.objectContaining({
-        runbookPath: 'runbook.md',
-        runbookRef: prepared.runbookRef,
         runbookSrc: '# Test',
         frontmatterOutputs: [],
       }),
     );
     expect(mockInitState).toHaveBeenCalled();
     expect(mockPushRunbook).toHaveBeenCalled();
-    const createBridgedEmitterMock = createBridgedEmitter as jest.MockedFunction<
-      (...args: unknown[]) => unknown
-    >;
-    expect(createBridgedEmitterMock.mock.calls).toContainEqual([
-      createdState,
-      ctx.output,
-      prepared.runbookRef,
-    ]);
+    expect(createBridgedEmitter).toHaveBeenCalledWith(createdState, ctx.output);
   });
 
   it('seeds frontmatterOutputs from prepared.frontmatter.outputs to manager.create', async () => {
@@ -1135,6 +1140,9 @@ describe('startRunbook', () => {
 
     const prepared = {
       filePath: '/test/runbook.md',
+      source: 'project',
+      sourceRoot: '/test',
+      runbookRef: { source: 'project', path: 'runbook.runbook.md' },
       rawContent: '# Test',
       runbook: { steps: [makeStep()] },
       mergedVariables: {},
@@ -1145,7 +1153,7 @@ describe('startRunbook', () => {
     await startRunbook(ctx, prepared, { file: 'runbook.md' });
 
     expect(mockCreate).toHaveBeenCalledWith(
-      'runbook.md',
+      prepared.runbookRef,
       prepared.runbook,
       expect.objectContaining({ frontmatterOutputs: outputDecls }),
     );
@@ -1195,6 +1203,9 @@ describe('startRunbook', () => {
     const substeps = [{ id: 'a' }, { id: 'b' }];
     const prepared = {
       filePath: '/test/runbook.md',
+      source: 'project',
+      sourceRoot: '/test',
+      runbookRef: { source: 'project', path: 'runbook.runbook.md' },
       rawContent: '# Test',
       runbook: { steps: [makeStep({ substeps })] },
       mergedVariables: {},
@@ -1691,6 +1702,7 @@ describe('claimAndLaunch', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/child.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     jest.mocked(parser.parseRunbookDocument).mockReturnValue(mockParseResult());
     jest.mocked(core.reconstituteContextVars).mockReturnValue({});
@@ -1751,7 +1763,7 @@ describe('claimAndLaunch', () => {
       expect(result.loopResult).toBe('waiting');
     }
     expect(mockCreate).toHaveBeenCalledWith(
-      'child.md',
+      { source: 'project', path: 'child.runbook.md' },
       expect.anything(),
       expect.objectContaining({
         parentLinkage: expect.objectContaining({
@@ -1808,6 +1820,7 @@ describe('claimAndLaunch', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/child.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     jest.mocked(parser.parseRunbookDocument).mockReturnValue(mockParseResult());
     jest.mocked(resolveVariables).mockResolvedValue({
@@ -1929,6 +1942,7 @@ describe('claimAndLaunch', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/child.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     jest.mocked(parser.parseRunbookDocument).mockReturnValue(mockParseResult());
     jest.mocked(core.extractInheritedUserVars).mockReturnValue({
@@ -2119,6 +2133,7 @@ describe('claimAndLaunch', () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue({
       path: '/test/child.md',
       source: 'project',
+      sourceRoot: '/test',
     });
     jest.mocked(parser.parseRunbookDocument).mockReturnValue(mockParseResult());
     jest.mocked(core.reconstituteContextVars).mockReturnValue({});
@@ -2173,7 +2188,7 @@ describe('claimAndLaunch', () => {
     await claimAndLaunch(ctx, 'rdtk_AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH', {});
 
     expect(mockCreate).toHaveBeenCalledWith(
-      'child.md',
+      { source: 'project', path: 'child.runbook.md' },
       expect.anything(),
       expect.objectContaining({
         prompted: true,

--- a/packages/cli/__tests__/helpers/status-builder.test.ts
+++ b/packages/cli/__tests__/helpers/status-builder.test.ts
@@ -80,8 +80,7 @@ const { buildInactiveStatus, buildStashedStatus, buildActiveStatus } = await imp
 function makeState(overrides: Partial<RunbookState> = {}): RunbookState {
   const baseState: RunbookState = {
     id: 'test-id',
-    runbook: 'test.runbook.md',
-    runbookPath: 'test.runbook.md',
+    runbook: { source: 'project', path: 'test.runbook.md' },
     step: '1',
     stepName: 'First Step',
     retryCount: 0,

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -35,7 +35,7 @@ export function getCliPath(): string {
 export interface TestWorkspace {
   cwd: string;
   cleanup: () => Promise<void>;
-  runbookPath: (name: string) => string;
+  runbookFilePath: (name: string) => string;
   statePath: () => string;
   sessionPath: () => string;
   /** Project-local runbook destination (`.rundown/runbooks/`). */
@@ -104,7 +104,7 @@ export async function createTestWorkspace(opts?: { fixtureDir?: string }): Promi
   return {
     cwd: tempDir,
     cleanup: () => rm(tempDir, { recursive: true, force: true }),
-    runbookPath: (name: string) => join(rootRunbooksDir, name),
+    runbookFilePath: (name: string) => join(rootRunbooksDir, name),
     statePath: () => runsDir(tempDir),
     sessionPath: () => _sessionPath(tempDir),
     runbooksDir: () => runbooksDir(tempDir),
@@ -491,17 +491,19 @@ function isRunbookState(value: unknown): value is RunbookState {
   const state = value as {
     id?: unknown;
     runbook?: unknown;
-    runbookPath?: unknown;
     step?: unknown;
     stepName?: unknown;
     retryCount?: unknown;
     variables?: unknown;
     steps?: unknown;
   };
+  const runbook = state.runbook as { source?: unknown; path?: unknown } | undefined;
   return (
     typeof state.id === 'string' &&
-    typeof state.runbook === 'string' &&
-    typeof state.runbookPath === 'string' &&
+    typeof runbook === 'object' &&
+    runbook !== null &&
+    typeof runbook.source === 'string' &&
+    typeof runbook.path === 'string' &&
     typeof state.step === 'string' &&
     typeof state.stepName === 'string' &&
     typeof state.retryCount === 'number' &&

--- a/packages/cli/__tests__/integration/action-display.test.ts
+++ b/packages/cli/__tests__/integration/action-display.test.ts
@@ -44,7 +44,7 @@ rd echo --result pass
 \`\`\`
 `;
 
-      writeFileSync(workspace.runbookPath('test.runbook.md'), runbook);
+      writeFileSync(workspace.runbookFilePath('test.runbook.md'), runbook);
 
       const result = runCli('run runbooks/test.runbook.md --text', workspace);
 
@@ -93,7 +93,7 @@ rd echo --result pass
 \`\`\`
 `;
 
-      writeFileSync(workspace.runbookPath('test.runbook.md'), runbook);
+      writeFileSync(workspace.runbookFilePath('test.runbook.md'), runbook);
 
       const result = runCli('run runbooks/test.runbook.md --text', workspace);
 
@@ -122,7 +122,7 @@ rd echo --result pass
 \`\`\`
 `;
 
-      writeFileSync(workspace.runbookPath('test.runbook.md'), runbook);
+      writeFileSync(workspace.runbookFilePath('test.runbook.md'), runbook);
 
       const result = runCli('run runbooks/test.runbook.md --text', workspace);
 
@@ -173,7 +173,7 @@ rd echo --result pass
 \`\`\`
 `;
 
-      writeFileSync(workspace.runbookPath('substeps-continue.runbook.md'), runbook);
+      writeFileSync(workspace.runbookFilePath('substeps-continue.runbook.md'), runbook);
 
       const result = runCli('run runbooks/substeps-continue.runbook.md --text', workspace);
 
@@ -213,7 +213,7 @@ rd echo --result pass
 \`\`\`
 `;
 
-      writeFileSync(workspace.runbookPath('substep-goto.runbook.md'), runbook);
+      writeFileSync(workspace.runbookFilePath('substep-goto.runbook.md'), runbook);
 
       const result = runCli('run runbooks/substep-goto.runbook.md --text', workspace);
 

--- a/packages/cli/__tests__/services/execution-helpers.test.ts
+++ b/packages/cli/__tests__/services/execution-helpers.test.ts
@@ -8,7 +8,11 @@
 // the full execution loop.
 
 import { describe, it, expect } from '@jest/globals';
-import { deriveOutputScope, extractUnitOutputs } from '../../src/services/execution.js';
+import {
+  buildMetadata,
+  deriveOutputScope,
+  extractUnitOutputs,
+} from '../../src/services/execution.js';
 import type { RunbookState, ForContext } from '@rundown-org/core';
 import type { ResolvedStep, OutputDeclaration, Substep } from '@rundown-org/parser';
 
@@ -18,9 +22,8 @@ import type { ResolvedStep, OutputDeclaration, Substep } from '@rundown-org/pars
 
 function makeState(step: string, forStack: readonly ForContext[] = []): RunbookState {
   return {
-    id: 'test-run',
-    runbook: 'test.md',
-    runbookPath: '/test.md',
+    id: 'wf_0123456789abcdef0123456789abcdef',
+    runbook: { source: 'project', path: 'test.runbook.md' },
     step,
     stepName: `Step ${step}`,
     retryCount: 0,
@@ -91,6 +94,21 @@ function makeSubstepsStep(
 // ---------------------------------------------------------------------------
 
 describe('deriveOutputScope', () => {
+  it('builds metadata from canonical runbook path', () => {
+    const state = makeState('1', []);
+    const metadata = buildMetadata({
+      ...state,
+      id: 'wf_0123456789abcdef0123456789abcdef',
+      runbook: { source: 'plugin', path: 'planning/review/review-plan.runbook.md' },
+    });
+
+    expect(metadata).toEqual({
+      file: 'planning/review/review-plan.runbook.md',
+      state: '.rundown/runs/wf_0123456789abcdef0123456789abcdef.json',
+      prompted: undefined,
+    });
+  });
+
   describe('step only (isSubstep=false)', () => {
     it('returns only stepId when no substep and no FOR stack', () => {
       const state = makeState('1');

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -337,6 +337,14 @@ describe('runExecutionLoop', () => {
   let mockManager: MockManagerLike;
   let mockEmitter: MockEmitterLike;
   const runbookId = 'test-run-123';
+  const runbookRef = { source: 'project' as const, path: 'test.runbook.md' };
+  const runningState = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+    id: runbookId,
+    step: '1',
+    status: 'running',
+    runbook: runbookRef,
+    ...overrides,
+  });
   const steps: LooseStep[] = [
     {
       kind: 'command',
@@ -369,6 +377,9 @@ describe('runExecutionLoop', () => {
     }));
 
     mockedPolicyContext.isPolicyEnforced.mockReturnValue(false);
+    mockedPolicyContext.getPolicyEvaluator.mockReturnValue({
+      setRunbookPath: jest.fn(),
+    } as unknown as ReturnType<typeof policyContext.getPolicyEvaluator>);
     mockedPolicyContext.getSandboxOptions.mockReturnValue({ sandbox: true, sandboxStrict: false });
     (core.executeCommand as any).mockReset();
     (core.executeCommandWithPolicy as any).mockReset();
@@ -434,11 +445,7 @@ describe('runExecutionLoop', () => {
   });
 
   it('returns waiting if prompted mode is on', async () => {
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      status: 'running',
-    });
+    mockManager.load.mockResolvedValue(runningState());
 
     const result = await runExecutionLoop(
       asManager(mockManager),
@@ -468,11 +475,7 @@ describe('runExecutionLoop', () => {
         transitions: { pass: { next: 'COMPLETE' } },
       },
     ];
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      status: 'running',
-    });
+    mockManager.load.mockResolvedValue(runningState());
 
     const result = await runExecutionLoop(
       asManager(mockManager),
@@ -488,13 +491,13 @@ describe('runExecutionLoop', () => {
 
   it('executes command and advances to next step', async () => {
     mockManager.load
-      .mockResolvedValueOnce({ id: runbookId, step: '1', status: 'running' })
-      .mockResolvedValueOnce({ id: runbookId, step: '2', status: 'running' });
+      .mockResolvedValueOnce(runningState())
+      .mockResolvedValueOnce(runningState({ step: '2' }));
 
     jest.mocked(core.executeCommand).mockResolvedValue({ success: true, exitCode: 0 });
 
     mockActorService.sendAndSync.mockResolvedValue({
-      state: { id: runbookId, step: '2', status: 'running' },
+      state: runningState({ step: '2' }),
       snapshot: {
         status: 'active',
         value: '2',
@@ -530,16 +533,15 @@ describe('runExecutionLoop', () => {
     // paired triple. Asserting them here keeps a regression in the injection
     // gates at execution.ts (`if (typeof workPath === 'string') ...`) from
     // silently dropping one half of the pair without any test failing.
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      status: 'running',
-      templateVars: {
-        WorkPath: '/tmp/work',
-        ContextId: 'ctx-abc',
-        RunId: 'run-123',
-      },
-    });
+    mockManager.load.mockResolvedValue(
+      runningState({
+        templateVars: {
+          WorkPath: '/tmp/work',
+          ContextId: 'ctx-abc',
+          RunId: 'run-123',
+        },
+      }),
+    );
 
     jest.mocked(core.executeCommand).mockResolvedValue({ success: true, exitCode: 0 });
     jest.mocked(core.executeCommandWithEnv).mockResolvedValue({ success: true, exitCode: 0 });
@@ -549,6 +551,7 @@ describe('runExecutionLoop', () => {
         id: runbookId,
         step: '1',
         status: 'done',
+        runbook: runbookRef,
         variables: {},
         templateVars: {
           WorkPath: '/tmp/work',
@@ -580,7 +583,7 @@ describe('runExecutionLoop', () => {
   });
 
   it('handles policy denial', async () => {
-    mockManager.load.mockResolvedValue({ id: runbookId, step: '1', status: 'running' });
+    mockManager.load.mockResolvedValue(runningState());
     jest.mocked(policyContext.isPolicyEnforced).mockReturnValue(true);
 
     // ExecutionResult requires `exitCode`; this fixture omits it because
@@ -610,7 +613,7 @@ describe('runExecutionLoop', () => {
   });
 
   it('stops with policy-denied when prepareIteration throws ForResolutionError policy-violation', async () => {
-    mockManager.load.mockResolvedValue({ id: runbookId, step: '1', status: 'running' });
+    mockManager.load.mockResolvedValue(runningState());
 
     (core.ForIterationService as unknown as jest.Mock).mockImplementation(() => {
       const prepareIteration = mockFn<(...args: unknown[]) => Promise<{ status: string }>>();
@@ -656,7 +659,7 @@ describe('runExecutionLoop', () => {
   });
 
   it('completes the runbook', async () => {
-    mockManager.load.mockResolvedValue({ id: runbookId, step: '1', status: 'running' });
+    mockManager.load.mockResolvedValue(runningState());
     jest.mocked(core.executeCommand).mockResolvedValue({ success: true, exitCode: 0 });
 
     mockActorService.sendAndSync.mockResolvedValue({
@@ -664,8 +667,8 @@ describe('runExecutionLoop', () => {
         id: runbookId,
         step: '1',
         status: 'done',
+        runbook: runbookRef,
         variables: {},
-        runbookPath: '/tmp/test.md',
       },
       snapshot: {
         status: 'done',
@@ -699,7 +702,7 @@ describe('runExecutionLoop', () => {
     // lastAction variant on the returned snapshot. runExecutionLoop should
     // emit ERROR_OCCURRED with the hook error's code + message before the
     // terminal RUNBOOK_STOPPED event.
-    mockManager.load.mockResolvedValue({ id: runbookId, step: '1', status: 'running' });
+    mockManager.load.mockResolvedValue(runningState());
     jest.mocked(core.executeCommand).mockResolvedValue({ success: false, exitCode: 1 });
 
     mockActorService.sendAndSync.mockResolvedValue({
@@ -708,8 +711,8 @@ describe('runExecutionLoop', () => {
         step: '1',
         status: 'done',
         lifecycle: 'stopped',
+        runbook: runbookRef,
         variables: {},
-        runbookPath: '/tmp/test.md',
       },
       snapshot: {
         status: 'done',
@@ -787,12 +790,11 @@ describe('runExecutionLoop', () => {
       },
     ];
 
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      substep: '1',
-      status: 'running',
-    });
+    mockManager.load.mockResolvedValue(
+      runningState({
+        substep: '1',
+      }),
+    );
 
     const result = await runExecutionLoop(
       asManager(mockManager),
@@ -825,12 +827,11 @@ describe('runExecutionLoop', () => {
       },
     ];
 
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      substep: '1',
-      status: 'running',
-    });
+    mockManager.load.mockResolvedValue(
+      runningState({
+        substep: '1',
+      }),
+    );
 
     await runExecutionLoop(
       asManager(mockManager),
@@ -869,12 +870,11 @@ describe('runExecutionLoop', () => {
       },
     ];
 
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      substep: '1',
-      status: 'running',
-    });
+    mockManager.load.mockResolvedValue(
+      runningState({
+        substep: '1',
+      }),
+    );
 
     await runExecutionLoop(
       asManager(mockManager),
@@ -912,12 +912,11 @@ describe('runExecutionLoop', () => {
       },
     ];
 
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      substep: '1',
-      status: 'running',
-    });
+    mockManager.load.mockResolvedValue(
+      runningState({
+        substep: '1',
+      }),
+    );
 
     await runExecutionLoop(
       asManager(mockManager),
@@ -957,12 +956,11 @@ describe('runExecutionLoop', () => {
       },
     ];
 
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      substep: '1',
-      status: 'running',
-    });
+    mockManager.load.mockResolvedValue(
+      runningState({
+        substep: '1',
+      }),
+    );
 
     const result = await runExecutionLoop(
       asManager(mockManager),
@@ -1013,15 +1011,11 @@ describe('runExecutionLoop', () => {
       // so we need two sequential returns: step 1 (initial load) → step 2 (reload after transition).
       mockManager.load
         .mockResolvedValueOnce({
-          id: runbookId,
-          step: '1',
-          status: 'running',
+          ...runningState(),
           templateVars: { ContextId: 'ctx-unit' },
         })
         .mockResolvedValueOnce({
-          id: runbookId,
-          step: '2',
-          status: 'running',
+          ...runningState({ step: '2' }),
           templateVars: { ContextId: 'ctx-unit' },
         });
 
@@ -1033,6 +1027,7 @@ describe('runExecutionLoop', () => {
           id: runbookId,
           step: '2',
           status: 'running',
+          runbook: runbookRef,
           templateVars: { ContextId: 'ctx-unit' },
         },
         snapshot: {
@@ -1085,13 +1080,12 @@ describe('runExecutionLoop', () => {
       },
     ];
 
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      substep: '1',
-      status: 'running',
-      substepStates: [],
-    });
+    mockManager.load.mockResolvedValue(
+      runningState({
+        substep: '1',
+        substepStates: [],
+      }),
+    );
 
     // inferAllDelegateSubsteps returns two targets
     jest.mocked(delegateInference.inferAllDelegateSubsteps).mockReturnValue([
@@ -1105,10 +1099,12 @@ describe('runExecutionLoop', () => {
       .mockResolvedValueOnce({
         path: '/project/.rundown/runbooks/child-a.runbook.md',
         source: 'project',
+        sourceRoot: '/project',
       })
       .mockResolvedValueOnce({
         path: '/project/.rundown/runbooks/child-b.runbook.md',
         source: 'project',
+        sourceRoot: '/project',
       });
 
     // createDelegation returns a token for each substep. The fixtures use
@@ -1205,13 +1201,12 @@ describe('runExecutionLoop', () => {
       },
     ];
 
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      substep: '1',
-      status: 'running',
-      substepStates: [],
-    });
+    mockManager.load.mockResolvedValue(
+      runningState({
+        substep: '1',
+        substepStates: [],
+      }),
+    );
 
     const preIssued = [
       { id: '1.1', runbook: 'child-a.runbook.md', token: 'rdtk_retry_a' },
@@ -1268,13 +1263,12 @@ describe('runExecutionLoop', () => {
       },
     ];
 
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      substep: '1',
-      status: 'running',
-      substepStates: [],
-    });
+    mockManager.load.mockResolvedValue(
+      runningState({
+        substep: '1',
+        substepStates: [],
+      }),
+    );
 
     // Snapshot with no pendingDelegateFrontier
     mockActorService.getContextSnapshot.mockResolvedValue({});
@@ -1286,6 +1280,7 @@ describe('runExecutionLoop', () => {
     jest.mocked(resolveRunbook.resolveRunbookFile).mockResolvedValue({
       path: '/project/.rundown/runbooks/child-a.runbook.md',
       source: 'project',
+      sourceRoot: '/project',
     });
 
     jest.mocked(core.createDelegation).mockReturnValue({
@@ -1354,20 +1349,19 @@ describe('runExecutionLoop', () => {
       },
     ];
 
-    mockManager.load.mockResolvedValue({
-      id: runbookId,
-      step: '1',
-      substep: '1',
-      status: 'running',
-      substepStates: [],
-      // Active runbook is itself a claimed child — guard should fire.
-      parentLinkage: {
-        kind: 'delegation',
-        parentRunId: 'parent-run-id',
-        parentStepId: '1',
-        tokenHash: `sha256:${'a'.repeat(64)}`,
-      },
-    });
+    mockManager.load.mockResolvedValue(
+      runningState({
+        substep: '1',
+        substepStates: [],
+        // Active runbook is itself a claimed child — guard should fire.
+        parentLinkage: {
+          kind: 'delegation',
+          parentRunId: 'parent-run-id',
+          parentStepId: '1',
+          tokenHash: `sha256:${'a'.repeat(64)}`,
+        },
+      }),
+    );
 
     jest
       .mocked(delegateInference.inferAllDelegateSubsteps)
@@ -1376,6 +1370,7 @@ describe('runExecutionLoop', () => {
     jest.mocked(resolveRunbook.resolveRunbookFile).mockResolvedValue({
       path: '/project/.rundown/runbooks/child-a.runbook.md',
       source: 'project',
+      sourceRoot: '/project',
     });
 
     // Real createDelegation enforces the guard — let it run rather than mock

--- a/packages/cli/__tests__/services/internal-commands.test.ts
+++ b/packages/cli/__tests__/services/internal-commands.test.ts
@@ -86,10 +86,13 @@ rd echo test
       };
 
       // Create runbook state
-      const state = await manager.create('test.runbook.md', runbook, {
-        runbookPath: 'test.runbook.md',
-        prompted: true,
-      });
+      const state = await manager.create(
+        { source: 'project', path: '.rundown/runbooks/test.runbook.md' },
+        runbook,
+        {
+          prompted: true,
+        },
+      );
 
       // Push to make it active
       const sessionService = new SessionService(manager);

--- a/packages/cli/jest.setup.ts
+++ b/packages/cli/jest.setup.ts
@@ -1,8 +1,13 @@
 import path from 'node:path';
+import { existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Set bundled runbooks path to dist/runbooks for tests
-process.env.BUNDLED_RUNBOOKS_PATH = path.join(__dirname, 'dist', 'runbooks');
+// Set bundled runbooks path to dist/runbooks for tests, falling back to the
+// source-tree runbooks directory before the package has been built.
+const distRunbooks = path.join(__dirname, 'dist', 'runbooks');
+process.env.BUNDLED_RUNBOOKS_PATH = existsSync(distRunbooks)
+  ? distRunbooks
+  : path.join(__dirname, '..', '..', 'runbooks');

--- a/packages/cli/src/commands/ls.ts
+++ b/packages/cli/src/commands/ls.ts
@@ -85,13 +85,14 @@ export function registerLsCommand(program: Command): void {
             states.map(async (state) => {
               const status = getStatus(state, active, stashedId);
 
-              const totalSteps = await getStepTotal(cwd, state.runbook);
+              const totalSteps = await getStepTotal(cwd, state.runbook.path);
               const displayStep = state.step;
 
               return {
                 ...state,
                 _status: status,
                 _displayStep: `${displayStep}/${String(totalSteps)}`,
+                _displayRunbook: state.runbook.path,
                 _step: displayStep,
                 _total: totalSteps,
               };
@@ -105,7 +106,7 @@ export function registerLsCommand(program: Command): void {
               { header: 'ID', key: (s) => s.id.slice(0, 8) },
               { header: 'STATUS', key: (s) => s._status },
               { header: 'STEP', key: (s) => s._displayStep },
-              { header: 'RUNBOOK', key: 'runbook' },
+              { header: 'RUNBOOK', key: (s) => s._displayRunbook },
               { header: 'TITLE', key: (s) => s.title ?? '' },
             ],
             {
@@ -113,7 +114,7 @@ export function registerLsCommand(program: Command): void {
                 'No active runbooks.\nRun "rundown ls --all" to see available runbooks.',
               jsonMapper: (s) => {
                 // Include status, step, total per docs/spec/cli-output.md
-                const { _status, _displayStep: _, _step, _total, ...original } = s;
+                const { _status, _displayStep: _, _displayRunbook, _step, _total, ...original } = s;
                 return {
                   ...original,
                   status: _status,

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -3,7 +3,12 @@
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { Command } from 'commander';
-import { RunbookStateManager, SessionService } from '@rundown-org/core';
+import {
+  RUN_ID_PATTERN,
+  RunbookStateManager,
+  SessionService,
+  assertSafeId,
+} from '@rundown-org/core';
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
@@ -92,12 +97,23 @@ export function registerPruneCommand(program: Command): void {
           // list() but can still be deleted. Treat them as inactive: prune with
           // --inactive or --all.
           const loadedIds = new Set(states.map((s) => s.id));
-          const staleIds = allIds.filter((id) => !loadedIds.has(id));
+          const staleIds = allIds.filter((id) => !loadedIds.has(id) && RUN_ID_PATTERN.test(id));
+          const nonCanonicalIds = allIds.filter((id) => {
+            if (RUN_ID_PATTERN.test(id)) return false;
+            try {
+              assertSafeId(id, 'runId');
+              return true;
+            } catch {
+              return false;
+            }
+          });
           const staleToDelete = (pruneInactive ?? options.all) ? staleIds : [];
+          const nonCanonicalToDelete = (pruneInactive ?? options.all) ? nonCanonicalIds : [];
 
           // Enrich items with status string for display
           const enrichedItems = toDelete.map((state) => ({
             ...state,
+            _displayRunbook: state.runbook.path,
             _status: getStatus(state, activeState, stashedId),
           }));
 
@@ -106,6 +122,7 @@ export function registerPruneCommand(program: Command): void {
             id: string;
             runbook: string;
             title: string | undefined;
+            _displayRunbook: string;
             _status: string;
           };
           type PruneRow = LoadedRow | StaleRow;
@@ -115,22 +132,34 @@ export function registerPruneCommand(program: Command): void {
             id,
             runbook: '(stale)',
             title: undefined,
+            _displayRunbook: '(stale)',
+            _status: 'stale',
+          }));
+          const nonCanonicalEnrichedItems: StaleRow[] = nonCanonicalToDelete.map((id) => ({
+            id,
+            runbook: '(stale)',
+            title: undefined,
+            _displayRunbook: '(stale)',
             _status: 'stale',
           }));
 
-          const allItems: PruneRow[] = [...enrichedItems, ...staleEnrichedItems];
+          const allItems: PruneRow[] = [
+            ...enrichedItems,
+            ...staleEnrichedItems,
+            ...nonCanonicalEnrichedItems,
+          ];
 
           // Define columns once for reuse
           const columns = [
             { header: 'ID', key: 'id' as const },
             { header: 'STATUS', key: (item: PruneRow) => item._status },
-            { header: 'RUNBOOK', key: 'runbook' as const },
+            { header: 'RUNBOOK', key: (item: PruneRow) => item._displayRunbook },
             { header: 'TITLE', key: (item: PruneRow) => (item.title ? `[${item.title}]` : '') },
           ];
 
           // JSON mapper to clean internal fields
           const jsonMapper = (item: PruneRow): Record<string, unknown> => {
-            const { _status, ...rest } = item as Record<string, unknown>;
+            const { _status, _displayRunbook, ...rest } = item as Record<string, unknown>;
             return { ...rest, status: _status };
           };
 
@@ -158,6 +187,9 @@ export function registerPruneCommand(program: Command): void {
           }
           for (const id of staleToDelete) {
             await manager.delete(id);
+          }
+          for (const id of nonCanonicalToDelete) {
+            await manager.purgeNonCanonicalRunState(id);
           }
 
           output.list(allItems, columns, { jsonMapper });

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -1,28 +1,11 @@
 // packages/cli/src/commands/prune.ts
 
-import { readdir } from 'node:fs/promises';
-import { join } from 'node:path';
 import type { Command } from 'commander';
-import {
-  RUN_ID_PATTERN,
-  RunbookStateManager,
-  SessionService,
-  assertSafeId,
-} from '@rundown-org/core';
+import { RunbookStateManager, SessionService } from '@rundown-org/core';
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { getStatus } from '../helpers/status.js';
-
-async function listAllRunIds(cwd: string): Promise<string[]> {
-  try {
-    const runsDir = join(cwd, '.rundown', 'runs');
-    const files = await readdir(runsDir);
-    return files.filter((f) => f.endsWith('.json')).map((f) => f.replace('.json', ''));
-  } catch {
-    return [];
-  }
-}
 
 interface PruneOptions {
   dryRun?: boolean;
@@ -46,7 +29,7 @@ export function registerPruneCommand(program: Command): void {
     .option('--completed', 'Prune successfully completed runbook state')
     .option('--stopped', 'Prune stopped (aborted/failed) runbook state')
     .option('--active', 'Prune active runbook state')
-    .option('--inactive', 'Prune inactive (orphaned) runbook state')
+    .option('--inactive', 'Prune inactive runbook state')
     .option('--all', 'Prune all runbook state')
     .option('--text', 'Output as human-readable text')
     .action(async (options: PruneOptions) => {
@@ -58,7 +41,6 @@ export function registerPruneCommand(program: Command): void {
           const manager = new RunbookStateManager(cwd);
           const sessionService = new SessionService(manager);
           const states = await manager.list();
-          const allIds = await listAllRunIds(cwd);
           let activeState: Awaited<ReturnType<typeof sessionService.getActive>>;
           try {
             activeState = await sessionService.getActive();
@@ -93,23 +75,6 @@ export function registerPruneCommand(program: Command): void {
             return false;
           });
 
-          // Stale files (skipped by list() due to schema version mismatch) are invisible to
-          // list() but can still be deleted. Treat them as inactive: prune with
-          // --inactive or --all.
-          const loadedIds = new Set(states.map((s) => s.id));
-          const staleIds = allIds.filter((id) => !loadedIds.has(id) && RUN_ID_PATTERN.test(id));
-          const nonCanonicalIds = allIds.filter((id) => {
-            if (RUN_ID_PATTERN.test(id)) return false;
-            try {
-              assertSafeId(id, 'runId');
-              return true;
-            } catch {
-              return false;
-            }
-          });
-          const staleToDelete = (pruneInactive ?? options.all) ? staleIds : [];
-          const nonCanonicalToDelete = (pruneInactive ?? options.all) ? nonCanonicalIds : [];
-
           // Enrich items with status string for display
           const enrichedItems = toDelete.map((state) => ({
             ...state,
@@ -118,36 +83,8 @@ export function registerPruneCommand(program: Command): void {
           }));
 
           type LoadedRow = (typeof enrichedItems)[0];
-          type StaleRow = {
-            id: string;
-            runbook: string;
-            title: string | undefined;
-            _displayRunbook: string;
-            _status: string;
-          };
-          type PruneRow = LoadedRow | StaleRow;
-
-          // Stale items carry only the fields needed for display and JSON output
-          const staleEnrichedItems: StaleRow[] = staleToDelete.map((id) => ({
-            id,
-            runbook: '(stale)',
-            title: undefined,
-            _displayRunbook: '(stale)',
-            _status: 'stale',
-          }));
-          const nonCanonicalEnrichedItems: StaleRow[] = nonCanonicalToDelete.map((id) => ({
-            id,
-            runbook: '(stale)',
-            title: undefined,
-            _displayRunbook: '(stale)',
-            _status: 'stale',
-          }));
-
-          const allItems: PruneRow[] = [
-            ...enrichedItems,
-            ...staleEnrichedItems,
-            ...nonCanonicalEnrichedItems,
-          ];
+          type PruneRow = LoadedRow;
+          const allItems: PruneRow[] = enrichedItems;
 
           // Define columns once for reuse
           const columns = [
@@ -184,12 +121,6 @@ export function registerPruneCommand(program: Command): void {
           // Perform deletion
           for (const state of toDelete) {
             await manager.delete(state.id);
-          }
-          for (const id of staleToDelete) {
-            await manager.delete(id);
-          }
-          for (const id of nonCanonicalToDelete) {
-            await manager.purgeNonCanonicalRunState(id);
           }
 
           output.list(allItems, columns, { jsonMapper });

--- a/packages/cli/src/commands/stash.ts
+++ b/packages/cli/src/commands/stash.ts
@@ -52,7 +52,7 @@ export function registerStashCommand(program: Command): void {
           }
           const state = active.state;
 
-          const totalSteps = await getStepTotal(cwd, state.runbook);
+          const totalSteps = await getStepTotal(cwd, state.runbook.path);
 
           // Stash the runbook
           const stashedId = await sessionService.stashRunbook(state.id);

--- a/packages/cli/src/helpers/bundled-runbooks.ts
+++ b/packages/cli/src/helpers/bundled-runbooks.ts
@@ -1,4 +1,5 @@
 import { dirname, join } from 'node:path';
+import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -12,9 +13,24 @@ const __dirname = dirname(__filename);
  */
 export function getBundledRunbooksPath(): string {
   // Allow override for testing or custom deployments
-  if (process.env.BUNDLED_RUNBOOKS_PATH) {
-    return process.env.BUNDLED_RUNBOOKS_PATH;
+  if (Object.hasOwn(process.env, 'BUNDLED_RUNBOOKS_PATH')) {
+    return process.env.BUNDLED_RUNBOOKS_PATH || join(process.cwd(), '.disabled-bundled-runbooks');
   }
-  // In dist: dist/helpers/bundled-runbooks.js -> dist/runbooks/
-  return join(__dirname, '..', 'runbooks');
+  const candidates = [
+    // In dist: dist/helpers/bundled-runbooks.js -> dist/runbooks/
+    join(__dirname, '..', 'runbooks'),
+    // In source tests: packages/cli/src/helpers -> repo/runbooks/
+    join(__dirname, '..', '..', '..', '..', 'runbooks'),
+    // Workspace root or package root depending on how npm invoked Jest.
+    join(process.cwd(), 'runbooks'),
+    join(process.cwd(), '..', '..', 'runbooks'),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return candidates[0];
 }

--- a/packages/cli/src/helpers/context.ts
+++ b/packages/cli/src/helpers/context.ts
@@ -18,12 +18,12 @@ export function getCwd(): string {
  * Named steps (like "RECOVER") are excluded from the count.
  *
  * @param cwd - Current working directory
- * @param runbookPath - Path to the runbook file
+ * @param runbookFile - Path to the runbook file
  * @returns Numbered step count or 0 on error
  */
-export async function getStepTotal(cwd: string, runbookPath: string): Promise<number> {
+export async function getStepTotal(cwd: string, runbookFile: string): Promise<number> {
   try {
-    const resolved = await resolveRunbookFile(cwd, runbookPath);
+    const resolved = await resolveRunbookFile(cwd, runbookFile);
     if (!resolved) return 0;
     const content = await fs.readFile(resolved.path, 'utf8');
     const steps = parseRunbook(content);

--- a/packages/cli/src/helpers/execution-emitter.ts
+++ b/packages/cli/src/helpers/execution-emitter.ts
@@ -7,12 +7,7 @@
  * @module helpers/execution-emitter
  */
 
-import {
-  ExecutionEventEmitter,
-  RunbookRefSchema,
-  type RunbookRef,
-  type RunbookState,
-} from '@rundown-org/core';
+import { ExecutionEventEmitter, type RunbookState } from '@rundown-org/core';
 import type { OutputEmitter } from '../services/output-emitter.js';
 
 /**
@@ -24,7 +19,6 @@ import type { OutputEmitter } from '../services/output-emitter.js';
  *
  * @param runbookState - The runbook state to create the emitter for
  * @param output - The OutputEmitter to bridge events to
- * @param runbookRef - Optional canonical runbook reference derived at preparation time
  * @returns The ExecutionEventEmitter configured with event bridging
  *
  * @example
@@ -36,12 +30,8 @@ import type { OutputEmitter } from '../services/output-emitter.js';
 export function createBridgedEmitter(
   runbookState: RunbookState,
   output: OutputEmitter,
-  runbookRef?: RunbookRef,
 ): ExecutionEventEmitter {
-  const emitter = new ExecutionEventEmitter(
-    runbookState.id,
-    resolveRunbookRef(runbookState, runbookRef),
-  );
+  const emitter = new ExecutionEventEmitter(runbookState.id, runbookState.runbook);
 
   // Bridge execution events to the unified output system
   emitter.subscribe((event) => {
@@ -49,41 +39,4 @@ export function createBridgedEmitter(
   });
 
   return emitter;
-}
-
-function resolveRunbookRef(runbookState: RunbookState, runbookRef?: RunbookRef): RunbookRef {
-  return runbookRef
-    ? RunbookRefSchema.parse(runbookRef)
-    : runbookState.runbookRef
-      ? RunbookRefSchema.parse(runbookState.runbookRef)
-      : createFallbackProjectRunbookRef(runbookState);
-}
-
-function createFallbackProjectRunbookRef(runbookState: RunbookState): RunbookRef {
-  for (const candidate of [runbookState.runbookPath, runbookState.runbook]) {
-    const ref = {
-      source: 'project' as const,
-      path: toCanonicalRunbookRefPath(candidate),
-    };
-    const result = RunbookRefSchema.safeParse(ref);
-    if (result.success) {
-      return result.data;
-    }
-  }
-
-  return RunbookRefSchema.parse({
-    source: 'project',
-    path: toCanonicalRunbookRefPath(runbookState.runbookPath),
-  });
-}
-
-function toCanonicalRunbookRefPath(value: string): string {
-  const normalized = value.startsWith('./') ? value.slice(2) : value;
-  if (normalized.endsWith('.runbook.md')) {
-    return normalized;
-  }
-  if (normalized.endsWith('.md')) {
-    return `${normalized.slice(0, -'.md'.length)}.runbook.md`;
-  }
-  return normalized;
 }

--- a/packages/cli/src/helpers/resolve-runbook.ts
+++ b/packages/cli/src/helpers/resolve-runbook.ts
@@ -80,20 +80,23 @@ async function resolveAbsolutePath(cwd: string, filename: string): Promise<Resol
     return null;
   }
 
-  if (pathWithin(runbooksDir(cwd), filename)) {
-    return { path: filename, source: 'project' };
+  const projectRunbooksDir = runbooksDir(cwd);
+  if (pathWithin(projectRunbooksDir, filename)) {
+    return { path: filename, source: 'project', sourceRoot: cwd };
   }
 
   const pluginRoot = getPluginRoot();
-  if (pluginRoot && pathWithin(path.join(pluginRoot, 'runbooks'), filename)) {
-    return { path: filename, source: 'plugin' };
+  const pluginRunbooksDir = pluginRoot ? path.join(pluginRoot, 'runbooks') : null;
+  if (pluginRunbooksDir && pathWithin(pluginRunbooksDir, filename)) {
+    return { path: filename, source: 'plugin', sourceRoot: pluginRunbooksDir };
   }
 
-  if (pathWithin(getBundledRunbooksPath(), filename)) {
-    return { path: filename, source: 'bundled' };
+  const bundledRunbooksDir = getBundledRunbooksPath();
+  if (pathWithin(bundledRunbooksDir, filename)) {
+    return { path: filename, source: 'bundled', sourceRoot: bundledRunbooksDir };
   }
 
-  return { path: filename, source: 'project' };
+  return { path: filename, source: 'project', sourceRoot: cwd };
 }
 
 /**

--- a/packages/cli/src/helpers/resolve-runbook.ts
+++ b/packages/cli/src/helpers/resolve-runbook.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { runbooksDir } from '@rundown-org/core';
+import { runbooksDir, type RunbookSource } from '@rundown-org/core';
 import { findRunbookByName, findRunbookByNameInSource } from '../services/discovery.js';
 import { getBundledRunbooksPath } from './bundled-runbooks.js';
 import { getPluginRoot } from './plugin-root.js';
@@ -16,7 +16,9 @@ export interface ResolvedRunbook {
   /** Absolute path to the resolved runbook file */
   path: string;
   /** Source directory where the runbook was found */
-  source: 'project' | 'plugin' | 'bundled';
+  source: RunbookSource;
+  /** Source root used to derive persisted runbook identity */
+  sourceRoot: string;
 }
 
 /**
@@ -53,7 +55,7 @@ export function parseIdentifier(identifier: string): ParsedIdentifier {
  * @param namespace - Namespace string
  * @returns Source type or null if namespace not recognized
  */
-function namespaceToSource(namespace: string): 'project' | 'plugin' | 'bundled' | null {
+function namespaceToSource(namespace: string): RunbookSource | null {
   if (namespace === 'rundown') {
     return 'plugin';
   }
@@ -115,7 +117,7 @@ async function resolveByPath(cwd: string, filename: string): Promise<ResolvedRun
   const localPath = path.join(runbooksDir(cwd), filename);
   try {
     await fs.access(localPath);
-    return { path: localPath, source: 'project' };
+    return { path: localPath, source: 'project', sourceRoot: cwd };
   } catch {
     /* not found */
   }
@@ -123,10 +125,11 @@ async function resolveByPath(cwd: string, filename: string): Promise<ResolvedRun
   // 2. Check plugin runbooks directory (env var or sibling package discovery)
   const pluginRoot = getPluginRoot();
   if (pluginRoot) {
-    const pluginPath = path.join(pluginRoot, 'runbooks', filename);
+    const pluginRunbooksDir = path.join(pluginRoot, 'runbooks');
+    const pluginPath = path.join(pluginRunbooksDir, filename);
     try {
       await fs.access(pluginPath);
-      return { path: pluginPath, source: 'plugin' };
+      return { path: pluginPath, source: 'plugin', sourceRoot: pluginRunbooksDir };
     } catch {
       /* not found */
     }
@@ -136,16 +139,17 @@ async function resolveByPath(cwd: string, filename: string): Promise<ResolvedRun
   const relativePath = path.resolve(cwd, filename);
   try {
     await fs.access(relativePath);
-    return { path: relativePath, source: 'project' };
+    return { path: relativePath, source: 'project', sourceRoot: cwd };
   } catch {
     /* not found */
   }
 
   // 4. Check bundled runbooks (lowest priority)
-  const bundledPath = path.join(getBundledRunbooksPath(), filename);
+  const bundledRunbooksDir = getBundledRunbooksPath();
+  const bundledPath = path.join(bundledRunbooksDir, filename);
   try {
     await fs.access(bundledPath);
-    return { path: bundledPath, source: 'bundled' };
+    return { path: bundledPath, source: 'bundled', sourceRoot: bundledRunbooksDir };
   } catch {
     /* not found */
   }
@@ -206,7 +210,9 @@ export async function resolveRunbookFile(
       return null;
     }
     const discovered = await findRunbookByNameInSource(cwd, name, source);
-    return discovered ? { path: discovered.path, source: discovered.source } : null;
+    return discovered
+      ? { path: discovered.path, source: discovered.source, sourceRoot: discovered.sourceRoot }
+      : null;
   }
 
   // Detect if identifier is path-based or name-based
@@ -220,12 +226,16 @@ export async function resolveRunbookFile(
     if (!name.includes('/') && name.endsWith('.runbook.md')) {
       const stem = name.replace(/\.runbook\.md$/, '');
       const discovered = await findRunbookByName(cwd, stem);
-      return discovered ? { path: discovered.path, source: discovered.source } : null;
+      return discovered
+        ? { path: discovered.path, source: discovered.source, sourceRoot: discovered.sourceRoot }
+        : null;
     }
     return null;
   } else {
     // Name-based resolution: use discovery service
     const discovered = await findRunbookByName(cwd, name);
-    return discovered ? { path: discovered.path, source: discovered.source } : null;
+    return discovered
+      ? { path: discovered.path, source: discovered.source, sourceRoot: discovered.sourceRoot }
+      : null;
   }
 }

--- a/packages/cli/src/helpers/runbook-loader.ts
+++ b/packages/cli/src/helpers/runbook-loader.ts
@@ -12,6 +12,7 @@
  * @throws {Error} if runbookSrc is missing (indicates corrupted state)
  */
 
+import * as path from 'node:path';
 import { parseRunbookDocument, areAllStepsResolved, type ResolvedStep } from '@rundown-org/parser';
 import type { RunbookState } from '@rundown-org/core';
 import { substituteRunbookVariables, resolveForBounds } from '../services/template-renderer.js';
@@ -42,6 +43,8 @@ import { substituteRunbookVariables, resolveForBounds } from '../services/templa
  * ```
  */
 export function getRunbookFromState(state: RunbookState, _cwd: string): readonly ResolvedStep[] {
+  const runbookPath = state.runbook.path;
+  const runbookBasename = path.basename(runbookPath);
   if (!state.runbookSrc) {
     throw new Error(
       `State file ${state.id} is missing runbookSrc. ` +
@@ -56,7 +59,7 @@ export function getRunbookFromState(state: RunbookState, _cwd: string): readonly
     const errors = diagnostics.filter((d) => d.severity === 'error');
     if (errors.length > 0) {
       throw new Error(
-        `Runbook ${state.runbook} has structural errors: ${errors[0].message}. ` +
+        `Runbook ${runbookPath} has structural errors: ${errors[0].message}. ` +
           `Delete state and re-run the runbook.`,
       );
     }
@@ -72,7 +75,7 @@ export function getRunbookFromState(state: RunbookState, _cwd: string): readonly
   // mergeEffectiveVars to include OUTPUTS for descriptions, prompts, and
   // downstream OUTPUTS expressions.
   if (state.templateVars) {
-    const { runbook, diagnostics } = parseRunbookDocument(state.runbookSrc, state.runbook);
+    const { runbook, diagnostics } = parseRunbookDocument(state.runbookSrc, runbookBasename);
     checkDiagnostics(diagnostics);
     const { runbook: resolved } = resolveForBounds(runbook, state.templateVars);
     const substituted = substituteRunbookVariables(resolved, state.templateVars);
@@ -82,12 +85,12 @@ export function getRunbookFromState(state: RunbookState, _cwd: string): readonly
   }
 
   // Backward compat: old state files have pre-expanded runbookSrc, no templateVars
-  const { runbook, diagnostics } = parseRunbookDocument(state.runbookSrc, state.runbook);
+  const { runbook, diagnostics } = parseRunbookDocument(state.runbookSrc, runbookBasename);
   checkDiagnostics(diagnostics);
 
   if (!areAllStepsResolved(runbook.steps)) {
     throw new Error(
-      `Runbook ${state.runbook} has unresolved FOR bounds or runbook references in pre-expanded state. ` +
+      `Runbook ${runbookPath} has unresolved FOR bounds or runbook references in pre-expanded state. ` +
         `This indicates stale state. Delete and re-run the runbook.`,
     );
   }

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -7,8 +7,8 @@
  * @module helpers/runbook-pipeline
  */
 
-import * as fsSync from 'node:fs';
 import * as fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
 import * as path from 'node:path';
 import {
   type RunbookStateManager,
@@ -22,12 +22,12 @@ import {
   type ExecutionEventEmitter,
   type ResolvedRunbook,
   type RunbookRef,
+  type RunbookSource,
   RunbookRefSchema,
   type DelegationLinkage,
   type ParentLinkage,
   type ClaimId,
   RUNS_DIR,
-  runbooksDir,
   DelegationScanService,
   DelegationLock,
   DelegationLockTimeoutError,
@@ -58,7 +58,6 @@ import type { ResolvedRunbook as ResolvedRunbookFile } from './resolve-runbook.j
 import { runExecutionLoop } from '../services/execution.js';
 import type { OutputEmitter } from '../services/output-emitter.js';
 import { createBridgedEmitter } from './execution-emitter.js';
-import { getBundledRunbooksPath } from './bundled-runbooks.js';
 import { FileSourcePolicyError, resolveVariables } from '../services/variable-discovery.js';
 import {
   substituteRunbookVariables,
@@ -105,6 +104,10 @@ export interface RunPipelineContext {
 export interface PreparedRunbook {
   /** Absolute path to the resolved runbook file */
   filePath: string;
+  /** Source where the runbook was discovered from */
+  source: RunbookSource;
+  /** Source root used to derive persisted runbook identity */
+  sourceRoot: string;
   /** Canonical runbook reference for events and artifact metadata */
   runbookRef: RunbookRef;
   /** Raw markdown content of the runbook file */
@@ -256,53 +259,11 @@ export function validateForVariables(
  * @returns Validated canonical runbook reference
  * @throws {Error} If the resolved file cannot be represented canonically
  */
-export function buildRunbookRef(resolved: ResolvedRunbookFile, cwd: string): RunbookRef {
-  const rootRelativePath = sourceRelativeRunbookPath(resolved, cwd);
-  return RunbookRefSchema.parse({
-    source: resolved.source,
-    path: toCanonicalRunbookRefPath(toPosixPath(rootRelativePath)),
-  });
+export function buildRunbookRef(resolved: ResolvedRunbookFile): RunbookRef {
+  return derivePersistedRunbookRef(resolved.path, resolved.source, resolved.sourceRoot);
 }
 
-function sourceRelativeRunbookPath(resolved: ResolvedRunbookFile, cwd: string): string {
-  switch (resolved.source) {
-    case 'project': {
-      const projectRunbooksRelative = pathRelativeWithin(runbooksDir(cwd), resolved.path);
-      return projectRunbooksRelative ?? pathRelativeRequired(cwd, resolved.path);
-    }
-    case 'plugin': {
-      const pluginRunbooksRoot = findRunbooksAncestor(resolved.path);
-      if (!pluginRunbooksRoot) {
-        throw new Error(`Plugin runbook is not beneath a runbooks directory: ${resolved.path}`);
-      }
-      return pathRelativeRequired(pluginRunbooksRoot, resolved.path);
-    }
-    case 'bundled':
-      return pathRelativeRequired(getBundledRunbooksPath(), resolved.path);
-    default: {
-      const _exhaustive: never = resolved.source;
-      throw new Error(`Unhandled runbook source: ${String(_exhaustive)}`);
-    }
-  }
-}
-
-function pathRelativeRequired(root: string, target: string): string {
-  const relativePath = pathRelativeWithin(root, target);
-  if (relativePath === null) {
-    throw new Error(`Resolved runbook path escapes source root: ${target}`);
-  }
-  return relativePath;
-}
-
-function pathRelativeWithin(root: string, target: string): string | null {
-  const relativePath = path.relative(resolveComparablePath(root), resolveComparablePath(target));
-  if (relativePath === '' || escapesRoot(relativePath)) {
-    return null;
-  }
-  return relativePath;
-}
-
-function resolveComparablePath(value: string): string {
+function realpathIfAvailable(value: string): string {
   try {
     return fsSync.realpathSync.native(value);
   } catch {
@@ -310,31 +271,30 @@ function resolveComparablePath(value: string): string {
   }
 }
 
-function escapesRoot(relativePath: string): boolean {
-  return (
-    relativePath === '..' ||
-    relativePath.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativePath)
-  );
-}
-
-function findRunbooksAncestor(filePath: string): string | null {
-  let current = path.dirname(path.resolve(filePath));
-  let outermost: string | null = null;
-  for (;;) {
-    if (path.basename(current) === 'runbooks') {
-      outermost = current;
-    }
-    const parent = path.dirname(current);
-    if (parent === current) {
-      return outermost;
-    }
-    current = parent;
+function toPosixRelative(sourceRoot: string, filePath: string): string {
+  const root = realpathIfAvailable(sourceRoot);
+  const resolvedFile = realpathIfAvailable(filePath);
+  const relative = path.relative(root, resolvedFile).split(path.sep).join('/');
+  if (
+    relative.length === 0 ||
+    relative === '..' ||
+    relative.startsWith('../') ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(`Resolved runbook path is outside ${sourceRoot}: ${filePath}`);
   }
+  return relative;
 }
 
-function toPosixPath(value: string): string {
-  return value.split(path.sep).join('/');
+function derivePersistedRunbookRef(
+  filePath: string,
+  source: RunbookSource,
+  sourceRoot: string,
+): RunbookRef {
+  return RunbookRefSchema.parse({
+    source,
+    path: toCanonicalRunbookRefPath(toPosixRelative(sourceRoot, filePath)),
+  });
 }
 
 function toCanonicalRunbookRefPath(value: string): string {
@@ -488,7 +448,11 @@ export interface LoadAndParseSuccess {
   /** Absolute path to the resolved runbook file */
   filePath: string;
   /** Source where the runbook was discovered from */
-  source: 'project' | 'plugin' | 'bundled';
+  source: RunbookSource;
+  /** Source root used to derive persisted runbook identity */
+  sourceRoot: string;
+  /** Canonical runbook reference for events and artifact metadata */
+  runbookRef: RunbookRef;
   /** Raw markdown content */
   rawContent: string;
   /** Parsed runbook AST (before variable substitution) */
@@ -509,7 +473,7 @@ export interface LoadAndParseSuccess {
 export interface LoadAndParseFailure {
   ok: false;
   error: string;
-  code: 'RUNBOOK_NOT_FOUND' | 'PARSE_ERROR';
+  code: 'RUNBOOK_NOT_FOUND' | 'PARSE_ERROR' | 'RUNBOOK_REF_RESOLUTION_ERROR';
   details: { runbook: string };
 }
 
@@ -546,7 +510,18 @@ export async function loadAndParseRunbook(file: string, cwd: string): Promise<Lo
     };
   }
 
-  const { path: filePath, source } = resolved;
+  const { path: filePath, source, sourceRoot } = resolved;
+  let runbookRef: RunbookRef;
+  try {
+    runbookRef = buildRunbookRef(resolved);
+  } catch (error) {
+    return {
+      ok: false,
+      error: getErrorMessage(error),
+      code: 'RUNBOOK_REF_RESOLUTION_ERROR',
+      details: { runbook: file },
+    };
+  }
 
   try {
     const rawContent = await fs.readFile(filePath, 'utf8');
@@ -571,6 +546,8 @@ export async function loadAndParseRunbook(file: string, cwd: string): Promise<Lo
       ok: true,
       filePath,
       source,
+      sourceRoot,
+      runbookRef,
       rawContent,
       runbook,
       frontmatter,
@@ -619,6 +596,8 @@ export async function prepareRunbook(
   const {
     filePath,
     source,
+    sourceRoot,
+    runbookRef,
     rawContent,
     runbook: rawRunbook,
     frontmatter,
@@ -626,28 +605,7 @@ export async function prepareRunbook(
     stats,
   } = parsed;
 
-  // Derive CLAUDE_PLUGIN_ROOT from resolved path when source is plugin
-  let runbookRef: RunbookRef;
-  let pluginRoot: string | undefined;
-  try {
-    runbookRef = buildRunbookRef({ path: filePath, source }, cwd);
-    if (source === 'plugin') {
-      const runbooksSep = `${path.sep}runbooks${path.sep}`;
-      const runbooksIdx = filePath.indexOf(runbooksSep);
-      if (runbooksIdx !== -1) {
-        pluginRoot = filePath.slice(0, runbooksIdx + 1); // include trailing separator
-      }
-    }
-  } catch (error) {
-    return {
-      ok: false,
-      error: getErrorMessage(error),
-      code: 'RUNBOOK_REF_RESOLUTION_ERROR',
-      details: { runbook: file },
-      stats,
-      diagnostics,
-    };
-  }
+  const pluginRoot = source === 'plugin' ? path.dirname(sourceRoot) : undefined;
 
   // Inherited user vars pass through untouched here. Context OUTPUTS are
   // inherited after variable resolution (stage 3.5 below), once the child's
@@ -818,6 +776,8 @@ export async function prepareRunbook(
     ok: true,
     prepared: {
       filePath,
+      source,
+      sourceRoot,
       runbookRef,
       rawContent,
       runbook,
@@ -859,9 +819,7 @@ async function launchRunbook(
   },
 ): Promise<RunbookStartResult> {
   const { output, manager, actorService, sessionService, lifecycleService, cwd } = ctx;
-  const { filePath, rawContent, runbook, mergedVariables } = prepared;
-
-  const runbookPath = path.relative(cwd, filePath);
+  const { rawContent, runbook, mergedVariables, runbookRef } = prepared;
 
   // Init phase: state creation through start-event emission. Failures here
   // produce a structured launch failure so callers (notably claimAndLaunch)
@@ -871,9 +829,7 @@ async function launchRunbook(
   let runbookSteps: ResolvedStep[];
   let emitter: ExecutionEventEmitter;
   try {
-    const state = await manager.create(options.runbookName, runbook, {
-      runbookPath,
-      runbookRef: prepared.runbookRef,
+    const state = await manager.create(runbookRef, runbook, {
       prompted: options.prompted,
       parentLinkage: options.parentLinkage,
       runbookSrc: rawContent,
@@ -919,7 +875,7 @@ async function launchRunbook(
     await manager.update(state.id, { lastAction: { type: 'START' } });
 
     // Create emitter bridged to unified output
-    emitter = createBridgedEmitter(state, output, prepared.runbookRef);
+    emitter = createBridgedEmitter(state, output);
 
     // Emit RUNBOOK_STARTED
     emitRunbookStarted(emitter, state, options.prompted);

--- a/packages/cli/src/schemas/output-schemas.ts
+++ b/packages/cli/src/schemas/output-schemas.ts
@@ -8,6 +8,7 @@
  */
 
 import { z } from 'zod';
+import { RunbookRefSchema } from '@rundown-org/core';
 
 // ============================================================================
 // Re-export from Core (Single Source of Truth)
@@ -92,7 +93,7 @@ export const PromptResponseSchema = z
 export const RunbookSchema = z
   .object({
     id: z.string().describe('Unique state file identifier'),
-    runbook: z.string().describe('Runbook filename'),
+    runbook: RunbookRefSchema.describe('Canonical runbook reference'),
     status: z.string().describe('Runbook status (active, stashed, completed, stale, or orphaned)'),
     step: z.string().optional().describe('Current step number'),
     total: z.number().optional().describe('Total number of steps'),

--- a/packages/cli/src/schemas/output-schemas.ts
+++ b/packages/cli/src/schemas/output-schemas.ts
@@ -94,7 +94,7 @@ export const RunbookSchema = z
   .object({
     id: z.string().describe('Unique state file identifier'),
     runbook: RunbookRefSchema.describe('Canonical runbook reference'),
-    status: z.string().describe('Runbook status (active, stashed, completed, stale, or orphaned)'),
+    status: z.string().describe('Runbook status (active, stashed, complete, stopped, inactive)'),
     step: z.string().optional().describe('Current step number'),
     total: z.number().optional().describe('Total number of steps'),
     title: z.string().optional().describe('Runbook title from metadata'),

--- a/packages/cli/src/services/discovery.ts
+++ b/packages/cli/src/services/discovery.ts
@@ -3,7 +3,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { extractFrontmatter, nameFromFilename } from '@rundown-org/parser';
-import { runbooksDir } from '@rundown-org/core';
+import { runbooksDir, type RunbookSource } from '@rundown-org/core';
 import { getBundledRunbooksPath } from '../helpers/bundled-runbooks.js';
 import { getPluginRoot } from '../helpers/plugin-root.js';
 
@@ -30,7 +30,9 @@ export interface DiscoveredRunbook {
   /** Absolute path to the runbook file */
   path: string;
   /** Source directory where the runbook was found */
-  source: 'project' | 'plugin' | 'bundled';
+  source: RunbookSource;
+  /** Source root used to derive persisted runbook identity */
+  sourceRoot: string;
   /** Optional description from frontmatter */
   description?: string;
   /** Optional tags from frontmatter for filtering */
@@ -42,7 +44,8 @@ export interface DiscoveredRunbook {
  */
 interface SearchPath {
   path: string;
-  source: 'project' | 'plugin' | 'bundled';
+  source: RunbookSource;
+  sourceRoot: string;
 }
 
 /**
@@ -59,6 +62,7 @@ export function getSearchPaths(cwd: string): SearchPath[] {
   paths.push({
     path: projectRunbooksDir,
     source: 'project',
+    sourceRoot: cwd,
   });
 
   // Plugin runbooks directory (env var or sibling package discovery)
@@ -68,6 +72,7 @@ export function getSearchPaths(cwd: string): SearchPath[] {
     paths.push({
       path: pluginRunbooksDir,
       source: 'plugin',
+      sourceRoot: pluginRunbooksDir,
     });
   }
 
@@ -76,6 +81,7 @@ export function getSearchPaths(cwd: string): SearchPath[] {
   paths.push({
     path: bundledRunbooksDir,
     source: 'bundled',
+    sourceRoot: bundledRunbooksDir,
   });
 
   return paths;
@@ -91,7 +97,8 @@ export function getSearchPaths(cwd: string): SearchPath[] {
  */
 export async function scanDirectory(
   dirPath: string,
-  source: 'project' | 'plugin' | 'bundled',
+  source: RunbookSource,
+  sourceRoot: string,
 ): Promise<DiscoveredRunbook[]> {
   const runbooks: DiscoveredRunbook[] = [];
 
@@ -118,6 +125,7 @@ export async function scanDirectory(
               filenameStem,
               path: fullPath,
               source,
+              sourceRoot,
               description: frontmatter?.description,
               tags: frontmatter?.tags,
             });
@@ -144,8 +152,8 @@ export async function discoverRunbooks(cwd: string): Promise<DiscoveredRunbook[]
   const allRunbooks: DiscoveredRunbook[] = [];
   const seen = new Set<string>();
 
-  for (const { path: dirPath, source } of searchPaths) {
-    const runbooks = await scanDirectory(dirPath, source);
+  for (const { path: dirPath, source, sourceRoot } of searchPaths) {
+    const runbooks = await scanDirectory(dirPath, source, sourceRoot);
 
     for (const runbook of runbooks) {
       // Skip if already seen (project takes precedence over plugin)
@@ -173,8 +181,8 @@ export async function findRunbookByName(
 ): Promise<DiscoveredRunbook | null> {
   const searchPaths = getSearchPaths(cwd);
 
-  for (const { path: dirPath, source } of searchPaths) {
-    const runbooks = await scanDirectory(dirPath, source);
+  for (const { path: dirPath, source, sourceRoot } of searchPaths) {
+    const runbooks = await scanDirectory(dirPath, source, sourceRoot);
 
     const lookupSlug = toSlug(name);
     for (const runbook of runbooks) {
@@ -198,15 +206,15 @@ export async function findRunbookByName(
 export async function findRunbookByNameInSource(
   cwd: string,
   name: string,
-  targetSource: 'project' | 'plugin' | 'bundled',
+  targetSource: RunbookSource,
 ): Promise<DiscoveredRunbook | null> {
   const searchPaths = getSearchPaths(cwd);
 
-  for (const { path: dirPath, source } of searchPaths) {
+  for (const { path: dirPath, source, sourceRoot } of searchPaths) {
     // Only search in the specified source
     if (source !== targetSource) continue;
 
-    const runbooks = await scanDirectory(dirPath, source);
+    const runbooks = await scanDirectory(dirPath, source, sourceRoot);
 
     const lookupSlug = toSlug(name);
     for (const runbook of runbooks) {

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -1024,7 +1024,7 @@ export async function runExecutionLoop(
         execResult = await executeCommandWithPolicyCheck(
           expandedCommandCode,
           cwd,
-          currentState.runbookPath,
+          currentState.runbook.path,
           rdInjected,
         );
       }
@@ -1032,7 +1032,7 @@ export async function runExecutionLoop(
       execResult = await executeCommandWithPolicyCheck(
         expandedCommandCode,
         cwd,
-        currentState.runbookPath,
+        currentState.runbook.path,
         rdInjected,
       );
     }
@@ -1170,7 +1170,7 @@ export function getStepRetryMax(item: Step | ResolvedStep | Substep): number {
  */
 export function buildMetadata(state: RunbookState): RunbookMetadata {
   return {
-    file: state.runbook,
+    file: state.runbook.path,
     state: `${RUNS_DIR}/${state.id}.json`,
     prompted: state.prompted ?? undefined,
   };

--- a/packages/core/__tests__/runbook/abort-delegation.test.ts
+++ b/packages/core/__tests__/runbook/abort-delegation.test.ts
@@ -21,9 +21,8 @@ function makeDelegation(overrides: Partial<StepDelegation> = {}): StepDelegation
 /** Helper: create minimal RunbookState for testing. */
 function makeState(substepStates: SubstepState[]): RunbookState {
   return {
-    id: 'run-1',
-    runbook: 'parent.md',
-    runbookPath: 'parent.md',
+    id: 'wf_0123456789abcdef0123456789abcdef',
+    runbook: { source: 'project', path: 'parent.runbook.md' },
     step: '1',
     stepName: 'Main step',
     retryCount: 0,
@@ -78,7 +77,7 @@ describe('abortDelegation', () => {
   });
 
   it('returns needs_force when delegation is claimed without force', () => {
-    const delegation = makeDelegation({ childRunId: 'child-run-1' });
+    const delegation = makeDelegation({ childRunId: 'wf_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' });
     const state = makeState([
       { id: '1', frameKey: buildFrameKey('1'), status: 'pending', delegation },
     ]);
@@ -91,12 +90,12 @@ describe('abortDelegation', () => {
 
     expect(result.status).toBe('needs_force');
     if (result.status === 'needs_force') {
-      expect(result.childRunId).toBe('child-run-1');
+      expect(result.childRunId).toBe('wf_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
     }
   });
 
   it('cancels a claimed delegation when force=true', () => {
-    const delegation = makeDelegation({ childRunId: 'child-run-1' });
+    const delegation = makeDelegation({ childRunId: 'wf_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' });
     const state = makeState([
       { id: '1', frameKey: buildFrameKey('1'), status: 'pending', delegation },
     ]);

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -35,10 +35,13 @@ async function createLifecycleHarness(markdown: string): Promise<LifecycleHarnes
     description: 'Lifecycle test runbook',
     steps,
   };
-  const state = await manager.create('lifecycle-test.md', mockRunbookDef, {
-    runbookPath: 'lifecycle-test.md',
-    frontmatterOutputs: [],
-  });
+  const state = await manager.create(
+    { source: 'project' as const, path: 'lifecycle-test.runbook.md' },
+    mockRunbookDef,
+    {
+      frontmatterOutputs: [],
+    },
+  );
 
   const actor = await service.createActor(state.id, steps);
   if (!actor) throw new Error('createLifecycleHarness: actor creation failed');
@@ -78,12 +81,19 @@ describe('RunbookActorService', () => {
 
   describe('createActor', () => {
     it('returns null for nonexistent runbook', async () => {
-      const actor = await actorService.createActor('nonexistent', mockSteps);
+      const actor = await actorService.createActor(
+        'wf_ffffffffffffffffffffffffffffffff',
+        mockSteps,
+      );
       expect(actor).toBeNull();
     });
 
     it('creates and starts actor from persisted state', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const actor = await actorService.createActor(state.id, mockSteps);
       expect(actor).not.toBeNull();
     });
@@ -91,7 +101,11 @@ describe('RunbookActorService', () => {
 
   describe('updateFromActor', () => {
     it('extracts substep ID from flattened machine state (step::N::M)', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const actor = mockActor({
         value: 'step::1::2',
         context: { variables: {}, retryCount: 0, substep: '2' },
@@ -103,7 +117,11 @@ describe('RunbookActorService', () => {
     });
 
     it('extracts step number from simple machine state (step::N)', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const actor = mockActor({
         value: 'step::3',
         context: { variables: {}, retryCount: 0 },
@@ -123,12 +141,19 @@ describe('RunbookActorService', () => {
 
   describe('initializeState', () => {
     it('returns null for nonexistent runbook', async () => {
-      const result = await actorService.initializeState('nonexistent', mockSteps);
+      const result = await actorService.initializeState(
+        'wf_ffffffffffffffffffffffffffffffff',
+        mockSteps,
+      );
       expect(result).toBeNull();
     });
 
     it('creates actor and syncs state without sending event', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const result = await actorService.initializeState(state.id, mockSteps);
       expect(result).not.toBeNull();
       expect(result?.step).toBe('1');
@@ -137,12 +162,20 @@ describe('RunbookActorService', () => {
 
   describe('sendAndSync', () => {
     it('returns null for nonexistent runbook', async () => {
-      const result = await actorService.sendAndSync('nonexistent', mockSteps, { type: 'PASS' });
+      const result = await actorService.sendAndSync(
+        'wf_ffffffffffffffffffffffffffffffff',
+        mockSteps,
+        { type: 'PASS' },
+      );
       expect(result).toBeNull();
     });
 
     it('sends event, syncs state, and returns state + snapshot', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const result = await actorService.sendAndSync(state.id, mockSteps, { type: 'PASS' });
 
       expect(result).not.toBeNull();
@@ -159,7 +192,11 @@ describe('RunbookActorService', () => {
 
   describe('FOR loop context via actor', () => {
     it('syncs FOR context fields from actor snapshot', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const actor = mockActor({
         value: 'step::1',
@@ -198,7 +235,11 @@ describe('RunbookActorService', () => {
     });
 
     it('clears FOR fields when runbook completes', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       // First, set forStack
       await manager.update(state.id, {
@@ -240,7 +281,11 @@ describe('RunbookActorService', () => {
 
   describe('implicit ForContext filtering', () => {
     it('implicit ForContext entries are not persisted', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const actor = mockActor({
         value: 'step::1::1',
         context: {
@@ -266,7 +311,11 @@ describe('RunbookActorService', () => {
     });
 
     it('iterationResults not persisted for implicit loops', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const actor = mockActor({
         value: 'step::1::1',
         context: {
@@ -292,7 +341,11 @@ describe('RunbookActorService', () => {
     });
 
     it('explicit ForContext entries are persisted normally', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const actor = mockActor({
         value: 'step::1::1',
         context: {
@@ -319,7 +372,11 @@ describe('RunbookActorService', () => {
     });
 
     it('iterationResults preserved after explicit FOR loop exits (empty forStack)', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const actor = mockActor({
         value: 'step::2',
         context: {
@@ -348,7 +405,11 @@ describe('RunbookActorService', () => {
 
   describe('forStack persistence via actor', () => {
     it('persists forStack with variable source through actor update and reload', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const actor = mockActor({
         value: 'step::1',
@@ -392,7 +453,11 @@ describe('RunbookActorService', () => {
     });
 
     it('persists forStack with variable source and snapshot through actor update and reload', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const actor = mockActor({
         value: 'step::1',
@@ -457,10 +522,13 @@ describe('RunbookActorService', () => {
       };
 
       // Create with templateVars containing arrays
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        templateVars: templateVars,
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          templateVars: templateVars,
+        },
+      );
 
       expect(state.templateVars?.items).toEqual(['a', 'b', 'c']);
 
@@ -493,10 +561,13 @@ describe('RunbookActorService', () => {
     // compileRunbookToMachine(steps) without options — Cause #1 in the handoff.
 
     it('seeds compiler context.frontmatterOutputs from RunbookState.frontmatterOutputs', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        frontmatterOutputs: [{ name: 'SomeVar' }],
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          frontmatterOutputs: [{ name: 'SomeVar' }],
+        },
+      );
 
       const actor = await actorService.createActor(state.id, mockSteps);
       expect(actor).not.toBeNull();
@@ -508,9 +579,11 @@ describe('RunbookActorService', () => {
     });
 
     it('defaults context.frontmatterOutputs to [] when no outputs declared at run time', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const actor = await actorService.createActor(state.id, mockSteps);
       const snapshot = actor!.getPersistedSnapshot() as unknown as {
@@ -521,10 +594,13 @@ describe('RunbookActorService', () => {
     });
 
     it('throws for stale run state missing frontmatterOutputs field', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        frontmatterOutputs: [],
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          frontmatterOutputs: [],
+        },
+      );
       // Simulate a pre-OUTPUTS-feature state file by stripping frontmatterOutputs from disk.
       const filePath = join(testDir, '.rundown', 'runs', `${state.id}.json`);
       const raw = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
@@ -537,10 +613,13 @@ describe('RunbookActorService', () => {
     });
 
     it('seeds compiler context.templateVars from RunbookState.templateVars (flattened)', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        templateVars: { SomeVar: 'hello', Items: ['a', 'b'] },
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          templateVars: { SomeVar: 'hello', Items: ['a', 'b'] },
+        },
+      );
 
       const actor = await actorService.createActor(state.id, mockSteps);
       const snapshot = actor!.getPersistedSnapshot() as unknown as {
@@ -564,13 +643,16 @@ describe('RunbookActorService', () => {
       // state load time; the stream itself is never read.
       const canonicalTestDir = await realpath(testDir);
       const stream = createJsonArrayStream(join(canonicalTestDir, 'data.jsonl'));
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        templateVars: {
-          Region: 'us-east-1',
-          Items: stream,
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          templateVars: {
+            Region: 'us-east-1',
+            Items: stream,
+          },
         },
-      });
+      );
 
       const actor = await actorService.createActor(state.id, mockSteps);
       expect(actor).not.toBeNull();
@@ -596,6 +678,7 @@ describe('RunbookActorService', () => {
           harness.steps,
         );
         expect(state.lifecycle).toBe('completed');
+        expect(state.terminalAt).toEqual(expect.any(String));
       } finally {
         harness.actor.stop();
         await rm(harness.testDir, { recursive: true, force: true });
@@ -612,6 +695,31 @@ describe('RunbookActorService', () => {
           harness.steps,
         );
         expect(state.lifecycle).toBe('stopped');
+        expect(state.terminalAt).toEqual(expect.any(String));
+      } finally {
+        harness.actor.stop();
+        await rm(harness.testDir, { recursive: true, force: true });
+      }
+    });
+
+    it('preserves terminalAt across repeated actor-service terminal syncs', async () => {
+      const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n');
+      try {
+        harness.actor.send({ type: 'PASS' });
+        const first = await harness.service.updateFromActor(
+          harness.runbookId,
+          harness.actor,
+          harness.steps,
+        );
+        const second = await harness.service.updateFromActor(
+          harness.runbookId,
+          harness.actor,
+          harness.steps,
+        );
+
+        expect(first.state.lifecycle).toBe('completed');
+        expect(second.state.lifecycle).toBe('completed');
+        expect(second.state.terminalAt).toBe(first.state.terminalAt);
       } finally {
         harness.actor.stop();
         await rm(harness.testDir, { recursive: true, force: true });
@@ -643,11 +751,14 @@ describe('RunbookActorService', () => {
     // wrote `variables` but never propagated `finalVars` out of the machine.
 
     it('persists context.finalVars to RunbookState.finalVars on STOPPED snapshot', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        frontmatterOutputs: [{ name: 'Result' }],
-        templateVars: { Result: 'failed-value' },
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          frontmatterOutputs: [{ name: 'Result' }],
+          templateVars: { Result: 'failed-value' },
+        },
+      );
 
       // Drive the actor to STOPPED via FAIL on the first step (mockSteps' default
       // transitions are PASS COMPLETE / FAIL STOP — confirm in test setup).
@@ -658,11 +769,14 @@ describe('RunbookActorService', () => {
     });
 
     it('persists context.finalVars to RunbookState.finalVars on COMPLETE snapshot', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        frontmatterOutputs: [{ name: 'Result' }],
-        templateVars: { Result: 'passed-value' },
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          frontmatterOutputs: [{ name: 'Result' }],
+          templateVars: { Result: 'passed-value' },
+        },
+      );
 
       const result = await actorService.sendAndSync(state.id, mockSteps, { type: 'PASS' });
       expect((result!.snapshot as { value: string }).value).toBe('COMPLETE');
@@ -670,21 +784,27 @@ describe('RunbookActorService', () => {
     });
 
     it('leaves RunbookState.finalVars undefined when no frontmatter outputs are declared', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        frontmatterOutputs: [],
-        // No frontmatterOutputs declared → context.finalVars stays {}
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          frontmatterOutputs: [],
+          // No frontmatterOutputs declared → context.finalVars stays {}
+        },
+      );
 
       const result = await actorService.sendAndSync(state.id, mockSteps, { type: 'FAIL' });
       expect(result!.state.finalVars).toBeUndefined();
     });
 
     it('leaves RunbookState.finalVars undefined when context.finalVars is empty on COMPLETE', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        frontmatterOutputs: [], // No frontmatterOutputs declared → context.finalVars stays {}
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          frontmatterOutputs: [], // No frontmatterOutputs declared → context.finalVars stays {}
+        },
+      );
 
       const result = await actorService.sendAndSync(state.id, mockSteps, { type: 'PASS' });
       expect(result!.state.finalVars).toBeUndefined();
@@ -693,7 +813,10 @@ describe('RunbookActorService', () => {
 
   describe('getContextSnapshot', () => {
     it('returns null for nonexistent runbook', async () => {
-      const result = await actorService.getContextSnapshot('nonexistent', mockSteps);
+      const result = await actorService.getContextSnapshot(
+        'wf_ffffffffffffffffffffffffffffffff',
+        mockSteps,
+      );
       expect(result).toBeNull();
     });
 
@@ -702,7 +825,11 @@ describe('RunbookActorService', () => {
       // the initial state's entry actions on every call — an observable side
       // effect callers of this method are not signing up for. We assert the
       // invariant directly by spying on XState's Actor.prototype.start.
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const xstate = await import('xstate');
       const startSpy = jest.spyOn(
         xstate.Actor.prototype as unknown as { start: () => void },
@@ -725,7 +852,11 @@ describe('RunbookActorService', () => {
       const frameKey = buildFrameKey('1');
       const substepStates: SubstepState[] = [{ id: '1', frameKey, status: 'done', result: 'pass' }];
 
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.update(state.id, {
         substepStates,
         activeFrameKey: frameKey,
@@ -751,7 +882,11 @@ describe('RunbookActorService', () => {
         { id: '2', frameKey, status: 'pending' },
       ];
 
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.update(state.id, {
         substepStates,
         activeFrameKey: frameKey,
@@ -782,7 +917,11 @@ describe('RunbookActorService', () => {
       const frameKey = buildFrameKey('1');
       const substepStates: SubstepState[] = [{ id: '1', frameKey, status: 'pending' }];
 
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.update(state.id, { substepStates });
 
       // Snapshot without substepStates in context (e.g. a legacy snapshot path
@@ -809,7 +948,11 @@ describe('RunbookActorService', () => {
       const staleFrameKey = buildFrameKey('1', 1);
       const newFrameKey = buildFrameKey('1', 2);
 
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.update(state.id, { activeFrameKey: staleFrameKey });
 
       const actor = mockActor({
@@ -836,7 +979,11 @@ describe('RunbookActorService', () => {
       // still mirrored — that signals the machine has left an active frame.)
       const frameKey = buildFrameKey('1');
 
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.update(state.id, { activeFrameKey: frameKey });
 
       const actor = mockActor({

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -9891,7 +9891,6 @@ echo "processing"
       let state: RunbookState = {
         id: 'test-run',
         runbook: 'parent.md',
-        runbookPath: 'parent.md',
         step: '1',
         stepName: 'Parent',
         retryCount: 0,
@@ -10502,7 +10501,6 @@ echo "processing"
       const baseState: RunbookState = {
         id: 'test-run',
         runbook: 'parent.md',
-        runbookPath: 'parent.md',
         step: '1',
         stepName: 'Parent',
         retryCount: 0,

--- a/packages/core/__tests__/runbook/delegation-context.test.ts
+++ b/packages/core/__tests__/runbook/delegation-context.test.ts
@@ -16,7 +16,6 @@ function makeMinimalState(overrides: Partial<RunbookState> = {}): RunbookState {
   return {
     id: 'run-1',
     runbook: 'parent.md',
-    runbookPath: 'parent.md',
     step: '1',
     stepName: 'Main step',
     retryCount: 0,

--- a/packages/core/__tests__/runbook/delegation-lock.test.ts
+++ b/packages/core/__tests__/runbook/delegation-lock.test.ts
@@ -32,60 +32,60 @@ describe('DelegationLock', () => {
   });
 
   it('acquires and releases a lock', async () => {
-    await lock.acquire('run-1');
+    await lock.acquire('wf_00000000000000000000000000000001');
 
     // Lock file should exist with pid and timestamp
-    const lockPath = delegationLockPath(tmpDir, 'run-1');
+    const lockPath = delegationLockPath(tmpDir, 'wf_00000000000000000000000000000001');
     const content = JSON.parse(await fs.readFile(lockPath, 'utf8'));
     expect(content.pid).toBe(process.pid);
     expect(content.created_at).toBeDefined();
 
-    await lock.release('run-1');
+    await lock.release('wf_00000000000000000000000000000001');
 
     // Lock file should be gone
     await expect(fs.access(lockPath)).rejects.toThrow();
   });
 
   it('creates lock file with owner-only permissions (0o600)', async () => {
-    await lock.acquire('run-perms');
+    await lock.acquire('wf_00000000000000000000000000000002');
 
-    const lockPath = delegationLockPath(tmpDir, 'run-perms');
+    const lockPath = delegationLockPath(tmpDir, 'wf_00000000000000000000000000000002');
     const stat = await fs.stat(lockPath);
     const fileMode = stat.mode & 0o777;
     expect(fileMode).toBe(0o600);
 
-    await lock.release('run-perms');
+    await lock.release('wf_00000000000000000000000000000002');
   });
 
   it('creates lock directory with owner-only permissions (0o700)', async () => {
-    await lock.acquire('run-dir-perms');
+    await lock.acquire('wf_00000000000000000000000000000003');
 
     const lockDir = locksDir(tmpDir);
     const stat = await fs.stat(lockDir);
     const dirMode = stat.mode & 0o777;
     expect(dirMode).toBe(0o700);
 
-    await lock.release('run-dir-perms');
+    await lock.release('wf_00000000000000000000000000000003');
   });
 
   it('second acquire blocks then succeeds after release', async () => {
-    await lock.acquire('run-2');
+    await lock.acquire('wf_00000000000000000000000000000004');
 
     // Schedule release after 100ms
     setTimeout(() => {
-      void lock.release('run-2');
+      void lock.release('wf_00000000000000000000000000000004');
     }, 100);
 
     // Second acquire should wait and then succeed
-    await lock.acquire('run-2');
+    await lock.acquire('wf_00000000000000000000000000000004');
 
     // Clean up
-    await lock.release('run-2');
+    await lock.release('wf_00000000000000000000000000000004');
   });
 
   it('release is idempotent', async () => {
     // Releasing a non-existent lock should not throw
-    await expect(lock.release('nonexistent-run')).resolves.toBeUndefined();
+    await expect(lock.release('wf_00000000000000000000000000000005')).resolves.toBeUndefined();
   });
 
   it('reclaims stale lock from dead PID', async () => {
@@ -93,7 +93,7 @@ describe('DelegationLock', () => {
     const lockDir = locksDir(tmpDir);
     await fs.mkdir(lockDir, { recursive: true });
 
-    const lockPath = delegationLockPath(tmpDir, 'run-stale');
+    const lockPath = delegationLockPath(tmpDir, 'wf_00000000000000000000000000000006');
     const staleLock = {
       pid: findDeadPid(),
       created_at: new Date(Date.now() - 120_000).toISOString(), // 2 minutes ago
@@ -101,42 +101,42 @@ describe('DelegationLock', () => {
     await fs.writeFile(lockPath, JSON.stringify(staleLock));
 
     // Should reclaim the stale lock and acquire
-    await lock.acquire('run-stale');
+    await lock.acquire('wf_00000000000000000000000000000006');
 
     // Verify our process now owns the lock
     const content = JSON.parse(await fs.readFile(lockPath, 'utf8'));
     expect(content.pid).toBe(process.pid);
 
-    await lock.release('run-stale');
+    await lock.release('wf_00000000000000000000000000000006');
   });
 
   it('reclaims corrupted lock file (non-JSON content)', async () => {
     const lockDir = locksDir(tmpDir);
     await fs.mkdir(lockDir, { recursive: true });
 
-    const lockPath = delegationLockPath(tmpDir, 'run-corrupt');
+    const lockPath = delegationLockPath(tmpDir, 'wf_00000000000000000000000000000007');
     await fs.writeFile(lockPath, 'NOT VALID JSON {{{');
 
     // Should reclaim the corrupted lock and acquire
-    await lock.acquire('run-corrupt');
+    await lock.acquire('wf_00000000000000000000000000000007');
 
     // Verify our process now owns the lock
     const content = JSON.parse(await fs.readFile(lockPath, 'utf8'));
     expect(content.pid).toBe(process.pid);
 
-    await lock.release('run-corrupt');
+    await lock.release('wf_00000000000000000000000000000007');
   });
 
   it('times out with typed DelegationLockTimeoutError when held by alive process', async () => {
     // Acquire the lock with current process
-    await lock.acquire('run-timeout');
+    await lock.acquire('wf_00000000000000000000000000000008');
 
     // Create a second lock instance — should time out because current process is alive
     const lock2 = new DelegationLock(tmpDir);
 
     let captured: unknown;
     try {
-      await lock2.acquire('run-timeout');
+      await lock2.acquire('wf_00000000000000000000000000000008');
     } catch (err) {
       captured = err;
     }
@@ -144,39 +144,43 @@ describe('DelegationLock', () => {
     expect(captured).toBeInstanceOf(DelegationLockTimeoutError);
     expect(captured).toBeInstanceOf(FileLockTimeoutError); // hierarchy preserved
     if (captured instanceof DelegationLockTimeoutError) {
-      expect(captured.parentRunId).toBe('run-timeout');
-      expect(captured.lockFile).toBe(delegationLockPath(tmpDir, 'run-timeout'));
-      expect(captured.message).toMatch(/Delegation lock timeout for run run-timeout/);
+      expect(captured.parentRunId).toBe('wf_00000000000000000000000000000008');
+      expect(captured.lockFile).toBe(
+        delegationLockPath(tmpDir, 'wf_00000000000000000000000000000008'),
+      );
+      expect(captured.message).toMatch(
+        /Delegation lock timeout for run wf_00000000000000000000000000000008/,
+      );
     }
 
-    await lock.release('run-timeout');
+    await lock.release('wf_00000000000000000000000000000008');
   }, 10_000);
 
   it('handles concurrent acquire attempts with retries', async () => {
-    await lock.acquire('run-concurrent');
+    await lock.acquire('wf_00000000000000000000000000000009');
 
     // Schedule release after a short delay
     setTimeout(() => {
-      void lock.release('run-concurrent');
+      void lock.release('wf_00000000000000000000000000000009');
     }, 200);
 
     // Second lock should retry and eventually acquire
     const lock2 = new DelegationLock(tmpDir);
-    await lock2.acquire('run-concurrent');
+    await lock2.acquire('wf_00000000000000000000000000000009');
 
     // Verify lock2 now owns the lock
-    const lockPath = delegationLockPath(tmpDir, 'run-concurrent');
+    const lockPath = delegationLockPath(tmpDir, 'wf_00000000000000000000000000000009');
     const content = JSON.parse(await fs.readFile(lockPath, 'utf8'));
     expect(content.pid).toBe(process.pid);
 
-    await lock2.release('run-concurrent');
+    await lock2.release('wf_00000000000000000000000000000009');
   });
 
   it('reclaims lock held by a dead process regardless of age', async () => {
     const lockDir = locksDir(tmpDir);
     await fs.mkdir(lockDir, { recursive: true });
 
-    const lockPath = delegationLockPath(tmpDir, 'run-dead-owner');
+    const lockPath = delegationLockPath(tmpDir, 'wf_0000000000000000000000000000000a');
     // PID 999999999 is beyond any valid PID on macOS/Linux so kill(pid,0) → ESRCH.
     const deadPid = 999999999;
     const staleLock = {
@@ -185,14 +189,14 @@ describe('DelegationLock', () => {
     };
     await fs.writeFile(lockPath, JSON.stringify(staleLock));
 
-    await lock.acquire('run-dead-owner');
+    await lock.acquire('wf_0000000000000000000000000000000a');
 
     const content = JSON.parse(await fs.readFile(lockPath, 'utf8'));
     expect(content.pid).toBe(process.pid);
     const age = Date.now() - new Date(content.created_at).getTime();
     expect(age).toBeLessThan(1000);
 
-    await lock.release('run-dead-owner');
+    await lock.release('wf_0000000000000000000000000000000a');
   });
 
   it('handles lock file disappearing between check and read (race condition)', async () => {
@@ -201,14 +205,14 @@ describe('DelegationLock', () => {
     const lockDir = locksDir(tmpDir);
     await fs.mkdir(lockDir, { recursive: true });
 
-    const lockPath = delegationLockPath(tmpDir, 'run-vanish');
+    const lockPath = delegationLockPath(tmpDir, 'wf_0000000000000000000000000000000b');
     await fs.writeFile(
       lockPath,
       JSON.stringify({ pid: findDeadPid(), created_at: new Date().toISOString() }),
     );
 
     // Start acquire, then delete the lock file to simulate race
-    const acquirePromise = lock.acquire('run-vanish');
+    const acquirePromise = lock.acquire('wf_0000000000000000000000000000000b');
 
     // Wait briefly for the first retry to hit
     await new Promise((resolve) => setTimeout(resolve, 80));
@@ -221,59 +225,59 @@ describe('DelegationLock', () => {
     // Should eventually succeed (acquire handles vanishing lock gracefully)
     await acquirePromise;
 
-    await lock.release('run-vanish');
+    await lock.release('wf_0000000000000000000000000000000b');
   });
 
   it('handles empty lock file (0 bytes)', async () => {
     const lockDir = locksDir(tmpDir);
     await fs.mkdir(lockDir, { recursive: true });
 
-    const lockPath = delegationLockPath(tmpDir, 'run-empty');
+    const lockPath = delegationLockPath(tmpDir, 'wf_0000000000000000000000000000000c');
     await fs.writeFile(lockPath, '');
 
     // Should reclaim the empty (corrupted) lock
-    await lock.acquire('run-empty');
+    await lock.acquire('wf_0000000000000000000000000000000c');
 
     const content = JSON.parse(await fs.readFile(lockPath, 'utf8'));
     expect(content.pid).toBe(process.pid);
 
-    await lock.release('run-empty');
+    await lock.release('wf_0000000000000000000000000000000c');
   });
 
   it('multiple sequential acquire-release cycles work correctly', async () => {
     // Test that lock state is properly reset between cycles
     for (let i = 0; i < 5; i++) {
-      await lock.acquire('run-cycle');
-      await lock.release('run-cycle');
+      await lock.acquire('wf_0000000000000000000000000000000d');
+      await lock.release('wf_0000000000000000000000000000000d');
     }
 
     // Final acquire should succeed
-    await lock.acquire('run-cycle');
-    await lock.release('run-cycle');
+    await lock.acquire('wf_0000000000000000000000000000000d');
+    await lock.release('wf_0000000000000000000000000000000d');
 
     // Verify lock file is gone
-    const lockPath = delegationLockPath(tmpDir, 'run-cycle');
+    const lockPath = delegationLockPath(tmpDir, 'wf_0000000000000000000000000000000d');
     await expect(fs.access(lockPath)).rejects.toThrow();
   });
 
   it('different run IDs have independent locks', async () => {
     // Acquire locks for multiple different runs
-    await lock.acquire('run-a');
-    await lock.acquire('run-b');
-    await lock.acquire('run-c');
+    await lock.acquire('wf_0000000000000000000000000000000e');
+    await lock.acquire('wf_0000000000000000000000000000000f');
+    await lock.acquire('wf_00000000000000000000000000000010');
 
     // All should coexist
-    const lockA = delegationLockPath(tmpDir, 'run-a');
-    const lockB = delegationLockPath(tmpDir, 'run-b');
-    const lockC = delegationLockPath(tmpDir, 'run-c');
+    const lockA = delegationLockPath(tmpDir, 'wf_0000000000000000000000000000000e');
+    const lockB = delegationLockPath(tmpDir, 'wf_0000000000000000000000000000000f');
+    const lockC = delegationLockPath(tmpDir, 'wf_00000000000000000000000000000010');
 
     await expect(fs.access(lockA)).resolves.toBeUndefined();
     await expect(fs.access(lockB)).resolves.toBeUndefined();
     await expect(fs.access(lockC)).resolves.toBeUndefined();
 
     // Release all
-    await lock.release('run-a');
-    await lock.release('run-b');
-    await lock.release('run-c');
+    await lock.release('wf_0000000000000000000000000000000e');
+    await lock.release('wf_0000000000000000000000000000000f');
+    await lock.release('wf_00000000000000000000000000000010');
   });
 });

--- a/packages/core/__tests__/runbook/delegation-propagation.test.ts
+++ b/packages/core/__tests__/runbook/delegation-propagation.test.ts
@@ -9,12 +9,14 @@ import { assertDelegationTokenHash } from '../../src/runbook/delegation-token.js
 import type { DelegationLinkage, RunbookState } from '../../src/runbook/types.js';
 import { brandStoredOutputsForTest } from '../helpers/effective-vars.js';
 
+const CHILD_RUN_ID = 'wf_00000000000000000000000000000021';
+const PARENT_RUN_ID = 'wf_00000000000000000000000000000022';
+
 describe('DelegationLinkage extended fields', () => {
   function makeSchemaState(parentLinkage: Record<string, unknown>): Record<string, unknown> {
     return {
-      id: 'run-child',
-      runbook: 'child.md',
-      runbookPath: '/tmp/child.md',
+      id: CHILD_RUN_ID,
+      runbook: { source: 'project', path: 'child.runbook.md' },
       runbookSrc: '## 1. Do\n- PASS COMPLETE\n\nDo it.',
       step: '1',
       stepName: 'Do',
@@ -30,7 +32,7 @@ describe('DelegationLinkage extended fields', () => {
   it('schema accepts delegation linkage with extended fields', () => {
     const state = makeSchemaState({
       kind: 'delegation',
-      parentRunId: 'run-parent',
+      parentRunId: PARENT_RUN_ID,
       parentStepId: '1',
       tokenHash: `sha256:${'a'.repeat(64)}`,
       parentStep: '1',
@@ -45,7 +47,7 @@ describe('DelegationLinkage extended fields', () => {
   it('schema accepts delegation linkage without extended fields', () => {
     const state = makeSchemaState({
       kind: 'delegation',
-      parentRunId: 'run-parent',
+      parentRunId: PARENT_RUN_ID,
       parentStepId: '1',
       tokenHash: `sha256:${'b'.repeat(64)}`,
     });
@@ -57,7 +59,7 @@ describe('DelegationLinkage extended fields', () => {
   it('schema rejects non-positive parentEntry', () => {
     const state = makeSchemaState({
       kind: 'delegation',
-      parentRunId: 'run-parent',
+      parentRunId: PARENT_RUN_ID,
       parentStepId: '1',
       tokenHash: `sha256:${'c'.repeat(64)}`,
       parentEntry: 0,
@@ -72,12 +74,12 @@ describe('DelegationLinkage type shape', () => {
   it('returns true when parentLinkage field is present', () => {
     const linkage: DelegationLinkage = {
       kind: 'delegation',
-      parentRunId: 'run-parent',
+      parentRunId: PARENT_RUN_ID,
       parentStepId: '1',
       tokenHash: assertDelegationTokenHash(`sha256:${'a'.repeat(64)}`),
     };
     expect(linkage).toBeDefined();
-    expect(linkage.parentRunId).toBe('run-parent');
+    expect(linkage.parentRunId).toBe(PARENT_RUN_ID);
     expect(linkage.kind).toBe('delegation');
   });
 
@@ -90,9 +92,8 @@ describe('DelegationLinkage type shape', () => {
 describe('parentLinkage discriminated union schema', () => {
   function makeBaseState(overrides: Record<string, unknown> = {}): Record<string, unknown> {
     return {
-      id: 'run-child',
-      runbook: 'child.md',
-      runbookPath: '/tmp/child.md',
+      id: CHILD_RUN_ID,
+      runbook: { source: 'project', path: 'child.runbook.md' },
       runbookSrc: '## 1. Do\n- PASS COMPLETE\n\nDo it.',
       step: '1',
       stepName: 'Do',
@@ -109,7 +110,7 @@ describe('parentLinkage discriminated union schema', () => {
     const state = makeBaseState({
       parentLinkage: {
         kind: 'delegation',
-        parentRunId: 'run-parent',
+        parentRunId: PARENT_RUN_ID,
         parentStepId: '1',
         tokenHash: `sha256:${'a'.repeat(64)}`,
         parentStep: '1',
@@ -131,7 +132,7 @@ describe('parentLinkage discriminated union schema', () => {
     const state = makeBaseState({
       parentLinkage: {
         kind: 'inline',
-        parentRunId: 'run-parent',
+        parentRunId: PARENT_RUN_ID,
         parentStepId: '2',
         parentStep: '1',
         parentFrameKey: '1|',
@@ -152,7 +153,7 @@ describe('parentLinkage discriminated union schema', () => {
     const state = makeBaseState({
       parentLinkage: {
         kind: 'bogus',
-        parentRunId: 'run-parent',
+        parentRunId: PARENT_RUN_ID,
         parentStepId: '1',
       },
     });
@@ -166,7 +167,7 @@ describe('parentLinkage discriminated union schema', () => {
     // State with only the old field should have no parentLinkage in the typed result.
     const state = makeBaseState({
       delegation: {
-        parentRunId: 'run-parent',
+        parentRunId: PARENT_RUN_ID,
         parentStepId: '1',
         tokenHash: `sha256:${'a'.repeat(64)}`,
       },
@@ -185,7 +186,7 @@ describe('parentLinkage discriminated union schema', () => {
     const state = makeBaseState({
       inlineLinkage: {
         kind: 'inline',
-        parentRunId: 'run-parent',
+        parentRunId: PARENT_RUN_ID,
         parentStepId: '1',
       },
     });
@@ -202,9 +203,8 @@ describe('parentLinkage discriminated union schema', () => {
 describe('frame identity derivation for propagation', () => {
   function makeState(overrides: Partial<RunbookState>): RunbookState {
     return {
-      id: 'run-1',
-      runbook: 'test.md',
-      runbookPath: '/tmp/test.md',
+      id: CHILD_RUN_ID,
+      runbook: { source: 'project', path: 'test.runbook.md' },
       runbookSrc: '## 1. Step\n- PASS COMPLETE\n\nTest.',
       step: '1',
       stepName: 'Step',

--- a/packages/core/__tests__/runbook/delegation-scan.test.ts
+++ b/packages/core/__tests__/runbook/delegation-scan.test.ts
@@ -13,6 +13,13 @@ import { buildFrameKey } from '../../src/runbook/targeting.js';
 import type { RunbookState, StepDelegation, DelegationLinkage } from '../../src/runbook/types.js';
 import { brandStoredOutputsForTest, brandEffectiveVarsForTest } from '../helpers/effective-vars.js';
 
+const PARENT_RUN_ID = 'wf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const OTHER_RUN_ID = 'wf_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const CHILD_RUN_ID = 'wf_cccccccccccccccccccccccccccccccc';
+const CHILD_RUN_ID_1 = 'wf_dddddddddddddddddddddddddddddddd';
+const CHILD_RUN_ID_2 = 'wf_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+const TARGET_RUN_ID = 'wf_ffffffffffffffffffffffffffffffff';
+
 describe('DelegationScanService', () => {
   let tmpDir: string;
   let manager: RunbookStateManager;
@@ -40,8 +47,7 @@ describe('DelegationScanService', () => {
   function makeState(id: string, overrides: Partial<RunbookState> = {}): RunbookState {
     return {
       id,
-      runbook: 'parent.md',
-      runbookPath: 'parent.md',
+      runbook: { source: 'project', path: 'parent.runbook.md' },
       step: '1',
       stepName: 'Main step',
       retryCount: 0,
@@ -71,7 +77,7 @@ describe('DelegationScanService', () => {
       const token = generateDelegationToken();
       const delegation = makeDelegation(token);
 
-      const state = makeState('run-parent', {
+      const state = makeState(PARENT_RUN_ID, {
         substepStates: [
           { id: '1', frameKey: buildFrameKey('1'), status: 'pending', delegation },
           { id: '2', frameKey: buildFrameKey('1'), status: 'pending' },
@@ -82,7 +88,7 @@ describe('DelegationScanService', () => {
       const result = await scanner.findByToken(token);
 
       expect(result).not.toBeNull();
-      expect(result!.parentState.id).toBe('run-parent');
+      expect(result!.parentState.id).toBe(PARENT_RUN_ID);
       expect(result!.substepId).toBe('1');
       expect(result!.delegation.tokenHash).toBe(delegation.tokenHash);
     });
@@ -92,7 +98,7 @@ describe('DelegationScanService', () => {
 
       // Write a state with a different token
       const otherToken = generateDelegationToken();
-      const state = makeState('run-other', {
+      const state = makeState(OTHER_RUN_ID, {
         substepStates: [
           {
             id: '1',
@@ -121,7 +127,7 @@ describe('DelegationScanService', () => {
         contextSnapshot: { vars: brandEffectiveVarsForTest({}), ancestors: [], step: '1' },
       };
 
-      const state = makeState('run-parent', {
+      const state = makeState(PARENT_RUN_ID, {
         step: '3',
         substepStates: [{ id: '1', frameKey: buildFrameKey('1'), status: 'pending', delegation }],
       });
@@ -140,7 +146,7 @@ describe('DelegationScanService', () => {
         contextSnapshot: { vars: brandEffectiveVarsForTest({}), ancestors: [] },
       };
 
-      const state = makeState('run-parent', {
+      const state = makeState(PARENT_RUN_ID, {
         step: '3',
         substepStates: [{ id: '1', frameKey: buildFrameKey('1'), status: 'pending', delegation }],
       });
@@ -160,19 +166,19 @@ describe('DelegationScanService', () => {
 
       const linkage: DelegationLinkage = {
         kind: 'delegation' as const,
-        parentRunId: 'parent-run',
+        parentRunId: PARENT_RUN_ID,
         parentStepId: '1',
         tokenHash,
       };
 
-      const childState = makeState('child-run', {
+      const childState = makeState(CHILD_RUN_ID, {
         parentLinkage: linkage,
       });
       await writeState(childState);
 
       const result = await scanner.findOrphanedChild(tokenHash);
       expect(result).not.toBeNull();
-      expect(result!.id).toBe('child-run');
+      expect(result!.id).toBe(CHILD_RUN_ID);
     });
 
     it('returns null when no orphaned child exists', async () => {
@@ -180,7 +186,7 @@ describe('DelegationScanService', () => {
       const tokenHash = hashDelegationToken(token);
 
       // Write an unrelated state
-      const state = makeState('unrelated-run');
+      const state = makeState(OTHER_RUN_ID);
       await writeState(state);
 
       const result = await scanner.findOrphanedChild(tokenHash);
@@ -193,20 +199,20 @@ describe('DelegationScanService', () => {
 
       const linkage1: DelegationLinkage = {
         kind: 'delegation' as const,
-        parentRunId: 'parent-run',
+        parentRunId: PARENT_RUN_ID,
         parentStepId: '1',
         tokenHash,
       };
 
       const linkage2: DelegationLinkage = {
         kind: 'delegation' as const,
-        parentRunId: 'parent-run',
+        parentRunId: PARENT_RUN_ID,
         parentStepId: '2',
         tokenHash,
       };
 
-      const child1 = makeState('child-1', { parentLinkage: linkage1 });
-      const child2 = makeState('child-2', { parentLinkage: linkage2 });
+      const child1 = makeState(CHILD_RUN_ID_1, { parentLinkage: linkage1 });
+      const child2 = makeState(CHILD_RUN_ID_2, { parentLinkage: linkage2 });
 
       await writeState(child1);
       await writeState(child2);
@@ -214,14 +220,14 @@ describe('DelegationScanService', () => {
       const result = await scanner.findOrphanedChild(tokenHash);
       expect(result).not.toBeNull();
       // Should return one of them (first match)
-      expect(['child-1', 'child-2']).toContain(result!.id);
+      expect([CHILD_RUN_ID_1, CHILD_RUN_ID_2]).toContain(result!.id);
     });
   });
 
   describe('edge cases', () => {
     it('findByToken handles state with no substepStates', async () => {
       const token = generateDelegationToken();
-      const state = makeState('run-no-substeps', {
+      const state = makeState(PARENT_RUN_ID, {
         substepStates: undefined,
       });
       await writeState(state);
@@ -232,7 +238,7 @@ describe('DelegationScanService', () => {
 
     it('findByToken handles state with empty substepStates array', async () => {
       const token = generateDelegationToken();
-      const state = makeState('run-empty-substeps', {
+      const state = makeState(PARENT_RUN_ID, {
         substepStates: [],
       });
       await writeState(state);
@@ -243,7 +249,7 @@ describe('DelegationScanService', () => {
 
     it('findByToken handles substep without delegation field', async () => {
       const token = generateDelegationToken();
-      const state = makeState('run-no-delegation', {
+      const state = makeState(PARENT_RUN_ID, {
         substepStates: [
           { id: '1', frameKey: buildFrameKey('1'), status: 'pending' },
           { id: '2', frameKey: buildFrameKey('1'), status: 'pending' },
@@ -259,7 +265,7 @@ describe('DelegationScanService', () => {
       const token1 = generateDelegationToken();
       const token2 = generateDelegationToken();
 
-      const state1 = makeState('run-1', {
+      const state1 = makeState(PARENT_RUN_ID, {
         substepStates: [
           {
             id: '1',
@@ -270,7 +276,7 @@ describe('DelegationScanService', () => {
         ],
       });
 
-      const state2 = makeState('run-2', {
+      const state2 = makeState(OTHER_RUN_ID, {
         substepStates: [
           {
             id: '1',
@@ -286,11 +292,11 @@ describe('DelegationScanService', () => {
 
       const result1 = await scanner.findByToken(token1);
       expect(result1).not.toBeNull();
-      expect(result1!.parentState.id).toBe('run-1');
+      expect(result1!.parentState.id).toBe(PARENT_RUN_ID);
 
       const result2 = await scanner.findByToken(token2);
       expect(result2).not.toBeNull();
-      expect(result2!.parentState.id).toBe('run-2');
+      expect(result2!.parentState.id).toBe(OTHER_RUN_ID);
     });
 
     it('findByToken scans large number of states efficiently', async () => {
@@ -299,7 +305,7 @@ describe('DelegationScanService', () => {
       // Write 50 states without the target token
       for (let i = 0; i < 50; i++) {
         const otherToken = generateDelegationToken();
-        const state = makeState(`run-${String(i)}`, {
+        const state = makeState(`wf_${String(i).padStart(32, '0')}`, {
           substepStates: [
             {
               id: '1',
@@ -313,7 +319,7 @@ describe('DelegationScanService', () => {
       }
 
       // Write one state with the target token
-      const targetState = makeState('run-target', {
+      const targetState = makeState(TARGET_RUN_ID, {
         substepStates: [
           {
             id: '1',
@@ -327,12 +333,12 @@ describe('DelegationScanService', () => {
 
       const result = await scanner.findByToken(targetToken);
       expect(result).not.toBeNull();
-      expect(result!.parentState.id).toBe('run-target');
+      expect(result!.parentState.id).toBe(TARGET_RUN_ID);
     });
 
     it('findOrphanedChild handles state with no delegation field', async () => {
       const tokenHash = hashDelegationToken(generateDelegationToken());
-      const state = makeState('run-no-delegation-linkage');
+      const state = makeState(PARENT_RUN_ID);
       await writeState(state);
 
       const result = await scanner.findOrphanedChild(tokenHash);
@@ -346,7 +352,7 @@ describe('DelegationScanService', () => {
         contextSnapshot: { vars: brandEffectiveVarsForTest({}), ancestors: [], step: '3' },
       };
 
-      const state = makeState('run-context-step', {
+      const state = makeState(PARENT_RUN_ID, {
         step: '5',
         substepStates: [
           { id: 'a', frameKey: buildFrameKey('5'), status: 'pending' },
@@ -378,7 +384,7 @@ describe('DelegationScanService', () => {
       // Add delegation to the 50th substep
       substeps[49] = { ...substeps[49], delegation: makeDelegation(token) };
 
-      const state = makeState('run-large-substeps', {
+      const state = makeState(PARENT_RUN_ID, {
         substepStates: substeps,
       });
       await writeState(state);

--- a/packages/core/__tests__/runbook/delegation-schemas.test.ts
+++ b/packages/core/__tests__/runbook/delegation-schemas.test.ts
@@ -11,10 +11,14 @@ import {
 import { DelegationStatusEntrySchema, StatusResponseSchema } from '../../src/output/zod-schemas.js';
 import { buildFrameKey } from '../../src/runbook/targeting.js';
 
+const PARENT_RUN_ID = 'wf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const CHILD_RUN_ID = 'wf_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const OTHER_RUN_ID = 'wf_cccccccccccccccccccccccccccccccc';
+
 describe('AncestorSnapshotSchema', () => {
   it('accepts valid ancestor snapshot', () => {
     const result = AncestorSnapshotSchema.safeParse({
-      runId: 'run-123',
+      runId: PARENT_RUN_ID,
       runbook: 'deploy.md',
       step: '1',
       substep: '2',
@@ -25,7 +29,7 @@ describe('AncestorSnapshotSchema', () => {
 
   it('accepts null substep', () => {
     const result = AncestorSnapshotSchema.safeParse({
-      runId: 'run-123',
+      runId: PARENT_RUN_ID,
       runbook: 'deploy.md',
       step: '1',
       substep: null,
@@ -38,7 +42,7 @@ describe('AncestorSnapshotSchema', () => {
 describe('AncestorSnapshotSchema structural fields', () => {
   it('accepts at and index fields', () => {
     const result = AncestorSnapshotSchema.safeParse({
-      runId: 'run-1',
+      runId: PARENT_RUN_ID,
       runbook: 'parent.md',
       step: '2',
       substep: '1',
@@ -51,7 +55,7 @@ describe('AncestorSnapshotSchema structural fields', () => {
 
   it('accepts without at and index (backward compat)', () => {
     const result = AncestorSnapshotSchema.safeParse({
-      runId: 'run-1',
+      runId: PARENT_RUN_ID,
       runbook: 'parent.md',
       step: '2',
       substep: null,
@@ -67,7 +71,7 @@ describe('ContextSnapshotSchema', () => {
       vars: { env: 'staging', version: '1.2.3' },
       ancestors: [
         {
-          runId: 'parent-1',
+          runId: PARENT_RUN_ID,
           runbook: 'parent.md',
           step: '1',
           substep: null,
@@ -212,7 +216,7 @@ describe('StepDelegationSchema', () => {
   it('accepts non-null childRunId', () => {
     const result = StepDelegationSchema.safeParse({
       ...validDelegation,
-      childRunId: 'child-run-456',
+      childRunId: CHILD_RUN_ID,
     });
     expect(result.success).toBe(true);
   });
@@ -221,7 +225,7 @@ describe('StepDelegationSchema', () => {
     const result = StepDelegationSchema.safeParse({
       ...validDelegation,
       token: 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
-      childRunId: 'child-run-456',
+      childRunId: CHILD_RUN_ID,
     });
     expect(result.success).toBe(false);
   });
@@ -280,9 +284,9 @@ describe('ClaimRecordSchema', () => {
   const validClaim = {
     kind: 'claim-record',
     claimId: 'rdclm_abcdefghijklmnopqrstu1',
-    childRunId: 'wf-2026-05-01-child',
+    childRunId: CHILD_RUN_ID,
     tokenHash: `sha256:${'a'.repeat(64)}`,
-    parentRunId: 'wf-2026-05-01-parent',
+    parentRunId: PARENT_RUN_ID,
     parentStepId: '1.1',
     parentStep: '1',
     parentFrameKey: '1|',
@@ -304,7 +308,7 @@ describe('ClaimRecordSchema', () => {
 
 describe('SessionDataSchema claims registry', () => {
   it('loads sessions without claims using an empty claims registry', () => {
-    const result = SessionDataSchema.safeParse({ defaultStack: ['parent'] });
+    const result = SessionDataSchema.safeParse({ defaultStack: [PARENT_RUN_ID] });
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.claims).toEqual({});
@@ -313,14 +317,14 @@ describe('SessionDataSchema claims registry', () => {
 
   it('rejects claim records whose map key differs from claimId', () => {
     const result = SessionDataSchema.safeParse({
-      defaultStack: ['parent'],
+      defaultStack: [PARENT_RUN_ID],
       claims: {
         rdclm_abcdefghijklmnopqrstu1: {
           kind: 'claim-record',
           claimId: 'rdclm_1234567890abcdefghijkl',
-          childRunId: 'child',
+          childRunId: CHILD_RUN_ID,
           tokenHash: `sha256:${'a'.repeat(64)}`,
-          parentRunId: 'parent',
+          parentRunId: PARENT_RUN_ID,
           parentStepId: '1.1',
           claimedAt: '2026-05-01T00:00:00.000Z',
           updatedAt: '2026-05-01T00:00:01.000Z',
@@ -333,16 +337,16 @@ describe('SessionDataSchema claims registry', () => {
   it('rejects duplicate claim records for the same childRunId', () => {
     const base = {
       kind: 'claim-record',
-      childRunId: 'child',
+      childRunId: CHILD_RUN_ID,
       tokenHash: `sha256:${'b'.repeat(64)}`,
-      parentRunId: 'parent',
+      parentRunId: PARENT_RUN_ID,
       parentStepId: '1.1',
       claimedAt: '2026-05-01T00:00:00.000Z',
       updatedAt: '2026-05-01T00:00:01.000Z',
     };
 
     const result = SessionDataSchema.safeParse({
-      defaultStack: ['parent'],
+      defaultStack: [PARENT_RUN_ID],
       claims: {
         rdclm_abcdefghijklmnopqrstu1: {
           ...base,
@@ -434,7 +438,7 @@ describe('RunbookStateSchema round-trip with delegation', () => {
         vars: { env: 'prod' },
         ancestors: [
           {
-            runId: 'parent-1',
+            runId: PARENT_RUN_ID,
             runbook: 'parent.md',
             step: '1',
             substep: '2',
@@ -442,7 +446,7 @@ describe('RunbookStateSchema round-trip with delegation', () => {
           },
         ],
       },
-      childRunId: 'child-run-789',
+      childRunId: CHILD_RUN_ID,
       createdAt: '2026-02-27T10:00:00.000Z',
       cancelledAt: null,
     };
@@ -457,7 +461,7 @@ describe('RunbookStateSchema round-trip with delegation', () => {
       expect(ss?.delegation?.childRunbookPath).toBe('child.md');
       expect(ss?.delegation?.contextSnapshot.vars).toEqual({ env: 'prod' });
       expect(ss?.delegation?.contextSnapshot.ancestors).toHaveLength(1);
-      expect(ss?.delegation?.childRunId).toBe('child-run-789');
+      expect(ss?.delegation?.childRunId).toBe(CHILD_RUN_ID);
     }
   });
 });
@@ -482,7 +486,7 @@ describe('DelegationStatusEntrySchema', () => {
       substep: '1.1',
       runbook: 'child.md',
       state: 'claimed',
-      childRunId: 'run_abc123',
+      childRunId: CHILD_RUN_ID,
       tokenHash: TOKEN_HASH,
     };
     expect(() => DelegationStatusEntrySchema.parse(entry)).not.toThrow();
@@ -533,7 +537,7 @@ describe('DelegationStatusEntrySchema', () => {
       substep: '1.1',
       runbook: 'child.md',
       state: 'claimed',
-      childRunId: 'run_abc123',
+      childRunId: CHILD_RUN_ID,
       tokenHash: TOKEN_HASH,
       token: TOKEN,
     };
@@ -556,7 +560,7 @@ describe('StatusResponseSchema with delegations', () => {
           substep: '1.2',
           runbook: 'test.md',
           state: 'claimed',
-          childRunId: 'run_xyz',
+          childRunId: OTHER_RUN_ID,
           tokenHash: TOKEN_HASH_B,
         },
       ],
@@ -578,9 +582,8 @@ describe('StatusResponseSchema with delegations', () => {
 /** Helper to create a minimal valid RunbookState for schema testing. */
 function createMinimalRunbookState(overrides: Record<string, unknown> = {}) {
   return {
-    id: 'test-id',
-    runbook: 'test.md',
-    runbookPath: 'test.md',
+    id: 'wf_0123456789abcdef0123456789abcdef',
+    runbook: { source: 'project', path: 'test.runbook.md' },
     step: '1',
     stepName: 'Test step',
     retryCount: 0,

--- a/packages/core/__tests__/runbook/delegation-service-fixtures.ts
+++ b/packages/core/__tests__/runbook/delegation-service-fixtures.ts
@@ -94,9 +94,8 @@ function makeTestSubstep(id: string): {
 /** Helper: create minimal RunbookState for testing. */
 export function makeState(overrides: Partial<RunbookState> = {}): RunbookState {
   return {
-    id: 'run-1',
-    runbook: 'parent.md',
-    runbookPath: 'parent.md',
+    id: 'wf_0123456789abcdef0123456789abcdef',
+    runbook: { source: 'project', path: 'parent.runbook.md' },
     step: '1',
     stepName: 'Main step',
     retryCount: 0,

--- a/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
+++ b/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
@@ -35,9 +35,11 @@ describe('ExecutionLifecycleService', () => {
 
   describe('ensureActiveEntry', () => {
     it('initializes entry to 1 on first call', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const result = await service.ensureActiveEntry(state.id);
 
@@ -47,9 +49,11 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('persists initialized entry to disk', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       await service.ensureActiveEntry(state.id);
 
@@ -59,9 +63,11 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('increments entry on frame switch', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       // Initialize at step 1
       const result1 = await service.ensureActiveEntry(state.id);
@@ -82,9 +88,11 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('increments entry on GOTO re-entry to same frame', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       // Initialize
       await service.ensureActiveEntry(state.id);
@@ -101,9 +109,11 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('increments entry on RETRY re-entry to same frame', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       // Initialize
       await service.ensureActiveEntry(state.id);
@@ -120,9 +130,11 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('returns without persisting when unchanged', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       // Initialize
       await service.ensureActiveEntry(state.id);
@@ -139,9 +151,11 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('uses provided nextState instead of loading from disk', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const result1 = await service.ensureActiveEntry(state.id);
       const prev = await manager.load(state.id);
@@ -160,9 +174,11 @@ describe('ExecutionLifecycleService', () => {
 
   describe('upsertResolvedCompletion', () => {
     it('stores a new completion', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const completion = {
         agentId: 'agent-1',
@@ -180,9 +196,11 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('overwrites existing completion', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const completion1 = {
         agentId: 'agent-1',
@@ -211,9 +229,11 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('persists completion to disk', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const completion = {
         agentId: 'agent-1',
@@ -235,25 +255,32 @@ describe('ExecutionLifecycleService', () => {
 
   describe('getResolvedCompletion', () => {
     it('returns null for missing key', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const retrieved = await service.getResolvedCompletion(state.id, 'nonexistent');
       expect(retrieved).toBeNull();
     });
 
     it('returns null for missing runbook', async () => {
-      const retrieved = await service.getResolvedCompletion('nonexistent-id', 'key');
+      const retrieved = await service.getResolvedCompletion(
+        'wf_ffffffffffffffffffffffffffffffff',
+        'key',
+      );
       expect(retrieved).toBeNull();
     });
   });
 
   describe('consumeResolvedCompletion', () => {
     it('returns and removes completion', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const completion = {
         agentId: 'agent-1',
@@ -276,23 +303,30 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('returns null for missing key', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const consumed = await service.consumeResolvedCompletion(state.id, 'nonexistent');
       expect(consumed).toBeNull();
     });
 
     it('returns null for missing runbook', async () => {
-      const consumed = await service.consumeResolvedCompletion('nonexistent-id', 'key');
+      const consumed = await service.consumeResolvedCompletion(
+        'wf_ffffffffffffffffffffffffffffffff',
+        'key',
+      );
       expect(consumed).toBeNull();
     });
 
     it('persists removal to disk', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const completion = {
         agentId: 'agent-1',
@@ -316,9 +350,11 @@ describe('ExecutionLifecycleService', () => {
 
   describe('listResolvedCompletions', () => {
     it('returns completions matching frameKey and entry', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const frameKey = buildFrameKey('1');
       const entry = 1;
@@ -353,9 +389,11 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('filters out non-matching entries', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const completion1 = {
         agentId: 'agent-1',
@@ -384,9 +422,11 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('returns empty array when no matches', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const listed = await service.listResolvedCompletions(
         state.id,
@@ -397,16 +437,22 @@ describe('ExecutionLifecycleService', () => {
     });
 
     it('returns empty array for missing runbook', async () => {
-      const listed = await service.listResolvedCompletions('nonexistent-id', buildFrameKey('1'), 1);
+      const listed = await service.listResolvedCompletions(
+        'wf_ffffffffffffffffffffffffffffffff',
+        buildFrameKey('1'),
+        1,
+      );
       expect(listed).toEqual([]);
     });
   });
 
   describe('listResolvedCompletions with sentinel', () => {
     it('includes entry=0 sentinel alongside exact matches', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const frameKey = buildFrameKey('1');
       const sentinelCompletion = {
@@ -442,9 +488,11 @@ describe('ExecutionLifecycleService', () => {
 
   describe('consumeResolvedCompletion with sentinel', () => {
     it('falls back to sentinel when exact key missing', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const frameKey = buildFrameKey('1');
       const sentinelCompletion = {

--- a/packages/core/__tests__/runbook/for-iteration-service.test.ts
+++ b/packages/core/__tests__/runbook/for-iteration-service.test.ts
@@ -53,9 +53,8 @@ const mockedIsStopped = isRunbookStopped as jest.MockedFunction<typeof isRunbook
 
 function makeState(overrides: Partial<RunbookState> = {}): RunbookState {
   return {
-    id: 'test-123',
-    runbook: 'test.md',
-    runbookPath: '/tmp/test.md',
+    id: 'wf_0123456789abcdef0123456789abcdef',
+    runbook: { source: 'project', path: 'test.runbook.md' },
     step: '1',
     stepName: 'Step 1',
     retryCount: 0,

--- a/packages/core/__tests__/runbook/runbook-ref.test.ts
+++ b/packages/core/__tests__/runbook/runbook-ref.test.ts
@@ -11,6 +11,15 @@ describe('RunbookRefSchema', () => {
     expect(RunbookRefSchema.parse(ref)).toEqual(ref);
   });
 
+  it('accepts project refs under .rundown/runbooks', () => {
+    const ref = {
+      source: 'project',
+      path: '.rundown/runbooks/planning/review.runbook.md',
+    };
+
+    expect(RunbookRefSchema.parse(ref)).toEqual(ref);
+  });
+
   it.each([
     { source: 'external', path: 'planning/review.runbook.md' },
     { source: 'plugin', path: '' },
@@ -19,7 +28,6 @@ describe('RunbookRefSchema', () => {
     { source: 'plugin', path: 'planning//review.runbook.md' },
     { source: 'plugin', path: 'planning/review plan.runbook.md' },
     { source: 'plugin', path: 'planning/review.md' },
-    { source: 'project', path: '.rundown/runbooks/planning/review.runbook.md' },
   ])('rejects invalid runbook ref %#', (ref) => {
     expect(() => RunbookRefSchema.parse(ref)).toThrow(RUNBOOK_REF_ERROR_TEXT.INVALID_RUNBOOK_REF);
   });

--- a/packages/core/__tests__/runbook/session-reader.test.ts
+++ b/packages/core/__tests__/runbook/session-reader.test.ts
@@ -34,13 +34,16 @@ describe('readActiveRunScope', () => {
   });
 
   it('returns active WorkPath and ContextId from effective vars', async () => {
-    const state = await manager.create('test.md', mockRunbook, {
-      runbookPath: 'test.md',
-      templateVars: {
-        WorkPath: '.rundown/work',
-        ContextId: 'ctx-abc',
+    const state = await manager.create(
+      { source: 'project' as const, path: 'test.runbook.md' },
+      mockRunbook,
+      {
+        templateVars: {
+          WorkPath: '.rundown/work',
+          ContextId: 'ctx-abc',
+        },
       },
-    });
+    );
     await sessionService.pushRunbook(state.id);
 
     await expect(readActiveRunScope(testDir)).resolves.toEqual({
@@ -50,13 +53,16 @@ describe('readActiveRunScope', () => {
   });
 
   it('uses stored outputs over template vars', async () => {
-    const state = await manager.create('test.md', mockRunbook, {
-      runbookPath: 'test.md',
-      templateVars: {
-        WorkPath: '.rundown/work',
-        ContextId: 'ctx-template',
+    const state = await manager.create(
+      { source: 'project' as const, path: 'test.runbook.md' },
+      mockRunbook,
+      {
+        templateVars: {
+          WorkPath: '.rundown/work',
+          ContextId: 'ctx-template',
+        },
       },
-    });
+    );
     await manager.update(state.id, {
       variables: {
         WorkPath: '.rundown/work/output',

--- a/packages/core/__tests__/runbook/session-service.test.ts
+++ b/packages/core/__tests__/runbook/session-service.test.ts
@@ -32,7 +32,11 @@ describe('SessionService', () => {
 
   describe('Runbook stack operations', () => {
     it('pushRunbook adds to stack', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await sessionService.pushRunbook(state.id);
 
       const active = await sessionService.getActive();
@@ -40,8 +44,16 @@ describe('SessionService', () => {
     });
 
     it('popRunbook removes from stack and returns new top', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
-      const child = await manager.create('child.md', mockRunbook, { runbookPath: 'child.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       await sessionService.pushRunbook(parent.id);
       await sessionService.pushRunbook(child.id);
@@ -54,9 +66,21 @@ describe('SessionService', () => {
     });
 
     it('supports arbitrary nesting depth', async () => {
-      const wf1 = await manager.create('level1.md', mockRunbook, { runbookPath: 'level1.md' });
-      const wf2 = await manager.create('level2.md', mockRunbook, { runbookPath: 'level2.md' });
-      const wf3 = await manager.create('level3.md', mockRunbook, { runbookPath: 'level3.md' });
+      const wf1 = await manager.create(
+        { source: 'project' as const, path: 'level1.runbook.md' },
+        mockRunbook,
+        {},
+      );
+      const wf2 = await manager.create(
+        { source: 'project' as const, path: 'level2.runbook.md' },
+        mockRunbook,
+        {},
+      );
+      const wf3 = await manager.create(
+        { source: 'project' as const, path: 'level3.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       await sessionService.pushRunbook(wf1.id);
       await sessionService.pushRunbook(wf2.id);
@@ -74,7 +98,11 @@ describe('SessionService', () => {
 
   describe('Stash and pop operations', () => {
     it('stash saves current runbook and removes from stack', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await sessionService.pushRunbook(state.id);
 
       const stashedId = await sessionService.stash();
@@ -85,7 +113,11 @@ describe('SessionService', () => {
     });
 
     it('unstash restores stashed runbook', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await sessionService.pushRunbook(state.id);
       await sessionService.stash();
 
@@ -97,7 +129,11 @@ describe('SessionService', () => {
     });
 
     it('unstash returns null and clears stash when persisted state is missing', async () => {
-      const state = await manager.create('temp.md', mockRunbook, { runbookPath: 'temp.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'temp.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await sessionService.pushRunbook(state.id);
       await sessionService.stash();
 
@@ -110,8 +146,16 @@ describe('SessionService', () => {
     });
 
     it('stash refuses to overwrite existing stash', async () => {
-      const s1 = await manager.create('a.md', mockRunbook, { runbookPath: 'a.md' });
-      const s2 = await manager.create('b.md', mockRunbook, { runbookPath: 'b.md' });
+      const s1 = await manager.create(
+        { source: 'project' as const, path: 'a.runbook.md' },
+        mockRunbook,
+        {},
+      );
+      const s2 = await manager.create(
+        { source: 'project' as const, path: 'b.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await sessionService.pushRunbook(s1.id);
 
       const first = await sessionService.stash();
@@ -151,11 +195,18 @@ describe('SessionService', () => {
     };
 
     it('registers a delegated child claim without changing the default stack', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkageFor(parent.id, 'a'),
-      });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkageFor(parent.id, 'a'),
+        },
+      );
       await sessionService.pushRunbook(parent.id);
 
       const claimed = assertClaimed(
@@ -174,12 +225,19 @@ describe('SessionService', () => {
     });
 
     it('reuses the same claim id for the same child', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, 'b');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
 
       const first = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
       const second = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
@@ -200,12 +258,19 @@ describe('SessionService', () => {
     });
 
     it('returns stale for a claim whose child state is missing', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, 'c');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
       const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
 
       await manager.delete(child.id);
@@ -218,12 +283,19 @@ describe('SessionService', () => {
     });
 
     it('returns terminal for a completed claim child', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, 'd');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
       const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
 
       await manager.update(child.id, { lifecycle: 'completed' });
@@ -236,12 +308,19 @@ describe('SessionService', () => {
     });
 
     it('returns unlinked for a child whose delegation linkage no longer matches the claim', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, 'e');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
       const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
 
       await manager.update(child.id, {
@@ -259,12 +338,19 @@ describe('SessionService', () => {
     });
 
     it('returns unlinked when the parent has ended', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, 'f');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
       const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
 
       await manager.update(parent.id, { lifecycle: 'completed' });
@@ -277,12 +363,19 @@ describe('SessionService', () => {
     });
 
     it('returns unlinked when the parent state is missing', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, '0');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
       const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
 
       await manager.delete(parent.id);
@@ -295,12 +388,19 @@ describe('SessionService', () => {
     });
 
     it('claimRunbook refuses when the child run state is missing', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, '1');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
       await manager.delete(child.id);
 
       const result = await sessionService.claimRunbook(child.id, linkage);
@@ -311,12 +411,19 @@ describe('SessionService', () => {
     });
 
     it('claimRunbook refuses when persisted child linkage diverges from incoming linkage', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, '2');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
 
       const drifted = { ...linkage, tokenHash: linkageFor(parent.id, '3').tokenHash };
       const result = await sessionService.claimRunbook(child.id, drifted);
@@ -330,8 +437,16 @@ describe('SessionService', () => {
     });
 
     it('claimRunbook refuses when child has no parent linkage at all', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
-      const child = await manager.create('child.md', mockRunbook, { runbookPath: 'child.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, '4');
 
       const result = await sessionService.claimRunbook(child.id, linkage);
@@ -342,12 +457,19 @@ describe('SessionService', () => {
     });
 
     it('releaseRunbook removes matching claim records', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, 'f');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
       const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
 
       await sessionService.releaseRunbook(child.id);
@@ -358,12 +480,19 @@ describe('SessionService', () => {
     });
 
     it('stash preserves a claim record and unstashForClaimId restores only the matching child', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, '1');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
       const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
 
       await sessionService.stashRunbook(child.id);
@@ -386,12 +515,19 @@ describe('SessionService', () => {
     });
 
     it('exposes a stashed claimed child read-only via includeStashed', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, '1');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
       const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
 
       await sessionService.stashRunbook(child.id);
@@ -416,12 +552,19 @@ describe('SessionService', () => {
     });
 
     it('releaseRunbook clears defaultStack and claim records together when the child completes', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const linkage = linkageFor(parent.id, '1');
-      const child = await manager.create('child.md', mockRunbook, {
-        runbookPath: 'child.md',
-        parentLinkage: linkage,
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {
+          parentLinkage: linkage,
+        },
+      );
       const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
 
       // Simulate the active-claimed-child state: child on default stack and
@@ -447,8 +590,16 @@ describe('SessionService', () => {
 
   describe('releaseRunbook default stack cleanup', () => {
     it('releaseRunbook pops a default-stack child by id', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
-      const child = await manager.create('child.md', mockRunbook, { runbookPath: 'child.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await sessionService.pushRunbook(parent.id);
       await sessionService.pushRunbook(child.id);
 
@@ -462,11 +613,21 @@ describe('SessionService', () => {
     });
 
     it('releaseRunbook removes a non-top default-stack entry by id', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
-      const child = await manager.create('child.md', mockRunbook, { runbookPath: 'child.md' });
-      const sibling = await manager.create('sibling.md', mockRunbook, {
-        runbookPath: 'sibling.md',
-      });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {},
+      );
+      const sibling = await manager.create(
+        { source: 'project' as const, path: 'sibling.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await sessionService.pushRunbook(parent.id);
       await sessionService.pushRunbook(child.id);
       await sessionService.pushRunbook(sibling.id);

--- a/packages/core/__tests__/runbook/state-schema-version.test.ts
+++ b/packages/core/__tests__/runbook/state-schema-version.test.ts
@@ -6,9 +6,8 @@ import { RunbookStateSchema } from '../../src/schemas.js';
 import { RunbookStateManager, StaleRunbookStateError } from '../../src/runbook/index.js';
 
 const BASE_SCHEMA_STATE = {
-  id: 'r1',
-  runbook: 'x.md',
-  runbookPath: 'x.md',
+  id: 'wf_0123456789abcdef0123456789abcdef',
+  runbook: { source: 'project', path: 'x.runbook.md' },
   step: '1',
   stepName: 'x',
   retryCount: 0,
@@ -89,9 +88,8 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
   let manager: RunbookStateManager;
 
   const V1_STATE = {
-    id: 'wf-stale-test',
-    runbook: 'x.md',
-    runbookPath: 'x.md',
+    id: 'wf_11111111111111111111111111111111',
+    runbook: { source: 'project', path: 'x.runbook.md' },
     step: '1',
     stepName: 'x',
     retryCount: 0,
@@ -135,7 +133,7 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
   });
 
   it('returns null for missing state file', async () => {
-    const result = await manager.load('wf-does-not-exist');
+    const result = await manager.load('wf_00000000000000000000000000000009');
     expect(result).toBeNull();
   });
 

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -245,35 +245,6 @@ describe('RunbookStateManager', () => {
     });
   });
 
-  describe('non-canonical state cleanup', () => {
-    it('purges safe legacy run ids without loading or validating state', async () => {
-      const legacyId = 'wf-2026-05-04-abc123';
-      const stateFile = join(testDir, '.rundown', 'runs', `${legacyId}.json`);
-      const outputDir = join(testDir, '.rundown', 'runs', legacyId);
-      await fs.mkdir(outputDir, { recursive: true });
-      await fs.writeFile(stateFile, '{ this is not json');
-      await fs.writeFile(join(outputDir, 'stdout.txt'), 'legacy output');
-
-      await expect(manager.load(legacyId)).rejects.toThrow('Invalid RunId');
-      await expect(manager.delete(legacyId)).rejects.toThrow('Invalid RunId');
-
-      await manager.purgeNonCanonicalRunState(legacyId);
-
-      await expect(fs.access(stateFile)).rejects.toThrow();
-      await expect(fs.access(outputDir)).rejects.toThrow();
-    });
-
-    it('rejects unsafe ids in non-canonical cleanup', async () => {
-      await expect(manager.purgeNonCanonicalRunState('../escape')).rejects.toThrow('Invalid runId');
-    });
-
-    it('rejects canonical run ids in non-canonical cleanup', async () => {
-      await expect(manager.purgeNonCanonicalRunState(VALID_RUN_ID)).rejects.toThrow(
-        'expected non-canonical runId',
-      );
-    });
-  });
-
   describe('getChildRunbookResult', () => {
     it('should return pass when child has lifecycle completed', async () => {
       const child = await manager.create(

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import fs from 'node:fs/promises';
+import { syncBuiltinESMExports } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { isError } from '../../src/errors.js';
 import { RunbookStateManager } from '../../src/runbook/state.js';
-import { statePath as _statePath } from '../../src/paths.js';
+import { RUN_ID_PATTERN, statePath as _statePath } from '../../src/paths.js';
 import { SessionService } from '../../src/runbook/session-service.js';
 import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
 import { buildFrameKey } from '../../src/runbook/targeting.js';
@@ -22,23 +23,264 @@ describe('RunbookStateManager', () => {
     description: 'A test',
     steps: mockSteps,
   };
+  const VALID_RUN_ID = 'wf_0123456789abcdef0123456789abcdef';
+
+  function projectRunbookRef(path = 'test.runbook.md') {
+    return { source: 'project' as const, path };
+  }
 
   beforeEach(async () => {
-    testDir = await mkdtemp(join(tmpdir(), 'ws-test-'));
+    testDir = await fs.mkdtemp(join(tmpdir(), 'ws-test-'));
     manager = new RunbookStateManager(testDir);
     lifecycleService = new ExecutionLifecycleService(manager);
     sessionService = new SessionService(manager);
   });
 
   afterEach(async () => {
-    await rm(testDir, { recursive: true, force: true });
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('run ids and persisted runbook identity', () => {
+    it('creates wf_ run ids with 32 lowercase hex chars', async () => {
+      const state = await manager.create(projectRunbookRef('probe.runbook.md'), mockRunbook, {});
+      const removedPathField = `runbook${'Path'}`;
+
+      expect(state.id).toMatch(RUN_ID_PATTERN);
+      expect(state.runbook).toEqual({ source: 'project', path: 'probe.runbook.md' });
+      expect(removedPathField in state).toBe(false);
+
+      const raw = JSON.parse(await fs.readFile(_statePath(testDir, state.id), 'utf8')) as Record<
+        string,
+        unknown
+      >;
+      expect(raw.runbook).toEqual({ source: 'project', path: 'probe.runbook.md' });
+      expect(raw).not.toHaveProperty(removedPathField);
+    });
+
+    it('uses a preallocated run id when provided', async () => {
+      const state = await manager.create(projectRunbookRef('probe.runbook.md'), mockRunbook, {
+        runId: VALID_RUN_ID,
+      });
+
+      expect(state.id).toBe(VALID_RUN_ID);
+      expect(await manager.load(VALID_RUN_ID)).toMatchObject({
+        id: VALID_RUN_ID,
+        runbook: { source: 'project', path: 'probe.runbook.md' },
+      });
+    });
+
+    it('rejects non-canonical runbook refs before writing state', async () => {
+      const writeSpy = jest.spyOn(fs, 'writeFile');
+      syncBuiltinESMExports();
+
+      await expect(
+        manager.create({ source: 'project', path: '../escape.runbook.md' }, mockRunbook, {
+          runId: VALID_RUN_ID,
+        }),
+      ).rejects.toThrow('Invalid runbook');
+
+      expect(writeSpy).not.toHaveBeenCalled();
+      writeSpy.mockRestore();
+      syncBuiltinESMExports();
+    });
+
+    it.each([
+      'wf_short',
+      'wf_ABCDEF0123456789ABCDEF0123456789',
+      'plain_id',
+      '../escape',
+    ])('rejects invalid run id %s before file access', async (badRunId) => {
+      const readSpy = jest.spyOn(fs, 'readFile');
+      const writeSpy = jest.spyOn(fs, 'writeFile');
+      const unlinkSpy = jest.spyOn(fs, 'unlink');
+      const rmSpy = jest.spyOn(fs, 'rm');
+      syncBuiltinESMExports();
+
+      expect(() => _statePath(testDir, badRunId)).toThrow('Invalid RunId');
+      await expect(manager.load(badRunId)).rejects.toThrow('Invalid RunId');
+      await expect(manager.update(badRunId, { lifecycle: 'completed' })).rejects.toThrow(
+        'Invalid RunId',
+      );
+      await expect(manager.delete(badRunId)).rejects.toThrow('Invalid RunId');
+      await expect(
+        manager.create(projectRunbookRef('probe.runbook.md'), mockRunbook, { runId: badRunId }),
+      ).rejects.toThrow('Invalid RunId');
+
+      expect(readSpy).not.toHaveBeenCalled();
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(unlinkSpy).not.toHaveBeenCalled();
+      expect(rmSpy).not.toHaveBeenCalled();
+      readSpy.mockRestore();
+      writeSpy.mockRestore();
+      unlinkSpy.mockRestore();
+      rmSpy.mockRestore();
+      syncBuiltinESMExports();
+    });
+
+    it.each([
+      {
+        name: 'delegation childRunId',
+        mutate: (raw: Record<string, unknown>) => ({
+          ...raw,
+          substepStates: [
+            {
+              id: '1.1',
+              frameKey: '1.1',
+              status: 'running',
+              delegation: {
+                tokenHash: `sha256:${'a'.repeat(64)}`,
+                childRunbookPath: 'child.runbook.md',
+                contextSnapshot: { vars: {}, ancestors: [] },
+                childRunId: '../escape',
+                createdAt: '2025-01-01T00:00:00.000Z',
+                cancelledAt: null,
+              },
+            },
+          ],
+        }),
+      },
+      {
+        name: 'ancestor runId',
+        mutate: (raw: Record<string, unknown>) => ({
+          ...raw,
+          substepStates: [
+            {
+              id: '1.1',
+              frameKey: '1.1',
+              status: 'running',
+              delegation: {
+                tokenHash: `sha256:${'a'.repeat(64)}`,
+                childRunbookPath: 'child.runbook.md',
+                contextSnapshot: {
+                  vars: {},
+                  ancestors: [
+                    {
+                      runId: 'old-id',
+                      runbook: 'parent.runbook.md',
+                      step: '1',
+                      substep: null,
+                      vars: {},
+                    },
+                  ],
+                },
+                childRunId: null,
+                createdAt: '2025-01-01T00:00:00.000Z',
+                cancelledAt: null,
+              },
+            },
+          ],
+        }),
+      },
+    ])('rejects invalid nested run ids on manager.load(): $name', async ({ mutate }) => {
+      const state = await manager.create(projectRunbookRef('nested.runbook.md'), mockRunbook, {
+        runId: VALID_RUN_ID,
+      });
+      const stateFile = _statePath(testDir, state.id);
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf8')) as Record<string, unknown>;
+
+      await fs.writeFile(stateFile, JSON.stringify(mutate(raw), null, 2));
+
+      await expect(manager.load(state.id)).rejects.toThrow('schema validation failed');
+    });
+  });
+
+  describe('terminalAt', () => {
+    it('sets terminalAt when lifecycle first becomes completed', async () => {
+      const state = await manager.create(projectRunbookRef('terminal.runbook.md'), mockRunbook, {
+        runId: VALID_RUN_ID,
+      });
+
+      const completed = await manager.update(state.id, { lifecycle: 'completed' });
+
+      expect(completed.lifecycle).toBe('completed');
+      expect(completed.terminalAt).toEqual(expect.any(String));
+      expect(completed.terminalAt).toBe(completed.updatedAt);
+      expect(Number.isNaN(Date.parse(completed.terminalAt!))).toBe(false);
+
+      const reloaded = await manager.load(state.id);
+      expect(reloaded?.terminalAt).toBe(completed.terminalAt);
+      expect(reloaded?.updatedAt).toBe(completed.updatedAt);
+      expect(reloaded?.terminalAt).toBe(reloaded?.updatedAt);
+    });
+
+    it('sets terminalAt when lifecycle first becomes stopped', async () => {
+      const state = await manager.create(projectRunbookRef('terminal.runbook.md'), mockRunbook, {
+        runId: VALID_RUN_ID,
+      });
+
+      const stopped = await manager.update(state.id, { lifecycle: 'stopped' });
+
+      expect(stopped.lifecycle).toBe('stopped');
+      expect(stopped.terminalAt).toEqual(expect.any(String));
+      expect(stopped.terminalAt).toBe(stopped.updatedAt);
+      expect(Number.isNaN(Date.parse(stopped.terminalAt!))).toBe(false);
+
+      const reloaded = await manager.load(state.id);
+      expect(reloaded?.terminalAt).toBe(stopped.terminalAt);
+      expect(reloaded?.updatedAt).toBe(stopped.updatedAt);
+      expect(reloaded?.terminalAt).toBe(reloaded?.updatedAt);
+    });
+
+    it('preserves terminalAt after later terminal updates', async () => {
+      const state = await manager.create(projectRunbookRef('terminal.runbook.md'), mockRunbook, {
+        runId: VALID_RUN_ID,
+      });
+
+      const completed = await manager.update(state.id, { lifecycle: 'completed' });
+      const preserved = await manager.update(state.id, { lifecycle: 'stopped' });
+
+      expect(preserved.lifecycle).toBe('stopped');
+      expect(preserved.terminalAt).toBe(completed.terminalAt);
+    });
+
+    it('does not set terminalAt for non-terminal updates', async () => {
+      const state = await manager.create(projectRunbookRef('terminal.runbook.md'), mockRunbook, {
+        runId: VALID_RUN_ID,
+      });
+
+      const running = await manager.update(state.id, { step: '1' });
+
+      expect(running.lifecycle).toBe('running');
+      expect(running.terminalAt).toBeUndefined();
+    });
+  });
+
+  describe('non-canonical state cleanup', () => {
+    it('purges safe legacy run ids without loading or validating state', async () => {
+      const legacyId = 'wf-2026-05-04-abc123';
+      const stateFile = join(testDir, '.rundown', 'runs', `${legacyId}.json`);
+      const outputDir = join(testDir, '.rundown', 'runs', legacyId);
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(stateFile, '{ this is not json');
+      await fs.writeFile(join(outputDir, 'stdout.txt'), 'legacy output');
+
+      await expect(manager.load(legacyId)).rejects.toThrow('Invalid RunId');
+      await expect(manager.delete(legacyId)).rejects.toThrow('Invalid RunId');
+
+      await manager.purgeNonCanonicalRunState(legacyId);
+
+      await expect(fs.access(stateFile)).rejects.toThrow();
+      await expect(fs.access(outputDir)).rejects.toThrow();
+    });
+
+    it('rejects unsafe ids in non-canonical cleanup', async () => {
+      await expect(manager.purgeNonCanonicalRunState('../escape')).rejects.toThrow('Invalid runId');
+    });
+
+    it('rejects canonical run ids in non-canonical cleanup', async () => {
+      await expect(manager.purgeNonCanonicalRunState(VALID_RUN_ID)).rejects.toThrow(
+        'expected non-canonical runId',
+      );
+    });
   });
 
   describe('getChildRunbookResult', () => {
     it('should return pass when child has lifecycle completed', async () => {
-      const child = await manager.create('child.runbook.md', mockRunbook, {
-        runbookPath: 'child.runbook.md',
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.update(child.id, { lifecycle: 'completed' });
 
       const result = await lifecycleService.getChildRunbookResult(child.id);
@@ -46,9 +288,11 @@ describe('RunbookStateManager', () => {
     });
 
     it('should return fail when child has lifecycle stopped', async () => {
-      const child = await manager.create('child.runbook.md', mockRunbook, {
-        runbookPath: 'child.runbook.md',
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.update(child.id, { lifecycle: 'stopped' });
 
       const result = await lifecycleService.getChildRunbookResult(child.id);
@@ -56,9 +300,11 @@ describe('RunbookStateManager', () => {
     });
 
     it('should return null when child is still active', async () => {
-      const child = await manager.create('child.runbook.md', mockRunbook, {
-        runbookPath: 'child.runbook.md',
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await sessionService.pushRunbook(child.id);
 
       const result = await lifecycleService.getChildRunbookResult(child.id);
@@ -66,14 +312,18 @@ describe('RunbookStateManager', () => {
     });
 
     it('should return pass when child state deleted', async () => {
-      const result = await lifecycleService.getChildRunbookResult('nonexistent-id');
+      const result = await lifecycleService.getChildRunbookResult(
+        'wf_ffffffffffffffffffffffffffffffff',
+      );
       expect(result).toBe('pass');
     });
 
     it('should return null when child is stashed', async () => {
-      const child = await manager.create('child.runbook.md', mockRunbook, {
-        runbookPath: 'child.runbook.md',
-      });
+      const child = await manager.create(
+        { source: 'project' as const, path: 'child.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await sessionService.pushRunbook(child.id);
       await sessionService.stash();
 
@@ -89,9 +339,11 @@ describe('RunbookStateManager', () => {
         makeSubstep({ id: '2', description: 'Second reviewer' }),
       ];
 
-      const state = await manager.create('test.runbook.md', mockRunbook, {
-        runbookPath: 'test.runbook.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.initializeSubsteps(state.id, substeps, buildFrameKey('1'));
 
       const updated = await manager.load(state.id);
@@ -110,9 +362,11 @@ describe('RunbookStateManager', () => {
         makeSubstep({ id: '2', description: 'Second' }),
       ];
 
-      const state = await manager.create('test.runbook.md', mockRunbook, {
-        runbookPath: 'test.runbook.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.initializeSubsteps(state.id, substeps, buildFrameKey('1', 1));
 
       const updated = await manager.load(state.id);
@@ -128,9 +382,11 @@ describe('RunbookStateManager', () => {
     it('preserves entries from other frames when frameKey is provided', async () => {
       const substeps = [makeSubstep({ id: '1', description: 'First' })];
 
-      const state = await manager.create('test.runbook.md', mockRunbook, {
-        runbookPath: 'test.runbook.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       // Initialize iteration 1
       await manager.initializeSubsteps(state.id, substeps, buildFrameKey('1', 1));
@@ -156,9 +412,11 @@ describe('RunbookStateManager', () => {
     it('replaces entries from same frame on re-initialization', async () => {
       const substeps = [makeSubstep({ id: '1', description: 'First' })];
 
-      const state = await manager.create('test.runbook.md', mockRunbook, {
-        runbookPath: 'test.runbook.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       await manager.initializeSubsteps(state.id, substeps, buildFrameKey('1', 1));
       // Re-initialize same frame — should replace, not duplicate
@@ -171,9 +429,11 @@ describe('RunbookStateManager', () => {
 
   describe('RunbookStateManager substep lifecycle', () => {
     it('completes substep with result', async () => {
-      const state = await manager.create('test.runbook.md', mockRunbook, {
-        runbookPath: 'test.runbook.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.update(state.id, {
         substepStates: [{ id: '1', frameKey: buildFrameKey('1'), status: 'running' }],
       });
@@ -190,9 +450,11 @@ describe('RunbookStateManager', () => {
     });
 
     it('completes substep scoped by frameKey', async () => {
-      const state = await manager.create('test.runbook.md', mockRunbook, {
-        runbookPath: 'test.runbook.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       // Initialize substeps for two different frames (simulating FOR loop iterations)
       const frameA = buildFrameKey('1', 1);
       const frameB = buildFrameKey('1', 2);
@@ -226,39 +488,35 @@ describe('RunbookStateManager', () => {
 
   describe('create with prompted flag', () => {
     it('defaults to auto mode (prompted undefined)', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       expect(state.prompted).toBeUndefined();
     });
 
     it('accepts prompted option', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        prompted: true,
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          prompted: true,
+        },
+      );
       expect(state.prompted).toBe(true);
-    });
-  });
-
-  describe('create with runbookRef', () => {
-    it('persists a canonical runbookRef through create/load round-trip', async () => {
-      const runbookRef = { source: 'plugin' as const, path: 'planning/write-plan.runbook.md' };
-      const state = await manager.create('rundown:write-plan', mockRunbook, {
-        runbookPath: '../../plugin/runbooks/planning/write-plan.runbook.md',
-        runbookRef,
-      });
-
-      expect(state.runbookRef).toEqual(runbookRef);
-
-      const loaded = await manager.load(state.id);
-      expect(loaded?.runbookRef).toEqual(runbookRef);
     });
   });
 
   describe('List and delete operations', () => {
     it('list returns all runbook states', async () => {
-      await manager.create('one.md', mockRunbook, { runbookPath: 'one.md' });
-      await manager.create('two.md', mockRunbook, { runbookPath: 'two.md' });
-      await manager.create('three.md', mockRunbook, { runbookPath: 'three.md' });
+      await manager.create({ source: 'project' as const, path: 'one.runbook.md' }, mockRunbook, {});
+      await manager.create({ source: 'project' as const, path: 'two.runbook.md' }, mockRunbook, {});
+      await manager.create(
+        { source: 'project' as const, path: 'three.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const states = await manager.list();
 
@@ -271,7 +529,11 @@ describe('RunbookStateManager', () => {
     });
 
     it('delete removes runbook state', async () => {
-      const state = await manager.create('delete.md', mockRunbook, { runbookPath: 'delete.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'delete.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       await manager.delete(state.id);
 
@@ -281,14 +543,14 @@ describe('RunbookStateManager', () => {
 
     it('delete silently handles nonexistent runbook', async () => {
       // Should not throw
-      await manager.delete('nonexistent-id');
+      await manager.delete('wf_ffffffffffffffffffffffffffffffff');
     });
   });
 
   describe('Load and save operations', () => {
     it('rejects legacy per-agent stacks session shape', async () => {
-      await mkdir(join(testDir, '.rundown'), { recursive: true });
-      await writeFile(
+      await fs.mkdir(join(testDir, '.rundown'), { recursive: true });
+      await fs.writeFile(
         join(testDir, '.rundown', 'session.json'),
         JSON.stringify({
           stacks: {
@@ -301,8 +563,8 @@ describe('RunbookStateManager', () => {
     });
 
     it('rejects legacy ownedRunbooks session shape', async () => {
-      await mkdir(join(testDir, '.rundown'), { recursive: true });
-      await writeFile(
+      await fs.mkdir(join(testDir, '.rundown'), { recursive: true });
+      await fs.writeFile(
         join(testDir, '.rundown', 'session.json'),
         JSON.stringify({
           defaultStack: ['parent'],
@@ -314,8 +576,8 @@ describe('RunbookStateManager', () => {
     });
 
     it('rejects legacy stashedRunbookOwnership session shape', async () => {
-      await mkdir(join(testDir, '.rundown'), { recursive: true });
-      await writeFile(
+      await fs.mkdir(join(testDir, '.rundown'), { recursive: true });
+      await fs.writeFile(
         join(testDir, '.rundown', 'session.json'),
         JSON.stringify({
           defaultStack: ['parent'],
@@ -327,12 +589,16 @@ describe('RunbookStateManager', () => {
     });
 
     it('load returns null for nonexistent runbook', async () => {
-      const result = await manager.load('nonexistent-id');
+      const result = await manager.load('wf_ffffffffffffffffffffffffffffffff');
       expect(result).toBeNull();
     });
 
     it('setLastResult updates last result', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       await lifecycleService.setLastResult(state.id, 'pass');
 
@@ -341,11 +607,17 @@ describe('RunbookStateManager', () => {
     });
 
     it('update throws for missing runbook', async () => {
-      await expect(manager.update('nonexistent', { step: '2' })).rejects.toThrow('not found');
+      await expect(
+        manager.update('wf_ffffffffffffffffffffffffffffffff', { step: '2' }),
+      ).rejects.toThrow('not found');
     });
 
     it('loads legacy targetPath fields and strips them on save', async () => {
-      const state = await manager.create('legacy.md', mockRunbook, { runbookPath: 'legacy.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'legacy.runbook.md' },
+        mockRunbook,
+        {},
+      );
       const resolvedKey = '1||1|';
 
       await manager.update(state.id, {
@@ -362,13 +634,13 @@ describe('RunbookStateManager', () => {
       });
 
       const stateFilePath = _statePath(testDir, state.id);
-      const raw = JSON.parse(await readFile(stateFilePath, 'utf8')) as Record<string, unknown>;
+      const raw = JSON.parse(await fs.readFile(stateFilePath, 'utf8')) as Record<string, unknown>;
 
       const resolved = (raw.resolvedCompletions as Record<string, Record<string, unknown>>)[
         resolvedKey
       ];
       resolved.targetPath = '1';
-      await writeFile(stateFilePath, JSON.stringify(raw), { mode: 0o600 });
+      await fs.writeFile(stateFilePath, JSON.stringify(raw), { mode: 0o600 });
 
       const loaded = await manager.load(state.id);
       expect(loaded).not.toBeNull();
@@ -378,17 +650,20 @@ describe('RunbookStateManager', () => {
       expect(loadedResolved?.targetPath).toBeUndefined();
 
       await manager.update(state.id, { stepName: 'updated' });
-      const saved = await readFile(stateFilePath, 'utf8');
+      const saved = await fs.readFile(stateFilePath, 'utf8');
       expect(saved).not.toContain('targetPath');
     });
   });
 
   describe('update variables/templateVars semantics', () => {
     it('replaces templateVars wholesale when updates.templateVars is defined', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        templateVars: { env: 'staging', port: 3000 },
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          templateVars: { env: 'staging', port: 3000 },
+        },
+      );
 
       const updated = await manager.update(state.id, {
         templateVars: { env: 'prod' },
@@ -399,10 +674,13 @@ describe('RunbookStateManager', () => {
     });
 
     it('preserves existing templateVars when updates.templateVars is undefined', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        templateVars: { env: 'staging', port: 3000 },
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          templateVars: { env: 'staging', port: 3000 },
+        },
+      );
 
       const updated = await manager.update(state.id, { stepName: 'next' });
 
@@ -410,9 +688,11 @@ describe('RunbookStateManager', () => {
     });
 
     it('shallow-merges variables when updates.variables is defined', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.update(state.id, { variables: { A: '1', B: '2' } });
 
       const updated = await manager.update(state.id, { variables: { B: 'two', C: '3' } });
@@ -421,9 +701,11 @@ describe('RunbookStateManager', () => {
     });
 
     it('preserves existing variables when updates.variables is undefined', async () => {
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
       await manager.update(state.id, { variables: { A: '1' } });
 
       const updated = await manager.update(state.id, { stepName: 'next' });
@@ -434,24 +716,31 @@ describe('RunbookStateManager', () => {
 
   describe('isPrompted', () => {
     it('returns true when parent has prompted flag', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, {
-        runbookPath: 'parent.md',
-        prompted: true,
-      });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {
+          prompted: true,
+        },
+      );
 
       const result = await lifecycleService.isPrompted(parent.id);
       expect(result).toBe(true);
     });
 
     it('returns false when parent has no prompted flag', async () => {
-      const parent = await manager.create('parent.md', mockRunbook, { runbookPath: 'parent.md' });
+      const parent = await manager.create(
+        { source: 'project' as const, path: 'parent.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const result = await lifecycleService.isPrompted(parent.id);
       expect(result).toBe(false);
     });
 
     it('returns false for nonexistent parent', async () => {
-      const result = await lifecycleService.isPrompted('nonexistent');
+      const result = await lifecycleService.isPrompted('wf_ffffffffffffffffffffffffffffffff');
       expect(result).toBe(false);
     });
   });
@@ -460,10 +749,13 @@ describe('RunbookStateManager', () => {
     it('should store runbookSrc when provided to create()', async () => {
       const runbookSrc = '# Test Runbook\n\n## 1. Step 1\n\nRendered content';
 
-      const state = await manager.create('test.runbook.md', mockRunbook, {
-        runbookPath: 'test.runbook.md',
-        runbookSrc,
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          runbookSrc,
+        },
+      );
 
       expect(state.runbookSrc).toBe(runbookSrc);
 
@@ -473,9 +765,11 @@ describe('RunbookStateManager', () => {
     });
 
     it('should allow runbookSrc to be undefined', async () => {
-      const state = await manager.create('test.runbook.md', mockRunbook, {
-        runbookPath: 'test.runbook.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       expect(state.runbookSrc).toBeUndefined();
     });
@@ -488,12 +782,14 @@ describe('RunbookStateManager', () => {
         return;
       }
 
-      const state = await manager.create('test.runbook.md', mockRunbook, {
-        runbookPath: 'test.runbook.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       const statePath = _statePath(testDir, state.id);
-      const stats = await stat(statePath);
+      const stats = await fs.stat(statePath);
 
       // Check mode is 0o600 (owner read/write only)
       // Note: mode includes file type bits, so mask with 0o777
@@ -503,7 +799,11 @@ describe('RunbookStateManager', () => {
 
   describe('FOR loop context persistence', () => {
     it('persists FOR fields through round-trip', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       // Update with forStack
       const updated = await manager.update(state.id, {
@@ -554,10 +854,13 @@ describe('RunbookStateManager', () => {
 
   describe('Legacy snapshot rejection', () => {
     it('rejects state with GOTO_NEXT action in lastAction', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       // Manually save legacy state with GOTO_NEXT
-      const fs = await import('node:fs/promises');
       const stateFilePath = _statePath(testDir, state.id);
       const legacyState = {
         ...state,
@@ -570,10 +873,13 @@ describe('RunbookStateManager', () => {
     });
 
     it('rejects state with instance field', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       // Manually save legacy state with instance field
-      const fs = await import('node:fs/promises');
       const stateFilePath = _statePath(testDir, state.id);
       const legacyState = {
         ...state,
@@ -586,10 +892,13 @@ describe('RunbookStateManager', () => {
     });
 
     it('provides helpful error message for legacy snapshots', async () => {
-      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {},
+      );
 
       // Manually save legacy state with GOTO_NEXT
-      const fs = await import('node:fs/promises');
       const stateFilePath = _statePath(testDir, state.id);
       const legacyState = {
         ...state,
@@ -618,10 +927,13 @@ describe('RunbookStateManager', () => {
         env: 'prod',
       };
 
-      const state = await manager.create('test.md', mockRunbook, {
-        runbookPath: 'test.md',
-        templateVars: templateVars,
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          templateVars: templateVars,
+        },
+      );
 
       // Verify templateVars are present in created state
       expect(state.templateVars?.items).toEqual(['a', 'b']);
@@ -635,32 +947,35 @@ describe('RunbookStateManager', () => {
 
   describe('RunbookStateManager.delete — output capture cleanup', () => {
     it('removes the per-run outputs directory alongside the state JSON', async () => {
-      const state = await manager.create('demo.runbook.md', mockRunbook, {
-        runbookPath: '/abs/demo.runbook.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'demo.runbook.md' },
+        mockRunbook,
+        {},
+      );
       // Simulate captured output files written during a run
       const outDir = join(testDir, '.rundown', 'runs', state.id, 'outputs', '1');
-      await (await import('node:fs/promises')).mkdir(outDir, { recursive: true });
-      await (await import('node:fs/promises')).writeFile(join(outDir, 'Version'), 'v1.2.3');
+      await fs.mkdir(outDir, { recursive: true });
+      await fs.writeFile(join(outDir, 'Version'), 'v1.2.3');
 
       await manager.delete(state.id);
 
       // Both the state file and the outputs dir should be gone
-      const { stat: fsStat } = await import('node:fs/promises');
       await expect(
-        fsStat(join(testDir, '.rundown', 'runs', `${state.id}.json`)),
+        fs.stat(join(testDir, '.rundown', 'runs', `${state.id}.json`)),
       ).rejects.toMatchObject({
         code: 'ENOENT',
       });
-      await expect(fsStat(join(testDir, '.rundown', 'runs', state.id))).rejects.toMatchObject({
+      await expect(fs.stat(join(testDir, '.rundown', 'runs', state.id))).rejects.toMatchObject({
         code: 'ENOENT',
       });
     });
 
     it('is a no-op when the outputs directory does not exist', async () => {
-      const state = await manager.create('demo.runbook.md', mockRunbook, {
-        runbookPath: '/abs/demo.runbook.md',
-      });
+      const state = await manager.create(
+        { source: 'project' as const, path: 'demo.runbook.md' },
+        mockRunbook,
+        {},
+      );
       // No outputs dir created — delete must still succeed
       await expect(manager.delete(state.id)).resolves.toBeUndefined();
     });

--- a/packages/core/__tests__/runbook/types.test.ts
+++ b/packages/core/__tests__/runbook/types.test.ts
@@ -106,9 +106,8 @@ describe('Substep interface', () => {
 describe('RunbookState runbookSrc field', () => {
   it('should include runbookSrc field', () => {
     const state: RunbookState = {
-      id: 'wf-2026-01-29-abc123',
-      runbook: 'test.runbook.md',
-      runbookPath: 'test.runbook.md',
+      id: 'wf_0123456789abcdef0123456789abcdef',
+      runbook: { source: 'project', path: 'test.runbook.md' },
       step: '1',
       stepName: 'Test step',
       retryCount: 0,

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -16,9 +16,8 @@ import { isJsonArrayStream } from '../src/runbook/types.js';
  * Note: step is now a string ("1", "ErrorHandler", etc.)
  */
 const createValidState = (overrides: Record<string, unknown> = {}) => ({
-  id: 'test-id',
-  runbook: 'test.md',
-  runbookPath: 'test.md',
+  id: 'wf_0123456789abcdef0123456789abcdef',
+  runbook: { source: 'project', path: 'test.runbook.md' },
   step: '1',
   stepName: 'Test Step',
   retryCount: 0,
@@ -112,6 +111,34 @@ describe('RunbookStateSchema - step name validation', () => {
 
   it('rejects non-string step', () => {
     const result = RunbookStateSchema.safeParse(createValidState({ step: 123 }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts structured canonical runbook refs and terminalAt', () => {
+    const result = RunbookStateSchema.safeParse(
+      createValidState({ terminalAt: '2025-01-01T00:01:00.000Z', lifecycle: 'completed' }),
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.runbook).toEqual({ source: 'project', path: 'test.runbook.md' });
+      expect(result.data.terminalAt).toBe('2025-01-01T00:01:00.000Z');
+    }
+  });
+
+  it('rejects legacy string runbook identity', () => {
+    const result = RunbookStateSchema.safeParse(createValidState({ runbook: 'test.runbook.md' }));
+
+    expect(result.success).toBe(false);
+  });
+
+  it.each([
+    'wf_short',
+    'wf_ABCDEF0123456789ABCDEF0123456789',
+    'plain_id',
+  ])('rejects invalid persisted run id %s', (id) => {
+    const result = RunbookStateSchema.safeParse(createValidState({ id }));
+
     expect(result.success).toBe(false);
   });
 });
@@ -352,27 +379,6 @@ describe('RunbookStateSchema frontmatterOutputs', () => {
 
   it('rejects frontmatterOutputs with non-string name field', () => {
     const state = createValidState({ frontmatterOutputs: [{ name: 42 }] });
-
-    expect(() => RunbookStateSchema.parse(state)).toThrow();
-  });
-});
-
-describe('RunbookStateSchema runbookRef', () => {
-  it('accepts a canonical optional runbookRef', () => {
-    const state = createValidState({
-      runbookRef: { source: 'plugin', path: 'planning/write-plan.runbook.md' },
-    });
-
-    expect(RunbookStateSchema.parse(state).runbookRef).toEqual({
-      source: 'plugin',
-      path: 'planning/write-plan.runbook.md',
-    });
-  });
-
-  it('rejects an invalid optional runbookRef', () => {
-    const state = createValidState({
-      runbookRef: { source: 'plugin', path: 'planning/write-plan.md' },
-    });
 
     expect(() => RunbookStateSchema.parse(state)).toThrow();
   });
@@ -777,7 +783,7 @@ describe('makeRunbookStateSchema — SEC1 nested snapshot var protection', () =>
               vars: {},
               ancestors: [
                 {
-                  runId: 'run-1',
+                  runId: 'wf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
                   runbook: 'parent.md',
                   step: '1',
                   substep: null,

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -18,6 +18,27 @@ export const RUNDOWN_DIR = '.rundown';
 export const SAFE_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 /**
+ * Canonical persisted run id shape.
+ *
+ * Run ids double as filenames under `.rundown/runs`, so this pattern is
+ * intentionally stricter than {@link SAFE_ID_PATTERN}.
+ */
+export const RUN_ID_PATTERN = /^wf_[a-f0-9]{32}$/;
+
+/**
+ * Validate a canonical Rundown run id.
+ *
+ * @param value - Candidate run id to validate
+ * @param field - Field label used in the thrown error message
+ * @throws {Error} If `value` is not `wf_` followed by 32 lowercase hex characters
+ */
+export function assertRunId(value: string, field = 'RunId'): void {
+  if (!RUN_ID_PATTERN.test(value)) {
+    throw new Error(`Invalid ${field}: expected wf_<32 lowercase hex chars>`);
+  }
+}
+
+/**
  * Validate that a user-supplied id is safe to interpolate into a filename.
  *
  * Rejects empty strings, `.`, `..`, and any value containing characters
@@ -112,12 +133,12 @@ export const contextsDir = (cwd: string): string => path.join(cwd, CONTEXTS_DIR)
  * Absolute path to a specific runbook state file.
  *
  * @param cwd - Project root directory
- * @param id - Runbook execution ID (must match `[A-Za-z0-9._-]+`)
+ * @param id - Runbook execution ID (must match `wf_<32 lowercase hex chars>`)
  * @returns Path to `.rundown/runs/<id>.json`
- * @throws {Error} If `id` contains path separators, `..`, or is otherwise unsafe
+ * @throws {Error} If `id` is not a canonical run id
  */
 export const statePath = (cwd: string, id: string): string => {
-  assertSafeId(id, 'id');
+  assertRunId(id);
   return path.join(cwd, RUNS_DIR, `${id}.json`);
 };
 
@@ -134,12 +155,12 @@ export const LEGACY_SESSION_FILE = '.claude/rundown/session.json';
  * Lock path: `.rundown/locks/run-<parentRunId>.delegation.lock`
  *
  * @param cwd - Project root directory
- * @param runId - Parent run ID to lock (must match `[A-Za-z0-9._-]+`)
+ * @param runId - Parent run ID to lock (must match `wf_<32 lowercase hex chars>`)
  * @returns Path to the lock file
- * @throws {Error} If `runId` contains path separators, `..`, or is otherwise unsafe
+ * @throws {Error} If `runId` is not a canonical run id
  */
 export const delegationLockPath = (cwd: string, runId: string): string => {
-  assertSafeId(runId, 'runId');
+  assertRunId(runId);
   return path.join(cwd, LOCKS_DIR, `run-${runId}.delegation.lock`);
 };
 

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -106,7 +106,6 @@ export {
   buildArtifactUri,
   parseExactArtifactUriParts,
   parseArtifactUri,
-  RUN_ID_PATTERN,
   type ArtifactPathOptions,
   type ArtifactIdentity,
   type ArtifactRef,

--- a/packages/core/src/runbook/runbook-ref.ts
+++ b/packages/core/src/runbook/runbook-ref.ts
@@ -76,10 +76,7 @@ export const RunbookRefSchema = z
     },
   )
   .superRefine((ref, ctx) => {
-    if (
-      !isValidRunbookPath(ref.path) ||
-      (ref.source === 'project' && ref.path.startsWith('.rundown/runbooks/'))
-    ) {
+    if (!isValidRunbookPath(ref.path)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: RUNBOOK_REF_ERROR_TEXT.INVALID_RUNBOOK_REF,

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -1,6 +1,7 @@
 // src/runbook/state.ts
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
 import type { OutputDeclaration } from '@rundown-org/parser';
 import type { FrameKey } from './targeting.js';
 import type {
@@ -12,9 +13,10 @@ import type {
   ResolvedRunbook,
   ParentLinkage,
   TemplateVarValue,
+  Lifecycle,
 } from './types.js';
 import type { ClaimRecord } from './claim-id.js';
-import type { RunbookRef } from './runbook-ref.js';
+import { RunbookRefSchema, type RunbookRef } from './runbook-ref.js';
 import { makeRunbookStateSchema, SessionDataSchema } from '../schemas.js';
 import { isNodeError } from '../errors.js';
 import { logger } from '../logger.js';
@@ -24,6 +26,9 @@ import {
   sessionPath as _sessionPath,
   statePath as _statePath,
   LEGACY_SESSION_FILE,
+  RUN_ID_PATTERN,
+  assertRunId,
+  assertSafeId,
 } from '../paths.js';
 
 /** Current persisted state schema version. Bump whenever RunbookState shape changes incompatibly. */
@@ -65,11 +70,35 @@ export class StaleRunbookStateError extends Error {
   }
 }
 
-function generateId(): string {
-  const now = new Date();
-  const date = now.toISOString().slice(0, 10);
-  const random = Math.random().toString(36).slice(2, 8);
-  return `wf-${date}-${random}`;
+/**
+ * Generate a canonical Rundown run id.
+ *
+ * @returns A `wf_` id followed by 32 lowercase hex characters
+ */
+function generateRunId(): string {
+  return `wf_${randomBytes(16).toString('hex')}`;
+}
+
+function isTerminalLifecycle(
+  lifecycle: Lifecycle | undefined,
+): lifecycle is 'completed' | 'stopped' {
+  return lifecycle === 'completed' || lifecycle === 'stopped';
+}
+
+function applyTerminalAt(
+  existing: RunbookState,
+  candidate: RunbookState,
+  now: string,
+): RunbookState {
+  if (existing.terminalAt !== undefined) {
+    return { ...candidate, terminalAt: existing.terminalAt };
+  }
+
+  if (isTerminalLifecycle(candidate.lifecycle)) {
+    return { ...candidate, terminalAt: now };
+  }
+
+  return candidate;
 }
 
 /**
@@ -87,8 +116,7 @@ export interface SessionData {
 }
 
 interface CreateOptions {
-  readonly runbookPath: string;
-  readonly runbookRef?: RunbookRef;
+  readonly runId?: string;
   readonly prompted?: boolean;
   /** Parent linkage when this run is a child (delegation or inline). */
   readonly parentLinkage?: ParentLinkage;
@@ -195,26 +223,26 @@ export class RunbookStateManager {
   /**
    * Create a new runbook state and persist it to disk.
    *
-   * @param runbookFile - Path to the runbook source file
+   * @param runbookRef - Canonical source-root-relative runbook reference
    * @param runbook - The parsed runbook definition
    * @param options - Configuration including agentId, parent runbook info, prompted flag, and templateVars for template variable replacements
    * @returns The newly created RunbookState
    */
   async create(
-    runbookFile: string,
+    runbookRef: RunbookRef,
     runbook: Runbook | ResolvedRunbook,
-    options: CreateOptions,
+    options: CreateOptions = {},
   ): Promise<RunbookState> {
-    const id = generateId();
+    const id = options.runId ?? generateRunId();
+    assertRunId(id);
+    const canonicalRunbookRef = RunbookRefSchema.parse(runbookRef);
     const now = new Date().toISOString();
 
     const initialStep = runbook.steps[0];
 
     const state: RunbookState = {
       id,
-      runbook: runbookFile,
-      runbookPath: options.runbookPath,
-      runbookRef: options.runbookRef,
+      runbook: canonicalRunbookRef,
       title: runbook.title,
       description: runbook.description,
       step: initialStep.name,
@@ -312,19 +340,19 @@ export class RunbookStateManager {
   /**
    * Save a runbook state to disk.
    *
-   * Creates the state directory if it does not exist and writes the state
-   * as a JSON file, automatically updating the `updatedAt` timestamp.
+   * Creates the state directory if it does not exist and writes the state as a
+   * JSON file. Callers are responsible for setting `updatedAt` at the mutation
+   * boundary so returned state and persisted state have the same timestamp.
    *
    * @param state - The runbook state to persist
    */
   async save(state: RunbookState): Promise<void> {
     await fs.mkdir(this.stateDir, { recursive: true });
-    const updated: RunbookState = {
+    const persisted: RunbookState = {
       ...state,
       schemaVersion: CURRENT_SCHEMA_VERSION,
-      updatedAt: new Date().toISOString(),
     };
-    const content = JSON.stringify(updated, null, 2);
+    const content = JSON.stringify(persisted, null, 2);
     await fs.writeFile(this.statePath(state.id), content, { mode: 0o600 }); // Owner read/write only
   }
 
@@ -341,7 +369,9 @@ export class RunbookStateManager {
    */
   async update(
     id: string,
-    updates: Partial<Omit<RunbookState, 'id' | 'startedAt' | 'variables' | 'templateVars'>> & {
+    updates: Partial<
+      Omit<RunbookState, 'id' | 'startedAt' | 'variables' | 'templateVars' | 'terminalAt'>
+    > & {
       // Accept unbranded records on the update path; the manager re-mints
       // the brand inside the merge below. Internal callers (actor-service
       // sync, compiler reducers) hold the unbranded XState context shape
@@ -372,15 +402,19 @@ export class RunbookStateManager {
         }
       : restUpdates;
 
-    const updated: RunbookState = {
+    const now = new Date().toISOString();
+
+    const candidate: RunbookState = {
       ...existing,
       ...patchedRestUpdates,
       variables: brandStoredOutputs({ ...existing.variables, ...(updatesVariables ?? {}) }),
       ...(updatesTemplateVars !== undefined
         ? { templateVars: brandInitialTemplateVars(updatesTemplateVars) }
         : {}),
-      updatedAt: new Date().toISOString(),
+      updatedAt: now,
     };
+
+    const updated = applyTerminalAt(existing, candidate, now);
 
     await this.save(updated);
     return updated;
@@ -408,6 +442,38 @@ export class RunbookStateManager {
       // Use rm -rf semantics so a non-empty directory is removed cleanly.
       const runDir = this.statePath(id).replace(/\.json$/, '');
       await fs.rm(runDir, { recursive: true, force: true });
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Delete a non-canonical but filename-safe run state without loading it.
+   *
+   * This is a prune-only escape hatch for pre-v1 dogfooding state files whose
+   * ids do not match {@link RUN_ID_PATTERN}. It does not migrate, parse, or
+   * otherwise adapt the state. Normal manager APIs continue to require canonical
+   * run ids before touching the filesystem.
+   *
+   * @param id - Filename-safe stale run id to remove
+   * @throws {Error} If `id` is canonical or unsafe for filename interpolation
+   */
+  async purgeNonCanonicalRunState(id: string): Promise<void> {
+    if (RUN_ID_PATTERN.test(id)) {
+      throw new Error('Invalid runId: expected non-canonical runId');
+    }
+    assertSafeId(id, 'runId');
+    try {
+      await fs.unlink(path.join(this.stateDir, `${id}.json`));
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+    try {
+      await fs.rm(path.join(this.stateDir, id), { recursive: true, force: true });
     } catch (error) {
       if (!isNodeError(error) || error.code !== 'ENOENT') {
         throw error;

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -26,9 +26,7 @@ import {
   sessionPath as _sessionPath,
   statePath as _statePath,
   LEGACY_SESSION_FILE,
-  RUN_ID_PATTERN,
   assertRunId,
-  assertSafeId,
 } from '../paths.js';
 
 /** Current persisted state schema version. Bump whenever RunbookState shape changes incompatibly. */
@@ -442,38 +440,6 @@ export class RunbookStateManager {
       // Use rm -rf semantics so a non-empty directory is removed cleanly.
       const runDir = this.statePath(id).replace(/\.json$/, '');
       await fs.rm(runDir, { recursive: true, force: true });
-    } catch (error) {
-      if (!isNodeError(error) || error.code !== 'ENOENT') {
-        throw error;
-      }
-    }
-  }
-
-  /**
-   * Delete a non-canonical but filename-safe run state without loading it.
-   *
-   * This is a prune-only escape hatch for pre-v1 dogfooding state files whose
-   * ids do not match {@link RUN_ID_PATTERN}. It does not migrate, parse, or
-   * otherwise adapt the state. Normal manager APIs continue to require canonical
-   * run ids before touching the filesystem.
-   *
-   * @param id - Filename-safe stale run id to remove
-   * @throws {Error} If `id` is canonical or unsafe for filename interpolation
-   */
-  async purgeNonCanonicalRunState(id: string): Promise<void> {
-    if (RUN_ID_PATTERN.test(id)) {
-      throw new Error('Invalid runId: expected non-canonical runId');
-    }
-    assertSafeId(id, 'runId');
-    try {
-      await fs.unlink(path.join(this.stateDir, `${id}.json`));
-    } catch (error) {
-      if (!isNodeError(error) || error.code !== 'ENOENT') {
-        throw error;
-      }
-    }
-    try {
-      await fs.rm(path.join(this.stateDir, id), { recursive: true, force: true });
     } catch (error) {
       if (!isNodeError(error) || error.code !== 'ENOENT') {
         throw error;

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -709,10 +709,8 @@ export type Lifecycle = 'running' | 'completed' | 'stopped';
  */
 export interface RunbookState {
   readonly id: string;
-  readonly runbook: string; // runbook identifier (name or path)
-  readonly runbookPath: string; // repo-relative resolved file path
-  /** Canonical runbook reference for events and artifact metadata. */
-  readonly runbookRef?: RunbookRef;
+  /** Canonical source-root-relative runbook reference for this run. */
+  readonly runbook: RunbookRef;
   readonly title?: string;
   readonly description?: string;
   readonly step: string; // "1" or "ErrorHandler"
@@ -757,6 +755,8 @@ export interface RunbookState {
 
   readonly startedAt: string;
   readonly updatedAt: string;
+  /** Timestamp set exactly once when lifecycle first reaches completed or stopped. */
+  readonly terminalAt?: string;
 
   readonly prompted?: boolean;
   readonly lastResult?: 'pass' | 'fail';

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -16,10 +16,14 @@ import {
   brandStoredOutputs,
 } from './runbook/effective-vars.js';
 import { getErrorMessage } from './errors.js';
+import { RUN_ID_PATTERN } from './paths.js';
 import { RunbookRefSchema } from './runbook/runbook-ref.js';
 
 /** Zod schema that parses strings and brands them as {@link FrameKey}. */
 const FrameKeySchema = z.string().transform((v) => v as FrameKey);
+
+/** Zod schema for persisted run ids. */
+const RunIdSchema = z.string().regex(RUN_ID_PATTERN, 'Invalid RunId');
 
 /** Zod schema that parses strings and brands them as {@link DelegationTokenHash}. */
 export const DelegationTokenHashSchema: z.ZodType<DelegationTokenHash, z.ZodTypeDef, string> = z
@@ -253,7 +257,7 @@ export const TemplateVarValueSchema: z.ZodType<TemplateVarValue> = z.union([
  * Zod schema for a single ancestor in the runbook lineage snapshot.
  */
 export const AncestorSnapshotSchema = z.object({
-  runId: z.string(),
+  runId: RunIdSchema,
   runbook: z.string(),
   step: z.string(),
   substep: z.string().nullable(),
@@ -301,7 +305,7 @@ export const StepDelegationSchema = z
     tokenHash: DelegationTokenHashSchema,
     childRunbookPath: z.string(),
     contextSnapshot: ContextSnapshotSchema,
-    childRunId: z.string().nullable(),
+    childRunId: RunIdSchema.nullable(),
     createdAt: z.string(),
     cancelledAt: z.string().nullable(),
     extraVars: z.record(z.string(), TemplateVarValueSchema).optional(),
@@ -344,9 +348,9 @@ export const ClaimIdSchema = z
 export const ClaimRecordSchema: z.ZodType<ClaimRecord, z.ZodTypeDef, unknown> = z.object({
   kind: z.literal('claim-record'),
   claimId: ClaimIdSchema,
-  childRunId: z.string().min(1),
+  childRunId: RunIdSchema,
   tokenHash: DelegationTokenHashSchema,
-  parentRunId: z.string().min(1),
+  parentRunId: RunIdSchema,
   parentStepId: z.string().min(1),
   parentStep: z.string().optional(),
   parentFrameKey: FrameKeySchema.optional(),
@@ -358,8 +362,8 @@ export const ClaimRecordSchema: z.ZodType<ClaimRecord, z.ZodTypeDef, unknown> = 
 /** Zod schema for `.rundown/session.json`. */
 export const SessionDataSchema = z
   .object({
-    defaultStack: z.array(z.string()).default([]),
-    stashedRunbookId: z.string().optional(),
+    defaultStack: z.array(RunIdSchema).default([]),
+    stashedRunbookId: RunIdSchema.optional(),
     claims: z.record(z.string(), ClaimRecordSchema).default({}),
   })
   .superRefine((session, ctx) => {
@@ -445,10 +449,8 @@ const ForStackEntrySchema = z.object({
  */
 export const RunbookStateSchema = z
   .object({
-    id: z.string(),
-    runbook: z.string(),
-    runbookPath: z.string(),
-    runbookRef: RunbookRefSchema.optional(),
+    id: RunIdSchema,
+    runbook: RunbookRefSchema,
     title: z.string().optional(),
     description: z.string().optional(),
     step: RunbookStepSchema, // "1" or "ErrorHandler"
@@ -474,7 +476,7 @@ export const RunbookStateSchema = z
       .discriminatedUnion('kind', [
         z.object({
           kind: z.literal('delegation'),
-          parentRunId: z.string(),
+          parentRunId: RunIdSchema,
           parentStepId: z.string(),
           tokenHash: DelegationTokenHashSchema,
           parentStep: z.string().optional(),
@@ -483,7 +485,7 @@ export const RunbookStateSchema = z
         }),
         z.object({
           kind: z.literal('inline'),
-          parentRunId: z.string(),
+          parentRunId: RunIdSchema,
           parentStepId: z.string(),
           parentStep: z.string().optional(),
           parentFrameKey: FrameKeySchema.optional(),
@@ -502,6 +504,7 @@ export const RunbookStateSchema = z
     iterationResults: z.array(z.enum(['pass', 'fail'])).optional(),
     startedAt: z.string(),
     updatedAt: z.string(),
+    terminalAt: z.string().datetime().optional(),
     // XState snapshot: intentionally not structurally validated. The persisted envelope
     // is opaque and version-unstable (see `.work/xstate-patterns/README.md`
     // type-check matrix — XState v5 does not expose a stable public shape for
@@ -644,7 +647,7 @@ export function makeTemplateVarValueSchema(projectRoot: string): z.ZodType<Templ
  */
 function makeAncestorSnapshotSchema(projectRoot: string): z.ZodTypeAny {
   return z.object({
-    runId: z.string(),
+    runId: RunIdSchema,
     runbook: z.string(),
     step: z.string(),
     substep: z.string().nullable(),
@@ -710,7 +713,7 @@ function makeStepDelegationSchema(projectRoot: string): z.ZodTypeAny {
       tokenHash: DelegationTokenHashSchema,
       childRunbookPath: z.string(),
       contextSnapshot: makeContextSnapshotSchema(projectRoot),
-      childRunId: z.string().nullable(),
+      childRunId: RunIdSchema.nullable(),
       createdAt: z.string(),
       cancelledAt: z.string().nullable(),
       extraVars: z.record(z.string(), TemplateVarValueSchema).optional(),


### PR DESCRIPTION
# Summary

@coderabbitai summary

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
