### PR TITLE
Consolidate runbook actor transition persistence

### DIFF
--- a/packages/cli/__tests__/commands/goto.test.ts
+++ b/packages/cli/__tests__/commands/goto.test.ts
@@ -42,6 +42,19 @@ describe('goto command', () => {
       expect(state?.retryCount).toBe(0);
     });
 
+    it('clears stale lastResult without rewriting machine-owned GOTO lastAction', async () => {
+      await runCliInProcess('stop --text', workspace);
+      await runCliInProcess('run --prompted runbooks/retry.runbook.md --text', workspace);
+      await runCliInProcess('fail --text', workspace);
+
+      const result = await runCliInProcess(['goto', '2', '--text'], workspace);
+
+      expect(result.exitCode).toBe(0);
+      const state = await getActiveState(workspace);
+      expect(state?.lastResult).toBeUndefined();
+      expect(state?.lastAction).toEqual({ type: 'GOTO', target: '2' });
+    });
+
     it('outputs jumped step info', async () => {
       const result = await runCliInProcess(['goto', '3', '--text'], workspace);
 

--- a/packages/cli/__tests__/commands/run-prompted.test.ts
+++ b/packages/cli/__tests__/commands/run-prompted.test.ts
@@ -94,6 +94,44 @@ Second step.
       expect(state?.step).toBe('2');
     });
 
+    it('persists first substep launch state through core initialization', async () => {
+      const runbook = `## 1. Parent
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.1 First
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.2 Second
+- PASS CONTINUE
+- FAIL STOP
+
+## 2. Done
+- PASS COMPLETE
+- FAIL STOP
+`;
+      await writeFile(join(workspace.cwd, 'substeps-start.runbook.md'), runbook);
+
+      const result = await runCliInProcess(
+        'run --prompted substeps-start.runbook.md --text',
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const state = await getActiveState(workspace);
+      expect(state?.step).toBe('1');
+      expect(state?.substep).toBe('1');
+      expect(state?.lastAction).toEqual({ type: 'START' });
+      expect(state?.activeFrameKey).toBe('1|');
+      expect(state?.activeEntry).toBe(1);
+      expect(state?.frameEntries).toEqual({ '1|': 1 });
+      expect(state?.substepStates).toEqual([
+        { id: '1', frameKey: '1|', status: 'pending' },
+        { id: '2', frameKey: '1|', status: 'pending' },
+      ]);
+    });
+
     it('shows command in output without executing', async () => {
       const result = await runCliInProcess(
         'run --prompted runbooks/with-commands.runbook.md --text',

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -1363,7 +1363,10 @@ describe('claimAndLaunch', () => {
         initializeSubsteps: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
       },
       actorService: {
-        initializeState: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
+        initializeState: mockFn<() => Promise<RunbookState>>().mockResolvedValue({
+          id: NEW_CHILD_ID,
+          step: '1',
+        } as unknown as RunbookState),
       },
       sessionService: {
         pushRunbook: mockFn<() => Promise<void>>().mockResolvedValue(undefined),

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -1607,9 +1607,9 @@ describe('claimAndLaunch', () => {
         load: mockFn<() => Promise<RunbookState>>().mockResolvedValue(
           parentState as unknown as RunbookState,
         ),
-        create: mockFn<(...args: unknown[]) => Promise<{ id: RunId; title: string }>>().mockResolvedValue(
-          { id: NEW_CHILD_ID, title: 'Child' },
-        ),
+        create: mockFn<
+          (...args: unknown[]) => Promise<{ id: RunId; title: string }>
+        >().mockResolvedValue({ id: NEW_CHILD_ID, title: 'Child' }),
         update: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
         list: mockFn<() => Promise<unknown[]>>().mockResolvedValue([]),
         initializeSubsteps: mockFn<() => Promise<void>>().mockResolvedValue(undefined),

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -7,6 +7,7 @@ import type {
   RunbookRef,
   RunId,
   RunbookState,
+  RunbookStateManager,
   SessionService,
   StepDelegation,
   TokenScanResult,
@@ -1652,6 +1653,8 @@ describe('claimAndLaunch', () => {
     }
     // Execution loop must not have run — the throw aborted launchRunbook before it
     expect(runExecutionLoop).not.toHaveBeenCalled();
+    // Claim was attempted against the newly created child run ID
+    expect(mockClaimRunbook).toHaveBeenCalledWith(NEW_CHILD_ID, expect.anything());
     // Lock must be released even on claim failure
     expect(mockRelease).toHaveBeenCalledWith(RUN_ID);
   });
@@ -1722,7 +1725,7 @@ describe('claimAndLaunch', () => {
       childRunId: NEW_CHILD_ID,
     });
 
-    const mockDelete = mockFn<() => Promise<void>>().mockResolvedValue(undefined);
+    const mockDelete = mockFn<RunbookStateManager['delete']>().mockResolvedValue(undefined);
 
     const ctx = makeCtx({
       manager: {

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -1655,4 +1655,119 @@ describe('claimAndLaunch', () => {
     // Lock must be released even on claim failure
     expect(mockRelease).toHaveBeenCalledWith(RUN_ID);
   });
+
+  it('deletes orphaned child state when afterInit throws due to claim invariant violation', async () => {
+    const parentState = {
+      id: RUN_ID,
+      step: '1',
+      variables: {},
+      substepStates: [
+        {
+          id: '1',
+          frameKey: '1|0',
+          status: 'pending',
+          delegation: {
+            tokenHash: MOCK_TOKEN_HASH,
+            childRunbookPath: 'child.md',
+            childRunbookRef: { source: 'project', path: 'child.md' },
+            childRunId: null,
+            cancelledAt: null,
+            contextSnapshot: { vars: {}, ancestors: [] },
+            createdAt: '2026-02-27T10:00:00.000Z',
+          },
+        },
+      ],
+    };
+
+    mockScanService(
+      scanResult({
+        parentState,
+        stepId: '1',
+        substepId: '1',
+        delegation: parentState.substepStates[0].delegation,
+        frameKey: brandFrameKeyForTest('1', 0),
+      }),
+      null,
+    );
+
+    mockHappyDelegationLock();
+
+    jest.mocked(resolveRunbookFile).mockResolvedValue({
+      path: '/tmp/test/child.md',
+      source: 'project',
+      sourceRoot: '/tmp/test',
+    });
+    jest.mocked(parser.parseRunbookDocument).mockReturnValue({
+      runbook: { steps: [{ kind: 'base', name: '1', description: 'Step' }] },
+      frontmatter: null,
+      diagnostics: [],
+    } as unknown as ReturnType<typeof parser.parseRunbookDocument>);
+    jest.mocked(validateOutputsDeclarations).mockReturnValue([]);
+    jest.mocked(resolveVariables).mockResolvedValue({
+      vars: {},
+      warnings: [],
+      providedKeys: new Set(),
+    } as unknown as Awaited<ReturnType<typeof resolveVariables>>);
+    jest
+      .mocked(resolveForBounds)
+      .mockImplementation(
+        (runbook) => ({ runbook, warnings: [] }) as unknown as ReturnType<typeof resolveForBounds>,
+      );
+    jest.mocked(substituteRunbookVariables).mockImplementation((runbook) => runbook);
+    jest.mocked(collectUnresolvedRunbookVariables).mockReturnValue(new Set());
+
+    // claimRunbook returns missing-child — simulates claimChildForPipeline failure
+    const mockClaimRunbook = mockFn<SessionService['claimRunbook']>().mockResolvedValue({
+      status: 'missing-child',
+      childRunId: NEW_CHILD_ID,
+    });
+
+    const mockDelete = mockFn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    const ctx = makeCtx({
+      manager: {
+        load: mockFn<() => Promise<RunbookState>>().mockResolvedValue(
+          parentState as unknown as RunbookState,
+        ),
+        create: mockFn<
+          (...args: unknown[]) => Promise<{ id: RunId; title: string }>
+        >().mockResolvedValue({ id: NEW_CHILD_ID, title: 'Child' }),
+        update: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
+        list: mockFn<() => Promise<unknown[]>>().mockResolvedValue([]),
+        initializeSubsteps: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
+        delete: mockDelete,
+      },
+      actorService: {
+        initializeState: mockFn<() => Promise<RunbookState>>().mockResolvedValue({
+          id: NEW_CHILD_ID,
+          step: '1',
+        } as unknown as RunbookState),
+      },
+      sessionService: {
+        pushRunbook: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
+        claimRunbook: mockClaimRunbook,
+        findClaimForDelegation:
+          mockFn<SessionService['findClaimForDelegation']>().mockResolvedValue(null),
+      },
+      lifecycleService: {
+        ensureActiveEntry: mockFn<
+          () => Promise<{
+            state: { activeEntry: number; activeFrameKey: string };
+            frameKey: string;
+            entry: number;
+          }>
+        >().mockResolvedValue({
+          state: { activeEntry: 1, activeFrameKey: '1|0' },
+          frameKey: '1|0',
+          entry: 1,
+        }),
+      },
+    });
+
+    // cspell:disable-next-line
+    await claimAndLaunch(ctx, 'rdtk_AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH', {});
+
+    // The orphaned child run created by manager.create must be cleaned up
+    expect(mockDelete).toHaveBeenCalledWith(NEW_CHILD_ID);
+  });
 });

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -150,6 +150,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
     TOKEN_CANCELLED: { code: 'RD-809' },
     DELEGATION_LOCK_TIMEOUT: { code: 'RD-810' },
     LAUNCH_FAILED: { code: 'RD-816' },
+    CLAIM_INVARIANT_VIOLATED: { code: 'RD-820' },
   },
   isJsonArray: jest.fn((v: unknown) => Array.isArray(v)),
   isJsonArrayStream: jest.fn(realIsJsonArrayStream),
@@ -1531,6 +1532,127 @@ describe('claimAndLaunch', () => {
       expect(result.cause).toContain('disk full');
     }
     // Lock must be released even on init failure
+    expect(mockRelease).toHaveBeenCalledWith(RUN_ID);
+  });
+
+  it('returns CLAIM_INVARIANT_VIOLATED (RD-820) when claimChildForPipeline fails after fresh launch and does not execute the loop', async () => {
+    const parentState = {
+      id: RUN_ID,
+      step: '1',
+      variables: {},
+      substepStates: [
+        {
+          id: '1',
+          frameKey: '1|0',
+          status: 'pending',
+          delegation: {
+            tokenHash: MOCK_TOKEN_HASH,
+            childRunbookPath: 'child.md',
+            childRunbookRef: { source: 'project', path: 'child.md' },
+            childRunId: null,
+            cancelledAt: null,
+            contextSnapshot: { vars: {}, ancestors: [] },
+            createdAt: '2026-02-27T10:00:00.000Z',
+          },
+        },
+      ],
+    };
+
+    mockScanService(
+      scanResult({
+        parentState,
+        stepId: '1',
+        substepId: '1',
+        delegation: parentState.substepStates[0].delegation,
+        frameKey: brandFrameKeyForTest('1', 0),
+      }),
+      null,
+    );
+
+    const { release: mockRelease } = mockHappyDelegationLock();
+
+    jest.mocked(resolveRunbookFile).mockResolvedValue({
+      path: '/tmp/test/child.md',
+      source: 'project',
+      sourceRoot: '/tmp/test',
+    });
+    // Cast through unknown: minimal parser fixture (see frameKey linkage test).
+    jest.mocked(parser.parseRunbookDocument).mockReturnValue({
+      runbook: { steps: [{ kind: 'base', name: '1', description: 'Step' }] },
+      frontmatter: null,
+      diagnostics: [],
+    } as unknown as ReturnType<typeof parser.parseRunbookDocument>);
+    jest.mocked(validateOutputsDeclarations).mockReturnValue([]);
+    jest.mocked(resolveVariables).mockResolvedValue({
+      vars: {},
+      warnings: [],
+      providedKeys: new Set(),
+    } as unknown as Awaited<ReturnType<typeof resolveVariables>>);
+    jest
+      .mocked(resolveForBounds)
+      .mockImplementation(
+        (runbook) => ({ runbook, warnings: [] }) as unknown as ReturnType<typeof resolveForBounds>,
+      );
+    jest.mocked(substituteRunbookVariables).mockImplementation((runbook) => runbook);
+    jest.mocked(collectUnresolvedRunbookVariables).mockReturnValue(new Set());
+
+    // claimRunbook returns missing-child — simulates claimChildForPipeline failure
+    const mockClaimRunbook = mockFn<SessionService['claimRunbook']>().mockResolvedValue({
+      status: 'missing-child',
+      childRunId: NEW_CHILD_ID,
+    });
+
+    const ctx = makeCtx({
+      manager: {
+        load: mockFn<() => Promise<RunbookState>>().mockResolvedValue(
+          parentState as unknown as RunbookState,
+        ),
+        create: mockFn<(...args: unknown[]) => Promise<{ id: RunId; title: string }>>().mockResolvedValue(
+          { id: NEW_CHILD_ID, title: 'Child' },
+        ),
+        update: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
+        list: mockFn<() => Promise<unknown[]>>().mockResolvedValue([]),
+        initializeSubsteps: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
+      },
+      actorService: {
+        initializeState: mockFn<() => Promise<RunbookState>>().mockResolvedValue({
+          id: NEW_CHILD_ID,
+          step: '1',
+        } as unknown as RunbookState),
+      },
+      sessionService: {
+        pushRunbook: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
+        claimRunbook: mockClaimRunbook,
+        findClaimForDelegation:
+          mockFn<SessionService['findClaimForDelegation']>().mockResolvedValue(null),
+      },
+      lifecycleService: {
+        ensureActiveEntry: mockFn<
+          () => Promise<{
+            state: { activeEntry: number; activeFrameKey: string };
+            frameKey: string;
+            entry: number;
+          }>
+        >().mockResolvedValue({
+          state: { activeEntry: 1, activeFrameKey: '1|0' },
+          frameKey: '1|0',
+          entry: 1,
+        }),
+      },
+    });
+
+    // cspell:disable-next-line
+    const result = await claimAndLaunch(ctx, 'rdtk_AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH', {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      assertVariant(result, 'reason', 'launch-failed');
+      expect(result.code).toBe('RD-820');
+      expect(result.cause).toContain(NEW_CHILD_ID);
+    }
+    // Execution loop must not have run — the throw aborted launchRunbook before it
+    expect(runExecutionLoop).not.toHaveBeenCalled();
+    // Lock must be released even on claim failure
     expect(mockRelease).toHaveBeenCalledWith(RUN_ID);
   });
 });

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -429,6 +429,8 @@ describe('executeGoto', () => {
     const update = mockFn<RunbookStateManager['update']>();
     update.mockImplementation(async (_id, _patch) => makeState({ step: '2' }));
     const sendAndSync = mockFn<RunbookActorService['sendAndSync']>();
+    const clearLastResult =
+      mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined);
     const syncResult: ActorSyncResult = {
       state: makeState({ step: '2' }),
       snapshot: {},
@@ -445,10 +447,7 @@ describe('executeGoto', () => {
       manager: { update } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
-      lifecycleService: {
-        clearLastResult:
-          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
-      } as unknown as ExecutionLifecycleService,
+      lifecycleService: { clearLastResult } as unknown as ExecutionLifecycleService,
       state: makeState(),
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
@@ -463,7 +462,7 @@ describe('executeGoto', () => {
       expect(result.loopResult).toBe('done');
     }
     expect(action).toHaveBeenCalled();
-    expect(ctx.lifecycleService.clearLastResult).toHaveBeenCalledWith(DEFAULT_RUNBOOK_ID);
+    expect(clearLastResult).toHaveBeenCalledWith(DEFAULT_RUNBOOK_ID);
     expect(sendAndSync).toHaveBeenCalledWith(DEFAULT_RUNBOOK_ID, ctx.steps, {
       type: 'GOTO',
       target,

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -398,6 +398,8 @@ describe('executeGoto', () => {
     const update = mockFn<RunbookStateManager['update']>();
     const sendAndSync = mockFn<RunbookActorService['sendAndSync']>();
     sendAndSync.mockResolvedValue(null);
+    const clearLastResult =
+      mockFn<ExecutionLifecycleService['clearLastResult']>().mockResolvedValue(undefined);
 
     const ctx = {
       output: {
@@ -407,10 +409,7 @@ describe('executeGoto', () => {
       manager: { update } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
-      lifecycleService: {
-        clearLastResult:
-          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
-      } as unknown as ExecutionLifecycleService,
+      lifecycleService: { clearLastResult } as unknown as ExecutionLifecycleService,
       state: makeState(),
       steps: [makeStep()],
       cwd: '/test',
@@ -423,6 +422,7 @@ describe('executeGoto', () => {
     if (!result.ok) {
       expect(result.code).toBe('ENGINE_INIT_FAILED');
     }
+    expect(clearLastResult).not.toHaveBeenCalled();
   });
 
   it('returns ok with loop result on success', async () => {
@@ -483,6 +483,8 @@ describe('executeGoto', () => {
     };
     sendAndSync.mockResolvedValue(syncResult);
     jest.mocked(runExecutionLoop).mockResolvedValue('stopped');
+    const clearLastResult =
+      mockFn<ExecutionLifecycleService['clearLastResult']>().mockResolvedValue(undefined);
 
     const ctx = {
       output: {
@@ -492,10 +494,7 @@ describe('executeGoto', () => {
       manager: { update } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
-      lifecycleService: {
-        clearLastResult:
-          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
-      } as unknown as ExecutionLifecycleService,
+      lifecycleService: { clearLastResult } as unknown as ExecutionLifecycleService,
       state: makeState(),
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
@@ -508,6 +507,7 @@ describe('executeGoto', () => {
     if (result.ok) {
       expect(result.loopResult).toBe('stopped');
     }
+    expect(clearLastResult).toHaveBeenCalledWith(DEFAULT_RUNBOOK_ID);
   });
 });
 

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import type { ResolvedStep, Substep, ForClause, Transitions } from '@rundown-org/parser';
 import type {
   ActorSyncResult,
+  ExecutionLifecycleService,
   RunbookActorService,
   RunbookState,
   RunbookStateManager,
@@ -22,6 +23,7 @@ const CLAIMED_RUNBOOK_ID = brandRunIdForTest(`rd_${'8'.repeat(32)}`);
 jest.unstable_mockModule('@rundown-org/core', () => ({
   RunbookStateManager: jest.fn(),
   RunbookActorService: jest.fn(),
+  ExecutionLifecycleService: jest.fn(),
   SessionService: jest.fn(),
   parseStepIdFromString: jest.fn(),
   stepIdToString: jest.fn((id: { step: string; substep?: string }) =>
@@ -405,6 +407,10 @@ describe('executeGoto', () => {
       manager: { update } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
+      lifecycleService: {
+        clearLastResult:
+          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+      } as unknown as ExecutionLifecycleService,
       state: makeState(),
       steps: [makeStep()],
       cwd: '/test',
@@ -439,6 +445,10 @@ describe('executeGoto', () => {
       manager: { update } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
+      lifecycleService: {
+        clearLastResult:
+          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+      } as unknown as ExecutionLifecycleService,
       state: makeState(),
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
@@ -453,9 +463,15 @@ describe('executeGoto', () => {
       expect(result.loopResult).toBe('done');
     }
     expect(action).toHaveBeenCalled();
-    const updateArg = update.mock.calls[0][1];
-    expect(updateArg).toHaveProperty('lastResult', undefined);
-    expect(updateArg).toHaveProperty('lastAction', { type: 'GOTO', target: '2' });
+    expect(ctx.lifecycleService.clearLastResult).toHaveBeenCalledWith(DEFAULT_RUNBOOK_ID);
+    expect(sendAndSync).toHaveBeenCalledWith(DEFAULT_RUNBOOK_ID, ctx.steps, {
+      type: 'GOTO',
+      target,
+    });
+    expect(update).not.toHaveBeenCalledWith(
+      DEFAULT_RUNBOOK_ID,
+      expect.objectContaining({ lastAction: expect.anything() }),
+    );
   });
 
   it('returns stopped when execution loop stops', async () => {
@@ -477,6 +493,10 @@ describe('executeGoto', () => {
       manager: { update } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
+      lifecycleService: {
+        clearLastResult:
+          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+      } as unknown as ExecutionLifecycleService,
       state: makeState(),
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -1423,10 +1423,6 @@ describe('startRunbook', () => {
     expect(mockEnsureActiveEntry).not.toHaveBeenCalled();
     expect(mockInitializeSubsteps).not.toHaveBeenCalled();
     expect(mockUpdate).not.toHaveBeenCalled();
-    expect(mockUpdate).not.toHaveBeenCalledWith(
-      createdState.id,
-      expect.objectContaining({ lastAction: { type: 'START' } }),
-    );
     expect(mockPushRunbook).toHaveBeenCalled();
     const createBridgedEmitterMock = createBridgedEmitter as jest.MockedFunction<
       (...args: unknown[]) => unknown

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -1346,13 +1346,20 @@ describe('prepareRunbook', () => {
 describe('startRunbook', () => {
   it('creates state and runs execution loop', async () => {
     const createdState = makeState(MOCK_RUN_ID) as unknown as RunbookState;
+    const initializedState = {
+      ...createdState,
+      lastAction: { type: 'START' as const },
+      activeFrameKey: '1|' as ReturnType<typeof core.buildFrameKey>,
+      activeEntry: 1,
+      frameEntries: { '1|': 1 },
+    } as unknown as RunbookState;
     const mockCreate = mockFn<RunbookStateManager['create']>().mockResolvedValue(createdState);
     const mockUpdate = mockFn<RunbookStateManager['update']>().mockResolvedValue(createdState);
     const mockLoad = mockFn<RunbookStateManager['load']>().mockResolvedValue(createdState);
     const mockInitializeSubsteps =
       mockFn<RunbookStateManager['initializeSubsteps']>().mockResolvedValue(undefined);
     const mockInitState =
-      mockFn<RunbookActorService['initializeState']>().mockResolvedValue(createdState);
+      mockFn<RunbookActorService['initializeState']>().mockResolvedValue(initializedState);
     const mockPushRunbook = mockFn<SessionService['pushRunbook']>().mockResolvedValue(undefined);
     const mockEnsureActiveEntry = mockFn<
       ExecutionLifecycleService['ensureActiveEntry']
@@ -1413,11 +1420,18 @@ describe('startRunbook', () => {
       }),
     );
     expect(mockInitState).toHaveBeenCalled();
+    expect(mockEnsureActiveEntry).not.toHaveBeenCalled();
+    expect(mockInitializeSubsteps).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalledWith(
+      createdState.id,
+      expect.objectContaining({ lastAction: { type: 'START' } }),
+    );
     expect(mockPushRunbook).toHaveBeenCalled();
     const createBridgedEmitterMock = createBridgedEmitter as jest.MockedFunction<
       (...args: unknown[]) => unknown
     >;
-    expect(createBridgedEmitterMock.mock.calls).toContainEqual([createdState, ctx.output]);
+    expect(createBridgedEmitterMock.mock.calls).toContainEqual([initializedState, ctx.output]);
   });
 
   it('seeds frontmatterOutputs from prepared.frontmatter.outputs to manager.create', async () => {
@@ -1438,8 +1452,12 @@ describe('startRunbook', () => {
           mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
       } as unknown as RunbookStateManager,
       actorService: {
-        initializeState:
-          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+        initializeState: mockFn<RunbookActorService['initializeState']>().mockResolvedValue({
+          id: 'sub-id',
+          step: '1',
+          activeFrameKey: '1|',
+          substep: 'a',
+        } as unknown as RunbookState),
       } as unknown as RunbookActorService,
       sessionService: {
         pushRunbook: mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
@@ -1500,8 +1518,12 @@ describe('startRunbook', () => {
         initializeSubsteps: mockInitSubsteps,
       } as unknown as RunbookStateManager,
       actorService: {
-        initializeState:
-          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+        initializeState: mockFn<RunbookActorService['initializeState']>().mockResolvedValue({
+          id: 'sub-id',
+          step: '1',
+          activeFrameKey: '1|',
+          substep: 'a',
+        } as unknown as RunbookState),
       } as unknown as RunbookActorService,
       sessionService: {
         pushRunbook: mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
@@ -1531,12 +1553,8 @@ describe('startRunbook', () => {
     const result = await startRunbook(ctx, prepared, { file: 'runbook.md' });
 
     expect(result.ok).toBe(true);
-    const firstStep = prepared.runbook.steps[0];
-    if (firstStep.kind !== 'substeps') {
-      throw new Error(`Expected first step to have substeps, got ${firstStep.kind}`);
-    }
-    expect(mockInitSubsteps).toHaveBeenCalledWith('sub-id', firstStep.substeps, '1|');
-    expect(mockUpdate).toHaveBeenCalledWith('sub-id', { substep: 'a' });
+    expect(mockInitSubsteps).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 });
 
@@ -2122,8 +2140,10 @@ describe('claimAndLaunch', () => {
       output: { status: jest.fn(), flush: jest.fn() } as unknown as OutputEmitter,
       manager: mockManager as unknown as RunbookStateManager,
       actorService: {
-        initializeState:
-          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+        initializeState: mockFn<RunbookActorService['initializeState']>().mockResolvedValue({
+          id: 'new-child-id',
+          step: '1',
+        } as unknown as RunbookState),
       } as unknown as RunbookActorService,
       sessionService: {
         pushRunbook: mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
@@ -2240,8 +2260,10 @@ describe('claimAndLaunch', () => {
       output: { status: jest.fn(), flush: jest.fn() } as unknown as OutputEmitter,
       manager: mockManager as unknown as RunbookStateManager,
       actorService: {
-        initializeState:
-          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+        initializeState: mockFn<RunbookActorService['initializeState']>().mockResolvedValue({
+          id: 'new-child-id',
+          step: '1',
+        } as unknown as RunbookState),
       } as unknown as RunbookActorService,
       sessionService: {
         pushRunbook: mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
@@ -2371,8 +2393,10 @@ describe('claimAndLaunch', () => {
       output: { status: jest.fn(), flush: jest.fn() } as unknown as OutputEmitter,
       manager: mockManager as unknown as RunbookStateManager,
       actorService: {
-        initializeState:
-          mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+        initializeState: mockFn<RunbookActorService['initializeState']>().mockResolvedValue({
+          id: 'new-child-id',
+          step: '1',
+        } as unknown as RunbookState),
       } as unknown as RunbookActorService,
       sessionService: {
         pushRunbook: mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),

--- a/packages/cli/__tests__/helpers/transition-boundary.test.ts
+++ b/packages/cli/__tests__/helpers/transition-boundary.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFile } from 'node:fs/promises';
+
+describe('CLI transition boundary', () => {
+  it('does not use raw actor send or updateFromActor in runbook transition helpers', async () => {
+    const files = [
+      new URL('../../src/helpers/transitions.ts', import.meta.url),
+      new URL('../../src/helpers/goto-workflow.ts', import.meta.url),
+    ];
+
+    for (const file of files) {
+      const source = await readFile(file, 'utf8');
+      expect(source).not.toMatch(/\bactor\.send\s*\(/);
+      expect(source).not.toMatch(/\bupdateFromActor\s*\(/);
+    }
+  });
+
+  it('does not write semantic launch initialization in runbook-pipeline', async () => {
+    const source = await readFile(
+      new URL('../../src/helpers/runbook-pipeline.ts', import.meta.url),
+      'utf8',
+    );
+
+    expect(source).not.toMatch(/\bensureActiveEntry\s*\(/);
+    expect(source).not.toMatch(/\binitializeSubsteps\s*\(/);
+    expect(source).not.toMatch(/lastAction\s*:\s*\{\s*type\s*:\s*['"]START['"]/);
+  });
+});

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -99,7 +99,7 @@ import type { TransitionContext } from '../../src/helpers/transitions.js';
  */
 type TestCtx = Omit<
   TransitionContext,
-  'output' | 'manager' | 'actorService' | 'lifecycleService' | 'actor' | 'steps'
+  'output' | 'manager' | 'actorService' | 'lifecycleService' | 'steps'
 > & {
   output: {
     action: jest.Mock;
@@ -112,8 +112,9 @@ type TestCtx = Omit<
     load: jest.Mock<(...args: unknown[]) => Promise<unknown>>;
   };
   actorService: {
-    updateFromActor: jest.Mock<
-      (...args: unknown[]) => Promise<{ state: Record<string, unknown>; snapshot: unknown }>
+    assertFreshState: jest.Mock<(...args: unknown[]) => Promise<boolean>>;
+    sendAndSync: jest.Mock<
+      (...args: unknown[]) => Promise<{ state: Record<string, unknown>; snapshot: unknown } | null>
     >;
   };
   lifecycleService: {
@@ -125,7 +126,6 @@ type TestCtx = Omit<
   };
   // Loosely-typed step fixtures — the kernel only consumes the union shape at runtime.
   steps: ReadonlyArray<Record<string, unknown>>;
-  actor: { send: jest.Mock; stop: jest.Mock };
 };
 
 function makeCtx(stateOverrides: Record<string, unknown> = {}): TestCtx {
@@ -149,11 +149,12 @@ function makeCtx(stateOverrides: Record<string, unknown> = {}): TestCtx {
       load: mockFn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(null),
     },
     actorService: {
-      updateFromActor: mockFn<
+      assertFreshState: mockFn<(...args: unknown[]) => Promise<boolean>>().mockResolvedValue(true),
+      sendAndSync: mockFn<
         (...args: unknown[]) => Promise<{ state: Record<string, unknown>; snapshot: unknown }>
       >().mockResolvedValue({
         state: { ...state },
-        snapshot: {},
+        snapshot: { context: { lastAction: { type: 'CONTINUE' } } },
       }),
     },
     sessionService: {},
@@ -177,10 +178,6 @@ function makeCtx(stateOverrides: Record<string, unknown> = {}): TestCtx {
         substeps: [{ id: '1' }, { id: '2' }],
       },
     ],
-    actor: {
-      send: mockFn<(...args: unknown[]) => void>(),
-      stop: mockFn<() => void>(),
-    },
     cwd: '/test',
   } as unknown as TestCtx;
 }
@@ -235,6 +232,24 @@ beforeEach(() => {
 });
 
 describe('executeTransition with ExplicitTarget', () => {
+  it('validates stale state before recording substep completions', async () => {
+    const ctx = makeCtx();
+    const staleError = new Error(
+      'Stale runbook state for "run-1": missing frontmatter outputs declarations.',
+    );
+    ctx.actorService.assertFreshState.mockRejectedValue(staleError);
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(asCtx(ctx), config, { stepId: '1.2' })).rejects.toThrow(
+      /Stale runbook state/,
+    );
+
+    expect(ctx.actorService.assertFreshState).toHaveBeenCalledWith('run-1', ctx.steps);
+    expect(ctx.lifecycleService.ensureActiveEntry).not.toHaveBeenCalled();
+    expect(ctx.lifecycleService.getResolvedCompletion).not.toHaveBeenCalled();
+    expect(ctx.lifecycleService.upsertResolvedCompletion).not.toHaveBeenCalled();
+  });
+
   it('throws when explicitTarget is provided but not in substep mode', async () => {
     const ctx = makeCtx({ substep: undefined }); // No active substep
     mockFindStep({ name: '1', kind: 'base' });
@@ -796,11 +811,13 @@ describe('step-level PASS transition no longer triggers CLI-side OUTPUTS evaluat
         load: mockFn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(null),
       },
       actorService: {
-        updateFromActor: mockFn<
+        assertFreshState:
+          mockFn<(...args: unknown[]) => Promise<boolean>>().mockResolvedValue(true),
+        sendAndSync: mockFn<
           (...args: unknown[]) => Promise<{ state: Record<string, unknown>; snapshot: unknown }>
         >().mockResolvedValue({
           state: { ...state, templateVars },
-          snapshot: {},
+          snapshot: { context: { lastAction: { type: 'CONTINUE' } } },
         }),
       },
       sessionService: {},
@@ -818,10 +835,6 @@ describe('step-level PASS transition no longer triggers CLI-side OUTPUTS evaluat
       },
       state,
       steps: [{ name: '1', kind: 'base' }],
-      actor: {
-        send: mockFn<(...args: unknown[]) => void>(),
-        stop: mockFn<() => void>(),
-      },
       cwd: '/test',
     } as unknown as TestCtx;
   }
@@ -852,8 +865,18 @@ describe('step-level PASS transition no longer triggers CLI-side OUTPUTS evaluat
 
     await executeTransition(asCtx(ctx), config);
 
-    // Verify the machine-owned path was exercised: the PASS transition drives
-    // the actor (where storeStepOutputs now lives), so actor.send must fire.
-    expect(ctx.actor.send).toHaveBeenCalled();
+    expect(ctx.actorService.sendAndSync).toHaveBeenCalledWith('run-1', ctx.steps, {
+      type: 'PASS',
+    });
+  });
+
+  it('throws when sendAndSync cannot initialize the runbook engine', async () => {
+    const ctx = makeStepLevelCtx();
+    ctx.actorService.sendAndSync.mockResolvedValue(null);
+    const config = createPassTransitionConfig();
+
+    await expect(executeTransition(asCtx(ctx), config)).rejects.toThrow(
+      'Failed to initialize runbook engine',
+    );
   });
 });

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -876,7 +876,7 @@ describe('step-level PASS transition no longer triggers CLI-side OUTPUTS evaluat
     const config = createPassTransitionConfig();
 
     await expect(executeTransition(asCtx(ctx), config)).rejects.toThrow(
-      'Failed to initialize runbook engine',
+      'Failed to dispatch transition to runbook engine',
     );
   });
 });

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -667,8 +667,12 @@ describe('runExecutionLoop', () => {
       }),
     );
 
-    // RUNBOOK_STOPPED still fires afterwards so terminal state is reported.
-    expect(mockEmitter.emit).toHaveBeenCalledWith('RUNBOOK_STOPPED', expect.any(Object));
+    // RUNBOOK_STOPPED still fires afterwards with a reason distinct from an
+    // author-configured FAIL STOP transition.
+    expect(mockEmitter.emit).toHaveBeenCalledWith(
+      'RUNBOOK_STOPPED',
+      expect.objectContaining({ reason: 'retry_error_failed' }),
+    );
 
     // Ordering: ERROR_OCCURRED precedes RUNBOOK_STOPPED.
     const emitCalls = mockEmitter.emit.mock.calls;

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -78,16 +78,11 @@ export function registerCollectCommand(program: Command): void {
             }
             const ctx = contextResult.ctx;
 
-            let shouldExitWithError = false;
-            try {
-              shouldExitWithError = await runCollect(ctx, cwd, {
-                step: options.step,
-                index: options.index,
-                text: options.text,
-              });
-            } finally {
-              ctx.actorService.stopActor(ctx.actor);
-            }
+            const shouldExitWithError = await runCollect(ctx, cwd, {
+              step: options.step,
+              index: options.index,
+              text: options.text,
+            });
 
             if (shouldExitWithError) {
               process.exitCode = 1;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -254,6 +254,7 @@ export function registerRunCommand(program: Command): void {
                 manager,
                 actorService,
                 sessionService,
+                lifecycleService,
                 state: gotoState,
                 steps: [...getRunbookFromState(gotoState, cwd)],
                 cwd,

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -13,6 +13,7 @@ import {
   derivePositionAt,
   RunbookStateManager,
   RunbookActorService,
+  ExecutionLifecycleService,
   SessionService,
   parseStepIdFromString,
   stepIdToString,
@@ -42,6 +43,8 @@ export interface GotoContext {
   actorService: RunbookActorService;
   /** Session service for tracking active/stashed runbooks */
   sessionService: SessionService;
+  /** Execution lifecycle service */
+  lifecycleService: ExecutionLifecycleService;
   /** Current active runbook state */
   state: RunbookState;
   /** Parsed steps from the active runbook */
@@ -112,6 +115,7 @@ export async function buildGotoContext(
 ): Promise<BuildGotoContextResult> {
   const manager = new RunbookStateManager(cwd);
   const sessionService = new SessionService(manager);
+  const lifecycleService = new ExecutionLifecycleService(manager);
   const active = await resolveActiveRunbook(sessionService, options);
 
   switch (active.kind) {
@@ -136,7 +140,17 @@ export async function buildGotoContext(
 
   return {
     kind: 'ready',
-    ctx: { output, manager, actorService, sessionService, state, steps, cwd, terminalReleaseMode },
+    ctx: {
+      output,
+      manager,
+      actorService,
+      sessionService,
+      lifecycleService,
+      state,
+      steps,
+      cwd,
+      terminalReleaseMode,
+    },
   };
 }
 
@@ -258,15 +272,7 @@ export async function executeGoto(ctx: GotoContext, target: StepId): Promise<Got
     return { ok: false, error: 'Failed to initialize runbook engine', code: 'ENGINE_INIT_FAILED' };
   }
 
-  // Update lastAction and CLEAR lastResult (prevent stale PASS/FAIL leaking)
-  await manager.update(state.id, {
-    lastAction: {
-      type: 'GOTO',
-      target: target.step,
-      ...(target.substep && { substep: target.substep }),
-    },
-    lastResult: undefined, // CRITICAL: Clear stale result on manual goto
-  });
+  await ctx.lifecycleService.clearLastResult(state.id);
 
   // Compute new position (the target of the goto)
   const totalSteps = countNumberedSteps(steps);

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -272,6 +272,8 @@ export async function executeGoto(ctx: GotoContext, target: StepId): Promise<Got
     return { ok: false, error: 'Failed to initialize runbook engine', code: 'ENGINE_INIT_FAILED' };
   }
 
+  // `sendAndSync` has already persisted the GOTO transition. Clear stale
+  // result metadata as a second write before reporting the new cursor.
   await ctx.lifecycleService.clearLastResult(state.id);
 
   // Compute new position (the target of the goto)

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -1059,6 +1059,15 @@ async function launchRunbook(
 
     runbookSteps = [...runbook.steps];
   } catch (err) {
+    // Best-effort cleanup: if the run was created before the failure, delete
+    // it so an unclaimed state file doesn't linger on disk with no session entry.
+    if (stateId!) {
+      try {
+        await manager.delete(stateId);
+      } catch {
+        // Ignore cleanup errors — the primary error is the important one.
+      }
+    }
     return {
       ok: false,
       reason: 'launch-failed',

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -14,8 +14,6 @@ import {
   type RunbookActorService,
   type SessionService,
   type ExecutionLifecycleService,
-  deriveActiveFrame,
-  buildFrameKey,
   type FrameKey,
   type RunbookState,
   type ExecutionEventEmitter,
@@ -46,7 +44,6 @@ import {
   parseRunbookDocument,
   isSourced,
   stepHasSubsteps,
-  resolvedStepHasSubsteps,
   type Step,
   type ResolvedStep,
   type ValidationDiagnostic,
@@ -1005,7 +1002,7 @@ async function launchRunbook(
     afterInit?: (stateId: RunId) => Promise<void>;
   },
 ): Promise<RunbookStartResult> {
-  const { output, manager, actorService, sessionService, lifecycleService, cwd } = ctx;
+  const { output, manager, actorService, sessionService, cwd } = ctx;
   const { filePath, rawContent, runbook, mergedVariables } = prepared;
 
   const runbookPath = path.relative(cwd, filePath);
@@ -1029,9 +1026,10 @@ async function launchRunbook(
     });
     stateId = state.id;
 
-    // Initialize actor state (populates forStack for first step)
-    await actorService.initializeState(state.id, [...runbook.steps]);
-    await lifecycleService.ensureActiveEntry(state.id);
+    const initializedState = await actorService.initializeState(state.id, [...runbook.steps]);
+    if (!initializedState) {
+      throw new Error('Failed to initialize runbook engine');
+    }
 
     // Optional post-init hook (e.g., linking delegation childRunId)
     if (options.afterInit) {
@@ -1053,23 +1051,11 @@ async function launchRunbook(
       }
     }
 
-    if (resolvedStepHasSubsteps(runbook.steps[0]) && runbook.steps[0].substeps.length > 0) {
-      const freshState = await manager.load(state.id);
-      const frame = freshState ? deriveActiveFrame(freshState) : undefined;
-      const frameKey =
-        freshState?.activeFrameKey ?? frame?.frameKey ?? buildFrameKey(runbook.steps[0].name);
-      await manager.initializeSubsteps(state.id, runbook.steps[0].substeps, frameKey);
-      await manager.update(state.id, { substep: runbook.steps[0].substeps[0].id });
-    }
-
-    // Update lastAction
-    await manager.update(state.id, { lastAction: { type: 'START' } });
-
     // Create emitter bridged to unified output
-    emitter = createBridgedEmitter(state, output);
+    emitter = createBridgedEmitter(initializedState, output);
 
     // Emit RUNBOOK_STARTED
-    emitRunbookStarted(emitter, state, options.prompted);
+    emitRunbookStarted(emitter, initializedState, options.prompted);
 
     runbookSteps = [...runbook.steps];
   } catch (err) {

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -1670,7 +1670,9 @@ export async function claimAndLaunch(
           // launch-failed envelope with CLAIM_INVARIANT_VIOLATED so
           // post-mortem from CLI output reveals the cause.
           invariantViolation = claimResult;
-          return;
+          throw new Error(
+            `Claim invariant violated for fresh child ${claimResult.childRunId}: ${claimResult.reason}`,
+          );
         }
         await updateStepDelegationChildRunId(
           manager,

--- a/packages/cli/src/helpers/transition-command.ts
+++ b/packages/cli/src/helpers/transition-command.ts
@@ -105,40 +105,36 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
             // propagation also stopped, RETRY exhausted, or no parent linkage
             // and the local lifecycle is `stopped`).
             let shouldExitWithError = false;
-            try {
-              const config = def.buildConfig();
-              const explicitTarget: ExplicitTarget | undefined = options.step
-                ? { stepId: options.step, index: options.index }
-                : undefined;
+            const config = def.buildConfig();
+            const explicitTarget: ExplicitTarget | undefined = options.step
+              ? { stepId: options.step, index: options.index }
+              : undefined;
 
-              const result = await executeTransition(ctx, config, explicitTarget);
-              if (result === 'stopped') shouldExitWithError = true;
+            const result = await executeTransition(ctx, config, explicitTarget);
+            if (result === 'stopped') shouldExitWithError = true;
 
-              // Parent propagation supersedes the local-stop signal:
-              // 'handled'        → parent absorbed non-terminally (RETRY/CONTINUE).
-              // 'stopped'        → parent also terminated (e.g. RETRY exhausted).
-              // 'not-applicable' → keep the local signal unchanged.
-              const freshState = await ctx.manager.load(ctx.state.id);
-              if (freshState && extractParentLinkage(freshState)) {
-                const isTerminal =
-                  freshState.lifecycle === 'completed' || freshState.lifecycle === 'stopped';
-                if (isTerminal) {
-                  const propResult = freshState.lifecycle === 'completed' ? 'pass' : 'fail';
-                  const propagationResult = await handleParentCompletion(
-                    freshState,
-                    propResult,
-                    cwd,
-                    output,
-                  );
-                  if (propagationResult === 'handled') {
-                    shouldExitWithError = false;
-                  } else if (propagationResult === 'stopped') {
-                    shouldExitWithError = true;
-                  }
+            // Parent propagation supersedes the local-stop signal:
+            // 'handled'        → parent absorbed non-terminally (RETRY/CONTINUE).
+            // 'stopped'        → parent also terminated (e.g. RETRY exhausted).
+            // 'not-applicable' → keep the local signal unchanged.
+            const freshState = await ctx.manager.load(ctx.state.id);
+            if (freshState && extractParentLinkage(freshState)) {
+              const isTerminal =
+                freshState.lifecycle === 'completed' || freshState.lifecycle === 'stopped';
+              if (isTerminal) {
+                const propResult = freshState.lifecycle === 'completed' ? 'pass' : 'fail';
+                const propagationResult = await handleParentCompletion(
+                  freshState,
+                  propResult,
+                  cwd,
+                  output,
+                );
+                if (propagationResult === 'handled') {
+                  shouldExitWithError = false;
+                } else if (propagationResult === 'stopped') {
+                  shouldExitWithError = true;
                 }
               }
-            } finally {
-              ctx.actorService.stopActor(ctx.actor);
             }
             if (shouldExitWithError) {
               process.exitCode = 1;

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -25,7 +25,6 @@ import {
   deriveActiveFrame,
   SENTINEL_ENTRY,
   type FrameKey,
-  type AnyActorRef,
   type ResolvedStep,
   type RunbookState,
   type RunbookCompletedPayload,
@@ -143,8 +142,6 @@ export interface TransitionContext {
   state: RunbookState;
   /** Parsed runbook steps */
   steps: ResolvedStep[];
-  /** XState actor for the runbook */
-  actor: AnyActorRef;
   /** Current working directory */
   cwd: string;
   /** How terminal follow-on execution should release this runbook from session targeting. */
@@ -159,7 +156,7 @@ export type BuildTransitionContextResult =
 /**
  * Build full transition context from resolved state.
  *
- * Loads runbook, parses steps, and creates actor.
+ * Loads runbook and parses steps.
  *
  * @param output - Output emitter for CLI output
  * @param cwd - Current working directory
@@ -167,7 +164,6 @@ export type BuildTransitionContextResult =
  * @param options.claimId - Claim id to resolve instead of the default stack
  * @returns TransitionContext or null if no active runbook
  * @throws {Error} if state is missing runbookSrc (corrupted state)
- * @throws {Error} if runbook engine fails to initialize
  */
 export async function buildTransitionContext(
   output: OutputEmitter,
@@ -198,10 +194,6 @@ export async function buildTransitionContext(
     active.kind === 'claim' ? 'release-runbook' : 'stack-pop';
   const readonlySteps = getRunbookFromState(state, cwd);
   const steps = [...readonlySteps]; // Convert to mutable array for TransitionContext
-  const actor = await actorService.createActor(state.id, steps);
-  if (!actor) {
-    throw new Error('Failed to initialize runbook engine');
-  }
 
   return {
     kind: 'ready',
@@ -213,7 +205,6 @@ export async function buildTransitionContext(
       lifecycleService,
       state,
       steps,
-      actor,
       cwd,
       terminalReleaseMode,
     },
@@ -280,7 +271,7 @@ export interface ExplicitTarget {
  * transition event to the runbook actor, orchestrates step-level changes, and runs the execution loop
  * as required. Emits CLI output for actions, completions, runbook completion, and stopped conditions.
  *
- * @param ctx - Runtime transition context containing output, services, current state, parsed steps, actor, and cwd
+ * @param ctx - Runtime transition context containing output, services, current state, parsed steps, and cwd
  * @param config - Transition configuration that determines the event type, persisted result, action-result mapping, and terminal policy
  * @param explicitTarget - Optional explicit step/substep target (e.g., "2.1") and optional raw `--index` value to target a specific iteration
  * @returns `'continue'` when execution proceeds or completes normally, `'stopped'` when a terminal stop was reached
@@ -292,7 +283,11 @@ export async function executeTransition(
   config: TransitionConfig,
   explicitTarget?: ExplicitTarget,
 ): Promise<'continue' | 'stopped'> {
-  const { output, manager, actorService, state, steps, actor, cwd, lifecycleService } = ctx;
+  const { output, manager, actorService, state, steps, cwd, lifecycleService } = ctx;
+  const stateIsFresh = await actorService.assertFreshState(state.id, steps);
+  if (!stateIsFresh) {
+    throw new Error('Failed to initialize runbook engine');
+  }
   const ensured = await lifecycleService.ensureActiveEntry(state.id, undefined, state);
   const activeState = ensured.state;
   const activeStep = findStepOrThrow(steps, activeState.step);
@@ -476,12 +471,13 @@ export async function executeTransition(
   const previousState = { ...activeState };
   const currentStep = findStepOrThrow(steps, previousState.step);
 
-  actor.send({ type: config.eventType });
-  const { state: actorUpdatedState, snapshot: rawSnapshot } = await actorService.updateFromActor(
-    activeState.id,
-    actor,
-    steps,
-  );
+  const syncResult = await actorService.sendAndSync(activeState.id, steps, {
+    type: config.eventType,
+  });
+  if (!syncResult) {
+    throw new Error('Failed to initialize runbook engine');
+  }
+  const { state: actorUpdatedState, snapshot: rawSnapshot } = syncResult;
 
   const actionType = parseActionType(extractLastAction(rawSnapshot));
 

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -162,7 +162,8 @@ export type BuildTransitionContextResult =
  * @param cwd - Current working directory
  * @param options - Optional explicit claim-id target
  * @param options.claimId - Claim id to resolve instead of the default stack
- * @returns TransitionContext or null if no active runbook
+ * @returns `{ kind: 'ready', ctx }` when a target is resolved; `{ kind: 'none' }` when
+ *   there is no active runbook; `{ kind: 'stale_claim' }` when the active claim is stale.
  * @throws {Error} if state is missing runbookSrc (corrupted state)
  */
 export async function buildTransitionContext(

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -286,7 +286,7 @@ export async function executeTransition(
   const { output, manager, actorService, state, steps, cwd, lifecycleService } = ctx;
   const stateIsFresh = await actorService.assertFreshState(state.id, steps);
   if (!stateIsFresh) {
-    throw new Error('Failed to initialize runbook engine');
+    throw new Error('Runbook state is stale or mismatched with current definition');
   }
   const ensured = await lifecycleService.ensureActiveEntry(state.id, undefined, state);
   const activeState = ensured.state;
@@ -475,7 +475,7 @@ export async function executeTransition(
     type: config.eventType,
   });
   if (!syncResult) {
-    throw new Error('Failed to initialize runbook engine');
+    throw new Error('Failed to dispatch transition to runbook engine');
   }
   const { state: actorUpdatedState, snapshot: rawSnapshot } = syncResult;
 

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -276,7 +276,6 @@ type TransitionApplicationResult =
 
 interface ObserveAndOrchestrateArgs {
   manager: RunbookStateManager;
-  actorService: RunbookActorService;
   sessionService: SessionService;
   lifecycleService: ExecutionLifecycleService;
   emitter: ExecutionEventEmitter;
@@ -292,7 +291,9 @@ interface ObserveAndOrchestrateArgs {
   postState: RunbookState;
 }
 
-type ApplyDrainedCompletionArgs = Omit<ObserveAndOrchestrateArgs, 'syncSnapshot' | 'postState'>;
+type ApplyDrainedCompletionArgs = Omit<ObserveAndOrchestrateArgs, 'syncSnapshot' | 'postState'> & {
+  actorService: RunbookActorService;
+};
 type ObserveCommandTransitionArgs = ObserveAndOrchestrateArgs;
 
 const EXECUTION_TERMINAL_POLICY: TransitionOrchestrationPolicy = {
@@ -1088,7 +1089,6 @@ export async function runExecutionLoop(
     }
     const transitionResult = await observeCommandTransition({
       manager,
-      actorService,
       sessionService,
       lifecycleService,
       emitter,

--- a/packages/core/__tests__/runbook/__snapshots__/compiler-machine-structural-snapshot.test.ts.snap
+++ b/packages/core/__tests__/runbook/__snapshots__/compiler-machine-structural-snapshot.test.ts.snap
@@ -7,6 +7,9 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     "forStack": [],
     "frontmatterOutputs": [],
     "iterationRetryCount": 0,
+    "lastAction": {
+      "type": "START",
+    },
     "lifecycle": "running",
     "parentRetryCount": 0,
     "retryCount": 0,
@@ -366,6 +369,9 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     "forStack": [],
     "frontmatterOutputs": [],
     "iterationRetryCount": 0,
+    "lastAction": {
+      "type": "START",
+    },
     "lifecycle": "running",
     "parentRetryCount": 0,
     "retryCount": 0,
@@ -776,6 +782,9 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     "forStack": [],
     "frontmatterOutputs": [],
     "iterationRetryCount": 0,
+    "lastAction": {
+      "type": "START",
+    },
     "lifecycle": "running",
     "parentRetryCount": 0,
     "retryCount": 0,
@@ -1033,6 +1042,9 @@ exports[`compileRunbookToMachine (lifecycle cleanup structural snapshot) produce
     "forStack": [],
     "frontmatterOutputs": [],
     "iterationRetryCount": 0,
+    "lastAction": {
+      "type": "START",
+    },
     "lifecycle": "running",
     "parentRetryCount": 0,
     "retryCount": 0,

--- a/packages/core/__tests__/runbook/actor-service-pending-effects.test.ts
+++ b/packages/core/__tests__/runbook/actor-service-pending-effects.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { assign, fromPromise, setup } from 'xstate';
+import type { ResolvedRunbook, ResolvedStep } from '../../src/runbook/types.js';
+import { makeBaseStep } from '../helpers/step-factories.js';
+
+const pendingTag = 'pending-machine-effect';
+let effectStarted = 0;
+let releaseEffect: (() => void) | undefined;
+let compileMode: 'initialize' | 'transition' = 'transition';
+
+function waitForRelease(): Promise<void> {
+  effectStarted += 1;
+  return new Promise((resolve) => {
+    releaseEffect = resolve;
+  });
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error('Timed out waiting for synthetic pending effect to start');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+jest.unstable_mockModule('../../src/runbook/compiler.js', () => ({
+  PENDING_MACHINE_EFFECT_TAG: pendingTag,
+  compileRunbookToMachine: () =>
+    setup({
+      actors: {
+        pendingEffect: fromPromise(waitForRelease),
+      },
+      actions: {
+        markPass: assign({ lastAction: () => ({ type: 'CONTINUE' as const }) }),
+        markFail: assign({ lastAction: () => ({ type: 'STOP' as const }) }),
+        markGoto: assign({ lastAction: () => ({ type: 'GOTO' as const, target: '4' }) }),
+        markStart: assign({ lastAction: () => ({ type: 'START' as const }) }),
+      },
+    }).createMachine({
+      id: 'runbook',
+      initial: compileMode === 'initialize' ? 'bootEffect' : 'step::1',
+      context: {
+        retryCount: 0,
+        variables: {},
+        forStack: [],
+        lifecycle: 'running',
+        frontmatterOutputs: [],
+        finalVars: {},
+      },
+      states: {
+        bootEffect: {
+          tags: [pendingTag],
+          invoke: { src: 'pendingEffect', onDone: { target: 'step::1', actions: 'markStart' } },
+        },
+        'step::1': {
+          on: {
+            PASS: 'passEffect',
+            FAIL: 'failEffect',
+            GOTO: 'gotoEffect',
+          },
+        },
+        passEffect: {
+          tags: [pendingTag],
+          invoke: { src: 'pendingEffect', onDone: { target: 'step::2', actions: 'markPass' } },
+        },
+        failEffect: {
+          tags: [pendingTag],
+          invoke: { src: 'pendingEffect', onDone: { target: 'step::3', actions: 'markFail' } },
+        },
+        gotoEffect: {
+          tags: [pendingTag],
+          invoke: { src: 'pendingEffect', onDone: { target: 'step::4', actions: 'markGoto' } },
+        },
+        'step::2': {},
+        'step::3': {},
+        'step::4': {},
+      },
+    }),
+}));
+
+const { RunbookStateManager } = await import('../../src/runbook/state.js');
+const { RunbookActorService } = await import('../../src/runbook/actor-service.js');
+
+function steps(): ResolvedStep[] {
+  return ['1', '2', '3', '4'].map((name) =>
+    makeBaseStep({
+      name,
+      description: `Step ${name}`,
+      transitions: {
+        pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+        fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+      },
+    }),
+  );
+}
+
+describe('RunbookActorService pending machine effects', () => {
+  let testDir: string;
+  let manager: InstanceType<typeof RunbookStateManager>;
+  let service: InstanceType<typeof RunbookActorService>;
+  let runbook: ResolvedRunbook;
+
+  beforeEach(async () => {
+    effectStarted = 0;
+    releaseEffect = undefined;
+    compileMode = 'transition';
+    testDir = await mkdtemp(join(tmpdir(), 'actor-pending-effects-'));
+    manager = new RunbookStateManager(testDir);
+    service = new RunbookActorService(manager);
+    runbook = { title: 'Pending effects', description: 'Synthetic wait tests', steps: steps() };
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('initializeState waits for a tagged startup effect before persisting', async () => {
+    compileMode = 'initialize';
+    const state = await manager.create({ source: 'project', path: 'pending.md' }, runbook, {
+      runbookPath: 'pending.md',
+      frontmatterOutputs: [],
+    });
+
+    const pending = service.initializeState(state.id, [...runbook.steps]);
+    await waitUntil(() => effectStarted === 1);
+    expect((await manager.load(state.id))?.snapshot).toBeUndefined();
+
+    releaseEffect?.();
+    const initialized = await pending;
+
+    expect(initialized?.step).toBe('1');
+    expect(initialized?.lastAction).toEqual({ type: 'START' });
+    expect(JSON.stringify(initialized?.snapshot)).not.toContain('bootEffect');
+  });
+
+  it.each([
+    ['PASS', { type: 'PASS' as const }, '2'],
+    ['FAIL', { type: 'FAIL' as const }, '3'],
+    ['GOTO', { type: 'GOTO' as const, target: { step: '4' } }, '4'],
+  ])('sendAndSync waits for a tagged %s effect before persisting', async (_name, event, expectedStep) => {
+    const state = await manager.create({ source: 'project', path: 'pending.md' }, runbook, {
+      runbookPath: 'pending.md',
+      frontmatterOutputs: [],
+    });
+    await service.initializeState(state.id, [...runbook.steps]);
+
+    const pending = service.sendAndSync(state.id, [...runbook.steps], event);
+    await waitUntil(() => effectStarted === 1);
+    expect((await manager.load(state.id))?.step).toBe('1');
+
+    releaseEffect?.();
+    const synced = await pending;
+
+    expect(synced?.state.step).toBe(expectedStep);
+    expect(JSON.stringify(synced?.state.snapshot)).not.toMatch(/passEffect|failEffect|gotoEffect/);
+  });
+});

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -521,6 +521,23 @@ echo hi
 
       await expect(manager.load(state.id)).resolves.toMatchObject({ lifecycle: 'stopped' });
     });
+
+    it('does not persist stopped lifecycle when post-effect actor sync rejects stale state', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      const syncError = new Error('Persisted stateValue "step::missing" references missing step');
+      const updateFromActor = jest
+        .spyOn(actorService, 'updateFromActor')
+        .mockRejectedValue(syncError);
+
+      await expect(actorService.sendAndSync(state.id, mockSteps, { type: 'PASS' })).rejects.toThrow(
+        syncError,
+      );
+
+      expect(updateFromActor).toHaveBeenCalled();
+      await expect(manager.load(state.id)).resolves.toMatchObject({ lifecycle: 'running' });
+    });
   });
 
   describe('FOR loop context via actor', () => {
@@ -605,6 +622,37 @@ echo hi
       // FOR fields should be cleared
       expect(completed.forStack).toBeUndefined();
       expect(completed.iterationResults).toBeUndefined();
+    });
+
+    it('mirrors terminal internal-failure lastAction onto persisted runbook state', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      const actor = mockActor({
+        value: 'STOPPED',
+        context: {
+          variables: {},
+          lifecycle: 'stopped',
+          retryCount: 0,
+          lastAction: {
+            type: 'OUTPUT_CAPTURE_FAILED' as const,
+            message: 'disk full',
+          },
+        },
+      });
+
+      const { state: updated } = await actorService.updateFromActor(state.id, actor, mockSteps);
+
+      expect(updated.lastAction).toEqual({
+        type: 'OUTPUT_CAPTURE_FAILED',
+        message: 'disk full',
+      });
+      await expect(manager.load(state.id)).resolves.toMatchObject({
+        lastAction: {
+          type: 'OUTPUT_CAPTURE_FAILED',
+          message: 'disk full',
+        },
+      });
     });
   });
 
@@ -944,6 +992,24 @@ echo hi
       await writeFile(filePath, JSON.stringify(raw));
 
       await expect(actorService.assertFreshState(state.id, mockSteps)).rejects.toThrow(
+        /Unsupported snapshot\.value shape/,
+      );
+    });
+
+    it('rejects persisted pending-effect __capture snapshots as stale state', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+        frontmatterOutputs: [],
+      });
+      const filePath = join(testDir, '.rundown', 'runs', `${state.id}.json`);
+      const raw = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
+      raw.snapshot = { value: { 'step::1': '__capture' } };
+      await writeFile(filePath, JSON.stringify(raw));
+
+      await expect(actorService.assertFreshState(state.id, mockSteps)).rejects.toThrow(
+        /Unsupported snapshot\.value shape/,
+      );
+      await expect(actorService.createActor(state.id, mockSteps)).rejects.toThrow(
         /Unsupported snapshot\.value shape/,
       );
     });
@@ -1403,8 +1469,8 @@ describe('stateValueAsString', () => {
     expect(stateValueAsString({ 'step::1': 'idle' })).toBe('step::1');
   });
 
-  it('returns the leaf ID for a compound-leaf __capture substate', () => {
-    expect(stateValueAsString({ 'step::1::1': '__capture' })).toBe('step::1::1');
+  it('returns null for a compound-leaf __capture substate', () => {
+    expect(stateValueAsString({ 'step::1::1': '__capture' })).toBeNull();
   });
 
   it('returns null for an unrecognized substate name', () => {

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -361,6 +361,48 @@ exit 1
         { id: '2', frameKey, status: 'pending' },
       ]);
     });
+
+    it('does not reload state when active substeps are already initialized', async () => {
+      const steps = createRunbook(`## 1. Parent
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.1 First
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.2 Second
+- PASS CONTINUE
+- FAIL STOP
+`);
+      const frameKey = buildFrameKey('1');
+      const state = await manager.create(
+        { source: 'project', path: 'substeps-initialized.md' },
+        { title: 'Substep reload', description: 'Fast path coverage', steps },
+        { runbookPath: 'substeps-initialized.md', frontmatterOutputs: [] },
+      );
+      const initializedState = await manager.update(state.id, {
+        substep: '1',
+        activeFrameKey: frameKey,
+        substepStates: [
+          { id: '1', frameKey, status: 'pending' },
+          { id: '2', frameKey, status: 'pending' },
+        ],
+      });
+      const load = jest.spyOn(manager, 'load');
+
+      await (
+        actorService as unknown as {
+          initializeActiveSubsteps: (
+            id: string,
+            state: RunbookState,
+            steps: ResolvedStep[],
+          ) => Promise<RunbookState>;
+        }
+      ).initializeActiveSubsteps(state.id, initializedState, steps);
+
+      expect(load).not.toHaveBeenCalled();
+    });
   });
 
   describe('sendAndSync', () => {
@@ -422,6 +464,26 @@ echo hi
       expect(persisted?.lifecycle).toBe('completed');
       expect(persisted?.variables).toEqual({ Foo: 'persisted-value' });
       expect(JSON.stringify(persisted?.snapshot)).not.toContain('__capture');
+    });
+
+    it('persists stopped lifecycle when machine-owned effects fail after an event send', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      const effectsError = new Error('machine effect timed out');
+      (
+        actorService as unknown as {
+          waitForMachineEffects: () => Promise<void>;
+        }
+      ).waitForMachineEffects = async () => {
+        throw effectsError;
+      };
+
+      await expect(actorService.sendAndSync(state.id, mockSteps, { type: 'PASS' })).rejects.toThrow(
+        effectsError,
+      );
+
+      await expect(manager.load(state.id)).resolves.toMatchObject({ lifecycle: 'stopped' });
     });
   });
 

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -272,6 +272,95 @@ exit 1
       expect(result).not.toBeNull();
       expect(result?.step).toBe('1');
     });
+
+    it('bootstraps first substep launch state through core initialization', async () => {
+      const steps = createRunbook(`## 1. Parent
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.1 First
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.2 Second
+- PASS CONTINUE
+- FAIL STOP
+
+## 2. Done
+- PASS COMPLETE
+- FAIL STOP
+`);
+      const runbook = {
+        title: 'Substep launch',
+        description: 'Launch initialization belongs to core',
+        steps,
+      };
+      const state = await manager.create({ source: 'project', path: 'substeps.md' }, runbook, {
+        runbookPath: 'substeps.md',
+        frontmatterOutputs: [],
+      });
+
+      const initialized = await actorService.initializeState(state.id, steps);
+
+      expect(initialized).not.toBeNull();
+      expect(initialized?.step).toBe('1');
+      expect(initialized?.substep).toBe('1');
+      expect(initialized?.lastAction).toEqual({ type: 'START' });
+      expect(initialized?.activeFrameKey).toBe(buildFrameKey('1'));
+      expect(initialized?.activeEntry).toBe(1);
+      expect(initialized?.frameEntries).toEqual({ [buildFrameKey('1')]: 1 });
+      expect(initialized?.substepStates).toEqual([
+        { id: '1', frameKey: buildFrameKey('1'), status: 'pending' },
+        { id: '2', frameKey: buildFrameKey('1'), status: 'pending' },
+      ]);
+    });
+
+    it('bootstraps first FOR substep state in the active iteration frame', async () => {
+      const steps = createRunbook(`## 1. Loop
+- FOR i IN 1 TO 2
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 First
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.2 Second
+- PASS CONTINUE
+- FAIL STOP
+
+## 2. Done
+- PASS COMPLETE
+- FAIL STOP
+`);
+      const runbook = {
+        title: 'FOR launch',
+        description: 'FOR launch frame bootstrap belongs to core',
+        steps,
+      };
+      const state = await manager.create({ source: 'project', path: 'for.md' }, runbook, {
+        runbookPath: 'for.md',
+        frontmatterOutputs: [],
+      });
+
+      const initialized = await actorService.initializeState(state.id, steps);
+      const frameKey = buildFrameKey('1', 1);
+
+      expect(initialized).not.toBeNull();
+      expect(initialized?.step).toBe('1');
+      expect(initialized?.substep).toBe('1');
+      expect(initialized?.lastAction).toEqual({ type: 'START' });
+      expect(initialized?.forStack?.[0]).toEqual(
+        expect.objectContaining({ stepId: '1', iteration: 1, variable: 'i', start: 1, end: 2 }),
+      );
+      expect(initialized?.activeFrameKey).toBe(frameKey);
+      expect(initialized?.activeEntry).toBe(1);
+      expect(initialized?.frameEntries).toEqual({ [frameKey]: 1 });
+      expect(initialized?.substepStates).toEqual([
+        { id: '1', frameKey, status: 'pending' },
+        { id: '2', frameKey, status: 'pending' },
+      ]);
+    });
   });
 
   describe('sendAndSync', () => {
@@ -727,6 +816,21 @@ echo hi
       await writeFile(filePath, JSON.stringify(raw));
 
       await expect(actorService.createActor(state.id, mockSteps)).rejects.toThrow(
+        /Stale runbook state.*missing frontmatter outputs/,
+      );
+    });
+
+    it('validates stale run state without creating an actor', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+        frontmatterOutputs: [],
+      });
+      const filePath = join(testDir, '.rundown', 'runs', `${state.id}.json`);
+      const raw = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
+      delete raw.frontmatterOutputs;
+      await writeFile(filePath, JSON.stringify(raw));
+
+      await expect(actorService.assertFreshState(state.id, mockSteps)).rejects.toThrow(
         /Stale runbook state.*missing frontmatter outputs/,
       );
     });

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -403,6 +403,42 @@ exit 1
 
       expect(load).not.toHaveBeenCalled();
     });
+
+    it('hydrateSnapshot overlays RunbookState.substep onto actor context after first-substep bootstrap', async () => {
+      const steps = createRunbook(`## 1. Parent
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.1 First
+- PASS CONTINUE
+- FAIL STOP
+
+### 1.2 Second
+- PASS CONTINUE
+- FAIL STOP
+
+## 2. Done
+- PASS COMPLETE
+- FAIL STOP
+`);
+      const runbook = { title: 'Hydrate substep', description: '', steps };
+      const state = await manager.create({ source: 'project', path: 'test.md' }, runbook, {
+        runbookPath: 'test.md',
+        frontmatterOutputs: [],
+      });
+
+      // initializeState calls initializeActiveSubsteps which writes RunbookState.substep = '1'
+      // via a direct manager.update — the snapshot is NOT updated at that point.
+      const initialized = await actorService.initializeState(state.id, steps);
+      expect(initialized?.substep).toBe('1');
+
+      // On the next createActor call, hydrateSnapshot must overlay RunbookState.substep
+      // onto context.substep so CLI and machine agree on the current substep position.
+      const actor = await actorService.createActor(state.id, steps);
+      expect(actor).not.toBeNull();
+      const snap = actor!.getPersistedSnapshot() as unknown as { context: { substep?: string } };
+      expect(snap.context.substep).toBe('1');
+    });
   });
 
   describe('sendAndSync', () => {

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -897,6 +897,51 @@ echo hi
       );
     });
 
+    it('throws for an unrecognized snapshot.value shape', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+        frontmatterOutputs: [],
+      });
+      const filePath = join(testDir, '.rundown', 'runs', `${state.id}.json`);
+      const raw = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
+      raw.snapshot = { value: { weird: true } };
+      await writeFile(filePath, JSON.stringify(raw));
+
+      await expect(actorService.assertFreshState(state.id, mockSteps)).rejects.toThrow(
+        /Unsupported snapshot\.value shape/,
+      );
+    });
+
+    it('throws for a malformed legacy state ID in snapshot.value', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+        frontmatterOutputs: [],
+      });
+      const filePath = join(testDir, '.rundown', 'runs', `${state.id}.json`);
+      const raw = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
+      raw.snapshot = { value: 'some-old-format' };
+      await writeFile(filePath, JSON.stringify(raw));
+
+      await expect(actorService.assertFreshState(state.id, mockSteps)).rejects.toThrow(
+        /Unsupported persisted stateValue/,
+      );
+    });
+
+    it('throws when snapshot references a step no longer in the runbook', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+        frontmatterOutputs: [],
+      });
+      const filePath = join(testDir, '.rundown', 'runs', `${state.id}.json`);
+      const raw = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
+      raw.snapshot = { value: 'step::nonexistent-step' };
+      await writeFile(filePath, JSON.stringify(raw));
+
+      await expect(actorService.assertFreshState(state.id, mockSteps)).rejects.toThrow(
+        /references missing step "nonexistent-step"/,
+      );
+    });
+
     it('seeds compiler context.templateVars from RunbookState.templateVars (flattened)', async () => {
       const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
         runbookPath: 'test.md',

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -8781,7 +8781,7 @@ echo hi
     });
 
     it('rejects relative transition targets that do not resolve to child states', () => {
-      expect(() =>
+      expect(() => {
         validateGraphForTest(
           {
             'step::1': {
@@ -8795,12 +8795,12 @@ echo hi
                 idle: {},
               },
             },
-          } as any,
+          },
           'step::1',
           new Set(['COMPLETE', 'STOPPED']),
           '#STOPPED',
-        ),
-      ).toThrow(/unknown relative target "\.__missing"/);
+        );
+      }).toThrow(/unknown relative target "\.__missing"/);
     });
 
     it('captures (no-op) with empty channels and still fires PASS', async () => {

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -7,6 +7,7 @@ import {
   compileRunbookToMachine,
   MAX_FILE_ITERATIONS,
   PENDING_MACHINE_EFFECT_TAG,
+  validateGraphForTest,
 } from '../../src/runbook/compiler.js';
 import type { RunbookContext } from '../../src/runbook/compiler.js';
 import { readArtifactManifest } from '../../src/runbook/artifact-manifest.js';
@@ -8777,6 +8778,29 @@ echo hi
 
       // No pendingResult-like context field
       expect('pendingResult' in machine.config.context).toBe(false);
+    });
+
+    it('rejects relative transition targets that do not resolve to child states', () => {
+      expect(() =>
+        validateGraphForTest(
+          {
+            'step::1': {
+              initial: 'idle',
+              on: {
+                COMMAND_RESULT: {
+                  target: '.__missing',
+                },
+              },
+              states: {
+                idle: {},
+              },
+            },
+          } as any,
+          'step::1',
+          new Set(['COMPLETE', 'STOPPED']),
+          '#STOPPED',
+        ),
+      ).toThrow(/unknown relative target "\.__missing"/);
     });
 
     it('captures (no-op) with empty channels and still fires PASS', async () => {

--- a/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
+++ b/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
@@ -33,6 +33,19 @@ describe('ExecutionLifecycleService', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
+  it('clears stale lastResult through a typed core operation', async () => {
+    const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+      runbookPath: 'test.md',
+      frontmatterOutputs: [],
+    });
+    await manager.update(state.id, { lastResult: 'fail' });
+
+    await service.clearLastResult(state.id);
+
+    const updated = await manager.load(state.id);
+    expect(updated?.lastResult).toBeUndefined();
+  });
+
   describe('ensureActiveEntry', () => {
     it('initializes entry to 1 on first call', async () => {
       const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {

--- a/packages/core/__tests__/runbook/transition-kernel.test.ts
+++ b/packages/core/__tests__/runbook/transition-kernel.test.ts
@@ -651,4 +651,28 @@ describe('transition-kernel', () => {
       ).toBeUndefined();
     });
   });
+
+  describe('RETRY_ERROR lastAction', () => {
+    it('extracts and classifies retry hook failures as internal failures', () => {
+      const snapshot = {
+        context: {
+          lastAction: {
+            type: 'RETRY_ERROR',
+            code: 'RD-902',
+            message: 'retry hook failed',
+          },
+        },
+      };
+
+      const action = extractLastAction(snapshot);
+      expect(action).toEqual({
+        type: 'RETRY_ERROR',
+        code: 'RD-902',
+        message: 'retry hook failed',
+      });
+      expect(isInternalFailureLastAction(action)).toBe(true);
+      expect(parseActionType(action)).toBe('RETRY_ERROR');
+      expect(deriveStoppedReason(action)).toBe('retry_error_failed');
+    });
+  });
 });

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -146,6 +146,7 @@ export interface RunbookStoppedPayload {
     | 'user_abort'
     | 'delegation_resolution_failed'
     | 'nested_delegation_forbidden'
+    | 'retry_error_failed'
     | 'output_capture_failed';
 }
 

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -100,12 +100,12 @@ const MACHINE_EFFECT_TIMEOUT_MS = 30_000;
  * Overlay RunbookState's frame-scoped fields onto a persisted XState snapshot
  * so hydration reflects CLI-level writes that happen between actor transitions.
  *
- * `rd delegate`, `rd pass`, `rd fail`, `rd claim`, `rd abort` write directly to
- * `RunbookState.substepStates` via {@link RunbookStateManager} — those writes
- * never reach the actor snapshot, which is only refreshed on actor transitions.
- * Without this overlay, the retry hook (and any other consumer that reads
- * `context.substepStates` during hydration) sees a stale snapshot view and
- * produces an empty frontier for manually-issued delegations.
+ * `rd delegate`, `rd pass`, `rd fail`, `rd claim`, `rd abort`, and
+ * `initializeActiveSubsteps` write directly to `RunbookState.substepStates`,
+ * `RunbookState.activeFrameKey`, and `RunbookState.substep` via
+ * {@link RunbookStateManager} — those writes never reach the actor snapshot,
+ * which is only refreshed on actor transitions. Without this overlay, the next
+ * `createActor()` sees a stale snapshot view with the wrong substep context.
  *
  * Initial bootstrap (no persisted snapshot) — the compiler options already seed
  * `substepStates`/`activeFrameKey` into `initial.context`, so no overlay needed.
@@ -138,6 +138,7 @@ function hydrateSnapshot(
       ...baseSnapshot.context,
       substepStates: state.substepStates ?? baseSnapshot.context.substepStates,
       activeFrameKey: state.activeFrameKey ?? baseSnapshot.context.activeFrameKey,
+      substep: state.substep ?? baseSnapshot.context.substep,
     },
   } as unknown as Snapshot<unknown>;
 }

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -21,8 +21,10 @@ import {
   type RunbookEvent,
   type RunbookContext,
 } from './compiler.js';
+import { ExecutionLifecycleService } from './execution-lifecycle-service.js';
 import { flattenTemplateVars } from './output-evaluator.js';
 import { merge } from './state-update-ops.js';
+import { deriveActiveFrame } from './targeting.js';
 import { resolvedStepHasSubsteps } from '@rundown-org/parser';
 import { logger } from '../logger.js';
 
@@ -301,6 +303,26 @@ export class RunbookActorService {
   }
 
   /**
+   * Assert that a persisted runbook state is valid for the current runtime.
+   *
+   * This runs the same core freshness guard used by actor creation without
+   * starting an actor or mutating persisted state. CLI paths that may perform
+   * non-machine writes before a transition can call this to fail closed on
+   * stale state before any display or completion fields are updated.
+   *
+   * @param id - Runbook run ID
+   * @param steps - Resolved steps for machine compilation
+   * @returns `true` when state exists and passes freshness checks; `false` when no state exists
+   * @throws {Error} When the loaded state is stale
+   */
+  async assertFreshState(id: string, steps: ResolvedStep[]): Promise<boolean> {
+    const state = await this.manager.load(id);
+    if (!state) return false;
+    this.compileMachineFromState(id, state, steps);
+    return true;
+  }
+
+  /**
    * Synchronise persisted state from actor snapshot.
    *
    * Extracts step/substep position, variables, forStack, and lastAction
@@ -468,11 +490,53 @@ export class RunbookActorService {
     const actor = await this.createActor(id, steps);
     if (!actor) return null;
     try {
-      const { state } = await this.updateFromActor(id, actor, steps);
-      return state;
+      const { state: synced } = await this.persistAfterMachineEffects(id, actor, steps);
+      const lifecycle = new ExecutionLifecycleService(this.manager);
+      const { state: withActiveEntry } = await lifecycle.ensureActiveEntry(id, undefined, synced);
+      return await this.initializeActiveSubsteps(id, withActiveEntry, steps);
     } finally {
       this.stopActor(actor);
     }
+  }
+
+  /**
+   * Ensure the active substep frame has persisted substep state.
+   *
+   * @param id - Runbook state ID
+   * @param state - Persisted state after actor synchronization and active-entry bootstrap
+   * @param steps - Parsed runbook steps
+   * @returns State reloaded after any substep bootstrap writes
+   */
+  private async initializeActiveSubsteps(
+    id: string,
+    state: RunbookState,
+    steps: ResolvedStep[],
+  ): Promise<RunbookState> {
+    const currentStep = steps.find((step) => step.name === state.step);
+    if (
+      !currentStep ||
+      !resolvedStepHasSubsteps(currentStep) ||
+      currentStep.substeps.length === 0
+    ) {
+      return state;
+    }
+
+    const activeFrame = deriveActiveFrame(state);
+    const alreadyInitialized = state.substepStates?.some(
+      (substepState) => substepState.frameKey === activeFrame.frameKey,
+    );
+
+    if (!alreadyInitialized) {
+      await this.manager.initializeSubsteps(id, currentStep.substeps, activeFrame.frameKey);
+    }
+
+    if (state.substep !== undefined) {
+      const reloaded = await this.manager.load(id);
+      if (!reloaded) throw new Error(`Runbook ${id} not found after substep initialization`);
+      return reloaded;
+    }
+
+    return this.manager.update(id, { substep: currentStep.substeps[0].id });
   }
 
   /**
@@ -493,6 +557,23 @@ export class RunbookActorService {
         !(snapshot as { hasTag: (tag: string) => boolean }).hasTag(PENDING_MACHINE_EFFECT_TAG),
       { timeout: MACHINE_EFFECT_TIMEOUT_MS },
     );
+  }
+
+  /**
+   * Wait for transient machine-owned effects, then persist the actor snapshot.
+   *
+   * @param id - Runbook state ID
+   * @param actor - Started actor to synchronize from
+   * @param steps - Parsed runbook steps
+   * @returns Updated persisted state and raw snapshot
+   */
+  private async persistAfterMachineEffects(
+    id: string,
+    actor: AnyActorRef,
+    steps: ResolvedStep[],
+  ): Promise<{ state: RunbookState; snapshot: unknown }> {
+    await this.waitForMachineEffects(actor);
+    return this.updateFromActor(id, actor, steps);
   }
 
   /**
@@ -583,8 +664,7 @@ export class RunbookActorService {
       }
 
       try {
-        await this.waitForMachineEffects(actor);
-        const { state, snapshot } = await this.updateFromActor(id, actor, steps);
+        const { state, snapshot } = await this.persistAfterMachineEffects(id, actor, steps);
         return { state, snapshot };
       } catch (effectsErr) {
         // The command has already executed (COMMAND_RESULT was sent above).

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -70,6 +70,7 @@ type PersistedRunbookSnapshot = {
  *
  * @param value - The raw `snapshot.value` returned by XState
  * @returns The flattened leaf/terminal id, or `null` for unrecognized shapes
+ * @internal
  */
 export function stateValueAsString(value: unknown): string | null {
   if (typeof value === 'string') return value;
@@ -528,6 +529,10 @@ export class RunbookActorService {
 
     if (!alreadyInitialized) {
       await this.manager.initializeSubsteps(id, currentStep.substeps, activeFrame.frameKey);
+    }
+
+    if (alreadyInitialized && state.substep !== undefined) {
+      return state;
     }
 
     if (state.substep !== undefined) {

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -81,7 +81,7 @@ export function stateValueAsString(value: unknown): string | null {
     Object.keys(value).length === 1
   ) {
     const [leafId, substate] = Object.entries(value as Record<string, unknown>)[0];
-    if (substate === 'idle' || substate === '__capture') return leafId;
+    if (substate === 'idle') return leafId;
   }
   return null;
 }
@@ -157,6 +157,35 @@ export class RunbookActorService {
    * @param manager - State manager for persisting runbook state to disk
    */
   constructor(private readonly manager: RunbookStateManager) {}
+
+  private assertFreshSnapshotValue(
+    id: string,
+    snapshot: PersistedRunbookSnapshot,
+    steps: ResolvedStep[],
+  ): void {
+    const stateValue = stateValueAsString(snapshot.value);
+    if (stateValue === null) {
+      throw new Error(
+        `Unsupported snapshot.value shape for runbook "${id}": ${JSON.stringify(snapshot.value)}`,
+      );
+    }
+    if (stateValue === 'COMPLETE' || stateValue === 'STOPPED') return;
+
+    const match = /^step::(.+?)(?:::(.+))?$/.exec(stateValue);
+    if (!match) {
+      throw new Error(
+        `Unsupported persisted stateValue "${stateValue}" for runbook "${id}". ` +
+          'Prune stale runbook state and restart execution.',
+      );
+    }
+    const stepName = match[1];
+    if (!steps.find((s) => s.name === stepName)) {
+      throw new Error(
+        `Persisted stateValue "${stateValue}" for runbook "${id}" references missing step "${stepName}". ` +
+          'Prune stale runbook state and restart execution.',
+      );
+    }
+  }
 
   /**
    * Compile a runbook machine from persisted state, asserting freshness.
@@ -252,6 +281,9 @@ export class RunbookActorService {
     const state = await this.manager.load(id);
     if (!state) return null;
 
+    if (state.snapshot) {
+      this.assertFreshSnapshotValue(id, state.snapshot as PersistedRunbookSnapshot, steps);
+    }
     const machine = this.compileMachineFromState(id, state, steps);
     const snapshot = hydrateSnapshot(machine, state);
 
@@ -322,29 +354,7 @@ export class RunbookActorService {
     const state = await this.manager.load(id);
     if (!state) return false;
     if (state.snapshot) {
-      const snapshot = state.snapshot as PersistedRunbookSnapshot;
-      const stateValue = stateValueAsString(snapshot.value);
-      if (stateValue === null) {
-        throw new Error(
-          `Unsupported snapshot.value shape for runbook "${id}": ${JSON.stringify(snapshot.value)}`,
-        );
-      }
-      if (stateValue !== 'COMPLETE' && stateValue !== 'STOPPED') {
-        const match = /^step::(.+?)(?:::(.+))?$/.exec(stateValue);
-        if (!match) {
-          throw new Error(
-            `Unsupported persisted stateValue "${stateValue}" for runbook "${id}". ` +
-              'Prune stale runbook state and restart execution.',
-          );
-        }
-        const stepName = match[1];
-        if (!steps.find((s) => s.name === stepName)) {
-          throw new Error(
-            `Persisted stateValue "${stateValue}" for runbook "${id}" references missing step "${stepName}". ` +
-              'Prune stale runbook state and restart execution.',
-          );
-        }
-      }
+      this.assertFreshSnapshotValue(id, state.snapshot as PersistedRunbookSnapshot, steps);
     }
     this.compileMachineFromState(id, state, steps);
     return true;
@@ -405,6 +415,10 @@ export class RunbookActorService {
         snapshot.context && 'activeFrameKey' in snapshot.context
           ? { activeFrameKey: snapshot.context.activeFrameKey }
           : {};
+      const lastActionTermPatch =
+        snapshot.context && 'lastAction' in snapshot.context
+          ? { lastAction: snapshot.context.lastAction }
+          : {};
       const state = await this.manager.update(id, {
         variables: merge(variables),
         finalVars,
@@ -415,6 +429,7 @@ export class RunbookActorService {
         iterationResults: undefined,
         ...substepStatesTermPatch,
         ...activeFrameKeyTermPatch,
+        ...lastActionTermPatch,
       });
       return { state, snapshot };
     }
@@ -696,8 +711,7 @@ export class RunbookActorService {
       }
 
       try {
-        const { state, snapshot } = await this.persistAfterMachineEffects(id, actor, steps);
-        return { state, snapshot };
+        await this.waitForMachineEffects(actor);
       } catch (effectsErr) {
         // The command has already executed (COMMAND_RESULT was sent above).
         // Persist a stopped lifecycle so a resume or retry cannot re-execute
@@ -713,6 +727,8 @@ export class RunbookActorService {
         }
         throw effectsErr;
       }
+      const { state, snapshot } = await this.updateFromActor(id, actor, steps);
+      return { state, snapshot };
     } finally {
       this.stopActor(actor);
     }

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -314,11 +314,37 @@ export class RunbookActorService {
    * @param id - Runbook run ID
    * @param steps - Resolved steps for machine compilation
    * @returns `true` when state exists and passes freshness checks; `false` when no state exists
-   * @throws {Error} When the loaded state is stale
+   * @throws {Error} When the loaded state is stale — missing frontmatter outputs, unrecognized
+   *   snapshot value shape, malformed/legacy state ID, or references a step removed from the runbook
    */
   async assertFreshState(id: string, steps: ResolvedStep[]): Promise<boolean> {
     const state = await this.manager.load(id);
     if (!state) return false;
+    if (state.snapshot) {
+      const snapshot = state.snapshot as PersistedRunbookSnapshot;
+      const stateValue = stateValueAsString(snapshot.value);
+      if (stateValue === null) {
+        throw new Error(
+          `Unsupported snapshot.value shape for runbook "${id}": ${JSON.stringify(snapshot.value)}`,
+        );
+      }
+      if (stateValue !== 'COMPLETE' && stateValue !== 'STOPPED') {
+        const match = /^step::(.+?)(?:::(.+))?$/.exec(stateValue);
+        if (!match) {
+          throw new Error(
+            `Unsupported persisted stateValue "${stateValue}" for runbook "${id}". ` +
+              'Prune stale runbook state and restart execution.',
+          );
+        }
+        const stepName = match[1];
+        if (!steps.find((s) => s.name === stepName)) {
+          throw new Error(
+            `Persisted stateValue "${stateValue}" for runbook "${id}" references missing step "${stepName}". ` +
+              'Prune stale runbook state and restart execution.',
+          );
+        }
+      }
+    }
     this.compileMachineFromState(id, state, steps);
     return true;
   }

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -2915,7 +2915,7 @@ export function compileRunbookToMachine(
       completedSubstep: undefined,
       completedForContext: undefined,
       variables: {},
-      lastAction: undefined,
+      lastAction: { type: 'START' },
       lastMessage: undefined,
       forStack: [],
       iterationResults: undefined,

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -2454,7 +2454,7 @@ function extractRelativeTargets(config: RunbookStateConfig): string[] {
       if (transition.startsWith('.')) targets.push(transition);
       return;
     }
-    if (transition && typeof transition === 'object' && 'target' in transition) {
+    if (typeof transition === 'object' && 'target' in transition) {
       const { target } = transition;
       if (typeof target === 'string' && target.startsWith('.')) targets.push(target);
     }
@@ -2462,10 +2462,10 @@ function extractRelativeTargets(config: RunbookStateConfig): string[] {
 
   if (config.on) {
     for (const transitions of Object.values(config.on)) {
-      collectFromTransitionConfig(transitions as Parameters<typeof collectFromTransitionConfig>[0]);
+      collectFromTransitionConfig(transitions);
     }
   }
-  collectFromTransitionConfig(config.always as Parameters<typeof collectFromTransitionConfig>[0]);
+  collectFromTransitionConfig(config.always);
   if ('invoke' in config && config.invoke && typeof config.invoke === 'object') {
     const invoke = config.invoke as {
       onDone?: unknown;
@@ -2553,7 +2553,11 @@ function validateGraph(
   }
 }
 
-/** @internal Test hook for generated graph structural validation. */
+/**
+ * Test hook for generated graph structural validation.
+ *
+ * @internal
+ */
 export const validateGraphForTest = validateGraph;
 
 /**

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1,4 +1,4 @@
-import { setup, assign, assertEvent, raise } from 'xstate';
+import { setup, assign, assertEvent } from 'xstate';
 import type {
   Action,
   Aggregation,
@@ -199,6 +199,14 @@ const STOPPED_STATE_NAME = 'STOPPED' as const;
  * Derived from `STOPPED_STATE_NAME` so both strings share a single source of truth.
  */
 const STOPPED_STATE_REF = `#${STOPPED_STATE_NAME}` as const; // '#STOPPED'
+
+function outputCaptureOutputFromDoneEvent(event: unknown): OutputCaptureOutput {
+  return (event as { output: OutputCaptureOutput }).output;
+}
+
+function errorFromErrorEvent(event: unknown): unknown {
+  return (event as { error?: unknown }).error;
+}
 
 /**
  * Context passed through the XState runbook state machine.
@@ -2423,6 +2431,55 @@ function extractTargets(config: RunbookStateConfig): string[] {
   return targets;
 }
 
+function extractRelativeTargets(config: RunbookStateConfig): string[] {
+  const targets: string[] = [];
+
+  const collectFromTransitionConfig = (
+    transition:
+      | RunbookEventTransition
+      | RunbookEventTransition[]
+      | RunbookAlwaysEntry
+      | RunbookAlwaysEntry[]
+      | string
+      | undefined,
+  ): void => {
+    if (!transition) return;
+    if (Array.isArray(transition)) {
+      for (const entry of transition) {
+        collectFromTransitionConfig(entry);
+      }
+      return;
+    }
+    if (typeof transition === 'string') {
+      if (transition.startsWith('.')) targets.push(transition);
+      return;
+    }
+    if (transition && typeof transition === 'object' && 'target' in transition) {
+      const { target } = transition;
+      if (typeof target === 'string' && target.startsWith('.')) targets.push(target);
+    }
+  };
+
+  if (config.on) {
+    for (const transitions of Object.values(config.on)) {
+      collectFromTransitionConfig(transitions as Parameters<typeof collectFromTransitionConfig>[0]);
+    }
+  }
+  collectFromTransitionConfig(config.always as Parameters<typeof collectFromTransitionConfig>[0]);
+  if ('invoke' in config && config.invoke && typeof config.invoke === 'object') {
+    const invoke = config.invoke as {
+      onDone?: unknown;
+      onError?: unknown;
+    };
+    collectFromTransitionConfig(invoke.onDone as Parameters<typeof collectFromTransitionConfig>[0]);
+    collectFromTransitionConfig(
+      invoke.onError as Parameters<typeof collectFromTransitionConfig>[0],
+    );
+  }
+
+  return targets;
+}
+
 /**
  * Validate the generated state graph for structural integrity.
  *
@@ -2460,6 +2517,15 @@ function validateGraph(
         );
       }
     }
+    for (const target of extractRelativeTargets(config)) {
+      const childTarget = target.slice(1);
+      const childStates = config.states as Record<string, unknown> | undefined;
+      if (!childStates || !(childTarget in childStates)) {
+        throw new Error(
+          `Compiler error: unknown relative target "${target}" referenced from state "${sourceId}"`,
+        );
+      }
+    }
   }
 
   // Invariant: every __capture child's onError must target captureErrorTarget.
@@ -2486,6 +2552,9 @@ function validateGraph(
     }
   }
 }
+
+/** @internal Test hook for generated graph structural validation. */
+export const validateGraphForTest = validateGraph;
 
 /**
  * Insert a state config into the states record, throwing on duplicate IDs.
@@ -2742,9 +2811,6 @@ export function compileRunbookToMachine(
       };
     });
 
-    // DoneActorEvent.output is typed by the actor; XState models the onDone
-    // event distinctly from RunbookEvent, hence the narrow cast at access.
-    type DoneEvent = { output: OutputCaptureOutput };
     type InvokeBlock = NonNullable<RunbookStateConfig['invoke']>;
 
     // Single source of truth for every __capture.onError transition.
@@ -2757,15 +2823,15 @@ export function compileRunbookToMachine(
         lifecycle: () => 'stopped' as const,
         lastAction: ({ event }) => ({
           type: 'OUTPUT_CAPTURE_FAILED' as const,
-          message: getErrorMessage((event as unknown as { error?: unknown }).error),
+          message: getErrorMessage(errorFromErrorEvent(event)),
         }),
       }),
     } satisfies { target: typeof STOPPED_STATE_REF; actions: unknown };
 
     // The actor's resolved output is delivered as a `DoneActorEvent` whose
     // `output` is `OutputCaptureOutput`; XState models it as a distinct
-    // event type from `RunbookEvent`, so direct type assignment fails. Cast
-    // the entire invoke block to `unknown` then to the expected shape.
+    // event type from `RunbookEvent`, so the invoke config cast remains the
+    // boundary. Keep output access behind `outputCaptureOutputFromDoneEvent`.
     const invokeBlock = {
       src: 'outputCaptureActor',
       input: ({ event }: { event: RunbookEvent }) => ({
@@ -2782,13 +2848,16 @@ export function compileRunbookToMachine(
         // order-independent with the merge.
         actions: [
           runbookSetup.assign({
-            variables: ({ context, event }) => ({
-              ...context.variables,
-              ...(event as unknown as DoneEvent).output.variables,
-            }),
+            variables: ({ context, event }) => {
+              const output = outputCaptureOutputFromDoneEvent(event);
+              return {
+                ...context.variables,
+                ...output.variables,
+              };
+            },
           }),
-          raise(({ event }) => ({
-            type: (event as unknown as DoneEvent).output.result === 'pass' ? 'PASS' : 'FAIL',
+          runbookSetup.raise(({ event }) => ({
+            type: outputCaptureOutputFromDoneEvent(event).result === 'pass' ? 'PASS' : 'FAIL',
           })),
         ],
       },

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -40,6 +40,20 @@ export class ExecutionLifecycleService {
   }
 
   /**
+   * Clear the last result display field after a non-result transition.
+   *
+   * GOTO is a navigation action, not a pass/fail result. Clearing this field in
+   * core prevents stale PASS/FAIL status from leaking into CLI status rendering
+   * without requiring the CLI to rewrite machine-owned lastAction data.
+   *
+   * @param id - The runbook state ID
+   * @throws {Error} If the runbook with the given ID is not found
+   */
+  async clearLastResult(id: string): Promise<void> {
+    await this.manager.update(id, { lastResult: undefined });
+  }
+
+  /**
    * Check if a runbook was started in prompted mode.
    *
    * @param runbookId - The runbook state ID to check

--- a/packages/core/src/runbook/transition-kernel.ts
+++ b/packages/core/src/runbook/transition-kernel.ts
@@ -14,6 +14,7 @@ type StoppedReason =
   | 'user_abort'
   | 'delegation_resolution_failed'
   | 'nested_delegation_forbidden'
+  | 'retry_error_failed'
   | 'output_capture_failed';
 
 /**
@@ -303,6 +304,7 @@ export function isInternalFailureLastAction(
  * @returns Public RUNBOOK_STOPPED reason
  */
 export function deriveStoppedReason(lastAction: LastAction | undefined): StoppedReason {
+  if (lastAction?.type === 'RETRY_ERROR') return 'retry_error_failed';
   if (lastAction?.type === 'OUTPUT_CAPTURE_FAILED') return 'output_capture_failed';
   return 'fail_transition';
 }


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new run stop reason ("retry_error_failed") and a lifecycle API to clear last results.
  * Run startup now reliably seeds substep/entry state so initial prompted runs behave consistently.

* **Bug Fixes**
  * Stricter freshness validation to prevent stale transition/state application.
  * Improved clearing of stale PASS/FAIL results to avoid residual artifacts.
  * Fixed missing lifecycle dependency in certain goto/run flows.

* **Tests**
  * Expanded coverage across actor services, initialization, lifecycle, transitions, and retry/error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/296)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
