### PR TITLE
State machine driven outputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,24 @@ These principles are foundational. They take precedence over local convenience a
 
 **Correctness over pragmatism.** Prefer making the work correct over shipping a "pragmatic" shortcut that compromises the values above. A workaround that papers over a state-machine gap, an `any` that hides a typing bug, a skipped test that masks a regression, or a one-off branch in the CLI that should have been a core capability — all are net-negative regardless of the time they save in the short term. When in doubt, raise the design question rather than patching around it.
 
+### Side-effect categorisation
+
+When a side effect needs to happen during runbook execution, classify it into one of three categories before deciding where the code lives. The category determines the architectural pattern.
+
+| Category | Description | Pattern | Examples |
+|----------|-------------|---------|----------|
+| **A** | Genuinely CLI. Inherently external to the runbook program. | Stays in CLI. CLI sends a typed event into the machine if state must update. | stdin reads, terminal rendering, child-process `spawn` syscall, env-var reads, exit-code-to-process mapping |
+| **B** | Machine-owned. Logic is part of the runbook program. No external dependency. | Machine invokes a `fromPromise` actor from core. Pure filesystem or pure computation. | OUTPUTS capture, ARTIFACTS resolution, FOR iteration advancement, frontmatter `outputs:` storage |
+| **C** | Machine-owned with DI callable. Logic is part of the runbook program, but execution requires an external service. | Machine invokes an actor parameterised by a callable supplied at machine-construction time. The callable is the DI seam. | Command execution (policy + spawn), helper invocation (helper registry) |
+
+Category B and C actors are placed under `packages/core/src/runbook/actors/` (the directory is established by the first migration that needs it). Each actor is a `fromPromise`-shaped function in its own file, takes a typed `input`, returns a typed `output`, and does not know about the runbook state manager, the actor service, or the CLI emitter. See [docs/internal/architecture.md § Per-step substate pattern](docs/internal/architecture.md#per-step-substate-pattern) for how the machine wires these actors into the per-step state graph.
+
+A side effect that lives in the CLI but classifies as B or C is architectural debt. The fix is to move it, not to rationalise its location.
+
+### Actor dependencies
+
+Machine-invoked Category B and C actors receive their inputs from two sources: **compile-time-bound dependencies** (process state, service references, parser-derived data, DI'd callables) flow through the per-state `invoke.input` builder closure constructed inside `compileRunbookToMachine`; **event-time-bound dependencies** (anything that varies per snapshot or per event) are read from `context` inside the `invoke.input` factory at fire time. The corollary is stricter than splitting the wiring: **persisted context contains only data; runtime references flow through invoke-input closures.** Function references cannot be serialised, process-runtime values like `cwd` may differ between the writer and reader of a snapshot, and service instance references go stale across process boundaries — routing each dependency through the right boundary is what prevents these failures by construction. See [docs/internal/architecture.md § Actor input wiring](docs/internal/architecture.md#actor-input-wiring) for the implementation pattern and the canonical worked example.
+
 ## Installation
 
 ```bash

--- a/biome.json
+++ b/biome.json
@@ -46,6 +46,15 @@
     }
   },
   "files": {
-    "includes": ["**", "!dist", "!coverage", "!site", "!.worktree", "!.worktrees", "!**/*.snap"]
+    "includes": [
+      "**",
+      "!dist",
+      "!coverage",
+      "!site",
+      "!.worktree",
+      "!.worktrees",
+      "!.claude/worktrees",
+      "!**/*.snap"
+    ]
   }
 }

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -139,7 +139,6 @@ parseable
 pasteable
 perf
 persistable
-rationalise
 picomatch
 pindex
 pipefail
@@ -150,6 +149,7 @@ promptable
 pstep
 psub
 pwd
+rationalise
 rdclm
 rdpath
 rdtest

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -137,9 +137,9 @@ parameterised
 parameterizing
 parseable
 pasteable
-rationalise
 perf
 persistable
+rationalise
 picomatch
 pindex
 pipefail

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -36,6 +36,7 @@ agentic
 aindex
 alnum
 ancvar
+antipattern
 args
 artefacts
 autobuild
@@ -46,6 +47,7 @@ biome
 biomejs
 callsites
 canonicalises
+categorisation
 categorises
 centralise
 Centralised
@@ -79,6 +81,7 @@ featurebranch
 finalvars
 footgun
 frontmatter
+generalises
 gitdir
 gopath
 gopls
@@ -130,9 +133,11 @@ notavar
 nums
 opts
 parallelised
+parameterised
 parameterizing
 parseable
 pasteable
+rationalise
 perf
 persistable
 picomatch
@@ -167,6 +172,7 @@ rustc
 sandboxing
 sarif
 selfref
+serialise
 serialised
 serialises
 serializable
@@ -184,10 +190,13 @@ subcommands
 subdirs
 subshell
 subshells
+substate
 substep
 substeps
 synchronisation
 synchronise
+synthesise
+syscall
 syscalls
 tcsh
 testctx

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -131,8 +131,9 @@ Worked example — ARTIFACTS resolution (`::__resolve-artifacts` substate):
 | Resolver field | Bound | Source |
 |---|---|---|
 | `cwd` | Compile | `evaluationOptions.cwd` (closure-bound) |
-| `loadRunEligibility` | Compile | `RunbookStateManager.buildArtifactRunEligibilityLoader()` (closure-bound) |
 | `declarations` | Compile | `step.artifacts` / `substep.artifacts` (closure-bound to the per-state factory) |
+| `workPath` | Event | `context.templateVars.WorkPath` (read in factory) |
+| `contextId` | Event | `context.templateVars.ContextId` (read in factory) |
 | `runId` | Event | `context.templateVars.RunId` (read in factory; branded with `assertRunId`) |
 | `runbook` | Event | `context.templateVars.RunbookRef` (read in factory; validated with `RunbookRefSchema.parse`) |
 | `scopeVars` | Event | `{ ...context.templateVars, ...context.variables }` (merged at fire time) |

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -105,13 +105,13 @@ Transition evaluation:
 
 ### Per-step substate pattern
 
-Each leaf step state in the compiled machine may be augmented with sibling transient states that wrap side-effect invocations. Today only the **retry transients** (`::pass-retry`, `::fail-retry` — see `compiler.ts:2693, 2710`) exist; they increment retry counters and self-target back to the leaf state when the budget allows.
+Each leaf step state in the compiled machine is a **compound state** with `initial: 'idle'` and a single nested transient child `__capture` tagged `PENDING_MACHINE_EFFECT_TAG`. Sibling states for retries (`::pass-retry`, `::fail-retry`) remain top-level as before and self-target back to the leaf when the retry budget allows.
 
-The pattern generalises for incoming side-effect-bearing transients (e.g. `::__capture-pass`, `::__capture-fail` for OUTPUTS capture, `::__resolve-artifacts` for ARTIFACTS resolution — both forward-looking, established by the artifacts-as-variables migration):
+On `COMMAND_RESULT` the leaf transitions to its relative child (`target: '.__capture'`). `__capture` invokes `outputCaptureActor`; its `input` carries `{ channels, result }` read from the entering event. The actor reads channel files into `variables` and returns `{ variables, result }` — `result` is opaque to the actor and passes through unchanged. `onDone` merges `event.output.variables` into context and `raise`s `{ type: 'PASS' | 'FAIL' }` with **no `target`**; the raised event bubbles up XState's active state chain to the leaf's own `PASS`/`FAIL` handler. `onError` targets `#STOPPED`.
 
-- **Side-effect-bearing transients**: invoke a Category B or C actor via `invoke.src` (see [`CLAUDE.md` § Side-effect categorisation](../../CLAUDE.md#side-effect-categorisation) for the A/B/C framework), chain `onDone` directly into the resolved transition target (precomputed via `buildTransition` for the corresponding outcome), and route `onError` to `STOPPED` with a typed `lastAction` discriminant.
+Because the leaf stays active throughout the capture cycle, `entryActions` (notably FOR-first-substep `initForStack`) are never re-run by capture. No context field stores the result discriminant — it lives in the actor's typed output and bubbles out as a typed event.
 
-Transient states are precomputed once per leaf state in the compile loop, alongside the existing PASS/FAIL transitions. They do not stash per-attempt state in `RunbookContext` — each variant of an outcome (pass vs fail) owns its own transient. Coordination state in `context` is an antipattern: it complicates persistence, creates ordering hazards in `assign`/`raise` interactions, and forces re-targeting the leaf state from `onDone` (which re-runs entry actions and risks duplicate observable events).
+The pattern composes for additional side-effect children (e.g. `__artifacts` for ARTIFACTS resolution — established by the artifacts-as-variables batch 2 migration): each child's `onDone` raises the trigger for the next stage, so the actor-passthrough contract scales without a context discriminant at any stage.
 
 ### Actor input wiring
 

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -34,6 +34,28 @@ The CLI is an orchestration and control interface. Claude executes the actual wo
 
 **No synthetic IDs.** Don't create artificial state identifiers (like `~channel` prefixes). Use XState's native event system and state graph structure.
 
+### Typed `lastAction` discriminants
+
+Machine-internal failures and step outcomes are signalled via the typed `LastAction` discriminated union, never via string-prefixed `lastMessage` parsing or other stringly-typed channels. Variants are defined in `packages/core/src/runbook/types.ts`: `START`, `CONTINUE`, `DEFER`, `GOTO`, `COMPLETE`, `STOP`, `RETRY`, `NEXT`, `BREAK`, and `RETRY_ERROR`. (`lastMessage` itself remains a legitimate diagnostic carrier for free-form context — what is forbidden is *type discrimination* via string parsing of it.)
+
+When the CLI needs to react to a specific variant (typically to route to an `ERROR_OCCURRED` or `RUNBOOK_STOPPED { reason }` emission), it does so through a narrowing helper. The canonical example is `extractRetryError` in `packages/cli/src/services/execution.ts:375`:
+
+```ts
+function extractRetryError(snapshot: unknown): { code: string; message: string } | undefined {
+  if (typeof snapshot !== 'object' || snapshot === null) return undefined;
+  const ctx = (snapshot as { context?: unknown }).context;
+  if (typeof ctx !== 'object' || ctx === null) return undefined;
+  const lastAction = (ctx as { lastAction?: unknown }).lastAction;
+  if (typeof lastAction !== 'object' || lastAction === null) return undefined;
+  const record = lastAction as { type?: unknown; code?: unknown; message?: unknown };
+  if (record.type !== 'RETRY_ERROR') return undefined;
+  if (typeof record.code !== 'string' || typeof record.message !== 'string') return undefined;
+  return { code: record.code, message: record.message };
+}
+```
+
+Each helper narrows on `lastAction.type`, returns the variant-specific fields as a typed record, and is the only call site that touches the variant. New `LastAction` variants come with a corresponding extraction helper following the same shape.
+
 ---
 
 ## State Machine
@@ -80,6 +102,74 @@ Transition evaluation:
 1. Check condition (PASS or FAIL)
 2. For RETRY: check if `retryCount < max`
 3. Execute action (CONTINUE, COMPLETE, STOP, GOTO)
+
+### Per-step substate pattern
+
+Each leaf step state in the compiled machine may be augmented with sibling transient states that wrap side-effect invocations. Today only the **retry transients** (`::pass-retry`, `::fail-retry` — see `compiler.ts:2693, 2710`) exist; they increment retry counters and self-target back to the leaf state when the budget allows.
+
+The pattern generalises for incoming side-effect-bearing transients (e.g. `::__capture-pass`, `::__capture-fail` for OUTPUTS capture, `::__resolve-artifacts` for ARTIFACTS resolution — both forward-looking, established by the artifacts-as-variables migration):
+
+- **Side-effect-bearing transients**: invoke a Category B or C actor via `invoke.src` (see [`CLAUDE.md` § Side-effect categorisation](../../CLAUDE.md#side-effect-categorisation) for the A/B/C framework), chain `onDone` directly into the resolved transition target (precomputed via `buildTransition` for the corresponding outcome), and route `onError` to `STOPPED` with a typed `lastAction` discriminant.
+
+Transient states are precomputed once per leaf state in the compile loop, alongside the existing PASS/FAIL transitions. They do not stash per-attempt state in `RunbookContext` — each variant of an outcome (pass vs fail) owns its own transient. Coordination state in `context` is an antipattern: it complicates persistence, creates ordering hazards in `assign`/`raise` interactions, and forces re-targeting the leaf state from `onDone` (which re-runs entry actions and risks duplicate observable events).
+
+### Actor input wiring
+
+A side-effect-bearing transient invokes a Category B or C actor (see [`CLAUDE.md` § Side-effect categorisation](../../CLAUDE.md#side-effect-categorisation)). The actor's `input` is assembled from two sources:
+
+- **Compile-time-bound** dependencies are captured by the per-state `invoke.input` builder closure constructed inside `compileRunbookToMachine`. Examples: process state (`cwd`), service references (`RunbookStateManager`), parser-derived data (declarations attached to the step or substep), DI'd callables (a policy evaluator, a helper registry).
+- **Event-time-bound** dependencies are read from `context` inside the `invoke.input` factory function at fire time. Examples: the current `runId`, captured variables, substep state, the result of a preceding command.
+
+The wiring rule that makes this load-bearing is stricter than just "split the wiring":
+
+> **Persisted context contains only data; runtime references flow through invoke-input closures.**
+
+Three constraints back this up. `getPersistedSnapshot()` JSON-serialises context, so function references cannot be persisted at all. Even values that *can* serialise — a path string like `cwd` — may be process-runtime state that differs between the process that wrote the snapshot and the process that reads it; persisting them would silently produce wrong behaviour after a process boundary. And service instance references (a `RunbookStateManager`, a registry) become stale across process boundaries even when they marshal — the new process needs its own instance. The compile-time / event-time split routes each dependency through the right boundary so none of these failures can happen by accident.
+
+Worked example — ARTIFACTS resolution (`::__resolve-artifacts` substate):
+
+| Resolver field | Bound | Source |
+|---|---|---|
+| `cwd` | Compile | `evaluationOptions.cwd` (closure-bound) |
+| `loadRunEligibility` | Compile | `RunbookStateManager.buildArtifactRunEligibilityLoader()` (closure-bound) |
+| `declarations` | Compile | `step.artifacts` / `substep.artifacts` (closure-bound to the per-state factory) |
+| `runId` | Event | `context.templateVars.RunId` (read in factory; branded with `assertRunId`) |
+| `runbook` | Event | `context.templateVars.RunbookRef` (read in factory; validated with `RunbookRefSchema.parse`) |
+| `scopeVars` | Event | `{ ...context.templateVars, ...context.variables }` (merged at fire time) |
+
+The canonical implementation site is `compileMachineFromState` in `packages/core/src/runbook/actor-service.ts` (around line 145), where `flattenTemplateVars(state.templateVars)` and `evaluationOptions.cwd` are passed into `compileRunbookToMachine` and threaded into every per-state `invoke.input` closure.
+
+---
+
+## CLI ↔ Core Event Boundary
+
+The CLI and core packages communicate through a typed event boundary. Two flows: events the CLI sends into the machine, and observable events the CLI renders by translating snapshot transitions.
+
+### Events the CLI sends into the machine
+
+| Event | Source | Notes |
+|---|---|---|
+| `PASS` / `FAIL` | `rd pass` / `rd fail` STDIN, substep-completion drain | Only from external user actions or pre-persisted completion records. The CLI MUST NOT synthesise these from internal observation. |
+| `GOTO { target }` | `rd goto` | Jumps. `target` is a `StepId`. The CLI's `--index` flag is resolved before dispatch; the event itself carries no index field. |
+| `RETRY` | (internal — generated by retry transitions) | |
+| `SET_VARIABLES { vars }` | Delegation completion | Used when a child runbook reports back. |
+| `PENDING_FRONTIER_CONSUMED` | Delegation issuance | Acknowledges the CLI consumed a pending frontier marker. |
+
+The set is small and stable. New CLI subcommands dispatch into existing events; they do not introduce new events without a corresponding state-machine handler. Transitional events introduced during incremental migrations (e.g. an event that bridges a CLI-owned side effect to a machine-owned one before the side effect itself moves into the machine) are scoped to the migration window and removed once the boundary collapses — they do not become permanent fixtures of the protocol.
+
+### Observable events the CLI renders
+
+The CLI subscribes to actor state changes and translates them into observer events for stdout/stderr (and for the MCP server when it is the front end):
+
+| Event | When |
+|---|---|
+| `STEP_ENTERED { stepId, ... }` | On entering a step state |
+| `RUNBOOK_STOPPED { reason, message }` | Final state, lifecycle = `'stopped'`. `reason` is narrowed from a typed `lastAction` variant where applicable. Payload shape defined in `packages/core/src/events/types.ts`. |
+| `RUNBOOK_COMPLETED` | Final state, lifecycle = `'completed'` |
+| `ERROR_OCCURRED { code, message }` | When a typed `lastAction` variant indicates a machine-internal failure (e.g. `RETRY_ERROR`). See [Typed `lastAction` Discriminants](#typed-lastaction-discriminants). |
+| `COMMAND_STARTED` / `COMMAND_COMPLETED` / `POLICY_DENIED` | Currently emitted directly by the CLI execution loop; will move into the machine when command execution becomes a Category C actor. |
+
+The narrowing layer between snapshot context and observer events uses the typed `lastAction` discriminant convention — never `lastMessage` string parsing.
 
 ---
 

--- a/docs/spec/deferred.md
+++ b/docs/spec/deferred.md
@@ -1,0 +1,86 @@
+# Rundown — Deferred / Speculative Spec Content
+
+> **Agent attention warning:** This document describes features that are NOT implemented in the current codebase. Agents MUST NOT use this document when implementing features, planning batches, writing tests, or answering questions about how the system works today. Refer to `docs/spec/language.md`, `docs/spec/uri.md`, `docs/spec/grammar.md`, and `docs/spec/cli-output.md` for the canonical current specification. Use this document ONLY when the user explicitly references "deferred", "speculative", "future", or "this deferred-spec doc" in their request.
+
+This document collects spec language that describes intended-but-not-yet-implemented behaviour. Each section names which canonical spec section the content was previously embedded in, and what gates re-promotion (typically: a future implementation batch landing the feature).
+
+---
+
+## Selector URI query parameters
+
+**Original location:** `docs/spec/uri.md §5.4`.
+**Re-promotion gate:** A future batch implementing query-parameter dispatch in `packages/core/src/runbook/artifact-directive-resolver.ts` (currently rejected at the resolver per the deleted "not yet implemented" path).
+
+### 5.4 Query parameters (selector form only)
+
+Query parameters appear only on selector URIs (§6.2). The complete set of
+allowed query keys is:
+
+| Key | Meaning |
+|-----|---------|
+| `status` | Lifecycle filter for sibling-run eligibility (e.g. `any`). |
+| `runbook` | Filter manifest rows by `runbook.path`. |
+| `source` | Filter manifest rows by `runbook.source`. |
+| `latest` | When `true`, reduce matches to the latest match per group. |
+
+Implementations MUST reject URIs that contain any query parameter outside this
+allow-list. Repeated keys are permitted; values are interpreted in source
+order.
+
+The selector URI grammar accordingly admits an optional `query_string`:
+
+```ebnf
+selector_artifact_uri
+                    ::= "rd://artifacts/" context_segment "/" run_selector "/" key_segment query_string?
+
+query_string        ::= "?" query_param ( "&" query_param )*
+query_param         ::= ( "status" | "runbook" | "source" | "latest" ) "=" query_value
+query_value         ::= [^&#]*
+```
+
+The classifier rule that "a URI is a selector when its `runId` segment is `*`
+OR when it carries a non-empty query string" is part of this deferred surface;
+in current behaviour the classifier sees no query strings because the resolver
+rejects any URI carrying one before the discriminator runs.
+
+---
+
+## Sibling-run lifecycle eligibility filtering
+
+**Original location:** `docs/spec/language.md §10.1` (sentence at line 447 of the version prior to this refactor).
+**Re-promotion gate:** Lands together with the `status` query parameter (above) so authors have a spec-blessed override.
+
+The deferred sentence read:
+
+> Records from other runs are eligible only when their run state is completed
+> and has `terminalAt`.
+
+This sentence was paired with the `status=any` query parameter: lifecycle
+filtering would be the default for cross-run selector matches, and authors
+could override per-selector by appending `?status=any`. Without the override
+the rule was the worst of both worlds — enforcement with no escape hatch — so
+the lifecycle filter was withdrawn alongside the query-parameter surface. When
+the `status` query parameter lands, this sentence (or its replacement)
+re-enters `language.md §10.1` next to the override clause.
+
+In the meantime the same-context guard and per-row file-existence check remain
+the active safety mechanisms for cross-run selector results.
+
+---
+
+## Future URI namespaces
+
+**Original location:** `docs/spec/uri.md §12`.
+**Re-promotion gate:** Each namespace requires its own grammar definition and an implementation batch.
+
+This section is non-normative.
+
+The following namespaces are reserved for possible future use. Their grammar
+and semantics are undefined; implementations MUST reject URIs that use them
+until they are registered in `uri.md §3.1`.
+
+- `rd://contexts/...` — context-scoped resources.
+- `rd://runs/...` — run-scoped resources outside the artifact namespace.
+
+The current `rd://artifacts/...` form leaves room for these and other
+namespace prefixes without grammar collisions.

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -539,6 +539,7 @@ Rules:
 | Forms | Step/substep entries are name-only. Expression-form step/substep `OUTPUTS` entries are parse errors. |
 | Timing | File-backed values are read and merged after command completion. |
 | Merge | Adds new keys to string-only `state.variables` and overwrites same-name string variables. |
+| Retry interaction | When a step has a `RETRY` handler, OUTPUTS are captured on every attempt. Each attempt's values overwrite any previously captured values. The final (succeeding or retry-exhausting) attempt's values are what persist in `state.variables`. |
 | Status visibility | The merged variable space is exposed in status output as `vars`. |
 
 A name-only entry activates a file-backed channel: Rundown creates a writable UTF-8 file, injects `RD_OUTPUTS_<VarName>` with its absolute path, then reads, trims, and merges the file content after command exit. Missing, empty, or non-UTF-8 content is omitted.

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -444,7 +444,7 @@ The directive writes manifest rows; it does NOT write the artifact file itself. 
 
 Resolved artifact references are emitted on `STEP_ENTERED.artifacts` when the directive evaluates. Authors typically consume the structured payload rather than interpolating URIs into shell.
 
-Selector matching includes current-run active records when the artifact file exists. Records from other runs are eligible only when their run state is completed and has `terminalAt`. Matching is across runbooks in the same `ContextId`; the current runbook identity is metadata and is not an implicit selector filter. Manifest coalescing follows the identity and tie-break rules in [uri.md §10](./uri.md#10-coalescing).
+Selector matching includes current-run records and cross-run records in the same `ContextId` when the artifact file exists. The same-context guard and the per-row file-existence check are the active safety mechanisms; selector resolution does not filter on sibling-run lifecycle. Matching is across runbooks in the same `ContextId`; the current runbook identity is metadata and is not an implicit selector filter. Manifest coalescing follows the identity and tie-break rules in [uri.md §10](./uri.md#10-coalescing).
 
 #### 10.1.1 Expansion rules
 

--- a/docs/spec/uri.md
+++ b/docs/spec/uri.md
@@ -11,8 +11,7 @@ specifies:
 
 - the registered scheme name and registered namespaces,
 - the URI grammar in W3C EBNF,
-- the constraints on each URI component (`contextId`, `runId`, `key`, query
-  parameters),
+- the constraints on each URI component (`contextId`, `runId`, `key`),
 - the two URI forms — exact and selector — and when each is used,
 - the deterministic mapping from URIs to filesystem paths under `WorkPath`,
 - the per-context manifest format and scoping rules,
@@ -95,16 +94,12 @@ artifact_uri        ::= exact_artifact_uri | selector_artifact_uri
 exact_artifact_uri  ::= "rd://artifacts/" context_segment "/" run_segment "/" key_segment
 
 selector_artifact_uri
-                    ::= "rd://artifacts/" context_segment "/" run_selector "/" key_segment query_string?
+                    ::= "rd://artifacts/" context_segment "/" run_selector "/" key_segment
 
 context_segment     ::= pct_encoded_safe_id   /* decoded value MUST satisfy ctx_ref */
 run_segment         ::= pct_encoded_run_id    /* decoded value MUST match RUN_ID_PATTERN */
 run_selector        ::= run_segment | "*"
 key_segment         ::= pct_encoded_artifact_key  /* decoded value MUST satisfy exact_artifact_key */
-
-query_string        ::= "?" query_param ( "&" query_param )*
-query_param         ::= ( "status" | "runbook" | "source" | "latest" ) "=" query_value
-query_value         ::= [^&#]*
 
 pct_encoded_safe_id ::= (* RFC 3986 percent-encoded segment whose decoded value matches [A-Za-z0-9._-]+ *)
 pct_encoded_run_id  ::= (* RFC 3986 percent-encoded segment whose decoded value matches RUN_ID_PATTERN *)
@@ -163,27 +158,12 @@ bytes, matching POSIX `NAME_MAX`). This is flagged for possible future
 tightening; until that decision is made, implementations SHOULD NOT reject
 keys solely on length grounds below an obvious filesystem limit.
 
-### 5.4 Query parameters (selector form only)
-
-Query parameters appear only on selector URIs (§6.2). The complete set of
-allowed query keys is:
-
-| Key | Meaning |
-|-----|---------|
-| `status` | Lifecycle filter for sibling-run eligibility (e.g. `any`). |
-| `runbook` | Filter manifest rows by `runbook.path`. |
-| `source` | Filter manifest rows by `runbook.source`. |
-| `latest` | When `true`, reduce matches to the latest match per group. |
-
-Implementations MUST reject URIs that contain any query parameter outside this
-allow-list. Repeated keys are permitted; values are interpreted in source
-order.
-
 ## 6. Forms
 
 A URI is either exact or selector. The discriminator is structural: an
 implementation MUST classify a URI as a selector when its `runId` segment is
-`*` OR when it carries a non-empty query string. Otherwise the URI is exact.
+`*`. Otherwise the URI is exact. URIs MUST NOT carry a query string;
+implementations MUST reject URIs containing one.
 
 ### 6.1 Exact form
 
@@ -198,10 +178,11 @@ references exactly one identity tuple (§8) in the owning manifest.
 ### 6.2 Selector form
 
 ```text
-rd://artifacts/<contextId>/(<runId>|*)/<key>[?<query>]
+rd://artifacts/<contextId>/*/<key>
 ```
 
-A selector URI is the read-only query form. It is produced by `ARTIFACTS`
+A selector URI is the read-only query form. Its `runId` segment is the literal
+`*`; all other segments are concrete. It is produced by `ARTIFACTS`
 declarations that name an explicit selector URI (see
 [language.md §10.1.1](./language.md#1011-expansion-rules)) and consumed by
 manifest selector resolution. A selector URI resolves to zero or more
@@ -340,21 +321,7 @@ properties.
    yields different `contextId`, `runId`, or `key` values than the row's
    structured fields MUST be rejected.
 
-## 12. Future namespaces
-
-This section is non-normative.
-
-The following namespaces are reserved for possible future use. Their grammar
-and semantics are undefined; implementations MUST reject URIs that use them
-until they are registered in §3.1.
-
-- `rd://contexts/...` — context-scoped resources.
-- `rd://runs/...` — run-scoped resources outside the artifact namespace.
-
-The current `rd://artifacts/...` form leaves room for these and other
-namespace prefixes without grammar collisions.
-
-## 13. Verified against
+## 12. Verified against
 
 This specification has been verified against the following implementation
 sources. The line ranges identify the canonical algorithms and constants that

--- a/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
+++ b/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import type { RunbookState, SessionService, RunbookStateManager } from '@rundown-org/core';
+import { orchestrateTransition } from '../../src/helpers/transition-orchestrator.js';
+
+const baseState = {
+  id: `rd_${'1'.repeat(32)}`,
+  step: '1',
+  status: 'running',
+  retryCount: 0,
+  variables: {},
+  startedAt: '2026-05-11T00:00:00.000Z',
+  updatedAt: '2026-05-11T00:00:00.000Z',
+} as unknown as RunbookState;
+
+const steps = [
+  {
+    kind: 'command',
+    name: '1',
+    description: 'Capture',
+    command: { code: 'echo hi', lang: 'sh' },
+    transitions: {
+      pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+      fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+    },
+  },
+] as any;
+
+describe('orchestrateTransition internal failure stop reasons', () => {
+  it('maps OUTPUT_CAPTURE_FAILED lastAction to output_capture_failed stop reason', async () => {
+    const manager = {
+      update: jest.fn(async () => undefined),
+      load: jest.fn(async () => null),
+    } as unknown as RunbookStateManager;
+    const sessionService = {
+      releaseRunbook: jest.fn(async () => undefined),
+    } as unknown as SessionService;
+    const sink = {
+      onStepTransitioned: jest.fn(),
+      onRunbookCompleted: jest.fn(),
+      onRunbookStopped: jest.fn(),
+    };
+
+    const result = await orchestrateTransition({
+      manager,
+      sessionService,
+      sink,
+      runbookId: baseState.id,
+      steps,
+      currentStep: steps[0],
+      previousState: baseState,
+      updatedState: { ...baseState, lifecycle: 'stopped' } as RunbookState,
+      snapshot: {
+        status: 'done',
+        value: 'STOPPED',
+        context: {
+          lastAction: {
+            type: 'OUTPUT_CAPTURE_FAILED',
+            message: 'failed to capture Foo',
+          },
+        },
+      },
+      result: 'fail',
+      actionResult: false,
+      policy: {
+        onComplete: { releaseRunbook: false },
+        onStopped: { releaseRunbook: false },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: 'stopped',
+        message: 'failed to capture Foo',
+      }),
+    );
+    expect(sink.onStepTransitioned).not.toHaveBeenCalled();
+    expect(sink.onRunbookStopped).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: 'output_capture_failed',
+        message: 'failed to capture Foo',
+      }),
+    );
+  });
+});

--- a/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
+++ b/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
@@ -5,7 +5,7 @@ import { orchestrateTransition } from '../../src/helpers/transition-orchestrator
 const baseState = {
   id: `rd_${'1'.repeat(32)}`,
   step: '1',
-  status: 'running',
+  lifecycle: 'running',
   retryCount: 0,
   variables: {},
   startedAt: '2026-05-11T00:00:00.000Z',

--- a/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
+++ b/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
@@ -48,7 +48,7 @@ describe('orchestrateTransition internal failure stop reasons', () => {
       steps,
       currentStep: steps[0],
       previousState: baseState,
-      updatedState: { ...baseState, lifecycle: 'stopped' } as RunbookState,
+      updatedState: { ...baseState, lifecycle: 'stopped' },
       snapshot: {
         status: 'done',
         value: 'STOPPED',

--- a/packages/cli/__tests__/integration/output-capture.test.ts
+++ b/packages/cli/__tests__/integration/output-capture.test.ts
@@ -332,13 +332,16 @@ printf '{{ RunId }}-staging' > "$RD_OUTPUTS_Tag"
     expect(state.variables?.Tag as string).toMatch(/-staging$/);
   });
 
-  it('does not publish captured outputs before a retry transition completes', async () => {
+  it('overwrites captured outputs on retry — final attempt value wins', async () => {
+    // Under the compound-leaf capture design, COMMAND_RESULT unconditionally
+    // enters __capture. Variables are written on every attempt; the final
+    // attempt's value is what persists in context.variables.
     const RUNBOOK = `---
 name: retry-capture
 ---
 # Retry Capture
 
-## 1. Capture during a failing attempt
+## 1. Capture during retry
 - OUTPUTS
   - Token
 - PASS COMPLETE
@@ -346,14 +349,12 @@ name: retry-capture
 
 \`\`\`sh
 if [ ! -f marker ]; then
-  printf 'stale' > "$RD_OUTPUTS_Token"
+  printf 'first-attempt' > "$RD_OUTPUTS_Token"
   touch marker
   exit 1
 fi
 
-if [ "{{ Token }}" = "stale" ]; then
-  exit 2
-fi
+printf 'second-attempt' > "$RD_OUTPUTS_Token"
 \`\`\`
 `;
     await writeFile(join(workspace.cwd, 'retry-capture.runbook.md'), RUNBOOK);
@@ -362,7 +363,7 @@ fi
 
     const states = await getAllRunbookStates(workspace);
     const state = states[0] as { variables?: Record<string, unknown> };
-    expect(state.variables?.Token).toBeUndefined();
+    expect(state.variables?.Token).toBe('second-attempt');
   });
 
   it('creates a per-substep directory when the OUTPUTS lives on a substep', async () => {

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -965,6 +965,74 @@ describe('runExecutionLoop', () => {
       // a step declares outputs. Behavioral coverage is in integration tests.
       expect(result).not.toBe('stopped');
     });
+
+    it('sends COMMAND_RESULT, not SET_VARIABLES or PASS, after a successful command with OUTPUTS', async () => {
+      const stepsWithOutputsForCommandResult: any[] = [
+        {
+          kind: 'command',
+          name: '1',
+          description: 'Capture version',
+          command: { code: 'printf v1 > "$RD_OUTPUTS_Version"', lang: 'sh' },
+          outputs: [{ name: 'Version' }],
+          transitions: {
+            pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' }, next: '2' },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' }, next: 'STOP' },
+          },
+        },
+        {
+          kind: 'base',
+          name: '2',
+          description: 'After capture',
+          transitions: {
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' }, next: 'COMPLETE' },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' }, next: 'STOP' },
+          },
+        },
+      ];
+
+      mockManager.load
+        .mockResolvedValueOnce(makeLoopState('1', { templateVars: { ContextId: 'ctx-unit' } }))
+        .mockResolvedValueOnce(
+          makeLoopState('2', {
+            variables: { Version: 'v1' },
+            templateVars: { ContextId: 'ctx-unit' },
+          }),
+        );
+      jest.mocked(core.executeCommand).mockResolvedValue({ success: true, exitCode: 0 });
+      mockActorService.sendAndSync.mockResolvedValue({
+        state: makeLoopState('2', {
+          variables: { Version: 'v1' },
+          templateVars: { ContextId: 'ctx-unit' },
+        }),
+        snapshot: {
+          status: 'active',
+          value: 'step::2',
+          context: { lastAction: { type: 'CONTINUE' }, variables: { Version: 'v1' } },
+        },
+      });
+
+      const result = await runExecutionLoop(
+        asManager(mockManager),
+        runbookId,
+        asSteps(stepsWithOutputsForCommandResult),
+        '/tmp',
+        false,
+        asEmitter(mockEmitter),
+      );
+
+      expect(result).not.toBe('stopped');
+      const events = mockActorService.sendAndSync.mock.calls.map((call: unknown[]) => call[2]);
+      expect(events).toEqual([
+        expect.objectContaining({
+          type: 'COMMAND_RESULT',
+          result: 'pass',
+          channels: expect.any(Array),
+        }),
+      ]);
+      expect(events).not.toContainEqual(expect.objectContaining({ type: 'SET_VARIABLES' }));
+      expect(events).not.toContainEqual(expect.objectContaining({ type: 'PASS' }));
+      expect(events).not.toContainEqual(expect.objectContaining({ type: 'FAIL' }));
+    });
   });
 
   it('auto-issues delegation tokens and includes delegateFrontier in STEP_ENTERED when entering a DELEGATE step', async () => {

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -690,6 +690,63 @@ describe('runExecutionLoop', () => {
     }
   });
 
+  it('emits ERROR_OCCURRED when the state machine stops with an OUTPUT_CAPTURE_FAILED lastAction', async () => {
+    mockManager.load.mockResolvedValue(makeLoopState());
+    jest.mocked(core.executeCommand).mockResolvedValue({ success: false, exitCode: 1 });
+
+    mockActorService.sendAndSync.mockResolvedValue({
+      state: {
+        id: runbookId,
+        step: '1',
+        status: 'done',
+        lifecycle: 'stopped',
+        variables: {},
+        runbookPath: '/tmp/test.md',
+      },
+      snapshot: {
+        status: 'done',
+        value: 'STOPPED',
+        context: {
+          lastAction: {
+            type: 'OUTPUT_CAPTURE_FAILED' as const,
+            message: 'failed to read channel file: /tmp/outputs/Foo',
+          },
+          lifecycle: 'stopped',
+        },
+      },
+    });
+
+    const result = await runExecutionLoop(
+      asManager(mockManager),
+      runbookId,
+      asSteps(steps),
+      '/tmp',
+      false,
+      asEmitter(mockEmitter),
+    );
+
+    expect(result).toBe('stopped');
+
+    // ERROR_OCCURRED is emitted with the OUTPUT_CAPTURE_FAILED message.
+    expect(mockEmitter.emit).toHaveBeenCalledWith(
+      'ERROR_OCCURRED',
+      expect.objectContaining({
+        message: 'failed to read channel file: /tmp/outputs/Foo',
+      }),
+    );
+
+    // RUNBOOK_STOPPED still fires afterwards so terminal state is reported.
+    expect(mockEmitter.emit).toHaveBeenCalledWith('RUNBOOK_STOPPED', expect.any(Object));
+
+    // Ordering: ERROR_OCCURRED precedes RUNBOOK_STOPPED.
+    const emitCalls = mockEmitter.emit.mock.calls;
+    const errorIdx = emitCalls.findIndex((c: any[]) => c[0] === 'ERROR_OCCURRED');
+    const stoppedIdx = emitCalls.findIndex((c: any[]) => c[0] === 'RUNBOOK_STOPPED');
+    expect(errorIdx).toBeGreaterThanOrEqual(0);
+    expect(stoppedIdx).toBeGreaterThanOrEqual(0);
+    expect(errorIdx).toBeLessThan(stoppedIdx);
+  });
+
   it('prompted-for step returns waiting without CLI prompted mode', async () => {
     const promptedForSteps = [
       {

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -235,7 +235,7 @@ async function runCollect(
 
   // Transition config is a per-substep envelope, not an aggregation decision:
   // drainResolvedCompletions fires a PASS or FAIL event for each substep based
-  // on that substep's OWN persisted `result` (see applyResultTransition in
+  // on that substep's OWN persisted `result` (see applyDrainedCompletion in
   // services/execution.ts). The config's `policy` and `computeActionResult`
   // fields are identical between pass/fail (`computeActionResult` is only used
   // to derive step-level output action results, which for DELEGATE aggregation

--- a/packages/cli/src/helpers/transition-orchestrator.ts
+++ b/packages/cli/src/helpers/transition-orchestrator.ts
@@ -3,11 +3,14 @@ import {
   buildStepPosition,
   countNumberedSteps,
   derivePositionAt,
+  deriveStoppedReason,
   deriveTransitionMessage,
+  extractInternalFailureMessage,
   extractLastAction,
   extractLastMessage,
   extractRetryDisplayCount,
   extractRetryMax,
+  isInternalFailureLastAction,
   isRunbookComplete,
   isRunbookStopped,
   parseActionType,
@@ -193,14 +196,15 @@ export async function orchestrateTransition(
   });
 
   const toPos = positions.to;
-  // RETRY_ERROR signals a machine-internal failure (retry hook threw /
-  // invariant violated). It is already surfaced via ERROR_OCCURRED +
-  // RUNBOOK_STOPPED (see execution.ts `applyResultTransition`). Emitting
-  // it through STEP_TRANSITIONED would widen the external action enum
-  // beyond the scenario schema (CONTINUE/DEFER/GOTO/STOP/COMPLETE/RETRY/
-  // BREAK/NEXT — see packages/cli/src/schemas/scenarios.ts). The terminal
-  // RUNBOOK_STOPPED emission below still fires.
-  if (actionType !== 'RETRY_ERROR') {
+  // Internal-failure lastAction variants (RETRY_ERROR, OUTPUT_CAPTURE_FAILED)
+  // signal a machine-internal failure (retry hook threw / invariant violated /
+  // output-capture actor errored). They are already surfaced via ERROR_OCCURRED
+  // + RUNBOOK_STOPPED. Emitting them through STEP_TRANSITIONED would widen the
+  // external action enum beyond the scenario schema
+  // (CONTINUE/DEFER/GOTO/STOP/COMPLETE/RETRY/BREAK/NEXT — see
+  // packages/cli/src/schemas/scenarios.ts). The terminal RUNBOOK_STOPPED
+  // emission below still fires.
+  if (!isInternalFailureLastAction(lastAction)) {
     sink.onStepTransitioned({
       action: actionType,
       from: fromStr,
@@ -236,8 +240,10 @@ export async function orchestrateTransition(
 
   if (isStopped) {
     const message =
+      extractInternalFailureMessage(lastAction) ??
       extractLastMessage(snapshot) ??
       deriveTransitionMessage(result, currentStep, previousState.retryCount);
+    const reason = deriveStoppedReason(lastAction);
 
     await manager.update(runbookId, {
       lifecycle: 'stopped',
@@ -245,7 +251,7 @@ export async function orchestrateTransition(
     sink.onRunbookStopped({
       message,
       position: positions.from,
-      reason: 'fail_transition',
+      reason,
     });
 
     await applyTerminalSideEffects(sessionService, policy.onStopped, runbookId);

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -413,7 +413,11 @@ async function applyDrainedCompletion(
   const syncResult = await args.actorService.sendAndSync(args.runbookId, args.steps, {
     type: args.result === 'pass' ? 'PASS' : 'FAIL',
   });
-  if (!syncResult) return { status: 'stopped' };
+  if (!syncResult) {
+    throw new Error(
+      `State machine sync failed after consuming ${args.result === 'pass' ? 'PASS' : 'FAIL'} completion — runbook ID: ${args.runbookId}`,
+    );
+  }
   return observeAndOrchestrate({
     ...args,
     syncSnapshot: syncResult.snapshot,
@@ -1071,7 +1075,17 @@ export async function runExecutionLoop(
       result: lastResult,
       channels: channels.prepared,
     });
-    if (!cmdSync) return 'stopped';
+    if (!cmdSync) {
+      emitter.emit('ERROR_OCCURRED', {
+        message: 'Failed to synchronize runbook state after COMMAND_RESULT',
+      });
+      emitter.emit('RUNBOOK_STOPPED', {
+        position: stepPosition,
+        message: 'Runbook state synchronization failed',
+      });
+      await applyExecutionTerminalRelease(sessionService, runbookId, terminalReleaseMode);
+      return 'stopped';
+    }
     const transitionResult = await observeCommandTransition({
       manager,
       actorService,

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -422,8 +422,9 @@ async function applyDrainedCompletion(
 }
 
 /**
- * Command path: COMMAND_RESULT's capture sibling onDone chains directly into
- * the resolved target state — no separate raise. Just observe.
+ * Command path: after COMMAND_RESULT the leaf enters __capture, the actor
+ * resolves, onDone raises PASS or FAIL internally to the leaf's handlers,
+ * and the leaf transitions to its resolved target. CLI role: observe.
  * @param args - Command transition arguments including sync snapshot and post-state
  * @returns Transition application result after observing the resolved transition
  */

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -50,7 +50,6 @@ import {
   type DelegateFrontierEntry,
   partitionOutputDeclarations,
   prepareOutputChannels,
-  readCapturedOutputs,
   resolveCurrentExecutionUnit,
   type OutputScope,
   type PreparedChannel,
@@ -268,30 +267,12 @@ export function extractUnitOutputs(
   return currentStep.outputs ?? [];
 }
 
-/**
- * Determine whether the current PASS/FAIL result will be consumed by a retry
- * transition before the authored exhausted action runs.
- *
- * File-backed OUTPUTS must follow expression OUTPUTS semantics: a retrying
- * attempt does not publish outputs to `context.variables`. The state machine
- * tracks the active retry budget in `retryCount` for command execution, so the
- * CLI can avoid pre-transition `SET_VARIABLES` while a retry is still pending.
- *
- * @param item - The step or substep currently executing
- * @param result - Command result that will be sent to the state machine
- * @param state - Current persisted runbook state
- * @returns True when the next transition is a retry, false otherwise
- */
-function resultWillRetry(
-  item: Step | ResolvedStep | Substep,
-  result: 'pass' | 'fail',
-  state: RunbookState,
-): boolean {
-  const transition = item.transitions[result];
-  return transition.retry > 0 && state.retryCount < transition.retry;
-}
+type TransitionApplicationResult =
+  | { status: 'continue'; state: RunbookState }
+  | { status: 'done' }
+  | { status: 'stopped' };
 
-interface ApplyResultTransitionArgs {
+interface ObserveAndOrchestrateArgs {
   manager: RunbookStateManager;
   actorService: RunbookActorService;
   sessionService: SessionService;
@@ -305,7 +286,12 @@ interface ApplyResultTransitionArgs {
   transitionPolicy: TransitionOrchestrationPolicy;
   computeActionResult?: (actionType: ActionType) => boolean;
   command?: string;
+  syncSnapshot: unknown;
+  postState: RunbookState;
 }
+
+type ApplyDrainedCompletionArgs = Omit<ObserveAndOrchestrateArgs, 'syncSnapshot' | 'postState'>;
+type ObserveCommandTransitionArgs = ObserveAndOrchestrateArgs;
 
 const EXECUTION_TERMINAL_POLICY: TransitionOrchestrationPolicy = {
   onComplete: {
@@ -384,9 +370,8 @@ function extractRetryError(snapshot: unknown): { code: string; message: string }
   return { code: record.code, message: record.message };
 }
 
-async function applyResultTransition({
+async function observeAndOrchestrate({
   manager,
-  actorService,
   sessionService,
   lifecycleService,
   emitter,
@@ -398,21 +383,11 @@ async function applyResultTransition({
   transitionPolicy,
   computeActionResult,
   command,
-}: ApplyResultTransitionArgs): Promise<
-  { status: 'continue'; state: RunbookState } | { status: 'done' } | { status: 'stopped' }
-> {
-  const syncResult = await actorService.sendAndSync(runbookId, steps, {
-    type: result === 'pass' ? 'PASS' : 'FAIL',
-  });
-  if (!syncResult) return { status: 'stopped' };
-
-  const actionType = parseActionType(extractLastAction(syncResult.snapshot));
-
-  const ensured = await lifecycleService.ensureActiveEntry(
-    runbookId,
-    currentState,
-    syncResult.state,
-  );
+  syncSnapshot,
+  postState,
+}: ObserveAndOrchestrateArgs): Promise<TransitionApplicationResult> {
+  const actionType = parseActionType(extractLastAction(syncSnapshot));
+  const ensured = await lifecycleService.ensureActiveEntry(runbookId, currentState, postState);
   const actionResult = computeActionResult ? computeActionResult(actionType) : result === 'pass';
 
   // If the retry hook failed and the machine routed to STOPPED as a result,
@@ -423,7 +398,7 @@ async function applyResultTransition({
   // transition — hence the dedicated event. A plain STOP action (authored
   // STOP transitions, `rd stop`) does NOT emit ERROR_OCCURRED.
   if (ensured.state.lifecycle === 'stopped') {
-    const retryError = extractRetryError(syncResult.snapshot);
+    const retryError = extractRetryError(syncSnapshot);
     if (retryError) {
       emitter.emit('ERROR_OCCURRED', {
         message: retryError.message,
@@ -441,7 +416,7 @@ async function applyResultTransition({
     currentStep,
     previousState: currentState,
     updatedState: ensured.state,
-    snapshot: syncResult.snapshot,
+    snapshot: syncSnapshot,
     result,
     actionResult,
     policy: transitionPolicy,
@@ -451,10 +426,38 @@ async function applyResultTransition({
   if (orchestration.status === 'continue') {
     return { status: 'continue', state: orchestration.state };
   }
-  if (orchestration.status === 'done') {
-    return { status: 'done' };
-  }
-  return { status: 'stopped' };
+  return { status: orchestration.status };
+}
+
+/**
+ * Drain path: result is fresh-to-the-machine, send PASS/FAIL ourselves.
+ *
+ * @remarks Used by substep-completion drain. When delegation batch (migration
+ * row 4) moves drain into the machine, this function collapses into
+ * observeCommandTransition and is removed.
+ */
+async function applyDrainedCompletion(
+  args: ApplyDrainedCompletionArgs,
+): Promise<TransitionApplicationResult> {
+  const syncResult = await args.actorService.sendAndSync(args.runbookId, args.steps, {
+    type: args.result === 'pass' ? 'PASS' : 'FAIL',
+  });
+  if (!syncResult) return { status: 'stopped' };
+  return observeAndOrchestrate({
+    ...args,
+    syncSnapshot: syncResult.snapshot,
+    postState: syncResult.state,
+  });
+}
+
+/**
+ * Command path: machine has already raised PASS/FAIL from COMMAND_RESULT's
+ * capture sibling onDone. Just observe.
+ */
+async function observeCommandTransition(
+  args: ObserveCommandTransitionArgs,
+): Promise<TransitionApplicationResult> {
+  return observeAndOrchestrate(args);
 }
 
 /** Arguments for draining resolved substep completions. */
@@ -577,7 +580,7 @@ export async function drainResolvedCompletions({
       return { status: 'continue', state, unresolved, applied };
     }
 
-    const transitionResult = await applyResultTransition({
+    const transitionResult = await applyDrainedCompletion({
       manager,
       actorService,
       sessionService,
@@ -1062,28 +1065,8 @@ export async function runExecutionLoop(
     });
 
     const lastResult = execResult.success ? 'pass' : 'fail';
-    const publishCapturedOutputs = !resultWillRetry(itemToRender, lastResult, currentState);
-
-    // --- Output capture: post-spawn ---------------------------------------
-    if (!execResult.policyDenied && publishCapturedOutputs && channels.prepared.length > 0) {
-      const captured = await readCapturedOutputs(channels.prepared);
-      if (Object.keys(captured).length > 0) {
-        const setSync = await actorService.sendAndSync(runbookId, steps, {
-          type: 'SET_VARIABLES',
-          vars: captured,
-        });
-        if (setSync) {
-          currentState = setSync.state;
-        } else {
-          void logger.warn('output-capture: SET_VARIABLES sync returned null', {
-            runbookId,
-            stepId: currentState.step,
-            captured: Object.keys(captured),
-          });
-        }
-      }
-    }
-    // --------------------------------------------------------------------
+    // OUTPUTS capture is now machine-invoked via COMMAND_RESULT below.
+    // See packages/core/src/runbook/actors/output-capture-actor.ts.
 
     // Handle policy denial
     if (execResult.policyDenied) {
@@ -1108,7 +1091,14 @@ export async function runExecutionLoop(
 
     // Store result
     await lifecycleService.setLastResult(runbookId, lastResult);
-    const transitionResult = await applyResultTransition({
+    const previousState = currentState;
+    const cmdSync = await actorService.sendAndSync(runbookId, steps, {
+      type: 'COMMAND_RESULT',
+      result: lastResult,
+      channels: channels.prepared,
+    });
+    if (!cmdSync) return 'stopped';
+    const transitionResult = await observeCommandTransition({
       manager,
       actorService,
       sessionService,
@@ -1116,7 +1106,9 @@ export async function runExecutionLoop(
       emitter,
       runbookId,
       steps,
-      currentState,
+      currentState: previousState,
+      postState: cmdSync.state,
+      syncSnapshot: cmdSync.snapshot,
       currentStep,
       result: lastResult,
       transitionPolicy: terminalPolicy,

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -404,6 +404,8 @@ async function observeAndOrchestrate({
  * @remarks Used by substep-completion drain. When delegation batch (migration
  * row 4) moves drain into the machine, this function collapses into
  * observeCommandTransition and is removed.
+ * @param args - Drained completion arguments including actor service, runbook ID, steps, and result
+ * @returns Transition application result after sending the PASS or FAIL event
  */
 async function applyDrainedCompletion(
   args: ApplyDrainedCompletionArgs,
@@ -422,6 +424,8 @@ async function applyDrainedCompletion(
 /**
  * Command path: COMMAND_RESULT's capture sibling onDone chains directly into
  * the resolved target state — no separate raise. Just observe.
+ * @param args - Command transition arguments including sync snapshot and post-state
+ * @returns Transition application result after observing the resolved transition
  */
 async function observeCommandTransition(
   args: ObserveCommandTransitionArgs,

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -53,6 +53,8 @@ import {
   resolveCurrentExecutionUnit,
   type OutputScope,
   type PreparedChannel,
+  isInternalFailureLastAction,
+  extractInternalFailureMessage,
 } from '@rundown-org/core';
 import {
   isSourced,
@@ -339,37 +341,6 @@ async function applyExecutionTerminalRelease(
   await sessionService.popRunbook();
 }
 
-/**
- * Extract a RETRY_ERROR diagnostic from a persisted XState snapshot.
- *
- * Reads `context.lastAction` and returns `code`/`message` only when the
- * variant is `RETRY_ERROR`. Other lastAction variants (including `STOP`)
- * return undefined — `STOP` is a pure domain action, not a machine-internal
- * failure signal.
- *
- * The retry hook writes a `RetryErrorLastAction` onto `context.lastAction`
- * when `createDelegation` surfaces an error variant during a parent-level
- * retry (or an invariant is violated). The priority-0 always-entry in the
- * compiler then
- * routes the machine to STOPPED. This helper narrows the opaque snapshot
- * envelope into the error record so the CLI can emit `ERROR_OCCURRED`
- * before the terminal RUNBOOK_STOPPED event.
- *
- * @param snapshot - Raw persisted XState snapshot (unknown shape)
- * @returns Coded diagnostic, or undefined if lastAction is not RETRY_ERROR
- */
-function extractRetryError(snapshot: unknown): { code: string; message: string } | undefined {
-  if (typeof snapshot !== 'object' || snapshot === null) return undefined;
-  const ctx = (snapshot as { context?: unknown }).context;
-  if (typeof ctx !== 'object' || ctx === null) return undefined;
-  const lastAction = (ctx as { lastAction?: unknown }).lastAction;
-  if (typeof lastAction !== 'object' || lastAction === null) return undefined;
-  const record = lastAction as { type?: unknown; code?: unknown; message?: unknown };
-  if (record.type !== 'RETRY_ERROR') return undefined;
-  if (typeof record.code !== 'string' || typeof record.message !== 'string') return undefined;
-  return { code: record.code, message: record.message };
-}
-
 async function observeAndOrchestrate({
   manager,
   sessionService,
@@ -386,23 +357,21 @@ async function observeAndOrchestrate({
   syncSnapshot,
   postState,
 }: ObserveAndOrchestrateArgs): Promise<TransitionApplicationResult> {
-  const actionType = parseActionType(extractLastAction(syncSnapshot));
+  const lastAction = extractLastAction(syncSnapshot);
+  const actionType = parseActionType(lastAction);
   const ensured = await lifecycleService.ensureActiveEntry(runbookId, currentState, postState);
   const actionResult = computeActionResult ? computeActionResult(actionType) : result === 'pass';
 
-  // If the retry hook failed and the machine routed to STOPPED as a result,
-  // emit ERROR_OCCURRED so the orchestrator/CLI observer sees the root cause.
-  // This must precede orchestrateTransition (which emits the terminal
-  // RUNBOOK_STOPPED event), so consumers can correlate the error with the
-  // stop. RETRY_ERROR is a machine-internal failure, not a normal fail
-  // transition — hence the dedicated event. A plain STOP action (authored
-  // STOP transitions, `rd stop`) does NOT emit ERROR_OCCURRED.
-  if (ensured.state.lifecycle === 'stopped') {
-    const retryError = extractRetryError(syncSnapshot);
-    if (retryError) {
+  // Machine-internal failures (RETRY_ERROR, OUTPUT_CAPTURE_FAILED) emit
+  // ERROR_OCCURRED before the terminal RUNBOOK_STOPPED so consumers can
+  // correlate the root cause. Plain STOP actions (authored STOP transitions,
+  // `rd stop`) do not emit ERROR_OCCURRED.
+  if (ensured.state.lifecycle === 'stopped' && isInternalFailureLastAction(lastAction)) {
+    const message = extractInternalFailureMessage(lastAction);
+    if (message !== undefined) {
       emitter.emit('ERROR_OCCURRED', {
-        message: retryError.message,
-        code: retryError.code,
+        message,
+        ...(lastAction.type === 'RETRY_ERROR' ? { code: lastAction.code } : {}),
       });
     }
   }
@@ -451,8 +420,8 @@ async function applyDrainedCompletion(
 }
 
 /**
- * Command path: machine has already raised PASS/FAIL from COMMAND_RESULT's
- * capture sibling onDone. Just observe.
+ * Command path: COMMAND_RESULT's capture sibling onDone chains directly into
+ * the resolved target state — no separate raise. Just observe.
  */
 async function observeCommandTransition(
   args: ObserveCommandTransitionArgs,

--- a/packages/core/__tests__/runbook/__snapshots__/compiler-machine-structural-snapshot.test.ts.snap
+++ b/packages/core/__tests__/runbook/__snapshots__/compiler-machine-structural-snapshot.test.ts.snap
@@ -44,6 +44,7 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
         "[fn]",
       ],
+      "id": "STOPPED",
       "output": "[fn]",
       "type": "final",
     },
@@ -71,25 +72,11 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     },
     "step::1::1": {
       "entry": "[fn]",
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::1::1::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::1::1::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": "[fn]",
           "target": "step::1",
@@ -125,67 +112,35 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::1::1",
         },
       },
-    },
-    "step::1::1::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
+            },
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
+            },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "step::1",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::1::1::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
-          ],
-          "target": "step::1",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
     "step::2": {
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::2::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::2::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": {
             "params": {
@@ -228,74 +183,35 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::2",
         },
       },
-    },
-    "step::2::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "STOP",
-                },
-              },
-              "type": "setLastAction",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
             },
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
+            },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "STOPPED",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::2::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
-          ],
-          "target": "step::4",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
     "step::3": {
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::3::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::3::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": {
             "params": {
@@ -338,74 +254,35 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::3",
         },
       },
-    },
-    "step::3::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "STOP",
-                },
-              },
-              "type": "setLastAction",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
             },
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
+            },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "STOPPED",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::3::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
-          ],
-          "target": "step::4",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
     "step::4": {
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::4::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::4::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": {
             "params": {
@@ -455,60 +332,28 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::4",
         },
       },
-    },
-    "step::4::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "STOP",
-                },
-              },
-              "type": "setLastAction",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
             },
-          ],
-          "target": "STOPPED",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::4::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "COMPLETE",
-                },
-              },
-              "type": "setLastAction",
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
             },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "COMPLETE",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
   },
 }
@@ -558,6 +403,7 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
         "[fn]",
       ],
+      "id": "STOPPED",
       "output": "[fn]",
       "type": "final",
     },
@@ -590,25 +436,11 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     },
     "step::1::1": {
       "entry": "[fn]",
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::1::1::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::1::1::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": "[fn]",
           "target": "step::1::2",
@@ -644,67 +476,35 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::1::1",
         },
       },
-    },
-    "step::1::1::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
+            },
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
+            },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "step::1::2",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::1::1::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
-          ],
-          "target": "step::1::2",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
     "step::1::2": {
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::1::2::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::1::2::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": {
             "params": {
@@ -747,53 +547,28 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::1::2",
         },
       },
-    },
-    "step::1::2::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "STOP",
-                },
-              },
-              "type": "setLastAction",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
             },
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
+            },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "STOPPED",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::1::2::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
-          ],
-          "target": "step::1",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
     "step::2": {
       "always": [
@@ -849,25 +624,11 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     },
     "step::2::1": {
       "entry": "[fn]",
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::2::1::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::2::1::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": "[fn]",
           "target": "step::2",
@@ -903,67 +664,35 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::2::1",
         },
       },
-    },
-    "step::2::1::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
+            },
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
+            },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "step::2",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::2::1::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
-          ],
-          "target": "step::2",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
     "step::3": {
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::3::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::3::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": {
             "params": {
@@ -1013,60 +742,28 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::3",
         },
       },
-    },
-    "step::3::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "STOP",
-                },
-              },
-              "type": "setLastAction",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
             },
-          ],
-          "target": "STOPPED",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::3::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "COMPLETE",
-                },
-              },
-              "type": "setLastAction",
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
             },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "COMPLETE",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
   },
 }
@@ -1116,29 +813,16 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
         "[fn]",
       ],
+      "id": "STOPPED",
       "output": "[fn]",
       "type": "final",
     },
     "step::1": {
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::1::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::1::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": {
             "params": {
@@ -1176,74 +860,35 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::1",
         },
       },
-    },
-    "step::1::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "STOP",
-                },
-              },
-              "type": "setLastAction",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
             },
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
+            },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "STOPPED",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::1::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
-          ],
-          "target": "step::3",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
     "step::2": {
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::2::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::2::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": {
             "params": {
@@ -1281,74 +926,35 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::2",
         },
       },
-    },
-    "step::2::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "STOP",
-                },
-              },
-              "type": "setLastAction",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
             },
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
+            },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "STOPPED",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::2::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
-          ],
-          "target": "step::3",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
     "step::3": {
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::3::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::3::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": {
             "params": {
@@ -1393,60 +999,28 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::3",
         },
       },
-    },
-    "step::3::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "STOP",
-                },
-              },
-              "type": "setLastAction",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
             },
-          ],
-          "target": "STOPPED",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::3::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "COMPLETE",
-                },
-              },
-              "type": "setLastAction",
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
             },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "COMPLETE",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
   },
 }
@@ -1496,6 +1070,7 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
         "[fn]",
       ],
+      "id": "STOPPED",
       "output": "[fn]",
       "type": "final",
     },
@@ -1528,25 +1103,11 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     },
     "step::1::1": {
       "entry": "[fn]",
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::1::1::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::1::1::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": "[fn]",
           "target": "step::1::2",
@@ -1577,67 +1138,35 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::1::1",
         },
       },
-    },
-    "step::1::1::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
+            },
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
+            },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "step::1::2",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::1::1::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
-          ],
-          "target": "step::1::2",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
     "step::1::2": {
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::1::2::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::1::2::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": {
             "params": {
@@ -1675,74 +1204,35 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::1::2",
         },
       },
-    },
-    "step::1::2::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "STOP",
-                },
-              },
-              "type": "setLastAction",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
             },
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
+            },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "STOPPED",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::1::2::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            "[fn]",
-          ],
-          "target": "step::1",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
     "step::2": {
+      "initial": "idle",
       "on": {
-        "COMMAND_RESULT": [
-          {
-            "guard": "[fn]",
-            "target": "step::2::__capture-pass",
-          },
-          {
-            "guard": "[fn]",
-            "target": "step::2::__capture-fail",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-          {
-            "actions": "[fn]",
-            "guard": "[fn]",
-          },
-        ],
+        "COMMAND_RESULT": {
+          "target": ".__capture",
+        },
         "FAIL": {
           "actions": {
             "params": {
@@ -1787,60 +1277,28 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::2",
         },
       },
-    },
-    "step::2::__capture-fail": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "STOP",
-                },
-              },
-              "type": "setLastAction",
+      "states": {
+        "__capture": {
+          "invoke": {
+            "input": "[fn]",
+            "onDone": {
+              "actions": [
+                "[fn]",
+                "[fn]",
+              ],
             },
-          ],
-          "target": "STOPPED",
-        },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
-      },
-      "tags": [
-        "pending-machine-effect",
-      ],
-    },
-    "step::2::__capture-pass": {
-      "invoke": {
-        "input": "[fn]",
-        "onDone": {
-          "actions": [
-            "[fn]",
-            {
-              "params": {
-                "action": {
-                  "type": "COMPLETE",
-                },
-              },
-              "type": "setLastAction",
+            "onError": {
+              "actions": "[fn]",
+              "target": "#STOPPED",
             },
+            "src": "outputCaptureActor",
+          },
+          "tags": [
+            "pending-machine-effect",
           ],
-          "target": "COMPLETE",
         },
-        "onError": {
-          "actions": "[fn]",
-          "target": "STOPPED",
-        },
-        "src": "outputCaptureActor",
+        "idle": {},
       },
-      "tags": [
-        "pending-machine-effect",
-      ],
     },
   },
 }

--- a/packages/core/__tests__/runbook/__snapshots__/compiler-machine-structural-snapshot.test.ts.snap
+++ b/packages/core/__tests__/runbook/__snapshots__/compiler-machine-structural-snapshot.test.ts.snap
@@ -72,6 +72,24 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     "step::1::1": {
       "entry": "[fn]",
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::1::1::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::1::1::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": "[fn]",
           "target": "step::1",
@@ -108,8 +126,66 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
       },
     },
+    "step::1::1::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::1",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::1::1::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::1",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
     "step::2": {
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::2::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::2::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": {
             "params": {
@@ -153,8 +229,73 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
       },
     },
+    "step::2::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "STOP",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "STOPPED",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::2::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::4",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
     "step::3": {
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::3::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::3::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": {
             "params": {
@@ -198,8 +339,73 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
       },
     },
+    "step::3::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "STOP",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "STOPPED",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::3::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::4",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
     "step::4": {
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::4::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::4::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": {
             "params": {
@@ -249,6 +455,60 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::4",
         },
       },
+    },
+    "step::4::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "STOP",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "STOPPED",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::4::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "COMPLETE",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "COMPLETE",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
     },
   },
 }
@@ -331,6 +591,24 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     "step::1::1": {
       "entry": "[fn]",
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::1::1::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::1::1::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": "[fn]",
           "target": "step::1::2",
@@ -367,8 +645,66 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
       },
     },
+    "step::1::1::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::1::2",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::1::1::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::1::2",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
     "step::1::2": {
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::1::2::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::1::2::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": {
             "params": {
@@ -411,6 +747,53 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::1::2",
         },
       },
+    },
+    "step::1::2::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "STOP",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "STOPPED",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::1::2::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::1",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
     },
     "step::2": {
       "always": [
@@ -467,6 +850,24 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     "step::2::1": {
       "entry": "[fn]",
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::2::1::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::2::1::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": "[fn]",
           "target": "step::2",
@@ -503,8 +904,66 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
       },
     },
+    "step::2::1::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::2",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::2::1::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::2",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
     "step::3": {
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::3::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::3::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": {
             "params": {
@@ -554,6 +1013,60 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::3",
         },
       },
+    },
+    "step::3::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "STOP",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "STOPPED",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::3::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "COMPLETE",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "COMPLETE",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
     },
   },
 }
@@ -608,6 +1121,24 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     },
     "step::1": {
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::1::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::1::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": {
             "params": {
@@ -646,8 +1177,73 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
       },
     },
+    "step::1::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "STOP",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "STOPPED",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::1::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::3",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
     "step::2": {
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::2::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::2::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": {
             "params": {
@@ -686,8 +1282,73 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
       },
     },
+    "step::2::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "STOP",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "STOPPED",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::2::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::3",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
     "step::3": {
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::3::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::3::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": {
             "params": {
@@ -732,6 +1393,60 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::3",
         },
       },
+    },
+    "step::3::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "STOP",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "STOPPED",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::3::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "COMPLETE",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "COMPLETE",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
     },
   },
 }
@@ -814,6 +1529,24 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     "step::1::1": {
       "entry": "[fn]",
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::1::1::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::1::1::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": "[fn]",
           "target": "step::1::2",
@@ -845,8 +1578,66 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
       },
     },
+    "step::1::1::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::1::2",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::1::1::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::1::2",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
     "step::1::2": {
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::1::2::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::1::2::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": {
             "params": {
@@ -885,8 +1676,73 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
         },
       },
     },
+    "step::1::2::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "STOP",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "STOPPED",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::1::2::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            "[fn]",
+          ],
+          "target": "step::1",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
     "step::2": {
       "on": {
+        "COMMAND_RESULT": [
+          {
+            "guard": "[fn]",
+            "target": "step::2::__capture-pass",
+          },
+          {
+            "guard": "[fn]",
+            "target": "step::2::__capture-fail",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+          {
+            "actions": "[fn]",
+            "guard": "[fn]",
+          },
+        ],
         "FAIL": {
           "actions": {
             "params": {
@@ -931,6 +1787,60 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
           "target": "step::2",
         },
       },
+    },
+    "step::2::__capture-fail": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "STOP",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "STOPPED",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
+    },
+    "step::2::__capture-pass": {
+      "invoke": {
+        "input": "[fn]",
+        "onDone": {
+          "actions": [
+            "[fn]",
+            {
+              "params": {
+                "action": {
+                  "type": "COMPLETE",
+                },
+              },
+              "type": "setLastAction",
+            },
+          ],
+          "target": "COMPLETE",
+        },
+        "onError": {
+          "actions": "[fn]",
+          "target": "STOPPED",
+        },
+        "src": "outputCaptureActor",
+      },
+      "tags": [
+        "pending-machine-effect",
+      ],
     },
   },
 }

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals
 import { mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createActor } from 'xstate';
 import { RunbookStateManager } from '../../src/runbook/state.js';
 import { merge } from '../../src/runbook/state-update-ops.js';
 import { RunbookActorService } from '../../src/runbook/actor-service.js';
@@ -17,6 +18,7 @@ import { makeBaseStep } from '../helpers/step-factories.js';
 import { createJsonArrayStream } from '../../src/runbook/types.js';
 import { buildFrameKey } from '../../src/runbook/targeting.js';
 import type { RunbookContext } from '../../src/runbook/compiler.js';
+import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
 import { createRunbook } from './fixtures.js';
 
 function mockActor(snapshot: { value: string; context: Record<string, unknown> }) {
@@ -188,6 +190,70 @@ describe('RunbookActorService', () => {
         /references missing step "missing"/,
       );
     });
+
+    it('persists and rehydrates a compound-leaf snapshot through a sendAndSync round-trip', async () => {
+      // Create a runbook with OUTPUTS + RETRY transitions
+      const steps = createRunbook(`## 1. capture
+- PASS COMPLETE
+- FAIL RETRY 2 STOP
+- OUTPUTS
+  - Foo
+\`\`\`bash
+exit 1
+\`\`\`
+`);
+      const runbook = {
+        title: 'Retry round-trip test',
+        description: 'Regression coverage for compound-leaf snapshot round-trip',
+        steps,
+      };
+      const state = await manager.create({ source: 'project', path: 'test.md' }, runbook, {
+        runbookPath: 'test.md',
+      });
+      const channelPath = join(testDir, 'Foo');
+      await writeFile(channelPath, 'persisted-value\n', 'utf-8');
+
+      // Drive the actor through a FAIL-RETRY cycle
+      const result = await actorService.sendAndSync(state.id, steps, {
+        type: 'COMMAND_RESULT',
+        result: 'fail',
+        channels: [{ name: 'Foo', path: channelPath }],
+      });
+
+      // Should not throw and should complete the FAIL-RETRY transition
+      expect(result).not.toBeNull();
+      expect(result?.state.step).toBe('1');
+      expect(result?.state.retryCount).toBeGreaterThan(0);
+
+      // Now test the round-trip: persist this snapshot and rehydrate it
+      const persistedSnapshot = result!.state.snapshot;
+      expect(persistedSnapshot).toBeDefined();
+
+      // Create a new actor from the persisted snapshot
+      const machine = compileRunbookToMachine(steps);
+      const rehydratedActor = createActor(machine, { snapshot: persistedSnapshot as any });
+      rehydratedActor.start();
+
+      // Get the rehydrated snapshot and verify round-trip equality
+      const rehydratedSnapshot = rehydratedActor.getPersistedSnapshot();
+      expect(rehydratedSnapshot).toEqual(persistedSnapshot);
+
+      // Verify the snapshot has the compound-leaf shape we expect
+      const snapValue = (rehydratedSnapshot as unknown as Record<string, unknown>).value as Record<
+        string,
+        unknown
+      >;
+      expect(snapValue).toEqual({ 'step::1': 'idle' });
+
+      // Verify step extraction works correctly on the rehydrated actor
+      const { state: updated } = await actorService.updateFromActor(
+        state.id,
+        rehydratedActor as any,
+        steps,
+      );
+      expect(updated.step).toBe('1');
+      expect(updated.retryCount).toBeGreaterThan(0);
+    });
   });
 
   describe('initializeState', () => {
@@ -264,7 +330,7 @@ echo hi
       const persisted = await manager.load(state.id);
       expect(persisted?.lifecycle).toBe('completed');
       expect(persisted?.variables).toEqual({ Foo: 'persisted-value' });
-      expect(JSON.stringify(persisted?.snapshot)).not.toContain('__capture-pass');
+      expect(JSON.stringify(persisted?.snapshot)).not.toContain('__capture');
     });
   });
 

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -230,6 +230,44 @@ describe('RunbookActorService', () => {
     });
   });
 
+  describe('sendAndSync pending machine effects', () => {
+    it('waits for tagged machine-owned invokes before persisting', async () => {
+      const steps = createRunbook(`## 1. capture
+- PASS COMPLETE
+- FAIL STOP
+- OUTPUTS
+  - Foo
+\`\`\`bash
+echo hi
+\`\`\`
+`);
+      const runbook = {
+        title: 'Invoke persistence',
+        description: 'Regression coverage for async invoke persistence',
+        steps,
+      };
+      const state = await manager.create({ source: 'project', path: 'test.md' }, runbook, {
+        runbookPath: 'test.md',
+      });
+      const channelPath = join(testDir, 'Foo');
+      await writeFile(channelPath, 'persisted-value\n', 'utf-8');
+
+      const result = await actorService.sendAndSync(state.id, steps, {
+        type: 'COMMAND_RESULT',
+        result: 'pass',
+        channels: [{ name: 'Foo', path: channelPath }],
+      });
+
+      expect(result).not.toBeNull();
+      expect(result?.state.lifecycle).toBe('completed');
+      expect(result?.state.variables).toEqual({ Foo: 'persisted-value' });
+      const persisted = await manager.load(state.id);
+      expect(persisted?.lifecycle).toBe('completed');
+      expect(persisted?.variables).toEqual({ Foo: 'persisted-value' });
+      expect(JSON.stringify(persisted?.snapshot)).not.toContain('__capture-pass');
+    });
+  });
+
   describe('FOR loop context via actor', () => {
     it('syncs FOR context fields from actor snapshot', async () => {
       const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals
 import { mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createActor } from 'xstate';
+import { createActor, type Snapshot } from 'xstate';
 import { RunbookStateManager } from '../../src/runbook/state.js';
 import { merge } from '../../src/runbook/state-update-ops.js';
 import { RunbookActorService, stateValueAsString } from '../../src/runbook/actor-service.js';
@@ -231,7 +231,9 @@ exit 1
 
       // Create a new actor from the persisted snapshot
       const machine = compileRunbookToMachine(steps);
-      const rehydratedActor = createActor(machine, { snapshot: persistedSnapshot as any });
+      const rehydratedActor = createActor(machine, {
+        snapshot: persistedSnapshot as Snapshot<unknown>,
+      });
       rehydratedActor.start();
 
       // Get the rehydrated snapshot and verify round-trip equality
@@ -248,7 +250,7 @@ exit 1
       // Verify step extraction works correctly on the rehydrated actor
       const { state: updated } = await actorService.updateFromActor(
         state.id,
-        rehydratedActor as any,
+        rehydratedActor as AnyActorRef,
         steps,
       );
       expect(updated.step).toBe('1');

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { createActor } from 'xstate';
 import { RunbookStateManager } from '../../src/runbook/state.js';
 import { merge } from '../../src/runbook/state-update-ops.js';
-import { RunbookActorService } from '../../src/runbook/actor-service.js';
+import { RunbookActorService, stateValueAsString } from '../../src/runbook/actor-service.js';
 import type { AnyActorRef } from '../../src/runbook/actor-service.js';
 import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
 import type {
@@ -1141,5 +1141,35 @@ echo hi
       const { state: updated } = await actorService.updateFromActor(state.id, actor, mockSteps);
       expect(updated.activeFrameKey).toBe(frameKey);
     });
+  });
+});
+
+describe('stateValueAsString', () => {
+  it('returns a plain string unchanged', () => {
+    expect(stateValueAsString('COMPLETE')).toBe('COMPLETE');
+    expect(stateValueAsString('step::1')).toBe('step::1');
+  });
+
+  it('returns the leaf ID for a compound-leaf idle substate', () => {
+    expect(stateValueAsString({ 'step::1': 'idle' })).toBe('step::1');
+  });
+
+  it('returns the leaf ID for a compound-leaf __capture substate', () => {
+    expect(stateValueAsString({ 'step::1::1': '__capture' })).toBe('step::1::1');
+  });
+
+  it('returns null for an unrecognized substate name', () => {
+    expect(stateValueAsString({ 'step::1': 'unknown-substate' })).toBeNull();
+  });
+
+  it('returns null for a multi-key object', () => {
+    expect(stateValueAsString({ 'step::1': 'idle', 'step::2': 'idle' })).toBeNull();
+  });
+
+  it('returns null for non-string, non-object values', () => {
+    expect(stateValueAsString(null)).toBeNull();
+    expect(stateValueAsString(undefined)).toBeNull();
+    expect(stateValueAsString(42)).toBeNull();
+    expect(stateValueAsString([])).toBeNull();
   });
 });

--- a/packages/core/__tests__/runbook/actors/output-capture-actor.test.ts
+++ b/packages/core/__tests__/runbook/actors/output-capture-actor.test.ts
@@ -20,44 +20,44 @@ describe('outputCaptureActor', () => {
     await fs.rm(tmp, { recursive: true, force: true });
   });
 
-  it('returns captured values from prepared channels', async () => {
+  it('returns captured values from prepared channels with result passthrough', async () => {
     const channels = [
       await makeChannel(tmp, 'Foo', 'foo-value\n'),
       await makeChannel(tmp, 'Bar', 'bar-value'),
     ];
-    const actor = createActor(outputCaptureActor, { input: { channels } });
+    const actor = createActor(outputCaptureActor, { input: { channels, result: 'pass' } });
     actor.start();
-    const output = await new Promise<Record<string, string>>((resolve) => {
+    const output = await new Promise((resolve) => {
       actor.subscribe((s) => {
         if (s.status === 'done') resolve(s.output);
       });
     });
-    expect(output).toEqual({ Foo: 'foo-value', Bar: 'bar-value' });
+    expect(output).toEqual({ variables: { Foo: 'foo-value', Bar: 'bar-value' }, result: 'pass' });
   });
 
-  it('omits missing channel files but does not reject', async () => {
+  it('omits missing channel files but does not reject, with result passthrough', async () => {
     const channels = [
       { name: 'Missing', path: path.join(tmp, 'does-not-exist') },
       await makeChannel(tmp, 'Present', 'ok'),
     ];
-    const actor = createActor(outputCaptureActor, { input: { channels } });
+    const actor = createActor(outputCaptureActor, { input: { channels, result: 'fail' } });
     actor.start();
-    const output = await new Promise<Record<string, string>>((resolve) => {
+    const output = await new Promise((resolve) => {
       actor.subscribe((s) => {
         if (s.status === 'done') resolve(s.output);
       });
     });
-    expect(output).toEqual({ Present: 'ok' });
+    expect(output).toEqual({ variables: { Present: 'ok' }, result: 'fail' });
   });
 
-  it('returns empty record when channels array is empty', async () => {
-    const actor = createActor(outputCaptureActor, { input: { channels: [] } });
+  it('returns empty record when channels array is empty, with result passthrough', async () => {
+    const actor = createActor(outputCaptureActor, { input: { channels: [], result: 'pass' } });
     actor.start();
-    const output = await new Promise<Record<string, string>>((resolve) => {
+    const output = await new Promise((resolve) => {
       actor.subscribe((s) => {
         if (s.status === 'done') resolve(s.output);
       });
     });
-    expect(output).toEqual({});
+    expect(output).toEqual({ variables: {}, result: 'pass' });
   });
 });

--- a/packages/core/__tests__/runbook/actors/output-capture-actor.test.ts
+++ b/packages/core/__tests__/runbook/actors/output-capture-actor.test.ts
@@ -29,7 +29,7 @@ describe('outputCaptureActor', () => {
     actor.start();
     const output = await new Promise<Record<string, string>>((resolve) => {
       actor.subscribe((s) => {
-        if (s.status === 'done') resolve(s.output as Record<string, string>);
+        if (s.status === 'done') resolve(s.output);
       });
     });
     expect(output).toEqual({ Foo: 'foo-value', Bar: 'bar-value' });
@@ -44,7 +44,7 @@ describe('outputCaptureActor', () => {
     actor.start();
     const output = await new Promise<Record<string, string>>((resolve) => {
       actor.subscribe((s) => {
-        if (s.status === 'done') resolve(s.output as Record<string, string>);
+        if (s.status === 'done') resolve(s.output);
       });
     });
     expect(output).toEqual({ Present: 'ok' });
@@ -55,7 +55,7 @@ describe('outputCaptureActor', () => {
     actor.start();
     const output = await new Promise<Record<string, string>>((resolve) => {
       actor.subscribe((s) => {
-        if (s.status === 'done') resolve(s.output as Record<string, string>);
+        if (s.status === 'done') resolve(s.output);
       });
     });
     expect(output).toEqual({});

--- a/packages/core/__tests__/runbook/actors/output-capture-actor.test.ts
+++ b/packages/core/__tests__/runbook/actors/output-capture-actor.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { createActor } from 'xstate';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { outputCaptureActor } from '../../../src/runbook/actors/output-capture-actor.js';
+
+async function makeChannel(dir: string, name: string, content: string) {
+  const filePath = path.join(dir, name);
+  await fs.writeFile(filePath, content, 'utf-8');
+  return { name, path: filePath };
+}
+
+describe('outputCaptureActor', () => {
+  let tmp: string;
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'oca-'));
+  });
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('returns captured values from prepared channels', async () => {
+    const channels = [
+      await makeChannel(tmp, 'Foo', 'foo-value\n'),
+      await makeChannel(tmp, 'Bar', 'bar-value'),
+    ];
+    const actor = createActor(outputCaptureActor, { input: { channels } });
+    actor.start();
+    const snapshot = await new Promise<unknown>((resolve) => {
+      actor.subscribe((s) => {
+        if (s.status === 'done') resolve(s.output);
+      });
+    });
+    expect(snapshot).toEqual({ Foo: 'foo-value', Bar: 'bar-value' });
+  });
+
+  it('omits missing channel files but does not reject', async () => {
+    const channels = [
+      { name: 'Missing', path: path.join(tmp, 'does-not-exist') },
+      await makeChannel(tmp, 'Present', 'ok'),
+    ];
+    const actor = createActor(outputCaptureActor, { input: { channels } });
+    actor.start();
+    const output = await new Promise<Record<string, string>>((resolve) => {
+      actor.subscribe((s) => {
+        if (s.status === 'done') resolve(s.output as Record<string, string>);
+      });
+    });
+    expect(output).toEqual({ Present: 'ok' });
+  });
+
+  it('returns empty record when channels array is empty', async () => {
+    const actor = createActor(outputCaptureActor, { input: { channels: [] } });
+    actor.start();
+    const output = await new Promise<Record<string, string>>((resolve) => {
+      actor.subscribe((s) => {
+        if (s.status === 'done') resolve(s.output as Record<string, string>);
+      });
+    });
+    expect(output).toEqual({});
+  });
+});

--- a/packages/core/__tests__/runbook/actors/output-capture-actor.test.ts
+++ b/packages/core/__tests__/runbook/actors/output-capture-actor.test.ts
@@ -27,12 +27,12 @@ describe('outputCaptureActor', () => {
     ];
     const actor = createActor(outputCaptureActor, { input: { channels } });
     actor.start();
-    const snapshot = await new Promise<unknown>((resolve) => {
+    const output = await new Promise<Record<string, string>>((resolve) => {
       actor.subscribe((s) => {
-        if (s.status === 'done') resolve(s.output);
+        if (s.status === 'done') resolve(s.output as Record<string, string>);
       });
     });
-    expect(snapshot).toEqual({ Foo: 'foo-value', Bar: 'bar-value' });
+    expect(output).toEqual({ Foo: 'foo-value', Bar: 'bar-value' });
   });
 
   it('omits missing channel files but does not reject', async () => {

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -7,7 +7,6 @@ import {
   appendArtifactManifestRecord,
   readArtifactManifest,
   resolveArtifactDeclarations,
-  type ArtifactRunEligibility,
 } from '../../src/runbook/index.js';
 import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
 import type { RunId } from '../../src/runbook/run-id.js';
@@ -59,10 +58,6 @@ async function touchArtifact(cwd: string, row: ArtifactRecord): Promise<void> {
   await fsp.writeFile(file, '{}');
 }
 
-function eligibility(states: ReadonlyMap<string, ArtifactRunEligibility | null>) {
-  return async (runId: RunId): Promise<ArtifactRunEligibility | null> => states.get(runId) ?? null;
-}
-
 describe('resolveArtifactDeclarations — bare key (producer form)', () => {
   it('builds the exact URI for the current context and current run', async () => {
     const cwd = await tempCwd();
@@ -73,7 +68,6 @@ describe('resolveArtifactDeclarations — bare key (producer form)', () => {
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.PlanPath).toMatchObject({
@@ -94,7 +88,6 @@ describe('resolveArtifactDeclarations — bare key (producer form)', () => {
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(Array.isArray(result.PlanPath)).toBe(false);
@@ -109,7 +102,6 @@ describe('resolveArtifactDeclarations — bare key (producer form)', () => {
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     const manifest = await readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
@@ -133,7 +125,6 @@ describe('resolveArtifactDeclarations — bare key (producer form)', () => {
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     await expect(
@@ -151,7 +142,6 @@ describe('resolveArtifactDeclarations — bare key (producer form)', () => {
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/exact_artifact_key|invalid key/);
   });
@@ -165,7 +155,6 @@ describe('resolveArtifactDeclarations — bare key (producer form)', () => {
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     // Both calls appended rows with identical identity.
@@ -194,7 +183,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Reviews).toEqual([a, b].sort((l, r) => l.uri.localeCompare(r.uri)));
@@ -212,7 +200,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Reviews).toEqual(row);
@@ -227,7 +214,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Reviews).toEqual([]);
@@ -244,7 +230,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     const after = await readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
@@ -261,7 +246,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/wildcard_artifact_key|invalid key|recursive/);
   });
@@ -276,7 +260,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/wildcard_artifact_key|invalid key/);
   });
@@ -305,12 +288,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(
-        new Map([
-          [CHILD_RUN, { runId: CHILD_RUN, terminalAt: '2026-05-07T02:00:00.000Z' }],
-          [OTHER_CONTEXT_RUN, { runId: OTHER_CONTEXT_RUN, terminalAt: '2026-05-07T02:00:00.000Z' }],
-        ]),
-      ),
     });
 
     expect(result.Reviews).toEqual(
@@ -330,7 +307,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Reviews).toEqual(hidden);
@@ -354,33 +330,9 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Reviews).toEqual(matching);
-  });
-
-  it('ignores incomplete sibling runs and missing files', async () => {
-    const cwd = await tempCwd();
-    const incomplete = record({ key: 'review-plan-incomplete.json' });
-    const missingFile = record({
-      runId: 'rd_dddddddddddddddddddddddddddddddd',
-      key: 'review-plan-missing.json',
-    });
-    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, incomplete);
-    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, missingFile);
-    await touchArtifact(cwd, incomplete);
-
-    const result = await resolveArtifactDeclarations([decl('Reviews', 'review-plan-*.json')], {
-      cwd,
-      workPath: WORK_PATH,
-      contextId: CONTEXT_ID,
-      runId: CURRENT_RUN,
-      runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map([[CHILD_RUN, null]])),
-    });
-
-    expect(result.Reviews).toEqual([]);
   });
 
   it('ignores symlinked artifact files', async () => {
@@ -412,9 +364,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(
-        new Map([[CHILD_RUN, { runId: CHILD_RUN, terminalAt: '2026-05-07T02:00:00.000Z' }]]),
-      ),
     });
 
     expect(result.Reviews).toEqual([]);
@@ -437,7 +386,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       },
     );
 
@@ -465,7 +413,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       },
     );
 
@@ -489,7 +436,6 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result).toEqual({});
@@ -508,7 +454,6 @@ describe('resolveArtifactDeclarations — URI literal', () => {
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       },
     );
 
@@ -542,9 +487,6 @@ describe('resolveArtifactDeclarations — URI literal', () => {
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(
-          new Map([[CHILD_RUN, { runId: CHILD_RUN, terminalAt: '2026-05-07T02:00:00.000Z' }]]),
-        ),
       },
     );
 
@@ -568,9 +510,6 @@ describe('resolveArtifactDeclarations — URI literal', () => {
           contextId: CONTEXT_ID,
           runId: CURRENT_RUN,
           runbook: RUNBOOK,
-          loadRunEligibility: eligibility(
-            new Map([[CHILD_RUN, { runId: CHILD_RUN, terminalAt: '2026-05-07T02:00:00.000Z' }]]),
-          ),
         },
       ),
     ).rejects.toThrow(/other-run|does not exist|selector/);
@@ -593,7 +532,6 @@ describe('resolveArtifactDeclarations — URI literal', () => {
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       },
     );
 
@@ -614,63 +552,12 @@ describe('resolveArtifactDeclarations — URI literal', () => {
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       },
     );
 
     await expect(
       fsp.stat(path.join(cwd, WORK_PATH, `.rd-${CONTEXT_ID}`, CURRENT_RUN)),
     ).resolves.toMatchObject({ isDirectory: expect.any(Function) });
-  });
-
-  it('rejects selector URI with status query param (filter not yet implemented)', async () => {
-    const cwd = await tempCwd();
-
-    await expect(
-      resolveArtifactDeclarations(
-        [decl('Plan', `rd://artifacts/${CONTEXT_ID}/*/plan.json?status=any`)],
-        {
-          cwd,
-          workPath: WORK_PATH,
-          contextId: CONTEXT_ID,
-          runId: CURRENT_RUN,
-          runbook: RUNBOOK,
-          loadRunEligibility: eligibility(new Map()),
-        },
-      ),
-    ).rejects.toThrow(/query parameters are not yet implemented:\s*status/);
-  });
-
-  it('rejects selector URI with multiple unsupported query params and names them all', async () => {
-    const cwd = await tempCwd();
-
-    let caught: unknown;
-    try {
-      await resolveArtifactDeclarations(
-        [
-          decl(
-            'Plan',
-            `rd://artifacts/${CONTEXT_ID}/*/plan.json?runbook=planning/*.runbook.md&source=project&latest=true`,
-          ),
-        ],
-        {
-          cwd,
-          workPath: WORK_PATH,
-          contextId: CONTEXT_ID,
-          runId: CURRENT_RUN,
-          runbook: RUNBOOK,
-          loadRunEligibility: eligibility(new Map()),
-        },
-      );
-    } catch (error) {
-      caught = error;
-    }
-    expect(caught).toBeInstanceOf(Error);
-    const message = (caught as Error).message;
-    expect(message).toMatch(/query parameters are not yet implemented/);
-    expect(message).toMatch(/runbook/);
-    expect(message).toMatch(/source/);
-    expect(message).toMatch(/latest/);
   });
 
   it('throws when the URI literal targets a different context', async () => {
@@ -683,7 +570,6 @@ describe('resolveArtifactDeclarations — URI literal', () => {
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/cross-context flow is not supported/);
   });
@@ -701,7 +587,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
       scopeVars: { Plan: planRecord },
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Plan).toEqual(planRecord);
@@ -723,7 +608,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
         scopeVars: { Plan: planRecord },
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/cross-context flow is not supported/);
   });
@@ -740,7 +624,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
       scopeVars: { Plans: [a, b] },
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Plans).toEqual([a, b]);
@@ -763,7 +646,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
         scopeVars: { Plans: [a, b] },
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/cross-context flow is not supported/);
   });
@@ -781,7 +663,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
       scopeVars: { Plan: row.uri },
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Plan).toEqual(row);
@@ -802,7 +683,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
       scopeVars: { Plans: [a.uri, b.uri] },
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Plans).toEqual([a, b]);
@@ -823,7 +703,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
       scopeVars: { Plans: JSON.stringify([a.uri, b.uri]) },
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Plans).toEqual([a, b]);
@@ -840,7 +719,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
         scopeVars: {},
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/unbound/);
   });
@@ -855,7 +733,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/unbound/);
   });
@@ -871,7 +748,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
         scopeVars: { Plan: 42 },
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/not-an-artifact/);
   });
@@ -887,7 +763,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
         scopeVars: { Plan: 'not-a-uri' },
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/unresolvable-uri/);
   });
@@ -903,7 +778,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
         scopeVars: { Plan: `rd://artifacts/${CONTEXT_ID}/*/missing.json` },
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/unresolvable-uri/);
   });
@@ -922,7 +796,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
         scopeVars: { Plans: [a.uri, `rd://artifacts/${CONTEXT_ID}/*/missing.json`] },
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/partial-resolve/);
   });
@@ -943,7 +816,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         scopeVars: {
           Plans: JSON.stringify([a.uri, `rd://artifacts/${CONTEXT_ID}/*/missing.json`]),
         },
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/partial-resolve/);
   });
@@ -959,7 +831,6 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
         scopeVars: { Plans: JSON.stringify([`rd://artifacts/${CONTEXT_ID}/*/plan.json`, 42]) },
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/unresolvable-uri/);
   });
@@ -976,7 +847,6 @@ describe('resolveArtifactDeclarations — bare-key glob validation', () => {
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/wildcard_artifact_key|invalid glob/);
   });
@@ -993,7 +863,6 @@ describe('resolveArtifactDeclarations — bare-key glob validation', () => {
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Reviews).toEqual(row);
@@ -1011,7 +880,6 @@ describe('resolveArtifactDeclarations — bare-key glob validation', () => {
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
-      loadRunEligibility: eligibility(new Map()),
     });
 
     expect(result.Reviews).toEqual(row);
@@ -1036,7 +904,6 @@ describe('resolveArtifactDeclarations — parent dir creation error propagation'
         contextId: CONTEXT_ID,
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
-        loadRunEligibility: eligibility(new Map()),
       }),
     ).rejects.toThrow(/ENOTDIR|EEXIST|not a directory|file already exists/i);
 

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -130,7 +130,7 @@ describe('runbook compiler', () => {
       actor.send({ type: 'PASS' }); // 1.1
       actor.send({ type: 'PASS' }); // 1.2 -> parent -> step::2
 
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       // Case D: non-FOR pass-through clears iterationResults
       expect(actor.getSnapshot().context.iterationResults).toBeUndefined();
     });
@@ -244,7 +244,7 @@ describe('runbook compiler', () => {
       actor.send({ type: 'PASS' }); // 1.2 CONTINUE -> parent -> Case D PASS GOTO 3 -> step::3
 
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::3');
+      expect(snapshot.value).toEqual({ 'step::3': 'idle' });
       expect(snapshot.context.lastAction).toEqual(
         expect.objectContaining({ type: 'GOTO', target: '3' }),
       );
@@ -268,7 +268,7 @@ describe('runbook compiler', () => {
 
       // 1.1 passes — DEFER advances to 1.2, aggregation waits
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
       // 1.2 passes — all results in, PASS ALL: COMPLETE
       actor.send({ type: 'PASS' });
@@ -298,7 +298,7 @@ describe('runbook compiler', () => {
 
       // 1.1 fails — DEFER collects result, advances to 1.2
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
       // 1.2 passes — all results in, FAIL ANY has a fail → STOPPED
       actor.send({ type: 'PASS' });
@@ -327,7 +327,7 @@ Write the plan manually.
       // Both substeps get DEFER under aggregating parent
       // 1.1 (prose) passes → DEFER → advances to 1.2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
       // 1.2 (runbook list) passes → DEFER → PASS ALL: COMPLETE
       actor.send({ type: 'PASS' });
@@ -367,7 +367,7 @@ Write the plan manually.
       actor.send({ type: 'PASS' }); // 1.3 CONTINUE → parent → Case D → step::2
 
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       // Case D: non-FOR pass-through clears deferredResults
       expect(snapshot.context.deferredResults).toBeUndefined();
       expect(snapshot.context.iterationResults).toBeUndefined();
@@ -427,7 +427,7 @@ Write the plan manually.
       actor.send({ type: 'PASS' }); // 1.2 -> parent -> loop-back -> 1.1
 
       // Should be back at first substep (iteration 2)
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']);
     });
@@ -467,7 +467,7 @@ Write the plan manually.
 
       // 1.1 fails — DEFER advances to 1.2, aggregation waits for all results
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
       // 1.2 passes — all results in, FAIL ANY (all=true) has a fail → STOPPED
       actor.send({ type: 'PASS' });
@@ -524,7 +524,7 @@ Write the plan manually.
 
       actor.send({ type: 'PASS' });
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
     });
   });
 
@@ -600,13 +600,13 @@ Write the plan manually.
       // Pass 1.2, should CONTINUE to step 2
       actor.send({ type: 'PASS' });
       expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'CONTINUE' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
 
       // Pass step 2, should CONTINUE to step 3.1
       // This was the bug: showed "GOTO 3.1" but should be "CONTINUE"
       actor.send({ type: 'PASS' });
       expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'CONTINUE' });
-      expect(actor.getSnapshot().value).toBe('step::3::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' });
     });
 
     it('sets lastAction to STOP for STOP transitions', () => {
@@ -797,7 +797,7 @@ Write the plan manually.
       actor.send({ type: 'PASS' });
       const snapshot = actor.getSnapshot();
 
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
     });
   });
 
@@ -828,17 +828,17 @@ Write the plan manually.
 
       // First FAIL: stay at step 1 (retry 1/2)
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(1);
 
       // Second FAIL: stay at step 1 (retry 2/2)
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(2);
 
       // Third FAIL: exhausted, GOTO step 2
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(0);
     });
 
@@ -860,11 +860,11 @@ Write the plan manually.
 
       // First PASS: stay (retry 1/2)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
 
       // Second PASS: stay (retry 2/2)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
 
       // Third PASS: exhausted, COMPLETE
       actor.send({ type: 'PASS' });
@@ -911,23 +911,23 @@ Write the plan manually.
 
       // Step 1 FAIL -> CONTINUE to step 2
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
 
       // Step 2 PASS -> RETRY GOTO 1 (should stay at step 2 for retry 1/2)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(1);
       expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'RETRY' });
 
       // Step 2 PASS again -> RETRY GOTO 1 (should stay at step 2 for retry 2/2)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(2);
 
       // Step 2 PASS again -> exhausted, execute GOTO to step 1
       actor.send({ type: 'PASS' });
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::1');
+      expect(snapshot.value).toEqual({ 'step::1': 'idle' });
       expect(snapshot.context.retryCount).toBe(0);
       expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '1' });
     });
@@ -972,23 +972,23 @@ Write the plan manually.
       actor.send({ type: 'FAIL' });
       // Step 2 PASS -> RETRY (1/2), stay at step 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(1);
 
       // Step 2 PASS -> RETRY (2/2), stay at step 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(2);
 
       // Step 2 PASS -> retries exhausted, execute GOTO to step 1
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
 
       // Step 1 FAIL -> step 2
       actor.send({ type: 'FAIL' });
       // Step 2 PASS -> fresh RETRY cycle, RETRY (1/2), stay at step 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(1);
     });
   });
@@ -1035,10 +1035,10 @@ Write the plan manually.
       actor.start();
 
       // Start at step::2, PASS to enter FOR step
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       actor.send({ type: 'PASS' }); // step::2 → step::3::1 (FOR initialized)
 
-      expect(actor.getSnapshot().value).toBe('step::3::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' });
       const top1 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(top1.iteration).toBe(1);
@@ -1046,11 +1046,11 @@ Write the plan manually.
 
       // Iteration 1: step::3::1 → step::3::2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::2': 'idle' });
 
       // Iteration 1: step::3::2 → loop back to step::3::1 (iteration 2)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' });
       const top2 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(top2.iteration).toBe(2);
@@ -1058,11 +1058,11 @@ Write the plan manually.
 
       // Iteration 2: step::3::1 → step::3::2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::2': 'idle' });
 
       // Iteration 2: step::3::2 → loop back to step::3::1 (iteration 3)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' });
       const top3 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(top3.iteration).toBe(3);
@@ -1070,11 +1070,11 @@ Write the plan manually.
 
       // Iteration 3: step::3::1 → step::3::2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::2': 'idle' });
 
       // Iteration 3: step::3::2 → exit loop → step::4
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::4');
+      expect(actor.getSnapshot().value).toEqual({ 'step::4': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
     });
 
@@ -1109,7 +1109,7 @@ Write the plan manually.
       actor.start();
 
       // Machine starts at step::1::1 (first substep of FOR step)
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       const top =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(top.iteration).toBe(1);
@@ -1118,14 +1118,14 @@ Write the plan manually.
 
       // Iteration 1: PASS → loop back (iteration 2)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       const top2a =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(top2a.iteration).toBe(2);
 
       // Iteration 2: PASS → exit loop
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
     });
 
@@ -1159,14 +1159,14 @@ Write the plan manually.
       const actor = createActor(machine);
       actor.start();
 
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       const topSingle =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topSingle.iteration).toBe(5);
 
       // Single pass should exit loop (5 is not < 5)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
     });
 
@@ -1305,7 +1305,7 @@ Write the plan manually.
       actor.start();
 
       // FOR with empty substeps is auto-skipped, machine starts at step 2
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       // PASS on step 2 completes the runbook
       actor.send({ type: 'PASS' });
       expect(actor.getSnapshot().value).toBe('COMPLETE');
@@ -1356,7 +1356,7 @@ Write the plan manually.
 
       // GOTO from step 1 to step 3
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' });
       const topGoto1 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topGoto1.iteration).toBe(1);
@@ -1364,14 +1364,14 @@ Write the plan manually.
 
       // Iteration 1: PASS → loop back
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' });
       const topGoto2 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topGoto2.iteration).toBe(2);
 
       // Iteration 2: PASS → exit loop
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::4');
+      expect(actor.getSnapshot().value).toEqual({ 'step::4': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
     });
 
@@ -1420,14 +1420,14 @@ Write the plan manually.
 
       // Setup step → FOR step first substep
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' });
       const topNext1 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topNext1.iteration).toBe(1);
 
       // Iteration 1: PASS on substep 1 → NEXT → skip substep 2, go to iteration 2's substep 1
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::1'); // Loop back to first substep
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' }); // Loop back to first substep
       const topNext2 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topNext2.iteration).toBe(2);
@@ -1436,7 +1436,7 @@ Write the plan manually.
 
       // Iteration 2: PASS → NEXT → iteration 3
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' });
       const topNext3 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topNext3.iteration).toBe(3);
@@ -1444,7 +1444,7 @@ Write the plan manually.
 
       // Iteration 3 (last): PASS → NEXT → exit loop
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::4'); // Exit to next step
+      expect(actor.getSnapshot().value).toEqual({ 'step::4': 'idle' }); // Exit to next step
       expect(actor.getSnapshot().context.forStack).toEqual([]);
     });
 
@@ -1496,7 +1496,7 @@ Write the plan manually.
 
       // Setup → FOR
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' });
       const topBreak1 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topBreak1.iteration).toBe(1);
@@ -1504,7 +1504,7 @@ Write the plan manually.
       // Iteration 1: FAIL on substep 1 → BREAK → exit loop
       // BREAK is non-accumulating — current iteration result NOT added to iterationResults
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::4');
+      expect(actor.getSnapshot().value).toEqual({ 'step::4': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
       expect(actor.getSnapshot().context.iterationResults).toEqual([]);
       expect(actor.getSnapshot().context.deferredResults).toEqual([]);
@@ -1560,7 +1560,7 @@ Write the plan manually.
 
       // Iteration 3 (last): PASS → NEXT → exit → PASS ALL: empty results → vacuous pass → CONTINUE
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.iterationResults).toEqual([]);
       expect(actor.getSnapshot().context.deferredResults).toEqual([]);
     });
@@ -1608,9 +1608,9 @@ Write the plan manually.
 
       // Iteration 1: PASS → loop back
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       const topBreakRes1 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topBreakRes1.iteration).toBe(2);
@@ -1618,9 +1618,9 @@ Write the plan manually.
 
       // Iteration 2: PASS → PASS → loop back
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       const topBreakRes2 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topBreakRes2.iteration).toBe(3);
@@ -1630,9 +1630,9 @@ Write the plan manually.
       // BREAK is non-accumulating — iteration 3's result is NOT added to iterationResults
       // Parent aggregation sees ['pass', 'pass'] from iterations 1-2 (DEFER'd) → all pass → CONTINUE
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
       expect(actor.getSnapshot().context.deferredResults).toEqual([]);
@@ -1724,7 +1724,7 @@ Write the plan manually.
 
       // GOTO 2 AT 2 → enters FOR step at iteration 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const topAt1 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topAt1.iteration).toBe(2);
@@ -1734,14 +1734,14 @@ Write the plan manually.
 
       // Iteration 2: PASS → loop back to iteration 3
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const topAt2 =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topAt2.iteration).toBe(3);
 
       // Iteration 3: PASS → exit
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3': 'idle' });
     });
 
     it('GOTO without AT targeting FOR step resets to first iteration', () => {
@@ -1784,7 +1784,7 @@ Write the plan manually.
 
       // GOTO 2 (no AT) → resets to iteration 1 (forClause.start)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const topNoAt =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topNoAt.iteration).toBe(1);
@@ -1829,7 +1829,7 @@ Write the plan manually.
 
       // Send external GOTO event with AT
       actor.send({ type: 'GOTO', target: { step: '2', at: 3 } });
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const topEvtAt =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topEvtAt.iteration).toBe(3);
@@ -1875,7 +1875,7 @@ Write the plan manually.
 
       // External GOTO without AT to FOR step → reset
       actor.send({ type: 'GOTO', target: { step: '2' } });
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const topEvtNoAt =
         actor.getSnapshot().context.forStack[actor.getSnapshot().context.forStack.length - 1];
       expect(topEvtNoAt.iteration).toBe(1);
@@ -1941,20 +1941,20 @@ Write the plan manually.
 
       // Enter FOR step via GOTO from step 1
       actor.send({ type: 'PASS' }); // step::1 → step::2::1
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const ctx1 = actor.getSnapshot().context;
       expect(ctx1.forStack.length).toBe(1);
       expect(ctx1.forStack[0].iteration).toBe(1);
 
       // PASS substep 1 → GOTO step 1 (non-FOR) — forStack should be cleared
       actor.send({ type: 'PASS' }); // step::2::1 → step::1
-      expect(actor.getSnapshot().value).toBe('step::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
       expect(actor.getSnapshot().context.iterationResults).toBeUndefined();
 
       // Re-enter FOR step → fresh loop context
       actor.send({ type: 'PASS' }); // step::1 → step::2::1 (fresh FOR)
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const ctx2 = actor.getSnapshot().context;
       expect(ctx2.forStack.length).toBe(1);
       expect(ctx2.forStack[0].iteration).toBe(1);
@@ -2005,7 +2005,7 @@ Write the plan manually.
 
       // GOTO 2 AT {{Offset}} — unresolved string should fall back to start (1)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const top = actor.getSnapshot().context.forStack[0];
       expect(top.iteration).toBe(1); // Falls back to start
       expect(top.start).toBe(1);
@@ -2074,7 +2074,7 @@ Write the plan manually.
       // FAIL at iteration 3 → GOTO 2 AT {{Index}} → should resolve to AT 3
       actor.send({ type: 'FAIL' });
       const snap = actor.getSnapshot();
-      expect(snap.value).toBe('step::2::1');
+      expect(snap.value).toEqual({ 'step::2::1': 'idle' });
       expect(snap.context.forStack[0].iteration).toBe(3);
     });
 
@@ -2138,7 +2138,7 @@ Write the plan manually.
       // FAIL at iteration 3 -> GOTO 2 AT {{item}} -> resolves to AT 3
       actor.send({ type: 'FAIL' });
       const snap = actor.getSnapshot();
-      expect(snap.value).toBe('step::2::1');
+      expect(snap.value).toEqual({ 'step::2::1': 'idle' });
       expect(snap.context.forStack[0].iteration).toBe(3);
     });
 
@@ -2184,7 +2184,7 @@ Write the plan manually.
 
       // Send GOTO event targeting second substep of FOR step
       actor.send({ type: 'GOTO', target: { step: '2', substep: '2' } });
-      expect(actor.getSnapshot().value).toBe('step::2::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::2': 'idle' });
 
       // Should have FOR context initialized (not cleared by buildSimpleGotoAssign)
       const ctx = actor.getSnapshot().context;
@@ -2267,7 +2267,7 @@ Write the plan manually.
       actor.send({ type: 'PASS' }); // substep 1 -> substep 2
       actor.send({ type: 'PASS' }); // substep 2 -> exits to step 2
 
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
     });
 
@@ -2294,7 +2294,7 @@ Write the plan manually.
 
       actor.send({ type: 'PASS' });
 
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       // Case D: non-FOR pass-through clears iterationResults
       expect(actor.getSnapshot().context.iterationResults).toBeUndefined();
     });
@@ -2333,7 +2333,7 @@ Write the plan manually.
 
       actor.send({ type: 'PASS' }); // GOTO step 2
 
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const ctx = actor.getSnapshot().context;
       expect(ctx.forStack).toHaveLength(1);
       expect(ctx.forStack[0]).toEqual(expect.objectContaining({ stepId: '2', implicit: true }));
@@ -2428,17 +2428,17 @@ Write the plan manually.
 
       // Iteration 1
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1'); // loops back
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' }); // loops back
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
 
       // Iteration 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(3);
 
       // Iteration 3 (last)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2'); // exits
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' }); // exits
       expect(actor.getSnapshot().context.forStack).toEqual([]);
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass', 'pass']);
       expect(actor.getSnapshot().context.deferredResults).toEqual(['pass']);
@@ -2491,7 +2491,7 @@ Write the plan manually.
       // First iteration: FAIL on substep 1 → GOTO 1.2 (intra-loop)
       actor.send({ type: 'FAIL' });
       let snap = actor.getSnapshot();
-      expect(snap.value).toBe('step::1::2');
+      expect(snap.value).toEqual({ 'step::1::2': 'idle' });
       // forStack should be preserved with iteration 1
       expect(snap.context.forStack).toHaveLength(1);
       expect(snap.context.forStack[0].iteration).toBe(1);
@@ -2499,21 +2499,21 @@ Write the plan manually.
       // PASS substep 2 → should loop back to substep 1 at iteration 2
       actor.send({ type: 'PASS' });
       snap = actor.getSnapshot();
-      expect(snap.value).toBe('step::1::1');
+      expect(snap.value).toEqual({ 'step::1::1': 'idle' });
       expect(snap.context.forStack[0].iteration).toBe(2);
 
       // Second iteration: PASS both → loop back at iteration 3
       actor.send({ type: 'PASS' }); // 1.1 → 1.2
       actor.send({ type: 'PASS' }); // 1.2 → loop back
       snap = actor.getSnapshot();
-      expect(snap.value).toBe('step::1::1');
+      expect(snap.value).toEqual({ 'step::1::1': 'idle' });
       expect(snap.context.forStack[0].iteration).toBe(3);
 
       // Third iteration (last): PASS both → exit loop
       actor.send({ type: 'PASS' }); // 1.1 → 1.2
       actor.send({ type: 'PASS' }); // 1.2 → exit
       snap = actor.getSnapshot();
-      expect(snap.value).toBe('step::2');
+      expect(snap.value).toEqual({ 'step::2': 'idle' });
       expect(snap.context.forStack).toEqual([]);
     });
 
@@ -2558,7 +2558,7 @@ Write the plan manually.
       actor.start();
 
       actor.send({ type: 'PASS' }); // GOTO 2.1
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const ctx = actor.getSnapshot().context;
       expect(ctx.forStack).toHaveLength(1);
       expect(ctx.forStack[0].stepId).toBe('2');
@@ -2609,7 +2609,7 @@ Write the plan manually.
       actor.start();
 
       actor.send({ type: 'PASS' }); // GOTO 2.1 AT 2
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const ctx = actor.getSnapshot().context;
       expect(ctx.forStack).toHaveLength(1);
       expect(ctx.forStack[0].iteration).toBe(2);
@@ -2656,7 +2656,7 @@ Write the plan manually.
       actor.start();
 
       actor.send({ type: 'PASS' }); // GOTO 2.2
-      expect(actor.getSnapshot().value).toBe('step::2::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::2': 'idle' });
       const ctx = actor.getSnapshot().context;
       expect(ctx.forStack).toHaveLength(1);
       expect(ctx.forStack[0]).toEqual(expect.objectContaining({ stepId: '2', implicit: true }));
@@ -2698,7 +2698,7 @@ Write the plan manually.
       // External GOTO to step 2's second substep
       actor.send({ type: 'GOTO', target: { step: '2', substep: '2' } });
 
-      expect(actor.getSnapshot().value).toBe('step::2::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::2': 'idle' });
       const ctx = actor.getSnapshot().context;
       expect(ctx.forStack).toHaveLength(1);
       expect(ctx.forStack[0]).toEqual(expect.objectContaining({ stepId: '2', implicit: true }));
@@ -2861,7 +2861,7 @@ Write the plan manually.
 
       // Should reach step 2 (PASS ALL with all passes → CONTINUE)
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.iterationResults).toEqual(['pass', 'pass', 'pass']);
       expect(snapshot.context.deferredResults).toEqual(['pass']);
     });
@@ -2916,7 +2916,7 @@ Write the plan manually.
 
       // PASS ANY with one pass → aggregation passes → CONTINUE to step 2
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.iterationResults).toEqual(['fail', 'pass', 'fail']);
       expect(snapshot.context.deferredResults).toEqual(['fail']);
     });
@@ -2976,7 +2976,7 @@ Write the plan manually.
       // iterationResults = ['pass', 'pass'] (from iterations 1-2 via DEFER loop-back)
       // PASS ALL: all pass → CONTINUE to step 2
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.iterationResults).toEqual(['pass', 'pass']);
       expect(snapshot.context.deferredResults).toEqual([]);
     });
@@ -3030,7 +3030,7 @@ Write the plan manually.
       // NEXT skips accumulation — no iteration results accumulated
       // PASS ALL with empty results → vacuous pass → CONTINUE to step 2
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.iterationResults).toEqual([]);
       expect(snapshot.context.deferredResults).toEqual([]);
     });
@@ -3148,7 +3148,7 @@ Write the plan manually.
 
       // PASS ALL succeeds → GOTO 3 AT 1
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::3::1');
+      expect(snapshot.value).toEqual({ 'step::3::1': 'idle' });
       expect(snapshot.context.lastAction).toEqual({
         type: 'GOTO',
         target: '3',
@@ -3311,7 +3311,7 @@ Write the plan manually.
 
       // PASS ALL with one failure → aggregation fails → GOTO 3
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::3');
+      expect(snapshot.value).toEqual({ 'step::3': 'idle' });
       expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3', aggregated: true });
       expect(snapshot.context.iterationResults).toEqual(['pass', 'fail']);
       expect(snapshot.context.deferredResults).toEqual(['fail']);
@@ -3377,7 +3377,7 @@ Write the plan manually.
 
       // PASS ALL with one failure → aggregation fails → GOTO 3 AT 2
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::3::1');
+      expect(snapshot.value).toEqual({ 'step::3::1': 'idle' });
       expect(snapshot.context.lastAction).toEqual({
         type: 'GOTO',
         target: '3',
@@ -3453,7 +3453,7 @@ Write the plan manually.
 
       // PASS ANY with one pass → aggregation passes → GOTO 3
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::3');
+      expect(snapshot.value).toEqual({ 'step::3': 'idle' });
       expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3', aggregated: true });
       expect(snapshot.context.iterationResults).toEqual(['fail', 'pass', 'fail']);
       expect(snapshot.context.deferredResults).toEqual(['fail']);
@@ -3519,7 +3519,7 @@ Write the plan manually.
       // BREAK on iteration 1: substep 2 BREAK is non-accumulating
       // iterationResults = [] (empty) → vacuous pass on PASS ALL → GOTO 3
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::3');
+      expect(snapshot.value).toEqual({ 'step::3': 'idle' });
       expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3', aggregated: true });
       expect(snapshot.context.iterationResults).toEqual([]);
       expect(snapshot.context.deferredResults).toEqual([]);
@@ -3562,7 +3562,7 @@ Write the plan manually.
       actor.start();
 
       // Iteration starts at 3
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       const top1 = actor.getSnapshot().context.forStack[0];
       expect(top1.iteration).toBe(3);
       expect(top1.start).toBe(3);
@@ -3570,19 +3570,19 @@ Write the plan manually.
 
       // Iteration 3 → 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']);
 
       // Iteration 2 → 1
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(1);
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
 
       // Iteration 1 (last) → exit loop
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass', 'pass']);
       expect(actor.getSnapshot().context.deferredResults).toEqual(['pass']);
@@ -3626,7 +3626,7 @@ Write the plan manually.
       // FAIL → BREAK → exit loop
       // BREAK does not populate deferredResults → vacuous pass → PASS ALL → CONTINUE to step 2
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
     });
 
@@ -3672,17 +3672,17 @@ Write the plan manually.
 
       // NEXT at 3 → skip to 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
 
       // NEXT at 2 → skip to 1
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(1);
 
       // NEXT at 1 (last) → exit loop
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
     });
 
@@ -3730,7 +3730,7 @@ Write the plan manually.
 
       // GOTO 2 AT 4 → enters at iteration 4 in a 5..1 loop
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       const top = actor.getSnapshot().context.forStack[0];
       expect(top.iteration).toBe(4);
       expect(top.start).toBe(5);
@@ -3750,7 +3750,7 @@ Write the plan manually.
 
       // 1 (last) → exit
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::3');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
     });
 
@@ -3788,7 +3788,7 @@ Write the plan manually.
 
       // Single pass exits immediately
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.forStack).toEqual([]);
     });
 
@@ -3912,7 +3912,7 @@ Write the plan manually.
 
       snapshot = actor.getSnapshot();
       // Should have exited to step 2
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.iterationResults).toEqual(['pass', 'pass', 'pass']);
       expect(snapshot.context.deferredResults).toEqual(['pass', 'pass']);
     });
@@ -4623,14 +4623,14 @@ echo "processing"
       const actor = createActor(machine);
       actor.start();
 
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       actor.send({ type: 'PASS' }); // iteration 1: DEFER → accumulates 'pass' → loop-back
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0]?.iteration).toBe(2);
 
       actor.send({ type: 'PASS' }); // iteration 2: DEFER → accumulates 'pass' → parent aggregation → PASS ALL → CONTINUE → step 2
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       // Aggregation mode: iteration results accumulated via default DEFER transitions
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass']);
     });
@@ -4657,12 +4657,12 @@ echo "processing"
 
       // Iteration 1: PASS → DEFER → accumulates 'pass' → loop-back
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       // Iteration 2: FAIL → DEFER → accumulates 'fail' → parent aggregation
       // FAIL ANY fires (fail in results) → GOTO Synthesize
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::Synthesize');
+      expect(actor.getSnapshot().value).toEqual({ 'step::Synthesize': 'idle' });
     });
 
     it('GOTO to shorthand-canonicalized FOR step enters substep .1', () => {
@@ -4686,10 +4686,10 @@ echo "processing"
       const actor = createActor(machine);
       actor.start();
 
-      expect(actor.getSnapshot().value).toBe('step::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
 
       actor.send({ type: 'PASS' }); // GOTO 2 -> first substep
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0]?.stepId).toBe('2');
     });
 
@@ -4722,27 +4722,27 @@ echo "processing"
       const actor = createActor(machine);
       actor.start();
 
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       actor.send({ type: 'PASS' }); // iteration 1, substep 1 -> substep 2
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
       expect(actor.getSnapshot().context.forStack[0]?.iteration).toBe(1);
 
       actor.send({ type: 'PASS' }); // substep 2 -> substep 3
-      expect(actor.getSnapshot().value).toBe('step::1::3');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::3': 'idle' });
 
       actor.send({ type: 'PASS' }); // substep 3 -> substep 4
-      expect(actor.getSnapshot().value).toBe('step::1::4');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::4': 'idle' });
 
       actor.send({ type: 'PASS' }); // end iteration 1 -> iteration 2 substep 1
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0]?.iteration).toBe(2);
 
       actor.send({ type: 'PASS' }); // iteration 2, substep 1
       actor.send({ type: 'PASS' }); // iteration 2, substep 2
       actor.send({ type: 'PASS' }); // iteration 2, substep 3
       actor.send({ type: 'PASS' }); // iteration 2, substep 4 -> PASS ALL -> step 2
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
   });
 
@@ -4783,7 +4783,7 @@ echo "processing"
       actor.send({ type: 'PASS' }); // 1.1 passes
       actor.send({ type: 'PASS' }); // 1.2 passes -> parent -> PASS ALL -> step::2
 
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.deferredResults).toEqual(['pass', 'pass']);
     });
 
@@ -4831,7 +4831,7 @@ echo "processing"
       actor.send({ type: 'PASS' }); // 1.1 passes
       actor.send({ type: 'FAIL' }); // 1.2 fails -> parent -> FAIL ANY -> GOTO 3
 
-      expect(actor.getSnapshot().value).toBe('step::3');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3': 'idle' });
     });
 
     it('parent GOTO to non-first implicit substep does not reuse prior aggregation results', () => {
@@ -4912,10 +4912,10 @@ echo "processing"
 
       actor.send({ type: 'PASS' }); // 1.1
       actor.send({ type: 'FAIL' }); // 1.2 -> parent FAIL -> GOTO 2.2
-      expect(actor.getSnapshot().value).toBe('step::2::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::2': 'idle' });
 
       actor.send({ type: 'PASS' }); // 2.2 -> parent PASS ALL -> should route to 3
-      expect(actor.getSnapshot().value).toBe('step::3');
+      expect(actor.getSnapshot().value).toEqual({ 'step::3': 'idle' });
     });
 
     it('PASS ANY: CONTINUE advances when any passes', () => {
@@ -4957,7 +4957,7 @@ echo "processing"
       actor.send({ type: 'FAIL' }); // 1.1 fails
       actor.send({ type: 'PASS' }); // 1.2 passes -> parent -> PASS ANY -> step::2
 
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
 
     it('single substep aggregation works correctly', () => {
@@ -4993,7 +4993,7 @@ echo "processing"
       const actor2 = createActor(machine2);
       actor2.start();
       actor2.send({ type: 'PASS' });
-      expect(actor2.getSnapshot().value).toBe('step::2');
+      expect(actor2.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
 
     it('three substeps with mixed results and PASS ALL waits for all DEFER results', () => {
@@ -5039,7 +5039,7 @@ echo "processing"
 
       actor.send({ type: 'PASS' }); // 1.1 passes → advance to 1.2
       actor.send({ type: 'FAIL' }); // 1.2 fails → advance to 1.3
-      expect(actor.getSnapshot().value).toBe('step::1::3');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::3': 'idle' });
 
       // 1.3 passes — all results in, FAIL ANY (all=true) has a fail → STOPPED
       actor.send({ type: 'PASS' });
@@ -5077,7 +5077,7 @@ echo "processing"
       actor.send({ type: 'PASS' }); // iteration 2 -> parent -> loop-back
       actor.send({ type: 'PASS' }); // iteration 3 (final) -> parent -> PASS ALL -> step::2
 
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass', 'pass', 'pass']);
       expect(actor.getSnapshot().context.deferredResults).toEqual(['pass']);
     });
@@ -5114,7 +5114,7 @@ echo "processing"
       actor.send({ type: 'PASS' }); // iteration 1 pass -> parent -> loop-back
       actor.send({ type: 'FAIL' }); // iteration 2 fail -> BREAK -> parent -> skip loop-back -> step::2
 
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
 
     it('NEXT skips to next iteration via parent state', () => {
@@ -5150,15 +5150,15 @@ echo "processing"
 
       // Iteration 1: substep 1 passes -> NEXT -> parent -> loop-back (skips substep 2)
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1'); // back at first substep, iteration 2
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' }); // back at first substep, iteration 2
 
       // Iteration 2: substep 1 passes -> NEXT -> parent -> loop-back
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1'); // iteration 3
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' }); // iteration 3
 
       // Iteration 3: substep 1 passes -> NEXT -> parent -> aggregation -> step::2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
 
     it('FAIL ALL: STOP stops when all substeps fail under PASS ANY mode', () => {
@@ -5234,7 +5234,7 @@ echo "processing"
 
       // First attempt: fail -> parent -> retry (retryCount < 1) -> back to 1.1
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(1);
 
       // Second attempt: fail -> parent -> exhausted (retryCount >= 1) -> STOPPED
@@ -5280,15 +5280,15 @@ echo "processing"
 
       // First FAIL at 1.1 → DEFER advances to 1.2, waits for all results
       actor.send({ type: 'FAIL' }); // 1.1 → advance to 1.2
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
       // 1.2 fails → all results in, FAIL ANY (all=true) → retry #1 → back to 1.1
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       // Retry: 1.1 fails again → advance to 1.2
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
       // 1.2 fails → all results in, retries exhausted → STOPPED
       actor.send({ type: 'FAIL' });
@@ -5356,19 +5356,19 @@ echo "processing"
 
       // 1.1 fails → DEFER advances to 1.2
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
       // 1.2 fails → all results in, FAIL ANY → retry #1 → back to 1.1
       actor.send({ type: 'FAIL' });
       expect(actor.getSnapshot().context.parentRetryCount).toBe(1);
 
       actor.send({ type: 'PASS' }); // 1.1 -> GOTO 2.2 (bypass parent)
-      expect(actor.getSnapshot().value).toBe('step::2::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::2': 'idle' });
       expect(actor.getSnapshot().context.parentRetryCount).toBe(0);
 
       // 2.2 is last substep of step 2: FAIL → parent aggregation → retry → 2.1
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
     });
 
     it('cross-step GOTO event resets parentRetryCount before target parent retries', () => {
@@ -5414,19 +5414,19 @@ echo "processing"
 
       // 1.1 fails → DEFER advances to 1.2
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
       // 1.2 fails → all results in, FAIL ANY → retry #1 → back to 1.1
       actor.send({ type: 'FAIL' });
       expect(actor.getSnapshot().context.parentRetryCount).toBe(1);
 
       actor.send({ type: 'GOTO', target: { step: '2', substep: '2' } });
-      expect(actor.getSnapshot().value).toBe('step::2::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::2': 'idle' });
       expect(actor.getSnapshot().context.parentRetryCount).toBe(0);
 
       // 2.2 is last substep: FAIL → parent aggregation → retry → 2.1
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::2::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2::1': 'idle' });
     });
 
     it('parent COMPLETE action forces early completion', () => {
@@ -5504,7 +5504,7 @@ echo "processing"
 
         actor.send({ type: 'PASS' }); // 1.1 passes -> should advance to 1.2, NOT COMPLETE
 
-        expect(actor.getSnapshot().value).toBe('step::1::2');
+        expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
         expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'CONTINUE' });
       });
 
@@ -5631,7 +5631,7 @@ echo "processing"
 
         actor.send({ type: 'PASS' }); // 1.1 passes -> should advance to 1.2, NOT COMPLETE
 
-        expect(actor.getSnapshot().value).toBe('step::1::2');
+        expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
         expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'DEFER' });
       });
 
@@ -5743,7 +5743,7 @@ echo "processing"
 
         // Substep 1.1 passes — DEFER advances to 1.2, aggregation waits for all results
         actor.send({ type: 'PASS' });
-        expect(actor.getSnapshot().value).toBe('step::1::2');
+        expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
         // Substep 1.2 fails — all results in, PASS ANY (all=false) has a pass → COMPLETE
         actor.send({ type: 'FAIL' });
@@ -5822,7 +5822,7 @@ echo "processing"
       actor.start();
 
       actor.send({ type: 'FAIL' }); // retry 1/3
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(1);
 
       actor.send({ type: 'FAIL' }); // retry 2/3
@@ -5906,7 +5906,7 @@ echo "processing"
 
       // FAIL retry 1/1: retryCount 0 < 1 → retry
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(1);
 
       // PASS exhausted: retryCount 1 < 1 is false → execute exhausted (COMPLETE)
@@ -6033,7 +6033,7 @@ echo "processing"
       // After BREAK: loop exits. BREAK is non-accumulating — iteration 2's fail
       // is NOT added to iterationResults. Parent aggregation sees only ['pass'] → passes → CONTINUE → step 2
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.iterationResults).toEqual(['pass']);
       expect(snapshot.context.deferredResults).toEqual([]);
     });
@@ -6129,7 +6129,7 @@ echo "processing"
 
       const snapshot = actor.getSnapshot();
       // Should reach step 2
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       // Non-FOR steps use deferredResults (one per substep)
       expect(snapshot.context.deferredResults).toEqual(['pass', 'pass']);
       // iterationResults is initialized but unused for non-FOR steps (entry action sets [])
@@ -6258,7 +6258,7 @@ echo "processing"
       // After BREAK: BREAK is non-accumulating — no iteration results reach parent.
       // Parent aggregation sees [] → PASS ALL with no fails → passes → CONTINUE → step 2
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
     });
 
     it('FOR with FAIL ANY: RETRY 1 DEFER retries once then defers', () => {
@@ -6376,7 +6376,7 @@ echo "processing"
       actor.send({ type: 'PASS' });
 
       // All iterations passed → step-level PASS ALL: [pass, pass] → CONTINUE → step 2
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       actor.send({ type: 'PASS' });
 
       const snapshot = actor.getSnapshot();
@@ -6445,7 +6445,7 @@ echo "processing"
 
       // iterationResults: [pass, pass] (loop-backed); iteration 3 computed inline as pass
       // Step-level PASS ALL: all pass → CONTINUE → step 2
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       actor.send({ type: 'PASS' });
 
       const snapshot = actor.getSnapshot();
@@ -6485,13 +6485,13 @@ echo "processing"
 
       // Iteration 1: substep PASS → CONTINUE → loop-back
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
       expect(actor.getSnapshot().context.iterationResults).toEqual([]);
 
       // Iteration 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(3);
       expect(actor.getSnapshot().context.iterationResults).toEqual([]);
 
@@ -6499,7 +6499,7 @@ echo "processing"
       actor.send({ type: 'PASS' });
 
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.forStack).toEqual([]);
       expect(snapshot.context.iterationResults).toEqual([]);
     });
@@ -6540,16 +6540,16 @@ echo "processing"
 
       // Iteration 1
       actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
       actor.send({ type: 'PASS' }); // 1.2 CONTINUE → loop-back → iter 2
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
 
       // Iteration 2
       actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
       actor.send({ type: 'PASS' }); // 1.2 CONTINUE → exit → step::2
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
 
     it('substep FAIL with STOP terminates immediately', () => {
@@ -6620,7 +6620,7 @@ echo "processing"
       actor.send({ type: 'FAIL' }); // iter 2 FAIL → BREAK → exit loop → step::2
 
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.forStack).toEqual([]);
       expect(snapshot.context.iterationResults).toEqual([]);
       expect(snapshot.context.lastAction).toEqual({ type: 'BREAK' });
@@ -6665,7 +6665,7 @@ echo "processing"
 
       // Iteration 1: 1.1 FAIL → NEXT → skip 1.2, advance to iter 2
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
       expect(actor.getSnapshot().context.iterationResults).toEqual([]);
       expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'NEXT' });
@@ -6679,7 +6679,7 @@ echo "processing"
       actor.send({ type: 'PASS' }); // 1.2 CONTINUE → exit → step::2
 
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.forStack).toEqual([]);
       expect(snapshot.context.iterationResults).toEqual([]);
     });
@@ -6801,7 +6801,7 @@ echo "processing"
       // iterationRetryCount reset to 0 by parent exit assign (intermediate checks proved retry fired)
       // BREAK exits loop (non-accumulating) → iterationResults = []
       // PASS ALL: vacuous pass → CONTINUE → step::2
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
     });
 
     it('substep NEXT bypasses iteration-level retry', () => {
@@ -6860,7 +6860,7 @@ echo "processing"
 
       // iterationResults: [pass] (iteration 2 loop-backed); iteration 3 computed inline as pass
       // Step-level PASS ALL: [pass, pass] → CONTINUE → step 2
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
 
     it('substep BREAK with iteration retry — retry fires before BREAK exits', () => {
@@ -6941,7 +6941,7 @@ echo "processing"
       // iterationRetryCount reset to 0 by parent exit assign (intermediate checks proved retry fired)
       // iterationResults: ['pass'] (iteration 1 from loop-back; iteration 2 BREAK'd = non-accumulating)
       // Aggregation: ['pass'] → PASS ALL passes → CONTINUE → step::2
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.iterationResults).toEqual(['pass']);
     });
   });
@@ -6990,20 +6990,20 @@ echo "processing"
 
       // Iteration 1: FAIL → NEXT at iteration level → loop back, no accumulation
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
       expect(actor.getSnapshot().context.iterationResults).toEqual([]); // NEXT skips
 
       // Iteration 2: PASS → DEFER → loop back with accumulation
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(3);
       expect(actor.getSnapshot().context.iterationResults).toEqual(['pass']); // DEFER accumulates
 
       // Iteration 3: PASS → last iteration, aggregation
       // iterationResults: ['pass'] + inline pass = all pass → CONTINUE → step 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
 
     it('CONTINUE at iteration level exits loop and routes through parent aggregation', () => {
@@ -7050,7 +7050,7 @@ echo "processing"
       // Iteration 1: PASS → substep DEFER feeds 'pass' → iteration pass → CONTINUE → exits loop
       // CONTINUE routes through parent aggregation: ['pass'] → PASS ALL → passes → CONTINUE → step 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
 
     it('CONTINUE at iteration level does not accumulate — only DEFER results reach parent', () => {
@@ -7096,13 +7096,13 @@ echo "processing"
 
       // Iteration 1: PASS → substep DEFER feeds 'pass' → iteration DEFER → loop back
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       // Iteration 2: FAIL → substep DEFER feeds 'fail' → iteration CONTINUE → exits loop
       // CONTINUE is non-accumulating — iteration 2's fail is NOT added to iterationResults
       // Parent aggregation sees only ['pass'] from iteration 1 → passes → CONTINUE → step 2
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
   });
 
@@ -7132,12 +7132,12 @@ echo "processing"
       const actor = createActor(machine);
       actor.start();
 
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       // Substep 1 fails — DEFAULT_AGGREGATION_SUBSTEP_TRANSITIONS FAIL: DEFER → routes to parent
       // PASS ANY: first fail doesn't determine outcome → advance to substep 2
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
       // Substep 2 also fails — aggregation: PASS ANY with no passes → STOP
       actor.send({ type: 'FAIL' });
@@ -7169,11 +7169,11 @@ echo "processing"
       const actor = createActor(machine);
       actor.start();
 
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       // Substep 1 fails — explicit CONTINUE advances to substep 2 (navigation works)
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
       // Substep 2 passes — CONTINUE does not feed deferredResults,
       // so aggregation sees zero results. PASS ANY with 0 passes → STOP.
@@ -7209,12 +7209,12 @@ echo "processing"
       const actor = createActor(machine);
       actor.start();
 
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       // Iteration 1: substep fails → DEFER → parent → iteration fails (ALL mode)
       // DEFAULT_FOR_TRANSITIONS FAIL: DEFER → loop-back with result accumulation
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
     });
 
@@ -7259,15 +7259,15 @@ echo "processing"
       const actor = createActor(machine);
       actor.start();
 
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       // Iteration 1: substep fails → CONTINUE → parent → iteration DEFER → loop-back
       actor.send({ type: 'FAIL' });
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       // Iteration 2: substep passes → loop completes → Case C (no step transitions) → step 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().value).toBe('step::2');
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
 
       // Step 2 passes → COMPLETE
       actor.send({ type: 'PASS' });
@@ -7454,7 +7454,7 @@ echo "processing"
 
         // Sub 1: PASS → DEFER feeds ['pass'] to deferredResults
         actor.send({ type: 'PASS' });
-        expect(actor.getSnapshot().value).toBe('step::1::2');
+        expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
         // Sub 2: FAIL → BREAK (clears deferredResults, exits loop)
         actor.send({ type: 'FAIL' });
@@ -8258,7 +8258,7 @@ echo "processing"
 
         actor.send({ type: 'PASS' }); // CONTINUE: count=1, deferredResults=[]
         expect(actor.getSnapshot().context.substepCompletedCount).toBe(1);
-        expect(actor.getSnapshot().value).toBe('step::1::2');
+        expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
 
         actor.send({ type: 'FAIL' }); // DEFER: count=2, deferredResults=['fail']
         expect(actor.getSnapshot().context.substepCompletedCount).toBe(2);
@@ -8671,7 +8671,7 @@ echo "processing"
       const snapshot = actor.getSnapshot();
       expect(snapshot.context.variables).toEqual({ PlanPath: 'plan.json', count: '3' });
       // Step should not have changed
-      expect(snapshot.value).toMatch(/step::1/);
+      expect(snapshot.value).toEqual({ 'step::1': 'idle' });
     });
 
     it('SET_VARIABLES merges additively (does not replace)', () => {
@@ -8730,7 +8730,7 @@ echo "processing"
       return { name, path: channelPath };
     }
 
-    it('invokes outputCaptureActor and assigns captured vars before PASS transition', async () => {
+    it('nests a single __capture child whose actor passes through the result discriminant', () => {
       const steps = createRunbook(`## 1. capture
 - PASS COMPLETE
 - FAIL STOP
@@ -8741,26 +8741,45 @@ echo hi
 \`\`\`
 `);
       const machine = compileRunbookToMachine(steps);
-      const actor = createActor(machine);
-      actor.start();
+      const states = machine.config.states as Record<string, any>;
 
-      actor.send({
-        type: 'COMMAND_RESULT',
-        result: 'pass',
-        channels: [await writeChannel('Foo', 'captured-value\n')],
-      });
+      // No top-level capture states (sibling-design relics)
+      expect(states['step::1::__capture']).toBeUndefined();
+      expect(states['step::1::__capture-pass']).toBeUndefined();
+      expect(states['step::1::__capture-fail']).toBeUndefined();
 
-      const snap = await waitFor(
-        actor,
-        (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG),
-        { timeout: 1_000 },
-      );
+      // Leaf is now compound with a single __capture child
+      const leaf = states['step::1'];
+      expect(leaf.initial).toBe('idle');
+      expect(leaf.states.idle).toBeDefined();
+      expect(leaf.states.__capture).toBeDefined();
+      expect(leaf.states.__capture.tags).toContain(PENDING_MACHINE_EFFECT_TAG);
 
-      expect(snap.context.variables.Foo).toBe('captured-value');
-      expect(snap.value).toBe('COMPLETE');
+      // Leaf's COMMAND_RESULT is a single unguarded transition to the child.
+      // No assign — discriminant passes through actor IO, not context.
+      // XState may normalise a single-object transition into an array of one;
+      // tolerate both shapes when reading back the config.
+      const cr = leaf.on.COMMAND_RESULT;
+      const crT = Array.isArray(cr) ? cr[0] : cr;
+      expect(crT.target).toBe('.__capture');
+      expect(crT.guard).toBeUndefined();
+      // `actions` may be absent or an empty array depending on normalization.
+      expect(crT.actions ?? []).toEqual([]);
+
+      // onDone has NO target — raised PASS/FAIL bubbles to the leaf.
+      expect(leaf.states.__capture.invoke.onDone.target).toBeUndefined();
+
+      // onError routes to top-level STOPPED via #STOPPED id reference
+      expect(leaf.states.__capture.invoke.onError.target).toBe('#STOPPED');
+
+      // STOPPED carries its id so #STOPPED resolves
+      expect(states.STOPPED.id).toBe('STOPPED');
+
+      // No pendingResult-like context field
+      expect('pendingResult' in machine.config.context).toBe(false);
     });
 
-    it('skips invoke when channels array is empty', async () => {
+    it('captures (no-op) with empty channels and still fires PASS', async () => {
       const steps = createRunbook(`## 1. capture
 - PASS COMPLETE
 - FAIL STOP
@@ -8773,19 +8792,27 @@ echo hi
       const actor = createActor(compileRunbookToMachine(steps));
       actor.start();
 
+      // Pin the `initial: 'idle'` contract — before any COMMAND_RESULT, the
+      // leaf must be settled in its idle child, not in __capture.
+      expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
+
       actor.send({
         type: 'COMMAND_RESULT',
         result: 'pass',
         channels: [],
       });
 
-      const snap = actor.getSnapshot();
-      expect(snap.hasTag(PENDING_MACHINE_EFFECT_TAG)).toBe(false);
+      const snap = await waitFor(
+        actor,
+        (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG),
+        { timeout: 1_000 },
+      );
+
       expect(snap.context.variables).toEqual({});
       expect(snap.value).toBe('COMPLETE');
     });
 
-    it('skips invoke when retryCount < transition.retry (will-retry guard)', async () => {
+    it('captures during pending retries and overwrites on subsequent attempts', async () => {
       const steps = createRunbook(`## 1. capture
 - PASS COMPLETE
 - FAIL RETRY 2 STOP
@@ -8801,33 +8828,56 @@ exit 1
       actor.send({
         type: 'COMMAND_RESULT',
         result: 'fail',
-        channels: [await writeChannel('Foo', 'retry-value')],
+        channels: [await writeChannel('Foo', 'first-attempt')],
       });
-
-      const snap = actor.getSnapshot();
-      expect(snap.hasTag(PENDING_MACHINE_EFFECT_TAG)).toBe(false);
-      expect(snap.context.variables).not.toHaveProperty('Foo');
+      const snap = await waitFor(
+        actor,
+        (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG),
+        { timeout: 1_000 },
+      );
+      expect(snap.context.variables.Foo).toBe('first-attempt');
       expect(snap.context.retryCount).toBe(1);
-      expect(snap.value).toBe('step::1');
+      // After RETRY cycle, leaf settles in the idle substate (compound shape).
+      // Assert the exact compound value so a regression that lands in
+      // __capture (still tagged) or a different leaf is caught.
+      expect(snap.value).toEqual({ 'step::1': 'idle' });
     });
 
-    it('tags capture invoke states and routes onError through typed lastAction', () => {
+    it('overwrites captured variables on the retry-exhausting attempt', async () => {
       const steps = createRunbook(`## 1. capture
 - PASS COMPLETE
-- FAIL STOP
+- FAIL RETRY 1 STOP
 - OUTPUTS
   - Foo
 \`\`\`bash
-echo hi
+exit 1
 \`\`\`
 `);
-      const machine = compileRunbookToMachine(steps);
-      const states = machine.config.states as Record<string, any>;
+      const actor = createActor(compileRunbookToMachine(steps));
+      actor.start();
 
-      expect(states['step::1::__capture-pass'].tags).toContain(PENDING_MACHINE_EFFECT_TAG);
-      expect(states['step::1::__capture-fail'].tags).toContain(PENDING_MACHINE_EFFECT_TAG);
-      expect(states['step::1::__capture-pass'].invoke.onError.target).toBe('STOPPED');
-      expect(states['step::1::__capture-fail'].invoke.onError.target).toBe('STOPPED');
+      actor.send({
+        type: 'COMMAND_RESULT',
+        result: 'fail',
+        channels: [await writeChannel('Foo', 'first-attempt')],
+      });
+      let snap = await waitFor(actor, (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG), {
+        timeout: 1_000,
+      });
+      expect(snap.context.variables.Foo).toBe('first-attempt');
+      expect(snap.context.retryCount).toBe(1);
+      expect(snap.value).toEqual({ 'step::1': 'idle' });
+
+      actor.send({
+        type: 'COMMAND_RESULT',
+        result: 'fail',
+        channels: [await writeChannel('Foo', 'final-attempt')],
+      });
+      snap = await waitFor(actor, (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG), {
+        timeout: 1_000,
+      });
+      expect(snap.context.variables.Foo).toBe('final-attempt');
+      expect(snap.value).toBe('STOPPED');
     });
 
     it('captures variables on COMMAND_RESULT inside a FOR-iteration substep leaf', async () => {
@@ -8854,7 +8904,8 @@ echo "deployed $i"
       actor.start();
 
       // Machine starts at step::1::1 (first FOR-iteration substep leaf)
-      expect(actor.getSnapshot().value).toBe('step::1::1');
+      // After Task 3, substep leaves are compound with nested __capture child
+      expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
 
       const channel1 = await writeChannel('DeployResult', 'ok-staging\n');
 
@@ -8871,9 +8922,13 @@ echo "deployed $i"
       );
 
       expect(snap.context.variables.DeployResult).toBe('ok-staging');
+      // The leaf stays active through idle ↔ __capture, so initForStack
+      // (entry action) is not re-fired during capture. forStack must have
+      // exactly one frame — double-init would push a second.
+      expect(snap.context.forStack.length).toBe(1);
     });
 
-    it('assigns captured variables only on the retry-exhausting attempt', async () => {
+    it('overwrites captured variables on each attempt — final attempt value persists', async () => {
       const steps = createRunbook(`## 1. capture
 - PASS COMPLETE
 - FAIL RETRY 1 STOP
@@ -8891,11 +8946,15 @@ exit 1
         result: 'fail',
         channels: [await writeChannel('Foo', 'first-attempt')],
       });
-      let snap = actor.getSnapshot();
-      expect(snap.context.variables).not.toHaveProperty('Foo');
+      // Wait for first capture to complete and machine to settle back to idle with retryCount=1
+      let snap = await waitFor(actor, (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG), {
+        timeout: 1_000,
+      });
+      expect(snap.context.variables.Foo).toBe('first-attempt');
       expect(snap.context.retryCount).toBe(1);
-      expect(snap.value).toBe('step::1');
+      expect(snap.value).toEqual({ 'step::1': 'idle' });
 
+      // Send second COMMAND_RESULT (final/exhausting attempt)
       actor.send({
         type: 'COMMAND_RESULT',
         result: 'fail',
@@ -8904,6 +8963,7 @@ exit 1
       snap = await waitFor(actor, (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG), {
         timeout: 1_000,
       });
+      // On the exhausting attempt, variables are overwritten with final value
       expect(snap.context.variables.Foo).toBe('final-attempt');
       expect(snap.value).toBe('STOPPED');
     });
@@ -9265,7 +9325,7 @@ exit 1
       actor.send({ type: 'PASS' });
 
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       for (const key of ['StepCursor', 'SubstepCursor', 'AtCursor']) {
         expect(snapshot.context.variables).not.toHaveProperty(key);
       }
@@ -9594,7 +9654,7 @@ exit 1
 
       // After GOTO 2, machine is at step::2 — parent outputs already fired during transition.
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::2');
+      expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       for (const key of ['ParentVar', 'StepCursor', 'SubstepCursor']) {
         expect(snapshot.context.variables).not.toHaveProperty(key);
       }
@@ -9939,7 +9999,7 @@ exit 1
 
       // All iterations passed → parent PASS action (GOTO 3) fires → step::3
       const snapshot = actor.getSnapshot();
-      expect(snapshot.value).toBe('step::3');
+      expect(snapshot.value).toEqual({ 'step::3': 'idle' });
       // lastAction must reflect the GOTO target, not stale substep data
       expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3' });
       expect(snapshot.context.lastMessage).toBeUndefined();

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from '@jest/globals';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { createActor } from 'xstate';
-import { compileRunbookToMachine, MAX_FILE_ITERATIONS } from '../../src/runbook/compiler.js';
+import { createActor, waitFor } from 'xstate';
+import {
+  compileRunbookToMachine,
+  MAX_FILE_ITERATIONS,
+  PENDING_MACHINE_EFFECT_TAG,
+} from '../../src/runbook/compiler.js';
 import type { RunbookContext } from '../../src/runbook/compiler.js';
 import { readArtifactManifest } from '../../src/runbook/artifact-manifest.js';
 import type {
@@ -8706,6 +8710,124 @@ echo "processing"
       actor.send({ type: 'SET_VARIABLES', vars: { Answer: '42' } });
 
       expect(actor.getSnapshot().context.variables).toEqual({ Answer: '42' });
+    });
+  });
+
+  describe('COMMAND_RESULT event with OUTPUTS', () => {
+    let tmp: string;
+
+    beforeEach(async () => {
+      tmp = await mkdtemp(path.join(tmpdir(), 'command-result-'));
+    });
+
+    afterEach(async () => {
+      await rm(tmp, { recursive: true, force: true });
+    });
+
+    async function writeChannel(name: string, contents: string) {
+      const channelPath = path.join(tmp, name);
+      await writeFile(channelPath, contents, 'utf-8');
+      return { name, path: channelPath };
+    }
+
+    it('invokes outputCaptureActor and assigns captured vars before PASS transition', async () => {
+      const steps = createRunbook(`## 1. capture
+- PASS COMPLETE
+- FAIL STOP
+- OUTPUTS
+  - Foo
+\`\`\`bash
+echo hi
+\`\`\`
+`);
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({
+        type: 'COMMAND_RESULT',
+        result: 'pass',
+        channels: [await writeChannel('Foo', 'captured-value\n')],
+      });
+
+      const snap = await waitFor(
+        actor,
+        (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG),
+        { timeout: 1_000 },
+      );
+
+      expect(snap.context.variables.Foo).toBe('captured-value');
+      expect(snap.value).toBe('COMPLETE');
+    });
+
+    it('skips invoke when channels array is empty', async () => {
+      const steps = createRunbook(`## 1. capture
+- PASS COMPLETE
+- FAIL STOP
+- OUTPUTS
+  - Foo
+\`\`\`bash
+echo hi
+\`\`\`
+`);
+      const actor = createActor(compileRunbookToMachine(steps));
+      actor.start();
+
+      actor.send({
+        type: 'COMMAND_RESULT',
+        result: 'pass',
+        channels: [],
+      });
+
+      const snap = actor.getSnapshot();
+      expect(snap.hasTag(PENDING_MACHINE_EFFECT_TAG)).toBe(false);
+      expect(snap.context.variables).toEqual({});
+      expect(snap.value).toBe('COMPLETE');
+    });
+
+    it('skips invoke when retryCount < transition.retry (will-retry guard)', async () => {
+      const steps = createRunbook(`## 1. capture
+- PASS COMPLETE
+- FAIL RETRY 2 STOP
+- OUTPUTS
+  - Foo
+\`\`\`bash
+exit 1
+\`\`\`
+`);
+      const actor = createActor(compileRunbookToMachine(steps));
+      actor.start();
+
+      actor.send({
+        type: 'COMMAND_RESULT',
+        result: 'fail',
+        channels: [await writeChannel('Foo', 'retry-value')],
+      });
+
+      const snap = actor.getSnapshot();
+      expect(snap.hasTag(PENDING_MACHINE_EFFECT_TAG)).toBe(false);
+      expect(snap.context.variables).not.toHaveProperty('Foo');
+      expect(snap.context.retryCount).toBe(1);
+      expect(snap.value).toBe('step::1');
+    });
+
+    it('tags capture invoke states and routes onError through typed lastAction', () => {
+      const steps = createRunbook(`## 1. capture
+- PASS COMPLETE
+- FAIL STOP
+- OUTPUTS
+  - Foo
+\`\`\`bash
+echo hi
+\`\`\`
+`);
+      const machine = compileRunbookToMachine(steps);
+      const states = machine.config.states as Record<string, any>;
+
+      expect(states['step::1::__capture-pass'].tags).toContain(PENDING_MACHINE_EFFECT_TAG);
+      expect(states['step::1::__capture-fail'].tags).toContain(PENDING_MACHINE_EFFECT_TAG);
+      expect(states['step::1::__capture-pass'].invoke.onError.target).toBe('STOPPED');
+      expect(states['step::1::__capture-fail'].invoke.onError.target).toBe('STOPPED');
     });
   });
 

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { createActor, waitFor } from 'xstate';
+import { createActor, fromPromise, waitFor } from 'xstate';
 import {
   compileRunbookToMachine,
   MAX_FILE_ITERATIONS,
@@ -8928,15 +8928,19 @@ echo "deployed $i"
       expect(snap.context.forStack.length).toBe(1);
     });
 
-    it('overwrites captured variables on each attempt — final attempt value persists', async () => {
+    it('captures variables and continues to next step on FAIL CONTINUE', async () => {
       const steps = createRunbook(`## 1. capture
 - PASS COMPLETE
-- FAIL RETRY 1 STOP
+- FAIL CONTINUE
 - OUTPUTS
   - Foo
 \`\`\`bash
 exit 1
 \`\`\`
+
+## 2. done
+- PASS COMPLETE
+- FAIL STOP
 `);
       const actor = createActor(compileRunbookToMachine(steps));
       actor.start();
@@ -8944,28 +8948,45 @@ exit 1
       actor.send({
         type: 'COMMAND_RESULT',
         result: 'fail',
-        channels: [await writeChannel('Foo', 'first-attempt')],
+        channels: [await writeChannel('Foo', 'captured-on-fail')],
       });
-      // Wait for first capture to complete and machine to settle back to idle with retryCount=1
-      let snap = await waitFor(actor, (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG), {
-        timeout: 1_000,
-      });
-      expect(snap.context.variables.Foo).toBe('first-attempt');
-      expect(snap.context.retryCount).toBe(1);
-      expect(snap.value).toEqual({ 'step::1': 'idle' });
+      const snap = await waitFor(
+        actor,
+        (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG),
+        {
+          timeout: 1_000,
+        },
+      );
 
-      // Send second COMMAND_RESULT (final/exhausting attempt)
-      actor.send({
-        type: 'COMMAND_RESULT',
-        result: 'fail',
-        channels: [await writeChannel('Foo', 'final-attempt')],
+      expect(snap.context.variables.Foo).toBe('captured-on-fail');
+      expect(snap.value).toEqual({ 'step::2': 'idle' });
+    });
+
+    it('routes to STOPPED with OUTPUT_CAPTURE_FAILED when outputCaptureActor rejects', async () => {
+      const steps = createRunbook(`## 1. capture
+- PASS COMPLETE
+- FAIL STOP
+- OUTPUTS
+  - Foo
+\`\`\`bash
+echo hi
+\`\`\`
+`);
+      const machine = compileRunbookToMachine(steps).provide({
+        actors: {
+          outputCaptureActor: fromPromise(() => Promise.reject(new Error('disk full'))),
+        },
       });
-      snap = await waitFor(actor, (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG), {
-        timeout: 1_000,
-      });
-      // On the exhausting attempt, variables are overwritten with final value
-      expect(snap.context.variables.Foo).toBe('final-attempt');
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'COMMAND_RESULT', result: 'pass', channels: [] });
+
+      const snap = await waitFor(actor, (s) => s.value === 'STOPPED', { timeout: 1_000 });
       expect(snap.value).toBe('STOPPED');
+      expect(snap.context.lastAction?.type).toBe('OUTPUT_CAPTURE_FAILED');
+      expect((snap.context.lastAction as { message?: string }).message).toBe('disk full');
+      expect(snap.context.lifecycle).toBe('stopped');
     });
   });
 

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -8829,6 +8829,49 @@ echo hi
       expect(states['step::1::__capture-pass'].invoke.onError.target).toBe('STOPPED');
       expect(states['step::1::__capture-fail'].invoke.onError.target).toBe('STOPPED');
     });
+
+    it('captures variables on COMMAND_RESULT inside a FOR-iteration substep leaf', async () => {
+      const steps = createRunbook(`## 1. deploy
+- FOR i IN 1 TO 2
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 run step
+- PASS CONTINUE
+- FAIL STOP
+- OUTPUTS
+  - DeployResult
+\`\`\`bash
+echo "deployed $i"
+\`\`\`
+
+## 2. done
+- PASS COMPLETE
+- FAIL STOP
+`);
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      // Machine starts at step::1::1 (first FOR-iteration substep leaf)
+      expect(actor.getSnapshot().value).toBe('step::1::1');
+
+      const channel1 = await writeChannel('DeployResult', 'ok-staging\n');
+
+      actor.send({
+        type: 'COMMAND_RESULT',
+        result: 'pass',
+        channels: [channel1],
+      });
+
+      const snap = await waitFor(
+        actor,
+        (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG),
+        { timeout: 1_000 },
+      );
+
+      expect(snap.context.variables.DeployResult).toBe('ok-staging');
+    });
   });
 
   describe('OUTPUTS actions', () => {

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -8872,6 +8872,41 @@ echo "deployed $i"
 
       expect(snap.context.variables.DeployResult).toBe('ok-staging');
     });
+
+    it('assigns captured variables only on the retry-exhausting attempt', async () => {
+      const steps = createRunbook(`## 1. capture
+- PASS COMPLETE
+- FAIL RETRY 1 STOP
+- OUTPUTS
+  - Foo
+\`\`\`bash
+exit 1
+\`\`\`
+`);
+      const actor = createActor(compileRunbookToMachine(steps));
+      actor.start();
+
+      actor.send({
+        type: 'COMMAND_RESULT',
+        result: 'fail',
+        channels: [await writeChannel('Foo', 'first-attempt')],
+      });
+      let snap = actor.getSnapshot();
+      expect(snap.context.variables).not.toHaveProperty('Foo');
+      expect(snap.context.retryCount).toBe(1);
+      expect(snap.value).toBe('step::1');
+
+      actor.send({
+        type: 'COMMAND_RESULT',
+        result: 'fail',
+        channels: [await writeChannel('Foo', 'final-attempt')],
+      });
+      snap = await waitFor(actor, (snapshot) => !snapshot.hasTag(PENDING_MACHINE_EFFECT_TAG), {
+        timeout: 1_000,
+      });
+      expect(snap.context.variables.Foo).toBe('final-attempt');
+      expect(snap.value).toBe('STOPPED');
+    });
   });
 
   describe('OUTPUTS actions', () => {

--- a/packages/core/__tests__/runbook/for-loop-test-helpers.ts
+++ b/packages/core/__tests__/runbook/for-loop-test-helpers.ts
@@ -9,6 +9,7 @@
 
 import { createActor, type AnyStateMachine } from 'xstate';
 import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
+import { stateValueAsString } from '../../src/runbook/actor-service.js';
 import type {
   ResolvedStep,
   Substep,
@@ -300,7 +301,7 @@ export function runFromSteps(steps: ResolvedStep[], events: EventType[]): RunRes
   while (eventIdx < events.length) {
     const snap = actor.getSnapshot();
     if (snap.status === 'done') break;
-    const state = String(snap.value);
+    const state = stateValueAsString(snap.value) ?? String(snap.value);
     // Once we exit the FOR loop step, stop sending patterned events
     if (!state.startsWith('step::1')) break;
     actor.send({ type: events[eventIdx++] });

--- a/packages/core/__tests__/runbook/goto-self.test.ts
+++ b/packages/core/__tests__/runbook/goto-self.test.ts
@@ -23,11 +23,11 @@ describe('GOTO to self (implicit retry)', () => {
     actor.start();
 
     expect(actor.getSnapshot().context.retryCount).toBe(0);
-    expect(actor.getSnapshot().value).toBe('step::1');
+    expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
 
     actor.send({ type: 'FAIL' });
     expect(actor.getSnapshot().context.retryCount).toBe(1);
-    expect(actor.getSnapshot().value).toBe('step::1');
+    expect(actor.getSnapshot().value).toEqual({ 'step::1': 'idle' });
 
     actor.send({ type: 'FAIL' });
     expect(actor.getSnapshot().context.retryCount).toBe(2);
@@ -67,7 +67,7 @@ describe('GOTO to self (implicit retry)', () => {
     // FAIL with GOTO to different step should reset
     actor.send({ type: 'FAIL' });
     expect(actor.getSnapshot().context.retryCount).toBe(0);
-    expect(actor.getSnapshot().value).toBe('step::2');
+    expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
   });
 
   it('should increment retryCount when GOTO targets same step and substep', () => {
@@ -113,12 +113,12 @@ describe('GOTO to self (implicit retry)', () => {
 
     // Initial state - starts at step 1 substep a
     expect(actor.getSnapshot().context.retryCount).toBe(0);
-    expect(actor.getSnapshot().value).toBe('step::1::a');
+    expect(actor.getSnapshot().value).toEqual({ 'step::1::a': 'idle' });
 
     // FAIL with GOTO to same step+substep should increment
     actor.send({ type: 'FAIL' });
     expect(actor.getSnapshot().context.retryCount).toBe(1);
-    expect(actor.getSnapshot().value).toBe('step::1::a');
+    expect(actor.getSnapshot().value).toEqual({ 'step::1::a': 'idle' });
 
     // Second FAIL should increment again
     actor.send({ type: 'FAIL' });
@@ -168,7 +168,7 @@ describe('GOTO to self (implicit retry)', () => {
 
     // Initial state - starts at step 1 substep a
     expect(actor.getSnapshot().context.retryCount).toBe(0);
-    expect(actor.getSnapshot().value).toBe('step::1::a');
+    expect(actor.getSnapshot().value).toEqual({ 'step::1::a': 'idle' });
 
     // Simulate some retries
     actor.send({ type: 'RETRY' });
@@ -178,6 +178,6 @@ describe('GOTO to self (implicit retry)', () => {
     // FAIL with GOTO to same step but different substep should reset
     actor.send({ type: 'FAIL' });
     expect(actor.getSnapshot().context.retryCount).toBe(0);
-    expect(actor.getSnapshot().value).toBe('step::1::b');
+    expect(actor.getSnapshot().value).toEqual({ 'step::1::b': 'idle' });
   });
 });

--- a/packages/core/__tests__/runbook/goto-transition.properties.test.ts
+++ b/packages/core/__tests__/runbook/goto-transition.properties.test.ts
@@ -8,6 +8,7 @@
 import fc from 'fast-check';
 import { createActor, type AnyStateMachine } from 'xstate';
 import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
+import { stateValueAsString } from '../../src/runbook/actor-service.js';
 import { inferSteps, makeTransitions, type StepInput } from './compiler-property-helpers.js';
 
 // ---------------------------------------------------------------------------
@@ -37,14 +38,16 @@ function runWithEvents(
 
   const statesVisited: string[] = [];
   actor.start();
-  statesVisited.push(String(actor.getSnapshot().value));
+  statesVisited.push(
+    stateValueAsString(actor.getSnapshot().value) ?? String(actor.getSnapshot().value),
+  );
 
   for (const event of events) {
     const snap = actor.getSnapshot();
     if (snap.status === 'done') break;
     actor.send(event);
     const after = actor.getSnapshot();
-    const stateStr = String(after.value);
+    const stateStr = stateValueAsString(after.value) ?? String(after.value);
     if (statesVisited[statesVisited.length - 1] !== stateStr) {
       statesVisited.push(stateStr);
     }
@@ -99,7 +102,7 @@ describe('GOTO transition properties', () => {
           const snap = actor.getSnapshot();
 
           // Immediate state after GOTO must be the target (no padding involved)
-          expect(String(snap.value)).toBe(`step::${String(targetStep)}`);
+          expect(stateValueAsString(snap.value)).toBe(`step::${String(targetStep)}`);
         },
       ),
       { numRuns: 200 },

--- a/packages/core/__tests__/runbook/goto-transition.properties.test.ts
+++ b/packages/core/__tests__/runbook/goto-transition.properties.test.ts
@@ -59,7 +59,7 @@ function runWithEvents(
     if (snap.status === 'done') break;
     actor.send({ type: 'PASS' });
     const after = actor.getSnapshot();
-    const stateStr = String(after.value);
+    const stateStr = stateValueAsString(after.value) ?? String(after.value);
     if (statesVisited[statesVisited.length - 1] !== stateStr) {
       statesVisited.push(stateStr);
     }

--- a/packages/core/__tests__/runbook/graph-invariants.properties.test.ts
+++ b/packages/core/__tests__/runbook/graph-invariants.properties.test.ts
@@ -147,6 +147,9 @@ describe('Graph invariant properties', () => {
           if (cfg.always) continue;
           // Retry states also use `always`
           if (id.includes('::pass-retry') || id.includes('::fail-retry')) continue;
+          // Capture sibling invoke states are transient — they use `invoke` (not `on`)
+          // and chain into the leaf state's resolved transition via `onDone`.
+          if (id.includes('::__capture-pass') || id.includes('::__capture-fail')) continue;
           const on = cfg.on as Record<string, unknown> | undefined;
           expect(on).toBeDefined();
           expect(on).toHaveProperty('PASS');

--- a/packages/core/__tests__/runbook/graph-invariants.properties.test.ts
+++ b/packages/core/__tests__/runbook/graph-invariants.properties.test.ts
@@ -147,9 +147,6 @@ describe('Graph invariant properties', () => {
           if (cfg.always) continue;
           // Retry states also use `always`
           if (id.includes('::pass-retry') || id.includes('::fail-retry')) continue;
-          // Capture sibling invoke states are transient — they use `invoke` (not `on`)
-          // and chain into the leaf state's resolved transition via `onDone`.
-          if (id.includes('::__capture-pass') || id.includes('::__capture-fail')) continue;
           const on = cfg.on as Record<string, unknown> | undefined;
           expect(on).toBeDefined();
           expect(on).toHaveProperty('PASS');
@@ -190,6 +187,9 @@ describe('Graph invariant properties', () => {
           const cfg = config as Record<string, unknown>;
           const targets = [...extractTargets(cfg.on), ...extractTargets(cfg.always)];
           for (const target of targets) {
+            // Skip relative descendant refs (e.g. '.__capture') and absolute
+            // ID refs (e.g. '#STOPPED') — these are not top-level state keys.
+            if (target.startsWith('.') || target.startsWith('#')) continue;
             expect(allIds.has(target)).toBe(true);
           }
         }

--- a/packages/core/__tests__/runbook/graph-invariants.properties.test.ts
+++ b/packages/core/__tests__/runbook/graph-invariants.properties.test.ts
@@ -185,7 +185,11 @@ describe('Graph invariant properties', () => {
         for (const [_id, config] of Object.entries(states)) {
           if (_id === 'COMPLETE' || _id === 'STOPPED') continue;
           const cfg = config as Record<string, unknown>;
-          const targets = [...extractTargets(cfg.on), ...extractTargets(cfg.always)];
+          const targets = [
+            ...extractTargets(cfg.on),
+            ...extractTargets(cfg.always),
+            ...extractTargets(cfg.invoke),
+          ];
           for (const target of targets) {
             // Skip relative descendant refs (e.g. '.__capture') and absolute
             // ID refs (e.g. '#STOPPED') — these are not top-level state keys.

--- a/packages/core/__tests__/runbook/transition-kernel.test.ts
+++ b/packages/core/__tests__/runbook/transition-kernel.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+  deriveStoppedReason,
   extractLastAction,
   extractRetryMax,
   extractRetryDisplayCount,
   extractLastMessage,
   formatActionForDisplay,
   formatTransitionAction,
+  isInternalFailureLastAction,
   parseActionType,
   deriveTransitionMessage,
 } from '../../src/runbook/transition-kernel.js';
@@ -614,6 +616,39 @@ describe('transition-kernel', () => {
       };
       const result = deriveTransitionMessage('pass', step, 2);
       expect(result).toBe('success after retry');
+    });
+  });
+
+  describe('OUTPUT_CAPTURE_FAILED lastAction', () => {
+    it('extracts and classifies output-capture failures as internal failures', () => {
+      const snapshot = {
+        context: {
+          lastAction: {
+            type: 'OUTPUT_CAPTURE_FAILED',
+            message: 'failed to read RD_OUTPUTS_Foo',
+          },
+        },
+      };
+
+      const action = extractLastAction(snapshot);
+      expect(action).toEqual({
+        type: 'OUTPUT_CAPTURE_FAILED',
+        message: 'failed to read RD_OUTPUTS_Foo',
+      });
+      expect(isInternalFailureLastAction(action)).toBe(true);
+      expect(parseActionType(action)).toBe('OUTPUT_CAPTURE_FAILED');
+      expect(deriveStoppedReason(action)).toBe('output_capture_failed');
+    });
+
+    it('rejects malformed output-capture failure actions', () => {
+      expect(
+        extractLastAction({ context: { lastAction: { type: 'OUTPUT_CAPTURE_FAILED' } } }),
+      ).toBeUndefined();
+      expect(
+        extractLastAction({
+          context: { lastAction: { type: 'OUTPUT_CAPTURE_FAILED', message: 42 } },
+        }),
+      ).toBeUndefined();
     });
   });
 });

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -1021,3 +1021,30 @@ describe('makeRunbookStateSchema variables value discriminated union', () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe('RunbookStateSchema lastAction internal failures', () => {
+  it('accepts OUTPUT_CAPTURE_FAILED with a string message', () => {
+    const state = createValidState({
+      lifecycle: 'stopped',
+      lastAction: {
+        type: 'OUTPUT_CAPTURE_FAILED',
+        message: 'failed to capture output',
+      },
+    });
+
+    const parsed = RunbookStateSchema.parse(state);
+    expect(parsed.lastAction).toEqual({
+      type: 'OUTPUT_CAPTURE_FAILED',
+      message: 'failed to capture output',
+    });
+  });
+
+  it('rejects OUTPUT_CAPTURE_FAILED without a string message', () => {
+    const state = createValidState({
+      lifecycle: 'stopped',
+      lastAction: { type: 'OUTPUT_CAPTURE_FAILED' },
+    });
+
+    expect(() => RunbookStateSchema.parse(state)).toThrow();
+  });
+});

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -1048,3 +1048,32 @@ describe('RunbookStateSchema lastAction internal failures', () => {
     expect(() => RunbookStateSchema.parse(state)).toThrow();
   });
 });
+
+describe('RunbookStateSchema lastAction RETRY_ERROR', () => {
+  it('accepts RETRY_ERROR with code and message', () => {
+    const state = createValidState({
+      lifecycle: 'stopped',
+      lastAction: {
+        type: 'RETRY_ERROR',
+        code: 'RD-902',
+        message: 'retry hook failed',
+      },
+    });
+
+    const parsed = RunbookStateSchema.parse(state);
+    expect(parsed.lastAction).toEqual({
+      type: 'RETRY_ERROR',
+      code: 'RD-902',
+      message: 'retry hook failed',
+    });
+  });
+
+  it('rejects RETRY_ERROR without code or message', () => {
+    const state = createValidState({
+      lifecycle: 'stopped',
+      lastAction: { type: 'RETRY_ERROR', message: 'no code' },
+    });
+
+    expect(() => RunbookStateSchema.parse(state)).toThrow();
+  });
+});

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -145,7 +145,8 @@ export interface RunbookStoppedPayload {
     | 'fail_transition'
     | 'user_abort'
     | 'delegation_resolution_failed'
-    | 'nested_delegation_forbidden';
+    | 'nested_delegation_forbidden'
+    | 'output_capture_failed';
 }
 
 /** Payload emitted when an error occurs during execution (ERROR_OCCURRED event). */

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -12,10 +12,15 @@
  * @module
  */
 
-import { createActor, type AnyActorRef, type Snapshot } from 'xstate';
+import { createActor, waitFor, type AnyActorRef, type Snapshot } from 'xstate';
 import type { ResolvedStep, RunbookState, ForContext } from './types.js';
 import type { RunbookStateManager } from './state.js';
-import { compileRunbookToMachine, type RunbookEvent, type RunbookContext } from './compiler.js';
+import {
+  compileRunbookToMachine,
+  PENDING_MACHINE_EFFECT_TAG,
+  type RunbookEvent,
+  type RunbookContext,
+} from './compiler.js';
 import { flattenTemplateVars } from './output-evaluator.js';
 import { merge } from './state-update-ops.js';
 import { resolvedStepHasSubsteps } from '@rundown-org/parser';
@@ -51,6 +56,16 @@ type PersistedRunbookSnapshot = {
   value: unknown;
   context?: Partial<RunbookContext>;
 };
+
+/**
+ * Maximum time, in milliseconds, that {@link RunbookActorService.sendAndSync}
+ * will wait for a transient machine-owned invoke (tagged
+ * {@link PENDING_MACHINE_EFFECT_TAG}) to resolve before timing out.
+ *
+ * The current sole producer is `outputCaptureActor`, which reads a small set
+ * of channel files; 30 seconds is generous for any plausible local filesystem.
+ */
+const MACHINE_EFFECT_TIMEOUT_MS = 30_000;
 
 /**
  * Overlay RunbookState's frame-scoped fields onto a persisted XState snapshot
@@ -435,6 +450,26 @@ export class RunbookActorService {
   }
 
   /**
+   * Wait until the actor leaves all states tagged with
+   * {@link PENDING_MACHINE_EFFECT_TAG}. Called by `sendAndSync()` between
+   * `actor.send()` and persistence so async `fromPromise` invokes (notably
+   * `outputCaptureActor`) get a chance to run their `onDone`/`onError`
+   * transitions before the snapshot is captured and the actor is stopped.
+   *
+   * @param actor - The XState actor to observe
+   * @throws {Error} If the tag does not clear within
+   *   {@link MACHINE_EFFECT_TIMEOUT_MS}
+   */
+  private async waitForMachineEffects(actor: AnyActorRef): Promise<void> {
+    await waitFor(
+      actor,
+      (snapshot) =>
+        !(snapshot as { hasTag: (tag: string) => boolean }).hasTag(PENDING_MACHINE_EFFECT_TAG),
+      { timeout: MACHINE_EFFECT_TIMEOUT_MS },
+    );
+  }
+
+  /**
    * Create actor, send event, sync state, and return updated state + snapshot.
    *
    * This is the dominant usage pattern: create actor from persisted state,
@@ -520,6 +555,7 @@ export class RunbookActorService {
         actor.send(event);
       }
 
+      await this.waitForMachineEffects(actor);
       const { state, snapshot } = await this.updateFromActor(id, actor, steps);
       return { state, snapshot };
     } finally {

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -58,6 +58,32 @@ type PersistedRunbookSnapshot = {
 };
 
 /**
+ * Flatten an XState 5 `snapshot.value` into the underlying leaf or terminal
+ * state ID expected by the rest of `actor-service`.
+ *
+ * Atomic states (`'COMPLETE'`, `'STOPPED'`, retry sub-state IDs, and any
+ * other top-level atomic node) return their value as-is. Compound-leaf states
+ * return as `{ '<leafId>': 'idle' | '__capture' }` and are flattened to the
+ * leaf id. Any other shape returns `null` so the caller throws.
+ *
+ * @param value - The raw `snapshot.value` returned by XState
+ * @returns The flattened leaf/terminal id, or `null` for unrecognized shapes
+ */
+export function stateValueAsString(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 1
+  ) {
+    const [leafId, substate] = Object.entries(value as Record<string, unknown>)[0];
+    if (substate === 'idle' || substate === '__capture') return leafId;
+  }
+  return null;
+}
+
+/**
  * Maximum time, in milliseconds, that {@link RunbookActorService.sendAndSync}
  * will wait for a transient machine-owned invoke (tagged
  * {@link PENDING_MACHINE_EFFECT_TAG}) to resolve before timing out.
@@ -297,12 +323,12 @@ export class RunbookActorService {
     const snapshot = actor.getPersistedSnapshot() as unknown as PersistedRunbookSnapshot;
     const rawValue: unknown = snapshot.value;
 
-    if (typeof rawValue !== 'string') {
+    const stateValue = stateValueAsString(rawValue);
+    if (stateValue === null) {
       throw new Error(
-        `Unexpected non-string stateValue for runbook "${id}": ${JSON.stringify(rawValue)}`,
+        `Unsupported snapshot.value shape for runbook "${id}": ${JSON.stringify(rawValue)}`,
       );
     }
-    const stateValue = rawValue;
 
     // If the runbook is in a final state, don't try to parse a step number.
     // Just update the snapshot and variables, preserving the last step number.
@@ -495,7 +521,7 @@ export class RunbookActorService {
       if (logger.isDebugEnabled()) {
         // Pre-send diagnostics
         const preSnapshot = actor.getPersistedSnapshot() as Record<string, unknown>;
-        const preValue = preSnapshot.value as string;
+        const preValue = stateValueAsString(preSnapshot.value) ?? JSON.stringify(preSnapshot.value);
         const preCtx = preSnapshot.context as Record<string, unknown> | undefined;
         const preSubstep = preCtx?.substep as string | undefined;
         const stepMatch = /^step::(.+?)(?:::(.+))?$/.exec(preValue);
@@ -518,7 +544,8 @@ export class RunbookActorService {
 
         // Post-send diagnostics
         const postSnapshot = actor.getPersistedSnapshot() as Record<string, unknown>;
-        const postValue = postSnapshot.value as string;
+        const postValue =
+          stateValueAsString(postSnapshot.value) ?? JSON.stringify(postSnapshot.value);
         const postCtx = postSnapshot.context as Record<string, unknown> | undefined;
         const postLastAction = postCtx?.lastAction as { type: string } | undefined;
 

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -582,9 +582,25 @@ export class RunbookActorService {
         actor.send(event);
       }
 
-      await this.waitForMachineEffects(actor);
-      const { state, snapshot } = await this.updateFromActor(id, actor, steps);
-      return { state, snapshot };
+      try {
+        await this.waitForMachineEffects(actor);
+        const { state, snapshot } = await this.updateFromActor(id, actor, steps);
+        return { state, snapshot };
+      } catch (effectsErr) {
+        // The command has already executed (COMMAND_RESULT was sent above).
+        // Persist a stopped lifecycle so a resume or retry cannot re-execute
+        // the same command. Best-effort — if this also fails, log and let
+        // the primary error propagate.
+        try {
+          await this.manager.update(id, { lifecycle: 'stopped' });
+        } catch {
+          void logger.warn(
+            'actor-service: failed to persist stopped lifecycle after effects failure',
+            { id },
+          );
+        }
+        throw effectsErr;
+      }
     } finally {
       this.stopActor(actor);
     }

--- a/packages/core/src/runbook/actors/output-capture-actor.ts
+++ b/packages/core/src/runbook/actors/output-capture-actor.ts
@@ -46,6 +46,9 @@ export interface OutputCaptureOutput {
  *   `{ input: OutputCaptureInput }` at actor construction
  * @returns `{ variables, result }` — captured `{ name → value }` and the
  *   unchanged passthrough result
+ * @throws {Error} Propagates unexpected runtime or I/O failures from
+ *   `readCapturedOutputs`; the machine's `invoke.onError` handles this
+ *   fail-closed path.
  */
 export const outputCaptureActor = fromPromise<OutputCaptureOutput, OutputCaptureInput>(
   async ({ input }) => {

--- a/packages/core/src/runbook/actors/output-capture-actor.ts
+++ b/packages/core/src/runbook/actors/output-capture-actor.ts
@@ -24,6 +24,7 @@ export interface OutputCaptureInput {
  * filesystem conditions; the machine's `onError` branch exists as a defensive
  * fail-closed contract for truly catastrophic I/O failures.
  *
+ * @param input - Channels to read; supplied via `{ input: OutputCaptureInput }` at actor construction
  * @returns Record of variable names to trimmed UTF-8 values
  */
 export const outputCaptureActor = fromPromise<Record<string, string>, OutputCaptureInput>(

--- a/packages/core/src/runbook/actors/output-capture-actor.ts
+++ b/packages/core/src/runbook/actors/output-capture-actor.ts
@@ -1,0 +1,33 @@
+import { fromPromise } from 'xstate';
+import { readCapturedOutputs, type PreparedChannel } from '../output-channels.js';
+
+/**
+ * Input shape for {@link outputCaptureActor}.
+ */
+export interface OutputCaptureInput {
+  /** Pre-created channel files to read values from. */
+  readonly channels: readonly PreparedChannel[];
+}
+
+/**
+ * Machine-invoked actor that reads naked OUTPUT channel files and returns the
+ * captured `{ name → value }` record.
+ *
+ * Establishes the Category B actor-factory pattern for the artifacts-as-variables
+ * migration: a `fromPromise` over an existing pure side effect, invoked by the
+ * machine via `invoke.src = 'outputCaptureActor'`. See the architectural principle
+ * in `.work/artifacts-as-variables-batch-1-outputs-machine-invoke-pilot.md`.
+ *
+ * Resolution semantics: always resolves with a record (possibly empty). Channel
+ * files that are missing, non-UTF-8, or empty are logged by `readCapturedOutputs`
+ * and omitted from the result. The actor itself never rejects under normal
+ * filesystem conditions; the machine's `onError` branch exists as a defensive
+ * fail-closed contract for truly catastrophic I/O failures.
+ *
+ * @returns Record of variable names to trimmed UTF-8 values
+ */
+export const outputCaptureActor = fromPromise<Record<string, string>, OutputCaptureInput>(
+  async ({ input }) => {
+    return await readCapturedOutputs(input.channels);
+  },
+);

--- a/packages/core/src/runbook/actors/output-capture-actor.ts
+++ b/packages/core/src/runbook/actors/output-capture-actor.ts
@@ -2,21 +2,39 @@ import { fromPromise } from 'xstate';
 import { readCapturedOutputs, type PreparedChannel } from '../output-channels.js';
 
 /**
- * Input shape for {@link outputCaptureActor}.
+ * Result discriminant carried opaquely through the actor.
+ *
+ * The actor itself never branches on this value; it is passed through from
+ * input to output unchanged so the machine's `onDone` transition can `raise`
+ * the corresponding `PASS` or `FAIL` event without a context-resident
+ * discriminant.
  */
+export type OutputCapturePassthroughResult = 'pass' | 'fail';
+
+/** Input shape for {@link outputCaptureActor}. */
 export interface OutputCaptureInput {
   /** Pre-created channel files to read values from. */
   readonly channels: readonly PreparedChannel[];
+  /** Command result, passed through to {@link OutputCaptureOutput} unchanged. */
+  readonly result: OutputCapturePassthroughResult;
+}
+
+/** Resolved output of {@link outputCaptureActor}. */
+export interface OutputCaptureOutput {
+  /** Captured `{ name → value }` record. */
+  readonly variables: Record<string, string>;
+  /** The {@link OutputCaptureInput#result} value, unchanged. */
+  readonly result: OutputCapturePassthroughResult;
 }
 
 /**
  * Machine-invoked actor that reads naked OUTPUT channel files and returns the
- * captured `{ name → value }` record.
+ * captured `{ name → value }` record alongside the input's `result` field,
+ * passed through unchanged.
  *
- * Establishes the Category B actor-factory pattern for the artifacts-as-variables
- * migration: a `fromPromise` over an existing pure side effect, invoked by the
- * machine via `invoke.src = 'outputCaptureActor'`. See the architectural principle
- * in `.work/artifacts-as-variables-batch-1-outputs-machine-invoke-pilot.md`.
+ * The `result` passthrough is the structural mechanism by which the leaf's
+ * `COMMAND_RESULT` discriminant reaches the nested `__capture` child's
+ * `onDone`-raised `PASS`/`FAIL` event. The actor never branches on it.
  *
  * Resolution semantics: always resolves with a record (possibly empty). Channel
  * files that are missing, non-UTF-8, or empty are logged by `readCapturedOutputs`
@@ -24,11 +42,14 @@ export interface OutputCaptureInput {
  * filesystem conditions; the machine's `onError` branch exists as a defensive
  * fail-closed contract for truly catastrophic I/O failures.
  *
- * @param input - Channels to read; supplied via `{ input: OutputCaptureInput }` at actor construction
- * @returns Record of variable names to trimmed UTF-8 values
+ * @param input - Channels to read and result to pass through; supplied via
+ *   `{ input: OutputCaptureInput }` at actor construction
+ * @returns `{ variables, result }` — captured `{ name → value }` and the
+ *   unchanged passthrough result
  */
-export const outputCaptureActor = fromPromise<Record<string, string>, OutputCaptureInput>(
+export const outputCaptureActor = fromPromise<OutputCaptureOutput, OutputCaptureInput>(
   async ({ input }) => {
-    return await readCapturedOutputs(input.channels);
+    const variables = await readCapturedOutputs(input.channels);
+    return { variables, result: input.result };
   },
 );

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -26,23 +26,8 @@ import {
   type SelectorArtifactRef,
 } from './artifact-uri.js';
 import type { RunbookRef } from './runbook-ref.js';
-import { assertRunId, type RunId } from './run-id.js';
+import type { RunId } from './run-id.js';
 import type { ArtifactVarValue } from './types.js';
-
-/**
- * Run eligibility for ARTIFACTS selector matching.
- *
- * Returned by `loadRunEligibility` ONLY for completed sibling runs (different
- * `runId` from the resolver's current run). The current run is short-circuited
- * inside the resolver before the loader is consulted, so there is no
- * `'current-run'` variant. Incomplete sibling runs are signalled by `null`.
- */
-export interface ArtifactRunEligibility {
-  /** Sibling completed run id, branded. */
-  readonly runId: RunId;
-  /** ISO-8601 timestamp at which the sibling run reached a terminal state. */
-  readonly terminalAt: string;
-}
 
 /**
  * In-scope variable map consulted for the naked-form ARTIFACTS assertion.
@@ -73,13 +58,6 @@ export interface ResolveArtifactDeclarationsOptions extends ArtifactPathOptions 
    * `unbound` error.
    */
   readonly scopeVars?: ArtifactScopeVars;
-  /**
-   * Loads eligibility for non-current run ids found in the manifest. Return
-   * `null` for incomplete or unknown sibling runs; return an
-   * {@link ArtifactRunEligibility} for completed sibling runs. The resolver
-   * never calls this loader with the current run's id.
-   */
-  readonly loadRunEligibility: (runId: RunId) => Promise<ArtifactRunEligibility | null>;
 }
 
 /**
@@ -119,7 +97,7 @@ export interface ResolveArtifactDeclarationsOptions extends ArtifactPathOptions 
  * file itself; the agent writes the file at the path mapped from the URI.
  *
  * @param declarations - Parser-owned artifact declarations from one execution unit
- * @param options - Current run identity, path options, and run eligibility loader
+ * @param options - Current run identity and path options
  * @returns Artifact variable map for the current execution unit
  * @throws {Error} For corrupt manifests, naked-form assertion failures, malformed
  *   URI literals, cross-context URI literals, missing other-run manifest rows,
@@ -130,10 +108,6 @@ export async function resolveArtifactDeclarations(
   options: ResolveArtifactDeclarationsOptions,
 ): Promise<Record<string, ArtifactVarValue>> {
   const result: Record<string, ArtifactVarValue> = {};
-  // Memoize sibling-run eligibility for the duration of one resolve pass so
-  // a manifest containing many records from the same sibling run only loads
-  // that run's state once.
-  const eligibilityCache = new Map<RunId, ArtifactRunEligibility | null>();
   // Cache the coalesced manifest read once per resolve pass. Producer-side
   // writes invalidate the cache so subsequent reads observe the appended row.
   let cachedManifest: ArtifactManifestRecord[] | null = null;
@@ -153,7 +127,6 @@ export async function resolveArtifactDeclarations(
         declaration.name,
         options,
         readManifest,
-        eligibilityCache,
       );
       continue;
     }
@@ -164,7 +137,6 @@ export async function resolveArtifactDeclarations(
         declaration.rawToken,
         options,
         readManifest,
-        eligibilityCache,
         invalidateManifestCache,
       );
       continue;
@@ -183,12 +155,7 @@ export async function resolveArtifactDeclarations(
     if (declaration.rawToken.includes('*') || declaration.rawToken.includes('?')) {
       validateBareKeyGlob(declaration.name, declaration.rawToken);
       const selector = buildImplicitBareKeySelector(declaration.rawToken, options.contextId);
-      result[declaration.name] = await resolveSelector(
-        selector,
-        options,
-        await readManifest(),
-        eligibilityCache,
-      );
+      result[declaration.name] = await resolveSelector(selector, options, await readManifest());
       continue;
     }
 
@@ -355,7 +322,6 @@ async function resolveBareKeyProducer(
  * @param rawToken - URI literal (post template expansion)
  * @param options - Resolver options carrying current identity and path config
  * @param readManifest - Lazy manifest snapshot loader
- * @param eligibilityCache - Per-pass cache of sibling-run eligibility
  * @param invalidateManifestCache - Invalidates the per-pass coalesced read cache
  * @returns Producer record (write branch), other-run record, or selector result
  * @throws {Error} For malformed URIs, cross-context URIs, or missing other-run rows
@@ -365,7 +331,6 @@ async function resolveUriLiteralDeclaration(
   rawToken: string,
   options: ResolveArtifactDeclarationsOptions,
   readManifest: () => Promise<ArtifactManifestRecord[]>,
-  eligibilityCache: Map<RunId, ArtifactRunEligibility | null>,
   invalidateManifestCache: () => void,
 ): Promise<ArtifactVarValue> {
   let ref: ArtifactRef;
@@ -393,12 +358,11 @@ async function resolveUriLiteralDeclaration(
       ref,
       options,
       readManifest,
-      eligibilityCache,
       invalidateManifestCache,
     );
   }
 
-  return await resolveSelector(ref, options, await readManifest(), eligibilityCache);
+  return await resolveSelector(ref, options, await readManifest());
 }
 
 /**
@@ -416,7 +380,6 @@ async function resolveUriLiteralDeclaration(
  * @param ref - Parsed exact artifact reference
  * @param options - Resolver options carrying current identity and path config
  * @param readManifest - Lazy manifest snapshot loader
- * @param eligibilityCache - Per-pass cache of sibling-run eligibility
  * @param invalidateManifestCache - Invalidates the per-pass coalesced read cache
  * @returns Producer record or other-run record from the manifest
  * @throws {Error} When an other-run URI has no matching manifest row
@@ -427,7 +390,6 @@ async function resolveExactUriDeclaration(
   ref: ExactArtifactRef,
   options: ResolveArtifactDeclarationsOptions,
   readManifest: () => Promise<ArtifactManifestRecord[]>,
-  eligibilityCache: Map<RunId, ArtifactRunEligibility | null>,
   invalidateManifestCache: () => void,
 ): Promise<ArtifactRecord> {
   if (ref.runId === options.runId) {
@@ -452,14 +414,13 @@ async function resolveExactUriDeclaration(
   }
 
   // Read-only reference to an other-run row. Look up by identity tuple and
-  // gate through the same eligibility/file-existence checks as a selector.
+  // gate through the file-existence check that selector matching also applies.
   const records = await readManifest();
   for (const candidate of records) {
     if (
       candidate.contextId === ref.contextId &&
       candidate.runId === ref.runId &&
       candidate.key === ref.key &&
-      (await isEligibleSelectorRecord(candidate, options, eligibilityCache)) &&
       isExistingRegularArtifactFile(candidate.uri, options) &&
       isArtifactRecord(candidate)
     ) {
@@ -475,34 +436,20 @@ async function resolveExactUriDeclaration(
  * Resolve a selector against the manifest snapshot.
  *
  * Returns one {@link ArtifactRecord} when the selector yields exactly one
- * match, an array (possibly empty) otherwise. Eligibility, file-existence,
- * and current-run shortcut semantics mirror the v1 wildcard branch.
+ * match, an array (possibly empty) otherwise. The same-context guard and the
+ * per-row file-existence check are the active safety mechanisms for cross-run
+ * results; selector matching does not filter on sibling-run lifecycle.
  *
  * @param selector - Selector reference (from URI literal selector form)
- * @param options - Current run identity, path options, and eligibility loader
+ * @param options - Current run identity and path options
  * @param records - Coalesced manifest snapshot for the current context
- * @param eligibilityCache - Per-pass cache of sibling-run eligibility results
  * @returns Single matching record or array of matches (possibly empty)
  */
 async function resolveSelector(
   selector: SelectorArtifactRef,
   options: ResolveArtifactDeclarationsOptions,
   records: readonly ArtifactManifestRecord[],
-  eligibilityCache: Map<RunId, ArtifactRunEligibility | null>,
 ): Promise<ArtifactVarValue> {
-  // TODO: filter implementation — wire selector.query through findArtifactMatches()
-  //   when filter support lands. Until then, REJECT to avoid silently ignoring
-  //   documented query parameters. See spec §5.4.
-  // Centralized gate: covers URI-literal selector dispatch (which can carry
-  // query parameters parsed from the URI) and the bare-key-with-glob path
-  // (which constructs a selector with query: {} and is safe by construction).
-  const queryKeys = Object.keys(selector.query);
-  if (queryKeys.length > 0) {
-    throw new Error(
-      `ARTIFACTS selector URI query parameters are not yet implemented: ${queryKeys.join(', ')}. Use the unfiltered selector form for now; filter support is tracked separately.`,
-    );
-  }
-
   const matcher = picomatch(selector.key, { dot: true });
   const matches: ArtifactRecord[] = [];
 
@@ -512,7 +459,6 @@ async function resolveSelector(
     if (record.contextId !== selector.contextId) continue;
     if (selector.runId !== '*' && record.runId !== selector.runId) continue;
     if (!matcher(record.key)) continue;
-    if (!(await isEligibleSelectorRecord(record, options, eligibilityCache))) continue;
     if (!isExistingRegularArtifactFile(record.uri, options)) continue;
     matches.push(record);
   }
@@ -523,26 +469,6 @@ async function resolveSelector(
     return matches[0];
   }
   return matches;
-}
-
-async function isEligibleSelectorRecord(
-  record: ArtifactManifestRecord,
-  options: ResolveArtifactDeclarationsOptions,
-  eligibilityCache: Map<RunId, ArtifactRunEligibility | null>,
-): Promise<boolean> {
-  if (record.runId === options.runId) {
-    return true;
-  }
-  const runId = assertRunId(record.runId);
-  let eligibility = eligibilityCache.get(runId);
-  if (eligibility === undefined) {
-    eligibility = await options.loadRunEligibility(runId);
-    eligibilityCache.set(runId, eligibility);
-  }
-  // Validate the loader response: only accept rows whose eligibility record
-  // refers back to the requested runId. Defends against a loader that
-  // returns cached data for a different sibling run.
-  return eligibility !== null && eligibility.runId === runId;
 }
 
 /**
@@ -559,7 +485,6 @@ async function isEligibleSelectorRecord(
  * @param name - Variable name to look up in `options.scopeVars`
  * @param options - Resolver options carrying `scopeVars` and manifest context
  * @param readManifest - Lazy manifest loader, called only when URI rehydration is needed
- * @param eligibilityCache - Per-pass cache of sibling-run eligibility results
  * @returns Validated/rehydrated artifact value
  * @throws {Error} With a named reason: `unbound`, `not-an-artifact`, `unresolvable-uri`, or `partial-resolve`
  */
@@ -567,7 +492,6 @@ async function resolveNakedDeclaration(
   name: string,
   options: ResolveArtifactDeclarationsOptions,
   readManifest: () => Promise<ArtifactManifestRecord[]>,
-  eligibilityCache: Map<RunId, ArtifactRunEligibility | null>,
 ): Promise<ArtifactVarValue> {
   const scope = options.scopeVars;
   if (scope === undefined || !(name in scope)) {
@@ -590,26 +514,14 @@ async function resolveNakedDeclaration(
   if (typeof value === 'string') {
     const uriArray = parseJsonArtifactUriArrayTransport(value);
     if (uriArray !== null) {
-      return await resolveUriStringArray(
-        name,
-        uriArray,
-        options,
-        await readManifest(),
-        eligibilityCache,
-      );
+      return await resolveUriStringArray(name, uriArray, options, await readManifest());
     }
-    return await resolveUriString(name, value, options, await readManifest(), eligibilityCache);
+    return await resolveUriString(name, value, options, await readManifest());
   }
 
   // URI[] — each entry must resolve; all-or-nothing.
   if (Array.isArray(value) && value.every((entry): entry is string => typeof entry === 'string')) {
-    return await resolveUriStringArray(
-      name,
-      value,
-      options,
-      await readManifest(),
-      eligibilityCache,
-    );
+    return await resolveUriStringArray(name, value, options, await readManifest());
   }
 
   throw new Error(
@@ -657,9 +569,8 @@ async function resolveUriString(
   uri: string,
   options: ResolveArtifactDeclarationsOptions,
   records: readonly ArtifactManifestRecord[],
-  eligibilityCache: Map<RunId, ArtifactRunEligibility | null>,
 ): Promise<ArtifactVarValue> {
-  const resolved = await resolveSingleUriAgainstManifest(uri, options, records, eligibilityCache);
+  const resolved = await resolveSingleUriAgainstManifest(uri, options, records);
   // Per spec §10.1.2: `unresolvable-uri` covers both "did not parse" (null)
   // and "parsed but matched no manifest row" (empty array). Naked-form
   // resolution is all-or-nothing, so an empty result is an error here.
@@ -678,11 +589,10 @@ async function resolveUriStringArray(
   uris: readonly string[],
   options: ResolveArtifactDeclarationsOptions,
   records: readonly ArtifactManifestRecord[],
-  eligibilityCache: Map<RunId, ArtifactRunEligibility | null>,
 ): Promise<ArtifactRecord[]> {
   const resolved: ArtifactRecord[] = [];
   for (const uri of uris) {
-    const matches = await resolveSingleUriAgainstManifest(uri, options, records, eligibilityCache);
+    const matches = await resolveSingleUriAgainstManifest(uri, options, records);
     if (matches === null || matches.length === 0) {
       throw new Error(
         `partial-resolve: ARTIFACTS naked declaration "${name}" URI "${uri}" did not resolve; URI[] resolution is all-or-nothing`,
@@ -706,14 +616,12 @@ async function resolveUriStringArray(
  * @param uri - URI string to resolve
  * @param options - Resolver options carrying current context identity
  * @param records - Coalesced manifest snapshot for the current context
- * @param eligibilityCache - Per-pass cache of sibling-run eligibility results
  * @returns Matching records, or `null` when the URI is malformed or cross-context
  */
 async function resolveSingleUriAgainstManifest(
   uri: string,
   options: ResolveArtifactDeclarationsOptions,
   records: readonly ArtifactManifestRecord[],
-  eligibilityCache: Map<RunId, ArtifactRunEligibility | null>,
 ): Promise<ArtifactRecord[] | null> {
   let ref: ArtifactRef;
   try {
@@ -726,13 +634,12 @@ async function resolveSingleUriAgainstManifest(
   }
   if (ref.kind === 'exact') {
     // Find the record by exact identity (contextId, runId, key) and gate
-    // through the same eligibility + file-existence checks as a selector.
+    // through the file-existence check that selector matching also applies.
     for (const record of records) {
       if (
         record.contextId === ref.contextId &&
         record.runId === ref.runId &&
         record.key === ref.key &&
-        (await isEligibleSelectorRecord(record, options, eligibilityCache)) &&
         isExistingRegularArtifactFile(record.uri, options) &&
         isArtifactRecord(record)
       ) {
@@ -749,7 +656,7 @@ async function resolveSingleUriAgainstManifest(
     key: ref.key,
     query: ref.query,
   };
-  const result = await resolveSelector(selector, options, records, eligibilityCache);
+  const result = await resolveSelector(selector, options, records);
   if (Array.isArray(result)) {
     return [...(result as readonly ArtifactRecord[])];
   }

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -155,7 +155,7 @@ export async function resolveArtifactDeclarations(
     if (declaration.rawToken.includes('*') || declaration.rawToken.includes('?')) {
       validateBareKeyGlob(declaration.name, declaration.rawToken);
       const selector = buildImplicitBareKeySelector(declaration.rawToken, options.contextId);
-      result[declaration.name] = await resolveSelector(selector, options, await readManifest());
+      result[declaration.name] = resolveSelector(selector, options, await readManifest());
       continue;
     }
 
@@ -362,7 +362,7 @@ async function resolveUriLiteralDeclaration(
     );
   }
 
-  return await resolveSelector(ref, options, await readManifest());
+  return resolveSelector(ref, options, await readManifest());
 }
 
 /**
@@ -445,11 +445,11 @@ async function resolveExactUriDeclaration(
  * @param records - Coalesced manifest snapshot for the current context
  * @returns Single matching record or array of matches (possibly empty)
  */
-async function resolveSelector(
+function resolveSelector(
   selector: SelectorArtifactRef,
   options: ResolveArtifactDeclarationsOptions,
   records: readonly ArtifactManifestRecord[],
-): Promise<ArtifactVarValue> {
+): ArtifactVarValue {
   const matcher = picomatch(selector.key, { dot: true });
   const matches: ArtifactRecord[] = [];
 
@@ -514,14 +514,14 @@ async function resolveNakedDeclaration(
   if (typeof value === 'string') {
     const uriArray = parseJsonArtifactUriArrayTransport(value);
     if (uriArray !== null) {
-      return await resolveUriStringArray(name, uriArray, options, await readManifest());
+      return resolveUriStringArray(name, uriArray, options, await readManifest());
     }
-    return await resolveUriString(name, value, options, await readManifest());
+    return resolveUriString(name, value, options, await readManifest());
   }
 
   // URI[] — each entry must resolve; all-or-nothing.
   if (Array.isArray(value) && value.every((entry): entry is string => typeof entry === 'string')) {
-    return await resolveUriStringArray(name, value, options, await readManifest());
+    return resolveUriStringArray(name, value, options, await readManifest());
   }
 
   throw new Error(
@@ -564,13 +564,13 @@ function parseJsonArtifactUriArrayTransport(value: string): readonly string[] | 
   return parsed;
 }
 
-async function resolveUriString(
+function resolveUriString(
   name: string,
   uri: string,
   options: ResolveArtifactDeclarationsOptions,
   records: readonly ArtifactManifestRecord[],
-): Promise<ArtifactVarValue> {
-  const resolved = await resolveSingleUriAgainstManifest(uri, options, records);
+): ArtifactVarValue {
+  const resolved = resolveSingleUriAgainstManifest(uri, options, records);
   // Per spec §10.1.2: `unresolvable-uri` covers both "did not parse" (null)
   // and "parsed but matched no manifest row" (empty array). Naked-form
   // resolution is all-or-nothing, so an empty result is an error here.
@@ -584,15 +584,15 @@ async function resolveUriString(
   return resolved.length === 1 ? resolved[0] : [...resolved];
 }
 
-async function resolveUriStringArray(
+function resolveUriStringArray(
   name: string,
   uris: readonly string[],
   options: ResolveArtifactDeclarationsOptions,
   records: readonly ArtifactManifestRecord[],
-): Promise<ArtifactRecord[]> {
+): ArtifactRecord[] {
   const resolved: ArtifactRecord[] = [];
   for (const uri of uris) {
-    const matches = await resolveSingleUriAgainstManifest(uri, options, records);
+    const matches = resolveSingleUriAgainstManifest(uri, options, records);
     if (matches === null || matches.length === 0) {
       throw new Error(
         `partial-resolve: ARTIFACTS naked declaration "${name}" URI "${uri}" did not resolve; URI[] resolution is all-or-nothing`,
@@ -618,11 +618,11 @@ async function resolveUriStringArray(
  * @param records - Coalesced manifest snapshot for the current context
  * @returns Matching records, or `null` when the URI is malformed or cross-context
  */
-async function resolveSingleUriAgainstManifest(
+function resolveSingleUriAgainstManifest(
   uri: string,
   options: ResolveArtifactDeclarationsOptions,
   records: readonly ArtifactManifestRecord[],
-): Promise<ArtifactRecord[] | null> {
+): ArtifactRecord[] | null {
   let ref: ArtifactRef;
   try {
     ref = parseArtifactUri(uri);
@@ -656,7 +656,7 @@ async function resolveSingleUriAgainstManifest(
     key: ref.key,
     query: ref.query,
   };
-  const result = await resolveSelector(selector, options, records);
+  const result = resolveSelector(selector, options, records);
   if (Array.isArray(result)) {
     return [...(result as readonly ArtifactRecord[])];
   }

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -15,7 +15,7 @@ import type { VariableValue } from './effective-vars.js';
 import type { StepId } from './step-id.js';
 import type { ForClause, OutputDeclaration } from '@rundown-org/parser';
 import type { PreparedChannel } from './output-channels.js';
-import { outputCaptureActor } from './actors/output-capture-actor.js';
+import { outputCaptureActor, type OutputCaptureOutput } from './actors/output-capture-actor.js';
 import {
   isSourced,
   isWindowed,
@@ -781,20 +781,6 @@ function buildTransition(
 
   // No retry: execute action directly
   return buildActionTransition(action, stepName, substepId, steps, resultKind, evaluationOptions);
-}
-
-/**
- * Guard factory: true when the current attempt is part of a retry budget that
- * has not yet been exhausted. Used by COMMAND_RESULT transitions to decide
- * whether OUTPUTS capture should fire on this attempt.
- *
- * @param transition - The PASS or FAIL transition descriptor for the leaf step
- * @param transition.retry - Maximum retry budget configured on the transition
- * @returns Guard function evaluating against the current snapshot context
- */
-function willRetryGuard(transition: { retry: number }) {
-  return ({ context }: { context: RunbookContext }) =>
-    transition.retry > 0 && context.retryCount < transition.retry;
 }
 
 /**
@@ -2358,12 +2344,19 @@ function extractTargets(config: RunbookStateConfig): string[] {
 
   const collectFromEntry = (entry: RunbookEventTransition | RunbookAlwaysEntry | string): void => {
     if (typeof entry === 'string') {
-      targets.push(entry);
+      // Skip relative targets (XState 5 syntax starting with '.' or '#')
+      // — they are resolved at runtime and cannot be validated against
+      // the top-level states record.
+      if (!entry.startsWith('.') && !entry.startsWith('#')) {
+        targets.push(entry);
+      }
       return;
     }
     if (entry && typeof entry === 'object' && 'target' in entry) {
       const { target: t } = entry;
-      if (typeof t === 'string') targets.push(t);
+      if (typeof t === 'string' && !t.startsWith('.') && !t.startsWith('#')) {
+        targets.push(t);
+      }
     }
   };
 
@@ -2707,39 +2700,77 @@ export function compileRunbookToMachine(
       };
     });
 
-    // Precompute once per leaf state — referenced by both the leaf's PASS/FAIL
-    // handlers and the capture siblings' onDone targets.
-    const passTransition = buildTransition(
-      config.transitions.pass,
-      config.id,
-      config.stepName,
-      config.substepId,
-      steps,
-      evaluationOptions,
-    );
-    const failTransition = buildTransition(
-      config.transitions.fail,
-      config.id,
-      config.stepName,
-      config.substepId,
-      steps,
-      evaluationOptions,
-    );
+    // DoneActorEvent.output is typed by the actor; XState models the onDone
+    // event distinctly from RunbookEvent, hence the narrow cast at access.
+    type DoneEvent = { output: OutputCaptureOutput };
+    type ErrorEvent = { error?: unknown };
+    type InvokeBlock = NonNullable<RunbookStateConfig['invoke']>;
 
-    // `buildTransition` always returns the single-object form (see
-    // `buildActionTransition`); the array form on `TransitionConfig` is
-    // unreachable here. Narrow once for downstream spread/composition.
-    const passTransitionObj = passTransition as RunbookTransitionObject;
-    const failTransitionObj = failTransition as RunbookTransitionObject;
+    // The actor's resolved output is delivered as a `DoneActorEvent` whose
+    // `output` is `OutputCaptureOutput`; XState models it as a distinct
+    // event type from `RunbookEvent`, so direct type assignment fails. Cast
+    // the entire invoke block to `unknown` then to the expected shape.
+    const invokeBlock = {
+      src: 'outputCaptureActor',
+      input: ({ event }: { event: RunbookEvent }) => ({
+        channels: event.type === 'COMMAND_RESULT' ? event.channels : [],
+        // The `result` passthrough is opaque to the actor; the 'pass'
+        // default is unreachable in normal operation (only entered via
+        // COMMAND_RESULT) and satisfies the input type.
+        result: event.type === 'COMMAND_RESULT' ? event.result : ('pass' as const),
+      }),
+      onDone: {
+        // No target — raised PASS|FAIL bubbles up to the leaf's
+        // handlers. Merge runs first so downstream consumers see
+        // captured variables; raise reads from event.output and is
+        // order-independent with the merge.
+        actions: [
+          runbookSetup.assign({
+            variables: ({ context, event }) => ({
+              ...context.variables,
+              ...(event as unknown as DoneEvent).output.variables,
+            }),
+          }),
+          raise(({ event }) => ({
+            type: (event as unknown as DoneEvent).output.result === 'pass' ? 'PASS' : 'FAIL',
+          })),
+        ],
+      },
+      onError: {
+        target: '#STOPPED',
+        actions: runbookSetup.assign({
+          lifecycle: () => 'stopped' as const,
+          lastAction: ({ event }) => ({
+            type: 'OUTPUT_CAPTURE_FAILED' as const,
+            message: getErrorMessage((event as unknown as ErrorEvent).error),
+          }),
+        }),
+      },
+    } as unknown as InvokeBlock;
 
     checkedStateInsert(
       states,
       config.id,
       runbookSetup.createStateConfig({
         ...entryActions,
+        initial: 'idle',
         on: {
-          PASS: passTransition,
-          FAIL: failTransition,
+          PASS: buildTransition(
+            config.transitions.pass,
+            config.id,
+            config.stepName,
+            config.substepId,
+            steps,
+            evaluationOptions,
+          ),
+          FAIL: buildTransition(
+            config.transitions.fail,
+            config.id,
+            config.stepName,
+            config.substepId,
+            steps,
+            evaluationOptions,
+          ),
           RETRY: {
             actions: runbookSetup.assign({
               lastAction: { type: 'RETRY' as const },
@@ -2750,111 +2781,20 @@ export function compileRunbookToMachine(
             target: config.id,
           },
           GOTO: buildGotoTransitionsForState,
-          COMMAND_RESULT: [
-            // Capture-and-pass: route to the sibling state that invokes
-            // outputCaptureActor and chains into the resolved PASS transition.
-            {
-              guard: ({ context, event }) =>
-                event.result === 'pass' &&
-                event.channels.length > 0 &&
-                !willRetryGuard(config.transitions.pass)({ context }),
-              target: `${config.id}::__capture-pass`,
-            },
-            // Capture-and-fail: symmetric sibling for the FAIL path.
-            {
-              guard: ({ context, event }) =>
-                event.result === 'fail' &&
-                event.channels.length > 0 &&
-                !willRetryGuard(config.transitions.fail)({ context }),
-              target: `${config.id}::__capture-fail`,
-            },
-            // Skip-capture: raise PASS/FAIL so the existing transition fires
-            // unchanged (no channels, or attempt will retry — no point reading
-            // partial output files for an attempt that won't take effect).
-            {
-              guard: ({ event }) => event.result === 'pass',
-              actions: raise({ type: 'PASS' as const }),
-            },
-            {
-              guard: ({ event }) => event.result === 'fail',
-              actions: raise({ type: 'FAIL' as const }),
-            },
-          ],
+          // Single unguarded transition. The result discriminant rides through
+          // the actor's typed input/output (Task 1) — no context field, no
+          // routing guard.
+          COMMAND_RESULT: {
+            target: '.__capture',
+          },
         } as NonNullable<RunbookStateConfig['on']>,
-      } satisfies RunbookStateConfig),
-    );
-
-    // Build the capture-sibling configs as builders so we can keep one place
-    // documenting the dual-typing dance:
-    //
-    // - `onDone` runs under XState's `DoneActorEvent` event type, but the
-    //   chained transition (`actions`, `guard`, `target`) was produced against
-    //   `RunbookEvent`. XState's narrow event-context inference can't reconcile
-    //   the two; the runtime is correct because none of the chained actions
-    //   actually inspect the event payload beyond the `output` cast we add
-    //   here, but the strong static check rejects the assignment.
-    // - We cast the whole `invoke` block to `unknown` then to the parameter
-    //   shape `runbookSetup.createStateConfig` expects. The surrounding
-    //   `satisfies RunbookStateConfig` still enforces the rest of the state.
-    type InvokeBlock = NonNullable<RunbookStateConfig['invoke']>;
-
-    // The actor's resolved output is delivered as a `DoneActorEvent` whose
-    // `output` is `Record<string, string>`; XState models it as a distinct
-    // event type from `RunbookEvent`, so `runbookSetup.assign` (typed against
-    // `RunbookEvent`) cannot statically prove the `output` access. The local
-    // casts narrow per-callback; the outer `invoke` cast collapses the wider
-    // `onDone`/`onError` event-context mismatch.
-    type DoneEvent = { output: Record<string, string> };
-    type ErrorEvent = { error?: unknown };
-
-    const captureMergeAssign = runbookSetup.assign({
-      variables: ({ context, event }) => ({
-        ...context.variables,
-        ...(event as unknown as DoneEvent).output,
-      }),
-    });
-
-    const captureFailureAssign = runbookSetup.assign({
-      lifecycle: () => 'stopped' as const,
-      lastAction: ({ event }) => ({
-        type: 'OUTPUT_CAPTURE_FAILED' as const,
-        message: getErrorMessage((event as unknown as ErrorEvent).error),
-      }),
-    });
-
-    const buildCaptureInvoke = (chained: RunbookTransitionObject): InvokeBlock =>
-      ({
-        src: 'outputCaptureActor',
-        input: ({ event }: { event: RunbookEvent }) => ({
-          channels: event.type === 'COMMAND_RESULT' ? event.channels : [],
-        }),
-        onDone: {
-          ...chained,
-          actions: [captureMergeAssign, ...toActionArray(chained.actions)],
+        states: {
+          idle: {},
+          __capture: {
+            tags: [PENDING_MACHINE_EFFECT_TAG],
+            invoke: invokeBlock,
+          },
         },
-        onError: {
-          target: 'STOPPED',
-          actions: captureFailureAssign,
-        },
-      }) as unknown as InvokeBlock;
-
-    // Sibling transient #1: capture, then chain into the pass-resolved transition.
-    checkedStateInsert(
-      states,
-      `${config.id}::__capture-pass`,
-      runbookSetup.createStateConfig({
-        tags: [PENDING_MACHINE_EFFECT_TAG],
-        invoke: buildCaptureInvoke(passTransitionObj),
-      } satisfies RunbookStateConfig),
-    );
-
-    // Sibling transient #2: symmetric for fail.
-    checkedStateInsert(
-      states,
-      `${config.id}::__capture-fail`,
-      runbookSetup.createStateConfig({
-        tags: [PENDING_MACHINE_EFFECT_TAG],
-        invoke: buildCaptureInvoke(failTransitionObj),
       } satisfies RunbookStateConfig),
     );
 
@@ -2955,6 +2895,7 @@ export function compileRunbookToMachine(
         output: ({ context }) => ({ finalVars: context.finalVars }),
       },
       STOPPED: {
+        id: 'STOPPED',
         type: 'final',
         entry: [
           actionRef('storeFrontmatterOutputs', withEvaluationOptions({}, evaluationOptions)),

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -275,9 +275,10 @@ export const PENDING_MACHINE_EFFECT_TAG = 'pending-machine-effect' as const;
  * - RETRY: Increment retry count and re-enter the current step
  * - GOTO: Jump directly to a specific step by ID
  * - SET_VARIABLES: Merge variables into context.variables without changing step
- * - COMMAND_RESULT: Command finished — capture OUTPUTS via invoke before
- *   raising PASS/FAIL into the existing transition. Skipped (raises PASS/FAIL
- *   directly) when channels is empty or when the result will retry.
+ *   (used by delegation completion; OUTPUTS capture uses COMMAND_RESULT below)
+ * - COMMAND_RESULT: Result of a CLI-driven command execution. Carries captured
+ *   channels. Triggers outputCaptureActor invocation when capture is
+ *   appropriate (no retry pending, channels non-empty).
  */
 export type RunbookEvent =
   | { type: 'PASS' }

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -38,6 +38,7 @@ import {
 import type { DelegateFrontierEntry } from '../events/types.js';
 import type { FrameKey } from './targeting.js';
 import { runRetryHook } from './retry-hook.js';
+import { getErrorMessage } from '../errors.js';
 
 /**
  * Module-level XState setup with typed context, events, and named actions.
@@ -2816,7 +2817,7 @@ export function compileRunbookToMachine(
       lifecycle: () => 'stopped' as const,
       lastAction: ({ event }) => ({
         type: 'OUTPUT_CAPTURE_FAILED' as const,
-        message: String((event as unknown as ErrorEvent).error),
+        message: getErrorMessage((event as unknown as ErrorEvent).error),
       }),
     });
 

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -190,6 +190,16 @@ const EMPTY_RESULTS = Object.freeze([]) as unknown as NonNullable<
   RunbookContext['iterationResults']
 >;
 
+/** Name of the top-level STOPPED final state; used for both `id:` and name-based targets. */
+const STOPPED_STATE_NAME = 'STOPPED' as const;
+/**
+ * XState absolute ID reference for the STOPPED final state.
+ * Required for `onError` targets inside nested compound children where
+ * a plain name-based target would not cross the compound-state boundary.
+ * Derived from `STOPPED_STATE_NAME` so both strings share a single source of truth.
+ */
+const STOPPED_STATE_REF = `#${STOPPED_STATE_NAME}` as const; // '#STOPPED'
+
 /**
  * Context passed through the XState runbook state machine.
  *
@@ -277,8 +287,10 @@ export const PENDING_MACHINE_EFFECT_TAG = 'pending-machine-effect' as const;
  * - SET_VARIABLES: Merge variables into context.variables without changing step
  *   (used by delegation completion; OUTPUTS capture uses COMMAND_RESULT below)
  * - COMMAND_RESULT: Result of a CLI-driven command execution. Carries captured
- *   channels. Triggers outputCaptureActor invocation when capture is
- *   appropriate (no retry pending, channels non-empty).
+ *   channels. Unconditionally transitions the leaf to its `__capture` child,
+ *   which invokes `outputCaptureActor`. Channels may be empty; the actor
+ *   resolves with an empty `variables` record and still fires the result-driven
+ *   `PASS` or `FAIL` event.
  */
 export type RunbookEvent =
   | { type: 'PASS' }
@@ -1720,7 +1732,7 @@ function buildParentStateConfig(
   // action assigns lifecycle='stopped' on arrival.
   always.unshift({
     guard: ({ context }: { context: RunbookContext }) => context.lastAction?.type === 'RETRY_ERROR',
-    target: 'STOPPED',
+    target: STOPPED_STATE_NAME,
   });
 
   return {
@@ -1927,7 +1939,7 @@ function buildLoopControlTransition(
   const currentStep = steps.find((s) => s.name === stepName);
   if (currentStep?.kind !== 'for') {
     return {
-      target: 'STOPPED',
+      target: STOPPED_STATE_NAME,
       actions: actionRef('setLastAction', {
         action: { type: actionType },
       }),
@@ -2417,16 +2429,19 @@ function extractTargets(config: RunbookStateConfig): string[] {
  * transition targets are dynamically computed strings:
  * 1. Initial state exists in the generated set
  * 2. All transition targets reference existing states or terminal states
+ * 3. Every `__capture` child's `onError.target` equals `captureErrorTarget`
  *
  * @param states - The generated states record
  * @param initialState - The computed initial state ID
  * @param terminalStates - Set of terminal state IDs (COMPLETE, STOPPED)
+ * @param captureErrorTarget - Expected `onError.target` for every `__capture` child (e.g. `'#STOPPED'`)
  * @throws {Error} If any structural invariant is violated
  */
 function validateGraph(
   states: Record<string, RunbookStateConfig>,
   initialState: string,
   terminalStates: Set<string>,
+  captureErrorTarget: string,
 ): void {
   const stateIds = new Set([...Object.keys(states), ...terminalStates]);
 
@@ -2440,6 +2455,29 @@ function validateGraph(
         throw new Error(
           `Compiler error: unknown target "${target}" referenced from state "${sourceId}"`,
         );
+      }
+    }
+  }
+
+  // Invariant: every __capture child's onError must target captureErrorTarget.
+  // Catches a mismatched #STOPPED reference that the cast in invokeBlock would otherwise hide.
+  for (const [stateId, config] of Object.entries(states)) {
+    const childStates = config.states as Record<string, unknown> | undefined;
+    const capture = childStates?.__capture;
+    if (capture && typeof capture === 'object' && 'invoke' in capture) {
+      const inv = (capture as Record<string, unknown>).invoke;
+      if (inv && typeof inv === 'object' && 'onError' in inv) {
+        const onErr = (inv as Record<string, unknown>).onError;
+        const t =
+          onErr && typeof onErr === 'object'
+            ? (onErr as Record<string, unknown>).target
+            : undefined;
+        if (t !== captureErrorTarget) {
+          throw new Error(
+            `Compiler invariant: "${stateId}.__capture.onError.target" must be ` +
+              `"${captureErrorTarget}", got "${String(t)}"`,
+          );
+        }
       }
     }
   }
@@ -2703,8 +2741,22 @@ export function compileRunbookToMachine(
     // DoneActorEvent.output is typed by the actor; XState models the onDone
     // event distinctly from RunbookEvent, hence the narrow cast at access.
     type DoneEvent = { output: OutputCaptureOutput };
-    type ErrorEvent = { error?: unknown };
     type InvokeBlock = NonNullable<RunbookStateConfig['invoke']>;
+
+    // Single source of truth for every __capture.onError transition.
+    // `satisfies` pins `target` to the `typeof STOPPED_STATE_REF` literal type
+    // before the outer `invokeBlock` cast strips it — a typo in STOPPED_STATE_REF
+    // propagates here as a compile error rather than a silent runtime failure.
+    const captureFailureTransition = {
+      target: STOPPED_STATE_REF,
+      actions: runbookSetup.assign({
+        lifecycle: () => 'stopped' as const,
+        lastAction: ({ event }) => ({
+          type: 'OUTPUT_CAPTURE_FAILED' as const,
+          message: getErrorMessage((event as unknown as { error?: unknown }).error),
+        }),
+      }),
+    } satisfies { target: typeof STOPPED_STATE_REF; actions: unknown };
 
     // The actor's resolved output is delivered as a `DoneActorEvent` whose
     // `output` is `OutputCaptureOutput`; XState models it as a distinct
@@ -2736,16 +2788,7 @@ export function compileRunbookToMachine(
           })),
         ],
       },
-      onError: {
-        target: '#STOPPED',
-        actions: runbookSetup.assign({
-          lifecycle: () => 'stopped' as const,
-          lastAction: ({ event }) => ({
-            type: 'OUTPUT_CAPTURE_FAILED' as const,
-            message: getErrorMessage((event as unknown as ErrorEvent).error),
-          }),
-        }),
-      },
+      onError: captureFailureTransition,
     } as unknown as InvokeBlock;
 
     checkedStateInsert(
@@ -2838,7 +2881,7 @@ export function compileRunbookToMachine(
   // Phase 5: Runtime graph validation — catch dynamic errors types cannot prove
   const terminalStates = new Set(['COMPLETE', 'STOPPED']);
   const initialState = allStates.length > 0 ? allStates[0].id : 'step::1';
-  validateGraph(states, initialState, terminalStates);
+  validateGraph(states, initialState, terminalStates, STOPPED_STATE_REF);
 
   return runbookSetup.createMachine({
     id: 'runbook',
@@ -2895,7 +2938,7 @@ export function compileRunbookToMachine(
         output: ({ context }) => ({ finalVars: context.finalVars }),
       },
       STOPPED: {
-        id: 'STOPPED',
+        id: STOPPED_STATE_NAME,
         type: 'final',
         entry: [
           actionRef('storeFrontmatterOutputs', withEvaluationOptions({}, evaluationOptions)),

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1,4 +1,4 @@
-import { setup, assign, assertEvent } from 'xstate';
+import { setup, assign, assertEvent, raise } from 'xstate';
 import type {
   Action,
   Aggregation,
@@ -14,6 +14,8 @@ import { isResolvedVariableForContext } from './types.js';
 import type { VariableValue } from './effective-vars.js';
 import type { StepId } from './step-id.js';
 import type { ForClause, OutputDeclaration } from '@rundown-org/parser';
+import type { PreparedChannel } from './output-channels.js';
+import { outputCaptureActor } from './actors/output-capture-actor.js';
 import {
   isSourced,
   isWindowed,
@@ -127,6 +129,9 @@ export const runbookSetup = setup({
       !(context.iterationResults ?? []).some((r) => r === 'fail') &&
       context.lastAction?.type !== 'BREAK' &&
       context.lastAction?.type !== 'NEXT',
+  },
+  actors: {
+    outputCaptureActor,
   },
 });
 
@@ -253,6 +258,15 @@ export interface RunbookContext {
 }
 
 /**
+ * Tag applied to transient machine-owned side-effect states.
+ *
+ * `RunbookActorService.sendAndSync()` waits for this tag to clear before
+ * persisting the actor snapshot, so async invokes cannot be torn off by the
+ * actor being stopped immediately after `.send()`.
+ */
+export const PENDING_MACHINE_EFFECT_TAG = 'pending-machine-effect' as const;
+
+/**
  * Events that can be sent to the XState runbook state machine.
  *
  * - PASS: Mark the current step as passed, triggering the PASS transition
@@ -260,6 +274,9 @@ export interface RunbookContext {
  * - RETRY: Increment retry count and re-enter the current step
  * - GOTO: Jump directly to a specific step by ID
  * - SET_VARIABLES: Merge variables into context.variables without changing step
+ * - COMMAND_RESULT: Command finished — capture OUTPUTS via invoke before
+ *   raising PASS/FAIL into the existing transition. Skipped (raises PASS/FAIL
+ *   directly) when channels is empty or when the result will retry.
  */
 export type RunbookEvent =
   | { type: 'PASS' }
@@ -267,7 +284,12 @@ export type RunbookEvent =
   | { type: 'RETRY' }
   | { type: 'GOTO'; target: StepId }
   | { type: 'SET_VARIABLES'; vars: Record<string, VariableValue> }
-  | { type: 'PENDING_FRONTIER_CONSUMED' };
+  | { type: 'PENDING_FRONTIER_CONSUMED' }
+  | {
+      type: 'COMMAND_RESULT';
+      result: 'pass' | 'fail';
+      channels: readonly PreparedChannel[];
+    };
 
 /**
  * Object-form XState transition entry — the `{ target?, actions?, guard? }` variant.
@@ -757,6 +779,20 @@ function buildTransition(
 
   // No retry: execute action directly
   return buildActionTransition(action, stepName, substepId, steps, resultKind, evaluationOptions);
+}
+
+/**
+ * Guard factory: true when the current attempt is part of a retry budget that
+ * has not yet been exhausted. Used by COMMAND_RESULT transitions to decide
+ * whether OUTPUTS capture should fire on this attempt.
+ *
+ * @param transition - The PASS or FAIL transition descriptor for the leaf step
+ * @param transition.retry - Maximum retry budget configured on the transition
+ * @returns Guard function evaluating against the current snapshot context
+ */
+function willRetryGuard(transition: { retry: number }) {
+  return ({ context }: { context: RunbookContext }) =>
+    transition.retry > 0 && context.retryCount < transition.retry;
 }
 
 /**
@@ -2357,6 +2393,25 @@ function extractTargets(config: RunbookStateConfig): string[] {
     }
   }
 
+  // invoke.onDone / invoke.onError carry transition targets that must be
+  // validated against the state set.
+  if ('invoke' in config && config.invoke && typeof config.invoke === 'object') {
+    const invoke = config.invoke as {
+      onDone?: unknown;
+      onError?: unknown;
+    };
+    if (invoke.onDone !== undefined) {
+      collectFromTransitionConfig(
+        invoke.onDone as Parameters<typeof collectFromTransitionConfig>[0],
+      );
+    }
+    if (invoke.onError !== undefined) {
+      collectFromTransitionConfig(
+        invoke.onError as Parameters<typeof collectFromTransitionConfig>[0],
+      );
+    }
+  }
+
   return targets;
 }
 
@@ -2650,28 +2705,39 @@ export function compileRunbookToMachine(
       };
     });
 
+    // Precompute once per leaf state — referenced by both the leaf's PASS/FAIL
+    // handlers and the capture siblings' onDone targets.
+    const passTransition = buildTransition(
+      config.transitions.pass,
+      config.id,
+      config.stepName,
+      config.substepId,
+      steps,
+      evaluationOptions,
+    );
+    const failTransition = buildTransition(
+      config.transitions.fail,
+      config.id,
+      config.stepName,
+      config.substepId,
+      steps,
+      evaluationOptions,
+    );
+
+    // `buildTransition` always returns the single-object form (see
+    // `buildActionTransition`); the array form on `TransitionConfig` is
+    // unreachable here. Narrow once for downstream spread/composition.
+    const passTransitionObj = passTransition as RunbookTransitionObject;
+    const failTransitionObj = failTransition as RunbookTransitionObject;
+
     checkedStateInsert(
       states,
       config.id,
       runbookSetup.createStateConfig({
         ...entryActions,
         on: {
-          PASS: buildTransition(
-            config.transitions.pass,
-            config.id,
-            config.stepName,
-            config.substepId,
-            steps,
-            evaluationOptions,
-          ),
-          FAIL: buildTransition(
-            config.transitions.fail,
-            config.id,
-            config.stepName,
-            config.substepId,
-            steps,
-            evaluationOptions,
-          ),
+          PASS: passTransition,
+          FAIL: failTransition,
           RETRY: {
             actions: runbookSetup.assign({
               lastAction: { type: 'RETRY' as const },
@@ -2682,7 +2748,111 @@ export function compileRunbookToMachine(
             target: config.id,
           },
           GOTO: buildGotoTransitionsForState,
+          COMMAND_RESULT: [
+            // Capture-and-pass: route to the sibling state that invokes
+            // outputCaptureActor and chains into the resolved PASS transition.
+            {
+              guard: ({ context, event }) =>
+                event.result === 'pass' &&
+                event.channels.length > 0 &&
+                !willRetryGuard(config.transitions.pass)({ context }),
+              target: `${config.id}::__capture-pass`,
+            },
+            // Capture-and-fail: symmetric sibling for the FAIL path.
+            {
+              guard: ({ context, event }) =>
+                event.result === 'fail' &&
+                event.channels.length > 0 &&
+                !willRetryGuard(config.transitions.fail)({ context }),
+              target: `${config.id}::__capture-fail`,
+            },
+            // Skip-capture: raise PASS/FAIL so the existing transition fires
+            // unchanged (no channels, or attempt will retry — no point reading
+            // partial output files for an attempt that won't take effect).
+            {
+              guard: ({ event }) => event.result === 'pass',
+              actions: raise({ type: 'PASS' as const }),
+            },
+            {
+              guard: ({ event }) => event.result === 'fail',
+              actions: raise({ type: 'FAIL' as const }),
+            },
+          ],
         } as NonNullable<RunbookStateConfig['on']>,
+      } satisfies RunbookStateConfig),
+    );
+
+    // Build the capture-sibling configs as builders so we can keep one place
+    // documenting the dual-typing dance:
+    //
+    // - `onDone` runs under XState's `DoneActorEvent` event type, but the
+    //   chained transition (`actions`, `guard`, `target`) was produced against
+    //   `RunbookEvent`. XState's narrow event-context inference can't reconcile
+    //   the two; the runtime is correct because none of the chained actions
+    //   actually inspect the event payload beyond the `output` cast we add
+    //   here, but the strong static check rejects the assignment.
+    // - We cast the whole `invoke` block to `unknown` then to the parameter
+    //   shape `runbookSetup.createStateConfig` expects. The surrounding
+    //   `satisfies RunbookStateConfig` still enforces the rest of the state.
+    type InvokeBlock = NonNullable<RunbookStateConfig['invoke']>;
+
+    // The actor's resolved output is delivered as a `DoneActorEvent` whose
+    // `output` is `Record<string, string>`; XState models it as a distinct
+    // event type from `RunbookEvent`, so `runbookSetup.assign` (typed against
+    // `RunbookEvent`) cannot statically prove the `output` access. The local
+    // casts narrow per-callback; the outer `invoke` cast collapses the wider
+    // `onDone`/`onError` event-context mismatch.
+    type DoneEvent = { output: Record<string, string> };
+    type ErrorEvent = { error?: unknown };
+
+    const captureMergeAssign = runbookSetup.assign({
+      variables: ({ context, event }) => ({
+        ...context.variables,
+        ...(event as unknown as DoneEvent).output,
+      }),
+    });
+
+    const captureFailureAssign = runbookSetup.assign({
+      lifecycle: () => 'stopped' as const,
+      lastAction: ({ event }) => ({
+        type: 'OUTPUT_CAPTURE_FAILED' as const,
+        message: String((event as unknown as ErrorEvent).error),
+      }),
+    });
+
+    const buildCaptureInvoke = (chained: RunbookTransitionObject): InvokeBlock =>
+      ({
+        src: 'outputCaptureActor',
+        input: ({ event }: { event: RunbookEvent }) => ({
+          channels: event.type === 'COMMAND_RESULT' ? event.channels : [],
+        }),
+        onDone: {
+          ...chained,
+          actions: [captureMergeAssign, ...toActionArray(chained.actions)],
+        },
+        onError: {
+          target: 'STOPPED',
+          actions: captureFailureAssign,
+        },
+      }) as unknown as InvokeBlock;
+
+    // Sibling transient #1: capture, then chain into the pass-resolved transition.
+    checkedStateInsert(
+      states,
+      `${config.id}::__capture-pass`,
+      runbookSetup.createStateConfig({
+        tags: [PENDING_MACHINE_EFFECT_TAG],
+        invoke: buildCaptureInvoke(passTransitionObj),
+      } satisfies RunbookStateConfig),
+    );
+
+    // Sibling transient #2: symmetric for fail.
+    checkedStateInsert(
+      states,
+      `${config.id}::__capture-fail`,
+      runbookSetup.createStateConfig({
+        tags: [PENDING_MACHINE_EFFECT_TAG],
+        invoke: buildCaptureInvoke(failTransitionObj),
       } satisfies RunbookStateConfig),
     );
 

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -2469,18 +2469,19 @@ function validateGraph(
     const capture = childStates?.__capture;
     if (capture && typeof capture === 'object' && 'invoke' in capture) {
       const inv = (capture as Record<string, unknown>).invoke;
-      if (inv && typeof inv === 'object' && 'onError' in inv) {
-        const onErr = (inv as Record<string, unknown>).onError;
-        const t =
-          onErr && typeof onErr === 'object'
-            ? (onErr as Record<string, unknown>).target
-            : undefined;
-        if (t !== captureErrorTarget) {
-          throw new Error(
-            `Compiler invariant: "${stateId}.__capture.onError.target" must be ` +
-              `"${captureErrorTarget}", got "${String(t)}"`,
-          );
-        }
+      if (!inv || typeof inv !== 'object' || !('onError' in inv)) {
+        throw new Error(
+          `Compiler invariant: "${stateId}.__capture.invoke.onError" must be defined`,
+        );
+      }
+      const onErr = (inv as Record<string, unknown>).onError;
+      const t =
+        onErr && typeof onErr === 'object' ? (onErr as Record<string, unknown>).target : undefined;
+      if (t !== captureErrorTarget) {
+        throw new Error(
+          `Compiler invariant: "${stateId}.__capture.onError.target" must be ` +
+            `"${captureErrorTarget}", got "${String(t)}"`,
+        );
       }
     }
   }

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -2356,17 +2356,18 @@ function extractTargets(config: RunbookStateConfig): string[] {
 
   const collectFromEntry = (entry: RunbookEventTransition | RunbookAlwaysEntry | string): void => {
     if (typeof entry === 'string') {
-      // Skip relative targets (XState 5 syntax starting with '.' or '#')
-      // — they are resolved at runtime and cannot be validated against
-      // the top-level states record.
-      if (!entry.startsWith('.') && !entry.startsWith('#')) {
+      // Skip relative descendant refs ('.' prefix) — resolved at runtime
+      // against the current state, not the top-level states record.
+      // Absolute ID refs ('#' prefix, e.g. '#STOPPED') ARE included so
+      // validateGraph can check them after stripping the '#'.
+      if (!entry.startsWith('.')) {
         targets.push(entry);
       }
       return;
     }
     if (entry && typeof entry === 'object' && 'target' in entry) {
       const { target: t } = entry;
-      if (typeof t === 'string' && !t.startsWith('.') && !t.startsWith('#')) {
+      if (typeof t === 'string' && !t.startsWith('.')) {
         targets.push(t);
       }
     }
@@ -2451,7 +2452,9 @@ function validateGraph(
 
   for (const [sourceId, config] of Object.entries(states)) {
     for (const target of extractTargets(config)) {
-      if (!stateIds.has(target)) {
+      // Absolute XState ID refs like '#STOPPED' resolve to the bare name.
+      const lookupTarget = target.startsWith('#') ? target.slice(1) : target;
+      if (!stateIds.has(lookupTarget)) {
         throw new Error(
           `Compiler error: unknown target "${target}" referenced from state "${sourceId}"`,
         );

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -176,7 +176,6 @@ export {
 } from './artifact-manifest.js';
 export {
   resolveArtifactDeclarations,
-  type ArtifactRunEligibility,
   type ResolveArtifactDeclarationsOptions,
 } from './artifact-directive-resolver.js';
 export {

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -261,7 +261,8 @@ export async function prepareOutputChannels(args: PrepareOutputChannelsArgs): Pr
  * UTF-8 only, trailing whitespace and newlines trimmed. Files that are
  * missing, empty after trim, non-UTF-8, or unreadable are logged and omitted
  * from the result. The caller decides what to do with the returned record;
- * the spec mandates merging into `context.variables` via `SET_VARIABLES`.
+ * the machine merges into `context.variables` via the `outputCaptureActor`
+ * invoked on COMMAND_RESULT (see compiler.ts).
  *
  * @param prepared - Channels returned by `prepareOutputChannels`, each carrying its name and absolute path
  * @returns Record `{ <VarName>: <trimmedValue> }` for every successful read

--- a/packages/core/src/runbook/transition-kernel.ts
+++ b/packages/core/src/runbook/transition-kernel.ts
@@ -1,5 +1,20 @@
 import { evaluateFailCondition, evaluatePassCondition } from './transition-handler.js';
-import type { LastAction, Step, ResolvedStep } from './types.js';
+import type { InternalFailureLastAction, LastAction, Step, ResolvedStep } from './types.js';
+
+/**
+ * Public stopped-reason codes attached to terminal `RUNBOOK_STOPPED` events.
+ *
+ * Duplicated locally (rather than imported from `../events/types.js`) to keep
+ * `transition-kernel.ts` free of an event-layer dependency. The CLI mapping
+ * layer narrows `RunbookStoppedPayload['reason']` through this type.
+ */
+type StoppedReason =
+  | 'policy_denied'
+  | 'fail_transition'
+  | 'user_abort'
+  | 'delegation_resolution_failed'
+  | 'nested_delegation_forbidden'
+  | 'output_capture_failed';
 
 /**
  * Action type derived from structured LastAction.
@@ -15,6 +30,7 @@ export type ActionType =
   | 'GOTO'
   | 'RETRY'
   | 'RETRY_ERROR'
+  | 'OUTPUT_CAPTURE_FAILED'
   | 'CONTINUE'
   | 'DEFER'
   | 'COMPLETE'
@@ -67,6 +83,9 @@ function isLastAction(value: unknown): value is LastAction {
     case 'RETRY_ERROR':
       // Machine-internal failure signal: requires code + message payload.
       return typeof value.code === 'string' && typeof value.message === 'string';
+    case 'OUTPUT_CAPTURE_FAILED':
+      // Machine-internal failure signal from the per-step capture sibling state.
+      return typeof value.message === 'string';
     case 'GOTO':
       if (typeof value.target !== 'string') return false;
       if ('substep' in value && value.substep !== undefined && typeof value.substep !== 'string') {
@@ -225,6 +244,8 @@ export function parseActionType(lastAction: LastAction | undefined): ActionType 
       return 'RETRY';
     case 'RETRY_ERROR':
       return 'RETRY_ERROR';
+    case 'OUTPUT_CAPTURE_FAILED':
+      return 'OUTPUT_CAPTURE_FAILED';
     case 'DEFER':
       return 'DEFER';
     case 'COMPLETE':
@@ -256,4 +277,46 @@ export function deriveTransitionMessage(
   return result === 'pass'
     ? evaluatePassCondition(step, retryCount).message
     : evaluateFailCondition(step, retryCount).message;
+}
+
+/**
+ * True when the action represents a machine-internal failure signal rather
+ * than an authored runbook action.
+ *
+ * @param lastAction - Last action extracted from a machine snapshot
+ * @returns true for internal failure variants
+ */
+export function isInternalFailureLastAction(
+  lastAction: LastAction | undefined,
+): lastAction is InternalFailureLastAction {
+  return lastAction?.type === 'RETRY_ERROR' || lastAction?.type === 'OUTPUT_CAPTURE_FAILED';
+}
+
+/**
+ * Derive a public stopped reason from a typed lastAction.
+ *
+ * Maps machine-internal failure variants to their corresponding public reason
+ * codes; everything else falls through to the generic `fail_transition` so
+ * authored STOP actions still report the historical reason.
+ *
+ * @param lastAction - Last action extracted from the terminal snapshot
+ * @returns Public RUNBOOK_STOPPED reason
+ */
+export function deriveStoppedReason(lastAction: LastAction | undefined): StoppedReason {
+  if (lastAction?.type === 'OUTPUT_CAPTURE_FAILED') return 'output_capture_failed';
+  return 'fail_transition';
+}
+
+/**
+ * Extract a user-facing terminal failure message from typed internal failures.
+ *
+ * @param lastAction - Last action extracted from the terminal snapshot
+ * @returns Message for internal failures, otherwise undefined
+ */
+export function extractInternalFailureMessage(
+  lastAction: LastAction | undefined,
+): string | undefined {
+  if (lastAction?.type === 'OUTPUT_CAPTURE_FAILED') return lastAction.message;
+  if (lastAction?.type === 'RETRY_ERROR') return lastAction.message;
+  return undefined;
 }

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -399,6 +399,30 @@ export interface RetryErrorLastAction extends LastActionBase {
 }
 
 /**
+ * Machine-internal failure variant emitted when the per-step `outputCaptureActor`
+ * sibling state's `onError` branch fires.
+ *
+ * Routed by the compiler to the `STOPPED` terminal state with this lastAction;
+ * the CLI orchestrator (Task 3) consumes this to derive a public
+ * `output_capture_failed` stopped reason and emit `ERROR_OCCURRED` with the
+ * message before the terminal `RUNBOOK_STOPPED` event.
+ */
+export interface OutputCaptureFailedLastAction extends LastActionBase {
+  readonly type: 'OUTPUT_CAPTURE_FAILED';
+  /** Human-readable description of the I/O failure. */
+  readonly message: string;
+}
+
+/**
+ * Union of machine-internal failure lastAction variants.
+ *
+ * These are emitted by the state machine when a machine-owned invoke or hook
+ * fails — they are not authored runbook actions. Consumers distinguish them
+ * via {@link isInternalFailureLastAction} in `transition-kernel.ts`.
+ */
+export type InternalFailureLastAction = RetryErrorLastAction | OutputCaptureFailedLastAction;
+
+/**
  * Discriminated union representing the last transition action taken by the state machine.
  */
 export type LastAction =
@@ -419,7 +443,7 @@ export type LastAction =
   | (LastActionBase & { readonly type: 'RETRY' })
   | (LastActionBase & { readonly type: 'NEXT' })
   | (LastActionBase & { readonly type: 'BREAK' })
-  | RetryErrorLastAction;
+  | InternalFailureLastAction;
 
 /**
  * Runtime state of a substep within a step

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -629,6 +629,15 @@ const RunbookStateObjectSchema = z
         z.object({ type: z.literal('RETRY') }),
         z.object({ type: z.literal('NEXT') }),
         z.object({ type: z.literal('BREAK') }),
+        z.object({
+          type: z.literal('RETRY_ERROR'),
+          code: z.string(),
+          message: z.string(),
+        }),
+        z.object({
+          type: z.literal('OUTPUT_CAPTURE_FAILED'),
+          message: z.string(),
+        }),
       ])
       .optional(),
     runbookSrc: z.string().optional(),

--- a/packages/parser/__tests__/artifacts.test.ts
+++ b/packages/parser/__tests__/artifacts.test.ts
@@ -291,4 +291,47 @@ Some prompt text first.
     if (step.kind !== 'substeps') throw new Error('expected substeps step');
     expect(step.substeps[0].artifacts).toEqual([{ name: 'ChildPath', rawToken: 'child.json' }]);
   });
+
+  /**
+   * Pins the parser's current behaviour for a step with substeps that carries
+   * step-level ARTIFACTS but NO substep-level ARTIFACTS on any child.
+   *
+   * The parser ACCEPTS this combination without error and exposes BOTH
+   * `step.artifacts` (populated) and `step.substeps` (populated, each with
+   * `artifacts === undefined`). It does not reject, does not silently drop,
+   * and does not lift/copy the parent ARTIFACTS onto child substeps.
+   *
+   * Why this matters: the AST `ContextDirectiveFields` mixin allows artifacts
+   * on every step and every substep independently, so the structural exposure
+   * is genuinely independent. Downstream consumers (compiler, resolver) must
+   * decide what to do with parent-level artifacts on a step with substeps — that
+   * design choice is intentionally NOT pinned by this test. This test only
+   * pins the parser contract: structural exposure of both fields is
+   * guaranteed.
+   */
+  it('accepts step-level ARTIFACTS alongside substeps and exposes both', () => {
+    const md = `## 1. Parent
+- ARTIFACTS
+  - ParentPath "parent.json"
+### 1.1 Child A
+- PASS DEFER
+- FAIL DEFER
+### 1.2 Child B
+- PASS DEFER
+- FAIL DEFER
+`;
+    const { runbook, diagnostics } = parseRunbookDocument(md);
+    expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const step = runbook.steps[0];
+    expect(step.artifacts).toEqual([{ name: 'ParentPath', rawToken: 'parent.json' }]);
+    expect(step.kind).toBe('substeps');
+    if (step.kind !== 'substeps') throw new Error('expected substeps step');
+
+    expect(step.substeps).toHaveLength(2);
+    // Parent-level ARTIFACTS is NOT lifted/copied onto children — children
+    // retain `artifacts === undefined` because they declared none of their own.
+    expect(step.substeps[0].artifacts).toBeUndefined();
+    expect(step.substeps[1].artifacts).toBeUndefined();
+  });
 });

--- a/scripts/check-xstate-doc-version.mjs
+++ b/scripts/check-xstate-doc-version.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const docPath = resolve(repoRoot, 'docs/internal/xstate-patterns.md');
-const xstatePkgPath = resolve(repoRoot, 'node_modules/xstate/package.json');
+const require = createRequire(import.meta.url);
+const xstatePkgPath = require.resolve('xstate/package.json');
 
 let installed;
 try {


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command steps can emit COMMAND_RESULT; prepared-file output channels are captured and merged into run state.

* **Bug Fixes**
  * Output-capture failures are treated as internal failures with a dedicated stopped reason and clearer error events.

* **Documentation**
  * Expanded architecture/spec guidance (state-machine patterns, actor wiring, URI selector semantics, deferred/spec notes).

* **Tests**
  * Broadened coverage for output capture, command-result flows, artifact resolution, lifecycle and schema validation.

* **Chores**
  * Minor config and dictionary updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/289)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
