### PR TITLE
fix: preserve last action aggregation origin

### DIFF
--- a/packages/cli/__tests__/commands/complete.test.ts
+++ b/packages/cli/__tests__/commands/complete.test.ts
@@ -71,7 +71,7 @@ This step should not become the persisted cursor.
     const stateAfter = await readRunbookState(workspace, stateBefore!.id);
     expect(stateAfter!.step).toBe('1');
     expect(stateAfter!.lifecycle).toBe('completed');
-    expect(stateAfter!.lastAction).toEqual({ type: 'COMPLETE' });
+    expect(stateAfter!.lastAction).toEqual({ type: 'COMPLETE', origin: 'direct' });
     expect(stateAfter!.finalVars).toEqual({ Result: 'complete-final' });
     expect(JSON.stringify(stateAfter!.snapshot)).toContain('Enough evidence collected');
 
@@ -120,7 +120,7 @@ This step should not become the persisted cursor.
     expect(session.active).toBeNull();
     const parentState = await readRunbookState(workspace, parentBefore!.id);
     expect(parentState!.lifecycle).toBe('completed');
-    expect(parentState!.lastAction).toEqual({ type: 'COMPLETE', aggregated: true });
+    expect(parentState!.lastAction).toEqual({ type: 'COMPLETE', origin: 'aggregation' });
   });
 
   it('dispatches FORCE_COMPLETE and exits cleanly when sendAndSync returns null', async () => {
@@ -205,8 +205,8 @@ This step should not become the persisted cursor.
     // Parent state is untouched: still in-flight, no terminal lastAction propagated.
     const parentState = await readRunbookState(workspace, parentBefore!.id);
     expect(parentState!.lifecycle).toBe(parentBefore!.lifecycle);
-    expect(parentState!.lastAction).not.toEqual({ type: 'COMPLETE' });
-    expect(parentState!.lastAction).not.toEqual({ type: 'STOP' });
+    expect(parentState!.lastAction).not.toEqual({ type: 'COMPLETE', origin: 'direct' });
+    expect(parentState!.lastAction).not.toEqual({ type: 'STOP', origin: 'direct' });
   });
 
   it('reports no active runbook', async () => {

--- a/packages/cli/__tests__/commands/goto.test.ts
+++ b/packages/cli/__tests__/commands/goto.test.ts
@@ -52,7 +52,7 @@ describe('goto command', () => {
       expect(result.exitCode).toBe(0);
       const state = await getActiveState(workspace);
       expect(state?.lastResult).toBeUndefined();
-      expect(state?.lastAction).toEqual({ type: 'GOTO', target: '2' });
+      expect(state?.lastAction).toEqual({ type: 'GOTO', origin: 'direct', target: '2' });
     });
 
     it('outputs jumped step info', async () => {

--- a/packages/cli/__tests__/commands/run-prompted.test.ts
+++ b/packages/cli/__tests__/commands/run-prompted.test.ts
@@ -122,7 +122,7 @@ Second step.
       const state = await getActiveState(workspace);
       expect(state?.step).toBe('1');
       expect(state?.substep).toBe('1');
-      expect(state?.lastAction).toEqual({ type: 'START' });
+      expect(state?.lastAction).toEqual({ type: 'START', origin: 'direct' });
       expect(state?.activeFrameKey).toBe('1|');
       expect(state?.activeEntry).toBe(1);
       expect(state?.frameEntries).toEqual({ '1|': 1 });

--- a/packages/cli/__tests__/commands/stash-pop.test.ts
+++ b/packages/cli/__tests__/commands/stash-pop.test.ts
@@ -475,7 +475,7 @@ rd echo "hello"
       updatedAt: new Date().toISOString(),
       runbookSrc, // Include runbookSrc so pop can read steps
       lifecycle: 'running',
-      schemaVersion: 4,
+      schemaVersion: 5,
     };
     await writeFile(stateFile, JSON.stringify(state, null, 2));
 
@@ -509,7 +509,7 @@ rd echo "hello"
           updatedAt: new Date().toISOString(),
           runbookSrc: '# Parent\n\n## 1. Parent step\n- PASS CONTINUE\n',
           lifecycle: 'running',
-          schemaVersion: 4,
+          schemaVersion: 5,
         },
         null,
         2,
@@ -551,7 +551,7 @@ rd echo "hello"
             tokenHash: `sha256:${'a'.repeat(64)}`,
           },
           lifecycle: 'running',
-          schemaVersion: 4,
+          schemaVersion: 5,
         },
         null,
         2,

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -57,7 +57,7 @@ describe('stop command', () => {
       // State should be preserved (not deleted)
       const stateAfter = await readRunbookState(workspace, runId);
       expect(stateAfter).not.toBeNull();
-      expect(stateAfter!.lastAction).toEqual({ type: 'STOP' });
+      expect(stateAfter!.lastAction).toEqual({ type: 'STOP', origin: 'direct' });
       expect(stateAfter!.lastResult).toBeUndefined();
       expect(stateAfter!.lifecycle).toBe('stopped');
     });
@@ -88,7 +88,7 @@ The result is {{ Result }}.
       expect(result.exitCode).toBe(0);
       const stateAfter = await readRunbookState(workspace, stateBefore!.id);
       expect(stateAfter!.lifecycle).toBe('stopped');
-      expect(stateAfter!.lastAction).toEqual({ type: 'STOP' });
+      expect(stateAfter!.lastAction).toEqual({ type: 'STOP', origin: 'direct' });
       expect(stateAfter!.lastResult).toBeUndefined();
       expect(stateAfter!.finalVars).toEqual({ Result: 'stop-final' });
       expect(JSON.stringify(stateAfter!.snapshot)).toContain('Cancelled after review');

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -1535,7 +1535,7 @@ describe('startRunbook', () => {
     const createdState = makeState(MOCK_RUN_ID) as unknown as RunbookState;
     const initializedState = {
       ...createdState,
-      lastAction: { type: 'START' as const },
+      lastAction: { type: 'START' as const, origin: 'direct' as const },
       activeFrameKey: '1|' as ReturnType<typeof core.buildFrameKey>,
       activeEntry: 1,
       frameEntries: { '1|': 1 },

--- a/packages/cli/__tests__/helpers/status-builder.test.ts
+++ b/packages/cli/__tests__/helpers/status-builder.test.ts
@@ -215,7 +215,7 @@ describe('buildActiveStatus', () => {
 
   it('includes lastAction when present', () => {
     const state = makeState({
-      lastAction: { type: 'RETRY' },
+      lastAction: { type: 'RETRY', origin: 'direct' },
       retryCount: 1,
       lastResult: 'fail',
     });
@@ -233,12 +233,12 @@ describe('buildActiveStatus', () => {
     const result = buildActiveStatus(state, '/test');
 
     expect(result.lastAction).toEqual({ action: 'RETRY (1/3)', result: 'FAIL' });
-    expect(formatActionForDisplay).toHaveBeenCalledWith({ type: 'RETRY' }, 1, 3);
+    expect(formatActionForDisplay).toHaveBeenCalledWith({ type: 'RETRY', origin: 'direct' }, 1, 3);
   });
 
   it('maps lastResult pass to result true', () => {
     const state = makeState({
-      lastAction: { type: 'CONTINUE' },
+      lastAction: { type: 'CONTINUE', origin: 'direct' },
       retryCount: 0,
       lastResult: 'pass',
     });

--- a/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
+++ b/packages/cli/__tests__/helpers/transition-orchestrator.test.ts
@@ -56,6 +56,7 @@ describe('orchestrateTransition', () => {
         context: {
           lastAction: {
             type: 'OUTPUT_CAPTURE_FAILED',
+            origin: 'direct',
             message: 'failed to capture Foo',
           },
         },
@@ -121,7 +122,7 @@ describe('orchestrateTransition', () => {
       snapshot: {
         status: 'active',
         value: { 'step::2': 'idle' },
-        context: { lastAction: { type: 'CONTINUE' } },
+        context: { lastAction: { type: 'CONTINUE', origin: 'direct' } },
       },
       result: 'pass',
       policy: {

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -165,7 +165,7 @@ function makeCtx(stateOverrides: Record<string, unknown> = {}): TestCtx {
         (...args: unknown[]) => Promise<{ state: Record<string, unknown>; snapshot: unknown }>
       >().mockResolvedValue({
         state: { ...state },
-        snapshot: { context: { lastAction: { type: 'CONTINUE' } } },
+        snapshot: { context: { lastAction: { type: 'CONTINUE', origin: 'direct' } } },
       }),
     },
     sessionService: {},
@@ -861,7 +861,7 @@ describe('step-level PASS transition no longer triggers CLI-side OUTPUTS evaluat
           (...args: unknown[]) => Promise<{ state: Record<string, unknown>; snapshot: unknown }>
         >().mockResolvedValue({
           state: { ...state, templateVars },
-          snapshot: { context: { lastAction: { type: 'CONTINUE' } } },
+          snapshot: { context: { lastAction: { type: 'CONTINUE', origin: 'direct' } } },
         }),
       },
       sessionService: {},

--- a/packages/cli/__tests__/services/execution-action.test.ts
+++ b/packages/cli/__tests__/services/execution-action.test.ts
@@ -6,11 +6,11 @@ describe('execution action helpers', () => {
     it('extracts lastAction from valid snapshot', () => {
       const snapshot = {
         context: {
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
           retryCount: 0,
         },
       };
-      expect(extractLastAction(snapshot)).toEqual({ type: 'CONTINUE' });
+      expect(extractLastAction(snapshot)).toEqual({ type: 'CONTINUE', origin: 'direct' });
     });
 
     it('returns undefined for snapshot without context', () => {
@@ -40,46 +40,69 @@ describe('execution action helpers', () => {
     });
 
     it('extracts various action types', () => {
-      expect(extractLastAction({ context: { lastAction: { type: 'STOP' } } })).toEqual({
+      expect(
+        extractLastAction({ context: { lastAction: { type: 'STOP', origin: 'direct' } } }),
+      ).toEqual({
         type: 'STOP',
-      });
-      expect(extractLastAction({ context: { lastAction: { type: 'COMPLETE' } } })).toEqual({
-        type: 'COMPLETE',
-      });
-      expect(extractLastAction({ context: { lastAction: { type: 'RETRY' } } })).toEqual({
-        type: 'RETRY',
+        origin: 'direct',
       });
       expect(
-        extractLastAction({ context: { lastAction: { type: 'GOTO', target: 'ErrorHandler' } } }),
-      ).toEqual({ type: 'GOTO', target: 'ErrorHandler' });
+        extractLastAction({ context: { lastAction: { type: 'COMPLETE', origin: 'direct' } } }),
+      ).toEqual({
+        type: 'COMPLETE',
+        origin: 'direct',
+      });
+      expect(
+        extractLastAction({ context: { lastAction: { type: 'RETRY', origin: 'direct' } } }),
+      ).toEqual({
+        type: 'RETRY',
+        origin: 'direct',
+      });
+      expect(
+        extractLastAction({
+          context: { lastAction: { type: 'GOTO', origin: 'direct', target: 'ErrorHandler' } },
+        }),
+      ).toEqual({ type: 'GOTO', origin: 'direct', target: 'ErrorHandler' });
     });
 
     it('rejects malformed lastAction shapes', () => {
-      expect(extractLastAction({ context: { lastAction: { type: 'GOTO' } } })).toBeUndefined();
       expect(
-        extractLastAction({ context: { lastAction: { type: 'GOTO', target: 42 } } }),
+        extractLastAction({ context: { lastAction: { type: 'GOTO', origin: 'direct' } } }),
       ).toBeUndefined();
       expect(
         extractLastAction({
-          context: { lastAction: { type: 'GOTO', target: '3', at: { bad: true } } },
+          context: { lastAction: { type: 'GOTO', origin: 'direct', target: 42 } },
         }),
       ).toBeUndefined();
-      expect(extractLastAction({ context: { lastAction: { type: 'NOT_REAL' } } })).toBeUndefined();
+      expect(
+        extractLastAction({
+          context: {
+            lastAction: { type: 'GOTO', origin: 'direct', target: '3', at: { bad: true } },
+          },
+        }),
+      ).toBeUndefined();
+      expect(
+        extractLastAction({ context: { lastAction: { type: 'NOT_REAL', origin: 'direct' } } }),
+      ).toBeUndefined();
     });
   });
 
   describe('formatActionForDisplay', () => {
     describe('basic action types', () => {
       it('returns CONTINUE when lastAction is CONTINUE', () => {
-        expect(formatActionForDisplay({ type: 'CONTINUE' }, 0, 3)).toBe('CONTINUE');
+        expect(formatActionForDisplay({ type: 'CONTINUE', origin: 'direct' }, 0, 3)).toBe(
+          'CONTINUE',
+        );
       });
 
       it('returns STOP when lastAction is STOP', () => {
-        expect(formatActionForDisplay({ type: 'STOP' }, 0, 3)).toBe('STOP');
+        expect(formatActionForDisplay({ type: 'STOP', origin: 'direct' }, 0, 3)).toBe('STOP');
       });
 
       it('returns COMPLETE when lastAction is COMPLETE', () => {
-        expect(formatActionForDisplay({ type: 'COMPLETE' }, 0, 3)).toBe('COMPLETE');
+        expect(formatActionForDisplay({ type: 'COMPLETE', origin: 'direct' }, 0, 3)).toBe(
+          'COMPLETE',
+        );
       });
 
       it('returns CONTINUE as default when lastAction is undefined', () => {
@@ -89,56 +112,82 @@ describe('execution action helpers', () => {
 
     describe('RETRY formatting', () => {
       it('formats RETRY with count details', () => {
-        expect(formatActionForDisplay({ type: 'RETRY' }, 1, 3)).toBe('RETRY (1/3)');
-        expect(formatActionForDisplay({ type: 'RETRY' }, 2, 3)).toBe('RETRY (2/3)');
-        expect(formatActionForDisplay({ type: 'RETRY' }, 3, 3)).toBe('RETRY (3/3)');
+        expect(formatActionForDisplay({ type: 'RETRY', origin: 'direct' }, 1, 3)).toBe(
+          'RETRY (1/3)',
+        );
+        expect(formatActionForDisplay({ type: 'RETRY', origin: 'direct' }, 2, 3)).toBe(
+          'RETRY (2/3)',
+        );
+        expect(formatActionForDisplay({ type: 'RETRY', origin: 'direct' }, 3, 3)).toBe(
+          'RETRY (3/3)',
+        );
       });
 
       it('formats RETRY with different max values', () => {
-        expect(formatActionForDisplay({ type: 'RETRY' }, 1, 5)).toBe('RETRY (1/5)');
-        expect(formatActionForDisplay({ type: 'RETRY' }, 1, 10)).toBe('RETRY (1/10)');
+        expect(formatActionForDisplay({ type: 'RETRY', origin: 'direct' }, 1, 5)).toBe(
+          'RETRY (1/5)',
+        );
+        expect(formatActionForDisplay({ type: 'RETRY', origin: 'direct' }, 1, 10)).toBe(
+          'RETRY (1/10)',
+        );
       });
     });
 
     describe('GOTO formatting', () => {
       it('formats GOTO with named step', () => {
-        expect(formatActionForDisplay({ type: 'GOTO', target: 'ErrorHandler' }, 0, 3)).toBe(
-          'GOTO ErrorHandler',
-        );
+        expect(
+          formatActionForDisplay({ type: 'GOTO', origin: 'direct', target: 'ErrorHandler' }, 0, 3),
+        ).toBe('GOTO ErrorHandler');
       });
 
       it('formats GOTO with numbered step', () => {
-        expect(formatActionForDisplay({ type: 'GOTO', target: '3' }, 0, 3)).toBe('GOTO 3');
+        expect(formatActionForDisplay({ type: 'GOTO', origin: 'direct', target: '3' }, 0, 3)).toBe(
+          'GOTO 3',
+        );
       });
 
       it('formats GOTO with substep', () => {
-        expect(formatActionForDisplay({ type: 'GOTO', target: '2', substep: '3' }, 0, 3)).toBe(
-          'GOTO 2.3',
-        );
+        expect(
+          formatActionForDisplay(
+            { type: 'GOTO', origin: 'direct', target: '2', substep: '3' },
+            0,
+            3,
+          ),
+        ).toBe('GOTO 2.3');
       });
 
       it('formats GOTO with AT qualifier', () => {
-        expect(formatActionForDisplay({ type: 'GOTO', target: '3', at: 2 }, 0, 3)).toBe(
-          'GOTO 3 AT 2',
-        );
+        expect(
+          formatActionForDisplay({ type: 'GOTO', origin: 'direct', target: '3', at: 2 }, 0, 3),
+        ).toBe('GOTO 3 AT 2');
       });
 
       it('formats GOTO with substep and AT qualifier', () => {
         expect(
-          formatActionForDisplay({ type: 'GOTO', target: '3', substep: '1', at: 5 }, 0, 3),
+          formatActionForDisplay(
+            { type: 'GOTO', origin: 'direct', target: '3', substep: '1', at: 5 },
+            0,
+            3,
+          ),
         ).toBe('GOTO 3.1 AT 5');
       });
 
       it('formats GOTO with template variable AT qualifier', () => {
-        expect(formatActionForDisplay({ type: 'GOTO', target: '3', at: '{{Index}}' }, 0, 3)).toBe(
-          'GOTO 3 AT {{Index}}',
-        );
+        expect(
+          formatActionForDisplay(
+            { type: 'GOTO', origin: 'direct', target: '3', at: '{{Index}}' },
+            0,
+            3,
+          ),
+        ).toBe('GOTO 3 AT {{Index}}');
       });
     });
 
     describe('edge cases', () => {
       it('handles zero retry count', () => {
-        expect(formatActionForDisplay({ type: 'RETRY' }, 0, 3)).toBe('RETRY (0/3)');
+        expect(formatActionForDisplay({ type: 'RETRY', origin: 'direct' }, 0, 3)).toBe(
+          'RETRY (0/3)',
+        );
       });
     });
   });

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -725,7 +725,7 @@ describe('runExecutionLoop', () => {
           status: 'done',
           value: 'COMPLETE',
           context: {
-            lastAction: { type: 'COMPLETE' },
+            lastAction: { type: 'COMPLETE', origin: 'direct' },
           },
         },
       }),
@@ -861,7 +861,7 @@ describe('runExecutionLoop', () => {
       snapshot: {
         status: 'active',
         value: '2',
-        context: { lastAction: { type: 'CONTINUE' } },
+        context: { lastAction: { type: 'CONTINUE', origin: 'direct' } },
       },
       effects: [commandCompletedEffect('pass')],
     });
@@ -929,7 +929,7 @@ describe('runExecutionLoop', () => {
       snapshot: {
         status: 'done',
         value: 'COMPLETE',
-        context: { lastAction: { type: 'COMPLETE' }, lastMessage: 'Success' },
+        context: { lastAction: { type: 'COMPLETE', origin: 'direct' }, lastMessage: 'Success' },
       },
       effects: [commandCompletedEffect('pass')],
     });
@@ -989,7 +989,7 @@ describe('runExecutionLoop', () => {
       snapshot: {
         status: 'done',
         value: 'COMPLETE',
-        context: { lastAction: { type: 'COMPLETE' }, lastMessage: 'Success' },
+        context: { lastAction: { type: 'COMPLETE', origin: 'direct' }, lastMessage: 'Success' },
       },
       effects: [commandCompletedEffect('pass')],
     });
@@ -1105,7 +1105,7 @@ describe('runExecutionLoop', () => {
       snapshot: {
         status: 'done',
         value: 'COMPLETE',
-        context: { lastAction: { type: 'COMPLETE' }, lastMessage: 'Success' },
+        context: { lastAction: { type: 'COMPLETE', origin: 'direct' }, lastMessage: 'Success' },
       },
       effects: [commandCompletedEffect('pass')],
     });
@@ -1153,6 +1153,7 @@ describe('runExecutionLoop', () => {
         context: {
           lastAction: {
             type: 'RETRY_ERROR' as const,
+            origin: 'direct',
             code: 'RD-902',
             message: 'hook failed: createDelegation returned step_not_found',
           },
@@ -1228,6 +1229,7 @@ describe('runExecutionLoop', () => {
         context: {
           lastAction: {
             type: 'OUTPUT_CAPTURE_FAILED' as const,
+            origin: 'direct',
             message: 'failed to read channel file: /tmp/outputs/Foo',
           },
           lifecycle: 'stopped',
@@ -1282,6 +1284,7 @@ describe('runExecutionLoop', () => {
           context: {
             lastAction: {
               type: 'ARTIFACT_RESOLUTION_FAILED' as const,
+              origin: 'direct',
               message: 'artifact "PlanPath" failed to resolve',
             },
             lifecycle: 'stopped',
@@ -1338,7 +1341,7 @@ describe('runExecutionLoop', () => {
         snapshot: {
           status: 'active',
           value: { 'step::1': 'idle' },
-          context: { lastAction: { type: 'CONTINUE' } },
+          context: { lastAction: { type: 'CONTINUE', origin: 'direct' } },
         },
       }),
     );
@@ -1651,7 +1654,7 @@ describe('runExecutionLoop', () => {
         snapshot: {
           status: 'active',
           value: '2',
-          context: { lastAction: { type: 'CONTINUE' } },
+          context: { lastAction: { type: 'CONTINUE', origin: 'direct' } },
         },
         effects: [commandCompletedEffect('pass')],
       });
@@ -1717,7 +1720,10 @@ describe('runExecutionLoop', () => {
         snapshot: {
           status: 'active',
           value: 'step::2',
-          context: { lastAction: { type: 'CONTINUE' }, variables: { Version: 'v1' } },
+          context: {
+            lastAction: { type: 'CONTINUE', origin: 'direct' },
+            variables: { Version: 'v1' },
+          },
         },
         effects: [commandCompletedEffect('pass')],
       });
@@ -2036,6 +2042,7 @@ describe('runExecutionLoop', () => {
         context: {
           lastAction: {
             type: 'DELEGATION_ISSUANCE_FAILED',
+            origin: 'direct',
             reason: 'nested_delegation_forbidden',
             message: 'Nested delegation forbidden',
           },

--- a/packages/core/__tests__/events/transition-observation.test.ts
+++ b/packages/core/__tests__/events/transition-observation.test.ts
@@ -302,6 +302,36 @@ describe('deriveTransitionObservation', () => {
       },
     });
   });
+
+  it('sets aggregated: true in STEP_TRANSITIONED payload when lastAction origin is aggregation', () => {
+    const previousState = state({ step: '1' });
+    const updatedState = state({ step: '2', stepName: 'Deploy' });
+
+    const observation = deriveTransitionObservation({
+      steps,
+      currentStep,
+      previousState,
+      updatedState,
+      snapshot: {
+        value: { 'step::2': 'idle' },
+        context: { lastAction: { type: 'COMPLETE', origin: 'aggregation' } },
+      },
+      result: 'pass',
+    });
+
+    expect(observation.events).toEqual([
+      {
+        type: 'STEP_TRANSITIONED',
+        payload: {
+          action: 'COMPLETE',
+          from: '1',
+          at: '2',
+          result: 'PASS',
+          aggregated: true,
+        },
+      },
+    ]);
+  });
 });
 
 describe('deriveGotoActionBlock', () => {

--- a/packages/core/__tests__/events/transition-observation.test.ts
+++ b/packages/core/__tests__/events/transition-observation.test.ts
@@ -59,7 +59,7 @@ describe('deriveTransitionObservation', () => {
       updatedState,
       snapshot: {
         value: { 'step::2': 'idle' },
-        context: { lastAction: { type: 'CONTINUE' } },
+        context: { lastAction: { type: 'CONTINUE', origin: 'direct' } },
       },
       result: 'pass',
       command: 'npm test',
@@ -98,7 +98,7 @@ describe('deriveTransitionObservation', () => {
       snapshot: {
         value: { 'step::1': 'idle' },
         context: {
-          lastAction: { type: 'RETRY' },
+          lastAction: { type: 'RETRY', origin: 'direct' },
           retryMax: 3,
           iterationRetryCount: 1,
         },
@@ -158,7 +158,7 @@ describe('deriveTransitionObservation', () => {
       updatedState,
       snapshot: {
         value: { 'step::1': 'idle' },
-        context: { lastAction: { type: 'NEXT' } },
+        context: { lastAction: { type: 'NEXT', origin: 'direct' } },
       },
       result: 'pass',
     });
@@ -190,7 +190,7 @@ describe('deriveTransitionObservation', () => {
         value: 'COMPLETE',
         context: {
           lifecycle: 'completed',
-          lastAction: { type: 'COMPLETE' },
+          lastAction: { type: 'COMPLETE', origin: 'direct' },
           lastMessage: 'Ship it',
         },
       },
@@ -238,6 +238,7 @@ describe('deriveTransitionObservation', () => {
           lifecycle: 'stopped',
           lastAction: {
             type: 'OUTPUT_CAPTURE_FAILED',
+            origin: 'direct',
             message: 'failed to capture Foo',
           },
         },
@@ -284,7 +285,7 @@ describe('deriveTransitionObservation', () => {
         value: 'STOPPED',
         context: {
           lifecycle: 'stopped',
-          lastAction: { type: 'STOP' },
+          lastAction: { type: 'STOP', origin: 'direct' },
         },
       },
       result: 'pass',

--- a/packages/core/__tests__/output/scenario-aggregation-schema.test.ts
+++ b/packages/core/__tests__/output/scenario-aggregation-schema.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@jest/globals';
+import { ScenarioRunResponseSchema } from '../../src/output/zod-schemas.js';
+
+describe('ScenarioRunResponseSchema aggregation metadata', () => {
+  it('preserves aggregated markers on assertions and matched transition events', () => {
+    const response = {
+      kind: 'scenario_run',
+      result: true,
+      scenario: 'delegated-complete',
+      expected: 'COMPLETE',
+      actual: 'COMPLETE',
+      stepAssertions: [
+        {
+          assertion: {
+            action: 'COMPLETE',
+            aggregated: true,
+          },
+          matched: true,
+          matchedEvent: {
+            action: 'COMPLETE',
+            from: '1.2',
+            at: '2',
+            result: 'PASS',
+            aggregated: true,
+          },
+        },
+      ],
+    };
+
+    expect(ScenarioRunResponseSchema.parse(response)).toEqual(response);
+  });
+});

--- a/packages/core/__tests__/runbook/actor-service-pending-effects.test.ts
+++ b/packages/core/__tests__/runbook/actor-service-pending-effects.test.ts
@@ -41,10 +41,18 @@ jest.unstable_mockModule('../../src/runbook/compiler.js', () => ({
         pendingEffect: fromPromise(waitForRelease),
       },
       actions: {
-        markPass: assign({ lastAction: () => ({ type: 'CONTINUE' as const }) }),
-        markFail: assign({ lastAction: () => ({ type: 'STOP' as const }) }),
-        markGoto: assign({ lastAction: () => ({ type: 'GOTO' as const, target: '4' }) }),
-        markStart: assign({ lastAction: () => ({ type: 'START' as const }) }),
+        markPass: assign({
+          lastAction: () => ({ type: 'CONTINUE' as const, origin: 'direct' as const }),
+        }),
+        markFail: assign({
+          lastAction: () => ({ type: 'STOP' as const, origin: 'direct' as const }),
+        }),
+        markGoto: assign({
+          lastAction: () => ({ type: 'GOTO' as const, origin: 'direct' as const, target: '4' }),
+        }),
+        markStart: assign({
+          lastAction: () => ({ type: 'START' as const, origin: 'direct' as const }),
+        }),
       },
     }).createMachine({
       id: 'runbook',
@@ -144,7 +152,7 @@ describe('RunbookActorService pending machine effects', () => {
     const initialized = await pending;
 
     expect(initialized?.step).toBe('1');
-    expect(initialized?.lastAction).toEqual({ type: 'START' });
+    expect(initialized?.lastAction).toEqual({ type: 'START', origin: 'direct' });
     expect(JSON.stringify(initialized?.snapshot)).not.toContain('bootEffect');
   });
 

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -366,7 +366,7 @@ exit 1
       expect(initialized).not.toBeNull();
       expect(initialized?.step).toBe('1');
       expect(initialized?.substep).toBe('1');
-      expect(initialized?.lastAction).toEqual({ type: 'START' });
+      expect(initialized?.lastAction).toEqual({ type: 'START', origin: 'direct' });
       expect(initialized?.activeFrameKey).toBe(buildFrameKey('1'));
       expect(initialized?.activeEntry).toBe(1);
       expect(initialized?.frameEntries).toEqual({ [buildFrameKey('1')]: 1 });
@@ -410,7 +410,7 @@ exit 1
       expect(initialized).not.toBeNull();
       expect(initialized?.step).toBe('1');
       expect(initialized?.substep).toBe('1');
-      expect(initialized?.lastAction).toEqual({ type: 'START' });
+      expect(initialized?.lastAction).toEqual({ type: 'START', origin: 'direct' });
       expect(initialized?.forStack?.[0]).toEqual(
         expect.objectContaining({ stepId: '1', iteration: 1, variable: 'i', start: 1, end: 2 }),
       );
@@ -562,11 +562,11 @@ exit 1
 
       expect(result?.state.lifecycle).toBe('stopped');
       expect(result?.state.lastResult).toBe('fail');
-      expect(result?.state.lastAction).toEqual({ type: 'STOP' });
+      expect(result?.state.lastAction).toEqual({ type: 'STOP', origin: 'direct' });
       await expect(manager.load(state.id)).resolves.toMatchObject({
         lifecycle: 'stopped',
         lastResult: 'fail',
-        lastAction: { type: 'STOP' },
+        lastAction: { type: 'STOP', origin: 'direct' },
       });
     });
 
@@ -892,11 +892,11 @@ echo ok
       });
 
       expect(result?.state.step).toBe('2');
-      expect(result?.state.lastAction).toEqual({ type: 'GOTO', target: '2' });
+      expect(result?.state.lastAction).toEqual({ type: 'GOTO', origin: 'direct', target: '2' });
       expect(result?.state.lastResult).toBeUndefined();
       await expect(manager.load(state.id)).resolves.toMatchObject({
         step: '2',
-        lastAction: { type: 'GOTO', target: '2' },
+        lastAction: { type: 'GOTO', origin: 'direct', target: '2' },
       });
       const persisted = await manager.load(state.id);
       expect(persisted?.lastResult).toBeUndefined();
@@ -1076,7 +1076,7 @@ echo ok
             },
           ],
           iterationResults: ['pass'],
-          lastAction: { type: 'START' },
+          lastAction: { type: 'START', origin: 'direct' },
         },
       });
 
@@ -1093,7 +1093,7 @@ echo ok
         },
       ]);
       expect(updated.iterationResults).toEqual(['pass']);
-      expect(updated.lastAction).toEqual({ type: 'START' });
+      expect(updated.lastAction).toEqual({ type: 'START', origin: 'direct' });
     });
 
     it('clears FOR fields when runbook completes', async () => {
@@ -1150,6 +1150,7 @@ echo ok
           retryCount: 0,
           lastAction: {
             type: 'OUTPUT_CAPTURE_FAILED' as const,
+            origin: 'direct',
             message: 'disk full',
           },
         },
@@ -1159,11 +1160,13 @@ echo ok
 
       expect(updated.lastAction).toEqual({
         type: 'OUTPUT_CAPTURE_FAILED',
+        origin: 'direct',
         message: 'disk full',
       });
       await expect(manager.load(state.id)).resolves.toMatchObject({
         lastAction: {
           type: 'OUTPUT_CAPTURE_FAILED',
+          origin: 'direct',
           message: 'disk full',
         },
       });
@@ -1191,7 +1194,7 @@ echo ok
           iterationResults: [],
           retryCount: 0,
           variables: {},
-          lastAction: { type: 'START' },
+          lastAction: { type: 'START', origin: 'direct' },
         },
       });
 
@@ -1219,7 +1222,7 @@ echo ok
           iterationResults: ['pass'],
           retryCount: 0,
           variables: {},
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
         },
       });
 
@@ -1247,7 +1250,7 @@ echo ok
           iterationResults: ['pass'],
           retryCount: 0,
           variables: {},
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
         },
       });
 
@@ -1267,7 +1270,7 @@ echo ok
           iterationResults: ['pass', 'fail', 'pass'],
           retryCount: 0,
           variables: {},
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
         },
       });
 
@@ -1309,7 +1312,7 @@ echo ok
             },
           ],
           iterationResults: ['pass'],
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
         },
       });
 
@@ -1360,7 +1363,7 @@ echo ok
             },
           ],
           iterationResults: ['pass'],
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
         },
       });
 
@@ -1418,7 +1421,7 @@ echo ok
         context: {
           variables: {},
           retryCount: 0,
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
         },
       });
 
@@ -1812,7 +1815,7 @@ echo ok
       expect(result).not.toBeNull();
       expect((result!.snapshot as { value: string }).value).toBe('STOPPED');
       expect(result!.state.lifecycle).toBe('stopped');
-      expect(result!.state.lastAction).toEqual({ type: 'STOP' });
+      expect(result!.state.lastAction).toEqual({ type: 'STOP', origin: 'direct' });
       expect(result!.state.lastResult).toBeUndefined();
       expect(result!.state.finalVars).toEqual({ Result: 'forced-stop-value' });
       expect((result!.snapshot as { context: { lastMessage?: string } }).context.lastMessage).toBe(
@@ -1835,7 +1838,7 @@ echo ok
       expect(result).not.toBeNull();
       expect((result!.snapshot as { value: string }).value).toBe('STOPPED');
       expect(result!.state.lifecycle).toBe('stopped');
-      expect(result!.state.lastAction).toEqual({ type: 'STOP' });
+      expect(result!.state.lastAction).toEqual({ type: 'STOP', origin: 'direct' });
       expect(result!.state.lastResult).toBeUndefined();
     });
 
@@ -1856,7 +1859,7 @@ echo ok
       expect((result!.snapshot as { value: string }).value).toBe('COMPLETE');
       expect(result!.state.step).toBe('1');
       expect(result!.state.lifecycle).toBe('completed');
-      expect(result!.state.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(result!.state.lastAction).toEqual({ type: 'COMPLETE', origin: 'direct' });
       expect(result!.state.finalVars).toEqual({ Result: 'forced-complete-value' });
       expect((result!.snapshot as { context: { lastMessage?: string } }).context.lastMessage).toBe(
         'Enough evidence collected',
@@ -1896,7 +1899,7 @@ echo ok
           variables: {},
           finalVars: {},
           lifecycle: 'stopped',
-          lastAction: { type: 'GOTO' }, // invalid: missing required `target`
+          lastAction: { type: 'GOTO', origin: 'direct' }, // invalid: missing required `target`
         },
       });
 
@@ -1916,7 +1919,11 @@ echo ok
           variables: {},
           finalVars: {},
           lifecycle: 'stopped',
-          lastAction: { type: 'FOR_RESOLUTION_FAILED', message: 'resolution failed' },
+          lastAction: {
+            type: 'FOR_RESOLUTION_FAILED',
+            origin: 'direct',
+            message: 'resolution failed',
+          },
         },
       });
 
@@ -1938,6 +1945,7 @@ echo ok
           lifecycle: 'stopped',
           lastAction: {
             type: 'FOR_RESOLUTION_FAILED',
+            origin: 'direct',
             code: 'not-a-real-code',
             message: 'resolution failed',
           },
@@ -1962,6 +1970,7 @@ echo ok
           lifecycle: 'stopped',
           lastAction: {
             type: 'FOR_RESOLUTION_FAILED',
+            origin: 'direct',
             code: 'type-mismatch',
             message: 'items is not iterable',
           },
@@ -1971,6 +1980,7 @@ echo ok
       const { state: updated } = await actorService.updateFromActor(state.id, actor, mockSteps);
       expect(updated.lastAction).toEqual({
         type: 'FOR_RESOLUTION_FAILED',
+        origin: 'direct',
         code: 'type-mismatch',
         message: 'items is not iterable',
       });
@@ -1990,6 +2000,7 @@ echo ok
           lifecycle: 'stopped',
           lastAction: {
             type: 'FOR_RESOLUTION_FAILED',
+            origin: 'direct',
             code: 'drift-detected',
             message: 'source changed between iterations',
           },
@@ -1999,12 +2010,14 @@ echo ok
       const { state: updated } = await actorService.updateFromActor(state.id, actor, mockSteps);
       expect(updated.lastAction).toEqual({
         type: 'FOR_RESOLUTION_FAILED',
+        origin: 'direct',
         code: 'drift-detected',
         message: 'source changed between iterations',
       });
       await expect(manager.load(state.id)).resolves.toMatchObject({
         lastAction: {
           type: 'FOR_RESOLUTION_FAILED',
+          origin: 'direct',
           code: 'drift-detected',
           message: 'source changed between iterations',
         },
@@ -2099,7 +2112,7 @@ echo ok
           retryCount: 0,
           substepStates,
           activeFrameKey: frameKey,
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
         },
       });
 
@@ -2127,7 +2140,7 @@ echo ok
         context: {
           variables: {},
           retryCount: 0,
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
         },
       });
 
@@ -2166,7 +2179,7 @@ echo ok
               source: { kind: 'range' as const },
             },
           ],
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
         },
       });
 
@@ -2193,7 +2206,7 @@ echo ok
         context: {
           variables: {},
           retryCount: 0,
-          lastAction: { type: 'CONTINUE' },
+          lastAction: { type: 'CONTINUE', origin: 'direct' },
         },
       });
 

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -705,7 +705,11 @@ echo ok
       });
 
       expect(sync?.state.lifecycle).toBe('stopped');
-      expect(sync?.state.lastAction).toEqual({ type: 'POLICY_DENIED', message: 'blocked' });
+      expect(sync?.state.lastAction).toEqual({
+        type: 'POLICY_DENIED',
+        origin: 'direct',
+        message: 'blocked',
+      });
       expect(sync?.state.lastResult).toBeUndefined();
     });
 
@@ -743,6 +747,7 @@ echo ok
       expect(sync?.state.lifecycle).toBe('stopped');
       expect(sync?.state.lastAction).toEqual({
         type: 'COMMAND_EXECUTION_FAILED',
+        origin: 'direct',
         message: 'spawn subsystem unavailable',
       });
       expect(sync?.state.lastResult).toBeUndefined();

--- a/packages/core/__tests__/runbook/compiler-actions.test.ts
+++ b/packages/core/__tests__/runbook/compiler-actions.test.ts
@@ -1,23 +1,24 @@
 import { describe, it, expect } from '@jest/globals';
 import { actionRef, type CompilerActionRef } from '../../src/runbook/compiler-actions.js';
+import { makeDirectLastAction } from '../../src/runbook/last-action.js';
 
 describe('actionRef', () => {
   it('builds a setLastAction ref with the exact shape the setup expects', () => {
     const ref = actionRef('setLastAction', {
-      action: { type: 'STOP' },
+      action: makeDirectLastAction({ type: 'STOP' }),
       msg: 'stopped for test',
     });
 
     expect(ref).toEqual({
       type: 'setLastAction',
-      params: { action: { type: 'STOP' }, msg: 'stopped for test' },
+      params: { action: { type: 'STOP', origin: 'direct' }, msg: 'stopped for test' },
     });
   });
 
   it('narrows on the discriminant so consumers can branch on ref.type', () => {
     const refs: CompilerActionRef[] = [
-      actionRef('setLastAction', { action: { type: 'STOP' }, msg: 'a' }),
-      actionRef('setLastAction', { action: { type: 'COMPLETE' } }),
+      actionRef('setLastAction', { action: makeDirectLastAction({ type: 'STOP' }), msg: 'a' }),
+      actionRef('setLastAction', { action: makeDirectLastAction({ type: 'COMPLETE' }) }),
     ];
 
     const seen: string[] = [];
@@ -45,7 +46,7 @@ describe('actionRef (type-level assertions)', () => {
     actionRef('setLastAction', { msg: 'no action' });
 
     // Sanity: the correct form compiles.
-    actionRef('setLastAction', { action: { type: 'STOP' } });
+    actionRef('setLastAction', { action: makeDirectLastAction({ type: 'STOP' }) });
     expect(true).toBe(true);
   });
 });

--- a/packages/core/__tests__/runbook/compiler-command-exec.test.ts
+++ b/packages/core/__tests__/runbook/compiler-command-exec.test.ts
@@ -138,6 +138,7 @@ describe('compiled machine command execution', () => {
     expect(snapshot.context.lifecycle).toBe('stopped');
     expect(snapshot.context.lastAction).toEqual({
       type: 'POLICY_DENIED',
+      origin: 'direct',
       message: 'blocked by test policy',
     });
   });
@@ -179,6 +180,7 @@ describe('compiled machine command execution', () => {
     expect(snapshot.context.lifecycle).toBe('stopped');
     expect(snapshot.context.lastAction).toEqual({
       type: 'COMMAND_EXECUTION_FAILED',
+      origin: 'direct',
       message: 'spawn subsystem unavailable',
     });
   });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -12462,7 +12462,7 @@ echo ok
 
       actor.send({ type: 'FAIL' });
 
-      const ctx = actor.getSnapshot().context as RunbookContext;
+      const ctx = actor.getSnapshot().context;
       expect(ctx.lastAction?.type).toBe('RETRY_ERROR');
       expect(ctx.lastAction?.origin).toBe('aggregation');
 

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -424,7 +424,7 @@ Write the plan manually.
 
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('STOPPED');
-      expect(snapshot.context.lastAction).toEqual({ type: 'STOP' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'STOP', origin: 'direct' });
     });
 
     it('last substep transitions to parent state', () => {
@@ -578,7 +578,7 @@ Write the plan manually.
       actor.start();
       actor.send({ type: 'PASS' });
       const snapshot = actor.getSnapshot();
-      expect(snapshot.context.lastAction).toEqual({ type: 'CONTINUE' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'CONTINUE', origin: 'direct' });
     });
 
     it('sets lastAction to CONTINUE even when jumping to non-sequential step via substeps', () => {
@@ -619,17 +619,26 @@ Write the plan manually.
 
       // Start at 1.1, pass to 1.2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'CONTINUE' });
+      expect(actor.getSnapshot().context.lastAction).toEqual({
+        type: 'CONTINUE',
+        origin: 'direct',
+      });
 
       // Pass 1.2, should CONTINUE to step 2
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'CONTINUE' });
+      expect(actor.getSnapshot().context.lastAction).toEqual({
+        type: 'CONTINUE',
+        origin: 'direct',
+      });
       expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
 
       // Pass step 2, should CONTINUE to step 3.1
       // This was the bug: showed "GOTO 3.1" but should be "CONTINUE"
       actor.send({ type: 'PASS' });
-      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'CONTINUE' });
+      expect(actor.getSnapshot().context.lastAction).toEqual({
+        type: 'CONTINUE',
+        origin: 'direct',
+      });
       expect(actor.getSnapshot().value).toEqual({ 'step::3::1': 'idle' });
     });
 
@@ -646,7 +655,7 @@ Write the plan manually.
       actor.start();
       actor.send({ type: 'FAIL' });
       const snapshot = actor.getSnapshot();
-      expect(snapshot.context.lastAction).toEqual({ type: 'STOP' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'STOP', origin: 'direct' });
     });
 
     it('sets lastAction to COMPLETE for COMPLETE transitions', () => {
@@ -665,7 +674,7 @@ Write the plan manually.
       actor.start();
       actor.send({ type: 'PASS' });
       const snapshot = actor.getSnapshot();
-      expect(snapshot.context.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'COMPLETE', origin: 'direct' });
     });
 
     it('sets lastAction to GOTO X for explicit GOTO transitions', () => {
@@ -693,7 +702,11 @@ Write the plan manually.
       actor.start();
       actor.send({ type: 'FAIL' });
       const snapshot = actor.getSnapshot();
-      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: 'ErrorHandler' });
+      expect(snapshot.context.lastAction).toEqual({
+        type: 'GOTO',
+        origin: 'direct',
+        target: 'ErrorHandler',
+      });
     });
 
     it('sets lastAction to GOTO X.Y for GOTO with substep', () => {
@@ -727,7 +740,12 @@ Write the plan manually.
       actor.start();
       actor.send({ type: 'PASS' });
       const snapshot = actor.getSnapshot();
-      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '2', substep: '3' });
+      expect(snapshot.context.lastAction).toEqual({
+        type: 'GOTO',
+        origin: 'direct',
+        target: '2',
+        substep: '3',
+      });
     });
 
     it('sets lastAction to RETRY for RETRY transitions', () => {
@@ -750,7 +768,7 @@ Write the plan manually.
       actor.start();
       actor.send({ type: 'FAIL' });
       const snapshot = actor.getSnapshot();
-      expect(snapshot.context.lastAction).toEqual({ type: 'RETRY' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'RETRY', origin: 'direct' });
       expect(snapshot.context.retryCount).toBe(1);
     });
 
@@ -772,7 +790,7 @@ Write the plan manually.
       actor.start();
       actor.send({ type: 'GOTO', target: { step: '2' } });
       const snapshot = actor.getSnapshot();
-      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '2' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', origin: 'direct', target: '2' });
     });
 
     it('sets lastAction for explicit RETRY event', () => {
@@ -788,7 +806,7 @@ Write the plan manually.
       actor.start();
       actor.send({ type: 'RETRY' });
       const snapshot = actor.getSnapshot();
-      expect(snapshot.context.lastAction).toEqual({ type: 'RETRY' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'RETRY', origin: 'direct' });
     });
   });
 
@@ -941,7 +959,7 @@ Write the plan manually.
       actor.send({ type: 'PASS' });
       expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
       expect(actor.getSnapshot().context.retryCount).toBe(1);
-      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'RETRY' });
+      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'RETRY', origin: 'direct' });
 
       // Step 2 PASS again -> RETRY GOTO 1 (should stay at step 2 for retry 2/2)
       actor.send({ type: 'PASS' });
@@ -953,7 +971,7 @@ Write the plan manually.
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toEqual({ 'step::1': 'idle' });
       expect(snapshot.context.retryCount).toBe(0);
-      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '1' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', origin: 'direct', target: '1' });
     });
 
     it('STOPs when RETRY+GOTO exhausts retries', () => {
@@ -1680,7 +1698,7 @@ Write the plan manually.
 
       actor.send({ type: 'PASS' });
       expect(actor.getSnapshot().value).toBe('STOPPED');
-      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'NEXT' });
+      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'NEXT', origin: 'direct' });
     });
 
     it('BREAK outside FOR loop goes to STOPPED', () => {
@@ -1701,7 +1719,7 @@ Write the plan manually.
 
       actor.send({ type: 'FAIL' });
       expect(actor.getSnapshot().value).toBe('STOPPED');
-      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'BREAK' });
+      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'BREAK', origin: 'direct' });
     });
 
     it('GOTO AT re-enters FOR step at specific iteration', () => {
@@ -1864,6 +1882,7 @@ Write the plan manually.
       // AT qualifier is preserved in lastAction for state persistence
       expect(actor.getSnapshot().context.lastAction).toEqual({
         type: 'GOTO',
+        origin: 'direct',
         target: '2',
         substep: '1',
         at: 3,
@@ -1907,6 +1926,7 @@ Write the plan manually.
       // No AT qualifier in lastAction
       expect(actor.getSnapshot().context.lastAction).toEqual({
         type: 'GOTO',
+        origin: 'direct',
         target: '2',
         substep: '1',
       });
@@ -2639,7 +2659,13 @@ Write the plan manually.
       expect(ctx.forStack[0].iteration).toBe(2);
       expect(ctx.forStack[0].variable).toBe('batch');
       expect(ctx.iterationResults).toEqual([]);
-      expect(ctx.lastAction).toEqual({ type: 'GOTO', target: '2', substep: '1', at: 2 });
+      expect(ctx.lastAction).toEqual({
+        type: 'GOTO',
+        origin: 'direct',
+        target: '2',
+        substep: '1',
+        at: 2,
+      });
     });
 
     it('GOTO action with substep to implicit (non-FOR) step initializes implicit forStack', () => {
@@ -3177,7 +3203,7 @@ Write the plan manually.
         type: 'GOTO',
         target: '3',
         at: 1,
-        aggregated: true,
+        origin: 'aggregation',
       });
       expect(snapshot.context.forStack).toEqual([
         {
@@ -3237,7 +3263,7 @@ Write the plan manually.
       // PASS ALL with one failure → aggregation fails → COMPLETE
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('COMPLETE');
-      expect(snapshot.context.lastAction).toEqual({ type: 'COMPLETE', aggregated: true });
+      expect(snapshot.context.lastAction).toEqual({ type: 'COMPLETE', origin: 'aggregation' });
     });
 
     it('PASS ALL with STOP action records STOP lastAction', () => {
@@ -3283,7 +3309,7 @@ Write the plan manually.
       // PASS ALL succeeds → STOP
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('STOPPED');
-      expect(snapshot.context.lastAction).toEqual({ type: 'STOP', aggregated: true });
+      expect(snapshot.context.lastAction).toEqual({ type: 'STOP', origin: 'aggregation' });
     });
 
     it('PASS ALL failure triggers fail-path GOTO to non-FOR step', () => {
@@ -3336,7 +3362,11 @@ Write the plan manually.
       // PASS ALL with one failure → aggregation fails → GOTO 3
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toEqual({ 'step::3': 'idle' });
-      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3', aggregated: true });
+      expect(snapshot.context.lastAction).toEqual({
+        type: 'GOTO',
+        origin: 'aggregation',
+        target: '3',
+      });
       expect(snapshot.context.iterationResults).toEqual(['pass', 'fail']);
       expect(snapshot.context.deferredResults).toEqual(['fail']);
       expect(snapshot.context.forStack).toEqual([]);
@@ -3406,7 +3436,7 @@ Write the plan manually.
         type: 'GOTO',
         target: '3',
         at: 2,
-        aggregated: true,
+        origin: 'aggregation',
       });
       expect(snapshot.context.forStack).toEqual([
         {
@@ -3478,7 +3508,11 @@ Write the plan manually.
       // PASS ANY with one pass → aggregation passes → GOTO 3
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toEqual({ 'step::3': 'idle' });
-      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3', aggregated: true });
+      expect(snapshot.context.lastAction).toEqual({
+        type: 'GOTO',
+        origin: 'aggregation',
+        target: '3',
+      });
       expect(snapshot.context.iterationResults).toEqual(['fail', 'pass', 'fail']);
       expect(snapshot.context.deferredResults).toEqual(['fail']);
       expect(snapshot.context.forStack).toEqual([]);
@@ -3544,7 +3578,11 @@ Write the plan manually.
       // iterationResults = [] (empty) → vacuous pass on PASS ALL → GOTO 3
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toEqual({ 'step::3': 'idle' });
-      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3', aggregated: true });
+      expect(snapshot.context.lastAction).toEqual({
+        type: 'GOTO',
+        origin: 'aggregation',
+        target: '3',
+      });
       expect(snapshot.context.iterationResults).toEqual([]);
       expect(snapshot.context.deferredResults).toEqual([]);
       expect(snapshot.context.forStack).toEqual([]);
@@ -5679,7 +5717,7 @@ echo "processing"
       expect(actor.getSnapshot().value).toBe('COMPLETE');
       expect(actor.getSnapshot().context.lastAction).toEqual({
         type: 'COMPLETE',
-        aggregated: true,
+        origin: 'aggregation',
       });
     });
 
@@ -5722,7 +5760,10 @@ echo "processing"
         actor.send({ type: 'PASS' }); // 1.1 passes -> should advance to 1.2, NOT COMPLETE
 
         expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
-        expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'CONTINUE' });
+        expect(actor.getSnapshot().context.lastAction).toEqual({
+          type: 'CONTINUE',
+          origin: 'direct',
+        });
       });
 
       it('Test B: explicit CONTINUE substeps with PASS ALL: COMPLETE parent — PASS both completes', () => {
@@ -5766,7 +5807,7 @@ echo "processing"
         expect(actor.getSnapshot().value).toBe('COMPLETE');
         expect(actor.getSnapshot().context.lastAction).toEqual({
           type: 'COMPLETE',
-          aggregated: true,
+          origin: 'aggregation',
         });
       });
 
@@ -5849,7 +5890,7 @@ echo "processing"
         actor.send({ type: 'PASS' }); // 1.1 passes -> should advance to 1.2, NOT COMPLETE
 
         expect(actor.getSnapshot().value).toEqual({ 'step::1::2': 'idle' });
-        expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'DEFER' });
+        expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'DEFER', origin: 'direct' });
       });
 
       it('Test E: substep with explicit COMPLETE stops substep sequence and routes to parent', () => {
@@ -6840,7 +6881,7 @@ echo "processing"
       expect(snapshot.value).toEqual({ 'step::2': 'idle' });
       expect(snapshot.context.forStack).toEqual([]);
       expect(snapshot.context.iterationResults).toEqual([]);
-      expect(snapshot.context.lastAction).toEqual({ type: 'BREAK' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'BREAK', origin: 'direct' });
     });
 
     it('NEXT advances iteration without accumulation', () => {
@@ -6885,7 +6926,7 @@ echo "processing"
       expect(actor.getSnapshot().value).toEqual({ 'step::1::1': 'idle' });
       expect(actor.getSnapshot().context.forStack[0].iteration).toBe(2);
       expect(actor.getSnapshot().context.iterationResults).toEqual([]);
-      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'NEXT' });
+      expect(actor.getSnapshot().context.lastAction).toEqual({ type: 'NEXT', origin: 'direct' });
 
       // Iteration 2: both substeps pass
       actor.send({ type: 'PASS' }); // 1.1 CONTINUE → 1.2
@@ -10554,7 +10595,7 @@ echo ok
       const machine = compileRunbookToMachine(steps);
       const parentAlways = getState(machine, 'step::1').always as any[];
       // The BREAK cleanup transition is identified by its target == self-state
-      // AND an assign that sets lastAction: { type: 'BREAK' }. Here we use the
+      // AND an assign that sets lastAction: { type: 'BREAK', origin: 'direct' }. Here we use the
       // simpler structural check: any always entry whose target is the parent
       // state itself must not carry storeStepOutputs.
       const selfTargeting = parentAlways.filter((entry) => entry.target === 'step::1');
@@ -11366,7 +11407,7 @@ echo ok
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toEqual({ 'step::3': 'idle' });
       // lastAction must reflect the GOTO target, not stale substep data
-      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', target: '3' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'GOTO', origin: 'direct', target: '3' });
       expect(snapshot.context.lastMessage).toBeUndefined();
     });
 
@@ -11413,7 +11454,7 @@ echo ok
 
       const snapshot = actor.getSnapshot();
       expect(snapshot.value).toBe('COMPLETE');
-      expect(snapshot.context.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(snapshot.context.lastAction).toEqual({ type: 'COMPLETE', origin: 'direct' });
       expect(snapshot.context.lastMessage).toBe('all done');
     });
 
@@ -11440,7 +11481,7 @@ echo ok
       expect(completeEntry).toBeDefined();
 
       const assignPayload = getAssignPayload(completeEntry.actions);
-      expect(assignPayload.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(assignPayload.lastAction).toEqual({ type: 'COMPLETE', origin: 'direct' });
     });
 
     it('records the parent declared FAIL action on lastAction when the FAIL-path exit fires', () => {
@@ -11463,7 +11504,7 @@ echo ok
       // Two STOPPED entries coexist on the parent: the priority-0
       // RETRY_ERROR router (no actions — lastAction is already the
       // RetryErrorLastAction variant, preserved verbatim) and the
-      // FAIL-path exit entry (assigns `lastAction: { type: 'STOP' }`).
+      // FAIL-path exit entry (assigns `lastAction: { type: 'STOP', origin: 'direct' }`).
       // This test targets the latter.
       const stoppedEntry = parentAlways.find(
         (entry) => entry.target === 'STOPPED' && entry.actions !== undefined,
@@ -11471,7 +11512,7 @@ echo ok
       expect(stoppedEntry).toBeDefined();
 
       const assignPayload = getAssignPayload(stoppedEntry.actions);
-      expect(assignPayload.lastAction).toEqual({ type: 'STOP' });
+      expect(assignPayload.lastAction).toEqual({ type: 'STOP', origin: 'direct' });
     });
 
     it('records the parent declared PASS action on lastAction for unconditional FOR exit (Case C)', () => {
@@ -11505,7 +11546,7 @@ echo ok
       const passEntry = parentAlways.find((e: any) => e.guard === 'loopCompletedNormally');
       expect(passEntry).toBeDefined();
       const assignPayload = getAssignPayload(passEntry.actions);
-      expect(assignPayload.lastAction).toEqual({ type: 'COMPLETE' });
+      expect(assignPayload.lastAction).toEqual({ type: 'COMPLETE', origin: 'direct' });
 
       // BREAK/NEXT entry must NOT override lastAction — it preserves the iteration's own disposition.
       const breakEntry = parentAlways.find((e: any) => e.guard === 'loopExitedViaControl');
@@ -11712,9 +11753,9 @@ echo ok
       expect(post1?.delegation?.tokenHash).not.toBe(preHash1);
       expect(post2?.delegation?.tokenHash).not.toBe(preHash2);
 
-      // lastAction is RETRY with aggregated: true (spec §3.5).
+      // lastAction is RETRY with origin: 'aggregation' (spec §3.5).
       expect(ctx.lastAction?.type).toBe('RETRY');
-      expect(ctx.lastAction?.aggregated).toBe(true);
+      expect(ctx.lastAction?.origin).toBe('aggregation');
 
       // Counters incremented on success.
       expect(ctx.parentRetryCount).toBe(1);
@@ -11827,7 +11868,12 @@ echo ok
           ...baseSnap.context,
           activeFrameKey: frameKey,
           substep: undefined,
-          lastAction: { type: 'RETRY_ERROR' as const, code: 'RD-902', message: 'hook failed' },
+          lastAction: {
+            type: 'RETRY_ERROR',
+            origin: 'direct' as const,
+            code: 'RD-902',
+            message: 'hook failed',
+          },
           parentRetryCount: 0,
           retryCount: 0,
           delegateFrontier: undefined,
@@ -12224,9 +12270,9 @@ echo ok
       expect(postIter1?.status).toBe('pending');
       expect(postIter1?.result).toBeUndefined();
 
-      // lastAction is RETRY with aggregated: true (spec §3.5).
+      // lastAction is RETRY with origin: 'aggregation' (spec §3.5).
       expect(ctx.lastAction?.type).toBe('RETRY');
-      expect(ctx.lastAction?.aggregated).toBe(true);
+      expect(ctx.lastAction?.origin).toBe('aggregation');
 
       // Iteration counters incremented on success.
       expect(ctx.iterationRetryCount).toBe(1);

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -7311,6 +7311,55 @@ echo "processing"
       expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
     });
 
+    it('BREAK at iteration level preserves aggregation origin when exiting loop', () => {
+      const steps = inferSteps([
+        {
+          name: '1',
+          forClause: {
+            start: 1,
+            end: 3,
+            transitions: {
+              pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+              fail: { kind: 'fail' as const, retry: 0, action: { type: 'BREAK' as const } },
+            },
+            aggregation: { strategy: 'ALL' },
+          },
+          description: 'Loop with BREAK exit on fail at iteration level',
+          transitions: DEFAULT_TRANSITIONS,
+          substeps: [
+            {
+              id: '1',
+              description: 'Check',
+              transitions: {
+                pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+                fail: { kind: 'fail' as const, retry: 0, action: { type: 'DEFER' as const } },
+              },
+            },
+          ],
+        },
+        {
+          name: '2',
+          description: 'Done',
+          transitions: {
+            ...DEFAULT_TRANSITIONS,
+            pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          },
+        },
+      ]);
+
+      const machine = compileRunbookToMachine(steps);
+      const actor = createActor(machine);
+      actor.start();
+
+      actor.send({ type: 'FAIL' });
+
+      expect(actor.getSnapshot().value).toEqual({ 'step::2': 'idle' });
+      expect(actor.getSnapshot().context.lastAction).toEqual({
+        type: 'BREAK',
+        origin: 'aggregation',
+      });
+    });
+
     it('CONTINUE at iteration level does not accumulate — only DEFER results reach parent', () => {
       const steps = inferSteps([
         {

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -11919,7 +11919,7 @@ echo ok
           substep: undefined,
           lastAction: {
             type: 'RETRY_ERROR',
-            origin: 'direct' as const,
+            origin: 'aggregation' as const,
             code: 'RD-902',
             message: 'hook failed',
           },
@@ -12019,6 +12019,7 @@ echo ok
           substep: undefined,
           lastAction: {
             type: 'RETRY_ERROR' as const,
+            origin: 'aggregation' as const,
             code: 'RD-902',
             message: 'iteration retry hook failed',
           },
@@ -12158,6 +12159,27 @@ echo ok
       expect(post2?.delegation).toBeUndefined();
       expect(post2?.status).toBe(pre2?.status);
       expect(post2?.result).toBe(pre2?.result);
+
+      actor.stop();
+    });
+
+    it('parent-aggregation retry hook failure emits RETRY_ERROR with origin=aggregation', () => {
+      // Natural-path regression: trimSteps drops substep '1' from compiled steps,
+      // so retryDelegation fails validation and runRetryHook returns
+      // { status: 'error' }. The assign at compiler.ts:1429-1446 fires and writes
+      // the RETRY_ERROR lastAction. Origin must be 'aggregation' — it sits on
+      // the parent-aggregation retry path, mirroring the sibling RETRY emission.
+      const { actor } = buildRetryScenario({
+        seedIds: ['1', '2'],
+        results: { '1': 'pass', '2': 'fail' },
+        trimSteps: true,
+      });
+
+      actor.send({ type: 'FAIL' });
+
+      const ctx = actor.getSnapshot().context as RunbookContext;
+      expect(ctx.lastAction?.type).toBe('RETRY_ERROR');
+      expect(ctx.lastAction?.origin).toBe('aggregation');
 
       actor.stop();
     });
@@ -12343,6 +12365,106 @@ echo ok
       const post1 = ctx.substepStates?.find((ss) => ss.id === '1' && ss.frameKey === iter1FrameKey);
       expect(post1?.delegation?.tokenHash).not.toBe(iter1Seeded.delegation?.tokenHash);
       expect(post1?.delegation?.childRunbookRef).toEqual(iter1ChildRef);
+
+      actor.stop();
+    });
+
+    it('FOR-iteration retry hook failure emits RETRY_ERROR with origin=aggregation', () => {
+      // Natural-path regression: seed the iteration delegation against the full
+      // step set, but compile the machine with an additional non-delegated
+      // substep '2' that the seeded substepStates lacks. retryDelegation
+      // validates against compiled steps; with the delegation pointing at a
+      // substep whose iteration substepStates are stale, runRetryHook returns
+      // { status: 'error' } and the assign at compiler.ts:1550-1570 fires.
+      // Origin must be 'aggregation' — sibling iteration RETRY uses
+      // makeAggregationLastAction.
+      const substepDefer = {
+        pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+        fail: { kind: 'fail' as const, retry: 0, action: { type: 'DEFER' as const } },
+      };
+      const fullSteps = inferSteps([
+        {
+          name: '1',
+          description: 'FOR with delegate substep',
+          forClause: {
+            start: 1,
+            end: 2,
+            transitions: {
+              pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+              fail: { kind: 'fail' as const, retry: 1, action: { type: 'DEFER' as const } },
+            },
+            aggregation: { strategy: 'ALL' },
+          },
+          transitions: DEFAULT_TRANSITIONS,
+          aggregation: { strategy: 'ALL' },
+          substeps: [{ id: '1', description: 'Sub 1', transitions: substepDefer }],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ]);
+
+      // Compile a "trimmed" variant without the delegated substep so
+      // retryDelegation can't find substep '1' on the compiled steps.
+      const compiledSteps = inferSteps([
+        {
+          name: '1',
+          description: 'FOR with delegate substep',
+          forClause: {
+            start: 1,
+            end: 2,
+            transitions: {
+              pass: { kind: 'pass' as const, retry: 0, action: { type: 'DEFER' as const } },
+              fail: { kind: 'fail' as const, retry: 1, action: { type: 'DEFER' as const } },
+            },
+            aggregation: { strategy: 'ALL' },
+          },
+          transitions: DEFAULT_TRANSITIONS,
+          aggregation: { strategy: 'ALL' },
+          substeps: [{ id: '2', description: 'Sub 2', transitions: substepDefer }],
+        },
+        { name: '2', description: 'Next', transitions: DEFAULT_TRANSITIONS },
+      ]);
+
+      const iter1FrameKey = buildFrameKey('1', 1);
+      const iter1Seeded = seedIterationDelegation(fullSteps, '1', 1);
+
+      const machine = compileRunbookToMachine(compiledSteps);
+      const tmp = createActor(machine);
+      tmp.start();
+      const baseSnap = tmp.getSnapshot();
+      tmp.stop();
+
+      const persisted = {
+        ...baseSnap,
+        value: `step::1::2`,
+        context: {
+          ...baseSnap.context,
+          substepStates: [iter1Seeded],
+          activeFrameKey: iter1FrameKey,
+          substep: '2',
+          forStack: [
+            {
+              stepId: '1',
+              iteration: 1,
+              start: 1,
+              end: 2,
+              implicit: false,
+              source: { kind: 'range' as const },
+            },
+          ],
+          deferredResults: [] as ('pass' | 'fail')[],
+          substepCompletedCount: 0,
+          iterationResults: [] as ('pass' | 'fail')[],
+        },
+      };
+
+      const actor = createActor(machine, { snapshot: persisted });
+      actor.start();
+
+      actor.send({ type: 'FAIL' });
+
+      const ctx = actor.getSnapshot().context as RunbookContext;
+      expect(ctx.lastAction?.type).toBe('RETRY_ERROR');
+      expect(ctx.lastAction?.origin).toBe('aggregation');
 
       actor.stop();
     });

--- a/packages/core/__tests__/runbook/delegation-context.test.ts
+++ b/packages/core/__tests__/runbook/delegation-context.test.ts
@@ -638,7 +638,7 @@ describe('buildContextSnapshot', () => {
         templateVars: brandInitialTemplateVarsForTest({}),
         variables: brandStoredOutputsForTest({ PlanPath: ARTIFACT_RECORD }),
       }),
-      schemaVersion: 4,
+      schemaVersion: 5,
     }) as unknown as RunbookState;
 
     const snap = buildContextSnapshot(parsed);

--- a/packages/core/__tests__/runbook/delegation-propagation.test.ts
+++ b/packages/core/__tests__/runbook/delegation-propagation.test.ts
@@ -105,7 +105,7 @@ describe('DelegationLinkage extended fields', () => {
       delete parentLinkage[field];
       const state = {
         ...makeSchemaState(parentLinkage),
-        schemaVersion: 4,
+        schemaVersion: 5,
         lifecycle: 'running',
         frontmatterOutputs: [],
       };

--- a/packages/core/__tests__/runbook/delegation-scan.test.ts
+++ b/packages/core/__tests__/runbook/delegation-scan.test.ts
@@ -71,7 +71,7 @@ describe('DelegationScanService', () => {
       startedAt: '2026-02-27T10:00:00.000Z',
       updatedAt: '2026-02-27T10:00:00.000Z',
       lifecycle: 'running',
-      schemaVersion: 4,
+      schemaVersion: 5,
       ...overrides,
     };
   }

--- a/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
+++ b/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
@@ -106,7 +106,7 @@ describe('ExecutionLifecycleService', () => {
 
       // Simulate GOTO re-entry: same step, lastAction is GOTO
       const next = await manager.update(state.id, {
-        lastAction: { type: 'GOTO', target: '1' },
+        lastAction: { type: 'GOTO', origin: 'direct', target: '1' },
       });
 
       const result = await service.ensureActiveEntry(state.id, prev!, next);
@@ -125,7 +125,7 @@ describe('ExecutionLifecycleService', () => {
 
       // Simulate RETRY re-entry
       const next = await manager.update(state.id, {
-        lastAction: { type: 'RETRY' },
+        lastAction: { type: 'RETRY', origin: 'direct' },
       });
 
       const result = await service.ensureActiveEntry(state.id, prev!, next);

--- a/packages/core/__tests__/runbook/last-action-schema.test.ts
+++ b/packages/core/__tests__/runbook/last-action-schema.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from '@jest/globals';
+import { LastActionSchema } from '../../src/runbook/last-action.js';
+
+describe('LastActionSchema', () => {
+  it.each([
+    { type: 'START', origin: 'direct' },
+    { type: 'CONTINUE', origin: 'direct' },
+    { type: 'DEFER', origin: 'direct' },
+    { type: 'GOTO', origin: 'direct', target: '2', substep: '1', at: 3 },
+    { type: 'COMPLETE', origin: 'direct' },
+    { type: 'STOP', origin: 'direct' },
+    { type: 'RETRY', origin: 'direct' },
+    { type: 'NEXT', origin: 'direct' },
+    { type: 'BREAK', origin: 'direct' },
+    { type: 'COMPLETE', origin: 'aggregation' },
+    { type: 'STOP', origin: 'aggregation' },
+    { type: 'GOTO', origin: 'aggregation', target: '3' },
+    { type: 'RETRY', origin: 'aggregation' },
+    { type: 'RETRY_ERROR', origin: 'direct', code: 'RD-902', message: 'retry hook failed' },
+    { type: 'OUTPUT_CAPTURE_FAILED', origin: 'direct', message: 'disk full' },
+    { type: 'ARTIFACT_RESOLUTION_FAILED', origin: 'direct', message: 'unbound artifact' },
+    {
+      type: 'FOR_RESOLUTION_FAILED',
+      origin: 'direct',
+      code: 'undefined-variable',
+      message: 'bad source',
+    },
+    {
+      type: 'DELEGATION_ISSUANCE_FAILED',
+      origin: 'direct',
+      reason: 'delegation_resolution_failed',
+      message: 'missing child',
+    },
+  ])('round-trips %#', (action) => {
+    expect(LastActionSchema.parse(action)).toEqual(action);
+  });
+
+  it('rejects legacy aggregation markers without explicit origin', () => {
+    expect(() => LastActionSchema.parse({ type: 'COMPLETE', aggregated: true })).toThrow();
+  });
+});

--- a/packages/core/__tests__/runbook/lifecycle-context.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-context.test.ts
@@ -72,7 +72,7 @@ describe('lifecycle context field', () => {
     const snapshot = actor.getSnapshot();
     expect(snapshot.value).toBe('COMPLETE');
     expect(snapshot.context.lifecycle).toBe('completed');
-    expect(snapshot.context.lastAction).toEqual({ type: 'COMPLETE' });
+    expect(snapshot.context.lastAction).toEqual({ type: 'COMPLETE', origin: 'direct' });
     expect(snapshot.context.lastMessage).toBe('Enough work is done');
     actor.stop();
   });
@@ -88,7 +88,7 @@ describe('lifecycle context field', () => {
     const snapshot = actor.getSnapshot();
     expect(snapshot.value).toBe('STOPPED');
     expect(snapshot.context.lifecycle).toBe('stopped');
-    expect(snapshot.context.lastAction).toEqual({ type: 'STOP' });
+    expect(snapshot.context.lastAction).toEqual({ type: 'STOP', origin: 'direct' });
     expect(snapshot.context.lastMessage).toBe('Operator cancelled');
     actor.stop();
   });

--- a/packages/core/__tests__/runbook/state-schema-version.test.ts
+++ b/packages/core/__tests__/runbook/state-schema-version.test.ts
@@ -20,16 +20,16 @@ const BASE_SCHEMA_STATE = {
   updatedAt: '2026-04-19T00:00:00.000Z',
 };
 
-describe('RunbookStateSchema — schema version 4 and lifecycle fields', () => {
-  it('accepts state with schemaVersion 4 and lifecycle field', () => {
+describe('RunbookStateSchema — schema version 5 and lifecycle fields', () => {
+  it('accepts state with schemaVersion 5 and lifecycle field', () => {
     const parsed = RunbookStateSchema.parse({
       ...BASE_SCHEMA_STATE,
       variables: {},
       lifecycle: 'running',
-      schemaVersion: 4,
+      schemaVersion: 5,
     });
     expect(parsed.lifecycle).toBe('running');
-    expect(parsed.schemaVersion).toBe(4);
+    expect(parsed.schemaVersion).toBe(5);
   });
 
   it('accepts all lifecycle enum values', () => {
@@ -38,7 +38,7 @@ describe('RunbookStateSchema — schema version 4 and lifecycle fields', () => {
         ...BASE_SCHEMA_STATE,
         variables: {},
         lifecycle: lc,
-        schemaVersion: 4,
+        schemaVersion: 5,
       });
       expect(parsed.lifecycle).toBe(lc);
     }
@@ -50,7 +50,7 @@ describe('RunbookStateSchema — schema version 4 and lifecycle fields', () => {
         ...BASE_SCHEMA_STATE,
         variables: { completed: true },
         lifecycle: 'running',
-        schemaVersion: 4,
+        schemaVersion: 5,
       }),
     ).toThrow();
   });
@@ -60,7 +60,7 @@ describe('RunbookStateSchema — schema version 4 and lifecycle fields', () => {
       ...BASE_SCHEMA_STATE,
       variables: { count: 42 },
       lifecycle: 'running',
-      schemaVersion: 4,
+      schemaVersion: 5,
     });
 
     expect(parsed.variables).toEqual({ count: 42 });
@@ -71,7 +71,7 @@ describe('RunbookStateSchema — schema version 4 and lifecycle fields', () => {
       ...BASE_SCHEMA_STATE,
       variables: {},
       lifecycle: 'running',
-      schemaVersion: 4,
+      schemaVersion: 5,
     });
     expect(parsed.variables).toEqual({});
   });
@@ -81,9 +81,21 @@ describe('RunbookStateSchema — schema version 4 and lifecycle fields', () => {
       ...BASE_SCHEMA_STATE,
       variables: { env: 'staging', version: '1.2.3' },
       lifecycle: 'running',
-      schemaVersion: 4,
+      schemaVersion: 5,
     });
     expect(parsed.variables).toEqual({ env: 'staging', version: '1.2.3' });
+  });
+
+  it('preserves aggregation origin on persisted lastAction', () => {
+    const parsed = RunbookStateSchema.parse({
+      ...BASE_SCHEMA_STATE,
+      variables: {},
+      lifecycle: 'running',
+      schemaVersion: 5,
+      lastAction: { type: 'COMPLETE', origin: 'aggregation' },
+    });
+
+    expect(parsed.lastAction).toEqual({ type: 'COMPLETE', origin: 'aggregation' });
   });
 
   it('accepts variables carrying exact and wildcard artifact records alongside strings', () => {
@@ -105,7 +117,7 @@ describe('RunbookStateSchema — schema version 4 and lifecycle fields', () => {
         Note: 'string-output',
       },
       lifecycle: 'running',
-      schemaVersion: 4,
+      schemaVersion: 5,
     });
 
     expect(parsed.variables).toEqual({
@@ -132,7 +144,7 @@ describe('RunbookStateSchema — schema version 4 and lifecycle fields', () => {
         variables: {},
         artifactVars: { PlanPath: artifact },
         lifecycle: 'running',
-        schemaVersion: 4,
+        schemaVersion: 5,
       }),
     ).toThrow(/artifactVars/);
   });
@@ -204,30 +216,30 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
     expect(result).toBeNull();
   });
 
-  it('loads valid v4 state successfully', async () => {
+  it('loads valid v5 state successfully', async () => {
     const runsDir = path.join(tmpDir, '.rundown', 'runs');
     await fs.mkdir(runsDir, { recursive: true });
-    const v4State = {
+    const v5State = {
       ...STALE_V3_STATE,
       runbook: { source: 'project', path: 'x.md' },
-      schemaVersion: 4,
+      schemaVersion: 5,
     };
-    await fs.writeFile(path.join(runsDir, `${v4State.id}.json`), JSON.stringify(v4State, null, 2));
+    await fs.writeFile(path.join(runsDir, `${v5State.id}.json`), JSON.stringify(v5State, null, 2));
 
-    const result = await manager.load(v4State.id);
+    const result = await manager.load(v5State.id);
     expect(result).not.toBeNull();
-    expect(result?.id).toBe(v4State.id);
+    expect(result?.id).toBe(v5State.id);
   });
 
-  it('rejects v4 state carrying removed artifactVars instead of silently dropping it', async () => {
+  it('rejects v5 state carrying removed artifactVars instead of silently dropping it', async () => {
     const runsDir = path.join(tmpDir, '.rundown', 'runs');
     await fs.mkdir(runsDir, { recursive: true });
     const id = 'rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
-    const v4StateWithArtifactVars = {
+    const v5StateWithArtifactVars = {
       ...STALE_V3_STATE,
       id,
       runbook: { source: 'project', path: 'x.md' },
-      schemaVersion: 4,
+      schemaVersion: 5,
       artifactVars: {
         PlanPath: {
           kind: 'artifact-record',
@@ -242,7 +254,7 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
     };
     await fs.writeFile(
       path.join(runsDir, `${id}.json`),
-      JSON.stringify(v4StateWithArtifactVars, null, 2),
+      JSON.stringify(v5StateWithArtifactVars, null, 2),
     );
 
     await expect(manager.load(id)).rejects.toThrow(/Stale runbook state.*schema validation failed/);
@@ -263,7 +275,7 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
     const id = 'rd_ffffffffffffffffffffffffffffffff';
     await fs.writeFile(
       path.join(runsDir, `${id}.json`),
-      JSON.stringify({ ...STALE_V3_STATE, id, schemaVersion: 5 }, null, 2),
+      JSON.stringify({ ...STALE_V3_STATE, id, schemaVersion: 6 }, null, 2),
     );
     await expect(manager.load(id)).rejects.toBeInstanceOf(StaleRunbookStateError);
   });
@@ -282,4 +294,42 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
   });
 
   // Not applicable: snapshot version travels with the wrapper schemaVersion.
+});
+
+describe('RunbookStateManager.update() — lastAction origin persistence', () => {
+  let tmpDir: string;
+  let manager: RunbookStateManager;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'rundown-test-'));
+    manager = new RunbookStateManager(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('preserves aggregation origin across unrelated updates', async () => {
+    const runsDir = path.join(tmpDir, '.rundown', 'runs');
+    await fs.mkdir(runsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(runsDir, `${BASE_RUN_ID}.json`),
+      JSON.stringify(
+        {
+          ...BASE_SCHEMA_STATE,
+          variables: {},
+          lifecycle: 'running',
+          schemaVersion: 5,
+          lastAction: { type: 'COMPLETE', origin: 'aggregation' },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await manager.update(BASE_RUN_ID, { stepName: 'updated' });
+    const reloaded = await manager.load(BASE_RUN_ID);
+
+    expect(reloaded?.lastAction).toEqual({ type: 'COMPLETE', origin: 'aggregation' });
+  });
 });

--- a/packages/core/__tests__/runbook/state-schema-version.test.ts
+++ b/packages/core/__tests__/runbook/state-schema-version.test.ts
@@ -166,7 +166,7 @@ describe('RunbookStateManager.load() — stale state enforcement', () => {
     startedAt: '2026-04-19T00:00:00.000Z',
     updatedAt: '2026-04-19T00:00:00.000Z',
     lifecycle: 'running',
-    schemaVersion: 3, // old version (v3 is now stale; current is v4)
+    schemaVersion: 3, // old version (v3 is now stale; current is v5)
   };
 
   beforeEach(async () => {

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -177,7 +177,7 @@ describe('RunbookStateManager', () => {
     expect(loaded?.variables.Foo).toEqual(artifact);
   });
 
-  it('preserves aggregated lastAction across unrelated updates after loading from disk', async () => {
+  it('preserves aggregation-origin lastAction across unrelated updates after loading from disk', async () => {
     const state = await manager.create(
       { source: 'project', path: 'test.runbook.md' },
       mockRunbook,
@@ -185,13 +185,13 @@ describe('RunbookStateManager', () => {
     );
 
     await manager.update(state.id, {
-      lastAction: { type: 'COMPLETE', aggregated: true },
+      lastAction: { type: 'COMPLETE', origin: 'aggregation' },
     });
     await manager.update(state.id, { stepName: 'Renamed step' });
 
     const loaded = await manager.load(state.id);
     expect(loaded?.stepName).toBe('Renamed step');
-    expect(loaded?.lastAction).toEqual({ type: 'COMPLETE', aggregated: true });
+    expect(loaded?.lastAction).toEqual({ type: 'COMPLETE', origin: 'aggregation' });
   });
 
   it('round-trips 100+ artifact-shaped variables entries through persistence', async () => {

--- a/packages/core/__tests__/runbook/substep-aggregation.properties.test.ts
+++ b/packages/core/__tests__/runbook/substep-aggregation.properties.test.ts
@@ -210,7 +210,7 @@ describe('Substep aggregation properties', () => {
           const events = Array.from({ length: numSubsteps }, () => 'PASS' as const);
           const result = runMachine(steps, events);
           expect(result.terminalState).toBe('COMPLETE');
-          // Parent aggregation fired → aggregated flag must be set
+          // Parent aggregation fired → lastAction.origin must be 'aggregation'
           expect(result.lastAction?.origin).toBe('aggregation');
         },
       ),

--- a/packages/core/__tests__/runbook/substep-aggregation.properties.test.ts
+++ b/packages/core/__tests__/runbook/substep-aggregation.properties.test.ts
@@ -211,7 +211,7 @@ describe('Substep aggregation properties', () => {
           const result = runMachine(steps, events);
           expect(result.terminalState).toBe('COMPLETE');
           // Parent aggregation fired → aggregated flag must be set
-          expect(result.lastAction?.aggregated).toBe(true);
+          expect(result.lastAction?.origin).toBe('aggregation');
         },
       ),
       { numRuns: 200 },

--- a/packages/core/__tests__/runbook/terminal-propagation.properties.test.ts
+++ b/packages/core/__tests__/runbook/terminal-propagation.properties.test.ts
@@ -120,7 +120,7 @@ describe('Terminal propagation properties', () => {
         const result = runMachine(steps, [event]);
         expect(result.terminalState).toBe(action === 'STOP' ? 'STOPPED' : 'COMPLETE');
         // Direct terminal from substep — no aggregated flag
-        expect(result.lastAction?.aggregated).toBeUndefined();
+        expect(result.lastAction?.origin).toBe('direct');
       }),
       { numRuns: 200 },
     );
@@ -144,7 +144,7 @@ describe('Terminal propagation properties', () => {
         const expectedTerminal = action === 'STOP' ? 'STOPPED' : 'COMPLETE';
         expect(result.terminalState).toBe(expectedTerminal);
         // Aggregated terminal — flag must be set
-        expect(result.lastAction?.aggregated).toBe(true);
+        expect(result.lastAction?.origin).toBe('aggregation');
       }),
       { numRuns: 200 },
     );
@@ -181,7 +181,7 @@ describe('Terminal propagation properties', () => {
           expect(result.terminalState).toBe(action === 'STOP' ? 'STOPPED' : 'COMPLETE');
           expect(result.lifecycle).toBe(action === 'STOP' ? 'stopped' : 'completed');
           expect(result.lastAction?.type).toBe(action);
-          expect(result.lastAction?.aggregated).toBeUndefined();
+          expect(result.lastAction?.origin).toBe('direct');
           expect(result.lastMessage).toBe(message);
         },
       ),

--- a/packages/core/__tests__/runbook/terminal-propagation.properties.test.ts
+++ b/packages/core/__tests__/runbook/terminal-propagation.properties.test.ts
@@ -119,7 +119,7 @@ describe('Terminal propagation properties', () => {
         ]);
         const result = runMachine(steps, [event]);
         expect(result.terminalState).toBe(action === 'STOP' ? 'STOPPED' : 'COMPLETE');
-        // Direct terminal from substep — no aggregated flag
+        // Direct terminal from substep — lastAction.origin must be 'direct'
         expect(result.lastAction?.origin).toBe('direct');
       }),
       { numRuns: 200 },
@@ -143,7 +143,7 @@ describe('Terminal propagation properties', () => {
         const result = runMachine(steps, [event]);
         const expectedTerminal = action === 'STOP' ? 'STOPPED' : 'COMPLETE';
         expect(result.terminalState).toBe(expectedTerminal);
-        // Aggregated terminal — flag must be set
+        // Aggregated terminal — lastAction.origin must be 'aggregation'
         expect(result.lastAction?.origin).toBe('aggregation');
       }),
       { numRuns: 200 },

--- a/packages/core/__tests__/runbook/transition-kernel.test.ts
+++ b/packages/core/__tests__/runbook/transition-kernel.test.ts
@@ -12,85 +12,88 @@ import {
   parseActionType,
   deriveTransitionMessage,
 } from '../../src/runbook/transition-kernel.js';
+import { makeDirectLastAction } from '../../src/runbook/last-action.js';
 import type { Step, LastAction } from '../../src/runbook/types.js';
 
 describe('transition-kernel', () => {
   describe('extractLastAction', () => {
     describe('valid action types', () => {
       it('extracts START action', () => {
-        const snapshot = { context: { lastAction: { type: 'START' } } };
+        const snapshot = { context: { lastAction: { type: 'START', origin: 'direct' } } };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'START' });
+        expect(result).toEqual({ type: 'START', origin: 'direct' });
       });
 
       it('extracts CONTINUE action', () => {
-        const snapshot = { context: { lastAction: { type: 'CONTINUE' } } };
+        const snapshot = { context: { lastAction: { type: 'CONTINUE', origin: 'direct' } } };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'CONTINUE' });
+        expect(result).toEqual({ type: 'CONTINUE', origin: 'direct' });
       });
 
       it('extracts COMPLETE action', () => {
-        const snapshot = { context: { lastAction: { type: 'COMPLETE' } } };
+        const snapshot = { context: { lastAction: { type: 'COMPLETE', origin: 'direct' } } };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'COMPLETE' });
+        expect(result).toEqual({ type: 'COMPLETE', origin: 'direct' });
       });
 
       it('extracts STOP action', () => {
-        const snapshot = { context: { lastAction: { type: 'STOP' } } };
+        const snapshot = { context: { lastAction: { type: 'STOP', origin: 'direct' } } };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'STOP' });
+        expect(result).toEqual({ type: 'STOP', origin: 'direct' });
       });
 
       it('extracts RETRY action', () => {
-        const snapshot = { context: { lastAction: { type: 'RETRY' } } };
+        const snapshot = { context: { lastAction: { type: 'RETRY', origin: 'direct' } } };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'RETRY' });
+        expect(result).toEqual({ type: 'RETRY', origin: 'direct' });
       });
 
       it('extracts NEXT action', () => {
-        const snapshot = { context: { lastAction: { type: 'NEXT' } } };
+        const snapshot = { context: { lastAction: { type: 'NEXT', origin: 'direct' } } };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'NEXT' });
+        expect(result).toEqual({ type: 'NEXT', origin: 'direct' });
       });
 
       it('extracts BREAK action', () => {
-        const snapshot = { context: { lastAction: { type: 'BREAK' } } };
+        const snapshot = { context: { lastAction: { type: 'BREAK', origin: 'direct' } } };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'BREAK' });
+        expect(result).toEqual({ type: 'BREAK', origin: 'direct' });
       });
     });
 
     describe('GOTO action variants', () => {
       it('extracts GOTO with target only', () => {
-        const snapshot = { context: { lastAction: { type: 'GOTO', target: '5' } } };
+        const snapshot = {
+          context: { lastAction: { type: 'GOTO', origin: 'direct', target: '5' } },
+        };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'GOTO', target: '5' });
+        expect(result).toEqual({ type: 'GOTO', origin: 'direct', target: '5' });
       });
 
       it('extracts GOTO with substep', () => {
         const snapshot = {
-          context: { lastAction: { type: 'GOTO', target: '3', substep: 'a' } },
+          context: { lastAction: { type: 'GOTO', origin: 'direct', target: '3', substep: 'a' } },
         };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'GOTO', target: '3', substep: 'a' });
+        expect(result).toEqual({ type: 'GOTO', origin: 'direct', target: '3', substep: 'a' });
       });
 
       it('extracts GOTO with at number', () => {
         const snapshot = {
-          context: { lastAction: { type: 'GOTO', target: '2', at: 1000 } },
+          context: { lastAction: { type: 'GOTO', origin: 'direct', target: '2', at: 1000 } },
         };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'GOTO', target: '2', at: 1000 });
+        expect(result).toEqual({ type: 'GOTO', origin: 'direct', target: '2', at: 1000 });
       });
 
       it('extracts GOTO with at string template', () => {
         const snapshot = {
           context: {
-            lastAction: { type: 'GOTO', target: '4', at: '{{delay}}' },
+            lastAction: { type: 'GOTO', origin: 'direct', target: '4', at: '{{delay}}' },
           },
         };
         const result = extractLastAction(snapshot);
-        expect(result).toEqual({ type: 'GOTO', target: '4', at: '{{delay}}' });
+        expect(result).toEqual({ type: 'GOTO', origin: 'direct', target: '4', at: '{{delay}}' });
       });
 
       it('extracts GOTO with all properties', () => {
@@ -98,6 +101,7 @@ describe('transition-kernel', () => {
           context: {
             lastAction: {
               type: 'GOTO',
+              origin: 'direct',
               target: '6',
               substep: 'b',
               at: 500,
@@ -107,6 +111,7 @@ describe('transition-kernel', () => {
         const result = extractLastAction(snapshot);
         expect(result).toEqual({
           type: 'GOTO',
+          origin: 'direct',
           target: '6',
           substep: 'b',
           at: 500,
@@ -151,14 +156,14 @@ describe('transition-kernel', () => {
 
     describe('isLastAction guard (tested via extractLastAction)', () => {
       it('rejects GOTO without target', () => {
-        const snapshot = { context: { lastAction: { type: 'GOTO' } } };
+        const snapshot = { context: { lastAction: { type: 'GOTO', origin: 'direct' } } };
         const result = extractLastAction(snapshot);
         expect(result).toBeUndefined();
       });
 
       it('rejects GOTO with non-string target', () => {
         const snapshot = {
-          context: { lastAction: { type: 'GOTO', target: 123 } },
+          context: { lastAction: { type: 'GOTO', origin: 'direct', target: 123 } },
         };
         const result = extractLastAction(snapshot);
         expect(result).toBeUndefined();
@@ -167,7 +172,7 @@ describe('transition-kernel', () => {
       it('rejects GOTO with non-string substep', () => {
         const snapshot = {
           context: {
-            lastAction: { type: 'GOTO', target: '5', substep: 123 },
+            lastAction: { type: 'GOTO', origin: 'direct', target: '5', substep: 123 },
           },
         };
         const result = extractLastAction(snapshot);
@@ -177,7 +182,7 @@ describe('transition-kernel', () => {
       it('rejects GOTO with non-number/non-string at', () => {
         const snapshot = {
           context: {
-            lastAction: { type: 'GOTO', target: '5', at: true },
+            lastAction: { type: 'GOTO', origin: 'direct', target: '5', at: true },
           },
         };
         const result = extractLastAction(snapshot);
@@ -185,7 +190,7 @@ describe('transition-kernel', () => {
       });
 
       it('rejects unknown action type', () => {
-        const snapshot = { context: { lastAction: { type: 'UNKNOWN' } } };
+        const snapshot = { context: { lastAction: { type: 'UNKNOWN', origin: 'direct' } } };
         const result = extractLastAction(snapshot);
         expect(result).toBeUndefined();
       });
@@ -334,78 +339,82 @@ describe('transition-kernel', () => {
     });
 
     it('formats RETRY with counts', () => {
-      const action: LastAction = { type: 'RETRY' };
+      const action: LastAction = makeDirectLastAction({ type: 'RETRY' });
       const result = formatActionForDisplay(action, 2, 3);
       expect(result).toBe('RETRY (2/3)');
     });
 
     it('formats GOTO with target only', () => {
-      const action: LastAction = { type: 'GOTO', target: '5' };
+      const action: LastAction = makeDirectLastAction({ type: 'GOTO', target: '5' });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('GOTO 5');
     });
 
     it('formats GOTO with substep', () => {
-      const action: LastAction = { type: 'GOTO', target: '3', substep: 'a' };
+      const action: LastAction = makeDirectLastAction({ type: 'GOTO', target: '3', substep: 'a' });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('GOTO 3.a');
     });
 
     it('formats GOTO with at number', () => {
-      const action: LastAction = { type: 'GOTO', target: '2', at: 1000 };
+      const action: LastAction = makeDirectLastAction({ type: 'GOTO', target: '2', at: 1000 });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('GOTO 2 AT 1000');
     });
 
     it('formats GOTO with at string template', () => {
-      const action: LastAction = { type: 'GOTO', target: '4', at: '{{delay}}' };
+      const action: LastAction = makeDirectLastAction({
+        type: 'GOTO',
+        target: '4',
+        at: '{{delay}}',
+      });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('GOTO 4 AT {{delay}}');
     });
 
     it('formats GOTO with substep and at', () => {
-      const action: LastAction = {
+      const action: LastAction = makeDirectLastAction({
         type: 'GOTO',
         target: '6',
         substep: 'b',
         at: 500,
-      };
+      });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('GOTO 6.b AT 500');
     });
 
     it('pass through START action', () => {
-      const action: LastAction = { type: 'START' };
+      const action: LastAction = makeDirectLastAction({ type: 'START' });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('START');
     });
 
     it('pass through COMPLETE action', () => {
-      const action: LastAction = { type: 'COMPLETE' };
+      const action: LastAction = makeDirectLastAction({ type: 'COMPLETE' });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('COMPLETE');
     });
 
     it('pass through STOP action', () => {
-      const action: LastAction = { type: 'STOP' };
+      const action: LastAction = makeDirectLastAction({ type: 'STOP' });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('STOP');
     });
 
     it('pass through CONTINUE action', () => {
-      const action: LastAction = { type: 'CONTINUE' };
+      const action: LastAction = makeDirectLastAction({ type: 'CONTINUE' });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('CONTINUE');
     });
 
     it('pass through NEXT action', () => {
-      const action: LastAction = { type: 'NEXT' };
+      const action: LastAction = makeDirectLastAction({ type: 'NEXT' });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('NEXT');
     });
 
     it('pass through BREAK action', () => {
-      const action: LastAction = { type: 'BREAK' };
+      const action: LastAction = makeDirectLastAction({ type: 'BREAK' });
       const result = formatActionForDisplay(action, 0, 0);
       expect(result).toBe('BREAK');
     });
@@ -460,25 +469,25 @@ describe('transition-kernel', () => {
     });
 
     it('returns GOTO for GOTO action', () => {
-      const action: LastAction = { type: 'GOTO', target: '5' };
+      const action: LastAction = makeDirectLastAction({ type: 'GOTO', target: '5' });
       const result = parseActionType(action);
       expect(result).toBe('GOTO');
     });
 
     it('returns RETRY for RETRY action', () => {
-      const action: LastAction = { type: 'RETRY' };
+      const action: LastAction = makeDirectLastAction({ type: 'RETRY' });
       const result = parseActionType(action);
       expect(result).toBe('RETRY');
     });
 
     it('returns COMPLETE for COMPLETE action', () => {
-      const action: LastAction = { type: 'COMPLETE' };
+      const action: LastAction = makeDirectLastAction({ type: 'COMPLETE' });
       const result = parseActionType(action);
       expect(result).toBe('COMPLETE');
     });
 
     it('returns STOP for STOP action', () => {
-      const action: LastAction = { type: 'STOP' };
+      const action: LastAction = makeDirectLastAction({ type: 'STOP' });
       const result = parseActionType(action);
       expect(result).toBe('STOP');
     });
@@ -488,7 +497,7 @@ describe('transition-kernel', () => {
       // 'START' to 'CONTINUE' via the default switch arm. This violates the
       // "no silent action mapping" principle — START is a distinct
       // pre-action category and must propagate as itself.
-      const action: LastAction = { type: 'START' };
+      const action: LastAction = makeDirectLastAction({ type: 'START' });
       const result = parseActionType(action);
       expect(result).toBe('START');
     });
@@ -502,19 +511,19 @@ describe('transition-kernel', () => {
     });
 
     it('returns CONTINUE for CONTINUE action', () => {
-      const action: LastAction = { type: 'CONTINUE' };
+      const action: LastAction = makeDirectLastAction({ type: 'CONTINUE' });
       const result = parseActionType(action);
       expect(result).toBe('CONTINUE');
     });
 
     it('returns NEXT for NEXT action', () => {
-      const action: LastAction = { type: 'NEXT' };
+      const action: LastAction = makeDirectLastAction({ type: 'NEXT' });
       const result = parseActionType(action);
       expect(result).toBe('NEXT');
     });
 
     it('returns BREAK for BREAK action', () => {
-      const action: LastAction = { type: 'BREAK' };
+      const action: LastAction = makeDirectLastAction({ type: 'BREAK' });
       const result = parseActionType(action);
       expect(result).toBe('BREAK');
     });
@@ -648,6 +657,7 @@ describe('transition-kernel', () => {
         context: {
           lastAction: {
             type: 'OUTPUT_CAPTURE_FAILED',
+            origin: 'direct',
             message: 'failed to read RD_OUTPUTS_Foo',
           },
         },
@@ -656,6 +666,7 @@ describe('transition-kernel', () => {
       const action = extractLastAction(snapshot);
       expect(action).toEqual({
         type: 'OUTPUT_CAPTURE_FAILED',
+        origin: 'direct',
         message: 'failed to read RD_OUTPUTS_Foo',
       });
       expect(isInternalFailureLastAction(action)).toBe(true);
@@ -665,11 +676,13 @@ describe('transition-kernel', () => {
 
     it('rejects malformed output-capture failure actions', () => {
       expect(
-        extractLastAction({ context: { lastAction: { type: 'OUTPUT_CAPTURE_FAILED' } } }),
+        extractLastAction({
+          context: { lastAction: { type: 'OUTPUT_CAPTURE_FAILED', origin: 'direct' } },
+        }),
       ).toBeUndefined();
       expect(
         extractLastAction({
-          context: { lastAction: { type: 'OUTPUT_CAPTURE_FAILED', message: 42 } },
+          context: { lastAction: { type: 'OUTPUT_CAPTURE_FAILED', origin: 'direct', message: 42 } },
         }),
       ).toBeUndefined();
     });
@@ -719,6 +732,7 @@ describe('transition-kernel', () => {
         context: {
           lastAction: {
             type: 'FOR_RESOLUTION_FAILED',
+            origin: 'direct',
             code,
             message: 'FOR source failed',
           },
@@ -727,6 +741,7 @@ describe('transition-kernel', () => {
 
       expect(extractLastAction(snapshot)).toEqual({
         type: 'FOR_RESOLUTION_FAILED',
+        origin: 'direct',
         code,
         message: 'FOR source failed',
       });
@@ -735,7 +750,9 @@ describe('transition-kernel', () => {
     it('rejects FOR_RESOLUTION_FAILED missing code', () => {
       expect(
         extractLastAction({
-          context: { lastAction: { type: 'FOR_RESOLUTION_FAILED', message: 'boom' } },
+          context: {
+            lastAction: { type: 'FOR_RESOLUTION_FAILED', origin: 'direct', message: 'boom' },
+          },
         }),
       ).toBeUndefined();
     });
@@ -743,7 +760,13 @@ describe('transition-kernel', () => {
     it('rejects FOR_RESOLUTION_FAILED missing message', () => {
       expect(
         extractLastAction({
-          context: { lastAction: { type: 'FOR_RESOLUTION_FAILED', code: 'policy-violation' } },
+          context: {
+            lastAction: {
+              type: 'FOR_RESOLUTION_FAILED',
+              origin: 'direct',
+              code: 'policy-violation',
+            },
+          },
         }),
       ).toBeUndefined();
     });
@@ -786,6 +809,7 @@ describe('transition-kernel', () => {
         context: {
           lastAction: {
             type: 'RETRY_ERROR',
+            origin: 'direct',
             code: 'RD-902',
             message: 'retry hook failed',
           },
@@ -795,6 +819,7 @@ describe('transition-kernel', () => {
       const action = extractLastAction(snapshot);
       expect(action).toEqual({
         type: 'RETRY_ERROR',
+        origin: 'direct',
         code: 'RD-902',
         message: 'retry hook failed',
       });

--- a/packages/core/__tests__/runbook/transition-kernel.test.ts
+++ b/packages/core/__tests__/runbook/transition-kernel.test.ts
@@ -59,6 +59,14 @@ describe('transition-kernel', () => {
         const result = extractLastAction(snapshot);
         expect(result).toEqual({ type: 'BREAK', origin: 'direct' });
       });
+
+      it('extracts COMPLETE action with aggregation origin', () => {
+        const snapshot = {
+          context: { lastAction: { type: 'COMPLETE', origin: 'aggregation' } },
+        };
+        const result = extractLastAction(snapshot);
+        expect(result).toEqual({ type: 'COMPLETE', origin: 'aggregation' });
+      });
     });
 
     describe('GOTO action variants', () => {

--- a/packages/core/__tests__/runbook/transition-kernel.test.ts
+++ b/packages/core/__tests__/runbook/transition-kernel.test.ts
@@ -529,12 +529,16 @@ describe('transition-kernel', () => {
     });
 
     it('returns command terminal action types without silent mapping', () => {
-      expect(parseActionType({ type: 'POLICY_DENIED', message: 'blocked' })).toBe('POLICY_DENIED');
       expect(
-        parseActionType({
-          type: 'COMMAND_EXECUTION_FAILED',
-          message: 'spawn failed',
-        }),
+        parseActionType(makeDirectLastAction({ type: 'POLICY_DENIED', message: 'blocked' })),
+      ).toBe('POLICY_DENIED');
+      expect(
+        parseActionType(
+          makeDirectLastAction({
+            type: 'COMMAND_EXECUTION_FAILED',
+            message: 'spawn failed',
+          }),
+        ),
       ).toBe('COMMAND_EXECUTION_FAILED');
     });
   });
@@ -831,32 +835,42 @@ describe('transition-kernel', () => {
 
   describe('command terminal lastAction variants', () => {
     it('maps policy denial and command execution failure distinctly', () => {
-      expect(deriveStoppedReason({ type: 'POLICY_DENIED', message: 'blocked' })).toBe(
-        'policy_denied',
-      );
       expect(
-        deriveStoppedReason({
-          type: 'COMMAND_EXECUTION_FAILED',
-          message: 'spawn failed',
-        }),
+        deriveStoppedReason(makeDirectLastAction({ type: 'POLICY_DENIED', message: 'blocked' })),
+      ).toBe('policy_denied');
+      expect(
+        deriveStoppedReason(
+          makeDirectLastAction({
+            type: 'COMMAND_EXECUTION_FAILED',
+            message: 'spawn failed',
+          }),
+        ),
       ).toBe('command_execution_failed');
-      expect(isInternalFailureLastAction({ type: 'POLICY_DENIED', message: 'blocked' })).toBe(
-        false,
-      );
       expect(
-        isInternalFailureLastAction({
-          type: 'COMMAND_EXECUTION_FAILED',
-          message: 'spawn failed',
-        }),
+        isInternalFailureLastAction(
+          makeDirectLastAction({ type: 'POLICY_DENIED', message: 'blocked' }),
+        ),
+      ).toBe(false);
+      expect(
+        isInternalFailureLastAction(
+          makeDirectLastAction({
+            type: 'COMMAND_EXECUTION_FAILED',
+            message: 'spawn failed',
+          }),
+        ),
       ).toBe(true);
       expect(
-        extractInternalFailureMessage({ type: 'POLICY_DENIED', message: 'blocked' }),
+        extractInternalFailureMessage(
+          makeDirectLastAction({ type: 'POLICY_DENIED', message: 'blocked' }),
+        ),
       ).toBeUndefined();
       expect(
-        extractInternalFailureMessage({
-          type: 'COMMAND_EXECUTION_FAILED',
-          message: 'spawn failed',
-        }),
+        extractInternalFailureMessage(
+          makeDirectLastAction({
+            type: 'COMMAND_EXECUTION_FAILED',
+            message: 'spawn failed',
+          }),
+        ),
       ).toBe('spawn failed');
     });
   });

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -113,14 +113,14 @@ describe('RunbookStateSchema - step name validation', () => {
     expect(result.success).toBe(true);
   });
 
-  it('preserves aggregated marker on persisted COMPLETE lastAction', () => {
+  it('preserves aggregation origin on persisted COMPLETE lastAction', () => {
     const parsed = RunbookStateSchema.parse(
       createValidState({
-        lastAction: { type: 'COMPLETE', aggregated: true },
+        lastAction: { type: 'COMPLETE', origin: 'aggregation' },
       }),
     );
 
-    expect(parsed.lastAction).toEqual({ type: 'COMPLETE', aggregated: true });
+    expect(parsed.lastAction).toEqual({ type: 'COMPLETE', origin: 'aggregation' });
   });
 
   it('accepts named step', () => {
@@ -1279,11 +1279,12 @@ describe('RunbookStateSchema lastAction internal failures', () => {
   it('accepts POLICY_DENIED with a string message', () => {
     const state = createValidState({
       lifecycle: 'stopped',
-      lastAction: { type: 'POLICY_DENIED', message: 'blocked' },
+      lastAction: { type: 'POLICY_DENIED', origin: 'direct', message: 'blocked' },
     });
 
     expect(RunbookStateSchema.parse(state).lastAction).toEqual({
       type: 'POLICY_DENIED',
+      origin: 'direct',
       message: 'blocked',
     });
   });
@@ -1293,12 +1294,14 @@ describe('RunbookStateSchema lastAction internal failures', () => {
       lifecycle: 'stopped',
       lastAction: {
         type: 'COMMAND_EXECUTION_FAILED',
+        origin: 'direct',
         message: 'spawn failed',
       },
     });
 
     expect(RunbookStateSchema.parse(state).lastAction).toEqual({
       type: 'COMMAND_EXECUTION_FAILED',
+      origin: 'direct',
       message: 'spawn failed',
     });
   });

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -1190,6 +1190,7 @@ describe('RunbookStateSchema lastAction internal failures', () => {
       lifecycle: 'stopped',
       lastAction: {
         type: 'OUTPUT_CAPTURE_FAILED',
+        origin: 'direct',
         message: 'failed to capture output',
       },
     });
@@ -1197,6 +1198,7 @@ describe('RunbookStateSchema lastAction internal failures', () => {
     const parsed = RunbookStateSchema.parse(state);
     expect(parsed.lastAction).toEqual({
       type: 'OUTPUT_CAPTURE_FAILED',
+      origin: 'direct',
       message: 'failed to capture output',
     });
   });
@@ -1204,7 +1206,7 @@ describe('RunbookStateSchema lastAction internal failures', () => {
   it('rejects OUTPUT_CAPTURE_FAILED without a string message', () => {
     const state = createValidState({
       lifecycle: 'stopped',
-      lastAction: { type: 'OUTPUT_CAPTURE_FAILED' },
+      lastAction: { type: 'OUTPUT_CAPTURE_FAILED', origin: 'direct' },
     });
 
     expect(() => RunbookStateSchema.parse(state)).toThrow();
@@ -1215,12 +1217,14 @@ describe('RunbookStateSchema lastAction internal failures', () => {
       lifecycle: 'stopped',
       lastAction: {
         type: 'ARTIFACT_RESOLUTION_FAILED',
+        origin: 'direct',
         message: 'ARTIFACTS declaration "PlanPath" is unbound',
       },
     });
 
     expect(RunbookStateSchema.parse(state).lastAction).toEqual({
       type: 'ARTIFACT_RESOLUTION_FAILED',
+      origin: 'direct',
       message: 'ARTIFACTS declaration "PlanPath" is unbound',
     });
   });
@@ -1228,7 +1232,7 @@ describe('RunbookStateSchema lastAction internal failures', () => {
   it('rejects ARTIFACT_RESOLUTION_FAILED without a string message', () => {
     const state = createValidState({
       lifecycle: 'stopped',
-      lastAction: { type: 'ARTIFACT_RESOLUTION_FAILED' },
+      lastAction: { type: 'ARTIFACT_RESOLUTION_FAILED', origin: 'direct' },
     });
 
     expect(() => RunbookStateSchema.parse(state)).toThrow();
@@ -1239,6 +1243,7 @@ describe('RunbookStateSchema lastAction internal failures', () => {
       lifecycle: 'stopped',
       lastAction: {
         type: 'FOR_RESOLUTION_FAILED',
+        origin: 'direct',
         code: 'policy-violation',
         message: 'JsonArrayStream path escapes project root',
       },
@@ -1246,6 +1251,7 @@ describe('RunbookStateSchema lastAction internal failures', () => {
 
     expect(RunbookStateSchema.parse(state).lastAction).toEqual({
       type: 'FOR_RESOLUTION_FAILED',
+      origin: 'direct',
       code: 'policy-violation',
       message: 'JsonArrayStream path escapes project root',
     });
@@ -1256,6 +1262,7 @@ describe('RunbookStateSchema lastAction internal failures', () => {
       lifecycle: 'stopped',
       lastAction: {
         type: 'FOR_RESOLUTION_FAILED',
+        origin: 'direct',
         code: 'drift-detected',
         message: 'File drift detected',
       },
@@ -1263,6 +1270,7 @@ describe('RunbookStateSchema lastAction internal failures', () => {
 
     expect(RunbookStateSchema.parse(state).lastAction).toEqual({
       type: 'FOR_RESOLUTION_FAILED',
+      origin: 'direct',
       code: 'drift-detected',
       message: 'File drift detected',
     });
@@ -1300,6 +1308,7 @@ describe('RunbookStateSchema lastAction internal failures', () => {
       lifecycle: 'stopped',
       lastAction: {
         type: 'FOR_RESOLUTION_FAILED',
+        origin: 'direct',
         code: 'iteration-cap-exceeded',
         message: 'too many iterations',
       },
@@ -1313,6 +1322,7 @@ describe('RunbookStateSchema lastAction internal failures', () => {
       lifecycle: 'stopped',
       lastAction: {
         type: 'FOR_RESOLUTION_FAILED',
+        origin: 'direct',
         code: 'parse-failure',
       },
     });
@@ -1327,6 +1337,7 @@ describe('RunbookStateSchema lastAction RETRY_ERROR', () => {
       lifecycle: 'stopped',
       lastAction: {
         type: 'RETRY_ERROR',
+        origin: 'direct',
         code: 'RD-902',
         message: 'retry hook failed',
       },
@@ -1335,6 +1346,7 @@ describe('RunbookStateSchema lastAction RETRY_ERROR', () => {
     const parsed = RunbookStateSchema.parse(state);
     expect(parsed.lastAction).toEqual({
       type: 'RETRY_ERROR',
+      origin: 'direct',
       code: 'RD-902',
       message: 'retry hook failed',
     });
@@ -1343,7 +1355,7 @@ describe('RunbookStateSchema lastAction RETRY_ERROR', () => {
   it('rejects RETRY_ERROR without code or message', () => {
     const state = createValidState({
       lifecycle: 'stopped',
-      lastAction: { type: 'RETRY_ERROR', message: 'no code' },
+      lastAction: { type: 'RETRY_ERROR', origin: 'direct', message: 'no code' },
     });
 
     expect(() => RunbookStateSchema.parse(state)).toThrow();

--- a/packages/core/src/events/transition-observation.ts
+++ b/packages/core/src/events/transition-observation.ts
@@ -19,6 +19,7 @@ import {
   parseActionType,
   type ActionType,
 } from '../runbook/transition-kernel.js';
+import { isAggregationLastAction } from '../runbook/last-action.js';
 import type { ResolvedStep, RunbookState } from '../runbook/types.js';
 import type {
   ErrorOccurredPayload,
@@ -155,7 +156,7 @@ export function deriveTransitionObservation(
   const actionType = parseActionType(lastAction);
   const retryMax = extractRetryMax(input.snapshot);
   const retryAttempt = extractRetryDisplayCount(input.snapshot, input.updatedState.retryCount);
-  const aggregated = (lastAction as Record<string, unknown> | undefined)?.aggregated === true;
+  const aggregated = isAggregationLastAction(lastAction);
   const positions = buildTransitionPositions(input.previousState, input.updatedState, input.steps);
   const from = derivePositionAt(positions.from);
   const at = derivePositionAt(positions.to);

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -673,8 +673,8 @@ export const StepAssertionInputSchema = z
     result: z.enum(['PASS', 'FAIL']).optional().describe('Step result'),
     /** Command executed */
     command: z.string().optional().describe('Command executed'),
-    /** Whether the action came from parent aggregation */
-    aggregated: z.boolean().optional().describe('Whether the action came from parent aggregation'),
+    /** Whether the transition was produced by aggregation */
+    aggregated: z.boolean().optional().describe('Whether transition came from aggregation'),
   })
   .describe('Step transition assertion from scenario definition');
 
@@ -693,8 +693,8 @@ export const CapturedTransitionSchema = z
     result: z.enum(['PASS', 'FAIL']).optional().describe('Step result'),
     /** Command executed */
     command: z.string().optional().describe('Command executed'),
-    /** Whether the action came from parent aggregation */
-    aggregated: z.boolean().optional().describe('Whether the action came from parent aggregation'),
+    /** Whether the transition was produced by aggregation */
+    aggregated: z.boolean().optional().describe('Whether transition came from aggregation'),
   })
   .describe('Captured step transition from execution');
 

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1436,9 +1436,10 @@ function buildParentStateConfig(
             // RETRY_ERROR variant: structurally distinct LastAction type. The
             // priority-0 always entry routes to STOPPED on this discriminant
             // — no counter increments, no frontier population, no substep
-            // reset.
+            // reset. Aggregation origin mirrors the sibling RETRY emission:
+            // both sit on the parent-aggregation retry path.
             return {
-              lastAction: makeDirectLastAction({
+              lastAction: makeAggregationLastAction({
                 type: 'RETRY_ERROR' as const,
                 code: hook.code,
                 message: hook.message,
@@ -1560,9 +1561,10 @@ function buildParentStateConfig(
               // The sibling priority-0 always entry on the parent state
               // routes to STOPPED on this discriminant. Counters are not
               // incremented (retry was never actually taken); no frontier
-              // is populated; no substep reset.
+              // is populated; no substep reset. Aggregation origin mirrors
+              // the iteration RETRY emission below.
               return {
-                lastAction: makeDirectLastAction({
+                lastAction: makeAggregationLastAction({
                   type: 'RETRY_ERROR' as const,
                   code: hook.code,
                   message: hook.message,

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -147,18 +147,20 @@ const baseRunbookSetup = setup({
     /** Mark command policy denial before routing to STOPPED. */
     setPolicyDenied: assign({
       lifecycle: () => 'stopped' as const,
-      lastAction: (_, params: ActionDefs['setPolicyDenied']) => ({
-        type: 'POLICY_DENIED' as const,
-        message: params.message,
-      }),
+      lastAction: (_, params: ActionDefs['setPolicyDenied']) =>
+        makeDirectLastAction({
+          type: 'POLICY_DENIED' as const,
+          message: params.message,
+        }),
     }),
     /** Mark catastrophic command execution failure before routing to STOPPED. */
     setCommandExecutionFailed: assign({
       lifecycle: () => 'stopped' as const,
-      lastAction: (_, params: ActionDefs['setCommandExecutionFailed']) => ({
-        type: 'COMMAND_EXECUTION_FAILED' as const,
-        message: params.message,
-      }),
+      lastAction: (_, params: ActionDefs['setCommandExecutionFailed']) =>
+        makeDirectLastAction({
+          type: 'COMMAND_EXECUTION_FAILED' as const,
+          message: params.message,
+        }),
     }),
     /** Store the hydrated FOR value returned by forIterateActor. */
     storeReadyIteration: assign({

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -78,6 +78,7 @@ import type { ParentLinkage } from './types.js';
 import type { ResolveDelegationRunbook } from './delegation-inference.js';
 import type { CurrentCursorResolvedCompletion } from './completion-service.js';
 import type { TemplateHelperRegistry } from './helper-invoke.js';
+import { makeAggregationLastAction, makeDirectLastAction } from './last-action.js';
 
 export { MAX_FILE_ITERATIONS } from './for-iteration-constants.js';
 
@@ -128,18 +129,20 @@ const baseRunbookSetup = setup({
     /** Mark output capture failure before routing to STOPPED. */
     setOutputCaptureFailed: assign({
       lifecycle: () => 'stopped' as const,
-      lastAction: (_, params: ActionDefs['setOutputCaptureFailed']) => ({
-        type: 'OUTPUT_CAPTURE_FAILED' as const,
-        message: params.message,
-      }),
+      lastAction: (_, params: ActionDefs['setOutputCaptureFailed']) =>
+        makeDirectLastAction({
+          type: 'OUTPUT_CAPTURE_FAILED' as const,
+          message: params.message,
+        }),
     }),
     /** Mark ARTIFACTS resolution failure before routing to STOPPED. */
     setArtifactResolutionFailed: assign({
       lifecycle: () => 'stopped' as const,
-      lastAction: (_, params: ActionDefs['setArtifactResolutionFailed']) => ({
-        type: 'ARTIFACT_RESOLUTION_FAILED' as const,
-        message: params.message,
-      }),
+      lastAction: (_, params: ActionDefs['setArtifactResolutionFailed']) =>
+        makeDirectLastAction({
+          type: 'ARTIFACT_RESOLUTION_FAILED' as const,
+          message: params.message,
+        }),
     }),
     /** Mark command policy denial before routing to STOPPED. */
     setPolicyDenied: assign({
@@ -190,7 +193,7 @@ const baseRunbookSetup = setup({
       },
       lastAction: ({ context }, params: ActionDefs['storeExhaustedIteration']) => {
         if (params.output.kind !== 'exhausted') return context.lastAction;
-        if (context.lastAction?.type === 'RETRY' && context.lastAction.aggregated === true) {
+        if (context.lastAction?.type === 'RETRY' && context.lastAction.origin === 'aggregation') {
           return undefined;
         }
         return context.lastAction;
@@ -201,20 +204,22 @@ const baseRunbookSetup = setup({
     /** Mark FOR resolution failure before routing to STOPPED. */
     setForResolutionFailed: assign({
       lifecycle: () => 'stopped' as const,
-      lastAction: (_, params: ActionDefs['setForResolutionFailed']) => ({
-        type: 'FOR_RESOLUTION_FAILED' as const,
-        code: params.code,
-        message: params.message,
-      }),
+      lastAction: (_, params: ActionDefs['setForResolutionFailed']) =>
+        makeDirectLastAction({
+          type: 'FOR_RESOLUTION_FAILED' as const,
+          code: params.code,
+          message: params.message,
+        }),
     }),
     /** Mark delegation issuance failure before routing to STOPPED. */
     setDelegationIssuanceFailed: assign({
       lifecycle: () => 'stopped' as const,
-      lastAction: (_, params: ActionDefs['setDelegationIssuanceFailed']) => ({
-        type: 'DELEGATION_ISSUANCE_FAILED' as const,
-        reason: params.reason,
-        message: params.message,
-      }),
+      lastAction: (_, params: ActionDefs['setDelegationIssuanceFailed']) =>
+        makeDirectLastAction({
+          type: 'DELEGATION_ISSUANCE_FAILED' as const,
+          reason: params.reason,
+          message: params.message,
+        }),
     }),
     /** Store issued delegation frontier and updated substep state. */
     storeDelegateFrontier: assign({
@@ -737,7 +742,9 @@ function routeThroughParentArtifactsIfNeeded(
  * @param target - The parsed GOTO target with step, substep, and optional at
  * @returns A structured GOTO LastAction
  */
-function buildGotoLastAction(target: StepId): LastAction {
+function buildGotoLastAction(
+  target: StepId,
+): Omit<Extract<LastAction, { type: 'GOTO' }>, 'origin'> {
   return {
     type: 'GOTO' as const,
     target: target.step,
@@ -761,11 +768,13 @@ function buildGotoLastActionFromEvent(
 ): (args: { event: RunbookEvent }) => LastAction | undefined {
   return ({ event }) => {
     if (event.type !== 'GOTO') return undefined;
-    return buildGotoLastAction({
-      step: event.target.step,
-      substep: event.target.substep ?? fallbackSubstepId,
-      at: event.target.at,
-    });
+    return makeDirectLastAction(
+      buildGotoLastAction({
+        step: event.target.step,
+        substep: event.target.substep ?? fallbackSubstepId,
+        at: event.target.at,
+      }),
+    );
   };
 }
 
@@ -1233,9 +1242,9 @@ function findNextStateId(
  * the substep level). Records the parent step's transition action as lastAction and
  * initializes forStack when the target is a FOR step.
  *
- * All actions produced by parent-exit aggregation carry `aggregated: true` on their
- * `lastAction`, allowing consumers to distinguish aggregation-terminal transitions
- * from direct step transitions.
+ * All actions produced by parent-exit aggregation carry `origin: 'aggregation'`
+ * on their `lastAction`, allowing consumers to distinguish aggregation-terminal
+ * transitions from direct step transitions.
  *
  * @param parentAction - The parent step's transition action
  * @param exitTarget - The resolved XState target state ID
@@ -1278,7 +1287,7 @@ function buildParentExitAssign(
           iterationResults: EMPTY_RESULTS,
           substepCompletedCount: 0,
           deferredResults: EMPTY_RESULTS,
-          lastAction: { ...buildGotoLastAction(parentAction.target), aggregated: true },
+          lastAction: makeAggregationLastAction(buildGotoLastAction(parentAction.target)),
           substep: parentAction.target.substep ?? targetStep.substeps[0]?.id,
         });
       }
@@ -1294,35 +1303,35 @@ function buildParentExitAssign(
               deferredResults: EMPTY_RESULTS,
             }
           : {}),
-        lastAction: { ...buildGotoLastAction(parentAction.target), aggregated: true },
+        lastAction: makeAggregationLastAction(buildGotoLastAction(parentAction.target)),
       });
     }
     case 'STOP':
       return runbookSetup.assign({
         ...baseAssign,
         forStack: EMPTY_FOR_STACK,
-        lastAction: { type: 'STOP' as const, aggregated: true },
+        lastAction: makeAggregationLastAction({ type: 'STOP' as const }),
         lastMessage: parentAction.message,
       });
     case 'COMPLETE':
       return runbookSetup.assign({
         ...baseAssign,
         forStack: EMPTY_FOR_STACK,
-        lastAction: { type: 'COMPLETE' as const, aggregated: true },
+        lastAction: makeAggregationLastAction({ type: 'COMPLETE' as const }),
         lastMessage: parentAction.message,
       });
     case 'CONTINUE':
       return runbookSetup.assign({
         ...baseAssign,
         forStack: EMPTY_FOR_STACK,
-        lastAction: { type: 'CONTINUE' as const, aggregated: true },
+        lastAction: makeAggregationLastAction({ type: 'CONTINUE' as const }),
         lastMessage: undefined,
       });
     default:
       return runbookSetup.assign({
         ...baseAssign,
         forStack: EMPTY_FOR_STACK,
-        lastAction: { type: parentAction.type, aggregated: true },
+        lastAction: makeAggregationLastAction({ type: parentAction.type }),
         lastMessage: undefined,
       });
   }
@@ -1427,17 +1436,17 @@ function buildParentStateConfig(
             // — no counter increments, no frontier population, no substep
             // reset.
             return {
-              lastAction: {
+              lastAction: makeDirectLastAction({
                 type: 'RETRY_ERROR' as const,
                 code: hook.code,
                 message: hook.message,
-              },
+              }),
               substepStates: hook.substepStates,
             };
           }
           return {
-            // `aggregated: true` marks this RETRY as aggregation-driven (spec §3.5).
-            lastAction: { type: 'RETRY' as const, aggregated: true },
+            // Aggregation origin marks this RETRY as aggregation-driven (spec §3.5).
+            lastAction: makeAggregationLastAction({ type: 'RETRY' as const }),
             parentRetryCount: context.parentRetryCount + 1,
             // Counter contract on parent-aggregation retry (see docs/internal/architecture.md §Retry Counters):
             //   parentRetryCount — machine-invariant counter used by the retry-budget guards
@@ -1551,11 +1560,11 @@ function buildParentStateConfig(
               // incremented (retry was never actually taken); no frontier
               // is populated; no substep reset.
               return {
-                lastAction: {
+                lastAction: makeDirectLastAction({
                   type: 'RETRY_ERROR' as const,
                   code: hook.code,
                   message: hook.message,
-                },
+                }),
                 substepStates: hook.substepStates,
               };
             }
@@ -1570,8 +1579,8 @@ function buildParentStateConfig(
               //     above for the contract.
               retryCount: context.retryCount + 1,
               retryMax: transition.retry,
-              // `aggregated: true` marks this RETRY as aggregation-driven (spec §3.5).
-              lastAction: { type: 'RETRY' as const, aggregated: true },
+              // Aggregation origin marks this RETRY as aggregation-driven (spec §3.5).
+              lastAction: makeAggregationLastAction({ type: 'RETRY' as const }),
               substepCompletedCount: 0,
               deferredResults: EMPTY_RESULTS,
               substep: firstSubstep?.id,
@@ -1597,7 +1606,7 @@ function buildParentStateConfig(
           completedForContext: ({ context }: { context: RunbookContext }) =>
             peekForStack(context.forStack),
           forStack: EMPTY_FOR_STACK,
-          lastAction: { type: 'BREAK' as const },
+          lastAction: makeDirectLastAction({ type: 'BREAK' as const }),
           iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
             context.iterationResults ?? [],
           deferredResults: EMPTY_RESULTS,
@@ -1702,7 +1711,7 @@ function buildParentStateConfig(
             completedForContext: ({ context }: { context: RunbookContext }) =>
               peekForStack(context.forStack),
             forStack: EMPTY_FOR_STACK,
-            lastAction: { type: 'CONTINUE' as const },
+            lastAction: makeDirectLastAction({ type: 'CONTINUE' as const }),
             iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
               context.iterationResults ?? [],
             deferredResults: EMPTY_RESULTS,
@@ -1734,7 +1743,7 @@ function buildParentStateConfig(
             completedForContext: ({ context }: { context: RunbookContext }) =>
               peekForStack(context.forStack),
             forStack: EMPTY_FOR_STACK,
-            lastAction: { type: 'BREAK' as const },
+            lastAction: makeDirectLastAction({ type: 'BREAK' as const }),
             iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
               context.iterationResults ?? [],
             deferredResults: EMPTY_RESULTS,
@@ -1824,7 +1833,7 @@ function buildParentStateConfig(
           completedForContext: ({ context }: { context: RunbookContext }) =>
             peekForStack(context.forStack),
           forStack: EMPTY_FOR_STACK,
-          lastAction: { type: 'BREAK' as const },
+          lastAction: makeDirectLastAction({ type: 'BREAK' as const }),
           iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
             context.iterationResults ?? [],
           deferredResults: EMPTY_RESULTS,
@@ -1977,21 +1986,21 @@ function buildParentStateConfig(
 
     // Derive a LastAction variant + optional message from the parent's
     // configured FAIL action. Mirrors the shape used elsewhere (e.g.
-    // buildParentExitAssign) but without `aggregated: true` — the
-    // unconditional-exit branch is not aggregation.
+    // buildParentExitAssign) but with direct origin — the unconditional-exit
+    // branch is not aggregation.
     const failAction = parentStep.transitions.fail.action;
     const failLastAction: LastAction =
       failAction.type === 'GOTO'
-        ? buildGotoLastAction(failAction.target)
-        : { type: failAction.type };
+        ? makeDirectLastAction(buildGotoLastAction(failAction.target))
+        : makeDirectLastAction({ type: failAction.type });
     const failLastMessage =
       failAction.type === 'STOP' || failAction.type === 'COMPLETE' ? failAction.message : undefined;
 
     const passAction = parentStep.transitions.pass.action;
     const passLastAction: LastAction =
       passAction.type === 'GOTO'
-        ? buildGotoLastAction(passAction.target)
-        : { type: passAction.type };
+        ? makeDirectLastAction(buildGotoLastAction(passAction.target))
+        : makeDirectLastAction({ type: passAction.type });
     const passLastMessage =
       passAction.type === 'STOP' || passAction.type === 'COMPLETE' ? passAction.message : undefined;
 
@@ -2102,13 +2111,13 @@ function buildParentStateConfig(
   //     without error. Routes to firstSubstepStateId to re-enter the
   //     substep chain with fresh delegation tokens. Must precede the retry
   //     branches so a re-evaluation of the aggregation path cannot re-run
-  //     the hook that just succeeded. Guarded on the aggregated marker to
+  //     the hook that just succeeded. Guarded on aggregation origin to
   //     avoid matching non-retry RETRY actions (none exist today, but the
   //     marker narrows intent).
   if (firstSubstep !== undefined) {
     always.unshift({
       guard: ({ context }: { context: RunbookContext }) =>
-        context.lastAction?.type === 'RETRY' && context.lastAction.aggregated === true,
+        context.lastAction?.type === 'RETRY' && context.lastAction.origin === 'aggregation',
       target: firstSubstepStateId,
     });
   }
@@ -2260,7 +2269,7 @@ function buildRetryStateConfig(
         guard: ({ context }: { context: RunbookContext }) => context.retryCount < transition.retry,
         target: routeThroughParentArtifactsIfNeeded(currentStateId, steps),
         actions: runbookSetup.assign({
-          lastAction: { type: 'RETRY' as const },
+          lastAction: makeDirectLastAction({ type: 'RETRY' as const }),
           retryCount: ({ context }: { context: RunbookContext }) => context.retryCount + 1,
           retryMax: transition.retry,
         }),
@@ -2336,7 +2345,7 @@ function buildTerminalTransition(
   return {
     target,
     actions: actionRef('setLastAction', {
-      action: { type: actionType },
+      action: makeDirectLastAction({ type: actionType }),
       msg: message,
     }),
   };
@@ -2351,7 +2360,7 @@ function buildForceCompleteTransition(): {
     actions: actionRef('setLastAction', ({ event }) => {
       assertEvent(event, 'FORCE_COMPLETE');
       return {
-        action: { type: 'COMPLETE' as const },
+        action: makeDirectLastAction({ type: 'COMPLETE' as const }),
         msg: event.message,
       };
     }),
@@ -2367,7 +2376,7 @@ function buildForceStopTransition(): {
     actions: actionRef('setLastAction', ({ event }) => {
       assertEvent(event, 'FORCE_STOP');
       return {
-        action: { type: 'STOP' as const },
+        action: makeDirectLastAction({ type: 'STOP' as const }),
         msg: event.message,
       };
     }),
@@ -2397,7 +2406,7 @@ function buildLoopControlTransition(
     return {
       target: STOPPED_STATE_NAME,
       actions: actionRef('setLastAction', {
-        action: { type: actionType },
+        action: makeDirectLastAction({ type: actionType }),
       }),
     };
   }
@@ -2409,7 +2418,7 @@ function buildLoopControlTransition(
     actions: runbookSetup.assign({
       substepCompletedCount: ({ context }: { context: RunbookContext }) =>
         context.substepCompletedCount + 1,
-      lastAction: { type: actionType },
+      lastAction: makeDirectLastAction({ type: actionType }),
       lastMessage: undefined,
       completedSubstep: substepId,
       substep: undefined,
@@ -2430,7 +2439,7 @@ function buildLoopControlTransition(
  *   next sibling. The transition reports `action=DEFER`.
  * - Last substep: DEFER routes to parent, the aggregation guard fires, and
  *   `lastAction` is overwritten by the parent's resolved action (COMPLETE, STOP,
- *   CONTINUE, etc.) with `aggregated: true`. The transition reports the **parent's
+ *   CONTINUE, etc.) with `origin: 'aggregation'`. The transition reports the **parent's
  *   action**, not DEFER. This is expected — the DEFER was accumulated and resolved
  *   by aggregation.
  *
@@ -2458,7 +2467,7 @@ function buildDeferTransition(
         deferredResults: appendDeferredResult(kind),
         substepCompletedCount: ({ context }: { context: RunbookContext }) =>
           context.substepCompletedCount + 1,
-        lastAction: { type: 'DEFER' as const },
+        lastAction: makeDirectLastAction({ type: 'DEFER' as const }),
         lastMessage: undefined,
         completedSubstep: substepId,
         // Keep substep set for non-last (advance guard signal); clear for last
@@ -2505,7 +2514,7 @@ function buildContinueTransition(
         actions: runbookSetup.assign({
           substepCompletedCount: ({ context }: { context: RunbookContext }) =>
             context.substepCompletedCount + 1,
-          lastAction: { type: 'CONTINUE' as const },
+          lastAction: makeDirectLastAction({ type: 'CONTINUE' as const }),
           lastMessage: undefined,
           completedSubstep: substepId,
           substep: undefined,
@@ -2522,7 +2531,7 @@ function buildContinueTransition(
       actions: runbookSetup.assign({
         substepCompletedCount: ({ context }: { context: RunbookContext }) =>
           context.substepCompletedCount + 1,
-        lastAction: { type: 'CONTINUE' as const },
+        lastAction: makeDirectLastAction({ type: 'CONTINUE' as const }),
         lastMessage: undefined,
         // Parent OUTPUTS only read this after a parent-exit transition. A later
         // completing substep must overwrite this sibling-routing value first.
@@ -2540,7 +2549,7 @@ function buildContinueTransition(
   return {
     target,
     actions: runbookSetup.assign({
-      lastAction: { type: 'CONTINUE' as const },
+      lastAction: makeDirectLastAction({ type: 'CONTINUE' as const }),
       lastMessage: undefined,
       substep: extractSubstepFromStateId(target),
     }),
@@ -2607,7 +2616,7 @@ function buildGotoTransition(
             targetStepObj.name,
             !isImplicit || !!targetStepObj.aggregation,
           ),
-        lastAction: buildGotoLastAction(target),
+        lastAction: makeDirectLastAction(buildGotoLastAction(target)),
         parentRetryCount:
           targetStepObj.name === stepName
             ? ({ context }: { context: RunbookContext }) => context.parentRetryCount
@@ -2652,7 +2661,7 @@ function buildGotoTransition(
   return {
     target: computedTarget,
     actions: buildSimpleGotoAssign({
-      lastAction: buildGotoLastAction(target),
+      lastAction: makeDirectLastAction(buildGotoLastAction(target)),
       resolvedSubstepId,
       isGotoToSelf,
       preserveForContext: isIntraLoopGoto,
@@ -3693,7 +3702,7 @@ export function compileRunbookToMachine(
         ),
         RETRY: {
           actions: runbookSetup.assign({
-            lastAction: { type: 'RETRY' as const },
+            lastAction: makeDirectLastAction({ type: 'RETRY' as const }),
             lastMessage: undefined,
             retryCount: ({ context }) => context.retryCount + 1,
             retryMax: retryMaxFromTransitions,
@@ -3961,7 +3970,7 @@ export function compileRunbookToMachine(
       completedForContext: undefined,
       variables: {},
       enteredArtifacts: undefined,
-      lastAction: { type: 'START' },
+      lastAction: makeDirectLastAction({ type: 'START' as const }),
       lastMessage: undefined,
       forStack: [],
       iterationResults: undefined,

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1743,7 +1743,7 @@ function buildParentStateConfig(
             completedForContext: ({ context }: { context: RunbookContext }) =>
               peekForStack(context.forStack),
             forStack: EMPTY_FOR_STACK,
-            lastAction: makeDirectLastAction({ type: 'BREAK' as const }),
+            lastAction: makeAggregationLastAction({ type: 'BREAK' as const }),
             iterationResults: ({ context }: { context: RunbookContext }): ('pass' | 'fail')[] =>
               context.iterationResults ?? [],
             deferredResults: EMPTY_RESULTS,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -46,6 +46,7 @@ export {
   type RunId,
 } from './run-id.js';
 export * from './claim-id.js';
+export * from './last-action.js';
 export * from './transition-kernel.js';
 export {
   generateRunId,

--- a/packages/core/src/runbook/last-action.ts
+++ b/packages/core/src/runbook/last-action.ts
@@ -1,0 +1,104 @@
+import { TEMPLATE_VAR_PATTERN } from '@rundown-org/parser';
+import { z } from 'zod';
+import { FOR_RESOLUTION_FAILURE_CODES } from './actors/for-iterate-actor.js';
+import type { LastAction } from './types.js';
+
+const LastActionOriginSchema = z.enum(['direct', 'aggregation']);
+
+const LastActionBaseSchema = z.object({
+  origin: LastActionOriginSchema,
+});
+
+const GotoAtSchema = z
+  .union([z.number().int().positive(), z.string().regex(TEMPLATE_VAR_PATTERN)])
+  .transform((value) => value as number | `{{${string}}}`);
+
+/**
+ * Canonical Zod schema for persisted and runtime `LastAction` values.
+ *
+ * This is the single schema owner for action-origin metadata. Public execution
+ * events still project aggregation-origin actions to `aggregated: true`.
+ */
+export const LastActionSchema: z.ZodType<LastAction> = z.discriminatedUnion('type', [
+  LastActionBaseSchema.extend({ type: z.literal('START') }),
+  LastActionBaseSchema.extend({ type: z.literal('CONTINUE') }),
+  LastActionBaseSchema.extend({ type: z.literal('DEFER') }),
+  LastActionBaseSchema.extend({
+    type: z.literal('GOTO'),
+    target: z.string(),
+    substep: z.string().optional(),
+    at: GotoAtSchema.optional(),
+  }),
+  LastActionBaseSchema.extend({ type: z.literal('COMPLETE') }),
+  LastActionBaseSchema.extend({ type: z.literal('STOP') }),
+  LastActionBaseSchema.extend({ type: z.literal('RETRY') }),
+  LastActionBaseSchema.extend({ type: z.literal('NEXT') }),
+  LastActionBaseSchema.extend({ type: z.literal('BREAK') }),
+  LastActionBaseSchema.extend({
+    type: z.literal('RETRY_ERROR'),
+    code: z.string(),
+    message: z.string(),
+  }),
+  LastActionBaseSchema.extend({
+    type: z.literal('OUTPUT_CAPTURE_FAILED'),
+    message: z.string(),
+  }),
+  LastActionBaseSchema.extend({
+    type: z.literal('ARTIFACT_RESOLUTION_FAILED'),
+    message: z.string(),
+  }),
+  LastActionBaseSchema.extend({
+    type: z.literal('FOR_RESOLUTION_FAILED'),
+    code: z.enum(FOR_RESOLUTION_FAILURE_CODES),
+    message: z.string(),
+  }),
+  LastActionBaseSchema.extend({
+    type: z.literal('DELEGATION_ISSUANCE_FAILED'),
+    reason: z.enum(['delegation_resolution_failed', 'nested_delegation_forbidden']),
+    message: z.string(),
+  }),
+]);
+
+/**
+ * Build a direct-origin `LastAction`.
+ *
+ * @param action - LastAction payload without origin
+ * @returns LastAction with `origin: 'direct'`
+ */
+export function makeDirectLastAction<T extends Omit<LastAction, 'origin'>>(
+  action: T,
+): T & { readonly origin: 'direct' } {
+  return { ...action, origin: 'direct' };
+}
+
+/**
+ * Build an aggregation-origin `LastAction`.
+ *
+ * @param action - LastAction payload without origin
+ * @returns LastAction with `origin: 'aggregation'`
+ */
+export function makeAggregationLastAction<T extends Omit<LastAction, 'origin'>>(
+  action: T,
+): T & { readonly origin: 'aggregation' } {
+  return { ...action, origin: 'aggregation' };
+}
+
+/**
+ * Test whether a `LastAction` was produced by parent aggregation.
+ *
+ * @param action - LastAction to inspect
+ * @returns True when the action origin is aggregation
+ */
+export function isAggregationLastAction(action: LastAction | undefined): boolean {
+  return action?.origin === 'aggregation';
+}
+
+/**
+ * Runtime type guard for canonical `LastAction` values.
+ *
+ * @param value - Unknown value to validate
+ * @returns True when the value satisfies `LastActionSchema`
+ */
+export function isLastAction(value: unknown): value is LastAction {
+  return LastActionSchema.safeParse(value).success;
+}

--- a/packages/core/src/runbook/last-action.ts
+++ b/packages/core/src/runbook/last-action.ts
@@ -97,7 +97,9 @@ export function makeAggregationLastAction<T extends Omit<LastAction, 'origin'>>(
  * @param action - LastAction to inspect
  * @returns True when the action origin is aggregation
  */
-export function isAggregationLastAction(action: LastAction | undefined): boolean {
+export function isAggregationLastAction(
+  action: LastAction | undefined,
+): action is LastAction & { readonly origin: 'aggregation' } {
   return action?.origin === 'aggregation';
 }
 

--- a/packages/core/src/runbook/last-action.ts
+++ b/packages/core/src/runbook/last-action.ts
@@ -53,6 +53,14 @@ export const LastActionSchema: z.ZodType<LastAction> = z.discriminatedUnion('typ
     message: z.string(),
   }),
   LastActionBaseSchema.extend({
+    type: z.literal('POLICY_DENIED'),
+    message: z.string(),
+  }),
+  LastActionBaseSchema.extend({
+    type: z.literal('COMMAND_EXECUTION_FAILED'),
+    message: z.string(),
+  }),
+  LastActionBaseSchema.extend({
     type: z.literal('DELEGATION_ISSUANCE_FAILED'),
     reason: z.enum(['delegation_resolution_failed', 'nested_delegation_forbidden']),
     message: z.string(),

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -37,7 +37,7 @@ import {
 } from '../paths.js';
 
 /** Current persisted state schema version. Bump whenever RunbookState shape changes incompatibly. */
-const CURRENT_SCHEMA_VERSION = 4;
+const CURRENT_SCHEMA_VERSION = 5;
 
 function patchSnapshotSubstepStates(
   snapshot: unknown,

--- a/packages/core/src/runbook/transition-kernel.ts
+++ b/packages/core/src/runbook/transition-kernel.ts
@@ -1,6 +1,6 @@
 import { evaluateFailCondition, evaluatePassCondition } from './transition-handler.js';
 import type { InternalFailureLastAction, LastAction, Step, ResolvedStep } from './types.js';
-import { isForResolutionFailureCode } from './actors/for-iterate-actor.js';
+import { isLastAction } from './last-action.js';
 
 /**
  * Public stopped-reason codes attached to terminal `RUNBOOK_STOPPED` events.
@@ -55,10 +55,6 @@ interface SnapshotContext {
   iterationRetryCount?: number;
 }
 
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
 /**
  * Narrow an XState snapshot to its context object.
  *
@@ -76,58 +72,6 @@ function narrowSnapshotContext(snapshot: unknown): SnapshotContext | undefined {
     return snapshot.context;
   }
   return undefined;
-}
-
-function isLastAction(value: unknown): value is LastAction {
-  if (!isObjectRecord(value) || typeof value.type !== 'string') return false;
-
-  switch (value.type) {
-    case 'START':
-    case 'CONTINUE':
-    case 'DEFER':
-    case 'COMPLETE':
-    case 'STOP':
-    case 'RETRY':
-    case 'NEXT':
-    case 'BREAK':
-      return true;
-    case 'RETRY_ERROR':
-      // Machine-internal failure signal: requires code + message payload.
-      return typeof value.code === 'string' && typeof value.message === 'string';
-    case 'OUTPUT_CAPTURE_FAILED':
-      // Machine-internal failure signal from the per-step capture sibling state.
-      return typeof value.message === 'string';
-    case 'ARTIFACT_RESOLUTION_FAILED':
-      // Machine-internal failure signal from the per-entry artifact resolver.
-      return typeof value.message === 'string';
-    case 'FOR_RESOLUTION_FAILED':
-      return isForResolutionFailureCode(value.code) && typeof value.message === 'string';
-    case 'POLICY_DENIED':
-    case 'COMMAND_EXECUTION_FAILED':
-      return typeof value.message === 'string';
-    case 'DELEGATION_ISSUANCE_FAILED':
-      return (
-        (value.reason === 'delegation_resolution_failed' ||
-          value.reason === 'nested_delegation_forbidden') &&
-        typeof value.message === 'string'
-      );
-    case 'GOTO':
-      if (typeof value.target !== 'string') return false;
-      if ('substep' in value && value.substep !== undefined && typeof value.substep !== 'string') {
-        return false;
-      }
-      if (
-        'at' in value &&
-        value.at !== undefined &&
-        typeof value.at !== 'number' &&
-        typeof value.at !== 'string'
-      ) {
-        return false;
-      }
-      return true;
-    default:
-      return false;
-  }
 }
 
 /**

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -410,15 +410,14 @@ export function isIterableVarValue(value: TemplateVarValue): value is IterableVa
  */
 type LastActionBase = {
   /**
-   * Marks this transition as the terminal point of a deferred aggregation sequence.
+   * Records whether this action was produced directly or by aggregation.
    *
-   * Set to `true` when the `lastAction` was produced by parent-exit aggregation logic
-   * (e.g., FOR loop completion, non-FOR substep aggregation, or BREAK). In these cases
-   * the action type reflects the **parent's** resolved outcome (COMPLETE, STOP, CONTINUE,
-   * etc.), not the child's original action (typically DEFER). Consumers can use this flag
-   * to distinguish aggregation-terminal transitions from direct step transitions.
+   * Aggregation-origin actions are produced by parent-exit aggregation logic
+   * (e.g., FOR loop completion, non-FOR substep aggregation, or aggregation retry).
+   * Public execution events project this to the compatibility field
+   * `aggregated: true`.
    */
-  readonly aggregated?: boolean;
+  readonly origin: 'direct' | 'aggregation';
 };
 
 /**

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -20,7 +20,7 @@ import {
 import { getErrorMessage } from './errors.js';
 import { RunbookRefSchema } from './runbook/runbook-ref.js';
 import { ArtifactRecordSchema, type ArtifactRecord } from './runbook/artifact-schema.js';
-import { FOR_RESOLUTION_FAILURE_CODES } from './runbook/actors/for-iterate-actor.js';
+import { LastActionSchema } from './runbook/last-action.js';
 
 /** Zod schema that parses strings and brands them as {@link FrameKey}. */
 const FrameKeySchema = z.string().transform((v) => v as FrameKey);
@@ -172,7 +172,6 @@ import {
   TransitionsSchema,
   OutputDeclarationSchema,
   MAX_FOR_BOUND,
-  TEMPLATE_VAR_PATTERN,
 } from '@rundown-org/parser';
 export { StepIdSchema, ActionSchema, TransitionsSchema };
 
@@ -645,57 +644,7 @@ const RunbookStateObjectSchema = z
     snapshot: z.unknown().optional(),
     prompted: z.boolean().optional(),
     lastResult: z.enum(['pass', 'fail']).optional(),
-    lastAction: z
-      .discriminatedUnion('type', [
-        lastActionVariant({ type: z.literal('START') }),
-        lastActionVariant({ type: z.literal('CONTINUE') }),
-        lastActionVariant({ type: z.literal('DEFER') }),
-        lastActionVariant({
-          type: z.literal('GOTO'),
-          target: z.string(),
-          substep: z.string().optional(),
-          at: z
-            .union([z.number().int().positive(), z.string().regex(TEMPLATE_VAR_PATTERN)])
-            .optional(),
-        }),
-        lastActionVariant({ type: z.literal('COMPLETE') }),
-        lastActionVariant({ type: z.literal('STOP') }),
-        lastActionVariant({ type: z.literal('RETRY') }),
-        lastActionVariant({ type: z.literal('NEXT') }),
-        lastActionVariant({ type: z.literal('BREAK') }),
-        lastActionVariant({
-          type: z.literal('RETRY_ERROR'),
-          code: z.string(),
-          message: z.string(),
-        }),
-        lastActionVariant({
-          type: z.literal('OUTPUT_CAPTURE_FAILED'),
-          message: z.string(),
-        }),
-        lastActionVariant({
-          type: z.literal('ARTIFACT_RESOLUTION_FAILED'),
-          message: z.string(),
-        }),
-        lastActionVariant({
-          type: z.literal('FOR_RESOLUTION_FAILED'),
-          code: z.enum(FOR_RESOLUTION_FAILURE_CODES),
-          message: z.string(),
-        }),
-        lastActionVariant({
-          type: z.literal('POLICY_DENIED'),
-          message: z.string(),
-        }),
-        lastActionVariant({
-          type: z.literal('COMMAND_EXECUTION_FAILED'),
-          message: z.string(),
-        }),
-        lastActionVariant({
-          type: z.literal('DELEGATION_ISSUANCE_FAILED'),
-          reason: z.enum(['delegation_resolution_failed', 'nested_delegation_forbidden']),
-          message: z.string(),
-        }),
-      ])
-      .optional(),
+    lastAction: LastActionSchema.optional(),
     runbookSrc: z.string().optional(),
     templateVars: z.record(z.string(), TemplateVarValueSchema).optional(),
     frontmatterOutputs: z.array(OutputDeclarationSchema).optional(),

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -45,14 +45,6 @@ export const DelegationTokenHashSchema: z.ZodType<DelegationTokenHash, string> =
 // exported schemas inferred from DelegationTokenHashSchema. This is type-only.
 type _DelegationTokenHashBrandForDeclarationEmit = typeof delegationTokenHashBrand;
 
-const lastActionVariant = <Shape extends z.ZodRawShape>(
-  shape: Shape,
-): z.ZodObject<{ aggregated: z.ZodOptional<z.ZodBoolean> } & Shape> =>
-  z.object({
-    aggregated: z.boolean().optional(),
-    ...shape,
-  });
-
 /**
  * Zod schema for tool_input in Step tool calls
  */


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Persisted run state bumped to schema v5 and now records explicit action provenance (direct vs aggregation).
  * Runbook runtime now consistently distinguishes direct vs aggregated actions.

* **New Features**
  * Introduced runtime/schema support and helpers for explicit last-action provenance and validation.

* **Tests**
  * Wide-ranging test updates to assert richer last-action metadata, stricter validation, and preserved aggregation semantics.

* **Docs**
  * Added/updated schema/validation tests to ensure new last-action shapes parse and round-trip correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
