### PR TITLE
feat(runtime): add artifact and run-scoped path helpers

### DIFF
--- a/packages/claude-code-plugin/__tests__/runbook-rdpath-outputs.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbook-rdpath-outputs.integration.test.ts
@@ -1,16 +1,9 @@
 /**
- * End-to-end integration test for rdpath / OUTPUTS / rdpath-find contracts.
+ * End-to-end regression guard for `rdpath find` glob behavior.
  *
  * Drives a synthetic runbook through `rd run` (NOT --prompted) so bash blocks
- * actually execute. Catches regressions that `rd check` and orchestration-only
- * scenarios both miss:
- *   - rdpath invocations missing --file
- *   - Truncated rdx --check "$(rdpath ...)" invocations
- *   - rdpath find globs broken by the YYYY-MM-DD- date prefix
- *
- * Pattern: combines the spawn-style runner from test-utils.ts with the
- * `state.variables` assertion model in
- * packages/cli/__tests__/integration/context-passing-outputs.test.ts.
+ * actually execute, then asserts that `rdpath find` without a `*-` prefix glob
+ * fails to match the date-prefixed file written by `rdpath --file`.
  *
  * Policy note: uses --allow-run with an explicit allowlist and --no-sandbox for the
  * mkdtemp workspace (an isolated trust boundary). --allow-write does not reach the
@@ -24,7 +17,6 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { spawnSync } from 'node:child_process';
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -147,45 +139,6 @@ describe('runbook end-to-end: rdpath + OUTPUTS contract', () => {
     const raw = await readFile(join(runsDir, files[0]), 'utf-8');
     return JSON.parse(raw) as Record<string, unknown>;
   }
-
-  it('runs end-to-end, populates OUTPUTS, finds fixture via rdpath find', async () => {
-    const runbookPath = join(tempDir, 'probe.runbook.md');
-    await writeFile(runbookPath, RUNBOOK_SOURCE);
-
-    const result = runRunbook(runbookPath);
-
-    // Diagnostic: surface CLI output if the run fails
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `runbook exited ${String(result.exitCode)}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
-      );
-    }
-    expect(result.exitCode).toBe(0);
-
-    // Assertion 1: OUTPUTS path helper resolved and merged into state.variables.
-    // Tolerates an optional <branch>/ segment between work/ and .rd-<ctx>/
-    // because WorkPath may include a branch suffix in some workspaces.
-    const state = await readSingleRunbookState();
-    const fixturePath = state.variables?.FixturePath;
-    expect(typeof fixturePath).toBe('string');
-    expect(fixturePath as string).toMatch(
-      /^\.rundown\/work\/(?:[^/]+\/)?\.rd-[A-Za-z0-9_-]+\/\d{4}-\d{2}-\d{2}-fixture\.json$/,
-    );
-
-    // Assertion 2: the fixture file actually exists at that resolved path,
-    // proving rdpath --file produces the same path as the OUTPUTS path helper.
-    const absoluteFixturePath = join(tempDir, fixturePath as string);
-    expect(existsSync(absoluteFixturePath)).toBe(true);
-    const fixtureContents = await readFile(absoluteFixturePath, 'utf-8');
-    expect(fixtureContents.trim()).toBe('{"ok":true}');
-
-    // Assertion 3: rdpath find with date-prefix glob ("*-fixture.json") matched
-    // and step 2 reached COMPLETE. Step 2 is PASS COMPLETE / FAIL STOP, so the
-    // runbook only completes if the bash block exited 0 — i.e. rdpath find
-    // matched at least one file. state.lifecycle is a string discriminant
-    // ("completed" | "stopped" | ...), not an object.
-    expect(state.lifecycle).toBe('completed');
-  }, 30_000);
 
   it('regression guard: rdpath find without "*-" prefix glob fails to match dated file', async () => {
     // Same as the happy path but step 2 uses an unprefixed glob.

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -93,7 +93,7 @@ Resolved path: {{ path "review.json" }}
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('{{ path "review.json" }}');
       expect(result.stdout).toMatch(
-        /\.rundown\/work\/\.rd-[A-Za-z0-9_-]+\/runs\/rd_[A-Za-z0-9]+\/review\.json/,
+        /\.rundown\/work\/\.rd-[A-Za-z0-9._-]+\/runs\/rd_[A-Za-z0-9._-]+\/review\.json/,
       );
     });
 

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -93,7 +93,7 @@ Resolved path: {{ path "review.json" }}
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('{{ path "review.json" }}');
       expect(result.stdout).toMatch(
-        /\.rundown\/work(?:\/[^/\s]+)?\/\.rd-[A-Za-z0-9_-]+\/\d{4}-\d{2}-\d{2}-review\.json/,
+        /\.rundown\/work\/\.rd-[A-Za-z0-9_-]+\/runs\/rd_[A-Za-z0-9]+\/review\.json/,
       );
     });
 

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -239,6 +239,22 @@ jest.unstable_mockModule('@rundown-org/core', () => {
       const date = new Date().toISOString().slice(0, 10);
       return `${dir}/.rd-${ctx}/${date}-${file}`;
     }),
+    applyRunArtifactHelper: jest.fn(
+      (
+        kind: 'artifact' | 'path',
+        key: string,
+        frame: Record<string, unknown>,
+        options: { cwd: string },
+      ) => {
+        const contextId = String(frame.ContextId ?? 'ctx');
+        const runId = String(frame.RunId ?? 'rd_0123456789abcdef0123456789abcdef');
+        const workPath = String(frame.WorkPath ?? '.rundown/work');
+        const uri = `rd://artifacts/${contextId}/runs/${runId}/${key}`;
+        return kind === 'artifact'
+          ? uri
+          : `${options.cwd}/${workPath}/.rd-${contextId}/runs/${runId}/${key}`;
+      },
+    ),
     ...mockErrorHelpers,
     RUNS_DIR: '.rundown/runs',
     WORK_DIR: '.rundown/work',

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -246,9 +246,10 @@ jest.unstable_mockModule('@rundown-org/core', () => {
         frame: Record<string, unknown>,
         options: { cwd: string },
       ) => {
-        const contextId = String(frame.ContextId ?? 'ctx');
-        const runId = String(frame.RunId ?? 'rd_0123456789abcdef0123456789abcdef');
-        const workPath = String(frame.WorkPath ?? '.rundown/work');
+        const contextId = typeof frame.ContextId === 'string' ? frame.ContextId : 'ctx';
+        const runId =
+          typeof frame.RunId === 'string' ? frame.RunId : 'rd_0123456789abcdef0123456789abcdef';
+        const workPath = typeof frame.WorkPath === 'string' ? frame.WorkPath : '.rundown/work';
         const uri = `rd://artifacts/${contextId}/runs/${runId}/${key}`;
         return kind === 'artifact'
           ? uri

--- a/packages/cli/__tests__/services/helper-registry.test.ts
+++ b/packages/cli/__tests__/services/helper-registry.test.ts
@@ -80,6 +80,16 @@ describe('loadHelperModules', () => {
     warnSpy.mockRestore();
   });
 
+  it('rejects "artifact" as a helper name with a warning', async () => {
+    const helperFile = path.join(tmpDir, 'bad-artifact.mjs');
+    await fs.writeFile(helperFile, 'export function artifact(v) { return v; }');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const registry = await loadHelperModules([helperFile], tmpDir, tmpDir);
+    expect(registry.has('artifact')).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"artifact" is reserved'));
+    warnSpy.mockRestore();
+  });
+
   it('skips non-function exports with a warning', async () => {
     const helperFile = path.join(tmpDir, 'mixed.mjs');
     await fs.writeFile(

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import { parseRunbookDocument } from '@rundown-org/core';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { parseRunbookDocument, readArtifactManifest } from '@rundown-org/core';
 import type {
   Runbook,
   Step,
@@ -31,6 +34,15 @@ import {
   assertStepWithCommand,
   parseResolvedRunbook,
 } from '../helpers/parse-helpers.js';
+
+const RUN_ID = 'rd_0123456789abcdef0123456789abcdef';
+const RUNBOOK_REF = {
+  source: 'plugin',
+  path: 'planning/review/review-plan-risk-safety.runbook.md',
+} as const;
+const DEFAULT_TEMPLATE_HELPER_OPTIONS = {
+  cwd: path.join(tmpdir(), `rd-template-renderer-${process.pid}`),
+};
 
 describe('expandLoopVariables', () => {
   it('should expand named loop variable', () => {
@@ -238,6 +250,123 @@ describe('substituteRunbookVariables', () => {
     const step = result.steps[0];
     assertStepWithCommand(step);
     expect(step.command.code).toBe('git checkout {{BRANCH}}');
+  });
+
+  it('renders path helper in command text and records a manifest row', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-'));
+    try {
+      const runbook = parseResolvedRunbook(
+        "# Test\n\n## 1. Produce\n\n```bash\nprintf '{}' > '{{ path \"review.json\" }}'\n```",
+      );
+      const variables = {
+        WorkPath: '.rundown/work',
+        ContextId: 'ctx1',
+        RunId: 'rd_0123456789abcdef0123456789abcdef',
+        RunbookRef: {
+          source: 'plugin',
+          path: 'planning/review/review-plan-risk-safety.runbook.md',
+        },
+      };
+
+      const result = substituteRunbookVariables(runbook, variables, { cwd });
+      const step = result.steps[0];
+      assertStepWithCommand(step);
+      const expectedPath = path.join(
+        cwd,
+        '.rundown/work/.rd-ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
+      );
+      expect(step.command.code).toBe(`printf '{}' > '${expectedPath}'`);
+
+      const records = await readArtifactManifest({ cwd, workPath: variables.WorkPath }, 'ctx1');
+      expect(records).toEqual([
+        expect.objectContaining({
+          uri: 'rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
+          runId: variables.RunId,
+          contextId: variables.ContextId,
+          runbook: variables.RunbookRef,
+          key: 'review.json',
+          timestamp: expect.any(String),
+        }),
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('renders path helper in prompt text and records a manifest row', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-'));
+    try {
+      const runbook = parseResolvedRunbook(
+        '# Test\n\n## 1. Confirm\n\n> Review {{ path "review.json" }}\n',
+      );
+      const variables = {
+        WorkPath: '.rundown/work',
+        ContextId: 'ctx1',
+        RunId: 'rd_0123456789abcdef0123456789abcdef',
+        RunbookRef: {
+          source: 'plugin',
+          path: 'planning/review/review-plan-risk-safety.runbook.md',
+        },
+      };
+
+      const result = substituteRunbookVariables(runbook, variables, { cwd });
+      const expectedPath = path.join(
+        cwd,
+        '.rundown/work/.rd-ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
+      );
+      expect(result.steps[0].prompt).toContain(expectedPath);
+
+      const records = await readArtifactManifest({ cwd, workPath: variables.WorkPath }, 'ctx1');
+      expect(records).toEqual([
+        expect.objectContaining({
+          uri: 'rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
+          runId: variables.RunId,
+          contextId: variables.ContextId,
+          runbook: variables.RunbookRef,
+          key: 'review.json',
+          timestamp: expect.any(String),
+        }),
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('renders artifact helper to an exact URI and records a manifest row', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-'));
+    try {
+      const runbook = parseResolvedRunbook(
+        '# Test\n\n## 1. Report\n\n> Artifact {{ artifact "review.json" }}\n',
+      );
+      const variables = {
+        WorkPath: '.rundown/work',
+        ContextId: 'ctx1',
+        RunId: 'rd_0123456789abcdef0123456789abcdef',
+        RunbookRef: {
+          source: 'plugin',
+          path: 'planning/review/review-plan-risk-safety.runbook.md',
+        },
+      };
+
+      const result = substituteRunbookVariables(runbook, variables, { cwd });
+      expect(result.steps[0].prompt).toContain(
+        'rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
+      );
+
+      const records = await readArtifactManifest({ cwd, workPath: variables.WorkPath }, 'ctx1');
+      expect(records).toEqual([
+        expect.objectContaining({
+          uri: 'rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
+          runId: variables.RunId,
+          contextId: variables.ContextId,
+          runbook: variables.RunbookRef,
+          key: 'review.json',
+          timestamp: expect.any(String),
+        }),
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('should substitute runbook title', () => {
@@ -1903,11 +2032,18 @@ describe('substituteText with HelperRegistry', () => {
 
   it('renders built-in path helper with default context', () => {
     expect(
-      substituteText('Artifact: {{ path "review.json" }}', {
-        WorkPath: '.rundown/work/demo',
-        ContextId: 'ctx-123',
-      }),
-    ).toMatch(/^Artifact: \.rundown\/work\/demo\/\.rd-ctx-123\/\d{4}-\d{2}-\d{2}-review\.json$/);
+      substituteText(
+        'Artifact: {{ path "review.json" }}',
+        {
+          WorkPath: '.rundown/work/demo',
+          ContextId: 'ctx-123',
+          RunId: RUN_ID,
+          RunbookRef: RUNBOOK_REF,
+        },
+        undefined,
+        DEFAULT_TEMPLATE_HELPER_OPTIONS,
+      ),
+    ).toContain(`.rundown/work/demo/.rd-ctx-123/runs/${RUN_ID}/review.json`);
   });
 
   it('preserves built-in path helper when required variables are missing', () => {
@@ -1917,23 +2053,23 @@ describe('substituteText with HelperRegistry', () => {
     );
   });
 
-  it('renders built-in path helper with ctx template override', () => {
+  it('preserves legacy path helper ctx template override as literal text', () => {
     expect(
       substituteText('{{ path "review.json" ctx={{ childCtx }} }}', {
         WorkPath: '.rundown/work/demo',
         ContextId: 'parent',
         childCtx: 'child-123',
       }),
-    ).toMatch(/^\.rundown\/work\/demo\/\.rd-child-123\/\d{4}-\d{2}-\d{2}-review\.json$/);
+    ).toBe('{{ path "review.json" ctx=child-123 }}');
   });
 
-  it('renders built-in path helper with bare literal ctx override', () => {
+  it('preserves legacy path helper bare ctx override as literal text', () => {
     expect(
       substituteText('{{ path "review.json" ctx=alt-ctx }}', {
         WorkPath: '.rundown/work/demo',
         ContextId: 'parent',
       }),
-    ).toMatch(/^\.rundown\/work\/demo\/\.rd-alt-ctx\/\d{4}-\d{2}-\d{2}-review\.json$/);
+    ).toBe('{{ path "review.json" ctx=alt-ctx }}');
   });
 
   it('calls helper with dotted variable path argument', () => {
@@ -2015,11 +2151,17 @@ describe('substituteText with HelperRegistry', () => {
 
   it('expandLoopVariables dispatches built-in path helper calls', () => {
     expect(
-      expandLoopVariables('{{ path "review.json" }}', {
-        WorkPath: '.rundown/work/demo',
-        ContextId: 'ctx-123',
-      }),
-    ).toMatch(/^\.rundown\/work\/demo\/\.rd-ctx-123\/\d{4}-\d{2}-\d{2}-review\.json$/);
+      expandLoopVariables(
+        '{{ path "review.json" }}',
+        {
+          WorkPath: '.rundown/work/demo',
+          ContextId: 'ctx-123',
+          RunId: RUN_ID,
+          RunbookRef: RUNBOOK_REF,
+        },
+        DEFAULT_TEMPLATE_HELPER_OPTIONS,
+      ),
+    ).toContain(`.rundown/work/demo/.rd-ctx-123/runs/${RUN_ID}/review.json`);
   });
 
   it('expandLoopVariablesForCommand dispatches helper calls with shell escaping', () => {
@@ -2031,11 +2173,17 @@ describe('substituteText with HelperRegistry', () => {
 
   it('expandLoopVariablesForCommand dispatches built-in path helper calls with shell escaping', () => {
     expect(
-      expandLoopVariablesForCommand('cat {{ path "review.json" }}', {
-        WorkPath: '.rundown/work/demo path',
-        ContextId: 'ctx-123',
-      }),
-    ).toMatch(/^cat '\.rundown\/work\/demo path\/\.rd-ctx-123\/\d{4}-\d{2}-\d{2}-review\.json'$/);
+      expandLoopVariablesForCommand(
+        'cat {{ path "review.json" }}',
+        {
+          WorkPath: '.rundown/work/demo path',
+          ContextId: 'ctx-123',
+          RunId: RUN_ID,
+          RunbookRef: RUNBOOK_REF,
+        },
+        DEFAULT_TEMPLATE_HELPER_OPTIONS,
+      ),
+    ).toContain(`.rundown/work/demo path/.rd-ctx-123/runs/${RUN_ID}/review.json`);
   });
 });
 

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -41,7 +41,7 @@ const RUNBOOK_REF = {
   path: 'planning/review/review-plan-risk-safety.runbook.md',
 } as const;
 const DEFAULT_TEMPLATE_HELPER_OPTIONS = {
-  cwd: path.join(tmpdir(), `rd-template-renderer-${process.pid}`),
+  cwd: path.join(tmpdir(), `rd-template-renderer-${String(process.pid)}`),
 };
 
 describe('expandLoopVariables', () => {

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -40,9 +40,6 @@ const RUNBOOK_REF = {
   source: 'plugin',
   path: 'planning/review/review-plan-risk-safety.runbook.md',
 } as const;
-const DEFAULT_TEMPLATE_HELPER_OPTIONS = {
-  cwd: path.join(tmpdir(), `rd-template-renderer-${String(process.pid)}`),
-};
 
 describe('expandLoopVariables', () => {
   it('should expand named loop variable', () => {
@@ -2030,20 +2027,25 @@ describe('substituteText with HelperRegistry', () => {
     expect(substituteText('{{ upper "hello world" }}', {})).toBe('HELLO WORLD');
   });
 
-  it('renders built-in path helper with default context', () => {
-    expect(
-      substituteText(
-        'Artifact: {{ path "review.json" }}',
-        {
-          WorkPath: '.rundown/work/demo',
-          ContextId: 'ctx-123',
-          RunId: RUN_ID,
-          RunbookRef: RUNBOOK_REF,
-        },
-        undefined,
-        DEFAULT_TEMPLATE_HELPER_OPTIONS,
-      ),
-    ).toContain(`.rundown/work/demo/.rd-ctx-123/runs/${RUN_ID}/review.json`);
+  it('renders built-in path helper with default context', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-renderer-'));
+    try {
+      expect(
+        substituteText(
+          'Artifact: {{ path "review.json" }}',
+          {
+            WorkPath: '.rundown/work/demo',
+            ContextId: 'ctx-123',
+            RunId: RUN_ID,
+            RunbookRef: RUNBOOK_REF,
+          },
+          undefined,
+          { cwd },
+        ),
+      ).toContain(`.rundown/work/demo/.rd-ctx-123/runs/${RUN_ID}/review.json`);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('preserves built-in path helper when required variables are missing', () => {
@@ -2149,19 +2151,24 @@ describe('substituteText with HelperRegistry', () => {
     expect(expandLoopVariables('{{ upper batch }}', { batch: 'hello' })).toBe('HELLO');
   });
 
-  it('expandLoopVariables dispatches built-in path helper calls', () => {
-    expect(
-      expandLoopVariables(
-        '{{ path "review.json" }}',
-        {
-          WorkPath: '.rundown/work/demo',
-          ContextId: 'ctx-123',
-          RunId: RUN_ID,
-          RunbookRef: RUNBOOK_REF,
-        },
-        DEFAULT_TEMPLATE_HELPER_OPTIONS,
-      ),
-    ).toContain(`.rundown/work/demo/.rd-ctx-123/runs/${RUN_ID}/review.json`);
+  it('expandLoopVariables dispatches built-in path helper calls', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-renderer-'));
+    try {
+      expect(
+        expandLoopVariables(
+          '{{ path "review.json" }}',
+          {
+            WorkPath: '.rundown/work/demo',
+            ContextId: 'ctx-123',
+            RunId: RUN_ID,
+            RunbookRef: RUNBOOK_REF,
+          },
+          { cwd },
+        ),
+      ).toContain(`.rundown/work/demo/.rd-ctx-123/runs/${RUN_ID}/review.json`);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('expandLoopVariablesForCommand dispatches helper calls with shell escaping', () => {
@@ -2171,19 +2178,24 @@ describe('substituteText with HelperRegistry', () => {
     );
   });
 
-  it('expandLoopVariablesForCommand dispatches built-in path helper calls with shell escaping', () => {
-    expect(
-      expandLoopVariablesForCommand(
-        'cat {{ path "review.json" }}',
-        {
-          WorkPath: '.rundown/work/demo path',
-          ContextId: 'ctx-123',
-          RunId: RUN_ID,
-          RunbookRef: RUNBOOK_REF,
-        },
-        DEFAULT_TEMPLATE_HELPER_OPTIONS,
-      ),
-    ).toContain(`.rundown/work/demo path/.rd-ctx-123/runs/${RUN_ID}/review.json`);
+  it('expandLoopVariablesForCommand dispatches built-in path helper calls with shell escaping', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-renderer-'));
+    try {
+      expect(
+        expandLoopVariablesForCommand(
+          'cat {{ path "review.json" }}',
+          {
+            WorkPath: '.rundown/work/demo path',
+            ContextId: 'ctx-123',
+            RunId: RUN_ID,
+            RunbookRef: RUNBOOK_REF,
+          },
+          { cwd },
+        ),
+      ).toContain(`.rundown/work/demo path/.rd-ctx-123/runs/${RUN_ID}/review.json`);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -366,6 +366,42 @@ describe('substituteRunbookVariables', () => {
     }
   });
 
+  it('preserves the helper placeholder when helperOptions is omitted (startup AST walk)', () => {
+    const runbook = parseResolvedRunbook(
+      '# Test\n\n## 1. Confirm\n\n> Review {{ path "review.json" }}\n',
+    );
+    const result = substituteRunbookVariables(runbook, {
+      WorkPath: '.rundown/work',
+      ContextId: 'ctx1',
+      RunId: RUN_ID,
+      RunbookRef: RUNBOOK_REF,
+    });
+    expect(result.steps[0].prompt).toContain('{{ path "review.json" }}');
+  });
+
+  it('propagates helper resolution failures when helperOptions is provided', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-'));
+    try {
+      const runbook = parseResolvedRunbook(
+        '# Test\n\n## 1. Confirm\n\n> Review {{ artifact "../escape" }}\n',
+      );
+      expect(() =>
+        substituteRunbookVariables(
+          runbook,
+          {
+            WorkPath: '.rundown/work',
+            ContextId: 'ctx1',
+            RunId: RUN_ID,
+            RunbookRef: RUNBOOK_REF,
+          },
+          { cwd },
+        ),
+      ).toThrow(/Invalid ArtifactKey/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('should substitute runbook title', () => {
     const rawMarkdown = '# {{project}} Runbook\n\n## 1. Start\n\nGo.';
     const runbook = parseResolvedRunbook(rawMarkdown);

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -958,15 +958,19 @@ export async function runExecutionLoop(
       }
     }
 
+    // Expand once: artifact-producing helpers in command code append a manifest
+    // row per call, so a second expansion would duplicate the entries.
+    const expandedCommandCode = command
+      ? expandLoopVariablesForCommand(command.code, stepVars, helperOptions)
+      : undefined;
+
     emitter.emit('STEP_ENTERED', {
       position: stepPosition,
       stepName: isSubstep ? itemToRender.id : itemToRender.name,
       description: expandedDescription,
       prompt: expandedPrompt,
       hasCommand: !!command,
-      commandCode: command?.code
-        ? expandLoopVariablesForCommand(command.code, stepVars, helperOptions)
-        : command?.code,
+      commandCode: expandedCommandCode,
       commandLang: command?.lang,
       isSubstep,
       prompted: prompted || stepIsPrompted,
@@ -981,16 +985,9 @@ export async function runExecutionLoop(
 
     // If CLI prompted mode, per-step prompted FOR, OR no command
     // Use itemToRender which may be a substep with its own command
-    if (prompted || stepIsPrompted || !command) {
+    if (prompted || stepIsPrompted || expandedCommandCode === undefined) {
       return 'waiting';
     }
-
-    // Expand command code for execution (after guard — command is guaranteed)
-    const expandedCommandCode = expandLoopVariablesForCommand(
-      command.code,
-      stepVars,
-      helperOptions,
-    );
 
     // --- Output capture: pre-spawn ---------------------------------------
     const substepId = isSubstep ? itemToRender.id : undefined;

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -811,11 +811,18 @@ export async function runExecutionLoop(
       currentStep.kind === 'for' ? currentStep.forClause : undefined,
       mergedTemplateVars,
     );
-    const expandedDescription = expandLoopVariables(itemToRender.description, stepVars);
+    const helperOptions = { cwd };
+    const expandedDescription = expandLoopVariables(
+      itemToRender.description,
+      stepVars,
+      helperOptions,
+    );
     // For prompted-for substeps, fall back to the step-level prompt (the reconstructed FOR text)
     const rawPrompt =
       itemToRender.prompt ?? (currentStep.kind === 'prompted-for' ? currentStep.prompt : undefined);
-    const expandedPrompt = rawPrompt ? expandLoopVariables(rawPrompt, stepVars) : rawPrompt;
+    const expandedPrompt = rawPrompt
+      ? expandLoopVariables(rawPrompt, stepVars, helperOptions)
+      : rawPrompt;
 
     // Emit STEP_ENTERED event
     const stepPosition = buildStepPosition(
@@ -958,7 +965,7 @@ export async function runExecutionLoop(
       prompt: expandedPrompt,
       hasCommand: !!command,
       commandCode: command?.code
-        ? expandLoopVariablesForCommand(command.code, stepVars)
+        ? expandLoopVariablesForCommand(command.code, stepVars, helperOptions)
         : command?.code,
       commandLang: command?.lang,
       isSubstep,
@@ -979,7 +986,11 @@ export async function runExecutionLoop(
     }
 
     // Expand command code for execution (after guard — command is guaranteed)
-    const expandedCommandCode = expandLoopVariablesForCommand(command.code, stepVars);
+    const expandedCommandCode = expandLoopVariablesForCommand(
+      command.code,
+      stepVars,
+      helperOptions,
+    );
 
     // --- Output capture: pre-spawn ---------------------------------------
     const substepId = isSubstep ? itemToRender.id : undefined;

--- a/packages/cli/src/services/helper-registry.ts
+++ b/packages/cli/src/services/helper-registry.ts
@@ -25,7 +25,7 @@ export type HelperRegistry = ReadonlyMap<string, (value: string) => string>;
  * future built-in that uses `{{ name arg }}` syntax in template bodies must be
  * added here, or a same-named user helper will intercept calls to it.
  */
-const RESERVED_HELPER_NAMES = new Set(['path']);
+const RESERVED_HELPER_NAMES = new Set(['artifact', 'path']);
 
 /**
  * Validate a helper module path is within the project root.
@@ -96,8 +96,8 @@ export async function validateHelperPath(
  * Load all helper modules from the given list of paths.
  *
  * Each module is loaded via dynamic `import()`. Named function exports become
- * helpers. Non-function exports, async functions, and the reserved name `path`
- * are skipped with a warning. Module load failures are warned and skipped.
+ * helpers. Non-function exports, async functions, and reserved built-in helper
+ * names are skipped with a warning. Module load failures are warned and skipped.
  *
  * @param paths - Absolute or project-relative paths to JS/ESM modules
  * @param cwd - Working directory for resolving relative paths

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -41,7 +41,6 @@ import {
   invokeHelperSafely,
   isJsonArrayStream,
   type EvaluateOutputOptions,
-  type OutputVars,
   type TemplateVarValue,
 } from '@rundown-org/core';
 import type { StepVariables } from './execution-vars.js';
@@ -733,12 +732,20 @@ function resolveHelperCall(helperName: string, argValue: string, original: strin
  * so prompt text, command text, descriptions, and OUTPUTS all share the same
  * reserved built-in semantics.
  *
+ * Fail-closed: when `helperOptions` is provided, errors from
+ * `applyRunArtifactHelper` (missing required frame variables, invalid artifact
+ * key, manifest write failure) propagate to the caller. Returning the original
+ * placeholder text is reserved for the case where helper resolution is
+ * intentionally disabled (`helperOptions === undefined`, e.g. AST walks at
+ * startup before runtime variables are available).
+ *
  * @param kind - Helper kind to resolve
  * @param key - Artifact key from the helper call
  * @param variables - Template variables available at the render site
  * @param helperOptions - Filesystem options for path resolution and manifest writes
- * @param original - Original helper call text to preserve on unresolved input
- * @returns Artifact URI/local path, or the original text when unresolved
+ * @param original - Original helper call text to preserve when resolution is disabled
+ * @returns Artifact URI/local path, or `original` when `helperOptions` is undefined
+ * @throws {Error} When `helperOptions` is provided and helper resolution fails
  */
 function resolveRunArtifactHelperCall(
   kind: 'artifact' | 'path',
@@ -748,11 +755,7 @@ function resolveRunArtifactHelperCall(
   original: string,
 ): string {
   if (helperOptions === undefined) return original;
-  try {
-    return applyRunArtifactHelper(kind, key, variables as OutputVars, helperOptions);
-  } catch {
-    return original;
-  }
+  return applyRunArtifactHelper(kind, key, variables, helperOptions);
 }
 
 /**

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -853,6 +853,7 @@ export function substituteText(
  *
  * @param command - Parsed command block, if present
  * @param variables - Variable map for substitution
+ * @param helperOptions - Filesystem options for artifact-producing helpers
  * @returns Command with code expanded and shell-escaped, or undefined
  */
 function substituteCommand(
@@ -864,6 +865,14 @@ function substituteCommand(
   return substituteRequiredCommand(command, variables, helperOptions);
 }
 
+/**
+ * Substitute template variables in a guaranteed command, applying shell escaping.
+ *
+ * @param command - Parsed command block (required)
+ * @param variables - Variable map for substitution
+ * @param helperOptions - Filesystem options for artifact-producing helpers
+ * @returns Command with code expanded and shell-escaped
+ */
 function substituteRequiredCommand(
   command: Command,
   variables: Record<string, unknown>,
@@ -880,6 +889,7 @@ function substituteRequiredCommand(
  *
  * @param substep - Parsed substep node
  * @param variables - Variable map for substitution
+ * @param helperOptions - Filesystem options for artifact-producing helpers
  * @param forVariable - FOR loop variable name — runbook paths scoped to it are skipped
  * @returns Substep with all string fields expanded
  */
@@ -912,6 +922,7 @@ function substituteSubstep(
  *
  * @param step - Parsed step node
  * @param variables - Variable map for substitution
+ * @param helperOptions - Filesystem options for artifact-producing helpers
  * @returns Step with all string fields expanded
  */
 function substituteStep(

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -37,9 +37,11 @@ import {
   RunbookSyntaxError,
 } from '@rundown-org/parser';
 import {
-  assembleArtifactPath,
+  applyRunArtifactHelper,
   invokeHelperSafely,
   isJsonArrayStream,
+  type EvaluateOutputOptions,
+  type OutputVars,
   type TemplateVarValue,
 } from '@rundown-org/core';
 import type { StepVariables } from './execution-vars.js';
@@ -99,14 +101,13 @@ const HELPER_CALL_TEMPLATE_REGEX =
 
 /**
  * Matches the built-in artifact path helper in inline template text.
- *
- * Mirrors the OUTPUTS evaluator syntax:
- * - `{{ path "file.json" }}`
- * - `{{ path "file.json" ctx=child-ctx }}`
- * - `{{ path "file.json" ctx={{ childCtx }} }}`
  */
-const PATH_HELPER_TEMPLATE_REGEX =
-  /\{\{\s*path\s+"([^"]+)"(?:\s+ctx=(\{\{[^}]*\}\}|[^\s}]+))?\s*\}\}/g;
+const PATH_HELPER_TEMPLATE_REGEX = /\{\{\s*path\s+"([^"]+)"\s*\}\}/g;
+
+/** Matches the built-in artifact URI helper in inline template text. */
+const ARTIFACT_HELPER_TEMPLATE_REGEX = /\{\{\s*artifact\s+"([^"]+)"\s*\}\}/g;
+
+type TemplateHelperOptions = EvaluateOutputOptions;
 
 /**
  * Resolve a dotted path in an object using own-property traversal.
@@ -221,10 +222,15 @@ function resolveTemplatePath(path: string, variables: Record<string, unknown>): 
  *
  * @param text - Input text that may contain placeholders
  * @param variables - Runtime/template variables for substitution (typed `StepVariables` at the call boundary)
+ * @param helperOptions - Filesystem options for artifact-producing helpers
  * @returns Expanded text with unresolved placeholders preserved
  */
-export function expandLoopVariables(text: string, variables: Readonly<StepVariables>): string {
-  return substituteText(text, variables);
+export function expandLoopVariables(
+  text: string,
+  variables: Readonly<StepVariables>,
+  helperOptions?: TemplateHelperOptions,
+): string {
+  return substituteText(text, variables, undefined, helperOptions);
 }
 
 // ─── FOR clause bound resolution ─────────────────────────────────────────────
@@ -712,7 +718,7 @@ const SAFE_SHELL_VALUE = /^(?!-)(?!.*\.\.)[a-zA-Z0-9_./-]+$/;
  * @returns Helper result or original match
  */
 function resolveHelperCall(helperName: string, argValue: string, original: string): string {
-  if (helperName === 'path') return original;
+  if (helperName === 'artifact' || helperName === 'path') return original;
   const registry = getHelperRegistry();
   const helper = registry.get(helperName);
   if (!helper) return original;
@@ -721,40 +727,29 @@ function resolveHelperCall(helperName: string, argValue: string, original: strin
 }
 
 /**
- * Resolve the built-in `path` helper against a template variable frame.
+ * Resolve a built-in artifact-producing helper against a template variable frame.
  *
  * The helper is intentionally handled here, not in the user helper registry,
  * so prompt text, command text, descriptions, and OUTPUTS all share the same
  * reserved built-in semantics.
  *
- * @param filename - Artifact filename from `{{ path "filename" }}`
- * @param ctxExpr - Optional raw `ctx=` expression
+ * @param kind - Helper kind to resolve
+ * @param key - Artifact key from the helper call
  * @param variables - Template variables available at the render site
+ * @param helperOptions - Filesystem options for path resolution and manifest writes
  * @param original - Original helper call text to preserve on unresolved input
- * @returns Assembled artifact path, or the original text when unresolved
+ * @returns Artifact URI/local path, or the original text when unresolved
  */
-function resolvePathHelperCall(
-  filename: string,
-  ctxExpr: string | undefined,
+function resolveRunArtifactHelperCall(
+  kind: 'artifact' | 'path',
+  key: string,
   variables: Record<string, unknown>,
+  helperOptions: TemplateHelperOptions | undefined,
   original: string,
 ): string {
-  const workPath = resolveTemplatePath('WorkPath', variables);
-  if (workPath === undefined) return original;
-
-  let contextId: string | undefined;
-  if (ctxExpr !== undefined) {
-    const trimmed = ctxExpr.trim();
-    contextId = trimmed.startsWith('{{') ? substituteText(trimmed, variables) : trimmed;
-    if (collectUnresolvedVariables(contextId).length > 0) return original;
-  } else {
-    contextId = resolveTemplatePath('ContextId', variables);
-  }
-
-  if (contextId === undefined) return original;
-
+  if (helperOptions === undefined) return original;
   try {
-    return assembleArtifactPath(workPath, contextId, filename);
+    return applyRunArtifactHelper(kind, key, variables as OutputVars, helperOptions);
   } catch {
     return original;
   }
@@ -777,7 +772,7 @@ export function shellEscapeValue(value: string): string {
  *
  * Supports four placeholder forms (processed in order):
  * 1. `{{ ./VarName }}` — explicit variable lookup, bypasses helper registry
- * 2. `{{ path "file.json" }}` — built-in artifact path helper
+ * 2. `{{ artifact "file.json" }}` / `{{ path "file.json" }}` — built-in artifact helpers
  * 3. `{{ helperName varRef }}` or `{{ helperName "literal" }}` — helper call
  * 4. `{{ identifier }}` — standard variable substitution
  *
@@ -792,12 +787,14 @@ export function shellEscapeValue(value: string): string {
  * @param text - Input text containing placeholders
  * @param variables - Variable map for substitution
  * @param escapeFn - Optional escape function for resolved values
+ * @param helperOptions - Filesystem options for artifact-producing helpers
  * @returns Text with resolved placeholders substituted
  */
 export function substituteText(
   text: string,
   variables: Record<string, unknown>,
   escapeFn?: (value: string) => string,
+  helperOptions?: TemplateHelperOptions,
 ): string {
   // Pass 1: {{ ./VarName }} explicit variable lookup, bypasses helper registry
   let result = text.replace(EXPLICIT_VAR_TEMPLATE_REGEX, (match, varPath: string) => {
@@ -806,15 +803,18 @@ export function substituteText(
     return escapeFn ? escapeFn(value) : value;
   });
 
-  // Pass 2: built-in {{ path "file" }} helper.
-  result = result.replace(
-    PATH_HELPER_TEMPLATE_REGEX,
-    (match, filename: string, ctxExpr: string | undefined) => {
-      const raw = resolvePathHelperCall(filename, ctxExpr, variables, match);
-      if (raw === match) return match;
-      return escapeFn ? escapeFn(raw) : raw;
-    },
-  );
+  // Pass 2: built-in artifact-producing helpers.
+  result = result.replace(ARTIFACT_HELPER_TEMPLATE_REGEX, (match, key: string) => {
+    const raw = resolveRunArtifactHelperCall('artifact', key, variables, helperOptions, match);
+    if (raw === match) return match;
+    return escapeFn ? escapeFn(raw) : raw;
+  });
+
+  result = result.replace(PATH_HELPER_TEMPLATE_REGEX, (match, key: string) => {
+    const raw = resolveRunArtifactHelperCall('path', key, variables, helperOptions, match);
+    if (raw === match) return match;
+    return escapeFn ? escapeFn(raw) : raw;
+  });
 
   // Pass 3: {{ helperName varRef }} or {{ helperName "literal" }}
   result = result.replace(
@@ -858,15 +858,20 @@ export function substituteText(
 function substituteCommand(
   command: Command | undefined,
   variables: Record<string, unknown>,
+  helperOptions?: TemplateHelperOptions,
 ): Command | undefined {
   if (!command) return undefined;
-  return substituteRequiredCommand(command, variables);
+  return substituteRequiredCommand(command, variables, helperOptions);
 }
 
-function substituteRequiredCommand(command: Command, variables: Record<string, unknown>): Command {
+function substituteRequiredCommand(
+  command: Command,
+  variables: Record<string, unknown>,
+  helperOptions?: TemplateHelperOptions,
+): Command {
   return {
     ...command,
-    code: substituteText(command.code, variables, shellEscapeValue),
+    code: substituteText(command.code, variables, shellEscapeValue, helperOptions),
   };
 }
 
@@ -881,20 +886,23 @@ function substituteRequiredCommand(command: Command, variables: Record<string, u
 function substituteSubstep(
   substep: Substep,
   variables: Record<string, unknown>,
+  helperOptions?: TemplateHelperOptions,
   forVariable?: string,
 ): Substep {
   return {
     ...substep,
-    description: substituteText(substep.description, variables),
-    prompt: substep.prompt ? substituteText(substep.prompt, variables) : substep.prompt,
-    command: substituteCommand(substep.command, variables),
+    description: substituteText(substep.description, variables, undefined, helperOptions),
+    prompt: substep.prompt
+      ? substituteText(substep.prompt, variables, undefined, helperOptions)
+      : substep.prompt,
+    command: substituteCommand(substep.command, variables, helperOptions),
     runbooks: substep.runbooks?.map((runbookPath) => {
       // Skip substitution for FOR-scoped runbook placeholders — they must remain
       // opaque until iteration time to prevent outer-scope variable capture
       if (forVariable && isForScoped(extractRefFromPlaceholder(runbookPath), forVariable)) {
         return runbookPath;
       }
-      return substituteText(runbookPath, variables);
+      return substituteText(runbookPath, variables, undefined, helperOptions);
     }),
   };
 }
@@ -906,9 +914,15 @@ function substituteSubstep(
  * @param variables - Variable map for substitution
  * @returns Step with all string fields expanded
  */
-function substituteStep(step: ResolvedStep, variables: Record<string, unknown>): ResolvedStep {
-  const description = substituteText(step.description, variables);
-  const prompt = step.prompt ? substituteText(step.prompt, variables) : step.prompt;
+function substituteStep(
+  step: ResolvedStep,
+  variables: Record<string, unknown>,
+  helperOptions?: TemplateHelperOptions,
+): ResolvedStep {
+  const description = substituteText(step.description, variables, undefined, helperOptions);
+  const prompt = step.prompt
+    ? substituteText(step.prompt, variables, undefined, helperOptions)
+    : step.prompt;
 
   // Handle kind-specific fields that contain text
   switch (step.kind) {
@@ -925,7 +939,7 @@ function substituteStep(step: ResolvedStep, variables: Record<string, unknown>):
         ...step,
         description,
         prompt,
-        command: substituteRequiredCommand(step.command, variables),
+        command: substituteRequiredCommand(step.command, variables, helperOptions),
       } satisfies Extract<ResolvedStep, { kind: 'command' }>;
       return resolved;
     }
@@ -934,7 +948,7 @@ function substituteStep(step: ResolvedStep, variables: Record<string, unknown>):
         ...step,
         description,
         prompt,
-        substeps: step.substeps.map((ss) => substituteSubstep(ss, variables)),
+        substeps: step.substeps.map((ss) => substituteSubstep(ss, variables, helperOptions)),
       } satisfies Extract<ResolvedStep, { kind: 'substeps' }>;
       return resolved;
     }
@@ -944,7 +958,7 @@ function substituteStep(step: ResolvedStep, variables: Record<string, unknown>):
         description,
         prompt,
         substeps: step.substeps.map((ss) =>
-          substituteSubstep(ss, variables, step.forClause.variable),
+          substituteSubstep(ss, variables, helperOptions, step.forClause.variable),
         ),
       } satisfies Extract<ResolvedStep, { kind: 'for' }>;
       return resolved;
@@ -954,7 +968,9 @@ function substituteStep(step: ResolvedStep, variables: Record<string, unknown>):
         ...step,
         description,
         prompt,
-        substeps: step.substeps.map((ss) => substituteSubstep(ss, variables, step.variable)),
+        substeps: step.substeps.map((ss) =>
+          substituteSubstep(ss, variables, helperOptions, step.variable),
+        ),
       } satisfies Extract<ResolvedStep, { kind: 'prompted-for' }>;
       return resolved;
     }
@@ -968,19 +984,23 @@ function substituteStep(step: ResolvedStep, variables: Record<string, unknown>):
  *
  * @param runbook - Parsed runbook AST
  * @param variables - Variable map for substitution
+ * @param helperOptions - Filesystem options for artifact-producing helpers
  * @returns New runbook AST with substitutions applied
  */
 export function substituteRunbookVariables(
   runbook: ResolvedRunbook,
   variables: Record<string, unknown>,
+  helperOptions?: TemplateHelperOptions,
 ): ResolvedRunbook {
   return {
     ...runbook,
-    title: runbook.title ? substituteText(runbook.title, variables) : runbook.title,
+    title: runbook.title
+      ? substituteText(runbook.title, variables, undefined, helperOptions)
+      : runbook.title,
     description: runbook.description
-      ? substituteText(runbook.description, variables)
+      ? substituteText(runbook.description, variables, undefined, helperOptions)
       : runbook.description,
-    steps: runbook.steps.map((step) => substituteStep(step, variables)),
+    steps: runbook.steps.map((step) => substituteStep(step, variables, helperOptions)),
   };
 }
 
@@ -1186,11 +1206,13 @@ export function warnUnresolvedRunbookVariables(runbook: ResolvedRunbook): string
  *
  * @param text - Command text containing placeholders
  * @param variables - Runtime/template variable map (typed `StepVariables` at the call boundary)
+ * @param helperOptions - Filesystem options for artifact-producing helpers
  * @returns Command text with resolved placeholders shell-escaped
  */
 export function expandLoopVariablesForCommand(
   text: string,
   variables: Readonly<StepVariables>,
+  helperOptions?: TemplateHelperOptions,
 ): string {
-  return substituteText(text, variables, shellEscapeValue);
+  return substituteText(text, variables, shellEscapeValue, helperOptions);
 }

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from '@jest/globals';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
 import { createActor } from 'xstate';
 import { compileRunbookToMachine, MAX_FILE_ITERATIONS } from '../../src/runbook/compiler.js';
 import type { RunbookContext } from '../../src/runbook/compiler.js';
+import { readArtifactManifest } from '../../src/runbook/artifact-manifest.js';
 import type {
   ResolvedStep,
   BaseStep,
@@ -8761,6 +8765,44 @@ echo "processing"
       expect(snapshot.value).toBe('STOPPED');
       expect(snapshot.context.variables).toMatchObject({ Result: 'failed-value' });
       expect(snapshot.context.finalVars).toEqual({ Result: 'failed-value' });
+    });
+
+    it('does not fall back to process cwd for artifact OUTPUTS without evaluation options', async () => {
+      const cwd = await mkdtemp(path.join(tmpdir(), 'rd-compiler-no-eval-options-'));
+      const previousCwd = process.cwd();
+      process.chdir(cwd);
+      try {
+        const runId = 'rd_0123456789abcdef0123456789abcdef';
+        const steps = createRunbook(`## 1. Produce
+- PASS COMPLETE
+- FAIL STOP
+- OUTPUTS
+  - ArtifactPath {{ path "review.json" }}
+`);
+
+        const machine = compileRunbookToMachine(steps, {
+          templateVars: brandFlattenedTemplateVarsForTest({
+            WorkPath: '.rundown/work',
+            ContextId: 'ctx1',
+            RunId: runId,
+            RunbookRef: {
+              source: 'plugin',
+              path: 'planning/review/review-plan-risk-safety.runbook.md',
+            },
+          }),
+        });
+        const actor = createActor(machine);
+        actor.start();
+        actor.send({ type: 'PASS' });
+
+        expect(actor.getSnapshot().context.variables).not.toHaveProperty('ArtifactPath');
+        await expect(
+          readArtifactManifest({ cwd, workPath: '.rundown/work' }, 'ctx1'),
+        ).resolves.toEqual([]);
+      } finally {
+        process.chdir(previousCwd);
+        await rm(cwd, { recursive: true, force: true });
+      }
     });
 
     it('decorates parent-step exit transitions with storeStepOutputs only (not storeFrontmatterOutputs)', () => {

--- a/packages/core/__tests__/runbook/output-evaluator.test.ts
+++ b/packages/core/__tests__/runbook/output-evaluator.test.ts
@@ -20,7 +20,7 @@ import {
 import { resetHelperInvokeWarnings } from '../../src/runbook/helper-invoke.js';
 
 const DEFAULT_EVALUATE_OPTIONS = {
-  cwd: path.join(tmpdir(), `rd-output-evaluator-${process.pid}`),
+  cwd: path.join(tmpdir(), `rd-output-evaluator-${String(process.pid)}`),
 } satisfies EvaluateOutputOptions;
 
 function evaluateOutputExpression(

--- a/packages/core/__tests__/runbook/output-evaluator.test.ts
+++ b/packages/core/__tests__/runbook/output-evaluator.test.ts
@@ -1,29 +1,159 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
 import type { OutputDeclaration } from '@rundown-org/parser';
 import { createJsonArrayStream } from '../../src/runbook/types.js';
 import type { ForContext, TemplateVarValue } from '../../src/runbook/types.js';
+import { readArtifactManifest } from '../../src/runbook/artifact-manifest.js';
 import {
   buildExecutionFrame,
-  evaluateFrontmatterOutputDeclarations,
-  evaluateOutputExpression,
-  evaluateStepOutputDeclarations,
+  evaluateFrontmatterOutputDeclarations as evaluateFrontmatterOutputDeclarationsRaw,
+  evaluateOutputExpression as evaluateOutputExpressionRaw,
+  evaluateStepOutputDeclarations as evaluateStepOutputDeclarationsRaw,
   flattenTemplateVars,
   setHelperRegistry,
   resetHelperRegistry,
+  type EvaluateOutputOptions,
+  type OutputVars,
 } from '../../src/runbook/output-evaluator.js';
 import { resetHelperInvokeWarnings } from '../../src/runbook/helper-invoke.js';
 
+const DEFAULT_EVALUATE_OPTIONS = {
+  cwd: path.join(tmpdir(), `rd-output-evaluator-${process.pid}`),
+} satisfies EvaluateOutputOptions;
+
+function evaluateOutputExpression(
+  expr: string,
+  variables: OutputVars,
+  options: EvaluateOutputOptions = DEFAULT_EVALUATE_OPTIONS,
+): string {
+  return evaluateOutputExpressionRaw(expr, variables, options);
+}
+
+function evaluateStepOutputDeclarations(
+  outputs: readonly OutputDeclaration[],
+  vars: OutputVars,
+  options: EvaluateOutputOptions = DEFAULT_EVALUATE_OPTIONS,
+): Record<string, string> {
+  return evaluateStepOutputDeclarationsRaw(outputs, vars, options);
+}
+
+function evaluateFrontmatterOutputDeclarations(
+  outputs: readonly OutputDeclaration[],
+  vars: OutputVars,
+  options: EvaluateOutputOptions = DEFAULT_EVALUATE_OPTIONS,
+): Record<string, string> {
+  return evaluateFrontmatterOutputDeclarationsRaw(outputs, vars, options);
+}
+
+const RUN_OUTPUT_VARS = {
+  WorkPath: '.rundown/work/demo',
+  ContextId: 'ctx-abc',
+  RunId: 'rd_0123456789abcdef0123456789abcdef',
+  RunbookRef: {
+    source: 'plugin',
+    path: 'planning/review/review-plan-risk-safety.runbook.md',
+  },
+} as const satisfies OutputVars;
+
 describe('evaluateOutputExpression', () => {
   it('supports path helper, quoted literal, template reference, and bare identifier forms', () => {
-    expect(
-      evaluateOutputExpression('{{ path "plan.json" }}', {
-        WorkPath: '.rundown/work/demo',
-        ContextId: 'ctx-abc',
-      }),
-    ).toMatch(/^\.rundown\/work\/demo\/\.rd-ctx-abc\/\d{4}-\d{2}-\d{2}-plan\.json$/);
+    expect(evaluateOutputExpression('{{ path "plan.json" }}', RUN_OUTPUT_VARS)).toContain(
+      '.rundown/work/demo/.rd-ctx-abc/runs/rd_0123456789abcdef0123456789abcdef/plan.json',
+    );
     expect(evaluateOutputExpression('"literal"', {})).toBe('literal');
     expect(evaluateOutputExpression('{{ Region }}', { Region: 'us-east-1' })).toBe('us-east-1');
     expect(evaluateOutputExpression('PlanPath', { PlanPath: '/tmp/plan.md' })).toBe('/tmp/plan.md');
+  });
+
+  it('evaluates artifact helper to an exact URI', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-helper-'));
+    try {
+      expect(
+        evaluateOutputExpression(
+          '{{ artifact "review.json" }}',
+          {
+            WorkPath: '.rundown/work',
+            ContextId: 'ctx1',
+            RunId: 'rd_0123456789abcdef0123456789abcdef',
+            RunbookRef: {
+              source: 'plugin',
+              path: 'planning/review/review-plan-risk-safety.runbook.md',
+            },
+          },
+          { cwd },
+        ),
+      ).toBe('rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('evaluates path helper to run-scoped artifact path', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-helper-'));
+    try {
+      expect(
+        evaluateOutputExpression(
+          '{{ path "review.json" }}',
+          {
+            WorkPath: '.rundown/work',
+            ContextId: 'ctx1',
+            RunId: 'rd_0123456789abcdef0123456789abcdef',
+            RunbookRef: {
+              source: 'plugin',
+              path: 'planning/review/review-plan-risk-safety.runbook.md',
+            },
+          },
+          { cwd },
+        ),
+      ).toContain('.rundown/work/.rd-ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('records manifest rows when helpers are evaluated', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-helper-'));
+    try {
+      const vars = {
+        WorkPath: '.rundown/work',
+        ContextId: 'ctx1',
+        RunId: 'rd_0123456789abcdef0123456789abcdef',
+        RunbookRef: {
+          source: 'plugin',
+          path: 'planning/review/review-plan-risk-safety.runbook.md',
+        },
+      };
+
+      const reviewUri = evaluateOutputExpression('{{ artifact "review.json" }}', vars, { cwd });
+      evaluateOutputExpression('{{ path "summary.md" }}', vars, { cwd });
+
+      const records = await readArtifactManifest({ cwd, workPath: vars.WorkPath }, 'ctx1');
+      expect(records).toHaveLength(2);
+      expect(records).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            uri: reviewUri,
+            runId: vars.RunId,
+            contextId: vars.ContextId,
+            runbook: vars.RunbookRef,
+            key: 'review.json',
+            timestamp: expect.any(String),
+          }),
+          expect.objectContaining({
+            uri: 'rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/summary.md',
+            runId: vars.RunId,
+            contextId: vars.ContextId,
+            runbook: vars.RunbookRef,
+            key: 'summary.md',
+            timestamp: expect.any(String),
+          }),
+        ]),
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('renders booleans and null the same way the CLI wrapper does today', () => {
@@ -49,32 +179,20 @@ describe('evaluateOutputExpression', () => {
     ).toThrow(/ContextId/);
   });
 
-  it('throws when ctx= expands to a value that is not a valid ContextId', () => {
-    expect(() =>
-      evaluateOutputExpression('{{ path "plan.json" ctx={{ Bad }} }}', {
-        WorkPath: '.rundown/work/demo',
-        Bad: 'not a valid id',
-      }),
-    ).toThrow(/valid ContextId/);
-  });
-
-  it('honours ctx= override with a nested Handlebars expression', () => {
+  it('preserves legacy ctx= path helper syntax as literal text', () => {
     expect(
       evaluateOutputExpression('{{ path "plan.json" ctx={{ childCtx }} }}', {
         WorkPath: '.rundown/work/demo',
         ContextId: 'parent',
         childCtx: 'child-123',
       }),
-    ).toMatch(/\.rd-child-123\/.*-plan\.json$/);
-  });
-
-  it('honours ctx= override with a bare literal containing hyphens', () => {
+    ).toBe('{{ path "plan.json" ctx=child-123 }}');
     expect(
       evaluateOutputExpression('{{ path "plan.json" ctx=alt-ctx }}', {
         WorkPath: '.rundown/work/demo',
         ContextId: 'parent',
       }),
-    ).toMatch(/\.rd-alt-ctx\/.*-plan\.json$/);
+    ).toBe('{{ path "plan.json" ctx=alt-ctx }}');
   });
 
   it('expands template references inside quoted strings', () => {
@@ -542,12 +660,9 @@ describe('evaluateOutputExpression with HelperRegistry', () => {
   });
 
   it('path built-in still takes priority over user helpers', () => {
-    expect(
-      evaluateOutputExpression('{{ path "plan.json" }}', {
-        WorkPath: '.rundown/work/demo',
-        ContextId: 'ctx-abc',
-      }),
-    ).toMatch(/plan\.json$/);
+    expect(evaluateOutputExpression('{{ path "plan.json" }}', RUN_OUTPUT_VARS)).toContain(
+      '/runs/rd_0123456789abcdef0123456789abcdef/plan.json',
+    );
   });
 });
 

--- a/packages/core/__tests__/runbook/output-evaluator.test.ts
+++ b/packages/core/__tests__/runbook/output-evaluator.test.ts
@@ -19,14 +19,32 @@ import {
 } from '../../src/runbook/output-evaluator.js';
 import { resetHelperInvokeWarnings } from '../../src/runbook/helper-invoke.js';
 
-const DEFAULT_EVALUATE_OPTIONS = {
-  cwd: path.join(tmpdir(), `rd-output-evaluator-${String(process.pid)}`),
-} satisfies EvaluateOutputOptions;
+let defaultEvaluateOptions: EvaluateOutputOptions | undefined;
+
+beforeEach(async () => {
+  defaultEvaluateOptions = {
+    cwd: await mkdtemp(path.join(tmpdir(), 'rd-output-evaluator-')),
+  };
+});
+
+afterEach(async () => {
+  if (defaultEvaluateOptions) {
+    await rm(defaultEvaluateOptions.cwd, { recursive: true, force: true });
+    defaultEvaluateOptions = undefined;
+  }
+});
+
+function getDefaultEvaluateOptions(): EvaluateOutputOptions {
+  if (!defaultEvaluateOptions) {
+    throw new Error('Default evaluate options were not initialized');
+  }
+  return defaultEvaluateOptions;
+}
 
 function evaluateOutputExpression(
   expr: string,
   variables: OutputVars,
-  options: EvaluateOutputOptions = DEFAULT_EVALUATE_OPTIONS,
+  options: EvaluateOutputOptions = getDefaultEvaluateOptions(),
 ): string {
   return evaluateOutputExpressionRaw(expr, variables, options);
 }
@@ -34,7 +52,7 @@ function evaluateOutputExpression(
 function evaluateStepOutputDeclarations(
   outputs: readonly OutputDeclaration[],
   vars: OutputVars,
-  options: EvaluateOutputOptions = DEFAULT_EVALUATE_OPTIONS,
+  options: EvaluateOutputOptions = getDefaultEvaluateOptions(),
 ): Record<string, string> {
   return evaluateStepOutputDeclarationsRaw(outputs, vars, options);
 }
@@ -42,7 +60,7 @@ function evaluateStepOutputDeclarations(
 function evaluateFrontmatterOutputDeclarations(
   outputs: readonly OutputDeclaration[],
   vars: OutputVars,
-  options: EvaluateOutputOptions = DEFAULT_EVALUATE_OPTIONS,
+  options: EvaluateOutputOptions = getDefaultEvaluateOptions(),
 ): Record<string, string> {
   return evaluateFrontmatterOutputDeclarationsRaw(outputs, vars, options);
 }

--- a/packages/core/__tests__/runbook/output-evaluator.test.ts
+++ b/packages/core/__tests__/runbook/output-evaluator.test.ts
@@ -197,20 +197,20 @@ describe('evaluateOutputExpression', () => {
     ).toThrow(/ContextId/);
   });
 
-  it('preserves legacy ctx= path helper syntax as literal text', () => {
+  it('resolves legacy ctx= path helper syntax to a context-scoped workspace path', () => {
     expect(
       evaluateOutputExpression('{{ path "plan.json" ctx={{ childCtx }} }}', {
         WorkPath: '.rundown/work/demo',
         ContextId: 'parent',
         childCtx: 'child-123',
       }),
-    ).toBe('{{ path "plan.json" ctx=child-123 }}');
+    ).toMatch(/^\.rundown\/work\/demo\/\.rd-child-123\/\d{4}-\d{2}-\d{2}-plan\.json$/);
     expect(
       evaluateOutputExpression('{{ path "plan.json" ctx=alt-ctx }}', {
         WorkPath: '.rundown/work/demo',
         ContextId: 'parent',
       }),
-    ).toBe('{{ path "plan.json" ctx=alt-ctx }}');
+    ).toMatch(/^\.rundown\/work\/demo\/\.rd-alt-ctx\/\d{4}-\d{2}-\d{2}-plan\.json$/);
   });
 
   it('expands template references inside quoted strings', () => {

--- a/packages/core/__tests__/runbook/output-evaluator.test.ts
+++ b/packages/core/__tests__/runbook/output-evaluator.test.ts
@@ -174,6 +174,41 @@ describe('evaluateOutputExpression', () => {
     }
   });
 
+  it.each([
+    ['../secret', 'parent traversal'],
+    ['/etc/passwd', 'absolute path'],
+    ['folder/../../evil', 'embedded traversal'],
+    ['..\\windows', 'backslash separator'],
+    ['nested/review.json', 'forward slash separator'],
+    ['..', 'literal dot-dot'],
+    ['.', 'literal dot'],
+  ])('rejects malicious artifact key %p (%s) and writes no manifest row', async (key) => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-helper-'));
+    try {
+      const vars = {
+        WorkPath: '.rundown/work',
+        ContextId: 'ctx1',
+        RunId: 'rd_0123456789abcdef0123456789abcdef',
+        RunbookRef: {
+          source: 'plugin',
+          path: 'planning/review/review-plan-risk-safety.runbook.md',
+        },
+      };
+
+      expect(() => evaluateOutputExpression(`{{ artifact "${key}" }}`, vars, { cwd })).toThrow(
+        /Invalid ArtifactKey/,
+      );
+      expect(() => evaluateOutputExpression(`{{ path "${key}" }}`, vars, { cwd })).toThrow(
+        /Invalid ArtifactKey/,
+      );
+
+      const records = await readArtifactManifest({ cwd, workPath: vars.WorkPath }, 'ctx1');
+      expect(records).toEqual([]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('renders booleans and null the same way the CLI wrapper does today', () => {
     expect(evaluateOutputExpression('{{ enabled }}', { enabled: false })).toBe('false');
     expect(evaluateOutputExpression('{{ nullable }}', { nullable: null })).toBe('null');

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -139,6 +139,7 @@ export class RunbookActorService {
     }
     return compileRunbookToMachine(steps, {
       templateVars: flattenTemplateVars(state.templateVars ?? {}),
+      evaluationOptions: { cwd: this.manager.cwd },
       frontmatterOutputs: state.frontmatterOutputs,
       substepStates: state.substepStates,
       activeFrameKey: state.activeFrameKey,

--- a/packages/core/src/runbook/artifact-paths.ts
+++ b/packages/core/src/runbook/artifact-paths.ts
@@ -12,6 +12,7 @@
 
 import * as path from 'node:path';
 import { assertSafeId, SAFE_ID_PATTERN } from '../paths.js';
+import { artifactUriToPath, buildArtifactUri, type ArtifactPathOptions } from './artifact-uri.js';
 
 /** Valid context identifier: alphanumeric, dots, hyphens, underscores. */
 export const VALID_CTX = SAFE_ID_PATTERN;
@@ -47,4 +48,26 @@ export function assembleArtifactPath(dir: string, ctx: string, file: string): st
   assertSafeId(file, 'file');
   const date = new Date().toISOString().slice(0, 10);
   return path.join(dir, `.rd-${ctx}`, `${date}-${file}`);
+}
+
+/**
+ * Assemble a run-scoped artifact path for a canonical artifact key.
+ *
+ * Produces: `<workPath>/.rd-<contextId>/runs/<runId>/<key>` resolved under
+ * the provided project root.
+ *
+ * @param options - Project root and work directory options
+ * @param contextId - Context identifier that owns the artifact
+ * @param runId - Concrete run identifier
+ * @param key - Artifact key / filename segment
+ * @returns Absolute local path for the run-scoped artifact
+ * @throws {Error} When any identity segment or path option is invalid
+ */
+export function assembleRunArtifactPath(
+  options: ArtifactPathOptions,
+  contextId: string,
+  runId: string,
+  key: string,
+): string {
+  return artifactUriToPath(buildArtifactUri({ contextId, runId, key }), options);
 }

--- a/packages/core/src/runbook/compiler-actions.ts
+++ b/packages/core/src/runbook/compiler-actions.ts
@@ -1,4 +1,5 @@
 import type { OutputDeclaration } from '@rundown-org/parser';
+import type { EvaluateOutputOptions } from './output-evaluator.js';
 import type { LastAction } from './types.js';
 
 /**
@@ -22,6 +23,8 @@ export interface ActionDefs {
   readonly storeStepOutputs: {
     /** OUTPUTS declarations authored on the exiting step or substep. */
     outputs: readonly OutputDeclaration[];
+    /** Filesystem options used by artifact-producing OUTPUTS helpers. */
+    evaluationOptions: EvaluateOutputOptions;
     /** Parent step name used to build the OUTPUTS execution frame. */
     stepName: string;
     /** Substep id when evaluating substep-level OUTPUTS; omitted for step-level evaluation. */
@@ -41,6 +44,8 @@ export interface ActionDefs {
   };
   /** Evaluates frontmatter OUTPUTS declarations and persists the result into terminal finalVars. */
   readonly storeFrontmatterOutputs: {
+    /** Filesystem options used by artifact-producing OUTPUTS helpers. */
+    evaluationOptions: EvaluateOutputOptions;
     /** Step name for non-terminal evaluation contexts; omitted at terminal entry. */
     stepName?: string;
     /** Substep id for non-terminal evaluation contexts; omitted at terminal entry. */

--- a/packages/core/src/runbook/compiler-actions.ts
+++ b/packages/core/src/runbook/compiler-actions.ts
@@ -23,8 +23,8 @@ export interface ActionDefs {
   readonly storeStepOutputs: {
     /** OUTPUTS declarations authored on the exiting step or substep. */
     outputs: readonly OutputDeclaration[];
-    /** Filesystem options used by artifact-producing OUTPUTS helpers. */
-    evaluationOptions: EvaluateOutputOptions;
+    /** Filesystem options used by artifact-producing OUTPUTS helpers, when available. */
+    evaluationOptions?: EvaluateOutputOptions;
     /** Parent step name used to build the OUTPUTS execution frame. */
     stepName: string;
     /** Substep id when evaluating substep-level OUTPUTS; omitted for step-level evaluation. */
@@ -44,8 +44,8 @@ export interface ActionDefs {
   };
   /** Evaluates frontmatter OUTPUTS declarations and persists the result into terminal finalVars. */
   readonly storeFrontmatterOutputs: {
-    /** Filesystem options used by artifact-producing OUTPUTS helpers. */
-    evaluationOptions: EvaluateOutputOptions;
+    /** Filesystem options used by artifact-producing OUTPUTS helpers, when available. */
+    evaluationOptions?: EvaluateOutputOptions;
     /** Step name for non-terminal evaluation contexts; omitted at terminal entry. */
     stepName?: string;
     /** Substep id for non-terminal evaluation contexts; omitted at terminal entry. */

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -155,12 +155,16 @@ type RunbookAlwaysEntry = Extract<
 
 function withEvaluationOptions<T extends object>(
   params: T,
-  evaluationOptions: EvaluateOutputOptions,
-): T & { readonly evaluationOptions: EvaluateOutputOptions } {
-  return Object.defineProperty({ ...params }, 'evaluationOptions', {
+  evaluationOptions: EvaluateOutputOptions | undefined,
+): T & { readonly evaluationOptions?: EvaluateOutputOptions } {
+  const withOptions = { ...params };
+  if (evaluationOptions === undefined) {
+    return withOptions;
+  }
+  return Object.defineProperty(withOptions, 'evaluationOptions', {
     value: evaluationOptions,
     enumerable: false,
-  }) as T & { readonly evaluationOptions: EvaluateOutputOptions };
+  });
 }
 
 /**
@@ -734,7 +738,7 @@ function buildTransition(
   stepName: string,
   substepId: string | undefined,
   steps: ResolvedStep[],
-  evaluationOptions: EvaluateOutputOptions,
+  evaluationOptions: EvaluateOutputOptions | undefined,
 ): TransitionConfig {
   const { retry, action, kind } = transition;
   // Normalize kind to pass/fail for iteration result recording
@@ -917,7 +921,7 @@ function buildParentExitAssign(
 function buildParentStateConfig(
   config: ParentStateConfig,
   steps: ResolvedStep[],
-  evaluationOptions: EvaluateOutputOptions,
+  evaluationOptions: EvaluateOutputOptions | undefined,
 ): RunbookStateConfig {
   const parentStep = config.parentStep;
   const stepName = config.stepName;
@@ -1722,7 +1726,7 @@ function decorateParentTransition<T extends RunbookAlwaysEntry & object>(
   transition: T,
   stepName: string,
   outputs: readonly OutputDeclaration[] | undefined,
-  evaluationOptions: EvaluateOutputOptions,
+  evaluationOptions: EvaluateOutputOptions | undefined,
 ): T {
   const extra: RunbookAction[] = [];
   const target = typeof transition.target === 'string' ? transition.target : undefined;
@@ -1777,7 +1781,7 @@ function buildRetryStateConfig(
   substepId: string | undefined,
   steps: ResolvedStep[],
   resultKind: 'pass' | 'fail',
-  evaluationOptions: EvaluateOutputOptions,
+  evaluationOptions: EvaluateOutputOptions | undefined,
 ): RunbookStateConfig {
   const exhaustedTransition = buildActionTransition(
     transition.action,
@@ -2214,7 +2218,7 @@ function buildActionTransition(
   substepId: string | undefined,
   steps: ResolvedStep[],
   kind: 'pass' | 'fail',
-  evaluationOptions: EvaluateOutputOptions,
+  evaluationOptions: EvaluateOutputOptions | undefined,
 ): TransitionConfig {
   const resultKind: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
 
@@ -2416,7 +2420,8 @@ function checkedStateInsert(
  * @param steps - The parsed runbook steps to compile
  * @param options - Optional compilation inputs
  * @param options.templateVars - Seeded template variables for OUTPUTS evaluation
- * @param options.evaluationOptions - Filesystem options used by artifact-producing OUTPUTS helpers
+ * @param options.evaluationOptions - Filesystem options used by artifact-producing OUTPUTS helpers.
+ *   If omitted, artifact-producing helpers fail closed instead of writing under `process.cwd()`.
  * @param options.frontmatterOutputs - Frontmatter `outputs:` declarations. Callers that pass a
  *   value loaded from persisted {@link RunbookState} must validate that the field is not `undefined`
  *   before calling (stale run states pre-dating the OUTPUTS feature will have it absent); the
@@ -2443,7 +2448,7 @@ export function compileRunbookToMachine(
     activeFrameKey?: FrameKey;
   },
 ) {
-  const evaluationOptions = options?.evaluationOptions ?? { cwd: process.cwd() };
+  const evaluationOptions = options?.evaluationOptions;
   const states: Record<string, RunbookStateConfig> = {};
 
   // Build a flat list of all states to generate GOTO transitions

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -725,6 +725,7 @@ function isNumberedStep(step: ResolvedStep): boolean {
  * @param stepName - The step name for target resolution
  * @param substepId - Optional substep ID within the step
  * @param steps - All parsed runbook steps for target lookup
+ * @param evaluationOptions - Filesystem options threaded through to OUTPUTS evaluation
  * @returns XState transition configuration
  */
 function buildTransition(
@@ -910,6 +911,7 @@ function buildParentExitAssign(
  *
  * @param config - The parent state config (discriminated by isParentState=true)
  * @param steps - The full steps array
+ * @param evaluationOptions - Filesystem options threaded through to OUTPUTS evaluation
  * @returns XState state config with `always` transitions
  */
 function buildParentStateConfig(
@@ -1713,6 +1715,7 @@ function buildParentStateConfig(
  * @param transition - The always transition entry to decorate
  * @param stepName - The parent step name
  * @param outputs - The parent step's OUTPUTS declarations (if any)
+ * @param evaluationOptions - Filesystem options threaded through to OUTPUTS evaluation
  * @returns The decorated transition (or the original if no decoration applies)
  */
 function decorateParentTransition<T extends RunbookAlwaysEntry & object>(
@@ -1764,6 +1767,7 @@ function decorateParentTransition<T extends RunbookAlwaysEntry & object>(
  * @param substepId - Substep ID for the exhausted action builder
  * @param steps - All parsed steps
  * @param resultKind - 'pass' or 'fail' for iteration result recording
+ * @param evaluationOptions - Filesystem options threaded through to OUTPUTS evaluation
  * @returns XState state config with `always` transitions
  */
 function buildRetryStateConfig(
@@ -2201,6 +2205,7 @@ function prependActions<T extends RunbookTransitionObject | (RunbookAlwaysEntry 
  * @param substepId - Optional current substep ID
  * @param steps - All parsed runbook steps
  * @param kind - Whether this transition is for 'pass' or 'fail'
+ * @param evaluationOptions - Filesystem options threaded through to OUTPUTS evaluation
  * @returns XState transition configuration
  */
 function buildActionTransition(

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -28,6 +28,7 @@ import {
   buildExecutionFrame,
   evaluateFrontmatterOutputDeclarations,
   evaluateStepOutputDeclarations,
+  type EvaluateOutputOptions,
   type FlattenedTemplateVars,
   type OutputVars,
 } from './output-evaluator.js';
@@ -84,7 +85,11 @@ export const runbookSetup = setup({
           stepName: params.stepName,
           substepId,
         });
-        const evaluated = evaluateStepOutputDeclarations(params.outputs, frame);
+        const evaluated = evaluateStepOutputDeclarations(
+          params.outputs,
+          frame,
+          params.evaluationOptions,
+        );
         return { ...context.variables, ...evaluated };
       },
     }),
@@ -105,7 +110,11 @@ export const runbookSetup = setup({
           stepName: params.stepName ?? '',
           substepId: params.substepId,
         });
-        return evaluateFrontmatterOutputDeclarations(context.frontmatterOutputs, frame);
+        return evaluateFrontmatterOutputDeclarations(
+          context.frontmatterOutputs,
+          frame,
+          params.evaluationOptions,
+        );
       },
     }),
   },
@@ -143,6 +152,16 @@ type RunbookAlwaysEntry = Extract<
   NonNullable<RunbookStateConfig['always']>,
   readonly unknown[]
 >[number];
+
+function withEvaluationOptions<T extends object>(
+  params: T,
+  evaluationOptions: EvaluateOutputOptions,
+): T & { readonly evaluationOptions: EvaluateOutputOptions } {
+  return Object.defineProperty({ ...params }, 'evaluationOptions', {
+    value: evaluationOptions,
+    enumerable: false,
+  }) as T & { readonly evaluationOptions: EvaluateOutputOptions };
+}
 
 /**
  * Safety limit for file-backed data sources with open iteration windows.
@@ -714,6 +733,7 @@ function buildTransition(
   stepName: string,
   substepId: string | undefined,
   steps: ResolvedStep[],
+  evaluationOptions: EvaluateOutputOptions,
 ): TransitionConfig {
   const { retry, action, kind } = transition;
   // Normalize kind to pass/fail for iteration result recording
@@ -726,7 +746,7 @@ function buildTransition(
   }
 
   // No retry: execute action directly
-  return buildActionTransition(action, stepName, substepId, steps, resultKind);
+  return buildActionTransition(action, stepName, substepId, steps, resultKind, evaluationOptions);
 }
 
 /**
@@ -895,6 +915,7 @@ function buildParentExitAssign(
 function buildParentStateConfig(
   config: ParentStateConfig,
   steps: ResolvedStep[],
+  evaluationOptions: EvaluateOutputOptions,
 ): RunbookStateConfig {
   const parentStep = config.parentStep;
   const stepName = config.stepName;
@@ -1669,7 +1690,7 @@ function buildParentStateConfig(
 
   return {
     always: always.map((transition) =>
-      decorateParentTransition(transition, stepName, parentStep.outputs),
+      decorateParentTransition(transition, stepName, parentStep.outputs, evaluationOptions),
     ),
   } satisfies RunbookStateConfig;
 }
@@ -1698,6 +1719,7 @@ function decorateParentTransition<T extends RunbookAlwaysEntry & object>(
   transition: T,
   stepName: string,
   outputs: readonly OutputDeclaration[] | undefined,
+  evaluationOptions: EvaluateOutputOptions,
 ): T {
   const extra: RunbookAction[] = [];
   const target = typeof transition.target === 'string' ? transition.target : undefined;
@@ -1708,12 +1730,18 @@ function decorateParentTransition<T extends RunbookAlwaysEntry & object>(
 
   if (exitsParent && outputs && outputs.length > 0) {
     extra.push(
-      actionRef('storeStepOutputs', {
-        outputs,
-        stepName,
-        useCompletedSubstep: true,
-        useCompletedForContext: true,
-      }),
+      actionRef(
+        'storeStepOutputs',
+        withEvaluationOptions(
+          {
+            outputs,
+            stepName,
+            useCompletedSubstep: true,
+            useCompletedForContext: true,
+          },
+          evaluationOptions,
+        ),
+      ),
     );
   }
 
@@ -1745,6 +1773,7 @@ function buildRetryStateConfig(
   substepId: string | undefined,
   steps: ResolvedStep[],
   resultKind: 'pass' | 'fail',
+  evaluationOptions: EvaluateOutputOptions,
 ): RunbookStateConfig {
   const exhaustedTransition = buildActionTransition(
     transition.action,
@@ -1752,6 +1781,7 @@ function buildRetryStateConfig(
     substepId,
     steps,
     resultKind,
+    evaluationOptions,
   );
   const rawEntries = Array.isArray(exhaustedTransition)
     ? exhaustedTransition
@@ -2179,6 +2209,7 @@ function buildActionTransition(
   substepId: string | undefined,
   steps: ResolvedStep[],
   kind: 'pass' | 'fail',
+  evaluationOptions: EvaluateOutputOptions,
 ): TransitionConfig {
   const resultKind: 'pass' | 'fail' = kind === 'fail' ? 'fail' : 'pass';
 
@@ -2215,7 +2246,19 @@ function buildActionTransition(
 
   const extra: RunbookAction[] = [];
   if (unitOutputs.length > 0) {
-    extra.push(actionRef('storeStepOutputs', { outputs: unitOutputs, stepName, substepId }));
+    extra.push(
+      actionRef(
+        'storeStepOutputs',
+        withEvaluationOptions(
+          {
+            outputs: unitOutputs,
+            stepName,
+            substepId,
+          },
+          evaluationOptions,
+        ),
+      ),
+    );
   }
 
   // When a substep bypasses the parent aggregation state by transitioning directly
@@ -2230,7 +2273,19 @@ function buildActionTransition(
       target !== formatStateId(stepName) &&
       !target.startsWith(`${formatStateId(stepName)}::`);
     if (exitsParent && parentOutputs && parentOutputs.length > 0) {
-      extra.push(actionRef('storeStepOutputs', { outputs: parentOutputs, stepName, substepId }));
+      extra.push(
+        actionRef(
+          'storeStepOutputs',
+          withEvaluationOptions(
+            {
+              outputs: parentOutputs,
+              stepName,
+              substepId,
+            },
+            evaluationOptions,
+          ),
+        ),
+      );
     }
   }
 
@@ -2356,6 +2411,7 @@ function checkedStateInsert(
  * @param steps - The parsed runbook steps to compile
  * @param options - Optional compilation inputs
  * @param options.templateVars - Seeded template variables for OUTPUTS evaluation
+ * @param options.evaluationOptions - Filesystem options used by artifact-producing OUTPUTS helpers
  * @param options.frontmatterOutputs - Frontmatter `outputs:` declarations. Callers that pass a
  *   value loaded from persisted {@link RunbookState} must validate that the field is not `undefined`
  *   before calling (stale run states pre-dating the OUTPUTS feature will have it absent); the
@@ -2377,10 +2433,12 @@ export function compileRunbookToMachine(
   options?: {
     templateVars?: FlattenedTemplateVars;
     frontmatterOutputs?: readonly OutputDeclaration[];
+    evaluationOptions?: EvaluateOutputOptions;
     substepStates?: readonly SubstepState[];
     activeFrameKey?: FrameKey;
   },
 ) {
+  const evaluationOptions = options?.evaluationOptions ?? { cwd: process.cwd() };
   const states: Record<string, RunbookStateConfig> = {};
 
   // Build a flat list of all states to generate GOTO transitions
@@ -2423,7 +2481,7 @@ export function compileRunbookToMachine(
       checkedStateInsert(
         states,
         config.id,
-        runbookSetup.createStateConfig(buildParentStateConfig(config, steps)),
+        runbookSetup.createStateConfig(buildParentStateConfig(config, steps, evaluationOptions)),
       );
       return;
     }
@@ -2589,6 +2647,7 @@ export function compileRunbookToMachine(
             config.stepName,
             config.substepId,
             steps,
+            evaluationOptions,
           ),
           FAIL: buildTransition(
             config.transitions.fail,
@@ -2596,6 +2655,7 @@ export function compileRunbookToMachine(
             config.stepName,
             config.substepId,
             steps,
+            evaluationOptions,
           ),
           RETRY: {
             actions: runbookSetup.assign({
@@ -2624,6 +2684,7 @@ export function compileRunbookToMachine(
             config.substepId,
             steps,
             'pass',
+            evaluationOptions,
           ),
         ),
       );
@@ -2640,6 +2701,7 @@ export function compileRunbookToMachine(
             config.substepId,
             steps,
             'fail',
+            evaluationOptions,
           ),
         ),
       );
@@ -2699,7 +2761,7 @@ export function compileRunbookToMachine(
       COMPLETE: {
         type: 'final',
         entry: [
-          actionRef('storeFrontmatterOutputs', {}),
+          actionRef('storeFrontmatterOutputs', withEvaluationOptions({}, evaluationOptions)),
           runbookSetup.assign({
             lifecycle: () => 'completed' as const,
           }),
@@ -2709,7 +2771,7 @@ export function compileRunbookToMachine(
       STOPPED: {
         type: 'final',
         entry: [
-          actionRef('storeFrontmatterOutputs', {}),
+          actionRef('storeFrontmatterOutputs', withEvaluationOptions({}, evaluationOptions)),
           runbookSetup.assign({
             lifecycle: () => 'stopped' as const,
           }),

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -108,6 +108,7 @@ export {
 } from './delegation-context.js';
 export {
   assembleArtifactPath,
+  assembleRunArtifactPath,
   validateArtifactCtx,
   VALID_CTX,
   VALID_FILE,
@@ -152,6 +153,7 @@ export {
   type FindArtifactOptions,
 } from './artifact-manifest.js';
 export {
+  applyRunArtifactHelper,
   buildExecutionFrame,
   evaluateFrontmatterOutputDeclarations,
   evaluateOutputExpression,
@@ -160,6 +162,7 @@ export {
   setHelperRegistry,
   getHelperRegistry,
   resetHelperRegistry,
+  type EvaluateOutputOptions,
   type FlattenedTemplateVars,
   type OutputFrameState,
   type OutputCursor,

--- a/packages/core/src/runbook/output-evaluator.ts
+++ b/packages/core/src/runbook/output-evaluator.ts
@@ -5,7 +5,7 @@ import { mergeEffectiveVars } from './effective-vars.js';
 import type { ForContext, JsonValue, TemplateVarValue } from './types.js';
 import { assertResolvedVariableForContext, isJsonArrayStream } from './types.js';
 import { deriveExecutionAt } from './targeting.js';
-import { assembleRunArtifactPath } from './artifact-paths.js';
+import { assembleArtifactPath, assembleRunArtifactPath, VALID_CTX } from './artifact-paths.js';
 import { appendArtifactManifestRecordSync } from './artifact-manifest.js';
 import { buildArtifactUri } from './artifact-uri.js';
 import { invokeHelperSafely } from './helper-invoke.js';
@@ -113,6 +113,8 @@ export function resetHelperRegistry(): void {
 const TEMPLATE_PATH_REGEX =
   /{{\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)\s*}}/g;
 const PATH_HELPER_REGEX = /^\{\{\s*path\s+"([^"]+)"\s*\}\}$/;
+const LEGACY_CTX_PATH_HELPER_REGEX =
+  /^\{\{\s*path\s+"([^"]+)"\s+ctx=(\{\{[^}]*\}\}|[^\s}]+)\s*\}\}$/;
 const ARTIFACT_HELPER_REGEX = /^\{\{\s*artifact\s+"([^"]+)"\s*\}\}$/;
 
 /**
@@ -267,6 +269,25 @@ export function applyRunArtifactHelper(
   return rendered;
 }
 
+function resolveLegacyCtxPathHelper(
+  filename: string,
+  ctxExpr: string,
+  variables: OutputVars,
+): string {
+  const workPath = requireOutputString('WorkPath', variables);
+  const expandedContextId = ctxExpr.trim().startsWith('{{')
+    ? expandOutputVariables(ctxExpr.trim(), variables)
+    : ctxExpr.trim();
+
+  if (!VALID_CTX.test(expandedContextId)) {
+    throw new Error(
+      `evaluateOutputExpression: ctx=${ctxExpr.trim()} expanded to "${expandedContextId}", which is not a valid ContextId.`,
+    );
+  }
+
+  return assembleArtifactPath(workPath, expandedContextId, filename);
+}
+
 function hasUnresolvedTemplateReferences(text: string, variables: OutputVars): boolean {
   const regex = new RegExp(TEMPLATE_PATH_REGEX.source, 'g');
   let match: RegExpExecArray | null = regex.exec(text);
@@ -328,21 +349,23 @@ function tryDispatchHelper(trimmed: string, variables: OutputVars): string | nul
  * Supported forms (evaluated in order):
  * 1. `{{ artifact "file.json" }}` — built-in artifact URI helper
  * 2. `{{ path "file.json" }}` — built-in run-scoped artifact path helper
- * 3. `{{ ./VarName }}` — explicit variable lookup; throws if not found in frame
- * 4. `{{ helperName varRef }}` — registered helper called with a variable value
- * 5. `{{ helperName "literal" }}` — registered helper called with a string literal
- * 6. `"quoted literal"` — may contain `{{ template }}` references expanded inline
- * 7. `{{ template }}` — template reference expanded against the variable frame
- * 8. `bare_Identifier` — direct variable lookup; throws if not found in frame
+ * 3. `{{ path "file.json" ctx=child }}` — legacy context-scoped path helper
+ * 4. `{{ ./VarName }}` — explicit variable lookup; throws if not found in frame
+ * 5. `{{ helperName varRef }}` — registered helper called with a variable value
+ * 6. `{{ helperName "literal" }}` — registered helper called with a string literal
+ * 7. `"quoted literal"` — may contain `{{ template }}` references expanded inline
+ * 8. `{{ template }}` — template reference expanded against the variable frame
+ * 9. `bare_Identifier` — direct variable lookup; throws if not found in frame
  *
- * For forms 3–4, if the helper throws the expression returns the original literal
- * text (best-effort; the error is logged as a warning).
+ * For registered helper forms, if the helper throws the expression returns the
+ * original literal text (best-effort; the error is logged as a warning).
  *
  * @param expr - Raw expression text from the runbook source
  * @param variables - Variable frame used to resolve references
  * @param options - Filesystem options used by artifact-producing helpers
  * @returns Rendered string value
  * @throws {Error} If an artifact-producing helper is used but options or required variables are missing
+ * @throws {Error} If the legacy `path` helper is used but `WorkPath` is missing or `ctx=` is invalid
  * @throws {Error} If an explicit variable lookup `{{ ./VarName }}` references a variable not in the output frame
  * @throws {Error} If a `{{ helperName varRef }}` form references a variable not in the output frame
  * @throws {Error} If the template reference has unresolved variables after expansion
@@ -375,7 +398,12 @@ export function evaluateOutputExpression(
     );
   }
 
-  // 2. Explicit variable lookup: {{ ./VarName }} — bypasses helper registry
+  const legacyCtxPathMatch = LEGACY_CTX_PATH_HELPER_REGEX.exec(trimmed);
+  if (legacyCtxPathMatch) {
+    return resolveLegacyCtxPathHelper(legacyCtxPathMatch[1], legacyCtxPathMatch[2], variables);
+  }
+
+  // Explicit variable lookup: {{ ./VarName }} — bypasses helper registry
   const explicitMatch = EXPLICIT_VAR_REGEX.exec(trimmed);
   if (explicitMatch) {
     const varName = explicitMatch[1];
@@ -386,13 +414,13 @@ export function evaluateOutputExpression(
     );
   }
 
-  // 3. Helper call dispatch
+  // Helper call dispatch
   const helperResult = tryDispatchHelper(trimmed, variables);
   if (helperResult !== null) {
     return helperResult ?? trimmed; // undefined = helper threw, return literal as best-effort
   }
 
-  // 4. Existing forms follow (quoted literal, template reference, bare identifier)
+  // Existing forms follow (quoted literal, template reference, bare identifier)
   const quotedMatch = /^"([^"]*)"$/.exec(trimmed);
   if (quotedMatch) {
     const inner = quotedMatch[1];

--- a/packages/core/src/runbook/output-evaluator.ts
+++ b/packages/core/src/runbook/output-evaluator.ts
@@ -165,7 +165,10 @@ function renderOutputValue(value: unknown): string {
   return JSON.stringify(value);
 }
 
-function resolveOutputPath(path: string, variables: OutputVars): string | undefined {
+function resolveOutputPath(
+  path: string,
+  variables: Readonly<Record<string, unknown>>,
+): string | undefined {
   if (Object.hasOwn(variables, path)) {
     return renderOutputValue(variables[path]);
   }
@@ -195,7 +198,7 @@ function expandOutputVariables(text: string, variables: OutputVars): string {
   });
 }
 
-function requireOutputString(name: string, variables: OutputVars): string {
+function requireOutputString(name: string, variables: Readonly<Record<string, unknown>>): string {
   const value = resolveOutputPath(name, variables);
   if (!value) {
     throw new Error(`evaluateOutputExpression: ${name} variable is not defined`);
@@ -203,7 +206,7 @@ function requireOutputString(name: string, variables: OutputVars): string {
   return value;
 }
 
-function requireRunbookRef(variables: OutputVars): RunbookRef {
+function requireRunbookRef(variables: Readonly<Record<string, unknown>>): RunbookRef {
   const parsed = RunbookRefSchema.safeParse(variables.RunbookRef);
   if (!parsed.success) {
     throw new Error('evaluateOutputExpression: RunbookRef variable is not defined or invalid');
@@ -229,17 +232,23 @@ function requireEvaluateOutputOptions(
  * local-path variant also creates the artifact parent directory synchronously so
  * the returned path is immediately writable by shell commands.
  *
+ * Accepts an unconstrained record because the helper validates each required
+ * frame field internally (`requireOutputString` / `requireRunbookRef`) and
+ * throws on missing or malformed entries. Callers that already hold a typed
+ * `OutputVars` (a subtype) pass through unchanged.
+ *
  * @param kind - Helper kind to evaluate
  * @param key - Artifact key / filename segment from the helper call
  * @param frame - Variable frame containing WorkPath, ContextId, RunId, and RunbookRef
  * @param options - Filesystem options for path resolution and manifest append
  * @returns Canonical artifact URI for `artifact`, local artifact path for `path`
- * @throws {Error} When required variables are missing or invalid
+ * @throws {Error} When required variables are missing or invalid, or when the
+ *   artifact key fails identity validation.
  */
 export function applyRunArtifactHelper(
   kind: 'artifact' | 'path',
   key: string,
-  frame: OutputVars,
+  frame: Readonly<Record<string, unknown>>,
   options: EvaluateOutputOptions,
 ): string {
   const workPath = requireOutputString('WorkPath', frame);

--- a/packages/core/src/runbook/output-evaluator.ts
+++ b/packages/core/src/runbook/output-evaluator.ts
@@ -1,10 +1,15 @@
 import type { OutputDeclaration } from '@rundown-org/parser';
+import { mkdirSync } from 'node:fs';
+import * as path from 'node:path';
 import { mergeEffectiveVars } from './effective-vars.js';
 import type { ForContext, JsonValue, TemplateVarValue } from './types.js';
 import { assertResolvedVariableForContext, isJsonArrayStream } from './types.js';
 import { deriveExecutionAt } from './targeting.js';
-import { assembleArtifactPath, VALID_CTX } from './artifact-paths.js';
+import { assembleRunArtifactPath } from './artifact-paths.js';
+import { appendArtifactManifestRecordSync } from './artifact-manifest.js';
+import { buildArtifactUri } from './artifact-uri.js';
 import { invokeHelperSafely } from './helper-invoke.js';
+import { RunbookRefSchema, type RunbookRef } from './runbook-ref.js';
 import { logger } from '../logger.js';
 
 /**
@@ -17,6 +22,12 @@ export type OutputValue = JsonValue;
 
 /** Readonly variable frame passed to OUTPUTS expression evaluation. */
 export type OutputVars = Readonly<Record<string, OutputValue>>;
+
+/** Options required for evaluating helpers with filesystem side effects. */
+export interface EvaluateOutputOptions {
+  /** Project root used to resolve work paths and append artifact manifest rows. */
+  readonly cwd: string;
+}
 
 /**
  * Module-private nominal brand applied to the output of {@link flattenTemplateVars}.
@@ -101,7 +112,8 @@ export function resetHelperRegistry(): void {
 
 const TEMPLATE_PATH_REGEX =
   /{{\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)\s*}}/g;
-const PATH_HELPER_REGEX = /^\{\{\s*path\s+"([^"]+)"(?:\s+ctx=(\{\{[^}]*\}\}|[^\s}]+))?\s*\}\}$/;
+const PATH_HELPER_REGEX = /^\{\{\s*path\s+"([^"]+)"\s*\}\}$/;
+const ARTIFACT_HELPER_REGEX = /^\{\{\s*artifact\s+"([^"]+)"\s*\}\}$/;
 
 /**
  * Matches `{{ ./VarName }}` — explicit variable lookup escape hatch.
@@ -181,6 +193,69 @@ function expandOutputVariables(text: string, variables: OutputVars): string {
   });
 }
 
+function requireOutputString(name: string, variables: OutputVars): string {
+  const value = resolveOutputPath(name, variables);
+  if (!value) {
+    throw new Error(`evaluateOutputExpression: ${name} variable is not defined`);
+  }
+  return value;
+}
+
+function requireRunbookRef(variables: OutputVars): RunbookRef {
+  const parsed = RunbookRefSchema.safeParse(variables.RunbookRef);
+  if (!parsed.success) {
+    throw new Error('evaluateOutputExpression: RunbookRef variable is not defined or invalid');
+  }
+  return parsed.data;
+}
+
+/**
+ * Apply a built-in artifact-producing helper against an OUTPUTS/runtime frame.
+ *
+ * Both `artifact` and `path` helpers intentionally append a manifest row. The
+ * local-path variant also creates the artifact parent directory synchronously so
+ * the returned path is immediately writable by shell commands.
+ *
+ * @param kind - Helper kind to evaluate
+ * @param key - Artifact key / filename segment from the helper call
+ * @param frame - Variable frame containing WorkPath, ContextId, RunId, and RunbookRef
+ * @param options - Filesystem options for path resolution and manifest append
+ * @returns Canonical artifact URI for `artifact`, local artifact path for `path`
+ * @throws {Error} When required variables are missing or invalid
+ */
+export function applyRunArtifactHelper(
+  kind: 'artifact' | 'path',
+  key: string,
+  frame: OutputVars,
+  options: EvaluateOutputOptions,
+): string {
+  const workPath = requireOutputString('WorkPath', frame);
+  const contextId = requireOutputString('ContextId', frame);
+  const runId = requireOutputString('RunId', frame);
+  const runbookRef = requireRunbookRef(frame);
+  const uri = buildArtifactUri({ contextId, runId, key });
+
+  let rendered = uri;
+  if (kind === 'path') {
+    rendered = assembleRunArtifactPath({ cwd: options.cwd, workPath }, contextId, runId, key);
+    mkdirSync(path.dirname(rendered), { recursive: true });
+  }
+
+  appendArtifactManifestRecordSync(
+    { cwd: options.cwd, workPath },
+    {
+      uri,
+      runId,
+      contextId,
+      runbook: runbookRef,
+      key,
+      timestamp: new Date().toISOString(),
+    },
+  );
+
+  return rendered;
+}
+
 function hasUnresolvedTemplateReferences(text: string, variables: OutputVars): boolean {
   const regex = new RegExp(TEMPLATE_PATH_REGEX.source, 'g');
   let match: RegExpExecArray | null = regex.exec(text);
@@ -240,61 +315,43 @@ function tryDispatchHelper(trimmed: string, variables: OutputVars): string | nul
  * Evaluate a single OUTPUTS expression against the supplied variable frame.
  *
  * Supported forms (evaluated in order):
- * 1. `{{ path "file.json" }}` — built-in path helper (optional `ctx=` suffix)
- * 2. `{{ ./VarName }}` — explicit variable lookup; throws if not found in frame
- * 3. `{{ helperName varRef }}` — registered helper called with a variable value
- * 4. `{{ helperName "literal" }}` — registered helper called with a string literal
- * 5. `"quoted literal"` — may contain `{{ template }}` references expanded inline
- * 6. `{{ template }}` — template reference expanded against the variable frame
- * 7. `bare_Identifier` — direct variable lookup; throws if not found in frame
+ * 1. `{{ artifact "file.json" }}` — built-in artifact URI helper
+ * 2. `{{ path "file.json" }}` — built-in run-scoped artifact path helper
+ * 3. `{{ ./VarName }}` — explicit variable lookup; throws if not found in frame
+ * 4. `{{ helperName varRef }}` — registered helper called with a variable value
+ * 5. `{{ helperName "literal" }}` — registered helper called with a string literal
+ * 6. `"quoted literal"` — may contain `{{ template }}` references expanded inline
+ * 7. `{{ template }}` — template reference expanded against the variable frame
+ * 8. `bare_Identifier` — direct variable lookup; throws if not found in frame
  *
  * For forms 3–4, if the helper throws the expression returns the original literal
  * text (best-effort; the error is logged as a warning).
  *
  * @param expr - Raw expression text from the runbook source
  * @param variables - Variable frame used to resolve references
+ * @param options - Filesystem options used by artifact-producing helpers
  * @returns Rendered string value
- * @throws {Error} If the `path` helper is used but `WorkPath` is missing from `variables`
- * @throws {Error} If the `path` helper is used without `ctx=` and `ContextId` is missing from `variables`
- * @throws {Error} If `ctx=` expands to a value that is not a valid ContextId identifier
- * @throws {Error} Propagated from {@link assembleArtifactPath} (e.g. invalid `WorkPath` / `contextId`)
+ * @throws {Error} If an artifact-producing helper is used but required variables are missing
  * @throws {Error} If an explicit variable lookup `{{ ./VarName }}` references a variable not in the output frame
  * @throws {Error} If a `{{ helperName varRef }}` form references a variable not in the output frame
  * @throws {Error} If the template reference has unresolved variables after expansion
  * @throws {Error} If a bare identifier is not defined in the output frame
  */
-export function evaluateOutputExpression(expr: string, variables: OutputVars): string {
+export function evaluateOutputExpression(
+  expr: string,
+  variables: OutputVars,
+  options: EvaluateOutputOptions,
+): string {
   const trimmed = expr.trim();
+
+  const artifactMatch = ARTIFACT_HELPER_REGEX.exec(trimmed);
+  if (artifactMatch) {
+    return applyRunArtifactHelper('artifact', artifactMatch[1], variables, options);
+  }
 
   const pathMatch = PATH_HELPER_REGEX.exec(trimmed);
   if (pathMatch) {
-    const filename = pathMatch[1];
-    const workPath = resolveOutputPath('WorkPath', variables);
-    if (!workPath) {
-      throw new Error('evaluateOutputExpression: WorkPath variable is not defined');
-    }
-
-    let contextId: string;
-    if (pathMatch[2]) {
-      const ctxExpr = pathMatch[2].trim();
-      const expanded = ctxExpr.startsWith('{{')
-        ? expandOutputVariables(ctxExpr, variables)
-        : ctxExpr; // bare ctx_ref literal — pass through directly
-      if (!VALID_CTX.test(expanded)) {
-        throw new Error(
-          `evaluateOutputExpression: ctx=${ctxExpr} expanded to "${expanded}", which is not a valid ContextId.`,
-        );
-      }
-      contextId = expanded;
-    } else {
-      const resolved = resolveOutputPath('ContextId', variables);
-      if (!resolved) {
-        throw new Error('evaluateOutputExpression: ContextId variable is not defined');
-      }
-      contextId = resolved;
-    }
-
-    return assembleArtifactPath(workPath, contextId, filename);
+    return applyRunArtifactHelper('path', pathMatch[1], variables, options);
   }
 
   // 2. Explicit variable lookup: {{ ./VarName }} — bypasses helper registry
@@ -371,12 +428,14 @@ export function evaluateOutputExpression(expr: string, variables: OutputVars): s
  *
  * @param outputs - Declarations parsed from the step's OUTPUTS block
  * @param vars - Variable frame for expression evaluation
+ * @param options - Filesystem options used by artifact-producing helpers
  * @returns Map of output name to rendered value; failed expression entries
  *   are omitted with a warning, naked entries are omitted silently
  */
 export function evaluateStepOutputDeclarations(
   outputs: readonly OutputDeclaration[],
   vars: OutputVars,
+  options: EvaluateOutputOptions,
 ): Record<string, string> {
   const evaluated: Record<string, string> = {};
 
@@ -387,7 +446,7 @@ export function evaluateStepOutputDeclarations(
       continue;
     }
     try {
-      evaluated[output.name] = evaluateOutputExpression(output.value, vars);
+      evaluated[output.name] = evaluateOutputExpression(output.value, vars, options);
     } catch (error) {
       void logger.warn('evaluateStepOutputDeclarations: failed to evaluate output', {
         name: output.name,
@@ -406,19 +465,21 @@ export function evaluateStepOutputDeclarations(
  *
  * @param outputs - Frontmatter `outputs:` declarations
  * @param vars - Variable frame at the terminal transition
+ * @param options - Filesystem options used by artifact-producing helpers
  * @returns Map of output name to rendered value; failed entries and
  *   naked entries whose referenced var is absent are omitted
  */
 export function evaluateFrontmatterOutputDeclarations(
   outputs: readonly OutputDeclaration[],
   vars: OutputVars,
+  options: EvaluateOutputOptions,
 ): Record<string, string> {
   const evaluated: Record<string, string> = {};
 
   for (const output of outputs) {
     try {
       if (output.value !== undefined) {
-        evaluated[output.name] = evaluateOutputExpression(output.value, vars);
+        evaluated[output.name] = evaluateOutputExpression(output.value, vars, options);
         continue;
       }
 

--- a/packages/core/src/runbook/output-evaluator.ts
+++ b/packages/core/src/runbook/output-evaluator.ts
@@ -209,6 +209,17 @@ function requireRunbookRef(variables: OutputVars): RunbookRef {
   return parsed.data;
 }
 
+function requireEvaluateOutputOptions(
+  options: EvaluateOutputOptions | undefined,
+): EvaluateOutputOptions {
+  if (options === undefined) {
+    throw new Error(
+      'evaluateOutputExpression: artifact-producing helpers require explicit evaluation options',
+    );
+  }
+  return options;
+}
+
 /**
  * Apply a built-in artifact-producing helper against an OUTPUTS/runtime frame.
  *
@@ -331,7 +342,7 @@ function tryDispatchHelper(trimmed: string, variables: OutputVars): string | nul
  * @param variables - Variable frame used to resolve references
  * @param options - Filesystem options used by artifact-producing helpers
  * @returns Rendered string value
- * @throws {Error} If an artifact-producing helper is used but required variables are missing
+ * @throws {Error} If an artifact-producing helper is used but options or required variables are missing
  * @throws {Error} If an explicit variable lookup `{{ ./VarName }}` references a variable not in the output frame
  * @throws {Error} If a `{{ helperName varRef }}` form references a variable not in the output frame
  * @throws {Error} If the template reference has unresolved variables after expansion
@@ -340,18 +351,28 @@ function tryDispatchHelper(trimmed: string, variables: OutputVars): string | nul
 export function evaluateOutputExpression(
   expr: string,
   variables: OutputVars,
-  options: EvaluateOutputOptions,
+  options?: EvaluateOutputOptions,
 ): string {
   const trimmed = expr.trim();
 
   const artifactMatch = ARTIFACT_HELPER_REGEX.exec(trimmed);
   if (artifactMatch) {
-    return applyRunArtifactHelper('artifact', artifactMatch[1], variables, options);
+    return applyRunArtifactHelper(
+      'artifact',
+      artifactMatch[1],
+      variables,
+      requireEvaluateOutputOptions(options),
+    );
   }
 
   const pathMatch = PATH_HELPER_REGEX.exec(trimmed);
   if (pathMatch) {
-    return applyRunArtifactHelper('path', pathMatch[1], variables, options);
+    return applyRunArtifactHelper(
+      'path',
+      pathMatch[1],
+      variables,
+      requireEvaluateOutputOptions(options),
+    );
   }
 
   // 2. Explicit variable lookup: {{ ./VarName }} — bypasses helper registry
@@ -435,7 +456,7 @@ export function evaluateOutputExpression(
 export function evaluateStepOutputDeclarations(
   outputs: readonly OutputDeclaration[],
   vars: OutputVars,
-  options: EvaluateOutputOptions,
+  options?: EvaluateOutputOptions,
 ): Record<string, string> {
   const evaluated: Record<string, string> = {};
 
@@ -472,7 +493,7 @@ export function evaluateStepOutputDeclarations(
 export function evaluateFrontmatterOutputDeclarations(
   outputs: readonly OutputDeclaration[],
   vars: OutputVars,
-  options: EvaluateOutputOptions,
+  options?: EvaluateOutputOptions,
 ): Record<string, string> {
   const evaluated: Record<string, string> = {};
 


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added artifact (URI) and run-scoped writable path helpers that record artifact manifests; template rendering accepts filesystem evaluation options.

* **Bug Fixes**
  * Ensured helper resolution consistently receives execution cwd/options for reliable path/URI substitution.
  * Reserved helper names expanded to include "artifact".

* **Tests**
  * Expanded tests for artifact/path rendering, manifest recording, reserved-name rejection, deterministic paths, and isolated temp-directory runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
