### PR TITLE
refactor(cli): tighten runExecutionLoop runbookId to RunId

### DIFF
--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -214,7 +214,7 @@ describe('execution.ts FOR boundary (Batch 4)', () => {
 describe('runExecutionLoop', () => {
   let mockManager: MockManagerLike;
   let mockEmitter: MockEmitterLike;
-  const runbookId = `rd_${'1'.repeat(32)}`;
+  const runbookId = actualCore.assertRunId(`rd_${'1'.repeat(32)}`);
   const steps: LooseStep[] = [
     {
       kind: 'command',
@@ -549,7 +549,7 @@ describe('runExecutionLoop', () => {
       sessionService: mockSessionService as any,
       lifecycleService: mockLifecycleService as any,
       emitter: asEmitter(mockEmitter),
-      runbookId: runbookId as any,
+      runbookId: runbookId,
       steps: asSteps(substepSteps),
       currentState: beforeFirst as any,
       transitionPolicy: {
@@ -600,7 +600,7 @@ describe('runExecutionLoop', () => {
       sessionService: mockSessionService as any,
       lifecycleService: mockLifecycleService as any,
       emitter: asEmitter(mockEmitter),
-      runbookId: runbookId as any,
+      runbookId: runbookId,
       steps: asSteps(steps),
       currentState: currentState as any,
       transitionPolicy: {
@@ -699,7 +699,7 @@ describe('runExecutionLoop', () => {
       sessionService: mockSessionService as any,
       lifecycleService: mockLifecycleService as any,
       emitter: asEmitter(mockEmitter),
-      runbookId: runbookId as any,
+      runbookId: runbookId,
       steps: asSteps(substepSteps),
       currentState: before as any,
       transitionPolicy: {

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -1,5 +1,4 @@
 import {
-  assertRunId,
   type RunId,
   buildStepVariables,
   buildStepPosition,
@@ -515,7 +514,7 @@ export async function drainResolvedCompletions({
  * - In prompted mode (no auto-execution)
  *
  * @param manager - Runbook state manager instance
- * @param runbookIdRaw - Unbranded run id; branded to RunId on entry
+ * @param runbookId - Branded run id
  * @param steps - Array of runbook steps
  * @param cwd - Current working directory for command execution
  * @param prompted - Whether to run in prompted mode (no auto-execution)
@@ -525,14 +524,13 @@ export async function drainResolvedCompletions({
  */
 export async function runExecutionLoop(
   manager: RunbookStateManager,
-  runbookIdRaw: string,
+  runbookId: RunId,
   steps: ResolvedStep[],
   cwd: string,
   prompted: boolean,
   emitter: ExecutionEventEmitter,
   options: ExecutionLoopOptions = {},
 ): Promise<'done' | 'stopped' | 'waiting'> {
-  const runbookId: RunId = assertRunId(runbookIdRaw);
   const state = await manager.load(runbookId);
   if (!state) return 'stopped';
 

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -521,6 +521,9 @@ export async function drainResolvedCompletions({
  * @param emitter - Event emitter for execution events
  * @param options - Optional execution loop behavior overrides
  * @returns 'done' if completed, 'stopped' if stopped, 'waiting' if prompt-only step reached
+ * @throws {Error} If state lookup via {@link findStepOrThrow} fails, the core
+ *   actor/lifecycle/session services throw while advancing transitions,
+ *   command execution rejects, or the emitter raises during event dispatch.
  */
 export async function runExecutionLoop(
   manager: RunbookStateManager,


### PR DESCRIPTION
## Summary
Final loose end from #269. `runExecutionLoop` took `runbookIdRaw: string` and branded at entry via `assertRunId`, but every caller already passes a branded `RunId`:

- `commands/collect.ts` — `state.id`
- `commands/abort.ts` — `parentRunId`
- `helpers/runbook-pipeline.ts` — `stateId: RunId`
- `helpers/transitions.ts` (×2) — branded
- `helpers/goto-workflow.ts` — branded
- `helpers/delegation-completion.ts` — branded

Widening the parameter to `RunId` drops the last `assertRunId` boundary in `execution.ts` and removes the now-unused import.

Closes #269.

## Test plan
- [x] `npm run build` (all packages)
- [x] `npm test --workspace=@rundown-org/cli` — 2303 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved CLI execution flow type consistency and API robustness, reducing edge-case failures when running workflows.
* **Tests**
  * Strengthened run-identifier validation in tests and removed unnecessary type casts, increasing test accuracy and confidence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->