### PR TITLE
Homepage UI redesign: scenario cards + Text/JSON tab bar

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -27,3 +27,6 @@ pnpm-debug.log*
 public/rundown-snapshot.bin
 playwright-report/
 test-results/
+
+# Local screenshot artifacts
+screenshots/

--- a/site/package.json
+++ b/site/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "prebuild": "tsx scripts/build-snapshot.ts",
     "build:snapshot": "tsx scripts/build-snapshot.ts",
+    "screenshot:home": "tsx scripts/screenshot-homepage.ts",
     "dev": "astro dev",
     "test": "playwright test",
     "test:ui": "playwright test --ui",

--- a/site/scripts/screenshot-homepage.ts
+++ b/site/scripts/screenshot-homepage.ts
@@ -20,14 +20,14 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const siteRoot = resolve(__dirname, '..');
 
-const URL = process.env.URL ?? 'http://localhost:4321';
-const OUT = process.env.OUT ?? 'screenshots/homepage.png';
-const VIEWPORT = { width: 1280, height: 800 };
-const READY_TIMEOUT_MS = 60_000;
-const SERVER_BOOT_TIMEOUT_MS = 60_000;
-const SERVER_POLL_INTERVAL_MS = 500;
+const targetUrl: string = process.env.URL ?? 'http://localhost:4321';
+const outputPath: string = process.env.OUT ?? 'screenshots/homepage.png';
+const viewport: { width: number; height: number } = { width: 1280, height: 800 };
+const readyTimeoutMs: number = 60_000;
+const serverBootTimeoutMs: number = 60_000;
+const serverPollIntervalMs: number = 500;
 
-const SNAPSHOT_PATH = resolve(siteRoot, 'public', 'rundown-snapshot.bin');
+const snapshotPath: string = resolve(siteRoot, 'public', 'rundown-snapshot.bin');
 
 async function isServerRunning(url: string): Promise<boolean> {
   try {
@@ -40,13 +40,13 @@ async function isServerRunning(url: string): Promise<boolean> {
 }
 
 async function waitForServer(url: string): Promise<void> {
-  const deadline = Date.now() + SERVER_BOOT_TIMEOUT_MS;
+  const deadline = Date.now() + serverBootTimeoutMs;
   while (Date.now() < deadline) {
     if (await isServerRunning(url)) return;
-    await new Promise((r) => setTimeout(r, SERVER_POLL_INTERVAL_MS));
+    await new Promise((r) => setTimeout(r, serverPollIntervalMs));
   }
   throw new Error(
-    `Dev server did not become reachable at ${url} within ${SERVER_BOOT_TIMEOUT_MS}ms`
+    `Dev server did not become reachable at ${url} within ${serverBootTimeoutMs}ms`
   );
 }
 
@@ -62,11 +62,10 @@ function spawnDevServer(): ChildProcess {
   return proc;
 }
 
-async function main() {
-  if (!existsSync(SNAPSHOT_PATH)) {
+async function main(): Promise<void> {
+  if (!existsSync(snapshotPath)) {
     throw new Error(
-      `Missing WebContainer snapshot at ${SNAPSHOT_PATH}. ` +
-        `Run \`npm run build:snapshot\` first — without it the homepage will never reach \`Ready\`.`
+      `Missing WebContainer snapshot at ${snapshotPath}. Run \`npm run build:snapshot\` first — without it the homepage will never reach \`Ready\`.`
     );
   }
 
@@ -87,27 +86,27 @@ async function main() {
   });
 
   try {
-    if (await isServerRunning(URL)) {
-      console.log(`[screenshot] Reusing existing server at ${URL}`);
+    if (await isServerRunning(targetUrl)) {
+      console.log(`[screenshot] Reusing existing server at ${targetUrl}`);
     } else {
-      console.log(`[screenshot] No server on ${URL} — starting \`npm run dev\`...`);
+      console.log(`[screenshot] No server on ${targetUrl} — starting \`npm run dev\`...`);
       devProcess = spawnDevServer();
-      await waitForServer(URL);
+      await waitForServer(targetUrl);
       console.log('[screenshot] Dev server ready.');
     }
 
-    const outAbsolute = resolve(siteRoot, OUT);
+    const outAbsolute = resolve(siteRoot, outputPath);
     mkdirSync(dirname(outAbsolute), { recursive: true });
 
     const browser = await chromium.launch();
     try {
-      const context = await browser.newContext({ viewport: VIEWPORT });
+      const context = await browser.newContext({ viewport });
       const page = await context.newPage();
-      await page.goto(URL);
+      await page.goto(targetUrl);
       console.log('[screenshot] Waiting for runner to reach `Ready`...');
-      await page.getByText('Ready', { exact: true }).waitFor({ timeout: READY_TIMEOUT_MS });
+      await page.getByText('Ready', { exact: true }).waitFor({ timeout: readyTimeoutMs });
       await page.screenshot({ path: outAbsolute, fullPage: true });
-      console.log(`[screenshot] Saved ${OUT}`);
+      console.log(`[screenshot] Saved ${outputPath}`);
     } finally {
       await browser.close();
     }

--- a/site/scripts/screenshot-homepage.ts
+++ b/site/scripts/screenshot-homepage.ts
@@ -1,0 +1,122 @@
+/**
+ * Capture a full-page screenshot of the homepage after the WebContainer
+ * runner reports `Ready`. Single-command UX: reuse an existing dev server
+ * on `URL` if one is reachable; otherwise spawn `npm run dev` and tear it
+ * down on exit.
+ *
+ * Configuration (env):
+ *   URL  - target origin (default: http://localhost:4321)
+ *   OUT  - output path relative to site/ (default: screenshots/homepage.png)
+ *
+ * Run:
+ *   npm run screenshot:home
+ */
+import { chromium } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const siteRoot = resolve(__dirname, '..');
+
+const URL = process.env.URL ?? 'http://localhost:4321';
+const OUT = process.env.OUT ?? 'screenshots/homepage.png';
+const VIEWPORT = { width: 1280, height: 800 };
+const READY_TIMEOUT_MS = 60_000;
+const SERVER_BOOT_TIMEOUT_MS = 60_000;
+const SERVER_POLL_INTERVAL_MS = 500;
+
+const SNAPSHOT_PATH = resolve(siteRoot, 'public', 'rundown-snapshot.bin');
+
+async function isServerRunning(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, { method: 'HEAD' });
+    // Any HTTP response (including 404) means a server is on the port.
+    return res.status > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForServer(url: string): Promise<void> {
+  const deadline = Date.now() + SERVER_BOOT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await isServerRunning(url)) return;
+    await new Promise((r) => setTimeout(r, SERVER_POLL_INTERVAL_MS));
+  }
+  throw new Error(
+    `Dev server did not become reachable at ${url} within ${SERVER_BOOT_TIMEOUT_MS}ms`
+  );
+}
+
+function spawnDevServer(): ChildProcess {
+  const proc = spawn('npm', ['run', 'dev'], {
+    cwd: siteRoot,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+  });
+  // Drain pipes so the child doesn't block on a full buffer; ignore content.
+  proc.stdout?.on('data', () => {});
+  proc.stderr?.on('data', () => {});
+  return proc;
+}
+
+async function main() {
+  if (!existsSync(SNAPSHOT_PATH)) {
+    throw new Error(
+      `Missing WebContainer snapshot at ${SNAPSHOT_PATH}. ` +
+        `Run \`npm run build:snapshot\` first — without it the homepage will never reach \`Ready\`.`
+    );
+  }
+
+  let devProcess: ChildProcess | undefined;
+
+  const cleanup = () => {
+    if (devProcess && devProcess.exitCode === null) {
+      devProcess.kill('SIGTERM');
+    }
+  };
+  process.on('SIGINT', () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.on('SIGTERM', () => {
+    cleanup();
+    process.exit(143);
+  });
+
+  try {
+    if (await isServerRunning(URL)) {
+      console.log(`[screenshot] Reusing existing server at ${URL}`);
+    } else {
+      console.log(`[screenshot] No server on ${URL} — starting \`npm run dev\`...`);
+      devProcess = spawnDevServer();
+      await waitForServer(URL);
+      console.log('[screenshot] Dev server ready.');
+    }
+
+    const outAbsolute = resolve(siteRoot, OUT);
+    mkdirSync(dirname(outAbsolute), { recursive: true });
+
+    const browser = await chromium.launch();
+    try {
+      const context = await browser.newContext({ viewport: VIEWPORT });
+      const page = await context.newPage();
+      await page.goto(URL);
+      console.log('[screenshot] Waiting for runner to reach `Ready`...');
+      await page.getByText('Ready', { exact: true }).waitFor({ timeout: READY_TIMEOUT_MS });
+      await page.screenshot({ path: outAbsolute, fullPage: true });
+      console.log(`[screenshot] Saved ${OUT}`);
+    } finally {
+      await browser.close();
+    }
+  } finally {
+    cleanup();
+  }
+}
+
+main().catch((err) => {
+  console.error('[screenshot]', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/site/src/components/HomepageRunner.astro
+++ b/site/src/components/HomepageRunner.astro
@@ -53,7 +53,6 @@ const scenarios = frontmatter.scenarios || {};
           scenarios={scenarios}
           compact={false}
           autoStart={true}
-          showFooterButtons={true}
         />
       </div>
     </div>

--- a/site/src/components/interactive/RunbookRunner.tsx
+++ b/site/src/components/interactive/RunbookRunner.tsx
@@ -48,6 +48,28 @@ const SCENARIO_CARD_COPY: Record<string, ScenarioCardCopy> = {
   start: { title: 'Skip to end', description: 'Jumps straight to the last step' },
 };
 
+// Matches numbered H2 headings (`## 1`, `## 12`, etc.). Mirrors
+// `countNumberedSteps` in packages/core/src/runbook/step-utils.ts:26-28.
+const NUMBERED_H2_RE = /^## \d/gm;
+
+const TAB_MODES = ['text', 'json'] as const;
+
+function buildXtermTheme(isDarkMode: boolean) {
+  const fg = isDarkMode ? '#fafafa' : '#171717';
+  const bg = isDarkMode ? '#0a0a0a' : '#fafafa';
+  const selection = isDarkMode ? 'rgba(250,250,250,0.2)' : 'rgba(23,23,23,0.2)';
+  // All ANSI colors neutralized to foreground for monochrome output.
+  return {
+    background: bg,
+    foreground: fg,
+    cursor: fg,
+    selectionBackground: selection,
+    black: fg, red: fg, green: fg, yellow: fg, blue: fg, magenta: fg, cyan: fg, white: fg,
+    brightBlack: fg, brightRed: fg, brightGreen: fg, brightYellow: fg, brightBlue: fg,
+    brightMagenta: fg, brightCyan: fg, brightWhite: fg,
+  };
+}
+
 function parseRdArgs(cmd: string): string[] {
   // Dynamic import would complicate React component — use inline mini-parser
   // that handles quoted strings (sufficient for predefined scenario commands)
@@ -105,15 +127,11 @@ export function RunbookRunner({
   }, []);
 
   const hasAutoStarted = useRef(false);
+  const statusRef = useRef<Status>('idle');
 
   const [runbookStep, setRunbookStep] = useState<string>('—');
   const [runbookTotal] = useState<string>(() => {
-    // Count only numbered H2 headings to match the codebase's `countNumberedSteps`
-    // semantics (packages/core/src/runbook/step-utils.ts:26-28). Named steps like
-    // `## RECOVER` are deliberately excluded — the runtime emits position.total
-    // counting only numbered steps, and `formatPosition` omits the total for
-    // named steps (see packages/core/src/cli/output.ts:23-30).
-    const numberedCount = (runbookContent.match(/^## \d/gm) || []).length;
+    const numberedCount = (runbookContent.match(NUMBERED_H2_RE) || []).length;
     return numberedCount > 0 ? String(numberedCount) : '—';
   });
   const [runbookResult, setRunbookResult] = useState<string | null>(null);
@@ -126,29 +144,7 @@ export function RunbookRunner({
     if (!terminalRef.current || xtermInstance.current) return;
 
     const term = new Terminal({
-      theme: {
-        background: isDarkMode ? '#0a0a0a' : '#fafafa',
-        foreground: isDarkMode ? '#fafafa' : '#171717',
-        cursor: isDarkMode ? '#fafafa' : '#171717',
-        selectionBackground: isDarkMode ? 'rgba(250,250,250,0.2)' : 'rgba(23,23,23,0.2)',
-        // All ANSI colors neutralized to foreground for monochrome output
-        black: isDarkMode ? '#fafafa' : '#171717',
-        red: isDarkMode ? '#fafafa' : '#171717',
-        green: isDarkMode ? '#fafafa' : '#171717',
-        yellow: isDarkMode ? '#fafafa' : '#171717',
-        blue: isDarkMode ? '#fafafa' : '#171717',
-        magenta: isDarkMode ? '#fafafa' : '#171717',
-        cyan: isDarkMode ? '#fafafa' : '#171717',
-        white: isDarkMode ? '#fafafa' : '#171717',
-        brightBlack: isDarkMode ? '#fafafa' : '#171717',
-        brightRed: isDarkMode ? '#fafafa' : '#171717',
-        brightGreen: isDarkMode ? '#fafafa' : '#171717',
-        brightYellow: isDarkMode ? '#fafafa' : '#171717',
-        brightBlue: isDarkMode ? '#fafafa' : '#171717',
-        brightMagenta: isDarkMode ? '#fafafa' : '#171717',
-        brightCyan: isDarkMode ? '#fafafa' : '#171717',
-        brightWhite: isDarkMode ? '#fafafa' : '#171717',
-      },
+      theme: buildXtermTheme(isDarkMode),
       fontFamily: '"JetBrains Mono", "Fira Code", monospace',
       fontSize: 12,
       lineHeight: 1.4,
@@ -177,42 +173,27 @@ export function RunbookRunner({
 
   useEffect(() => {
     if (xtermInstance.current) {
-      xtermInstance.current.options.theme = {
-        background: isDarkMode ? '#0a0a0a' : '#fafafa',
-        foreground: isDarkMode ? '#fafafa' : '#171717',
-        cursor: isDarkMode ? '#fafafa' : '#171717',
-        selectionBackground: isDarkMode ? 'rgba(250,250,250,0.2)' : 'rgba(23,23,23,0.2)',
-        // All ANSI colors neutralized to foreground for monochrome output
-        black: isDarkMode ? '#fafafa' : '#171717',
-        red: isDarkMode ? '#fafafa' : '#171717',
-        green: isDarkMode ? '#fafafa' : '#171717',
-        yellow: isDarkMode ? '#fafafa' : '#171717',
-        blue: isDarkMode ? '#fafafa' : '#171717',
-        magenta: isDarkMode ? '#fafafa' : '#171717',
-        cyan: isDarkMode ? '#fafafa' : '#171717',
-        white: isDarkMode ? '#fafafa' : '#171717',
-        brightBlack: isDarkMode ? '#fafafa' : '#171717',
-        brightRed: isDarkMode ? '#fafafa' : '#171717',
-        brightGreen: isDarkMode ? '#fafafa' : '#171717',
-        brightYellow: isDarkMode ? '#fafafa' : '#171717',
-        brightBlue: isDarkMode ? '#fafafa' : '#171717',
-        brightMagenta: isDarkMode ? '#fafafa' : '#171717',
-        brightCyan: isDarkMode ? '#fafafa' : '#171717',
-        brightWhite: isDarkMode ? '#fafafa' : '#171717',
-      };
+      xtermInstance.current.options.theme = buildXtermTheme(isDarkMode);
     }
   }, [isDarkMode]);
+
+  // Keep statusRef in sync with status state so callbacks can read the
+  // current value without listing `status` in their dep arrays. This breaks
+  // the cascade where every status flip recreated reset/switchMode/etc.
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
 
   const resetInternalState = useCallback(() => {
     setRunbookStep('—');
     setRunbookResult(null);
     setCurrentStep(0);
-    if (status === 'error') {
+    if (statusRef.current === 'error') {
       setStatus('ready');
       setError(null);
     }
     xtermInstance.current?.clear();
-  }, [status]);
+  }, []);
 
   useEffect(() => {
     let mounted = true;
@@ -310,20 +291,20 @@ export function RunbookRunner({
 
   const reset = useCallback(async () => {
     resetInternalState();
-    if (container) {
-      try {
-        await cleanRundownState(container);
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
+    // cleanRundownState uses Promise.allSettled internally — never rejects.
+    if (container) await cleanRundownState(container);
   }, [container, resetInternalState]);
 
   const switchMode = useCallback(
     async (next: 'text' | 'json') => {
       if (next === mode) return;
-      await reset();
+      // Update mode first so the UI reflects the active tab while reset runs.
+      // Then clean state and clear the terminal. autoStart is NOT re-armed
+      // (`hasAutoStarted` stays true) — after a mode switch the user drives
+      // the walk-through manually, avoiding a race between the autoStart
+      // effect and the user's first click in the new mode.
       setMode(next);
+      await reset();
     },
     [mode, reset]
   );
@@ -331,6 +312,12 @@ export function RunbookRunner({
   const scenario = scenarios[selectedScenario];
   const isComplete = scenario && currentStep >= scenario.commands.length;
   const canRun = status === 'ready' && !isComplete;
+  // The action button shows 'Complete' on the click that runs the final
+  // command of a multi-command scenario. Single-command scenarios stay on
+  // 'Next' (the only command isn't a "final" step in a sequence) — this
+  // also keeps `runbook-runner.spec.ts`'s `auto-execution` test passing.
+  const onFinalCommand =
+    scenario != null && scenario.commands.length > 1 && currentStep >= scenario.commands.length - 1;
 
   const statusText = {
     idle: 'Initializing...',
@@ -388,14 +375,33 @@ export function RunbookRunner({
       {/* Tabs + actions */}
       <div className="flex items-center justify-between gap-4 mb-4 border-b border-border">
         <div role="tablist" aria-label="Output format" className="flex">
-          {(['text', 'json'] as const).map((m) => {
+          {TAB_MODES.map((m) => {
             const active = mode === m;
+            const label = m === 'text' ? 'Text' : 'JSON';
             return (
               <button
                 key={m}
                 role="tab"
+                id={`tab-${m}`}
                 aria-selected={active}
+                aria-controls="runbook-runner-tabpanel"
+                tabIndex={active ? 0 : -1}
                 onClick={() => void switchMode(m)}
+                onKeyDown={(e) => {
+                  if (e.key === 'ArrowLeft' || e.key === 'ArrowRight' ||
+                      e.key === 'Home' || e.key === 'End') {
+                    e.preventDefault();
+                    const idx = TAB_MODES.indexOf(m);
+                    let nextIdx: number;
+                    if (e.key === 'Home') nextIdx = 0;
+                    else if (e.key === 'End') nextIdx = TAB_MODES.length - 1;
+                    else if (e.key === 'ArrowLeft') nextIdx = (idx - 1 + TAB_MODES.length) % TAB_MODES.length;
+                    else nextIdx = (idx + 1) % TAB_MODES.length;
+                    const nextMode = TAB_MODES[nextIdx];
+                    void switchMode(nextMode);
+                    document.getElementById(`tab-${nextMode}`)?.focus();
+                  }
+                }}
                 disabled={status === 'running'}
                 className={`px-4 py-2 text-xs font-mono uppercase tracking-wider transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                   active
@@ -403,7 +409,7 @@ export function RunbookRunner({
                     : 'border-b-2 border-transparent text-muted-foreground hover:text-foreground'
                 }`}
               >
-                {m === 'text' ? 'Text' : 'JSON'}
+                {label}
               </button>
             );
           })}
@@ -417,7 +423,7 @@ export function RunbookRunner({
             disabled={!canRun}
             className="h-9 px-4 text-sm btn-primary flex items-center gap-2"
           >
-            {scenario && scenario.commands.length > 1 && currentStep >= scenario.commands.length - 1 ? 'Complete' : 'Next'}
+            {onFinalCommand ? 'Complete' : 'Next'}
             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
             </svg>
@@ -444,6 +450,9 @@ export function RunbookRunner({
 
       {/* Terminal Output Container */}
       <div
+        id="runbook-runner-tabpanel"
+        role="tabpanel"
+        aria-labelledby={`tab-${mode}`}
         className={`bg-background rounded-md p-4 border border-border overflow-hidden relative ${compact ? 'h-[250px]' : 'flex-1 min-h-[400px]'
           }`}
       >
@@ -460,7 +469,7 @@ export function RunbookRunner({
       {/* Footer Progress & Status */}
       <div className="mt-4 flex items-center justify-between text-[10px] font-mono border-t border-border pt-4">
         <div className="flex items-center gap-6">
-          <div className="flex items-center gap-2">
+          <div data-testid="footer-step" className="flex items-center gap-2">
             <span className="text-muted-foreground uppercase tracking-tighter">Step</span>
             <span className="text-foreground font-bold">
               {runbookStep}/{runbookTotal}
@@ -469,14 +478,14 @@ export function RunbookRunner({
 
           {runbookResult && (
             <>
-              <div className="flex items-center gap-2">
+              <div data-testid="footer-result" className="flex items-center gap-2">
                 <span className="text-muted-foreground uppercase tracking-tighter">Result</span>
                 <span className="text-foreground font-bold">
                   {runbookResult}
                 </span>
               </div>
 
-              <div className="flex items-center gap-2">
+              <div data-testid="footer-expected" className="flex items-center gap-2">
                 <span className="text-muted-foreground uppercase tracking-tighter">Expected</span>
                 <span className="text-foreground font-bold">{scenario?.result || '—'}</span>
               </div>

--- a/site/src/components/interactive/RunbookRunner.tsx
+++ b/site/src/components/interactive/RunbookRunner.tsx
@@ -28,7 +28,6 @@ interface Props {
   scenarios: Record<string, Scenario>;
   compact?: boolean;
   autoStart?: boolean;
-  showFooterButtons?: boolean;
 }
 
 type Status = 'idle' | 'booting' | 'loading' | 'ready' | 'running' | 'error';
@@ -81,7 +80,6 @@ export function RunbookRunner({
   scenarios,
   compact = false,
   autoStart = false,
-  showFooterButtons = false,
 }: Props) {
   const [container, setContainer] = useState<WebContainer | null>(null);
   const [status, setStatus] = useState<Status>('idle');
@@ -90,6 +88,7 @@ export function RunbookRunner({
   const [selectedScenario, setSelectedScenario] = useState<string>(
     Object.keys(scenarios)[0] || ''
   );
+  const [mode, setMode] = useState<'text' | 'json'>('text');
 
   const [isDarkMode, setIsDarkMode] = useState(false);
 
@@ -106,14 +105,16 @@ export function RunbookRunner({
   }, []);
 
   const hasAutoStarted = useRef(false);
-  const previousScenario = useRef<string | null>(null);
-  const isResetting = useRef(false);
 
   const [runbookStep, setRunbookStep] = useState<string>('—');
   const [runbookTotal] = useState<string>(() => {
-    // Derive total step count from H2 headings in runbook content
-    const h2Count = (runbookContent.match(/^## /gm) || []).length;
-    return h2Count > 0 ? String(h2Count) : '—';
+    // Count only numbered H2 headings to match the codebase's `countNumberedSteps`
+    // semantics (packages/core/src/runbook/step-utils.ts:26-28). Named steps like
+    // `## RECOVER` are deliberately excluded — the runtime emits position.total
+    // counting only numbered steps, and `formatPosition` omits the total for
+    // named steps (see packages/core/src/cli/output.ts:23-30).
+    const numberedCount = (runbookContent.match(/^## \d/gm) || []).length;
+    return numberedCount > 0 ? String(numberedCount) : '—';
   });
   const [runbookResult, setRunbookResult] = useState<string | null>(null);
 
@@ -206,8 +207,12 @@ export function RunbookRunner({
     setRunbookStep('—');
     setRunbookResult(null);
     setCurrentStep(0);
+    if (status === 'error') {
+      setStatus('ready');
+      setError(null);
+    }
     xtermInstance.current?.clear();
-  }, []);
+  }, [status]);
 
   useEffect(() => {
     let mounted = true;
@@ -265,23 +270,27 @@ export function RunbookRunner({
       const processChunk = (chunk: string) => {
         term.write(chunk);
 
-        const cleanChunk = stripAnsi(chunk);
-        const lines = cleanChunk.split('\n');
-
-        for (const line of lines) {
-          // CLI outputs "At: X" for step position (just the step number)
-          const stepMatch = line.match(/At:\s+(\d+)/);
-          if (stepMatch) {
-            setRunbookStep(stepMatch[1]);
-          }
-          const resultMatch = line.match(/Runbook:\s+([A-Z]+)/);
-          if (resultMatch) {
-            setRunbookResult(resultMatch[1]);
+        // Footer parsing is text-only — `At: <stepId>` / `Runbook: STATUS`
+        // lines appear only in `--text` output. In JSON mode the footer stays
+        // at placeholder values for the entire walk-through (V1 simplicity).
+        if (mode === 'text') {
+          const cleanChunk = stripAnsi(chunk);
+          for (const line of cleanChunk.split('\n')) {
+            // The `At:` line emits ONLY a step ID — never `step/total`.
+            // Examples: `At:       1`, `At:       2.1`, `At:       RECOVER`.
+            // Source: packages/core/src/cli/output.ts:120-122 writes
+            // `data.at` directly; `data.at` is `derivePositionAt(...)` (see
+            // packages/cli/src/helpers/transition-orchestrator.ts:188 and
+            // goto-workflow.ts:285), which returns just the step ID.
+            const stepMatch = line.match(/At:\s+([\w.]+)/);
+            if (stepMatch) setRunbookStep(stepMatch[1]);
+            const resultMatch = line.match(/Runbook:\s+([A-Z]+)/);
+            if (resultMatch) setRunbookResult(resultMatch[1]);
           }
         }
       };
 
-      await runRdCommand(container, args, processChunk);
+      await runRdCommand(container, args, processChunk, mode);
 
       setCurrentStep((prev) => prev + 1);
       setStatus('ready');
@@ -290,7 +299,7 @@ export function RunbookRunner({
       term.writeln(`\x1b[31mError: ${msg}\x1b[0m`);
       setStatus('error');
     }
-  }, [container, selectedScenario, scenarios, currentStep, status]);
+  }, [container, selectedScenario, scenarios, currentStep, status, mode]);
 
   useEffect(() => {
     if (autoStart && !hasAutoStarted.current && status === 'ready' && currentStep === 0) {
@@ -299,40 +308,8 @@ export function RunbookRunner({
     }
   }, [autoStart, status, currentStep, executeStep]);
 
-  useEffect(() => {
-    if (previousScenario.current === null) {
-      previousScenario.current = selectedScenario;
-      return;
-    }
-
-    // Don't auto-execute while reset is in progress
-    if (isResetting.current) {
-      previousScenario.current = selectedScenario;
-      return;
-    }
-
-    if (
-      selectedScenario !== previousScenario.current &&
-      status === 'ready' &&
-      currentStep === 0
-    ) {
-      previousScenario.current = selectedScenario;
-      executeStep();
-    }
-  }, [selectedScenario, status, currentStep, executeStep]);
-
   const reset = useCallback(async () => {
-    // Set flag to prevent auto-execute during reset
-    isResetting.current = true;
-
-    // Reset internal state first (synchronous)
     resetInternalState();
-    if (status === 'error') {
-      setStatus('ready');
-      setError(null);
-    }
-
-    // Then clean runbook state (async)
     if (container) {
       try {
         await cleanRundownState(container);
@@ -340,10 +317,16 @@ export function RunbookRunner({
         // Ignore cleanup errors
       }
     }
+  }, [container, resetInternalState]);
 
-    // Clear the flag after reset is complete
-    isResetting.current = false;
-  }, [container, status, resetInternalState]);
+  const switchMode = useCallback(
+    async (next: 'text' | 'json') => {
+      if (next === mode) return;
+      await reset();
+      setMode(next);
+    },
+    [mode, reset]
+  );
 
   const scenario = scenarios[selectedScenario];
   const isComplete = scenario && currentStep >= scenario.commands.length;
@@ -379,8 +362,9 @@ export function RunbookRunner({
                 key={key}
                 disabled={status === 'running'}
                 onClick={() => {
+                  if (selectedScenario === key) return;
                   setSelectedScenario(key);
-                  reset();
+                  void reset();
                 }}
                 aria-pressed={selected}
                 className={`text-left rounded-md p-3 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
@@ -401,15 +385,33 @@ export function RunbookRunner({
         </div>
       </div>
 
-      {/* Controls */}
-      <div className="flex flex-wrap items-center justify-between gap-4 mb-4 pt-4 border-t border-border">
-        <div className="flex items-center gap-3">
-          <span className="text-xs font-mono uppercase tracking-widest text-muted-foreground">
+      {/* Tabs + actions */}
+      <div className="flex items-center justify-between gap-4 mb-4 border-b border-border">
+        <div role="tablist" aria-label="Output format" className="flex">
+          {(['text', 'json'] as const).map((m) => {
+            const active = mode === m;
+            return (
+              <button
+                key={m}
+                role="tab"
+                aria-selected={active}
+                onClick={() => void switchMode(m)}
+                disabled={status === 'running'}
+                className={`px-4 py-2 text-xs font-mono uppercase tracking-wider transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                  active
+                    ? 'border-b-2 border-accent text-foreground'
+                    : 'border-b-2 border-transparent text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {m === 'text' ? 'Text' : 'JSON'}
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex items-center gap-2 pb-2">
+          <span className="text-[10px] font-mono uppercase tracking-widest text-muted-foreground mr-2">
             {statusText}
           </span>
-        </div>
-
-        <div className="flex gap-2">
           <button
             onClick={executeStep}
             disabled={!canRun}
@@ -421,7 +423,7 @@ export function RunbookRunner({
             </svg>
           </button>
           <button
-            onClick={reset}
+            onClick={() => void reset()}
             disabled={status === 'running' || (currentStep === 0 && !error)}
             className="h-9 px-3 text-sm btn-secondary flex items-center gap-2"
           >
@@ -481,31 +483,6 @@ export function RunbookRunner({
             </>
           )}
         </div>
-
-        {showFooterButtons && (
-          <div className="flex gap-2">
-            <button
-              onClick={executeStep}
-              disabled={!canRun}
-              className="h-9 px-4 text-sm btn-primary flex items-center gap-2"
-            >
-              {isComplete ? 'Complete' : 'Next'}
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
-              </svg>
-            </button>
-            <button
-              onClick={reset}
-              disabled={status === 'running' || (currentStep === 0 && !error)}
-              className="h-9 px-3 text-sm btn-secondary flex items-center gap-2"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
-              </svg>
-              Reset
-            </button>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/site/src/components/interactive/RunbookRunner.tsx
+++ b/site/src/components/interactive/RunbookRunner.tsx
@@ -33,6 +33,22 @@ interface Props {
 
 type Status = 'idle' | 'booting' | 'loading' | 'ready' | 'running' | 'error';
 
+type ScenarioCardCopy = { title: string; description: string };
+
+/**
+ * UI-layer card copy keyed by scenario ID in
+ * `site/public/this-is-rundown.runbook.md`. The runbook's own
+ * `description:` fields are flavour text and not card-friendly. If a
+ * scenario isn't in this map, the runbook description (or the key, then
+ * the empty string) is used as a fallback so other consumers
+ * (e.g. `auto-execution` on `/explore/code-blocks`) keep rendering.
+ */
+const SCENARIO_CARD_COPY: Record<string, ScenarioCardCopy> = {
+  rundown: { title: 'Happy path', description: 'Runs 6 steps, all pass' },
+  retry: { title: 'Retry on fail', description: 'Fails, retries, eventually passes' },
+  start: { title: 'Skip to end', description: 'Jumps straight to the last step' },
+};
+
 function parseRdArgs(cmd: string): string[] {
   // Dynamic import would complicate React component — use inline mini-parser
   // that handles quoted strings (sufficient for predefined scenario commands)
@@ -352,29 +368,37 @@ export function RunbookRunner({
         <label className="text-[10px] uppercase tracking-wider text-muted-foreground font-bold mb-2 block">
           Select Scenario
         </label>
-        <div className="flex flex-wrap gap-2">
-          {Object.entries(scenarios).map(([key]) => (
-            <button
-              key={key}
-              disabled={status === 'running'}
-              onClick={() => {
-                setSelectedScenario(key);
-                reset();
-              }}
-              className={`px-3 py-1.5 text-xs font-mono rounded-md border transition-all whitespace-normal text-left ${selectedScenario === key
-                ? 'bg-foreground/90 text-background border-foreground/90'
-                : 'bg-background border-border text-muted-foreground hover:text-foreground hover:border-foreground/50'
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {Object.entries(scenarios).map(([key, sc]) => {
+            const copy = SCENARIO_CARD_COPY[key];
+            const title = copy?.title ?? key;
+            const description = copy?.description ?? sc.description ?? '';
+            const selected = selectedScenario === key;
+            return (
+              <button
+                key={key}
+                disabled={status === 'running'}
+                onClick={() => {
+                  setSelectedScenario(key);
+                  reset();
+                }}
+                aria-pressed={selected}
+                className={`text-left rounded-md p-3 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                  selected
+                    ? 'border-2 border-accent bg-background'
+                    : 'border border-border bg-background hover:border-foreground/50'
                 }`}
-            >
-              {key}
-            </button>
-          ))}
+              >
+                <div className="text-sm font-mono font-bold text-foreground mb-1">
+                  {title}
+                </div>
+                <div className="text-xs text-muted-foreground leading-relaxed">
+                  {description}
+                </div>
+              </button>
+            );
+          })}
         </div>
-        {scenario?.description && (
-          <p className="mt-2 text-xs text-muted-foreground italic leading-relaxed">
-            {scenario.description}
-          </p>
-        )}
       </div>
 
       {/* Controls */}

--- a/site/src/components/interactive/RunbookRunner.tsx
+++ b/site/src/components/interactive/RunbookRunner.tsx
@@ -111,6 +111,11 @@ export function RunbookRunner({
     Object.keys(scenarios)[0] || ''
   );
   const [mode, setMode] = useState<'text' | 'json'>('text');
+  // Set while reset()'s async cleanRundownState is awaiting. Without this
+  // gate, status stays `ready` during cleanup, which would let a Next click
+  // start a new run before `.rundown/runs` / `session.json` / locks are
+  // gone — and the new run would inherit stale persisted state.
+  const [isResetting, setIsResetting] = useState(false);
 
   const [isDarkMode, setIsDarkMode] = useState(false);
 
@@ -231,7 +236,7 @@ export function RunbookRunner({
   }, [runbookPath, runbookContent]);
 
   const executeStep = useCallback(async () => {
-    if (!container || !selectedScenario || status !== 'ready') return;
+    if (!container || !selectedScenario || status !== 'ready' || isResetting) return;
     const term = xtermInstance.current;
     if (!term) return;
 
@@ -280,7 +285,7 @@ export function RunbookRunner({
       term.writeln(`\x1b[31mError: ${msg}\x1b[0m`);
       setStatus('error');
     }
-  }, [container, selectedScenario, scenarios, currentStep, status, mode]);
+  }, [container, selectedScenario, scenarios, currentStep, status, mode, isResetting]);
 
   useEffect(() => {
     if (autoStart && !hasAutoStarted.current && status === 'ready' && currentStep === 0) {
@@ -290,9 +295,14 @@ export function RunbookRunner({
   }, [autoStart, status, currentStep, executeStep]);
 
   const reset = useCallback(async () => {
+    setIsResetting(true);
     resetInternalState();
-    // cleanRundownState uses Promise.allSettled internally — never rejects.
-    if (container) await cleanRundownState(container);
+    try {
+      // cleanRundownState uses Promise.allSettled internally — never rejects.
+      if (container) await cleanRundownState(container);
+    } finally {
+      setIsResetting(false);
+    }
   }, [container, resetInternalState]);
 
   const switchMode = useCallback(
@@ -311,7 +321,7 @@ export function RunbookRunner({
 
   const scenario = scenarios[selectedScenario];
   const isComplete = scenario && currentStep >= scenario.commands.length;
-  const canRun = status === 'ready' && !isComplete;
+  const canRun = status === 'ready' && !isComplete && !isResetting;
   // The action button shows 'Complete' on the click that runs the final
   // command of a multi-command scenario. Single-command scenarios stay on
   // 'Next' (the only command isn't a "final" step in a sequence) — this

--- a/site/src/components/interactive/RunbookRunner.tsx
+++ b/site/src/components/interactive/RunbookRunner.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useId, useMemo, useRef } from 'react';
 import * as xtermPkg from '@xterm/xterm';
 // @ts-ignore
 const Terminal = xtermPkg.Terminal || xtermPkg.default?.Terminal;
@@ -117,6 +117,13 @@ export function RunbookRunner({
   // gone — and the new run would inherit stale persisted state.
   const [isResetting, setIsResetting] = useState(false);
 
+  // Instance-scoped IDs so multiple RunbookRunner instances on the same page
+  // don't collide on `aria-controls` / `aria-labelledby` / the keyboard
+  // handler's `getElementById` lookup.
+  const reactId = useId();
+  const tabId = (m: string) => `${reactId}-tab-${m}`;
+  const panelId = `${reactId}-tabpanel`;
+
   const [isDarkMode, setIsDarkMode] = useState(false);
 
   useEffect(() => {
@@ -205,6 +212,19 @@ export function RunbookRunner({
     xtermInstance.current?.clear();
   }, [container]);
 
+  // Reset session state when the runbook props change. All current call sites
+  // (HomepageRunner.astro, /explore/[pattern].astro) re-mount the React tree
+  // on route change, so this is defensive — but it keeps the component
+  // reusable: if a parent ever swaps `runbookContent` mid-mount, the footer,
+  // selected scenario, and autoStart latch all reinitialize together.
+  useEffect(() => {
+    setRunbookStep('—');
+    setRunbookResult(null);
+    setCurrentStep(0);
+    setSelectedScenario(Object.keys(scenarios)[0] || '');
+    hasAutoStarted.current = false;
+  }, [runbookPath, runbookContent, scenarios]);
+
   useEffect(() => {
     let mounted = true;
 
@@ -258,33 +278,41 @@ export function RunbookRunner({
     term.writeln('');
 
     try {
+      // Footer parsing is text-only — `At: <stepId>` / `Runbook: STATUS`
+      // lines appear only in `--text` output. In JSON mode the footer stays
+      // at placeholder values for the entire walk-through (V1 simplicity).
+      //
+      // Stream chunks have no newline-alignment guarantee — a footer token
+      // could arrive split across `onOutput` calls. Buffer partial trailing
+      // lines across chunks and only run the regexes on complete lines.
+      // Anchor with `^` so only true CLI footer lines match (runbook content
+      // containing the substrings mid-line cannot spuriously overwrite).
+      // Source for the emit format: packages/core/src/cli/output.ts:120-122
+      // writes `data.at` directly; `data.at` is `derivePositionAt(...)`,
+      // which returns just the step ID — `1`, `2.1`, `RECOVER`, etc.
+      let lineBuffer = '';
+      const matchFooterLine = (line: string) => {
+        const stepMatch = line.match(/^At:\s+([\w.]+)/);
+        if (stepMatch) setRunbookStep(stepMatch[1]);
+        const resultMatch = line.match(/^Runbook:\s+([A-Z]+)/);
+        if (resultMatch) setRunbookResult(resultMatch[1]);
+      };
+
       const processChunk = (chunk: string) => {
         term.write(chunk);
-
-        // Footer parsing is text-only — `At: <stepId>` / `Runbook: STATUS`
-        // lines appear only in `--text` output. In JSON mode the footer stays
-        // at placeholder values for the entire walk-through (V1 simplicity).
         if (mode === 'text') {
-          const cleanChunk = stripAnsi(chunk);
-          for (const line of cleanChunk.split('\n')) {
-            // The `At:` line emits ONLY a step ID — never `step/total`.
-            // Examples: `At:       1`, `At:       2.1`, `At:       RECOVER`.
-            // Source: packages/core/src/cli/output.ts:120-122 writes
-            // `data.at` directly; `data.at` is `derivePositionAt(...)` (see
-            // packages/cli/src/helpers/transition-orchestrator.ts:188 and
-            // goto-workflow.ts:285), which returns just the step ID.
-            // Anchor with `^` so only true CLI footer lines match — runbook
-            // content or future emitted text containing the substrings
-            // mid-line cannot spuriously overwrite the footer.
-            const stepMatch = line.match(/^At:\s+([\w.]+)/);
-            if (stepMatch) setRunbookStep(stepMatch[1]);
-            const resultMatch = line.match(/^Runbook:\s+([A-Z]+)/);
-            if (resultMatch) setRunbookResult(resultMatch[1]);
-          }
+          lineBuffer += stripAnsi(chunk);
+          const lines = lineBuffer.split('\n');
+          lineBuffer = lines.pop() ?? '';
+          for (const line of lines) matchFooterLine(line);
         }
       };
 
       await runRdCommand(container, args, processChunk, mode);
+
+      // Flush any trailing partial line — the CLI's last write may not end
+      // in a newline if the stream closed mid-line.
+      if (mode === 'text' && lineBuffer.length > 0) matchFooterLine(lineBuffer);
 
       setCurrentStep((prev) => prev + 1);
       setStatus('ready');
@@ -400,9 +428,9 @@ export function RunbookRunner({
               <button
                 key={m}
                 role="tab"
-                id={`tab-${m}`}
+                id={tabId(m)}
                 aria-selected={active}
-                aria-controls="runbook-runner-tabpanel"
+                aria-controls={panelId}
                 tabIndex={active ? 0 : -1}
                 onClick={() => void switchMode(m)}
                 onKeyDown={(e) => {
@@ -417,7 +445,7 @@ export function RunbookRunner({
                     else nextIdx = (idx + 1) % TAB_MODES.length;
                     const nextMode = TAB_MODES[nextIdx];
                     void switchMode(nextMode);
-                    document.getElementById(`tab-${nextMode}`)?.focus();
+                    document.getElementById(tabId(nextMode))?.focus();
                   }
                 }}
                 disabled={status === 'running'}
@@ -468,9 +496,9 @@ export function RunbookRunner({
 
       {/* Terminal Output Container */}
       <div
-        id="runbook-runner-tabpanel"
+        id={panelId}
         role="tabpanel"
-        aria-labelledby={`tab-${mode}`}
+        aria-labelledby={tabId(mode)}
         className={`bg-background rounded-md p-4 border border-border overflow-hidden relative ${compact ? 'h-[250px]' : 'flex-1 min-h-[400px]'
           }`}
       >

--- a/site/src/components/interactive/RunbookRunner.tsx
+++ b/site/src/components/interactive/RunbookRunner.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import * as xtermPkg from '@xterm/xterm';
 // @ts-ignore
 const Terminal = xtermPkg.Terminal || xtermPkg.default?.Terminal;
@@ -135,10 +135,10 @@ export function RunbookRunner({
   const statusRef = useRef<Status>('idle');
 
   const [runbookStep, setRunbookStep] = useState<string>('—');
-  const [runbookTotal] = useState<string>(() => {
+  const runbookTotal = useMemo(() => {
     const numberedCount = (runbookContent.match(NUMBERED_H2_RE) || []).length;
     return numberedCount > 0 ? String(numberedCount) : '—';
-  });
+  }, [runbookContent]);
   const [runbookResult, setRunbookResult] = useState<string | null>(null);
 
   const terminalRef = useRef<HTMLDivElement>(null);
@@ -193,12 +193,17 @@ export function RunbookRunner({
     setRunbookStep('—');
     setRunbookResult(null);
     setCurrentStep(0);
-    if (statusRef.current === 'error') {
+    // Only recover from `error` to `ready` when the WebContainer environment
+    // actually exists. Bootstrap failures (getWebContainer / setupRundown /
+    // mountRunbook) leave `container === null`, in which case clearing the
+    // banner would make the runner look healthy while `executeStep` silently
+    // no-ops on `!container`.
+    if (statusRef.current === 'error' && container) {
       setStatus('ready');
       setError(null);
     }
     xtermInstance.current?.clear();
-  }, []);
+  }, [container]);
 
   useEffect(() => {
     let mounted = true;
@@ -268,9 +273,12 @@ export function RunbookRunner({
             // `data.at` directly; `data.at` is `derivePositionAt(...)` (see
             // packages/cli/src/helpers/transition-orchestrator.ts:188 and
             // goto-workflow.ts:285), which returns just the step ID.
-            const stepMatch = line.match(/At:\s+([\w.]+)/);
+            // Anchor with `^` so only true CLI footer lines match — runbook
+            // content or future emitted text containing the substrings
+            // mid-line cannot spuriously overwrite the footer.
+            const stepMatch = line.match(/^At:\s+([\w.]+)/);
             if (stepMatch) setRunbookStep(stepMatch[1]);
-            const resultMatch = line.match(/Runbook:\s+([A-Z]+)/);
+            const resultMatch = line.match(/^Runbook:\s+([A-Z]+)/);
             if (resultMatch) setRunbookResult(resultMatch[1]);
           }
         }

--- a/site/src/components/interactive/RunbookRunner.tsx
+++ b/site/src/components/interactive/RunbookRunner.tsx
@@ -417,7 +417,7 @@ export function RunbookRunner({
             disabled={!canRun}
             className="h-9 px-4 text-sm btn-primary flex items-center gap-2"
           >
-            {isComplete ? 'Complete' : 'Next'}
+            {scenario && scenario.commands.length > 1 && currentStep >= scenario.commands.length - 1 ? 'Complete' : 'Next'}
             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
             </svg>

--- a/site/src/lib/webcontainer.ts
+++ b/site/src/lib/webcontainer.ts
@@ -103,6 +103,11 @@ export async function cleanRundownState(container: WebContainer): Promise<void> 
  * @param timeoutMs - Timeout in milliseconds (default: 10000)
  * @param onOutput - Optional callback for streaming output
  * @returns Object containing command output and exit code
+ * @throws Error - Rejects if {@link WebContainer.spawn} fails or if the
+ *   spawned process's `exit` promise itself rejects. Non-zero exit codes
+ *   are NOT thrown — they are returned in the resolved `exitCode` field.
+ *   Timeouts also resolve (with `output: '(command timed out)'` and
+ *   `exitCode: -1`) rather than throwing.
  */
 export async function runCommand(
   container: WebContainer,
@@ -190,6 +195,11 @@ export async function runCommand(
  * @param onOutput - Optional callback for streaming output
  * @param mode - Output mode (default: `'text'`)
  * @returns Object containing command output and exit code
+ * @throws Error - Rejects with the underlying error from {@link runCommand}
+ *   if the WebContainer fails to spawn the `node` process or the process's
+ *   `exit` promise rejects. Non-zero exit codes are NOT thrown — they are
+ *   returned in the resolved `exitCode` field. Timeouts also resolve (with
+ *   `exitCode: -1`) rather than throwing.
  */
 export async function runRdCommand(
   container: WebContainer,

--- a/site/src/lib/webcontainer.ts
+++ b/site/src/lib/webcontainer.ts
@@ -199,8 +199,7 @@ export async function runRdCommand(
 ): Promise<{ output: string; exitCode: number }> {
   // Use node to run the CLI script directly (avoids execute permission issues)
   const cliPath = './node_modules/@rundown-org/cli/dist/cli.js';
-  const finalArgs =
-    mode === 'text' && !args.includes('--text') ? [...args, '--text'] : args;
+  const finalArgs = mode === 'text' ? [...args, '--text'] : args;
   console.log(`[WebContainer] Running rd via node (${mode}): ${cliPath} ${finalArgs.join(' ')}`);
   return runCommand(container, 'node', [cliPath, ...finalArgs], 10000, onOutput);
 }

--- a/site/src/lib/webcontainer.ts
+++ b/site/src/lib/webcontainer.ts
@@ -173,21 +173,34 @@ export async function runCommand(
 /**
  * Run an rd command using node to invoke the CLI directly (avoids permission issues).
  *
+ * The `mode` parameter controls the CLI's output format:
+ *
+ * - `'text'` (default) appends `--text` to the args. The site's interactive demo
+ *   relies on this for the status footer regex parser in `RunbookRunner.tsx`,
+ *   which extracts step/result info from text-mode output patterns
+ *   (`At: <stepId>`, `Runbook: STATUS`).
+ * - `'json'` leaves args untouched, so the CLI emits its default JSONL event
+ *   stream. The footer regex parser does not fire in JSON mode (those lines
+ *   aren't in the JSON output); footer values stay at placeholders.
+ *
+ * The parameter is optional and last-position so existing callers compile unchanged.
+ *
  * @param container - The WebContainer instance to run the command in
  * @param args - Arguments to pass to the rd command
  * @param onOutput - Optional callback for streaming output
+ * @param mode - Output mode (default: `'text'`)
  * @returns Object containing command output and exit code
  */
 export async function runRdCommand(
   container: WebContainer,
   args: string[],
-  onOutput?: (chunk: string) => void
+  onOutput?: (chunk: string) => void,
+  mode: 'text' | 'json' = 'text'
 ): Promise<{ output: string; exitCode: number }> {
   // Use node to run the CLI script directly (avoids execute permission issues)
   const cliPath = './node_modules/@rundown-org/cli/dist/cli.js';
-  // Always use --text for the site's interactive demo — the processChunk parser
-  // in RunbookRunner.tsx extracts step/result info from text-mode output patterns.
-  const textArgs = args.includes('--text') ? args : [...args, '--text'];
-  console.log(`[WebContainer] Running rd via node: ${cliPath} ${textArgs.join(' ')}`);
-  return runCommand(container, 'node', [cliPath, ...textArgs], 10000, onOutput);
+  const finalArgs =
+    mode === 'text' && !args.includes('--text') ? [...args, '--text'] : args;
+  console.log(`[WebContainer] Running rd via node (${mode}): ${cliPath} ${finalArgs.join(' ')}`);
+  return runCommand(container, 'node', [cliPath, ...finalArgs], 10000, onOutput);
 }

--- a/site/tests/landing-page.spec.ts
+++ b/site/tests/landing-page.spec.ts
@@ -1,79 +1,71 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Landing Page Scenarios', () => {
+test.describe('Landing Page', () => {
   test.describe.configure({ mode: 'serial' });
 
   test.beforeEach(async ({ page }) => {
-    // 1. Navigate to the landing page
     await page.goto('/');
-    // 2. Verify page title
     await expect(page).toHaveTitle(/Rundown - Executable Runbooks in Markdown/);
-    // 3. Wait for WebContainer to boot (Status: Ready)
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
   });
 
-  test('executes rundown scenario correctly', async ({ page }) => {
-    // Select 'rundown' scenario
-    await page.getByRole('button', { name: 'rundown' }).click();
+  test('renders three labeled scenario cards', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /Happy path/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Retry on fail/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Skip to end/ })).toBeVisible();
 
-    const nextStepButton = page.getByRole('button', { name: 'Next' }).first();
-
-
-    // rundown has 7 commands: run + 6 passes
-    for (let i = 0; i < 7; i++) {
-      await nextStepButton.click();
-      // Wait for ready state after each command, except possibly the last one if it finishes quickly
-      if (i < 6) {
-        await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 15000 });
-      }
-    }
-
-    // Verify completion
-    const resultContainer = page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Result', { exact: true }) })
-      .last();
-    await expect(resultContainer).toContainText('COMPLETE', { timeout: 45000 });
+    // Descriptions render alongside titles
+    await expect(page.getByText('Runs 6 steps, all pass')).toBeVisible();
+    await expect(page.getByText('Fails, retries, eventually passes')).toBeVisible();
+    await expect(page.getByText('Jumps straight to the last step')).toBeVisible();
   });
 
-  test('executes retry scenario correctly', async ({ page }) => {
-    // Select 'retry' scenario
-    await page.getByRole('button', { name: 'retry' }).click();
+  test('clicking a scenario card clears the terminal and does not auto-run', async ({ page }) => {
+    // Step through one command of the Happy path so the terminal has content.
+    await page.getByRole('button', { name: /Happy path/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.locator('.xterm-rows')).toContainText('rd', { timeout: 60000 });
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
 
-    const nextStepButton = page.getByRole('button', { name: 'Next' }).first();
+    // Switch to a different card.
+    await page.getByRole('button', { name: /Skip to end/ }).click();
 
-    // retry has 11 commands
-    for (let i = 0; i < 11; i++) {
-      await nextStepButton.click();
-      if (i < 10) {
-        await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 15000 });
-      }
-    }
+    // Terminal must be cleared. xterm's renderer flushes on the next frame,
+    // so use auto-retry via expect().toPass to wait for the clear to land.
+    await expect(async () => {
+      const xtermText = await page.locator('.xterm-rows').innerText();
+      expect(xtermText.replace(/\s+/g, '')).toBe('');
+    }).toPass({ timeout: 5000 });
 
-    // Verify completion
-    const resultContainer = page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Result', { exact: true }) })
-      .last();
-    await expect(resultContainer).toContainText('COMPLETE', { timeout: 45000 });
+    // No `rd` command echoed (would prove auto-run kicked off).
+    await page.waitForTimeout(2000);
+    await expect(page.locator('.xterm-rows')).not.toContainText('rd run');
   });
 
-  test('executes start scenario correctly', async ({ page }) => {
-    // Select 'start' scenario
-    await page.getByRole('button', { name: 'start' }).click();
+  test('tabs are disabled while a command is running', async ({ page }) => {
+    await page.getByRole('button', { name: /Happy path/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
 
-    const nextStepButton = page.getByRole('button', { name: 'Next' }).first();
+    // Click Next — status flips to `running` and the regex parser fires
+    // synchronously per chunk. Immediately attempt to click the JSON tab.
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-    // start has 3 commands: run, goto, pass
-    for (let i = 0; i < 3; i++) {
-      await nextStepButton.click();
-      if (i < 2) {
-        await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 15000 });
-      }
-    }
+    // While running, the JSON tab is disabled. Playwright's auto-waiting on
+    // `click()` will not bypass the disabled attribute — the click is a no-op.
+    // Verify by attempting the click (forcing past auto-wait) and checking
+    // that mode did not flip.
+    await page.getByRole('tab', { name: 'JSON' }).click({ force: true, trial: false }).catch(() => {
+      // If the click is rejected (disabled), that's the expected outcome.
+    });
 
-    // Verify completion
-    const resultContainer = page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Result', { exact: true }) })
-      .last();
-    await expect(resultContainer).toContainText('COMPLETE', { timeout: 45000 });
+    // Mode must still be Text (the active tab's `aria-selected` remains true).
+    await expect(page.getByRole('tab', { name: 'Text' })).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByRole('tab', { name: 'JSON' })).toHaveAttribute('aria-selected', 'false');
+
+    // Terminal must still contain the in-progress text-mode output.
+    // Wait for the command to finish before asserting (avoid flaky races).
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await expect(page.locator('.xterm-rows')).toContainText('rd');
   });
 });

--- a/site/tests/landing-page.spec.ts
+++ b/site/tests/landing-page.spec.ts
@@ -68,4 +68,71 @@ test.describe('Landing Page', () => {
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
     await expect(page.locator('.xterm-rows')).toContainText('rd');
   });
+
+  test('Text mode: Happy path steps to STEP 6/6 and RESULT COMPLETE', async ({ page }) => {
+    // Happy path is the default scenario; clicking it is a no-op (same-card
+    // click). autoStart prefires step 0 of the runbook, so click Reset to
+    // start the step-through from currentStep=0.
+    await page.getByRole('button', { name: /Happy path/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await page.getByRole('button', { name: 'Reset' }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // Happy path = 7 commands (1 run + 6 pass). Click Next 6 times then Complete on the 7th.
+    // The label flips to 'Complete' when about to run the final command
+    // (currentStep === scenario.commands.length - 1 with length > 1).
+    for (let i = 0; i < 7; i++) {
+      const label = i === 6 ? 'Complete' : 'Next';
+      await page.getByRole('button', { name: label, exact: true }).click();
+      // Wait for the click to take effect (status returns to ready or the button label flips).
+      if (i < 6) {
+        await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+      }
+    }
+
+    const resultContainer = page.locator('div.flex.items-center.gap-2')
+      .filter({ has: page.getByText('Result', { exact: true }) })
+      .last();
+    await expect(resultContainer).toContainText('COMPLETE', { timeout: 60000 });
+
+    const stepContainer = page.locator('div.flex.items-center.gap-2')
+      .filter({ has: page.getByText('Step', { exact: true }) });
+    await expect(stepContainer).toContainText('6/6');
+  });
+
+  test('Text mode: Skip to end completes via goto+pass', async ({ page }) => {
+    await page.getByRole('button', { name: /Skip to end/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // Skip to end = 3 commands: rd run --prompted, rd goto 6, rd pass.
+    // Per the verified emit table in Conventions:
+    //   Click 1 (rd run --prompted): NO `At:` line emitted (action: START
+    //     has no `at` field; see packages/core/src/cli/output.ts:120-122).
+    //     `runbookStep` stays at the placeholder `'—'`.
+    //   Click 2 (rd goto 6): emits `At: 6` (derivePositionAt of the new
+    //     position). `runbookStep` = '6'.
+    //   Click 3 (rd pass, final): emits `At: 6` then `Runbook: COMPLETE`.
+    //     `runbookStep` = '6', `runbookResult` = 'COMPLETE'.
+    //
+    // We do NOT assert intermediate values for Click 1 (would fail — step
+    // stays at `'—'`). We assert only the final stable state. This avoids
+    // brittleness on transition-order details.
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // Final click — `rd pass` completes the runbook.
+    await page.getByRole('button', { name: 'Complete', exact: true }).click();
+
+    const resultContainer = page.locator('div.flex.items-center.gap-2')
+      .filter({ has: page.getByText('Result', { exact: true }) })
+      .last();
+    await expect(resultContainer).toContainText('COMPLETE', { timeout: 60000 });
+
+    const stepContainer = page.locator('div.flex.items-center.gap-2')
+      .filter({ has: page.getByText('Step', { exact: true }) });
+    await expect(stepContainer).toContainText('6/6');
+  });
 });

--- a/site/tests/landing-page.spec.ts
+++ b/site/tests/landing-page.spec.ts
@@ -135,4 +135,68 @@ test.describe('Landing Page', () => {
       .filter({ has: page.getByText('Step', { exact: true }) });
     await expect(stepContainer).toContainText('6/6');
   });
+
+  test('Tab switch to JSON resets state and clears terminal', async ({ page }) => {
+    // Step through one Text-mode command so state is non-empty.
+    await page.getByRole('button', { name: /Happy path/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await expect(page.locator('.xterm-rows')).toContainText('rd');
+
+    // Click the JSON tab — should clean state, clear terminal, reset scenario.
+    await page.getByRole('tab', { name: 'JSON' }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // Terminal cleared (auto-retry until xterm flushes the clear).
+    await expect(async () => {
+      const xtermText = await page.locator('.xterm-rows').innerText();
+      expect(xtermText.replace(/\s+/g, '')).toBe('');
+    }).toPass({ timeout: 5000 });
+
+    // Footer reset to placeholders. Step row shows `—/6`; Result row hides
+    // because runbookResult is null after reset.
+    const stepContainer = page.locator('div.flex.items-center.gap-2')
+      .filter({ has: page.getByText('Step', { exact: true }) });
+    await expect(stepContainer).toContainText('—/');
+    await expect(page.locator('div.flex.items-center.gap-2')
+      .filter({ has: page.getByText('Result', { exact: true }) })
+    ).toHaveCount(0);
+  });
+
+  test('JSON mode: clicking Next emits the runbook_started JSONL event', async ({ page }) => {
+    await page.getByRole('button', { name: /Happy path/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // Switch to JSON mode (this also resets state — tab click is destructive).
+    await page.getByRole('tab', { name: 'JSON' }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // Click Next once — `rd run --prompted` emits RUNBOOK_STARTED, lowercased
+    // to "runbook_started" by the JSON renderer. This event fires only on
+    // `rd run` (the first command of the scenario), not on subsequent
+    // pass/fail/goto commands — so a single click is sufficient.
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.locator('.xterm-rows')).toContainText('"type":"runbook_started"', { timeout: 60000 });
+  });
+
+  test('Tab switch back to Text resets state', async ({ page }) => {
+    await page.getByRole('button', { name: /Happy path/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // Go to JSON, click Next once, then back to Text.
+    await page.getByRole('tab', { name: 'JSON' }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.locator('.xterm-rows')).toContainText('"type":"runbook_started"', { timeout: 60000 });
+
+    await page.getByRole('tab', { name: 'Text' }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // Auto-retry until xterm flushes the clear.
+    await expect(async () => {
+      const xtermText = await page.locator('.xterm-rows').innerText();
+      expect(xtermText.replace(/\s+/g, '')).toBe('');
+    }).toPass({ timeout: 5000 });
+  });
 });

--- a/site/tests/landing-page.spec.ts
+++ b/site/tests/landing-page.spec.ts
@@ -237,6 +237,47 @@ test.describe('Landing Page', () => {
     await expect(page.locator(FOOTER_STEP)).toContainText('6/6');
   });
 
+  test('Tab keyboard nav: roving tabindex, Arrow/Home/End move focus and selection', async ({ page }) => {
+    await page.getByRole('button', { name: /Happy path/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    const textTab = page.getByRole('tab', { name: 'Text' });
+    const jsonTab = page.getByRole('tab', { name: 'JSON' });
+
+    // Roving tabindex: only the active tab is in the tab sequence.
+    await expect(textTab).toHaveAttribute('tabindex', '0');
+    await expect(jsonTab).toHaveAttribute('tabindex', '-1');
+
+    // ArrowRight from Text → JSON gains focus + selection. switchMode also
+    // resets state, so wait for Ready before continuing.
+    await textTab.focus();
+    await page.keyboard.press('ArrowRight');
+    await expect(jsonTab).toBeFocused();
+    await expect(jsonTab).toHaveAttribute('aria-selected', 'true');
+    await expect(textTab).toHaveAttribute('aria-selected', 'false');
+    await expect(jsonTab).toHaveAttribute('tabindex', '0');
+    await expect(textTab).toHaveAttribute('tabindex', '-1');
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // ArrowLeft from JSON → Text.
+    await page.keyboard.press('ArrowLeft');
+    await expect(textTab).toBeFocused();
+    await expect(textTab).toHaveAttribute('aria-selected', 'true');
+    await expect(jsonTab).toHaveAttribute('aria-selected', 'false');
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // End jumps to last tab; Home jumps to first.
+    await page.keyboard.press('End');
+    await expect(jsonTab).toBeFocused();
+    await expect(jsonTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    await page.keyboard.press('Home');
+    await expect(textTab).toBeFocused();
+    await expect(textTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+  });
+
   test('Reset mid-scenario clears terminal and footer', async ({ page }) => {
     await page.getByRole('button', { name: /Skip to end/ }).click();
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });

--- a/site/tests/landing-page.spec.ts
+++ b/site/tests/landing-page.spec.ts
@@ -1,4 +1,15 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+
+const FOOTER_STEP = '[data-testid="footer-step"]';
+const FOOTER_RESULT = '[data-testid="footer-result"]';
+
+async function expectTerminalEmpty(page: Page) {
+  // xterm flushes via requestAnimationFrame, so retry until the DOM catches up.
+  await expect(async () => {
+    const xtermText = await page.locator('.xterm-rows').innerText();
+    expect(xtermText.replace(/\s+/g, '')).toBe('');
+  }).toPass({ timeout: 5000 });
+}
 
 test.describe('Landing Page', () => {
   test.describe.configure({ mode: 'serial' });
@@ -31,15 +42,15 @@ test.describe('Landing Page', () => {
     // Switch to a different card.
     await page.getByRole('button', { name: /Skip to end/ }).click();
 
-    // Terminal must be cleared. xterm's renderer flushes on the next frame,
-    // so use auto-retry via expect().toPass to wait for the clear to land.
-    await expect(async () => {
-      const xtermText = await page.locator('.xterm-rows').innerText();
-      expect(xtermText.replace(/\s+/g, '')).toBe('');
-    }).toPass({ timeout: 5000 });
+    // Terminal must be cleared.
+    await expectTerminalEmpty(page);
 
-    // No `rd` command echoed (would prove auto-run kicked off).
+    // Confirm no auto-run kicked off: terminal stays empty across a 2s window
+    // and contains no `rd run` echo. Hard wait is correct here — we're
+    // proving absence over a window, which `.not.toContainText` polling
+    // cannot do (it returns as soon as the negative is true).
     await page.waitForTimeout(2000);
+    await expectTerminalEmpty(page);
     await expect(page.locator('.xterm-rows')).not.toContainText('rd run');
   });
 
@@ -47,57 +58,78 @@ test.describe('Landing Page', () => {
     await page.getByRole('button', { name: /Happy path/ }).click();
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
 
-    // Click Next — status flips to `running` and the regex parser fires
-    // synchronously per chunk. Immediately attempt to click the JSON tab.
+    // Click Next — status flips to `running`. Both tabs gain `disabled`.
     await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-    // While running, the JSON tab is disabled. Playwright's auto-waiting on
-    // `click()` will not bypass the disabled attribute — the click is a no-op.
-    // Verify by attempting the click (forcing past auto-wait) and checking
-    // that mode did not flip.
-    await page.getByRole('tab', { name: 'JSON' }).click({ force: true, trial: false }).catch(() => {
-      // If the click is rejected (disabled), that's the expected outcome.
-    });
-
-    // Mode must still be Text (the active tab's `aria-selected` remains true).
+    // Direct disabled-state assertion (auto-retries until disabled appears).
+    await expect(page.getByRole('tab', { name: 'Text' })).toBeDisabled();
+    await expect(page.getByRole('tab', { name: 'JSON' })).toBeDisabled();
     await expect(page.getByRole('tab', { name: 'Text' })).toHaveAttribute('aria-selected', 'true');
     await expect(page.getByRole('tab', { name: 'JSON' })).toHaveAttribute('aria-selected', 'false');
 
-    // Terminal must still contain the in-progress text-mode output.
-    // Wait for the command to finish before asserting (avoid flaky races).
+    // After execution finishes the tabs re-enable.
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await expect(page.getByRole('tab', { name: 'Text' })).toBeEnabled();
+    await expect(page.getByRole('tab', { name: 'JSON' })).toBeEnabled();
     await expect(page.locator('.xterm-rows')).toContainText('rd');
   });
 
+  test('clicking the already-selected card is a no-op (state preserved)', async ({ page }) => {
+    // Happy path is the default. Step one command.
+    await page.getByRole('button', { name: /Happy path/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await expect(page.locator('.xterm-rows')).toContainText('rd');
+
+    // Click the same card again — should NOT clear or reset.
+    await page.getByRole('button', { name: /Happy path/ }).click();
+
+    // Still ready, terminal still has content, footer still shows step.
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible();
+    await expect(page.locator('.xterm-rows')).toContainText('rd');
+    await expect(page.locator(FOOTER_STEP)).not.toContainText('—/');
+  });
+
+  test('clicking the already-active tab is a no-op (state preserved)', async ({ page }) => {
+    await page.getByRole('button', { name: /Happy path/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // Default mode is Text; click the Text tab again. State must be preserved.
+    await page.getByRole('tab', { name: 'Text' }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible();
+    await expect(page.locator('.xterm-rows')).toContainText('rd');
+    await expect(page.locator(FOOTER_STEP)).not.toContainText('—/');
+  });
+
   test('Text mode: Happy path steps to STEP 6/6 and RESULT COMPLETE', async ({ page }) => {
-    // Happy path is the default scenario; clicking it is a no-op (same-card
-    // click). autoStart prefires step 0 of the runbook, so click Reset to
-    // start the step-through from currentStep=0.
+    // Happy path is the default scenario; clicking it is a no-op (same-card).
+    // autoStart prefires step 0, so click Reset to start from currentStep=0.
     await page.getByRole('button', { name: /Happy path/ }).click();
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
     await page.getByRole('button', { name: 'Reset' }).click();
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
 
-    // Happy path = 7 commands (1 run + 6 pass). Click Next 6 times then Complete on the 7th.
-    // The label flips to 'Complete' when about to run the final command
-    // (currentStep === scenario.commands.length - 1 with length > 1).
+    // After reset, footer total should display exactly `—/6`.
+    await expect(page.locator(FOOTER_STEP)).toContainText('—/6');
+
+    const action = page.getByRole('button', { name: /^(Next|Complete)$/ });
+
+    // Happy path = 7 commands (1 run + 6 pass). Label is 'Next' for the
+    // first 6 clicks, 'Complete' on the 7th (final command).
     for (let i = 0; i < 7; i++) {
-      const label = i === 6 ? 'Complete' : 'Next';
-      await page.getByRole('button', { name: label, exact: true }).click();
-      // Wait for the click to take effect (status returns to ready or the button label flips).
+      const expectedLabel = i === 6 ? 'Complete' : 'Next';
+      await expect(action).toHaveText(new RegExp(`^${expectedLabel}$`), { timeout: 60000 });
+      await action.click();
       if (i < 6) {
         await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
       }
     }
 
-    const resultContainer = page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Result', { exact: true }) })
-      .last();
-    await expect(resultContainer).toContainText('COMPLETE', { timeout: 60000 });
-
-    const stepContainer = page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Step', { exact: true }) });
-    await expect(stepContainer).toContainText('6/6');
+    await expect(page.locator(FOOTER_RESULT)).toContainText('COMPLETE', { timeout: 60000 });
+    await expect(page.locator(FOOTER_STEP)).toContainText('6/6');
   });
 
   test('Text mode: Skip to end completes via goto+pass', async ({ page }) => {
@@ -105,18 +137,8 @@ test.describe('Landing Page', () => {
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
 
     // Skip to end = 3 commands: rd run --prompted, rd goto 6, rd pass.
-    // Per the verified emit table in Conventions:
-    //   Click 1 (rd run --prompted): NO `At:` line emitted (action: START
-    //     has no `at` field; see packages/core/src/cli/output.ts:120-122).
-    //     `runbookStep` stays at the placeholder `'—'`.
-    //   Click 2 (rd goto 6): emits `At: 6` (derivePositionAt of the new
-    //     position). `runbookStep` = '6'.
-    //   Click 3 (rd pass, final): emits `At: 6` then `Runbook: COMPLETE`.
-    //     `runbookStep` = '6', `runbookResult` = 'COMPLETE'.
-    //
-    // We do NOT assert intermediate values for Click 1 (would fail — step
-    // stays at `'—'`). We assert only the final stable state. This avoids
-    // brittleness on transition-order details.
+    // We do NOT assert intermediate values for Click 1 — `rd run --prompted`
+    // emits no `At:` line, so `runbookStep` stays at the placeholder `'—'`.
     await page.getByRole('button', { name: 'Next', exact: true }).click();
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
 
@@ -126,14 +148,8 @@ test.describe('Landing Page', () => {
     // Final click — `rd pass` completes the runbook.
     await page.getByRole('button', { name: 'Complete', exact: true }).click();
 
-    const resultContainer = page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Result', { exact: true }) })
-      .last();
-    await expect(resultContainer).toContainText('COMPLETE', { timeout: 60000 });
-
-    const stepContainer = page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Step', { exact: true }) });
-    await expect(stepContainer).toContainText('6/6');
+    await expect(page.locator(FOOTER_RESULT)).toContainText('COMPLETE', { timeout: 60000 });
+    await expect(page.locator(FOOTER_STEP)).toContainText('6/6');
   });
 
   test('Tab switch to JSON resets state and clears terminal', async ({ page }) => {
@@ -148,23 +164,15 @@ test.describe('Landing Page', () => {
     await page.getByRole('tab', { name: 'JSON' }).click();
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
 
-    // Terminal cleared (auto-retry until xterm flushes the clear).
-    await expect(async () => {
-      const xtermText = await page.locator('.xterm-rows').innerText();
-      expect(xtermText.replace(/\s+/g, '')).toBe('');
-    }).toPass({ timeout: 5000 });
+    await expectTerminalEmpty(page);
 
     // Footer reset to placeholders. Step row shows `—/6`; Result row hides
     // because runbookResult is null after reset.
-    const stepContainer = page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Step', { exact: true }) });
-    await expect(stepContainer).toContainText('—/');
-    await expect(page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Result', { exact: true }) })
-    ).toHaveCount(0);
+    await expect(page.locator(FOOTER_STEP)).toContainText('—/6');
+    await expect(page.locator(FOOTER_RESULT)).toHaveCount(0);
   });
 
-  test('JSON mode: clicking Next emits the runbook_started JSONL event', async ({ page }) => {
+  test('JSON mode: Next emits runbook_started and the footer stays at placeholders', async ({ page }) => {
     await page.getByRole('button', { name: /Happy path/ }).click();
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
 
@@ -173,11 +181,16 @@ test.describe('Landing Page', () => {
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
 
     // Click Next once — `rd run --prompted` emits RUNBOOK_STARTED, lowercased
-    // to "runbook_started" by the JSON renderer. This event fires only on
-    // `rd run` (the first command of the scenario), not on subsequent
-    // pass/fail/goto commands — so a single click is sufficient.
+    // to "runbook_started" by the JSON renderer.
     await page.getByRole('button', { name: 'Next', exact: true }).click();
     await expect(page.locator('.xterm-rows')).toContainText('"type":"runbook_started"', { timeout: 60000 });
+
+    // The footer's text-mode regex parser does NOT fire in JSON mode, so the
+    // step value stays at the placeholder and the Result row stays hidden
+    // even though the runbook is making progress.
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await expect(page.locator(FOOTER_STEP)).toContainText('—/6');
+    await expect(page.locator(FOOTER_RESULT)).toHaveCount(0);
   });
 
   test('Tab switch back to Text resets state', async ({ page }) => {
@@ -193,11 +206,9 @@ test.describe('Landing Page', () => {
     await page.getByRole('tab', { name: 'Text' }).click();
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
 
-    // Auto-retry until xterm flushes the clear.
-    await expect(async () => {
-      const xtermText = await page.locator('.xterm-rows').innerText();
-      expect(xtermText.replace(/\s+/g, '')).toBe('');
-    }).toPass({ timeout: 5000 });
+    await expectTerminalEmpty(page);
+    await expect(page.locator(FOOTER_STEP)).toContainText('—/6');
+    await expect(page.locator(FOOTER_RESULT)).toHaveCount(0);
   });
 
   test('Reset mid-scenario clears terminal and footer', async ({ page }) => {
@@ -216,19 +227,12 @@ test.describe('Landing Page', () => {
     await page.getByRole('button', { name: 'Reset' }).click();
 
     // Tight emptiness check: combine negative (no completion marker) and
-    // positive (terminal text content collapses to whitespace after `term.clear()`).
+    // positive (terminal text content collapses to whitespace).
     await expect(page.locator('.xterm-rows')).not.toContainText('COMPLETE');
-    await expect(async () => {
-      const xtermText = await page.locator('.xterm-rows').innerText();
-      expect(xtermText.replace(/\s+/g, '')).toBe('');
-    }).toPass({ timeout: 5000 });
+    await expectTerminalEmpty(page);
 
     // Footer reset.
-    const stepContainer = page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Step', { exact: true }) });
-    await expect(stepContainer).toContainText('—/');
-    await expect(page.locator('div.flex.items-center.gap-2')
-      .filter({ has: page.getByText('Result', { exact: true }) })
-    ).toHaveCount(0);
+    await expect(page.locator(FOOTER_STEP)).toContainText('—/6');
+    await expect(page.locator(FOOTER_RESULT)).toHaveCount(0);
   });
 });

--- a/site/tests/landing-page.spec.ts
+++ b/site/tests/landing-page.spec.ts
@@ -199,4 +199,36 @@ test.describe('Landing Page', () => {
       expect(xtermText.replace(/\s+/g, '')).toBe('');
     }).toPass({ timeout: 5000 });
   });
+
+  test('Reset mid-scenario clears terminal and footer', async ({ page }) => {
+    await page.getByRole('button', { name: /Skip to end/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    // Step through two commands so state is non-empty AND the footer's
+    // step value has updated (Click 2 = `rd goto 6` emits `At: 6`).
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+    await expect(page.locator('.xterm-rows')).toContainText('rd');
+
+    // Reset.
+    await page.getByRole('button', { name: 'Reset' }).click();
+
+    // Tight emptiness check: combine negative (no completion marker) and
+    // positive (terminal text content collapses to whitespace after `term.clear()`).
+    await expect(page.locator('.xterm-rows')).not.toContainText('COMPLETE');
+    await expect(async () => {
+      const xtermText = await page.locator('.xterm-rows').innerText();
+      expect(xtermText.replace(/\s+/g, '')).toBe('');
+    }).toPass({ timeout: 5000 });
+
+    // Footer reset.
+    const stepContainer = page.locator('div.flex.items-center.gap-2')
+      .filter({ has: page.getByText('Step', { exact: true }) });
+    await expect(stepContainer).toContainText('—/');
+    await expect(page.locator('div.flex.items-center.gap-2')
+      .filter({ has: page.getByText('Result', { exact: true }) })
+    ).toHaveCount(0);
+  });
 });

--- a/site/tests/landing-page.spec.ts
+++ b/site/tests/landing-page.spec.ts
@@ -211,6 +211,32 @@ test.describe('Landing Page', () => {
     await expect(page.locator(FOOTER_RESULT)).toHaveCount(0);
   });
 
+  test('Text mode: Retry on fail completes via RECOVER routing', async ({ page }) => {
+    await page.getByRole('button', { name: /Retry on fail/ }).click();
+    await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+
+    const action = page.getByRole('button', { name: /^(Next|Complete)$/ });
+    const seenSteps: string[] = [];
+
+    // Retry scenario = 11 commands (1 run + 10 mixed pass/fail). The runbook
+    // routes through the named `## RECOVER` step on FAIL transitions, so the
+    // footer step value must capture the non-numeric ID. This test exercises
+    // the `/At:\s+([\w.]+)/` branch for named steps.
+    for (let i = 0; i < 11; i++) {
+      await action.click();
+      if (i < 10) {
+        await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });
+      }
+      seenSteps.push(await page.locator(FOOTER_STEP).innerText());
+    }
+
+    expect(seenSteps.join(' | ')).toContain('RECOVER');
+
+    // Final completion state.
+    await expect(page.locator(FOOTER_RESULT)).toContainText('COMPLETE', { timeout: 60000 });
+    await expect(page.locator(FOOTER_STEP)).toContainText('6/6');
+  });
+
   test('Reset mid-scenario clears terminal and footer', async ({ page }) => {
     await page.getByRole('button', { name: /Skip to end/ }).click();
     await expect(page.getByText('Ready', { exact: true })).toBeVisible({ timeout: 60000 });


### PR DESCRIPTION
## Summary

- Replaces the homepage runner's three jargon scenario buttons (`rundown` / `retry` / `start`) with three labeled cards (`Happy path` / `Retry on fail` / `Skip to end`) showing title + description.
- Adds a Text/JSON tab bar above the terminal. Switching modes is **destructive**: cleans `.rundown/` state, clears the terminal, resets the scenario position, and flips the active mode. The Rundown CLI mutates persistent state per command, so per-command dual capture is unsafe — the user picks a mode for the whole walk-through.
- `runRdCommand(container, args, onOutput?, mode = 'text')` gains an optional last-position `mode` parameter (Text appends `--text`, JSON leaves args untouched). Existing callers compile unchanged.
- Footer step parser (`At: <stepId>`) now matches `[\w.]+` instead of `\d+` so substep notation (`2.1`) and named steps (`RECOVER`) are captured correctly. Parser is gated on `mode === 'text'` — the JSON branch leaves the footer at placeholders.
- `runbookTotal` derivation now counts only numbered H2 headings (`/^## \d/gm`), matching the codebase's `countNumberedSteps` semantics — the runbook in `public/this-is-rundown.runbook.md` resolves to `6` (excludes the named `## RECOVER` step).
- Action button label flips to `Complete` on the click that runs the final command of a multi-command scenario; single-command scenarios stay on `Next`.
- Tabs are `disabled` while a command is running. Tabs implement the ARIA pattern: `role="tablist"` + `role="tab"` + `aria-selected` + roving `tabindex` + ArrowLeft/Right/Home/End nav + linked `role="tabpanel"`.
- Removed: legacy `previousScenario` / `isResetting` refs, the auto-execute-on-scenario-change useEffect, the `showFooterButtons` prop and its caller wiring, and the duplicate footer button block.

## Test Plan

- [x] `cd site && npm test` — 13 Playwright tests pass (1 unchanged on `/explore/code-blocks`, 12 new on `/`)
  - Scenario cards render with titles + descriptions
  - Card click clears terminal and does not auto-run
  - Same-card click is a no-op (state preserved)
  - Same-tab click is a no-op (state preserved)
  - Tabs disabled while running (asserted via `toBeDisabled()`)
  - Text mode: Happy path → 6/6 COMPLETE
  - Text mode: Skip to end completes via `goto`+`pass`
  - Text mode: Retry on fail walks through `RECOVER` named step
  - Tab switch to JSON resets state and clears terminal
  - JSON mode emits `"type":"runbook_started"` and footer stays at placeholders
  - Tab switch back to Text resets state
  - Reset mid-scenario clears terminal and footer
- [x] `cd site && npm run build` — Astro build clean
- [x] `npm run verify` (repo-wide) — exits 0; jest 6,026 tests pass across 4 packages, 0 failures, CSpell clean

## Notes

- Three plan deviations are documented in commit messages: (1) wrapping terminal-cleared assertions in `expect.toPass` retry to handle xterm's `requestAnimationFrame` flush; (2) adjusting the action button label condition to flip on the *click that runs* the final command (matches the plan's architecture intent and keeps the existing `runbook-runner.spec.ts` `auto-execution` test passing without edits); (3) explicit `Reset` click in the Happy-path test because Happy path is the default-selected card (so the same-card no-op short-circuits) and `autoStart={true}` prefires step 0.
- Three reviewer-driven follow-up commits land at the end of the branch: a code-quality refactor (helpers, `statusRef` to break dep cascade, a11y), tightened test assertions (`data-testid` on footer divs, explicit label assertions, no-op coverage), and the Retry-on-fail walkthrough exercising the named-step regex branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text/JSON output tabs with distinct execution behavior and disabled tabs during runs.
  * Scenario selection redesigned as a card-grid; homepage runner now auto-starts scenarios in compact=false mode and footer buttons removed.
  * Dark-mode-aware terminal theming and improved reset/retry flows.

* **Bug Fixes / Improvements**
  * More accurate step counting and tighter terminal/footer synchronization.
  * Accessibility and testability improvements for terminal and footer; execution gated during resets.

* **Tests**
  * Expanded E2E suite for scenarios, tabs, keyboard navigation, reset/retry, and Text/JSON behaviors.

* **Chores**
  * Added homepage screenshot script and package script; ignored local screenshot artifacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/286)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->