### PR TITLE
Phase 3 rendering and helpers

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -164,6 +164,7 @@ rustc
 sandboxing
 sarif
 selfref
+serialised
 serialises
 serializable
 shellquote

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -267,11 +267,26 @@ jest.unstable_mockModule('@rundown-org/core', () => {
       }
       return (value as { uri: string }).uri;
     }),
-    renderArtifactPathValue: jest.fn((value: unknown) => {
-      if (Array.isArray(value)) return JSON.stringify(value.map((r: { key: string }) => r.key));
-      return (value as { key: string }).key;
+    renderArtifactPathValue: jest.fn(
+      (value: unknown, options: { cwd: string; workPath: string }) => {
+        const buildPath = (record: { contextId: string; runId: string; key: string }) =>
+          `${options.cwd}/${options.workPath}/.rd-${record.contextId}/runs/${record.runId}/${record.key}`;
+        if (Array.isArray(value)) {
+          return JSON.stringify(
+            (value as ReadonlyArray<{ contextId: string; runId: string; key: string }>).map(
+              buildPath,
+            ),
+          );
+        }
+        return buildPath(value as { contextId: string; runId: string; key: string });
+      },
+    ),
+    renderArtifactRecordValue: jest.fn((value: unknown) => {
+      if (Array.isArray(value)) {
+        return JSON.stringify(value.map((r: { uri: string }) => r.uri));
+      }
+      return (value as { uri: string }).uri;
     }),
-    renderArtifactRecordValue: jest.fn((value: unknown) => JSON.stringify(value)),
     renderLiteralArtifactPath: jest.fn(
       (key: string, options: { cwd: string; workPath: string; contextId: string; runId: string }) =>
         `${options.cwd}/${options.workPath}/.rd-${options.contextId}/runs/${options.runId}/${key}`,

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -262,6 +262,15 @@ jest.unstable_mockModule('@rundown-org/core', () => {
       }
       return (value as { uri: string }).uri;
     }),
+    renderArtifactPathValue: jest.fn((value: unknown) => {
+      if (Array.isArray(value)) return JSON.stringify(value.map((r: { key: string }) => r.key));
+      return (value as { key: string }).key;
+    }),
+    renderArtifactRecordValue: jest.fn((value: unknown) => JSON.stringify(value)),
+    renderLiteralArtifactPath: jest.fn(
+      (key: string, options: { cwd: string; workPath: string; contextId: string; runId: string }) =>
+        `${options.cwd}/${options.workPath}/.rd-${options.contextId}/runs/${options.runId}/${key}`,
+    ),
     ...mockErrorHelpers,
     RUNS_DIR: '.rundown/runs',
     WORK_DIR: '.rundown/work',

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -256,6 +256,11 @@ jest.unstable_mockModule('@rundown-org/core', () => {
           : `${options.cwd}/${workPath}/.rd-${contextId}/runs/${runId}/${key}`;
       },
     ),
+    parseExactArtifactUriParts: jest.fn((uri: string) => {
+      const m = /^rd:\/\/artifacts\/([^/]+)\/runs\/([^/]+)\/(.+)$/.exec(uri);
+      if (!m) return null;
+      return { contextId: m[1], runId: m[2], key: m[3] };
+    }),
     renderArtifactValue: jest.fn((value: unknown) => {
       if (Array.isArray(value)) {
         return JSON.stringify(value.map((r: { uri: string }) => r.uri));

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -256,6 +256,12 @@ jest.unstable_mockModule('@rundown-org/core', () => {
           : `${options.cwd}/${workPath}/.rd-${contextId}/runs/${runId}/${key}`;
       },
     ),
+    renderArtifactValue: jest.fn((value: unknown) => {
+      if (Array.isArray(value)) {
+        return JSON.stringify(value.map((r: { uri: string }) => r.uri));
+      }
+      return (value as { uri: string }).uri;
+    }),
     ...mockErrorHelpers,
     RUNS_DIR: '.rundown/runs',
     WORK_DIR: '.rundown/work',

--- a/packages/cli/__tests__/services/template-renderer.artifacts.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.artifacts.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  appendArtifactManifestRecord,
+  manifestPathForContext,
+  type ArtifactRecord,
+} from '@rundown-org/core';
+import type { ResolvedRunbook } from '@rundown-org/parser';
+import {
+  expandLoopVariablesForCommand,
+  substituteRunbookVariables,
+  substituteText,
+} from '../../src/services/template-renderer.js';
+
+const RUN_ID = 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const CONTEXT_ID = 'ctx1';
+const WORK_PATH = '.rundown/work';
+const RUNBOOK = { source: 'project' as const, path: 'planning/write-plan.runbook.md' };
+
+const PLAN: ArtifactRecord = {
+  uri: `rd://artifacts/${CONTEXT_ID}/runs/${RUN_ID}/plan.json`,
+  runId: RUN_ID,
+  contextId: CONTEXT_ID,
+  runbook: RUNBOOK,
+  key: 'plan.json',
+  timestamp: '2026-05-07T00:00:00.000Z',
+};
+
+const REVIEW_A: ArtifactRecord = {
+  uri: `rd://artifacts/${CONTEXT_ID}/runs/${RUN_ID}/review-plan-a.json`,
+  runId: RUN_ID,
+  contextId: CONTEXT_ID,
+  runbook: RUNBOOK,
+  key: 'review-plan-a.json',
+  timestamp: '2026-05-07T00:00:00.000Z',
+};
+
+describe('template rendering does not mutate the artifact manifest', () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await fsp.mkdtemp(path.join(os.tmpdir(), 'render-purity-'));
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, PLAN);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, REVIEW_A);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(cwd, { recursive: true, force: true });
+  });
+
+  async function readManifestBytes(): Promise<string> {
+    const file = manifestPathForContext({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
+    return fsp.readFile(file, 'utf8');
+  }
+
+  /**
+   * Snapshot the recursive directory listing under `<cwd>/<workPath>` so the
+   * test catches non-manifest filesystem mutations (e.g. a stray `mkdirSync`
+   * or a file write that bypasses the manifest helper). Byte-equal manifest
+   * comparison kills "appended row" mutants but misses "created sibling
+   * directory" mutants — both are forbidden by spec §313.
+   */
+  async function snapshotWorkDir(): Promise<readonly string[]> {
+    const root = path.join(cwd, WORK_PATH);
+    const entries = await fsp.readdir(root, { recursive: true });
+    return [...entries].sort();
+  }
+
+  it('renders 100 prompt/command substitutions without changing the manifest or work directory', async () => {
+    const beforeManifest = await readManifestBytes();
+    const beforeDir = await snapshotWorkDir();
+
+    const variables = {
+      WorkPath: WORK_PATH,
+      ContextId: CONTEXT_ID,
+      RunId: RUN_ID,
+      PlanPath: PLAN,
+      Reviews: [REVIEW_A],
+    } as const;
+
+    for (let i = 0; i < 100; i++) {
+      substituteText(
+        'Plan {{ PlanPath }} at {{ path PlanPath }} record {{ artifact PlanPath }} reviews {{ Reviews }} paths {{ path Reviews }} records {{ artifact Reviews }} literal {{ path "plan.json" }}',
+        variables,
+        undefined,
+        { cwd },
+      );
+      expandLoopVariablesForCommand(
+        'echo {{ PlanPath }} {{ path PlanPath }} {{ Reviews }} {{ path "plan.json" }}',
+        variables,
+        { cwd },
+      );
+    }
+
+    expect(await readManifestBytes()).toBe(beforeManifest);
+    expect(await snapshotWorkDir()).toEqual(beforeDir);
+  });
+
+  it('renders empty wildcards across forms without changing the manifest or work directory', async () => {
+    const beforeManifest = await readManifestBytes();
+    const beforeDir = await snapshotWorkDir();
+
+    const variables = {
+      WorkPath: WORK_PATH,
+      ContextId: CONTEXT_ID,
+      RunId: RUN_ID,
+      Reviews: [],
+    } as const;
+
+    for (let i = 0; i < 50; i++) {
+      substituteText(
+        '{{ Reviews }} | {{ path Reviews }} | {{ artifact Reviews }}',
+        variables,
+        undefined,
+        { cwd },
+      );
+    }
+
+    expect(await readManifestBytes()).toBe(beforeManifest);
+    expect(await snapshotWorkDir()).toEqual(beforeDir);
+  });
+
+  it('substituteRunbookVariables preserves manifest and work-dir contents across whole-runbook renders', async () => {
+    const beforeManifest = await readManifestBytes();
+    const beforeDir = await snapshotWorkDir();
+    // ResolvedRunbook = Omit<Runbook, 'steps'> & { steps: ResolvedStep[] }.
+    // It does NOT carry `frontmatter` or `sourcePath` — those live on
+    // `ParseResult` and are stripped before resolution. Use only `Runbook`
+    // fields (`name`, `title`, `description`, `version`, `author`, `tags`)
+    // plus `steps`.
+    const runbook: ResolvedRunbook = {
+      name: 'render-purity-test',
+      title: '{{ PlanPath }}',
+      description: 'Render plan {{ path PlanPath }} reviews {{ Reviews }}',
+      steps: [],
+    };
+    const variables = {
+      WorkPath: WORK_PATH,
+      ContextId: CONTEXT_ID,
+      RunId: RUN_ID,
+      PlanPath: PLAN,
+      Reviews: [REVIEW_A],
+    } as const;
+
+    for (let i = 0; i < 25; i++) {
+      substituteRunbookVariables(runbook, variables, { cwd });
+    }
+
+    expect(await readManifestBytes()).toBe(beforeManifest);
+    expect(await snapshotWorkDir()).toEqual(beforeDir);
+  });
+
+  it('rendered command output is identical across repeated renders (byte-equal)', () => {
+    const variables = {
+      WorkPath: WORK_PATH,
+      ContextId: CONTEXT_ID,
+      RunId: RUN_ID,
+      PlanPath: PLAN,
+      Reviews: [REVIEW_A],
+    } as const;
+
+    const first = expandLoopVariablesForCommand(
+      'cat {{ path PlanPath }}; jq . {{ path Reviews }}; echo {{ artifact PlanPath }}',
+      variables,
+      { cwd },
+    );
+    const second = expandLoopVariablesForCommand(
+      'cat {{ path PlanPath }}; jq . {{ path Reviews }}; echo {{ artifact PlanPath }}',
+      variables,
+      { cwd },
+    );
+    expect(second).toBe(first);
+  });
+});

--- a/packages/cli/__tests__/services/template-renderer.artifacts.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.artifacts.test.ts
@@ -80,6 +80,17 @@ describe('template rendering does not mutate the artifact manifest', () => {
       Reviews: [REVIEW_A],
     } as const;
 
+    // Sample render once to assert rendering actually happened — kills mutants
+    // that return '' (or any stable string) for everything while still passing
+    // the manifest/dir purity snapshots below.
+    const sampleSubstitute = substituteText('Plan {{ PlanPath }}', variables, undefined, { cwd });
+    expect(sampleSubstitute).toBe(`Plan ${PLAN.uri}`);
+    const sampleCommand = expandLoopVariablesForCommand('cat {{ path PlanPath }}', variables, {
+      cwd,
+    });
+    expect(sampleCommand).toContain(`.rd-${CONTEXT_ID}`);
+    expect(sampleCommand.endsWith('plan.json')).toBe(true);
+
     for (let i = 0; i < 100; i++) {
       substituteText(
         'Plan {{ PlanPath }} at {{ path PlanPath }} record {{ artifact PlanPath }} reviews {{ Reviews }} paths {{ path Reviews }} records {{ artifact Reviews }} literal {{ path "plan.json" }}',
@@ -108,6 +119,15 @@ describe('template rendering does not mutate the artifact manifest', () => {
       RunId: RUN_ID,
       Reviews: [],
     } as const;
+
+    // Sample once to assert each helper form renders an empty array as '[]'.
+    const sampleEmpty = substituteText(
+      '{{ Reviews }} | {{ path Reviews }} | {{ artifact Reviews }}',
+      variables,
+      undefined,
+      { cwd },
+    );
+    expect(sampleEmpty).toBe('[] | [] | []');
 
     for (let i = 0; i < 50; i++) {
       substituteText(

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -2289,3 +2289,77 @@ describe('substituteText call-time helper validation', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+import type { ArtifactRecord, RenderArtifactOptions } from '@rundown-org/core';
+
+const ARTIFACT_RUN_ID = 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const ARTIFACT_CONTEXT = 'ctx1';
+const ARTIFACT_RUNBOOK = { source: 'project' as const, path: 'planning/write-plan.runbook.md' };
+
+const PLAN: ArtifactRecord = {
+  uri: `rd://artifacts/${ARTIFACT_CONTEXT}/runs/${ARTIFACT_RUN_ID}/plan.json`,
+  runId: ARTIFACT_RUN_ID,
+  contextId: ARTIFACT_CONTEXT,
+  runbook: ARTIFACT_RUNBOOK,
+  key: 'plan.json',
+  timestamp: '2026-05-07T00:00:00.000Z',
+};
+
+const REVIEW_A: ArtifactRecord = {
+  uri: `rd://artifacts/${ARTIFACT_CONTEXT}/runs/${ARTIFACT_RUN_ID}/review-plan-a.json`,
+  runId: ARTIFACT_RUN_ID,
+  contextId: ARTIFACT_CONTEXT,
+  runbook: ARTIFACT_RUNBOOK,
+  key: 'review-plan-a.json',
+  timestamp: '2026-05-07T00:00:00.000Z',
+};
+
+const ARTIFACT_HELPER_OPTIONS: RenderArtifactOptions = {
+  cwd: '/tmp/project',
+  workPath: '.rundown/work',
+  contextId: ARTIFACT_CONTEXT,
+  runId: ARTIFACT_RUN_ID,
+};
+
+describe('substituteText with ArtifactRecord values', () => {
+  it('renders {{ PlanPath }} as the artifact URI when value is an ArtifactRecord', () => {
+    const out = substituteText(
+      'Plan at {{ PlanPath }}',
+      { PlanPath: PLAN },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out).toBe(`Plan at ${PLAN.uri}`);
+  });
+
+  it('renders {{ Reviews }} as a JSON array of URIs when value is ArtifactRecord[]', () => {
+    const out = substituteText(
+      'Reviews: {{ Reviews }}',
+      { Reviews: [REVIEW_A] },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out).toBe(`Reviews: ${JSON.stringify([REVIEW_A.uri])}`);
+  });
+
+  it('renders {{ Reviews }} as "[]" when value is empty ArtifactRecord[]', () => {
+    const out = substituteText(
+      'Reviews: {{ Reviews }}',
+      { Reviews: [] },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out).toBe('Reviews: []');
+  });
+
+  it('does not flatten an ArtifactRecord through JSON.stringify', () => {
+    const out = substituteText(
+      '{{ PlanPath }}',
+      { PlanPath: PLAN },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out.startsWith('rd://')).toBe(true);
+    expect(out.startsWith('{')).toBe(false);
+  });
+});

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -2475,3 +2475,72 @@ describe('empty wildcard renders consistently across all helper forms', () => {
     expect(out).toBe(`echo '[]' && echo '[]'`);
   });
 });
+
+describe('substituteText preserves placeholder when helperOptions is undefined', () => {
+  it('preserves {{ PlanPath }} for an ArtifactRecord with no helperOptions', () => {
+    expect(substituteText('Plan: {{ PlanPath }}', { PlanPath: PLAN })).toBe('Plan: {{ PlanPath }}');
+  });
+
+  it('preserves {{ artifact PlanPath }} with no helperOptions', () => {
+    expect(substituteText('{{ artifact PlanPath }}', { PlanPath: PLAN })).toBe(
+      '{{ artifact PlanPath }}',
+    );
+  });
+});
+
+describe('artifact helpers reject missing frame fields', () => {
+  it('throws when WorkPath is missing for {{ path Var }}', () => {
+    expect(() =>
+      substituteText('{{ path PlanPath }}', { PlanPath: PLAN }, undefined, ARTIFACT_HELPER_OPTIONS),
+    ).toThrow(/WorkPath/);
+  });
+
+  it('throws when ContextId is missing for literal {{ path "key" }}', () => {
+    expect(() =>
+      substituteText(
+        '{{ path "plan.json" }}',
+        { WorkPath: '.rundown/work', RunId: ARTIFACT_RUN_ID },
+        undefined,
+        ARTIFACT_HELPER_OPTIONS,
+      ),
+    ).toThrow(/ContextId/);
+  });
+
+  it('throws when RunId is missing for literal {{ path "key" }}', () => {
+    expect(() =>
+      substituteText(
+        '{{ path "plan.json" }}',
+        { WorkPath: '.rundown/work', ContextId: ARTIFACT_CONTEXT },
+        undefined,
+        ARTIFACT_HELPER_OPTIONS,
+      ),
+    ).toThrow(/RunId/);
+  });
+});
+
+describe('isArtifactRecordArray rejects mixed-element arrays', () => {
+  it('treats a [ArtifactRecord, non-record] array via {{ path Var }} as a non-artifact value', () => {
+    // The structural guard requires every element to be an ArtifactRecord; a
+    // mixed array falls through to the non-artifact error branch.
+    expect(() =>
+      substituteText(
+        '{{ path Reviews }}',
+        { Reviews: [PLAN, 'string'], WorkPath: '.rundown/work' },
+        undefined,
+        ARTIFACT_HELPER_OPTIONS,
+      ),
+    ).toThrow(/ArtifactRecord/);
+  });
+});
+
+describe('substituteRunbookVariables with ArtifactRecord direct-alias', () => {
+  it('renders an ArtifactRecord direct-alias as URI in the title', () => {
+    const runbook = parseResolvedRunbook('# {{ PlanPath }}\n\n## 1. Step\n\nGo.\n');
+    const result = substituteRunbookVariables(
+      runbook,
+      { PlanPath: PLAN, WorkPath: '.rundown/work' },
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(result.title).toBe(PLAN.uri);
+  });
+});

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -2453,3 +2453,25 @@ describe('substituteText with artifact helper', () => {
     ).toThrow(/ArtifactRecord/);
   });
 });
+
+describe('empty wildcard renders consistently across all helper forms', () => {
+  it('renders direct alias, path, and artifact helpers as "[]"', () => {
+    const out = substituteText(
+      'A:{{ Reviews }} B:{{ path Reviews }} C:{{ artifact Reviews }}',
+      { Reviews: [], WorkPath: '.rundown/work' },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out).toBe('A:[] B:[] C:[]');
+  });
+
+  it('renders empty wildcards in command code with shell escaping', () => {
+    const out = expandLoopVariablesForCommand(
+      'echo {{ Reviews }} && echo {{ path Reviews }}',
+      { Reviews: [], WorkPath: '.rundown/work' },
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    // shellEscapeValue wraps `[]` because brackets are not in SAFE_SHELL_VALUE
+    expect(out).toBe(`echo '[]' && echo '[]'`);
+  });
+});

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -249,7 +249,7 @@ describe('substituteRunbookVariables', () => {
     expect(step.command.code).toBe('git checkout {{BRANCH}}');
   });
 
-  it('renders path helper in command text and records a manifest row', async () => {
+  it('renders literal path helper in command text without mutating the manifest', async () => {
     const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-'));
     try {
       const runbook = parseResolvedRunbook(
@@ -274,23 +274,15 @@ describe('substituteRunbookVariables', () => {
       );
       expect(step.command.code).toBe(`printf '{}' > '${expectedPath}'`);
 
+      // Phase 3: template helpers are pure render-only projections (spec §313).
       const records = await readArtifactManifest({ cwd, workPath: variables.WorkPath }, 'ctx1');
-      expect(records).toEqual([
-        expect.objectContaining({
-          uri: 'rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
-          runId: variables.RunId,
-          contextId: variables.ContextId,
-          runbook: variables.RunbookRef,
-          key: 'review.json',
-          timestamp: expect.any(String),
-        }),
-      ]);
+      expect(records).toEqual([]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('renders path helper in prompt text and records a manifest row', async () => {
+  it('renders literal path helper in prompt text without mutating the manifest', async () => {
     const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-'));
     try {
       const runbook = parseResolvedRunbook(
@@ -314,22 +306,13 @@ describe('substituteRunbookVariables', () => {
       expect(result.steps[0].prompt).toContain(expectedPath);
 
       const records = await readArtifactManifest({ cwd, workPath: variables.WorkPath }, 'ctx1');
-      expect(records).toEqual([
-        expect.objectContaining({
-          uri: 'rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
-          runId: variables.RunId,
-          contextId: variables.ContextId,
-          runbook: variables.RunbookRef,
-          key: 'review.json',
-          timestamp: expect.any(String),
-        }),
-      ]);
+      expect(records).toEqual([]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('renders artifact helper to an exact URI and records a manifest row', async () => {
+  it('rejects literal {{ artifact "key" }} form in prompt text (spec §327)', async () => {
     const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-'));
     try {
       const runbook = parseResolvedRunbook(
@@ -345,22 +328,10 @@ describe('substituteRunbookVariables', () => {
         },
       };
 
-      const result = substituteRunbookVariables(runbook, variables, { cwd });
-      expect(result.steps[0].prompt).toContain(
-        'rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
-      );
+      expect(() => substituteRunbookVariables(runbook, variables, { cwd })).toThrow(/literal key/);
 
       const records = await readArtifactManifest({ cwd, workPath: variables.WorkPath }, 'ctx1');
-      expect(records).toEqual([
-        expect.objectContaining({
-          uri: 'rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json',
-          runId: variables.RunId,
-          contextId: variables.ContextId,
-          runbook: variables.RunbookRef,
-          key: 'review.json',
-          timestamp: expect.any(String),
-        }),
-      ]);
+      expect(records).toEqual([]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -383,7 +354,7 @@ describe('substituteRunbookVariables', () => {
     const cwd = await mkdtemp(path.join(tmpdir(), 'rd-template-'));
     try {
       const runbook = parseResolvedRunbook(
-        '# Test\n\n## 1. Confirm\n\n> Review {{ artifact "../escape" }}\n',
+        '# Test\n\n## 1. Confirm\n\n> Review {{ path "../escape" }}\n',
       );
       expect(() =>
         substituteRunbookVariables(
@@ -2361,5 +2332,124 @@ describe('substituteText with ArtifactRecord values', () => {
     );
     expect(out.startsWith('rd://')).toBe(true);
     expect(out.startsWith('{')).toBe(false);
+  });
+});
+
+describe('substituteText with path helper', () => {
+  it('renders {{ path PlanPath }} as the local path for an ArtifactRecord', () => {
+    const out = substituteText(
+      'Plan: {{ path PlanPath }}',
+      { PlanPath: PLAN, WorkPath: '.rundown/work' },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out).toContain(`.rd-${ARTIFACT_CONTEXT}`);
+    expect(out).toContain(ARTIFACT_RUN_ID);
+    expect(out.endsWith('plan.json')).toBe(true);
+  });
+
+  it('renders {{ path Reviews }} as a JSON array of local paths', () => {
+    const out = substituteText(
+      'Reviews: {{ path Reviews }}',
+      { Reviews: [REVIEW_A], WorkPath: '.rundown/work' },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    const prefix = 'Reviews: ';
+    expect(out.startsWith(prefix)).toBe(true);
+    const parsed = JSON.parse(out.slice(prefix.length)) as string[];
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].endsWith('review-plan-a.json')).toBe(true);
+  });
+
+  it('renders {{ path Reviews }} as "[]" for an empty ArtifactRecord[]', () => {
+    const out = substituteText(
+      'Reviews: {{ path Reviews }}',
+      { Reviews: [], WorkPath: '.rundown/work' },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out).toBe('Reviews: []');
+  });
+
+  it('renders literal {{ path "plan.json" }} as the current-run local path', () => {
+    const out = substituteText(
+      'Plan: {{ path "plan.json" }}',
+      {
+        WorkPath: '.rundown/work',
+        ContextId: ARTIFACT_CONTEXT,
+        RunId: ARTIFACT_RUN_ID,
+      },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out).toContain(`.rd-${ARTIFACT_CONTEXT}`);
+    expect(out).toContain(ARTIFACT_RUN_ID);
+    expect(out.endsWith('plan.json')).toBe(true);
+  });
+});
+
+describe('substituteText with artifact helper', () => {
+  it('renders {{ artifact PlanPath }} as full record JSON', () => {
+    const out = substituteText(
+      '{{ artifact PlanPath }}',
+      { PlanPath: PLAN, WorkPath: '.rundown/work' },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(JSON.parse(out)).toEqual(PLAN);
+  });
+
+  it('renders {{ artifact Reviews }} as a JSON array of records', () => {
+    const out = substituteText(
+      '{{ artifact Reviews }}',
+      { Reviews: [REVIEW_A], WorkPath: '.rundown/work' },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(JSON.parse(out)).toEqual([REVIEW_A]);
+  });
+
+  it('renders {{ artifact Reviews }} as "[]" for an empty ArtifactRecord[]', () => {
+    const out = substituteText(
+      '{{ artifact Reviews }}',
+      { Reviews: [], WorkPath: '.rundown/work' },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out).toBe('[]');
+  });
+
+  it('rejects literal {{ artifact "plan.json" }} as a hard error', () => {
+    expect(() =>
+      substituteText(
+        '{{ artifact "plan.json" }}',
+        { WorkPath: '.rundown/work' },
+        undefined,
+        ARTIFACT_HELPER_OPTIONS,
+      ),
+    ).toThrow(/literal key/);
+  });
+
+  it('throws when {{ path Var }} variable is not an ArtifactRecord/ArtifactRecord[]', () => {
+    expect(() =>
+      substituteText(
+        '{{ path PlanPath }}',
+        { PlanPath: 'not-a-record', WorkPath: '.rundown/work' },
+        undefined,
+        ARTIFACT_HELPER_OPTIONS,
+      ),
+    ).toThrow(/ArtifactRecord/);
+  });
+
+  it('throws when {{ artifact Var }} variable is not an ArtifactRecord/ArtifactRecord[]', () => {
+    expect(() =>
+      substituteText(
+        '{{ artifact PlanPath }}',
+        { PlanPath: 42, WorkPath: '.rundown/work' },
+        undefined,
+        ARTIFACT_HELPER_OPTIONS,
+      ),
+    ).toThrow(/ArtifactRecord/);
   });
 });

--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -2390,24 +2390,28 @@ describe('substituteText with path helper', () => {
 });
 
 describe('substituteText with artifact helper', () => {
-  it('renders {{ artifact PlanPath }} as full record JSON', () => {
+  // Spec §9.3: `{{ artifact Var }}` renders artifact URI values with the same
+  // shape as the direct alias `{{ Var }}` — scalar URI for an ArtifactRecord,
+  // JSON array of URIs for ArtifactRecord[].
+
+  it('renders {{ artifact PlanPath }} as the artifact URI', () => {
     const out = substituteText(
       '{{ artifact PlanPath }}',
       { PlanPath: PLAN, WorkPath: '.rundown/work' },
       undefined,
       ARTIFACT_HELPER_OPTIONS,
     );
-    expect(JSON.parse(out)).toEqual(PLAN);
+    expect(out).toBe(PLAN.uri);
   });
 
-  it('renders {{ artifact Reviews }} as a JSON array of records', () => {
+  it('renders {{ artifact Reviews }} as a JSON array of URIs', () => {
     const out = substituteText(
       '{{ artifact Reviews }}',
       { Reviews: [REVIEW_A], WorkPath: '.rundown/work' },
       undefined,
       ARTIFACT_HELPER_OPTIONS,
     );
-    expect(JSON.parse(out)).toEqual([REVIEW_A]);
+    expect(out).toBe(JSON.stringify([REVIEW_A.uri]));
   });
 
   it('renders {{ artifact Reviews }} as "[]" for an empty ArtifactRecord[]', () => {

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -39,6 +39,7 @@ import {
 import {
   invokeHelperSafely,
   isJsonArrayStream,
+  parseExactArtifactUriParts,
   renderArtifactPathValue,
   renderArtifactRecordValue,
   renderArtifactValue,
@@ -184,6 +185,13 @@ function isArtifactRecord(value: unknown): value is ArtifactRecord {
   const record = value as Partial<ArtifactRecord>;
   return (
     typeof record.uri === 'string' &&
+    // Defensive: refuse records whose URI is not a well-formed exact artifact
+    // URI. Records reaching the renderer via `artifactVars` are Zod-validated
+    // upstream by the resolver, but variable values from frontmatter `inputs:`
+    // and CLI `--input-json` are not. A malformed URI would later throw deep
+    // inside `artifactUriToPath`; rejecting at the guard surface keeps the
+    // contract at the structural-detection layer.
+    parseExactArtifactUriParts(record.uri) !== null &&
     typeof record.runId === 'string' &&
     typeof record.contextId === 'string' &&
     typeof record.key === 'string' &&
@@ -221,17 +229,17 @@ function isArtifactRecordArray(value: unknown): value is readonly ArtifactRecord
 }
 
 /**
- * Sentinel string returned by `renderTemplateValue` when an artifact value is
+ * Sentinel value returned by `renderTemplateValue` when an artifact value is
  * encountered without a `helperOptions` frame. Pass 4 detects this and leaves
  * the original `{{ Var }}` placeholder in place, mirroring the helper-call
  * convention.
  *
- * The leading and trailing spaces and `__rundown_` prefix make collision with
- * legitimate rendered output essentially impossible — the Pass 4 detection is
- * a `===` comparison, so any user content that happened to contain this token
- * as a substring would not trigger the placeholder fallback.
+ * Implemented as a unique `Symbol` so identity comparison is collision-proof
+ * — no user variable string value can equal it, eliminating the silent-drop
+ * risk a string sentinel would carry (CLAUDE.md "No silent mapping").
  */
-const ARTIFACT_PLACEHOLDER_SENTINEL = ' __rundown_artifact_no_options__ ';
+const ARTIFACT_PLACEHOLDER_SENTINEL: unique symbol = Symbol('rundown_artifact_no_options');
+type ArtifactPlaceholderSentinel = typeof ARTIFACT_PLACEHOLDER_SENTINEL;
 
 /**
  * Render a template value for interpolation.
@@ -254,7 +262,7 @@ function renderTemplateValue(
   value: unknown,
   variables: Readonly<Record<string, unknown>>,
   helperOptions?: TemplateHelperOptions,
-): string {
+): string | ArtifactPlaceholderSentinel {
   if (typeof value === 'string') {
     return value;
   }
@@ -321,8 +329,17 @@ function resolveTemplatePath(
   variables: Record<string, unknown>,
   helperOptions?: TemplateHelperOptions,
 ): string | undefined {
+  // Translate the sentinel into `undefined` so Pass 1 and Pass 3 can use
+  // their existing "value is undefined" branch to preserve the placeholder.
+  // Pass 4 calls `renderTemplateValue` directly via `resolveTemplatePathRaw`
+  // and handles the sentinel with an explicit Symbol comparison.
+  const renderOrSentinel = (raw: unknown): string | undefined => {
+    const rendered = renderTemplateValue(raw, variables, helperOptions);
+    return rendered === ARTIFACT_PLACEHOLDER_SENTINEL ? undefined : rendered;
+  };
+
   if (Object.hasOwn(variables, path) && variables[path] !== undefined) {
-    return renderTemplateValue(variables[path], variables, helperOptions);
+    return renderOrSentinel(variables[path]);
   }
 
   if (!path.includes('.')) {
@@ -342,7 +359,7 @@ function resolveTemplatePath(
     const remainder = segments.slice(i).join('.');
     const resolved = resolveDottedPath(variables[prefix], remainder);
     if (resolved !== undefined) {
-      return renderTemplateValue(resolved, variables, helperOptions);
+      return renderOrSentinel(resolved);
     }
   }
 
@@ -1075,7 +1092,7 @@ export function substituteText(
   // Pass 1: {{ ./VarName }} explicit variable lookup, bypasses helper registry
   let result = text.replace(EXPLICIT_VAR_TEMPLATE_REGEX, (match, varPath: string) => {
     const value = resolveTemplatePath(varPath, variables, helperOptions);
-    if (value === undefined || value === ARTIFACT_PLACEHOLDER_SENTINEL) return match;
+    if (value === undefined) return match;
     return escapeFn ? escapeFn(value) : value;
   });
 
@@ -1110,12 +1127,11 @@ export function substituteText(
       let argValue: string;
       if (varRef !== undefined) {
         const resolved = resolveTemplatePath(varRef, variables, helperOptions);
-        // Preserve the original placeholder when the variable arg is unresolved
-        // or is an unrenderable artifact value (no helper options available).
-        // Mirrors Pass 3 below and the `./VarName` branch in Pass 1: silently
-        // substituting `''` would corrupt downstream output (see "No silent
-        // mapping" principle in CLAUDE.md).
-        if (resolved === undefined || resolved === ARTIFACT_PLACEHOLDER_SENTINEL) return match;
+        // Preserve the original placeholder when the variable arg is unresolved.
+        // `resolveTemplatePath` already maps the artifact-no-options sentinel to
+        // `undefined`, so this single branch covers both. Silently substituting
+        // `''` would corrupt downstream output (CLAUDE.md "No silent mapping").
+        if (resolved === undefined) return match;
         argValue = resolved;
       } else {
         argValue = literal ?? '';

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -111,7 +111,7 @@ const HELPER_CALL_TEMPLATE_REGEX =
  *  - `{{ path VarRef }}`          (group 2; dotted paths permitted)
  */
 const PATH_HELPER_TEMPLATE_REGEX =
-  /\{\{\s*path\s+(?:"([^"]+)"|([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*))\s*\}\}/g;
+  /\{\{\s*path\s+(?:"([^"]*)"|([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*))\s*\}\}/g;
 
 /**
  * Matches the built-in `artifact` helper in variable-reference form only:
@@ -128,7 +128,7 @@ const ARTIFACT_HELPER_TEMPLATE_REGEX =
  * Matches the explicitly-rejected literal `artifact` helper form, so we can
  * raise a hard error rather than fall through to the generic helper dispatch.
  */
-const LITERAL_ARTIFACT_HELPER_REGEX = /\{\{\s*artifact\s+"([^"]+)"\s*\}\}/g;
+const LITERAL_ARTIFACT_HELPER_REGEX = /\{\{\s*artifact\s+"([^"]*)"\s*\}\}/g;
 
 type TemplateHelperOptions = EvaluateOutputOptions;
 
@@ -1039,9 +1039,13 @@ function resolveArtifactHelperCall(
     );
   }
   const artifactValue = value as ArtifactVarValue;
+  // `renderArtifactRecordValue` projects URIs (spec §9.3) and never reads
+  // `workPath` — match the lazy read in `renderTemplateValue` so the helper
+  // does not require `WorkPath` in the variable frame.
+  const workPath = typeof variables.WorkPath === 'string' ? variables.WorkPath : '';
   return renderArtifactRecordValue(artifactValue, {
     cwd: helperOptions.cwd,
-    workPath: requireWorkPath(variables),
+    workPath,
     /** Empty-array projection ignores contextId/runId — see notes above. */
     contextId: isArtifactRecord(artifactValue) ? artifactValue.contextId : '',
     runId: isArtifactRecord(artifactValue) ? artifactValue.runId : '',

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -37,10 +37,12 @@ import {
   RunbookSyntaxError,
 } from '@rundown-org/parser';
 import {
-  applyRunArtifactHelper,
   invokeHelperSafely,
   isJsonArrayStream,
+  renderArtifactPathValue,
+  renderArtifactRecordValue,
   renderArtifactValue,
+  renderLiteralArtifactPath,
   type ArtifactRecord,
   type ArtifactVarValue,
   type EvaluateOutputOptions,
@@ -103,12 +105,29 @@ const HELPER_CALL_TEMPLATE_REGEX =
   /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s+(?:([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)|"([^"]*)")\s*\}\}/g;
 
 /**
- * Matches the built-in artifact path helper in inline template text.
+ * Matches the built-in `path` helper in either form:
+ *  - `{{ path "literal-key" }}`  (group 1)
+ *  - `{{ path VarRef }}`          (group 2; dotted paths permitted)
  */
-const PATH_HELPER_TEMPLATE_REGEX = /\{\{\s*path\s+"([^"]+)"\s*\}\}/g;
+const PATH_HELPER_TEMPLATE_REGEX =
+  /\{\{\s*path\s+(?:"([^"]+)"|([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*))\s*\}\}/g;
 
-/** Matches the built-in artifact URI helper in inline template text. */
-const ARTIFACT_HELPER_TEMPLATE_REGEX = /\{\{\s*artifact\s+"([^"]+)"\s*\}\}/g;
+/**
+ * Matches the built-in `artifact` helper in variable-reference form only:
+ *  - `{{ artifact VarRef }}`      (group 1)
+ *
+ * The literal-key form `{{ artifact "key" }}` is intentionally NOT matched
+ * here. It is rejected separately so the runtime never silently produces a
+ * record-shaped projection from a literal key (spec §327).
+ */
+const ARTIFACT_HELPER_TEMPLATE_REGEX =
+  /\{\{\s*artifact\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)\s*\}\}/g;
+
+/**
+ * Matches the explicitly-rejected literal `artifact` helper form, so we can
+ * raise a hard error rather than fall through to the generic helper dispatch.
+ */
+const LITERAL_ARTIFACT_HELPER_REGEX = /\{\{\s*artifact\s+"([^"]+)"\s*\}\}/g;
 
 type TemplateHelperOptions = EvaluateOutputOptions;
 
@@ -874,36 +893,141 @@ function resolveHelperCall(helperName: string, argValue: string, original: strin
 }
 
 /**
- * Resolve a built-in artifact-producing helper against a template variable frame.
+ * Pull `WorkPath` out of the variable frame, throwing when missing.
  *
- * The helper is intentionally handled here, not in the user helper registry,
- * so prompt text, command text, descriptions, and OUTPUTS all share the same
- * reserved built-in semantics.
+ * Direct-alias rendering of `ArtifactRecord[]` (and the `path` helper) needs
+ * the work path to assemble local paths. The projector accepts the same
+ * options shape for API symmetry across the four projector functions.
  *
- * Fail-closed: when `helperOptions` is provided, errors from
- * `applyRunArtifactHelper` (missing required frame variables, invalid artifact
- * key, manifest write failure) propagate to the caller. Returning the original
- * placeholder text is reserved for the case where helper resolution is
- * intentionally disabled (`helperOptions === undefined`, e.g. AST walks at
- * startup before runtime variables are available).
- *
- * @param kind - Helper kind to resolve
- * @param key - Artifact key from the helper call
- * @param variables - Template variables available at the render site
- * @param helperOptions - Filesystem options for path resolution and manifest writes
- * @param original - Original helper call text to preserve when resolution is disabled
- * @returns Artifact URI/local path, or `original` when `helperOptions` is undefined
- * @throws {Error} When `helperOptions` is provided and helper resolution fails
+ * @param variables - Render-frame variables
+ * @returns The `WorkPath` string
+ * @throws {Error} when `WorkPath` is missing or non-string
  */
-function resolveRunArtifactHelperCall(
-  kind: 'artifact' | 'path',
-  key: string,
-  variables: Record<string, unknown>,
+function requireWorkPath(variables: Readonly<Record<string, unknown>>): string {
+  const wp = variables.WorkPath;
+  if (typeof wp !== 'string') {
+    throw new Error('Artifact rendering requires WorkPath in the render frame');
+  }
+  return wp;
+}
+
+/**
+ * Pull a required string field out of the render frame.
+ *
+ * @param name - Variable name
+ * @param variables - Render-frame variables
+ * @returns The value as a string
+ * @throws {Error} when the value is missing or not a string
+ */
+function requireFrameString(name: string, variables: Readonly<Record<string, unknown>>): string {
+  const value = variables[name];
+  if (typeof value !== 'string') {
+    throw new Error(`Artifact rendering requires string ${name} in the render frame`);
+  }
+  return value;
+}
+
+/**
+ * Render the `path` helper for either a literal key or a variable reference.
+ *
+ * Cardinality rules (spec §317):
+ * - literal key -> single local path string
+ * - `ArtifactRecord` -> single local path string
+ * - `ArtifactRecord[]` -> JSON array of local paths (`[]` when empty)
+ *
+ * Pure: no manifest writes, no `mkdir`, no file truncation.
+ *
+ * @param literalKey - Quoted literal key from `{{ path "key" }}`, or undefined
+ * @param varRef - Variable reference from `{{ path Var }}`, or undefined
+ * @param variables - Render-frame variables (for variable-reference resolution and `WorkPath`)
+ * @param helperOptions - Filesystem options (`cwd`); render-only
+ * @param original - Original match text returned when `helperOptions` is unavailable (AST-walk path)
+ * @returns Rendered string
+ * @throws {Error} When the variable reference resolves to a non-artifact value, or when `WorkPath` is missing
+ */
+function resolvePathHelperCall(
+  literalKey: string | undefined,
+  varRef: string | undefined,
+  variables: Readonly<Record<string, unknown>>,
   helperOptions: TemplateHelperOptions | undefined,
   original: string,
 ): string {
   if (helperOptions === undefined) return original;
-  return applyRunArtifactHelper(kind, key, variables, helperOptions);
+  const workPath = requireWorkPath(variables);
+
+  if (literalKey !== undefined) {
+    return renderLiteralArtifactPath(literalKey, {
+      cwd: helperOptions.cwd,
+      workPath,
+      contextId: requireFrameString('ContextId', variables),
+      runId: requireFrameString('RunId', variables),
+    });
+  }
+  if (varRef === undefined) return original;
+
+  const value = resolveTemplatePathRaw(varRef, variables);
+  if (value === undefined) return original;
+  // Accept empty arrays explicitly here (the structural `isArtifactRecordArray`
+  // guard rejects them to avoid false positives in Pass 4 — see its TSDoc).
+  // In a helper call site the user has explicitly opted into artifact
+  // semantics by writing `{{ path Var }}`, so an empty array is treated as a
+  // wildcard with zero matches and renders as `[]`.
+  const isEmptyArray = Array.isArray(value) && value.length === 0;
+  if (!isArtifactRecord(value) && !isArtifactRecordArray(value) && !isEmptyArray) {
+    throw new Error(
+      `path helper expects an ArtifactRecord or ArtifactRecord[] for "${varRef}", got ${typeof value}`,
+    );
+  }
+  const artifactValue = value as ArtifactVarValue;
+  return renderArtifactPathValue(artifactValue, {
+    cwd: helperOptions.cwd,
+    workPath,
+    /**
+     * Empty arrays carry no identity; the projector ignores `contextId`/`runId`
+     * for the array case (and the empty-array short-circuit returns `'[]'`
+     * before any URI/path assembly). Accepting `''` here is load-bearing —
+     * see `RenderArtifactOptions` documentation in `renderer/artifact-helper.ts`.
+     */
+    contextId: isArtifactRecord(artifactValue) ? artifactValue.contextId : '',
+    runId: isArtifactRecord(artifactValue) ? artifactValue.runId : '',
+  });
+}
+
+/**
+ * Render the `artifact` helper for a variable reference only.
+ *
+ * Literal-key form is rejected separately (`LITERAL_ARTIFACT_HELPER_REGEX`).
+ *
+ * @param varRef - Variable reference from `{{ artifact Var }}`
+ * @param variables - Render-frame variables
+ * @param helperOptions - Filesystem options; required to render
+ * @param original - Original match text returned when `helperOptions` is unavailable
+ * @returns Full record JSON (or array of records)
+ * @throws {Error} When the variable reference resolves to a non-artifact value
+ */
+function resolveArtifactHelperCall(
+  varRef: string,
+  variables: Readonly<Record<string, unknown>>,
+  helperOptions: TemplateHelperOptions | undefined,
+  original: string,
+): string {
+  if (helperOptions === undefined) return original;
+  const value = resolveTemplatePathRaw(varRef, variables);
+  if (value === undefined) return original;
+  const isEmptyArray = Array.isArray(value) && value.length === 0;
+  if (!isArtifactRecord(value) && !isArtifactRecordArray(value) && !isEmptyArray) {
+    throw new Error(
+      `artifact helper expects an ArtifactRecord or ArtifactRecord[] for "${varRef}", got ${typeof value}`,
+    );
+  }
+  const artifactValue = value as ArtifactVarValue;
+  return renderArtifactRecordValue(artifactValue, {
+    cwd: helperOptions.cwd,
+    workPath: requireWorkPath(variables),
+    /** Empty-array projection ignores contextId/runId — see notes above. */
+    contextId: isArtifactRecord(artifactValue) ? artifactValue.contextId : '',
+    runId: isArtifactRecord(artifactValue) ? artifactValue.runId : '',
+  });
 }
 
 /**
@@ -954,18 +1078,29 @@ export function substituteText(
     return escapeFn ? escapeFn(value) : value;
   });
 
-  // Pass 2: built-in artifact-producing helpers.
-  result = result.replace(ARTIFACT_HELPER_TEMPLATE_REGEX, (match, key: string) => {
-    const raw = resolveRunArtifactHelperCall('artifact', key, variables, helperOptions, match);
+  // Pass 2: built-in artifact-producing helpers — pure render-only projection.
+  // The literal `artifact` form is rejected before any other dispatch so a
+  // misuse fails fast, even if the input also contains valid helper calls.
+  result = result.replace(LITERAL_ARTIFACT_HELPER_REGEX, (match, _key: string) => {
+    throw new Error(
+      `artifact helper does not accept a literal key (${match}); declare it via ARTIFACTS and pass the alias.`,
+    );
+  });
+
+  result = result.replace(ARTIFACT_HELPER_TEMPLATE_REGEX, (match, varRef: string) => {
+    const raw = resolveArtifactHelperCall(varRef, variables, helperOptions, match);
     if (raw === match) return match;
     return escapeFn ? escapeFn(raw) : raw;
   });
 
-  result = result.replace(PATH_HELPER_TEMPLATE_REGEX, (match, key: string) => {
-    const raw = resolveRunArtifactHelperCall('path', key, variables, helperOptions, match);
-    if (raw === match) return match;
-    return escapeFn ? escapeFn(raw) : raw;
-  });
+  result = result.replace(
+    PATH_HELPER_TEMPLATE_REGEX,
+    (match, literalKey: string | undefined, varRef: string | undefined) => {
+      const raw = resolvePathHelperCall(literalKey, varRef, variables, helperOptions, match);
+      if (raw === match) return match;
+      return escapeFn ? escapeFn(raw) : raw;
+    },
+  );
 
   // Pass 3: {{ helperName varRef }} or {{ helperName "literal" }}
   result = result.replace(

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -40,7 +40,11 @@ import {
   applyRunArtifactHelper,
   invokeHelperSafely,
   isJsonArrayStream,
+  renderArtifactValue,
+  type ArtifactRecord,
+  type ArtifactVarValue,
   type EvaluateOutputOptions,
+  type RenderArtifactOptions,
   type TemplateVarValue,
 } from '@rundown-org/core';
 import type { StepVariables } from './execution-vars.js';
@@ -143,20 +147,130 @@ function resolveDottedPath(obj: unknown, path: string): unknown {
 }
 
 /**
+ * Detect an `ArtifactRecord` value structurally.
+ *
+ * The render frame may carry both `TemplateVarValue` and `ArtifactVarValue`
+ * (Phase 2 widened the merge), so the renderer must distinguish records from
+ * generic JSON objects without relying on a Symbol brand. A record always
+ * has all of: string `uri`, string `runId`, string `contextId`, string `key`,
+ * string `timestamp`, and a `runbook` object with string `source` and `path`.
+ *
+ * Defensive: callers may pass arbitrary `unknown` values from the variable map.
+ *
+ * @param value - Value to test
+ * @returns `true` when the value matches the `ArtifactRecord` structural shape
+ */
+function isArtifactRecord(value: unknown): value is ArtifactRecord {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Partial<ArtifactRecord>;
+  return (
+    typeof record.uri === 'string' &&
+    typeof record.runId === 'string' &&
+    typeof record.contextId === 'string' &&
+    typeof record.key === 'string' &&
+    typeof record.timestamp === 'string' &&
+    typeof record.runbook === 'object' &&
+    record.runbook !== null &&
+    typeof record.runbook.source === 'string' &&
+    typeof record.runbook.path === 'string'
+  );
+}
+
+/**
+ * Detect an `ArtifactRecord[]` value structurally.
+ *
+ * Treats a JSON array as an artifact-record array only when it is non-empty
+ * AND every element matches `isArtifactRecord`. The empty-array case is
+ * intentionally NOT routed through the artifact projector here — there is no
+ * runtime brand on individual variable values (the `artifactVarsBrand` in
+ * `effective-vars.ts` is purely type-level), so we cannot distinguish a
+ * wildcard with zero matches from a user `OUTPUTS: Items: []`. Both produce
+ * `'[]'` when serialised — `renderArtifactValue([], …)` returns `'[]'` and
+ * `JSON.stringify([])` returns `'[]'` — so falling through to the generic
+ * JSON-stringify path for empty arrays preserves the spec-required rendering
+ * without coupling unrelated semantics. The non-empty-array short-circuit
+ * stays because element-shape detection is unambiguous in that case.
+ *
+ * @param value - Value to test
+ * @returns `true` when the value is a non-empty array of `ArtifactRecord`
+ */
+function isArtifactRecordArray(value: unknown): value is readonly ArtifactRecord[] {
+  if (!Array.isArray(value)) return false;
+  if (value.length === 0) return false;
+  return value.every(isArtifactRecord);
+}
+
+/**
+ * Sentinel string returned by `renderTemplateValue` when an artifact value is
+ * encountered without a `helperOptions` frame. Pass 4 detects this and leaves
+ * the original `{{ Var }}` placeholder in place, mirroring the helper-call
+ * convention.
+ *
+ * The leading and trailing spaces and `__rundown_` prefix make collision with
+ * legitimate rendered output essentially impossible — the Pass 4 detection is
+ * a `===` comparison, so any user content that happened to contain this token
+ * as a substring would not trigger the placeholder fallback.
+ */
+const ARTIFACT_PLACEHOLDER_SENTINEL = ' __rundown_artifact_no_options__ ';
+
+/**
  * Render a template value for interpolation.
  *
  * Accepts renderable variable types: string, number, JsonObject, or JsonArray
- * (i.e. TemplateVarValue excluding JsonArrayStream).
- * Strings are preserved as-is. Non-strings are serialized with JSON to keep
+ * (i.e. TemplateVarValue excluding JsonArrayStream), plus `ArtifactRecord` and
+ * `ArtifactRecord[]` from the artifact-aware render frame.
+ * Strings are preserved as-is. Artifact-record values are routed through the
+ * pure projector so they render as URIs (or JSON arrays of URIs) instead of
+ * record-shaped JSON. Other non-strings are serialized with JSON to keep
  * deterministic display behavior across text and command expansion paths.
  *
  * @param value - Resolved template value (must not be JsonArrayStream, which is iterable-only)
+ * @param variables - Render-frame variables (used for `WorkPath` lookup)
+ * @param helperOptions - Filesystem options. When undefined (AST walks before runtime is wired), artifact values produce a sentinel that Pass 4 honours by preserving the original `{{ Var }}` placeholder.
  * @returns String representation for interpolation
  * @throws {Error} if value is a JsonArrayStream, which is iterable but not renderable
  */
-function renderTemplateValue(value: unknown): string {
+function renderTemplateValue(
+  value: unknown,
+  variables: Readonly<Record<string, unknown>>,
+  helperOptions?: TemplateHelperOptions,
+): string {
   if (typeof value === 'string') {
     return value;
+  }
+  // Artifact-aware short-circuits — must come before the generic JSON fallback so
+  // ArtifactRecord values render as URIs (or JSON arrays of URIs) rather than as
+  // record-shaped JSON. When `helperOptions` is absent (e.g. AST walks at startup
+  // before runtime is wired), preserve the original `{{ Var }}` placeholder by
+  // returning a sentinel that Pass 4 detects — mirroring the helper-call
+  // convention. This avoids the silent-mapping anti-pattern of `JSON.stringify`-ing
+  // an `ArtifactRecord` (CLAUDE.md "No silent mapping").
+  if (isArtifactRecord(value) || isArtifactRecordArray(value)) {
+    if (helperOptions === undefined) {
+      return ARTIFACT_PLACEHOLDER_SENTINEL;
+    }
+    // Empty arrays never reach here — `isArtifactRecordArray` rejects them so
+    // the JSON-stringify fallback below produces `'[]'` (same output as the
+    // projector). For non-empty arrays the first record's identity stands in
+    // for the array as a whole; the projector reads URIs off each record and
+    // does not consume `contextId`/`runId` for the array case.
+    //
+    // `renderArtifactValue` only needs `cwd` for symmetry with the other
+    // projectors — it returns URIs from the records' own `.uri` fields and
+    // does not touch the filesystem. `workPath` is read lazily here so the
+    // direct-alias path does not require `WorkPath` to be present in the
+    // variable frame; the helper-call path (`{{ path Var }}`) always has it.
+    const workPath = typeof variables.WorkPath === 'string' ? variables.WorkPath : '';
+    const artifactValue: ArtifactVarValue = value;
+    const renderOptions: RenderArtifactOptions = {
+      cwd: helperOptions.cwd,
+      workPath,
+      contextId: isArtifactRecord(artifactValue)
+        ? artifactValue.contextId
+        : artifactValue[0].contextId,
+      runId: isArtifactRecord(artifactValue) ? artifactValue.runId : artifactValue[0].runId,
+    };
+    return renderArtifactValue(artifactValue, renderOptions);
   }
   // JsonArrayStream cannot be rendered in templates — it's a lazy file reference
   if (typeof value === 'object' && value !== null && isJsonArrayStream(value as TemplateVarValue)) {
@@ -179,11 +293,16 @@ function renderTemplateValue(value: unknown): string {
  *
  * @param path - Placeholder path (e.g. `item.name`, `context.vars.config.host`)
  * @param variables - Runtime/template variable map
+ * @param helperOptions - Filesystem options forwarded to `renderTemplateValue` so artifact-record values render via the pure projector
  * @returns Rendered value string or undefined when unresolved
  */
-function resolveTemplatePath(path: string, variables: Record<string, unknown>): string | undefined {
+function resolveTemplatePath(
+  path: string,
+  variables: Record<string, unknown>,
+  helperOptions?: TemplateHelperOptions,
+): string | undefined {
   if (Object.hasOwn(variables, path) && variables[path] !== undefined) {
-    return renderTemplateValue(variables[path]);
+    return renderTemplateValue(variables[path], variables, helperOptions);
   }
 
   if (!path.includes('.')) {
@@ -203,10 +322,39 @@ function resolveTemplatePath(path: string, variables: Record<string, unknown>): 
     const remainder = segments.slice(i).join('.');
     const resolved = resolveDottedPath(variables[prefix], remainder);
     if (resolved !== undefined) {
-      return renderTemplateValue(resolved);
+      return renderTemplateValue(resolved, variables, helperOptions);
     }
   }
 
+  return undefined;
+}
+
+/**
+ * Resolve a template path to its raw value. Distinct from `resolveTemplatePath`,
+ * which renders the value as a string. Used by the artifact-aware Pass 4 so the
+ * raw `ArtifactRecord` / `ArtifactRecord[]` value reaches the renderer with its
+ * structural identity intact.
+ *
+ * @param path - Placeholder path
+ * @param variables - Runtime/template variable map
+ * @returns Raw resolved value or undefined when unresolved
+ */
+function resolveTemplatePathRaw(
+  path: string,
+  variables: Readonly<Record<string, unknown>>,
+): unknown {
+  if (Object.hasOwn(variables, path) && variables[path] !== undefined) {
+    return variables[path];
+  }
+  if (!path.includes('.')) return undefined;
+  const segments = path.split('.');
+  for (let i = 1; i < segments.length; i++) {
+    const prefix = segments.slice(0, i).join('.');
+    if (!Object.hasOwn(variables, prefix)) continue;
+    const remainder = segments.slice(i).join('.');
+    const resolved = resolveDottedPath(variables[prefix], remainder);
+    if (resolved !== undefined) return resolved;
+  }
   return undefined;
 }
 
@@ -801,8 +949,8 @@ export function substituteText(
 ): string {
   // Pass 1: {{ ./VarName }} explicit variable lookup, bypasses helper registry
   let result = text.replace(EXPLICIT_VAR_TEMPLATE_REGEX, (match, varPath: string) => {
-    const value = resolveTemplatePath(varPath, variables);
-    if (value === undefined) return match;
+    const value = resolveTemplatePath(varPath, variables, helperOptions);
+    if (value === undefined || value === ARTIFACT_PLACEHOLDER_SENTINEL) return match;
     return escapeFn ? escapeFn(value) : value;
   });
 
@@ -825,12 +973,13 @@ export function substituteText(
     (match, helperName: string, varRef: string | undefined, literal: string | undefined) => {
       let argValue: string;
       if (varRef !== undefined) {
-        const resolved = resolveTemplatePath(varRef, variables);
-        // Preserve the original placeholder when the variable arg is unresolved.
+        const resolved = resolveTemplatePath(varRef, variables, helperOptions);
+        // Preserve the original placeholder when the variable arg is unresolved
+        // or is an unrenderable artifact value (no helper options available).
         // Mirrors Pass 3 below and the `./VarName` branch in Pass 1: silently
         // substituting `''` would corrupt downstream output (see "No silent
         // mapping" principle in CLAUDE.md).
-        if (resolved === undefined) return match;
+        if (resolved === undefined || resolved === ARTIFACT_PLACEHOLDER_SENTINEL) return match;
         argValue = resolved;
       } else {
         argValue = literal ?? '';
@@ -843,9 +992,11 @@ export function substituteText(
 
   // Pass 4: {{ identifier }} standard variable substitution
   result = result.replace(TEMPLATE_PATH_REGEX, (match, path: string) => {
-    const value = resolveTemplatePath(path, variables);
+    const value = resolveTemplatePathRaw(path, variables);
     if (value === undefined) return match;
-    return escapeFn ? escapeFn(value) : value;
+    const rendered = renderTemplateValue(value, variables, helperOptions);
+    if (rendered === ARTIFACT_PLACEHOLDER_SENTINEL) return match;
+    return escapeFn ? escapeFn(rendered) : rendered;
   });
 
   return result;

--- a/packages/cli/src/services/template-renderer.ts
+++ b/packages/cli/src/services/template-renderer.ts
@@ -189,6 +189,7 @@ function isArtifactRecord(value: unknown): value is ArtifactRecord {
     typeof record.key === 'string' &&
     typeof record.timestamp === 'string' &&
     typeof record.runbook === 'object' &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- load-bearing: typeof null === 'object', so the next access would throw on null despite the declared `runbook: RunbookRef` type
     record.runbook !== null &&
     typeof record.runbook.source === 'string' &&
     typeof record.runbook.path === 'string'

--- a/packages/core/__tests__/runbook/output-evaluator.test.ts
+++ b/packages/core/__tests__/runbook/output-evaluator.test.ts
@@ -108,6 +108,52 @@ describe('evaluateOutputExpression', () => {
     }
   });
 
+  it('rejects empty literal {{ artifact "" }} via the evaluator dispatch', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-helper-'));
+    try {
+      expect(() =>
+        evaluateOutputExpression(
+          '{{ artifact "" }}',
+          {
+            WorkPath: '.rundown/work',
+            ContextId: 'ctx1',
+            RunId: 'rd_0123456789abcdef0123456789abcdef',
+            RunbookRef: {
+              source: 'plugin',
+              path: 'planning/review/review-plan-risk-safety.runbook.md',
+            },
+          },
+          { cwd },
+        ),
+      ).toThrow(/literal key/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects empty literal {{ path "" }} via the evaluator dispatch', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'rd-helper-'));
+    try {
+      expect(() =>
+        evaluateOutputExpression(
+          '{{ path "" }}',
+          {
+            WorkPath: '.rundown/work',
+            ContextId: 'ctx1',
+            RunId: 'rd_0123456789abcdef0123456789abcdef',
+            RunbookRef: {
+              source: 'plugin',
+              path: 'planning/review/review-plan-risk-safety.runbook.md',
+            },
+          },
+          { cwd },
+        ),
+      ).toThrow(/key must not be empty/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('evaluates path helper to run-scoped artifact path', async () => {
     const cwd = await mkdtemp(path.join(tmpdir(), 'rd-helper-'));
     try {

--- a/packages/core/__tests__/runbook/output-evaluator.test.ts
+++ b/packages/core/__tests__/runbook/output-evaluator.test.ts
@@ -85,10 +85,10 @@ describe('evaluateOutputExpression', () => {
     expect(evaluateOutputExpression('PlanPath', { PlanPath: '/tmp/plan.md' })).toBe('/tmp/plan.md');
   });
 
-  it('evaluates artifact helper to an exact URI', async () => {
+  it('rejects literal {{ artifact "key" }} form (spec §327)', async () => {
     const cwd = await mkdtemp(path.join(tmpdir(), 'rd-helper-'));
     try {
-      expect(
+      expect(() =>
         evaluateOutputExpression(
           '{{ artifact "review.json" }}',
           {
@@ -102,7 +102,7 @@ describe('evaluateOutputExpression', () => {
           },
           { cwd },
         ),
-      ).toBe('rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/review.json');
+      ).toThrow(/literal key/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -131,7 +131,7 @@ describe('evaluateOutputExpression', () => {
     }
   });
 
-  it('records manifest rows when helpers are evaluated', async () => {
+  it('does not record manifest rows when helpers are evaluated (spec §313)', async () => {
     const cwd = await mkdtemp(path.join(tmpdir(), 'rd-helper-'));
     try {
       const vars = {
@@ -144,31 +144,12 @@ describe('evaluateOutputExpression', () => {
         },
       };
 
-      const reviewUri = evaluateOutputExpression('{{ artifact "review.json" }}', vars, { cwd });
+      evaluateOutputExpression('{{ path "review.json" }}', vars, { cwd });
       evaluateOutputExpression('{{ path "summary.md" }}', vars, { cwd });
 
+      // Phase 3: template helpers are pure render-only projections.
       const records = await readArtifactManifest({ cwd, workPath: vars.WorkPath }, 'ctx1');
-      expect(records).toHaveLength(2);
-      expect(records).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            uri: reviewUri,
-            runId: vars.RunId,
-            contextId: vars.ContextId,
-            runbook: vars.RunbookRef,
-            key: 'review.json',
-            timestamp: expect.any(String),
-          }),
-          expect.objectContaining({
-            uri: 'rd://artifacts/ctx1/runs/rd_0123456789abcdef0123456789abcdef/summary.md',
-            runId: vars.RunId,
-            contextId: vars.ContextId,
-            runbook: vars.RunbookRef,
-            key: 'summary.md',
-            timestamp: expect.any(String),
-          }),
-        ]),
-      );
+      expect(records).toEqual([]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -195,9 +176,13 @@ describe('evaluateOutputExpression', () => {
         },
       };
 
+      // Phase 3: literal {{ artifact "key" }} is hard-rejected (spec §327)
+      // before any key validation runs.
       expect(() => evaluateOutputExpression(`{{ artifact "${key}" }}`, vars, { cwd })).toThrow(
-        /Invalid ArtifactKey/,
+        /literal key/,
       );
+      // Literal {{ path "key" }} is allowed and continues to enforce the
+      // ArtifactKey safety rules.
       expect(() => evaluateOutputExpression(`{{ path "${key}" }}`, vars, { cwd })).toThrow(
         /Invalid ArtifactKey/,
       );
@@ -792,5 +777,65 @@ describe('evaluateOutputExpression call-time helper validation', () => {
     } finally {
       process.off('unhandledRejection', unhandledHandler);
     }
+  });
+});
+
+describe('evaluateOutputExpression run-artifact helpers do not mutate the manifest', () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(path.join(tmpdir(), 'output-evaluator-purity-'));
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('rejects literal {{ artifact "key" }} as a hard error (spec §327)', async () => {
+    const variables: OutputVars = {
+      WorkPath: '.rundown/work',
+      ContextId: 'ctx1',
+      RunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      RunbookRef: { source: 'project', path: 'a.runbook.md' },
+    };
+
+    expect(() =>
+      evaluateOutputExpressionRaw('{{ artifact "plan.json" }}', variables, { cwd }),
+    ).toThrow(/literal key/);
+
+    const records = await readArtifactManifest({ cwd, workPath: '.rundown/work' }, 'ctx1');
+    expect(records).toEqual([]);
+  });
+
+  it('does not append a manifest row when {{ path "key" }} is evaluated', async () => {
+    const variables: OutputVars = {
+      WorkPath: '.rundown/work',
+      ContextId: 'ctx1',
+      RunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      RunbookRef: { source: 'project', path: 'a.runbook.md' },
+    };
+
+    evaluateOutputExpressionRaw('{{ path "plan.json" }}', variables, { cwd });
+
+    const records = await readArtifactManifest({ cwd, workPath: '.rundown/work' }, 'ctx1');
+    expect(records).toEqual([]);
+  });
+
+  it('does not create the parent directory when {{ path "key" }} is evaluated', async () => {
+    const variables: OutputVars = {
+      WorkPath: '.rundown/work',
+      ContextId: 'ctx1',
+      RunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      RunbookRef: { source: 'project', path: 'a.runbook.md' },
+    };
+
+    evaluateOutputExpressionRaw('{{ path "plan.json" }}', variables, { cwd });
+
+    const fsp = await import('node:fs/promises');
+    await expect(
+      fsp.stat(
+        path.join(cwd, '.rundown/work', '.rd-ctx1', 'runs', 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });

--- a/packages/core/__tests__/runbook/render-artifact-helper.properties.test.ts
+++ b/packages/core/__tests__/runbook/render-artifact-helper.properties.test.ts
@@ -62,4 +62,35 @@ describe('render projector properties', () => {
       }),
     );
   });
+
+  it('renderArtifactValue array projection is per-element URI', () => {
+    fc.assert(
+      fc.property(fc.array(recordArb, { maxLength: 20, minLength: 1 }), (records) => {
+        const parsed = JSON.parse(renderArtifactValue(records, OPTIONS)) as string[];
+        for (const [i, r] of records.entries()) {
+          expect(parsed[i]).toBe(r.uri);
+        }
+      }),
+    );
+  });
+
+  it('renderArtifactPathValue array length and per-element key match', () => {
+    fc.assert(
+      fc.property(fc.array(recordArb, { maxLength: 20, minLength: 1 }), (records) => {
+        const parsed = JSON.parse(renderArtifactPathValue(records, OPTIONS)) as string[];
+        expect(parsed).toHaveLength(records.length);
+        for (const [i, r] of records.entries()) {
+          expect(parsed[i].endsWith(r.key)).toBe(true);
+        }
+      }),
+    );
+  });
+
+  it('renderArtifactRecordValue array round-trips per element', () => {
+    fc.assert(
+      fc.property(fc.array(recordArb, { maxLength: 10, minLength: 1 }), (records) => {
+        expect(JSON.parse(renderArtifactRecordValue(records, OPTIONS))).toEqual(records);
+      }),
+    );
+  });
 });

--- a/packages/core/__tests__/runbook/render-artifact-helper.properties.test.ts
+++ b/packages/core/__tests__/runbook/render-artifact-helper.properties.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fc from 'fast-check';
+import {
+  renderArtifactValue,
+  renderArtifactPathValue,
+  renderArtifactRecordValue,
+  type RenderArtifactOptions,
+} from '../../src/runbook/renderer/artifact-helper.js';
+import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
+
+const RUN_ID = 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const CONTEXT_ID = 'ctx1';
+const OPTIONS: RenderArtifactOptions = {
+  cwd: '/tmp/project',
+  workPath: '.rundown/work',
+  contextId: CONTEXT_ID,
+  runId: RUN_ID,
+};
+
+const recordArb: fc.Arbitrary<ArtifactRecord> = fc
+  .constantFrom('plan.json', 'review.json', 'output.json', 'a-reviews.json')
+  .map((key) => ({
+    uri: `rd://artifacts/${CONTEXT_ID}/runs/${RUN_ID}/${key}`,
+    runId: RUN_ID,
+    contextId: CONTEXT_ID,
+    runbook: { source: 'project' as const, path: 'planning/write-plan.runbook.md' },
+    key,
+    timestamp: '2026-05-07T00:00:00.000Z',
+  }));
+
+describe('render projector properties', () => {
+  it('renderArtifactValue is idempotent for records', () => {
+    fc.assert(
+      fc.property(recordArb, (record) => {
+        expect(renderArtifactValue(record, OPTIONS)).toBe(renderArtifactValue(record, OPTIONS));
+      }),
+    );
+  });
+
+  it('renderArtifactValue array length matches input length', () => {
+    fc.assert(
+      fc.property(fc.array(recordArb, { maxLength: 20 }), (records) => {
+        const rendered = renderArtifactValue(records, OPTIONS);
+        const parsed = JSON.parse(rendered) as string[];
+        expect(parsed).toHaveLength(records.length);
+      }),
+    );
+  });
+
+  it('all projectors render empty array as "[]"', () => {
+    expect(renderArtifactValue([], OPTIONS)).toBe('[]');
+    expect(renderArtifactPathValue([], OPTIONS)).toBe('[]');
+    expect(renderArtifactRecordValue([], OPTIONS)).toBe('[]');
+  });
+
+  it('renderArtifactRecordValue is idempotent for arrays', () => {
+    fc.assert(
+      fc.property(fc.array(recordArb, { maxLength: 10 }), (records) => {
+        expect(renderArtifactRecordValue(records, OPTIONS)).toBe(
+          renderArtifactRecordValue(records, OPTIONS),
+        );
+      }),
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/render-artifact-helper.properties.test.ts
+++ b/packages/core/__tests__/runbook/render-artifact-helper.properties.test.ts
@@ -86,10 +86,14 @@ describe('render projector properties', () => {
     );
   });
 
-  it('renderArtifactRecordValue array round-trips per element', () => {
+  it('renderArtifactRecordValue array projection is per-element URI (spec §9.3)', () => {
     fc.assert(
       fc.property(fc.array(recordArb, { maxLength: 10, minLength: 1 }), (records) => {
-        expect(JSON.parse(renderArtifactRecordValue(records, OPTIONS))).toEqual(records);
+        const parsed = JSON.parse(renderArtifactRecordValue(records, OPTIONS)) as string[];
+        expect(parsed).toHaveLength(records.length);
+        for (const [i, r] of records.entries()) {
+          expect(parsed[i]).toBe(r.uri);
+        }
       }),
     );
   });

--- a/packages/core/__tests__/runbook/render-artifact-helper.test.ts
+++ b/packages/core/__tests__/runbook/render-artifact-helper.test.ts
@@ -74,12 +74,18 @@ describe('renderArtifactPathValue (path helper)', () => {
 });
 
 describe('renderArtifactRecordValue (artifact helper)', () => {
-  it('renders an ArtifactRecord as its full JSON record', () => {
-    expect(renderArtifactRecordValue(PLAN, OPTIONS)).toBe(JSON.stringify(PLAN));
+  // Per spec §9.3 the `artifact` helper renders URI values with the same shape
+  // as direct-alias rendering — scalar URI for an ArtifactRecord, JSON array
+  // of URIs for ArtifactRecord[]. It is functionally identical to
+  // `renderArtifactValue`; the helper exists as an explicit author-visible
+  // surface for "render this as an artifact URI".
+
+  it('renders an ArtifactRecord as its URI string', () => {
+    expect(renderArtifactRecordValue(PLAN, OPTIONS)).toBe(PLAN.uri);
   });
 
-  it('renders an ArtifactRecord[] as a JSON array of records', () => {
-    expect(renderArtifactRecordValue([REVIEW_A], OPTIONS)).toBe(JSON.stringify([REVIEW_A]));
+  it('renders an ArtifactRecord[] as a JSON array of URIs', () => {
+    expect(renderArtifactRecordValue([REVIEW_A], OPTIONS)).toBe(JSON.stringify([REVIEW_A.uri]));
   });
 
   it('renders empty ArtifactRecord[] as "[]"', () => {

--- a/packages/core/__tests__/runbook/render-artifact-helper.test.ts
+++ b/packages/core/__tests__/runbook/render-artifact-helper.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  renderArtifactValue,
+  renderArtifactPathValue,
+  renderArtifactRecordValue,
+  renderLiteralArtifactPath,
+  type RenderArtifactOptions,
+} from '../../src/runbook/renderer/artifact-helper.js';
+import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
+
+const CWD = '/tmp/project';
+const WORK_PATH = '.rundown/work';
+const CONTEXT_ID = 'ctx1';
+const RUN_ID = 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const RUNBOOK = { source: 'project' as const, path: 'planning/write-plan.runbook.md' };
+
+const PLAN: ArtifactRecord = {
+  uri: `rd://artifacts/${CONTEXT_ID}/runs/${RUN_ID}/plan.json`,
+  runId: RUN_ID,
+  contextId: CONTEXT_ID,
+  runbook: RUNBOOK,
+  key: 'plan.json',
+  timestamp: '2026-05-07T00:00:00.000Z',
+};
+
+const REVIEW_A: ArtifactRecord = {
+  uri: `rd://artifacts/${CONTEXT_ID}/runs/${RUN_ID}/review-plan-a.json`,
+  runId: RUN_ID,
+  contextId: CONTEXT_ID,
+  runbook: RUNBOOK,
+  key: 'review-plan-a.json',
+  timestamp: '2026-05-07T00:00:00.000Z',
+};
+
+const OPTIONS: RenderArtifactOptions = {
+  cwd: CWD,
+  workPath: WORK_PATH,
+  contextId: CONTEXT_ID,
+  runId: RUN_ID,
+};
+
+describe('renderArtifactValue (direct alias projection)', () => {
+  it('renders an ArtifactRecord as its URI string', () => {
+    expect(renderArtifactValue(PLAN, OPTIONS)).toBe(PLAN.uri);
+  });
+
+  it('renders an ArtifactRecord[] as a JSON array of URIs', () => {
+    expect(renderArtifactValue([REVIEW_A], OPTIONS)).toBe(JSON.stringify([REVIEW_A.uri]));
+  });
+
+  it('renders an empty ArtifactRecord[] as the literal "[]"', () => {
+    expect(renderArtifactValue([], OPTIONS)).toBe('[]');
+  });
+});
+
+describe('renderArtifactPathValue (path helper)', () => {
+  it('renders an ArtifactRecord as its local artifact path', () => {
+    const out = renderArtifactPathValue(PLAN, OPTIONS);
+    expect(out).toContain(`.rd-${CONTEXT_ID}`);
+    expect(out).toContain(RUN_ID);
+    expect(out.endsWith('plan.json')).toBe(true);
+  });
+
+  it('renders an ArtifactRecord[] as a JSON array of local paths', () => {
+    const out = renderArtifactPathValue([REVIEW_A], OPTIONS);
+    const parsed = JSON.parse(out) as string[];
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].endsWith('review-plan-a.json')).toBe(true);
+  });
+
+  it('renders empty ArtifactRecord[] as "[]"', () => {
+    expect(renderArtifactPathValue([], OPTIONS)).toBe('[]');
+  });
+});
+
+describe('renderArtifactRecordValue (artifact helper)', () => {
+  it('renders an ArtifactRecord as its full JSON record', () => {
+    expect(renderArtifactRecordValue(PLAN, OPTIONS)).toBe(JSON.stringify(PLAN));
+  });
+
+  it('renders an ArtifactRecord[] as a JSON array of records', () => {
+    expect(renderArtifactRecordValue([REVIEW_A], OPTIONS)).toBe(JSON.stringify([REVIEW_A]));
+  });
+
+  it('renders empty ArtifactRecord[] as "[]"', () => {
+    expect(renderArtifactRecordValue([], OPTIONS)).toBe('[]');
+  });
+});
+
+describe('renderLiteralArtifactPath (literal path helper)', () => {
+  it('renders the current-run local path for a valid key', () => {
+    const out = renderLiteralArtifactPath('plan.json', OPTIONS);
+    expect(out).toContain(`.rd-${CONTEXT_ID}`);
+    expect(out).toContain(RUN_ID);
+    expect(out.endsWith('plan.json')).toBe(true);
+  });
+
+  it('throws for an invalid key shape', () => {
+    expect(() => renderLiteralArtifactPath('../escape.json', OPTIONS)).toThrow();
+  });
+
+  it('throws for empty key', () => {
+    expect(() => renderLiteralArtifactPath('', OPTIONS)).toThrow();
+  });
+});

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -55,6 +55,13 @@ export {
   type PolicyExecutionOptions,
 } from './executor.js';
 export { renderRunbook, renderStep } from './renderer/renderer.js';
+export {
+  renderArtifactValue,
+  renderArtifactPathValue,
+  renderArtifactRecordValue,
+  renderLiteralArtifactPath,
+  type RenderArtifactOptions,
+} from './renderer/artifact-helper.js';
 export { evaluateFailCondition, evaluatePassCondition } from './transition-handler.js';
 export { createFileProvider, computeFileSnapshot, validateFileSnapshot } from './file-provider.js';
 export type { FileProvider } from './file-provider.js';

--- a/packages/core/src/runbook/output-evaluator.ts
+++ b/packages/core/src/runbook/output-evaluator.ts
@@ -109,10 +109,10 @@ export function resetHelperRegistry(): void {
 
 const TEMPLATE_PATH_REGEX =
   /{{\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)\s*}}/g;
-const PATH_HELPER_REGEX = /^\{\{\s*path\s+"([^"]+)"\s*\}\}$/;
+const PATH_HELPER_REGEX = /^\{\{\s*path\s+"([^"]*)"\s*\}\}$/;
 const LEGACY_CTX_PATH_HELPER_REGEX =
   /^\{\{\s*path\s+"([^"]+)"\s+ctx=(\{\{[^}]*\}\}|[^\s}]+)\s*\}\}$/;
-const ARTIFACT_HELPER_REGEX = /^\{\{\s*artifact\s+"([^"]+)"\s*\}\}$/;
+const ARTIFACT_HELPER_REGEX = /^\{\{\s*artifact\s+"([^"]*)"\s*\}\}$/;
 
 /**
  * Matches `{{ ./VarName }}` — explicit variable lookup escape hatch.

--- a/packages/core/src/runbook/output-evaluator.ts
+++ b/packages/core/src/runbook/output-evaluator.ts
@@ -1,14 +1,11 @@
 import type { OutputDeclaration } from '@rundown-org/parser';
-import { mkdirSync } from 'node:fs';
-import * as path from 'node:path';
 import { mergeEffectiveVars } from './effective-vars.js';
 import type { ForContext, JsonValue, TemplateVarValue } from './types.js';
 import { assertResolvedVariableForContext, isJsonArrayStream } from './types.js';
 import { deriveExecutionAt } from './targeting.js';
-import { assembleArtifactPath, assembleRunArtifactPath, VALID_CTX } from './artifact-paths.js';
-import { appendArtifactManifestRecordSync } from './artifact-manifest.js';
-import { buildArtifactUri } from './artifact-uri.js';
+import { assembleArtifactPath, VALID_CTX } from './artifact-paths.js';
 import { invokeHelperSafely } from './helper-invoke.js';
+import { renderLiteralArtifactPath } from './renderer/artifact-helper.js';
 import { RunbookRefSchema, type RunbookRef } from './runbook-ref.js';
 import { logger } from '../logger.js';
 
@@ -226,24 +223,33 @@ function requireEvaluateOutputOptions(
 }
 
 /**
- * Apply a built-in artifact-producing helper against an OUTPUTS/runtime frame.
+ * Render a built-in artifact-producing template helper against an OUTPUTS frame.
  *
- * Both `artifact` and `path` helpers intentionally append a manifest row. The
- * local-path variant also creates the artifact parent directory synchronously so
- * the returned path is immediately writable by shell commands.
+ * Pure: does NOT append manifest rows, create directories, or mutate runbook
+ * state. Phase 3 made every artifact-producing helper render-only; only the
+ * `ARTIFACTS` directive resolver writes to the manifest.
  *
- * Accepts an unconstrained record because the helper validates each required
- * frame field internally (`requireOutputString` / `requireRunbookRef`) and
- * throws on missing or malformed entries. Callers that already hold a typed
- * `OutputVars` (a subtype) pass through unchanged.
+ * Cardinality:
+ * - `kind === 'path'` and a literal key — projects to a local artifact path.
+ *   Spec §327 explicitly permits this because a path projection does not
+ *   assert the artifact is in the manifest; commands may write to it.
+ * - `kind === 'artifact'` and a literal key — REJECTED. Spec §327: a record
+ *   projection from a literal would invent metadata for an artifact that may
+ *   not be in the manifest. The CLI renderer (Pass 2 in `template-renderer.ts`)
+ *   already rejects the same shape; this sibling raises so frontmatter
+ *   `outputs:` expression evaluation matches.
+ *
+ * The function still validates that the OUTPUTS frame supplies `WorkPath`,
+ * `ContextId`, `RunId`, and `RunbookRef` because the projector needs them to
+ * build canonical paths.
  *
  * @param kind - Helper kind to evaluate
- * @param key - Artifact key / filename segment from the helper call
- * @param frame - Variable frame containing WorkPath, ContextId, RunId, and RunbookRef
- * @param options - Filesystem options for path resolution and manifest append
- * @returns Canonical artifact URI for `artifact`, local artifact path for `path`
- * @throws {Error} When required variables are missing or invalid, or when the
- *   artifact key fails identity validation.
+ * @param key - Artifact key from the helper call
+ * @param frame - Variable frame
+ * @param options - Filesystem options (`cwd`)
+ * @returns Local artifact path for literal `path`
+ * @throws {Error} When `kind === 'artifact'` (literal-key artifact form is forbidden, spec §327)
+ * @throws {Error} When required frame variables are missing or the key fails validation
  */
 export function applyRunArtifactHelper(
   kind: 'artifact' | 'path',
@@ -251,31 +257,22 @@ export function applyRunArtifactHelper(
   frame: Readonly<Record<string, unknown>>,
   options: EvaluateOutputOptions,
 ): string {
+  if (kind === 'artifact') {
+    throw new Error(
+      `artifact helper does not accept a literal key ("${key}"); declare it via ARTIFACTS and pass the alias.`,
+    );
+  }
   const workPath = requireOutputString('WorkPath', frame);
   const contextId = requireOutputString('ContextId', frame);
   const runId = requireOutputString('RunId', frame);
-  const runbookRef = requireRunbookRef(frame);
-  const uri = buildArtifactUri({ contextId, runId, key });
+  // `requireRunbookRef` survives as a frame-validation invariant: its absence
+  // signals a misconfigured caller (the OUTPUTS evaluator must always have a
+  // runbook ref attached). The projector itself does not consume the value,
+  // so do NOT delete this call as dead — the throw is the load-bearing
+  // behaviour that catches frame mis-assembly upstream.
+  requireRunbookRef(frame);
 
-  let rendered = uri;
-  if (kind === 'path') {
-    rendered = assembleRunArtifactPath({ cwd: options.cwd, workPath }, contextId, runId, key);
-    mkdirSync(path.dirname(rendered), { recursive: true });
-  }
-
-  appendArtifactManifestRecordSync(
-    { cwd: options.cwd, workPath },
-    {
-      uri,
-      runId,
-      contextId,
-      runbook: runbookRef,
-      key,
-      timestamp: new Date().toISOString(),
-    },
-  );
-
-  return rendered;
+  return renderLiteralArtifactPath(key, { cwd: options.cwd, workPath, contextId, runId });
 }
 
 function resolveLegacyCtxPathHelper(

--- a/packages/core/src/runbook/renderer/artifact-helper.ts
+++ b/packages/core/src/runbook/renderer/artifact-helper.ts
@@ -74,6 +74,7 @@ export function renderArtifactValue(
   _options: RenderArtifactOptions,
 ): string {
   if (isArtifactRecordArray(value)) {
+    if (value.length === 0) return '[]';
     return JSON.stringify(value.map((record) => record.uri));
   }
   return value.uri;
@@ -99,6 +100,7 @@ export function renderArtifactPathValue(
   options: RenderArtifactOptions,
 ): string {
   if (isArtifactRecordArray(value)) {
+    if (value.length === 0) return '[]';
     return JSON.stringify(value.map((record) => artifactUriToPath(record.uri, options)));
   }
   return artifactUriToPath(value.uri, options);
@@ -118,6 +120,7 @@ export function renderArtifactRecordValue(
   value: ArtifactVarValue,
   _options: RenderArtifactOptions,
 ): string {
+  if (isArtifactRecordArray(value) && value.length === 0) return '[]';
   return JSON.stringify(value);
 }
 

--- a/packages/core/src/runbook/renderer/artifact-helper.ts
+++ b/packages/core/src/runbook/renderer/artifact-helper.ts
@@ -107,21 +107,26 @@ export function renderArtifactPathValue(
 }
 
 /**
- * Render an artifact variable value as full record JSON (`{{ artifact Var }}`).
+ * Render an artifact variable value as URI(s) for the `{{ artifact Var }}` form.
  *
- * - `ArtifactRecord` -> JSON serialisation of the record.
- * - `ArtifactRecord[]` -> JSON array of records; empty array renders as `"[]"`.
+ * Per spec §9.3, the `artifact` helper "renders artifact URI values with the
+ * same scalar or array shape" — i.e. its output matches direct-alias rendering
+ * (`{{ Var }}`). The helper exists as an explicit, type-marked surface for
+ * authors who want to assert "render this as an artifact URI" at the call
+ * site; the projection itself is identical to `renderArtifactValue`.
+ *
+ * - `ArtifactRecord` -> the canonical artifact URI string.
+ * - `ArtifactRecord[]` -> JSON array of URI strings; empty array renders as `"[]"`.
  *
  * @param value - Artifact variable value
- * @param _options - Render options (unused; included for API symmetry)
- * @returns JSON string
+ * @param options - Render options (unused; included for API symmetry)
+ * @returns Rendered string
  */
 export function renderArtifactRecordValue(
   value: ArtifactVarValue,
-  _options: RenderArtifactOptions,
+  options: RenderArtifactOptions,
 ): string {
-  if (isArtifactRecordArray(value) && value.length === 0) return '[]';
-  return JSON.stringify(value);
+  return renderArtifactValue(value, options);
 }
 
 /**

--- a/packages/core/src/runbook/renderer/artifact-helper.ts
+++ b/packages/core/src/runbook/renderer/artifact-helper.ts
@@ -19,6 +19,9 @@ import type { ArtifactVarValue } from '../types.js';
  * narrow `readonly T[]` unions in strict mode — see TypeScript issue #17002 —
  * so callers route through this guard to expose `value` as either
  * `ArtifactRecord` or `readonly ArtifactRecord[]` to the body.
+ *
+ * @param value - Artifact variable value to test
+ * @returns `true` when the value is an `ArtifactRecord[]` (readonly)
  */
 function isArtifactRecordArray(value: ArtifactVarValue): value is readonly ArtifactRecord[] {
   return Array.isArray(value);

--- a/packages/core/src/runbook/renderer/artifact-helper.ts
+++ b/packages/core/src/runbook/renderer/artifact-helper.ts
@@ -1,0 +1,145 @@
+/**
+ * Pure render-only projectors for ARTIFACTS variable values.
+ *
+ * The artifact directive resolver (`artifact-directive-resolver.ts`) is the
+ * sole writer to the manifest. These projectors derive URI, path, and full
+ * record renderings from already-resolved `ArtifactRecord` / `ArtifactRecord[]`
+ * values without touching the filesystem. They do not append manifest rows,
+ * create directories, create files, or mutate runbook state.
+ *
+ * @module
+ */
+
+import type { ArtifactRecord } from '../artifact-schema.js';
+import { artifactUriToPath, buildArtifactUri, type ArtifactPathOptions } from '../artifact-uri.js';
+import type { ArtifactVarValue } from '../types.js';
+
+/**
+ * Narrowing helper for `ArtifactVarValue`. `Array.isArray` does not reliably
+ * narrow `readonly T[]` unions in strict mode — see TypeScript issue #17002 —
+ * so callers route through this guard to expose `value` as either
+ * `ArtifactRecord` or `readonly ArtifactRecord[]` to the body.
+ */
+function isArtifactRecordArray(value: ArtifactVarValue): value is readonly ArtifactRecord[] {
+  return Array.isArray(value);
+}
+
+/**
+ * Required render-frame fields for projecting artifact values.
+ *
+ * `cwd` and `workPath` come from the existing `ArtifactPathOptions` shape;
+ * `contextId` and `runId` are needed only by the literal-key `path` helper,
+ * which builds a URI on the fly. The record-shaped projectors ignore them
+ * because every record carries its own identity.
+ *
+ * **Empty-array invariant.** Callers projecting an empty `ArtifactRecord[]`
+ * MAY pass empty strings (`''`) for both `contextId` and `runId`. The
+ * empty-array branch of every projector returns `'[]'` before any URI or
+ * path assembly, so the empty values are never read. This is load-bearing:
+ * a wildcard `ArtifactRecord[]` with zero matches has no identity to
+ * inherit, and forcing the call site to invent fake identifiers would
+ * obscure the "no matches" semantics. Do NOT remove the empty-string
+ * accepting behaviour without first updating every call site that relies
+ * on it (`resolvePathHelperCall`, `resolveArtifactHelperCall`,
+ * `renderTemplateValue`).
+ */
+export interface RenderArtifactOptions extends ArtifactPathOptions {
+  /**
+   * Current context identifier; required by literal-key `path` helper.
+   * Empty string is accepted only for empty `ArtifactRecord[]` projection.
+   */
+  readonly contextId: string;
+  /**
+   * Current run identifier; required by literal-key `path` helper.
+   * Empty string is accepted only for empty `ArtifactRecord[]` projection.
+   */
+  readonly runId: string;
+}
+
+/**
+ * Render an artifact variable value as it appears via direct alias `{{ Var }}`.
+ *
+ * - `ArtifactRecord` -> the canonical artifact URI string.
+ * - `ArtifactRecord[]` -> JSON array of URI strings; empty array renders as `"[]"`.
+ *
+ * @param value - Artifact variable value
+ * @param _options - Render options (unused for direct alias; included for API symmetry with the helper variants)
+ * @returns Rendered string
+ */
+export function renderArtifactValue(
+  value: ArtifactVarValue,
+  _options: RenderArtifactOptions,
+): string {
+  if (isArtifactRecordArray(value)) {
+    return JSON.stringify(value.map((record) => record.uri));
+  }
+  return value.uri;
+}
+
+/**
+ * Render an artifact variable value as a local path projection (`{{ path Var }}`).
+ *
+ * - `ArtifactRecord` -> local artifact path under `<cwd>/<workPath>/.rd-<ctx>/runs/<run>/<key>`.
+ * - `ArtifactRecord[]` -> JSON array of local paths; empty array renders as `"[]"`.
+ *
+ * Pure: does not create directories or files. Phase 2's directive resolver is
+ * responsible for ensuring the parent directory exists for exact declarations
+ * before commands run; this projector does not duplicate that work.
+ *
+ * @param value - Artifact variable value
+ * @param options - Render options carrying project root and work path
+ * @returns Rendered string
+ * @throws {Error} When any record's URI fails path validation
+ */
+export function renderArtifactPathValue(
+  value: ArtifactVarValue,
+  options: RenderArtifactOptions,
+): string {
+  if (isArtifactRecordArray(value)) {
+    return JSON.stringify(value.map((record) => artifactUriToPath(record.uri, options)));
+  }
+  return artifactUriToPath(value.uri, options);
+}
+
+/**
+ * Render an artifact variable value as full record JSON (`{{ artifact Var }}`).
+ *
+ * - `ArtifactRecord` -> JSON serialisation of the record.
+ * - `ArtifactRecord[]` -> JSON array of records; empty array renders as `"[]"`.
+ *
+ * @param value - Artifact variable value
+ * @param _options - Render options (unused; included for API symmetry)
+ * @returns JSON string
+ */
+export function renderArtifactRecordValue(
+  value: ArtifactVarValue,
+  _options: RenderArtifactOptions,
+): string {
+  return JSON.stringify(value);
+}
+
+/**
+ * Render a current-run local path projection from a literal artifact key
+ * (`{{ path "plan.json" }}`).
+ *
+ * Validates the key (existing safe-id rules from `artifactUriToPath`) and
+ * builds the canonical URI for the current run before deriving the local
+ * path. Does NOT register an artifact, append a manifest row, or create the
+ * artifact file (spec §327). The artifact need not exist on disk.
+ *
+ * @param key - Quoted literal artifact key from the helper call
+ * @param options - Render options including current `contextId` and `runId`
+ * @returns Local artifact path string
+ * @throws {Error} When the key is empty, contains unsafe characters, or fails URI/path assembly
+ */
+export function renderLiteralArtifactPath(key: string, options: RenderArtifactOptions): string {
+  if (key === '') {
+    throw new Error('renderLiteralArtifactPath: key must not be empty');
+  }
+  const uri = buildArtifactUri({
+    contextId: options.contextId,
+    runId: options.runId,
+    key,
+  });
+  return artifactUriToPath(uri, options);
+}


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template rendering now understands artifact values, producing user-facing URIs and local paths for artifacts without changing stored manifests.

* **Bug Fixes**
  * Rendering and output evaluation are side-effect free (no filesystem or manifest writes) and misuse of literal artifact keys is rejected with clear errors.

* **Tests**
  * Extensive tests added/updated to verify artifact rendering, placeholder preservation, determinism, and no side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
