### PR TITLE
chore(scripts): loosen xstate doc version check to major.minor

### DIFF
--- a/scripts/check-xstate-doc-version.mjs
+++ b/scripts/check-xstate-doc-version.mjs
@@ -36,9 +36,17 @@ if (!banner) {
 
 const documented = banner[1];
 
-if (documented !== installed) {
+// Policy: enforce major.minor match only. Patch bumps cannot change documented
+// xstate patterns, so they pass with a note rather than failing CI (e.g. dependabot).
+// Minor and major bumps still error — those can shift the API surface the doc
+// references, so the banner must be re-verified.
+const majorMinor = (v) => v.split('.').slice(0, 2).join('.');
+const documentedMajorMinor = majorMinor(documented);
+const installedMajorMinor = majorMinor(installed);
+
+if (documentedMajorMinor !== installedMajorMinor) {
   console.error(
-    `error: docs/internal/xstate-patterns.md banner says xstate@${documented} but installed is xstate@${installed}.`,
+    `error: docs/internal/xstate-patterns.md banner says xstate@${documented} but installed is xstate@${installed} (major.minor mismatch).`,
   );
   console.error(
     "Re-verify the doc's claims against the installed version, then update the verification banner.",
@@ -46,4 +54,10 @@ if (documented !== installed) {
   process.exit(1);
 }
 
-console.log(`docs/internal/xstate-patterns.md banner matches installed xstate@${installed}`);
+if (documented !== installed) {
+  console.log(
+    `note: docs/internal/xstate-patterns.md banner says xstate@${documented}, installed is xstate@${installed} (patch difference only).`,
+  );
+} else {
+  console.log(`docs/internal/xstate-patterns.md banner matches installed xstate@${installed}`);
+}


### PR DESCRIPTION
The doc banner check did an exact-string match between docs/internal/xstate-patterns.md and the installed xstate version, so any patch bump (e.g. 5.31.0 -> 5.31.1) failed CI even though the documented patterns are unchanged. Enforce major.minor match instead; patch differences now pass with a note. Minor/major bumps still error so the banner is re-verified when the API surface could shift.

# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved version verification to allow patch-level differences between documentation and installed dependencies without blocking CI, while major.minor mismatches remain as hard failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/300)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
