### PR TITLE
[codex] Implement completion frame model

### DIFF
--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { buildFrameKey, buildCompletionKey, type FrameKey } from '@rundown-org/core';
+import { activeFrame, buildFrameKey, buildCompletionKey, type FrameKey } from '@rundown-org/core';
 import {
   createTestWorkspace,
   createRunbook,
@@ -89,7 +89,7 @@ async function markSubstepsResolved(
   const resolvedCompletions: Record<string, ResolvedCompletion> = {};
   for (let i = 0; i < results.length; i++) {
     const substepId = String(i + 1);
-    const key = buildCompletionKey(frameKey, entry, substepId);
+    const key = buildCompletionKey(activeFrame(frameKey, entry), substepId);
     resolvedCompletions[key] = {
       agentId: 'manual',
       result: results[i],

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -9,6 +9,7 @@ import {
 } from './brand-helpers.js';
 import { mockFn } from './typed-mocks.js';
 import type {
+  Frame,
   FrameKey,
   RunbookState,
   DelegationLinkage,
@@ -55,17 +56,29 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   SessionService: jest.fn(),
   ExecutionLifecycleService: jest.fn(),
   DelegationLock: jest.fn(),
-  buildCompletionKey: mockFn<
-    (frameKey: FrameKey, entry: number, substep?: string) => string
-  >().mockImplementation(
-    (frameKey, entry, substepId) => `${String(frameKey)}|${String(entry)}|${substepId ?? ''}`,
+  exactFrame: mockFn<
+    (frameKey: FrameKey, entry: number) => { kind: 'exact'; frameKey: FrameKey; entry: number }
+  >().mockImplementation((frameKey, entry) => ({ kind: 'exact', frameKey, entry })),
+  inactiveFrame: mockFn<
+    (frameKey: FrameKey) => { kind: 'inactive'; frameKey: FrameKey }
+  >().mockImplementation((frameKey) => ({ kind: 'inactive', frameKey })),
+  buildCompletionKey: mockFn<(frame: Frame, substep?: string) => string>().mockImplementation(
+    (frame, substepId) => {
+      const entry = frame.kind === 'inactive' ? 0 : frame.entry;
+      return `${String(frame.frameKey)}|${String(entry)}|${substepId ?? ''}`;
+    },
   ),
   buildResolvedCompletion: mockFn<
     (
-      fields: Omit<ResolvedCompletion, 'completedAt'> & { completedAt?: string },
+      fields: Omit<ResolvedCompletion, 'completedAt' | 'targetFrameKey' | 'targetEntry'> & {
+        targetFrame: Frame;
+        completedAt?: string;
+      },
     ) => ResolvedCompletion
   >().mockImplementation((fields) => ({
     ...fields,
+    targetFrameKey: fields.targetFrame.frameKey,
+    targetEntry: fields.targetFrame.kind === 'inactive' ? 0 : fields.targetFrame.entry,
     completedAt: fields.completedAt ?? '2026-02-27T10:00:00.000Z',
   })),
   deriveActiveFrame: mockFn<
@@ -336,12 +349,19 @@ beforeEach(() => {
   mockCreateCliRunbookActorService.mockImplementation(() => makeActorDouble());
   // Re-establish default mock implementations
   jest
-    .mocked(core.buildCompletionKey)
-    .mockImplementation(
-      (frameKey, entry, substepId) => `${String(frameKey)}|${String(entry)}|${substepId ?? ''}`,
-    );
+    .mocked(core.exactFrame)
+    .mockImplementation((frameKey, entry) => ({ kind: 'exact', frameKey, entry }));
+  jest
+    .mocked(core.inactiveFrame)
+    .mockImplementation((frameKey) => ({ kind: 'inactive', frameKey }));
+  jest.mocked(core.buildCompletionKey).mockImplementation((frame, substepId) => {
+    const entry = frame.kind === 'inactive' ? 0 : frame.entry;
+    return `${String(frame.frameKey)}|${String(entry)}|${substepId ?? ''}`;
+  });
   jest.mocked(core.buildResolvedCompletion).mockImplementation((fields) => ({
     ...fields,
+    targetFrameKey: fields.targetFrame.frameKey,
+    targetEntry: fields.targetFrame.kind === 'inactive' ? 0 : fields.targetFrame.entry,
     completedAt: fields.completedAt ?? '2026-02-27T10:00:00.000Z',
   }));
   jest.mocked(core.deriveActiveFrame).mockImplementation((state) => ({
@@ -877,7 +897,7 @@ describe('handleParentCompletion', () => {
     expect(output.flush).toHaveBeenCalled();
   });
 
-  it('passes parentFrameKey as frameKeyOverride to drain', async () => {
+  it('passes parentFrameKey as frameOverride to drain', async () => {
     const delegation = makeDelegationLinkage({ parentFrameKey: brandFrameKeyForTest('1', 3) });
     const childState = makeState(CHILD_RUN_ID, { parentLinkage: delegation });
     const parentState = makeState(PARENT_RUN_ID, {
@@ -903,37 +923,9 @@ describe('handleParentCompletion', () => {
 
     expect(drainResolvedCompletions).toHaveBeenCalledWith(
       expect.objectContaining({
-        frameKeyOverride: '1|3',
+        frameOverride: { kind: 'exact', frameKey: '1|3', entry: delegation.parentEntry },
       }),
     );
-  });
-
-  it('does not pass frameKeyOverride when parentFrameKey is undefined', async () => {
-    const delegation = makeDelegationLinkage({ parentFrameKey: undefined });
-    const childState = makeState(CHILD_RUN_ID, { parentLinkage: delegation });
-    const parentState = makeState(PARENT_RUN_ID, {
-      substepStates: [{ id: '1', frameKey: brandFrameKeyForTest('1'), status: 'pending' }],
-    });
-
-    const states = new Map([[parentState.id, parentState]]);
-    const manager = makeManager(states);
-    const _lock = makeLock();
-    const lifecycleService = makeLifecycleService();
-    const output = makeOutput();
-
-    wireMocks(manager, lifecycleService);
-
-    jest.mocked(drainResolvedCompletions).mockResolvedValue({
-      unresolved: 0,
-      status: 'continue',
-      applied: 0,
-      state: parentState,
-    });
-
-    await handleParentCompletion(childState, 'pass', '/test', output);
-
-    const drainCall = jest.mocked(drainResolvedCompletions).mock.calls[0]?.[0];
-    expect(drainCall.frameKeyOverride).toBeUndefined();
   });
 
   it('passes child finalVars through to the core recordChildCompletion call', async () => {

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { mockErrorHelpers } from './mock-error-helpers.js';
 import { mockFn } from './typed-mocks.js';
-import type { ActionType, FrameKey, ResolvedCompletion, RunbookState } from '@rundown-org/core';
+import type {
+  ActionType,
+  Frame,
+  FrameKey,
+  ResolvedCompletion,
+  RunbookState,
+} from '@rundown-org/core';
 import type { ResolvedStep, StepId } from '@rundown-org/parser';
 
 // Mock @rundown-org/core
@@ -30,10 +36,20 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   }),
   parseStepIdFromString: mockFn<(input: string) => StepId | null>(),
   SENTINEL_ENTRY: 0,
-  buildCompletionKey: mockFn<
-    (frameKey: FrameKey, entry: number, substep?: string) => string
-  >().mockImplementation(
-    (frameKey, entry, substep) => `${String(frameKey)}:${String(entry)}:${substep ?? ''}`,
+  activeFrame: mockFn<
+    (frameKey: FrameKey, entry: number) => { kind: 'active'; frameKey: FrameKey; entry: number }
+  >().mockImplementation((frameKey, entry) => ({ kind: 'active', frameKey, entry })),
+  exactFrame: mockFn<
+    (frameKey: FrameKey, entry: number) => { kind: 'exact'; frameKey: FrameKey; entry: number }
+  >().mockImplementation((frameKey, entry) => ({ kind: 'exact', frameKey, entry })),
+  inactiveFrame: mockFn<
+    (frameKey: FrameKey) => { kind: 'inactive'; frameKey: FrameKey }
+  >().mockImplementation((frameKey) => ({ kind: 'inactive', frameKey })),
+  buildCompletionKey: mockFn<(frame: Frame, substep?: string) => string>().mockImplementation(
+    (frame, substep) => {
+      const entry = frame.kind === 'inactive' ? 0 : frame.entry;
+      return `${String(frame.frameKey)}:${String(entry)}:${substep ?? ''}`;
+    },
   ),
   buildFrameKey: mockFn<(step: string, iteration?: number) => FrameKey>().mockImplementation(
     (step, iteration) =>
@@ -202,6 +218,10 @@ function asCtx(ctx: TestCtx): TransitionContext {
   return ctx as unknown as TransitionContext;
 }
 
+function frameEntry(frame: Frame): number | undefined {
+  return frame.kind === 'inactive' ? undefined : frame.entry;
+}
+
 /**
  * Configure findStepOrThrow to return a partial step shape. The kernel only
  * inspects a handful of fields (name/kind/substeps/forClause/outputs) so
@@ -234,12 +254,10 @@ beforeEach(() => {
   // Default: parseStepIdFromString returns valid parse
   jest.mocked(core.parseStepIdFromString).mockReturnValue({ step: '1', substep: '1' });
   // Reset buildCompletionKey
-  jest
-    .mocked(core.buildCompletionKey)
-    .mockImplementation(
-      (frameKey: FrameKey, entry: number, substep?: string) =>
-        `${frameKey}:${String(entry)}:${substep ?? ''}`,
-    );
+  jest.mocked(core.buildCompletionKey).mockImplementation((frame: Frame, substep?: string) => {
+    const entry = frame.kind === 'inactive' ? 0 : frame.entry;
+    return `${String(frame.frameKey)}:${String(entry)}:${substep ?? ''}`;
+  });
   (
     core.RunbookCompletionService as unknown as jest.Mock<
       (
@@ -255,16 +273,14 @@ beforeEach(() => {
       (...args: unknown[]) => Promise<{ status: string; key: string }>
     >().mockImplementation(async (raw) => {
       const args = raw as {
-        targetFrameKey: FrameKey;
-        targetEntry: number;
+        targetFrame: Frame;
         targetSubstep: string;
       };
-      const key = core.buildCompletionKey(
-        args.targetFrameKey,
-        args.targetEntry,
+      const key = core.buildCompletionKey(args.targetFrame, args.targetSubstep);
+      const sentinelKey = core.buildCompletionKey(
+        core.inactiveFrame(args.targetFrame.frameKey),
         args.targetSubstep,
       );
-      const sentinelKey = core.buildCompletionKey(args.targetFrameKey, 0, args.targetSubstep);
       const existing =
         (await lifecycleService.getResolvedCompletion('run', key)) ??
         (await lifecycleService.getResolvedCompletion('run', sentinelKey));
@@ -384,7 +400,7 @@ describe('executeTransition with ExplicitTarget', () => {
 
     // buildCompletionKey should use '2' (from explicit target), not '1' (from activeState)
     const completionKeyCall = jest.mocked(core.buildCompletionKey).mock.calls[0];
-    expect(completionKeyCall[2]).toBe('2'); // substep argument
+    expect(completionKeyCall[1]).toBe('2'); // substep argument
   });
 
   it('falls back to activeCursorTarget when no explicit target', async () => {
@@ -395,7 +411,7 @@ describe('executeTransition with ExplicitTarget', () => {
 
     // buildCompletionKey should use activeState.substep ('1')
     const completionKeyCall = jest.mocked(core.buildCompletionKey).mock.calls[0];
-    expect(completionKeyCall[2]).toBe('1');
+    expect(completionKeyCall[1]).toBe('1');
   });
 
   it('throws when target substep does not exist in the step', async () => {
@@ -517,7 +533,9 @@ describe('executeTransition with ExplicitTarget', () => {
     // buildCompletionKey should have been called with entry=0 (sentinel)
     const completionKeyCalls = jest.mocked(core.buildCompletionKey).mock.calls;
     // The toRuntimeTarget call uses buildCompletionKey; check entry argument
-    const runtimeTargetCall = completionKeyCalls.find((c: unknown[]) => c[1] === 0);
+    const runtimeTargetCall = completionKeyCalls.find(
+      (c: unknown[]) => (c[0] as Frame).kind === 'inactive',
+    );
     expect(runtimeTargetCall).toBeDefined();
   });
 
@@ -532,7 +550,9 @@ describe('executeTransition with ExplicitTarget', () => {
 
     // buildCompletionKey should have been called with entry=2 (activeEntry)
     const completionKeyCalls = jest.mocked(core.buildCompletionKey).mock.calls;
-    const runtimeTargetCall = completionKeyCalls.find((c: unknown[]) => c[1] === 2);
+    const runtimeTargetCall = completionKeyCalls.find(
+      (c: unknown[]) => (c[0] as Frame).kind === 'active' && frameEntry(c[0] as Frame) === 2,
+    );
     expect(runtimeTargetCall).toBeDefined();
   });
 
@@ -575,7 +595,9 @@ describe('executeTransition with ExplicitTarget', () => {
     expect(core.buildFrameKey).toHaveBeenCalledWith('1', 3);
     // Entry should be activeEntry (2), not sentinel (0), since frame matches
     const completionKeyCalls = jest.mocked(core.buildCompletionKey).mock.calls;
-    const call = completionKeyCalls.find((c: unknown[]) => c[1] === 2);
+    const call = completionKeyCalls.find(
+      (c: unknown[]) => (c[0] as Frame).kind === 'active' && frameEntry(c[0] as Frame) === 2,
+    );
     expect(call).toBeDefined();
   });
 
@@ -649,13 +671,13 @@ describe('executeTransition with ExplicitTarget', () => {
     jest.mocked(core.parseStepIdFromString).mockReturnValue({ step: '1', substep: '1' });
     // Track which keys were built so we can identify the cross-check key
     const builtKeys: Array<{ frameKey: string; entry: number; substep?: string; key: string }> = [];
-    jest
-      .mocked(core.buildCompletionKey)
-      .mockImplementation((frameKey: string, entry: number, substep?: string) => {
-        const key = `${frameKey}:${String(entry)}:${substep ?? ''}`;
-        builtKeys.push({ frameKey, entry, substep, key });
-        return key;
-      });
+    jest.mocked(core.buildCompletionKey).mockImplementation((frame: Frame, substep?: string) => {
+      const entry = frame.kind === 'inactive' ? 0 : frame.entry;
+      const key = `${String(frame.frameKey)}:${String(entry)}:${substep ?? ''}`;
+      const frameKey = String(frame.frameKey);
+      builtKeys.push({ frameKey, entry, substep, key });
+      return key;
+    });
     ctx.lifecycleService.getResolvedCompletion.mockImplementation(
       async (_id: string, key: string) => {
         // Return match for the cross-check (sentinel) key, miss for the exact key
@@ -698,13 +720,13 @@ describe('executeTransition with ExplicitTarget', () => {
     ctx.steps = [forStep];
     jest.mocked(core.parseStepIdFromString).mockReturnValue({ step: '1', substep: '1' });
     const builtKeys: Array<{ frameKey: string; entry: number; substep?: string; key: string }> = [];
-    jest
-      .mocked(core.buildCompletionKey)
-      .mockImplementation((frameKey: string, entry: number, substep?: string) => {
-        const key = `${frameKey}:${String(entry)}:${substep ?? ''}`;
-        builtKeys.push({ frameKey, entry, substep, key });
-        return key;
-      });
+    jest.mocked(core.buildCompletionKey).mockImplementation((frame: Frame, substep?: string) => {
+      const entry = frame.kind === 'inactive' ? 0 : frame.entry;
+      const key = `${String(frame.frameKey)}:${String(entry)}:${substep ?? ''}`;
+      const frameKey = String(frame.frameKey);
+      builtKeys.push({ frameKey, entry, substep, key });
+      return key;
+    });
     ctx.lifecycleService.getResolvedCompletion.mockImplementation(
       async (_id: string, key: string) => {
         // Primary key (sentinel) misses; cross-check (exact entry=4) hits
@@ -722,7 +744,7 @@ describe('executeTransition with ExplicitTarget', () => {
     expect(ctx.lifecycleService.upsertResolvedCompletion).toHaveBeenCalled();
   });
 
-  it('passes frameKeyOverride to drain when explicit target provided', async () => {
+  it('passes frameOverride to drain when explicit target provided', async () => {
     const forStep = {
       name: '1',
       kind: 'for',
@@ -739,14 +761,14 @@ describe('executeTransition with ExplicitTarget', () => {
 
     expect(drainResolvedCompletions).toHaveBeenCalledWith(
       expect.objectContaining({
-        frameKeyOverride: expect.any(String),
+        frameOverride: expect.objectContaining({ frameKey: core.buildFrameKey('1', 3) }),
       }),
     );
     // The override should be the cursor's frameKey (built from step + index)
     const drainCall = jest.mocked(drainResolvedCompletions).mock.calls[0]?.[0] as {
-      frameKeyOverride?: unknown;
+      frameOverride?: Frame;
     };
-    expect(drainCall.frameKeyOverride).toBe(core.buildFrameKey('1', 3));
+    expect(drainCall.frameOverride?.frameKey).toBe(core.buildFrameKey('1', 3));
   });
 
   it('sentinel write is not suppressed when non-active frame has exact-entry completion', async () => {
@@ -810,15 +832,15 @@ describe('executeTransition with ExplicitTarget', () => {
 
     await executeTransition(asCtx(ctx), config, { stepId: '1.1', index: '3' });
 
-    // Drain should be called with frameKeyOverride so it can consume the sentinel
+    // Drain should be called with frameOverride so it can observe the targeted frame
     expect(drainResolvedCompletions).toHaveBeenCalledWith(
       expect.objectContaining({
-        frameKeyOverride: '1[3]',
+        frameOverride: expect.objectContaining({ frameKey: '1[3]' }),
       }),
     );
   });
 
-  it('does not pass frameKeyOverride when no explicit target', async () => {
+  it('does not pass frameOverride when no explicit target', async () => {
     const ctx = makeCtx({ substep: '1' });
     const config = createPassTransitionConfig();
 
@@ -826,9 +848,9 @@ describe('executeTransition with ExplicitTarget', () => {
 
     expect(drainResolvedCompletions).toHaveBeenCalled();
     const drainCall = jest.mocked(drainResolvedCompletions).mock.calls[0]?.[0] as {
-      frameKeyOverride?: unknown;
+      frameOverride?: unknown;
     };
-    expect(drainCall.frameKeyOverride).toBeUndefined();
+    expect(drainCall.frameOverride).toBeUndefined();
   });
 });
 

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -45,6 +45,9 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   inactiveFrame: mockFn<
     (frameKey: FrameKey) => { kind: 'inactive'; frameKey: FrameKey }
   >().mockImplementation((frameKey) => ({ kind: 'inactive', frameKey })),
+  completionEntryForFrame: mockFn<(frame: Frame) => number>().mockImplementation((frame) =>
+    frame.kind === 'inactive' ? 0 : frame.entry,
+  ),
   buildCompletionKey: mockFn<(frame: Frame, substep?: string) => string>().mockImplementation(
     (frame, substep) => {
       const entry = frame.kind === 'inactive' ? 0 : frame.entry;

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -706,7 +706,7 @@ describe('runExecutionLoop', () => {
         onComplete: { releaseRunbook: false },
         onStopped: { releaseRunbook: false },
       },
-      frameKeyOverride: '1|' as any,
+      frameOverride: { kind: 'inactive', frameKey: '1|' } as any,
     });
 
     expect(drained).toEqual({

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -11,8 +11,10 @@ import {
   isDelegationToken,
   truncateDelegationToken,
   Errors,
+  activeFrame,
   buildCompletionKey,
-  SENTINEL_ENTRY,
+  exactFrame,
+  inactiveFrame,
   type RunId,
   type RunbookState,
   type FrameKey,
@@ -208,8 +210,12 @@ export function registerAbortCommand(program: Command): void {
               state.activeFrameKey === frameKey
                 ? (state.activeEntry ?? 1)
                 : (state.frameEntries?.[frameKey] ?? 1);
-            const exactKey = buildCompletionKey(frameKey, entry, substepId);
-            const sentinelKey = buildCompletionKey(frameKey, SENTINEL_ENTRY, substepId);
+            const exactFrameTarget =
+              state.activeFrameKey === frameKey
+                ? activeFrame(frameKey, entry)
+                : exactFrame(frameKey, entry);
+            const exactKey = buildCompletionKey(exactFrameTarget, substepId);
+            const sentinelKey = buildCompletionKey(inactiveFrame(frameKey), substepId);
             return (
               !!(await lifecycleService.getResolvedCompletion(runbookId, exactKey)) ||
               !!(await lifecycleService.getResolvedCompletion(runbookId, sentinelKey))
@@ -345,7 +351,10 @@ export function registerAbortCommand(program: Command): void {
                   currentState: freshParent,
                   targetStep: freshParent.step,
                   targetSubstep: targetSubstepId,
-                  targetFrameKey: scanFrameKey,
+                  targetFrame:
+                    scanFrameKey === freshParent.activeFrameKey
+                      ? activeFrame(scanFrameKey, freshParent.activeEntry ?? 1)
+                      : inactiveFrame(scanFrameKey),
                   result: 'fail',
                   agentId: 'delegation',
                 });

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -13,6 +13,7 @@ import {
   Errors,
   activeFrame,
   buildCompletionKey,
+  deriveActiveFrame,
   exactFrame,
   inactiveFrame,
   type RunId,
@@ -206,14 +207,14 @@ export function registerAbortCommand(program: Command): void {
             frameKey: FrameKey,
             substepId: string,
           ): Promise<boolean> {
-            const entry =
-              state.activeFrameKey === frameKey
-                ? (state.activeEntry ?? 1)
-                : (state.frameEntries?.[frameKey] ?? 1);
-            const exactFrameTarget =
-              state.activeFrameKey === frameKey
-                ? activeFrame(frameKey, entry)
-                : exactFrame(frameKey, entry);
+            const activeFrameKey = state.activeFrameKey ?? deriveActiveFrame(state).frameKey;
+            const isActiveFrame = activeFrameKey === frameKey;
+            const entry = isActiveFrame
+              ? (state.activeEntry ?? 1)
+              : (state.frameEntries?.[frameKey] ?? 1);
+            const exactFrameTarget = isActiveFrame
+              ? activeFrame(frameKey, entry)
+              : exactFrame(frameKey, entry);
             const exactKey = buildCompletionKey(exactFrameTarget, substepId);
             const sentinelKey = buildCompletionKey(inactiveFrame(frameKey), substepId);
             return (
@@ -346,15 +347,17 @@ export function registerAbortCommand(program: Command): void {
               } else {
                 // No linked child state — fall back to the parent-substep
                 // recording helper.
+                const activeFrameKey =
+                  freshParent.activeFrameKey ?? deriveActiveFrame(freshParent).frameKey;
+                const isActiveFrame = activeFrameKey === scanFrameKey;
                 await completionService.recordManualCompletion({
                   runbookId: freshParent.id,
                   currentState: freshParent,
                   targetStep: freshParent.step,
                   targetSubstep: targetSubstepId,
-                  targetFrame:
-                    scanFrameKey === freshParent.activeFrameKey
-                      ? activeFrame(scanFrameKey, freshParent.activeEntry ?? 1)
-                      : inactiveFrame(scanFrameKey),
+                  targetFrame: isActiveFrame
+                    ? activeFrame(scanFrameKey, freshParent.activeEntry ?? 1)
+                    : inactiveFrame(scanFrameKey),
                   result: 'fail',
                   agentId: 'delegation',
                 });

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -2,9 +2,12 @@
 
 import type { Command } from 'commander';
 import {
+  activeFrame,
   buildFrameKey,
   deriveActiveFrame,
   findSubstepState,
+  inactiveFrame,
+  type Frame,
   type FrameKey,
 } from '@rundown-org/core';
 import { parseStepIdFromString, resolvedStepHasSubsteps } from '@rundown-org/parser';
@@ -129,11 +132,14 @@ function resolveCollectScope(
   state: TransitionContext['state'],
   options: CollectOptions,
   output: OutputEmitter,
-): { stepName: string; frameKey: FrameKey } | null {
+): { stepName: string; frameKey: FrameKey; frame: Frame } | null {
   if (!options.step) {
+    const active = deriveActiveFrame(state);
+    const frameKey = state.activeFrameKey ?? active.frameKey;
     return {
       stepName: state.step,
-      frameKey: state.activeFrameKey ?? deriveActiveFrame(state).frameKey,
+      frameKey,
+      frame: activeFrame(frameKey, state.activeEntry ?? 1),
     };
   }
 
@@ -169,7 +175,14 @@ function resolveCollectScope(
         : buildFrameKey(parsed.step);
   }
 
-  return { stepName: parsed.step, frameKey };
+  const active = deriveActiveFrame(state);
+  const activeFrameKey = state.activeFrameKey ?? active.frameKey;
+  const frame =
+    frameKey === activeFrameKey
+      ? activeFrame(frameKey, state.activeEntry ?? 1)
+      : inactiveFrame(frameKey);
+
+  return { stepName: parsed.step, frameKey, frame };
 }
 
 /**
@@ -243,12 +256,10 @@ async function runCollect(
   // substep results and selects the appropriate parent transition.
   //
   // When `--step` targets a non-active frame (e.g., a different FOR iteration),
-  // pass `frameKeyOverride` so the lookup scans the requested frame's resolved
+  // pass `frameOverride` so the lookup scans the requested frame's resolved
   // completions rather than the cursor's active frame.
   const emitter = createBridgedEmitter(state, output);
   const activeFrameKey: FrameKey = state.activeFrameKey ?? deriveActiveFrame(state).frameKey;
-  const frameKeyOverride: FrameKey | undefined =
-    scope.frameKey === activeFrameKey ? undefined : scope.frameKey;
   const drained = await drainResolvedCompletions({
     actorService,
     manager,
@@ -260,7 +271,7 @@ async function runCollect(
     currentState: state,
     transitionPolicy: transitionConfig.policy,
     computeActionResult: transitionConfig.computeActionResult,
-    ...(frameKeyOverride ? { frameKeyOverride } : {}),
+    ...(options.step ? { frameOverride: scope.frame } : {}),
   });
 
   // Mirror the post-runExecutionLoop branch: when the drain itself terminates the

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -16,6 +16,7 @@ import {
   SessionService,
   ExecutionLifecycleService,
   RunbookCompletionService,
+  exactFrame,
   type RunbookState,
   type ParentLinkageBase,
 } from '@rundown-org/core';
@@ -133,7 +134,7 @@ export async function handleParentCompletion(
     currentState: parentState,
     transitionPolicy: delegationPolicy,
     computeActionResult: transitionConfig.computeActionResult,
-    ...(parentFrameKey ? { frameKeyOverride: parentFrameKey } : {}),
+    frameOverride: exactFrame(parentFrameKey, linkage.parentEntry),
   });
 
   // 8. Check if parent reached terminal state — cascade if it also has parent linkage

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -16,13 +16,13 @@ import {
   formatTransitionAction,
   parseStepIdFromString,
   type ActionType,
-  buildCompletionKey,
   buildFrameKey,
   deriveExecutionAt,
   deriveActiveFrame,
-  SENTINEL_ENTRY,
+  activeFrame,
+  inactiveFrame,
+  type Frame,
   type RunbookActorService,
-  type FrameKey,
   type ResolvedStep,
   type RunbookState,
   type RunbookCompletedPayload,
@@ -216,9 +216,7 @@ interface RuntimeTarget {
   step: string;
   substep?: string;
   iteration?: number;
-  frameKey: FrameKey;
-  entry: number;
-  completionKey: string;
+  frame: Frame;
   at: string;
 }
 
@@ -226,29 +224,25 @@ function toRuntimeTarget(
   step: string,
   substep: string | undefined,
   iteration: number | undefined,
-  entry: number,
-  frameKey?: FrameKey,
+  frame: Frame,
 ): RuntimeTarget {
-  const resolvedFrameKey = frameKey ?? buildFrameKey(step, iteration);
   return {
     step,
     substep,
     iteration,
-    frameKey: resolvedFrameKey,
-    entry,
-    completionKey: buildCompletionKey(resolvedFrameKey, entry, substep),
+    frame,
     at: deriveExecutionAt(step, substep, iteration),
   };
 }
 
 function activeCursorTarget(state: RunbookState): RuntimeTarget {
-  const activeFrame = deriveActiveFrame(state);
+  const active = deriveActiveFrame(state);
+  const frameKey = state.activeFrameKey ?? active.frameKey;
   return toRuntimeTarget(
-    activeFrame.step,
+    active.step,
     state.substep,
-    activeFrame.iteration,
-    state.activeEntry ?? 1,
-    activeFrame.frameKey,
+    active.iteration,
+    activeFrame(frameKey, state.activeEntry ?? 1),
   );
 }
 
@@ -375,19 +369,16 @@ export async function executeTransition(
         }
       }
 
-      // Use sentinel entry (0) for non-active frames to avoid entry prediction issues
       const targetFrameKey = buildFrameKey(parsed.step, resolvedIndex);
-      const isActiveFrame =
-        targetFrameKey === (activeState.activeFrameKey ?? buildFrameKey(activeState.step));
-      const entryForCompletion = isActiveFrame ? (activeState.activeEntry ?? 1) : SENTINEL_ENTRY;
+      const active = deriveActiveFrame(activeState);
+      const activeFrameKey = activeState.activeFrameKey ?? active.frameKey;
+      const activeEntry = activeState.activeEntry ?? 1;
+      const frame =
+        targetFrameKey === activeFrameKey
+          ? activeFrame(targetFrameKey, activeEntry)
+          : inactiveFrame(targetFrameKey);
 
-      cursor = toRuntimeTarget(
-        parsed.step,
-        parsed.substep,
-        resolvedIndex,
-        entryForCompletion,
-        targetFrameKey,
-      );
+      cursor = toRuntimeTarget(parsed.step, parsed.substep, resolvedIndex, frame);
     } else {
       cursor = activeCursorTarget(activeState);
     }
@@ -402,16 +393,15 @@ export async function executeTransition(
       targetStep: cursor.step,
       targetSubstep,
       targetIteration: cursor.iteration,
-      targetFrameKey: cursor.frameKey,
-      targetEntry: cursor.entry,
+      targetFrame: cursor.frame,
       result: config.lastResult,
       agentId: 'manual',
     });
     if (recorded.status === 'duplicate') {
       output.status('completion_duplicate', `Completion already recorded for ${cursor.at}`, {
         at: cursor.at,
-        frameKey: cursor.frameKey,
-        entry: cursor.entry,
+        frameKey: cursor.frame.frameKey,
+        entry: cursor.frame.kind === 'inactive' ? 0 : cursor.frame.entry,
       });
     }
 
@@ -427,7 +417,7 @@ export async function executeTransition(
       currentState: activeState,
       transitionPolicy: config.policy,
       computeActionResult: config.computeActionResult,
-      ...(explicitTarget ? { frameKeyOverride: cursor.frameKey } : {}),
+      ...(explicitTarget ? { frameOverride: cursor.frame } : {}),
     });
     if (drained.status === 'done') {
       output.flush();

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -21,6 +21,7 @@ import {
   deriveActiveFrame,
   activeFrame,
   inactiveFrame,
+  completionEntryForFrame,
   type Frame,
   type RunbookActorService,
   type ResolvedStep,
@@ -401,7 +402,7 @@ export async function executeTransition(
       output.status('completion_duplicate', `Completion already recorded for ${cursor.at}`, {
         at: cursor.at,
         frameKey: cursor.frame.frameKey,
-        entry: cursor.frame.kind === 'inactive' ? 0 : cursor.frame.entry,
+        entry: completionEntryForFrame(cursor.frame),
       });
     }
 

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -28,7 +28,7 @@ import {
   countNumberedSteps,
   extractDisplayCommand,
   type ExecutionEventEmitter,
-  type FrameKey,
+  type Frame,
   RUNS_DIR,
   type DelegateFrontierEntry,
   partitionOutputDeclarations,
@@ -345,8 +345,8 @@ export interface DrainResolvedCompletionsArgs {
   computeActionResult?: (actionType: ActionType) => boolean;
   /** Optional command string for event context. */
   command?: string;
-  /** Override frame key for frame-scoped lookups (e.g., prompted-for with explicit --index). */
-  frameKeyOverride?: FrameKey;
+  /** Override frame for frame-scoped lookups (e.g., prompted-for with explicit --index). */
+  frameOverride?: Frame;
 }
 
 /** Result of draining resolved substep completions. */
@@ -400,7 +400,7 @@ export type DrainResolvedCompletionsResult =
  * @param args.transitionPolicy - Policy governing transition orchestration
  * @param args.computeActionResult - Optional function to compute action result for transitions
  * @param args.command - Optional command string for event context
- * @param args.frameKeyOverride - Optional frame key override for frame-scoped lookups (e.g., prompted-for with explicit --index)
+ * @param args.frameOverride - Optional frame override for frame-scoped lookups (e.g., prompted-for with explicit --index)
  * @returns Drain result indicating continue/done/stopped with counts of applied and unresolved completions
  * @throws {Error} If the core completion service, session update, or transition event handling fails
  */
@@ -416,7 +416,7 @@ export async function drainResolvedCompletions({
   transitionPolicy,
   computeActionResult,
   command,
-  frameKeyOverride,
+  frameOverride,
 }: DrainResolvedCompletionsArgs): Promise<DrainResolvedCompletionsResult> {
   const completionService = new RunbookCompletionService(manager, lifecycleService, actorService);
   let drainState = currentState;
@@ -429,7 +429,7 @@ export async function drainResolvedCompletions({
       steps,
       currentState: drainState,
       maxApplied: 1,
-      ...(frameKeyOverride ? { frameKeyOverride } : {}),
+      ...(frameOverride ? { frameOverride } : {}),
     });
 
     if (drained.status === 'failed') {

--- a/packages/core/__tests__/events/transition-observation.test.ts
+++ b/packages/core/__tests__/events/transition-observation.test.ts
@@ -332,6 +332,39 @@ describe('deriveTransitionObservation', () => {
       },
     ]);
   });
+
+  it('sets aggregated: true in STEP_TRANSITIONED payload for STOP origin aggregation', () => {
+    const previousState = state({ step: '1' });
+    const updatedState = state({ step: '1', lifecycle: 'stopped' });
+
+    const observation = deriveTransitionObservation({
+      steps,
+      currentStep,
+      previousState,
+      updatedState,
+      snapshot: {
+        status: 'done',
+        value: 'STOPPED',
+        context: {
+          lifecycle: 'stopped',
+          lastAction: { type: 'STOP', origin: 'aggregation' },
+        },
+      },
+      result: 'pass',
+      computeActionResult: (action) => action !== 'STOP',
+    });
+
+    expect(observation.events[0]).toEqual({
+      type: 'STEP_TRANSITIONED',
+      payload: {
+        action: 'STOP',
+        from: '1',
+        at: '1',
+        result: 'FAIL',
+        aggregated: true,
+      },
+    });
+  });
 });
 
 describe('deriveGotoActionBlock', () => {

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -747,8 +747,8 @@ echo ok
       expect(sync?.state.lifecycle).toBe('stopped');
       expect(sync?.state.lastAction).toEqual({
         type: 'COMMAND_EXECUTION_FAILED',
-        origin: 'direct',
         message: 'spawn subsystem unavailable',
+        origin: 'direct',
       });
       expect(sync?.state.lastResult).toBeUndefined();
     });

--- a/packages/core/__tests__/runbook/compiler-command-exec.test.ts
+++ b/packages/core/__tests__/runbook/compiler-command-exec.test.ts
@@ -138,8 +138,8 @@ describe('compiled machine command execution', () => {
     expect(snapshot.context.lifecycle).toBe('stopped');
     expect(snapshot.context.lastAction).toEqual({
       type: 'POLICY_DENIED',
-      origin: 'direct',
       message: 'blocked by test policy',
+      origin: 'direct',
     });
   });
 
@@ -180,8 +180,8 @@ describe('compiled machine command execution', () => {
     expect(snapshot.context.lifecycle).toBe('stopped');
     expect(snapshot.context.lastAction).toEqual({
       type: 'COMMAND_EXECUTION_FAILED',
-      origin: 'direct',
       message: 'spawn subsystem unavailable',
+      origin: 'direct',
     });
   });
 });

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -40,7 +40,7 @@ import type {
 } from '../../src/runbook/types.js';
 import { createDelegation } from '../../src/runbook/delegation-service.js';
 import type { RunbookRef } from '../../src/runbook/runbook-ref.js';
-import { buildCompletionKey, buildFrameKey } from '../../src/runbook/targeting.js';
+import { activeFrame, buildCompletionKey, buildFrameKey } from '../../src/runbook/targeting.js';
 import { brandCurrentCursorResolvedCompletionForTest } from '../../src/runbook/completion-service.js';
 import { createRunbook } from './fixtures.js';
 import {
@@ -9456,7 +9456,7 @@ echo hi
 
       actor.send({
         type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
-        completionKey: buildCompletionKey(buildFrameKey('1'), 1, '1'),
+        completionKey: buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1'),
         completion: brandCurrentCursorResolvedCompletionForTest({
           agentId: 'delegation',
           result: 'fail',

--- a/packages/core/__tests__/runbook/completion-event.test.ts
+++ b/packages/core/__tests__/runbook/completion-event.test.ts
@@ -21,7 +21,7 @@ describe('APPLY_CURRENT_RESOLVED_COMPLETION event', () => {
   ): CurrentCursorResolvedCompletion {
     // The brand is a module-private `unique symbol`, so we cast through
     // `unknown` to fabricate a fixture. In production this type is only ever
-    // produced by `validateCurrentCompletionTarget`; the cast is acceptable
+    // produced by `resolveAgainstCurrentCursor`; the cast is acceptable
     // here because the event handler under test treats the brand as a proof
     // token and does not re-validate.
     return {

--- a/packages/core/__tests__/runbook/completion-event.test.ts
+++ b/packages/core/__tests__/runbook/completion-event.test.ts
@@ -3,7 +3,7 @@ import { createActor } from 'xstate';
 import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
 import type { CurrentCursorResolvedCompletion } from '../../src/runbook/completion-service.js';
 import type { BaseStep, ResolvedStep } from '../../src/runbook/types.js';
-import { buildCompletionKey, buildFrameKey } from '../../src/runbook/targeting.js';
+import { activeFrame, buildCompletionKey, buildFrameKey } from '../../src/runbook/targeting.js';
 
 describe('APPLY_CURRENT_RESOLVED_COMPLETION event', () => {
   const DEFAULT_TRANSITIONS = {
@@ -54,7 +54,7 @@ describe('APPLY_CURRENT_RESOLVED_COMPLETION event', () => {
 
     actor.send({
       type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
-      completionKey: buildCompletionKey(buildFrameKey('1'), 1, '1'),
+      completionKey: buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1'),
       completion: currentCompletion('pass', { ChildValue: 'ready' }),
     });
 
@@ -76,7 +76,7 @@ describe('APPLY_CURRENT_RESOLVED_COMPLETION event', () => {
 
     actor.send({
       type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
-      completionKey: buildCompletionKey(buildFrameKey('1'), 1, '1'),
+      completionKey: buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1'),
       completion: currentCompletion('fail'),
     });
 
@@ -98,7 +98,7 @@ describe('APPLY_CURRENT_RESOLVED_COMPLETION event', () => {
 
     actor.send({
       type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
-      completionKey: buildCompletionKey(buildFrameKey('1'), 1, '1'),
+      completionKey: buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1'),
       completion: currentCompletion('fail', { ChildValue: 'failed-but-set' }),
     });
 

--- a/packages/core/__tests__/runbook/completion-service.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.test.ts
@@ -13,10 +13,12 @@ import {
 import { CompletionLock } from '../../src/runbook/completion-lock.js';
 import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
 import {
-  SENTINEL_ENTRY,
+  activeFrame,
   buildCompletionKey,
   buildFrameKey,
   buildResolvedCompletion,
+  exactFrame,
+  inactiveFrame,
 } from '../../src/runbook/targeting.js';
 import {
   brandEffectiveVarsForTest,
@@ -108,7 +110,7 @@ describe('RunbookCompletionService', () => {
       currentState: current,
       targetStep: '1',
       targetSubstep: '2',
-      targetFrameKey: buildFrameKey('1', 2),
+      targetFrame: inactiveFrame(buildFrameKey('1', 2)),
       targetIteration: 2,
       result: 'pass',
       agentId: 'manual',
@@ -119,14 +121,14 @@ describe('RunbookCompletionService', () => {
       currentState: current,
       targetStep: '1',
       targetSubstep: '2',
-      targetFrameKey: buildFrameKey('1', 2),
+      targetFrame: inactiveFrame(buildFrameKey('1', 2)),
       targetIteration: 2,
       result: 'fail',
       agentId: 'manual',
       completedAt: '2026-01-01T00:00:01.000Z',
     });
 
-    const key = buildCompletionKey(buildFrameKey('1', 2), SENTINEL_ENTRY, '2');
+    const key = buildCompletionKey(inactiveFrame(buildFrameKey('1', 2)), '2');
     const persisted = await lifecycleService.getResolvedCompletion(runbookId, key);
     expect(first).toEqual({ status: 'recorded', key });
     expect(second).toEqual({ status: 'duplicate', key });
@@ -135,7 +137,7 @@ describe('RunbookCompletionService', () => {
 
   it('returns target_mismatch without dispatching or consuming when completion is not for current substep', async () => {
     const current = state();
-    const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
     await manager.save({
       ...current,
       resolvedCompletions: {
@@ -144,8 +146,7 @@ describe('RunbookCompletionService', () => {
           result: 'pass',
           targetStep: '1',
           targetSubstep: '2',
-          targetFrameKey: buildFrameKey('1'),
-          targetEntry: 1,
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
           completedAt: '2026-01-01T00:00:00.000Z',
         }),
       },
@@ -165,7 +166,7 @@ describe('RunbookCompletionService', () => {
 
   it('normalizes sentinel completions before dispatching the validated event', async () => {
     const current = state();
-    const key = buildCompletionKey(buildFrameKey('1'), SENTINEL_ENTRY, '1');
+    const key = buildCompletionKey(inactiveFrame(buildFrameKey('1')), '1');
     await manager.save({
       ...current,
       resolvedCompletions: {
@@ -174,8 +175,7 @@ describe('RunbookCompletionService', () => {
           result: 'pass',
           targetStep: '1',
           targetSubstep: '1',
-          targetFrameKey: buildFrameKey('1'),
-          targetEntry: SENTINEL_ENTRY,
+          targetFrame: inactiveFrame(buildFrameKey('1')),
           completedAt: '2026-01-01T00:00:00.000Z',
         }),
       },
@@ -210,14 +210,13 @@ describe('RunbookCompletionService', () => {
 
   it('does not delete a resolved completion when actor sync fails before applying it', async () => {
     const current = state();
-    const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
     const completion = buildResolvedCompletion({
       agentId: 'manual',
       result: 'pass',
       targetStep: '1',
       targetSubstep: '1',
-      targetFrameKey: buildFrameKey('1'),
-      targetEntry: 1,
+      targetFrame: activeFrame(buildFrameKey('1'), 1),
       completedAt: '2026-01-01T00:00:00.000Z',
     });
     await manager.save({
@@ -242,7 +241,7 @@ describe('RunbookCompletionService', () => {
 
   it('consumes a resolved completion only after actor sync persists the applied transition', async () => {
     const current = state();
-    const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
     await manager.save({
       ...current,
       resolvedCompletions: {
@@ -251,8 +250,7 @@ describe('RunbookCompletionService', () => {
           result: 'pass',
           targetStep: '1',
           targetSubstep: '1',
-          targetFrameKey: buildFrameKey('1'),
-          targetEntry: 1,
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
           completedAt: '2026-01-01T00:00:00.000Z',
         }),
       },
@@ -281,22 +279,20 @@ describe('RunbookCompletionService', () => {
     await manager.save({
       ...current,
       resolvedCompletions: {
-        [buildCompletionKey(activeFrameKey, 1, '1')]: buildResolvedCompletion({
+        [buildCompletionKey(activeFrame(activeFrameKey, 1), '1')]: buildResolvedCompletion({
           agentId: 'manual',
           result: 'pass',
           targetStep: '1',
           targetSubstep: '1',
-          targetFrameKey: activeFrameKey,
-          targetEntry: 1,
+          targetFrame: activeFrame(activeFrameKey, 1),
           completedAt: '2026-01-01T00:00:00.000Z',
         }),
-        [buildCompletionKey(activeFrameKey, 1, '2')]: buildResolvedCompletion({
+        [buildCompletionKey(activeFrame(activeFrameKey, 1), '2')]: buildResolvedCompletion({
           agentId: 'manual',
           result: 'pass',
           targetStep: '1',
           targetSubstep: '2',
-          targetFrameKey: activeFrameKey,
-          targetEntry: 1,
+          targetFrame: activeFrame(activeFrameKey, 1),
           completedAt: '2026-01-01T00:00:01.000Z',
         }),
       },
@@ -361,7 +357,7 @@ describe('RunbookCompletionService', () => {
 
     const result = await service.recordChildCompletion({ childState: child, result: 'pass' });
 
-    const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
     await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
       expect.objectContaining({ finalVars: { ChildValue: 'ready' }, result: 'pass' }),
     );
@@ -376,7 +372,7 @@ describe('RunbookCompletionService', () => {
   describe('drain target mismatch variants', () => {
     it('returns target_mismatch for wrong targetStep', async () => {
       const current = state();
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -386,8 +382,7 @@ describe('RunbookCompletionService', () => {
             // Wrong step
             targetStep: '99',
             targetSubstep: '1',
-            targetFrameKey: buildFrameKey('1'),
-            targetEntry: 1,
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -410,7 +405,7 @@ describe('RunbookCompletionService', () => {
 
     it('returns target_mismatch for wrong targetFrameKey', async () => {
       const current = state();
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -420,8 +415,7 @@ describe('RunbookCompletionService', () => {
             targetStep: '1',
             targetSubstep: '1',
             // Wrong frame key (different iteration)
-            targetFrameKey: buildFrameKey('1', 2),
-            targetEntry: 1,
+            targetFrame: exactFrame(buildFrameKey('1', 2), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -445,7 +439,7 @@ describe('RunbookCompletionService', () => {
     it('returns target_mismatch for wrong targetEntry (non-sentinel)', async () => {
       const current = state();
       // Key matches current substep but targetEntry is different (and not SENTINEL_ENTRY)
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -454,9 +448,7 @@ describe('RunbookCompletionService', () => {
             result: 'pass',
             targetStep: '1',
             targetSubstep: '1',
-            targetFrameKey: buildFrameKey('1'),
-            // Wrong entry (and not sentinel)
-            targetEntry: 99,
+            targetFrame: exactFrame(buildFrameKey('1'), 99),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -534,8 +526,8 @@ describe('RunbookCompletionService', () => {
           },
         ],
       });
-      const key1 = buildCompletionKey(buildFrameKey('1'), 1, '1');
-      const key2 = buildCompletionKey(buildFrameKey('1'), 1, '2');
+      const key1 = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      const key2 = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '2');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -544,8 +536,7 @@ describe('RunbookCompletionService', () => {
             result: 'pass',
             targetStep: '1',
             targetSubstep: '1',
-            targetFrameKey: buildFrameKey('1'),
-            targetEntry: 1,
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
           [key2]: buildResolvedCompletion({
@@ -553,8 +544,7 @@ describe('RunbookCompletionService', () => {
             result: 'pass',
             targetStep: '1',
             targetSubstep: '2',
-            targetFrameKey: buildFrameKey('1'),
-            targetEntry: 1,
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -593,8 +583,8 @@ describe('RunbookCompletionService', () => {
           },
         ],
       });
-      const key1 = buildCompletionKey(buildFrameKey('1'), 1, '1');
-      const key3 = buildCompletionKey(buildFrameKey('1'), 1, '3');
+      const key1 = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      const key3 = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '3');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -603,8 +593,7 @@ describe('RunbookCompletionService', () => {
             result: 'pass',
             targetStep: '1',
             targetSubstep: '1',
-            targetFrameKey: buildFrameKey('1'),
-            targetEntry: 1,
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
           [key3]: buildResolvedCompletion({
@@ -612,8 +601,7 @@ describe('RunbookCompletionService', () => {
             result: 'pass',
             targetStep: '1',
             targetSubstep: '3',
-            targetFrameKey: buildFrameKey('1'),
-            targetEntry: 1,
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -663,7 +651,7 @@ describe('RunbookCompletionService', () => {
       const current = state({
         substep: '1',
       });
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -672,8 +660,7 @@ describe('RunbookCompletionService', () => {
             result: 'pass',
             targetStep: '1',
             targetSubstep: '1',
-            targetFrameKey: buildFrameKey('1'),
-            targetEntry: 1,
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -718,7 +705,7 @@ describe('RunbookCompletionService', () => {
       const current = state({
         substep: '1',
       });
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -727,8 +714,7 @@ describe('RunbookCompletionService', () => {
             result: 'fail',
             targetStep: '1',
             targetSubstep: '1',
-            targetFrameKey: buildFrameKey('1'),
-            targetEntry: 1,
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -746,9 +732,9 @@ describe('RunbookCompletionService', () => {
       }
     });
 
-    it('frameKeyOverride that differs from active frame returns not_active without dispatching', async () => {
+    it('frameOverride that differs from active frame returns not_active without dispatching', async () => {
       const current = state();
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -757,8 +743,7 @@ describe('RunbookCompletionService', () => {
             result: 'pass',
             targetStep: '1',
             targetSubstep: '1',
-            targetFrameKey: buildFrameKey('1'),
-            targetEntry: 1,
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -770,7 +755,7 @@ describe('RunbookCompletionService', () => {
         runbookId,
         steps,
         currentState: current,
-        frameKeyOverride: overrideKey,
+        frameOverride: inactiveFrame(overrideKey),
       });
 
       expect(result.status).toBe('not_active');
@@ -787,7 +772,7 @@ describe('RunbookCompletionService', () => {
     it('not_active unresolved count excludes substeps that already have completions in the override frame', async () => {
       const current = state();
       const overrideKey = buildFrameKey('1', 5);
-      const completedKey = buildCompletionKey(overrideKey, SENTINEL_ENTRY, '1');
+      const completedKey = buildCompletionKey(inactiveFrame(overrideKey), '1');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -796,8 +781,7 @@ describe('RunbookCompletionService', () => {
             result: 'pass',
             targetStep: '1',
             targetSubstep: '1',
-            targetFrameKey: overrideKey,
-            targetEntry: SENTINEL_ENTRY,
+            targetFrame: inactiveFrame(overrideKey),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -807,7 +791,50 @@ describe('RunbookCompletionService', () => {
         runbookId,
         steps,
         currentState: current,
-        frameKeyOverride: overrideKey,
+        frameOverride: inactiveFrame(overrideKey),
+      });
+
+      expect(result.status).toBe('not_active');
+      if (result.status === 'not_active') {
+        expect(result.unresolved).toBe(1);
+      }
+    });
+
+    it('not_active unresolved counts exact existing rows as completed during observation', async () => {
+      const requestedFrameKey = buildFrameKey('1');
+      const current = state({
+        activeFrameKey: buildFrameKey('1', 2),
+        activeEntry: 1,
+        forStack: [
+          {
+            stepId: '1',
+            iteration: 2,
+            start: 1,
+            end: 2,
+            implicit: false,
+            source: { kind: 'range' },
+          },
+        ],
+      });
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [buildCompletionKey(exactFrame(requestedFrameKey, 4), '1')]: buildResolvedCompletion({
+            agentId: 'delegation',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrame: exactFrame(requestedFrameKey, 4),
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+
+      const result = await service.drainResolvedCompletions({
+        runbookId,
+        steps,
+        currentState: current,
+        frameOverride: inactiveFrame(requestedFrameKey),
       });
 
       expect(result.status).toBe('not_active');
@@ -818,35 +845,135 @@ describe('RunbookCompletionService', () => {
   });
 
   describe('manual recording', () => {
-    it('serializes duplicate detection and resolved completion writes behind the completion lock', async () => {
-      const current = state();
+    it('recordManualCompletion writes the resolved row and mirrored substep state', async () => {
+      const current = state({
+        substepStates: [{ id: '1', frameKey: buildFrameKey('1'), status: 'running' }],
+      });
       await manager.save(current);
 
-      const first = service.recordManualCompletion({
+      const result = await service.recordManualCompletion({
         runbookId,
         currentState: current,
         targetStep: '1',
         targetSubstep: '1',
-        targetFrameKey: buildFrameKey('1'),
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
+        result: 'pass',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:00.000Z',
+      });
+
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      expect(result).toEqual({ status: 'recorded', key });
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
+        expect.objectContaining({ result: 'pass', targetEntry: 1 }),
+      );
+      await expect(manager.load(runbookId)).resolves.toEqual(
+        expect.objectContaining({
+          substepStates: [expect.objectContaining({ id: '1', status: 'done', result: 'pass' })],
+        }),
+      );
+    });
+
+    it('duplicate manual completion returns before changing substep state', async () => {
+      const current = state({
+        substepStates: [{ id: '1', frameKey: buildFrameKey('1'), status: 'done', result: 'pass' }],
+      });
+      await manager.save(current);
+
+      const firstKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      await lifecycleService.upsertResolvedCompletion(
+        runbookId,
+        firstKey,
+        buildResolvedCompletion({
+          agentId: 'manual',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      );
+
+      const result = await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
+        result: 'fail',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:01.000Z',
+      });
+
+      expect(result).toEqual({ status: 'duplicate', key: firstKey });
+      await expect(manager.load(runbookId)).resolves.toEqual(
+        expect.objectContaining({
+          substepStates: [expect.objectContaining({ id: '1', status: 'done', result: 'pass' })],
+        }),
+      );
+    });
+
+    it('inactive manual completion detects an existing exact row for the same frame and substep', async () => {
+      const current = state({ activeFrameKey: buildFrameKey('1', 2) });
+      await manager.save(current);
+
+      const exactKey = buildCompletionKey(exactFrame(buildFrameKey('1'), 4), '1');
+      await lifecycleService.upsertResolvedCompletion(
+        runbookId,
+        exactKey,
+        buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(buildFrameKey('1'), 4),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      );
+
+      const result = await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrame: inactiveFrame(buildFrameKey('1')),
+        result: 'fail',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:01.000Z',
+      });
+
+      expect(result).toEqual({ status: 'duplicate', key: exactKey });
+    });
+
+    it('returns duplicate for an existing active completion', async () => {
+      const current = state();
+      await manager.save(current);
+
+      const first = await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
         result: 'pass',
         agentId: 'manual-a',
         completedAt: '2026-01-01T00:00:00.000Z',
       });
-      const second = service.recordManualCompletion({
+      const second = await service.recordManualCompletion({
         runbookId,
         currentState: current,
         targetStep: '1',
         targetSubstep: '1',
-        targetFrameKey: buildFrameKey('1'),
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
         result: 'fail',
         agentId: 'manual-b',
         completedAt: '2026-01-01T00:00:01.000Z',
       });
 
-      const results = await Promise.all([first, second]);
+      const results = [first, second];
       expect(results.map((recorded) => recorded.status).sort()).toEqual(['duplicate', 'recorded']);
 
-      const exactKey = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const exactKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       const persisted = await lifecycleService.getResolvedCompletion(runbookId, exactKey);
       const recorded = results.find((result) => result.status === 'recorded');
       expect(recorded).toEqual({ status: 'recorded', key: exactKey });
@@ -873,15 +1000,15 @@ describe('RunbookCompletionService', () => {
         currentState: current,
         targetStep: '1',
         targetSubstep: '1',
-        targetFrameKey: buildFrameKey('1'),
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
         result: 'pass',
         agentId: 'manual',
         completedAt: '2026-01-01T00:00:00.000Z',
       });
 
       // Active frame → exact key (entry=1), NOT sentinel
-      const exactKey = buildCompletionKey(buildFrameKey('1'), 1, '1');
-      const sentinelKey = buildCompletionKey(buildFrameKey('1'), SENTINEL_ENTRY, '1');
+      const exactKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      const sentinelKey = buildCompletionKey(inactiveFrame(buildFrameKey('1')), '1');
       expect(result).toEqual({ status: 'recorded', key: exactKey });
       await expect(lifecycleService.getResolvedCompletion(runbookId, exactKey)).resolves.toEqual(
         expect.objectContaining({ result: 'pass', targetEntry: 1 }),
@@ -902,12 +1029,12 @@ describe('RunbookCompletionService', () => {
         currentState: current,
         targetStep: '1',
         targetSubstep: '1',
-        targetFrameKey: buildFrameKey('1'),
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
         result: 'pass',
         agentId: 'manual',
         completedAt: '2026-01-01T00:00:00.000Z',
       });
-      const exactKey = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const exactKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       expect(first).toEqual({ status: 'recorded', key: exactKey });
 
       // Second write: same substep but pretend target frame is non-active so
@@ -924,8 +1051,7 @@ describe('RunbookCompletionService', () => {
         targetStep: '1',
         targetSubstep: '1',
         // Target frame is not the active frame ('2|'), so sentinel would be chosen.
-        targetFrameKey: buildFrameKey('1'),
-        targetEntry: 1,
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
         result: 'fail',
         agentId: 'manual',
         completedAt: '2026-01-01T00:00:01.000Z',
@@ -942,7 +1068,7 @@ describe('RunbookCompletionService', () => {
       const current = state();
       await manager.save(current);
 
-      const exactKey = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const exactKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await lifecycleService.upsertResolvedCompletion(
         runbookId,
         exactKey,
@@ -951,8 +1077,7 @@ describe('RunbookCompletionService', () => {
           result: 'pass',
           targetStep: '1',
           targetSubstep: '1',
-          targetFrameKey: buildFrameKey('1'),
-          targetEntry: 1,
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
           completedAt: '2026-01-01T00:00:00.000Z',
         }),
       );
@@ -968,14 +1093,13 @@ describe('RunbookCompletionService', () => {
         currentState: otherCurrent,
         targetStep: '1',
         targetSubstep: '1',
-        targetFrameKey: buildFrameKey('1'),
-        targetEntry: SENTINEL_ENTRY,
+        targetFrame: inactiveFrame(buildFrameKey('1')),
         result: 'fail',
         agentId: 'manual',
         completedAt: '2026-01-01T00:00:01.000Z',
       });
 
-      const sentinelKey = buildCompletionKey(buildFrameKey('1'), SENTINEL_ENTRY, '1');
+      const sentinelKey = buildCompletionKey(inactiveFrame(buildFrameKey('1')), '1');
       expect(second).toEqual({ status: 'duplicate', key: exactKey });
       await expect(lifecycleService.getResolvedCompletion(runbookId, exactKey)).resolves.toEqual(
         expect.objectContaining({
@@ -1004,13 +1128,12 @@ describe('RunbookCompletionService', () => {
         currentState: otherCurrent,
         targetStep: '1',
         targetSubstep: '1',
-        targetFrameKey: buildFrameKey('1'),
-        targetEntry: 1,
+        targetFrame: inactiveFrame(buildFrameKey('1')),
         result: 'pass',
         agentId: 'manual',
         completedAt: '2026-01-01T00:00:00.000Z',
       });
-      const sentinelKey = buildCompletionKey(buildFrameKey('1'), SENTINEL_ENTRY, '1');
+      const sentinelKey = buildCompletionKey(inactiveFrame(buildFrameKey('1')), '1');
       expect(first).toEqual({ status: 'recorded', key: sentinelKey });
 
       // Second: now write with target frame = active frame, so the exact key
@@ -1020,7 +1143,7 @@ describe('RunbookCompletionService', () => {
         currentState: current,
         targetStep: '1',
         targetSubstep: '1',
-        targetFrameKey: buildFrameKey('1'),
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
         result: 'fail',
         agentId: 'manual',
         completedAt: '2026-01-01T00:00:01.000Z',
@@ -1043,7 +1166,7 @@ describe('RunbookCompletionService', () => {
         currentState: current,
         targetStep: '1',
         targetSubstep: '1',
-        targetFrameKey: buildFrameKey('1'),
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
         result: 'pass',
         agentId: 'manual',
         completedAt: '2026-01-01T00:00:00.000Z',
@@ -1054,7 +1177,7 @@ describe('RunbookCompletionService', () => {
         currentState: current,
         targetStep: '1',
         targetSubstep: '1',
-        targetFrameKey: buildFrameKey('1'),
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
         result: 'fail',
         agentId: 'manual',
         completedAt: '2026-01-01T00:00:01.000Z',
@@ -1119,7 +1242,7 @@ describe('RunbookCompletionService', () => {
       const result = await service.recordChildCompletion({ childState: child, result: 'fail' });
 
       expect(result).toBe('recorded');
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
         expect.objectContaining({ result: 'fail', agentId: 'delegation' }),
       );
@@ -1157,7 +1280,7 @@ describe('RunbookCompletionService', () => {
       const result = await service.recordChildCompletion({ childState: child, result: 'pass' });
 
       expect(result).toBe('recorded');
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
         expect.objectContaining({ result: 'pass', agentId: 'inline' }),
       );
@@ -1171,13 +1294,13 @@ describe('RunbookCompletionService', () => {
       const result = await service.recordChildCompletion({ childState: child, result: 'pass' });
 
       expect(result).toBe('cancelled');
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toBeNull();
     });
 
     it('does not consume a resolved completion when sendAndSync returns null', async () => {
       const current = state();
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -1186,8 +1309,7 @@ describe('RunbookCompletionService', () => {
             result: 'pass',
             targetStep: '1',
             targetSubstep: '1',
-            targetFrameKey: buildFrameKey('1'),
-            targetEntry: 1,
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -1206,7 +1328,7 @@ describe('RunbookCompletionService', () => {
 
     it('does not consume a resolved completion when sendAndSync throws', async () => {
       const current = state();
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await manager.save({
         ...current,
         resolvedCompletions: {
@@ -1215,8 +1337,7 @@ describe('RunbookCompletionService', () => {
             result: 'pass',
             targetStep: '1',
             targetSubstep: '1',
-            targetFrameKey: buildFrameKey('1'),
-            targetEntry: 1,
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
             completedAt: '2026-01-01T00:00:00.000Z',
           }),
         },
@@ -1245,7 +1366,7 @@ describe('RunbookCompletionService', () => {
       });
 
       expect(result).toBe('recorded');
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
         expect.objectContaining({ result: 'fail', agentId: 'delegation' }),
       );
@@ -1286,7 +1407,7 @@ describe('RunbookCompletionService', () => {
       expect(first).toBe('recorded');
       expect(second).toBe('duplicate');
 
-      const key = buildCompletionKey(buildFrameKey('1'), 1, '1');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
       await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
         expect.objectContaining({ result: 'pass' }),
       );

--- a/packages/core/__tests__/runbook/delegation-propagation.test.ts
+++ b/packages/core/__tests__/runbook/delegation-propagation.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { RunbookStateSchema } from '../../src/schemas.js';
 import { RunbookStateManager } from '../../src/runbook/state.js';
 import {
+  activeFrame,
   buildCompletionKey,
   buildFrameKey,
   deriveActiveFrame,
@@ -325,7 +326,7 @@ describe('frame identity derivation for propagation', () => {
     const frameKey = buildFrameKey('1');
     expect(frameKey).toBe('1|');
 
-    const completionKey = buildCompletionKey(frameKey, 1, '2');
+    const completionKey = buildCompletionKey(activeFrame(frameKey, 1), '2');
     expect(completionKey).toBe('1||1|2');
   });
 
@@ -343,7 +344,7 @@ describe('frame identity derivation for propagation', () => {
     // When parentFrameKey is present, use it directly instead of deriving
     const frameKey = linkage.parentFrameKey;
     const entry = linkage.parentEntry;
-    const completionKey = buildCompletionKey(frameKey, entry, linkage.parentStepId);
+    const completionKey = buildCompletionKey(activeFrame(frameKey, entry), linkage.parentStepId);
 
     expect(completionKey).toBe('1||1|1');
   });

--- a/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
+++ b/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
@@ -4,7 +4,14 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { RunbookStateManager } from '../../src/runbook/state.js';
 import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
-import { buildFrameKey } from '../../src/runbook/targeting.js';
+import {
+  SENTINEL_ENTRY,
+  activeFrame,
+  buildCompletionKey,
+  buildFrameKey,
+  exactFrame,
+  inactiveFrame,
+} from '../../src/runbook/targeting.js';
 import type { Runbook, Step } from '../../src/runbook/types.js';
 import { makeBaseStep } from '../helpers/step-factories.js';
 
@@ -360,7 +367,7 @@ describe('ExecutionLifecycleService', () => {
       await service.upsertResolvedCompletion(state.id, key1, completion1);
       await service.upsertResolvedCompletion(state.id, key2, completion2);
 
-      const listed = await service.listResolvedCompletions(state.id, frameKey, entry);
+      const listed = await service.listResolvedCompletions(state.id, activeFrame(frameKey, entry));
       expect(listed).toHaveLength(2);
       expect(listed.map((l) => l.completion.agentId).sort()).toEqual(['agent-1', 'agent-2']);
     });
@@ -391,7 +398,10 @@ describe('ExecutionLifecycleService', () => {
       await service.upsertResolvedCompletion(state.id, '1||1|sub1', completion1);
       await service.upsertResolvedCompletion(state.id, '2||2|sub1', completion2);
 
-      const listed = await service.listResolvedCompletions(state.id, buildFrameKey('1'), 1);
+      const listed = await service.listResolvedCompletions(
+        state.id,
+        activeFrame(buildFrameKey('1'), 1),
+      );
       expect(listed).toHaveLength(1);
       expect(listed[0].completion.agentId).toBe('agent-1');
     });
@@ -403,15 +413,54 @@ describe('ExecutionLifecycleService', () => {
 
       const listed = await service.listResolvedCompletions(
         state.id,
-        buildFrameKey('nonexistent'),
-        1,
+        activeFrame(buildFrameKey('nonexistent'), 1),
       );
       expect(listed).toEqual([]);
     });
 
     it('returns empty array for missing runbook', async () => {
-      const listed = await service.listResolvedCompletions('nonexistent-id', buildFrameKey('1'), 1);
+      const listed = await service.listResolvedCompletions(
+        'nonexistent-id',
+        activeFrame(buildFrameKey('1'), 1),
+      );
       expect(listed).toEqual([]);
+    });
+
+    it('lists only exact-entry completions for exact frames', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      const frameKey = buildFrameKey('1', 5);
+      await service.upsertResolvedCompletion(
+        state.id,
+        buildCompletionKey(exactFrame(frameKey, 4), 'sub1'),
+        {
+          agentId: 'agent-exact',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: 'sub1',
+          targetFrameKey: frameKey,
+          targetEntry: 4,
+          completedAt: new Date().toISOString(),
+        },
+      );
+      await service.upsertResolvedCompletion(
+        state.id,
+        buildCompletionKey(inactiveFrame(frameKey), 'sub2'),
+        {
+          agentId: 'agent-sentinel',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: 'sub2',
+          targetFrameKey: frameKey,
+          targetEntry: 0,
+          completedAt: new Date().toISOString(),
+        },
+      );
+
+      const listed = await service.listResolvedCompletions(state.id, exactFrame(frameKey, 4));
+
+      expect(listed.map((row) => row.completion.agentId)).toEqual(['agent-exact']);
     });
   });
 
@@ -444,9 +493,77 @@ describe('ExecutionLifecycleService', () => {
       await service.upsertResolvedCompletion(state.id, `${frameKey}|2|sub2`, exactCompletion);
 
       // List with entry=2 should return both sentinel and exact
-      const listed = await service.listResolvedCompletions(state.id, frameKey, 2);
+      const listed = await service.listResolvedCompletions(state.id, activeFrame(frameKey, 2));
       expect(listed).toHaveLength(2);
       expect(listed.map((l) => l.completion.agentId).sort()).toEqual([
+        'agent-exact',
+        'agent-sentinel',
+      ]);
+    });
+
+    it('lists only sentinel completions for inactive frames', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+
+      const frameKey = buildFrameKey('1');
+      await service.upsertResolvedCompletion(state.id, `${frameKey}|0|sub1`, {
+        agentId: 'agent-sentinel',
+        result: 'pass',
+        targetStep: '1',
+        targetFrameKey: frameKey,
+        targetEntry: SENTINEL_ENTRY,
+        completedAt: new Date().toISOString(),
+      });
+      await service.upsertResolvedCompletion(state.id, `${frameKey}|2|sub2`, {
+        agentId: 'agent-exact',
+        result: 'pass',
+        targetStep: '1',
+        targetFrameKey: frameKey,
+        targetEntry: 2,
+        completedAt: new Date().toISOString(),
+      });
+
+      const listed = await service.listResolvedCompletions(state.id, inactiveFrame(frameKey));
+
+      expect(listed.map((row) => row.completion.targetEntry)).toEqual([SENTINEL_ENTRY]);
+    });
+
+    it('observes all persisted completions for a frame key across entries', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      const frameKey = buildFrameKey('1', 5);
+      await service.upsertResolvedCompletion(
+        state.id,
+        buildCompletionKey(exactFrame(frameKey, 4), 'sub1'),
+        {
+          agentId: 'agent-exact',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: 'sub1',
+          targetFrameKey: frameKey,
+          targetEntry: 4,
+          completedAt: new Date().toISOString(),
+        },
+      );
+      await service.upsertResolvedCompletion(
+        state.id,
+        buildCompletionKey(inactiveFrame(frameKey), 'sub2'),
+        {
+          agentId: 'agent-sentinel',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: 'sub2',
+          targetFrameKey: frameKey,
+          targetEntry: 0,
+          completedAt: new Date().toISOString(),
+        },
+      );
+
+      const observed = await service.listResolvedCompletionsForFrameObservation(state.id, frameKey);
+
+      expect(observed.map((row) => row.completion.agentId).sort()).toEqual([
         'agent-exact',
         'agent-sentinel',
       ]);

--- a/packages/core/__tests__/runbook/last-action-schema.test.ts
+++ b/packages/core/__tests__/runbook/last-action-schema.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
-import { LastActionSchema } from '../../src/runbook/last-action.js';
+import {
+  LastActionSchema,
+  clearAggregationRetryOnExhaustion,
+  isAggregationLastAction,
+} from '../../src/runbook/last-action.js';
+import type { LastAction } from '../../src/runbook/types.js';
 
 describe('LastActionSchema', () => {
   it.each([
@@ -31,11 +36,66 @@ describe('LastActionSchema', () => {
       reason: 'delegation_resolution_failed',
       message: 'missing child',
     },
+    { type: 'POLICY_DENIED', origin: 'direct', message: 'command not in allowlist' },
+    { type: 'COMMAND_EXECUTION_FAILED', origin: 'direct', message: 'spawn ENOENT' },
   ])('round-trips %#', (action) => {
     expect(LastActionSchema.parse(action)).toEqual(action);
   });
 
   it('rejects legacy aggregation markers without explicit origin', () => {
     expect(() => LastActionSchema.parse({ type: 'COMPLETE', aggregated: true })).toThrow();
+  });
+
+  it.each([
+    {
+      label: 'missing required message',
+      input: { type: 'RETRY_ERROR', origin: 'direct', code: 'RD-902' },
+    },
+    { label: 'unknown origin literal', input: { type: 'COMPLETE', origin: 'derived' } },
+    { label: 'unknown discriminant type', input: { type: 'WAT', origin: 'direct' } },
+    { label: 'missing origin', input: { type: 'COMPLETE' } },
+  ])('rejects malformed payload: $label', ({ input }) => {
+    expect(LastActionSchema.safeParse(input).success).toBe(false);
+  });
+});
+
+describe('clearAggregationRetryOnExhaustion', () => {
+  it('clears RETRY with origin aggregation', () => {
+    const action: LastAction = { type: 'RETRY', origin: 'aggregation' };
+    expect(clearAggregationRetryOnExhaustion(action)).toBeUndefined();
+  });
+
+  it('preserves RETRY with origin direct', () => {
+    const action: LastAction = { type: 'RETRY', origin: 'direct' };
+    expect(clearAggregationRetryOnExhaustion(action)).toBe(action);
+  });
+
+  it('preserves other actions with origin aggregation', () => {
+    const action: LastAction = { type: 'COMPLETE', origin: 'aggregation' };
+    expect(clearAggregationRetryOnExhaustion(action)).toBe(action);
+  });
+
+  it('preserves undefined', () => {
+    expect(clearAggregationRetryOnExhaustion(undefined)).toBeUndefined();
+  });
+});
+
+describe('isAggregationLastAction', () => {
+  it('narrows to the aggregation variant when true', () => {
+    const action: LastAction | undefined = { type: 'RETRY', origin: 'aggregation' };
+    if (isAggregationLastAction(action)) {
+      const origin: 'aggregation' = action.origin;
+      expect(origin).toBe('aggregation');
+    } else {
+      throw new Error('expected aggregation-origin action');
+    }
+  });
+
+  it('returns false for direct-origin actions', () => {
+    expect(isAggregationLastAction({ type: 'COMPLETE', origin: 'direct' })).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isAggregationLastAction(undefined)).toBe(false);
   });
 });

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -8,6 +8,7 @@ import { merge, replace } from '../../src/runbook/state-update-ops.js';
 import { statePath as _statePath } from '../../src/paths.js';
 import { SessionService } from '../../src/runbook/session-service.js';
 import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
+import { makeAggregationLastAction } from '../../src/runbook/last-action.js';
 import { buildFrameKey } from '../../src/runbook/targeting.js';
 import type { Step, Runbook, RunId } from '../../src/runbook/types.js';
 import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
@@ -185,7 +186,7 @@ describe('RunbookStateManager', () => {
     );
 
     await manager.update(state.id, {
-      lastAction: { type: 'COMPLETE', origin: 'aggregation' },
+      lastAction: makeAggregationLastAction({ type: 'COMPLETE' }),
     });
     await manager.update(state.id, { stepName: 'Renamed step' });
 

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -178,6 +178,19 @@ describe('RunbookStateManager', () => {
     expect(loaded?.variables.Foo).toEqual(artifact);
   });
 
+  it('round-trips an aggregation-origin lastAction through manager.save then manager.load', async () => {
+    const state = await manager.create(
+      { source: 'project', path: 'test.runbook.md' },
+      mockRunbook,
+      { runbookPath: 'test.runbook.md' },
+    );
+    await manager.update(state.id, {
+      lastAction: makeAggregationLastAction({ type: 'STOP' }),
+    });
+    const loaded = await manager.load(state.id);
+    expect(loaded?.lastAction).toEqual({ type: 'STOP', origin: 'aggregation' });
+  });
+
   it('preserves aggregation-origin lastAction across unrelated updates after loading from disk', async () => {
     const state = await manager.create(
       { source: 'project', path: 'test.runbook.md' },

--- a/packages/core/__tests__/runbook/targeting.test.ts
+++ b/packages/core/__tests__/runbook/targeting.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, it } from '@jest/globals';
 import {
   SENTINEL_ENTRY,
+  activeFrame,
   buildCompletionKey,
   buildFrameKey,
   buildResolvedCompletion,
   buildStepPosition,
   buildTargetKey,
+  completionEntryForFrame,
   deriveActiveFrame,
   deriveExecutionAt,
   derivePositionAt,
+  exactFrame,
   findSubstepState,
+  frameHasExactEntry,
   getActiveForContext,
+  inactiveFrame,
   parseCompletionKey,
   upsertSubstepState,
 } from '../../src/runbook/targeting.js';
@@ -59,13 +64,57 @@ describe('targeting helpers', () => {
     });
   });
 
-  describe('buildCompletionKey', () => {
-    it('builds completion key with substep', () => {
-      expect(buildCompletionKey(buildFrameKey('1', 2), 3, '1')).toBe('1|2|3|1');
+  describe('Frame', () => {
+    it('constructs an active frame with an entry', () => {
+      const frameKey = buildFrameKey('1', 2);
+      expect(activeFrame(frameKey, 7)).toEqual({
+        kind: 'active',
+        frameKey,
+        entry: 7,
+      });
     });
 
-    it('builds completion key without substep', () => {
-      expect(buildCompletionKey(buildFrameKey('1', 2), 3)).toBe('1|2|3|');
+    it('constructs an exact frame with an entry', () => {
+      const frameKey = buildFrameKey('1', 2);
+      expect(exactFrame(frameKey, 7)).toEqual({
+        kind: 'exact',
+        frameKey,
+        entry: 7,
+      });
+    });
+
+    it('constructs an inactive frame without an entry', () => {
+      const frameKey = buildFrameKey('1', 2);
+      expect(inactiveFrame(frameKey)).toEqual({
+        kind: 'inactive',
+        frameKey,
+      });
+    });
+
+    it('derives exact entries for active/exact frames and sentinel entry for inactive frames', () => {
+      expect(completionEntryForFrame(activeFrame(buildFrameKey('1'), 3))).toBe(3);
+      expect(completionEntryForFrame(exactFrame(buildFrameKey('1'), 4))).toBe(4);
+      expect(completionEntryForFrame(inactiveFrame(buildFrameKey('1', 5)))).toBe(SENTINEL_ENTRY);
+    });
+
+    it('narrows frames that carry exact entries', () => {
+      expect(frameHasExactEntry(activeFrame(buildFrameKey('1'), 3))).toBe(true);
+      expect(frameHasExactEntry(exactFrame(buildFrameKey('1'), 4))).toBe(true);
+      expect(frameHasExactEntry(inactiveFrame(buildFrameKey('1')))).toBe(false);
+    });
+  });
+
+  describe('buildCompletionKey', () => {
+    it('builds active-frame completion key with substep', () => {
+      expect(buildCompletionKey(activeFrame(buildFrameKey('1', 2), 3), '1')).toBe('1|2|3|1');
+    });
+
+    it('builds exact-frame completion key with substep', () => {
+      expect(buildCompletionKey(exactFrame(buildFrameKey('1', 2), 4), '1')).toBe('1|2|4|1');
+    });
+
+    it('builds inactive-frame completion key with sentinel entry', () => {
+      expect(buildCompletionKey(inactiveFrame(buildFrameKey('1', 2)), '1')).toBe('1|2|0|1');
     });
   });
 
@@ -131,11 +180,12 @@ describe('targeting helpers', () => {
         targetStep: '2',
         targetSubstep: '1',
         targetIteration: 3,
-        targetFrameKey: buildFrameKey('2', 3),
-        targetEntry: 1,
+        targetFrame: exactFrame(buildFrameKey('2', 3), 1),
         finalVars: { childOutput: 'value' },
         completedAt: '2026-01-01T00:00:00.000Z',
       });
+      expect(completion.targetFrameKey).toBe(buildFrameKey('2', 3));
+      expect(completion.targetEntry).toBe(1);
       expect(completion).toEqual({
         agentId: 'agent-1',
         result: 'pass',
@@ -154,10 +204,11 @@ describe('targeting helpers', () => {
         agentId: 'agent-1',
         result: 'fail',
         targetStep: '1',
-        targetFrameKey: buildFrameKey('1'),
-        targetEntry: 2,
+        targetFrame: inactiveFrame(buildFrameKey('1')),
         completedAt: '2026-01-01T00:00:00.000Z',
       });
+      expect(completion.targetFrameKey).toBe(buildFrameKey('1'));
+      expect(completion.targetEntry).toBe(SENTINEL_ENTRY);
       expect(completion).not.toHaveProperty('targetSubstep');
       expect(completion).not.toHaveProperty('targetIteration');
     });
@@ -168,8 +219,7 @@ describe('targeting helpers', () => {
         agentId: 'agent-1',
         result: 'pass',
         targetStep: '1',
-        targetFrameKey: buildFrameKey('1'),
-        targetEntry: 1,
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
       });
       const after = new Date().toISOString();
       expect(completion.completedAt >= before).toBe(true);

--- a/packages/core/__tests__/runbook/targeting.test.ts
+++ b/packages/core/__tests__/runbook/targeting.test.ts
@@ -102,6 +102,21 @@ describe('targeting helpers', () => {
       expect(frameHasExactEntry(exactFrame(buildFrameKey('1'), 4))).toBe(true);
       expect(frameHasExactEntry(inactiveFrame(buildFrameKey('1')))).toBe(false);
     });
+
+    it('rejects non-positive entries in activeFrame', () => {
+      const frameKey = buildFrameKey('1');
+      expect(() => activeFrame(frameKey, 0)).toThrow(RangeError);
+      expect(() => activeFrame(frameKey, -1)).toThrow(RangeError);
+      expect(() => activeFrame(frameKey, Number.NaN)).toThrow(RangeError);
+      expect(() => activeFrame(frameKey, 1.5)).toThrow(RangeError);
+    });
+
+    it('rejects non-positive entries in exactFrame', () => {
+      const frameKey = buildFrameKey('1');
+      expect(() => exactFrame(frameKey, 0)).toThrow(RangeError);
+      expect(() => exactFrame(frameKey, -2)).toThrow(RangeError);
+      expect(() => exactFrame(frameKey, Number.NaN)).toThrow(RangeError);
+    });
   });
 
   describe('buildCompletionKey', () => {

--- a/packages/core/__tests__/runbook/transition-kernel.test.ts
+++ b/packages/core/__tests__/runbook/transition-kernel.test.ts
@@ -843,43 +843,18 @@ describe('transition-kernel', () => {
 
   describe('command terminal lastAction variants', () => {
     it('maps policy denial and command execution failure distinctly', () => {
-      expect(
-        deriveStoppedReason(makeDirectLastAction({ type: 'POLICY_DENIED', message: 'blocked' })),
-      ).toBe('policy_denied');
-      expect(
-        deriveStoppedReason(
-          makeDirectLastAction({
-            type: 'COMMAND_EXECUTION_FAILED',
-            message: 'spawn failed',
-          }),
-        ),
-      ).toBe('command_execution_failed');
-      expect(
-        isInternalFailureLastAction(
-          makeDirectLastAction({ type: 'POLICY_DENIED', message: 'blocked' }),
-        ),
-      ).toBe(false);
-      expect(
-        isInternalFailureLastAction(
-          makeDirectLastAction({
-            type: 'COMMAND_EXECUTION_FAILED',
-            message: 'spawn failed',
-          }),
-        ),
-      ).toBe(true);
-      expect(
-        extractInternalFailureMessage(
-          makeDirectLastAction({ type: 'POLICY_DENIED', message: 'blocked' }),
-        ),
-      ).toBeUndefined();
-      expect(
-        extractInternalFailureMessage(
-          makeDirectLastAction({
-            type: 'COMMAND_EXECUTION_FAILED',
-            message: 'spawn failed',
-          }),
-        ),
-      ).toBe('spawn failed');
+      const policyDenied = makeDirectLastAction({ type: 'POLICY_DENIED', message: 'blocked' });
+      const commandFailed = makeDirectLastAction({
+        type: 'COMMAND_EXECUTION_FAILED',
+        message: 'spawn failed',
+      });
+
+      expect(deriveStoppedReason(policyDenied)).toBe('policy_denied');
+      expect(deriveStoppedReason(commandFailed)).toBe('command_execution_failed');
+      expect(isInternalFailureLastAction(policyDenied)).toBe(false);
+      expect(isInternalFailureLastAction(commandFailed)).toBe(true);
+      expect(extractInternalFailureMessage(policyDenied)).toBeUndefined();
+      expect(extractInternalFailureMessage(commandFailed)).toBe('spawn failed');
     });
   });
 });

--- a/packages/core/__tests__/schemas.test.ts
+++ b/packages/core/__tests__/schemas.test.ts
@@ -1294,15 +1294,15 @@ describe('RunbookStateSchema lastAction internal failures', () => {
       lifecycle: 'stopped',
       lastAction: {
         type: 'COMMAND_EXECUTION_FAILED',
-        origin: 'direct',
         message: 'spawn failed',
+        origin: 'direct',
       },
     });
 
     expect(RunbookStateSchema.parse(state).lastAction).toEqual({
       type: 'COMMAND_EXECUTION_FAILED',
-      origin: 'direct',
       message: 'spawn failed',
+      origin: 'direct',
     });
   });
 

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -78,7 +78,11 @@ import type { ParentLinkage } from './types.js';
 import type { ResolveDelegationRunbook } from './delegation-inference.js';
 import type { CurrentCursorResolvedCompletion } from './completion-service.js';
 import type { TemplateHelperRegistry } from './helper-invoke.js';
-import { makeAggregationLastAction, makeDirectLastAction } from './last-action.js';
+import {
+  clearAggregationRetryOnExhaustion,
+  makeAggregationLastAction,
+  makeDirectLastAction,
+} from './last-action.js';
 
 export { MAX_FILE_ITERATIONS } from './for-iteration-constants.js';
 
@@ -195,10 +199,7 @@ const baseRunbookSetup = setup({
       },
       lastAction: ({ context }, params: ActionDefs['storeExhaustedIteration']) => {
         if (params.output.kind !== 'exhausted') return context.lastAction;
-        if (context.lastAction?.type === 'RETRY' && context.lastAction.origin === 'aggregation') {
-          return undefined;
-        }
-        return context.lastAction;
+        return clearAggregationRetryOnExhaustion(context.lastAction);
       },
       substep: () => undefined,
       completedSubstep: () => undefined,

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -6,11 +6,15 @@ import type { RunbookActorService, ActorSyncResult } from './actor-service.js';
 import type { RunbookStateManager } from './state.js';
 import {
   SENTINEL_ENTRY,
+  activeFrame,
   buildCompletionKey,
   buildResolvedCompletion,
   deriveActiveFrame,
+  exactFrame,
   findSubstepState,
+  inactiveFrame,
   upsertSubstepState,
+  type Frame,
   type FrameKey,
 } from './targeting.js';
 import type { ResolvedCompletion, ResolvedStep, RunId, RunbookState } from './types.js';
@@ -123,8 +127,8 @@ export interface RecordManualCompletionArgs {
   readonly targetSubstep: string;
   /** Optional FOR iteration index if the target is inside a FOR-loop frame. */
   readonly targetIteration?: number;
-  /** Frame key identifying the (step, iteration) the target belongs to. */
-  readonly targetFrameKey: FrameKey;
+  /** Frame target identifying the completion scope. */
+  readonly targetFrame: Frame;
   /** Recorded result — drives the eventual PASS/FAIL raise on drain. */
   readonly result: 'pass' | 'fail';
   /** Agent identifier (`delegation`, `inline`, or a manual command id). */
@@ -133,11 +137,6 @@ export interface RecordManualCompletionArgs {
   readonly completedAt?: string;
   /** Final variables produced by a child runbook, merged into context on drain. */
   readonly finalVars?: Readonly<Record<string, string>>;
-  /**
-   * Explicit frame-entry counter — overrides the active-frame entry. Pass when
-   * the caller already resolved the entry (e.g., child propagation).
-   */
-  readonly targetEntry?: number;
 }
 
 /** Arguments for recording a completed child run against its parent. */
@@ -168,10 +167,10 @@ export interface DrainResolvedCompletionsArgs {
   /** Current persisted state to derive active frame/cursor from. */
   readonly currentState: RunbookState;
   /**
-   * Optional override frame key — when supplied and not equal to the active
+   * Optional override frame — when supplied and not equal to the active
    * frame, drain short-circuits to `not_active` without dispatching any event.
    */
-  readonly frameKeyOverride?: FrameKey;
+  readonly frameOverride?: Frame;
   /**
    * Optional upper bound on completions to apply in this drain pass.
    *
@@ -206,7 +205,7 @@ export type DrainResolvedCompletionsResult =
   | {
       /** Requested frame is not currently active; drain is observation-only. */
       readonly status: 'not_active';
-      /** Frame key that was requested via `frameKeyOverride`. */
+      /** Frame key that was requested via `frameOverride`. */
       readonly frameKey: FrameKey;
       /** Frame key the machine is actually positioned on. */
       readonly activeFrameKey: FrameKey;
@@ -255,33 +254,50 @@ export class RunbookCompletionService {
     private readonly actorService: RunbookActorService,
   ) {}
 
-  private activeFrameEntry(state: RunbookState, frameKey: FrameKey): number {
-    if (state.activeFrameKey === frameKey && state.activeEntry !== undefined) {
-      return state.activeEntry;
-    }
-    return state.frameEntries?.[frameKey] ?? 1;
-  }
-
-  private duplicateCandidateKeys(args: {
-    readonly frameKey: FrameKey;
-    readonly exactEntry: number;
-    readonly substep: string;
-  }): readonly string[] {
-    return [
-      buildCompletionKey(args.frameKey, args.exactEntry, args.substep),
-      buildCompletionKey(args.frameKey, SENTINEL_ENTRY, args.substep),
-    ];
-  }
-
   private async findExistingCompletion(
     runbookId: RunId,
-    keys: readonly string[],
+    args: { readonly frame: Frame; readonly substep: string },
   ): Promise<string | null> {
-    for (const key of keys) {
-      const existing = await this.lifecycleService.getResolvedCompletion(runbookId, key);
-      if (existing) return key;
+    if (args.frame.kind === 'active') {
+      const exactKey = buildCompletionKey(args.frame, args.substep);
+      const sentinelKey = buildCompletionKey(inactiveFrame(args.frame.frameKey), args.substep);
+      if (await this.lifecycleService.getResolvedCompletion(runbookId, exactKey)) return exactKey;
+      if (await this.lifecycleService.getResolvedCompletion(runbookId, sentinelKey))
+        return sentinelKey;
+      return null;
     }
-    return null;
+
+    if (args.frame.kind === 'exact') {
+      const exactKey = buildCompletionKey(args.frame, args.substep);
+      const sentinelKey = buildCompletionKey(inactiveFrame(args.frame.frameKey), args.substep);
+      if (await this.lifecycleService.getResolvedCompletion(runbookId, exactKey)) return exactKey;
+      if (await this.lifecycleService.getResolvedCompletion(runbookId, sentinelKey))
+        return sentinelKey;
+      return null;
+    }
+
+    const observed = await this.lifecycleService.listResolvedCompletionsForFrameObservation(
+      runbookId,
+      args.frame.frameKey,
+    );
+    return (
+      observed.find(({ completion }) => completion.targetSubstep === args.substep)?.key ?? null
+    );
+  }
+
+  private async observedSubstepsForFrame(
+    runbookId: RunId,
+    frameKey: FrameKey,
+  ): Promise<ReadonlySet<string>> {
+    const observed = await this.lifecycleService.listResolvedCompletionsForFrameObservation(
+      runbookId,
+      frameKey,
+    );
+    return new Set(
+      observed
+        .map(({ completion }) => completion.targetSubstep)
+        .filter((substep): substep is string => substep !== undefined),
+    );
   }
 
   private async countUnresolvedForState(
@@ -292,11 +308,9 @@ export class RunbookCompletionService {
     const currentStep = findStepOrThrow(steps, state.step);
     if (!resolvedStepHasSubsteps(currentStep) || !state.substep) return 0;
     const activeFrameKey = state.activeFrameKey ?? deriveActiveFrame(state).frameKey;
-    const entry = state.activeEntry ?? this.activeFrameEntry(state, activeFrameKey);
     const resolved = await this.lifecycleService.listResolvedCompletions(
       runbookId,
-      activeFrameKey,
-      entry,
+      activeFrame(activeFrameKey, state.activeEntry ?? 1),
     );
     const resolvedSubsteps = new Set(
       resolved
@@ -345,10 +359,6 @@ export class RunbookCompletionService {
   /**
    * Record a manual completion for a parent substep.
    *
-   * Acquires a per-run {@link CompletionLock} around duplicate detection and
-   * persistence so concurrent CLI processes cannot both miss the existing row
-   * and write competing exact/sentinel completions.
-   *
    * @param args - Manual completion target and result
    * @returns Whether a completion was recorded or already existed
    */
@@ -363,7 +373,7 @@ export class RunbookCompletionService {
   }
 
   /**
-   * Record a manual completion while the caller already holds the completion lock.
+   * Record a manual completion while the caller holds the completion lock.
    *
    * @param args - Manual completion target and result
    * @returns Whether a completion was recorded or already existed
@@ -371,37 +381,37 @@ export class RunbookCompletionService {
   private async recordManualCompletionUnlocked(
     args: RecordManualCompletionArgs,
   ): Promise<RecordCompletionResult> {
-    const activeFrameKey =
-      args.currentState.activeFrameKey ?? deriveActiveFrame(args.currentState).frameKey;
-    const isActiveFrame = args.targetFrameKey === activeFrameKey;
-    const explicitExactEntry =
-      args.targetEntry !== undefined && args.targetEntry !== SENTINEL_ENTRY
-        ? args.targetEntry
-        : undefined;
-    const exactEntry =
-      explicitExactEntry ?? this.activeFrameEntry(args.currentState, args.targetFrameKey);
-    const entry = isActiveFrame ? exactEntry : SENTINEL_ENTRY;
-    const keys = this.duplicateCandidateKeys({
-      frameKey: args.targetFrameKey,
-      exactEntry,
+    const existingKey = await this.findExistingCompletion(args.runbookId, {
+      frame: args.targetFrame,
       substep: args.targetSubstep,
     });
-    const existingKey = await this.findExistingCompletion(args.runbookId, keys);
     if (existingKey) return { status: 'duplicate', key: existingKey };
 
-    const key = buildCompletionKey(args.targetFrameKey, entry, args.targetSubstep);
+    const key = buildCompletionKey(args.targetFrame, args.targetSubstep);
     const completion = buildResolvedCompletion({
       agentId: args.agentId,
       result: args.result,
       targetStep: args.targetStep,
       targetSubstep: args.targetSubstep,
       targetIteration: args.targetIteration,
-      targetFrameKey: args.targetFrameKey,
-      targetEntry: entry,
+      targetFrame: args.targetFrame,
       finalVars: args.finalVars,
       completedAt: args.completedAt,
     });
     await this.lifecycleService.upsertResolvedCompletion(args.runbookId, key, completion);
+
+    const freshParent = await this.manager.load(args.runbookId);
+    if (freshParent) {
+      await this.manager.update(args.runbookId, {
+        substepStates: upsertSubstepState(
+          freshParent.substepStates ?? [],
+          args.targetSubstep,
+          args.targetFrame.frameKey,
+          { status: 'done', result: args.result },
+        ),
+      });
+    }
+
     return { status: 'recorded', key };
   }
 
@@ -460,6 +470,9 @@ export class RunbookCompletionService {
 
     const parentState = await this.manager.load(linkage.parentRunId);
     if (!parentState) return 'not-applicable';
+    const activeParentFrameKey =
+      parentState.activeFrameKey ?? deriveActiveFrame(parentState).frameKey;
+    const activeParentEntry = parentState.activeEntry ?? 1;
     const frameKey = linkage.parentFrameKey;
     const substepState = findSubstepState(
       parentState.substepStates ?? [],
@@ -473,32 +486,21 @@ export class RunbookCompletionService {
     ) {
       return 'cancelled';
     }
-    const entry = linkage.parentEntry;
+    const targetFrame =
+      frameKey === activeParentFrameKey && linkage.parentEntry === activeParentEntry
+        ? activeFrame(frameKey, activeParentEntry)
+        : exactFrame(frameKey, linkage.parentEntry);
     const recorded = await this.recordManualCompletion({
       runbookId: linkage.parentRunId,
       currentState: parentState,
       targetStep: linkage.parentStep,
       targetSubstep: linkage.parentStepId,
-      targetFrameKey: frameKey,
-      targetEntry: entry,
+      targetFrame,
       result,
       agentId: linkage.kind === 'inline' ? 'inline' : 'delegation',
       finalVars: args.childState.finalVars,
       completedAt: args.completedAt,
     });
-    if (recorded.status === 'recorded') {
-      const freshParent = await this.manager.load(linkage.parentRunId);
-      if (freshParent) {
-        await this.manager.update(linkage.parentRunId, {
-          substepStates: upsertSubstepState(
-            freshParent.substepStates ?? [],
-            linkage.parentStepId,
-            frameKey,
-            { status: 'done', result },
-          ),
-        });
-      }
-    }
     return recorded.status;
   }
 
@@ -529,7 +531,8 @@ export class RunbookCompletionService {
         );
         state = ensured.state;
         const activeFrameKey = state.activeFrameKey ?? ensured.frameKey;
-        if (args.frameKeyOverride && args.frameKeyOverride !== activeFrameKey) {
+        const requestedFrame = args.frameOverride;
+        if (requestedFrame && requestedFrame.frameKey !== activeFrameKey) {
           // The cursor has moved off the override frame. Two cases:
           //
           // 1. Initial mismatch (`applied.length === 0`): the override targets a
@@ -546,22 +549,16 @@ export class RunbookCompletionService {
           if (applied.length > 0) {
             return { status: 'continue', state, unresolved: 0, applied };
           }
-          const overrideResolved = await this.lifecycleService.listResolvedCompletions(
+          const overrideResolvedSubsteps = await this.observedSubstepsForFrame(
             args.runbookId,
-            args.frameKeyOverride,
-            SENTINEL_ENTRY,
-          );
-          const overrideResolvedSubsteps = new Set(
-            overrideResolved
-              .map(({ completion }) => completion.targetSubstep)
-              .filter((substep): substep is string => substep !== undefined),
+            requestedFrame.frameKey,
           );
           const unresolved = currentStep.substeps.filter(
             (substep) => !overrideResolvedSubsteps.has(substep.id),
           ).length;
           return {
             status: 'not_active',
-            frameKey: args.frameKeyOverride,
+            frameKey: requestedFrame.frameKey,
             activeFrameKey,
             unresolved,
             applied: [],
@@ -569,10 +566,10 @@ export class RunbookCompletionService {
         }
 
         const entry = state.activeEntry ?? ensured.entry;
+        const activeTargetFrame = activeFrame(activeFrameKey, entry);
         const resolved = await this.lifecycleService.listResolvedCompletions(
           args.runbookId,
-          activeFrameKey,
-          entry,
+          activeTargetFrame,
         );
         const resolvedBySubstep = new Map(
           resolved
@@ -582,12 +579,12 @@ export class RunbookCompletionService {
         const unresolved = currentStep.substeps.filter(
           (substep) => !resolvedBySubstep.has(substep.id),
         ).length;
-        const currentKey = buildCompletionKey(activeFrameKey, entry, state.substep);
+        const currentKey = buildCompletionKey(activeTargetFrame, state.substep);
         const current =
           resolved.find(({ key }) => key === currentKey) ??
           resolved.find(
             ({ key, completion }) =>
-              key === buildCompletionKey(activeFrameKey, SENTINEL_ENTRY, state.substep) ||
+              key === buildCompletionKey(inactiveFrame(activeFrameKey), state.substep) ||
               completion.targetSubstep === state.substep,
           );
         if (!current) {

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -12,6 +12,7 @@ import {
   deriveActiveFrame,
   exactFrame,
   findSubstepState,
+  frameHasExactEntry,
   inactiveFrame,
   upsertSubstepState,
   type Frame,
@@ -25,7 +26,7 @@ import type { ResolvedCompletion, ResolvedStep, RunId, RunbookState } from './ty
  * Declared as a real `Symbol()` (typed as `unique symbol`) so callers outside
  * this module cannot forge the branded shape: TypeScript treats the symbol as
  * a distinct nominal value, and the binding is not exported. The only producer
- * of branded values is `validateCurrentCompletionTarget` inside this module.
+ * of branded values is `resolveAgainstCurrentCursor` inside this module.
  */
 const currentCursorValidatedBrand: unique symbol = Symbol('currentCursorValidated');
 
@@ -33,7 +34,7 @@ const currentCursorValidatedBrand: unique symbol = Symbol('currentCursorValidate
  * Resolved completion that has been validated against the machine's active cursor.
  *
  * The `currentCursorValidatedBrand` symbol is unique to this module and cannot
- * be produced outside `validateCurrentCompletionTarget`, so callers receiving
+ * be produced outside `resolveAgainstCurrentCursor`, so callers receiving
  * this type can rely on `targetSubstep` matching the current cursor.
  */
 export type CurrentCursorResolvedCompletion = ResolvedCompletion & {
@@ -58,6 +59,12 @@ export function brandCurrentCursorResolvedCompletionForTest(
   completion: ResolvedCompletion & { readonly targetSubstep: string },
 ): CurrentCursorResolvedCompletion {
   return completion as unknown as CurrentCursorResolvedCompletion;
+}
+
+function lifecycleToResult(lifecycle: RunbookState['lifecycle']): 'pass' | 'fail' | undefined {
+  if (lifecycle === 'completed') return 'pass';
+  if (lifecycle === 'stopped') return 'fail';
+  return undefined;
 }
 
 /** Completion applied to the machine during a drain pass. */
@@ -258,16 +265,7 @@ export class RunbookCompletionService {
     runbookId: RunId,
     args: { readonly frame: Frame; readonly substep: string },
   ): Promise<string | null> {
-    if (args.frame.kind === 'active') {
-      const exactKey = buildCompletionKey(args.frame, args.substep);
-      const sentinelKey = buildCompletionKey(inactiveFrame(args.frame.frameKey), args.substep);
-      if (await this.lifecycleService.getResolvedCompletion(runbookId, exactKey)) return exactKey;
-      if (await this.lifecycleService.getResolvedCompletion(runbookId, sentinelKey))
-        return sentinelKey;
-      return null;
-    }
-
-    if (args.frame.kind === 'exact') {
+    if (frameHasExactEntry(args.frame)) {
       const exactKey = buildCompletionKey(args.frame, args.substep);
       const sentinelKey = buildCompletionKey(inactiveFrame(args.frame.frameKey), args.substep);
       if (await this.lifecycleService.getResolvedCompletion(runbookId, exactKey)) return exactKey;
@@ -320,10 +318,27 @@ export class RunbookCompletionService {
     return currentStep.substeps.filter((substep) => !resolvedSubsteps.has(substep.id)).length;
   }
 
-  private validateCurrentCompletionTarget(
+  /**
+   * Narrow a {@link ResolvedCompletion} to the current cursor, rejecting any
+   * row whose target step/substep/frame does not match.
+   *
+   * On a match the returned value is normalised against the live cursor:
+   * `targetSubstep` is set to `state.substep`, and `targetEntry` is rewritten
+   * from {@link SENTINEL_ENTRY} (or any persisted entry) to the live active
+   * entry so downstream consumers always see the resolved entry rather than
+   * the sentinel.
+   *
+   * @param state - Current runbook state.
+   * @param completion - Resolved completion candidate.
+   * @param ensured - Live active entry derived by the caller.
+   * @param ensured.entry - Live active entry number.
+   * @returns A branded {@link CurrentCursorResolvedCompletion} on match, or a
+   *   {@link CompletionTargetMismatch} describing the rejection.
+   */
+  private resolveAgainstCurrentCursor(
     state: RunbookState,
     completion: ResolvedCompletion,
-    ensured: { readonly frameKey: FrameKey; readonly entry: number },
+    ensured: { readonly entry: number },
   ): CurrentCursorResolvedCompletion | CompletionTargetMismatch {
     if (!state.substep) {
       return {
@@ -459,13 +474,7 @@ export class RunbookCompletionService {
   ): Promise<'recorded' | 'duplicate' | 'not-applicable' | 'cancelled'> {
     if (!args.childState.parentLinkage) return 'not-applicable';
     const linkage = assertCompleteParentLinkage(args.childState);
-    const result =
-      args.result ??
-      (args.childState.lifecycle === 'completed'
-        ? 'pass'
-        : args.childState.lifecycle === 'stopped'
-          ? 'fail'
-          : undefined);
+    const result = args.result ?? lifecycleToResult(args.childState.lifecycle);
     if (!result) return 'not-applicable';
 
     const parentState = await this.manager.load(linkage.parentRunId);
@@ -591,7 +600,7 @@ export class RunbookCompletionService {
           return { status: 'continue', state, unresolved, applied };
         }
 
-        const validated = this.validateCurrentCompletionTarget(state, current.completion, ensured);
+        const validated = this.resolveAgainstCurrentCursor(state, current.completion, ensured);
         if (!(currentCursorValidatedBrand in validated))
           return { ...validated, unresolved, applied };
 

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -2,11 +2,15 @@
 import type { RunbookStateManager } from './state.js';
 import { merge, replace } from './state-update-ops.js';
 import {
-  buildCompletionKey,
-  deriveActiveFrame,
-  buildFrameKey,
-  parseCompletionKey,
   SENTINEL_ENTRY,
+  activeFrame,
+  buildCompletionKey,
+  buildFrameKey,
+  completionEntryForFrame,
+  deriveActiveFrame,
+  inactiveFrame,
+  parseCompletionKey,
+  type Frame,
   type FrameKey,
 } from './targeting.js';
 import type { ResolvedCompletion, RunbookState } from './types.js';
@@ -195,7 +199,7 @@ export class ExecutionLifecycleService {
     if (!existing) {
       const parsed = parseCompletionKey(key);
       if (parsed && parsed.entry !== SENTINEL_ENTRY) {
-        const sentinelKey = buildCompletionKey(parsed.frameKey, SENTINEL_ENTRY, parsed.substep);
+        const sentinelKey = buildCompletionKey(inactiveFrame(parsed.frameKey), parsed.substep);
         const sentinelMatch = state.resolvedCompletions?.[sentinelKey];
         if (sentinelMatch) {
           existing = sentinelMatch;
@@ -215,29 +219,48 @@ export class ExecutionLifecycleService {
   }
 
   /**
-   * List resolved completions for a specific frame+entry.
+   * List resolved completions for a frame target.
    *
    * @param id - The runbook state ID
-   * @param frameKey - Frame key (`step|iteration`)
-   * @param entry - Frame entry number
-   * @returns Array of key/completion pairs matching the frame+entry prefix
+   * @param frame - Frame target to list
+   * @returns Array of key/completion pairs matching the frame target
    */
   async listResolvedCompletions(
     id: string,
-    frameKey: FrameKey,
-    entry: number,
+    frame: Frame,
   ): Promise<ReadonlyArray<{ key: string; completion: ResolvedCompletion }>> {
     const state = await this.manager.load(id);
     if (!state) return [];
 
-    const exactPrefix = `${frameKey}|${String(entry)}|`;
-    const sentinelPrefix = `${frameKey}|${String(SENTINEL_ENTRY)}|`;
+    const entry = completionEntryForFrame(frame);
+    const exactPrefix = `${frame.frameKey}|${String(entry)}|`;
+    const sentinelPrefix = `${frame.frameKey}|${String(SENTINEL_ENTRY)}|`;
     return Object.entries(state.resolvedCompletions ?? {})
-      .filter(
-        ([key]) =>
-          key.startsWith(exactPrefix) ||
-          (entry !== SENTINEL_ENTRY && key.startsWith(sentinelPrefix)),
-      )
+      .filter(([key]) => {
+        if (frame.kind === 'active') {
+          return key.startsWith(exactPrefix) || key.startsWith(sentinelPrefix);
+        }
+        return key.startsWith(exactPrefix);
+      })
+      .map(([key, completion]) => ({ key, completion }));
+  }
+
+  /**
+   * Observe all persisted completions for a frame key across entries.
+   *
+   * @param id - The runbook state ID
+   * @param frameKey - Frame key to observe
+   * @returns Array of key/completion pairs with matching persisted target frame
+   */
+  async listResolvedCompletionsForFrameObservation(
+    id: string,
+    frameKey: FrameKey,
+  ): Promise<ReadonlyArray<{ key: string; completion: ResolvedCompletion }>> {
+    const state = await this.manager.load(id);
+    if (!state) return [];
+
+    return Object.entries(state.resolvedCompletions ?? {})
+      .filter(([, completion]) => completion.targetFrameKey === frameKey)
       .map(([key, completion]) => ({ key, completion }));
   }
 
@@ -250,8 +273,8 @@ export class ExecutionLifecycleService {
    */
   buildActiveCompletionKey(state: RunbookState, substep?: string): string {
     const frame = deriveActiveFrame(state);
-    const entry = state.activeEntry ?? 1;
-    return buildCompletionKey(frame.frameKey, entry, substep);
+    const frameKey = state.activeFrameKey ?? frame.frameKey;
+    return buildCompletionKey(activeFrame(frameKey, state.activeEntry ?? 1), substep);
   }
 
   /**

--- a/packages/core/src/runbook/last-action.ts
+++ b/packages/core/src/runbook/last-action.ts
@@ -104,6 +104,25 @@ export function isAggregationLastAction(
 }
 
 /**
+ * Clear a `RETRY + origin: 'aggregation'` last action on FOR-iteration exhaustion.
+ *
+ * Aggregation-origin RETRY only describes the immediately preceding loop
+ * iteration; once the loop is exhausted the marker is no longer meaningful and
+ * is dropped so downstream observers don't see a stale aggregation hint past
+ * the loop boundary. All other last actions (including direct-origin RETRY)
+ * are preserved.
+ *
+ * @param action - Current lastAction value
+ * @returns `undefined` for `RETRY + aggregation`; the input unchanged otherwise
+ */
+export function clearAggregationRetryOnExhaustion(
+  action: LastAction | undefined,
+): LastAction | undefined {
+  if (action?.type === 'RETRY' && action.origin === 'aggregation') return undefined;
+  return action;
+}
+
+/**
  * Runtime type guard for canonical `LastAction` values.
  *
  * @param value - Unknown value to validate

--- a/packages/core/src/runbook/targeting.ts
+++ b/packages/core/src/runbook/targeting.ts
@@ -19,6 +19,72 @@ export const SENTINEL_ENTRY = 0;
 export type FrameKey = string & { readonly __brand: 'FrameKey' };
 
 /**
+ * Runtime frame target used when constructing completion identities.
+ *
+ * Active frames are the current cursor and active entry. Exact frames carry a
+ * known historical/linkage entry that is not necessarily current. Inactive
+ * frames carry only a frame key and persist with the sentinel entry.
+ */
+export type Frame =
+  | { readonly kind: 'active'; readonly frameKey: FrameKey; readonly entry: number }
+  | { readonly kind: 'exact'; readonly frameKey: FrameKey; readonly entry: number }
+  | { readonly kind: 'inactive'; readonly frameKey: FrameKey };
+
+/**
+ * Construct a frame for the current active cursor.
+ *
+ * @param frameKey - Current active frame key
+ * @param entry - Current active entry
+ * @returns Active frame target
+ */
+export function activeFrame(frameKey: FrameKey, entry: number): Frame {
+  return { kind: 'active', frameKey, entry };
+}
+
+/**
+ * Construct a frame with a known exact entry that is not necessarily current.
+ *
+ * @param frameKey - Target frame key
+ * @param entry - Known entry for the target frame
+ * @returns Exact frame target
+ */
+export function exactFrame(frameKey: FrameKey, entry: number): Frame {
+  return { kind: 'exact', frameKey, entry };
+}
+
+/**
+ * Construct a frame-only target with no reliable entry.
+ *
+ * @param frameKey - Target frame key
+ * @returns Inactive frame target
+ */
+export function inactiveFrame(frameKey: FrameKey): Frame {
+  return { kind: 'inactive', frameKey };
+}
+
+/**
+ * Determine whether a frame carries an exact entry.
+ *
+ * @param frame - Frame target to inspect
+ * @returns True when the frame includes an entry
+ */
+export function frameHasExactEntry(
+  frame: Frame,
+): frame is Extract<Frame, { kind: 'active' | 'exact' }> {
+  return frame.kind === 'active' || frame.kind === 'exact';
+}
+
+/**
+ * Resolve the completion entry used for persistence.
+ *
+ * @param frame - Frame target
+ * @returns Exact entry for active/exact frames, otherwise the sentinel entry
+ */
+export function completionEntryForFrame(frame: Frame): number {
+  return frameHasExactEntry(frame) ? frame.entry : SENTINEL_ENTRY;
+}
+
+/**
  * Derive execution location notation for runtime targets.
  *
  * - Non-loop step/substep: `STEP.SUBSTEP` (for example, `2.1`)
@@ -87,13 +153,12 @@ export function buildFrameKey(step: string, iteration?: number): FrameKey {
  *
  * Format: `<frameKey>|<entry>|<substep-or-empty>`
  *
- * @param frameKey - Frame key from {@link buildFrameKey}
- * @param entry - Monotonic entry counter within the frame
+ * @param frame - Frame target
  * @param substep - Optional substep identifier
  * @returns Pipe-delimited completion key
  */
-export function buildCompletionKey(frameKey: FrameKey, entry: number, substep?: string): string {
-  return `${frameKey}|${String(entry)}|${substep ?? ''}`;
+export function buildCompletionKey(frame: Frame, substep?: string): string {
+  return `${frame.frameKey}|${String(completionEntryForFrame(frame))}|${substep ?? ''}`;
 }
 
 /**
@@ -198,8 +263,7 @@ export function buildStepPosition(
  * @param fields.targetStep - Step name this completion targets
  * @param fields.targetSubstep - Optional substep ID within the target step
  * @param fields.targetIteration - Optional FOR loop iteration number
- * @param fields.targetFrameKey - Frame key identifying the step+iteration context
- * @param fields.targetEntry - Monotonic entry counter within the frame
+ * @param fields.targetFrame - Frame target identifying the completion scope
  * @param fields.finalVars - Optional final variables produced by a child runbook
  * @param fields.completedAt - ISO 8601 timestamp (defaults to current time)
  * @returns A fully-formed ResolvedCompletion
@@ -210,8 +274,7 @@ export function buildResolvedCompletion(fields: {
   targetStep: string;
   targetSubstep?: string;
   targetIteration?: number;
-  targetFrameKey: FrameKey;
-  targetEntry: number;
+  targetFrame: Frame;
   finalVars?: Readonly<Record<string, string>>;
   completedAt?: string;
 }): ResolvedCompletion {
@@ -221,8 +284,8 @@ export function buildResolvedCompletion(fields: {
     targetStep: fields.targetStep,
     ...(fields.targetSubstep ? { targetSubstep: fields.targetSubstep } : {}),
     ...(fields.targetIteration !== undefined ? { targetIteration: fields.targetIteration } : {}),
-    targetFrameKey: fields.targetFrameKey,
-    targetEntry: fields.targetEntry,
+    targetFrameKey: fields.targetFrame.frameKey,
+    targetEntry: completionEntryForFrame(fields.targetFrame),
     ...(fields.finalVars ? { finalVars: fields.finalVars } : {}),
     completedAt: fields.completedAt ?? new Date().toISOString(),
   };

--- a/packages/core/src/runbook/targeting.ts
+++ b/packages/core/src/runbook/targeting.ts
@@ -31,13 +31,31 @@ export type Frame =
   | { readonly kind: 'inactive'; readonly frameKey: FrameKey };
 
 /**
+ * Validate that a frame entry is a positive integer.
+ *
+ * Entries must be >= 1; entry=0 is reserved for {@link SENTINEL_ENTRY}, and
+ * negatives/NaN/non-integer values would produce invalid completion keys.
+ *
+ * @param entry - Entry value to validate
+ * @param kind - Frame kind for error reporting
+ * @throws {RangeError} When entry is not a positive integer
+ */
+function assertPositiveEntry(entry: number, kind: 'active' | 'exact'): void {
+  if (!Number.isInteger(entry) || entry < 1) {
+    throw new RangeError(`${kind} frame entry must be a positive integer, got ${String(entry)}`);
+  }
+}
+
+/**
  * Construct a frame for the current active cursor.
  *
  * @param frameKey - Current active frame key
- * @param entry - Current active entry
+ * @param entry - Current active entry (must be a positive integer)
  * @returns Active frame target
+ * @throws {RangeError} When `entry` is not a positive integer
  */
 export function activeFrame(frameKey: FrameKey, entry: number): Frame {
+  assertPositiveEntry(entry, 'active');
   return { kind: 'active', frameKey, entry };
 }
 
@@ -45,10 +63,12 @@ export function activeFrame(frameKey: FrameKey, entry: number): Frame {
  * Construct a frame with a known exact entry that is not necessarily current.
  *
  * @param frameKey - Target frame key
- * @param entry - Known entry for the target frame
+ * @param entry - Known entry for the target frame (must be a positive integer)
  * @returns Exact frame target
+ * @throws {RangeError} When `entry` is not a positive integer
  */
 export function exactFrame(frameKey: FrameKey, entry: number): Frame {
+  assertPositiveEntry(entry, 'exact');
   return { kind: 'exact', frameKey, entry };
 }
 


### PR DESCRIPTION
## Summary

Implements the issue 310 completion frame model across core and CLI.

- Adds typed completion frame targets (active, exact, inactive) and routes completion key construction through them.
- Updates lifecycle completion listing so active frames drain exact plus sentinel rows, exact frames drain exact rows only, and inactive frame observations do not predict frame entries.
- Updates manual, delegated, collect, abort, and transition paths to pass frame targets consistently.
- Preserves duplicate detection and completion locking around the full resolved-completion persistence path.
- Fixes LastAction origin/schema consistency for policy-denied and command-execution-failed actions uncovered by verification.

## Impact

This removes the old loose frameKey/entry plumbing from completion dispatch and makes frame targeting explicit at the core API boundary. CLI commands remain thin callers into core frame semantics.

## Verification

- npm run test:unit -w packages/core -- completion-service.test.ts
- npm run test:unit -w packages/core
- npm run test:unit -w packages/cli
- focused CLI Jest tests for transitions, delegation completion, and collect
- npm run check:types
- npm run build
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion draining for targeted steps and aggregated transitions.
  * Enhanced state persistence for step transitions with better entry validation.

* **Tests**
  * Added test coverage for aggregated step transitions with proper payload validation.
  * Expanded completion service tests for frame-aware targeting semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->