### PR TITLE
Artifacts directive phase 2 core runtime and state

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -64,6 +64,7 @@ delegatable
 deps
 deserialized
 dirfd
+documentational
 dogfooding
 dotdot
 émoji
@@ -74,6 +75,7 @@ exfiltration
 fdisk
 featurebranch
 finalvars
+footgun
 frontmatter
 gitdir
 gopath
@@ -115,6 +117,7 @@ netcat
 nocase
 nodenext
 nodenv
+nonmatching
 noninteractive
 normalise
 normaliser

--- a/notes/mutation-survivors.md
+++ b/notes/mutation-survivors.md
@@ -1,11 +1,11 @@
-# Mutation Survivors: Artifact Resolver and Coalescing
+# Mutation Survivors: Artifact Resolver, Coalescing, and Update-Op Dispatch
 
 Date: 2026-05-08
 
 Command:
 
 ```bash
-npx stryker run --inPlace --force --mutate src/runbook/artifact-manifest.ts:193-213,src/runbook/artifact-directive-resolver.ts:75-181 --testFiles __tests__/runbook/artifact-manifest.test.ts,__tests__/runbook/artifact-directive-resolver.test.ts
+npx stryker run --inPlace --force --mutate src/runbook/artifact-manifest.ts:193-213,src/runbook/artifact-directive-resolver.ts:75-181,src/runbook/state-update-ops.ts,src/runbook/state.ts:422-440 --testFiles __tests__/runbook/artifact-manifest.test.ts,__tests__/runbook/artifact-directive-resolver.test.ts,__tests__/runbook/state-update-ops.test.ts,__tests__/runbook/state.test.ts
 ```
 
 Report:
@@ -13,10 +13,12 @@ Report:
 - `packages/core/reports/mutation/mutation-report.json`
 - `packages/core/reports/mutation/index.html`
 
-Targeted range result, parsed from the JSON report:
+Targeted range result:
 
 - `src/runbook/artifact-manifest.ts:193-213`: 14 killed, 0 survived
 - `src/runbook/artifact-directive-resolver.ts:75-181`: 63 killed, 6 survived
+- `src/runbook/state-update-ops.ts`: 15 killed, 0 survived (full file)
+- `src/runbook/state.ts:422-440` (`update()` dispatch): 20 killed, 0 survived
 
 Remaining justified survivors:
 

--- a/notes/mutation-survivors.md
+++ b/notes/mutation-survivors.md
@@ -1,0 +1,30 @@
+# Mutation Survivors: Artifact Resolver and Coalescing
+
+Date: 2026-05-08
+
+Command:
+
+```bash
+npx stryker run --inPlace --force --mutate src/runbook/artifact-manifest.ts:193-213,src/runbook/artifact-directive-resolver.ts:75-181 --testFiles __tests__/runbook/artifact-manifest.test.ts,__tests__/runbook/artifact-directive-resolver.test.ts
+```
+
+Report:
+
+- `packages/core/reports/mutation/mutation-report.json`
+- `packages/core/reports/mutation/index.html`
+
+Targeted range result, parsed from the JSON report:
+
+- `src/runbook/artifact-manifest.ts:193-213`: 14 killed, 0 survived
+- `src/runbook/artifact-directive-resolver.ts:75-181`: 63 killed, 6 survived
+
+Remaining justified survivors:
+
+- `artifact-directive-resolver.ts:102` (`exacts.length > 0`), mutants 12, 13, 14, 15.
+  This branch controls whether wildcard resolution rereads the manifest after exact declarations have run. Under the resolver's deterministic public contract, both branches produce the same wildcard record set: `recordsForExacts` is updated after every exact declaration, and when there are no exact declarations there is no internal manifest-changing operation between the initial read and wildcard resolution. The reread exists to preserve a fresh disk view after exact writes, including best-effort observation of external concurrent manifest changes. That concurrency timing is not injectable through `resolveArtifactDeclarations`, so these mutants are equivalent for deterministic unit tests.
+
+- `artifact-directive-resolver.ts:152` (`record.contextId === options.contextId`), mutant 37.
+  `findExistingExactRecord()` receives records read through `readArtifactManifest(options, options.contextId)`, and that reader rejects any manifest row whose `contextId` differs from the requested manifest context. Exact records created inside the same resolver call also use `options.contextId`. A wrong-context row cannot reach this predicate through the exported resolver API. The remaining exact identity fields (`runId`, `runbook.source`, `runbook.path`, and `key`) are covered by targeted near-match tests.
+
+- `artifact-directive-resolver.ts:169` (`record.contextId !== options.contextId`), mutant 54.
+  Wildcard records come from the same context-scoped manifest reader, or from exact records created in the current context. A wrong-context row cannot reach this loop through the exported resolver API because the manifest reader rejects it earlier. The matcher half of this guard is covered by the same-context nonmatching-key test.

--- a/notes/mutation-survivors.md
+++ b/notes/mutation-survivors.md
@@ -2,13 +2,13 @@
 
 Date: 2026-05-08
 
-Command:
+Command (run from `packages/core`):
 
 ```bash
 npx stryker run --inPlace --force --mutate src/runbook/artifact-manifest.ts:193-213,src/runbook/artifact-directive-resolver.ts:75-181,src/runbook/state-update-ops.ts,src/runbook/state.ts:422-440 --testFiles __tests__/runbook/artifact-manifest.test.ts,__tests__/runbook/artifact-directive-resolver.test.ts,__tests__/runbook/state-update-ops.test.ts,__tests__/runbook/state.test.ts
 ```
 
-Report:
+Report (paths relative to repo root; written by Stryker into `packages/core/reports/mutation/`):
 
 - `packages/core/reports/mutation/mutation-report.json`
 - `packages/core/reports/mutation/index.html`

--- a/packages/cli/__tests__/commands/prune.test.ts
+++ b/packages/cli/__tests__/commands/prune.test.ts
@@ -53,6 +53,34 @@ describe('prune command', () => {
       expect(statesAfter.length).toBe(0);
     });
 
+    it('removes artifactVars when pruning a completed run', async () => {
+      await runCliInProcess('run runbooks/simple.runbook.md --text', workspace);
+      const statesBefore = await listRunbookStates(workspace);
+      expect(statesBefore).toHaveLength(1);
+
+      const stateFile = statesBefore[0];
+      const stateId = stateFile.replace('.json', '');
+      const state = await readRunbookState(workspace, stateId);
+      expect(state).not.toBeNull();
+      const artifact = {
+        uri: `rd://artifacts/ctx1/runs/${stateId}/plan.json`,
+        runId: stateId,
+        contextId: 'ctx1',
+        runbook: state!.runbook,
+        key: 'plan.json',
+        timestamp: '2026-05-07T00:00:00.000Z',
+      };
+      await writeFile(
+        join(workspace.statePath(), stateFile),
+        JSON.stringify({ ...state, artifactVars: { PlanPath: artifact } }, null, 2),
+      );
+
+      await runCliInProcess('prune --completed --text', workspace);
+
+      const loaded = await readRunbookState(workspace, stateId);
+      expect(loaded).toBeNull();
+    });
+
     it('prunes stopped runbook state by default', async () => {
       // Start runbook then stop it — leaves state with lifecycle=stopped
       await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);

--- a/packages/cli/__tests__/commands/stash-pop.test.ts
+++ b/packages/cli/__tests__/commands/stash-pop.test.ts
@@ -475,7 +475,7 @@ rd echo "hello"
       updatedAt: new Date().toISOString(),
       runbookSrc, // Include runbookSrc so pop can read steps
       lifecycle: 'running',
-      schemaVersion: 2,
+      schemaVersion: 3,
     };
     await writeFile(stateFile, JSON.stringify(state, null, 2));
 
@@ -509,7 +509,7 @@ rd echo "hello"
           updatedAt: new Date().toISOString(),
           runbookSrc: '# Parent\n\n## 1. Parent step\n- PASS CONTINUE\n',
           lifecycle: 'running',
-          schemaVersion: 2,
+          schemaVersion: 3,
         },
         null,
         2,
@@ -549,7 +549,7 @@ rd echo "hello"
             tokenHash: `sha256:${'a'.repeat(64)}`,
           },
           lifecycle: 'running',
-          schemaVersion: 2,
+          schemaVersion: 3,
         },
         null,
         2,

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -86,7 +86,7 @@ export function registerCollectCommand(program: Command): void {
                 text: options.text,
               });
             } finally {
-              ctx.actor.stop();
+              ctx.actorService.stopActor(ctx.state.id, ctx.actor);
             }
 
             if (shouldExitWithError) {

--- a/packages/cli/src/helpers/transition-command.ts
+++ b/packages/cli/src/helpers/transition-command.ts
@@ -138,7 +138,7 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
                 }
               }
             } finally {
-              ctx.actor.stop();
+              ctx.actorService.stopActor(ctx.state.id, ctx.actor);
             }
             if (shouldExitWithError) {
               process.exitCode = 1;

--- a/packages/core/__tests__/helpers/effective-vars.ts
+++ b/packages/core/__tests__/helpers/effective-vars.ts
@@ -1,7 +1,9 @@
 import {
+  brandArtifactVars,
   brandEffectiveVars,
   brandInitialTemplateVars,
   brandStoredOutputs,
+  type ArtifactVars,
   type EffectiveVars,
   type InitialTemplateVars,
   type StoredOutputs,
@@ -11,7 +13,19 @@ import {
   flattenTemplateVars,
   type FlattenedTemplateVars,
 } from '../../src/runbook/output-evaluator.js';
-import type { TemplateVarValue } from '../../src/runbook/types.js';
+import type { ArtifactVarValue, TemplateVarValue } from '../../src/runbook/types.js';
+
+/**
+ * Test-only producer of {@link ArtifactVars} for fixture construction.
+ *
+ * @param vars - Plain artifact-variable record
+ * @returns The same record typed as `ArtifactVars`
+ */
+export function brandArtifactVarsForTest(
+  vars: Readonly<Record<string, ArtifactVarValue>>,
+): ArtifactVars {
+  return brandArtifactVars(vars);
+}
 
 /**
  * Test-only producer of {@link InitialTemplateVars} for fixture construction.

--- a/packages/core/__tests__/integration/artifact-resolver.integration.test.ts
+++ b/packages/core/__tests__/integration/artifact-resolver.integration.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
+import { artifactUriToPath } from '../../src/runbook/artifact-uri.js';
+import { RunbookStateManager } from '../../src/runbook/state.js';
+import type { RunId } from '../../src/runbook/run-id.js';
+import type { ResolvedRunbook } from '../../src/runbook/types.js';
+import { brandRunIdForTest } from '../helpers/effective-vars.js';
+import { makeBaseStep } from '../helpers/step-factories.js';
+
+const WORK_PATH = '.rundown/work';
+const CONTEXT_ID = 'ctx1';
+const RUNBOOK_REF = { source: 'project' as const, path: 'artifact.integration.md' };
+const SIBLING_RUN = brandRunIdForTest('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+const CURRENT_RUN = brandRunIdForTest('rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+
+const runbook: ResolvedRunbook = {
+  title: 'Artifact Integration',
+  description: 'Artifact integration test',
+  steps: [
+    makeBaseStep({
+      name: '1',
+      description: 'Only step',
+      transitions: {
+        pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+        fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+      },
+    }),
+  ],
+};
+
+let tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => fsp.rm(dir, { recursive: true, force: true })));
+  tempDirs = [];
+});
+
+async function tempCwd(): Promise<string> {
+  const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), 'artifact-resolver-integration-'));
+  tempDirs.push(cwd);
+  return cwd;
+}
+
+async function createRun(manager: RunbookStateManager, runId: RunId) {
+  return manager.create(RUNBOOK_REF, runbook, {
+    runbookPath: RUNBOOK_REF.path,
+    runId,
+    frontmatterOutputs: [],
+    templateVars: {
+      WorkPath: WORK_PATH,
+      ContextId: CONTEXT_ID,
+      RunId: runId,
+      RunbookRef: RUNBOOK_REF,
+    },
+  });
+}
+
+describe('artifact resolver integration', () => {
+  it('resolves artifacts from a completed sibling run in the same context', async () => {
+    const cwd = await tempCwd();
+    const manager = new RunbookStateManager(cwd);
+
+    const sibling = await createRun(manager, SIBLING_RUN);
+    const siblingArtifacts = await manager.resolveArtifactsForRun(sibling.id, [
+      { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
+    ]);
+    const siblingRecord = siblingArtifacts.PlanPath as ArtifactRecord;
+    const siblingPath = artifactUriToPath(siblingRecord.uri, { cwd, workPath: WORK_PATH });
+    await fsp.mkdir(path.dirname(siblingPath), { recursive: true });
+    await fsp.writeFile(siblingPath, '{}');
+    await manager.update(sibling.id, {
+      lifecycle: 'completed',
+      updatedAt: new Date().toISOString(),
+    });
+
+    const current = await createRun(manager, CURRENT_RUN);
+    const artifacts = await manager.resolveArtifactsForRun(current.id, [
+      { name: 'Plans', key: 'plan*.json', kind: 'wildcard' },
+    ]);
+
+    expect(artifacts.Plans).toHaveLength(1);
+    expect((artifacts.Plans as ArtifactRecord[])[0].runId).toBe(sibling.id);
+  });
+});

--- a/packages/core/__tests__/integration/artifact-resolver.integration.test.ts
+++ b/packages/core/__tests__/integration/artifact-resolver.integration.test.ts
@@ -82,6 +82,11 @@ describe('artifact resolver integration', () => {
     ]);
 
     expect(artifacts.Plans).toHaveLength(1);
-    expect((artifacts.Plans as ArtifactRecord[])[0].runId).toBe(sibling.id);
+    expect((artifacts.Plans as ArtifactRecord[])[0]).toMatchObject({
+      contextId: CONTEXT_ID,
+      runId: sibling.id,
+      key: 'plan.json',
+      runbook: RUNBOOK_REF,
+    });
   });
 });

--- a/packages/core/__tests__/integration/artifact-resolver.integration.test.ts
+++ b/packages/core/__tests__/integration/artifact-resolver.integration.test.ts
@@ -73,7 +73,6 @@ describe('artifact resolver integration', () => {
     await fsp.writeFile(siblingPath, '{}');
     await manager.update(sibling.id, {
       lifecycle: 'completed',
-      updatedAt: new Date().toISOString(),
     });
 
     const current = await createRun(manager, CURRENT_RUN);

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { RunbookStateManager } from '../../src/runbook/state.js';
+import { replace } from '../../src/runbook/state-update-ops.js';
 import { RunbookActorService } from '../../src/runbook/actor-service.js';
 import type { AnyActorRef } from '../../src/runbook/actor-service.js';
 import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
@@ -642,7 +643,7 @@ describe('RunbookActorService', () => {
   describe('lifecycle surfacing from actor snapshot', () => {
     it('preserves artifactVars when syncing actor snapshots', async () => {
       const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n', {
-        artifactVars: { PlanPath: ARTIFACT_RECORD },
+        artifactVars: replace({ PlanPath: ARTIFACT_RECORD }),
       });
       try {
         const result = await harness.service.initializeState(harness.state.id, harness.steps);
@@ -662,7 +663,7 @@ describe('RunbookActorService', () => {
         await harness.service.initializeState(harness.state.id, harness.steps);
 
         await harness.manager.update(harness.state.id, {
-          artifactVars: { PlanPath: ARTIFACT_RECORD },
+          artifactVars: replace({ PlanPath: ARTIFACT_RECORD }),
         });
 
         const result = await harness.service.initializeState(harness.state.id, harness.steps);
@@ -688,7 +689,7 @@ describe('RunbookActorService', () => {
         uri: ARTIFACT_RECORD.uri.replace('plan', 'new'),
       };
       const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n', {
-        artifactVars: { PlanPath: persisted },
+        artifactVars: replace({ PlanPath: persisted }),
       });
       try {
         const actor = mockActor({
@@ -703,6 +704,10 @@ describe('RunbookActorService', () => {
         );
 
         expect(state.artifactVars).toEqual({ PlanPath: updated });
+
+        // Verify the override survived the round-trip to disk.
+        const reloaded = await harness.manager.load(harness.state.id);
+        expect(reloaded?.artifactVars).toEqual({ PlanPath: updated });
       } finally {
         harness.actor.stop();
         await rm(harness.testDir, { recursive: true, force: true });
@@ -711,7 +716,7 @@ describe('RunbookActorService', () => {
 
     it('preserves persisted artifactVars when actor context omits the field', async () => {
       const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n', {
-        artifactVars: { PlanPath: ARTIFACT_RECORD },
+        artifactVars: replace({ PlanPath: ARTIFACT_RECORD }),
       });
       try {
         const actor = mockActor({

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -5,7 +5,13 @@ import { join } from 'node:path';
 import { RunbookStateManager } from '../../src/runbook/state.js';
 import { RunbookActorService } from '../../src/runbook/actor-service.js';
 import type { AnyActorRef } from '../../src/runbook/actor-service.js';
-import type { ResolvedRunbook, ResolvedStep, SubstepState } from '../../src/runbook/types.js';
+import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
+import type {
+  ResolvedRunbook,
+  ResolvedStep,
+  RunbookState,
+  SubstepState,
+} from '../../src/runbook/types.js';
 import { makeBaseStep } from '../helpers/step-factories.js';
 import { createJsonArrayStream } from '../../src/runbook/types.js';
 import { buildFrameKey } from '../../src/runbook/targeting.js';
@@ -18,13 +24,18 @@ function mockActor(snapshot: { value: string; context: Record<string, unknown> }
 
 interface LifecycleHarness {
   actor: AnyActorRef;
+  manager: RunbookStateManager;
   service: RunbookActorService;
+  state: RunbookState;
   runbookId: string;
   steps: ResolvedStep[];
   testDir: string;
 }
 
-async function createLifecycleHarness(markdown: string): Promise<LifecycleHarness> {
+async function createLifecycleHarness(
+  markdown: string,
+  overrides: Parameters<RunbookStateManager['update']>[1] = {},
+): Promise<LifecycleHarness> {
   const steps = createRunbook(markdown);
   const testDir = await mkdtemp(join(tmpdir(), 'lifecycle-harness-'));
   const manager = new RunbookStateManager(testDir);
@@ -35,7 +46,7 @@ async function createLifecycleHarness(markdown: string): Promise<LifecycleHarnes
     description: 'Lifecycle test runbook',
     steps,
   };
-  const state = await manager.create(
+  const created = await manager.create(
     { source: 'project', path: 'lifecycle-test.md' },
     mockRunbookDef,
     {
@@ -43,12 +54,25 @@ async function createLifecycleHarness(markdown: string): Promise<LifecycleHarnes
       frontmatterOutputs: [],
     },
   );
+  if (Object.keys(overrides).length > 0) {
+    await manager.update(created.id, overrides);
+  }
+  const state = (await manager.load(created.id))!;
 
   const actor = await service.createActor(state.id, steps);
   if (!actor) throw new Error('createLifecycleHarness: actor creation failed');
 
-  return { actor, service, runbookId: state.id, steps, testDir };
+  return { actor, manager, service, state, runbookId: state.id, steps, testDir };
 }
+
+const ARTIFACT_RECORD = {
+  uri: 'rd://artifacts/ctx1/runs/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+  runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  contextId: 'ctx1',
+  runbook: { source: 'project' as const, path: 'lifecycle-test.md' },
+  key: 'plan.json',
+  timestamp: '2026-05-07T00:00:00.000Z',
+} satisfies ArtifactRecord;
 
 describe('RunbookActorService', () => {
   let testDir: string;
@@ -616,6 +640,98 @@ describe('RunbookActorService', () => {
   });
 
   describe('lifecycle surfacing from actor snapshot', () => {
+    it('preserves artifactVars when syncing actor snapshots', async () => {
+      const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n', {
+        artifactVars: { PlanPath: ARTIFACT_RECORD },
+      });
+      try {
+        const result = await harness.service.initializeState(harness.state.id, harness.steps);
+        const loaded = await harness.manager.load(harness.state.id);
+
+        expect(result?.artifactVars).toEqual({ PlanPath: ARTIFACT_RECORD });
+        expect(loaded?.artifactVars).toEqual({ PlanPath: ARTIFACT_RECORD });
+      } finally {
+        harness.actor.stop();
+        await rm(harness.testDir, { recursive: true, force: true });
+      }
+    });
+
+    it('preserves artifactVars persisted after an older actor snapshot was created', async () => {
+      const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n');
+      try {
+        await harness.service.initializeState(harness.state.id, harness.steps);
+
+        await harness.manager.update(harness.state.id, {
+          artifactVars: { PlanPath: ARTIFACT_RECORD },
+        });
+
+        const result = await harness.service.initializeState(harness.state.id, harness.steps);
+        const loaded = await harness.manager.load(harness.state.id);
+
+        expect(result?.artifactVars).toEqual({ PlanPath: ARTIFACT_RECORD });
+        expect(loaded?.artifactVars).toEqual({ PlanPath: ARTIFACT_RECORD });
+      } finally {
+        harness.actor.stop();
+        await rm(harness.testDir, { recursive: true, force: true });
+      }
+    });
+
+    it('overrides persisted artifactVars when actor context provides a new value', async () => {
+      const persisted = {
+        ...ARTIFACT_RECORD,
+        key: 'old.json',
+        uri: ARTIFACT_RECORD.uri.replace('plan', 'old'),
+      };
+      const updated = {
+        ...ARTIFACT_RECORD,
+        key: 'new.json',
+        uri: ARTIFACT_RECORD.uri.replace('plan', 'new'),
+      };
+      const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n', {
+        artifactVars: { PlanPath: persisted },
+      });
+      try {
+        const actor = mockActor({
+          value: 'step::1',
+          context: { variables: {}, retryCount: 0, artifactVars: { PlanPath: updated } },
+        });
+
+        const { state } = await harness.service.updateFromActor(
+          harness.state.id,
+          actor,
+          harness.steps,
+        );
+
+        expect(state.artifactVars).toEqual({ PlanPath: updated });
+      } finally {
+        harness.actor.stop();
+        await rm(harness.testDir, { recursive: true, force: true });
+      }
+    });
+
+    it('preserves persisted artifactVars when actor context omits the field', async () => {
+      const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n', {
+        artifactVars: { PlanPath: ARTIFACT_RECORD },
+      });
+      try {
+        const actor = mockActor({
+          value: 'step::1',
+          context: { variables: {}, retryCount: 0 },
+        });
+
+        const { state } = await harness.service.updateFromActor(
+          harness.state.id,
+          actor,
+          harness.steps,
+        );
+
+        expect(state.artifactVars).toEqual({ PlanPath: ARTIFACT_RECORD });
+      } finally {
+        harness.actor.stop();
+        await rm(harness.testDir, { recursive: true, force: true });
+      }
+    });
+
     it('persists lifecycle = "completed" when machine reaches COMPLETE', async () => {
       const harness = await createLifecycleHarness('## 1. Only\n- PASS COMPLETE\n- FAIL STOP\n');
       try {

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ArtifactDeclaration } from '@rundown-org/parser';
+import {
+  appendArtifactManifestRecord,
+  readArtifactManifest,
+  resolveArtifactDeclarations,
+  type ArtifactRunEligibility,
+} from '../../src/runbook/index.js';
+import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
+import type { RunId } from '../../src/runbook/run-id.js';
+import { brandRunIdForTest } from '../helpers/effective-vars.js';
+
+const CURRENT_RUN: RunId = brandRunIdForTest('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+const CHILD_RUN: RunId = brandRunIdForTest('rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+const OTHER_CONTEXT_RUN: RunId = brandRunIdForTest('rd_cccccccccccccccccccccccccccccccc');
+const CONTEXT_ID = 'ctx1';
+const WORK_PATH = '.rundown/work';
+const RUNBOOK = { source: 'project' as const, path: 'planning/write-plan.runbook.md' };
+const CHILD_RUNBOOK = { source: 'project' as const, path: 'planning/review.runbook.md' };
+
+let tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => fsp.rm(dir, { recursive: true, force: true })));
+  tempDirs = [];
+});
+
+async function tempCwd(): Promise<string> {
+  const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), 'artifact-directive-'));
+  tempDirs.push(cwd);
+  return cwd;
+}
+
+function exact(name: string, key: string): ArtifactDeclaration {
+  return { name, key, kind: 'exact' };
+}
+
+function wildcard(name: string, key: string): ArtifactDeclaration {
+  return { name, key, kind: 'wildcard' };
+}
+
+function record(overrides: Partial<ArtifactRecord> = {}): ArtifactRecord {
+  const runId = overrides.runId ?? CHILD_RUN;
+  const contextId = overrides.contextId ?? CONTEXT_ID;
+  const key = overrides.key ?? 'review-plan-a.json';
+  return {
+    uri: `rd://artifacts/${contextId}/runs/${runId}/${key}`,
+    runId,
+    contextId,
+    runbook: overrides.runbook ?? CHILD_RUNBOOK,
+    key,
+    timestamp: overrides.timestamp ?? '2026-05-07T00:00:00.000Z',
+  };
+}
+
+async function touchArtifact(cwd: string, row: ArtifactRecord): Promise<void> {
+  const file = path.join(cwd, WORK_PATH, `.rd-${row.contextId}`, 'runs', row.runId, row.key);
+  await fsp.mkdir(path.dirname(file), { recursive: true });
+  await fsp.writeFile(file, '{}');
+}
+
+function eligibility(states: ReadonlyMap<string, ArtifactRunEligibility | null>) {
+  return async (runId: RunId): Promise<ArtifactRunEligibility | null> => states.get(runId) ?? null;
+}
+
+describe('resolveArtifactDeclarations', () => {
+  it('registers an exact artifact once and creates only its parent directory', async () => {
+    const cwd = await tempCwd();
+
+    const result = await resolveArtifactDeclarations([exact('PlanPath', 'plan.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      now: () => '2026-05-07T01:00:00.000Z',
+      loadRunEligibility: eligibility(new Map()),
+    });
+
+    expect(result.PlanPath).toEqual({
+      uri: `rd://artifacts/${CONTEXT_ID}/runs/${CURRENT_RUN}/plan.json`,
+      runId: CURRENT_RUN,
+      contextId: CONTEXT_ID,
+      runbook: RUNBOOK,
+      key: 'plan.json',
+      timestamp: '2026-05-07T01:00:00.000Z',
+    });
+    const runDirStat = await fsp.stat(
+      path.join(cwd, WORK_PATH, `.rd-${CONTEXT_ID}`, 'runs', CURRENT_RUN),
+    );
+    expect(runDirStat.isDirectory()).toBe(true);
+    await expect(
+      fsp.stat(path.join(cwd, WORK_PATH, `.rd-${CONTEXT_ID}`, 'runs', CURRENT_RUN, 'plan.json')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(
+      readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID),
+    ).resolves.toHaveLength(1);
+  });
+
+  it('reuses an existing coalesced exact record instead of appending', async () => {
+    const cwd = await tempCwd();
+    const existing = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'plan.json',
+      timestamp: '2026-05-07T00:00:00.000Z',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, existing);
+
+    const result = await resolveArtifactDeclarations([exact('PlanPath', 'plan.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      now: () => '2026-05-07T01:00:00.000Z',
+      loadRunEligibility: eligibility(new Map()),
+    });
+
+    expect(result.PlanPath).toEqual(existing);
+    await expect(readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID)).resolves.toEqual([
+      existing,
+    ]);
+  });
+
+  it('wildcards match current-run files and completed sibling runbook files in the same context', async () => {
+    const cwd = await tempCwd();
+    const current = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'review-plan-current.json',
+    });
+    const completedChild = record({ key: 'review-plan-child.json' });
+    const otherContext = record({
+      runId: OTHER_CONTEXT_RUN,
+      contextId: 'ctx2',
+      key: 'review-plan-other.json',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, completedChild);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, current);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, otherContext);
+    await Promise.all(
+      [current, completedChild, otherContext].map((row) => touchArtifact(cwd, row)),
+    );
+
+    const result = await resolveArtifactDeclarations([wildcard('Reviews', 'review-plan-*.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      now: () => '2026-05-07T01:00:00.000Z',
+      loadRunEligibility: eligibility(
+        new Map([
+          [CHILD_RUN, { runId: CHILD_RUN, terminalAt: '2026-05-07T02:00:00.000Z' }],
+          [OTHER_CONTEXT_RUN, { runId: OTHER_CONTEXT_RUN, terminalAt: '2026-05-07T02:00:00.000Z' }],
+        ]),
+      ),
+    });
+
+    expect(result.Reviews).toEqual(
+      [current, completedChild].sort((a, b) => a.uri.localeCompare(b.uri)),
+    );
+  });
+
+  it('wildcards ignore incomplete other runs and missing files', async () => {
+    const cwd = await tempCwd();
+    const incomplete = record({ key: 'review-plan-incomplete.json' });
+    const missingFile = record({
+      runId: 'rd_dddddddddddddddddddddddddddddddd',
+      key: 'review-plan-missing.json',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, incomplete);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, missingFile);
+    await touchArtifact(cwd, incomplete);
+
+    const result = await resolveArtifactDeclarations([wildcard('Reviews', 'review-plan-*.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      now: () => '2026-05-07T01:00:00.000Z',
+      loadRunEligibility: eligibility(
+        // Incomplete sibling run signalled by `null`; the resolver's null-check
+        // filters it out of wildcard matches.
+        new Map([[CHILD_RUN, null]]),
+      ),
+    });
+
+    expect(result.Reviews).toEqual([]);
+  });
+
+  it('wildcards ignore symlinked artifact files', async () => {
+    const cwd = await tempCwd();
+    const outside = await tempCwd();
+    const target = path.join(outside, 'review-plan-a.json');
+    const row = record({ key: 'review-plan-symlink.json' });
+    await fsp.writeFile(target, '{}');
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, row);
+    const artifactPath = path.join(
+      cwd,
+      WORK_PATH,
+      `.rd-${row.contextId}`,
+      'runs',
+      row.runId,
+      row.key,
+    );
+    await fsp.mkdir(path.dirname(artifactPath), { recursive: true });
+    try {
+      await fsp.symlink(target, artifactPath);
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        error.code === 'EPERM'
+      ) {
+        return;
+      }
+      throw error;
+    }
+
+    const result = await resolveArtifactDeclarations([wildcard('Reviews', 'review-plan-*.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      now: () => '2026-05-07T01:00:00.000Z',
+      loadRunEligibility: eligibility(
+        new Map([[CHILD_RUN, { runId: CHILD_RUN, terminalAt: '2026-05-07T02:00:00.000Z' }]]),
+      ),
+    });
+
+    expect(result.Reviews).toEqual([]);
+  });
+
+  it('wildcards ignore artifact paths whose parent directory is a symlink', async () => {
+    const cwd = await tempCwd();
+    const outside = await tempCwd();
+    const row = record({ key: 'review-plan-parent-symlink.json' });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, row);
+    await fsp.writeFile(path.join(outside, row.key), '{}');
+    const runDir = path.join(cwd, WORK_PATH, `.rd-${row.contextId}`, 'runs', row.runId);
+    await fsp.mkdir(path.dirname(runDir), { recursive: true });
+    try {
+      await fsp.symlink(outside, runDir, 'dir');
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        error.code === 'EPERM'
+      ) {
+        return;
+      }
+      throw error;
+    }
+
+    const result = await resolveArtifactDeclarations([wildcard('Reviews', 'review-plan-*.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      now: () => '2026-05-07T01:00:00.000Z',
+      loadRunEligibility: eligibility(
+        new Map([[CHILD_RUN, { runId: CHILD_RUN, terminalAt: '2026-05-07T02:00:00.000Z' }]]),
+      ),
+    });
+
+    expect(result.Reviews).toEqual([]);
+  });
+
+  it('resolves exact declarations before wildcards in the same block', async () => {
+    const cwd = await tempCwd();
+    await fsp.mkdir(path.join(cwd, WORK_PATH, `.rd-${CONTEXT_ID}`, 'runs', CURRENT_RUN), {
+      recursive: true,
+    });
+    await fsp.writeFile(
+      path.join(cwd, WORK_PATH, `.rd-${CONTEXT_ID}`, 'runs', CURRENT_RUN, 'plan.json'),
+      '{}',
+    );
+
+    const result = await resolveArtifactDeclarations(
+      [wildcard('Plans', 'plan*.json'), exact('PlanPath', 'plan.json')],
+      {
+        cwd,
+        workPath: WORK_PATH,
+        contextId: CONTEXT_ID,
+        runId: CURRENT_RUN,
+        runbook: RUNBOOK,
+        now: () => '2026-05-07T01:00:00.000Z',
+        loadRunEligibility: eligibility(new Map()),
+      },
+    );
+
+    expect(result.PlanPath).toMatchObject({ key: 'plan.json' });
+    expect(result.Plans).toEqual([result.PlanPath]);
+  });
+
+  it('exact resolution adds a manifest row that a same-block wildcard observes (file NOT pre-created)', async () => {
+    // Isolates the manifest-update ordering from the file-existence check.
+    // The exact appends a new manifest row during this call; the wildcard
+    // (declared first in source order) sees the row because resolution runs
+    // exacts before wildcards. The file is never written, so the wildcard's
+    // hardened file-existence filter rejects the row — what we assert is the
+    // manifest row count growing from 0 to 1 inside one call.
+    const cwd = await tempCwd();
+    const before = await readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
+    expect(before).toHaveLength(0);
+
+    const result = await resolveArtifactDeclarations(
+      [wildcard('Plans', 'plan*.json'), exact('PlanPath', 'plan.json')],
+      {
+        cwd,
+        workPath: WORK_PATH,
+        contextId: CONTEXT_ID,
+        runId: CURRENT_RUN,
+        runbook: RUNBOOK,
+        now: () => '2026-05-07T01:00:00.000Z',
+        loadRunEligibility: eligibility(new Map()),
+      },
+    );
+
+    expect(result.PlanPath).toMatchObject({ key: 'plan.json' });
+    expect(result.Plans).toEqual([]);
+
+    const after = await readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
+    expect(after).toHaveLength(1);
+  });
+
+  it('coalesces concurrent duplicate appends on the next resolver read', async () => {
+    // Two appends with identical (contextId, runId, runbook, key) — simulating
+    // a race between two writers in the same context. coalesceManifestRecords
+    // is invoked during the next resolver call and reduces them to one row.
+    const cwd = await tempCwd();
+    const first = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'plan.json',
+      timestamp: '2026-05-07T00:00:00.000Z',
+    });
+    const duplicate = { ...first, timestamp: '2026-05-07T00:00:00.000Z' };
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, first);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, duplicate);
+
+    const raw = await readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
+    expect(raw).toHaveLength(2);
+
+    const result = await resolveArtifactDeclarations([exact('PlanPath', 'plan.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      now: () => '2026-05-07T01:00:00.000Z',
+      loadRunEligibility: eligibility(new Map()),
+    });
+
+    expect(result.PlanPath).toEqual(first);
+    const afterRaw = await readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
+    expect(afterRaw).toHaveLength(2);
+  });
+});

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -126,6 +126,107 @@ describe('resolveArtifactDeclarations', () => {
     ]);
   });
 
+  it('reuses a same-block exact record for duplicate exact declarations', async () => {
+    const cwd = await tempCwd();
+    const timestamps = ['2026-05-07T01:00:00.000Z', '2026-05-07T01:00:01.000Z'];
+    let timestampIndex = 0;
+
+    const result = await resolveArtifactDeclarations(
+      [exact('FirstPlan', 'plan.json'), exact('SecondPlan', 'plan.json')],
+      {
+        cwd,
+        workPath: WORK_PATH,
+        contextId: CONTEXT_ID,
+        runId: CURRENT_RUN,
+        runbook: RUNBOOK,
+        now: () => timestamps[timestampIndex++] ?? '2026-05-07T01:00:02.000Z',
+        loadRunEligibility: eligibility(new Map()),
+      },
+    );
+
+    expect(result.SecondPlan).toBe(result.FirstPlan);
+    expect(result.FirstPlan).toMatchObject({
+      key: 'plan.json',
+      timestamp: '2026-05-07T01:00:00.000Z',
+    });
+    await expect(readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID)).resolves.toEqual([
+      result.FirstPlan,
+    ]);
+  });
+
+  it('uses the system clock for exact declarations when no clock is injected', async () => {
+    const cwd = await tempCwd();
+
+    const result = await resolveArtifactDeclarations([exact('PlanPath', 'plan.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      loadRunEligibility: eligibility(new Map()),
+    });
+
+    expect(result.PlanPath).toMatchObject({
+      runId: CURRENT_RUN,
+      contextId: CONTEXT_ID,
+      runbook: RUNBOOK,
+      key: 'plan.json',
+    });
+    expect(typeof (result.PlanPath as ArtifactRecord).timestamp).toBe('string');
+    expect(Number.isNaN(Date.parse((result.PlanPath as ArtifactRecord).timestamp))).toBe(false);
+  });
+
+  it('does not reuse exact records that differ by run, runbook, or key', async () => {
+    const nearMatches = [
+      record({
+        runId: CHILD_RUN,
+        runbook: RUNBOOK,
+        key: 'plan.json',
+      }),
+      record({
+        runId: CURRENT_RUN,
+        runbook: { source: 'plugin', path: RUNBOOK.path },
+        key: 'plan.json',
+      }),
+      record({
+        runId: CURRENT_RUN,
+        runbook: { source: RUNBOOK.source, path: 'planning/other.runbook.md' },
+        key: 'plan.json',
+      }),
+      record({
+        runId: CURRENT_RUN,
+        runbook: RUNBOOK,
+        key: 'other.json',
+      }),
+    ];
+
+    for (const nearMatch of nearMatches) {
+      const cwd = await tempCwd();
+      await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, nearMatch);
+
+      const result = await resolveArtifactDeclarations([exact('PlanPath', 'plan.json')], {
+        cwd,
+        workPath: WORK_PATH,
+        contextId: CONTEXT_ID,
+        runId: CURRENT_RUN,
+        runbook: RUNBOOK,
+        now: () => '2026-05-07T01:00:00.000Z',
+        loadRunEligibility: eligibility(new Map()),
+      });
+
+      expect(result.PlanPath).not.toEqual(nearMatch);
+      expect(result.PlanPath).toMatchObject({
+        runId: CURRENT_RUN,
+        runbook: RUNBOOK,
+        key: 'plan.json',
+        timestamp: '2026-05-07T01:00:00.000Z',
+      });
+      await expect(
+        readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID),
+      ).resolves.toHaveLength(2);
+    }
+  });
+
   it('wildcards match current-run files and completed sibling runbook files in the same context', async () => {
     const cwd = await tempCwd();
     const current = record({
@@ -164,6 +265,58 @@ describe('resolveArtifactDeclarations', () => {
     expect(result.Reviews).toEqual(
       [current, completedChild].sort((a, b) => a.uri.localeCompare(b.uri)),
     );
+  });
+
+  it('wildcards match dotfile artifact keys', async () => {
+    const cwd = await tempCwd();
+    const hidden = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: '.review-plan.json',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, hidden);
+    await touchArtifact(cwd, hidden);
+
+    const result = await resolveArtifactDeclarations([wildcard('Reviews', '*.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      now: () => '2026-05-07T01:00:00.000Z',
+      loadRunEligibility: eligibility(new Map()),
+    });
+
+    expect(result.Reviews).toEqual([hidden]);
+  });
+
+  it('wildcards ignore existing same-context files whose keys do not match', async () => {
+    const cwd = await tempCwd();
+    const matching = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'review-plan-current.json',
+    });
+    const nonmatching = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'notes.json',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, nonmatching);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, matching);
+    await Promise.all([matching, nonmatching].map((row) => touchArtifact(cwd, row)));
+
+    const result = await resolveArtifactDeclarations([wildcard('Reviews', 'review-plan-*.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      now: () => '2026-05-07T01:00:00.000Z',
+      loadRunEligibility: eligibility(new Map()),
+    });
+
+    expect(result.Reviews).toEqual([matching]);
   });
 
   it('wildcards ignore incomplete other runs and missing files', async () => {

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -128,8 +128,7 @@ describe('resolveArtifactDeclarations', () => {
 
   it('reuses a same-block exact record for duplicate exact declarations', async () => {
     const cwd = await tempCwd();
-    const timestamps = ['2026-05-07T01:00:00.000Z', '2026-05-07T01:00:01.000Z'];
-    let timestampIndex = 0;
+    const fixedTimestamp = '2026-05-07T01:00:00.000Z';
 
     const result = await resolveArtifactDeclarations(
       [exact('FirstPlan', 'plan.json'), exact('SecondPlan', 'plan.json')],
@@ -139,19 +138,100 @@ describe('resolveArtifactDeclarations', () => {
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        now: () => timestamps[timestampIndex++] ?? '2026-05-07T01:00:02.000Z',
+        now: () => fixedTimestamp,
         loadRunEligibility: eligibility(new Map()),
       },
     );
 
+    // Second declaration must reuse the first declaration's record (same identity).
     expect(result.SecondPlan).toBe(result.FirstPlan);
-    expect(result.FirstPlan).toMatchObject({
-      key: 'plan.json',
-      timestamp: '2026-05-07T01:00:00.000Z',
-    });
+    expect(result.FirstPlan).toMatchObject({ key: 'plan.json', timestamp: fixedTimestamp });
     await expect(readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID)).resolves.toEqual([
       result.FirstPlan,
     ]);
+  });
+
+  it('returns an empty result map for an empty declarations array', async () => {
+    const cwd = await tempCwd();
+
+    const result = await resolveArtifactDeclarations([], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      loadRunEligibility: eligibility(new Map()),
+    });
+
+    expect(result).toEqual({});
+    // Manifest is absent (no exact declarations were processed); reading it
+    // returns an empty list rather than throwing.
+    await expect(readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID)).resolves.toEqual(
+      [],
+    );
+  });
+
+  it('a wildcard declaration overwrites an exact declaration sharing the same alias name', async () => {
+    const cwd = await tempCwd();
+    const existing = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'plan.json',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, existing);
+    await touchArtifact(cwd, existing);
+
+    const result = await resolveArtifactDeclarations(
+      [exact('Out', 'plan.json'), wildcard('Out', '*.json')],
+      {
+        cwd,
+        workPath: WORK_PATH,
+        contextId: CONTEXT_ID,
+        runId: CURRENT_RUN,
+        runbook: RUNBOOK,
+        loadRunEligibility: eligibility(new Map()),
+      },
+    );
+
+    // Wildcards run after exacts and overwrite the alias slot when names collide.
+    expect(Array.isArray(result.Out)).toBe(true);
+    expect(result.Out).toHaveLength(1);
+    expect((result.Out as ArtifactRecord[])[0]).toMatchObject({ key: 'plan.json' });
+  });
+
+  it('later wildcard declarations sharing an alias name overwrite earlier ones', async () => {
+    const cwd = await tempCwd();
+    const planRecord = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'plan.json',
+    });
+    const reviewRecord = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'review.json',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, planRecord);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, reviewRecord);
+    await touchArtifact(cwd, planRecord);
+    await touchArtifact(cwd, reviewRecord);
+
+    const result = await resolveArtifactDeclarations(
+      [wildcard('Out', 'plan*'), wildcard('Out', 'review*')],
+      {
+        cwd,
+        workPath: WORK_PATH,
+        contextId: CONTEXT_ID,
+        runId: CURRENT_RUN,
+        runbook: RUNBOOK,
+        loadRunEligibility: eligibility(new Map()),
+      },
+    );
+
+    // Last writer wins at the alias level.
+    expect(Array.isArray(result.Out)).toBe(true);
+    expect(result.Out).toHaveLength(1);
+    expect((result.Out as ArtifactRecord[])[0]).toMatchObject({ key: 'review.json' });
   });
 
   it('uses the system clock for exact declarations when no clock is injected', async () => {

--- a/packages/core/__tests__/runbook/artifact-manifest.properties.test.ts
+++ b/packages/core/__tests__/runbook/artifact-manifest.properties.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from '@jest/globals';
+import * as fc from 'fast-check';
+import {
+  coalesceManifestRecords,
+  type ArtifactManifestRecord,
+} from '../../src/runbook/artifact-manifest.js';
+
+const recordArb: fc.Arbitrary<ArtifactManifestRecord> = fc.record({
+  uri: fc.string({ minLength: 1 }),
+  runId: fc.constantFrom(
+    'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    'rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  ),
+  contextId: fc.constantFrom('ctx1', 'ctx2'),
+  runbook: fc.record({
+    source: fc.constantFrom('project' as const, 'plugin' as const, 'bundled' as const),
+    path: fc.constantFrom('a.runbook.md', 'b.runbook.md'),
+  }),
+  key: fc.constantFrom('plan.json', 'review.json', 'output.json'),
+  timestamp: fc.constantFrom(
+    '2026-05-07T00:00:00.000Z',
+    '2026-05-07T01:00:00.000Z',
+    '2026-05-07T02:00:00.000Z',
+  ),
+});
+
+function identityKey(record: ArtifactManifestRecord): string {
+  return [
+    record.contextId,
+    record.runId,
+    record.runbook.source,
+    record.runbook.path,
+    record.key,
+  ].join('\0');
+}
+
+describe('coalesceManifestRecords properties', () => {
+  it('is idempotent: coalesce(coalesce(rs)) deep-equals coalesce(rs)', () => {
+    fc.assert(
+      fc.property(fc.array(recordArb, { maxLength: 50 }), (records) => {
+        const once = coalesceManifestRecords(records);
+        const twice = coalesceManifestRecords(once);
+        expect(twice).toEqual(once);
+      }),
+    );
+  });
+
+  it('preserves the identity set: identities(coalesce(rs)) === identities(rs)', () => {
+    fc.assert(
+      fc.property(fc.array(recordArb, { maxLength: 50 }), (records) => {
+        const inputIdentities = new Set(records.map(identityKey));
+        const outputIdentities = new Set(coalesceManifestRecords(records).map(identityKey));
+        expect(outputIdentities).toEqual(inputIdentities);
+      }),
+    );
+  });
+
+  it('on equal timestamps, the later input row wins', () => {
+    fc.assert(
+      fc.property(
+        recordArb,
+        recordArb.map((record) => ({
+          ...record,
+          timestamp: '2026-05-07T00:00:00.000Z',
+        })),
+        (left, right) => {
+          const sameIdentity = {
+            ...right,
+            contextId: left.contextId,
+            runId: left.runId,
+            runbook: left.runbook,
+            key: left.key,
+            timestamp: left.timestamp,
+          };
+          const result = coalesceManifestRecords([left, sameIdentity]);
+          expect(result).toEqual([sameIdentity]);
+          expect(result[0]).toBe(sameIdentity);
+        },
+      ),
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/artifact-manifest.properties.test.ts
+++ b/packages/core/__tests__/runbook/artifact-manifest.properties.test.ts
@@ -10,17 +10,33 @@ const recordArb: fc.Arbitrary<ArtifactManifestRecord> = fc.record({
   runId: fc.constantFrom(
     'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     'rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    'rd_cccccccccccccccccccccccccccccccc',
   ),
   contextId: fc.constantFrom('ctx1', 'ctx2'),
   runbook: fc.record({
     source: fc.constantFrom('project' as const, 'plugin' as const, 'bundled' as const),
-    path: fc.constantFrom('a.runbook.md', 'b.runbook.md'),
+    path: fc.constantFrom(
+      'a.runbook.md',
+      'b.runbook.md',
+      'c.runbook.md',
+      'planning/write-plan.runbook.md',
+      'planning/review.runbook.md',
+    ),
   }),
-  key: fc.constantFrom('plan.json', 'review.json', 'output.json'),
+  key: fc.constantFrom(
+    'plan.json',
+    'review.json',
+    'output.json',
+    'review-plan-a.json',
+    'review-plan-b.json',
+    'config.yaml',
+  ),
   timestamp: fc.constantFrom(
     '2026-05-07T00:00:00.000Z',
     '2026-05-07T01:00:00.000Z',
     '2026-05-07T02:00:00.000Z',
+    '2026-05-07T03:00:00.000Z',
+    '2026-05-07T04:00:00.000Z',
   ),
 });
 
@@ -51,6 +67,24 @@ describe('coalesceManifestRecords properties', () => {
         const inputIdentities = new Set(records.map(identityKey));
         const outputIdentities = new Set(coalesceManifestRecords(records).map(identityKey));
         expect(outputIdentities).toEqual(inputIdentities);
+      }),
+    );
+  });
+
+  it('newest timestamp wins per identity', () => {
+    fc.assert(
+      fc.property(fc.array(recordArb, { maxLength: 50 }), (records) => {
+        const coalesced = coalesceManifestRecords(records);
+        // For each identity in the coalesced output, the timestamp must equal
+        // the maximum timestamp of all input rows sharing that identity.
+        for (const row of coalesced) {
+          const id = identityKey(row);
+          const maxInputTs = records
+            .filter((r) => identityKey(r) === id)
+            .map((r) => r.timestamp)
+            .reduce((a, b) => (a > b ? a : b));
+          expect(row.timestamp).toBe(maxInputTs);
+        }
       }),
     );
   });

--- a/packages/core/__tests__/runbook/artifact-manifest.test.ts
+++ b/packages/core/__tests__/runbook/artifact-manifest.test.ts
@@ -151,6 +151,30 @@ describe('artifact manifest storage', () => {
     expect(coalesceManifestRecords([record, newer])).toEqual([newer]);
   });
 
+  it('does not coalesce records from different runbook refs', () => {
+    const sameRunAndKeyDifferentRunbook = withRunId(RUN_ID, {
+      runbook: { source: 'project', path: 'planning/write-plan.runbook.md' },
+      timestamp: '2026-05-04T04:15:24.000Z',
+    });
+
+    expect(coalesceManifestRecords([record, sameRunAndKeyDifferentRunbook])).toEqual([
+      record,
+      sameRunAndKeyDifferentRunbook,
+    ]);
+  });
+
+  it('breaks coalescing timestamp ties by later manifest row', () => {
+    const first = withRunId(RUN_ID, { timestamp: '2026-05-04T03:15:24.000Z' });
+    const later = withRunId(RUN_ID, {
+      timestamp: '2026-05-04T03:15:24.000Z',
+      uri: first.uri,
+    });
+
+    const result = coalesceManifestRecords([first, later]);
+    expect(result).toEqual([later]);
+    expect(result[0]).toBe(later);
+  });
+
   it('returns an empty manifest for missing, empty, and whitespace-only files', async () => {
     const missingCwd = await tempCwd();
     await expect(readArtifactManifest(optionsFor(missingCwd), 'ctx1')).resolves.toEqual([]);

--- a/packages/core/__tests__/runbook/artifact-manifest.test.ts
+++ b/packages/core/__tests__/runbook/artifact-manifest.test.ts
@@ -151,6 +151,30 @@ describe('artifact manifest storage', () => {
     expect(coalesceManifestRecords([record, newer])).toEqual([newer]);
   });
 
+  it('keeps the newest duplicate even when it appears before an older row', () => {
+    const newer = { ...record, timestamp: '2026-05-04T04:15:24.000Z' };
+    const older = { ...record, timestamp: '2026-05-04T03:15:24.000Z' };
+
+    const result = coalesceManifestRecords([newer, older]);
+
+    expect(result).toEqual([newer]);
+    expect(result[0]).toBe(newer);
+  });
+
+  it('does not coalesce identities that only collide without field separators', () => {
+    const first = withRunId(RUN_ID, {
+      runbook: { source: 'plugin', path: 'a.md' },
+      key: 'b.md-c',
+    });
+    const second = withRunId(RUN_ID, {
+      runbook: { source: 'plugin', path: 'a.mdb.md' },
+      key: '-c',
+      timestamp: '2026-05-04T04:15:24.000Z',
+    });
+
+    expect(coalesceManifestRecords([first, second])).toEqual([first, second]);
+  });
+
   it('does not coalesce records from different runbook refs', () => {
     const sameRunAndKeyDifferentRunbook = withRunId(RUN_ID, {
       runbook: { source: 'project', path: 'planning/write-plan.runbook.md' },

--- a/packages/core/__tests__/runbook/delegation-context.test.ts
+++ b/packages/core/__tests__/runbook/delegation-context.test.ts
@@ -630,6 +630,10 @@ describe('buildContextSnapshot', () => {
   });
 
   it('keeps artifactVars after RunbookStateSchema parse before snapshot build', () => {
+    // Cast required: this test deliberately exercises the unbranded
+    // RunbookStateSchema (parses to ValidatedRunbookState, no brand transforms).
+    // The branded variant is makeRunbookStateSchema(projectRoot). buildContextSnapshot
+    // consumes the branded RunbookState type, so we coerce after parse.
     const parsed = RunbookStateSchema.parse({
       ...makeMinimalState({
         templateVars: brandInitialTemplateVarsForTest({}),

--- a/packages/core/__tests__/runbook/delegation-context.test.ts
+++ b/packages/core/__tests__/runbook/delegation-context.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_ANCESTOR_DEPTH,
 } from '../../src/runbook/delegation-context.js';
 import { mergeEffectiveVars } from '../../src/runbook/effective-vars.js';
+import { RunbookStateSchema } from '../../src/schemas.js';
 import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
 import type {
   AncestorSnapshot,
@@ -626,5 +627,19 @@ describe('buildContextSnapshot', () => {
 
     expect(snap.vars.PlanPath).toEqual(ARTIFACT_RECORD);
     expect(snap.vars.OutputWins).toBe('from-output');
+  });
+
+  it('keeps artifactVars after RunbookStateSchema parse before snapshot build', () => {
+    const parsed = RunbookStateSchema.parse({
+      ...makeMinimalState({
+        templateVars: brandInitialTemplateVarsForTest({}),
+        artifactVars: brandArtifactVarsForTest({ PlanPath: ARTIFACT_RECORD }),
+      }),
+      schemaVersion: 3,
+    }) as unknown as RunbookState;
+
+    const snap = buildContextSnapshot(parsed);
+
+    expect(snap.vars.PlanPath).toEqual(ARTIFACT_RECORD);
   });
 });

--- a/packages/core/__tests__/runbook/delegation-context.test.ts
+++ b/packages/core/__tests__/runbook/delegation-context.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_ANCESTOR_DEPTH,
 } from '../../src/runbook/delegation-context.js';
 import { mergeEffectiveVars } from '../../src/runbook/effective-vars.js';
+import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
 import type {
   AncestorSnapshot,
   ContextSnapshot,
@@ -14,6 +15,7 @@ import type {
   RunId,
 } from '../../src/runbook/types.js';
 import {
+  brandArtifactVarsForTest,
   brandEffectiveVarsForTest,
   brandInitialTemplateVarsForTest,
   brandRunIdForTest,
@@ -556,6 +558,15 @@ describe('extractInheritedUserVars', () => {
 });
 
 describe('buildContextSnapshot', () => {
+  const ARTIFACT_RECORD = {
+    uri: 'rd://artifacts/ctx1/runs/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+    runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    contextId: 'ctx1',
+    runbook: { source: 'project' as const, path: 'planning/write-plan.runbook.md' },
+    key: 'plan.json',
+    timestamp: '2026-05-07T00:00:00.000Z',
+  } satisfies ArtifactRecord;
+
   it('merges state.variables (step OUTPUTS) into snapshot.vars', () => {
     const state = makeMinimalState({
       templateVars: brandInitialTemplateVarsForTest({ Other: 'kept' }),
@@ -599,5 +610,21 @@ describe('buildContextSnapshot', () => {
     });
     const snap = buildContextSnapshot(state);
     expect(snap.vars.Just).toBe('outputs');
+  });
+
+  it('includes artifactVars in snapshot vars below step OUTPUTS', () => {
+    const state = makeMinimalState({
+      templateVars: brandInitialTemplateVarsForTest({ PlanPath: 'from-template' }),
+      artifactVars: brandArtifactVarsForTest({
+        PlanPath: ARTIFACT_RECORD,
+        OutputWins: ARTIFACT_RECORD,
+      }),
+      variables: brandStoredOutputsForTest({ OutputWins: 'from-output' }),
+    });
+
+    const snap = buildContextSnapshot(state);
+
+    expect(snap.vars.PlanPath).toEqual(ARTIFACT_RECORD);
+    expect(snap.vars.OutputWins).toBe('from-output');
   });
 });

--- a/packages/core/__tests__/runbook/delegation-scan.test.ts
+++ b/packages/core/__tests__/runbook/delegation-scan.test.ts
@@ -71,7 +71,7 @@ describe('DelegationScanService', () => {
       startedAt: '2026-02-27T10:00:00.000Z',
       updatedAt: '2026-02-27T10:00:00.000Z',
       lifecycle: 'running',
-      schemaVersion: 2,
+      schemaVersion: 3,
       ...overrides,
     };
   }

--- a/packages/core/__tests__/runbook/effective-vars.test.ts
+++ b/packages/core/__tests__/runbook/effective-vars.test.ts
@@ -8,8 +8,19 @@ import {
   type InitialTemplateVars,
   type StoredOutputs,
 } from '../../src/runbook/effective-vars.js';
+import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
 import { resolveForValue } from '../../src/runbook/source-resolver.js';
 import type { ForContext, TemplateVarValue } from '../../src/runbook/types.js';
+import { brandArtifactVarsForTest } from '../helpers/effective-vars.js';
+
+const ARTIFACT_RECORD = {
+  uri: 'rd://artifacts/ctx1/runs/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+  runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  contextId: 'ctx1',
+  runbook: { source: 'project', path: 'planning/write-plan.runbook.md' },
+  key: 'plan.json',
+  timestamp: '2026-05-07T00:00:00.000Z',
+} satisfies ArtifactRecord;
 
 describe('brandInitialTemplateVars', () => {
   it('returns the same reference (zero runtime cost)', () => {
@@ -70,6 +81,15 @@ describe('brandEffectiveVars', () => {
   });
 });
 
+describe('brandArtifactVars', () => {
+  it('returns the same reference (zero runtime cost)', async () => {
+    const { brandArtifactVars } = await import('../../src/runbook/effective-vars.js');
+    const input = { PlanPath: ARTIFACT_RECORD };
+    const out = brandArtifactVars(input);
+    expect(out).toBe(input);
+  });
+});
+
 describe('mergeEffectiveVars accepts the new brands', () => {
   it('merges branded sources without further casting', () => {
     const tv = brandInitialTemplateVars({ a: 'tv', b: 'tv' });
@@ -84,6 +104,42 @@ describe('mergeEffectiveVars accepts the new brands', () => {
     const extra: Readonly<Record<string, TemplateVarValue>> = { c: 'extra', d: 'extra' };
     const merged = mergeEffectiveVars({ templateVars: tv, variables: sv }, extra);
     expect(merged).toEqual({ a: 'tv', b: 'sv', c: 'extra', d: 'extra' });
+  });
+});
+
+describe('mergeEffectiveVars with artifactVars', () => {
+  it('applies precedence templateVars < artifactVars < variables < extraVars', () => {
+    const tv = brandInitialTemplateVars({ PlanPath: 'from-template', OnlyTemplate: 't' });
+    const artifactVars = brandArtifactVarsForTest({
+      PlanPath: ARTIFACT_RECORD,
+      OnlyArtifact: [ARTIFACT_RECORD],
+      OutputWins: ARTIFACT_RECORD,
+    });
+    const sv = brandStoredOutputs({ OutputWins: 'from-output' });
+    const extra: Readonly<Record<string, TemplateVarValue>> = { OutputWins: 'from-extra' };
+
+    const merged = mergeEffectiveVars({ templateVars: tv, artifactVars, variables: sv }, extra);
+
+    expect(merged).toEqual({
+      PlanPath: ARTIFACT_RECORD,
+      OnlyTemplate: 't',
+      OnlyArtifact: [ARTIFACT_RECORD],
+      OutputWins: 'from-extra',
+    });
+  });
+
+  it('extraVars overrides artifactVars even when no variables are present', () => {
+    const artifactVars = brandArtifactVarsForTest({ PlanPath: ARTIFACT_RECORD });
+    const merged = mergeEffectiveVars({ artifactVars }, { PlanPath: 'from-extra' });
+    expect(merged).toEqual({ PlanPath: 'from-extra' });
+  });
+
+  it('merges cleanly when artifactVars is empty', () => {
+    const merged = mergeEffectiveVars({
+      templateVars: brandInitialTemplateVars({ PlanPath: 'from-template' }),
+      artifactVars: brandArtifactVarsForTest({}),
+    });
+    expect(merged).toEqual({ PlanPath: 'from-template' });
   });
 });
 

--- a/packages/core/__tests__/runbook/effective-vars.test.ts
+++ b/packages/core/__tests__/runbook/effective-vars.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import {
+  brandArtifactVars,
   brandEffectiveVars,
   brandInitialTemplateVars,
   brandStoredOutputs,
@@ -82,8 +83,7 @@ describe('brandEffectiveVars', () => {
 });
 
 describe('brandArtifactVars', () => {
-  it('returns the same reference (zero runtime cost)', async () => {
-    const { brandArtifactVars } = await import('../../src/runbook/effective-vars.js');
+  it('returns the same reference (zero runtime cost)', () => {
     const input = { PlanPath: ARTIFACT_RECORD };
     const out = brandArtifactVars(input);
     expect(out).toBe(input);

--- a/packages/core/__tests__/runbook/session-reader.test.ts
+++ b/packages/core/__tests__/runbook/session-reader.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { readActiveRunScope } from '../../src/runbook/session-reader.js';
 import { RunbookStateManager } from '../../src/runbook/state.js';
+import { merge } from '../../src/runbook/state-update-ops.js';
 import { SessionService } from '../../src/runbook/session-service.js';
 import type { Runbook, Step } from '../../src/runbook/types.js';
 import { makeBaseStep } from '../helpers/step-factories.js';
@@ -58,10 +59,10 @@ describe('readActiveRunScope', () => {
       },
     });
     await manager.update(state.id, {
-      variables: {
+      variables: merge({
         WorkPath: '.rundown/work/output',
         ContextId: 'ctx-output',
-      },
+      }),
     });
     await sessionService.pushRunbook(state.id);
 

--- a/packages/core/__tests__/runbook/state-schema-version.test.ts
+++ b/packages/core/__tests__/runbook/state-schema-version.test.ts
@@ -20,16 +20,16 @@ const BASE_SCHEMA_STATE = {
   updatedAt: '2026-04-19T00:00:00.000Z',
 };
 
-describe('RunbookStateSchema — schema version and lifecycle fields', () => {
-  it('accepts state with schemaVersion 2 and lifecycle field', () => {
+describe('RunbookStateSchema — schema version 3 and lifecycle fields', () => {
+  it('accepts state with schemaVersion 3 and lifecycle field', () => {
     const parsed = RunbookStateSchema.parse({
       ...BASE_SCHEMA_STATE,
       variables: {},
       lifecycle: 'running',
-      schemaVersion: 2,
+      schemaVersion: 3,
     });
     expect(parsed.lifecycle).toBe('running');
-    expect(parsed.schemaVersion).toBe(2);
+    expect(parsed.schemaVersion).toBe(3);
   });
 
   it('accepts all lifecycle enum values', () => {
@@ -38,7 +38,7 @@ describe('RunbookStateSchema — schema version and lifecycle fields', () => {
         ...BASE_SCHEMA_STATE,
         variables: {},
         lifecycle: lc,
-        schemaVersion: 2,
+        schemaVersion: 3,
       });
       expect(parsed.lifecycle).toBe(lc);
     }
@@ -50,7 +50,7 @@ describe('RunbookStateSchema — schema version and lifecycle fields', () => {
         ...BASE_SCHEMA_STATE,
         variables: { completed: true },
         lifecycle: 'running',
-        schemaVersion: 2,
+        schemaVersion: 3,
       }),
     ).toThrow();
   });
@@ -61,7 +61,7 @@ describe('RunbookStateSchema — schema version and lifecycle fields', () => {
         ...BASE_SCHEMA_STATE,
         variables: { count: 42 },
         lifecycle: 'running',
-        schemaVersion: 2,
+        schemaVersion: 3,
       }),
     ).toThrow();
   });
@@ -71,7 +71,7 @@ describe('RunbookStateSchema — schema version and lifecycle fields', () => {
       ...BASE_SCHEMA_STATE,
       variables: {},
       lifecycle: 'running',
-      schemaVersion: 2,
+      schemaVersion: 3,
     });
     expect(parsed.variables).toEqual({});
   });
@@ -81,9 +81,36 @@ describe('RunbookStateSchema — schema version and lifecycle fields', () => {
       ...BASE_SCHEMA_STATE,
       variables: { env: 'staging', version: '1.2.3' },
       lifecycle: 'running',
-      schemaVersion: 2,
+      schemaVersion: 3,
     });
     expect(parsed.variables).toEqual({ env: 'staging', version: '1.2.3' });
+  });
+
+  it('accepts artifactVars with exact and wildcard artifact records', () => {
+    const artifact = {
+      uri: 'rd://artifacts/ctx1/runs/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+      runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      contextId: 'ctx1',
+      runbook: { source: 'project', path: 'planning/write-plan.runbook.md' },
+      key: 'plan.json',
+      timestamp: '2026-05-07T00:00:00.000Z',
+    };
+
+    const parsed = RunbookStateSchema.parse({
+      ...BASE_SCHEMA_STATE,
+      variables: {},
+      artifactVars: {
+        PlanPath: artifact,
+        Reviews: [artifact],
+      },
+      lifecycle: 'running',
+      schemaVersion: 3,
+    });
+
+    expect(parsed.artifactVars).toEqual({
+      PlanPath: artifact,
+      Reviews: [artifact],
+    });
   });
 });
 
@@ -91,7 +118,7 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
   let tmpDir: string;
   let manager: RunbookStateManager;
 
-  const V1_STATE = {
+  const STALE_V2_STATE = {
     id: STALE_RUN_ID,
     runbook: 'x.md',
     runbookPath: 'x.md',
@@ -103,7 +130,7 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
     startedAt: '2026-04-19T00:00:00.000Z',
     updatedAt: '2026-04-19T00:00:00.000Z',
     lifecycle: 'running',
-    schemaVersion: 1, // old version
+    schemaVersion: 2, // old version
   };
 
   beforeEach(async () => {
@@ -115,26 +142,26 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it('throws StaleRunbookStateError when loading v1 state', async () => {
+  it('throws StaleRunbookStateError when loading v2 state', async () => {
     const runsDir = path.join(tmpDir, '.rundown', 'runs');
     await fs.mkdir(runsDir, { recursive: true });
     await fs.writeFile(
-      path.join(runsDir, `${V1_STATE.id}.json`),
-      JSON.stringify(V1_STATE, null, 2),
+      path.join(runsDir, `${STALE_V2_STATE.id}.json`),
+      JSON.stringify(STALE_V2_STATE, null, 2),
     );
 
-    await expect(manager.load(V1_STATE.id)).rejects.toBeInstanceOf(StaleRunbookStateError);
+    await expect(manager.load(STALE_V2_STATE.id)).rejects.toBeInstanceOf(StaleRunbookStateError);
   });
 
   it('throws StaleRunbookStateError with helpful message', async () => {
     const runsDir = path.join(tmpDir, '.rundown', 'runs');
     await fs.mkdir(runsDir, { recursive: true });
     await fs.writeFile(
-      path.join(runsDir, `${V1_STATE.id}.json`),
-      JSON.stringify(V1_STATE, null, 2),
+      path.join(runsDir, `${STALE_V2_STATE.id}.json`),
+      JSON.stringify(STALE_V2_STATE, null, 2),
     );
 
-    await expect(manager.load(V1_STATE.id)).rejects.toThrow('rd prune --all');
+    await expect(manager.load(STALE_V2_STATE.id)).rejects.toThrow('rd prune --all');
   });
 
   it('returns null for missing state file', async () => {
@@ -142,18 +169,53 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
     expect(result).toBeNull();
   });
 
-  it('loads valid v2 state successfully', async () => {
+  it('loads valid v3 state successfully', async () => {
     const runsDir = path.join(tmpDir, '.rundown', 'runs');
     await fs.mkdir(runsDir, { recursive: true });
-    const v2State = {
-      ...V1_STATE,
+    const v3State = {
+      ...STALE_V2_STATE,
       runbook: { source: 'project', path: 'x.md' },
-      schemaVersion: 2,
+      schemaVersion: 3,
     };
-    await fs.writeFile(path.join(runsDir, `${v2State.id}.json`), JSON.stringify(v2State, null, 2));
+    await fs.writeFile(path.join(runsDir, `${v3State.id}.json`), JSON.stringify(v3State, null, 2));
 
-    const result = await manager.load(v2State.id);
+    const result = await manager.load(v3State.id);
     expect(result).not.toBeNull();
-    expect(result?.id).toBe(v2State.id);
+    expect(result?.id).toBe(v3State.id);
   });
+
+  it('rejects state with missing schemaVersion', async () => {
+    const runsDir = path.join(tmpDir, '.rundown', 'runs');
+    await fs.mkdir(runsDir, { recursive: true });
+    const id = 'rd_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+    const { schemaVersion: _omit, ...rest } = STALE_V2_STATE;
+    await fs.writeFile(path.join(runsDir, `${id}.json`), JSON.stringify({ ...rest, id }, null, 2));
+    await expect(manager.load(id)).rejects.toBeInstanceOf(StaleRunbookStateError);
+  });
+
+  it('rejects state with future schemaVersion', async () => {
+    const runsDir = path.join(tmpDir, '.rundown', 'runs');
+    await fs.mkdir(runsDir, { recursive: true });
+    const id = 'rd_ffffffffffffffffffffffffffffffff';
+    await fs.writeFile(
+      path.join(runsDir, `${id}.json`),
+      JSON.stringify({ ...STALE_V2_STATE, id, schemaVersion: 4 }, null, 2),
+    );
+    await expect(manager.load(id)).rejects.toBeInstanceOf(StaleRunbookStateError);
+  });
+
+  it('rejects state with non-numeric schemaVersion', async () => {
+    const runsDir = path.join(tmpDir, '.rundown', 'runs');
+    await fs.mkdir(runsDir, { recursive: true });
+    const id = 'rd_99999999999999999999999999999999';
+    await fs.writeFile(
+      path.join(runsDir, `${id}.json`),
+      JSON.stringify({ ...STALE_V2_STATE, id, schemaVersion: 'v3' }, null, 2),
+    );
+    // Either the version guard or the schema parse rejects this — both are acceptable
+    // as long as the loader does NOT silently coerce or migrate.
+    await expect(manager.load(id)).rejects.toThrow();
+  });
+
+  // Not applicable: snapshot version travels with the wrapper schemaVersion.
 });

--- a/packages/core/__tests__/runbook/state-update-ops.test.ts
+++ b/packages/core/__tests__/runbook/state-update-ops.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RunbookStateManager } from '../../src/runbook/state.js';
+import { applyOp, merge, replace } from '../../src/runbook/state-update-ops.js';
+import type { MergeOp, ReplaceOp } from '../../src/runbook/state-update-ops.js';
+import { buildFrameKey } from '../../src/runbook/targeting.js';
+import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
+import type { Runbook, ResolvedCompletion } from '../../src/runbook/types.js';
+import { makeBaseStep } from '../helpers/step-factories.js';
+
+describe('RunbookStateManager.update() — per-field op semantics', () => {
+  let testDir: string;
+  let manager: RunbookStateManager;
+  const mockRunbook: Runbook = {
+    title: 'Update ops',
+    description: 'Tests update() merge/replace ops',
+    steps: [makeBaseStep({ name: '1', description: 'Only' })],
+  };
+
+  const artifact = {
+    uri: 'rd://artifacts/ctx1/runs/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+    runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    contextId: 'ctx1',
+    runbook: { source: 'project' as const, path: 'planning/write-plan.runbook.md' },
+    key: 'plan.json',
+    timestamp: '2026-05-07T00:00:00.000Z',
+  } satisfies ArtifactRecord;
+
+  const otherArtifact = {
+    ...artifact,
+    uri: 'rd://artifacts/ctx1/runs/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/review.json',
+    key: 'review.json',
+  } satisfies ArtifactRecord;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'update-ops-test-'));
+    manager = new RunbookStateManager(testDir);
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function freshState() {
+    return manager.create({ source: 'project', path: 'test.runbook.md' }, mockRunbook, {
+      runbookPath: 'test.runbook.md',
+    });
+  }
+
+  describe('variables — merge-only (MergeOp<string>)', () => {
+    it('shallow-merges new keys into existing variables', async () => {
+      const state = await freshState();
+      await manager.update(state.id, { variables: merge({ a: '1' }) });
+      await manager.update(state.id, { variables: merge({ b: '2' }) });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.variables).toEqual({ a: '1', b: '2' });
+    });
+
+    it('caller-supplied keys overlay existing values', async () => {
+      const state = await freshState();
+      await manager.update(state.id, { variables: merge({ a: '1', b: '2' }) });
+      await manager.update(state.id, { variables: merge({ b: 'updated' }) });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.variables).toEqual({ a: '1', b: 'updated' });
+    });
+
+    it('omitting variables preserves existing entries', async () => {
+      const state = await freshState();
+      await manager.update(state.id, { variables: merge({ a: '1', b: '2' }) });
+      await manager.update(state.id, { lifecycle: 'running' });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.variables).toEqual({ a: '1', b: '2' });
+    });
+  });
+
+  describe('templateVars — replace-only (ReplaceOp)', () => {
+    it('wholesale-replaces existing templateVars', async () => {
+      const state = await manager.create(
+        { source: 'project', path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          runbookPath: 'test.runbook.md',
+          templateVars: { x: '1', y: '2' },
+        },
+      );
+      await manager.update(state.id, { templateVars: replace({ x: '3' }) });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.templateVars).toEqual({ x: '3' });
+    });
+
+    it('omitting templateVars preserves existing entries', async () => {
+      const state = await manager.create(
+        { source: 'project', path: 'test.runbook.md' },
+        mockRunbook,
+        {
+          runbookPath: 'test.runbook.md',
+          templateVars: { x: '1', y: '2' },
+        },
+      );
+      await manager.update(state.id, { lifecycle: 'running' });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.templateVars).toEqual({ x: '1', y: '2' });
+    });
+  });
+
+  describe('artifactVars — merge ∪ replace', () => {
+    it('merge() adds entries without wiping existing', async () => {
+      const state = await freshState();
+      await manager.update(state.id, {
+        artifactVars: merge({ A: artifact }),
+      });
+      await manager.update(state.id, {
+        artifactVars: merge({ B: otherArtifact }),
+      });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.artifactVars).toEqual({ A: artifact, B: otherArtifact });
+    });
+
+    it('replace() wholesale-replaces existing artifactVars', async () => {
+      const state = await freshState();
+      await manager.update(state.id, {
+        artifactVars: merge({ A: artifact, B: otherArtifact }),
+      });
+      await manager.update(state.id, {
+        artifactVars: replace({ C: artifact }),
+      });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.artifactVars).toEqual({ C: artifact });
+    });
+
+    it('omitting artifactVars preserves existing entries', async () => {
+      const state = await freshState();
+      await manager.update(state.id, {
+        artifactVars: merge({ A: artifact }),
+      });
+      await manager.update(state.id, { lifecycle: 'running' });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.artifactVars).toEqual({ A: artifact });
+    });
+  });
+
+  describe('resolvedCompletions — merge ∪ replace', () => {
+    function makeCompletion(agentId: string): ResolvedCompletion {
+      return {
+        agentId,
+        result: 'pass',
+        targetStep: '1',
+        targetFrameKey: buildFrameKey('1'),
+        targetEntry: 1,
+        completedAt: '2026-05-07T00:00:00.000Z',
+      };
+    }
+
+    it('merge() adds one entry without wiping existing', async () => {
+      const state = await freshState();
+      const first = makeCompletion('agent-1');
+      const second = makeCompletion('agent-2');
+
+      await manager.update(state.id, {
+        resolvedCompletions: merge({ 'k1|1|': first }),
+      });
+      await manager.update(state.id, {
+        resolvedCompletions: merge({ 'k2|1|': second }),
+      });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.resolvedCompletions).toEqual({
+        'k1|1|': first,
+        'k2|1|': second,
+      });
+    });
+
+    it('replace() wipes existing keys', async () => {
+      const state = await freshState();
+      const first = makeCompletion('agent-1');
+      const second = makeCompletion('agent-2');
+
+      await manager.update(state.id, {
+        resolvedCompletions: merge({ 'k1|1|': first }),
+      });
+      await manager.update(state.id, {
+        resolvedCompletions: replace({ 'k2|1|': second }),
+      });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.resolvedCompletions).toEqual({ 'k2|1|': second });
+    });
+  });
+
+  describe('frameEntries — replace-only', () => {
+    it('replace() wholesale-replaces existing frameEntries', async () => {
+      const state = await freshState();
+      const k1 = buildFrameKey('1');
+      const k2 = buildFrameKey('2');
+
+      await manager.update(state.id, {
+        frameEntries: replace({ [k1]: 1 }),
+      });
+      await manager.update(state.id, {
+        frameEntries: replace({ [k2]: 5 }),
+      });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.frameEntries).toEqual({ [k2]: 5 });
+    });
+
+    it('omitting frameEntries preserves existing entries', async () => {
+      const state = await freshState();
+      const k1 = buildFrameKey('1');
+
+      await manager.update(state.id, {
+        frameEntries: replace({ [k1]: 1 }),
+      });
+      await manager.update(state.id, { lifecycle: 'running' });
+
+      const loaded = await manager.load(state.id);
+      expect(loaded?.frameEntries).toEqual({ [k1]: 1 });
+    });
+  });
+
+  // Compile-time-only checks: each function body is unreachable at runtime; the
+  // `@ts-expect-error` directive is the assertion. tsc reports an unused
+  // directive (TS2578) if the expected type error vanishes, failing the build.
+  describe('compile-time footgun closure', () => {
+    function _rejectsRawArtifactVars() {
+      void manager.update('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', {
+        // @ts-expect-error - missing `op` discriminant; raw map is not assignable
+        artifactVars: { A: artifact },
+      });
+    }
+
+    function _rejectsMergeOnTemplateVars() {
+      void manager.update('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', {
+        // @ts-expect-error - MergeOp is not assignable to TemplateVarsOp (replace-only)
+        templateVars: merge({ x: '1' }),
+      });
+    }
+
+    function _rejectsReplaceOnVariables() {
+      void manager.update('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', {
+        // @ts-expect-error - ReplaceOp is not assignable to VariablesOp (merge-only)
+        variables: replace({ x: '1' }),
+      });
+    }
+
+    function _rejectsMergeOnFrameEntries() {
+      const k1 = buildFrameKey('1');
+      void manager.update('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', {
+        // @ts-expect-error - MergeOp is not assignable to FrameEntriesOp (replace-only)
+        frameEntries: merge({ [k1]: 1 }),
+      });
+    }
+
+    it('exposes type-only checks (compile-time assertions)', () => {
+      expect(typeof _rejectsRawArtifactVars).toBe('function');
+      expect(typeof _rejectsMergeOnTemplateVars).toBe('function');
+      expect(typeof _rejectsReplaceOnVariables).toBe('function');
+      expect(typeof _rejectsMergeOnFrameEntries).toBe('function');
+    });
+  });
+
+  describe('applyOp dispatch contract', () => {
+    it('throws on an unknown op tag (load-bearing for mutation testing)', () => {
+      const malformed = { op: 'bogus', value: { x: 1 } } as unknown as
+        | MergeOp<number>
+        | ReplaceOp<Readonly<Record<string, number>>>;
+      expect(() => applyOp({ a: 1 }, malformed)).toThrow(/unknown op tag/);
+    });
+
+    it('merges into an undefined existing record', () => {
+      expect(applyOp(undefined, merge({ a: 1 }))).toEqual({ a: 1 });
+    });
+
+    it('replaces with the op value verbatim', () => {
+      expect(applyOp({ a: 1, b: 2 }, replace({ c: 3 }))).toEqual({ c: 3 });
+    });
+  });
+});

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -155,11 +155,48 @@ describe('RunbookStateManager', () => {
   });
 
   it('resolveArtifactsForRun throws when run id is not found', async () => {
+    // Canonical run-id format (lowercase hex), guaranteed absent from disk.
+    // See run-id.ts RUN_ID_PATTERN — non-hex literals fail validation before
+    // reaching the not-found branch this test is covering.
     await expect(
-      manager.resolveArtifactsForRun('rd_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz', [
+      manager.resolveArtifactsForRun('rd_ffffffffffffffffffffffffffffffff', [
         { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
       ]),
     ).rejects.toThrow(/not found/);
+  });
+
+  it('resolveArtifactsForRun refuses while a live actor is registered for the run id', async () => {
+    const state = await manager.create(
+      { source: 'project', path: 'test.runbook.md' },
+      mockRunbook,
+      {
+        runbookPath: 'test.runbook.md',
+        runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as RunId,
+        templateVars: {
+          WorkPath: '.rundown/work',
+          ContextId: 'ctx1',
+          RunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          RunbookRef: { source: 'project', path: 'test.runbook.md' },
+        },
+      },
+    );
+
+    manager.markActorStarted(state.id);
+    expect(manager.isActorLive(state.id)).toBe(true);
+
+    await expect(
+      manager.resolveArtifactsForRun(state.id, [
+        { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
+      ]),
+    ).rejects.toThrow(/live RunbookActor exists/);
+
+    manager.markActorStopped(state.id);
+    expect(manager.isActorLive(state.id)).toBe(false);
+
+    const artifacts = await manager.resolveArtifactsForRun(state.id, [
+      { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
+    ]);
+    expect(artifacts.PlanPath).toMatchObject({ key: 'plan.json' });
   });
 
   it('round-trips empty artifactVars through persistence', async () => {

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -86,6 +86,140 @@ describe('RunbookStateManager', () => {
     expect(loaded?.variables).toEqual({ PlanPath: 'output-mask' });
   });
 
+  it('resolveArtifactsForRun persists resolved artifactVars and leaves variables untouched', async () => {
+    const state = await manager.create(
+      { source: 'project', path: 'test.runbook.md' },
+      mockRunbook,
+      {
+        runbookPath: 'test.runbook.md',
+        runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as RunId,
+        templateVars: {
+          WorkPath: '.rundown/work',
+          ContextId: 'ctx1',
+          RunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          RunbookRef: { source: 'project', path: 'test.runbook.md' },
+        },
+      },
+    );
+    await manager.update(state.id, { variables: { PlanPath: 'output-mask' } });
+
+    const artifacts = await manager.resolveArtifactsForRun(state.id, [
+      { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
+    ]);
+
+    const loaded = await manager.load(state.id);
+    expect(artifacts.PlanPath).toMatchObject({ key: 'plan.json' });
+    expect(loaded?.artifactVars?.PlanPath).toEqual(artifacts.PlanPath);
+    expect(loaded?.variables).toEqual({ PlanPath: 'output-mask' });
+  });
+
+  it('resolveArtifactsForRun throws when WorkPath is missing', async () => {
+    const state = await manager.create(
+      { source: 'project', path: 'test.runbook.md' },
+      mockRunbook,
+      {
+        runbookPath: 'test.runbook.md',
+        runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as RunId,
+        templateVars: {
+          ContextId: 'ctx1',
+          RunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        },
+      },
+    );
+    await expect(
+      manager.resolveArtifactsForRun(state.id, [
+        { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
+      ]),
+    ).rejects.toThrow(/WorkPath/);
+  });
+
+  it('resolveArtifactsForRun throws when ContextId is missing', async () => {
+    const state = await manager.create(
+      { source: 'project', path: 'test.runbook.md' },
+      mockRunbook,
+      {
+        runbookPath: 'test.runbook.md',
+        runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as RunId,
+        templateVars: {
+          WorkPath: '.rundown/work',
+          RunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        },
+      },
+    );
+    await expect(
+      manager.resolveArtifactsForRun(state.id, [
+        { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
+      ]),
+    ).rejects.toThrow(/ContextId/);
+  });
+
+  it('resolveArtifactsForRun throws when run id is not found', async () => {
+    await expect(
+      manager.resolveArtifactsForRun('rd_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz', [
+        { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
+      ]),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('round-trips empty artifactVars through persistence', async () => {
+    const state = await manager.create(
+      { source: 'project', path: 'test.runbook.md' },
+      mockRunbook,
+      { runbookPath: 'test.runbook.md' },
+    );
+    await manager.update(state.id, { artifactVars: {} });
+    const loaded = await manager.load(state.id);
+    expect(loaded?.artifactVars ?? {}).toEqual({});
+  });
+
+  it('round-trips 100+ artifactVars entries through persistence', async () => {
+    const state = await manager.create(
+      { source: 'project', path: 'test.runbook.md' },
+      mockRunbook,
+      { runbookPath: 'test.runbook.md' },
+    );
+    const baseRecord = {
+      uri: 'rd://artifacts/ctx1/runs/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+      runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      contextId: 'ctx1',
+      runbook: { source: 'project' as const, path: 'planning/write-plan.runbook.md' },
+      key: 'plan.json',
+      timestamp: '2026-05-07T00:00:00.000Z',
+    } satisfies ArtifactRecord;
+    const entries: Record<string, ArtifactRecord> = {};
+    for (let i = 0; i < 120; i++) {
+      entries[`Var${String(i)}`] = baseRecord;
+    }
+    await manager.update(state.id, { artifactVars: entries });
+    const loaded = await manager.load(state.id);
+    expect(Object.keys(loaded?.artifactVars ?? {})).toHaveLength(120);
+  });
+
+  it('subsequent resolveArtifactsForRun calls with the same alias name overwrite', async () => {
+    const state = await manager.create(
+      { source: 'project', path: 'test.runbook.md' },
+      mockRunbook,
+      {
+        runbookPath: 'test.runbook.md',
+        runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as RunId,
+        templateVars: {
+          WorkPath: '.rundown/work',
+          ContextId: 'ctx1',
+          RunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          RunbookRef: { source: 'project', path: 'test.runbook.md' },
+        },
+      },
+    );
+    await manager.resolveArtifactsForRun(state.id, [
+      { name: 'Output', key: 'first.json', kind: 'exact' },
+    ]);
+    await manager.resolveArtifactsForRun(state.id, [
+      { name: 'Output', key: 'second.json', kind: 'exact' },
+    ]);
+    const loaded = await manager.load(state.id);
+    expect(loaded?.artifactVars?.Output).toMatchObject({ key: 'second.json' });
+  });
+
   describe('getChildRunbookResult', () => {
     it('should return pass when child has lifecycle completed', async () => {
       const child = await manager.create(

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -9,6 +9,7 @@ import { SessionService } from '../../src/runbook/session-service.js';
 import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
 import { buildFrameKey } from '../../src/runbook/targeting.js';
 import type { Step, Runbook, RunId } from '../../src/runbook/types.js';
+import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
 import { makeBaseStep, makeSubstep } from '../helpers/step-factories.js';
 
 describe('RunbookStateManager', () => {
@@ -57,6 +58,32 @@ describe('RunbookStateManager', () => {
       expect(branded).toBe(state.id);
       expect(branded).toMatch(/^rd_[a-f0-9]{32}$/);
     });
+  });
+
+  it('persists artifactVars separately from string-only variables', async () => {
+    const artifact = {
+      uri: 'rd://artifacts/ctx1/runs/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+      runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      contextId: 'ctx1',
+      runbook: { source: 'project' as const, path: 'planning/write-plan.runbook.md' },
+      key: 'plan.json',
+      timestamp: '2026-05-07T00:00:00.000Z',
+    } satisfies ArtifactRecord;
+
+    const state = await manager.create(
+      { source: 'project', path: 'test.runbook.md' },
+      mockRunbook,
+      { runbookPath: 'test.runbook.md' },
+    );
+
+    await manager.update(state.id, {
+      artifactVars: { PlanPath: artifact, Reviews: [artifact] },
+      variables: { PlanPath: 'output-mask' },
+    });
+
+    const loaded = await manager.load(state.id);
+    expect(loaded?.artifactVars).toEqual({ PlanPath: artifact, Reviews: [artifact] });
+    expect(loaded?.variables).toEqual({ PlanPath: 'output-mask' });
   });
 
   describe('getChildRunbookResult', () => {

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { isError } from '../../src/errors.js';
 import { generateRunId, RunbookStateManager } from '../../src/runbook/state.js';
+import { merge, replace } from '../../src/runbook/state-update-ops.js';
 import { statePath as _statePath } from '../../src/paths.js';
 import { SessionService } from '../../src/runbook/session-service.js';
 import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
@@ -77,8 +78,8 @@ describe('RunbookStateManager', () => {
     );
 
     await manager.update(state.id, {
-      artifactVars: { PlanPath: artifact, Reviews: [artifact] },
-      variables: { PlanPath: 'output-mask' },
+      artifactVars: replace({ PlanPath: artifact, Reviews: [artifact] }),
+      variables: merge({ PlanPath: 'output-mask' }),
     });
 
     const loaded = await manager.load(state.id);
@@ -101,7 +102,7 @@ describe('RunbookStateManager', () => {
         },
       },
     );
-    await manager.update(state.id, { variables: { PlanPath: 'output-mask' } });
+    await manager.update(state.id, { variables: merge({ PlanPath: 'output-mask' }) });
 
     const artifacts = await manager.resolveArtifactsForRun(state.id, [
       { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
@@ -130,7 +131,7 @@ describe('RunbookStateManager', () => {
       manager.resolveArtifactsForRun(state.id, [
         { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
       ]),
-    ).rejects.toThrow(/WorkPath/);
+    ).rejects.toThrow(/cannot resolve ARTIFACTS without string WorkPath/);
   });
 
   it('resolveArtifactsForRun throws when ContextId is missing', async () => {
@@ -150,7 +151,7 @@ describe('RunbookStateManager', () => {
       manager.resolveArtifactsForRun(state.id, [
         { name: 'PlanPath', key: 'plan.json', kind: 'exact' },
       ]),
-    ).rejects.toThrow(/ContextId/);
+    ).rejects.toThrow(/cannot resolve ARTIFACTS without string ContextId/);
   });
 
   it('resolveArtifactsForRun throws when run id is not found', async () => {
@@ -167,7 +168,7 @@ describe('RunbookStateManager', () => {
       mockRunbook,
       { runbookPath: 'test.runbook.md' },
     );
-    await manager.update(state.id, { artifactVars: {} });
+    await manager.update(state.id, { artifactVars: replace({}) });
     const loaded = await manager.load(state.id);
     expect(loaded?.artifactVars ?? {}).toEqual({});
   });
@@ -178,21 +179,23 @@ describe('RunbookStateManager', () => {
       mockRunbook,
       { runbookPath: 'test.runbook.md' },
     );
-    const baseRecord = {
-      uri: 'rd://artifacts/ctx1/runs/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
-      runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      contextId: 'ctx1',
-      runbook: { source: 'project' as const, path: 'planning/write-plan.runbook.md' },
-      key: 'plan.json',
-      timestamp: '2026-05-07T00:00:00.000Z',
-    } satisfies ArtifactRecord;
     const entries: Record<string, ArtifactRecord> = {};
     for (let i = 0; i < 120; i++) {
-      entries[`Var${String(i)}`] = baseRecord;
+      const key = `plan-${String(i)}.json`;
+      entries[`Var${String(i)}`] = {
+        uri: `rd://artifacts/ctx1/runs/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/${key}`,
+        runId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        contextId: 'ctx1',
+        runbook: { source: 'project' as const, path: 'planning/write-plan.runbook.md' },
+        key,
+        timestamp: '2026-05-07T00:00:00.000Z',
+      } satisfies ArtifactRecord;
     }
-    await manager.update(state.id, { artifactVars: entries });
+    await manager.update(state.id, { artifactVars: replace(entries) });
     const loaded = await manager.load(state.id);
     expect(Object.keys(loaded?.artifactVars ?? {})).toHaveLength(120);
+    expect(loaded?.artifactVars?.Var0).toMatchObject({ key: 'plan-0.json' });
+    expect(loaded?.artifactVars?.Var119).toMatchObject({ key: 'plan-119.json' });
   });
 
   it('subsequent resolveArtifactsForRun calls with the same alias name overwrite', async () => {
@@ -218,6 +221,9 @@ describe('RunbookStateManager', () => {
     ]);
     const loaded = await manager.load(state.id);
     expect(loaded?.artifactVars?.Output).toMatchObject({ key: 'second.json' });
+    // Catch a per-key merge regression: the old key must be gone.
+    const output = loaded?.artifactVars?.Output as ArtifactRecord;
+    expect(output.key).not.toBe('first.json');
   });
 
   describe('getChildRunbookResult', () => {
@@ -598,7 +604,7 @@ describe('RunbookStateManager', () => {
       const resolvedKey = '1||1|';
 
       await manager.update(state.id, {
-        resolvedCompletions: {
+        resolvedCompletions: merge({
           [resolvedKey]: {
             agentId: 'agent-1',
             result: 'pass',
@@ -607,7 +613,7 @@ describe('RunbookStateManager', () => {
             targetEntry: 1,
             completedAt: new Date().toISOString(),
           },
-        },
+        }),
       });
 
       const stateFilePath = _statePath(testDir, state.id);
@@ -640,7 +646,7 @@ describe('RunbookStateManager', () => {
       });
 
       const updated = await manager.update(state.id, {
-        templateVars: { env: 'prod' },
+        templateVars: replace({ env: 'prod' }),
       });
 
       expect(updated.templateVars).toEqual({ env: 'prod' });
@@ -662,9 +668,9 @@ describe('RunbookStateManager', () => {
       const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
         runbookPath: 'test.md',
       });
-      await manager.update(state.id, { variables: { A: '1', B: '2' } });
+      await manager.update(state.id, { variables: merge({ A: '1', B: '2' }) });
 
-      const updated = await manager.update(state.id, { variables: { B: 'two', C: '3' } });
+      const updated = await manager.update(state.id, { variables: merge({ B: 'two', C: '3' }) });
 
       expect(updated.variables).toEqual({ A: '1', B: 'two', C: '3' });
     });
@@ -673,7 +679,7 @@ describe('RunbookStateManager', () => {
       const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
         runbookPath: 'test.md',
       });
-      await manager.update(state.id, { variables: { A: '1' } });
+      await manager.update(state.id, { variables: merge({ A: '1' }) });
 
       const updated = await manager.update(state.id, { stepName: 'next' });
 

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -214,7 +214,26 @@ export class RunbookActorService {
 
     const actor = createActor(machine, { snapshot });
     actor.start();
+    this.manager.markActorStarted(id);
     return actor;
+  }
+
+  /**
+   * Stop a `RunbookActor` and deregister its run id from the manager's
+   * live-actor registry.
+   *
+   * Replaces direct `actor.stop()` calls so {@link RunbookStateManager} sees
+   * a balanced started/stopped pair. Required for callers that hold an actor
+   * ref returned by {@link createActor}; internal helpers
+   * ({@link initializeState}, {@link sendAndSync}) call this in their
+   * `finally` blocks already.
+   *
+   * @param id - Runbook state id matching the one passed to {@link createActor}
+   * @param actor - The actor returned by {@link createActor}
+   */
+  stopActor(id: string, actor: AnyActorRef): void {
+    actor.stop();
+    this.manager.markActorStopped(id);
   }
 
   /**
@@ -430,7 +449,7 @@ export class RunbookActorService {
       const { state } = await this.updateFromActor(id, actor, steps);
       return state;
     } finally {
-      actor.stop();
+      this.stopActor(id, actor);
     }
   }
 
@@ -523,7 +542,7 @@ export class RunbookActorService {
       const { state, snapshot } = await this.updateFromActor(id, actor, steps);
       return { state, snapshot };
     } finally {
-      actor.stop();
+      this.stopActor(id, actor);
     }
   }
 }

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -17,6 +17,7 @@ import type { ResolvedStep, RunbookState, ForContext } from './types.js';
 import type { RunbookStateManager } from './state.js';
 import { compileRunbookToMachine, type RunbookEvent, type RunbookContext } from './compiler.js';
 import { flattenTemplateVars } from './output-evaluator.js';
+import { merge, replace } from './state-update-ops.js';
 import { resolvedStepHasSubsteps } from '@rundown-org/parser';
 import { logger } from '../logger.js';
 
@@ -300,12 +301,16 @@ export class RunbookActorService {
         snapshot.context && 'activeFrameKey' in snapshot.context
           ? { activeFrameKey: snapshot.context.activeFrameKey }
           : {};
+      // Same `'in'`-vs-`!== undefined` rationale as activeFrameKeyTermPatch
+      // above: preserves persisted value when context omits the field.
       const artifactVarsTermPatch =
-        snapshot.context && 'artifactVars' in snapshot.context
-          ? { artifactVars: snapshot.context.artifactVars }
+        snapshot.context &&
+        'artifactVars' in snapshot.context &&
+        snapshot.context.artifactVars !== undefined
+          ? { artifactVars: replace(snapshot.context.artifactVars) }
           : {};
       const state = await this.manager.update(id, {
-        variables,
+        variables: merge(variables),
         finalVars,
         lifecycle,
         snapshot,
@@ -381,9 +386,13 @@ export class RunbookActorService {
       snapshot.context && 'activeFrameKey' in snapshot.context
         ? { activeFrameKey: snapshot.context.activeFrameKey }
         : {};
+    // Same `'in'`-vs-`!== undefined` rationale as activeFrameKeyPatch above:
+    // preserves persisted value when context omits the field.
     const artifactVarsPatch =
-      snapshot.context && 'artifactVars' in snapshot.context
-        ? { artifactVars: snapshot.context.artifactVars }
+      snapshot.context &&
+      'artifactVars' in snapshot.context &&
+      snapshot.context.artifactVars !== undefined
+        ? { artifactVars: replace(snapshot.context.artifactVars) }
         : {};
 
     const state = await this.manager.update(id, {
@@ -391,7 +400,7 @@ export class RunbookActorService {
       substep,
       stepName: step.description,
       retryCount,
-      variables,
+      variables: merge(variables),
       lifecycle: snapshot.context?.lifecycle ?? 'running',
       snapshot,
       forStack: computedForStack,

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -93,6 +93,7 @@ function hydrateSnapshot(
       ...baseSnapshot.context,
       substepStates: state.substepStates ?? baseSnapshot.context.substepStates,
       activeFrameKey: state.activeFrameKey ?? baseSnapshot.context.activeFrameKey,
+      artifactVars: state.artifactVars ?? baseSnapshot.context.artifactVars,
     },
   } as unknown as Snapshot<unknown>;
 }
@@ -143,6 +144,7 @@ export class RunbookActorService {
       frontmatterOutputs: state.frontmatterOutputs,
       substepStates: state.substepStates,
       activeFrameKey: state.activeFrameKey,
+      artifactVars: state.artifactVars,
     });
   }
 
@@ -298,6 +300,10 @@ export class RunbookActorService {
         snapshot.context && 'activeFrameKey' in snapshot.context
           ? { activeFrameKey: snapshot.context.activeFrameKey }
           : {};
+      const artifactVarsTermPatch =
+        snapshot.context && 'artifactVars' in snapshot.context
+          ? { artifactVars: snapshot.context.artifactVars }
+          : {};
       const state = await this.manager.update(id, {
         variables,
         finalVars,
@@ -308,6 +314,7 @@ export class RunbookActorService {
         iterationResults: undefined,
         ...substepStatesTermPatch,
         ...activeFrameKeyTermPatch,
+        ...artifactVarsTermPatch,
       });
       return { state, snapshot };
     }
@@ -374,6 +381,10 @@ export class RunbookActorService {
       snapshot.context && 'activeFrameKey' in snapshot.context
         ? { activeFrameKey: snapshot.context.activeFrameKey }
         : {};
+    const artifactVarsPatch =
+      snapshot.context && 'artifactVars' in snapshot.context
+        ? { artifactVars: snapshot.context.artifactVars }
+        : {};
 
     const state = await this.manager.update(id, {
       step: stepName, // string
@@ -388,6 +399,7 @@ export class RunbookActorService {
       lastAction,
       ...substepStatesPatch,
       ...activeFrameKeyPatch,
+      ...artifactVarsPatch,
     });
     return { state, snapshot };
   }

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -1,0 +1,201 @@
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import type {
+  ArtifactDeclaration,
+  ExactArtifactDeclaration,
+  WildcardArtifactDeclaration,
+} from '@rundown-org/parser';
+import picomatch from 'picomatch';
+import {
+  appendArtifactManifestRecord,
+  coalesceManifestRecords,
+  isExistingRegularArtifactFile,
+  readArtifactManifest,
+  type ArtifactManifestRecord,
+} from './artifact-manifest.js';
+import type { ArtifactRecord } from './artifact-schema.js';
+import { artifactUriToPath, buildArtifactUri, type ArtifactPathOptions } from './artifact-uri.js';
+import type { RunbookRef } from './runbook-ref.js';
+import { assertRunId, type RunId } from './run-id.js';
+import type { ArtifactVarValue } from './types.js';
+
+/**
+ * Run eligibility for ARTIFACTS wildcard matching.
+ *
+ * Returned by `loadRunEligibility` ONLY for completed sibling runs (different
+ * `runId` from the resolver's current run). The current run is short-circuited
+ * inside the resolver before the loader is consulted, so there is no
+ * `'current-run'` variant. Incomplete sibling runs are signalled by `null`.
+ */
+export interface ArtifactRunEligibility {
+  /** Sibling completed run id, branded. */
+  readonly runId: RunId;
+  /** ISO-8601 timestamp at which the sibling run reached a terminal state. */
+  readonly terminalAt: string;
+}
+
+/**
+ * Options for resolving one ARTIFACTS block.
+ */
+export interface ResolveArtifactDeclarationsOptions extends ArtifactPathOptions {
+  /** Current context identifier. */
+  readonly contextId: string;
+  /** Current run identifier. */
+  readonly runId: RunId;
+  /** Resolved runbook identity for the current run. */
+  readonly runbook: RunbookRef;
+  /** Clock used for newly-appended exact manifest records. */
+  readonly now?: () => string;
+  /**
+   * Loads eligibility for non-current run ids found in the manifest. Return
+   * `null` for incomplete or unknown sibling runs; return an
+   * {@link ArtifactRunEligibility} for completed sibling runs. The resolver
+   * never calls this loader with the current run's id.
+   */
+  readonly loadRunEligibility: (runId: RunId) => Promise<ArtifactRunEligibility | null>;
+}
+
+/**
+ * Resolve a step/substep ARTIFACTS block.
+ *
+ * Exact declarations are processed before wildcard declarations regardless of
+ * source order, so a same-block wildcard can match an artifact created by an
+ * exact declaration in the same block. Exact declarations append or reuse
+ * manifest records; wildcard declarations only read the manifest.
+ *
+ * Reads the manifest once up front and, when any exact declaration ran, once
+ * again before wildcard resolution so wildcards observe same-block exact rows.
+ *
+ * @param declarations - Parser-owned artifact declarations from one execution unit
+ * @param options - Current run identity, path options, clock, and run eligibility loader
+ * @returns Artifact variable map for the current execution unit
+ * @throws {Error} For corrupt manifests, invalid artifact records, invalid path options,
+ *                 or unexpected filesystem failures
+ */
+export async function resolveArtifactDeclarations(
+  declarations: readonly ArtifactDeclaration[],
+  options: ResolveArtifactDeclarationsOptions,
+): Promise<Record<string, ArtifactVarValue>> {
+  const result: Record<string, ArtifactVarValue> = {};
+  const exacts: ExactArtifactDeclaration[] = [];
+  const wildcards: WildcardArtifactDeclaration[] = [];
+
+  for (const declaration of declarations) {
+    if (declaration.kind === 'exact') {
+      exacts.push(declaration);
+    } else {
+      wildcards.push(declaration);
+    }
+  }
+
+  let recordsForExacts = coalesceManifestRecords(
+    await readArtifactManifest(options, options.contextId),
+  );
+
+  for (const declaration of exacts) {
+    const record = await resolveExactDeclaration(declaration, options, recordsForExacts);
+    result[declaration.name] = record;
+    recordsForExacts = coalesceManifestRecords([...recordsForExacts, record]);
+  }
+
+  const recordsForWildcards =
+    exacts.length > 0
+      ? coalesceManifestRecords(await readArtifactManifest(options, options.contextId))
+      : recordsForExacts;
+
+  for (const declaration of wildcards) {
+    result[declaration.name] = await resolveWildcardDeclaration(
+      declaration,
+      options,
+      recordsForWildcards,
+    );
+  }
+
+  return result;
+}
+
+async function resolveExactDeclaration(
+  declaration: ExactArtifactDeclaration,
+  options: ResolveArtifactDeclarationsOptions,
+  records: readonly ArtifactManifestRecord[],
+): Promise<ArtifactRecord> {
+  const existing = findExistingExactRecord(declaration.key, options, records);
+  if (existing !== undefined) {
+    await ensureArtifactParentDirectory(existing.uri, options);
+    return existing;
+  }
+
+  const record: ArtifactRecord = {
+    uri: buildArtifactUri({
+      contextId: options.contextId,
+      runId: options.runId,
+      key: declaration.key,
+    }),
+    runId: options.runId,
+    contextId: options.contextId,
+    runbook: options.runbook,
+    key: declaration.key,
+    timestamp: options.now?.() ?? new Date().toISOString(),
+  };
+  await ensureArtifactParentDirectory(record.uri, options);
+  await appendArtifactManifestRecord(options, record);
+  return record;
+}
+
+function findExistingExactRecord(
+  key: string,
+  options: ResolveArtifactDeclarationsOptions,
+  records: readonly ArtifactManifestRecord[],
+): ArtifactManifestRecord | undefined {
+  return records.find(
+    (record) =>
+      record.contextId === options.contextId &&
+      record.runId === options.runId &&
+      record.runbook.source === options.runbook.source &&
+      record.runbook.path === options.runbook.path &&
+      record.key === key,
+  );
+}
+
+async function resolveWildcardDeclaration(
+  declaration: WildcardArtifactDeclaration,
+  options: ResolveArtifactDeclarationsOptions,
+  records: readonly ArtifactManifestRecord[],
+): Promise<ArtifactRecord[]> {
+  const matcher = picomatch(declaration.key, { dot: true });
+  const matches: ArtifactRecord[] = [];
+
+  for (const record of records) {
+    if (record.contextId !== options.contextId || !matcher(record.key)) {
+      continue;
+    }
+    if (!(await isEligibleWildcardRecord(record, options))) {
+      continue;
+    }
+    if (!isExistingRegularArtifactFile(record.uri, options)) {
+      continue;
+    }
+    matches.push(record);
+  }
+
+  return matches.sort((left, right) => left.uri.localeCompare(right.uri));
+}
+
+async function isEligibleWildcardRecord(
+  record: ArtifactManifestRecord,
+  options: ResolveArtifactDeclarationsOptions,
+): Promise<boolean> {
+  if (record.runId === options.runId) {
+    return true;
+  }
+  const eligibility = await options.loadRunEligibility(assertRunId(record.runId));
+  return eligibility !== null;
+}
+
+async function ensureArtifactParentDirectory(
+  uri: string,
+  options: ArtifactPathOptions,
+): Promise<void> {
+  const file = artifactUriToPath(uri, options);
+  await fsp.mkdir(path.dirname(file), { recursive: true });
+}

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -98,6 +98,9 @@ export async function resolveArtifactDeclarations(
     recordsForExacts = coalesceManifestRecords([...recordsForExacts, record]);
   }
 
+  // The reread observes external concurrent manifest writes; that timing isn't
+  // injectable through the resolver API, so the two branches are equivalent
+  // under deterministic unit tests. See notes/mutation-survivors.md.
   const recordsForWildcards =
     exacts.length > 0
       ? coalesceManifestRecords(await readArtifactManifest(options, options.contextId))
@@ -149,6 +152,10 @@ function findExistingExactRecord(
 ): ArtifactManifestRecord | undefined {
   return records.find(
     (record) =>
+      // Defense-in-depth: readArtifactManifest already rejects rows whose
+      // contextId differs (artifact-manifest.ts readArtifactManifest). Kept
+      // here so a refactor of the manifest reader cannot silently weaken
+      // the resolver's identity check. See notes/mutation-survivors.md.
       record.contextId === options.contextId &&
       record.runId === options.runId &&
       record.runbook.source === options.runbook.source &&
@@ -166,6 +173,9 @@ async function resolveWildcardDeclaration(
   const matches: ArtifactRecord[] = [];
 
   for (const record of records) {
+    // Defense-in-depth on contextId: readArtifactManifest already rejects
+    // mismatched rows; this guard catches a contract weakening in the reader.
+    // See notes/mutation-survivors.md.
     if (record.contextId !== options.contextId || !matcher(record.key)) {
       continue;
     }

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -106,11 +106,17 @@ export async function resolveArtifactDeclarations(
       ? coalesceManifestRecords(await readArtifactManifest(options, options.contextId))
       : recordsForExacts;
 
+  // Memoize sibling-run eligibility for the duration of one resolve pass so
+  // a manifest containing many records from the same sibling run only loads
+  // that run's state once.
+  const eligibilityCache = new Map<RunId, ArtifactRunEligibility | null>();
+
   for (const declaration of wildcards) {
     result[declaration.name] = await resolveWildcardDeclaration(
       declaration,
       options,
       recordsForWildcards,
+      eligibilityCache,
     );
   }
 
@@ -168,6 +174,7 @@ async function resolveWildcardDeclaration(
   declaration: WildcardArtifactDeclaration,
   options: ResolveArtifactDeclarationsOptions,
   records: readonly ArtifactManifestRecord[],
+  eligibilityCache: Map<RunId, ArtifactRunEligibility | null>,
 ): Promise<ArtifactRecord[]> {
   const matcher = picomatch(declaration.key, { dot: true });
   const matches: ArtifactRecord[] = [];
@@ -179,7 +186,7 @@ async function resolveWildcardDeclaration(
     if (record.contextId !== options.contextId || !matcher(record.key)) {
       continue;
     }
-    if (!(await isEligibleWildcardRecord(record, options))) {
+    if (!(await isEligibleWildcardRecord(record, options, eligibilityCache))) {
       continue;
     }
     if (!isExistingRegularArtifactFile(record.uri, options)) {
@@ -194,12 +201,21 @@ async function resolveWildcardDeclaration(
 async function isEligibleWildcardRecord(
   record: ArtifactManifestRecord,
   options: ResolveArtifactDeclarationsOptions,
+  eligibilityCache: Map<RunId, ArtifactRunEligibility | null>,
 ): Promise<boolean> {
   if (record.runId === options.runId) {
     return true;
   }
-  const eligibility = await options.loadRunEligibility(assertRunId(record.runId));
-  return eligibility !== null;
+  const runId = assertRunId(record.runId);
+  let eligibility = eligibilityCache.get(runId);
+  if (eligibility === undefined) {
+    eligibility = await options.loadRunEligibility(runId);
+    eligibilityCache.set(runId, eligibility);
+  }
+  // Validate the loader response: only accept rows whose eligibility record
+  // refers back to the requested runId. Defends against a loader that
+  // returns cached data for a different sibling run.
+  return eligibility !== null && eligibility.runId === runId;
 }
 
 async function ensureArtifactParentDirectory(

--- a/packages/core/src/runbook/artifact-manifest.ts
+++ b/packages/core/src/runbook/artifact-manifest.ts
@@ -173,19 +173,39 @@ export async function readArtifactManifest(
 }
 
 /**
- * Coalesce repeated manifest rows by context, run, and artifact key.
+ * Coalesce repeated manifest rows by artifact identity.
+ *
+ * **Identity:** `(contextId, runId, runbook.source, runbook.path, key)`.
+ *
+ * **Selection rule:** the newest `timestamp` wins.
+ *
+ * **Tie-break rule:** when two rows share the same identity AND the same
+ * timestamp, the row appearing LATER in the input order wins. This is
+ * implemented by the `>=` comparison below (not `>`); equal timestamps
+ * deliberately allow the later row to overwrite the earlier one. This rule
+ * is observable to callers and stable: it lets a caller append a duplicate
+ * identity row to the manifest and have the new row take precedence on the
+ * next coalesced read.
  *
  * @param records - Manifest records to coalesce
- * @returns Records with duplicate identities reduced to the newest timestamp
+ * @returns Records with duplicate identities reduced to the winning row
  */
 export function coalesceManifestRecords(
   records: readonly ArtifactManifestRecord[],
 ): ArtifactManifestRecord[] {
   const byIdentity = new Map<string, ArtifactManifestRecord>();
   for (const record of records) {
-    const identity = `${record.contextId}\0${record.runId}\0${record.key}`;
+    const identity = [
+      record.contextId,
+      record.runId,
+      record.runbook.source,
+      record.runbook.path,
+      record.key,
+    ].join('\0');
     const existing = byIdentity.get(identity);
-    if (existing === undefined || record.timestamp > existing.timestamp) {
+    // `>=` (not `>`) implements the tie-break rule documented above:
+    // equal timestamps allow the later row to overwrite the earlier one.
+    if (existing === undefined || record.timestamp >= existing.timestamp) {
       byIdentity.set(identity, record);
     }
   }

--- a/packages/core/src/runbook/artifact-manifest.ts
+++ b/packages/core/src/runbook/artifact-manifest.ts
@@ -286,6 +286,32 @@ export async function findArtifactMatches(
   return latestMatches.sort((left, right) => left.record.uri.localeCompare(right.record.uri));
 }
 
+/**
+ * Check whether an exact artifact URI resolves to an existing regular file
+ * contained under the configured work root.
+ *
+ * Returns `false` for missing files, non-directories, symlinks, and invalid
+ * artifact path shapes. Throws only for unexpected filesystem failures.
+ *
+ * @param uri - Exact artifact URI to check
+ * @param options - Project root and work directory options
+ * @returns `true` when the artifact is an existing contained regular file
+ * @throws {Error} For unexpected filesystem failures while opening the file
+ */
+export function isExistingRegularArtifactFile(uri: string, options: ArtifactPathOptions): boolean {
+  let artifactPath: string;
+  try {
+    artifactPath = artifactUriToPath(uri, options);
+  } catch (error) {
+    if (error instanceof Error && error.message === ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE) {
+      return false;
+    }
+    throw error;
+  }
+  const workRoot = resolveContainedWorkRoot(options);
+  return isExistingRegularContainedFile(workRoot, artifactPath);
+}
+
 function writeManifestLineSync(
   workRoot: string,
   manifestPath: string,

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -11,6 +11,7 @@ import type {
   SubstepState,
 } from './types.js';
 import { isResolvedVariableForContext } from './types.js';
+import type { ArtifactVars } from './effective-vars.js';
 import type { StepId } from './step-id.js';
 import type { ForClause, OutputDeclaration } from '@rundown-org/parser';
 import {
@@ -211,6 +212,8 @@ export interface RunbookContext {
   completedForContext?: ForContext;
   /** User-defined runbook variables. String-only after lifecycle flags moved out. */
   variables: Record<string, string>;
+  /** Accumulated ARTIFACTS variables, mirrored from persisted RunbookState. */
+  readonly artifactVars?: ArtifactVars;
   /** Last action taken by the state machine (source of truth for transition type) */
   lastAction?: LastAction;
   /** Message from STOP/COMPLETE actions */
@@ -2432,6 +2435,7 @@ function checkedStateInsert(
  *   `createActor` call.
  * @param options.activeFrameKey - Seeds `RunbookContext.activeFrameKey` at machine bootstrap.
  *   Paired with `substepStates` for frame-scoped substep lookup in the retry hook.
+ * @param options.artifactVars - Seeds `RunbookContext.artifactVars` from persisted run state.
  * @returns An XState state machine definition
  * @throws {Error} When a GOTO target references a non-existent step or when graph invariants are violated (e.g., duplicate state IDs)
  */
@@ -2446,6 +2450,7 @@ export function compileRunbookToMachine(
     evaluationOptions?: EvaluateOutputOptions;
     substepStates?: readonly SubstepState[];
     activeFrameKey?: FrameKey;
+    artifactVars?: ArtifactVars;
   },
 ) {
   const evaluationOptions = options?.evaluationOptions;
@@ -2752,6 +2757,7 @@ export function compileRunbookToMachine(
       completedSubstep: undefined,
       completedForContext: undefined,
       variables: {},
+      artifactVars: options?.artifactVars,
       lastAction: undefined,
       lastMessage: undefined,
       forStack: [],

--- a/packages/core/src/runbook/delegation-context.ts
+++ b/packages/core/src/runbook/delegation-context.ts
@@ -31,7 +31,8 @@ const IDENTITY_OWNED_BUILTIN_SET = new Set<string>(IDENTITY_OWNED_BUILTINS);
  *
  * @param snapshot - The frozen context snapshot from delegation metadata
  * @returns Variable map with string values for structural fields (step, substep, at, index)
- *          and TemplateVarValue entries (strings, numbers, or objects) from snapshot.vars
+ *          and ContextSnapshotVarValue entries (template values or artifact records)
+ *          from snapshot.vars
  * @throws {Error} When the ancestor chain exceeds {@link MAX_ANCESTOR_DEPTH} levels
  */
 export function reconstituteContextVars(

--- a/packages/core/src/runbook/delegation-context.ts
+++ b/packages/core/src/runbook/delegation-context.ts
@@ -1,6 +1,12 @@
 import { IDENTITY_OWNED_BUILTINS } from '@rundown-org/parser';
 import { mergeEffectiveVars } from './effective-vars.js';
-import type { AncestorSnapshot, ContextSnapshot, RunbookState, TemplateVarValue } from './types.js';
+import type {
+  AncestorSnapshot,
+  ContextSnapshot,
+  ContextSnapshotVarValue,
+  RunbookState,
+  TemplateVarValue,
+} from './types.js';
 import { getActiveForContext, deriveExecutionAt } from './targeting.js';
 
 /** Maximum depth for parent context chain addressing. */
@@ -30,14 +36,14 @@ const IDENTITY_OWNED_BUILTIN_SET = new Set<string>(IDENTITY_OWNED_BUILTINS);
  */
 export function reconstituteContextVars(
   snapshot: ContextSnapshot,
-): Record<string, TemplateVarValue> {
+): Record<string, ContextSnapshotVarValue> {
   if (snapshot.ancestors.length > MAX_ANCESTOR_DEPTH) {
     throw new Error(
       `Parent context chain depth (${String(snapshot.ancestors.length)}) exceeds maximum of ${String(MAX_ANCESTOR_DEPTH)} levels`,
     );
   }
 
-  const result: Record<string, TemplateVarValue> = {};
+  const result: Record<string, ContextSnapshotVarValue> = {};
 
   // Parent structural fields: step, substep, at, index
   if (snapshot.step) {
@@ -180,8 +186,8 @@ export function buildContextSnapshot(
  */
 export function extractInheritedUserVars(
   snapshot: ContextSnapshot,
-): Record<string, TemplateVarValue> {
-  const result: Record<string, TemplateVarValue> = {};
+): Record<string, ContextSnapshotVarValue> {
+  const result: Record<string, ContextSnapshotVarValue> = {};
   for (const [key, value] of Object.entries(snapshot.vars)) {
     if (!key.startsWith('context.') && !IDENTITY_OWNED_BUILTIN_SET.has(key)) {
       result[key] = value;

--- a/packages/core/src/runbook/effective-vars.ts
+++ b/packages/core/src/runbook/effective-vars.ts
@@ -28,6 +28,15 @@ export type ArtifactVars = Readonly<Record<string, ArtifactVarValue>> & {
 /**
  * Sole producer of {@link ArtifactVars}.
  *
+ * Apply at the two seams where artifact variables enter {@link RunbookState}:
+ *   1. The Zod parse seam in {@link makeRunbookStateSchema} when state is
+ *      loaded from disk.
+ *   2. {@link RunbookStateManager.update} when the resolver or actor mirror
+ *      writes the field through `merge(...)` / `replace(...)`.
+ *
+ * Identity-preserving — the brand is type-only. Mirrors the seam-application
+ * pattern of {@link brandInitialTemplateVars} and {@link brandStoredOutputs}.
+ *
  * @param vars - Plain artifact variable map
  * @returns The same object, branded
  */

--- a/packages/core/src/runbook/effective-vars.ts
+++ b/packages/core/src/runbook/effective-vars.ts
@@ -1,5 +1,5 @@
 import type { OutputValue } from './output-evaluator.js';
-import type { TemplateVarValue } from './types.js';
+import type { ArtifactVarValue, TemplateVarValue } from './types.js';
 
 /**
  * Module-private nominal brand applied to the output of {@link mergeEffectiveVars}.
@@ -13,13 +13,36 @@ import type { TemplateVarValue } from './types.js';
  */
 declare const effectiveVarsBrand: unique symbol;
 
+declare const artifactVarsBrand: unique symbol;
+
+/**
+ * Persisted ARTIFACTS variable accumulator.
+ *
+ * Carries exact `ArtifactRecord` values and wildcard `ArtifactRecord[]` values
+ * separately from string-only step OUTPUTS.
+ */
+export type ArtifactVars = Readonly<Record<string, ArtifactVarValue>> & {
+  readonly [artifactVarsBrand]: true;
+};
+
+/**
+ * Sole producer of {@link ArtifactVars}.
+ *
+ * @param vars - Plain artifact variable map
+ * @returns The same object, branded
+ */
+export function brandArtifactVars(vars: Readonly<Record<string, ArtifactVarValue>>): ArtifactVars {
+  return vars as ArtifactVars;
+}
+
 /**
  * Fully-merged effective variable space at a moment in execution.
  *
  * Layered, lowest precedence first:
  *   1. `state.templateVars` — CLI-seeded inputs / built-ins / frontmatter
- *   2. `state.variables`   — accumulated step OUTPUTS
- *   3. caller-supplied `extraVars` — delegation-side overrides (e.g. --input)
+ *   2. `state.artifactVars` — accumulated ARTIFACTS declarations
+ *   3. `state.variables`   — accumulated step OUTPUTS
+ *   4. caller-supplied `extraVars` — delegation-side overrides (e.g. --input)
  *
  * Used wherever delegation snapshots, OUTPUTS frames, or template renderers need
  * "the variables a child or expression should see right now". By accepting only
@@ -51,8 +74,9 @@ export type EffectiveVars<V = TemplateVarValue> = Readonly<Record<string, V>> & 
  *
  * Merges the variable sources in precedence order:
  *   1. `state.templateVars` (low) — CLI-seeded inputs / built-ins / frontmatter
- *   2. `state.variables`     (mid) — accumulated step OUTPUTS
- *   3. `extraVars`           (top) — caller-supplied overrides (typically --input
+ *   2. `state.artifactVars`  (mid) — accumulated ARTIFACTS declarations
+ *   3. `state.variables`     (mid) — accumulated step OUTPUTS
+ *   4. `extraVars`           (top) — caller-supplied overrides (typically --input
  *                                     flags routed through delegation/run commands)
  *
  * Mirrors the precedence used by `buildExecutionFrame` for OUTPUTS evaluation
@@ -66,24 +90,44 @@ export type EffectiveVars<V = TemplateVarValue> = Readonly<Record<string, V>> & 
  * both `TemplateVarValue` and `OutputValue`, so the field shape is uniform.
  *
  * @template V - Value type of the merged record (inferred from arguments)
- * @param state - Runbook-state subset providing the two persisted variable sources
+ * @param state - Runbook-state subset providing the persisted variable sources
  * @param state.templateVars - Seeded template variables (built-ins, frontmatter inputs, CLI overrides)
+ * @param state.artifactVars - Accumulated ARTIFACTS variables
  * @param state.variables - Accumulated step OUTPUTS already rendered to strings
  * @param extraVars - Optional caller-supplied variables overlaid on top
  * @returns Branded effective variable space
  */
-export function mergeEffectiveVars<V extends TemplateVarValue | OutputValue = TemplateVarValue>(
+export function mergeEffectiveVars<V extends OutputValue>(
   state: {
     readonly templateVars?: Readonly<Record<string, V>>;
     readonly variables?: Readonly<Record<string, string>>;
   },
   extraVars?: Readonly<Record<string, V>>,
-): EffectiveVars<V> {
+): EffectiveVars<V>;
+
+export function mergeEffectiveVars<V extends TemplateVarValue = TemplateVarValue>(
+  state: {
+    readonly templateVars?: Readonly<Record<string, V>>;
+    readonly artifactVars?: Readonly<Record<string, ArtifactVarValue>>;
+    readonly variables?: Readonly<Record<string, string>>;
+  },
+  extraVars?: Readonly<Record<string, V>>,
+): EffectiveVars<V | ArtifactVarValue>;
+
+export function mergeEffectiveVars<V extends TemplateVarValue | OutputValue = TemplateVarValue>(
+  state: {
+    readonly templateVars?: Readonly<Record<string, V>>;
+    readonly artifactVars?: Readonly<Record<string, ArtifactVarValue>>;
+    readonly variables?: Readonly<Record<string, string>>;
+  },
+  extraVars?: Readonly<Record<string, V>>,
+): EffectiveVars<V | ArtifactVarValue> {
   return {
     ...(state.templateVars ?? {}),
+    ...(state.artifactVars ?? {}),
     ...(state.variables ?? {}),
     ...(extraVars ?? {}),
-  } as EffectiveVars<V>;
+  } as EffectiveVars<V | ArtifactVarValue>;
 }
 
 /**

--- a/packages/core/src/runbook/effective-vars.ts
+++ b/packages/core/src/runbook/effective-vars.ts
@@ -258,6 +258,14 @@ export function brandStoredOutputs(vars: Readonly<Record<string, string>>): Stor
  * @param vars - Plain merged-record shape
  * @returns The same object, branded.
  */
+export function brandEffectiveVars(
+  vars: Readonly<Record<string, TemplateVarValue | ArtifactVarValue>>,
+): EffectiveVars<TemplateVarValue | ArtifactVarValue>;
+
+export function brandEffectiveVars<V extends TemplateVarValue | OutputValue = TemplateVarValue>(
+  vars: Readonly<Record<string, V>>,
+): EffectiveVars<V>;
+
 export function brandEffectiveVars<V extends TemplateVarValue | OutputValue = TemplateVarValue>(
   vars: Readonly<Record<string, V>>,
 ): EffectiveVars<V> {

--- a/packages/core/src/runbook/effective-vars.ts
+++ b/packages/core/src/runbook/effective-vars.ts
@@ -97,14 +97,6 @@ export type EffectiveVars<V = TemplateVarValue> = Readonly<Record<string, V>> & 
  * @param extraVars - Optional caller-supplied variables overlaid on top
  * @returns Branded effective variable space
  */
-export function mergeEffectiveVars<V extends OutputValue>(
-  state: {
-    readonly templateVars?: Readonly<Record<string, V>>;
-    readonly variables?: Readonly<Record<string, string>>;
-  },
-  extraVars?: Readonly<Record<string, V>>,
-): EffectiveVars<V>;
-
 export function mergeEffectiveVars<V extends TemplateVarValue = TemplateVarValue>(
   state: {
     readonly templateVars?: Readonly<Record<string, V>>;
@@ -113,6 +105,14 @@ export function mergeEffectiveVars<V extends TemplateVarValue = TemplateVarValue
   },
   extraVars?: Readonly<Record<string, V>>,
 ): EffectiveVars<V | ArtifactVarValue>;
+
+export function mergeEffectiveVars<V extends OutputValue>(
+  state: {
+    readonly templateVars?: Readonly<Record<string, V>>;
+    readonly variables?: Readonly<Record<string, string>>;
+  },
+  extraVars?: Readonly<Record<string, V>>,
+): EffectiveVars<V>;
 
 export function mergeEffectiveVars<V extends TemplateVarValue | OutputValue = TemplateVarValue>(
   state: {

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -1,5 +1,6 @@
 // src/runbook/execution-lifecycle-service.ts
 import type { RunbookStateManager } from './state.js';
+import { merge, replace } from './state-update-ops.js';
 import {
   buildCompletionKey,
   deriveActiveFrame,
@@ -122,7 +123,7 @@ export class ExecutionLifecycleService {
     const updated = await this.manager.update(id, {
       activeFrameKey: toFrameKey,
       activeEntry: entry,
-      frameEntries,
+      frameEntries: replace(frameEntries),
     });
 
     return { state: updated, frameKey: toFrameKey, entry };
@@ -145,10 +146,7 @@ export class ExecutionLifecycleService {
     if (!state) throw new Error(`Runbook ${id} not found`);
 
     await this.manager.update(id, {
-      resolvedCompletions: {
-        ...(state.resolvedCompletions ?? {}),
-        [key]: completion,
-      },
+      resolvedCompletions: merge({ [key]: completion }),
     });
   }
 
@@ -197,7 +195,7 @@ export class ExecutionLifecycleService {
     const next = { ...(state.resolvedCompletions ?? {}) };
     delete next[actualKey];
     await this.manager.update(id, {
-      resolvedCompletions: Object.keys(next).length > 0 ? next : {},
+      resolvedCompletions: replace(next),
     });
     return existing;
   }

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -27,6 +27,18 @@ export {
   StaleRunbookStateError,
   type SessionData,
 } from './state.js';
+export {
+  applyOp,
+  merge,
+  replace,
+  type ArtifactVarsOp,
+  type FrameEntriesOp,
+  type MergeOp,
+  type ReplaceOp,
+  type ResolvedCompletionsOp,
+  type TemplateVarsOp,
+  type VariablesOp,
+} from './state-update-ops.js';
 export { SessionService, type ReleaseRunbookResult } from './session-service.js';
 export { readActiveRunScope, type ActiveRunScope } from './session-reader.js';
 export { ExecutionLifecycleService } from './execution-lifecycle-service.js';

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -146,12 +146,18 @@ export {
   appendArtifactManifestRecordSync,
   coalesceManifestRecords,
   findArtifactMatches,
+  isExistingRegularArtifactFile,
   manifestPathForContext,
   readArtifactManifest,
   type ArtifactManifestRecord,
   type ArtifactSelectorMatch,
   type FindArtifactOptions,
 } from './artifact-manifest.js';
+export {
+  resolveArtifactDeclarations,
+  type ArtifactRunEligibility,
+  type ResolveArtifactDeclarationsOptions,
+} from './artifact-directive-resolver.js';
 export {
   applyRunArtifactHelper,
   buildExecutionFrame,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -171,9 +171,11 @@ export {
 export { invokeHelperSafely, resetHelperInvokeWarnings } from './helper-invoke.js';
 export {
   mergeEffectiveVars,
+  brandArtifactVars,
   brandInitialTemplateVars,
   brandStoredOutputs,
   brandEffectiveVars,
+  type ArtifactVars,
   type EffectiveVars,
   type InitialTemplateVars,
   type StoredOutputs,

--- a/packages/core/src/runbook/state-update-ops.ts
+++ b/packages/core/src/runbook/state-update-ops.ts
@@ -1,0 +1,118 @@
+// src/runbook/state-update-ops.ts
+import type { FrameKey } from './targeting.js';
+import type { ArtifactVarValue, ResolvedCompletion, TemplateVarValue } from './types.js';
+
+/**
+ * Shallow-merge the payload into the existing record. Caller-supplied keys
+ * overlay existing values; keys not mentioned are preserved.
+ */
+export interface MergeOp<V> {
+  readonly op: 'merge';
+  readonly value: Readonly<Record<string, V>>;
+}
+
+/**
+ * Replace the field wholesale. The value passes through verbatim.
+ */
+export interface ReplaceOp<V> {
+  readonly op: 'replace';
+  readonly value: V;
+}
+
+/**
+ * Construct a {@link MergeOp} that shallow-merges the given map into the
+ * existing field. Use at call sites where the new entries should add to or
+ * overlay existing keys without wiping the rest.
+ *
+ * @template V - Value type of the record entries
+ * @param value - Partial record whose entries are merged onto the existing field
+ * @returns Tagged merge operation consumed by {@link RunbookStateManager.update}
+ */
+export function merge<V>(value: Readonly<Record<string, V>>): MergeOp<V> {
+  return { op: 'merge', value };
+}
+
+/**
+ * Construct a {@link ReplaceOp} that wholesale-replaces the field. Use at call
+ * sites where the caller owns the full set, e.g. mirroring an XState context
+ * that is the source of truth for the field.
+ *
+ * @template V - Type of the value being replaced
+ * @param value - The full replacement value
+ * @returns Tagged replace operation consumed by {@link RunbookStateManager.update}
+ */
+export function replace<V>(value: V): ReplaceOp<V> {
+  return { op: 'replace', value };
+}
+
+/**
+ * Op shape accepted for `RunbookState.variables`. Merge-only because the
+ * actor reducer always emits the full live OUTPUTS map; merging it onto the
+ * persisted view is idempotent and the only correct semantic.
+ */
+export type VariablesOp = MergeOp<string>;
+
+/**
+ * Op shape accepted for `RunbookState.templateVars`. Replace-only because
+ * template inputs are seeded once at run creation and only re-written
+ * wholesale (e.g. by delegation snapshot writes carrying the full inherited
+ * map). There is no partial-patch call site.
+ */
+export type TemplateVarsOp = ReplaceOp<Readonly<Record<string, TemplateVarValue>>>;
+
+/**
+ * Op shape accepted for `RunbookState.artifactVars`. Both ops are real:
+ * `resolveArtifactsForRun` adds entries (merge); the actor mirror replays
+ * the full XState context (replace).
+ */
+export type ArtifactVarsOp =
+  | MergeOp<ArtifactVarValue>
+  | ReplaceOp<Readonly<Record<string, ArtifactVarValue>>>;
+
+/**
+ * Op shape accepted for `RunbookState.resolvedCompletions`. `recordCompletion`
+ * adds one entry (merge); `consumeResolvedCompletion` removes a key, which is
+ * a wholesale replace at the field level.
+ */
+export type ResolvedCompletionsOp =
+  | MergeOp<ResolvedCompletion>
+  | ReplaceOp<Readonly<Record<string, ResolvedCompletion>>>;
+
+/**
+ * Op shape accepted for `RunbookState.frameEntries`. Replace-only — the only
+ * caller (`ensureActiveEntry`) constructs the full updated map externally
+ * before passing it through.
+ */
+export type FrameEntriesOp = ReplaceOp<Readonly<Record<FrameKey, number>>>;
+
+/**
+ * Internal dispatcher: apply a {@link MergeOp} or {@link ReplaceOp} against an
+ * existing record-shaped field value. Returns the new field value.
+ *
+ * The exhaustive `op.op` check guards both constructor tags. A mutant that
+ * silently changes either `'merge'` or `'replace'` would route through the
+ * unknown-tag branch and trip the throw at runtime, surfacing in tests.
+ *
+ * @template V - Value type of the record entries
+ * @param existing - The currently-persisted field value (may be undefined)
+ * @param op - The tagged operation
+ * @returns The post-op record value
+ * @throws {Error} If `op.op` is neither `'merge'` nor `'replace'` (impossible
+ *   through the public API; load-bearing for mutation testing)
+ */
+export function applyOp<V>(
+  existing: Readonly<Record<string, V>> | undefined,
+  op: MergeOp<V> | ReplaceOp<Readonly<Record<string, V>>>,
+): Readonly<Record<string, V>> {
+  switch (op.op) {
+    case 'merge':
+      return { ...(existing ?? {}), ...op.value };
+    case 'replace':
+      return op.value;
+    default:
+      // Defensive: the public type forbids this branch, but it remains
+      // load-bearing under mutation testing (kills equivalent-tag mutants
+      // on the constructors).
+      throw new Error(`applyOp: unknown op tag "${(op as { readonly op: string }).op}"`);
+  }
+}

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -13,13 +13,18 @@ import type {
   ResolvedRunbook,
   ParentLinkage,
   TemplateVarValue,
+  ArtifactVarValue,
 } from './types.js';
 import type { ClaimRecord } from './claim-id.js';
 import type { RunbookRef } from './runbook-ref.js';
 import { makeRunbookStateSchema, SessionDataSchema } from '../schemas.js';
 import { isNodeError } from '../errors.js';
 import { logger } from '../logger.js';
-import { brandInitialTemplateVars, brandStoredOutputs } from './effective-vars.js';
+import {
+  brandArtifactVars,
+  brandInitialTemplateVars,
+  brandStoredOutputs,
+} from './effective-vars.js';
 import { assertRunId, RUN_ID_PREFIX, type RunId } from './run-id.js';
 import {
   runsDir as _runsDir,
@@ -29,7 +34,7 @@ import {
 } from '../paths.js';
 
 /** Current persisted state schema version. Bump whenever RunbookState shape changes incompatibly. */
-const CURRENT_SCHEMA_VERSION = 2;
+const CURRENT_SCHEMA_VERSION = 3;
 
 function patchSnapshotSubstepStates(
   snapshot: unknown,
@@ -344,13 +349,16 @@ export class RunbookStateManager {
    */
   async update(
     id: string,
-    updates: Partial<Omit<RunbookState, 'id' | 'startedAt' | 'variables' | 'templateVars'>> & {
+    updates: Partial<
+      Omit<RunbookState, 'id' | 'startedAt' | 'variables' | 'templateVars' | 'artifactVars'>
+    > & {
       // Accept unbranded records on the update path; the manager re-mints
       // the brand inside the merge below. Internal callers (actor-service
       // sync, compiler reducers) hold the unbranded XState context shape
       // and shouldn't need to know about the persistence-layer brand.
       readonly variables?: Readonly<Record<string, string>>;
       readonly templateVars?: Readonly<Record<string, TemplateVarValue>>;
+      readonly artifactVars?: Readonly<Record<string, ArtifactVarValue>>;
     },
   ): Promise<RunbookState> {
     const existing = await this.load(id);
@@ -362,6 +370,7 @@ export class RunbookStateManager {
     // `...updates` spread does not leak the unbranded types into the
     // strictly-typed RunbookState literal.
     const {
+      artifactVars: updatesArtifactVars,
       variables: updatesVariables,
       templateVars: updatesTemplateVars,
       ...restUpdates
@@ -381,6 +390,9 @@ export class RunbookStateManager {
       variables: brandStoredOutputs({ ...existing.variables, ...(updatesVariables ?? {}) }),
       ...(updatesTemplateVars !== undefined
         ? { templateVars: brandInitialTemplateVars(updatesTemplateVars) }
+        : {}),
+      ...(updatesArtifactVars !== undefined
+        ? { artifactVars: brandArtifactVars(updatesArtifactVars) }
         : {}),
       updatedAt: new Date().toISOString(),
     };

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -171,7 +171,7 @@ export class RunbookStateManager {
    * Deregister a run id whose actor has been stopped.
    *
    * Called by {@link RunbookActorService.stopActor} after `actor.stop()`.
-   * Idempotent: deregistering an unknown id is a no-op.
+   * Idempotent: removing an unknown id is a no-op.
    *
    * @param id - Runbook state id
    */

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -16,6 +16,15 @@ import type {
   ArtifactVarValue,
 } from './types.js';
 import {
+  applyOp,
+  merge,
+  type ArtifactVarsOp,
+  type FrameEntriesOp,
+  type ResolvedCompletionsOp,
+  type TemplateVarsOp,
+  type VariablesOp,
+} from './state-update-ops.js';
+import {
   resolveArtifactDeclarations,
   type ArtifactRunEligibility,
 } from './artifact-directive-resolver.js';
@@ -343,26 +352,46 @@ export class RunbookStateManager {
   /**
    * Update an existing runbook state with partial changes.
    *
-   * Merges the provided updates with the existing state. Variables are
-   * shallow-merged rather than replaced entirely.
+   * Per-field semantics:
+   * - `variables` — `merge(...)` shallow-merges OUTPUTS (merge-only)
+   * - `templateVars` — `replace(...)` wholesale-replaces (replace-only; seeded once)
+   * - `artifactVars` — `merge(...)` adds entries; `replace(...)` mirrors the full set
+   * - `resolvedCompletions` — `merge(...)` adds one entry; `replace(...)` rewrites the map
+   * - `frameEntries` — `replace(...)` wholesale-replaces (replace-only)
+   * - All other fields — provided value is taken verbatim; omitted fields are preserved
+   *
+   * Use the {@link merge} and {@link replace} constructors at call sites to make
+   * intent visible at the type level; passing a raw record without a tag is a
+   * compile error.
    *
    * @param id - The runbook state ID to update
-   * @param updates - Partial state updates to apply (id and startedAt cannot be changed)
+   * @param updates - Partial state updates with tagged ops on record-shaped fields
    * @returns The updated runbook state
    * @throws {Error} If the runbook with the given ID is not found
    */
   async update(
     id: string,
     updates: Partial<
-      Omit<RunbookState, 'id' | 'startedAt' | 'variables' | 'templateVars' | 'artifactVars'>
+      Omit<
+        RunbookState,
+        | 'id'
+        | 'startedAt'
+        | 'variables'
+        | 'templateVars'
+        | 'artifactVars'
+        | 'resolvedCompletions'
+        | 'frameEntries'
+      >
     > & {
-      // Accept unbranded records on the update path; the manager re-mints
-      // the brand inside the merge below. Internal callers (actor-service
-      // sync, compiler reducers) hold the unbranded XState context shape
-      // and shouldn't need to know about the persistence-layer brand.
-      readonly variables?: Readonly<Record<string, string>>;
-      readonly templateVars?: Readonly<Record<string, TemplateVarValue>>;
-      readonly artifactVars?: Readonly<Record<string, ArtifactVarValue>>;
+      // Tagged ops on record-shaped fields make merge-vs-replace intent
+      // visible at the call site. Internal callers (actor-service sync,
+      // compiler reducers) hold the unbranded XState context shape; the
+      // manager re-mints persistence brands inside the dispatch below.
+      readonly variables?: VariablesOp;
+      readonly templateVars?: TemplateVarsOp;
+      readonly artifactVars?: ArtifactVarsOp;
+      readonly resolvedCompletions?: ResolvedCompletionsOp;
+      readonly frameEntries?: FrameEntriesOp;
     },
   ): Promise<RunbookState> {
     const existing = await this.load(id);
@@ -370,13 +399,15 @@ export class RunbookStateManager {
       throw new Error(`Runbook ${id} not found`);
     }
 
-    // Pull branded/unbranded fields out of updates so the subsequent
-    // `...updates` spread does not leak the unbranded types into the
-    // strictly-typed RunbookState literal.
+    // Pull tagged-op fields out of updates so the subsequent `...updates`
+    // spread does not leak the wrapper shapes into the strictly-typed
+    // RunbookState literal.
     const {
-      artifactVars: updatesArtifactVars,
-      variables: updatesVariables,
-      templateVars: updatesTemplateVars,
+      variables: variablesOp,
+      templateVars: templateVarsOp,
+      artifactVars: artifactVarsOp,
+      resolvedCompletions: resolvedCompletionsOp,
+      frameEntries: frameEntriesOp,
       ...restUpdates
     } = updates;
     const shouldPatchSnapshotSubstepStates =
@@ -391,13 +422,20 @@ export class RunbookStateManager {
     const updated: RunbookState = {
       ...existing,
       ...patchedRestUpdates,
-      variables: brandStoredOutputs({ ...existing.variables, ...(updatesVariables ?? {}) }),
-      ...(updatesTemplateVars !== undefined
-        ? { templateVars: brandInitialTemplateVars(updatesTemplateVars) }
+      variables:
+        variablesOp !== undefined
+          ? brandStoredOutputs(applyOp(existing.variables, variablesOp))
+          : existing.variables,
+      ...(templateVarsOp !== undefined
+        ? { templateVars: brandInitialTemplateVars(templateVarsOp.value) }
         : {}),
-      ...(updatesArtifactVars !== undefined
-        ? { artifactVars: brandArtifactVars(updatesArtifactVars) }
+      ...(artifactVarsOp !== undefined
+        ? { artifactVars: brandArtifactVars(applyOp(existing.artifactVars, artifactVarsOp)) }
         : {}),
+      ...(resolvedCompletionsOp !== undefined
+        ? { resolvedCompletions: applyOp(existing.resolvedCompletions, resolvedCompletionsOp) }
+        : {}),
+      ...(frameEntriesOp !== undefined ? { frameEntries: frameEntriesOp.value } : {}),
       updatedAt: new Date().toISOString(),
     };
 
@@ -411,6 +449,15 @@ export class RunbookStateManager {
    *
    * This method is intentionally explicit: it does not inspect the active step
    * or emit events. Phase 4 owns deciding when to call it at step/substep entry.
+   *
+   * @remarks
+   * Must not be called while a live `RunbookActor` exists for the same `id`.
+   * The actor seeds `context.artifactVars` once at compile time
+   * (`actor-service.ts` `compileMachineFromState`); a later
+   * `RunbookActorService.updateFromActor` mirrors the actor's stale view back
+   * to disk via `replace(...)` (`actor-service.ts` artifactVars patches),
+   * which would overwrite this method's writes. Phase 4 will own scheduling
+   * resolver calls relative to actor lifecycle.
    *
    * @param id - Current run id
    * @param declarations - Parser-owned artifact declarations for one execution unit
@@ -455,10 +502,7 @@ export class RunbookStateManager {
     });
 
     await this.update(id, {
-      artifactVars: {
-        ...(state.artifactVars ?? {}),
-        ...resolved,
-      },
+      artifactVars: merge(resolved),
     });
     return resolved;
   }

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -137,12 +137,57 @@ export class RunbookStateManager {
   private readonly _cwd: string;
 
   /**
+   * Per-process registry of run ids whose `RunbookActor` is currently running.
+   *
+   * Maintained by {@link RunbookActorService} via {@link markActorStarted} and
+   * {@link markActorStopped}. {@link resolveArtifactsForRun} consults this set
+   * to refuse writes that would race with the actor's stale-context replay
+   * through `RunbookActorService.updateFromActor`.
+   */
+  private readonly liveActors = new Set<string>();
+
+  /**
    * Create a new RunbookStateManager.
    *
    * @param cwd - The working directory (project root) for state file paths
    */
   constructor(cwd: string) {
     this._cwd = cwd;
+  }
+
+  /**
+   * Register a run id as having a live actor in this process.
+   *
+   * Called by {@link RunbookActorService.createActor} after `actor.start()`.
+   * Idempotent: re-registering a live id is a no-op.
+   *
+   * @param id - Runbook state id
+   */
+  markActorStarted(id: string): void {
+    this.liveActors.add(id);
+  }
+
+  /**
+   * Deregister a run id whose actor has been stopped.
+   *
+   * Called by {@link RunbookActorService.stopActor} after `actor.stop()`.
+   * Idempotent: deregistering an unknown id is a no-op.
+   *
+   * @param id - Runbook state id
+   */
+  markActorStopped(id: string): void {
+    this.liveActors.delete(id);
+  }
+
+  /**
+   * Whether a `RunbookActor` is currently live for the given run id.
+   *
+   * @param id - Runbook state id
+   * @returns `true` if {@link markActorStarted} was called without a matching
+   *   {@link markActorStopped}
+   */
+  isActorLive(id: string): boolean {
+    return this.liveActors.has(id);
   }
 
   /**
@@ -376,6 +421,8 @@ export class RunbookStateManager {
         RunbookState,
         | 'id'
         | 'startedAt'
+        | 'updatedAt'
+        | 'schemaVersion'
         | 'variables'
         | 'templateVars'
         | 'artifactVars'
@@ -451,25 +498,34 @@ export class RunbookStateManager {
    * or emit events. Phase 4 owns deciding when to call it at step/substep entry.
    *
    * @remarks
-   * Must not be called while a live `RunbookActor` exists for the same `id`.
-   * The actor seeds `context.artifactVars` once at compile time
-   * (`actor-service.ts` `compileMachineFromState`); a later
-   * `RunbookActorService.updateFromActor` mirrors the actor's stale view back
-   * to disk via `replace(...)` (`actor-service.ts` artifactVars patches),
-   * which would overwrite this method's writes. Phase 4 will own scheduling
-   * resolver calls relative to actor lifecycle.
+   * Refuses to run while a live `RunbookActor` exists for the same `id` (as
+   * tracked by {@link markActorStarted}/{@link markActorStopped}). The actor
+   * seeds `context.artifactVars` once at compile time (`actor-service.ts`
+   * `compileMachineFromState`); a later `RunbookActorService.updateFromActor`
+   * mirrors the actor's stale view back to disk via `replace(...)`
+   * (`actor-service.ts` artifactVars patches), which would overwrite this
+   * method's writes. Phase 4 will replace the refusal with a machine-mediated
+   * write path so resolver output flows through the actor's context.
    *
    * @param id - Current run id
    * @param declarations - Parser-owned artifact declarations for one execution unit
    * @returns The current execution unit's resolved artifact working set
-   * @throws {Error} If the run is not found, is missing required built-ins
-   * (`WorkPath`, `ContextId`), has corrupt artifact manifests, or encounters
-   * unexpected artifact filesystem failures
+   * @throws {Error} If a live `RunbookActor` exists for `id`, the run is not
+   * found, is missing required built-ins (`WorkPath`, `ContextId`), has
+   * corrupt artifact manifests, or encounters unexpected artifact filesystem
+   * failures
    */
   async resolveArtifactsForRun(
     id: string,
     declarations: readonly ArtifactDeclaration[],
   ): Promise<Record<string, ArtifactVarValue>> {
+    if (this.liveActors.has(id)) {
+      throw new Error(
+        `Refusing to resolve artifacts for "${id}": a live RunbookActor exists for this run. ` +
+          `Stop the actor (RunbookActorService.stopActor) before calling resolveArtifactsForRun, ` +
+          `or wait for Phase 4 machine-mediated artifact resolution.`,
+      );
+    }
     const state = await this.load(id);
     if (!state) {
       throw new Error(`Runbook ${id} not found`);

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -2,7 +2,7 @@
 import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import type { OutputDeclaration } from '@rundown-org/parser';
+import type { ArtifactDeclaration, OutputDeclaration } from '@rundown-org/parser';
 import type { FrameKey } from './targeting.js';
 import type {
   RunbookState,
@@ -15,6 +15,10 @@ import type {
   TemplateVarValue,
   ArtifactVarValue,
 } from './types.js';
+import {
+  resolveArtifactDeclarations,
+  type ArtifactRunEligibility,
+} from './artifact-directive-resolver.js';
 import type { ClaimRecord } from './claim-id.js';
 import type { RunbookRef } from './runbook-ref.js';
 import { makeRunbookStateSchema, SessionDataSchema } from '../schemas.js';
@@ -399,6 +403,64 @@ export class RunbookStateManager {
 
     await this.save(updated);
     return updated;
+  }
+
+  /**
+   * Resolve one ARTIFACTS block for a persisted run and merge the result into
+   * `RunbookState.artifactVars`.
+   *
+   * This method is intentionally explicit: it does not inspect the active step
+   * or emit events. Phase 4 owns deciding when to call it at step/substep entry.
+   *
+   * @param id - Current run id
+   * @param declarations - Parser-owned artifact declarations for one execution unit
+   * @returns The current execution unit's resolved artifact working set
+   * @throws {Error} If the run is not found, is missing required built-ins
+   * (`WorkPath`, `ContextId`), has corrupt artifact manifests, or encounters
+   * unexpected artifact filesystem failures
+   */
+  async resolveArtifactsForRun(
+    id: string,
+    declarations: readonly ArtifactDeclaration[],
+  ): Promise<Record<string, ArtifactVarValue>> {
+    const state = await this.load(id);
+    if (!state) {
+      throw new Error(`Runbook ${id} not found`);
+    }
+    const workPath = state.templateVars?.WorkPath;
+    const contextId = state.templateVars?.ContextId;
+    if (typeof workPath !== 'string') {
+      throw new Error(`Runbook ${id} cannot resolve ARTIFACTS without string WorkPath`);
+    }
+    if (typeof contextId !== 'string') {
+      throw new Error(`Runbook ${id} cannot resolve ARTIFACTS without string ContextId`);
+    }
+
+    const runId: RunId = assertRunId(state.id);
+    const resolved = await resolveArtifactDeclarations(declarations, {
+      cwd: this.cwd,
+      workPath,
+      contextId,
+      runId,
+      runbook: state.runbook,
+      loadRunEligibility: async (otherRunId: RunId): Promise<ArtifactRunEligibility | null> => {
+        const other = await this.load(otherRunId);
+        if (!other) return null;
+        if (other.id === state.id) return null;
+        if (other.lifecycle === 'completed' && other.updatedAt) {
+          return { runId: otherRunId, terminalAt: other.updatedAt };
+        }
+        return null;
+      },
+    });
+
+    await this.update(id, {
+      artifactVars: {
+        ...(state.artifactVars ?? {}),
+        ...resolved,
+      },
+    });
+    return resolved;
   }
 
   /**

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -1,7 +1,13 @@
 // src/runbook/types.ts
 import type { OutputDeclaration } from '@rundown-org/parser';
+import type { ArtifactRecord } from './artifact-schema.js';
 import type { DelegationTokenHash } from './delegation-token.js';
-import type { EffectiveVars, InitialTemplateVars, StoredOutputs } from './effective-vars.js';
+import type {
+  ArtifactVars,
+  EffectiveVars,
+  InitialTemplateVars,
+  StoredOutputs,
+} from './effective-vars.js';
 import type { RunbookRef } from './runbook-ref.js';
 import type { RunId } from './run-id.js';
 import type { FrameKey } from './targeting.js';
@@ -229,6 +235,24 @@ export type IterableVarValue = JsonArray | JsonArrayStream;
  * @see IterableVarValue for the subset that drives FOR loop iteration
  */
 export type TemplateVarValue = string | number | JsonObject | JsonArray | JsonArrayStream;
+
+/**
+ * Structured value stored by an `ARTIFACTS` declaration.
+ *
+ * Exact declarations store one {@link ArtifactRecord}; wildcard declarations
+ * store an array of records. These values live in `RunbookState.artifactVars`,
+ * not in string-only step OUTPUTS (`RunbookState.variables`).
+ */
+export type ArtifactVarValue = ArtifactRecord | readonly ArtifactRecord[];
+
+/**
+ * Value shape carried by delegation context snapshots.
+ *
+ * Existing OUTPUTS-frame callers can produce `JsonValue`-typed effective vars,
+ * while ARTIFACTS-aware snapshots can additionally carry structured artifact
+ * records.
+ */
+export type ContextSnapshotVarValue = TemplateVarValue | ArtifactVarValue | JsonValue;
 
 /**
  * Type guard for JSON object values within the template variable map.
@@ -471,7 +495,7 @@ export interface ContextSnapshot {
    * prevents the regression class fixed in commit `19067f6f`, where
    * `buildContextSnapshot` silently dropped `state.variables`.
    */
-  readonly vars: EffectiveVars;
+  readonly vars: EffectiveVars<ContextSnapshotVarValue>;
   readonly ancestors: readonly AncestorSnapshot[];
   /** Current step identifier at delegation time (e.g., "1"). */
   readonly step?: string;
@@ -489,7 +513,7 @@ export interface AncestorSnapshot {
   readonly runbook: string;
   readonly step: string;
   readonly substep: string | null;
-  readonly vars: Readonly<Record<string, TemplateVarValue>>;
+  readonly vars: Readonly<Record<string, ContextSnapshotVarValue>>;
   /** Qualified execution location at delegation time (e.g., "1.2.1"). */
   readonly at?: string;
   /** FOR loop iteration number at delegation time (1-based). */
@@ -730,6 +754,15 @@ export interface RunbookState {
    * variables were declared up-front versus produced during execution.
    */
   readonly variables: StoredOutputs;
+  /**
+   * Accumulated ARTIFACTS variables. Exact declarations store one
+   * `ArtifactRecord`; wildcard declarations store `ArtifactRecord[]`.
+   *
+   * This field is persisted separately from string-only step OUTPUTS. Same-name
+   * OUTPUTS can mask an artifact variable in the effective render context, but
+   * must never overwrite this map.
+   */
+  readonly artifactVars?: ArtifactVars;
   readonly steps: readonly StepState[];
 
   // Orchestration fields

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -250,6 +250,12 @@ export type ArtifactVarValue = ArtifactRecord | readonly ArtifactRecord[];
  *
  * ARTIFACTS-aware snapshots can additionally carry structured artifact
  * records alongside ordinary template values.
+ *
+ * @remarks
+ * Documentational widening only. `ArtifactRecord` is structurally assignable
+ * to {@link JsonObject}, and `readonly ArtifactRecord[]` is assignable to
+ * {@link JsonArray}, so this union does not strengthen any type checks beyond
+ * `TemplateVarValue`. The named alias clarifies intent at delegation sites.
  */
 export type ContextSnapshotVarValue = TemplateVarValue | ArtifactVarValue;
 

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -248,11 +248,10 @@ export type ArtifactVarValue = ArtifactRecord | readonly ArtifactRecord[];
 /**
  * Value shape carried by delegation context snapshots.
  *
- * Existing OUTPUTS-frame callers can produce `JsonValue`-typed effective vars,
- * while ARTIFACTS-aware snapshots can additionally carry structured artifact
- * records.
+ * ARTIFACTS-aware snapshots can additionally carry structured artifact
+ * records alongside ordinary template values.
  */
-export type ContextSnapshotVarValue = TemplateVarValue | ArtifactVarValue | JsonValue;
+export type ContextSnapshotVarValue = TemplateVarValue | ArtifactVarValue;
 
 /**
  * Type guard for JSON object values within the template variable map.

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -12,12 +12,14 @@ import { createJsonArrayStream } from './runbook/types.js';
 import type { JsonValue, TemplateVarValue } from './runbook/types.js';
 import { RUN_ID_PATTERN, type RunId, type runIdBrand } from './runbook/run-id.js';
 import {
+  brandArtifactVars,
   brandEffectiveVars,
   brandInitialTemplateVars,
   brandStoredOutputs,
 } from './runbook/effective-vars.js';
 import { getErrorMessage } from './errors.js';
 import { RunbookRefSchema } from './runbook/runbook-ref.js';
+import { ArtifactRecordSchema } from './runbook/artifact-schema.js';
 
 /** Zod schema that parses strings and brands them as {@link FrameKey}. */
 const FrameKeySchema = z.string().transform((v) => v as FrameKey);
@@ -261,6 +263,19 @@ export const TemplateVarValueSchema: z.ZodType<TemplateVarValue> = z.union([
 ]);
 
 /**
+ * Zod schema for a persisted ARTIFACTS variable value.
+ *
+ * Exact aliases store one `ArtifactRecord`; wildcard aliases store an array of
+ * `ArtifactRecord` values, including empty arrays for no matches.
+ */
+export const ArtifactVarValueSchema = z.union([
+  ArtifactRecordSchema,
+  z.array(ArtifactRecordSchema).readonly(),
+]);
+
+const ContextSnapshotVarValueSchema = z.union([TemplateVarValueSchema, ArtifactVarValueSchema]);
+
+/**
  * Zod schema for a single ancestor in the runbook lineage snapshot.
  */
 export const AncestorSnapshotSchema = z.object({
@@ -268,7 +283,7 @@ export const AncestorSnapshotSchema = z.object({
   runbook: z.string(),
   step: z.string(),
   substep: z.string().nullable(),
-  vars: z.record(z.string(), TemplateVarValueSchema),
+  vars: z.record(z.string(), ContextSnapshotVarValueSchema),
   at: z.string().optional(),
   index: z.number().int().positive().optional(),
 });
@@ -278,7 +293,7 @@ export const AncestorSnapshotSchema = z.object({
  */
 export const ContextSnapshotSchema = z
   .object({
-    vars: z.record(z.string(), TemplateVarValueSchema),
+    vars: z.record(z.string(), ContextSnapshotVarValueSchema),
     ancestors: z.array(AncestorSnapshotSchema).readonly(),
     step: z.string().optional(),
     substep: z.string().optional(),
@@ -480,6 +495,7 @@ const RunbookStateObjectSchema = z
     stepName: z.string(),
     retryCount: z.number().nonnegative().int(),
     variables: z.record(z.string(), z.string()),
+    artifactVars: z.record(z.string(), ArtifactVarValueSchema).optional(),
     steps: z.array(
       z.object({
         id: z.string(),
@@ -677,12 +693,16 @@ export function makeTemplateVarValueSchema(projectRoot: string): z.ZodType<Templ
  * @returns Zod schema for AncestorSnapshot with path-validated vars
  */
 function makeAncestorSnapshotSchema(projectRoot: string): z.ZodTypeAny {
+  const ContextVarsSchema = z.union([
+    makeTemplateVarValueSchema(projectRoot),
+    ArtifactVarValueSchema,
+  ]);
   return z.object({
     runId: RunIdSchema,
     runbook: z.string(),
     step: z.string(),
     substep: z.string().nullable(),
-    vars: z.record(z.string(), makeTemplateVarValueSchema(projectRoot)),
+    vars: z.record(z.string(), ContextVarsSchema),
     at: z.string().optional(),
     index: z.number().int().positive().optional(),
   });
@@ -700,15 +720,17 @@ function makeAncestorSnapshotSchema(projectRoot: string): z.ZodTypeAny {
  * @returns Zod schema for ContextSnapshot with path-validated vars and ancestors
  */
 function makeContextSnapshotSchema(projectRoot: string): z.ZodTypeAny {
+  const ContextVarsSchema = z.union([
+    makeTemplateVarValueSchema(projectRoot),
+    ArtifactVarValueSchema,
+  ]);
   return z
     .object({
       // Brand at the parse seam so disk-loaded ContextSnapshot.vars re-enters
       // the process through a sanctioned producer, matching how
       // makeRunbookStateSchema handles templateVars / variables. The brand is
       // purely nominal — identity-preserving, zero runtime cost.
-      vars: z
-        .record(z.string(), makeTemplateVarValueSchema(projectRoot))
-        .transform((v) => brandEffectiveVars(v)),
+      vars: z.record(z.string(), ContextVarsSchema).transform((v) => brandEffectiveVars(v)),
       ancestors: z.array(makeAncestorSnapshotSchema(projectRoot)).readonly(),
       step: z.string().optional(),
       substep: z.string().optional(),
@@ -805,6 +827,10 @@ export function makeRunbookStateSchema(projectRoot: string): z.ZodTypeAny {
       v === undefined ? undefined : brandInitialTemplateVars(v),
     ),
     variables: z.record(z.string(), z.string()).transform((v) => brandStoredOutputs(v)),
+    artifactVars: z
+      .record(z.string(), ArtifactVarValueSchema)
+      .optional()
+      .transform((v) => (v === undefined ? undefined : brandArtifactVars(v))),
     substepStates: z.array(SubstepStateSchemaValidated).optional(),
   }).superRefine(rejectRemovedRunbookRefField);
 }

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -273,7 +273,31 @@ export const ArtifactVarValueSchema = z.union([
   z.array(ArtifactRecordSchema).readonly(),
 ]);
 
-const ContextSnapshotVarValueSchema = z.union([TemplateVarValueSchema, ArtifactVarValueSchema]);
+/**
+ * Build the union schema for a single context-vars value.
+ *
+ * `vars` records on persisted snapshots may carry either a template value
+ * (`TemplateVarValue`) or an artifact value (`ArtifactVarValue`). When
+ * `projectRoot` is provided, the template variant is path-validated via
+ * {@link makeTemplateVarValueSchema}; otherwise the static
+ * {@link TemplateVarValueSchema} is used.
+ *
+ * Centralised so the three callers (the static
+ * `ContextSnapshotVarValueSchema`, {@link makeAncestorSnapshotSchema}, and
+ * {@link makeContextSnapshotSchema}) cannot drift independently when the
+ * value union changes.
+ *
+ * @param projectRoot - Optional project root for path-validated template variant
+ * @returns Zod union schema accepting both template and artifact values
+ */
+function makeContextVarValueSchema(projectRoot?: string): z.ZodTypeAny {
+  return z.union([
+    projectRoot === undefined ? TemplateVarValueSchema : makeTemplateVarValueSchema(projectRoot),
+    ArtifactVarValueSchema,
+  ]);
+}
+
+const ContextSnapshotVarValueSchema = makeContextVarValueSchema();
 
 /**
  * Zod schema for a single ancestor in the runbook lineage snapshot.
@@ -693,10 +717,7 @@ export function makeTemplateVarValueSchema(projectRoot: string): z.ZodType<Templ
  * @returns Zod schema for AncestorSnapshot with path-validated vars
  */
 function makeAncestorSnapshotSchema(projectRoot: string): z.ZodTypeAny {
-  const ContextVarsSchema = z.union([
-    makeTemplateVarValueSchema(projectRoot),
-    ArtifactVarValueSchema,
-  ]);
+  const ContextVarsSchema = makeContextVarValueSchema(projectRoot);
   return z.object({
     runId: RunIdSchema,
     runbook: z.string(),
@@ -720,10 +741,7 @@ function makeAncestorSnapshotSchema(projectRoot: string): z.ZodTypeAny {
  * @returns Zod schema for ContextSnapshot with path-validated vars and ancestors
  */
 function makeContextSnapshotSchema(projectRoot: string): z.ZodTypeAny {
-  const ContextVarsSchema = z.union([
-    makeTemplateVarValueSchema(projectRoot),
-    ArtifactVarValueSchema,
-  ]);
+  const ContextVarsSchema = makeContextVarValueSchema(projectRoot);
   return z
     .object({
       // Brand at the parse seam so disk-loaded ContextSnapshot.vars re-enters


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artifact variables are now persisted separately, can be resolved from completed sibling runs, and are seeded into runbook execution context.

* **Bug Fixes**
  * Prune reliably removes completed runbook state with artifact variables present.
  * Improved actor shutdown to ensure commands stop background actors cleanly.
  * Artifact resolution now refuses to run while a live actor exists to avoid races.

* **Tests**
  * Extensive new unit, integration, and property tests covering artifact resolution, manifest coalescing, and state-update ops.

* **Chores**
  * Persisted runbook schema bumped to v3 to support artifact-vars and new update semantics.

* **Documentation**
  * Added mutation-testing notes summarizing mutation-run results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
