### PR TITLE
Batch 3 core owned transition observation payloads

### DIFF
--- a/packages/cli/__tests__/commands/complete.test.ts
+++ b/packages/cli/__tests__/commands/complete.test.ts
@@ -120,7 +120,7 @@ This step should not become the persisted cursor.
     expect(session.active).toBeNull();
     const parentState = await readRunbookState(workspace, parentBefore!.id);
     expect(parentState!.lifecycle).toBe('completed');
-    expect(parentState!.lastAction).toEqual({ type: 'COMPLETE' });
+    expect(parentState!.lastAction).toEqual({ type: 'COMPLETE', aggregated: true });
   });
 
   it('dispatches FORCE_COMPLETE and exits cleanly when sendAndSync returns null', async () => {

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import type { ResolvedStep, Substep, ForClause, Transitions } from '@rundown-org/parser';
 import type {
   ActorSyncResult,
-  ExecutionLifecycleService,
   RunbookActorService,
   RunbookState,
   RunbookStateManager,
@@ -23,22 +22,18 @@ const CLAIMED_RUNBOOK_ID = brandRunIdForTest(`rd_${'8'.repeat(32)}`);
 jest.unstable_mockModule('@rundown-org/core', () => ({
   RunbookStateManager: jest.fn(),
   RunbookActorService: jest.fn(),
-  ExecutionLifecycleService: jest.fn(),
   SessionService: jest.fn(),
   parseStepIdFromString: jest.fn(),
   stepIdToString: jest.fn((id: { step: string; substep?: string }) =>
     id.substep ? `${id.step}.${id.substep}` : id.step,
   ),
-  buildStepPosition: jest.fn((current: string, total: number, substep?: string) => ({
-    current,
-    total,
-    ...(substep ? { substep } : {}),
-  })),
-  derivePositionAt: jest.fn(
-    (pos: { current: string; substep?: string; for?: { index: number } }) =>
-      `${pos.current}${pos.for?.index != null ? `.${String(pos.for.index)}` : ''}${pos.substep ? `.${pos.substep}` : ''}`,
+  deriveGotoActionBlock: jest.fn(
+    ({ target }: { target: { step: string; substep?: string } }) => ({
+      action: `GOTO ${target.substep ? `${target.step}.${target.substep}` : target.step}`,
+      from: '1',
+      at: target.step,
+    }),
   ),
-  countNumberedSteps: mockFn<(steps: readonly { name: string }[]) => number>().mockReturnValue(3),
   // Runtime-only validator with no service dependencies; pass-through preserves
   // structural mocking — every static import from @rundown-org/core resolves
   // through the factory rather than leaking the real module.
@@ -142,18 +137,13 @@ beforeEach(() => {
   jest
     .mocked(core.stepIdToString)
     .mockImplementation((id) => (id.substep ? `${id.step}.${id.substep}` : id.step));
-  jest.mocked(core.buildStepPosition).mockImplementation((current, total, substep) => ({
-    current,
-    total,
-    ...(substep ? { substep } : {}),
-  }));
   jest
-    .mocked(core.derivePositionAt)
-    .mockImplementation(
-      (pos) =>
-        `${pos.current}${pos.for?.index != null ? `.${String(pos.for.index)}` : ''}${pos.substep ? `.${pos.substep}` : ''}`,
-    );
-  jest.mocked(core.countNumberedSteps).mockReturnValue(3);
+    .mocked(core.deriveGotoActionBlock)
+    .mockImplementation(({ target }) => ({
+      action: `GOTO ${target.substep ? `${target.step}.${target.substep}` : target.step}`,
+      from: '1',
+      at: target.step,
+    }));
   jest.mocked(runExecutionLoop).mockResolvedValue('done');
 });
 
@@ -398,8 +388,6 @@ describe('executeGoto', () => {
     const update = mockFn<RunbookStateManager['update']>();
     const sendAndSync = mockFn<RunbookActorService['sendAndSync']>();
     sendAndSync.mockResolvedValue(null);
-    const clearLastResult =
-      mockFn<ExecutionLifecycleService['clearLastResult']>().mockResolvedValue(undefined);
 
     const ctx = {
       output: {
@@ -409,7 +397,6 @@ describe('executeGoto', () => {
       manager: { update } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
-      lifecycleService: { clearLastResult } as unknown as ExecutionLifecycleService,
       state: makeState(),
       steps: [makeStep()],
       cwd: '/test',
@@ -422,15 +409,12 @@ describe('executeGoto', () => {
     if (!result.ok) {
       expect(result.code).toBe('ENGINE_INIT_FAILED');
     }
-    expect(clearLastResult).not.toHaveBeenCalled();
   });
 
   it('returns ok with loop result on success', async () => {
     const update = mockFn<RunbookStateManager['update']>();
     update.mockImplementation(async (_id, _patch) => makeState({ step: '2' }));
     const sendAndSync = mockFn<RunbookActorService['sendAndSync']>();
-    const clearLastResult =
-      mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined);
     const syncResult: ActorSyncResult = {
       state: makeState({ step: '2' }),
       snapshot: {},
@@ -447,7 +431,6 @@ describe('executeGoto', () => {
       manager: { update } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
-      lifecycleService: { clearLastResult } as unknown as ExecutionLifecycleService,
       state: makeState(),
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
@@ -462,7 +445,6 @@ describe('executeGoto', () => {
       expect(result.loopResult).toBe('done');
     }
     expect(action).toHaveBeenCalled();
-    expect(clearLastResult).toHaveBeenCalledWith(DEFAULT_RUNBOOK_ID);
     expect(sendAndSync).toHaveBeenCalledWith(DEFAULT_RUNBOOK_ID, ctx.steps, {
       type: 'GOTO',
       target,
@@ -471,6 +453,42 @@ describe('executeGoto', () => {
       DEFAULT_RUNBOOK_ID,
       expect.objectContaining({ lastAction: expect.anything() }),
     );
+  });
+
+  it('does not call clearLastResult after core GOTO synchronization', async () => {
+    const clearLastResult = jest.fn(async () => undefined);
+    const sendAndSync = mockFn<RunbookActorService['sendAndSync']>();
+    const syncResult: ActorSyncResult = {
+      state: makeState({ step: '2' }),
+      snapshot: {},
+    };
+    sendAndSync.mockResolvedValue(syncResult);
+    jest.mocked(runExecutionLoop).mockResolvedValue('done');
+
+    const output = {
+      action: jest.fn(),
+      flush: jest.fn(),
+    } as unknown as OutputEmitter;
+    const ctx = {
+      output,
+      manager: {} as RunbookStateManager,
+      actorService: { sendAndSync } as unknown as RunbookActorService,
+      sessionService: {} as SessionService,
+      state: makeState(),
+      steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
+      cwd: '/test',
+      terminalReleaseMode: 'stack-pop' as const,
+    };
+
+    const result = await executeGoto(ctx, { step: '2' });
+
+    expect(result.ok).toBe(true);
+    expect(clearLastResult).not.toHaveBeenCalled();
+    expect(output.action).toHaveBeenCalledWith({
+      action: 'GOTO 2',
+      from: '1',
+      at: '2',
+    });
   });
 
   it('returns stopped when execution loop stops', async () => {
@@ -483,8 +501,6 @@ describe('executeGoto', () => {
     };
     sendAndSync.mockResolvedValue(syncResult);
     jest.mocked(runExecutionLoop).mockResolvedValue('stopped');
-    const clearLastResult =
-      mockFn<ExecutionLifecycleService['clearLastResult']>().mockResolvedValue(undefined);
 
     const ctx = {
       output: {
@@ -494,7 +510,6 @@ describe('executeGoto', () => {
       manager: { update } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
-      lifecycleService: { clearLastResult } as unknown as ExecutionLifecycleService,
       state: makeState(),
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
@@ -507,7 +522,6 @@ describe('executeGoto', () => {
     if (result.ok) {
       expect(result.loopResult).toBe('stopped');
     }
-    expect(clearLastResult).toHaveBeenCalledWith(DEFAULT_RUNBOOK_ID);
   });
 });
 

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -27,13 +27,11 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   stepIdToString: jest.fn((id: { step: string; substep?: string }) =>
     id.substep ? `${id.step}.${id.substep}` : id.step,
   ),
-  deriveGotoActionBlock: jest.fn(
-    ({ target }: { target: { step: string; substep?: string } }) => ({
-      action: `GOTO ${target.substep ? `${target.step}.${target.substep}` : target.step}`,
-      from: '1',
-      at: target.step,
-    }),
-  ),
+  deriveGotoActionBlock: jest.fn(({ target }: { target: { step: string; substep?: string } }) => ({
+    action: `GOTO ${target.substep ? `${target.step}.${target.substep}` : target.step}`,
+    from: '1',
+    at: target.step,
+  })),
   // Runtime-only validator with no service dependencies; pass-through preserves
   // structural mocking — every static import from @rundown-org/core resolves
   // through the factory rather than leaking the real module.
@@ -137,13 +135,11 @@ beforeEach(() => {
   jest
     .mocked(core.stepIdToString)
     .mockImplementation((id) => (id.substep ? `${id.step}.${id.substep}` : id.step));
-  jest
-    .mocked(core.deriveGotoActionBlock)
-    .mockImplementation(({ target }) => ({
-      action: `GOTO ${target.substep ? `${target.step}.${target.substep}` : target.step}`,
-      from: '1',
-      at: target.step,
-    }));
+  jest.mocked(core.deriveGotoActionBlock).mockImplementation(({ target }) => ({
+    action: `GOTO ${target.substep ? `${target.step}.${target.substep}` : target.step}`,
+    from: '1',
+    at: target.step,
+  }));
   jest.mocked(runExecutionLoop).mockResolvedValue('done');
 });
 
@@ -465,8 +461,9 @@ describe('executeGoto', () => {
     sendAndSync.mockResolvedValue(syncResult);
     jest.mocked(runExecutionLoop).mockResolvedValue('done');
 
+    const outputAction = jest.fn();
     const output = {
-      action: jest.fn(),
+      action: outputAction,
       flush: jest.fn(),
     } as unknown as OutputEmitter;
     const ctx = {
@@ -484,7 +481,7 @@ describe('executeGoto', () => {
 
     expect(result.ok).toBe(true);
     expect(clearLastResult).not.toHaveBeenCalled();
-    expect(output.action).toHaveBeenCalledWith({
+    expect(outputAction).toHaveBeenCalledWith({
       action: 'GOTO 2',
       from: '1',
       at: '2',

--- a/packages/cli/__tests__/helpers/transition-boundary.test.ts
+++ b/packages/cli/__tests__/helpers/transition-boundary.test.ts
@@ -25,4 +25,46 @@ describe('CLI transition boundary', () => {
     expect(source).not.toMatch(/\binitializeSubsteps\s*\(/);
     expect(source).not.toMatch(/lastAction\s*:\s*\{\s*type\s*:\s*['"]START['"]/);
   });
+
+  it('keeps transition-orchestrator render-only after actor sync', async () => {
+    const source = await readFile(
+      new URL('../../src/helpers/transition-orchestrator.ts', import.meta.url),
+      'utf8',
+    );
+
+    expect(source).not.toMatch(/manager\.update\s*\(/);
+    expect(source).not.toMatch(/manager\.load\s*\(/);
+    expect(source).not.toMatch(/lastAction\s*:/);
+    expect(source).not.toMatch(/lastResult\s*:/);
+    expect(source).not.toMatch(/lifecycle\s*:\s*['"](completed|stopped)['"]/);
+  });
+
+  it('does not clear lastResult in goto-workflow', async () => {
+    const source = await readFile(
+      new URL('../../src/helpers/goto-workflow.ts', import.meta.url),
+      'utf8',
+    );
+
+    expect(source).not.toMatch(/clearLastResult\s*\(/);
+  });
+
+  it('does not assemble synthetic transition events from execution.ts', async () => {
+    const source = await readFile(
+      new URL('../../src/services/execution.ts', import.meta.url),
+      'utf8',
+    );
+
+    // The stopped-on-entry path (artifact resolution failure pre-loop) must
+    // route through deriveTransitionObservation, not local payload assembly.
+    expect(source).not.toMatch(/extractLastAction\s*\(/);
+    expect(source).not.toMatch(/isInternalFailureLastAction\s*\(/);
+    expect(source).not.toMatch(/extractInternalFailureMessage\s*\(/);
+    expect(source).not.toMatch(/deriveStoppedReason\s*\(/);
+    expect(source).not.toMatch(/parseActionType\s*\(/);
+  });
+
+  // Positive emit coverage is provided by transition-orchestrator.test.ts
+  // ('returns the synchronized updated state on non-terminal transitions'),
+  // which asserts the exact { action: 'CONTINUE', from: '1', at: '2', result: 'PASS' }
+  // shape through the sink. Duplicating it here is unnecessary.
 });

--- a/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
+++ b/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
@@ -31,8 +31,9 @@ const steps = [
 
 describe('orchestrateTransition', () => {
   it('renders core-projected internal failure events without mutating runbook state', async () => {
+    const releaseRunbook = jest.fn(async () => undefined);
     const sessionService = {
-      releaseRunbook: jest.fn(async () => undefined),
+      releaseRunbook,
     } as unknown as SessionService;
     const sink = {
       onErrorOccurred: jest.fn(),
@@ -82,7 +83,7 @@ describe('orchestrateTransition', () => {
         message: 'failed to capture Foo',
       }),
     );
-    expect(sessionService.releaseRunbook).not.toHaveBeenCalled();
+    expect(releaseRunbook).not.toHaveBeenCalled();
   });
 
   it('returns the synchronized updated state on non-terminal transitions', async () => {

--- a/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
+++ b/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import type { RunbookState, SessionService, RunbookStateManager } from '@rundown-org/core';
+import type { RunbookState, SessionService } from '@rundown-org/core';
 import { orchestrateTransition } from '../../src/helpers/transition-orchestrator.js';
 
 const baseState = {
   id: `rd_${'1'.repeat(32)}`,
+  runbook: { source: 'project', path: 'test.runbook.md' },
+  runbookPath: 'test.runbook.md',
   step: '1',
+  stepName: 'Capture',
   lifecycle: 'running',
   retryCount: 0,
   variables: {},
+  steps: [],
   startedAt: '2026-05-11T00:00:00.000Z',
   updatedAt: '2026-05-11T00:00:00.000Z',
 } as unknown as RunbookState;
@@ -25,23 +29,19 @@ const steps = [
   },
 ] as any;
 
-describe('orchestrateTransition internal failure stop reasons', () => {
-  it('maps OUTPUT_CAPTURE_FAILED lastAction to output_capture_failed stop reason', async () => {
-    const manager = {
-      update: jest.fn(async () => undefined),
-      load: jest.fn(async () => null),
-    } as unknown as RunbookStateManager;
+describe('orchestrateTransition', () => {
+  it('renders core-projected internal failure events without mutating runbook state', async () => {
     const sessionService = {
       releaseRunbook: jest.fn(async () => undefined),
     } as unknown as SessionService;
     const sink = {
+      onErrorOccurred: jest.fn(),
       onStepTransitioned: jest.fn(),
       onRunbookCompleted: jest.fn(),
       onRunbookStopped: jest.fn(),
     };
 
     const result = await orchestrateTransition({
-      manager,
       sessionService,
       sink,
       runbookId: baseState.id,
@@ -60,7 +60,6 @@ describe('orchestrateTransition internal failure stop reasons', () => {
         },
       },
       result: 'fail',
-      actionResult: false,
       policy: {
         onComplete: { releaseRunbook: false },
         onStopped: { releaseRunbook: false },
@@ -74,11 +73,74 @@ describe('orchestrateTransition internal failure stop reasons', () => {
       }),
     );
     expect(sink.onStepTransitioned).not.toHaveBeenCalled();
+    expect(sink.onErrorOccurred).toHaveBeenCalledWith({
+      message: 'failed to capture Foo',
+    });
     expect(sink.onRunbookStopped).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: 'output_capture_failed',
         message: 'failed to capture Foo',
       }),
     );
+    expect(sessionService.releaseRunbook).not.toHaveBeenCalled();
+  });
+
+  it('returns the synchronized updated state on non-terminal transitions', async () => {
+    const sessionService = {
+      releaseRunbook: jest.fn(async () => undefined),
+    } as unknown as SessionService;
+    const sink = {
+      onErrorOccurred: jest.fn(),
+      onStepTransitioned: jest.fn(),
+      onRunbookCompleted: jest.fn(),
+      onRunbookStopped: jest.fn(),
+    };
+    const updatedState = { ...baseState, step: '2', stepName: 'Next' };
+
+    const result = await orchestrateTransition({
+      sessionService,
+      sink,
+      runbookId: baseState.id,
+      steps: [
+        ...steps,
+        {
+          kind: 'command',
+          name: '2',
+          description: 'Next',
+          command: { code: 'echo next', lang: 'sh' },
+          transitions: {
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+          },
+        },
+      ] as any,
+      currentStep: steps[0],
+      previousState: baseState,
+      updatedState,
+      snapshot: {
+        status: 'active',
+        value: { 'step::2': 'idle' },
+        context: { lastAction: { type: 'CONTINUE' } },
+      },
+      result: 'pass',
+      policy: {
+        onComplete: { releaseRunbook: false },
+        onStopped: { releaseRunbook: false },
+      },
+    });
+
+    expect(result).toEqual({
+      status: 'continue',
+      state: updatedState,
+      action: 'CONTINUE',
+      from: '1',
+      at: '2',
+    });
+    expect(sink.onStepTransitioned).toHaveBeenCalledWith({
+      action: 'CONTINUE',
+      from: '1',
+      at: '2',
+      result: 'PASS',
+    });
   });
 });

--- a/packages/cli/__tests__/services/execution-action.test.ts
+++ b/packages/cli/__tests__/services/execution-action.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import {
-  formatActionForDisplay,
-  extractLastAction,
-  extractLastMessage,
-} from '../../src/services/execution.js';
+import { formatActionForDisplay, extractLastAction, extractLastMessage } from '@rundown-org/core';
 
 describe('execution action helpers', () => {
   describe('extractLastAction', () => {

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -855,6 +855,74 @@ describe('runExecutionLoop', () => {
     expect(stepTransitionedCalls).toHaveLength(0);
   });
 
+  it('emits RUNBOOK_STOPPED when lifecycle is stopped but XState snapshot is non-terminal (CLI-owned stop recovery)', async () => {
+    // Regression: policy denial / delegation-resolution failure patches only
+    // lifecycle:'stopped' without driving the XState machine to its terminal STOPPED
+    // state. The snapshot stays active. deriveTransitionObservation must not be used
+    // for this path — it returns { status:'continue' } for non-terminal snapshots
+    // and RUNBOOK_STOPPED is never emitted.
+    mockManager.load.mockResolvedValue(
+      makeLoopState('1', {
+        lifecycle: 'stopped',
+        snapshot: {
+          status: 'active',
+          value: { 'step::1': 'idle' },
+          context: { lastAction: { type: 'CONTINUE' } },
+        },
+      }),
+    );
+
+    const result = await runExecutionLoop(
+      asManager(mockManager),
+      runbookId,
+      asSteps(steps),
+      '/tmp',
+      false,
+      asEmitter(mockEmitter),
+    );
+
+    expect(result).toBe('stopped');
+    expect(mockActorService.sendAndSync).not.toHaveBeenCalled();
+    expect(mockEmitter.emit).toHaveBeenCalledWith(
+      'RUNBOOK_STOPPED',
+      expect.objectContaining({ position: expect.any(Object), reason: expect.any(String) }),
+    );
+    expect(
+      (mockEmitter.emit as jest.Mock).mock.calls.filter(
+        (c: unknown[]) => c[0] === 'STEP_TRANSITIONED',
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('emits RUNBOOK_STOPPED when lifecycle is stopped and snapshot has no lastAction', async () => {
+    mockManager.load.mockResolvedValue(
+      makeLoopState('1', {
+        lifecycle: 'stopped',
+        snapshot: { status: 'active', value: { 'step::1': 'idle' }, context: {} },
+      }),
+    );
+
+    const result = await runExecutionLoop(
+      asManager(mockManager),
+      runbookId,
+      asSteps(steps),
+      '/tmp',
+      false,
+      asEmitter(mockEmitter),
+    );
+
+    expect(result).toBe('stopped');
+    expect(mockEmitter.emit).toHaveBeenCalledWith(
+      'RUNBOOK_STOPPED',
+      expect.objectContaining({ position: expect.any(Object) }),
+    );
+    expect(
+      (mockEmitter.emit as jest.Mock).mock.calls.filter(
+        (c: unknown[]) => c[0] === 'STEP_TRANSITIONED',
+      ),
+    ).toHaveLength(0);
+  });
+
   it('prompted-for step returns waiting without CLI prompted mode', async () => {
     const promptedForSteps = [
       {

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -78,12 +78,6 @@ jest.unstable_mockModule('@rundown-org/core', () => {
     evaluatePassCondition: jest.fn(),
     evaluateFailCondition: jest.fn(),
 
-    // Transition coordinator — chains into evaluators; stub returns the
-    // transition message tests assert on.
-    deriveTransitionMessage: jest.fn((result: 'pass' | 'fail') =>
-      result === 'pass' ? 'Success' : 'Failed',
-    ),
-
     // Print / terminal output
     printActionBlock: jest.fn(),
     printStepBlock: jest.fn(),
@@ -476,7 +470,7 @@ describe('runExecutionLoop', () => {
       snapshot: {
         status: 'done',
         value: 'COMPLETE',
-        context: { lastAction: { type: 'COMPLETE' } },
+        context: { lastAction: { type: 'COMPLETE' }, lastMessage: 'Success' },
       },
     });
 
@@ -533,7 +527,7 @@ describe('runExecutionLoop', () => {
       snapshot: {
         status: 'done',
         value: 'COMPLETE',
-        context: { lastAction: { type: 'COMPLETE' } },
+        context: { lastAction: { type: 'COMPLETE' }, lastMessage: 'Success' },
       },
     });
 
@@ -643,7 +637,7 @@ describe('runExecutionLoop', () => {
       snapshot: {
         status: 'done',
         value: 'COMPLETE',
-        context: { lastAction: { type: 'COMPLETE' } },
+        context: { lastAction: { type: 'COMPLETE' }, lastMessage: 'Success' },
       },
     });
 
@@ -800,6 +794,65 @@ describe('runExecutionLoop', () => {
     expect(errorIdx).toBeGreaterThanOrEqual(0);
     expect(stoppedIdx).toBeGreaterThanOrEqual(0);
     expect(errorIdx).toBeLessThan(stoppedIdx);
+  });
+
+  it('emits ERROR_OCCURRED + RUNBOOK_STOPPED when loaded state is already stopped with ARTIFACT_RESOLUTION_FAILED', async () => {
+    // Batch-2 introduced the pre-loop stopped-on-entry projection so artifact
+    // resolution failures surfaced during initializeState() (before the loop
+    // sends any machine event) still route through deriveTransitionObservation
+    // and emit ERROR_OCCURRED before RUNBOOK_STOPPED. STEP_TRANSITIONED is
+    // suppressed because the failure is machine-internal.
+    mockManager.load.mockResolvedValue(
+      makeLoopState('1', {
+        lifecycle: 'stopped',
+        snapshot: {
+          status: 'done',
+          value: 'STOPPED',
+          context: {
+            lastAction: {
+              type: 'ARTIFACT_RESOLUTION_FAILED' as const,
+              message: 'artifact "PlanPath" failed to resolve',
+            },
+            lifecycle: 'stopped',
+          },
+        },
+      }),
+    );
+
+    const result = await runExecutionLoop(
+      asManager(mockManager),
+      runbookId,
+      asSteps(steps),
+      '/tmp',
+      false,
+      asEmitter(mockEmitter),
+    );
+
+    expect(result).toBe('stopped');
+    expect(mockActorService.sendAndSync).not.toHaveBeenCalled();
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith(
+      'ERROR_OCCURRED',
+      expect.objectContaining({
+        message: 'artifact "PlanPath" failed to resolve',
+      }),
+    );
+    expect(mockEmitter.emit).toHaveBeenCalledWith(
+      'RUNBOOK_STOPPED',
+      expect.objectContaining({
+        message: 'artifact "PlanPath" failed to resolve',
+        reason: 'artifact_resolution_failed',
+      }),
+    );
+
+    const emitCalls = mockEmitter.emit.mock.calls;
+    const errorIdx = emitCalls.findIndex((c: any[]) => c[0] === 'ERROR_OCCURRED');
+    const stoppedIdx = emitCalls.findIndex((c: any[]) => c[0] === 'RUNBOOK_STOPPED');
+    expect(errorIdx).toBeGreaterThanOrEqual(0);
+    expect(stoppedIdx).toBeGreaterThan(errorIdx);
+
+    const stepTransitionedCalls = emitCalls.filter((c) => c[0] === 'STEP_TRANSITIONED');
+    expect(stepTransitionedCalls).toHaveLength(0);
   });
 
   it('prompted-for step returns waiting without CLI prompted mode', async () => {
@@ -1149,6 +1202,7 @@ describe('runExecutionLoop', () => {
       expect(events).not.toContainEqual(expect.objectContaining({ type: 'SET_VARIABLES' }));
       expect(events).not.toContainEqual(expect.objectContaining({ type: 'PASS' }));
       expect(events).not.toContainEqual(expect.objectContaining({ type: 'FAIL' }));
+      expect(mockLifecycleService.setLastResult).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -66,7 +66,6 @@ async function propagateForceAbort(
   const emitter = createBridgedEmitter(reloadedParent, output);
 
   const drained = await drainResolvedCompletions({
-    manager,
     actorService: parentActorService,
     sessionService,
     lifecycleService,

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -250,7 +250,6 @@ async function runCollect(
   const frameKeyOverride: FrameKey | undefined =
     scope.frameKey === activeFrameKey ? undefined : scope.frameKey;
   const drained = await drainResolvedCompletions({
-    manager,
     actorService,
     sessionService,
     lifecycleService,

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -210,7 +210,6 @@ export async function handleParentCompletion(
 
   const emitter = createBridgedEmitter(parentState, output);
   const drained = await drainResolvedCompletions({
-    manager,
     actorService: parentActorService,
     sessionService,
     lifecycleService,

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -9,15 +9,12 @@
  */
 
 import {
-  buildStepPosition,
-  derivePositionAt,
   RunbookStateManager,
   RunbookActorService,
-  ExecutionLifecycleService,
   SessionService,
   parseStepIdFromString,
   stepIdToString,
-  countNumberedSteps,
+  deriveGotoActionBlock,
   type ResolvedStep,
   type StepId,
   type RunbookState,
@@ -43,8 +40,6 @@ export interface GotoContext {
   actorService: RunbookActorService;
   /** Session service for tracking active/stashed runbooks */
   sessionService: SessionService;
-  /** Execution lifecycle service */
-  lifecycleService: ExecutionLifecycleService;
   /** Current active runbook state */
   state: RunbookState;
   /** Parsed steps from the active runbook */
@@ -115,7 +110,6 @@ export async function buildGotoContext(
 ): Promise<BuildGotoContextResult> {
   const manager = new RunbookStateManager(cwd);
   const sessionService = new SessionService(manager);
-  const lifecycleService = new ExecutionLifecycleService(manager);
   const active = await resolveActiveRunbook(sessionService, options);
 
   switch (active.kind) {
@@ -145,7 +139,6 @@ export async function buildGotoContext(
       manager,
       actorService,
       sessionService,
-      lifecycleService,
       state,
       steps,
       cwd,
@@ -261,9 +254,6 @@ export function validateGotoTarget(
 export async function executeGoto(ctx: GotoContext, target: StepId): Promise<GotoExecutionResult> {
   const { output, manager, actorService, state, steps, cwd } = ctx;
 
-  const prevStep = state.step;
-  const prevSubstep = state.substep;
-
   const syncResult = await actorService.sendAndSync(state.id, steps, {
     type: 'GOTO',
     target,
@@ -272,29 +262,14 @@ export async function executeGoto(ctx: GotoContext, target: StepId): Promise<Got
     return { ok: false, error: 'Failed to initialize runbook engine', code: 'ENGINE_INIT_FAILED' };
   }
 
-  // `sendAndSync` has already persisted the GOTO transition. Clear stale
-  // result metadata as a second write before reporting the new cursor.
-  await ctx.lifecycleService.clearLastResult(state.id);
-
-  // Compute new position (the target of the goto)
-  const totalSteps = countNumberedSteps(steps);
-  const newPos = buildStepPosition(
-    syncResult.state.step,
-    totalSteps,
-    syncResult.state.substep,
-    syncResult.state.forStack,
+  output.action(
+    deriveGotoActionBlock({
+      steps,
+      previousState: state,
+      updatedState: syncResult.state,
+      target,
+    }),
   );
-  const prevPos = buildStepPosition(prevStep, totalSteps, prevSubstep, state.forStack);
-
-  // Build action data for goto
-  const actionData = {
-    action: `GOTO ${stepIdToString(target)}`,
-    from: derivePositionAt(prevPos),
-    at: derivePositionAt(newPos),
-  };
-
-  // Emit structured action output
-  output.action(actionData);
 
   // Create emitter bridged to unified output
   const emitter = createBridgedEmitter(state, output);

--- a/packages/cli/src/helpers/transition-orchestrator.ts
+++ b/packages/cli/src/helpers/transition-orchestrator.ts
@@ -1,28 +1,14 @@
 import {
-  asTerminalSnapshotOrDefault,
-  buildStepPosition,
-  countNumberedSteps,
-  derivePositionAt,
-  deriveStoppedReason,
-  deriveTransitionMessage,
-  extractInternalFailureMessage,
-  extractLastAction,
-  extractLastMessage,
-  extractRetryDisplayCount,
-  extractRetryMax,
-  isInternalFailureLastAction,
-  isRunbookComplete,
-  isRunbookStopped,
-  parseActionType,
+  deriveTransitionObservation,
+  type ActionType,
+  type ErrorOccurredPayload,
   type ExecutionEventEmitter,
   type RunbookCompletedPayload,
   type RunbookState,
-  type RunbookStateManager,
   type RunbookStoppedPayload,
   type RunId,
   type SessionService,
   type ResolvedStep,
-  type StepPosition,
   type StepTransitionedPayload,
 } from '@rundown-org/core';
 
@@ -42,6 +28,8 @@ export interface TransitionOrchestrationPolicy {
 
 /** Event sink for transition lifecycle events. */
 export interface TransitionEventSink {
+  /** Called when a machine-internal transition failure should be surfaced. */
+  onErrorOccurred?(payload: ErrorOccurredPayload): void;
   /** Called when a step transition occurs. */
   onStepTransitioned(payload: StepTransitionedPayload): void;
   /** Called when the runbook completes successfully. */
@@ -54,12 +42,15 @@ export interface TransitionEventSink {
  * Create a {@link TransitionEventSink} that delegates to an event emitter.
  *
  * @param emitter - Event emitter with an `emit` method for forwarding transition events
- * @returns TransitionEventSink that forwards step-transitioned, runbook-completed, and runbook-stopped events
+ * @returns TransitionEventSink that forwards error, step-transitioned, runbook-completed, and runbook-stopped events
  */
 export function transitionSinkFromEmitter(
   emitter: Pick<ExecutionEventEmitter, 'emit'>,
 ): TransitionEventSink {
   return {
+    onErrorOccurred: (payload) => {
+      emitter.emit('ERROR_OCCURRED', payload);
+    },
     onStepTransitioned: (payload) => {
       emitter.emit('STEP_TRANSITIONED', payload);
     },
@@ -73,8 +64,6 @@ export function transitionSinkFromEmitter(
 }
 
 interface OrchestrateTransitionArgs {
-  /** State manager for persisting runbook state updates. */
-  manager: RunbookStateManager;
   /** Session service for managing the active runbook stack. */
   sessionService: SessionService;
   /** Event sink for emitting transition lifecycle events. */
@@ -93,8 +82,8 @@ interface OrchestrateTransitionArgs {
   snapshot: unknown;
   /** Whether the step passed or failed. */
   result: 'pass' | 'fail';
-  /** Whether the action (command execution or prompt response) succeeded. */
-  actionResult: boolean;
+  /** Optional display-result policy for direct pass/fail commands. */
+  computeActionResult?: (actionType: ActionType) => boolean;
   /** Policy governing side effects for terminal outcomes. */
   policy: TransitionOrchestrationPolicy;
   /** The command string that triggered this transition, included in events. */
@@ -119,28 +108,6 @@ export type OrchestrateTransitionResult =
   | { status: 'done'; action: string; from: string; at: string; message?: string }
   | { status: 'stopped'; action: string; from: string; at: string; message?: string };
 
-function buildTransitionPositions(
-  previousState: RunbookState,
-  updatedState: RunbookState,
-  steps: ResolvedStep[],
-): { from: StepPosition; to: StepPosition } {
-  const totalSteps = countNumberedSteps(steps);
-  return {
-    from: buildStepPosition(
-      previousState.step,
-      totalSteps,
-      previousState.substep,
-      previousState.forStack,
-    ),
-    to: buildStepPosition(
-      updatedState.step,
-      totalSteps,
-      updatedState.substep,
-      updatedState.forStack,
-    ),
-  };
-}
-
 async function applyTerminalSideEffects(
   sessionService: SessionService,
   policy: TerminalSideEffectsPolicy,
@@ -152,12 +119,13 @@ async function applyTerminalSideEffects(
 }
 
 /**
- * Persist transition state, emit transition/terminal events, and apply side effects.
+ * Emit core-projected transition events and apply terminal side effects.
  *
  * This is the shared transition application path for command-driven transitions
- * and execution-loop transitions.
+ * and execution-loop transitions. Payload derivation is delegated to the core
+ * `deriveTransitionObservation` projection; this function is render-only.
  *
- * @param args - Transition context including state manager, step data, and side-effect policy.
+ * @param args - Transition context including state, snapshot, steps, and side-effect policy.
  *   See {@link OrchestrateTransitionArgs} for field descriptions.
  * @returns A result indicating whether execution should continue, has completed, or was stopped.
  *   See {@link OrchestrateTransitionResult} for the discriminated union variants.
@@ -165,103 +133,66 @@ async function applyTerminalSideEffects(
 export async function orchestrateTransition(
   args: OrchestrateTransitionArgs,
 ): Promise<OrchestrateTransitionResult> {
-  const {
-    manager,
-    sessionService,
-    sink,
-    runbookId,
-    steps,
-    currentStep,
-    previousState,
-    updatedState,
-    snapshot,
-    result,
-    actionResult,
-    policy,
-    command,
-  } = args;
-
-  const retryMax = extractRetryMax(snapshot);
-  const lastAction = extractLastAction(snapshot);
-  const retryDisplayCount = extractRetryDisplayCount(snapshot, updatedState.retryCount);
-  const actionType = parseActionType(lastAction);
-  const aggregated = lastAction?.aggregated === true;
-  const positions = buildTransitionPositions(previousState, updatedState, steps);
-  const fromStr = derivePositionAt(positions.from);
-  const atStr = derivePositionAt(positions.to);
-
-  await manager.update(runbookId, {
-    lastAction,
-    lastResult: result,
+  const { sessionService, sink, runbookId, policy } = args;
+  const observation = deriveTransitionObservation({
+    steps: args.steps,
+    currentStep: args.currentStep,
+    previousState: args.previousState,
+    updatedState: args.updatedState,
+    snapshot: args.snapshot,
+    result: args.result,
+    computeActionResult: args.computeActionResult,
+    command: args.command,
   });
 
-  const toPos = positions.to;
-  // Internal-failure lastAction variants (RETRY_ERROR, OUTPUT_CAPTURE_FAILED)
-  // signal a machine-internal failure (retry hook threw / invariant violated /
-  // output-capture actor errored). They are already surfaced via ERROR_OCCURRED
-  // + RUNBOOK_STOPPED. Emitting them through STEP_TRANSITIONED would widen the
-  // external action enum beyond the scenario schema
-  // (CONTINUE/DEFER/GOTO/STOP/COMPLETE/RETRY/BREAK/NEXT — see
-  // packages/cli/src/schemas/scenarios.ts). The terminal RUNBOOK_STOPPED
-  // emission below still fires.
-  if (!isInternalFailureLastAction(lastAction)) {
-    sink.onStepTransitioned({
-      action: actionType,
-      from: fromStr,
-      at: atStr,
-      result: actionResult ? 'PASS' : 'FAIL',
-      command,
-      ...(actionType === 'RETRY' ? { retryAttempt: retryDisplayCount, retryMax } : {}),
-      ...(toPos.for ? { forIndex: toPos.for.index, forEnd: toPos.for.end } : {}),
-      ...(aggregated ? { aggregated: true } : {}),
-    });
+  for (const event of observation.events) {
+    switch (event.type) {
+      case 'ERROR_OCCURRED':
+        sink.onErrorOccurred?.(event.payload);
+        break;
+      case 'STEP_TRANSITIONED':
+        sink.onStepTransitioned(event.payload);
+        break;
+      case 'RUNBOOK_COMPLETED':
+        sink.onRunbookCompleted(event.payload);
+        break;
+      case 'RUNBOOK_STOPPED':
+        sink.onRunbookStopped(event.payload);
+        break;
+      default: {
+        const _exhaustive: never = event;
+        return _exhaustive;
+      }
+    }
   }
 
-  const terminalSnapshot = asTerminalSnapshotOrDefault(snapshot);
-  const isComplete = isRunbookComplete(terminalSnapshot);
-  const isStopped = isRunbookStopped(terminalSnapshot);
-
-  if (isComplete) {
-    const message =
-      extractLastMessage(snapshot) ??
-      deriveTransitionMessage(result, currentStep, previousState.retryCount);
-
-    await manager.update(runbookId, {
-      lifecycle: 'completed',
-    });
-    sink.onRunbookCompleted({
-      message,
-      finalPosition: positions.to,
-    });
-
+  if (observation.status === 'done') {
     await applyTerminalSideEffects(sessionService, policy.onComplete, runbookId);
-    return { status: 'done', action: actionType, from: fromStr, at: atStr, message };
+    return {
+      status: 'done',
+      action: observation.action,
+      from: observation.from,
+      at: observation.at,
+      message: observation.message,
+    };
   }
 
-  if (isStopped) {
-    const message =
-      extractInternalFailureMessage(lastAction) ??
-      extractLastMessage(snapshot) ??
-      deriveTransitionMessage(result, currentStep, previousState.retryCount);
-    const reason = deriveStoppedReason(lastAction);
-
-    await manager.update(runbookId, {
-      lifecycle: 'stopped',
-    });
-    sink.onRunbookStopped({
-      message,
-      position: positions.from,
-      reason,
-    });
-
+  if (observation.status === 'stopped') {
     await applyTerminalSideEffects(sessionService, policy.onStopped, runbookId);
-    return { status: 'stopped', action: actionType, from: fromStr, at: atStr, message };
+    return {
+      status: 'stopped',
+      action: observation.action,
+      from: observation.from,
+      at: observation.at,
+      message: observation.message,
+    };
   }
 
-  const reloaded = await manager.load(runbookId);
-  if (!reloaded) {
-    return { status: 'stopped', action: actionType, from: fromStr, at: atStr };
-  }
-
-  return { status: 'continue', state: reloaded, action: actionType, from: fromStr, at: atStr };
+  return {
+    status: 'continue',
+    state: observation.state,
+    action: observation.action,
+    from: observation.from,
+    at: observation.at,
+  };
 }

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -426,7 +426,6 @@ export async function executeTransition(
 
     const emitter = createBridgedEmitter(activeState, output);
     const drained = await drainResolvedCompletions({
-      manager,
       actorService,
       sessionService: ctx.sessionService,
       lifecycleService,

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -13,9 +13,7 @@ import {
   RunbookActorService,
   SessionService,
   ExecutionLifecycleService,
-  extractLastAction,
   formatTransitionAction,
-  parseActionType,
   parseStepIdFromString,
   type ActionType,
   buildCompletionKey,
@@ -30,6 +28,7 @@ import {
   type RunbookCompletedPayload,
   type RunbookStoppedPayload,
   type StepTransitionedPayload,
+  type ErrorOccurredPayload,
   type ClaimId,
 } from '@rundown-org/core';
 import { resolvedStepHasSubsteps } from '@rundown-org/parser';
@@ -480,8 +479,6 @@ export async function executeTransition(
   }
   const { state: actorUpdatedState, snapshot: rawSnapshot } = syncResult;
 
-  const actionType = parseActionType(extractLastAction(rawSnapshot));
-
   const ensuredAfterTransition = await lifecycleService.ensureActiveEntry(
     activeState.id,
     previousState,
@@ -489,8 +486,10 @@ export async function executeTransition(
   );
   const updatedState = ensuredAfterTransition.state;
 
-  const actionResult = config.computeActionResult(actionType);
   const commandSink: TransitionEventSink = {
+    onErrorOccurred: (payload: ErrorOccurredPayload) => {
+      output.error(payload.message, payload.code);
+    },
     onStepTransitioned: (payload: StepTransitionedPayload) => {
       output.action({
         action: formatTransitionAction(
@@ -518,7 +517,6 @@ export async function executeTransition(
   };
 
   const orchestration = await orchestrateTransition({
-    manager,
     sessionService: ctx.sessionService,
     sink: commandSink,
     runbookId: activeState.id,
@@ -528,7 +526,7 @@ export async function executeTransition(
     updatedState,
     snapshot: rawSnapshot,
     result: config.lastResult,
-    actionResult,
+    computeActionResult: config.computeActionResult,
     policy: config.policy,
   });
 

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -8,9 +8,7 @@ import {
   deriveExecutionAt,
   buildCompletionKey,
   deriveActiveFrame,
-  parseActionType,
   type ActionType,
-  extractLastAction,
   extractLastMessage,
   extractRetryDisplayCount,
   extractRetryMax,
@@ -53,10 +51,8 @@ import {
   resolveCurrentExecutionUnit,
   type OutputScope,
   type PreparedChannel,
-  isInternalFailureLastAction,
-  extractInternalFailureMessage,
   extractEnteredArtifacts,
-  deriveStoppedReason,
+  deriveTransitionObservation,
 } from '@rundown-org/core';
 import {
   isSourced,
@@ -360,27 +356,9 @@ async function observeAndOrchestrate({
   syncSnapshot,
   postState,
 }: ObserveAndOrchestrateArgs): Promise<TransitionApplicationResult> {
-  const lastAction = extractLastAction(syncSnapshot);
-  const actionType = parseActionType(lastAction);
   const ensured = await lifecycleService.ensureActiveEntry(runbookId, currentState, postState);
-  const actionResult = computeActionResult ? computeActionResult(actionType) : result === 'pass';
-
-  // Machine-internal failures (RETRY_ERROR, OUTPUT_CAPTURE_FAILED) emit
-  // ERROR_OCCURRED before the terminal RUNBOOK_STOPPED so consumers can
-  // correlate the root cause. Plain STOP actions (authored STOP transitions,
-  // `rd stop`) do not emit ERROR_OCCURRED.
-  if (ensured.state.lifecycle === 'stopped' && isInternalFailureLastAction(lastAction)) {
-    const message = extractInternalFailureMessage(lastAction);
-    if (message !== undefined) {
-      emitter.emit('ERROR_OCCURRED', {
-        message,
-        ...(lastAction.type === 'RETRY_ERROR' ? { code: lastAction.code } : {}),
-      });
-    }
-  }
 
   const orchestration = await orchestrateTransition({
-    manager,
     sessionService,
     sink: transitionSinkFromEmitter(emitter),
     runbookId,
@@ -390,7 +368,7 @@ async function observeAndOrchestrate({
     updatedState: ensured.state,
     snapshot: syncSnapshot,
     result,
-    actionResult,
+    computeActionResult,
     policy: transitionPolicy,
     command,
   });
@@ -653,27 +631,34 @@ export async function runExecutionLoop(
   let currentState: RunbookState = ensuredInitial.state;
 
   if (currentState.lifecycle === 'stopped') {
-    const lastAction = extractLastAction(currentState.snapshot);
-    const message =
-      extractInternalFailureMessage(lastAction) ?? extractLastMessage(currentState.snapshot);
-    const position = buildStepPosition(
-      currentState.step,
-      countNumberedSteps(steps),
-      currentState.substep,
-      currentState.forStack,
-    );
-
-    if (isInternalFailureLastAction(lastAction) && message !== undefined) {
-      emitter.emit('ERROR_OCCURRED', {
-        message,
-        ...(lastAction.type === 'RETRY_ERROR' ? { code: lastAction.code } : {}),
-      });
-    }
-    emitter.emit('RUNBOOK_STOPPED', {
-      position,
-      reason: deriveStoppedReason(lastAction),
-      message,
+    const currentStepForProjection = findStepOrThrow(steps, currentState.step);
+    const observation = deriveTransitionObservation({
+      steps,
+      currentStep: currentStepForProjection,
+      previousState: currentState,
+      updatedState: currentState,
+      snapshot: currentState.snapshot,
+      result: 'fail',
     });
+
+    for (const event of observation.events) {
+      switch (event.type) {
+        case 'ERROR_OCCURRED':
+          emitter.emit('ERROR_OCCURRED', event.payload);
+          break;
+        case 'RUNBOOK_STOPPED':
+          emitter.emit('RUNBOOK_STOPPED', event.payload);
+          break;
+        case 'STEP_TRANSITIONED':
+        case 'RUNBOOK_COMPLETED':
+          break;
+        default: {
+          const _exhaustive: never = event;
+          return _exhaustive;
+        }
+      }
+    }
+
     await applyExecutionTerminalRelease(sessionService, runbookId, terminalReleaseMode);
     return 'stopped';
   }
@@ -1098,8 +1083,6 @@ export async function runExecutionLoop(
       return 'stopped';
     }
 
-    // Store result
-    await lifecycleService.setLastResult(runbookId, lastResult);
     const previousState = currentState;
     const cmdSync = await actorService.sendAndSync(runbookId, steps, {
       type: 'COMMAND_RESULT',
@@ -1149,7 +1132,6 @@ export async function runExecutionLoop(
 }
 
 export {
-  extractLastAction,
   extractLastMessage,
   extractRetryDisplayCount,
   extractRetryMax,

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -53,6 +53,9 @@ import {
   type PreparedChannel,
   extractEnteredArtifacts,
   deriveTransitionObservation,
+  asTerminalSnapshotOrDefault,
+  isRunbookStopped,
+  isRunbookComplete,
 } from '@rundown-org/core';
 import {
   isSourced,
@@ -624,32 +627,56 @@ export async function runExecutionLoop(
   let currentState: RunbookState = ensuredInitial.state;
 
   if (currentState.lifecycle === 'stopped') {
-    const currentStepForProjection = findStepOrThrow(steps, currentState.step);
-    const observation = deriveTransitionObservation({
-      steps,
-      currentStep: currentStepForProjection,
-      previousState: currentState,
-      updatedState: currentState,
-      snapshot: currentState.snapshot,
-      result: 'fail',
-    });
+    const terminalSnap = asTerminalSnapshotOrDefault(currentState.snapshot);
+    const snapIsTerminal = isRunbookStopped(terminalSnap) || isRunbookComplete(terminalSnap);
 
-    for (const event of observation.events) {
-      switch (event.type) {
-        case 'ERROR_OCCURRED':
-          emitter.emit('ERROR_OCCURRED', event.payload);
-          break;
-        case 'RUNBOOK_STOPPED':
-          emitter.emit('RUNBOOK_STOPPED', event.payload);
-          break;
-        case 'STEP_TRANSITIONED':
-        case 'RUNBOOK_COMPLETED':
-          break;
-        default: {
-          const _exhaustive: never = event;
-          return _exhaustive;
+    if (snapIsTerminal) {
+      // Machine-driven stop: delegate to core projection
+      const currentStepForProjection = findStepOrThrow(steps, currentState.step);
+      const observation = deriveTransitionObservation({
+        steps,
+        currentStep: currentStepForProjection,
+        previousState: currentState,
+        updatedState: currentState,
+        snapshot: currentState.snapshot,
+        result: 'fail',
+      });
+
+      for (const event of observation.events) {
+        switch (event.type) {
+          case 'ERROR_OCCURRED':
+            emitter.emit('ERROR_OCCURRED', event.payload);
+            break;
+          case 'RUNBOOK_STOPPED':
+            emitter.emit('RUNBOOK_STOPPED', event.payload);
+            break;
+          case 'STEP_TRANSITIONED':
+          case 'RUNBOOK_COMPLETED':
+            break;
+          default: {
+            const _exhaustive: never = event;
+            return _exhaustive;
+          }
         }
       }
+    } else {
+      // CLI-owned stop: XState machine was never transitioned to STOPPED.
+      // The persisted snapshot is non-terminal (e.g. policy denial or
+      // delegation-resolution failure wrote lifecycle:'stopped' without
+      // driving the machine to its STOPPED state). Emit RUNBOOK_STOPPED
+      // directly from the persisted step position.
+      const position = buildStepPosition(
+        currentState.step,
+        countNumberedSteps(steps),
+        currentState.substep,
+        currentState.forStack,
+      );
+      const message = extractLastMessage(currentState.snapshot);
+      emitter.emit('RUNBOOK_STOPPED', {
+        position,
+        reason: 'fail_transition',
+        message,
+      });
     }
 
     await applyExecutionTerminalRelease(sessionService, runbookId, terminalReleaseMode);

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -273,7 +273,6 @@ type TransitionApplicationResult =
   | { status: 'stopped' };
 
 interface ObserveAndOrchestrateArgs {
-  manager: RunbookStateManager;
   sessionService: SessionService;
   lifecycleService: ExecutionLifecycleService;
   emitter: ExecutionEventEmitter;
@@ -341,7 +340,6 @@ async function applyExecutionTerminalRelease(
 }
 
 async function observeAndOrchestrate({
-  manager,
   sessionService,
   lifecycleService,
   emitter,
@@ -421,8 +419,6 @@ async function observeCommandTransition(
 
 /** Arguments for draining resolved substep completions. */
 export interface DrainResolvedCompletionsArgs {
-  /** State manager for raw state persistence. */
-  manager: RunbookStateManager;
   /** Actor service for sending events to the runbook machine. */
   actorService: RunbookActorService;
   /** Session service for active runbook tracking. */
@@ -472,8 +468,7 @@ export type DrainResolvedCompletionsResult =
  *
  * Applies completions in substep order and stops at the first unresolved substep.
  *
- * @param args - Drain arguments including state manager, services, and current state
- * @param args.manager - State manager for raw state persistence
+ * @param args - Drain arguments including services and current state
  * @param args.actorService - Actor service for sending events to the runbook machine
  * @param args.sessionService - Session service for active runbook tracking
  * @param args.lifecycleService - Lifecycle service for completion read/write operations
@@ -488,7 +483,6 @@ export type DrainResolvedCompletionsResult =
  * @returns Drain result indicating continue/done/stopped with counts of applied and unresolved completions
  */
 export async function drainResolvedCompletions({
-  manager,
   actorService,
   sessionService,
   lifecycleService,
@@ -540,7 +534,6 @@ export async function drainResolvedCompletions({
     }
 
     const transitionResult = await applyDrainedCompletion({
-      manager,
       actorService,
       sessionService,
       lifecycleService,
@@ -766,7 +759,6 @@ export async function runExecutionLoop(
     }
 
     const drainResult = await drainResolvedCompletions({
-      manager,
       actorService,
       sessionService,
       lifecycleService,
@@ -1101,7 +1093,6 @@ export async function runExecutionLoop(
       return 'stopped';
     }
     const transitionResult = await observeCommandTransition({
-      manager,
       sessionService,
       lifecycleService,
       emitter,
@@ -1131,12 +1122,7 @@ export async function runExecutionLoop(
   }
 }
 
-export {
-  extractLastMessage,
-  extractRetryDisplayCount,
-  extractRetryMax,
-  formatActionForDisplay,
-};
+export { extractLastMessage, extractRetryDisplayCount, extractRetryMax, formatActionForDisplay };
 
 /**
  * Check if value is a valid result ('pass' | 'fail').

--- a/packages/core/__tests__/events/exports.test.ts
+++ b/packages/core/__tests__/events/exports.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from '@jest/globals';
 import {
   ExecutionEventEmitter,
+  deriveGotoActionBlock,
+  deriveTransitionObservation,
   type RunbookEventV1,
   type StepTransitionedPayload,
+  type TransitionObservation,
+  type TransitionObservationEvent,
 } from '../../src/index.js';
 
 describe('core exports', () => {
@@ -26,5 +30,14 @@ describe('core exports', () => {
       } satisfies StepTransitionedPayload,
     };
     expect(event.type).toBe('STEP_TRANSITIONED');
+  });
+
+  it('exports transition observation helpers', () => {
+    expect(typeof deriveTransitionObservation).toBe('function');
+    expect(typeof deriveGotoActionBlock).toBe('function');
+    const _observation: TransitionObservation | undefined = undefined;
+    const _event: TransitionObservationEvent | undefined = undefined;
+    expect(_observation).toBeUndefined();
+    expect(_event).toBeUndefined();
   });
 });

--- a/packages/core/__tests__/events/transition-observation.test.ts
+++ b/packages/core/__tests__/events/transition-observation.test.ts
@@ -122,7 +122,20 @@ describe('deriveTransitionObservation', () => {
   });
 
   it('includes FOR loop position metadata on transition payloads', () => {
-    const previousState = state({ step: '1' });
+    const previousState = state({
+      step: '1',
+      forStack: [
+        {
+          stepId: '1',
+          iteration: 1,
+          start: 1,
+          end: 4,
+          variable: 'item',
+          source: { kind: 'range' },
+          implicit: false,
+        },
+      ],
+    });
     const updatedState = state({
       step: '1',
       forStack: [
@@ -133,6 +146,7 @@ describe('deriveTransitionObservation', () => {
           end: 4,
           variable: 'item',
           source: { kind: 'range' },
+          implicit: false,
         },
       ],
     });
@@ -153,8 +167,8 @@ describe('deriveTransitionObservation', () => {
       type: 'STEP_TRANSITIONED',
       payload: {
         action: 'NEXT',
-        from: '1',
-        at: '1',
+        from: '1.1',
+        at: '1.2',
         result: 'PASS',
         forIndex: 2,
         forEnd: 4,
@@ -184,6 +198,9 @@ describe('deriveTransitionObservation', () => {
     });
 
     expect(observation.status).toBe('done');
+    if (observation.status !== 'done') {
+      throw new Error(`Expected done observation, got ${observation.status}`);
+    }
     expect(observation.message).toBe('Ship it');
     expect(observation.events).toEqual([
       {

--- a/packages/core/__tests__/events/transition-observation.test.ts
+++ b/packages/core/__tests__/events/transition-observation.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from '@jest/globals';
+import type { ResolvedStep, RunbookState } from '../../src/runbook/types.js';
+import {
+  deriveGotoActionBlock,
+  deriveTransitionObservation,
+} from '../../src/events/transition-observation.js';
+
+const steps = [
+  {
+    kind: 'command',
+    name: '1',
+    description: 'Build',
+    command: { code: 'npm test', lang: 'bash' },
+    transitions: {
+      pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+      fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+    },
+  },
+  {
+    kind: 'command',
+    name: '2',
+    description: 'Deploy',
+    command: { code: 'npm run deploy', lang: 'bash' },
+    transitions: {
+      pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+      fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+    },
+  },
+] as unknown as ResolvedStep[];
+
+const currentStep = steps[0];
+
+function state(overrides: Partial<RunbookState> = {}): RunbookState {
+  return {
+    id: `rd_${'1'.repeat(32)}`,
+    runbook: { source: 'project', path: 'test.runbook.md' },
+    runbookPath: 'test.runbook.md',
+    step: '1',
+    stepName: 'Build',
+    retryCount: 0,
+    variables: {},
+    steps: [],
+    startedAt: '2026-05-12T00:00:00.000Z',
+    updatedAt: '2026-05-12T00:00:00.000Z',
+    lifecycle: 'running',
+    ...overrides,
+  } as RunbookState;
+}
+
+describe('deriveTransitionObservation', () => {
+  it('derives a STEP_TRANSITIONED payload for non-terminal transitions', () => {
+    const previousState = state({ step: '1' });
+    const updatedState = state({ step: '2', stepName: 'Deploy' });
+
+    const observation = deriveTransitionObservation({
+      steps,
+      currentStep,
+      previousState,
+      updatedState,
+      snapshot: {
+        value: { 'step::2': 'idle' },
+        context: { lastAction: { type: 'CONTINUE' } },
+      },
+      result: 'pass',
+      command: 'npm test',
+    });
+
+    expect(observation).toMatchObject({
+      status: 'continue',
+      action: 'CONTINUE',
+      from: '1',
+      at: '2',
+      state: updatedState,
+    });
+    expect(observation.events).toEqual([
+      {
+        type: 'STEP_TRANSITIONED',
+        payload: {
+          action: 'CONTINUE',
+          from: '1',
+          at: '2',
+          result: 'PASS',
+          command: 'npm test',
+        },
+      },
+    ]);
+  });
+
+  it('derives RETRY metadata using the snapshot retry counters', () => {
+    const previousState = state({ step: '1', retryCount: 0 });
+    const updatedState = state({ step: '1', retryCount: 1 });
+
+    const observation = deriveTransitionObservation({
+      steps,
+      currentStep,
+      previousState,
+      updatedState,
+      snapshot: {
+        value: { 'step::1': 'idle' },
+        context: {
+          lastAction: { type: 'RETRY' },
+          retryMax: 3,
+          iterationRetryCount: 1,
+        },
+      },
+      result: 'fail',
+    });
+
+    expect(observation.events).toEqual([
+      {
+        type: 'STEP_TRANSITIONED',
+        payload: {
+          action: 'RETRY',
+          from: '1',
+          at: '1',
+          result: 'FAIL',
+          retryAttempt: 1,
+          retryMax: 3,
+        },
+      },
+    ]);
+  });
+
+  it('includes FOR loop position metadata on transition payloads', () => {
+    const previousState = state({ step: '1' });
+    const updatedState = state({
+      step: '1',
+      forStack: [
+        {
+          stepId: '1',
+          iteration: 2,
+          start: 1,
+          end: 4,
+          variable: 'item',
+          source: { kind: 'range' },
+        },
+      ],
+    });
+
+    const observation = deriveTransitionObservation({
+      steps,
+      currentStep,
+      previousState,
+      updatedState,
+      snapshot: {
+        value: { 'step::1': 'idle' },
+        context: { lastAction: { type: 'NEXT' } },
+      },
+      result: 'pass',
+    });
+
+    expect(observation.events[0]).toEqual({
+      type: 'STEP_TRANSITIONED',
+      payload: {
+        action: 'NEXT',
+        from: '1',
+        at: '1',
+        result: 'PASS',
+        forIndex: 2,
+        forEnd: 4,
+      },
+    });
+  });
+
+  it('emits STEP_TRANSITIONED then RUNBOOK_COMPLETED for terminal completion', () => {
+    const previousState = state({ step: '2', retryCount: 0 });
+    const updatedState = state({ step: '2', lifecycle: 'completed' });
+
+    const observation = deriveTransitionObservation({
+      steps,
+      currentStep: steps[1],
+      previousState,
+      updatedState,
+      snapshot: {
+        status: 'done',
+        value: 'COMPLETE',
+        context: {
+          lifecycle: 'completed',
+          lastAction: { type: 'COMPLETE' },
+          lastMessage: 'Ship it',
+        },
+      },
+      result: 'pass',
+    });
+
+    expect(observation.status).toBe('done');
+    expect(observation.message).toBe('Ship it');
+    expect(observation.events).toEqual([
+      {
+        type: 'STEP_TRANSITIONED',
+        payload: {
+          action: 'COMPLETE',
+          from: '2',
+          at: '2',
+          result: 'PASS',
+        },
+      },
+      {
+        type: 'RUNBOOK_COMPLETED',
+        payload: {
+          message: 'Ship it',
+          finalPosition: { current: '2', total: 2 },
+        },
+      },
+    ]);
+  });
+
+  it('suppresses STEP_TRANSITIONED and emits ERROR_OCCURRED before RUNBOOK_STOPPED for internal failures', () => {
+    const previousState = state({ step: '1', retryCount: 0 });
+    const updatedState = state({ step: '1', lifecycle: 'stopped' });
+
+    const observation = deriveTransitionObservation({
+      steps,
+      currentStep,
+      previousState,
+      updatedState,
+      snapshot: {
+        status: 'done',
+        value: 'STOPPED',
+        context: {
+          lifecycle: 'stopped',
+          lastAction: {
+            type: 'OUTPUT_CAPTURE_FAILED',
+            message: 'failed to capture Foo',
+          },
+        },
+      },
+      result: 'fail',
+    });
+
+    expect(observation).toMatchObject({
+      status: 'stopped',
+      action: 'OUTPUT_CAPTURE_FAILED',
+      from: '1',
+      at: '1',
+      message: 'failed to capture Foo',
+    });
+    expect(observation.events).toEqual([
+      {
+        type: 'ERROR_OCCURRED',
+        payload: {
+          message: 'failed to capture Foo',
+        },
+      },
+      {
+        type: 'RUNBOOK_STOPPED',
+        payload: {
+          message: 'failed to capture Foo',
+          position: { current: '1', total: 2 },
+          reason: 'output_capture_failed',
+        },
+      },
+    ]);
+  });
+
+  it('uses computeActionResult for direct pass/fail display parity', () => {
+    const previousState = state({ step: '1' });
+    const updatedState = state({ step: '1', lifecycle: 'stopped' });
+
+    const observation = deriveTransitionObservation({
+      steps,
+      currentStep,
+      previousState,
+      updatedState,
+      snapshot: {
+        status: 'done',
+        value: 'STOPPED',
+        context: {
+          lifecycle: 'stopped',
+          lastAction: { type: 'STOP' },
+        },
+      },
+      result: 'pass',
+      computeActionResult: (action) => action !== 'STOP',
+    });
+
+    expect(observation.events[0]).toEqual({
+      type: 'STEP_TRANSITIONED',
+      payload: {
+        action: 'STOP',
+        from: '1',
+        at: '1',
+        result: 'FAIL',
+      },
+    });
+  });
+});
+
+describe('deriveGotoActionBlock', () => {
+  it('derives the goto action display payload from previous and updated state', () => {
+    expect(
+      deriveGotoActionBlock({
+        steps,
+        previousState: state({ step: '1' }),
+        updatedState: state({ step: '2' }),
+        target: { step: '2' },
+      }),
+    ).toEqual({
+      action: 'GOTO 2',
+      from: '1',
+      at: '2',
+    });
+  });
+});

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -504,6 +504,112 @@ exit 1
       expect(typeof snap.status).toBe('string');
       expect(snap).toHaveProperty('value');
     });
+
+    it('persists lastResult from PASS events without a CLI post-sync write', async () => {
+      const steps = createRunbook(`## 1. First
+- PASS CONTINUE
+- FAIL STOP
+
+## 2. Second
+- PASS COMPLETE
+- FAIL STOP
+`);
+      const state = await manager.create(
+        { source: 'project', path: 'pass-result.md' },
+        { title: 'PASS result', description: '', steps },
+        { runbookPath: 'pass-result.md', frontmatterOutputs: [] },
+      );
+
+      const result = await actorService.sendAndSync(state.id, steps, { type: 'PASS' });
+
+      expect(result?.state.step).toBe('2');
+      expect(result?.state.lastResult).toBe('pass');
+      await expect(manager.load(state.id)).resolves.toMatchObject({ lastResult: 'pass' });
+    });
+
+    it('persists lastResult from terminal FAIL events', async () => {
+      const steps = createRunbook(`## 1. Stop
+- PASS COMPLETE
+- FAIL STOP
+`);
+      const state = await manager.create(
+        { source: 'project', path: 'fail-result.md' },
+        { title: 'FAIL result', description: '', steps },
+        { runbookPath: 'fail-result.md', frontmatterOutputs: [] },
+      );
+
+      const result = await actorService.sendAndSync(state.id, steps, { type: 'FAIL' });
+
+      expect(result?.state.lifecycle).toBe('stopped');
+      expect(result?.state.lastResult).toBe('fail');
+      expect(result?.state.lastAction).toEqual({ type: 'STOP' });
+      await expect(manager.load(state.id)).resolves.toMatchObject({
+        lifecycle: 'stopped',
+        lastResult: 'fail',
+        lastAction: { type: 'STOP' },
+      });
+    });
+
+    it('persists lastResult from COMMAND_RESULT events', async () => {
+      const steps = createRunbook(`## 1. Command
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`bash
+echo ok
+\`\`\`
+`);
+      const state = await manager.create(
+        { source: 'project', path: 'command-result.md' },
+        { title: 'Command result', description: '', steps },
+        { runbookPath: 'command-result.md', frontmatterOutputs: [] },
+      );
+
+      const result = await actorService.sendAndSync(state.id, steps, {
+        type: 'COMMAND_RESULT',
+        result: 'pass',
+        channels: [],
+      });
+
+      expect(result?.state.lifecycle).toBe('completed');
+      expect(result?.state.lastResult).toBe('pass');
+      await expect(manager.load(state.id)).resolves.toMatchObject({
+        lifecycle: 'completed',
+        lastResult: 'pass',
+      });
+    });
+
+    it('clears stale lastResult when GOTO is synchronized from the machine', async () => {
+      const steps = createRunbook(`## 1. First
+- PASS CONTINUE
+- FAIL STOP
+
+## 2. Second
+- PASS COMPLETE
+- FAIL STOP
+`);
+      const state = await manager.create(
+        { source: 'project', path: 'goto-clear.md' },
+        { title: 'GOTO clear', description: '', steps },
+        { runbookPath: 'goto-clear.md', frontmatterOutputs: [] },
+      );
+      await manager.update(state.id, { lastResult: 'fail' });
+
+      const result = await actorService.sendAndSync(state.id, steps, {
+        type: 'GOTO',
+        target: { step: '2' },
+      });
+
+      expect(result?.state.step).toBe('2');
+      expect(result?.state.lastAction).toEqual({ type: 'GOTO', target: '2' });
+      expect(result?.state.lastResult).toBeUndefined();
+      await expect(manager.load(state.id)).resolves.toMatchObject({
+        step: '2',
+        lastAction: { type: 'GOTO', target: '2' },
+      });
+      const persisted = await manager.load(state.id);
+      expect(persisted?.lastResult).toBeUndefined();
+    });
   });
 
   describe('sendAndSync pending machine effects', () => {

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -669,6 +669,82 @@ echo hi
       await expect(manager.load(state.id)).resolves.toMatchObject({ lifecycle: 'stopped' });
     });
 
+    it('persists lastResult from COMMAND_RESULT when machine effects fail after event send', async () => {
+      const steps = createRunbook(`## 1. Command
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`bash
+echo ok
+\`\`\`
+`);
+      const state = await manager.create(
+        { source: 'project', path: 'effects-fail-result.md' },
+        { title: 'Effects fail result', description: '', steps },
+        { runbookPath: 'effects-fail-result.md', frontmatterOutputs: [] },
+      );
+
+      const effectsError = new Error('machine effect timed out');
+      (
+        actorService as unknown as {
+          waitForMachineEffects: () => Promise<void>;
+        }
+      ).waitForMachineEffects = async () => {
+        throw effectsError;
+      };
+
+      await expect(
+        actorService.sendAndSync(state.id, steps, {
+          type: 'COMMAND_RESULT',
+          result: 'pass',
+          channels: [],
+        }),
+      ).rejects.toThrow(effectsError);
+
+      await expect(manager.load(state.id)).resolves.toMatchObject({
+        lifecycle: 'stopped',
+        lastResult: 'pass',
+      });
+    });
+
+    it('persists lastResult from COMMAND_RESULT fail when machine effects fail after event send', async () => {
+      const steps = createRunbook(`## 1. Command
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`bash
+echo ok
+\`\`\`
+`);
+      const state = await manager.create(
+        { source: 'project', path: 'effects-fail-result-fail.md' },
+        { title: 'Effects fail result fail', description: '', steps },
+        { runbookPath: 'effects-fail-result-fail.md', frontmatterOutputs: [] },
+      );
+
+      const effectsError = new Error('machine effect timed out');
+      (
+        actorService as unknown as {
+          waitForMachineEffects: () => Promise<void>;
+        }
+      ).waitForMachineEffects = async () => {
+        throw effectsError;
+      };
+
+      await expect(
+        actorService.sendAndSync(state.id, steps, {
+          type: 'COMMAND_RESULT',
+          result: 'fail',
+          channels: [],
+        }),
+      ).rejects.toThrow(effectsError);
+
+      await expect(manager.load(state.id)).resolves.toMatchObject({
+        lifecycle: 'stopped',
+        lastResult: 'fail',
+      });
+    });
+
     it('does not persist stopped lifecycle when post-effect actor sync rejects stale state', async () => {
       const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
         runbookPath: 'test.md',

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -1,3 +1,4 @@
 export type * from './types.js';
 export * from './emitter.js';
+export * from './transition-observation.js';
 export * from './subscribers/index.js';

--- a/packages/core/src/events/transition-observation.ts
+++ b/packages/core/src/events/transition-observation.ts
@@ -131,8 +131,8 @@ function buildStepTransitionedPayload({
   const toPos = positions.to;
   return {
     action: actionType,
-    from: derivePositionAt({ current: positions.from.current, substep: positions.from.substep }),
-    at: derivePositionAt({ current: toPos.current, substep: toPos.substep }),
+    from: derivePositionAt(positions.from),
+    at: derivePositionAt(toPos),
     result: actionResult ? 'PASS' : 'FAIL',
     ...(command ? { command } : {}),
     ...(actionType === 'RETRY' ? { retryAttempt, retryMax } : {}),

--- a/packages/core/src/events/transition-observation.ts
+++ b/packages/core/src/events/transition-observation.ts
@@ -1,0 +1,281 @@
+import type { ActionBlockData } from '../cli/types.js';
+import {
+  asTerminalSnapshotOrDefault,
+  isRunbookComplete,
+  isRunbookStopped,
+} from '../runbook/snapshot-utils.js';
+import { countNumberedSteps } from '../runbook/step-utils.js';
+import { stepIdToString, type StepId } from '../runbook/step-id.js';
+import { buildStepPosition, derivePositionAt } from '../runbook/targeting.js';
+import {
+  deriveStoppedReason,
+  deriveTransitionMessage,
+  extractInternalFailureMessage,
+  extractLastAction,
+  extractLastMessage,
+  extractRetryDisplayCount,
+  extractRetryMax,
+  isInternalFailureLastAction,
+  parseActionType,
+  type ActionType,
+} from '../runbook/transition-kernel.js';
+import type { ResolvedStep, RunbookState } from '../runbook/types.js';
+import type {
+  ErrorOccurredPayload,
+  RunbookCompletedPayload,
+  RunbookStoppedPayload,
+  StepPosition,
+  StepTransitionedPayload,
+} from './types.js';
+
+/** Payload event variants derived after a machine transition has synchronized. */
+export type TransitionObservationEvent =
+  | { readonly type: 'ERROR_OCCURRED'; readonly payload: ErrorOccurredPayload }
+  | { readonly type: 'STEP_TRANSITIONED'; readonly payload: StepTransitionedPayload }
+  | { readonly type: 'RUNBOOK_COMPLETED'; readonly payload: RunbookCompletedPayload }
+  | { readonly type: 'RUNBOOK_STOPPED'; readonly payload: RunbookStoppedPayload };
+
+/** Input for deriving post-transition observation payloads. */
+export interface TransitionObservationInput {
+  /** Resolved runbook steps used for position calculations. */
+  readonly steps: readonly ResolvedStep[];
+  /** The execution unit whose result caused the transition. */
+  readonly currentStep: ResolvedStep;
+  /** Persisted state before the machine event was sent. */
+  readonly previousState: RunbookState;
+  /** Persisted state after actor synchronization and active-entry bookkeeping. */
+  readonly updatedState: RunbookState;
+  /** Raw XState snapshot returned by `RunbookActorService.sendAndSync()`. */
+  readonly snapshot: unknown;
+  /** Result signal that triggered the machine transition. */
+  readonly result: 'pass' | 'fail';
+  /** Optional display-result policy for direct `rd pass` / `rd fail` commands. */
+  readonly computeActionResult?: (actionType: ActionType) => boolean;
+  /** Display command associated with the transition, when command-driven. */
+  readonly command?: string;
+}
+
+/** Core-derived observation result for a synchronized machine transition. */
+export type TransitionObservation =
+  | {
+      readonly status: 'continue';
+      readonly state: RunbookState;
+      readonly action: ActionType;
+      readonly from: string;
+      readonly at: string;
+      readonly events: readonly TransitionObservationEvent[];
+    }
+  | {
+      readonly status: 'done';
+      readonly action: ActionType;
+      readonly from: string;
+      readonly at: string;
+      readonly message?: string;
+      readonly events: readonly TransitionObservationEvent[];
+    }
+  | {
+      readonly status: 'stopped';
+      readonly action: ActionType;
+      readonly from: string;
+      readonly at: string;
+      readonly message?: string;
+      readonly events: readonly TransitionObservationEvent[];
+    };
+
+interface TransitionPositions {
+  readonly from: StepPosition;
+  readonly to: StepPosition;
+}
+
+function buildTransitionPositions(
+  previousState: RunbookState,
+  updatedState: RunbookState,
+  steps: readonly ResolvedStep[],
+): TransitionPositions {
+  const totalSteps = countNumberedSteps(steps);
+  return {
+    from: buildStepPosition(
+      previousState.step,
+      totalSteps,
+      previousState.substep,
+      previousState.forStack,
+    ),
+    to: buildStepPosition(
+      updatedState.step,
+      totalSteps,
+      updatedState.substep,
+      updatedState.forStack,
+    ),
+  };
+}
+
+function buildStepTransitionedPayload({
+  actionType,
+  positions,
+  result,
+  actionResult,
+  command,
+  retryAttempt,
+  retryMax,
+  aggregated,
+}: {
+  readonly actionType: ActionType;
+  readonly positions: TransitionPositions;
+  readonly result: 'pass' | 'fail';
+  readonly actionResult: boolean;
+  readonly command?: string;
+  readonly retryAttempt: number;
+  readonly retryMax: number;
+  readonly aggregated: boolean;
+}): StepTransitionedPayload {
+  const toPos = positions.to;
+  return {
+    action: actionType,
+    from: derivePositionAt({ current: positions.from.current, substep: positions.from.substep }),
+    at: derivePositionAt({ current: toPos.current, substep: toPos.substep }),
+    result: actionResult ? 'PASS' : 'FAIL',
+    ...(command ? { command } : {}),
+    ...(actionType === 'RETRY' ? { retryAttempt, retryMax } : {}),
+    ...(toPos.for ? { forIndex: toPos.for.index, forEnd: toPos.for.end } : {}),
+    ...(aggregated ? { aggregated: true } : {}),
+  };
+}
+
+/**
+ * Derive post-transition event payloads from the synchronized machine snapshot.
+ *
+ * This function performs no persistence and no external side effects. Front ends
+ * consume the returned event list and render it through their own emitters.
+ *
+ * @param input - Previous state, updated state, snapshot, steps, and triggering result
+ * @returns Typed observation result and ordered payload events
+ */
+export function deriveTransitionObservation(
+  input: TransitionObservationInput,
+): TransitionObservation {
+  const lastAction = extractLastAction(input.snapshot);
+  const actionType = parseActionType(lastAction);
+  const retryMax = extractRetryMax(input.snapshot);
+  const retryAttempt = extractRetryDisplayCount(input.snapshot, input.updatedState.retryCount);
+  const aggregated = (lastAction as Record<string, unknown> | undefined)?.aggregated === true;
+  const positions = buildTransitionPositions(input.previousState, input.updatedState, input.steps);
+  const from = derivePositionAt(positions.from);
+  const at = derivePositionAt(positions.to);
+  const actionResult = input.computeActionResult
+    ? input.computeActionResult(actionType)
+    : input.result === 'pass';
+  const events: TransitionObservationEvent[] = [];
+
+  if (!isInternalFailureLastAction(lastAction)) {
+    events.push({
+      type: 'STEP_TRANSITIONED',
+      payload: buildStepTransitionedPayload({
+        actionType,
+        positions,
+        result: input.result,
+        actionResult,
+        command: input.command,
+        retryAttempt,
+        retryMax,
+        aggregated,
+      }),
+    });
+  }
+
+  const terminalSnapshot = asTerminalSnapshotOrDefault(input.snapshot);
+  const complete = isRunbookComplete(terminalSnapshot);
+  const stopped = isRunbookStopped(terminalSnapshot);
+
+  if (complete) {
+    const message =
+      extractLastMessage(input.snapshot) ??
+      deriveTransitionMessage(input.result, input.currentStep, input.previousState.retryCount);
+    events.push({
+      type: 'RUNBOOK_COMPLETED',
+      payload: {
+        message,
+        finalPosition: positions.to,
+      },
+    });
+    return { status: 'done', action: actionType, from, at, message, events };
+  }
+
+  if (stopped) {
+    const message =
+      extractInternalFailureMessage(lastAction) ??
+      extractLastMessage(input.snapshot) ??
+      deriveTransitionMessage(input.result, input.currentStep, input.previousState.retryCount);
+    const reason = deriveStoppedReason(lastAction);
+
+    if (isInternalFailureLastAction(lastAction)) {
+      const internalMessage = extractInternalFailureMessage(lastAction);
+      if (internalMessage !== undefined) {
+        events.push({
+          type: 'ERROR_OCCURRED',
+          payload: {
+            message: internalMessage,
+            ...(lastAction.type === 'RETRY_ERROR' ? { code: lastAction.code } : {}),
+          },
+        });
+      }
+    }
+
+    events.push({
+      type: 'RUNBOOK_STOPPED',
+      payload: {
+        message,
+        position: positions.from,
+        reason,
+      },
+    });
+    return { status: 'stopped', action: actionType, from, at, message, events };
+  }
+
+  return {
+    status: 'continue',
+    state: input.updatedState,
+    action: actionType,
+    from,
+    at,
+    events,
+  };
+}
+
+/** Input for deriving `rd goto` action display from core position helpers. */
+export interface GotoActionBlockInput {
+  /** All resolved runbook steps, used to calculate total numbered steps. */
+  readonly steps: readonly ResolvedStep[];
+  /** State before the GOTO machine event. */
+  readonly previousState: RunbookState;
+  /** State after the GOTO machine event. */
+  readonly updatedState: RunbookState;
+  /** Validated GOTO target supplied to the machine event. */
+  readonly target: StepId;
+}
+
+/**
+ * Derive the action block rendered by `rd goto`.
+ *
+ * @param input - Previous state, updated state, steps, and target
+ * @returns Format-agnostic action block data for CLI rendering
+ */
+export function deriveGotoActionBlock(input: GotoActionBlockInput): ActionBlockData {
+  const totalSteps = countNumberedSteps(input.steps);
+  const from = buildStepPosition(
+    input.previousState.step,
+    totalSteps,
+    input.previousState.substep,
+    input.previousState.forStack,
+  );
+  const at = buildStepPosition(
+    input.updatedState.step,
+    totalSteps,
+    input.updatedState.substep,
+    input.updatedState.forStack,
+  );
+  return {
+    action: `GOTO ${stepIdToString(input.target)}`,
+    from: derivePositionAt(from),
+    at: derivePositionAt(at),
+  };
+}

--- a/packages/core/src/events/transition-observation.ts
+++ b/packages/core/src/events/transition-observation.ts
@@ -112,7 +112,6 @@ function buildTransitionPositions(
 function buildStepTransitionedPayload({
   actionType,
   positions,
-  result,
   actionResult,
   command,
   retryAttempt,
@@ -121,7 +120,6 @@ function buildStepTransitionedPayload({
 }: {
   readonly actionType: ActionType;
   readonly positions: TransitionPositions;
-  readonly result: 'pass' | 'fail';
   readonly actionResult: boolean;
   readonly command?: string;
   readonly retryAttempt: number;
@@ -172,7 +170,6 @@ export function deriveTransitionObservation(
       payload: buildStepTransitionedPayload({
         actionType,
         positions,
-        result: input.result,
         actionResult,
         command: input.command,
         retryAttempt,

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -549,6 +549,7 @@ export class RunbookActorService {
    * @param id - Runbook state ID
    * @param actor - The XState actor to read snapshot from
    * @param steps - Parsed runbook steps for step name lookup
+   * @param lastResultSync - Optional persisted-result update applied alongside the snapshot sync
    * @returns Updated persisted RunbookState and the raw snapshot
    * @throws {Error} If the actor snapshot's stateValue is not a string
    * @throws {Error} If the actor snapshot's active state ID is stale or unsupported
@@ -807,6 +808,7 @@ export class RunbookActorService {
    * @param id - Runbook state ID
    * @param actor - Started actor to synchronize from
    * @param steps - Parsed runbook steps
+   * @param lastResultSync - Optional persisted-result update applied alongside the snapshot sync
    * @returns Updated persisted state and raw snapshot
    */
   private async persistAfterMachineEffects(

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -132,6 +132,55 @@ function isPersistableLastAction(value: unknown): value is LastAction {
   );
 }
 
+type LastResultSync =
+  | { readonly kind: 'preserve' }
+  | { readonly kind: 'clear' }
+  | { readonly kind: 'set'; readonly result: 'pass' | 'fail' };
+
+function lastResultSyncForEvent(event: RunbookEvent): LastResultSync {
+  switch (event.type) {
+    case 'PASS':
+      return { kind: 'set', result: 'pass' };
+    case 'FAIL':
+      return { kind: 'set', result: 'fail' };
+    case 'COMMAND_RESULT':
+      return { kind: 'set', result: event.result };
+    case 'GOTO':
+    case 'FORCE_STOP':
+    case 'FORCE_COMPLETE':
+      return { kind: 'clear' };
+    case 'RETRY':
+    case 'SET_VARIABLES':
+    case 'PENDING_FRONTIER_CONSUMED':
+      return { kind: 'preserve' };
+    default: {
+      const _exhaustive: never = event;
+      return _exhaustive;
+    }
+  }
+}
+
+function lastResultPatch(
+  sync: LastResultSync | undefined,
+  options: { readonly terminal: boolean },
+): { readonly lastResult?: 'pass' | 'fail' } {
+  if (!sync) {
+    return options.terminal ? { lastResult: undefined } : {};
+  }
+  switch (sync.kind) {
+    case 'set':
+      return { lastResult: sync.result };
+    case 'clear':
+      return { lastResult: undefined };
+    case 'preserve':
+      return {};
+    default: {
+      const _exhaustive: never = sync;
+      return _exhaustive;
+    }
+  }
+}
+
 /**
  * Per-entry structural guard for the `enteredArtifacts` map.
  *
@@ -510,6 +559,7 @@ export class RunbookActorService {
     id: string,
     actor: AnyActorRef,
     steps: readonly ResolvedStep[],
+    lastResultSync?: LastResultSync,
   ): Promise<{ state: RunbookState; snapshot: unknown }> {
     const snapshot = actor.getPersistedSnapshot() as unknown as PersistedRunbookSnapshot;
     const rawValue: unknown = snapshot.value;
@@ -554,11 +604,11 @@ export class RunbookActorService {
         finalVars,
         lifecycle,
         lastAction,
-        lastResult: undefined,
         snapshot,
         // Clear FOR loop state on completion
         forStack: undefined,
         iterationResults: undefined,
+        ...lastResultPatch(lastResultSync, { terminal: true }),
         ...substepStatesTermPatch,
         ...activeFrameKeyTermPatch,
       });
@@ -657,6 +707,7 @@ export class RunbookActorService {
       forStack: computedForStack,
       iterationResults: computedIterationResults,
       lastAction,
+      ...lastResultPatch(lastResultSync, { terminal: false }),
       ...substepStatesPatch,
       ...activeFrameKeyPatch,
     });
@@ -762,9 +813,10 @@ export class RunbookActorService {
     id: string,
     actor: AnyActorRef,
     steps: readonly ResolvedStep[],
+    lastResultSync?: LastResultSync,
   ): Promise<{ state: RunbookState; snapshot: unknown }> {
     await this.waitForMachineEffects(actor);
-    return this.updateFromActor(id, actor, steps);
+    return this.updateFromActor(id, actor, steps, lastResultSync);
   }
 
   /**
@@ -871,7 +923,8 @@ export class RunbookActorService {
         }
         throw effectsErr;
       }
-      const { state, snapshot } = await this.updateFromActor(id, actor, steps);
+      const lastResultSync = lastResultSyncForEvent(event);
+      const { state, snapshot } = await this.updateFromActor(id, actor, steps, lastResultSync);
       return { state, snapshot };
     } finally {
       this.stopActor(actor);

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -908,6 +908,7 @@ export class RunbookActorService {
         actor.send(event);
       }
 
+      const lastResultSync = lastResultSyncForEvent(event);
       try {
         await this.waitForMachineEffects(actor);
       } catch (effectsErr) {
@@ -916,7 +917,10 @@ export class RunbookActorService {
         // the same command. Best-effort — if this also fails, log and let
         // the primary error propagate.
         try {
-          await this.manager.update(id, { lifecycle: 'stopped' });
+          await this.manager.update(id, {
+            lifecycle: 'stopped',
+            ...lastResultPatch(lastResultSync, { terminal: true }),
+          });
         } catch {
           void logger.warn(
             'actor-service: failed to persist stopped lifecycle after effects failure',
@@ -925,7 +929,6 @@ export class RunbookActorService {
         }
         throw effectsErr;
       }
-      const lastResultSync = lastResultSyncForEvent(event);
       const { state, snapshot } = await this.updateFromActor(id, actor, steps, lastResultSync);
       return { state, snapshot };
     } finally {


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed transition-observation helpers to compute post-transition events and formatted GOTO action blocks.

* **Bug Fixes**
  * GOTO outputs now include full action details with source/target positions.
  * Improved error handling: explicit error events emitted and terminal event ordering corrected.
  * Persisted action results now handled consistently across syncs.

* **Tests**
  * Expanded coverage for transition observations, GOTO rendering, error scenarios, and result persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/302)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
