### PR TITLE
feat: switch concrete run IDs to rd prefix

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -302,7 +302,7 @@ rundown status
 **Output:**
 ```text
 File:     my-runbook.runbook.md
-State:    .rundown/runs/wf-2024-01-07-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 Action:   CONTINUE
 Result:   PASS
 
@@ -652,7 +652,7 @@ Output formatting is implemented in `packages/cli/src/services/output-emitter.ts
 
 ```text
 File:     runbook.runbook.md
-State:    .rundown/runs/wf-xxx.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 Action:   START
 At:       1
 

--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -216,15 +216,15 @@ The session tracks top-level runs and delegated children separately.
 
 ```json
 {
-  "defaultStack": ["wf-2026-04-28-parent"],
+  "defaultStack": ["rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
   "stashedRunbookId": null,
   "claims": {
     "rdclm_F3J3n3d_f8fo0a0b1B2c3Q": {
       "kind": "claim-record",
       "claimId": "rdclm_F3J3n3d_f8fo0a0b1B2c3Q",
-      "childRunId": "wf-2026-04-28-child",
+      "childRunId": "rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       "tokenHash": "sha256:...",
-      "parentRunId": "wf-2026-04-28-parent",
+      "parentRunId": "rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "parentStepId": "1.1",
       "parentFrameKey": "1|",
       "parentEntry": 1,
@@ -286,7 +286,7 @@ Each run state file stores enough information to resume deterministically.
 
 ```json
 {
-  "id": "wf-2024-01-07-abc123",
+  "id": "rd_0123456789abcdef0123456789abcdef",
   "runbook": "my-runbook.runbook.md",
   "runbookPath": ".rundown/runbooks/my-runbook.runbook.md",
   "title": "My Runbook",

--- a/docs/spec/cli-output.md
+++ b/docs/spec/cli-output.md
@@ -99,7 +99,7 @@ onboarding        plugin   New hire setup                 hr, setup
 **Text:**
 ```text
 File:     runbooks/deploy.runbook.md
-State:    .rundown/runs/wf-2026-01-26-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 Prompt:   Yes
 
 ## 1. First Step
@@ -113,7 +113,7 @@ Step description here.
   "active": true,
   "stashed": false,
   "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/wf-2026-01-26-abc123.json",
+  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
   "prompted": true,
   "position": { "current": "1", "total": 3 },
   "step": { "name": "1", "description": "First Step" }
@@ -148,7 +148,7 @@ Same output shape as active `rd status`, but resolves the delegated child identi
 **Text:**
 ```text
 File:     runbooks/deploy.runbook.md
-State:    .rundown/runs/wf-2026-01-26-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 
 Action:   START
 
@@ -167,7 +167,7 @@ Runbook:  COMPLETE
 {
   "action": "complete",
   "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/wf-2026-01-26-abc123.json",
+  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
   "position": { "current": "1", "total": 1 }
 }
 ```
@@ -191,9 +191,9 @@ CLAIMED: Claimed rdtk_abcd... -> child.runbook.md
   "action": "claimed",
   "token": "rdtk_abcd...",
   "claim_id": "rdclm_F3J3n3d_f8fo0a0b1B2c3Q",
-  "run_id": "wf-2026-01-26-child",
+  "run_id": "rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "runbook": "child.runbook.md",
-  "parent_run_id": "wf-2026-01-26-parent",
+  "parent_run_id": "rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "parent_step": "1.1"
 }
 ```
@@ -211,7 +211,7 @@ The `action` field shows the transition (e.g., "CONTINUE" to next step, "GOTO 3"
 **Text:**
 ```text
 File:     runbooks/deploy.runbook.md
-State:    .rundown/runs/wf-2026-01-26-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 
 ─── 2 ──────────────────────────────────────────
 
@@ -229,7 +229,7 @@ Next step description.
 {
   "action": "CONTINUE",
   "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/wf-2026-01-26-abc123.json",
+  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
   "from": { "current": "1", "total": 3 },
   "to": { "current": "2", "total": 3 }
 }
@@ -250,7 +250,7 @@ The `action` field shows the transition (e.g., "RETRY (1/3)" for retry, "STOP" f
 **Text:**
 ```text
 File:     runbooks/deploy.runbook.md
-State:    .rundown/runs/wf-2026-01-26-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 
 Action:   RETRY (1/3)
 At:       1/3
@@ -265,7 +265,7 @@ Step description.
 {
   "action": "RETRY (1/3)",
   "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/wf-2026-01-26-abc123.json",
+  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
   "to": { "current": "1", "total": 3 }
 }
 ```
@@ -275,7 +275,7 @@ Step description.
 **Text:**
 ```text
 File:     runbooks/deploy.runbook.md
-State:    .rundown/runs/wf-2026-01-26-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 
 Runbook:  STOP
 ```
@@ -285,7 +285,7 @@ Runbook:  STOP
 {
   "action": "STOP",
   "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/wf-2026-01-26-abc123.json",
+  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
   "stopped": true
 }
 ```
@@ -305,7 +305,7 @@ The `action` field is combined (e.g., "GOTO 3"), not a separate `target` field.
 **Text:**
 ```text
 File:     runbooks/deploy.runbook.md
-State:    .rundown/runs/wf-2026-01-26-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 
 ─── 3 ──────────────────────────────────────────
 
@@ -323,7 +323,7 @@ Step description.
 {
   "action": "GOTO 3",
   "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/wf-2026-01-26-abc123.json",
+  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
   "from": { "current": "1", "total": 5 },
   "to": { "current": "3", "total": 5 }
 }
@@ -340,7 +340,7 @@ Uses `action: "stop"` (command-name action). Stopping sets a non-zero exit code.
 **Text:**
 ```text
 File:     runbooks/deploy.runbook.md
-State:    .rundown/runs/wf-2026-01-26-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 
 Runbook:  STOP
 ```
@@ -351,7 +351,7 @@ Runbook:  STOP
   "action": "stop",
   "message": "User requested stop",
   "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/wf-2026-01-26-abc123.json"
+  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json"
 }
 ```
 
@@ -364,7 +364,7 @@ Runbook:  STOP
 **Text:**
 ```text
 File:     runbooks/deploy.runbook.md
-State:    .rundown/runs/wf-2026-01-26-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 
 Runbook:  COMPLETE
 ```
@@ -375,7 +375,7 @@ Runbook:  COMPLETE
   "action": "complete",
   "message": "Deployment finished",
   "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/wf-2026-01-26-abc123.json"
+  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json"
 }
 ```
 
@@ -390,7 +390,7 @@ Uses `action: "stash"` (command-name action).
 **Text:**
 ```text
 File:     runbooks/deploy.runbook.md
-State:    .rundown/runs/wf-2026-01-26-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 Prompt:   Yes
 
 Step:     1/3
@@ -403,7 +403,7 @@ Runbook:  STASHED
 {
   "action": "stash",
   "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/wf-2026-01-26-abc123.json",
+  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
   "prompted": true,
   "position": { "current": "1", "total": 3 }
 }
@@ -424,7 +424,7 @@ Uses `action: "pop"` (command-name action).
 **Text:**
 ```text
 File:     runbooks/deploy.runbook.md
-State:    .rundown/runs/wf-2026-01-26-abc123.json
+State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
 Prompt:   Yes
 
 Action:   PASS
@@ -440,7 +440,7 @@ Step description.
 {
   "action": "pop",
   "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/wf-2026-01-26-abc123.json",
+  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
   "prompted": true,
   "position": { "current": "2", "total": 3 },
   "step": { "name": "2", "description": "Second Step" }

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -162,7 +162,7 @@ describe('delegate command', () => {
       const substepStates = state?.substepStates as Array<Record<string, unknown>> | undefined;
       const ss1 = substepStates?.find((ss) => ss.id === '1');
       const delegation = ss1?.delegation as Record<string, unknown>;
-      expect(delegation.childRunId).toEqual(expect.stringMatching(/^wf-/));
+      expect(delegation.childRunId).toEqual(expect.stringMatching(/^rd_[a-f0-9]{32}$/));
       expect(delegation.tokenHash).toEqual(expect.stringMatching(/^sha256:[a-f0-9]{64}$/));
       expect(delegation.token).toBeUndefined();
 

--- a/packages/cli/__tests__/commands/output-format.test.ts
+++ b/packages/cli/__tests__/commands/output-format.test.ts
@@ -34,7 +34,7 @@ describe('output format integration tests', () => {
         workspace,
       );
 
-      expect(result.stdout).toMatch(/wf-\d{4}-\d{2}-\d{2}/);
+      expect(result.stdout).toMatch(/rd_[a-f0-9]{32}/);
     });
 
     it('shows first step details in action block', async () => {
@@ -164,7 +164,7 @@ describe('output format integration tests', () => {
       const result = await runCliInProcess('status --text', workspace);
 
       expect(result.stdout).toContain('State:');
-      expect(result.stdout).toMatch(/wf-\d{4}-\d{2}-\d{2}/);
+      expect(result.stdout).toMatch(/rd_[a-f0-9]{32}/);
     });
 
     it('shows current step block', async () => {
@@ -191,7 +191,7 @@ describe('output format integration tests', () => {
     it('includes runbook ID in output', async () => {
       const result = await runCliInProcess('stop --text', workspace);
 
-      expect(result.stdout).toMatch(/wf-\d{4}-\d{2}-\d{2}/);
+      expect(result.stdout).toMatch(/rd_[a-f0-9]{32}/);
     });
 
     it('shows confirmation message', async () => {

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -57,7 +57,7 @@ describe('status command', () => {
     const result = await runCliInProcess('status --text', workspace);
 
     expect(result.stdout).toContain('State:');
-    expect(result.stdout).toMatch(/wf-\d{4}-\d{2}-\d{2}/);
+    expect(result.stdout).toMatch(/rd_[a-f0-9]{32}/);
   });
 
   it('outputs "No active runbook" when none', async () => {

--- a/packages/cli/__tests__/helpers/normalize-cli-output.test.ts
+++ b/packages/cli/__tests__/helpers/normalize-cli-output.test.ts
@@ -62,15 +62,12 @@ describe('normalizeCliOutput', () => {
     expect(normalizeCliOutput(input, workspace)).toBe('"runId": "<uuid>"');
   });
 
-  it('masks an 8-char hex RunId template-variable value as <hex8>', () => {
-    // {{RunId}} is a built-in template variable — `randomBytes(4).toString('hex')`.
-    const input = 'RunId value is abcd1234 done';
-    expect(normalizeCliOutput(input, workspace)).toBe('RunId value is <hex8> done');
+  it('masks a concrete RunId template-variable value as <runbookId>', () => {
+    const input = 'RunId value is rd_0123456789abcdef0123456789abcdef done';
+    expect(normalizeCliOutput(input, workspace)).toBe('RunId value is <runbookId> done');
   });
 
   it('masks an 8-char hex ContextId template-variable value as <hex8>', () => {
-    // {{ContextId}} shares the same randomBytes(4)→hex shape as {{RunId}};
-    // one rule covers both.
     const input = 'ContextId value is deadbeef';
     expect(normalizeCliOutput(input, workspace)).toBe('ContextId value is <hex8>');
   });
@@ -145,40 +142,26 @@ describe('normalizeCliOutput', () => {
     expect(normalizeCliOutput(input, workspace)).toBe('loaded from <tmpdir>/other-file');
   });
 
-  it('replaces wf-YYYY-MM-DD-xxxxxx runbookId values with <runbookId>', () => {
-    // cspell:disable-next-line
-    const input = '"runbookId":"wf-2026-04-22-8gcrrf"';
+  it('replaces rd-prefixed runbookId values with <runbookId>', () => {
+    const input = '"runbookId":"rd_0123456789abcdef0123456789abcdef"';
     expect(normalizeCliOutput(input, workspace)).toBe('"runbookId":"<runbookId>"');
   });
 
   it('replaces runbookId values embedded in state paths', () => {
-    const input = '"statePath":".rundown/runs/wf-2026-04-22-zxn59z.json"';
+    const input = '"statePath":".rundown/runs/rd_0123456789abcdef0123456789abcdef.json"';
     expect(normalizeCliOutput(input, workspace)).toBe(
       '"statePath":".rundown/runs/<runbookId>.json"',
     );
   });
 
-  it('replaces runbookId with shorter base-36 suffix', () => {
-    const input = '"runbookId":"wf-2026-04-22-a1"';
-    expect(normalizeCliOutput(input, workspace)).toBe('"runbookId":"<runbookId>"');
-  });
-
-  describe('runbook ID normalization is bounded to 1-6 base-36 chars', () => {
-    it('normalizes a 3-char base-36 suffix', () => {
-      const input = '"runbookId":"wf-2026-04-23-abc"';
-      expect(normalizeCliOutput(input, workspace)).toBe('"runbookId":"<runbookId>"');
+  describe('runbook ID normalization is bounded to 32 lowercase hex chars', () => {
+    it('does NOT normalize uppercase hex', () => {
+      const input = '"runbookId":"rd_0123456789abcdef0123456789ABCDEF"';
+      expect(normalizeCliOutput(input, workspace)).toBe(input);
     });
 
-    it('normalizes a 6-char suffix (upper boundary)', () => {
-      const input = '"runbookId":"wf-2026-04-23-abcdef"';
-      expect(normalizeCliOutput(input, workspace)).toBe('"runbookId":"<runbookId>"');
-    });
-
-    it('does NOT normalize a 7-char suffix (malformed runbook ID)', () => {
-      // Suffixes longer than 6 base-36 chars do not match the production
-      // ID generator; leave them alone so genuine garbage stays visible
-      // in snapshot diffs rather than getting masked.
-      const input = '"runbookId":"wf-2026-04-23-abcdefg"';
+    it('does NOT normalize malformed lengths', () => {
+      const input = '"runbookId":"rd_0123456789abcdef0123456789abcde"';
       expect(normalizeCliOutput(input, workspace)).toBe(input);
     });
   });

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -1072,20 +1072,20 @@ export function buildSubstep(overrides: Partial<Substep> = {}): Substep {
  *   3.  Delegation tokens (`rdtk_` + alnum, including truncated `rdtk_XXX...YYYY`) → `<token>`
  *   4.  SHA-256 hex digests (e.g. delegation token_hash field) → `<tokenHash>`
  *   5.  Full UUIDs → `<uuid>`
- *   6.  Runbook state IDs of the form `wf-YYYY-MM-DD-xxxxxx` (base-36 suffix) → `<runbookId>`
+ *   6.  Runbook state IDs of the form `rd_<32 lowercase hex>` → `<runbookId>`
  *   7.  Numeric `"startedAt"` / `"completedAt"` / `"expiresAt"` / etc. epoch ms field values → `<epochMs>`
  *   8.  `"durationMs"` / `"took"` numeric field values → `<ms>`
  *   9.  Any 8-char lowercase hex string at word boundaries → `<hex8>` (see note)
  *   10. ISO 8601 timestamps → `<timestamp>`
  *   11. PID banners → `<pid>`
  *
- * Rule 9 note: the 8-hex rule is the catch-all for built-in template variables
- * `{{RunId}}` and `{{ContextId}}` (both `randomBytes(4).toString('hex')`, see
+ * Rule 9 note: the 8-hex rule is the catch-all for the built-in `{{ContextId}}`
+ * template variable (`randomBytes(4).toString('hex')`, see
  * `packages/cli/src/services/variable-discovery.ts`). It is deliberately
  * aggressive and will ALSO mask git short SHAs, step-frame hashes, and any
- * 8-hex token that happens to appear in user prompt text. Rules 7 and 8
- * (field-scoped epoch ms and duration) run BEFORE this rule so pure-digit
- * 8-char values in known fields aren't stolen by the generic hex8 pattern.
+ * 8-hex token that happens to appear in user prompt text. Rules 6, 7, and 8
+ * run BEFORE this rule so concrete run IDs, pure-digit epoch ms values in
+ * known fields, and durations aren't stolen by the generic hex8 pattern.
  * When reviewing a snapshot diff, confirm each `<hex8>` substitution is
  * legitimate — anything unexpected masked by this rule is a signal, not noise.
  *
@@ -1149,8 +1149,8 @@ export function normalizeCliOutput(output: string, workspace: TestWorkspace): st
     '<uuid>',
   );
 
-  // 6. Runbook state IDs of the form `wf-YYYY-MM-DD-xxxxxx` (base-36 suffix, 1-6 chars)
-  text = text.replace(/\bwf-\d{4}-\d{2}-\d{2}-[a-z0-9]{1,6}\b/g, '<runbookId>');
+  // 6. Runbook state IDs of the form `rd_<32 lowercase hex>`.
+  text = text.replace(/\brd_[a-f0-9]{32}\b/g, '<runbookId>');
 
   // 7. Numeric epoch ms for known fields (field-scoped so we don't eat arbitrary numbers).
   //    Runs BEFORE rule 9 so an 8-digit epoch ms value isn't stolen by the
@@ -1165,13 +1165,13 @@ export function normalizeCliOutput(output: string, workspace: TestWorkspace): st
   text = text.replace(/"durationMs":\s*\d+/g, '"durationMs": <ms>');
   text = text.replace(/"took":\s*\d+/g, '"took": <ms>');
 
-  // 9. Any 8-char lowercase hex at word boundaries — the catch-all for
-  //    {{RunId}} and {{ContextId}} template variables (both 4 random bytes
-  //    rendered as hex, see variable-discovery.ts). Deliberately aggressive:
-  //    also masks git short SHAs, step-frame hashes, and 8-hex tokens in
-  //    user prompt text. Rules 5, 6, 7, and 8 run first so UUIDs, wf-* ids,
-  //    field-scoped epoch ms, and duration values are preserved. Review
-  //    each `<hex8>` substitution in snapshot diffs.
+  // 9. Any 8-char lowercase hex at word boundaries — the catch-all for the
+  //    {{ContextId}} template variable (4 random bytes rendered as hex, see
+  //    variable-discovery.ts). Deliberately aggressive: also masks git short
+  //    SHAs, step-frame hashes, and 8-hex tokens in user prompt text. Rules
+  //    5, 6, 7, and 8 run first so UUIDs, run IDs, field-scoped epoch ms, and
+  //    duration values are preserved. Review each `<hex8>` substitution in
+  //    snapshot diffs.
   text = text.replace(/\b[0-9a-f]{8}\b/g, '<hex8>');
 
   // 10. ISO 8601 timestamps (with or without fractional seconds, Z or ±HH:MM)

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -244,6 +244,7 @@ jest.unstable_mockModule('@rundown-org/core', () => {
     CONFIG_FILE: '.rundown/config.yaml',
     isJsonValue: jest.fn((v: unknown) => v != null),
     createJsonArrayStream: jest.fn(),
+    generateRunId: jest.fn(() => 'rd_0123456789abcdef0123456789abcdef'),
     createDelegation: jest.fn(),
     Errors: RealErrors,
     RundownError: RealRundownError,

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -166,12 +166,11 @@ describe('getBuiltinVariables', () => {
     expect(builtins.Branch).toBe('');
   });
 
-  it('should return RunId as alphanumeric string', () => {
+  it('should return RunId as canonical concrete run id', () => {
     const builtins = getBuiltinVariables();
 
     expect(builtins).toHaveProperty('RunId');
-    expect(builtins.RunId).toMatch(/^[a-f0-9]+$/);
-    expect(builtins.RunId).toHaveLength(8);
+    expect(builtins.RunId).toMatch(/^rd_[a-f0-9]{32}$/);
   });
 
   it('should return unique RunId across calls', () => {

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -17,6 +17,7 @@ import { execFileSync as nodeExecFileSync } from 'node:child_process';
 import * as yaml from 'js-yaml';
 import {
   createJsonArrayStream,
+  generateRunId,
   isJsonValue,
   type JsonArray,
   type JsonObject,
@@ -308,7 +309,7 @@ export function getBuiltinVariables(): Record<string, string> {
     [BUILTIN_VARIABLES.Day]: String(now.getUTCDate()).padStart(2, '0'), // DD (01-31, UTC)
     [BUILTIN_VARIABLES.Branch]: branch ?? '', // Raw git branch name (empty when not in git)
     [BUILTIN_VARIABLES.WorkPath]: computeWorkPath(branch), // Branch-isolated artifact directory
-    [BUILTIN_VARIABLES.RunId]: randomBytes(4).toString('hex'), // 8-char hex
+    [BUILTIN_VARIABLES.RunId]: generateRunId(), // Concrete run ID
     [BUILTIN_VARIABLES.ContextId]: randomBytes(4).toString('hex'), // 8-char hex
   };
 }

--- a/packages/core/__tests__/runbook/artifact-manifest-toctou.test.ts
+++ b/packages/core/__tests__/runbook/artifact-manifest-toctou.test.ts
@@ -28,8 +28,8 @@ jest.unstable_mockModule('node:fs', () => ({
 const { appendArtifactManifestRecordSync, findArtifactMatches, readArtifactManifest } =
   await import('../../src/runbook/artifact-manifest.js');
 
-const RUN_ID = 'wf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-const SECOND_RUN_ID = 'wf_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const RUN_ID = 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const SECOND_RUN_ID = 'rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
 const record = {
   uri: `rd://artifacts/ctx1/runs/${RUN_ID}/review.json`,

--- a/packages/core/__tests__/runbook/artifact-manifest.test.ts
+++ b/packages/core/__tests__/runbook/artifact-manifest.test.ts
@@ -18,9 +18,9 @@ import {
 } from '../../src/runbook/artifact-manifest.js';
 import type { ArtifactPathOptions } from '../../src/runbook/artifact-uri.js';
 
-const RUN_ID = 'wf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-const SECOND_RUN_ID = 'wf_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
-const THIRD_RUN_ID = 'wf_cccccccccccccccccccccccccccccccc';
+const RUN_ID = 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const SECOND_RUN_ID = 'rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const THIRD_RUN_ID = 'rd_cccccccccccccccccccccccccccccccc';
 
 const record = {
   uri: `rd://artifacts/ctx1/runs/${RUN_ID}/review.json`,
@@ -291,14 +291,14 @@ describe('artifact selector resolution', () => {
     const newer = withRunId(THIRD_RUN_ID, {
       timestamp: '2026-05-04T03:25:24.000Z',
     });
-    const wrongRunbook = withRunId('wf_dddddddddddddddddddddddddddddddd', {
+    const wrongRunbook = withRunId('rd_dddddddddddddddddddddddddddddddd', {
       runbook: { source: 'plugin', path: 'ops/deploy.runbook.md' },
       timestamp: '2026-05-04T03:30:24.000Z',
     });
-    const incomplete = withRunId('wf_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', {
+    const incomplete = withRunId('rd_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', {
       timestamp: '2026-05-04T03:35:24.000Z',
     });
-    const missingFile = withRunId('wf_ffffffffffffffffffffffffffffffff', {
+    const missingFile = withRunId('rd_ffffffffffffffffffffffffffffffff', {
       timestamp: '2026-05-04T03:40:24.000Z',
     });
     await writeManifest(cwd, [older, newer, wrongRunbook, incomplete, missingFile]);

--- a/packages/core/__tests__/runbook/artifact-schema.test.ts
+++ b/packages/core/__tests__/runbook/artifact-schema.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../src/runbook/artifact-schema.js';
 import { RUNBOOK_REF_ERROR_TEXT, RunbookRefSchema } from '../../src/runbook/runbook-ref.js';
 
-const RUN_ID = 'wf_0123456789abcdef0123456789abcdef';
+const RUN_ID = 'rd_0123456789abcdef0123456789abcdef';
 const URI = `rd://artifacts/ctx1/runs/${RUN_ID}/review.json`;
 const VALID_RECORD = {
   uri: URI,
@@ -98,7 +98,7 @@ describe('artifact schemas', () => {
     expect(() =>
       ArtifactRecordSchema.parse({
         ...VALID_RECORD,
-        runId: 'wf_ffffffffffffffffffffffffffffffff',
+        runId: 'rd_ffffffffffffffffffffffffffffffff',
       }),
     ).toThrow(ARTIFACT_ERROR_TEXT.URI_RUN_ID_MISMATCH);
     expect(() => ArtifactRecordSchema.parse({ ...VALID_RECORD, key: 'other.json' })).toThrow(

--- a/packages/core/__tests__/runbook/artifact-uri.test.ts
+++ b/packages/core/__tests__/runbook/artifact-uri.test.ts
@@ -10,7 +10,7 @@ import {
   parseExactArtifactUriParts,
 } from '../../src/runbook/artifact-uri.js';
 
-const RUN_ID = 'wf_0123456789abcdef0123456789abcdef';
+const RUN_ID = 'rd_0123456789abcdef0123456789abcdef';
 const EXACT_URI = `rd://artifacts/ctx1/runs/${RUN_ID}/review.json`;
 
 describe('artifact URI utilities', () => {
@@ -99,8 +99,9 @@ describe('artifact URI utilities', () => {
   });
 
   it.each([
-    'wf_short',
-    'wf_0123456789abcdef0123456789ABCDEF',
+    'rd_short',
+    'rd_0123456789abcdef0123456789ABCDEF',
+    'wf_0123456789abcdef0123456789abcdef',
     'plain_id',
   ])('rejects invalid concrete run id %s', (runId) => {
     expect(() => parseArtifactUri(`rd://artifacts/ctx1/runs/${runId}/review.json`)).toThrow(
@@ -125,7 +126,7 @@ describe('artifact URI utilities', () => {
     expect(artifactUriToPath(EXACT_URI, { cwd: '/repo', workPath: '.rundown/work' })).toBe(
       path.join(
         '/repo',
-        '.rundown/work/.rd-ctx1/runs/wf_0123456789abcdef0123456789abcdef/review.json',
+        '.rundown/work/.rd-ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
       ),
     );
   });

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -225,6 +225,12 @@ describe('RunbookStateManager', () => {
   });
 
   describe('create with prompted flag', () => {
+    it('generates canonical rd-prefixed run ids', async () => {
+      const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
+
+      expect(state.id).toMatch(/^rd_[a-f0-9]{32}$/);
+    });
+
     it('defaults to auto mode (prompted undefined)', async () => {
       const state = await manager.create('test.md', mockRunbook, { runbookPath: 'test.md' });
       expect(state.prompted).toBeUndefined();

--- a/packages/core/src/runbook/artifact-errors.ts
+++ b/packages/core/src/runbook/artifact-errors.ts
@@ -7,7 +7,7 @@ export const ARTIFACT_ERROR_TEXT = {
   RECURSIVE_WILDCARD: 'Recursive artifact URI wildcards are not supported in v1',
   UNRESOLVED_TEMPLATE_MARKER: 'Artifact URI contains unresolved template marker',
   BARE_BUILTIN_PLACEHOLDER: 'Artifact URI contains bare built-in placeholder',
-  INVALID_RUN_ID: 'Invalid RunId: expected wf_<32 lowercase hex chars>',
+  INVALID_RUN_ID: 'Invalid RunId: expected rd_<32 lowercase hex chars>',
   INVALID_URI_FRAGMENT: 'Artifact URI fragments are not supported',
   URI_MUST_BE_EXACT: 'uri must be an exact artifact URI',
   URI_CONTEXT_MISMATCH: 'uri contextId does not match contextId',

--- a/packages/core/src/runbook/artifact-uri.ts
+++ b/packages/core/src/runbook/artifact-uri.ts
@@ -7,7 +7,7 @@ import { ARTIFACT_ERROR_TEXT } from './artifact-errors.js';
 /**
  * Concrete run identifier syntax used by artifact producer URIs and metadata.
  */
-export const RUN_ID_PATTERN = /^wf_[a-f0-9]{32}$/;
+export const RUN_ID_PATTERN = /^rd_[a-f0-9]{32}$/;
 const TEMPLATE_MARKER_PATTERN = /{{.*}}/;
 const BARE_BUILTIN_PLACEHOLDERS = new Set(['ContextId', 'RunId']);
 const SUPPORTED_SELECTOR_QUERY_KEYS = new Set(['status', 'runbook', 'source', 'latest']);
@@ -284,7 +284,7 @@ function validateConcreteRunId(runId: string): void {
  * Validate that a run id names one concrete run.
  *
  * @param runId - Candidate run identifier
- * @throws {Error} When the run id is not `wf_` plus 32 lowercase hex characters
+ * @throws {Error} When the run id is not `rd_` plus 32 lowercase hex characters
  */
 export function assertConcreteRunId(runId: string): void {
   validateConcreteRunId(runId);

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -13,7 +13,12 @@ export * from './step-utils.js';
 export * from './targeting.js';
 export * from './claim-id.js';
 export * from './transition-kernel.js';
-export { RunbookStateManager, StaleRunbookStateError, type SessionData } from './state.js';
+export {
+  generateRunId,
+  RunbookStateManager,
+  StaleRunbookStateError,
+  type SessionData,
+} from './state.js';
 export { SessionService, type ReleaseRunbookResult } from './session-service.js';
 export { readActiveRunScope, type ActiveRunScope } from './session-reader.js';
 export { ExecutionLifecycleService } from './execution-lifecycle-service.js';

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -1,4 +1,5 @@
 // src/runbook/state.ts
+import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { OutputDeclaration } from '@rundown-org/parser';
@@ -65,11 +66,13 @@ export class StaleRunbookStateError extends Error {
   }
 }
 
-function generateId(): string {
-  const now = new Date();
-  const date = now.toISOString().slice(0, 10);
-  const random = Math.random().toString(36).slice(2, 8);
-  return `wf-${date}-${random}`;
+/**
+ * Generate a concrete Rundown run identifier.
+ *
+ * @returns Run ID in canonical `rd_<32 lowercase hex>` form
+ */
+export function generateRunId(): string {
+  return `rd_${randomBytes(16).toString('hex')}`;
 }
 
 /**
@@ -205,7 +208,7 @@ export class RunbookStateManager {
     runbook: Runbook | ResolvedRunbook,
     options: CreateOptions,
   ): Promise<RunbookState> {
-    const id = generateId();
+    const id = generateRunId();
     const now = new Date().toISOString();
 
     const initialStep = runbook.steps[0];
@@ -245,7 +248,7 @@ export class RunbookStateManager {
   /**
    * Load a runbook state from disk by ID.
    *
-   * @param id - The runbook state ID (e.g., 'wf-2025-01-12-abc123')
+   * @param id - The runbook state ID (e.g., 'rd_0123456789abcdef0123456789abcdef')
    * @returns The loaded RunbookState, or null if file not found
    * @throws {Error} If the state file exists but fails schema validation (stale state)
    * @throws {Error} If the runbook state uses deprecated dynamic-step snapshots


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runbook ID format changed to rd_<32 lowercase hexadecimal characters>, replacing the previous wf-based patterns.

* **Documentation**
  * Updated all examples to reflect the new Runbook ID format in CLI and runtime references.

* **Tests**
  * Updated test expectations across commands and services to validate the new ID format and pattern validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
