### PR TITLE
fix: align ARTIFACTS conformance

### DIFF
--- a/docs/internal/scenarios.md
+++ b/docs/internal/scenarios.md
@@ -185,7 +185,7 @@ scenarios:
 
 Do not hide workflow steps inside opaque shell wrappers such as `node -e`, `bash -c`, npm scripts, helper scripts, or shell pipelines that call `rd` internally. The scenario runner derives terminal state, step transitions, delegation tokens, and claim ids only from visible `rd`/`rundown` command entries. Hidden `rd` invocations obscure that state and make scenario assertions depend on shell behavior instead of the scenario runner's command model.
 
-Detailed payload assertions, ad hoc JSON checks, and state-file inspections belong in dedicated Jest integration or unit tests. Frontmatter scenarios should assert through the scenario schema (`expect.result`, `expect.steps`, `expect.errors`) and keep `commands:` focused on the CLI interaction sequence.
+Detailed payload assertions, ad hoc JSON checks, and state-file inspections belong in dedicated Jest integration or unit tests. Frontmatter scenarios should assert through the scenario schema (`expect.result`, `expect.steps`, `expect.errors`, `expect.artifacts`) and keep `commands:` focused on the CLI interaction sequence.
 
 Commands output JSON by default. The scenario runner parses every `rd`/`rundown` command's stdout to collect terminal state, step transitions, delegation tokens, and claim ids. Use `--text` for human-readable terminal output in demo scenarios; `--text` output is not useful for `expect.steps`, token capture, or claim-id capture.
 

--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -437,9 +437,13 @@ when a per-run location is required.
 
 `ARTIFACTS` declarations may also bind aliases to existing files. Relative file
 references search project files first, then plugin files, then bundled files.
-Explicit absolute paths are accepted only when read policy allows them. File
-references are recorded in the artifact manifest with `kind:
-file-artifact-record`, the literal declaration token as `key`, and the resolved
+Explicit absolute paths are accepted only when read policy allows them. Missing,
+denied, escaped, or out-of-root file candidates MUST fail visibly; they MUST NOT
+resolve as an empty artifact result or silently fall back to a managed artifact
+key. Containment is enforced after realpath resolution so symlinks and traversal
+cannot escape the configured search roots.
+File references are recorded in the artifact manifest with `kind:
+file-artifact-record`, the expanded declaration token as `key`, and the resolved
 canonical `file:///...` URI.
 
 `RunbookRef` is available before template substitution so runbooks can render

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -114,11 +114,15 @@ artifacts_directive    ::= "- ARTIFACTS" newline artifact_list
 artifact_list          ::= ( ws "- " artifact_entry newline )+
 artifact_entry         ::= variable_name [ ws quoted_artifact_token ]
 quoted_artifact_token  ::= '"' artifact_token '"'
-artifact_token         ::= artifact_key | uri_artifact_token
+artifact_token         ::= artifact_key | uri_artifact_token | file_artifact_token
 artifact_key           ::= exact_artifact_key | wildcard_artifact_key
 exact_artifact_key     ::= [A-Za-z0-9._-]+
 wildcard_artifact_key  ::= [A-Za-z0-9._*?-]+
 uri_artifact_token     ::= "rd://artifacts/" ctx_ref "/" run_segment "/" exact_artifact_key
+file_artifact_token    ::= relative_file_ref | absolute_file_ref
+relative_file_ref      ::= safe_path_segment "/" safe_path_segment ( "/" safe_path_segment )*
+absolute_file_ref      ::= "/" safe_path_segment ( "/" safe_path_segment )*
+safe_path_segment      ::= [A-Za-z0-9._-]+
 run_segment            ::= [A-Za-z0-9_-]+ | "*"
 
 outputs_directive ::= "- OUTPUTS" newline output_list
@@ -135,7 +139,7 @@ A step or substep may declare at most one `ARTIFACTS` directive and at most one 
 
 `ARTIFACTS` declares the current execution unit's artifact working set. Each entry maps a variable name to an optional quoted artifact token. The variable name must match `variable_name` and must not be a [reserved variable name](#reserved-variable-names). Duplicate names in one `ARTIFACTS` block are syntax errors.
 
-Artifact entries take four forms: (1) **naked** — a bare `variable_name` with no token, asserting the name is already bound as an artifact reference; (2) **quoted managed key** — `"plan.json"` or `"review-*.json"`; (3) **quoted file reference** — `"schemas/review.schema.json"` or an explicit absolute path; (4) **quoted URI literal** — `"rd://artifacts/<ctx>/<run>/<key>"` or selector form with `*` in the run segment. Quoted tokens are template-expanded BEFORE classification, so `"{{ContextId}}-plan.json"` is valid. After expansion, exact managed keys use `exact_artifact_key`; wildcard managed keys use `wildcard_artifact_key` and contain `*` or `?`. File references resolve existing files via the deterministic search path defined in [docs/spec/language.md §10.1.1](language.md#1011-expansion-rules). Empty managed keys, `.`, `..`, traversal, and recursive `**` are invalid. The full URI grammar — including selector form, scheme registration, and component constraints — is normatively defined in [docs/spec/uri.md §4](uri.md#4-grammar-ebnf). Naked-form semantics are defined in [docs/spec/language.md §10.1.2](language.md#1012-naked-declaration-assertion-form).
+Artifact entries take four forms: (1) **naked** — a bare `variable_name` with no token, asserting the name is already bound as an artifact reference; (2) **quoted managed key** — `"plan.json"` or `"review-*.json"`; (3) **quoted file reference** — `"schemas/review.schema.json"` or an explicit absolute path; (4) **quoted URI literal** — `"rd://artifacts/<ctx>/<run>/<key>"` or selector form with `*` in the run segment. Quoted tokens are template-expanded BEFORE classification, so `"{{ContextId}}-plan.json"` is valid. After expansion, exact managed keys use `exact_artifact_key`; wildcard managed keys use `wildcard_artifact_key` and contain `*` or `?`. File references are quoted relative or absolute paths, are not glob selectors, and must resolve to an existing contained file through the runtime search/read-policy rules. Empty managed keys, `.`, `..`, traversal, and recursive `**` are invalid. The full URI grammar — including selector form, scheme registration, and component constraints — is normatively defined in [docs/spec/uri.md §4](uri.md#4-grammar-ebnf). Naked-form semantics are defined in [docs/spec/language.md §10.1.2](language.md#1012-naked-declaration-assertion-form).
 
 `OUTPUTS` at step/substep level declares name-only command output channels. Expression-form step/substep `OUTPUTS` entries are parse errors. Naked entries activate a file-backed channel: Rundown creates an empty file whose path is composed from the active scope tiers (step id, optional substep id, optional FOR iteration index) followed by `<VarName>` and exports its absolute path as `RD_OUTPUTS_<VarName>` to the spawned command. The three possible paths are:
 
@@ -350,8 +354,10 @@ The following names are reserved for runtime context resolution and cannot be us
 - `step`
 - `index`
 - `context`
+- `runid`
+- `runbookref`
 
-Matching is **case-insensitive**: `step`, `Step`, `STEP`, `CONTEXT`, `INDEX` are all reserved. These names are owned by runtime context resolution (`{{step}}`, `{{index}}`, `{{context.*}}`) and cannot be shadowed by user values.
+Matching is **case-insensitive**: `step`, `Step`, `STEP`, `CONTEXT`, `INDEX`, `RunId`, and `RunbookRef` are all reserved. These names are owned by runtime context resolution (`{{step}}`, `{{index}}`, `{{context.*}}`, `{{RunId}}`, `{{RunbookRef}}`) and cannot be shadowed by user values.
 
 ## Lexical Rules
 

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -122,7 +122,8 @@ uri_artifact_token     ::= "rd://artifacts/" ctx_ref "/" run_segment "/" exact_a
 file_artifact_token    ::= relative_file_ref | absolute_file_ref
 relative_file_ref      ::= safe_path_segment "/" safe_path_segment ( "/" safe_path_segment )*
 absolute_file_ref      ::= "/" safe_path_segment ( "/" safe_path_segment )*
-safe_path_segment      ::= [A-Za-z0-9._-]+
+safe_path_segment      ::= safe_path_chars - ( "." | ".." )
+safe_path_chars        ::= [A-Za-z0-9._-]+
 run_segment            ::= [A-Za-z0-9_-]+ | "*"
 
 outputs_directive ::= "- OUTPUTS" newline output_list

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -617,7 +617,7 @@ In particular:
 23. `ARTIFACTS` must be ordered before `OUTPUTS` and all other step content.
 24. `ARTIFACTS` is invalid in frontmatter.
 25. Duplicate aliases in one `ARTIFACTS` block are invalid.
-26. Artifact keys must be quoted safe artifact key literals.
+26. Quoted artifact tokens must parse as safe managed keys, file references, or `rd://` URIs after template expansion.
 27. Step/substep `OUTPUTS` entries must be name-only; expression-form entries are invalid.
 28. Empty wildcard artifact results are valid values and must not be collapsed to absence.
 29. Parser conformance fixtures for `ARTIFACTS` should cover valid exact declarations, valid wildcard declarations, duplicate aliases, invalid keys, misplaced directives, frontmatter misuse, and expression-form step/substep `OUTPUTS`.

--- a/packages/cli/__tests__/integration/artifacts-resolution.test.ts
+++ b/packages/cli/__tests__/integration/artifacts-resolution.test.ts
@@ -163,6 +163,7 @@ printf '{}' > "{{ PlanPath.uri }}"
       expect(entered.artifacts.PlanPath.uri).toMatch(
         /^rd:\/\/artifacts\/[^/]+\/rd_[a-f0-9]{32}\/plan\.json$/,
       );
+      expect(entered.artifacts.PlanPath).not.toHaveProperty('kind');
       expect(entered.commandCode).toContain(entered.artifacts.PlanPath.uri);
     } finally {
       await workspace.cleanup();

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -689,9 +689,7 @@ function artifactEventMatchesAssertion(
 function publicArtifactRecordKind(
   record: PublicArtifactRecord,
 ): 'artifact-record' | 'file-artifact-record' {
-  return 'kind' in record && record.kind === 'file-artifact-record'
-    ? 'file-artifact-record'
-    : 'artifact-record';
+  return 'kind' in record ? 'file-artifact-record' : 'artifact-record';
 }
 
 /**

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -9,9 +9,9 @@
 
 import { spawn } from 'node:child_process';
 import {
-  isArtifactRecord,
+  ArtifactManifestRecordSchema,
   RunbookRefSchema,
-  type ArtifactRecord,
+  type PublicArtifactRecord,
   type RunbookRef,
 } from '@rundown-org/core';
 import { parse as shellParse } from 'shell-quote';
@@ -52,7 +52,7 @@ export interface CapturedArtifactEntry {
   /** Qualified entered step position, if present on the event. */
   at?: string;
   /** Artifact working set keyed by ARTIFACTS alias. */
-  artifacts: Record<string, ArtifactRecord | ArtifactRecord[] | undefined>;
+  artifacts: Record<string, PublicArtifactRecord | PublicArtifactRecord[] | undefined>;
   /** Runbook that produced the entered event (from event envelope). */
   runbook?: RunbookRef;
 }
@@ -86,7 +86,7 @@ export interface ArtifactAssertionResult {
   /** The event that matched (if any) */
   matchedEntry?: CapturedArtifactEntry;
   /** Artifact records matched for the assertion's alias (if any) */
-  matchedRecords?: ArtifactRecord[];
+  matchedRecords?: PublicArtifactRecord[];
 }
 
 /** Result of executing a command sequence. */
@@ -450,19 +450,25 @@ function extractEnteredPosition(position: unknown): string | undefined {
 
 function parseCapturedArtifacts(
   value: unknown,
-): Record<string, ArtifactRecord | ArtifactRecord[] | undefined> | null {
+): Record<string, PublicArtifactRecord | PublicArtifactRecord[] | undefined> | null {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     return null;
   }
 
-  const artifacts: Record<string, ArtifactRecord | ArtifactRecord[] | undefined> = {};
+  const artifacts: Record<string, PublicArtifactRecord | PublicArtifactRecord[] | undefined> = {};
   for (const [alias, artifactValue] of Object.entries(value)) {
-    if (isArtifactRecord(artifactValue)) {
-      artifacts[alias] = artifactValue;
+    const parsedRecord = ArtifactManifestRecordSchema.safeParse(artifactValue);
+    if (parsedRecord.success) {
+      artifacts[alias] = parsedRecord.data;
       continue;
     }
-    if (Array.isArray(artifactValue) && artifactValue.every(isArtifactRecord)) {
-      artifacts[alias] = artifactValue;
+    if (Array.isArray(artifactValue)) {
+      const parsedRecords = artifactValue.map((entry) =>
+        ArtifactManifestRecordSchema.safeParse(entry),
+      );
+      if (parsedRecords.every((entry) => entry.success)) {
+        artifacts[alias] = parsedRecords.map((entry) => entry.data);
+      }
     }
   }
 
@@ -650,7 +656,7 @@ function artifactEventMatchesAssertion(
   event: CapturedArtifactEntry,
   assertion: ArtifactAssertion,
   exists?: ArtifactExistsPredicate,
-): ArtifactRecord[] | null {
+): PublicArtifactRecord[] | null {
   if (assertion.at !== undefined && event.at !== assertion.at) return null;
   if (assertion.runbook !== undefined && !runbookMatches(event.runbook, assertion.runbook)) {
     return null;
@@ -661,7 +667,10 @@ function artifactEventMatchesAssertion(
   const records = Array.isArray(value) ? value : [value];
 
   if (assertion.count !== undefined && records.length !== assertion.count) return null;
-  if (assertion.kind !== undefined && !records.some((record) => record.kind === assertion.kind)) {
+  if (
+    assertion.kind !== undefined &&
+    !records.some((record) => publicArtifactRecordKind(record) === assertion.kind)
+  ) {
     return null;
   }
   if (assertion.key !== undefined && !records.some((record) => record.key === assertion.key)) {
@@ -675,6 +684,14 @@ function artifactEventMatchesAssertion(
   }
 
   return records;
+}
+
+function publicArtifactRecordKind(
+  record: PublicArtifactRecord,
+): 'artifact-record' | 'file-artifact-record' {
+  return 'kind' in record && record.kind === 'file-artifact-record'
+    ? 'file-artifact-record'
+    : 'artifact-record';
 }
 
 /**

--- a/packages/core/__tests__/events/execution-observation.test.ts
+++ b/packages/core/__tests__/events/execution-observation.test.ts
@@ -42,6 +42,24 @@ const wildcardArtifacts = [
   },
 ];
 
+const publicExactArtifact = {
+  uri: exactArtifact.uri,
+  runId: exactArtifact.runId,
+  contextId: exactArtifact.contextId,
+  runbook: exactArtifact.runbook,
+  key: exactArtifact.key,
+  timestamp: exactArtifact.timestamp,
+};
+
+const publicWildcardArtifacts = wildcardArtifacts.map((artifact) => ({
+  uri: artifact.uri,
+  runId: artifact.runId,
+  contextId: artifact.contextId,
+  runbook: artifact.runbook,
+  key: artifact.key,
+  timestamp: artifact.timestamp,
+}));
+
 describe('execution observation projection', () => {
   it('derives STEP_ENTERED artifacts from enteredArtifacts exact entries', () => {
     expect(
@@ -80,7 +98,7 @@ describe('execution observation projection', () => {
           commandLang: 'bash',
           isSubstep: false,
           prompted: false,
-          artifacts: { PlanPath: exactArtifact },
+          artifacts: { PlanPath: publicExactArtifact },
           delegateFrontier: [{ id: '1.1', runbook: 'child', token: 'rdt_example' }],
         },
       },
@@ -106,7 +124,7 @@ describe('execution observation projection', () => {
 
     expect(effect.event.type).toBe('STEP_ENTERED');
     if (effect.event.type !== 'STEP_ENTERED') throw new Error('expected STEP_ENTERED');
-    expect(effect.event.payload.artifacts).toEqual({ Logs: wildcardArtifacts });
+    expect(effect.event.payload.artifacts).toEqual({ Logs: publicWildcardArtifacts });
   });
 
   it('projects parent-entry artifacts when the current execution unit is a substep', () => {
@@ -130,7 +148,7 @@ describe('execution observation projection', () => {
 
     expect(effect.event.type).toBe('STEP_ENTERED');
     if (effect.event.type !== 'STEP_ENTERED') throw new Error('expected STEP_ENTERED');
-    expect(effect.event.payload.artifacts).toEqual({ ParentPlan: exactArtifact });
+    expect(effect.event.payload.artifacts).toEqual({ ParentPlan: publicExactArtifact });
     expect(effect.event.payload.isSubstep).toBe(true);
   });
 

--- a/packages/core/__tests__/output/schema.test.ts
+++ b/packages/core/__tests__/output/schema.test.ts
@@ -304,7 +304,6 @@ describe('ScenarioRunResponseSchema step assertions', () => {
 
   it('accepts artifact assertion results', () => {
     const artifact = {
-      kind: 'artifact-record' as const,
       uri: 'rd://artifacts/ctx1/rd_11111111111111111111111111111111/plan.json',
       runId: 'rd_11111111111111111111111111111111',
       contextId: 'ctx1',
@@ -324,7 +323,6 @@ describe('ScenarioRunResponseSchema step assertions', () => {
           assertion: {
             at: '1',
             alias: 'PlanPath',
-            kind: 'artifact-record',
             key: 'plan.json',
             exists: true,
           },

--- a/packages/core/__tests__/output/suite-schemas.test.ts
+++ b/packages/core/__tests__/output/suite-schemas.test.ts
@@ -58,7 +58,6 @@ describe('ScenarioSuiteRunResponseSchema', () => {
 
   it('accepts artifact assertion results on case entries', () => {
     const artifact = {
-      kind: 'artifact-record' as const,
       uri: 'rd://artifacts/ctx1/rd_11111111111111111111111111111111/plan.json',
       runId: 'rd_11111111111111111111111111111111',
       contextId: 'ctx1',

--- a/packages/core/__tests__/runbook/actor-service.test.ts
+++ b/packages/core/__tests__/runbook/actor-service.test.ts
@@ -802,6 +802,14 @@ echo ok
         path: '.rundown/work/ctx/plan.md',
         timestamp: '2026-05-15T00:00:00.000Z',
       };
+      const publicArtifact = {
+        uri: artifact.uri,
+        runId: artifact.runId,
+        contextId: artifact.contextId,
+        runbook: artifact.runbook,
+        key: artifact.key,
+        timestamp: artifact.timestamp,
+      };
       const state = await manager.create(
         { source: 'project', path: 'workflow.runbook.md' },
         { title: 'Step effects', description: '', steps: stepsWithOneCommand },
@@ -840,7 +848,7 @@ echo ok
       expect(effects).toHaveLength(1);
       expect(effects[0]?.event.type).toBe('STEP_ENTERED');
       if (effects[0]?.event.type !== 'STEP_ENTERED') throw new Error('expected STEP_ENTERED');
-      expect(effects[0]?.event.payload.artifacts).toEqual({ PlanPath: artifact });
+      expect(effects[0]?.event.payload.artifacts).toEqual({ PlanPath: publicArtifact });
       const persisted = await manager.load(state.id);
       expect('enteredArtifacts' in (persisted ?? {})).toBe(false);
       expect(JSON.stringify(persisted)).not.toContain('STEP_ENTERED');

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -331,6 +331,27 @@ describe('resolveArtifactDeclarations — bare key (producer form)', () => {
     });
   });
 
+  it('returns the canonical manifest row when a producer write coalesces', async () => {
+    const cwd = await tempCwd();
+    const canonical = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'plan.json',
+      timestamp: '2026-05-07T00:00:00.000Z',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, canonical);
+
+    const result = await resolveArtifactDeclarations([decl('PlanPath', 'plan.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+    });
+
+    expect(result.PlanPath).toEqual(canonical);
+  });
+
   it('falls through to managed producer for a bare token even when no file exists', async () => {
     // Pinning baseline: non-path-like bare tokens that do not resolve to any
     // file still flow to the managed-artifact producer (unchanged behaviour).
@@ -349,6 +370,39 @@ describe('resolveArtifactDeclarations — bare key (producer form)', () => {
       uri: `rd://artifacts/${CONTEXT_ID}/${CURRENT_RUN}/plan.json`,
       key: 'plan.json',
     });
+  });
+
+  it('expands quoted tokens from runtime scope variables before classification', async () => {
+    const cwd = await tempCwd();
+
+    const result = await resolveArtifactDeclarations([decl('PlanPath', '{{PlanKey}}')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      scopeVars: { PlanKey: 'plan.json' },
+    });
+
+    expect(result.PlanPath).toMatchObject({
+      uri: `rd://artifacts/${CONTEXT_ID}/${CURRENT_RUN}/plan.json`,
+      key: 'plan.json',
+    });
+  });
+
+  it('expands quoted tokens from dotted runtime scope variables', async () => {
+    const cwd = await tempCwd();
+
+    const result = await resolveArtifactDeclarations([decl('PlanPath', '{{item.key}}')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      scopeVars: { item: { key: 'plan.json' } },
+    });
+
+    expect(result.PlanPath).toMatchObject({ key: 'plan.json' });
   });
 });
 

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -9,7 +9,12 @@ import {
   readArtifactManifest,
   resolveArtifactDeclarations,
 } from '../../src/runbook/index.js';
-import type { ArtifactRecord, FileArtifactRecord } from '../../src/runbook/artifact-schema.js';
+import { toStateArtifactRecord } from '../../src/runbook/artifact-directive-resolver.js';
+import type {
+  ArtifactRecord,
+  FileArtifactRecord,
+  ManagedArtifactManifestRecord,
+} from '../../src/runbook/artifact-schema.js';
 import type { RunId } from '../../src/runbook/run-id.js';
 import { brandRunIdForTest } from '../helpers/effective-vars.js';
 
@@ -1369,5 +1374,37 @@ describe('resolveArtifactDeclarations — parent dir creation error propagation'
     // a failed parent-dir creation must short-circuit before append.
     const manifestPath = path.join(cwd, WORK_PATH, `.rd-${CONTEXT_ID}`, 'manifest.jsonl');
     await expect(fsp.stat(manifestPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});
+
+describe('toStateArtifactRecord — kind-spread guard', () => {
+  const MANAGED_ROW: ManagedArtifactManifestRecord = {
+    uri: `rd://artifacts/${CONTEXT_ID}/${CURRENT_RUN}/plan.json`,
+    runId: CURRENT_RUN,
+    contextId: CONTEXT_ID,
+    runbook: RUNBOOK,
+    key: 'plan.json',
+    timestamp: '2026-05-07T00:00:00.000Z',
+  };
+
+  it('projects a managed manifest row (no kind) into a tagged state record', () => {
+    const result = toStateArtifactRecord(MANAGED_ROW);
+    expect(result).toEqual({ kind: 'artifact-record', ...MANAGED_ROW });
+  });
+
+  it('throws when the input carries any kind field (belt-and-braces guard)', () => {
+    const polluted = {
+      kind: 'file-artifact-record',
+      ...MANAGED_ROW,
+    } as unknown as ManagedArtifactManifestRecord;
+    expect(() => toStateArtifactRecord(polluted)).toThrow(/managed manifest row without 'kind'/);
+  });
+
+  it('throws even when kind matches the target state discriminator', () => {
+    const polluted = {
+      kind: 'artifact-record',
+      ...MANAGED_ROW,
+    } as unknown as ManagedArtifactManifestRecord;
+    expect(() => toStateArtifactRecord(polluted)).toThrow(/managed manifest row without 'kind'/);
   });
 });

--- a/packages/core/__tests__/runbook/artifact-schema.test.ts
+++ b/packages/core/__tests__/runbook/artifact-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import { ARTIFACT_ERROR_TEXT } from '../../src/runbook/artifact-errors.js';
+import { z } from 'zod';
 import {
   ArtifactKeySchema,
   ArtifactManifestRecordSchema,
@@ -7,6 +8,10 @@ import {
   ArtifactRecordSchema,
   FileArtifactRecordSchema,
   isArtifactRecord,
+  toPublicArtifactMap,
+  toPublicArtifactRecord,
+  toPublicArtifactVarValue,
+  type ArtifactRecord,
 } from '../../src/runbook/artifact-schema.js';
 import { RUNBOOK_REF_ERROR_TEXT, RunbookRefSchema } from '../../src/runbook/runbook-ref.js';
 
@@ -126,6 +131,34 @@ describe('artifact schemas', () => {
         uri: `rd://artifacts/%63tx1/${RUN_ID}/review.json`,
       }),
     ).toThrow(ARTIFACT_ERROR_TEXT.URI_MUST_BE_EXACT);
+  });
+
+  describe('public projection helpers @throws contract', () => {
+    const INVALID_RECORD = {
+      kind: 'artifact-record',
+      uri: 'not-a-valid-uri',
+      runId: 'plain_id',
+      contextId: '../escape',
+      runbook: { source: 'external', path: 'x.md' },
+      key: '../bad',
+      timestamp: 'not-a-timestamp',
+    } as unknown as ArtifactRecord;
+
+    it('toPublicArtifactRecord throws ZodError on invalid input', () => {
+      expect(() => toPublicArtifactRecord(INVALID_RECORD)).toThrow(z.ZodError);
+    });
+
+    it('toPublicArtifactVarValue throws ZodError on invalid scalar', () => {
+      expect(() => toPublicArtifactVarValue(INVALID_RECORD)).toThrow(z.ZodError);
+    });
+
+    it('toPublicArtifactVarValue throws ZodError on invalid element in array', () => {
+      expect(() => toPublicArtifactVarValue([INVALID_RECORD])).toThrow(z.ZodError);
+    });
+
+    it('toPublicArtifactMap throws ZodError when any entry is invalid', () => {
+      expect(() => toPublicArtifactMap({ Plan: INVALID_RECORD })).toThrow(z.ZodError);
+    });
   });
 
   it('rejects uri/top-level field mismatches', () => {

--- a/packages/core/src/events/execution-observation.ts
+++ b/packages/core/src/events/execution-observation.ts
@@ -11,7 +11,11 @@ import type {
   CommandExecutionOutput,
   CommandExecutionPolicyDeniedOutput,
 } from '../runbook/actors/command-exec-actor.js';
-import { isArtifactRecord } from '../runbook/artifact-schema.js';
+import {
+  isArtifactRecord,
+  toPublicArtifactMap,
+  type PublicArtifactVarValue,
+} from '../runbook/artifact-schema.js';
 import type { ArtifactVarValue } from '../runbook/types.js';
 
 /** Execution lifecycle events projected from machine-owned execution effects. */
@@ -120,7 +124,7 @@ function isArtifactVarRecord(value: unknown): value is Readonly<Record<string, A
 
 function extractSnapshotEnteredArtifacts(
   snapshot: unknown,
-): Readonly<Record<string, ArtifactVarValue>> {
+): Readonly<Record<string, PublicArtifactVarValue>> {
   const candidate =
     snapshot &&
     typeof snapshot === 'object' &&
@@ -133,7 +137,7 @@ function extractSnapshotEnteredArtifacts(
   if (candidate && typeof candidate === 'object' && 'enteredArtifacts' in candidate) {
     const value = (candidate as { enteredArtifacts?: unknown }).enteredArtifacts;
     if (isArtifactVarRecord(value)) {
-      return value;
+      return toPublicArtifactMap(value);
     }
   }
   return {};

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -1,7 +1,7 @@
 import type { StepPosition } from '../cli/types.js';
 import type { RunbookRef } from '../runbook/runbook-ref.js';
 import type { ActionType } from '../runbook/transition-kernel.js';
-import type { ArtifactVarValue } from '../runbook/types.js';
+import type { PublicArtifactVarValue } from '../runbook/artifact-schema.js';
 
 // Re-export StepPosition for backwards compatibility and event payload typing
 export type { StepPosition };
@@ -65,7 +65,7 @@ export interface StepEnteredPayload {
   /** Whether runbook is in prompted mode (affects command display) */
   readonly prompted: boolean;
   /** Current execution unit's resolved ARTIFACTS working set. */
-  readonly artifacts: Readonly<Record<string, ArtifactVarValue>>;
+  readonly artifacts: Readonly<Record<string, PublicArtifactVarValue>>;
   /**
    * Delegation frontier — present when entering the first substep of a DELEGATE step.
    * Each entry contains the substep id, runbook path, and pre-issued delegation token.

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -18,7 +18,7 @@ import { z } from 'zod';
 import { TemplateVarValueSchema } from '../schemas.js';
 import { CLAIM_ID_PATTERN } from '../runbook/claim-id.js';
 import { DELEGATION_TOKEN_PATTERN } from '../runbook/delegation-token.js';
-import { ArtifactRecordSchema } from '../runbook/artifact-schema.js';
+import { ArtifactManifestRecordSchema } from '../runbook/artifact-schema.js';
 import { RunbookRefSchema } from '../runbook/runbook-ref.js';
 
 // ============================================================================
@@ -790,7 +790,10 @@ export const CapturedArtifactEntrySchema = z
     at: z.string().optional().describe('Entered step position'),
     /** Artifact working set keyed by ARTIFACTS alias */
     artifacts: z
-      .record(z.string(), z.union([ArtifactRecordSchema, z.array(ArtifactRecordSchema)]))
+      .record(
+        z.string(),
+        z.union([ArtifactManifestRecordSchema, z.array(ArtifactManifestRecordSchema)]),
+      )
       .describe('Artifact working set keyed by alias'),
     /** Runbook that produced the entered event */
     runbook: RunbookRefSchema.optional().describe('Runbook that produced the event'),
@@ -810,7 +813,7 @@ export const ScenarioArtifactAssertionResultSchema = z
     matchedEntry: CapturedArtifactEntrySchema.optional().describe('The entry that matched'),
     /** The artifact records that matched (if any) */
     matchedRecords: z
-      .array(ArtifactRecordSchema)
+      .array(ArtifactManifestRecordSchema)
       .optional()
       .describe('The artifact records that matched'),
   })

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -18,6 +18,7 @@ import {
   type ArtifactRecord,
   type FileArtifactRecord,
   type ArtifactManifestRecord as ArtifactManifestRow,
+  type ManagedArtifactManifestRecord,
 } from './artifact-schema.js';
 import {
   artifactUriToPath,
@@ -311,7 +312,60 @@ function expandArtifactToken(
   });
 }
 
-function toStateArtifactRecord(record: ArtifactManifestRow): ArtifactRecord {
+/**
+ * Branch on the manifest union and project a managed row into a state
+ * record. Producer call sites construct a managed `ArtifactRecord` and
+ * write it through {@link appendArtifactManifestRecord}, which returns the
+ * canonical row typed as the broader `ArtifactManifestRow` union. Receiving
+ * a file-artifact row on a producer path indicates a manifest invariant
+ * violation; throw a clear error rather than silently produce a malformed
+ * state record.
+ *
+ * @param row - Canonical manifest row returned from append
+ * @param declarationName - Variable name driving the producer call, for diagnostics
+ * @returns Tagged state artifact record
+ * @throws {Error} If the manifest returned a file-artifact row on a producer path
+ */
+function projectManagedManifestRow(
+  row: ArtifactManifestRow,
+  declarationName: string,
+): ArtifactRecord {
+  // The manifest union narrows on the presence of `kind`: managed rows have
+  // no `kind` field, file-artifact rows carry `kind: 'file-artifact-record'`.
+  if ('kind' in row) {
+    throw new Error(
+      `ARTIFACTS producer for "${declarationName}" received an unexpected file-artifact manifest row; managed-artifact identity expected`,
+    );
+  }
+  return toStateArtifactRecord(row);
+}
+
+/**
+ * Project a managed manifest row into a tagged state artifact record.
+ *
+ * Manifest rows for managed artifacts carry the six-field shape without a
+ * `kind` discriminator (see {@link ManagedArtifactManifestRecord}); state
+ * records add `kind: 'artifact-record'`. File-artifact manifest rows
+ * already carry `kind: 'file-artifact-record'` and MUST NOT be passed
+ * through here — call sites handle them directly as the file record kind.
+ *
+ * The function tightens its parameter to `ManagedArtifactManifestRecord` and
+ * adds a runtime guard rejecting any input that carries a `kind` field. The
+ * type narrows compile-time risk; the guard defends against unchecked
+ * casts and silent contract violations at runtime (belt and braces).
+ *
+ * @param record - Managed manifest row without a `kind` discriminator
+ * @returns Tagged state artifact record with `kind: 'artifact-record'`
+ * @throws {Error} When the input carries a `kind` field (indicates a
+ *   call-site bug — file rows must not reach this projection)
+ * @throws {z.ZodError} When the constructed record fails schema validation
+ */
+export function toStateArtifactRecord(record: ManagedArtifactManifestRecord): ArtifactRecord {
+  if ('kind' in record && (record as { kind?: unknown }).kind !== undefined) {
+    throw new Error(
+      `toStateArtifactRecord expected a managed manifest row without 'kind', got kind=${String((record as { kind: unknown }).kind)}`,
+    );
+  }
   return ArtifactRecordSchema.parse({ kind: 'artifact-record', ...record });
 }
 
@@ -449,7 +503,7 @@ async function resolveBareKeyProducer(
   };
   const canonical = await appendArtifactManifestRecord(options, record);
   invalidateManifestCache();
-  return toStateArtifactRecord(canonical);
+  return projectManagedManifestRow(canonical, name);
 }
 
 /**
@@ -555,7 +609,7 @@ async function resolveExactUriDeclaration(
     };
     const canonical = await appendArtifactManifestRecord(options, record);
     invalidateManifestCache();
-    return toStateArtifactRecord(canonical);
+    return projectManagedManifestRow(canonical, name);
   }
 
   // Read-only reference to an other-run row. Look up by identity tuple and

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -17,6 +17,7 @@ import {
   isArtifactValue,
   type ArtifactRecord,
   type FileArtifactRecord,
+  type ArtifactManifestRecord as ArtifactManifestRow,
 } from './artifact-schema.js';
 import {
   artifactUriToPath,
@@ -30,6 +31,7 @@ import {
 import type { RunbookRef } from './runbook-ref.js';
 import type { RunId } from './run-id.js';
 import type { ArtifactVarValue } from './types.js';
+import { substituteText } from './template-renderer.js';
 
 /**
  * In-scope variable map consulted for the naked-form ARTIFACTS assertion.
@@ -148,10 +150,12 @@ export async function resolveArtifactDeclarations(
       continue;
     }
 
-    if (declaration.rawToken.startsWith('rd://')) {
+    const rawToken = expandArtifactToken(declaration, options);
+
+    if (rawToken.startsWith('rd://')) {
       result[declaration.name] = await resolveUriLiteralDeclaration(
         declaration.name,
-        declaration.rawToken,
+        rawToken,
         options,
         readManifest,
         invalidateManifestCache,
@@ -169,9 +173,9 @@ export async function resolveArtifactDeclarations(
     //   current context and current run, write a manifest row, return the
     //   resulting ArtifactRecord.
     // Templates MUST already be expanded by the caller.
-    if (declaration.rawToken.includes('*') || declaration.rawToken.includes('?')) {
-      validateBareKeyGlob(declaration.name, declaration.rawToken);
-      const selector = buildImplicitBareKeySelector(declaration.rawToken, options.contextId);
+    if (rawToken.includes('*') || rawToken.includes('?')) {
+      validateBareKeyGlob(declaration.name, rawToken);
+      const selector = buildImplicitBareKeySelector(rawToken, options.contextId);
       result[declaration.name] = resolveSelector(selector, options, await readManifest());
       continue;
     }
@@ -181,10 +185,10 @@ export async function resolveArtifactDeclarations(
     // managed-artifact producer so that a same-named file at the search root
     // cannot silently shadow the producer intent (see issue: silent shadowing
     // of managed-artifact producer).
-    if (isPathLikeArtifactToken(declaration.rawToken)) {
+    if (isPathLikeArtifactToken(rawToken)) {
       const fileRecord = await resolveFileReferenceDeclaration(
         declaration.name,
-        declaration.rawToken,
+        rawToken,
         options,
         invalidateManifestCache,
       );
@@ -196,7 +200,7 @@ export async function resolveArtifactDeclarations(
 
     result[declaration.name] = await resolveBareKeyProducer(
       declaration.name,
-      declaration.rawToken,
+      rawToken,
       options,
       invalidateManifestCache,
     );
@@ -293,6 +297,22 @@ function isPathInside(root: string, candidate: string): boolean {
     relative === '' ||
     (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
   );
+}
+
+function expandArtifactToken(
+  declaration: ArtifactDeclaration,
+  options: ResolveArtifactDeclarationsOptions,
+): string {
+  if (declaration.rawToken === null) {
+    throw new Error(`ARTIFACTS declaration "${declaration.name}" has no quoted token to expand`);
+  }
+  return substituteText(declaration.rawToken, options.scopeVars ?? {}, undefined, {
+    cwd: options.cwd,
+  });
+}
+
+function toStateArtifactRecord(record: ArtifactManifestRow): ArtifactRecord {
+  return ArtifactRecordSchema.parse({ kind: 'artifact-record', ...record });
 }
 
 /**
@@ -427,9 +447,9 @@ async function resolveBareKeyProducer(
     key: rawToken,
     timestamp: new Date().toISOString(),
   };
-  await appendArtifactManifestRecord(options, record);
+  const canonical = await appendArtifactManifestRecord(options, record);
   invalidateManifestCache();
-  return record;
+  return toStateArtifactRecord(canonical);
 }
 
 /**
@@ -533,9 +553,9 @@ async function resolveExactUriDeclaration(
       key: ref.key,
       timestamp: new Date().toISOString(),
     };
-    await appendArtifactManifestRecord(options, record);
+    const canonical = await appendArtifactManifestRecord(options, record);
     invalidateManifestCache();
-    return record;
+    return toStateArtifactRecord(canonical);
   }
 
   // Read-only reference to an other-run row. Look up by identity tuple and

--- a/packages/core/src/runbook/artifact-schema.ts
+++ b/packages/core/src/runbook/artifact-schema.ts
@@ -149,9 +149,19 @@ const FileUriSchema = z.string().superRefine((value, ctx) => {
  * Manifest JSONL is the documented six-field shape and does not carry the
  * state-only `kind` discriminator.
  */
-const ManagedArtifactManifestRecordSchema = ArtifactMetadataSchema.extend({
+export const ManagedArtifactManifestRecordSchema = ArtifactMetadataSchema.extend({
   uri: z.string(),
 }).superRefine(validateArtifactRecordIdentity);
+
+/**
+ * Managed artifact manifest row — the six-field shape persisted on disk for
+ * managed (`rd://`) artifacts, with no `kind` discriminator.
+ *
+ * State records add the `kind: 'artifact-record'` tag; manifest rows do not.
+ * Use this type at the boundary between manifest IO and state record
+ * construction (see {@link toStateArtifactRecord}).
+ */
+export type ManagedArtifactManifestRecord = z.infer<typeof ManagedArtifactManifestRecordSchema>;
 
 /**
  * Zod schema for one file reference artifact record.
@@ -255,6 +265,7 @@ export function isArtifactValue(
  *
  * @param record - Internal tagged artifact record
  * @returns Public artifact record without internal discriminator fields
+ * @throws {z.ZodError} When `record` fails {@link ArtifactManifestRecordSchema} validation
  */
 export function toPublicArtifactRecord(record: ArtifactRecord): PublicArtifactRecord {
   return ArtifactManifestRecordSchema.parse(record);
@@ -265,6 +276,8 @@ export function toPublicArtifactRecord(record: ArtifactRecord): PublicArtifactRe
  *
  * @param value - Internal artifact variable value
  * @returns Public artifact variable value
+ * @throws {z.ZodError} When `value` (or any element of an array `value`) fails
+ *   {@link ArtifactManifestRecordSchema} validation
  */
 export function toPublicArtifactVarValue(
   value: ArtifactRecord | readonly ArtifactRecord[],
@@ -280,6 +293,8 @@ export function toPublicArtifactVarValue(
  *
  * @param artifacts - Internal ARTIFACTS working set
  * @returns Public ARTIFACTS working set
+ * @throws {z.ZodError} When any entry in `artifacts` fails
+ *   {@link ArtifactManifestRecordSchema} validation
  */
 export function toPublicArtifactMap(
   artifacts: Readonly<Record<string, ArtifactRecord | readonly ArtifactRecord[]>>,

--- a/packages/core/src/runbook/artifact-schema.ts
+++ b/packages/core/src/runbook/artifact-schema.ts
@@ -216,6 +216,12 @@ export const ArtifactRecordSchema = z.discriminatedUnion('kind', [
  */
 export type ArtifactRecord = z.infer<typeof ArtifactRecordSchema>;
 
+/** Public ArtifactRecord shape exposed in events and CLI output. */
+export type PublicArtifactRecord = ArtifactManifestRecord;
+
+/** Public artifact value shape exposed in events and CLI output. */
+export type PublicArtifactVarValue = PublicArtifactRecord | readonly PublicArtifactRecord[];
+
 /**
  * Type guard for {@link ArtifactRecord}.
  *
@@ -242,4 +248,43 @@ export function isArtifactValue(
     return value.length > 0 && value.every(isArtifactRecord);
   }
   return isArtifactRecord(value);
+}
+
+/**
+ * Project an internal state artifact record to the public six-field shape.
+ *
+ * @param record - Internal tagged artifact record
+ * @returns Public artifact record without internal discriminator fields
+ */
+export function toPublicArtifactRecord(record: ArtifactRecord): PublicArtifactRecord {
+  return ArtifactManifestRecordSchema.parse(record);
+}
+
+/**
+ * Project an internal artifact variable value to the public event/output shape.
+ *
+ * @param value - Internal artifact variable value
+ * @returns Public artifact variable value
+ */
+export function toPublicArtifactVarValue(
+  value: ArtifactRecord | readonly ArtifactRecord[],
+): PublicArtifactVarValue {
+  if (Array.isArray(value)) {
+    return (value as readonly ArtifactRecord[]).map(toPublicArtifactRecord);
+  }
+  return toPublicArtifactRecord(value as ArtifactRecord);
+}
+
+/**
+ * Project an internal artifact working set to public event/output values.
+ *
+ * @param artifacts - Internal ARTIFACTS working set
+ * @returns Public ARTIFACTS working set
+ */
+export function toPublicArtifactMap(
+  artifacts: Readonly<Record<string, ArtifactRecord | readonly ArtifactRecord[]>>,
+): Readonly<Record<string, PublicArtifactVarValue>> {
+  return Object.fromEntries(
+    Object.entries(artifacts).map(([name, value]) => [name, toPublicArtifactVarValue(value)]),
+  );
 }

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -67,7 +67,7 @@ import {
 } from './output-evaluator.js';
 import type { DelegateFrontierEntry } from '../events/types.js';
 import type { MachineExecutionObserver } from '../events/execution-observation.js';
-import { buildFrameKey } from './targeting.js';
+import { buildFrameKey, deriveExecutionAt } from './targeting.js';
 import { runRetryHook } from './retry-hook.js';
 import { asTemplateVars } from './template-vars.js';
 import { getErrorMessage } from '../errors.js';
@@ -453,9 +453,15 @@ function isCommandCompletedOutput(
 
 function buildArtifactResolveInput(
   declarations: readonly ArtifactDeclaration[],
+  stepName: string,
+  substepId: string | undefined,
   context: RunbookContext,
   evaluationOptions: EvaluateOutputOptions | undefined,
 ): ArtifactResolveInput {
+  const scopeVars = {
+    ...mergeEffectiveVars({ templateVars: context.templateVars, variables: context.variables }),
+    ...buildArtifactRuntimeScope(stepName, substepId, context.forStack),
+  };
   return {
     declarations,
     cwd: requireArtifactsCwd(evaluationOptions),
@@ -463,10 +469,42 @@ function buildArtifactResolveInput(
     contextId: requireStringTemplateVar(context.templateVars, 'ContextId'),
     runId: assertRunId(requireStringTemplateVar(context.templateVars, 'RunId')),
     runbook: requireRunbookRef(context.templateVars),
-    scopeVars: { ...context.templateVars, ...context.variables },
+    scopeVars,
     fileArtifactSearchRoots: evaluationOptions?.fileArtifactSearchRoots,
     allowFileArtifactRead: evaluationOptions?.allowFileArtifactRead,
   };
+}
+
+function buildArtifactRuntimeScope(
+  stepName: string,
+  substepId: string | undefined,
+  forStack: readonly ForContext[],
+): Record<string, unknown> {
+  const step = substepId ? `${stepName}.${substepId}` : stepName;
+  const vars: Record<string, unknown> = {
+    Step: step,
+    step,
+    'context.current.step': step,
+    'context.current.at': deriveExecutionAt(stepName, substepId),
+  };
+  if (substepId) {
+    vars['context.current.substep'] = substepId;
+  }
+  const top = forStack.at(-1);
+  if (top && !top.implicit) {
+    vars.Index = String(top.iteration);
+    vars.index = String(top.iteration);
+    vars['context.current.index'] = String(top.iteration);
+    vars['context.current.at'] = deriveExecutionAt(stepName, substepId, top.iteration);
+    if (top.variable) {
+      if (top.source.kind === 'range') {
+        vars[top.variable] = String(top.iteration);
+      } else if (isResolvedVariableForContext(top)) {
+        vars[top.variable] = top.currentValue;
+      }
+    }
+  }
+  return vars;
 }
 
 // Typed constants for empty array values that need explicit types
@@ -3252,11 +3290,13 @@ export function compileRunbookToMachine(
   };
   const buildArtifactResolveInvokeBlock = (
     declarations: readonly ArtifactDeclaration[],
+    stepName: string,
+    substepId: string | undefined,
     target: string,
   ): NonNullable<RunbookStateConfig['invoke']> => ({
     src: 'artifactResolveActor' as const,
     input: ({ context }: { context: RunbookContext }) =>
-      buildArtifactResolveInput(declarations, context, evaluationOptions),
+      buildArtifactResolveInput(declarations, stepName, substepId, context, evaluationOptions),
     onDone: {
       target,
       actions: {
@@ -3450,6 +3490,8 @@ export function compileRunbookToMachine(
           tags: [PENDING_MACHINE_EFFECT_TAG],
           invoke: buildArtifactResolveInvokeBlock(
             step.artifacts,
+            step.name,
+            substep.id,
             formatStateId(step.name, substep.id),
           ),
         }),
@@ -3554,6 +3596,8 @@ export function compileRunbookToMachine(
     const afterArtifactsTarget = shouldIssueDelegations ? '__issue-delegations' : 'idle';
     const artifactResolveInvokeBlock = buildArtifactResolveInvokeBlock(
       artifactDeclarations,
+      config.stepName,
+      config.substepId,
       afterArtifactsTarget,
     );
     const initialSubstate = needsIteration

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -237,10 +237,15 @@ export {
   ArtifactRecordSchema,
   isArtifactRecord,
   isArtifactValue,
+  toPublicArtifactMap,
+  toPublicArtifactRecord,
+  toPublicArtifactVarValue,
   type ArtifactKey,
   type FileArtifactRecord,
   type ArtifactMetadata,
   type ArtifactRecord,
+  type PublicArtifactRecord,
+  type PublicArtifactVarValue,
 } from './artifact-schema.js';
 export {
   appendArtifactManifestRecord,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -231,6 +231,7 @@ export {
 } from './runbook-ref.js';
 export {
   ArtifactKeySchema,
+  ArtifactManifestRecordSchema,
   FileArtifactRecordSchema,
   ArtifactMetadataSchema,
   ManagedArtifactRecordSchema,

--- a/packages/parser/__tests__/artifacts.test.ts
+++ b/packages/parser/__tests__/artifacts.test.ts
@@ -54,6 +54,27 @@ describe('parseArtifactDeclaration', () => {
     expect(parseArtifactDeclaration('Plans "**.json"')).toBeNull();
   });
 
+  it.each([
+    'Plans "dir/**/x.json"',
+    'Plans "rd://artifacts/ctx/*/**.json"',
+    'Plans "rd://artifacts/**/plan.json"',
+    'Plans "a/**"',
+  ])('rejects recursive `**` in path/URI token form: %s', (input) => {
+    expect(parseArtifactDeclaration(input)).toBeNull();
+  });
+
+  it.each([
+    'Plans "./plan.json"',
+    'Plans "../plan.json"',
+    'Plans "a/./b.json"',
+    'Plans "a/../b.json"',
+    'Plans "rd://artifacts/ctx/../plan.json"',
+    'Plans "dir/."',
+    'Plans "dir/.."',
+  ])('rejects path-traversal segments: %s', (input) => {
+    expect(parseArtifactDeclaration(input)).toBeNull();
+  });
+
   it('rejects the empty quoted token', () => {
     expect(parseArtifactDeclaration('PlanPath ""')).toBeNull();
   });

--- a/packages/parser/__tests__/artifacts.test.ts
+++ b/packages/parser/__tests__/artifacts.test.ts
@@ -50,18 +50,16 @@ describe('parseArtifactDeclaration', () => {
     });
   });
 
-  it('accepts a recursive `**` token (resolver enforces the rule)', () => {
-    expect(parseArtifactDeclaration('Plans "**.json"')).toEqual({
-      name: 'Plans',
-      rawToken: '**.json',
-    });
+  it('rejects a recursive `**` token', () => {
+    expect(parseArtifactDeclaration('Plans "**.json"')).toBeNull();
   });
 
-  it('accepts the empty quoted token (resolver enforces the rule)', () => {
-    expect(parseArtifactDeclaration('PlanPath ""')).toEqual({
-      name: 'PlanPath',
-      rawToken: '',
-    });
+  it('rejects the empty quoted token', () => {
+    expect(parseArtifactDeclaration('PlanPath ""')).toBeNull();
+  });
+
+  it.each(['"."', '".."'])('rejects invalid bare-key literal %s', (token) => {
+    expect(parseArtifactDeclaration(`PlanPath ${token}`)).toBeNull();
   });
 
   it('parses the naked form (no quoted token)', () => {
@@ -71,11 +69,8 @@ describe('parseArtifactDeclaration', () => {
     });
   });
 
-  it('parses with single-quoted token', () => {
-    expect(parseArtifactDeclaration("Plan 'plan.json'")).toEqual({
-      name: 'Plan',
-      rawToken: 'plan.json',
-    });
+  it('rejects single-quoted tokens', () => {
+    expect(parseArtifactDeclaration("Plan 'plan.json'")).toBeNull();
   });
 
   it('returns null when the token is not quoted', () => {
@@ -209,6 +204,25 @@ describe('parseRunbookDocument with ARTIFACTS directive', () => {
 `;
     expect(() => parseRunbookDocument(md)).toThrow(RunbookSyntaxError);
     expect(() => parseRunbookDocument(md)).toThrow(/duplicate.*alias.*PlanPath/i);
+  });
+
+  it('reports frontmatter ARTIFACTS as invalid directive misuse', () => {
+    const md = `---
+ARTIFACTS:
+  - Plan "plan.json"
+---
+## 1. Write plan
+`;
+
+    const { diagnostics } = parseRunbookDocument(md);
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          message: expect.stringMatching(/ARTIFACTS.*frontmatter/i),
+        }),
+      ]),
+    );
   });
 
   it('throws on a reserved-name alias', () => {

--- a/packages/parser/src/frontmatter.ts
+++ b/packages/parser/src/frontmatter.ts
@@ -185,6 +185,12 @@ export function extractFrontmatter(markdown: string): {
   // diagnostics for each invalid one — instead of silently dropping the whole
   // array on the first bad element).
   const diagnostics: ValidationDiagnostic[] = [];
+  if (Object.keys(data).some((key) => key.toLowerCase() === 'artifacts')) {
+    diagnostics.push({
+      severity: 'error',
+      message: 'ARTIFACTS is invalid in frontmatter; declare ARTIFACTS on a step or substep',
+    });
+  }
   const inputs =
     parsed.inputs !== undefined ? filterInputDeclarations(parsed.inputs, diagnostics) : undefined;
   const required =

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -1205,14 +1205,28 @@ export function parseArtifactDeclaration(text: string): ArtifactDeclaration | nu
 
 function isStructurallyValidArtifactToken(token: string): boolean {
   if (token.length === 0) return false;
+  // Reject-first: these rules apply across all token classes (bare, wildcard,
+  // path, URI). Placing them above the early accept branches prevents
+  // path-like and URI tokens from bypassing structural validation.
+  if (token === '.' || token === '..' || token.includes('**')) return false;
+  if (hasTraversalSegment(token)) return false;
   if (token.includes('{{')) return true;
   if (token.startsWith('rd://')) return true;
   if (token.includes('/') || token.includes('\\')) return true;
-  if (token === '.' || token === '..' || token.includes('**')) return false;
   if (token.includes('*') || token.includes('?')) {
     return WILDCARD_ARTIFACT_KEY_PATTERN.test(token);
   }
   return EXACT_ARTIFACT_KEY_PATTERN.test(token);
+}
+
+function hasTraversalSegment(token: string): boolean {
+  // Reject `.` or `..` appearing as a whole path segment under either separator.
+  for (const sep of ['/', '\\'] as const) {
+    if (token.startsWith(`.${sep}`) || token.startsWith(`..${sep}`)) return true;
+    if (token.endsWith(`${sep}.`) || token.endsWith(`${sep}..`)) return true;
+    if (token.includes(`${sep}.${sep}`) || token.includes(`${sep}..${sep}`)) return true;
+  }
+  return false;
 }
 
 /**

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -14,7 +14,13 @@ import type {
   TerminalAction,
   Transitions,
 } from './schemas.js';
-import { MAX_FOR_BOUND, MAX_STEP_NUMBER, TEMPLATE_VAR_PATH_PATTERN } from './schemas.js';
+import {
+  EXACT_ARTIFACT_KEY_PATTERN,
+  MAX_FOR_BOUND,
+  MAX_STEP_NUMBER,
+  TEMPLATE_VAR_PATH_PATTERN,
+  WILDCARD_ARTIFACT_KEY_PATTERN,
+} from './schemas.js';
 import {
   parseStepIdFromString,
   stepIdToString,
@@ -1185,16 +1191,28 @@ export function parseArtifactDeclaration(text: string): ArtifactDeclaration | nu
     return { name, rawToken: null };
   }
 
-  // The remainder must be a single quoted string and nothing else.
-  const first = rest.charAt(0);
-  if (first !== '"' && first !== "'") return null;
-  if (rest.length < 2 || !rest.endsWith(first)) return null;
+  // The grammar admits only double-quoted artifact tokens.
+  if (!rest.startsWith('"')) return null;
+  if (rest.length < 2 || !rest.endsWith('"')) return null;
   const inner = rest.slice(1, -1);
   // Reject embedded matching quotes — guards against `Name "a" "b"` and
   // unbalanced quoting that would otherwise pass the start/end check.
-  if (inner.includes(first)) return null;
+  if (inner.includes('"')) return null;
+  if (!isStructurallyValidArtifactToken(inner)) return null;
 
   return { name, rawToken: inner };
+}
+
+function isStructurallyValidArtifactToken(token: string): boolean {
+  if (token.length === 0) return false;
+  if (token.includes('{{')) return true;
+  if (token.startsWith('rd://')) return true;
+  if (token.includes('/') || token.includes('\\')) return true;
+  if (token === '.' || token === '..' || token.includes('**')) return false;
+  if (token.includes('*') || token.includes('?')) {
+    return WILDCARD_ARTIFACT_KEY_PATTERN.test(token);
+  }
+  return EXACT_ARTIFACT_KEY_PATTERN.test(token);
 }
 
 /**


### PR DESCRIPTION
## Summary
- tighten ARTIFACTS parser validation and reject invalid quoted tokens/frontmatter ARTIFACTS declarations
- expand ARTIFACTS tokens with runtime scope before resolution and preserve canonical manifest rows for producer artifacts
- strip internal artifact record fields from public event/schema output and update docs/spec wording, including #324 file-reference notes

## Verification
- npm run test:unit -w packages/parser
- npm run test:unit -w packages/core
- npm test -w packages/cli -- --runTestsByPath __tests__/helpers/command-sequence.test.ts __tests__/services/execution-loop.test.ts __tests__/integration/artifacts-resolution.test.ts
- npm run build -w packages/parser -w packages/core -w packages/cli
- npm run check:types -w packages/parser && npm run check:types -w packages/core && npm run check:types -w packages/cli
- npm run check:format
- npm run check:lint:fast
- npm run check:lint:typed

Refs #324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded scenario guidance to include expect.artifacts; tightened ARTIFACTS grammar/runtime rules (allowed token forms, absolute-path/read-policy handling, realpath containment, manifest key vs recorded URI); ARTIFACTS in frontmatter now flagged invalid; reserved names runid and runbookref added.

* **Changes**
  * Artifact tokens now require double quotes and stricter structural validation.
  * Events/CLI emit a public artifact shape (uri, key, timestamp, runId, contextId, runbook) without internal fields.
  * Artifact declaration resolution uses runtime-expanded tokens/scope and stricter manifest handling.

* **Tests**
  * Tests updated to match public artifact shapes and tightened parsing expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->