### PR TITLE
Artifacts directive phase 0 core spec docs

### DIFF
--- a/docs/spec/cli-output.md
+++ b/docs/spec/cli-output.md
@@ -41,6 +41,56 @@ Authoritative TypeScript types: `packages/core/src/output/schema.ts`
 }
 ```
 
+**RunbookRef** - Resolved runbook identity stored on artifact records:
+
+```json
+{
+  "source": "project",
+  "path": "planning/write-plan.runbook.md"
+}
+```
+
+`source` is one of `project`, `plugin`, `bundled`, or `external`.
+
+**ArtifactRecord** - Structured artifact value and manifest row shape:
+
+```json
+{
+  "uri": "rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/plan.json",
+  "runId": "rd_0123456789abcdef0123456789abcdef",
+  "contextId": "ctx1",
+  "runbook": {
+    "source": "project",
+    "path": "planning/write-plan.runbook.md"
+  },
+  "key": "plan.json",
+  "timestamp": "2026-05-07T00:00:00.000Z"
+}
+```
+
+**ArtifactMap** - Object keyed by artifact variable name. Values are either `ArtifactRecord` or `ArtifactRecord[]`:
+
+```json
+{
+  "PlanPath": {
+    "uri": "rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/plan.json",
+    "runId": "rd_0123456789abcdef0123456789abcdef",
+    "contextId": "ctx1",
+    "runbook": {
+      "source": "project",
+      "path": "planning/write-plan.runbook.md"
+    },
+    "key": "plan.json",
+    "timestamp": "2026-05-07T00:00:00.000Z"
+  },
+  "Reviews": []
+}
+```
+
+Empty wildcard results are represented as `[]`. Required current-unit artifact fields use `{}` when empty. Optional accumulated artifact fields are omitted when empty. `null` is not used as an absence marker.
+
+Future schema tests should assert that active current-unit fields use empty containers when empty, optional accumulated fields are omitted when empty, inactive status omits artifact fields, and `rd run` JSON output remains newline-delimited event objects.
+
 ---
 
 ## ls
@@ -116,9 +166,25 @@ Step description here.
   "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
   "prompted": true,
   "position": { "current": "1", "total": 3 },
-  "step": { "name": "1", "description": "First Step" }
+  "step": { "name": "1", "description": "First Step" },
+  "artifacts": {},
+  "artifactVars": {
+    "PlanPath": {
+      "uri": "rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/plan.json",
+      "runId": "rd_0123456789abcdef0123456789abcdef",
+      "contextId": "ctx1",
+      "runbook": {
+        "source": "project",
+        "path": "planning/write-plan.runbook.md"
+      },
+      "key": "plan.json",
+      "timestamp": "2026-05-07T00:00:00.000Z"
+    }
+  }
 }
 ```
+
+`artifacts` is required for active status responses and contains the active step/substep working set. It is `{}` when the active execution unit has no artifacts. `artifactVars` contains the accumulated persisted artifact variable map and is omitted when there are no accumulated artifact variables.
 
 ### `rd status` (no active runbook)
 
@@ -134,6 +200,8 @@ No active runbook.
   "stashed": false
 }
 ```
+
+Inactive status responses omit both `artifacts` and `artifactVars`.
 
 ### `rd status --claim-id <claim_id>`
 
@@ -163,14 +231,30 @@ Runbook:  COMPLETE
 ```
 
 **JSON:**
-```json
-{
-  "action": "complete",
-  "file": "runbooks/deploy.runbook.md",
-  "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
-  "position": { "current": "1", "total": 1 }
-}
+
+`rd run` emits newline-delimited JSON events. Each line is one JSON object. Event type names are lowercase snake_case, and event payload fields are flattened onto the JSONL object alongside envelope fields such as `timestamp`, `runbookId`, `runbook`, and `seq`. The final line is a terminal lifecycle event.
+
+```jsonl
+{"type":"runbook_started","prompted":false,"statePath":".rundown/runs/rd_0123456789abcdef0123456789abcdef.json","timestamp":"2026-05-07T00:00:00.000Z","runbookId":"rd_0123456789abcdef0123456789abcdef","runbook":{"source":"project","path":"runbooks/deploy.runbook.md"},"seq":1}
+{"type":"step_entered","position":{"current":"1","total":1},"stepName":"1","description":"First Step","hasCommand":true,"commandCode":"echo \"hello\"","commandLang":"bash","isSubstep":false,"prompted":false,"artifacts":{},"timestamp":"2026-05-07T00:00:00.000Z","runbookId":"rd_0123456789abcdef0123456789abcdef","runbook":{"source":"project","path":"runbooks/deploy.runbook.md"},"seq":2}
+{"type":"command_started","command":"echo \"hello\"","displayCommand":"echo \"hello\"","position":{"current":"1","total":1},"timestamp":"2026-05-07T00:00:00.000Z","runbookId":"rd_0123456789abcdef0123456789abcdef","runbook":{"source":"project","path":"runbooks/deploy.runbook.md"},"seq":3}
+{"type":"command_completed","command":"echo \"hello\"","success":true,"exitCode":0,"position":{"current":"1","total":1},"timestamp":"2026-05-07T00:00:00.000Z","runbookId":"rd_0123456789abcdef0123456789abcdef","runbook":{"source":"project","path":"runbooks/deploy.runbook.md"},"seq":4}
+{"type":"runbook_completed","finalPosition":{"current":"1","total":1},"timestamp":"2026-05-07T00:00:00.000Z","runbookId":"rd_0123456789abcdef0123456789abcdef","runbook":{"source":"project","path":"runbooks/deploy.runbook.md"},"seq":5}
 ```
+
+The internal event payload field is `STEP_ENTERED.payload.artifacts`; the CLI JSONL field is flattened as `artifacts` on the `step_entered` line. `artifacts` is required and contains only the entered step/substep's working set. It is `{}` when that execution unit has no `ARTIFACTS` directive. It is not the full accumulated `artifactVars` map.
+
+Runtime command text is rendered once per execution. The exact rendered string is reused for the flattened `step_entered.commandCode` field and actual command execution.
+
+### `STEP_ENTERED` with artifacts
+
+```jsonl
+{"type":"step_entered","position":{"current":"2","total":4},"stepName":"2","description":"Write plan","hasCommand":true,"commandCode":"printf '%s\n' '/project/.rundown/work/.rd-ctx1/runs/rd_0123456789abcdef0123456789abcdef/plan.json'","commandLang":"bash","isSubstep":false,"prompted":false,"artifacts":{"PlanPath":{"uri":"rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/plan.json","runId":"rd_0123456789abcdef0123456789abcdef","contextId":"ctx1","runbook":{"source":"project","path":"planning/write-plan.runbook.md"},"key":"plan.json","timestamp":"2026-05-07T00:00:00.000Z"},"Reviews":[]},"timestamp":"2026-05-07T00:00:00.000Z","runbookId":"rd_0123456789abcdef0123456789abcdef","runbook":{"source":"project","path":"planning/write-plan.runbook.md"},"seq":2}
+```
+
+`Reviews: []` is a meaningful empty wildcard result and must be preserved in JSON output.
+
+Text output remains human-readable and does not print raw artifact JSON by default. Artifact values may appear in rendered prompt or command text when authors reference them directly or through helpers. JSON output is the authoritative interface for artifact identity and provenance.
 
 ---
 

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -58,26 +58,31 @@ tag            ::= text
 input_list     ::= ( ws "- " variable_name newline )+
 required_list  ::= ( ws "- " variable_name newline )+
 inline_sequence ::= "[" variable_name ( "," variable_name )* "]"
-output_fm_list ::= ( ws "- " quoted_output_entry newline
-                   | ws "- " output_entry newline )+
+output_fm_list   ::= ( ws "- " quoted_output_fm_entry newline
+                     | ws "- " output_fm_entry newline )+
+output_fm_entry  ::= variable_name ( ws output_value )?
+quoted_output_fm_entry ::= quoted_string
 ```
 
 Public frontmatter keys are case-insensitive (`inputs:`, `INPUTS:`, and `Inputs:` are equivalent); unknown keys are preserved with their original casing. All fields are optional.
 
 `inputs:` declares variable names only. Runtime values come from CLI flags, config, environment bridge variables, or delegation inheritance. Each name must match `variable_name` and must not be [reserved](#reserved-variable-names). `required:` entries must also be declared in `inputs:`. Both block YAML sequences and inline YAML sequences such as `inputs: [PlanPath]` are valid.
 
-`outputs:` uses the same entry grammar as [OUTPUTS directives](#context-directives). Quote entries that contain template expressions in YAML:
+`outputs:` declares terminal runbook outputs evaluated at run completion. A frontmatter output entry may be name-only or may include an expression value. Quote entries that contain template expressions in YAML:
 
 ```yaml
 outputs:
   - Result
-  - 'PlanPath {{ path "plan.json" }}'
+  - 'PlanPath {{ path PlanPath }}'
 ```
+
+Frontmatter `outputs:` is separate from step/substep `OUTPUTS`. Frontmatter expression behavior remains valid; step/substep `OUTPUTS` entries are name-only.
 
 ## Steps
 
 ```ebnf
 step ::= "## " step_id separator? text? newline
+         artifacts_directive?
          outputs_directive?
          for_clause?
          delegate_annotation?
@@ -86,12 +91,13 @@ step ::= "## " step_id separator? text? newline
          body?
 ```
 
-Content must appear in the order shown: OUTPUTS, FOR, DELEGATE, transitions, prompt, body.
+Content must appear in the order shown: ARTIFACTS, OUTPUTS, FOR, DELEGATE, transitions, prompt, body.
 
 ## Substeps
 
 ```ebnf
 substep ::= "### " substep_id separator? text? newline
+            artifacts_directive?
             outputs_directive?
             delegate_annotation?
             transition*
@@ -104,25 +110,31 @@ Substeps cannot contain nested substeps. See [docs/spec/language.md §1.1](langu
 ## Context Directives
 
 ```ebnf
+artifacts_directive ::= "- ARTIFACTS" newline artifact_list
+artifact_list       ::= ( ws "- " artifact_entry newline )+
+artifact_entry      ::= variable_name ws quoted_artifact_key
+quoted_artifact_key ::= '"' artifact_key '"'
+artifact_key        ::= exact_artifact_key | wildcard_artifact_key
+exact_artifact_key  ::= [A-Za-z0-9._-]+
+wildcard_artifact_key ::= [A-Za-z0-9._*?-]+
+
 outputs_directive ::= "- OUTPUTS" newline output_list
 output_list       ::= ( ws "- " output_entry newline )+
-output_entry      ::= variable_name ( ws output_value )?
-quoted_output_entry ::= quoted_string
+output_entry      ::= variable_name
+
 output_value      ::= helper_call | template_variable | quoted_string | variable_name
 helper_call       ::= "{{" ws? variable_name ( ws helper_argument )+ ws? "}}"
 helper_argument   ::= quoted_string | variable_path | keyed_argument
 keyed_argument    ::= variable_name "=" ( quoted_string | variable_path | ctx_ref )
 ```
 
-A step or substep may declare at most one OUTPUTS directive. Duplicate directives on the same target are rejected. The `- INPUTS` directive has been removed — use the frontmatter `inputs:` field to declare variable names.
+A step or substep may declare at most one `ARTIFACTS` directive and at most one `OUTPUTS` directive. Duplicate directives on the same target are rejected. `ARTIFACTS` is valid only on steps and substeps; it is not a frontmatter field.
 
-OUTPUTS declares values to inject into the runbook's live variable space
-after step completion. An entry may be a **naked declaration** (name only)
-or carry a value expression. Naked entries at step / substep level activate
-a file-backed channel: Rundown creates an empty file whose path is composed
-from the active scope tiers (step id, optional substep id, optional FOR
-iteration index) followed by `<VarName>` and exports its absolute path as
-`RD_OUTPUTS_<VarName>` to the spawned command. The three possible paths are:
+`ARTIFACTS` declares the current execution unit's artifact working set. Each entry maps a variable name to a quoted artifact key. The variable name must match `variable_name` and must not be a [reserved variable name](#reserved-variable-names). Duplicate names in one `ARTIFACTS` block are syntax errors.
+
+Artifact keys are quoted literals. Template markers are not expanded inside keys. Exact keys use `exact_artifact_key`; wildcard keys use `wildcard_artifact_key` and contain `*` or `?`. Empty keys, `.`, `..`, slashes, absolute paths, traversal, and recursive `**` are invalid.
+
+`OUTPUTS` at step/substep level declares name-only command output channels. Expression-form step/substep `OUTPUTS` entries are parse errors. Naked entries activate a file-backed channel: Rundown creates an empty file whose path is composed from the active scope tiers (step id, optional substep id, optional FOR iteration index) followed by `<VarName>` and exports its absolute path as `RD_OUTPUTS_<VarName>` to the spawned command. The three possible paths are:
 
 | Scope | Path |
 |---|---|
@@ -130,14 +142,9 @@ iteration index) followed by `<VarName>` and exports its absolute path as
 | Substep | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<VarName>` |
 | FOR iteration (in substep) | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<iteration>/<VarName>` |
 
-See [docs/spec/language.md §7.1](language.md#71-outputs). Expression-form output values
-may be Handlebars helper calls (`{{ path "file.json" }}`), template variable
-references (`{{ VarName }}`), quoted literals (`"value"`), or bare variable
-references (`VarName`).
+See [docs/spec/language.md §10.1](language.md#101-step-outputs).
 
-Variable names in OUTPUTS must match `variable_name` and must not be [reserved variable names](#reserved-variable-names).
-
-The `path` helper call `{{ path "file.json" }}` is syntactic sugar for the CLI form `rdpath --dir WorkPath --ctx ContextId --file file.json`. The optional `ctx=` argument (`{{ path "file.json" ctx=alt-ctx }}`) overrides the default `ContextId`. Filenames must match the [`filename`](#lexical-rules) production; context identifiers must match [`ctx_ref`](#lexical-rules). See [docs/reference/rdpath.md](../reference/rdpath.md) for the full path-assembly contract.
+The `path` helper call `{{ path "file.json" }}` is valid in frontmatter `outputs:` and rendered content. For literal filenames it is syntactic sugar for the CLI form `rdpath --dir WorkPath --ctx ContextId --file file.json`. The optional `ctx=` argument (`{{ path "file.json" ctx=alt-ctx }}`) overrides the default `ContextId`. Filenames must match the [`filename`](#lexical-rules) production; context identifiers must match [`ctx_ref`](#lexical-rules). See [docs/reference/rdpath.md](../reference/rdpath.md) for the full path-assembly contract.
 
 ## Identifiers
 
@@ -223,7 +230,7 @@ Aggregation modifiers must pair complementarily: `PASS ALL` + `FAIL ANY` (pessim
 
 **Default transitions:** When no transitions are authored, the parser supplies `PASS CONTINUE`, `FAIL STOP`. Substeps under aggregation or with runbook delegation default to `PASS DEFER`, `FAIL DEFER`.
 
-**Disambiguation:** A `-`-prefixed bullet inside a step is resolved by priority: (1) context directive (`- OUTPUTS` as exact, case-sensitive list-item text with no trailing content), (2) FOR clause (`FOR` keyword), (3) DELEGATE annotation (`- DELEGATE` as exact, case-sensitive list-item text with no trailing content), (4) transition (`PASS`, `FAIL`, `YES`, `NO`, or standalone `DEFER`), (5) runbook reference (`.runbook.md` suffix), (6) prompt text. A bullet whose text merely contains `OUTPUTS` or `DELEGATE` inside prose, or uses a different case (e.g., `Outputs`, `delegate`), falls through to normal list semantics.
+**Disambiguation:** A `-`-prefixed bullet inside a step is resolved by priority: (1) `ARTIFACTS` directive (`- ARTIFACTS` as exact, case-sensitive list-item text with no trailing content), (2) `OUTPUTS` directive (`- OUTPUTS` as exact, case-sensitive list-item text with no trailing content), (3) FOR clause (`FOR` keyword), (4) DELEGATE annotation (`- DELEGATE` as exact, case-sensitive list-item text with no trailing content), (5) transition (`PASS`, `FAIL`, `YES`, `NO`, or standalone `DEFER`), (6) runbook reference (`.runbook.md` suffix), (7) prompt text. A bullet whose text merely contains `ARTIFACTS`, `OUTPUTS`, or `DELEGATE` inside prose, or uses a different case (for example `Artifacts`, `Outputs`, `delegate`), falls through to normal list semantics.
 
 ## Actions
 
@@ -335,7 +342,7 @@ These reserved words apply to step identifiers, action keywords, and transition 
 
 ## Reserved Variable Names
 
-The following names are reserved for runtime context resolution and cannot be used as variable identifiers in `OUTPUTS`, frontmatter `inputs:` / `required:`, `--input` CLI flags, `--input-file` contents, `.rundown/config.yaml`, or `RD_INPUT_*` environment variables:
+The following names are reserved for runtime context resolution and cannot be used as variable identifiers in `ARTIFACTS`, step/substep `OUTPUTS`, frontmatter `inputs:` / `required:`, `--input` CLI flags, `--input-file` contents, `.rundown/config.yaml`, or `RD_INPUT_*` environment variables:
 
 - `step`
 - `index`
@@ -364,3 +371,5 @@ content          ::= (* opaque code block content *)
 Upper bounds: step identifiers are capped at 999,999; FOR loop bounds at 10,000.
 
 `filename` and `ctx_ref` source from `VALID_FILE` and `VALID_CTX` in `packages/core/src/runbook/artifact-paths.ts`. They constrain the arguments of the [`path`](#context-directives) helper used in OUTPUTS and the underlying `rdpath` CLI.
+
+`exact_artifact_key` shares the safe artifact key character set used by `filename`, but exact artifact keys identify manifest entries rather than path-helper output files. `wildcard_artifact_key` permits `*` and `?` for manifest lookup. Artifact keys reject slashes, traversal, empty keys, `.`, `..`, and recursive `**`.

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -26,7 +26,10 @@ interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 | Result | Execution outcome: `PASS` or `FAIL`. |
 | Handler | A transition mapping a result to an action. |
 | Action | Control-flow effect such as `CONTINUE`, `STOP`, or `GOTO`. |
-| Directive | Structural bullet: `OUTPUTS`, `FOR`, or `DELEGATE`. |
+| Directive | Structural bullet: `ARTIFACTS`, `OUTPUTS`, `FOR`, or `DELEGATE`. |
+| Artifact manifest | Context-scoped JSONL file at `<WorkPath>/.rd-<ContextId>/manifest.jsonl`. |
+| ArtifactRecord | The only structured artifact variable value; one manifest row with artifact URI, run identity, runbook identity, key, and timestamp. |
+| Artifact working set | The current step/substep's resolved `ARTIFACTS` aliases for the active execution unit. |
 
 ## 3. Document Model
 
@@ -91,12 +94,13 @@ Reserved identifiers, matched exactly and case-sensitively: `NEXT`, `CONTINUE`,
 
 Step and substep content MUST appear in this order:
 
-1. `OUTPUTS` directive.
-2. `FOR` directive.
-3. `DELEGATE` directive.
-4. Transitions.
-5. Prompt text.
-6. Body.
+1. `ARTIFACTS` directive.
+2. `OUTPUTS` directive.
+3. `FOR` directive.
+4. `DELEGATE` directive.
+5. Transitions.
+6. Prompt text.
+7. Body.
 
 Each item is optional except the step heading itself. Misordered content is
 invalid.
@@ -392,7 +396,17 @@ branch, checkout path, or run id. Isolation for `{{ path "..." }}` is provided b
 `ContextId` (`.rd-<ContextId>/`), with run-scoped artifact locations adding the
 current `RunId` below that context when needed.
 
-### 9.3 Shell Environment
+### 9.3 Artifact Rendering Helpers
+
+Helpers are render-only. The `path` and `artifact` helpers MUST NOT append manifest rows, create artifact records, or mutate runbook state. Only `ARTIFACTS` resolution writes exact manifest rows.
+
+Rendering an `ArtifactRecord` directly yields its `uri`. Rendering an `ArtifactRecord[]` directly yields a JSON array of artifact URIs. An empty artifact array renders as `[]`.
+
+`{{ path ArtifactName }}` renders the contained local filesystem path for an `ArtifactRecord`. For an `ArtifactRecord[]`, it renders a JSON array of contained local filesystem paths. `{{ artifact ArtifactName }}` renders artifact URI values with the same scalar or array shape.
+
+Runtime command rendering MUST render command text once per execution and reuse that exact rendered string for both `STEP_ENTERED.commandCode` and actual execution.
+
+### 9.4 Shell Environment
 
 Executable shell blocks receive `RD_WORK_PATH`, `RD_CONTEXT_ID`, `RD_RUN_ID`,
 `RD_RUNBOOK_REF`, and `RD_RUNBOOK_SOURCE` from `WorkPath`, `ContextId`, `RunId`,
@@ -405,34 +419,76 @@ reserved for Rundown-injected variables.
 
 ## 10. Context Passing
 
-Context passing uses step `OUTPUTS`, frontmatter `outputs`, and delegation
-inheritance.
+Context passing uses step `ARTIFACTS`, step `OUTPUTS`, frontmatter `outputs`,
+and delegation inheritance.
+
+### 10.1 Step `ARTIFACTS`
+
+`ARTIFACTS` declares artifact aliases for the step or substep being entered. It is an execution-unit directive only; it is valid on steps and substeps and is not valid in frontmatter.
+
+Rules:
+
+| Rule | Requirement |
+| --- | --- |
+| Cardinality | At most one `ARTIFACTS` directive per step or substep. |
+| Ordering | MUST be the first directive after the heading. |
+| Names | MUST match variable-name rules and MUST NOT be reserved runtime names, case-insensitively. |
+| Keys | MUST be quoted artifact key literals; templates are not expanded inside keys. |
+| Scope | Applies only to the declaring step or substep's current execution-unit working set. |
+| Persistence | Writes resolved values to persisted `artifactVars`, not to string-only `state.variables`. |
+| Same-block resolution | Exact declarations resolve first, then wildcard declarations. |
+
+Exact declarations create or reuse one `ArtifactRecord` for the current run and key. Wildcard declarations read the same-context artifact manifest, coalesce duplicate rows, filter by run eligibility and file existence, and produce an `ArtifactRecord[]`. Empty wildcard results are meaningful and render as `[]`.
+
+Wildcard matching includes current-run active records when the artifact file exists. Records from other runs are eligible only when their run state is completed and has `terminalAt`. Matching is across runbooks in the same `ContextId`; the current runbook identity is metadata and is not an implicit wildcard filter.
+
+Manifest coalescing identity is `contextId`, `runId`, `runbook.source`, `runbook.path`, and `key`. The newest `timestamp` wins. If timestamps tie, the later manifest row wins.
+
+`ArtifactRecord` is the only structured artifact value:
+
+```json
+{
+  "uri": "rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/plan.json",
+  "runId": "rd_0123456789abcdef0123456789abcdef",
+  "contextId": "ctx1",
+  "runbook": {
+    "source": "project",
+    "path": "planning/write-plan.runbook.md"
+  },
+  "key": "plan.json",
+  "timestamp": "2026-05-07T00:00:00.000Z"
+}
+```
+
+Persisted runbook state stores artifact variables separately from command outputs:
+
+```text
+templateVars < artifactVars < variables < extraVars
+```
+
+`state.variables` remains string-only command `OUTPUTS`. `artifactVars` stores `ArtifactRecord` or `ArtifactRecord[]` values. Effective rendering and delegation contexts merge `templateVars`, `artifactVars`, `variables`, and `extraVars` in the order shown, so same-name `OUTPUTS` values mask artifact aliases after command completion without deleting the stored artifact value.
+
+Same-name `ARTIFACTS` and `OUTPUTS` declarations are allowed. `ARTIFACTS` writes `artifactVars` at step/substep entry. `OUTPUTS` writes `state.variables` after command completion and wins in the merged effective variable context because `variables` has higher precedence than `artifactVars`.
 
 <a id="71-outputs"></a>
 
-### 10.1 Step `OUTPUTS`
+### 10.2 Step OUTPUTS
 
-`OUTPUTS` declares values to merge into the live variable space after a step or
-substep completes.
+`OUTPUTS` declares name-only command output channels to merge into the live variable space after a step or substep completes.
 
 Rules:
 
 | Rule | Requirement |
 | --- | --- |
 | Cardinality | At most one `OUTPUTS` directive per step or substep. |
-| Ordering | MUST be the first directive after the heading. |
+| Ordering | MUST follow `ARTIFACTS` when present and MUST precede `FOR`, `DELEGATE`, transitions, prompt, and body. |
 | Names | MUST NOT be reserved runtime names, case-insensitively. |
-| Timing | Evaluated on both `PASS` and `FAIL` transitions. |
-| Forms | Handlebars expression, quoted literal with templates, bare variable reference, or naked file-backed entry. |
-| Merge | Adds new keys and overwrites same-name live variables. |
-| Failure | Failed expressions are omitted and logged; transition is not rolled back. |
+| Forms | Step/substep entries are name-only. Expression-form step/substep `OUTPUTS` entries are parse errors. |
+| Timing | File-backed values are read and merged after command completion. |
+| Merge | Adds new keys to string-only `state.variables` and overwrites same-name string variables. |
 | Status visibility | The merged variable space is exposed in status output as `vars`. |
 
-A naked entry is only a variable name. It activates a file-backed channel:
-Rundown creates a writable UTF-8 file, injects `RD_OUTPUTS_<VarName>` with its
-absolute path, then reads, trims, and merges the file content after command exit.
-Missing, empty, or non-UTF-8 content is omitted. Naked and expression forms MAY
-mix in one `OUTPUTS` block.
+A name-only entry activates a file-backed channel: Rundown creates a writable UTF-8 file, injects `RD_OUTPUTS_<VarName>` with its absolute path, then reads, trims, and merges the file content after command exit. Missing, empty, or non-UTF-8 content is omitted.
 
 File-backed output path scopes:
 
@@ -442,25 +498,27 @@ File-backed output path scopes:
 | Substep | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<VarName>` |
 | `FOR` iteration | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<iteration>/<VarName>` |
 
-`RD_OUTPUTS_*` is injected after policy filtering and cannot be blocked or
-overridden by user environment variables. Expression-form entries do not create
-files or environment variables.
+`RD_OUTPUTS_*` is injected after policy filtering and cannot be blocked or overridden by user environment variables. Step/substep `OUTPUTS` does not create artifact records and does not write `artifactVars`.
 
-The removed `INPUTS` step directive is invalid; use frontmatter `inputs`.
+### 10.3 Frontmatter outputs
 
-### 10.2 Frontmatter `outputs`
+Frontmatter `outputs` is evaluated at terminal `COMPLETE` or `STOPPED` transition against the merged effective variable context. Entries may be name-only or may include expression values. Name-only frontmatter entries read variables by name and do not create file-backed channels.
 
-Frontmatter `outputs` is evaluated at terminal `COMPLETE` or `STOPPED`
-transition against the merged variable space. Entries use the same declaration
-grammar as step `OUTPUTS`, except naked frontmatter entries read variables by
-name and do not create file-backed channels. Results are written to final run
-state and forwarded from child runbooks to parent live variables on completion.
+Frontmatter `outputs:` expression behavior is separate from step/substep `OUTPUTS`. A frontmatter output may export an artifact variable by name through normal variable flow; no artifact-specific frontmatter syntax is needed. For example, if `PlanPath` resolves to an `ArtifactRecord`, `outputs: [PlanPath]` exports that value through the established context-passing path.
 
-### 10.3 Delegation Inheritance
+Results are written to final run state and forwarded from child runbooks to parent live variables on completion.
 
-Delegated children inherit the parent's `ContextId` and non-context template
-variables. Step outputs accumulate during execution; terminal frontmatter
-outputs propagate back to the parent.
+### 10.4 Delegation Inheritance
+
+Delegated children inherit the parent's `ContextId` and non-context template variables. They do not inherit the parent's `RunId` or `RunbookRef`.
+
+Effective delegation variables use the same merge order as rendering:
+
+```text
+templateVars < artifactVars < variables < extraVars
+```
+
+Step `OUTPUTS` accumulate during execution in `state.variables`. Step `ARTIFACTS` accumulate in `artifactVars`. Terminal frontmatter `outputs` propagate selected values, including artifact values, back to the parent through normal variable flow.
 
 ## 11. Conformance
 
@@ -488,6 +546,14 @@ In particular:
 19. `GOTO` to a `FOR` target without `AT` enters at the target loop's start value.
 20. Delegation retry must cancel and reissue every delegated substep in the active frame.
 21. Naked `OUTPUTS` entries alone create `RD_OUTPUTS_<VarName>`.
+22. At most one `ARTIFACTS` directive is allowed per step or substep.
+23. `ARTIFACTS` must be ordered before `OUTPUTS` and all other step content.
+24. `ARTIFACTS` is invalid in frontmatter.
+25. Duplicate aliases in one `ARTIFACTS` block are invalid.
+26. Artifact keys must be quoted safe artifact key literals.
+27. Step/substep `OUTPUTS` entries must be name-only; expression-form entries are invalid.
+28. Empty wildcard artifact results are valid values and must not be collapsed to absence.
+29. Parser conformance fixtures for `ARTIFACTS` should cover valid exact declarations, valid wildcard declarations, duplicate aliases, invalid keys, misplaced directives, frontmatter misuse, and expression-form step/substep `OUTPUTS`.
 
 ## 12. Compatibility
 
@@ -501,3 +567,5 @@ incompatible, implementations SHOULD require the user to complete, stop, or
 prune the run and restart from the source document. See
 [runtime recovery](../reference/runtime.md#stale-persisted-state--no-migration)
 for operational details.
+
+Adding persisted `artifactVars` is a `RunbookState` schema/version change. Stale active state from versions without compatible artifact state MUST be rejected and surfaced to the user for completion, stopping, or pruning. Implementations MUST NOT migrate or shim older persisted state into the new artifact-aware shape.


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated CLI output specification to formalize artifact data structures and JSON emission rules for active/inactive runbook states
  * Enhanced runbook grammar and language specifications with artifact directive parsing, context-passing semantics, and helper behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
