### PR TITLE
Fix completion drain atomicity and collect schema coverage

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -32,6 +32,7 @@ NOTVALID
 Subcategorize
 TOCTOU
 Turborepo
+Unforgeable
 agentic
 aindex
 alnum
@@ -222,6 +223,7 @@ unsandboxed
 unserialisable
 unstash
 unsub
+unvalidated
 unwritable
 uppercased
 urandom

--- a/packages/cli/__tests__/commands/abort.test.ts
+++ b/packages/cli/__tests__/commands/abort.test.ts
@@ -399,6 +399,16 @@ describe('abort command - unit tests', () => {
       const afterAbortParent = await readRunbookState(workspace, parentState.id);
       expect(afterAbortParent?.lifecycle).toBe('running');
       expect(await readRunbookState(workspace, childRunId)).toBeNull();
+
+      // FAIL propagation must reach the parent: the substepState for the
+      // delegated parent substep must be marked done/fail. Without
+      // `ignoreCancellation: true` on the abort path, the
+      // `recordChildCompletionUnlocked` short-circuit would block this from
+      // happening because step 8 of the abort flow already wrote
+      // `delegation.cancelledAt` onto the substep state.
+      const propagatedSubstep = afterAbortParent?.substepStates?.find((entry) => entry.id === '1');
+      expect(propagatedSubstep?.status).toBe('done');
+      expect(propagatedSubstep?.result).toBe('fail');
     });
   });
 

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -338,6 +338,47 @@ describe('collect command', () => {
     });
   });
 
+  describe('not-active behavior', () => {
+    /**
+     * When `--step` targets a frame other than the cursor's active frame, the
+     * drain refuses to dispatch and returns `not_active`. `rd collect` must
+     * surface this as a visible JSON payload with the requested and active
+     * frame keys — never an empty silent success.
+     */
+    it('emits a not-active JSON payload when --step --index targets a non-active iteration', async () => {
+      const runbookId = await setupReadyToCollect(['pass', 'pass']);
+
+      // Rewrite substepStates to be in frame `1|99` (iteration 99) while the
+      // cursor stays on the active step-1 frame. `--step 1.1 --index 99` then
+      // resolves to scope.frameKey `1|99` which differs from the cursor's
+      // active frame — drain returns `not_active`.
+      const statePath = join(workspace.statePath(), `${runbookId}.json`);
+      const raw = JSON.parse(await readFile(statePath, 'utf-8')) as MutableRunbookState;
+      const overrideFrame = buildFrameKey('1', 99);
+      if (raw.substepStates) {
+        raw.substepStates = raw.substepStates.map((ss) => ({ ...ss, frameKey: overrideFrame }));
+      }
+      await writeFile(statePath, JSON.stringify(raw, null, 2));
+
+      const result = await runCliInProcess(
+        ['collect', '--step', '1.1', '--index', '99'],
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+      expect(parsed.kind).toBe('collect');
+      expect(parsed.action).toBe('collect');
+      expect(parsed.status).toBe('not-active');
+      expect(parsed.step).toBe('1');
+      expect(parsed.parentRunId).toBe(runbookId);
+      expect(parsed.frameKey).toBe(overrideFrame);
+      expect(typeof parsed.activeFrameKey).toBe('string');
+      expect(parsed.activeFrameKey).not.toBe(overrideFrame);
+      expect(typeof parsed.unresolved).toBe('number');
+    });
+  });
+
   describe('end-to-end CLI flow', () => {
     /**
      * End-to-end smoke coverage that exercises the full

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -49,6 +49,9 @@ const mockCreateCliRunbookActorService = mockFn<() => RunbookActorServiceType>()
 jest.unstable_mockModule('@rundown-org/core', () => ({
   RunbookStateManager: jest.fn(),
   RunbookActorService: jest.fn(),
+  RunbookCompletionService: jest.fn().mockImplementation(() => ({
+    recordChildCompletion: mockFn<() => Promise<string>>().mockResolvedValue('recorded'),
+  })),
   SessionService: jest.fn(),
   ExecutionLifecycleService: jest.fn(),
   DelegationLock: jest.fn(),
@@ -280,12 +283,48 @@ function wireMocks(manager: MockManager, lifecycleService: MockLifecycleService)
     () => ExecutionLifecycleServiceType
   >;
   const MockSession = core.SessionService as unknown as jest.Mock<() => SessionServiceType>;
+  const MockCompletion = core.RunbookCompletionService as unknown as jest.Mock<
+    () => { recordChildCompletion: jest.Mock<(...args: unknown[]) => Promise<string>> }
+  >;
 
   MockManagerClass.mockImplementation(() => manager as unknown as RunbookStateManagerType);
   MockLifecycle.mockImplementation(
     () => lifecycleService as unknown as ExecutionLifecycleServiceType,
   );
   jest.mocked(createCliRunbookActorService).mockImplementation(() => makeActorDouble());
+  MockCompletion.mockImplementation(() => ({
+    recordChildCompletion: mockFn<(...args: unknown[]) => Promise<string>>().mockImplementation(
+      async (raw) => {
+        const { childState, result } = raw as { childState: RunbookState; result: 'pass' | 'fail' };
+        const linkage = childState.parentLinkage;
+        if (!linkage) return 'not-applicable';
+        const parent = await manager.load(linkage.parentRunId);
+        if (!parent) return 'not-applicable';
+        const frameKey = linkage.parentFrameKey ?? brandFrameKeyForTest(`${parent.step}|`);
+        const substep = parent.substepStates?.find(
+          (ss) => ss.id === linkage.parentStepId && ss.frameKey === frameKey,
+        );
+        if (linkage.kind === 'delegation' && substep?.delegation?.cancelledAt) {
+          return 'cancelled';
+        }
+        await lifecycleService.upsertResolvedCompletion(
+          linkage.parentRunId,
+          `${String(frameKey)}|${String(linkage.parentEntry ?? 1)}|${linkage.parentStepId}`,
+          {
+            agentId: linkage.kind === 'inline' ? 'inline' : 'delegation',
+            result,
+            targetStep: linkage.parentStep ?? parent.step,
+            targetSubstep: linkage.parentStepId,
+            targetFrameKey: frameKey,
+            targetEntry: linkage.parentEntry ?? 1,
+            finalVars: childState.finalVars,
+            completedAt: '2026-02-27T10:00:00.000Z',
+          },
+        );
+        return 'recorded';
+      },
+    ),
+  }));
   MockSession.mockImplementation(
     () =>
       ({
@@ -363,7 +402,7 @@ describe('handleParentCompletion', () => {
     expect(result).toBe('not-applicable');
   });
 
-  it('acquires delegation lock on parent run ID', async () => {
+  it('delegates child completion recording to core service', async () => {
     const delegation = makeDelegationLinkage();
     const childState = makeState(CHILD_RUN_ID, { parentLinkage: delegation });
     const parentState = makeState(PARENT_RUN_ID, {
@@ -372,7 +411,7 @@ describe('handleParentCompletion', () => {
 
     const states = new Map([[parentState.id, parentState]]);
     const manager = makeManager(states);
-    const lock = makeLock();
+    const _lock = makeLock();
     const lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
@@ -380,8 +419,8 @@ describe('handleParentCompletion', () => {
 
     await handleParentCompletion(childState, 'pass', '/test', output);
 
-    expect(lock.acquire).toHaveBeenCalledWith(PARENT_RUN_ID);
-    expect(lock.release).toHaveBeenCalledWith(PARENT_RUN_ID);
+    expect(core.RunbookCompletionService).toHaveBeenCalled();
+    expect(lifecycleService.upsertResolvedCompletion).toHaveBeenCalled();
   });
 
   it('returns not-applicable when parent no longer exists', async () => {
@@ -390,7 +429,7 @@ describe('handleParentCompletion', () => {
 
     const states = new Map([[PARENT_RUN_ID, null]]);
     const manager = makeManager(states);
-    const lock = makeLock();
+    const _lock = makeLock();
     const lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
@@ -399,7 +438,7 @@ describe('handleParentCompletion', () => {
     const result = await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(result).toBe('not-applicable');
-    expect(lock.release).toHaveBeenCalled();
+    expect(core.RunbookCompletionService).toHaveBeenCalled();
   });
 
   it('does not block inline child when substep has cancelled delegation', async () => {
@@ -652,7 +691,7 @@ describe('handleParentCompletion', () => {
       [grandparentState.id, grandparentState],
     ]);
     const manager = makeManager(states);
-    const lock = makeLock();
+    const _lock = makeLock();
     const lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
@@ -666,9 +705,8 @@ describe('handleParentCompletion', () => {
 
     await handleParentCompletion(childState, 'pass', '/test', output);
 
-    // Should cascade - second acquire should be on grandparent
-    expect(lock.acquire).toHaveBeenCalledWith(PARENT_RUN_ID);
-    expect(lock.acquire).toHaveBeenCalledWith(GRANDPARENT_RUN_ID);
+    // Should cascade through the core completion service for parent and grandparent.
+    expect(core.RunbookCompletionService).toHaveBeenCalledTimes(2);
   });
 
   it('respects maximum recursion depth', async () => {
@@ -893,7 +931,7 @@ describe('handleParentCompletion', () => {
     expect(drainCall.frameKeyOverride).toBeUndefined();
   });
 
-  it('forwards child finalVars to parent actor via SET_VARIABLES before drain', async () => {
+  it('records child finalVars on the parent resolved completion before drain', async () => {
     const delegation = makeDelegationLinkage();
     const childState = makeState(CHILD_RUN_ID, {
       parentLinkage: delegation,
@@ -920,16 +958,16 @@ describe('handleParentCompletion', () => {
 
     await handleParentCompletion(childState, 'pass', '/test', output);
 
-    const actorInstance = mockCreateCliRunbookActorService.mock.results[0]?.value as {
-      sendAndSync: jest.Mock<(...args: unknown[]) => Promise<unknown>>;
-    };
-    expect(actorInstance.sendAndSync).toHaveBeenCalledWith(PARENT_RUN_ID, expect.any(Array), {
-      type: 'SET_VARIABLES',
-      vars: { PlanPath: '/work/plan.json', version: '2.1' },
-    });
+    expect(lifecycleService.upsertResolvedCompletion).toHaveBeenCalledWith(
+      PARENT_RUN_ID,
+      expect.any(String),
+      expect.objectContaining({
+        finalVars: { PlanPath: '/work/plan.json', version: '2.1' },
+      }),
+    );
   });
 
-  it('surfaces a warning to output when SET_VARIABLES fails', async () => {
+  it('does not send SET_VARIABLES when child finalVars are present', async () => {
     const delegation = makeDelegationLinkage();
     const childState = makeState(CHILD_RUN_ID, {
       parentLinkage: delegation,
@@ -945,32 +983,7 @@ describe('handleParentCompletion', () => {
     const _lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
-    // Override the actor mock so sendAndSync throws for this test
-    jest
-      .mocked(createCliRunbookActorService)
-      .mockImplementation(() =>
-        makeActorDouble(
-          mockFn<(...args: unknown[]) => Promise<unknown>>().mockRejectedValue(
-            new Error('machine rejected event'),
-          ),
-        ),
-      );
-
-    (
-      core.RunbookStateManager as unknown as jest.Mock<() => RunbookStateManagerType>
-    ).mockImplementation(() => manager as unknown as RunbookStateManagerType);
-    (
-      core.ExecutionLifecycleService as unknown as jest.Mock<() => ExecutionLifecycleServiceType>
-    ).mockImplementation(() => makeLifecycleService() as unknown as ExecutionLifecycleServiceType);
-    (core.SessionService as unknown as jest.Mock<() => SessionServiceType>).mockImplementation(
-      () =>
-        ({
-          popRunbook: mockFn<() => Promise<string | null>>().mockResolvedValue(null),
-          releaseRunbook: mockFn<() => Promise<unknown>>().mockResolvedValue({
-            status: 'released',
-          }),
-        }) as unknown as SessionServiceType,
-    );
+    wireMocks(manager, _lifecycleService);
 
     jest.mocked(drainResolvedCompletions).mockResolvedValue({
       unresolved: 0,
@@ -981,7 +994,15 @@ describe('handleParentCompletion', () => {
 
     await handleParentCompletion(childState, 'pass', '/test', output);
 
-    expect(output.warning).toHaveBeenCalledWith(expect.stringContaining('SET_VARIABLES'));
+    const actorInstance = mockCreateCliRunbookActorService.mock.results[0]?.value as {
+      sendAndSync: jest.Mock<(...args: unknown[]) => Promise<unknown>>;
+    };
+    expect(actorInstance.sendAndSync).not.toHaveBeenCalledWith(
+      PARENT_RUN_ID,
+      expect.any(Array),
+      expect.objectContaining({ type: 'SET_VARIABLES' }),
+    );
+    expect(output.warning).not.toHaveBeenCalled();
   });
 
   it('does not call sendAndSync when child has no finalVars', async () => {

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -275,7 +275,28 @@ function makeLifecycleService(
   };
 }
 
-function wireMocks(manager: MockManager, lifecycleService: MockLifecycleService): void {
+/**
+ * Mock for the core `RunbookCompletionService`. Per project convention
+ * (CLAUDE.md "Mock injected core services structurally"), this is a plain
+ * structural stub: tests assert on call arguments to `recordChildCompletion`
+ * and vary the return value to cover behavioral branches. The real recording
+ * logic — parent lookup, cancellation detection, lifecycle upsert — is owned
+ * by core and tested in `packages/core/__tests__/runbook/completion-service.test.ts`.
+ */
+type RecordChildCompletionMock = jest.Mock<(...args: unknown[]) => Promise<string>>;
+
+function wireMocks(
+  manager: MockManager,
+  lifecycleService: MockLifecycleService,
+  options: {
+    /** Stub return value for `recordChildCompletion`; default `'recorded'`. */
+    readonly recordChildCompletionResult?:
+      | 'recorded'
+      | 'duplicate'
+      | 'not-applicable'
+      | 'cancelled';
+  } = {},
+): RecordChildCompletionMock {
   const MockManagerClass = core.RunbookStateManager as unknown as jest.Mock<
     () => RunbookStateManagerType
   >;
@@ -284,7 +305,7 @@ function wireMocks(manager: MockManager, lifecycleService: MockLifecycleService)
   >;
   const MockSession = core.SessionService as unknown as jest.Mock<() => SessionServiceType>;
   const MockCompletion = core.RunbookCompletionService as unknown as jest.Mock<
-    () => { recordChildCompletion: jest.Mock<(...args: unknown[]) => Promise<string>> }
+    () => { recordChildCompletion: RecordChildCompletionMock }
   >;
 
   MockManagerClass.mockImplementation(() => manager as unknown as RunbookStateManagerType);
@@ -292,39 +313,11 @@ function wireMocks(manager: MockManager, lifecycleService: MockLifecycleService)
     () => lifecycleService as unknown as ExecutionLifecycleServiceType,
   );
   jest.mocked(createCliRunbookActorService).mockImplementation(() => makeActorDouble());
-  MockCompletion.mockImplementation(() => ({
-    recordChildCompletion: mockFn<(...args: unknown[]) => Promise<string>>().mockImplementation(
-      async (raw) => {
-        const { childState, result } = raw as { childState: RunbookState; result: 'pass' | 'fail' };
-        const linkage = childState.parentLinkage;
-        if (!linkage) return 'not-applicable';
-        const parent = await manager.load(linkage.parentRunId);
-        if (!parent) return 'not-applicable';
-        const frameKey = linkage.parentFrameKey ?? brandFrameKeyForTest(`${parent.step}|`);
-        const substep = parent.substepStates?.find(
-          (ss) => ss.id === linkage.parentStepId && ss.frameKey === frameKey,
-        );
-        if (linkage.kind === 'delegation' && substep?.delegation?.cancelledAt) {
-          return 'cancelled';
-        }
-        await lifecycleService.upsertResolvedCompletion(
-          linkage.parentRunId,
-          `${String(frameKey)}|${String(linkage.parentEntry ?? 1)}|${linkage.parentStepId}`,
-          {
-            agentId: linkage.kind === 'inline' ? 'inline' : 'delegation',
-            result,
-            targetStep: linkage.parentStep ?? parent.step,
-            targetSubstep: linkage.parentStepId,
-            targetFrameKey: frameKey,
-            targetEntry: linkage.parentEntry ?? 1,
-            finalVars: childState.finalVars,
-            completedAt: '2026-02-27T10:00:00.000Z',
-          },
-        );
-        return 'recorded';
-      },
-    ),
-  }));
+
+  const recordChildCompletion = mockFn<(...args: unknown[]) => Promise<string>>().mockResolvedValue(
+    options.recordChildCompletionResult ?? 'recorded',
+  );
+  MockCompletion.mockImplementation(() => ({ recordChildCompletion }));
   MockSession.mockImplementation(
     () =>
       ({
@@ -334,6 +327,8 @@ function wireMocks(manager: MockManager, lifecycleService: MockLifecycleService)
         }),
       }) as unknown as SessionServiceType,
   );
+
+  return recordChildCompletion;
 }
 
 beforeEach(() => {
@@ -415,12 +410,18 @@ describe('handleParentCompletion', () => {
     const lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
-    wireMocks(manager, lifecycleService);
+    const recordChildCompletion = wireMocks(manager, lifecycleService);
 
     await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(core.RunbookCompletionService).toHaveBeenCalled();
-    expect(lifecycleService.upsertResolvedCompletion).toHaveBeenCalled();
+    // CLI layer delegates child-completion recording wholesale to the core
+    // service. The contract is the call args, not the lifecycle row write
+    // (that's an implementation detail tested in core).
+    expect(recordChildCompletion).toHaveBeenCalledWith({
+      childState,
+      result: 'pass',
+    });
   });
 
   it('returns not-applicable when parent no longer exists', async () => {
@@ -442,6 +443,10 @@ describe('handleParentCompletion', () => {
   });
 
   it('does not block inline child when substep has cancelled delegation', async () => {
+    // Inline child: parentLinkage.kind === 'inline'. The core service is
+    // expected to record (return 'recorded'), not return 'cancelled' — the
+    // CLI layer simply forwards the call. Stub the core service to return
+    // 'recorded' so the CLI proceeds with drain.
     const childState = makeState(CHILD_RUN_ID, {
       parentLinkage: {
         kind: 'inline' as const,
@@ -480,7 +485,7 @@ describe('handleParentCompletion', () => {
     const lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
-    wireMocks(manager, lifecycleService);
+    const recordChildCompletion = wireMocks(manager, lifecycleService);
 
     jest.mocked(drainResolvedCompletions).mockResolvedValue({
       unresolved: 0,
@@ -491,20 +496,21 @@ describe('handleParentCompletion', () => {
 
     const result = await handleParentCompletion(childState, 'pass', '/test', output);
 
-    // Inline child should NOT be blocked by the cancelled delegation
+    // Inline child should NOT be blocked by the cancelled delegation — the
+    // core service is invoked with the inline-linkage child state, and the
+    // CLI advances to drain (not the 'cancelled' early-return path).
     expect(result).not.toBe('not-applicable');
-    expect(lifecycleService.upsertResolvedCompletion).toHaveBeenCalledWith(
-      PARENT_RUN_ID,
-      expect.any(String),
-      expect.objectContaining({
-        agentId: 'inline',
-        result: 'pass',
-        targetSubstep: '1',
-      }),
-    );
+    expect(recordChildCompletion).toHaveBeenCalledWith({
+      childState,
+      result: 'pass',
+    });
+    expect(drainResolvedCompletions).toHaveBeenCalled();
   });
 
   it('skips propagation when delegation was cancelled', async () => {
+    // The cancellation detection lives in the core completion service; the
+    // CLI's contract is "if the core service says 'cancelled', short-circuit
+    // to 'handled' and do not drain". Drive the stub to return 'cancelled'.
     const delegation = makeDelegationLinkage();
     const childState = makeState(CHILD_RUN_ID, { parentLinkage: delegation });
     const parentState = makeState(PARENT_RUN_ID, {
@@ -532,15 +538,19 @@ describe('handleParentCompletion', () => {
     const lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
-    wireMocks(manager, lifecycleService);
+    wireMocks(manager, lifecycleService, { recordChildCompletionResult: 'cancelled' });
 
     const result = await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(result).toBe('handled');
-    expect(lifecycleService.upsertResolvedCompletion).not.toHaveBeenCalled();
+    // Drain must NOT be called when the core service reports 'cancelled'.
+    expect(drainResolvedCompletions).not.toHaveBeenCalled();
   });
 
-  it('records resolved completion on parent', async () => {
+  it('records resolved completion on parent via core completion service', async () => {
+    // Contract at the CLI seam: the helper forwards childState + result to
+    // the core service. The lifecycle row write itself is an implementation
+    // detail of core and is covered in completion-service.test.ts.
     const delegation = makeDelegationLinkage();
     const childState = makeState(CHILD_RUN_ID, { parentLinkage: delegation });
     const parentState = makeState(PARENT_RUN_ID, {
@@ -556,7 +566,7 @@ describe('handleParentCompletion', () => {
     const lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
-    wireMocks(manager, lifecycleService);
+    const recordChildCompletion = wireMocks(manager, lifecycleService);
 
     jest.mocked(drainResolvedCompletions).mockResolvedValue({
       unresolved: 0,
@@ -567,15 +577,10 @@ describe('handleParentCompletion', () => {
 
     await handleParentCompletion(childState, 'pass', '/test', output);
 
-    expect(lifecycleService.upsertResolvedCompletion).toHaveBeenCalledWith(
-      PARENT_RUN_ID,
-      '1||1|1',
-      expect.objectContaining({
-        agentId: 'delegation',
-        result: 'pass',
-        targetSubstep: '1',
-      }),
-    );
+    expect(recordChildCompletion).toHaveBeenCalledWith({
+      childState,
+      result: 'pass',
+    });
   });
 
   it('drains resolved completions on parent after recording', async () => {
@@ -931,7 +936,12 @@ describe('handleParentCompletion', () => {
     expect(drainCall.frameKeyOverride).toBeUndefined();
   });
 
-  it('records child finalVars on the parent resolved completion before drain', async () => {
+  it('passes child finalVars through to the core recordChildCompletion call', async () => {
+    // The CLI helper forwards childState (carrying finalVars) to the core
+    // service unchanged. The core service is responsible for materializing
+    // finalVars onto the persisted ResolvedCompletion row — exercised in
+    // completion-service.test.ts. At the CLI seam we only verify the
+    // childState argument carries the finalVars the child published.
     const delegation = makeDelegationLinkage();
     const childState = makeState(CHILD_RUN_ID, {
       parentLinkage: delegation,
@@ -947,7 +957,7 @@ describe('handleParentCompletion', () => {
     const lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
-    wireMocks(manager, lifecycleService);
+    const recordChildCompletion = wireMocks(manager, lifecycleService);
 
     jest.mocked(drainResolvedCompletions).mockResolvedValue({
       unresolved: 0,
@@ -958,13 +968,12 @@ describe('handleParentCompletion', () => {
 
     await handleParentCompletion(childState, 'pass', '/test', output);
 
-    expect(lifecycleService.upsertResolvedCompletion).toHaveBeenCalledWith(
-      PARENT_RUN_ID,
-      expect.any(String),
-      expect.objectContaining({
+    expect(recordChildCompletion).toHaveBeenCalledWith({
+      childState: expect.objectContaining({
         finalVars: { PlanPath: '/work/plan.json', version: '2.1' },
       }),
-    );
+      result: 'pass',
+    });
   });
 
   it('does not send SET_VARIABLES when child finalVars are present', async () => {
@@ -1057,7 +1066,11 @@ describe('inline linkage path', () => {
     expect(linkage!.parentRunId).toBe(PARENT_RUN_ID);
   });
 
-  it('agentId is inline for inline children', async () => {
+  it('inline child state flows through to the core service unchanged', async () => {
+    // The agentId='inline' mapping itself lives in core and is exercised in
+    // completion-service.test.ts. At the CLI seam we verify the helper
+    // forwards the child carrying `parentLinkage.kind === 'inline'` to the
+    // core service so the inline branch is taken there.
     const childState = makeState(CHILD_RUN_ID, {
       parentLinkage: {
         kind: 'inline' as const,
@@ -1081,7 +1094,7 @@ describe('inline linkage path', () => {
     const lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
-    wireMocks(manager, lifecycleService);
+    const recordChildCompletion = wireMocks(manager, lifecycleService);
 
     jest.mocked(drainResolvedCompletions).mockResolvedValue({
       unresolved: 0,
@@ -1092,14 +1105,11 @@ describe('inline linkage path', () => {
 
     await handleParentCompletion(childState, 'pass', '/test', output);
 
-    expect(lifecycleService.upsertResolvedCompletion).toHaveBeenCalledWith(
-      PARENT_RUN_ID,
-      expect.any(String),
-      expect.objectContaining({
-        agentId: 'inline',
-        result: 'pass',
-        targetSubstep: '1',
+    expect(recordChildCompletion).toHaveBeenCalledWith({
+      childState: expect.objectContaining({
+        parentLinkage: expect.objectContaining({ kind: 'inline' }),
       }),
-    );
+      result: 'pass',
+    });
   });
 });

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -8,6 +8,11 @@ import type { ResolvedStep, StepId } from '@rundown-org/parser';
 jest.unstable_mockModule('@rundown-org/core', () => ({
   RunbookStateManager: jest.fn(),
   RunbookActorService: jest.fn(),
+  RunbookCompletionService: jest.fn().mockImplementation(() => ({
+    recordManualCompletion: mockFn<
+      () => Promise<{ status: string; key: string }>
+    >().mockResolvedValue({ status: 'recorded', key: 'key' }),
+  })),
   SessionService: jest.fn(),
   ExecutionLifecycleService: jest.fn(),
   extractLastAction: mockFn<(snapshot: unknown) => unknown>().mockReturnValue(undefined),
@@ -235,6 +240,39 @@ beforeEach(() => {
       (frameKey: FrameKey, entry: number, substep?: string) =>
         `${frameKey}:${String(entry)}:${substep ?? ''}`,
     );
+  (
+    core.RunbookCompletionService as unknown as jest.Mock<
+      (
+        manager: unknown,
+        lifecycleService: {
+          getResolvedCompletion: jest.Mock;
+          upsertResolvedCompletion: jest.Mock;
+        },
+      ) => unknown
+    >
+  ).mockImplementation((_manager, lifecycleService) => ({
+    recordManualCompletion: mockFn<
+      (...args: unknown[]) => Promise<{ status: string; key: string }>
+    >().mockImplementation(async (raw) => {
+      const args = raw as {
+        targetFrameKey: FrameKey;
+        targetEntry: number;
+        targetSubstep: string;
+      };
+      const key = core.buildCompletionKey(
+        args.targetFrameKey,
+        args.targetEntry,
+        args.targetSubstep,
+      );
+      const sentinelKey = core.buildCompletionKey(args.targetFrameKey, 0, args.targetSubstep);
+      const existing =
+        (await lifecycleService.getResolvedCompletion('run', key)) ??
+        (await lifecycleService.getResolvedCompletion('run', sentinelKey));
+      if (existing) return { status: 'duplicate', key };
+      await lifecycleService.upsertResolvedCompletion('run', key, { result: 'pass' });
+      return { status: 'recorded', key };
+    }),
+  }));
 });
 
 describe('executeTransition with ExplicitTarget', () => {

--- a/packages/cli/__tests__/integration/delegation-propagation.test.ts
+++ b/packages/cli/__tests__/integration/delegation-propagation.test.ts
@@ -460,6 +460,126 @@ describe('Delegation propagation integration', () => {
     });
   });
 
+  describe('child outputs propagate into parent context', () => {
+    it('child frontmatter outputs flow to parent via ResolvedCompletion.finalVars (not SET_VARIABLES)', async () => {
+      // Parent: 2-substep step 1 then step 2 whose prompt references {{resultKey}}.
+      // The child's resultKey value must reach parent.context.variables
+      // via APPLY_CURRENT_RESOLVED_COMPLETION's finalVars merge, NOT via
+      // a SET_VARIABLES event.
+      const parentContent = [
+        '---',
+        'name: chain-outputs-parent',
+        'inputs:',
+        '  - resultKey',
+        '---',
+        '# Parent',
+        '',
+        '## 1. Review',
+        '- PASS CONTINUE',
+        '',
+        '### 1.1 Delegated child',
+        'Child does the work.',
+        '',
+        '### 1.2 Verify',
+        'After child: result is {{resultKey}}.',
+        '',
+        '## 2. Done',
+        '- PASS COMPLETE',
+        '',
+        'Observed child result: {{resultKey}}.',
+        '',
+      ].join('\n');
+      await writeFile(join(workspace.cwd, 'parent.runbook.md'), parentContent);
+
+      // Child has outputs: [resultKey], inputs: [resultKey] — when child
+      // completes, state.finalVars carries { resultKey: <published value> }.
+      const childContent = [
+        '---',
+        'name: chain-outputs-child',
+        'inputs:',
+        '  - resultKey',
+        'outputs:',
+        '  - resultKey',
+        '---',
+        '# Child',
+        '',
+        '## 1. Publish',
+        '- PASS COMPLETE',
+        '- FAIL STOP',
+        '',
+        'Publishing resultKey={{resultKey}}.',
+        '',
+      ].join('\n');
+      await writeFile(join(workspace.cwd, 'child.runbook.md'), childContent);
+
+      // Start parent in prompted mode (parent.inputs.resultKey has no value;
+      // not required, so omitted at startup).
+      let result = await runCliInProcess('run --prompted parent.runbook.md --text', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parentState = await getActiveState(workspace);
+      expect(parentState).not.toBeNull();
+      const parentRunId = parentState!.id;
+
+      // Delegate substep 1.1 to the child runbook.
+      result = await runCliInProcess('delegate child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+      const token = extractToken(result.stdout);
+
+      // Claim with resultKey value — child captures this as finalVars on
+      // completion via its frontmatter outputs declaration.
+      result = await runCliInProcess(
+        ['claim', token, '--input', 'resultKey=published-value'],
+        workspace,
+      );
+      expect(result.exitCode).toBe(0);
+      const claimAction = findActionOutput(result.stdout);
+      expect(claimAction).not.toBeNull();
+      const childRunId = String(claimAction!.run_id);
+      const claimId = String(claimAction!.claim_id);
+
+      // Pass child — completes child; propagation records finalVars on the
+      // parent's resolved completion and drains via APPLY_CURRENT_RESOLVED_COMPLETION.
+      result = await runCliInProcess(['pass', '--claim-id', claimId, '--text'], workspace);
+      if (result.exitCode !== 0) {
+        throw new Error(`rd pass failed: ${result.stdout}\n${result.stderr}`);
+      }
+
+      // Child completed with finalVars set
+      const finalChildState = await readRunbookState(workspace, childRunId);
+      expect(finalChildState).not.toBeNull();
+      expect(finalChildState!.lifecycle).toBe('completed');
+      expect(finalChildState!.finalVars).toEqual({ resultKey: 'published-value' });
+
+      // Parent now sits at substep 1.2 (1.1 PASS CONTINUE), and {{resultKey}}
+      // must already be visible in parent context because it was merged before
+      // PASS raised. The variable lives in parent state.variables (StoredOutputs).
+      const parentAfter11 = await readRunbookState(workspace, parentRunId);
+      expect(parentAfter11).not.toBeNull();
+      expect(parentAfter11!.step).toBe('1');
+      expect(parentAfter11!.substep).toBe('2');
+      expect(parentAfter11!.variables).toEqual(
+        expect.objectContaining({ resultKey: 'published-value' }),
+      );
+
+      // Drive substep 1.2 → parent step 2.
+      result = await runCliInProcess('pass --text', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Step 2's prompt should be templated with the propagated value.
+      // Look at step_entered events emitted during that pass.
+      expect(result.stdout).toContain('published-value');
+
+      const parentAfter12 = await readRunbookState(workspace, parentRunId);
+      expect(parentAfter12).not.toBeNull();
+      expect(parentAfter12!.step).toBe('2');
+      // Variable persisted in parent state across the substep advance.
+      expect(parentAfter12!.variables).toEqual(
+        expect.objectContaining({ resultKey: 'published-value' }),
+      );
+    });
+  });
+
   describe('edge cases', () => {
     it('handles completion when parent has no substep states', async () => {
       // Create a parent runbook without substeps

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -3,6 +3,7 @@ import {
   RunbookStateManager,
   SessionService,
   ExecutionLifecycleService,
+  RunbookCompletionService,
   DelegationScanService,
   DelegationLock,
   abortDelegation,
@@ -11,7 +12,6 @@ import {
   truncateDelegationToken,
   Errors,
   buildCompletionKey,
-  buildResolvedCompletion,
   deriveActiveFrame,
   type RunId,
   type RunbookState,
@@ -67,6 +67,7 @@ async function propagateForceAbort(
 
   const drained = await drainResolvedCompletions({
     actorService: parentActorService,
+    manager,
     sessionService,
     lifecycleService,
     emitter,
@@ -85,6 +86,11 @@ async function propagateForceAbort(
       const cascadeResult: 'pass' | 'fail' = drained.status === 'done' ? 'pass' : 'fail';
       await handleParentCompletion(cascadeParent, cascadeResult, cwd, output);
     }
+  } else if (drained.status === 'failed') {
+    throw new Error(drained.message);
+  } else if (drained.status === 'not_active') {
+    output.flush();
+    return;
   } else if (drained.applied > 0) {
     // Run execution loop to advance past resolved step
     const loopResult = await runExecutionLoop(
@@ -281,23 +287,21 @@ export function registerAbortCommand(program: Command): void {
 
               // Record fail resolved completion on parent substep
               const lifecycleService = new ExecutionLifecycleService(manager);
-              const completionKey = deriveCompletionKey(freshParent, targetSubstepId);
-              const frame = deriveActiveFrame(freshParent);
-              const frameKey = freshParent.activeFrameKey ?? frame.frameKey;
-              const entry = freshParent.activeEntry ?? 1;
-              const completion = buildResolvedCompletion({
-                agentId: 'delegation',
-                result: 'fail',
+              const completionService = new RunbookCompletionService(
+                manager,
+                lifecycleService,
+                createCliRunbookActorService(manager),
+              );
+              await completionService.recordParentSubstepCompletion({
+                runbookId: freshParent.id,
+                currentState: freshParent,
                 targetStep: freshParent.step,
                 targetSubstep: targetSubstepId,
-                targetFrameKey: frameKey,
-                targetEntry: entry,
+                targetFrameKey: scanFrameKey,
+                targetEntry: freshParent.activeEntry,
+                result: 'fail',
+                agentId: 'delegation',
               });
-              await lifecycleService.upsertResolvedCompletion(
-                freshParent.id,
-                completionKey,
-                completion,
-              );
             }
           } finally {
             // 10. Release lock

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -277,31 +277,56 @@ export function registerAbortCommand(program: Command): void {
 
             // 9. If force + childRunId: stop child run and record fail completion
             if (options.force && childRunId) {
-              // Stop child run: capture linkage, delete state, pop session
+              // Capture child linkage BEFORE deleting child state — we need it
+              // to drive `recordChildCompletionUnlocked` along the child path.
               const childState = await manager.load(childRunId);
+
+              // Stop child run: delete state, pop session
               if (childState) {
                 await manager.delete(childRunId);
                 const sessionService = new SessionService(manager);
                 await sessionService.releaseRunbook(childRunId);
               }
 
-              // Record fail resolved completion on parent substep
               const lifecycleService = new ExecutionLifecycleService(manager);
               const completionService = new RunbookCompletionService(
                 manager,
                 lifecycleService,
                 createCliRunbookActorService(manager),
               );
-              await completionService.recordParentSubstepCompletion({
-                runbookId: freshParent.id,
-                currentState: freshParent,
-                targetStep: freshParent.step,
-                targetSubstep: targetSubstepId,
-                targetFrameKey: scanFrameKey,
-                targetEntry: freshParent.activeEntry,
-                result: 'fail',
-                agentId: 'delegation',
-              });
+
+              // Plan Task 11: when a linked child state exists, route through
+              // the child-recording path so `finalVars`, parentLinkage handling,
+              // and SubstepState `{ status: 'done', result }` propagation all
+              // happen via the same core code as normal child completion. The
+              // unlocked variant is required because `abort.ts` already holds
+              // the parent DelegationLock — calling the locking
+              // `recordChildCompletion` here would deadlock.
+              if (childState?.parentLinkage) {
+                // `ignoreCancellation: true` is required here: step 8 above
+                // persisted `cancelledAt` on the parent substep *as* this
+                // abort's propagation event. Without the override,
+                // `recordChildCompletionUnlocked` would short-circuit to
+                // `'cancelled'` and the parent would never receive FAIL.
+                await completionService.recordChildCompletionUnlocked({
+                  childState,
+                  result: 'fail',
+                  ignoreCancellation: true,
+                });
+              } else {
+                // No linked child state — fall back to the parent-substep
+                // recording helper.
+                await completionService.recordManualCompletion({
+                  runbookId: freshParent.id,
+                  currentState: freshParent,
+                  targetStep: freshParent.step,
+                  targetSubstep: targetSubstepId,
+                  targetFrameKey: scanFrameKey,
+                  targetEntry: freshParent.activeEntry,
+                  result: 'fail',
+                  agentId: 'delegation',
+                });
+              }
             }
           } finally {
             // 10. Release lock

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -251,6 +251,7 @@ async function runCollect(
     scope.frameKey === activeFrameKey ? undefined : scope.frameKey;
   const drained = await drainResolvedCompletions({
     actorService,
+    manager,
     sessionService,
     lifecycleService,
     emitter,
@@ -282,6 +283,13 @@ async function runCollect(
       const propagation = await handleParentCompletion(freshState, 'pass', cwd, output);
       if (propagation === 'stopped') return true;
     }
+    return false;
+  }
+  if (drained.status === 'failed') {
+    throw new Error(drained.message);
+  }
+  if (drained.status === 'not_active') {
+    output.flush();
     return false;
   }
 

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -289,6 +289,23 @@ async function runCollect(
     throw new Error(drained.message);
   }
   if (drained.status === 'not_active') {
+    if (!options.text) {
+      output.json({
+        kind: 'collect',
+        action: 'collect',
+        status: 'not-active',
+        step: scope.stepName,
+        parentRunId: state.id,
+        frameKey: scope.frameKey,
+        activeFrameKey,
+        unresolved: drained.unresolved,
+      });
+    } else {
+      output.message(
+        `Frame not active: step ${scope.stepName} requested frame ${scope.frameKey} but cursor is on ${activeFrameKey}.`,
+        'info',
+      );
+    }
     output.flush();
     return false;
   }

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -15,14 +15,7 @@ import {
   RunbookStateManager,
   SessionService,
   ExecutionLifecycleService,
-  DelegationLock,
-  buildCompletionKey,
-  buildResolvedCompletion,
-  deriveActiveFrame,
-  findSubstepState,
-  upsertSubstepState,
-  getErrorMessage,
-  logger,
+  RunbookCompletionService,
   type RunbookState,
   type ParentLinkageBase,
 } from '@rundown-org/core';
@@ -93,75 +86,22 @@ export async function handleParentCompletion(
     return 'handled';
   }
 
-  const { parentRunId, parentStepId, parentStep, parentFrameKey, parentEntry } = linkage;
+  const { parentRunId, parentFrameKey } = linkage;
 
   const manager = new RunbookStateManager(cwd);
-  const lock = new DelegationLock(cwd);
+  const parentActorService = createCliRunbookActorService(manager);
+  const sessionService = new SessionService(manager);
+  const lifecycleService = new ExecutionLifecycleService(manager);
+  const completionService = new RunbookCompletionService(
+    manager,
+    lifecycleService,
+    parentActorService,
+  );
+  const recorded = await completionService.recordChildCompletion({ childState, result });
+  if (recorded === 'not-applicable') return 'not-applicable';
+  if (recorded === 'cancelled') return 'handled';
 
-  // 1. Acquire delegation lock on the parent
-  await lock.acquire(parentRunId);
-
-  let parentState: RunbookState | null;
-  try {
-    // 2. Load parent state under lock
-    parentState = await manager.load(parentRunId);
-    if (!parentState) {
-      // Orphaned child — parent was deleted
-      return 'not-applicable';
-    }
-
-    // 3. Check if delegation was cancelled (frame-scoped lookup)
-    const frameKey = parentFrameKey ?? deriveActiveFrame(parentState).frameKey;
-    const substepState = findSubstepState(parentState.substepStates ?? [], parentStepId, frameKey);
-    if (childState.parentLinkage?.kind === 'delegation' && substepState?.delegation?.cancelledAt) {
-      // Abort wins — skip propagation (only for delegation children)
-      return 'handled';
-    }
-
-    // 4. Build completion key from stored parent frame identity
-    const entry =
-      parentEntry ??
-      (frameKey === parentState.activeFrameKey ? parentState.activeEntry : undefined) ??
-      parentState.frameEntries?.[frameKey] ??
-      1;
-    const completionKey = buildCompletionKey(frameKey, entry, parentStepId);
-
-    // 5. Record resolved completion
-    const lifecycleService = new ExecutionLifecycleService(manager);
-    const existing = await lifecycleService.getResolvedCompletion(parentRunId, completionKey);
-    if (!existing) {
-      const agentId = childState.parentLinkage?.kind === 'inline' ? 'inline' : 'delegation';
-      const completion = buildResolvedCompletion({
-        agentId,
-        result,
-        targetStep: parentStep ?? parentState.step,
-        targetSubstep: parentStepId,
-        targetFrameKey: frameKey,
-        targetEntry: entry,
-      });
-      await lifecycleService.upsertResolvedCompletion(parentRunId, completionKey, completion);
-    }
-
-    // 5b. Mark the SubstepState as done (frame-scoped).
-    // Drain consumes the resolved completion but does not update substepStates,
-    // so without this the status === 'done' guard in buildInlineLinkage would
-    // miss already-resolved non-active frame substeps and allow re-execution.
-    const freshParentForSubstep = await manager.load(parentRunId);
-    if (freshParentForSubstep) {
-      const updatedSubsteps = upsertSubstepState(
-        freshParentForSubstep.substepStates ?? [],
-        parentStepId,
-        frameKey,
-        { status: 'done' as const, result },
-      );
-      await manager.update(parentRunId, { substepStates: updatedSubsteps });
-    }
-  } finally {
-    // 6. Release lock
-    await lock.release(parentRunId);
-  }
-
-  // 7. Drain resolved completions on the parent (outside lock)
+  // Drain resolved completions on the parent after core-owned recording.
   const transitionConfig =
     result === 'pass' ? createPassTransitionConfig() : createFailTransitionConfig();
 
@@ -172,12 +112,8 @@ export async function handleParentCompletion(
     onStopped: { releaseRunbook: false },
   };
 
-  const parentActorService = createCliRunbookActorService(manager);
-  const sessionService = new SessionService(manager);
-  const lifecycleService = new ExecutionLifecycleService(manager);
-
   // Re-load parent state outside lock for drain
-  parentState = await manager.load(parentRunId);
+  const parentState = await manager.load(parentRunId);
   if (!parentState) {
     return 'not-applicable';
   }
@@ -185,32 +121,10 @@ export async function handleParentCompletion(
   const readonlySteps = getRunbookFromState(parentState, cwd);
   const parentSteps = [...readonlySteps];
 
-  // Forward child's finalVars into the parent actor's context.variables via SET_VARIABLES.
-  // Must use actorService.sendAndSync (not manager.update) — createActor() restores from
-  // state.snapshot, so a direct manager.update({ variables }) is invisible to the next actor.
-  if (childState.finalVars && Object.keys(childState.finalVars).length > 0) {
-    try {
-      const vars: Record<string, string> = { ...childState.finalVars };
-      await parentActorService.sendAndSync(parentRunId, parentSteps, {
-        type: 'SET_VARIABLES',
-        vars,
-      });
-    } catch (err) {
-      const errMsg = getErrorMessage(err);
-      void logger.warn('delegation-completion: failed to forward child finalVars to parent actor', {
-        error: errMsg,
-        childRunId: childState.id,
-        parentRunId,
-      });
-      output.warning(
-        `SET_VARIABLES failed — child variables not forwarded to parent run. ${errMsg}`,
-      );
-    }
-  }
-
   const emitter = createBridgedEmitter(parentState, output);
   const drained = await drainResolvedCompletions({
     actorService: parentActorService,
+    manager,
     sessionService,
     lifecycleService,
     emitter,
@@ -239,6 +153,13 @@ export async function handleParentCompletion(
     if (freshParent && extractParentLinkage(freshParent)) {
       return handleParentCompletion(freshParent, 'pass', cwd, output, depth + 1);
     }
+    output.flush();
+    return 'handled';
+  }
+  if (drained.status === 'failed') {
+    throw new Error(drained.message);
+  }
+  if (drained.status === 'not_active') {
     output.flush();
     return 'handled';
   }

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -10,7 +10,7 @@
 
 import {
   RunbookStateManager,
-  type RunbookActorService,
+  RunbookCompletionService,
   SessionService,
   ExecutionLifecycleService,
   formatTransitionAction,
@@ -18,10 +18,10 @@ import {
   type ActionType,
   buildCompletionKey,
   buildFrameKey,
-  buildResolvedCompletion,
   deriveExecutionAt,
   deriveActiveFrame,
   SENTINEL_ENTRY,
+  type RunbookActorService,
   type FrameKey,
   type ResolvedStep,
   type RunbookState,
@@ -392,32 +392,22 @@ export async function executeTransition(
       cursor = activeCursorTarget(activeState);
     }
     const targetSubstep = explicitTarget ? cursor.substep : activeState.substep;
-    const completionKey = buildCompletionKey(cursor.frameKey, cursor.entry, targetSubstep);
-    let existing = await lifecycleService.getResolvedCompletion(activeState.id, completionKey);
-
-    // Cross-check sentinel/exact keys to prevent coexisting completions for the same frame/substep
-    if (!existing && cursor.entry !== SENTINEL_ENTRY) {
-      // Look up the target frame's entry (not the active frame's) for correct cross-check
-      const targetFrameEntry =
-        activeState.activeFrameKey === cursor.frameKey
-          ? (activeState.activeEntry ?? 1)
-          : (activeState.frameEntries?.[cursor.frameKey] ?? 1);
-      const crossEntry = cursor.entry === SENTINEL_ENTRY ? targetFrameEntry : SENTINEL_ENTRY;
-      const crossKey = buildCompletionKey(cursor.frameKey, crossEntry, targetSubstep);
-      existing = await lifecycleService.getResolvedCompletion(activeState.id, crossKey);
+    if (!targetSubstep) {
+      throw new Error('Substep completion requires an active or explicit substep target');
     }
-    if (!existing) {
-      const completion = buildResolvedCompletion({
-        agentId: 'manual',
-        result: config.lastResult,
-        targetStep: cursor.step,
-        targetSubstep: cursor.substep,
-        targetIteration: cursor.iteration,
-        targetFrameKey: cursor.frameKey,
-        targetEntry: cursor.entry,
-      });
-      await lifecycleService.upsertResolvedCompletion(activeState.id, completionKey, completion);
-    } else {
+    const completionService = new RunbookCompletionService(manager, lifecycleService, actorService);
+    const recorded = await completionService.recordManualCompletion({
+      runbookId: activeState.id,
+      currentState: activeState,
+      targetStep: cursor.step,
+      targetSubstep,
+      targetIteration: cursor.iteration,
+      targetFrameKey: cursor.frameKey,
+      targetEntry: cursor.entry,
+      result: config.lastResult,
+      agentId: 'manual',
+    });
+    if (recorded.status === 'duplicate') {
       output.status('completion_duplicate', `Completion already recorded for ${cursor.at}`, {
         at: cursor.at,
         frameKey: cursor.frameKey,
@@ -428,6 +418,7 @@ export async function executeTransition(
     const emitter = createBridgedEmitter(activeState, output);
     const drained = await drainResolvedCompletions({
       actorService,
+      manager,
       sessionService: ctx.sessionService,
       lifecycleService,
       emitter,
@@ -445,6 +436,13 @@ export async function executeTransition(
     if (drained.status === 'stopped') {
       output.flush();
       return 'stopped';
+    }
+    if (drained.status === 'failed') {
+      throw new Error(drained.message);
+    }
+    if (drained.status === 'not_active') {
+      output.flush();
+      return 'continue';
     }
     if (drained.applied === 0) {
       output.flush();

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -447,6 +447,7 @@ export type DrainResolvedCompletionsResult =
  *
  * @param args - Drain arguments including services and current state
  * @param args.actorService - Actor service for sending events to the runbook machine
+ * @param args.manager - Runbook state manager used to construct the core completion service
  * @param args.sessionService - Session service for active runbook tracking
  * @param args.lifecycleService - Lifecycle service for completion read/write operations
  * @param args.emitter - Event emitter for execution progress notifications
@@ -522,20 +523,31 @@ export async function drainResolvedCompletions({
     observedState = observed.state;
   }
 
-  if (drained.status === 'done' || drained.status === 'stopped') {
-    return {
-      status: drained.status,
-      unresolved: drained.unresolved,
-      applied: drained.applied.length,
-    };
+  // The `failed` and `not_active` branches return early above; the per-applied
+  // loop returns early on observed terminal states. `done`/`stopped` from the
+  // drain itself reaches here when the observation loop didn't already report
+  // a terminal status (e.g., the last applied completion was terminal but no
+  // observation step was needed). The remaining branch is `continue`.
+  switch (drained.status) {
+    case 'done':
+    case 'stopped':
+      return {
+        status: drained.status,
+        unresolved: drained.unresolved,
+        applied: drained.applied.length,
+      };
+    case 'continue':
+      return {
+        status: 'continue',
+        state: drained.applied.length > 0 ? observedState : drained.state,
+        unresolved: drained.unresolved,
+        applied: drained.applied.length,
+      };
+    default: {
+      const _exhaustive: never = drained;
+      return _exhaustive;
+    }
   }
-  const state = drained.status === 'continue' ? drained.state : observedState;
-  return {
-    status: 'continue',
-    state: drained.applied.length > 0 ? observedState : state,
-    unresolved: drained.unresolved,
-    applied: drained.applied.length,
-  };
 }
 
 /**

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -3,7 +3,6 @@ import {
   type RunId,
   buildStepPosition,
   deriveExecutionAt,
-  deriveActiveFrame,
   type ActionType,
   extractLastMessage,
   extractRetryDisplayCount,

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -3,7 +3,6 @@ import {
   type RunId,
   buildStepPosition,
   deriveExecutionAt,
-  buildCompletionKey,
   deriveActiveFrame,
   type ActionType,
   extractLastMessage,
@@ -11,16 +10,16 @@ import {
   extractRetryMax,
   formatActionForDisplay,
   type RunbookStateManager,
-  type RunbookActorService,
+  RunbookCompletionService,
   SessionService,
   ExecutionLifecycleService,
-  logger,
   mergeEffectiveVars,
   type Step,
   type ResolvedStep,
   type Substep,
   type RunbookMetadata,
   type RunbookState,
+  type RunbookActorService,
   type ExecutionResult,
   executeCommand,
   executeCommandWithEnv,
@@ -280,9 +279,6 @@ interface ObserveAndOrchestrateArgs {
   postState: RunbookState;
 }
 
-type ApplyDrainedCompletionArgs = Omit<ObserveAndOrchestrateArgs, 'syncSnapshot' | 'postState'> & {
-  actorService: RunbookActorService;
-};
 type ObserveCommandTransitionArgs = ObserveAndOrchestrateArgs;
 
 const EXECUTION_TERMINAL_POLICY: TransitionOrchestrationPolicy = {
@@ -370,33 +366,6 @@ async function observeAndOrchestrate({
 }
 
 /**
- * Drain path: result is fresh-to-the-machine, send PASS/FAIL ourselves.
- *
- * @remarks Used by substep-completion drain. When delegation batch (migration
- * row 4) moves drain into the machine, this function collapses into
- * observeCommandTransition and is removed.
- * @param args - Drained completion arguments including actor service, runbook ID, steps, and result
- * @returns Transition application result after sending the PASS or FAIL event
- */
-async function applyDrainedCompletion(
-  args: ApplyDrainedCompletionArgs,
-): Promise<TransitionApplicationResult> {
-  const syncResult = await args.actorService.sendAndSync(args.runbookId, args.steps, {
-    type: args.result === 'pass' ? 'PASS' : 'FAIL',
-  });
-  if (!syncResult) {
-    throw new Error(
-      `State machine sync failed after consuming ${args.result === 'pass' ? 'PASS' : 'FAIL'} completion — runbook ID: ${args.runbookId}`,
-    );
-  }
-  return observeAndOrchestrate({
-    ...args,
-    syncSnapshot: syncResult.snapshot,
-    postState: syncResult.state,
-  });
-}
-
-/**
  * Command path: after COMMAND_RESULT the leaf enters __capture, the actor
  * resolves, onDone raises PASS or FAIL internally to the leaf's handlers,
  * and the leaf transitions to its resolved target. CLI role: observe.
@@ -413,6 +382,8 @@ async function observeCommandTransition(
 export interface DrainResolvedCompletionsArgs {
   /** Actor service for sending events to the runbook machine. */
   actorService: RunbookActorService;
+  /** State manager used by the core completion service. */
+  manager: RunbookStateManager;
   /** Session service for active runbook tracking. */
   sessionService: SessionService;
   /** Lifecycle service for completion read/write operations. */
@@ -453,6 +424,20 @@ export type DrainResolvedCompletionsResult =
       /** Runbook stopped due to a STOP transition. */ status: 'stopped';
       unresolved: number;
       applied: number;
+    }
+  | {
+      /** Core rejected a persisted completion that did not match the active cursor. */
+      status: 'failed';
+      reason: 'target_mismatch';
+      message: string;
+      unresolved: number;
+      applied: 0;
+    }
+  | {
+      /** Requested frame is not currently active, so drain is observation-only. */
+      status: 'not_active';
+      unresolved: number;
+      applied: 0;
     };
 
 /**
@@ -476,6 +461,7 @@ export type DrainResolvedCompletionsResult =
  */
 export async function drainResolvedCompletions({
   actorService,
+  manager,
   sessionService,
   lifecycleService,
   emitter,
@@ -487,81 +473,69 @@ export async function drainResolvedCompletions({
   command,
   frameKeyOverride,
 }: DrainResolvedCompletionsArgs): Promise<DrainResolvedCompletionsResult> {
-  let state = currentState;
-  let applied = 0;
+  const completionService = new RunbookCompletionService(manager, lifecycleService, actorService);
+  const drained = await completionService.drainResolvedCompletions({
+    runbookId,
+    steps,
+    currentState,
+    ...(frameKeyOverride ? { frameKeyOverride } : {}),
+  });
 
-  // Loop invariant: `state` always reflects the latest persisted runbook state.
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  while (true) {
-    const currentStep = findStepOrThrow(steps, state.step);
-    const hasActiveSubsteps =
-      resolvedStepHasSubsteps(currentStep) && currentStep.substeps.length > 0 && !!state.substep;
-    if (!hasActiveSubsteps) {
-      return { status: 'continue', state, unresolved: 0, applied };
-    }
+  if (drained.status === 'failed') {
+    return {
+      status: 'failed',
+      reason: drained.reason,
+      message: drained.message,
+      unresolved: 0,
+      applied: 0,
+    };
+  }
+  if (drained.status === 'not_active') {
+    return { status: 'not_active', unresolved: drained.unresolved, applied: 0 };
+  }
 
-    const ensured = await lifecycleService.ensureActiveEntry(runbookId, undefined, state);
-    state = ensured.state;
-
-    const derivedFrame = deriveActiveFrame(state);
-    const frameKey = frameKeyOverride ?? derivedFrame.frameKey;
-    const entry = state.activeEntry ?? ensured.entry;
-    const orderedSubsteps = currentStep.substeps.map((s) => s.id);
-    const resolved = await lifecycleService.listResolvedCompletions(runbookId, frameKey, entry);
-    const resolvedBySubstep = new Map(
-      resolved
-        .filter(
-          (r): r is typeof r & { completion: { targetSubstep: string } } =>
-            r.completion.targetSubstep !== undefined,
-        )
-        .map(({ completion }) => [completion.targetSubstep, completion]),
-    );
-
-    const unresolved = orderedSubsteps.filter((id) => !resolvedBySubstep.has(id)).length;
-
-    const cursorKey = buildCompletionKey(frameKey, entry, state.substep);
-    const completion = await lifecycleService.consumeResolvedCompletion(runbookId, cursorKey);
-    if (!completion) {
-      return { status: 'continue', state, unresolved, applied };
-    }
-
-    const transitionResult = await applyDrainedCompletion({
-      actorService,
+  let observedState = currentState;
+  for (const applied of drained.applied) {
+    const currentStep = findStepOrThrow(steps, applied.stateBefore.step);
+    const observed = await observeAndOrchestrate({
       sessionService,
       lifecycleService,
       emitter,
       runbookId,
       steps,
-      currentState: state,
+      currentState: applied.stateBefore,
       currentStep,
-      result: completion.result,
+      result: applied.completion.result,
       transitionPolicy,
       computeActionResult,
       command,
+      syncSnapshot: applied.snapshot,
+      postState: applied.stateAfter,
     });
-    applied += 1;
-
-    if (transitionResult.status === 'done' || transitionResult.status === 'stopped') {
-      // Defense-in-depth: warn if terminal status reached with unresolved substeps
-      const remainingUnresolved = orderedSubsteps.filter(
-        (id) => !resolvedBySubstep.has(id) && id !== completion.targetSubstep,
-      ).length;
-      if (remainingUnresolved > 0) {
-        void logger.warn('drainResolvedCompletions: terminal status with unresolved substeps', {
-          runbookId,
-          stepName: currentStep.name,
-          status: transitionResult.status,
-          substepCount: orderedSubsteps.length,
-          // resolvedBySubstep.size excludes the current completion (filtered separately above)
-          resolvedCount: resolvedBySubstep.size,
-          unresolvedCount: remainingUnresolved,
-          appliedSubstep: state.substep,
-        });
-      }
-      return { status: transitionResult.status, unresolved: 0, applied };
+    if (observed.status === 'done' || observed.status === 'stopped') {
+      return {
+        status: observed.status,
+        unresolved: drained.unresolved,
+        applied: drained.applied.length,
+      };
     }
-    state = transitionResult.state;
+    observedState = observed.state;
   }
+
+  if (drained.status === 'done' || drained.status === 'stopped') {
+    return {
+      status: drained.status,
+      unresolved: drained.unresolved,
+      applied: drained.applied.length,
+    };
+  }
+  const state = drained.status === 'continue' ? drained.state : observedState;
+  return {
+    status: 'continue',
+    state: drained.applied.length > 0 ? observedState : state,
+    unresolved: drained.unresolved,
+    applied: drained.applied.length,
+  };
 }
 
 /**
@@ -717,6 +691,7 @@ export async function runExecutionLoop(
 
     const drainResult = await drainResolvedCompletions({
       actorService,
+      manager,
       sessionService,
       lifecycleService,
       emitter,
@@ -736,6 +711,12 @@ export async function runExecutionLoop(
         await applyExecutionTerminalRelease(sessionService, runbookId, terminalReleaseMode);
       }
       return 'stopped';
+    }
+    if (drainResult.status === 'failed') {
+      throw new Error(drainResult.message);
+    }
+    if (drainResult.status === 'not_active') {
+      return 'waiting';
     }
     if (drainResult.applied > 0) {
       currentState = drainResult.state;

--- a/packages/core/__tests__/runbook/completion-event.test.ts
+++ b/packages/core/__tests__/runbook/completion-event.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from '@jest/globals';
+import { createActor } from 'xstate';
+import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
+import type { CurrentCursorResolvedCompletion } from '../../src/runbook/completion-service.js';
+import type { BaseStep, ResolvedStep } from '../../src/runbook/types.js';
+import { buildFrameKey } from '../../src/runbook/targeting.js';
+
+describe('APPLY_CURRENT_RESOLVED_COMPLETION event', () => {
+  const DEFAULT_TRANSITIONS = {
+    pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+    fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+  };
+
+  function inferSteps(raw: Array<Omit<BaseStep, 'kind'>>): ResolvedStep[] {
+    return raw.map((step) => ({ ...step, kind: 'base' }) as ResolvedStep);
+  }
+
+  function currentCompletion(
+    result: 'pass' | 'fail',
+    finalVars?: Readonly<Record<string, string>>,
+  ): CurrentCursorResolvedCompletion {
+    return {
+      agentId: 'delegation',
+      result,
+      targetStep: '1',
+      targetSubstep: '1',
+      targetFrameKey: buildFrameKey('1'),
+      targetEntry: 1,
+      ...(finalVars ? { finalVars } : {}),
+      completedAt: '2026-01-01T00:00:00.000Z',
+      __currentCursorValidated: true,
+    };
+  }
+
+  it('merges finalVars before applying a pass completion', () => {
+    const steps = inferSteps([
+      {
+        name: '1',
+        description: 'First',
+        transitions: DEFAULT_TRANSITIONS,
+      },
+      {
+        name: '2',
+        description: 'Second',
+        transitions: DEFAULT_TRANSITIONS,
+      },
+    ]);
+    const actor = createActor(compileRunbookToMachine(steps));
+    actor.start();
+
+    actor.send({
+      type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
+      completion: currentCompletion('pass', { ChildValue: 'ready' }),
+    });
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.context.variables).toEqual({ ChildValue: 'ready' });
+    expect(snapshot.value).toEqual({ 'step::2': 'idle' });
+  });
+
+  it('applies a fail completion as fail behavior', () => {
+    const steps = inferSteps([
+      {
+        name: '1',
+        description: 'First',
+        transitions: DEFAULT_TRANSITIONS,
+      },
+    ]);
+    const actor = createActor(compileRunbookToMachine(steps));
+    actor.start();
+
+    actor.send({
+      type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
+      completion: currentCompletion('fail'),
+    });
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe('STOPPED');
+    expect(snapshot.context.lastAction).toEqual(expect.objectContaining({ type: 'STOP' }));
+  });
+});

--- a/packages/core/__tests__/runbook/completion-event.test.ts
+++ b/packages/core/__tests__/runbook/completion-event.test.ts
@@ -12,13 +12,18 @@ describe('APPLY_CURRENT_RESOLVED_COMPLETION event', () => {
   };
 
   function inferSteps(raw: Array<Omit<BaseStep, 'kind'>>): ResolvedStep[] {
-    return raw.map((step) => ({ ...step, kind: 'base' }) as ResolvedStep);
+    return raw.map((step) => ({ ...step, kind: 'base' }));
   }
 
   function currentCompletion(
     result: 'pass' | 'fail',
     finalVars?: Readonly<Record<string, string>>,
   ): CurrentCursorResolvedCompletion {
+    // The brand is a module-private `unique symbol`, so we cast through
+    // `unknown` to fabricate a fixture. In production this type is only ever
+    // produced by `validateCurrentCompletionTarget`; the cast is acceptable
+    // here because the event handler under test treats the brand as a proof
+    // token and does not re-validate.
     return {
       agentId: 'delegation',
       result,
@@ -28,8 +33,7 @@ describe('APPLY_CURRENT_RESOLVED_COMPLETION event', () => {
       targetEntry: 1,
       ...(finalVars ? { finalVars } : {}),
       completedAt: '2026-01-01T00:00:00.000Z',
-      __currentCursorValidated: true,
-    };
+    } as unknown as CurrentCursorResolvedCompletion;
   }
 
   it('merges finalVars before applying a pass completion', () => {
@@ -75,6 +79,30 @@ describe('APPLY_CURRENT_RESOLVED_COMPLETION event', () => {
     });
 
     const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe('STOPPED');
+    expect(snapshot.context.lastAction).toEqual(expect.objectContaining({ type: 'STOP' }));
+  });
+
+  it('merges finalVars before applying a fail completion', () => {
+    const steps = inferSteps([
+      {
+        name: '1',
+        description: 'First',
+        transitions: DEFAULT_TRANSITIONS,
+      },
+    ]);
+    const actor = createActor(compileRunbookToMachine(steps));
+    actor.start();
+
+    actor.send({
+      type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
+      completion: currentCompletion('fail', { ChildValue: 'failed-but-set' }),
+    });
+
+    const snapshot = actor.getSnapshot();
+    // finalVars merged into context.variables BEFORE FAIL is raised — observable
+    // on the STOPPED snapshot.
+    expect(snapshot.context.variables).toEqual({ ChildValue: 'failed-but-set' });
     expect(snapshot.value).toBe('STOPPED');
     expect(snapshot.context.lastAction).toEqual(expect.objectContaining({ type: 'STOP' }));
   });

--- a/packages/core/__tests__/runbook/completion-service.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.test.ts
@@ -81,6 +81,7 @@ describe('RunbookCompletionService', () => {
       updatedAt: '2026-01-01T00:00:00.000Z',
       lifecycle: 'running',
       schemaVersion: 3,
+      frontmatterOutputs: [],
       ...overrides,
     };
   }
@@ -190,12 +191,15 @@ describe('RunbookCompletionService', () => {
     });
 
     expect(result.status).toBe('continue');
+    // The brand is a module-private `unique symbol` so we can no longer assert
+    // on `__currentCursorValidated`; verifying `targetEntry: 1` (sentinel
+    // normalized to active entry) and the event type proves the validator ran.
     expect(sendAndSync).toHaveBeenCalledWith(
       runbookId,
       steps,
       expect.objectContaining({
         type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
-        completion: expect.objectContaining({ targetEntry: 1, __currentCursorValidated: true }),
+        completion: expect.objectContaining({ targetEntry: 1, targetSubstep: '1' }),
       }),
     );
     await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toBeNull();
@@ -247,5 +251,713 @@ describe('RunbookCompletionService', () => {
       }),
     );
     expect(result).toBe('recorded');
+  });
+
+  describe('drain target mismatch variants', () => {
+    it('returns target_mismatch for wrong targetStep', async () => {
+      const current = state();
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [key]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'pass',
+            // Wrong step
+            targetStep: '99',
+            targetSubstep: '1',
+            targetFrameKey: buildFrameKey('1'),
+            targetEntry: 1,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+      const sendAndSync = jest.spyOn(actorService, 'sendAndSync');
+
+      const result = await service.drainResolvedCompletions({
+        runbookId,
+        steps,
+        currentState: current,
+      });
+
+      expect(result.status).toBe('failed');
+      if (result.status === 'failed') {
+        expect(result.reason).toBe('target_mismatch');
+      }
+      expect(sendAndSync).not.toHaveBeenCalled();
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.not.toBeNull();
+    });
+
+    it('returns target_mismatch for wrong targetFrameKey', async () => {
+      const current = state();
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [key]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '1',
+            // Wrong frame key (different iteration)
+            targetFrameKey: buildFrameKey('1', 2),
+            targetEntry: 1,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+      const sendAndSync = jest.spyOn(actorService, 'sendAndSync');
+
+      const result = await service.drainResolvedCompletions({
+        runbookId,
+        steps,
+        currentState: current,
+      });
+
+      expect(result.status).toBe('failed');
+      if (result.status === 'failed') {
+        expect(result.reason).toBe('target_mismatch');
+      }
+      expect(sendAndSync).not.toHaveBeenCalled();
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.not.toBeNull();
+    });
+
+    it('returns target_mismatch for wrong targetEntry (non-sentinel)', async () => {
+      const current = state();
+      // Key matches current substep but targetEntry is different (and not SENTINEL_ENTRY)
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [key]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrameKey: buildFrameKey('1'),
+            // Wrong entry (and not sentinel)
+            targetEntry: 99,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+      const sendAndSync = jest.spyOn(actorService, 'sendAndSync');
+
+      const result = await service.drainResolvedCompletions({
+        runbookId,
+        steps,
+        currentState: current,
+      });
+
+      expect(result.status).toBe('failed');
+      if (result.status === 'failed') {
+        expect(result.reason).toBe('target_mismatch');
+      }
+      expect(sendAndSync).not.toHaveBeenCalled();
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.not.toBeNull();
+    });
+  });
+
+  describe('drain semantics', () => {
+    /** Build a 3-substep runbook for ordered drain tests. */
+    const threeSubstepSteps: ResolvedStep[] = [
+      {
+        kind: 'substeps',
+        name: '1',
+        description: 'Parent',
+        aggregation: { strategy: 'ALL' },
+        substeps: [
+          {
+            id: '1',
+            description: 'First',
+            transitions: {
+              pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+              fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+            },
+          },
+          {
+            id: '2',
+            description: 'Second',
+            transitions: {
+              pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+              fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+            },
+          },
+          {
+            id: '3',
+            description: 'Third',
+            transitions: {
+              pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+              fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+            },
+          },
+        ],
+        transitions: {
+          pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+          fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+        },
+      },
+    ];
+
+    it('applies completions in substep order across a single drain', async () => {
+      // Persist completions for substeps 1.1 and 1.2; drain should apply both
+      // in order and stop at 1.3 (unresolved).
+      const current = state({
+        substep: '1',
+        substepStates: [
+          {
+            id: '1',
+            frameKey: buildFrameKey('1'),
+            status: 'running',
+          },
+        ],
+      });
+      const key1 = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key2 = buildCompletionKey(buildFrameKey('1'), 1, '2');
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [key1]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrameKey: buildFrameKey('1'),
+            targetEntry: 1,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+          [key2]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '2',
+            targetFrameKey: buildFrameKey('1'),
+            targetEntry: 1,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+
+      const result = await service.drainResolvedCompletions({
+        runbookId,
+        steps: threeSubstepSteps,
+        currentState: current,
+      });
+
+      // Both completions applied in substep order
+      expect(result.status).toBe('continue');
+      if (result.status === 'continue') {
+        expect(result.applied.length).toBe(2);
+        expect(result.applied[0].completion.targetSubstep).toBe('1');
+        expect(result.applied[1].completion.targetSubstep).toBe('2');
+      }
+      // Both rows consumed
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key1)).resolves.toBeNull();
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key2)).resolves.toBeNull();
+    });
+
+    it('stops at the first unresolved substep — substep 1.1 only when 1.3 persisted without 1.2', async () => {
+      // Persist completion for 1.1 and 1.3 only. Drain should apply 1.1, then
+      // stop because 1.2 has no persisted completion.
+      const current = state({
+        substep: '1',
+        substepStates: [
+          {
+            id: '1',
+            frameKey: buildFrameKey('1'),
+            status: 'running',
+          },
+        ],
+      });
+      const key1 = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key3 = buildCompletionKey(buildFrameKey('1'), 1, '3');
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [key1]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrameKey: buildFrameKey('1'),
+            targetEntry: 1,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+          [key3]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '3',
+            targetFrameKey: buildFrameKey('1'),
+            targetEntry: 1,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+
+      const result = await service.drainResolvedCompletions({
+        runbookId,
+        steps: threeSubstepSteps,
+        currentState: current,
+      });
+
+      expect(result.status).toBe('continue');
+      if (result.status === 'continue') {
+        expect(result.applied.length).toBe(1);
+        expect(result.applied[0].completion.targetSubstep).toBe('1');
+        expect(result.unresolved).toBeGreaterThanOrEqual(1);
+      }
+      // 1.1 consumed; 1.3 remains
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key1)).resolves.toBeNull();
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key3)).resolves.not.toBeNull();
+    });
+
+    it('active-frame drain reaches terminal done when all substeps pass to COMPLETE', async () => {
+      // Single substep with PASS COMPLETE: drain should produce status: 'done'.
+      const stepsDone: ResolvedStep[] = [
+        {
+          kind: 'substeps',
+          name: '1',
+          description: 'Parent',
+          aggregation: { strategy: 'ALL' },
+          substeps: [
+            {
+              id: '1',
+              description: 'Only',
+              transitions: {
+                pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+                fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+              },
+            },
+          ],
+          transitions: {
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+          },
+        },
+      ];
+      const current = state({
+        substep: '1',
+      });
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [key]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrameKey: buildFrameKey('1'),
+            targetEntry: 1,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+
+      const result = await service.drainResolvedCompletions({
+        runbookId,
+        steps: stepsDone,
+        currentState: current,
+      });
+
+      expect(result.status).toBe('done');
+      if (result.status === 'done') {
+        expect(result.applied.length).toBe(1);
+      }
+    });
+
+    it('active-frame drain reaches terminal stopped when substep fails', async () => {
+      // Single substep with FAIL STOP: drain should produce status: 'stopped'.
+      const stepsStopped: ResolvedStep[] = [
+        {
+          kind: 'substeps',
+          name: '1',
+          description: 'Parent',
+          aggregation: { strategy: 'ALL' },
+          substeps: [
+            {
+              id: '1',
+              description: 'Only',
+              transitions: {
+                pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+                fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+              },
+            },
+          ],
+          transitions: {
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+          },
+        },
+      ];
+      const current = state({
+        substep: '1',
+      });
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [key]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'fail',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrameKey: buildFrameKey('1'),
+            targetEntry: 1,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+
+      const result = await service.drainResolvedCompletions({
+        runbookId,
+        steps: stepsStopped,
+        currentState: current,
+      });
+
+      expect(result.status).toBe('stopped');
+      if (result.status === 'stopped') {
+        expect(result.applied.length).toBe(1);
+      }
+    });
+
+    it('frameKeyOverride that differs from active frame returns not_active without dispatching', async () => {
+      const current = state();
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [key]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrameKey: buildFrameKey('1'),
+            targetEntry: 1,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+      const sendAndSync = jest.spyOn(actorService, 'sendAndSync');
+
+      const overrideKey = buildFrameKey('1', 5);
+      const result = await service.drainResolvedCompletions({
+        runbookId,
+        steps,
+        currentState: current,
+        frameKeyOverride: overrideKey,
+      });
+
+      expect(result.status).toBe('not_active');
+      if (result.status === 'not_active') {
+        expect(result.frameKey).toBe(overrideKey);
+        expect(result.activeFrameKey).toBe(buildFrameKey('1'));
+        expect(result.applied).toEqual([]);
+      }
+      expect(sendAndSync).not.toHaveBeenCalled();
+      // Persisted completion untouched
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.not.toBeNull();
+    });
+  });
+
+  describe('manual recording', () => {
+    it('writes exact key when target frame matches the active frame', async () => {
+      const current = state();
+      await manager.save(current);
+
+      const result = await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrameKey: buildFrameKey('1'),
+        result: 'pass',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:00.000Z',
+      });
+
+      // Active frame → exact key (entry=1), NOT sentinel
+      const exactKey = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const sentinelKey = buildCompletionKey(buildFrameKey('1'), SENTINEL_ENTRY, '1');
+      expect(result).toEqual({ status: 'recorded', key: exactKey });
+      await expect(lifecycleService.getResolvedCompletion(runbookId, exactKey)).resolves.toEqual(
+        expect.objectContaining({ result: 'pass', targetEntry: 1 }),
+      );
+      await expect(
+        lifecycleService.getResolvedCompletion(runbookId, sentinelKey),
+      ).resolves.toBeNull();
+    });
+
+    it('exact existing blocks sentinel write (exact first, then sentinel attempt → duplicate at exact)', async () => {
+      // Use a different step/substep id so it's part of the active frame.
+      const current = state();
+      await manager.save(current);
+
+      // First write: exact key (target is active frame)
+      const first = await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrameKey: buildFrameKey('1'),
+        result: 'pass',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:00.000Z',
+      });
+      const exactKey = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      expect(first).toEqual({ status: 'recorded', key: exactKey });
+
+      // Second write: same substep but pretend target frame is non-active so
+      // sentinel would normally be chosen — but pass a synthetic currentState
+      // whose active frame is different.
+      const otherCurrent = state({
+        step: '2',
+        substep: undefined,
+        activeFrameKey: buildFrameKey('2'),
+      });
+      const second = await service.recordManualCompletion({
+        runbookId,
+        currentState: otherCurrent,
+        targetStep: '1',
+        targetSubstep: '1',
+        // Target frame is not the active frame ('2|'), so sentinel would be chosen.
+        targetFrameKey: buildFrameKey('1'),
+        targetEntry: 1,
+        result: 'fail',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:01.000Z',
+      });
+
+      expect(second).toEqual({ status: 'duplicate', key: exactKey });
+      // Payload preserved: pass, not fail
+      await expect(lifecycleService.getResolvedCompletion(runbookId, exactKey)).resolves.toEqual(
+        expect.objectContaining({ result: 'pass' }),
+      );
+    });
+
+    it('sentinel existing blocks exact write (sentinel first, then exact attempt → duplicate at sentinel)', async () => {
+      const current = state();
+      await manager.save(current);
+
+      // First: write sentinel by targeting a non-active frame
+      const otherCurrent = state({
+        step: '2',
+        substep: undefined,
+        activeFrameKey: buildFrameKey('2'),
+      });
+      const first = await service.recordManualCompletion({
+        runbookId,
+        currentState: otherCurrent,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrameKey: buildFrameKey('1'),
+        targetEntry: 1,
+        result: 'pass',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:00.000Z',
+      });
+      const sentinelKey = buildCompletionKey(buildFrameKey('1'), SENTINEL_ENTRY, '1');
+      expect(first).toEqual({ status: 'recorded', key: sentinelKey });
+
+      // Second: now write with target frame = active frame, so the exact key
+      // would normally be chosen — but the sentinel already covers this target.
+      const second = await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrameKey: buildFrameKey('1'),
+        result: 'fail',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:01.000Z',
+      });
+
+      expect(second).toEqual({ status: 'duplicate', key: sentinelKey });
+      // Payload preserved
+      await expect(lifecycleService.getResolvedCompletion(runbookId, sentinelKey)).resolves.toEqual(
+        expect.objectContaining({ result: 'pass' }),
+      );
+    });
+
+    it('duplicate result preserves the original completion payload', async () => {
+      const current = state();
+      await manager.save(current);
+
+      // First write — pass
+      const first = await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrameKey: buildFrameKey('1'),
+        result: 'pass',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:00.000Z',
+      });
+      // Second write — attempt to overwrite with fail
+      const second = await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrameKey: buildFrameKey('1'),
+        result: 'fail',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:01.000Z',
+      });
+
+      expect(first.status).toBe('recorded');
+      expect(second.status).toBe('duplicate');
+      // The persisted row remains `pass`, original timestamp
+      await expect(lifecycleService.getResolvedCompletion(runbookId, first.key)).resolves.toEqual(
+        expect.objectContaining({
+          result: 'pass',
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      );
+    });
+  });
+
+  describe('child recording', () => {
+    const childRunId = brandRunIdForTest('rd_cccccccccccccccccccccccccccccccc');
+
+    function makeParentWithDelegation(cancelledAt: string | null = null): RunbookState {
+      return state({
+        substepStates: [
+          {
+            id: '1',
+            frameKey: buildFrameKey('1'),
+            status: 'running',
+            delegation: {
+              tokenHash: assertDelegationTokenHash(`sha256:${'c'.repeat(64)}`),
+              childRunbookPath: 'child.md',
+              childRunbookRef: { source: 'project', path: 'child.md' },
+              contextSnapshot: { vars: brandEffectiveVarsForTest({}), ancestors: [], at: '1.1' },
+              childRunId,
+              createdAt: '2026-01-01T00:00:00.000Z',
+              cancelledAt,
+            },
+          },
+        ],
+      });
+    }
+
+    function makeChildWithDelegationLinkage(): RunbookState {
+      return state({
+        id: childRunId,
+        parentLinkage: {
+          kind: 'delegation',
+          parentRunId: runbookId,
+          parentStepId: '1',
+          parentStep: '1',
+          parentFrameKey: buildFrameKey('1'),
+          parentEntry: 1,
+          tokenHash: assertDelegationTokenHash(`sha256:${'c'.repeat(64)}`),
+        },
+      });
+    }
+
+    it('delegated child fail propagates as result: fail on the recorded completion', async () => {
+      const parent = makeParentWithDelegation();
+      await manager.save(parent);
+      const child = makeChildWithDelegationLinkage();
+
+      const result = await service.recordChildCompletion({ childState: child, result: 'fail' });
+
+      expect(result).toBe('recorded');
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
+        expect.objectContaining({ result: 'fail', agentId: 'delegation' }),
+      );
+      await expect(manager.load(runbookId)).resolves.toEqual(
+        expect.objectContaining({
+          substepStates: [expect.objectContaining({ id: '1', status: 'done', result: 'fail' })],
+        }),
+      );
+    });
+
+    it('inline child completion records agentId as inline', async () => {
+      // Parent has substep but no delegation — inline child has linkage kind: 'inline'.
+      const parent = state({
+        substepStates: [
+          {
+            id: '1',
+            frameKey: buildFrameKey('1'),
+            status: 'running',
+          },
+        ],
+      });
+      await manager.save(parent);
+      const child = state({
+        id: childRunId,
+        parentLinkage: {
+          kind: 'inline',
+          parentRunId: runbookId,
+          parentStepId: '1',
+          parentStep: '1',
+          parentFrameKey: buildFrameKey('1'),
+          parentEntry: 1,
+        },
+      });
+
+      const result = await service.recordChildCompletion({ childState: child, result: 'pass' });
+
+      expect(result).toBe('recorded');
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
+        expect.objectContaining({ result: 'pass', agentId: 'inline' }),
+      );
+    });
+
+    it('cancelled delegation returns cancelled and does not record', async () => {
+      const parent = makeParentWithDelegation('2026-01-01T00:00:30.000Z');
+      await manager.save(parent);
+      const child = makeChildWithDelegationLinkage();
+
+      const result = await service.recordChildCompletion({ childState: child, result: 'pass' });
+
+      expect(result).toBe('cancelled');
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toBeNull();
+    });
+
+    it('ignoreCancellation bypasses the cancelled short-circuit', async () => {
+      const parent = makeParentWithDelegation('2026-01-01T00:00:30.000Z');
+      await manager.save(parent);
+      const child = makeChildWithDelegationLinkage();
+
+      const result = await service.recordChildCompletion({
+        childState: child,
+        result: 'fail',
+        ignoreCancellation: true,
+      });
+
+      expect(result).toBe('recorded');
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
+        expect.objectContaining({ result: 'fail', agentId: 'delegation' }),
+      );
+    });
+
+    it('missing parentLinkage returns not-applicable', async () => {
+      const child = state({ id: childRunId });
+
+      const result = await service.recordChildCompletion({ childState: child, result: 'pass' });
+
+      expect(result).toBe('not-applicable');
+    });
+
+    it('duplicate child completion returns duplicate', async () => {
+      const parent = makeParentWithDelegation();
+      await manager.save(parent);
+      const child = makeChildWithDelegationLinkage();
+
+      const first = await service.recordChildCompletion({ childState: child, result: 'pass' });
+      const second = await service.recordChildCompletion({ childState: child, result: 'pass' });
+
+      expect(first).toBe('recorded');
+      expect(second).toBe('duplicate');
+    });
   });
 });

--- a/packages/core/__tests__/runbook/completion-service.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.test.ts
@@ -659,6 +659,38 @@ describe('RunbookCompletionService', () => {
       // Persisted completion untouched
       await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.not.toBeNull();
     });
+
+    it('not_active unresolved count excludes substeps that already have completions in the override frame', async () => {
+      const current = state();
+      const overrideKey = buildFrameKey('1', 5);
+      const completedKey = buildCompletionKey(overrideKey, SENTINEL_ENTRY, '1');
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [completedKey]: buildResolvedCompletion({
+            agentId: 'manual',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrameKey: overrideKey,
+            targetEntry: SENTINEL_ENTRY,
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+
+      const result = await service.drainResolvedCompletions({
+        runbookId,
+        steps,
+        currentState: current,
+        frameKeyOverride: overrideKey,
+      });
+
+      expect(result.status).toBe('not_active');
+      if (result.status === 'not_active') {
+        expect(result.unresolved).toBe(1);
+      }
+    });
   });
 
   describe('manual recording', () => {
@@ -958,6 +990,32 @@ describe('RunbookCompletionService', () => {
 
       expect(first).toBe('recorded');
       expect(second).toBe('duplicate');
+    });
+
+    it('duplicate child completion with different result does not overwrite parent substep state', async () => {
+      const parent = makeParentWithDelegation();
+      await manager.save(parent);
+      const child = makeChildWithDelegationLinkage();
+
+      const first = await service.recordChildCompletion({ childState: child, result: 'pass' });
+      const second = await service.recordChildCompletion({
+        childState: child,
+        result: 'fail',
+        ignoreCancellation: true,
+      });
+
+      expect(first).toBe('recorded');
+      expect(second).toBe('duplicate');
+
+      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
+        expect.objectContaining({ result: 'pass' }),
+      );
+      await expect(manager.load(runbookId)).resolves.toEqual(
+        expect.objectContaining({
+          substepStates: [expect.objectContaining({ id: '1', status: 'done', result: 'pass' })],
+        }),
+      );
     });
   });
 });

--- a/packages/core/__tests__/runbook/completion-service.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  assertDelegationTokenHash,
+  RunbookActorService,
+  RunbookCompletionService,
+  RunbookStateManager,
+  type RunbookState,
+  type ResolvedStep,
+} from '../../src/runbook/index.js';
+import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
+import {
+  SENTINEL_ENTRY,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+} from '../../src/runbook/targeting.js';
+import {
+  brandEffectiveVarsForTest,
+  brandRunIdForTest,
+  brandStoredOutputsForTest,
+} from '../helpers/effective-vars.js';
+
+describe('RunbookCompletionService', () => {
+  const runbookId = brandRunIdForTest('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  let tmp: string;
+  let manager: RunbookStateManager;
+  let lifecycleService: ExecutionLifecycleService;
+  let actorService: RunbookActorService;
+  let service: RunbookCompletionService;
+
+  const steps: ResolvedStep[] = [
+    {
+      kind: 'substeps',
+      name: '1',
+      description: 'Parent',
+      aggregation: { strategy: 'ALL' },
+      substeps: [
+        {
+          id: '1',
+          description: 'First',
+          transitions: {
+            pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+          },
+        },
+        {
+          id: '2',
+          description: 'Second',
+          transitions: {
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+            fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+          },
+        },
+      ],
+      transitions: {
+        pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+        fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+      },
+    },
+  ];
+
+  function state(overrides: Partial<RunbookState> = {}): RunbookState {
+    return {
+      id: runbookId,
+      runbook: { source: 'project', path: 'test.md' },
+      runbookPath: 'test.md',
+      step: '1',
+      stepName: 'Parent',
+      substep: '1',
+      retryCount: 0,
+      variables: brandStoredOutputsForTest({}),
+      steps: [],
+      resolvedCompletions: {},
+      frameEntries: { [buildFrameKey('1')]: 1 },
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      startedAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      lifecycle: 'running',
+      schemaVersion: 3,
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'completion-service-'));
+    manager = new RunbookStateManager(tmp);
+    lifecycleService = new ExecutionLifecycleService(manager);
+    actorService = new RunbookActorService(manager);
+    service = new RunbookCompletionService(manager, lifecycleService, actorService);
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('records non-active manual completions with sentinel entry and exact/sentinel duplicate detection', async () => {
+    const current = state();
+    await manager.save(current);
+
+    const first = await service.recordManualCompletion({
+      runbookId,
+      currentState: current,
+      targetStep: '1',
+      targetSubstep: '2',
+      targetFrameKey: buildFrameKey('1', 2),
+      targetIteration: 2,
+      result: 'pass',
+      agentId: 'manual',
+      completedAt: '2026-01-01T00:00:00.000Z',
+    });
+    const second = await service.recordManualCompletion({
+      runbookId,
+      currentState: current,
+      targetStep: '1',
+      targetSubstep: '2',
+      targetFrameKey: buildFrameKey('1', 2),
+      targetIteration: 2,
+      result: 'fail',
+      agentId: 'manual',
+      completedAt: '2026-01-01T00:00:01.000Z',
+    });
+
+    const key = buildCompletionKey(buildFrameKey('1', 2), SENTINEL_ENTRY, '2');
+    const persisted = await lifecycleService.getResolvedCompletion(runbookId, key);
+    expect(first).toEqual({ status: 'recorded', key });
+    expect(second).toEqual({ status: 'duplicate', key });
+    expect(persisted).toEqual(expect.objectContaining({ result: 'pass', targetEntry: 0 }));
+  });
+
+  it('returns target_mismatch without dispatching or consuming when completion is not for current substep', async () => {
+    const current = state();
+    const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+    await manager.save({
+      ...current,
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'manual',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '2',
+          targetFrameKey: buildFrameKey('1'),
+          targetEntry: 1,
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+    const sendAndSync = jest.spyOn(actorService, 'sendAndSync');
+
+    const result = await service.drainResolvedCompletions({
+      runbookId,
+      steps,
+      currentState: current,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(sendAndSync).not.toHaveBeenCalled();
+    await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.not.toBeNull();
+  });
+
+  it('normalizes sentinel completions before dispatching the validated event', async () => {
+    const current = state();
+    const key = buildCompletionKey(buildFrameKey('1'), SENTINEL_ENTRY, '1');
+    await manager.save({
+      ...current,
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'manual',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrameKey: buildFrameKey('1'),
+          targetEntry: SENTINEL_ENTRY,
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+    const sendAndSync = jest.spyOn(actorService, 'sendAndSync').mockResolvedValue({
+      state: state({ substep: '2' }),
+      snapshot: {},
+    });
+
+    const result = await service.drainResolvedCompletions({
+      runbookId,
+      steps,
+      currentState: current,
+    });
+
+    expect(result.status).toBe('continue');
+    expect(sendAndSync).toHaveBeenCalledWith(
+      runbookId,
+      steps,
+      expect.objectContaining({
+        type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
+        completion: expect.objectContaining({ targetEntry: 1, __currentCursorValidated: true }),
+      }),
+    );
+    await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toBeNull();
+  });
+
+  it('records child completion with finalVars on the parent completion', async () => {
+    const parent = state({
+      substepStates: [
+        {
+          id: '1',
+          frameKey: buildFrameKey('1'),
+          status: 'running',
+          delegation: {
+            tokenHash: assertDelegationTokenHash(`sha256:${'a'.repeat(64)}`),
+            childRunbookPath: 'child.md',
+            childRunbookRef: { source: 'project', path: 'child.md' },
+            contextSnapshot: { vars: brandEffectiveVarsForTest({}), ancestors: [], at: '1.1' },
+            childRunId: brandRunIdForTest('rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
+            createdAt: '2026-01-01T00:00:00.000Z',
+            cancelledAt: null,
+          },
+        },
+      ],
+    });
+    await manager.save(parent);
+    const child = state({
+      id: brandRunIdForTest('rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
+      parentLinkage: {
+        kind: 'delegation',
+        parentRunId: runbookId,
+        parentStepId: '1',
+        parentStep: '1',
+        parentFrameKey: buildFrameKey('1'),
+        parentEntry: 1,
+        tokenHash: assertDelegationTokenHash(`sha256:${'a'.repeat(64)}`),
+      },
+      finalVars: { ChildValue: 'ready' },
+    });
+
+    const result = await service.recordChildCompletion({ childState: child, result: 'pass' });
+
+    const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+    await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
+      expect.objectContaining({ finalVars: { ChildValue: 'ready' }, result: 'pass' }),
+    );
+    await expect(manager.load(runbookId)).resolves.toEqual(
+      expect.objectContaining({
+        substepStates: [expect.objectContaining({ id: '1', status: 'done', result: 'pass' })],
+      }),
+    );
+    expect(result).toBe('recorded');
+  });
+});

--- a/packages/core/__tests__/runbook/targeting.test.ts
+++ b/packages/core/__tests__/runbook/targeting.test.ts
@@ -133,6 +133,7 @@ describe('targeting helpers', () => {
         targetIteration: 3,
         targetFrameKey: buildFrameKey('2', 3),
         targetEntry: 1,
+        finalVars: { childOutput: 'value' },
         completedAt: '2026-01-01T00:00:00.000Z',
       });
       expect(completion).toEqual({
@@ -143,6 +144,7 @@ describe('targeting helpers', () => {
         targetIteration: 3,
         targetFrameKey: buildFrameKey('2', 3),
         targetEntry: 1,
+        finalVars: { childOutput: 'value' },
         completedAt: '2026-01-01T00:00:00.000Z',
       });
     });

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -334,6 +334,48 @@ describe('RunbookStateSchema finalVars', () => {
   });
 });
 
+describe('RunbookStateSchema resolvedCompletions finalVars', () => {
+  it('accepts resolved completions with string finalVars', () => {
+    const state = createValidState({
+      resolvedCompletions: {
+        '1||1|1': {
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrameKey: '1|',
+          targetEntry: 1,
+          finalVars: { ChildResult: 'ready' },
+          completedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    });
+
+    expect(RunbookStateSchema.parse(state).resolvedCompletions?.['1||1|1']?.finalVars).toEqual({
+      ChildResult: 'ready',
+    });
+  });
+
+  it('rejects resolved completion finalVars with non-string values', () => {
+    const state = createValidState({
+      resolvedCompletions: {
+        '1||1|1': {
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrameKey: '1|',
+          targetEntry: 1,
+          finalVars: { ChildResult: 42 },
+          completedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    });
+
+    expect(() => RunbookStateSchema.parse(state)).toThrow();
+  });
+});
+
 describe('RunbookStateSchema frontmatterOutputs', () => {
   it('accepts frontmatterOutputs as optional readonly OutputDeclaration array', () => {
     const state = createValidState({

--- a/packages/core/src/runbook/actor-service.ts
+++ b/packages/core/src/runbook/actor-service.ts
@@ -170,6 +170,8 @@ function lastResultSyncForEvent(event: RunbookEvent): LastResultSync {
       return { kind: 'set', result: 'fail' };
     case 'COMMAND_RESULT':
       return { kind: 'set', result: event.result };
+    case 'APPLY_CURRENT_RESOLVED_COMPLETION':
+      return { kind: 'set', result: event.completion.result };
     case 'GOTO':
     case 'FORCE_STOP':
     case 'FORCE_COMPLETE':

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -511,8 +511,11 @@ export interface RunbookContext {
  * - GOTO: Jump directly to a specific step by ID
  * - FORCE_STOP: User-forced stop command intent routed through the machine
  * - FORCE_COMPLETE: User-forced complete command intent routed through the machine
- * - SET_VARIABLES: Merge variables into context.variables without changing step
- *   (used by delegation completion; OUTPUTS capture uses COMMAND_RESULT below)
+ * - SET_VARIABLES: Merge variables into context.variables without changing step.
+ *   Available as a general-purpose variable-merge primitive; delegation
+ *   completion now flows through APPLY_CURRENT_RESOLVED_COMPLETION below, which
+ *   merges `finalVars` atomically with the pass/fail raise. OUTPUTS capture
+ *   uses COMMAND_RESULT below.
  * - DELEGATE_FRONTIER_CONSUMED: Clear the one-shot delegation frontier after
  *   a frontend emits the plain claim tokens.
  * - APPLY_CURRENT_RESOLVED_COMPLETION: Apply a core-validated resolved completion

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -68,6 +68,7 @@ import { RunbookRefSchema, type RunbookRef } from './runbook-ref.js';
 import { MAX_FILE_ITERATIONS } from './for-iteration-constants.js';
 import type { ParentLinkage } from './types.js';
 import type { ResolveDelegationRunbook } from './delegation-inference.js';
+import type { CurrentCursorResolvedCompletion } from './completion-service.js';
 
 export { MAX_FILE_ITERATIONS } from './for-iteration-constants.js';
 
@@ -514,6 +515,8 @@ export interface RunbookContext {
  *   (used by delegation completion; OUTPUTS capture uses COMMAND_RESULT below)
  * - DELEGATE_FRONTIER_CONSUMED: Clear the one-shot delegation frontier after
  *   a frontend emits the plain claim tokens.
+ * - APPLY_CURRENT_RESOLVED_COMPLETION: Apply a core-validated resolved completion
+ *   at the current cursor, merging child finalVars before raising PASS/FAIL
  * - COMMAND_RESULT: Result of a CLI-driven command execution. Carries captured
  *   channels. Unconditionally transitions the leaf to its `__capture` child,
  *   which invokes `outputCaptureActor`. Channels may be empty; the actor
@@ -529,6 +532,10 @@ export type RunbookEvent =
   | { type: 'FORCE_COMPLETE'; message?: string }
   | { type: 'SET_VARIABLES'; vars: Record<string, VariableValue> }
   | { type: 'DELEGATE_FRONTIER_CONSUMED' }
+  | {
+      type: 'APPLY_CURRENT_RESOLVED_COMPLETION';
+      completion: CurrentCursorResolvedCompletion;
+    }
   | {
       type: 'COMMAND_RESULT';
       result: 'pass' | 'fail';
@@ -3741,6 +3748,34 @@ export function compileRunbookToMachine(
           delegateFrontier: undefined,
         }),
       },
+      APPLY_CURRENT_RESOLVED_COMPLETION: [
+        {
+          guard: ({ event }) => {
+            assertEvent(event, 'APPLY_CURRENT_RESOLVED_COMPLETION');
+            return event.completion.result === 'pass';
+          },
+          actions: [
+            runbookSetup.assign({
+              variables: ({ context, event }) => {
+                assertEvent(event, 'APPLY_CURRENT_RESOLVED_COMPLETION');
+                return { ...context.variables, ...(event.completion.finalVars ?? {}) };
+              },
+            }),
+            { type: 'raisePass' },
+          ],
+        },
+        {
+          actions: [
+            runbookSetup.assign({
+              variables: ({ context, event }) => {
+                assertEvent(event, 'APPLY_CURRENT_RESOLVED_COMPLETION');
+                return { ...context.variables, ...(event.completion.finalVars ?? {}) };
+              },
+            }),
+            { type: 'raiseFail' },
+          ],
+        },
+      ],
     },
     context: {
       retryCount: 0,

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -399,16 +399,18 @@ export class RunbookCompletionService {
       finalVars: args.childState.finalVars,
       completedAt: args.completedAt,
     });
-    const freshParent = await this.manager.load(linkage.parentRunId);
-    if (freshParent) {
-      await this.manager.update(linkage.parentRunId, {
-        substepStates: upsertSubstepState(
-          freshParent.substepStates ?? [],
-          linkage.parentStepId,
-          frameKey,
-          { status: 'done', result },
-        ),
-      });
+    if (recorded.status === 'recorded') {
+      const freshParent = await this.manager.load(linkage.parentRunId);
+      if (freshParent) {
+        await this.manager.update(linkage.parentRunId, {
+          substepStates: upsertSubstepState(
+            freshParent.substepStates ?? [],
+            linkage.parentStepId,
+            frameKey,
+            { status: 'done', result },
+          ),
+        });
+      }
     }
     return recorded.status;
   }
@@ -439,11 +441,24 @@ export class RunbookCompletionService {
       state = ensured.state;
       const activeFrameKey = state.activeFrameKey ?? ensured.frameKey;
       if (args.frameKeyOverride && args.frameKeyOverride !== activeFrameKey) {
+        const overrideResolved = await this.lifecycleService.listResolvedCompletions(
+          args.runbookId,
+          args.frameKeyOverride,
+          SENTINEL_ENTRY,
+        );
+        const overrideResolvedSubsteps = new Set(
+          overrideResolved
+            .map(({ completion }) => completion.targetSubstep)
+            .filter((substep): substep is string => substep !== undefined),
+        );
+        const unresolved = currentStep.substeps.filter(
+          (substep) => !overrideResolvedSubsteps.has(substep.id),
+        ).length;
         return {
           status: 'not_active',
           frameKey: args.frameKeyOverride,
           activeFrameKey,
-          unresolved: currentStep.substeps.length,
+          unresolved,
           applied: [],
         };
       }

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -506,7 +506,7 @@ export class RunbookCompletionService {
       }
 
       const validated = this.validateCurrentCompletionTarget(state, current.completion, ensured);
-      if ('status' in validated) return validated;
+      if (!(currentCursorValidatedBrand in validated)) return validated;
 
       // Consume by the key that `listResolvedCompletions` returned, so the
       // lifecycle row we delete matches `applied[].key` exactly — `current.key`

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -1,0 +1,404 @@
+import { resolvedStepHasSubsteps } from '@rundown-org/parser';
+import { DelegationLock } from './delegation-lock.js';
+import type { ExecutionLifecycleService } from './execution-lifecycle-service.js';
+import type { RunbookActorService, ActorSyncResult } from './actor-service.js';
+import type { RunbookStateManager } from './state.js';
+import {
+  SENTINEL_ENTRY,
+  buildCompletionKey,
+  buildResolvedCompletion,
+  deriveActiveFrame,
+  findSubstepState,
+  upsertSubstepState,
+  type FrameKey,
+} from './targeting.js';
+import type { ResolvedCompletion, ResolvedStep, RunId, RunbookState } from './types.js';
+
+/**
+ * Resolved completion that has been validated against the machine's active cursor.
+ */
+export interface CurrentCursorResolvedCompletion extends ResolvedCompletion {
+  /** Substep is required after current-cursor validation. */
+  readonly targetSubstep: string;
+  /** Brand proving this completion passed current-cursor validation. */
+  readonly __currentCursorValidated: true;
+}
+
+/** Completion applied to the machine during a drain pass. */
+export interface AppliedResolvedCompletion {
+  /** Persisted completion key consumed for this application. */
+  readonly key: string;
+  /** Validated completion sent into the machine. */
+  readonly completion: CurrentCursorResolvedCompletion;
+  /** State before the completion was applied. */
+  readonly stateBefore: RunbookState;
+  /** State after the completion was applied. */
+  readonly stateAfter: RunbookState;
+  /** Raw actor snapshot after the completion was applied. */
+  readonly snapshot: unknown;
+}
+
+/** Target mismatch returned when a persisted completion is not for the active cursor. */
+export interface CompletionTargetMismatch {
+  readonly status: 'failed';
+  readonly reason: 'target_mismatch';
+  readonly message: string;
+  readonly completion: ResolvedCompletion;
+}
+
+/** Result of recording a deferred completion. */
+export type RecordCompletionResult =
+  | { readonly status: 'recorded'; readonly key: string }
+  | { readonly status: 'duplicate'; readonly key: string };
+
+/** Arguments for recording a manual parent/substep completion. */
+export interface RecordManualCompletionArgs {
+  readonly runbookId: RunId;
+  readonly currentState: RunbookState;
+  readonly targetStep: string;
+  readonly targetSubstep: string;
+  readonly targetIteration?: number;
+  readonly targetFrameKey: FrameKey;
+  readonly result: 'pass' | 'fail';
+  readonly agentId: string;
+  readonly completedAt?: string;
+  readonly finalVars?: Readonly<Record<string, string>>;
+  readonly targetEntry?: number;
+}
+
+/** Arguments for recording a completed child run against its parent. */
+export interface RecordChildCompletionArgs {
+  readonly childState: RunbookState;
+  readonly result?: 'pass' | 'fail';
+  readonly completedAt?: string;
+}
+
+/** Arguments for draining persisted completions into the current machine cursor. */
+export interface DrainResolvedCompletionsArgs {
+  readonly runbookId: RunId;
+  readonly steps: readonly ResolvedStep[];
+  readonly currentState: RunbookState;
+  readonly frameKeyOverride?: FrameKey;
+}
+
+/** Result of a resolved-completion drain pass. */
+export type DrainResolvedCompletionsResult =
+  | {
+      readonly status: 'continue';
+      readonly state: RunbookState;
+      readonly unresolved: number;
+      readonly applied: readonly AppliedResolvedCompletion[];
+    }
+  | {
+      readonly status: 'done' | 'stopped';
+      readonly unresolved: number;
+      readonly applied: readonly AppliedResolvedCompletion[];
+    }
+  | CompletionTargetMismatch
+  | {
+      readonly status: 'not_active';
+      readonly frameKey: FrameKey;
+      readonly activeFrameKey: FrameKey;
+      readonly unresolved: number;
+      readonly applied: readonly [];
+    };
+
+function findStepOrThrow(steps: readonly ResolvedStep[], stepName: string): ResolvedStep {
+  const step = steps.find((candidate) => candidate.name === stepName);
+  if (!step) throw new Error(`Step "${stepName}" not found`);
+  return step;
+}
+
+function terminalStatus(result: ActorSyncResult): 'done' | 'stopped' | undefined {
+  if (result.state.lifecycle === 'completed') return 'done';
+  if (result.state.lifecycle === 'stopped') return 'stopped';
+  return undefined;
+}
+
+/**
+ * Core service for recording and applying resolved runbook completions.
+ */
+export class RunbookCompletionService {
+  /**
+   * Create a completion service.
+   *
+   * @param manager - Runbook state manager
+   * @param lifecycleService - Lifecycle persistence helper
+   * @param actorService - DI-aware actor service used to apply validated completions
+   */
+  constructor(
+    private readonly manager: RunbookStateManager,
+    private readonly lifecycleService: ExecutionLifecycleService,
+    private readonly actorService: RunbookActorService,
+  ) {}
+
+  private activeFrameEntry(state: RunbookState, frameKey: FrameKey): number {
+    if (state.activeFrameKey === frameKey && state.activeEntry !== undefined) {
+      return state.activeEntry;
+    }
+    return state.frameEntries?.[frameKey] ?? 1;
+  }
+
+  private duplicateCandidateKeys(args: {
+    readonly frameKey: FrameKey;
+    readonly exactEntry: number;
+    readonly substep: string;
+  }): readonly string[] {
+    return [
+      buildCompletionKey(args.frameKey, args.exactEntry, args.substep),
+      buildCompletionKey(args.frameKey, SENTINEL_ENTRY, args.substep),
+    ];
+  }
+
+  private async findExistingCompletion(
+    runbookId: RunId,
+    keys: readonly string[],
+  ): Promise<string | null> {
+    for (const key of keys) {
+      const existing = await this.lifecycleService.getResolvedCompletion(runbookId, key);
+      if (existing) return key;
+    }
+    return null;
+  }
+
+  private validateCurrentCompletionTarget(
+    state: RunbookState,
+    completion: ResolvedCompletion,
+    ensured: { readonly frameKey: FrameKey; readonly entry: number },
+  ): CurrentCursorResolvedCompletion | CompletionTargetMismatch {
+    if (!state.substep) {
+      return {
+        status: 'failed',
+        reason: 'target_mismatch',
+        message: 'Resolved completion cannot apply because the current cursor has no substep.',
+        completion,
+      };
+    }
+    const activeFrameKey = state.activeFrameKey ?? deriveActiveFrame(state).frameKey;
+    const activeEntry = state.activeEntry ?? ensured.entry;
+    const mismatch =
+      completion.targetStep !== state.step ||
+      completion.targetSubstep !== state.substep ||
+      completion.targetFrameKey !== activeFrameKey ||
+      (completion.targetEntry !== activeEntry && completion.targetEntry !== SENTINEL_ENTRY);
+    if (mismatch) {
+      return {
+        status: 'failed',
+        reason: 'target_mismatch',
+        message: `Resolved completion target does not match current cursor ${state.step}.${state.substep}.`,
+        completion,
+      };
+    }
+    return {
+      ...completion,
+      targetSubstep: state.substep,
+      targetEntry: activeEntry,
+      __currentCursorValidated: true,
+    };
+  }
+
+  /**
+   * Record a manual completion for a parent substep.
+   *
+   * @param args - Manual completion target and result
+   * @returns Whether a completion was recorded or already existed
+   */
+  async recordManualCompletion(args: RecordManualCompletionArgs): Promise<RecordCompletionResult> {
+    const activeFrameKey =
+      args.currentState.activeFrameKey ?? deriveActiveFrame(args.currentState).frameKey;
+    const isActiveFrame = args.targetFrameKey === activeFrameKey;
+    const exactEntry =
+      args.targetEntry ?? this.activeFrameEntry(args.currentState, args.targetFrameKey);
+    const entry = isActiveFrame ? exactEntry : SENTINEL_ENTRY;
+    const keys = this.duplicateCandidateKeys({
+      frameKey: args.targetFrameKey,
+      exactEntry,
+      substep: args.targetSubstep,
+    });
+    const existingKey = await this.findExistingCompletion(args.runbookId, keys);
+    if (existingKey) return { status: 'duplicate', key: existingKey };
+
+    const key = buildCompletionKey(args.targetFrameKey, entry, args.targetSubstep);
+    const completion = buildResolvedCompletion({
+      agentId: args.agentId,
+      result: args.result,
+      targetStep: args.targetStep,
+      targetSubstep: args.targetSubstep,
+      targetIteration: args.targetIteration,
+      targetFrameKey: args.targetFrameKey,
+      targetEntry: entry,
+      finalVars: args.finalVars,
+      completedAt: args.completedAt,
+    });
+    await this.lifecycleService.upsertResolvedCompletion(args.runbookId, key, completion);
+    return { status: 'recorded', key };
+  }
+
+  /**
+   * Record a parent substep completion through the same duplicate rules as manual completion.
+   *
+   * @param args - Parent substep completion target and result
+   * @returns Whether a completion was recorded or already existed
+   */
+  async recordParentSubstepCompletion(
+    args: RecordManualCompletionArgs,
+  ): Promise<RecordCompletionResult> {
+    return this.recordManualCompletion(args);
+  }
+
+  /**
+   * Record a completed child run against its parent linkage.
+   *
+   * @param args - Child completion input
+   * @returns Recording outcome
+   */
+  async recordChildCompletion(
+    args: RecordChildCompletionArgs,
+  ): Promise<'recorded' | 'duplicate' | 'not-applicable' | 'cancelled'> {
+    const linkage = args.childState.parentLinkage;
+    if (!linkage) return 'not-applicable';
+    const result =
+      args.result ??
+      (args.childState.lifecycle === 'completed'
+        ? 'pass'
+        : args.childState.lifecycle === 'stopped'
+          ? 'fail'
+          : undefined);
+    if (!result) return 'not-applicable';
+
+    const lock = new DelegationLock(this.manager.cwd);
+    await lock.acquire(linkage.parentRunId);
+    try {
+      const parentState = await this.manager.load(linkage.parentRunId);
+      if (!parentState) return 'not-applicable';
+      const frameKey = linkage.parentFrameKey ?? deriveActiveFrame(parentState).frameKey;
+      const substepState = findSubstepState(
+        parentState.substepStates ?? [],
+        linkage.parentStepId,
+        frameKey,
+      );
+      if (linkage.kind === 'delegation' && substepState?.delegation?.cancelledAt) {
+        return 'cancelled';
+      }
+      const entry = linkage.parentEntry ?? this.activeFrameEntry(parentState, frameKey);
+      const recorded = await this.recordManualCompletion({
+        runbookId: linkage.parentRunId,
+        currentState: parentState,
+        targetStep: linkage.parentStep ?? parentState.step,
+        targetSubstep: linkage.parentStepId,
+        targetFrameKey: frameKey,
+        targetEntry: entry,
+        result,
+        agentId: linkage.kind === 'inline' ? 'inline' : 'delegation',
+        finalVars: args.childState.finalVars,
+        completedAt: args.completedAt,
+      });
+      const freshParent = await this.manager.load(linkage.parentRunId);
+      if (freshParent) {
+        await this.manager.update(linkage.parentRunId, {
+          substepStates: upsertSubstepState(
+            freshParent.substepStates ?? [],
+            linkage.parentStepId,
+            frameKey,
+            { status: 'done', result },
+          ),
+        });
+      }
+      return recorded.status;
+    } finally {
+      await lock.release(linkage.parentRunId);
+    }
+  }
+
+  /**
+   * Drain active-frame resolved completions into the runbook state machine.
+   *
+   * @param args - Drain target and current state
+   * @returns Drain outcome
+   */
+  async drainResolvedCompletions(
+    args: DrainResolvedCompletionsArgs,
+  ): Promise<DrainResolvedCompletionsResult> {
+    let state = args.currentState;
+    const applied: AppliedResolvedCompletion[] = [];
+
+    while (true) {
+      const currentStep = findStepOrThrow(args.steps, state.step);
+      if (!resolvedStepHasSubsteps(currentStep) || !state.substep) {
+        return { status: 'continue', state, unresolved: 0, applied };
+      }
+
+      const ensured = await this.lifecycleService.ensureActiveEntry(
+        args.runbookId,
+        undefined,
+        state,
+      );
+      state = ensured.state;
+      const activeFrameKey = state.activeFrameKey ?? ensured.frameKey;
+      if (args.frameKeyOverride && args.frameKeyOverride !== activeFrameKey) {
+        return {
+          status: 'not_active',
+          frameKey: args.frameKeyOverride,
+          activeFrameKey,
+          unresolved: currentStep.substeps.length,
+          applied: [],
+        };
+      }
+
+      const entry = state.activeEntry ?? ensured.entry;
+      const resolved = await this.lifecycleService.listResolvedCompletions(
+        args.runbookId,
+        activeFrameKey,
+        entry,
+      );
+      const resolvedBySubstep = new Map(
+        resolved
+          .filter(({ completion }) => completion.targetSubstep !== undefined)
+          .map(({ completion }) => [completion.targetSubstep, completion]),
+      );
+      const unresolved = currentStep.substeps.filter(
+        (substep) => !resolvedBySubstep.has(substep.id),
+      ).length;
+      const currentKey = buildCompletionKey(activeFrameKey, entry, state.substep);
+      const current =
+        resolved.find(({ key }) => key === currentKey) ??
+        resolved.find(
+          ({ key, completion }) =>
+            key === buildCompletionKey(activeFrameKey, SENTINEL_ENTRY, state.substep) ||
+            completion.targetSubstep === state.substep,
+        );
+      if (!current) {
+        return { status: 'continue', state, unresolved, applied };
+      }
+
+      const validated = this.validateCurrentCompletionTarget(state, current.completion, ensured);
+      if ('status' in validated) return validated;
+
+      const consumed = await this.lifecycleService.consumeResolvedCompletion(
+        args.runbookId,
+        currentKey,
+      );
+      if (!consumed) {
+        return { status: 'continue', state, unresolved, applied };
+      }
+
+      const result = await this.actorService.sendAndSync(args.runbookId, args.steps, {
+        type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
+        completion: validated,
+      });
+      if (!result) {
+        return { status: 'continue', state, unresolved, applied };
+      }
+      applied.push({
+        key: current.key,
+        completion: validated,
+        stateBefore: state,
+        stateAfter: result.state,
+        snapshot: result.snapshot,
+      });
+      const terminal = terminalStatus(result);
+      if (terminal) return { status: terminal, unresolved: 0, applied };
+      state = result.state;
+    }
+  }
+}

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -15,18 +15,38 @@ import {
 import type { ResolvedCompletion, ResolvedStep, RunId, RunbookState } from './types.js';
 
 /**
- * Resolved completion that has been validated against the machine's active cursor.
+ * Module-private brand symbol for {@link CurrentCursorResolvedCompletion}.
+ *
+ * Declared as a real `Symbol()` (typed as `unique symbol`) so callers outside
+ * this module cannot forge the branded shape: TypeScript treats the symbol as
+ * a distinct nominal value, and the binding is not exported. The only producer
+ * of branded values is `validateCurrentCompletionTarget` inside this module.
  */
-export interface CurrentCursorResolvedCompletion extends ResolvedCompletion {
+const currentCursorValidatedBrand: unique symbol = Symbol('currentCursorValidated');
+
+/**
+ * Resolved completion that has been validated against the machine's active cursor.
+ *
+ * The `currentCursorValidatedBrand` symbol is unique to this module and cannot
+ * be produced outside `validateCurrentCompletionTarget`, so callers receiving
+ * this type can rely on `targetSubstep` matching the current cursor.
+ */
+export type CurrentCursorResolvedCompletion = ResolvedCompletion & {
   /** Substep is required after current-cursor validation. */
   readonly targetSubstep: string;
-  /** Brand proving this completion passed current-cursor validation. */
-  readonly __currentCursorValidated: true;
-}
+  /** Unforgeable brand proving this completion passed current-cursor validation. */
+  readonly [currentCursorValidatedBrand]: true;
+};
 
 /** Completion applied to the machine during a drain pass. */
 export interface AppliedResolvedCompletion {
-  /** Persisted completion key consumed for this application. */
+  /**
+   * Lifecycle key consumed for this application. Matches the key returned by
+   * `consumeResolvedCompletion` — when the exact key was missing and a
+   * sentinel-keyed completion was consumed, this reflects the sentinel key,
+   * so logs and audits stay consistent with the lifecycle row that was
+   * actually deleted.
+   */
   readonly key: string;
   /** Validated completion sent into the machine. */
   readonly completion: CurrentCursorResolvedCompletion;
@@ -40,66 +60,125 @@ export interface AppliedResolvedCompletion {
 
 /** Target mismatch returned when a persisted completion is not for the active cursor. */
 export interface CompletionTargetMismatch {
+  /** Discriminant: drain refused to apply this completion. */
   readonly status: 'failed';
+  /** Specific reason for the refusal — currently only `target_mismatch`. */
   readonly reason: 'target_mismatch';
+  /** Human-readable diagnostic message naming the current cursor. */
   readonly message: string;
+  /** The unvalidated completion that triggered the mismatch. */
   readonly completion: ResolvedCompletion;
 }
 
 /** Result of recording a deferred completion. */
 export type RecordCompletionResult =
-  | { readonly status: 'recorded'; readonly key: string }
-  | { readonly status: 'duplicate'; readonly key: string };
+  | {
+      /** Discriminant: a new lifecycle row was written. */
+      readonly status: 'recorded';
+      /** Canonical completion key under which the completion was written. */
+      readonly key: string;
+    }
+  | {
+      /** Discriminant: an existing row already covered this target. */
+      readonly status: 'duplicate';
+      /** Canonical key of the pre-existing row that blocked the write. */
+      readonly key: string;
+    };
 
 /** Arguments for recording a manual parent/substep completion. */
 export interface RecordManualCompletionArgs {
+  /** Run id of the parent state owning the lifecycle row. */
   readonly runbookId: RunId;
+  /** Current persisted parent state — used for active-frame detection only. */
   readonly currentState: RunbookState;
+  /** Target step id the completion is being recorded against. */
   readonly targetStep: string;
+  /** Target substep id within the parent step. */
   readonly targetSubstep: string;
+  /** Optional FOR iteration index if the target is inside a FOR-loop frame. */
   readonly targetIteration?: number;
+  /** Frame key identifying the (step, iteration) the target belongs to. */
   readonly targetFrameKey: FrameKey;
+  /** Recorded result — drives the eventual PASS/FAIL raise on drain. */
   readonly result: 'pass' | 'fail';
+  /** Agent identifier (`delegation`, `inline`, or a manual command id). */
   readonly agentId: string;
+  /** Optional ISO 8601 timestamp; defaults to current time when omitted. */
   readonly completedAt?: string;
+  /** Final variables produced by a child runbook, merged into context on drain. */
   readonly finalVars?: Readonly<Record<string, string>>;
+  /**
+   * Explicit frame-entry counter — overrides the active-frame entry. Pass when
+   * the caller already resolved the entry (e.g., child propagation).
+   */
   readonly targetEntry?: number;
 }
 
 /** Arguments for recording a completed child run against its parent. */
 export interface RecordChildCompletionArgs {
+  /** Terminal child state carrying `parentLinkage` and optional `finalVars`. */
   readonly childState: RunbookState;
+  /** Optional explicit result; defaults to the child's terminal lifecycle. */
   readonly result?: 'pass' | 'fail';
+  /** Optional ISO 8601 timestamp; defaults to current time when omitted. */
   readonly completedAt?: string;
+  /**
+   * Bypass the `delegation.cancelledAt` short-circuit. The default behavior
+   * returns `'cancelled'` without writing a completion when the parent
+   * substep has been cancelled, which protects against a still-running child
+   * racing past a user-initiated cancel. The `abort --force` path persists
+   * `cancelledAt` *as* the propagation event and needs the FAIL completion
+   * recorded anyway, so it sets this flag.
+   */
+  readonly ignoreCancellation?: boolean;
 }
 
 /** Arguments for draining persisted completions into the current machine cursor. */
 export interface DrainResolvedCompletionsArgs {
+  /** Run id of the runbook being drained. */
   readonly runbookId: RunId;
+  /** Resolved step definitions for the runbook (used for substep ordering). */
   readonly steps: readonly ResolvedStep[];
+  /** Current persisted state to derive active frame/cursor from. */
   readonly currentState: RunbookState;
+  /**
+   * Optional override frame key — when supplied and not equal to the active
+   * frame, drain short-circuits to `not_active` without dispatching any event.
+   */
   readonly frameKeyOverride?: FrameKey;
 }
 
 /** Result of a resolved-completion drain pass. */
 export type DrainResolvedCompletionsResult =
   | {
+      /** Drain advanced the cursor with remaining substeps still pending. */
       readonly status: 'continue';
+      /** State after the last applied completion (or current state if none). */
       readonly state: RunbookState;
+      /** Count of substeps still without a persisted completion. */
       readonly unresolved: number;
+      /** Each completion applied during this pass, in dispatch order. */
       readonly applied: readonly AppliedResolvedCompletion[];
     }
   | {
+      /** Runbook reached a terminal lifecycle (`done` or `stopped`). */
       readonly status: 'done' | 'stopped';
+      /** Always zero on terminal exits. */
       readonly unresolved: number;
+      /** Each completion applied during this pass, in dispatch order. */
       readonly applied: readonly AppliedResolvedCompletion[];
     }
   | CompletionTargetMismatch
   | {
+      /** Requested frame is not currently active; drain is observation-only. */
       readonly status: 'not_active';
+      /** Frame key that was requested via `frameKeyOverride`. */
       readonly frameKey: FrameKey;
+      /** Frame key the machine is actually positioned on. */
       readonly activeFrameKey: FrameKey;
+      /** Count of substeps still without a persisted completion. */
       readonly unresolved: number;
+      /** Always empty when `not_active`. */
       readonly applied: readonly [];
     };
 
@@ -193,12 +272,18 @@ export class RunbookCompletionService {
       ...completion,
       targetSubstep: state.substep,
       targetEntry: activeEntry,
-      __currentCursorValidated: true,
+      [currentCursorValidatedBrand]: true,
     };
   }
 
   /**
    * Record a manual completion for a parent substep.
+   *
+   * Locking contract: this method performs no locking. Callers that mutate
+   * concurrent parent state (e.g., delegation propagation) are responsible for
+   * acquiring the appropriate {@link DelegationLock} around the call.
+   * {@link recordChildCompletion} acquires the parent delegation lock for you;
+   * `recordManualCompletion` does not.
    *
    * @param args - Manual completion target and result
    * @returns Whether a completion was recorded or already existed
@@ -235,24 +320,44 @@ export class RunbookCompletionService {
   }
 
   /**
-   * Record a parent substep completion through the same duplicate rules as manual completion.
-   *
-   * @param args - Parent substep completion target and result
-   * @returns Whether a completion was recorded or already existed
-   */
-  async recordParentSubstepCompletion(
-    args: RecordManualCompletionArgs,
-  ): Promise<RecordCompletionResult> {
-    return this.recordManualCompletion(args);
-  }
-
-  /**
    * Record a completed child run against its parent linkage.
+   *
+   * Acquires the parent {@link DelegationLock} for the duration of the
+   * recording. Callers that already hold the parent delegation lock must use
+   * {@link recordChildCompletionUnlocked} instead to avoid deadlock.
    *
    * @param args - Child completion input
    * @returns Recording outcome
    */
   async recordChildCompletion(
+    args: RecordChildCompletionArgs,
+  ): Promise<'recorded' | 'duplicate' | 'not-applicable' | 'cancelled'> {
+    const linkage = args.childState.parentLinkage;
+    if (!linkage) return 'not-applicable';
+
+    const lock = new DelegationLock(this.manager.cwd);
+    await lock.acquire(linkage.parentRunId);
+    try {
+      return await this.recordChildCompletionUnlocked(args);
+    } finally {
+      await lock.release(linkage.parentRunId);
+    }
+  }
+
+  /**
+   * Record a completed child run against its parent linkage, assuming the
+   * caller already holds the parent {@link DelegationLock}.
+   *
+   * Locking contract: this method performs no locking and MUST only be called
+   * by code paths that already hold the parent delegation lock (for example,
+   * the `abort --force` command which acquires the lock to mutate substep
+   * state before recording the failure). Callers without the lock should use
+   * {@link recordChildCompletion}.
+   *
+   * @param args - Child completion input
+   * @returns Recording outcome
+   */
+  async recordChildCompletionUnlocked(
     args: RecordChildCompletionArgs,
   ): Promise<'recorded' | 'duplicate' | 'not-applicable' | 'cancelled'> {
     const linkage = args.childState.parentLinkage;
@@ -266,48 +371,46 @@ export class RunbookCompletionService {
           : undefined);
     if (!result) return 'not-applicable';
 
-    const lock = new DelegationLock(this.manager.cwd);
-    await lock.acquire(linkage.parentRunId);
-    try {
-      const parentState = await this.manager.load(linkage.parentRunId);
-      if (!parentState) return 'not-applicable';
-      const frameKey = linkage.parentFrameKey ?? deriveActiveFrame(parentState).frameKey;
-      const substepState = findSubstepState(
-        parentState.substepStates ?? [],
-        linkage.parentStepId,
-        frameKey,
-      );
-      if (linkage.kind === 'delegation' && substepState?.delegation?.cancelledAt) {
-        return 'cancelled';
-      }
-      const entry = linkage.parentEntry ?? this.activeFrameEntry(parentState, frameKey);
-      const recorded = await this.recordManualCompletion({
-        runbookId: linkage.parentRunId,
-        currentState: parentState,
-        targetStep: linkage.parentStep ?? parentState.step,
-        targetSubstep: linkage.parentStepId,
-        targetFrameKey: frameKey,
-        targetEntry: entry,
-        result,
-        agentId: linkage.kind === 'inline' ? 'inline' : 'delegation',
-        finalVars: args.childState.finalVars,
-        completedAt: args.completedAt,
-      });
-      const freshParent = await this.manager.load(linkage.parentRunId);
-      if (freshParent) {
-        await this.manager.update(linkage.parentRunId, {
-          substepStates: upsertSubstepState(
-            freshParent.substepStates ?? [],
-            linkage.parentStepId,
-            frameKey,
-            { status: 'done', result },
-          ),
-        });
-      }
-      return recorded.status;
-    } finally {
-      await lock.release(linkage.parentRunId);
+    const parentState = await this.manager.load(linkage.parentRunId);
+    if (!parentState) return 'not-applicable';
+    const frameKey = linkage.parentFrameKey ?? deriveActiveFrame(parentState).frameKey;
+    const substepState = findSubstepState(
+      parentState.substepStates ?? [],
+      linkage.parentStepId,
+      frameKey,
+    );
+    if (
+      linkage.kind === 'delegation' &&
+      substepState?.delegation?.cancelledAt &&
+      !args.ignoreCancellation
+    ) {
+      return 'cancelled';
     }
+    const entry = linkage.parentEntry ?? this.activeFrameEntry(parentState, frameKey);
+    const recorded = await this.recordManualCompletion({
+      runbookId: linkage.parentRunId,
+      currentState: parentState,
+      targetStep: linkage.parentStep ?? parentState.step,
+      targetSubstep: linkage.parentStepId,
+      targetFrameKey: frameKey,
+      targetEntry: entry,
+      result,
+      agentId: linkage.kind === 'inline' ? 'inline' : 'delegation',
+      finalVars: args.childState.finalVars,
+      completedAt: args.completedAt,
+    });
+    const freshParent = await this.manager.load(linkage.parentRunId);
+    if (freshParent) {
+      await this.manager.update(linkage.parentRunId, {
+        substepStates: upsertSubstepState(
+          freshParent.substepStates ?? [],
+          linkage.parentStepId,
+          frameKey,
+          { status: 'done', result },
+        ),
+      });
+    }
+    return recorded.status;
   }
 
   /**
@@ -322,7 +425,7 @@ export class RunbookCompletionService {
     let state = args.currentState;
     const applied: AppliedResolvedCompletion[] = [];
 
-    while (true) {
+    for (;;) {
       const currentStep = findStepOrThrow(args.steps, state.step);
       if (!resolvedStepHasSubsteps(currentStep) || !state.substep) {
         return { status: 'continue', state, unresolved: 0, applied };
@@ -374,9 +477,13 @@ export class RunbookCompletionService {
       const validated = this.validateCurrentCompletionTarget(state, current.completion, ensured);
       if ('status' in validated) return validated;
 
+      // Consume by the key that `listResolvedCompletions` returned, so the
+      // lifecycle row we delete matches `applied[].key` exactly — `current.key`
+      // may be the sentinel key (no exact entry) or the exact-entry key, but
+      // both cases must consume the same row that was listed.
       const consumed = await this.lifecycleService.consumeResolvedCompletion(
         args.runbookId,
-        currentKey,
+        current.key,
       );
       if (!consumed) {
         return { status: 'continue', state, unresolved, applied };

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -441,6 +441,22 @@ export class RunbookCompletionService {
       state = ensured.state;
       const activeFrameKey = state.activeFrameKey ?? ensured.frameKey;
       if (args.frameKeyOverride && args.frameKeyOverride !== activeFrameKey) {
+        // The cursor has moved off the override frame. Two cases:
+        //
+        // 1. Initial mismatch (`applied.length === 0`): the override targets a
+        //    frame other than the current cursor — drain is observation-only.
+        //    Return `not_active` so the caller knows nothing was applied.
+        //
+        // 2. Subsequent mismatch (`applied.length > 0`): we already drained
+        //    the override frame, and the apply itself advanced the cursor to
+        //    a new frame (e.g., a FOR loop-back into the next iteration). We
+        //    must NOT discard the applied entries — the CLI still needs to
+        //    observe them so STEP_TRANSITIONED is emitted. Stop draining here
+        //    and return `continue` with what we have; the next iteration's
+        //    frame belongs to a different delegation/claim flow.
+        if (applied.length > 0) {
+          return { status: 'continue', state, unresolved: 0, applied };
+        }
         const overrideResolved = await this.lifecycleService.listResolvedCompletions(
           args.runbookId,
           args.frameKeyOverride,

--- a/packages/core/src/runbook/delegation-service.ts
+++ b/packages/core/src/runbook/delegation-service.ts
@@ -164,14 +164,15 @@ export function readConsumedDelegationClosure(
     };
   }
 
-  if (parentMatches.length === 0) {
-    if (childMatches.length === 0) {
+  const parent = parentMatches.at(0);
+  const child = childMatches.at(0);
+
+  if (!parent) {
+    if (!child) {
       return { status: 'unknown', reason: 'missing', requiresClosure: true };
     }
-    return activeChildModel(childMatches[0]);
+    return activeChildModel(child);
   }
-
-  const parent = parentMatches[0];
 
   if (parent.delegation.cancelledAt !== null) {
     return {

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -42,6 +42,17 @@ export {
 export { SessionService, type ReleaseRunbookResult } from './session-service.js';
 export { readActiveRunScope, type ActiveRunScope } from './session-reader.js';
 export { ExecutionLifecycleService } from './execution-lifecycle-service.js';
+export {
+  RunbookCompletionService,
+  type AppliedResolvedCompletion,
+  type CompletionTargetMismatch,
+  type CurrentCursorResolvedCompletion,
+  type DrainResolvedCompletionsArgs,
+  type DrainResolvedCompletionsResult,
+  type RecordChildCompletionArgs,
+  type RecordCompletionResult,
+  type RecordManualCompletionArgs,
+} from './completion-service.js';
 export { compileRunbookToMachine, runbookSetup, MAX_FILE_ITERATIONS } from './compiler.js';
 export type { RunbookMachine } from './compiler.js';
 export { runRetryHook } from './retry-hook.js';

--- a/packages/core/src/runbook/targeting.ts
+++ b/packages/core/src/runbook/targeting.ts
@@ -200,6 +200,7 @@ export function buildStepPosition(
  * @param fields.targetIteration - Optional FOR loop iteration number
  * @param fields.targetFrameKey - Frame key identifying the step+iteration context
  * @param fields.targetEntry - Monotonic entry counter within the frame
+ * @param fields.finalVars - Optional final variables produced by a child runbook
  * @param fields.completedAt - ISO 8601 timestamp (defaults to current time)
  * @returns A fully-formed ResolvedCompletion
  */
@@ -211,6 +212,7 @@ export function buildResolvedCompletion(fields: {
   targetIteration?: number;
   targetFrameKey: FrameKey;
   targetEntry: number;
+  finalVars?: Readonly<Record<string, string>>;
   completedAt?: string;
 }): ResolvedCompletion {
   return {
@@ -221,6 +223,7 @@ export function buildResolvedCompletion(fields: {
     ...(fields.targetIteration !== undefined ? { targetIteration: fields.targetIteration } : {}),
     targetFrameKey: fields.targetFrameKey,
     targetEntry: fields.targetEntry,
+    ...(fields.finalVars ? { finalVars: fields.finalVars } : {}),
     completedAt: fields.completedAt ?? new Date().toISOString(),
   };
 }

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -532,6 +532,8 @@ export interface ResolvedCompletion {
   readonly targetFrameKey: FrameKey;
   /** Monotonic entry counter within the frame, distinguishing repeated visits. */
   readonly targetEntry: number;
+  /** Final output variables produced by a completed child runbook. */
+  readonly finalVars?: Readonly<Record<string, string>>;
   /** ISO 8601 timestamp when the agent completed. */
   readonly completedAt: string;
 }

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -402,6 +402,7 @@ const ResolvedCompletionSchema = z
     targetIteration: z.number().int().positive().max(MAX_FOR_BOUND).optional(),
     targetFrameKey: FrameKeySchema,
     targetEntry: z.number().int().nonnegative().max(MAX_FOR_BOUND),
+    finalVars: z.record(z.string(), z.string()).optional(),
     completedAt: z.string(),
   })
   .strict();


### PR DESCRIPTION
## Summary

- Make resolved completion recording and drain consumption concurrency-safe.
- Reject incomplete child parent linkage instead of deriving target identity from live parent state.
- Add collect response schema coverage for both already-aggregated and not-active JSON outputs.

## Testing

- npm run test:unit -w packages/core -- completion-service.test.ts completion-event.test.ts delegation-propagation.test.ts delegation-schemas.test.ts session-service.test.ts state-schema-version.test.ts
- npm run test:unit -w packages/cli -- --runTestsByPath __tests__/commands/claim.test.ts __tests__/commands/delegate.test.ts __tests__/commands/stash-pop.test.ts __tests__/commands/collect.test.ts __tests__/commands/schema-validation.test.ts __tests__/services/schema-coverage.test.ts __tests__/services/execution-loop.test.ts
- npm run check:types:core
- npm run check:types:cli
- npm run build -w packages/core -w packages/cli
- npm run check:format