### PR TITLE
[codex] Classify ARTIFACTS tokens in parser

### DIFF
--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -27,8 +27,10 @@ const RUNBOOK = { source: 'project' as const, path: 'planning/write-plan.runbook
 const CHILD_RUNBOOK = { source: 'project' as const, path: 'planning/review.runbook.md' };
 
 let tempDirs: string[] = [];
+const originalProcessCwd = process.cwd();
 
 afterEach(async () => {
+  process.chdir(originalProcessCwd);
   await Promise.all(tempDirs.map((dir) => fsp.rm(dir, { recursive: true, force: true })));
   tempDirs = [];
 });
@@ -395,6 +397,108 @@ describe('resolveArtifactDeclarations — bare key (producer form)', () => {
     });
   });
 
+  it('dispatches an expanded template to the URI literal resolver', async () => {
+    const cwd = await tempCwd();
+
+    const result = await resolveArtifactDeclarations([decl('Plan', '{{PlanUri}}')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      scopeVars: {
+        PlanUri: `rd://artifacts/${CONTEXT_ID}/${CURRENT_RUN}/plan.json`,
+      },
+    });
+
+    expect(result.Plan).toMatchObject({
+      kind: 'artifact-record',
+      uri: `rd://artifacts/${CONTEXT_ID}/${CURRENT_RUN}/plan.json`,
+      key: 'plan.json',
+    });
+  });
+
+  it('dispatches an expanded template to the wildcard selector resolver', async () => {
+    const cwd = await tempCwd();
+    const row = record({ runId: CURRENT_RUN, runbook: RUNBOOK, key: 'review-plan-a.json' });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, row);
+    await touchArtifact(cwd, row);
+
+    const result = await resolveArtifactDeclarations([decl('Reviews', '{{ReviewGlob}}')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      scopeVars: { ReviewGlob: 'review-*.json' },
+    });
+
+    expect(result.Reviews).toEqual(row);
+  });
+
+  it('dispatches an expanded template to the path-like file resolver', async () => {
+    const cwd = await tempCwd();
+    await fsp.mkdir(path.join(cwd, 'schemas'), { recursive: true });
+    const schemaPath = path.join(cwd, 'schemas', 'review.schema.json');
+    await fsp.writeFile(schemaPath, '{}');
+    const canonicalSchemaPath = await fsp.realpath(schemaPath);
+
+    const result = await resolveArtifactDeclarations([decl('Schema', '{{SchemaPath}}')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      scopeVars: { SchemaPath: 'schemas/review.schema.json' },
+    });
+
+    expect(result.Schema).toMatchObject({
+      kind: 'file-artifact-record',
+      uri: pathToFileURL(canonicalSchemaPath).href,
+      key: 'schemas/review.schema.json',
+    });
+  });
+
+  it('rejects Windows-style absolute paths on POSIX before resolving against process cwd', async () => {
+    if (process.platform === 'win32') return;
+
+    const cwd = await tempCwd();
+    const processCwd = await tempCwd();
+    const windowsToken = 'C:\\tmp\\plan.json';
+    await fsp.writeFile(path.join(processCwd, windowsToken), '{}');
+    process.chdir(processCwd);
+    let policyConsulted = false;
+
+    await expect(
+      resolveArtifactDeclarations([decl('Plan', windowsToken)], {
+        cwd,
+        workPath: WORK_PATH,
+        contextId: CONTEXT_ID,
+        runId: CURRENT_RUN,
+        runbook: RUNBOOK,
+        allowFileArtifactRead: () => {
+          policyConsulted = true;
+          return true;
+        },
+      }),
+    ).rejects.toThrow(/unsupported|absolute|platform/i);
+    expect(policyConsulted).toBe(false);
+  });
+
+  it('rejects unresolved template markers after expansion', async () => {
+    const cwd = await tempCwd();
+
+    await expect(
+      resolveArtifactDeclarations([decl('Plan', 'rd://{{Missing}}/file.yaml')], {
+        cwd,
+        workPath: WORK_PATH,
+        contextId: CONTEXT_ID,
+        runId: CURRENT_RUN,
+        runbook: RUNBOOK,
+      }),
+    ).rejects.toThrow(/unresolved template/i);
+  });
+
   it('expands quoted tokens from dotted runtime scope variables', async () => {
     const cwd = await tempCwd();
 
@@ -421,7 +525,8 @@ describe('resolveArtifactDeclarations — symlink and traversal containment', ()
     const outside = await tempCwd();
     const outsideTarget = path.join(outside, 'secret.json');
     await fsp.writeFile(outsideTarget, '{}');
-    const link = path.join(cwd, 'escape');
+    await fsp.mkdir(path.join(cwd, 'links'), { recursive: true });
+    const link = path.join(cwd, 'links', 'escape');
     try {
       await fsp.symlink(outsideTarget, link);
     } catch (error) {
@@ -437,7 +542,7 @@ describe('resolveArtifactDeclarations — symlink and traversal containment', ()
     }
 
     await expect(
-      resolveArtifactDeclarations([decl('Escape', './escape')], {
+      resolveArtifactDeclarations([decl('Escape', 'links/escape')], {
         cwd,
         workPath: WORK_PATH,
         contextId: CONTEXT_ID,
@@ -448,9 +553,9 @@ describe('resolveArtifactDeclarations — symlink and traversal containment', ()
   });
 
   it('rejects parent-traversal tokens without consulting allowFileArtifactRead (Test B)', async () => {
-    // A relative path-like token containing `../..` is constrained by the
-    // search-root containment check. The read-policy callable must never be
-    // invoked for relative tokens — only for explicit absolute paths.
+    // A relative path-like token containing `../..` is rejected by classifier
+    // before file probing. The read-policy callable must never be invoked for
+    // relative tokens — only for explicit absolute paths.
     const cwd = await tempCwd();
     let policyConsulted = false;
 
@@ -466,7 +571,7 @@ describe('resolveArtifactDeclarations — symlink and traversal containment', ()
           return true;
         },
       }),
-    ).rejects.toThrow(/file reference|not found/i);
+    ).rejects.toThrow(/dot|traversal|invalid token/i);
     expect(policyConsulted).toBe(false);
   });
 
@@ -766,11 +871,12 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
 
 describe('resolveArtifactDeclarations — file-reference manifest audit identity', () => {
   it('keeps two file rows with the same canonical URI but different raw tokens', async () => {
-    // File-reference rows are audit records. Two spellings of the same file
-    // (`./x.md` vs `x.md`) normalise to the same canonical `file://` URI, but
-    // the raw declaration token remains part of the manifest identity.
+    // File-reference rows are audit records. Two declaration tokens can
+    // normalise to the same canonical `file://` URI, but the raw declaration
+    // token remains part of the manifest identity.
     const cwd = await tempCwd();
-    const filePath = path.join(cwd, 'x.md');
+    const filePath = path.join(cwd, 'dir', 'x.md');
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
     await fsp.writeFile(filePath, '# x');
     const canonical = await fsp.realpath(filePath);
     const canonicalUri = pathToFileURL(canonical).href;
@@ -783,10 +889,13 @@ describe('resolveArtifactDeclarations — file-reference manifest audit identity
       runbook: RUNBOOK,
       timestamp: '2026-05-07T00:00:00.000Z',
     };
-    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, { ...baseRow, key: './x.md' });
     await appendArtifactManifestRecord(
       { cwd, workPath: WORK_PATH },
-      { ...baseRow, key: 'x.md', timestamp: '2026-05-07T01:00:00.000Z' },
+      { ...baseRow, key: 'dir/x.md' },
+    );
+    await appendArtifactManifestRecord(
+      { cwd, workPath: WORK_PATH },
+      { ...baseRow, key: 'dir/link.md', timestamp: '2026-05-07T01:00:00.000Z' },
     );
 
     const { coalesceManifestRecords, readArtifactManifest: readMan } = await import(
@@ -797,8 +906,12 @@ describe('resolveArtifactDeclarations — file-reference manifest audit identity
     );
     expect(coalesced).toHaveLength(2);
     expect(coalesced).toEqual([
-      expect.objectContaining({ kind: 'file-artifact-record', key: './x.md', uri: canonicalUri }),
-      expect.objectContaining({ kind: 'file-artifact-record', key: 'x.md', uri: canonicalUri }),
+      expect.objectContaining({ kind: 'file-artifact-record', key: 'dir/x.md', uri: canonicalUri }),
+      expect.objectContaining({
+        kind: 'file-artifact-record',
+        key: 'dir/link.md',
+        uri: canonicalUri,
+      }),
     ]);
   });
 
@@ -806,17 +919,34 @@ describe('resolveArtifactDeclarations — file-reference manifest audit identity
     // Idempotency only applies to the same audit identity. Different raw
     // declaration tokens for the same canonical file must remain distinct.
     const cwd = await tempCwd();
-    const filePath = path.join(cwd, 'x.md');
+    const dir = path.join(cwd, 'dir');
+    await fsp.mkdir(dir, { recursive: true });
+    const filePath = path.join(dir, 'x.md');
     await fsp.writeFile(filePath, '# x');
+    const linkPath = path.join(dir, 'link.md');
+    try {
+      await fsp.symlink(filePath, linkPath);
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        error.code === 'EPERM'
+      ) {
+        await fsp.link(filePath, linkPath);
+      } else {
+        throw error;
+      }
+    }
 
-    await resolveArtifactDeclarations([decl('X1', './x.md')], {
+    await resolveArtifactDeclarations([decl('X1', 'dir/x.md')], {
       cwd,
       workPath: WORK_PATH,
       contextId: CONTEXT_ID,
       runId: CURRENT_RUN,
       runbook: RUNBOOK,
     });
-    await resolveArtifactDeclarations([decl('X2', './sub/../x.md')], {
+    await resolveArtifactDeclarations([decl('X2', 'dir/link.md')], {
       cwd,
       workPath: WORK_PATH,
       contextId: CONTEXT_ID,
@@ -827,8 +957,8 @@ describe('resolveArtifactDeclarations — file-reference manifest audit identity
     const raw = await readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
     expect(raw).toHaveLength(2);
     expect(raw).toEqual([
-      expect.objectContaining({ kind: 'file-artifact-record', key: './x.md' }),
-      expect.objectContaining({ kind: 'file-artifact-record', key: './sub/../x.md' }),
+      expect.objectContaining({ kind: 'file-artifact-record', key: 'dir/x.md' }),
+      expect.objectContaining({ kind: 'file-artifact-record', key: 'dir/link.md' }),
     ]);
   });
 });
@@ -1311,7 +1441,7 @@ describe('resolveArtifactDeclarations — bare-key glob validation', () => {
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
       }),
-    ).rejects.toThrow(/wildcard_artifact_key|invalid glob/);
+    ).rejects.toThrow(/dot|traversal|invalid token|invalid glob/);
   });
 
   it('accepts a single-char bare-key glob (`?`) — no regression', async () => {

--- a/packages/core/__tests__/runbook/artifact-file-reference.properties.test.ts
+++ b/packages/core/__tests__/runbook/artifact-file-reference.properties.test.ts
@@ -62,18 +62,19 @@ describe('artifact file reference properties', () => {
   });
 
   it('always rejects symlinks under cwd whose realpath escapes the search roots', async () => {
-    // Property: for any token of the shape `./<segment>` resolving to a
-    // symlink under `cwd` that points OUTSIDE the search roots, the resolver
-    // throws "not found" — never silently follows the symlink to the outside
-    // target. This pins the realpath + containment guard at
+    // Property: for any non-dot relative token resolving to a symlink under
+    // `cwd` that points OUTSIDE the search roots, the resolver throws
+    // "not found" — never silently follows the symlink to the outside target.
+    // This pins the realpath + containment guard at
     // `artifact-directive-resolver.ts` `resolveExistingFileReference`.
     await fc.assert(
-      fc.asyncProperty(safeSegment, safeSegment, async (linkName, targetName) => {
+      fc.asyncProperty(safeSegment, safeSegment, safeSegment, async (dir, linkName, targetName) => {
         const cwd = await tempCwd();
         const outside = await tempCwd();
         const outsideTarget = path.join(outside, `${targetName}.json`);
         await fsp.writeFile(outsideTarget, '{}');
-        const link = path.join(cwd, linkName);
+        await fsp.mkdir(path.join(cwd, dir), { recursive: true });
+        const link = path.join(cwd, dir, linkName);
         try {
           await fsp.symlink(outsideTarget, link);
         } catch (error) {
@@ -89,7 +90,7 @@ describe('artifact file reference properties', () => {
         }
 
         await expect(
-          resolveArtifactDeclarations([decl('Esc', `./${linkName}`)], {
+          resolveArtifactDeclarations([decl('Esc', `${dir}/${linkName}`)], {
             cwd,
             workPath: WORK_PATH,
             contextId: CONTEXT_ID,

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -1,9 +1,13 @@
-import { WILDCARD_ARTIFACT_KEY_PATTERN, type ArtifactDeclaration } from '@rundown-org/parser';
+import {
+  classifyExpandedArtifactToken,
+  formatArtifactTokenRejectReason,
+  type ArtifactDeclaration,
+  type ParsedArtifactToken,
+} from '@rundown-org/parser';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import picomatch from 'picomatch';
-import { SAFE_ID_PATTERN } from '../paths.js';
 import {
   appendArtifactManifestRecord,
   coalesceManifestRecords,
@@ -83,14 +87,19 @@ export interface ResolveArtifactDeclarationsOptions extends ArtifactPathOptions 
 /**
  * Resolve a step/substep ARTIFACTS block.
  *
- * Each declaration's `rawToken` is classified at resolve time:
+ * Each quoted declaration token is expanded once, classified with the
+ * parser-owned ARTIFACTS token classifier, then dispatched by token kind:
  *
  * - **Bare key shortcut** — non-URI quoted token, e.g. `"plan.json"`. Per
  *   spec §10.1.1, this is syntactic sugar for an exact URI in the current
- *   context and current run. The resolver validates the key (no glob chars,
- *   matches `exact_artifact_key`), builds the exact URI, **appends a manifest
- *   row** for the producer identity tuple, and returns the resulting
+ *   context and current run. The parser classifier has already validated
+ *   exact-key syntax; the resolver builds the exact URI, **appends a
+ *   manifest row** for the producer identity tuple, and returns the resulting
  *   {@link ArtifactRecord}.
+ * - **Bare key selector** — wildcard key token, e.g. `"review-*.json"`.
+ *   The parser classifier has already validated wildcard-key syntax. The
+ *   resolver builds the implicit same-context selector and resolves it
+ *   read-only against the manifest.
  * - **URI literal exact (current ctx + current run)** — `rawToken` parses
  *   as an exact URI whose `runId` equals the current run. Behaves identically
  *   to the bare-key form: appends a manifest row and returns the
@@ -121,7 +130,7 @@ export interface ResolveArtifactDeclarationsOptions extends ArtifactPathOptions 
  * @returns Artifact variable map for the current execution unit
  * @throws {Error} For corrupt manifests, naked-form assertion failures, malformed
  *   URI literals, cross-context URI literals, missing other-run manifest rows,
- *   invalid bare-key tokens, or unexpected filesystem failures
+ *   invalid classified tokens, or unexpected filesystem failures
  */
 export async function resolveArtifactDeclarations(
   declarations: readonly ArtifactDeclaration[],
@@ -152,59 +161,48 @@ export async function resolveArtifactDeclarations(
     }
 
     const rawToken = expandArtifactToken(declaration, options);
-
-    if (rawToken.startsWith('rd://')) {
-      result[declaration.name] = await resolveUriLiteralDeclaration(
-        declaration.name,
-        rawToken,
-        options,
-        readManifest,
-        invalidateManifestCache,
+    const classification = classifyExpandedArtifactToken(rawToken);
+    if (!classification.ok) {
+      throw new Error(
+        `ARTIFACTS declaration "${declaration.name}" has invalid token "${rawToken}": ${formatArtifactTokenRejectReason(classification.reason)}`,
       );
-      continue;
     }
 
-    // Bare-key dispatch (spec §10.1.1):
-    // - With glob characters (`*` or `?`) — selector form: read-only discovery
-    //   across the current context and sibling runs. The exact_artifact_key
-    //   character class (uri.md §5.3) explicitly excludes these characters,
-    //   so a bare-key string carrying them cannot be an exact URI key — it
-    //   MUST be classified as the selector form.
-    // - Without glob characters — producer form: build the exact URI for the
-    //   current context and current run, write a manifest row, return the
-    //   resulting ArtifactRecord.
-    // Templates MUST already be expanded by the caller.
-    if (rawToken.includes('*') || rawToken.includes('?')) {
-      validateBareKeyGlob(declaration.name, rawToken);
-      const selector = buildImplicitBareKeySelector(rawToken, options.contextId);
-      result[declaration.name] = resolveSelector(selector, options, await readManifest());
-      continue;
-    }
-
-    // Dispatch gate: only path-like tokens are probed as file references.
-    // Bare non-path tokens (no '/' or '\\', not absolute) flow straight to the
-    // managed-artifact producer so that a same-named file at the search root
-    // cannot silently shadow the producer intent (see issue: silent shadowing
-    // of managed-artifact producer).
-    if (isPathLikeArtifactToken(rawToken)) {
-      const fileRecord = await resolveFileReferenceDeclaration(
-        declaration.name,
-        rawToken,
-        options,
-        invalidateManifestCache,
-      );
-      if (fileRecord !== null) {
-        result[declaration.name] = fileRecord;
-        continue;
+    switch (classification.token.kind) {
+      case 'rd-uri':
+        result[declaration.name] = await resolveUriLiteralDeclaration(
+          declaration.name,
+          classification.token.uri,
+          options,
+          readManifest,
+          invalidateManifestCache,
+        );
+        break;
+      case 'wildcard-key': {
+        const selector = buildImplicitBareKeySelector(classification.token.key, options.contextId);
+        result[declaration.name] = resolveSelector(selector, options, await readManifest());
+        break;
       }
+      case 'abs-path':
+      case 'rel-path': {
+        const fileRecord = await resolveFileReferenceDeclaration(
+          declaration.name,
+          classification.token,
+          options,
+          invalidateManifestCache,
+        );
+        result[declaration.name] = fileRecord;
+        break;
+      }
+      case 'bare-key':
+        result[declaration.name] = await resolveBareKeyProducer(
+          declaration.name,
+          classification.token.key,
+          options,
+          invalidateManifestCache,
+        );
+        break;
     }
-
-    result[declaration.name] = await resolveBareKeyProducer(
-      declaration.name,
-      rawToken,
-      options,
-      invalidateManifestCache,
-    );
   }
 
   return result;
@@ -212,18 +210,15 @@ export async function resolveArtifactDeclarations(
 
 async function resolveFileReferenceDeclaration(
   name: string,
-  rawToken: string,
+  token: Extract<ParsedArtifactToken, { kind: 'abs-path' | 'rel-path' }>,
   options: ResolveArtifactDeclarationsOptions,
   invalidateManifestCache: () => void,
-): Promise<FileArtifactRecord | null> {
-  const candidate = await resolveExistingFileReference(rawToken, options);
+): Promise<FileArtifactRecord> {
+  const candidate = await resolveExistingFileReference(token, options);
   if (candidate === null) {
-    if (isPathLikeArtifactToken(rawToken)) {
-      throw new Error(
-        `ARTIFACTS file reference "${rawToken}" for "${name}" was not found in the configured search path`,
-      );
-    }
-    return null;
+    throw new Error(
+      `ARTIFACTS file reference "${token.path}" for "${name}" was not found in the configured search path`,
+    );
   }
 
   const record: FileArtifactRecord = {
@@ -232,7 +227,7 @@ async function resolveFileReferenceDeclaration(
     runId: options.runId,
     contextId: options.contextId,
     runbook: options.runbook,
-    key: rawToken,
+    key: token.path,
     timestamp: new Date().toISOString(),
   };
   await appendArtifactManifestRecord(options, record);
@@ -241,14 +236,19 @@ async function resolveFileReferenceDeclaration(
 }
 
 async function resolveExistingFileReference(
-  rawToken: string,
+  token: Extract<ParsedArtifactToken, { kind: 'abs-path' | 'rel-path' }>,
   options: ResolveArtifactDeclarationsOptions,
 ): Promise<string | null> {
-  if (path.isAbsolute(rawToken)) {
-    const canonical = await canonicalRegularFile(rawToken);
+  if (token.kind === 'abs-path') {
+    if (!path.isAbsolute(token.path)) {
+      throw new Error(
+        `ARTIFACTS absolute file reference "${token.path}" uses unsupported absolute path syntax for this platform`,
+      );
+    }
+    const canonical = await canonicalRegularFile(token.path);
     if (canonical === null) return null;
     if (options.allowFileArtifactRead?.(canonical) !== true) {
-      throw new Error(`ARTIFACTS absolute file reference "${rawToken}" is not allowed by policy`);
+      throw new Error(`ARTIFACTS absolute file reference "${token.path}" is not allowed by policy`);
     }
     return canonical;
   }
@@ -257,7 +257,7 @@ async function resolveExistingFileReference(
   for (const root of roots) {
     const canonicalRoot = await canonicalDirectory(root);
     if (canonicalRoot === null) continue;
-    const candidate = path.resolve(canonicalRoot, rawToken);
+    const candidate = path.resolve(canonicalRoot, token.path);
     const canonical = await canonicalRegularFile(candidate);
     if (canonical === null) continue;
     if (isPathInside(canonicalRoot, canonical)) {
@@ -266,10 +266,6 @@ async function resolveExistingFileReference(
   }
 
   return null;
-}
-
-function isPathLikeArtifactToken(rawToken: string): boolean {
-  return path.isAbsolute(rawToken) || rawToken.includes('/') || rawToken.includes('\\');
 }
 
 async function canonicalDirectory(rawPath: string): Promise<string | null> {
@@ -396,37 +392,6 @@ function buildImplicitBareKeySelector(rawToken: string, contextId: string): Sele
 }
 
 /**
- * Validate a bare-key token that carries glob characters (`*` or `?`) before
- * it dispatches to the selector pathway.
- *
- * The parser used to enforce `wildcard_artifact_key` directly on these tokens
- * but has been relaxed; the resolver is now the gate. This helper restores
- * what the parser used to enforce — the token must match
- * {@link WILDCARD_ARTIFACT_KEY_PATTERN} (alphanumerics plus `.`, `_`, `-`,
- * `*`, `?`, with at least one wildcard character) and MUST NOT be the
- * recursive `**` form (per spec §10.1.1 / uri.md §5.3). Slashes and
- * traversal segments are rejected by virtue of the character class.
- *
- * @param name - Variable name being declared, used in error messages
- * @param rawToken - Bare-key token (post template expansion) carrying `*` or `?`
- * @throws {Error} When the token violates `wildcard_artifact_key`
- */
-function validateBareKeyGlob(name: string, rawToken: string): void {
-  // Reject recursive `**` explicitly. The wildcard pattern's character class
-  // would otherwise admit the literal token `**`.
-  if (rawToken.includes('**')) {
-    throw new Error(
-      `ARTIFACTS bare-key declaration "${name}" has invalid glob "${rawToken}"; recursive '**' is not permitted (spec §10.1.1 / uri.md §5.3)`,
-    );
-  }
-  if (!WILDCARD_ARTIFACT_KEY_PATTERN.test(rawToken)) {
-    throw new Error(
-      `ARTIFACTS bare-key declaration "${name}" has invalid glob "${rawToken}"; keys must match wildcard_artifact_key (alphanumerics, '.', '_', '-', '*', '?'); slashes and traversal are forbidden`,
-    );
-  }
-}
-
-/**
  * Ensure the parent directory for an exact artifact URI exists on disk.
  *
  * Producer declarations (bare-key without glob, and exact URI literal for the
@@ -452,19 +417,20 @@ async function ensureArtifactParentDir(uri: string, options: ArtifactPathOptions
  * Resolve a bare-key declaration in producer form (no glob characters).
  *
  * Per spec §10.1.1, `Plan "plan.json"` is sugar for the exact URI in the
- * current context and current run. The resolver validates the key, builds
- * the URI, appends a manifest row, and returns the resulting record.
+ * current context and current run. The parser classifier has already
+ * validated exact-key syntax; this helper builds the URI, appends a manifest
+ * row, and returns the resulting record. `buildArtifactUri` retains its own
+ * URI identity validation as defense-in-depth.
  *
- * The caller is responsible for ensuring `rawToken` does NOT contain glob
- * characters (`*`, `?`); bare keys with globs dispatch to the selector
- * pathway upstream and never reach this helper.
+ * The caller is responsible for dispatching only `bare-key` classified tokens
+ * here; wildcard keys dispatch to the selector pathway upstream.
  *
  * @param name - Variable name being declared
  * @param rawToken - Bare-key token (post template expansion), no glob characters
  * @param options - Resolver options carrying current identity and path config
  * @param invalidateManifestCache - Invalidates the per-pass coalesced read cache
  * @returns The newly-written {@link ArtifactRecord}
- * @throws {Error} If the key fails `exact_artifact_key` validation
+ * @throws {Error} If downstream URI identity validation fails
  */
 async function resolveBareKeyProducer(
   name: string,
@@ -472,17 +438,6 @@ async function resolveBareKeyProducer(
   options: ResolveArtifactDeclarationsOptions,
   invalidateManifestCache: () => void,
 ): Promise<ArtifactRecord> {
-  // Validate the key satisfies exact_artifact_key. SAFE_ID_PATTERN matches the
-  // character class; `assertSafeId` would also reject `.` and `..` but rejects
-  // other valid bare-key shapes when called via buildArtifactUri's helpers.
-  // We validate here with a clearer error; buildArtifactUri's internal
-  // validation acts as a defense-in-depth check.
-  if (rawToken === '.' || rawToken === '..' || !SAFE_ID_PATTERN.test(rawToken)) {
-    throw new Error(
-      `ARTIFACTS bare-key declaration "${name}" has invalid key "${rawToken}"; keys must match exact_artifact_key (alphanumerics, '.', '_', '-')`,
-    );
-  }
-
   const uri = buildArtifactUri({
     contextId: options.contextId,
     runId: options.runId,

--- a/packages/parser/__tests__/artifact-token.test.ts
+++ b/packages/parser/__tests__/artifact-token.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  classifyExpandedArtifactToken,
+  classifyRawArtifactToken,
+  parseArtifactDeclaration,
+} from '../src/index.js';
+
+describe('classifyRawArtifactToken', () => {
+  it.each([
+    ['plan.json', 'bare-key'],
+    ['review-*.json', 'wildcard-key'],
+    ['rd://artifacts/ctx1/*/plan.json', 'rd-uri'],
+    ['/tmp/plan.json', 'abs-path'],
+    ['schemas/review.schema.json', 'rel-path'],
+  ] as const)('classifies %s as %s', (raw, kind) => {
+    expect(classifyRawArtifactToken(raw)).toMatchObject({
+      ok: true,
+      token: { kind, raw },
+    });
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['   ', 'invalid-bare-key'],
+    ['.', 'dot-segment'],
+    ['..', 'dot-segment'],
+    ['**', 'recursive-wildcard'],
+    ['dir/**/plan.json', 'recursive-wildcard'],
+    ['a/./b.json', 'dot-segment'],
+    ['a/../b.json', 'dot-segment'],
+    ['foo bar', 'invalid-bare-key'],
+    ['foo:bar', 'invalid-bare-key'],
+    ['plan#.json', 'invalid-bare-key'],
+    ['dir/*.json', 'invalid-wildcard-key'],
+    ['review-*.json extra', 'invalid-wildcard-key'],
+  ] as const)('rejects %s with reason %s', (raw, reason) => {
+    expect(classifyRawArtifactToken(raw)).toEqual({ ok: false, reason, raw });
+  });
+
+  it('accepts raw template tokens before runtime expansion', () => {
+    expect(classifyRawArtifactToken('{{ContextId}}-plan.json')).toMatchObject({
+      ok: true,
+      token: { kind: 'bare-key', raw: '{{ContextId}}-plan.json' },
+    });
+  });
+
+  it('accepts raw templated tokens as advisory before expanded classification', () => {
+    expect(classifyRawArtifactToken('{{Dir}}/review-*.json')).toMatchObject({
+      ok: true,
+      token: { kind: 'wildcard-key', raw: '{{Dir}}/review-*.json' },
+    });
+
+    expect(classifyExpandedArtifactToken('reports/review-*.json')).toEqual({
+      ok: false,
+      reason: 'invalid-wildcard-key',
+      raw: 'reports/review-*.json',
+    });
+  });
+
+  it('accepts raw templated rd URI tokens without carrying parsed segments', () => {
+    expect(classifyRawArtifactToken('rd://{{ContextId}}/{{RunId}}/plan.json')).toEqual({
+      ok: true,
+      token: {
+        kind: 'rd-uri',
+        raw: 'rd://{{ContextId}}/{{RunId}}/plan.json',
+        uri: 'rd://{{ContextId}}/{{RunId}}/plan.json',
+      },
+    });
+  });
+});
+
+describe('parseArtifactDeclaration classifier validation', () => {
+  it.each(['foo bar', 'foo:bar'])('rejects invalid exact bare key %s', (rawToken) => {
+    expect(parseArtifactDeclaration(`Plan "${rawToken}"`)).toBeNull();
+  });
+
+  it.each(['dir/*.json', 'review-*.json extra'])('rejects invalid wildcard key %s', (rawToken) => {
+    expect(parseArtifactDeclaration(`Plan "${rawToken}"`)).toBeNull();
+  });
+});
+
+describe('classifyExpandedArtifactToken', () => {
+  it.each([
+    ['plan.json', 'bare-key'],
+    ['review-?.json', 'wildcard-key'],
+    ['rd://artifacts/ctx1/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json', 'rd-uri'],
+    ['/tmp/plan.json', 'abs-path'],
+    ['C:\\tmp\\plan.json', 'abs-path'],
+    ['\\\\server\\share\\plan.json', 'abs-path'],
+    ['schemas/review.schema.json', 'rel-path'],
+  ] as const)('classifies expanded %s as %s', (raw, kind) => {
+    expect(classifyExpandedArtifactToken(raw)).toMatchObject({
+      ok: true,
+      token: { kind, raw },
+    });
+  });
+
+  it('rejects unresolved template markers after expansion', () => {
+    expect(classifyExpandedArtifactToken('rd://{{env}}/file.yaml')).toEqual({
+      ok: false,
+      reason: 'unresolved-template',
+      raw: 'rd://{{env}}/file.yaml',
+    });
+
+    expect(classifyExpandedArtifactToken('{{Name}}-plan.json')).toEqual({
+      ok: false,
+      reason: 'unresolved-template',
+      raw: '{{Name}}-plan.json',
+    });
+  });
+
+  it('classifies an expanded templated rd URI as an rd URI without carrying parsed segments', () => {
+    expect(
+      classifyExpandedArtifactToken(
+        'rd://artifacts/ctx1/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+      ),
+    ).toEqual({
+      ok: true,
+      token: {
+        kind: 'rd-uri',
+        raw: 'rd://artifacts/ctx1/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+        uri: 'rd://artifacts/ctx1/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+      },
+    });
+  });
+});

--- a/packages/parser/src/artifact-token.ts
+++ b/packages/parser/src/artifact-token.ts
@@ -1,0 +1,203 @@
+import { EXACT_ARTIFACT_KEY_PATTERN, WILDCARD_ARTIFACT_KEY_PATTERN } from './schemas.js';
+
+/**
+ * Typed reason explaining why an ARTIFACTS token was rejected by the parser
+ * classifier.
+ */
+export type ArtifactTokenRejectReason =
+  | 'empty'
+  | 'dot-segment'
+  | 'recursive-wildcard'
+  | 'unresolved-template'
+  | 'invalid-bare-key'
+  | 'invalid-wildcard-key';
+
+/** Parsed ARTIFACTS token classified by syntactic dispatch kind. */
+export type ParsedArtifactToken =
+  | {
+      /** Exact managed artifact key token. */
+      readonly kind: 'bare-key';
+      /** Original token text supplied to the classifier. */
+      readonly raw: string;
+      /** Artifact key text. */
+      readonly key: string;
+    }
+  | {
+      /** Managed artifact wildcard selector key token. */
+      readonly kind: 'wildcard-key';
+      /** Original token text supplied to the classifier. */
+      readonly raw: string;
+      /** Wildcard key pattern text. */
+      readonly key: string;
+    }
+  | {
+      /** Rundown artifact URI token. */
+      readonly kind: 'rd-uri';
+      /** Original token text supplied to the classifier. */
+      readonly raw: string;
+      /** URI text. */
+      readonly uri: string;
+    }
+  | {
+      /** Absolute filesystem path token. */
+      readonly kind: 'abs-path';
+      /** Original token text supplied to the classifier. */
+      readonly raw: string;
+      /** Path text. */
+      readonly path: string;
+    }
+  | {
+      /** Relative filesystem path token. */
+      readonly kind: 'rel-path';
+      /** Original token text supplied to the classifier. */
+      readonly raw: string;
+      /** Path text. */
+      readonly path: string;
+    };
+
+/**
+ * Classification result for an ARTIFACTS token.
+ *
+ * Successful results carry a discriminated token suitable for resolver
+ * dispatch; rejected results preserve the raw text and a typed reason.
+ */
+export type ArtifactTokenClassificationResult =
+  | { readonly ok: true; readonly token: ParsedArtifactToken }
+  | { readonly ok: false; readonly reason: ArtifactTokenRejectReason; readonly raw: string };
+
+/**
+ * Classify a raw ARTIFACTS token as it appears in the runbook source.
+ *
+ * Raw classification performs shared reject-first safety checks but allows
+ * template markers because they are expanded later by core at runtime.
+ *
+ * @param raw - Unquoted ARTIFACTS token text from the parser
+ * @returns Classified token or typed rejection reason
+ */
+export function classifyRawArtifactToken(raw: string): ArtifactTokenClassificationResult {
+  const sharedRejection = rejectUnsafeArtifactToken(raw);
+  if (sharedRejection !== null) return { ok: false, reason: sharedRejection, raw };
+  return classifyAcceptedArtifactToken(raw, { allowTemplateMarkers: true });
+}
+
+/**
+ * Classify a runtime-expanded ARTIFACTS token.
+ *
+ * Expanded classification performs the same shared safety checks as raw
+ * classification and additionally rejects unresolved `{{...}}` template
+ * markers before final dispatch.
+ *
+ * @param raw - Runtime-expanded ARTIFACTS token text
+ * @returns Classified token or typed rejection reason
+ */
+export function classifyExpandedArtifactToken(raw: string): ArtifactTokenClassificationResult {
+  const sharedRejection = rejectUnsafeArtifactToken(raw);
+  if (sharedRejection !== null) return { ok: false, reason: sharedRejection, raw };
+  if (hasTemplateMarker(raw)) return { ok: false, reason: 'unresolved-template', raw };
+  return classifyAcceptedArtifactToken(raw, { allowTemplateMarkers: false });
+}
+
+/**
+ * Format an ARTIFACTS token rejection reason for diagnostics.
+ *
+ * @param reason - Typed classifier rejection reason
+ * @returns Human-readable diagnostic fragment
+ */
+export function formatArtifactTokenRejectReason(reason: ArtifactTokenRejectReason): string {
+  switch (reason) {
+    case 'empty':
+      return 'token must not be empty';
+    case 'dot-segment':
+      return 'dot and traversal path segments are not allowed';
+    case 'recursive-wildcard':
+      return "recursive wildcard '**' is not allowed";
+    case 'unresolved-template':
+      return 'unresolved template marker remains after expansion';
+    case 'invalid-bare-key':
+      return 'bare keys must match exact_artifact_key (alphanumerics, dots, underscores, and hyphens)';
+    case 'invalid-wildcard-key':
+      return "wildcard keys must match wildcard_artifact_key (alphanumerics, dots, underscores, hyphens, '*', and '?')";
+    default: {
+      const exhaustive: never = reason;
+      return exhaustive;
+    }
+  }
+}
+
+function classifyAcceptedArtifactToken(
+  raw: string,
+  options: { readonly allowTemplateMarkers: boolean },
+): ArtifactTokenClassificationResult {
+  const hasTemplates = options.allowTemplateMarkers && hasTemplateMarker(raw);
+
+  if (raw.startsWith('rd://')) {
+    return {
+      ok: true,
+      token: {
+        kind: 'rd-uri',
+        raw,
+        uri: raw,
+      },
+    };
+  }
+
+  if (raw.includes('*') || raw.includes('?')) {
+    if (!hasTemplates && !WILDCARD_ARTIFACT_KEY_PATTERN.test(raw)) {
+      return { ok: false, reason: 'invalid-wildcard-key', raw };
+    }
+    return { ok: true, token: { kind: 'wildcard-key', raw, key: raw } };
+  }
+
+  if (isAbsoluteArtifactPath(raw)) {
+    return {
+      ok: true,
+      token: {
+        kind: 'abs-path',
+        raw,
+        path: raw,
+      },
+    };
+  }
+
+  if (raw.includes('/') || raw.includes('\\')) {
+    return {
+      ok: true,
+      token: {
+        kind: 'rel-path',
+        raw,
+        path: raw,
+      },
+    };
+  }
+
+  if (!hasTemplates && !EXACT_ARTIFACT_KEY_PATTERN.test(raw)) {
+    return { ok: false, reason: 'invalid-bare-key', raw };
+  }
+  return { ok: true, token: { kind: 'bare-key', raw, key: raw } };
+}
+
+function rejectUnsafeArtifactToken(raw: string): ArtifactTokenRejectReason | null {
+  if (raw.length === 0) return 'empty';
+  if (raw === '.' || raw === '..') return 'dot-segment';
+  if (raw.includes('**')) return 'recursive-wildcard';
+  if (hasDotSegment(raw)) return 'dot-segment';
+  return null;
+}
+
+function hasTemplateMarker(raw: string): boolean {
+  const open = raw.indexOf('{{');
+  if (open === -1) return false;
+  return raw.includes('}}', open + 2);
+}
+
+function hasDotSegment(raw: string): boolean {
+  return splitPathSegments(raw).some((segment) => segment === '.' || segment === '..');
+}
+
+function splitPathSegments(raw: string): string[] {
+  return raw.split(/[\\/]+/).filter(Boolean);
+}
+
+function isAbsoluteArtifactPath(raw: string): boolean {
+  return raw.startsWith('/') || /^[A-Za-z]:[\\/]/.test(raw) || raw.startsWith('\\\\');
+}

--- a/packages/parser/src/helpers.ts
+++ b/packages/parser/src/helpers.ts
@@ -14,13 +14,7 @@ import type {
   TerminalAction,
   Transitions,
 } from './schemas.js';
-import {
-  EXACT_ARTIFACT_KEY_PATTERN,
-  MAX_FOR_BOUND,
-  MAX_STEP_NUMBER,
-  TEMPLATE_VAR_PATH_PATTERN,
-  WILDCARD_ARTIFACT_KEY_PATTERN,
-} from './schemas.js';
+import { MAX_FOR_BOUND, MAX_STEP_NUMBER, TEMPLATE_VAR_PATH_PATTERN } from './schemas.js';
 import {
   parseStepIdFromString,
   stepIdToString,
@@ -36,6 +30,7 @@ import type {
   RunbookRef,
 } from './ast.js';
 import { isBoundRef } from './guards.js';
+import { classifyRawArtifactToken } from './artifact-token.js';
 
 /**
  * Check if an action accumulates results into parent aggregation (DEFER only).
@@ -1198,35 +1193,9 @@ export function parseArtifactDeclaration(text: string): ArtifactDeclaration | nu
   // Reject embedded matching quotes — guards against `Name "a" "b"` and
   // unbalanced quoting that would otherwise pass the start/end check.
   if (inner.includes('"')) return null;
-  if (!isStructurallyValidArtifactToken(inner)) return null;
+  if (!classifyRawArtifactToken(inner).ok) return null;
 
   return { name, rawToken: inner };
-}
-
-function isStructurallyValidArtifactToken(token: string): boolean {
-  if (token.length === 0) return false;
-  // Reject-first: these rules apply across all token classes (bare, wildcard,
-  // path, URI). Placing them above the early accept branches prevents
-  // path-like and URI tokens from bypassing structural validation.
-  if (token === '.' || token === '..' || token.includes('**')) return false;
-  if (hasTraversalSegment(token)) return false;
-  if (token.includes('{{')) return true;
-  if (token.startsWith('rd://')) return true;
-  if (token.includes('/') || token.includes('\\')) return true;
-  if (token.includes('*') || token.includes('?')) {
-    return WILDCARD_ARTIFACT_KEY_PATTERN.test(token);
-  }
-  return EXACT_ARTIFACT_KEY_PATTERN.test(token);
-}
-
-function hasTraversalSegment(token: string): boolean {
-  // Reject `.` or `..` appearing as a whole path segment under either separator.
-  for (const sep of ['/', '\\'] as const) {
-    if (token.startsWith(`.${sep}`) || token.startsWith(`..${sep}`)) return true;
-    if (token.endsWith(`${sep}.`) || token.endsWith(`${sep}..`)) return true;
-    if (token.includes(`${sep}.${sep}`) || token.includes(`${sep}..${sep}`)) return true;
-  }
-  return false;
 }
 
 /**

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -40,6 +40,16 @@ export {
 } from './helpers.js';
 export type { ConvertedTransitions, ParsedStepHeader, ParsedSubstepHeader } from './helpers.js';
 export {
+  classifyRawArtifactToken,
+  classifyExpandedArtifactToken,
+  formatArtifactTokenRejectReason,
+} from './artifact-token.js';
+export type {
+  ArtifactTokenRejectReason,
+  ParsedArtifactToken,
+  ArtifactTokenClassificationResult,
+} from './artifact-token.js';
+export {
   parseStepIdFromString,
   stepIdToString,
   stepIdEquals,


### PR DESCRIPTION
## Summary
- Add a parser-owned ARTIFACTS token classifier with typed rejection reasons and frozen segment payloads.
- Route core artifact resolution through classified token kinds instead of re-sniffing raw strings.
- Fix review regressions around dot-segment property coverage, queried rd:// URI segments, and Windows-style absolute path dispatch.

## Test Plan
- npm test -w packages/parser -- artifact-token.test.ts
- npm test -w packages/parser -- artifact-token.test.ts artifacts.test.ts
- npm test -w packages/core -- artifact-file-reference.properties.test.ts artifact-directive-resolver.test.ts
- npm run test:unit:core
- npm run check:types -w packages/parser
- npm run build -w packages/parser
- npm run check:types -w packages/core
- npm run check:lint:fast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for artifact declarations, file references, and path validation across multiple scenarios including Windows paths and symlink containment.

* **Chores**
  * Refactored artifact resolution system with improved classification and validation logic.
  * Enhanced error diagnostics for invalid artifact references.
  * Improved support for absolute and relative file path handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->