### PR TITLE
fix(cli): parse step_entered artifacts as public records

### DIFF
--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -9,7 +9,7 @@
 
 import { spawn } from 'node:child_process';
 import {
-  ArtifactManifestRecordSchema,
+  isPublicArtifactRecord,
   RunbookRefSchema,
   type PublicArtifactRecord,
   type RunbookRef,
@@ -457,18 +457,12 @@ function parseCapturedArtifacts(
 
   const artifacts: Record<string, PublicArtifactRecord | PublicArtifactRecord[] | undefined> = {};
   for (const [alias, artifactValue] of Object.entries(value)) {
-    const parsedRecord = ArtifactManifestRecordSchema.safeParse(artifactValue);
-    if (parsedRecord.success) {
-      artifacts[alias] = parsedRecord.data;
+    if (isPublicArtifactRecord(artifactValue)) {
+      artifacts[alias] = artifactValue;
       continue;
     }
-    if (Array.isArray(artifactValue)) {
-      const parsedRecords = artifactValue.map((entry) =>
-        ArtifactManifestRecordSchema.safeParse(entry),
-      );
-      if (parsedRecords.every((entry) => entry.success)) {
-        artifacts[alias] = parsedRecords.map((entry) => entry.data);
-      }
+    if (Array.isArray(artifactValue) && artifactValue.every(isPublicArtifactRecord)) {
+      artifacts[alias] = artifactValue;
     }
   }
 

--- a/packages/core/src/runbook/artifact-schema.ts
+++ b/packages/core/src/runbook/artifact-schema.ts
@@ -243,6 +243,17 @@ export function isArtifactRecord(value: unknown): value is ArtifactRecord {
 }
 
 /**
+ * Type guard for {@link PublicArtifactRecord} — the six-field shape emitted
+ * in events and CLI output (no `kind` discriminator).
+ *
+ * @param value - Value to test
+ * @returns `true` when the value validates as a public artifact record
+ */
+export function isPublicArtifactRecord(value: unknown): value is PublicArtifactRecord {
+  return ArtifactManifestRecordSchema.safeParse(value).success;
+}
+
+/**
  * Type guard for `ArtifactRecord | readonly ArtifactRecord[]`.
  *
  * Tag-narrows via {@link isArtifactRecord}. Empty arrays return `false` —

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -238,6 +238,7 @@ export {
   ArtifactRecordSchema,
   isArtifactRecord,
   isArtifactValue,
+  isPublicArtifactRecord,
   toPublicArtifactMap,
   toPublicArtifactRecord,
   toPublicArtifactVarValue,


### PR DESCRIPTION
## Summary
Fixes the `global-artifact-variable` scenario failure on this branch.

Commit `0571bf4e` ("fix: align artifacts conformance") routed `extractSnapshotEnteredArtifacts` through `toPublicArtifactMap`, so `step_entered` events now emit the six-field **public** artifact shape (no `kind` discriminator). The scenario CLI consumer in `packages/cli/src/helpers/command-sequence.ts` was not updated — it still calls `isArtifactRecord`, which insists on `kind: 'artifact-record'` and silently rejects every emitted record. Result: `artifactEntries` end up with empty `artifacts` maps, and artifact assertions (newly added in #321) can never match.

## Changes
- Add `isPublicArtifactRecord` guard in `packages/core/src/runbook/artifact-schema.ts` — validates against `ArtifactManifestRecordSchema` (the six-field public shape).
- Export it from `packages/core/src/runbook/index.ts`.
- Switch `packages/cli/src/helpers/command-sequence.ts` to import `PublicArtifactRecord` / `isPublicArtifactRecord` and use them throughout `CapturedArtifactEntry`, `ArtifactAssertionResult`, `parseCapturedArtifacts`, and `artifactEventMatchesAssertion`.

## Test plan
- [x] `npm run verify` — exit 0
- [x] `node scripts/test-scenarios.mjs` — 264 passed, 0 failed (previously 263 passed, 1 failed)

## Base
Branched off `2026-05-18-sync-docs` because `0571bf4e` only lives there, not on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved artifact validation logic for better type safety and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->