### PR TITLE
Speed up scenario execution

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -1,0 +1,20 @@
+name: Setup Node dependencies
+description: Install Node.js and npm dependencies with the shared CI defaults.
+
+inputs:
+  node-version:
+    description: Node.js version to install.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Use Node.js ${{ inputs.node-version }}
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci --prefer-offline --no-audit --fund=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,16 @@ concurrency:
 jobs:
   quality-checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      - uses: ./.github/actions/setup-node-deps
         with:
           node-version: 24
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Format check
         run: npm run check:format
@@ -39,38 +39,34 @@ jobs:
 
   complexity-checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      - uses: ./.github/actions/setup-node-deps
         with:
           node-version: 24
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Complexity checks
         run: npm run check:complexity
 
-  setup-build:
+  setup-build-node24:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: ${{ fromJSON(((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && '[24, 25]' || '[24]') }}
+    permissions:
+      actions: write
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          persist-credentials: false
 
-      - name: Install dependencies
-        run: npm ci
+      - uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: 24
 
       - name: Build
         run: npm run build
@@ -78,7 +74,38 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: build-artifacts-node${{ matrix.node-version }}
+          name: build-artifacts-node24
+          path: |
+            packages/parser/dist/
+            packages/core/dist/
+            packages/cli/dist/
+            packages/claude-code-plugin/dist/
+            packages/mcp/dist/
+          retention-days: 1
+
+  setup-build-node25:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: 25
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: build-artifacts-node25
           path: |
             packages/parser/dist/
             packages/core/dist/
@@ -89,28 +116,24 @@ jobs:
 
   lint-typed:
     runs-on: ubuntu-latest
-    needs: setup-build
-
-    strategy:
-      matrix:
-        node-version: ${{ fromJSON(((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && '[24, 25]' || '[24]') }}
+    needs: setup-build-node24
+    permissions:
+      actions: read
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          persist-credentials: false
 
-      - name: Install dependencies
-        run: npm ci
+      - uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: 24
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: build-artifacts-node${{ matrix.node-version }}
+          name: build-artifacts-node24
           path: packages
 
       - name: Type-checked lint (ESLint)
@@ -125,57 +148,236 @@ jobs:
       - name: Type check (cli)
         run: npm run check:types:cli
 
-  test:
+  coverage-parser:
     runs-on: ubuntu-latest
-    needs: setup-build
-
-    strategy:
-      matrix:
-        node-version: ${{ fromJSON(((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && '[24, 25]' || '[24]') }}
+    needs: setup-build-node24
+    permissions:
+      actions: write
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          persist-credentials: false
 
-      - name: Install dependencies
-        run: npm ci
+      - uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: 24
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: build-artifacts-node${{ matrix.node-version }}
+          name: build-artifacts-node24
           path: packages
 
-      - name: Test with coverage
-        run: npm run test:coverage
+      - name: Test parser with coverage
+        run: npm run test:coverage:parser
 
-      - name: Upload coverage to Codecov
-        if: matrix.node-version == 24
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v5
+      - name: Upload parser coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          files: ./packages/parser/coverage/lcov.info,./packages/core/coverage/lcov.info,./packages/cli/coverage/lcov.info,./packages/claude-code-plugin/coverage/lcov.info
-          fail_ci_if_error: false
+          name: coverage-parser
+          path: packages/parser/coverage/lcov.info
+          retention-days: 1
 
-  perf:
+  coverage-core:
     runs-on: ubuntu-latest
-    needs: setup-build
+    needs: setup-build-node24
+    permissions:
+      actions: write
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
-      - name: Use Node.js 24
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      - uses: ./.github/actions/setup-node-deps
         with:
           node-version: 24
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifacts-node24
+          path: packages
+
+      - name: Test core with coverage
+        run: npm run test:coverage:core
+
+      - name: Upload core coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: coverage-core
+          path: packages/core/coverage/lcov.info
+          retention-days: 1
+
+  coverage-cli:
+    runs-on: ubuntu-latest
+    needs: setup-build-node24
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: 24
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifacts-node24
+          path: packages
+
+      - name: Test CLI with coverage
+        run: npm run test:coverage:cli
+
+      - name: Upload CLI coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: coverage-cli
+          path: packages/cli/coverage/lcov.info
+          retention-days: 1
+
+  coverage-plugin:
+    runs-on: ubuntu-latest
+    needs: setup-build-node24
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: 24
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifacts-node24
+          path: packages
+
+      - name: Test plugin with coverage
+        run: npm run test:coverage:plugin
+
+      - name: Upload plugin coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: coverage-plugin
+          path: packages/claude-code-plugin/coverage/lcov.info
+          retention-days: 1
+
+  coverage-mcp:
+    runs-on: ubuntu-latest
+    needs: setup-build-node24
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: 24
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifacts-node24
+          path: packages
+
+      - name: Test MCP with coverage
+        run: npm run test:coverage:mcp
+
+      - name: Upload MCP coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: coverage-mcp
+          path: packages/mcp/coverage/lcov.info
+          retention-days: 1
+
+  upload-coverage:
+    runs-on: ubuntu-latest
+    needs:
+      - coverage-parser
+      - coverage-core
+      - coverage-cli
+      - coverage-plugin
+      - coverage-mcp
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v5
+        with:
+          files: ./coverage-artifacts/coverage-parser/lcov.info,./coverage-artifacts/coverage-core/lcov.info,./coverage-artifacts/coverage-cli/lcov.info,./coverage-artifacts/coverage-plugin/lcov.info,./coverage-artifacts/coverage-mcp/lcov.info
+          fail_ci_if_error: false
+
+  node25-smoke:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs: setup-build-node25
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: 25
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifacts-node25
+          path: packages
+
+      - name: Test Node 25 smoke
+        run: npm test
+
+  perf:
+    runs-on: ubuntu-latest
+    needs: setup-build-node24
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: 24
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -188,18 +390,21 @@ jobs:
 
   scenarios:
     runs-on: ubuntu-latest
-    needs: setup-build
+    needs: setup-build-node24
+    permissions:
+      actions: read
+      contents: read
+    env:
+      RUNDOWN_SCENARIO_IN_PROCESS: '1'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      - uses: ./.github/actions/setup-node-deps
         with:
           node-version: 24
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -208,24 +413,25 @@ jobs:
           path: packages
 
       - name: Run frontmatter scenarios
-        run: npm run test:scenarios
+        run: npm run test:scenarios:raw
 
       - name: Run scenario suites
-        run: npm run test:scenario-suites
+        run: npm run test:scenario-suites:raw
 
   playwright:
     runs-on: ubuntu-latest
-    needs: setup-build
+    needs: setup-build-node24
+    permissions:
+      actions: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      - uses: ./.github/actions/setup-node-deps
         with:
           node-version: 24
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/packages/cli/__tests__/commands/scenario-suite.test.ts
+++ b/packages/cli/__tests__/commands/scenario-suite.test.ts
@@ -620,6 +620,53 @@ cases:
       expect(parsed.cases).toHaveLength(3);
     }, 60000);
 
+    it('emits case timings to stderr when enabled', async () => {
+      const result = await runCliInProcess(
+        'scenario-suite run test.scenario-suite.yaml --all',
+        workspace,
+        { env: { RUNDOWN_SCENARIO_COMMAND_TIMINGS: '1' } },
+      );
+
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout.trim().split(/\n(?=\{)/)[0]);
+      expect(parsed.total).toBe(3);
+      expect(result.stderr).toContain('SCENARIO_TIMING');
+      expect(result.stderr).toContain('"scope":"case"');
+      expect(result.stderr).toContain('"case":"happy-path"');
+      expect(result.stderr).toContain('"scope":"command"');
+    }, 60000);
+
+    it('runs suite case commands in-process when enabled', async () => {
+      const result = await runCliInProcess(
+        'scenario-suite run test.scenario-suite.yaml happy-path',
+        workspace,
+        {
+          env: {
+            RUNDOWN_SCENARIO_IN_PROCESS: '1',
+            RUNDOWN_SCENARIO_COMMAND_TIMINGS: '1',
+          },
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim().split(/\n(?=\{)/)[0]);
+      expect(parsed.result).toBe(true);
+      const timingLines = result.stderr
+        .split('\n')
+        .filter((line) => line.startsWith('SCENARIO_TIMING '))
+        .map(
+          (line) =>
+            JSON.parse(line.slice('SCENARIO_TIMING '.length)) as {
+              kind: string;
+              exitCode: number;
+            },
+        );
+      expect(timingLines).toHaveLength(3);
+      expect(timingLines).toEqual(
+        expect.arrayContaining([expect.objectContaining({ kind: 'rd', exitCode: 0 })]),
+      );
+    }, 30000);
+
     it('errors without case name or --all', async () => {
       const result = await runCliInProcess(
         'scenario-suite run test.scenario-suite.yaml --text',

--- a/packages/cli/__tests__/commands/scenarios.test.ts
+++ b/packages/cli/__tests__/commands/scenarios.test.ts
@@ -108,4 +108,54 @@ name: no-scenarios
       expect(result.stderr).toContain('SCENARIO_NOT_FOUND');
     });
   });
+
+  describe('run subcommand timings', () => {
+    it('emits command timings to stderr when enabled', async () => {
+      const result = await runCliInProcess(
+        'scenario run test-runbook.runbook.md success',
+        workspace,
+        {
+          env: { RUNDOWN_SCENARIO_COMMAND_TIMINGS: '1' },
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim().split(/\n(?=\{)/)[0]);
+      expect(parsed.result).toBe(true);
+      expect(result.stderr).toContain('SCENARIO_TIMING');
+      expect(result.stderr).toContain('"scope":"command"');
+      expect(result.stderr).toContain('"command":"rd run --prompted test-runbook.runbook.md"');
+    }, 30000);
+
+    it('runs scenario commands in-process when enabled', async () => {
+      const result = await runCliInProcess(
+        'scenario run test-runbook.runbook.md success',
+        workspace,
+        {
+          env: {
+            RUNDOWN_SCENARIO_IN_PROCESS: '1',
+            RUNDOWN_SCENARIO_COMMAND_TIMINGS: '1',
+          },
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim().split(/\n(?=\{)/)[0]);
+      expect(parsed.result).toBe(true);
+      const timingLines = result.stderr
+        .split('\n')
+        .filter((line) => line.startsWith('SCENARIO_TIMING '))
+        .map(
+          (line) =>
+            JSON.parse(line.slice('SCENARIO_TIMING '.length)) as {
+              kind: string;
+              exitCode: number;
+            },
+        );
+      expect(timingLines).toHaveLength(3);
+      expect(timingLines).toEqual(
+        expect.arrayContaining([expect.objectContaining({ kind: 'rd', exitCode: 0 })]),
+      );
+    }, 30000);
+  });
 });

--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   parseJsonLines,
   matchStepAssertions,
@@ -12,8 +15,12 @@ import {
   formatErrorAssertionDescription,
   matchArtifactAssertions,
   formatArtifactAssertionDescription,
+  executeCommandSequence,
+  createInProcessCommandExecutor,
 } from '../../src/helpers/command-sequence.js';
+import type { InProcessCliRunner } from '../../src/helpers/command-sequence.js';
 import type { ArtifactAssertion, StepAssertion } from '../../src/schemas/scenarios.js';
+import { mockFn } from './typed-mocks.js';
 
 describe('parseJsonLines', () => {
   it('extracts transition from step_transitioned event', () => {
@@ -798,6 +805,173 @@ describe('parseRdCommandWithEnv', () => {
     expect(() => parseRdCommandWithEnv('echo setup && FOO=agent-a rd pass')).toThrow(
       /Unsupported shell operators/,
     );
+  });
+});
+
+describe('executeCommandSequence timings', () => {
+  async function writeFakeCli(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'rd-command-sequence-'));
+    const cliPath = join(dir, 'fake-cli.js');
+    await writeFile(
+      cliPath,
+      [
+        '#!/usr/bin/env node',
+        'const args = process.argv.slice(2);',
+        "if (args[0] === 'pass') {",
+        '  console.log(JSON.stringify({ type: "runbook_completed" }));',
+        '  process.exit(0);',
+        '}',
+        "if (args[0] === 'fail') {",
+        '  console.log(JSON.stringify({ kind: "error", command: "fail", code: "EXPECTED" }));',
+        '  process.exit(1);',
+        '}',
+        'process.exit(2);',
+        '',
+      ].join('\n'),
+      { mode: 0o755 },
+    );
+    return cliPath;
+  }
+
+  it('returns command timings and invokes onCommandComplete for rd and shell commands', async () => {
+    const cliPath = await writeFakeCli();
+    const observed: unknown[] = [];
+
+    const result = await executeCommandSequence({
+      commands: ['rd pass', 'node -e "process.exit(0)"'],
+      cwd: process.cwd(),
+      cliPath,
+      quiet: true,
+      onCommandComplete: (timing) => observed.push(timing),
+    });
+
+    expect(result.terminalResult).toBe('COMPLETE');
+    expect(result.commandTimings).toHaveLength(2);
+    expect(observed).toEqual(result.commandTimings);
+    expect(result.commandTimings[0]).toEqual(
+      expect.objectContaining({
+        command: 'rd pass',
+        kind: 'rd',
+        exitCode: 0,
+        expectedFailure: false,
+      }),
+    );
+    expect(result.commandTimings[0]?.durationMs).toBeGreaterThanOrEqual(0);
+    expect(result.commandTimings[1]).toEqual(
+      expect.objectContaining({
+        command: 'node -e "process.exit(0)"',
+        kind: 'shell',
+        exitCode: 0,
+        expectedFailure: false,
+      }),
+    );
+  });
+
+  it('marks expected-failure command timings', async () => {
+    const cliPath = await writeFakeCli();
+
+    const result = await executeCommandSequence({
+      commands: ['! rd fail'],
+      cwd: process.cwd(),
+      cliPath,
+      quiet: true,
+    });
+
+    expect(result.commandTimings).toEqual([
+      expect.objectContaining({
+        command: 'rd fail',
+        kind: 'rd',
+        exitCode: 1,
+        expectedFailure: true,
+      }),
+    ]);
+  });
+
+  it('uses an injected rd executor while shell commands still use shell execution', async () => {
+    const calls: string[][] = [];
+
+    const result = await executeCommandSequence({
+      commands: [
+        'rd pass',
+        'node -e "console.log(JSON.stringify({ type: \\"runbook_stopped\\" }))"',
+      ],
+      cwd: process.cwd(),
+      cliPath: '/unused/cli.js',
+      quiet: true,
+      commandExecutor: {
+        runRd: async (args) => {
+          calls.push(args);
+          return {
+            stdout: `${JSON.stringify({ type: 'runbook_completed' })}\n`,
+            stderr: '',
+            exitCode: 0,
+          };
+        },
+      },
+    });
+
+    expect(calls).toEqual([['pass']]);
+    expect(result.terminalResult).toBe('STOP');
+    expect(result.commandTimings).toEqual([
+      expect.objectContaining({ command: 'rd pass', kind: 'rd', exitCode: 0 }),
+      expect.objectContaining({
+        command: 'node -e "console.log(JSON.stringify({ type: \\"runbook_stopped\\" }))"',
+        kind: 'shell',
+        exitCode: 0,
+      }),
+    ]);
+  });
+});
+
+describe('createInProcessCommandExecutor', () => {
+  it('returns undefined unless in-process scenario execution is enabled', () => {
+    const originalValue = process.env.RUNDOWN_SCENARIO_IN_PROCESS;
+    try {
+      delete process.env.RUNDOWN_SCENARIO_IN_PROCESS;
+
+      const executor = createInProcessCommandExecutor(mockFn<InProcessCliRunner>());
+
+      expect(executor).toBeUndefined();
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env.RUNDOWN_SCENARIO_IN_PROCESS;
+      } else {
+        process.env.RUNDOWN_SCENARIO_IN_PROCESS = originalValue;
+      }
+    }
+  });
+
+  it('delegates rd commands to the supplied in-process runner', async () => {
+    const originalValue = process.env.RUNDOWN_SCENARIO_IN_PROCESS;
+    const runCli = mockFn<InProcessCliRunner>().mockResolvedValue({
+      stdout: 'ok',
+      stderr: '',
+      exitCode: 0,
+    });
+    try {
+      process.env.RUNDOWN_SCENARIO_IN_PROCESS = '1';
+
+      const executor = createInProcessCommandExecutor(runCli);
+      const result = await executor?.runRd?.(['status'], {
+        cwd: '/tmp/workspace',
+        quiet: true,
+        cliPath: '/tmp/cli.js',
+        env: { NO_COLOR: '1' },
+      });
+
+      expect(result).toEqual({ stdout: 'ok', stderr: '', exitCode: 0 });
+      expect(runCli).toHaveBeenCalledWith({
+        args: ['status'],
+        cwd: '/tmp/workspace',
+        env: { NO_COLOR: '1' },
+      });
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env.RUNDOWN_SCENARIO_IN_PROCESS;
+      } else {
+        process.env.RUNDOWN_SCENARIO_IN_PROCESS = originalValue;
+      }
+    }
   });
 });
 

--- a/packages/cli/__tests__/helpers/scenario-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/scenario-workflow.test.ts
@@ -86,6 +86,8 @@ jest.unstable_mockModule('../../src/helpers/command-sequence', () => ({
   matchStepAssertions: jest.fn(),
   matchErrorAssertions: jest.fn(),
   matchArtifactAssertions: jest.fn(),
+  emitScenarioTiming: jest.fn(),
+  createInProcessCommandExecutor: actualCommandSequence.createInProcessCommandExecutor,
   formatErrorAssertionDescription: actualCommandSequence.formatErrorAssertionDescription,
   extractRunbookReferences: actualCommandSequence.extractRunbookReferences,
   extractInputFileReferences: actualCommandSequence.extractInputFileReferences,
@@ -462,6 +464,7 @@ describe('executeScenario', () => {
       capturedClaimIds: [],
       errors: [],
       artifactEntries: [],
+      commandTimings: [],
       ...overrides,
     };
   }

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -4,14 +4,7 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { CommanderError } from 'commander';
-import { createProgram } from '../../src/cli.js';
-import { resetPolicyContext } from '../../src/services/policy-context.js';
 import {
-  resetColorCache,
-  setWriter,
-  ConsoleWriter,
-  getErrorMessage,
   RUNBOOK_SOURCES,
   isRunId,
   runsDir,
@@ -22,6 +15,10 @@ import {
 import type { RunbookState } from '@rundown-org/core';
 import { NAMED_IDENTIFIER_PATTERN, isReservedWord } from '@rundown-org/parser';
 import type { ResolvedStep, Substep } from '@rundown-org/parser';
+import {
+  runCliInProcess as runCliInProcessCore,
+  stripExitArtefact,
+} from '../../src/services/in-process-cli-runner.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -155,41 +152,7 @@ export function runCli(args: string | string[], workspace: TestWorkspace): CliRe
   };
 }
 
-/** Sentinel error thrown when a command calls `process.exit()` in-process. */
-class ExitSignal extends Error {
-  constructor(public readonly code: number) {
-    super(`process.exit(${String(code)})`);
-    this.name = 'ExitSignal';
-  }
-}
-
-/**
- * Strip in-process `ExitSignal` artefacts from a captured buffer.
- *
- * The harness intercepts `process.exit()` by throwing an `ExitSignal`. When
- * production `withErrorHandling` catches that sentinel, it routes it through
- * `toRundownError` and emits a JSON UNKNOWN_ERROR block whose `error` field
- * reads "process.exit(N)". A real subprocess never sees this — `process.exit()`
- * simply terminates. This function removes the artefact (and any bare
- * `process.exit(N)` tail) so test snapshots match real subprocess output.
- *
- * Idempotent: stripping an already-clean buffer is a no-op.
- *
- * @param buf - Captured stdout or stderr buffer.
- * @returns The buffer with end-of-buffer artefacts removed.
- */
-export function stripExitArtefact(buf: string): string {
-  // The leading `(^|\n)` (preserved via $1) covers both an artefact at buffer
-  // start AND one preceded by a newline that terminated a legitimate line.
-  // The previous `(?<=\n)` lookbehind missed the buffer-start case.
-  const artefactPattern =
-    /(^|\n)\{\s*"error":\s*"process\.exit\(\d+\)",\s*"kind":\s*"error",\s*"code":\s*"UNKNOWN_ERROR"(?:,\s*"command":\s*"[^"]+")?\s*\}\s*$/;
-  let out = buf.replace(artefactPattern, '$1');
-  // `getErrorMessage(err)` on ExitSignal also produces a bare "process.exit(N)"
-  // tail that may be appended elsewhere; swallow that too at end-of-buffer.
-  out = out.replace(/\s*process\.exit\(\d+\)\s*$/, '');
-  return out;
-}
+export { stripExitArtefact };
 
 /**
  * Options for in-process CLI test execution.
@@ -216,173 +179,17 @@ export async function runCliInProcess(
   options: RunCliInProcessOptions = {},
 ): Promise<CliResult> {
   const argArray = Array.isArray(args) ? args : args.split(' ').filter(Boolean);
-  const extraEnv = options.env ?? {};
-  const extraEnvKeys = Object.keys(extraEnv);
-  const origExtraEnv: Record<string, string | undefined> = Object.fromEntries(
-    extraEnvKeys.map((key) => [key, process.env[key]]),
-  );
   const binPath = workspace.binPath();
   const pluginDir = join(workspace.cwd, 'plugin');
-
-  // Save originals
-  const origCwd = process.cwd();
-  const origStdoutWrite = process.stdout.write.bind(process.stdout);
-  const origStderrWrite = process.stderr.write.bind(process.stderr);
-  const origExit = process.exit.bind(process);
-  const origConsoleError = console.error.bind(console);
-  const origConsoleLog = console.log.bind(console);
-  const envKeys = ['NO_COLOR', 'RUNDOWN_LOG', 'CLAUDE_PLUGIN_ROOT', 'PATH', 'FORCE_COLOR'] as const;
-  type EnvKey = (typeof envKeys)[number];
-  const origEnv = Object.fromEntries(envKeys.map((k) => [k, process.env[k]])) as Record<
-    EnvKey,
-    string | undefined
-  >;
-
-  let stdoutBuf = '';
-  let stderrBuf = '';
-  let exitCode = 0;
-  // Wrapped in a holder object: the writer is the process.exit override
-  // below, and TS flow analysis can't see through the callback. Without
-  // the indirection, the post-try `if` looks unreachable to eslint.
-  const exit = { signalled: false };
-
-  try {
-    // Reset global state before each invocation
-    resetPolicyContext();
-    resetColorCache();
-
-    // Change real cwd — covers process.cwd() everywhere
-    process.chdir(workspace.cwd);
-
-    // Set env vars (matching runCli)
-    process.env.NO_COLOR = '1';
-    process.env.RUNDOWN_LOG = '0';
-    process.env.CLAUDE_PLUGIN_ROOT = pluginDir;
-    process.env.PATH = `${binPath}:${origEnv.PATH ?? ''}`;
-    delete process.env.FORCE_COLOR;
-    for (const [key, value] of Object.entries(extraEnv)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-
-    // Capture stdout/stderr via process.stdout/stderr.write
-    // ConsoleWriter consistently uses these (not console.log/error)
-    process.stdout.write = (chunk: unknown, ...rest: unknown[]): boolean => {
-      stdoutBuf +=
-        typeof chunk === 'string'
-          ? chunk
-          : chunk instanceof Uint8Array
-            ? new TextDecoder().decode(chunk)
-            : String(chunk);
-      const cb = rest.find((a) => typeof a === 'function') as
-        | ((err?: Error | null) => void)
-        | undefined;
-      cb?.();
-      return true;
-    };
-    process.stderr.write = (chunk: unknown, ...rest: unknown[]): boolean => {
-      stderrBuf +=
-        typeof chunk === 'string'
-          ? chunk
-          : chunk instanceof Uint8Array
-            ? new TextDecoder().decode(chunk)
-            : String(chunk);
-      const cb = rest.find((a) => typeof a === 'function') as
-        | ((err?: Error | null) => void)
-        | undefined;
-      cb?.();
-      return true;
-    };
-
-    // Create ConsoleWriter AFTER monkey-patching stdout/stderr so it
-    // captures output into the buffers above (not the original streams)
-    setWriter(new ConsoleWriter());
-
-    // Intercept console.error/log — Jest may replace these with its own
-    // Console that bypasses process.stderr/stdout.write, so we route them
-    // into the capture buffers explicitly.
-    console.error = (...args: unknown[]) => {
-      stderrBuf += `${args.map(String).join(' ')}\n`;
-    };
-    console.log = (...args: unknown[]) => {
-      stdoutBuf += `${args.map(String).join(' ')}\n`;
-    };
-
-    // Intercept process.exit. Set the cleanup flag at interception so the
-    // artefact stripper still runs even if a downstream caller swallows the
-    // ExitSignal before it surfaces to the outer catch.
-    process.exit = (code?: number) => {
-      exit.signalled = true;
-      throw new ExitSignal(code ?? 0);
-    };
-
-    // Create fresh program and parse
-    const program = createProgram();
-    program.exitOverride();
-    await program.parseAsync(argArray, { from: 'user' });
-
-    // Capture exitCode set via process.exitCode (used by pass/fail commands).
-    // process.exitCode is typed `string | number | undefined` (Node accepts a
-    // string alias like "SUCCESS"); coerce to number for our test API.
-    exitCode = Number(process.exitCode ?? 0);
-    process.exitCode = undefined;
-  } catch (err: unknown) {
-    if (err instanceof ExitSignal) {
-      exitCode = err.code;
-      // exit.signalled is set at interception (in the process.exit override)
-      // so it stays true even if a downstream caller swallows the signal.
-    } else if (err instanceof CommanderError) {
-      exitCode = err.exitCode;
-    } else {
-      exitCode = 1;
-      stderrBuf += getErrorMessage(err);
-    }
-  } finally {
-    // Restore everything
-    process.stdout.write = origStdoutWrite;
-    process.stderr.write = origStderrWrite;
-    process.exit = origExit;
-    console.error = origConsoleError;
-    console.log = origConsoleLog;
-    process.exitCode = undefined;
-
-    // Restore cwd
-    process.chdir(origCwd);
-
-    // Restore env (only the keys we modified)
-    for (const key of envKeys) {
-      if (origEnv[key] === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = origEnv[key];
-      }
-    }
-    for (const [key, value] of Object.entries(origExtraEnv)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-
-    // Reset globals again for clean state
-    resetPolicyContext();
-    resetColorCache();
-    setWriter(new ConsoleWriter());
-  }
-
-  if (exit.signalled) {
-    // Strip ExitSignal artefacts from whichever buffer captured them
-    // (console.error routes to stderr, but the writer's pipeline can surface
-    // them in stdout depending on mode). See stripExitArtefact for details.
-    stdoutBuf = stripExitArtefact(stdoutBuf);
-    stderrBuf = stripExitArtefact(stderrBuf);
-  }
-
-  return { stdout: stdoutBuf, stderr: stderrBuf, exitCode, exitIntercepted: exit.signalled };
+  return runCliInProcessCore({
+    args: argArray,
+    cwd: workspace.cwd,
+    env: {
+      PATH: `${binPath}:${process.env.PATH ?? ''}`,
+      CLAUDE_PLUGIN_ROOT: pluginDir,
+      ...(options.env ?? {}),
+    },
+  });
 }
 
 /**

--- a/packages/cli/__tests__/integration/scenario-runner.test.ts
+++ b/packages/cli/__tests__/integration/scenario-runner.test.ts
@@ -23,6 +23,7 @@ import {
   formatErrorAssertionDescription,
   formatStepAssertionDescription,
 } from '../../src/helpers/command-sequence.js';
+import { runCliInProcess } from '../../src/services/in-process-cli-runner.js';
 import { copyFileSync, mkdirSync, readFileSync, readdirSync, statSync } from 'node:fs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -231,18 +232,27 @@ async function executeScenario(
 
   const cliPath = getCliPath();
   const binPath = workspace.binPath();
-  const pluginDir = join(workspace.cwd, 'plugin');
+  const pluginDir = `${join(workspace.cwd, 'plugin')}/`;
+  const env = {
+    PATH: `${binPath}${delimiter}${process.env.PATH ?? ''}`,
+    CLAUDE_PLUGIN_ROOT: pluginDir,
+    NO_COLOR: '1',
+    FORCE_COLOR: undefined,
+  };
 
   const seqResult = await executeCommandSequence({
     commands: scenario.commands,
     cwd: workspace.cwd,
     cliPath,
     quiet: true,
-    env: {
-      PATH: `${binPath}${delimiter}${process.env.PATH ?? ''}`,
-      CLAUDE_PLUGIN_ROOT: pluginDir,
-      NO_COLOR: '1',
-      FORCE_COLOR: undefined,
+    env,
+    commandExecutor: {
+      runRd: (args, options) =>
+        runCliInProcess({
+          args,
+          cwd: options.cwd,
+          env: options.env,
+        }),
     },
   });
 

--- a/packages/cli/__tests__/services/in-process-cli-runner.test.ts
+++ b/packages/cli/__tests__/services/in-process-cli-runner.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { describe, expect, it } from '@jest/globals';
 import { runCliInProcess } from '../../src/services/in-process-cli-runner.js';
 import { createTestWorkspace } from '../helpers/test-utils.js';
@@ -24,7 +24,7 @@ name: smoke
         args: ['run', '--prompted', 'smoke.runbook.md'],
         cwd: workspace.cwd,
         env: {
-          PATH: `${workspace.binPath()}:${process.env.PATH ?? ''}`,
+          PATH: `${workspace.binPath()}${delimiter}${process.env.PATH ?? ''}`,
           CLAUDE_PLUGIN_ROOT: `${join(workspace.cwd, 'plugin')}/`,
         },
       });
@@ -107,7 +107,7 @@ rd echo "{{ marker }}"
         args: ['run', markerFile, '--allow-all'],
         cwd: workspace.cwd,
         env: {
-          PATH: `${workspace.binPath()}:${process.env.PATH ?? ''}`,
+          PATH: `${workspace.binPath()}${delimiter}${process.env.PATH ?? ''}`,
           CLAUDE_PLUGIN_ROOT: `${join(workspace.cwd, 'plugin')}/`,
         },
       });

--- a/packages/cli/__tests__/services/in-process-cli-runner.test.ts
+++ b/packages/cli/__tests__/services/in-process-cli-runner.test.ts
@@ -1,0 +1,122 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from '@jest/globals';
+import { runCliInProcess } from '../../src/services/in-process-cli-runner.js';
+import { createTestWorkspace } from '../helpers/test-utils.js';
+
+describe('in-process CLI runner', () => {
+  it('runs CLI commands in the requested cwd and captures stdout', async () => {
+    const workspace = await createTestWorkspace();
+    try {
+      const runbook = `---
+name: smoke
+---
+
+# Smoke
+
+## 1. Done
+- PASS COMPLETE
+`;
+      await mkdir(workspace.runbooksDir(), { recursive: true });
+      await writeFile(join(workspace.runbooksDir(), 'smoke.runbook.md'), runbook);
+
+      const result = await runCliInProcess({
+        args: ['run', '--prompted', 'smoke.runbook.md'],
+        cwd: workspace.cwd,
+        env: {
+          PATH: `${workspace.binPath()}:${process.env.PATH ?? ''}`,
+          CLAUDE_PLUGIN_ROOT: `${join(workspace.cwd, 'plugin')}/`,
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('smoke');
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  it('captures process.exit codes without leaking ExitSignal artifacts', async () => {
+    const workspace = await createTestWorkspace();
+    try {
+      const result = await runCliInProcess({
+        args: ['scenario', 'ls', 'missing.runbook.md'],
+        cwd: workspace.cwd,
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).not.toContain('process.exit');
+      expect(result.stdout + result.stderr).toContain('RUNBOOK_NOT_FOUND');
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
+  it('restores cwd and environment after invocation', async () => {
+    const workspace = await createTestWorkspace();
+    const originalCwd = process.cwd();
+    const originalValue = process.env.RD_IN_PROCESS_TEST_VALUE;
+    try {
+      const result = await runCliInProcess({
+        args: ['prompt', 'ok'],
+        cwd: workspace.cwd,
+        env: { RD_IN_PROCESS_TEST_VALUE: 'set-inside-runner' },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(process.cwd()).toBe(originalCwd);
+      expect(process.env.RD_IN_PROCESS_TEST_VALUE).toBe(originalValue);
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env.RD_IN_PROCESS_TEST_VALUE;
+      } else {
+        process.env.RD_IN_PROCESS_TEST_VALUE = originalValue;
+      }
+      await workspace.cleanup();
+    }
+  });
+
+  it('does not leak env overrides between sequential invocations', async () => {
+    const workspace = await createTestWorkspace();
+    try {
+      await runCliInProcess({
+        args: ['prompt', 'first'],
+        cwd: workspace.cwd,
+        env: { RD_INPUT_marker: 'first' },
+      });
+
+      const markerFile = join(workspace.cwd, 'marker.runbook.md');
+      await writeFile(
+        markerFile,
+        `---
+name: marker
+---
+
+# Marker
+
+## 1. Echo
+- PASS COMPLETE
+
+\`\`\`bash
+rd echo "{{ marker }}"
+\`\`\`
+`,
+      );
+
+      const result = await runCliInProcess({
+        args: ['run', markerFile, '--allow-all'],
+        cwd: workspace.cwd,
+        env: {
+          PATH: `${workspace.binPath()}:${process.env.PATH ?? ''}`,
+          CLAUDE_PLUGIN_ROOT: `${join(workspace.cwd, 'plugin')}/`,
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      const stateFiles = await readFile(join(workspace.cwd, '.rundown/session.json'), 'utf-8');
+      expect(stateFiles).not.toContain('first');
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+});

--- a/packages/cli/src/commands/scenario-suite.ts
+++ b/packages/cli/src/commands/scenario-suite.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'node:url';
 import { cp, rm } from 'node:fs/promises';
 import { copyFileSync, existsSync, mkdirSync, mkdtempSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { performance } from 'node:perf_hooks';
 import {
   getErrorMessage,
   isExistingRegularArtifactFile,
@@ -22,7 +23,9 @@ import {
 import { OutputEmitter } from '../services/output-emitter.js';
 import { loadScenarioSuite, type ScenarioSuiteCase } from '../schemas/scenario-suite.js';
 import {
+  createInProcessCommandExecutor,
   executeCommandSequence,
+  emitScenarioTiming,
   extractInputFileReferences,
   extractRunbookReferences,
   formatArtifactAssertionDescription,
@@ -33,6 +36,7 @@ import {
   type StepAssertionResult,
 } from '../helpers/command-sequence.js';
 import { getEffectiveResult } from '../schemas/scenarios.js';
+import { runCliInProcess } from '../services/in-process-cli-runner.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -222,6 +226,10 @@ async function executeSuiteCase(
         : (cmd) => {
             output.message(`$ ${cmd}`, 'info');
           },
+      onCommandComplete: (timing) => {
+        emitScenarioTiming({ scope: 'command', ...timing });
+      },
+      commandExecutor: createInProcessCommandExecutor(runCliInProcess),
     });
 
     const actualResult = seqResult.terminalResult;
@@ -395,6 +403,7 @@ export function registerScenarioSuiteCommand(program: Command): void {
             let failedCount = 0;
 
             for (const [name, c] of Object.entries(result.suite.cases)) {
+              const caseStart = performance.now();
               try {
                 const caseResult = await executeSuiteCase(name, c, suiteDir, runQuiet, output);
                 caseResults.push(caseResult);
@@ -412,6 +421,12 @@ export function registerScenarioSuiteCommand(program: Command): void {
                   actual: `ERROR: ${getErrorMessage(err)}`,
                 });
                 failedCount++;
+              } finally {
+                emitScenarioTiming({
+                  scope: 'case',
+                  case: name,
+                  durationMs: Math.round(performance.now() - caseStart),
+                });
               }
             }
 

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -8,6 +8,7 @@
  */
 
 import { spawn } from 'node:child_process';
+import { performance } from 'node:perf_hooks';
 import {
   isPublicArtifactRecord,
   RunbookRefSchema,
@@ -57,6 +58,20 @@ export interface CapturedArtifactEntry {
   runbook?: RunbookRef;
 }
 
+/** Timing record for one command executed by a scenario command sequence. */
+export interface CommandTiming {
+  /** Command text after placeholder substitution and expected-failure marker removal. */
+  command: string;
+  /** Whether the command was executed as a parsed Rundown command or shell command. */
+  kind: 'rd' | 'shell';
+  /** Command wall-clock duration in milliseconds, rounded to the nearest integer. */
+  durationMs: number;
+  /** Process exit code returned by the command. */
+  exitCode: number;
+  /** Whether this command was prefixed with `! ` and expected to fail. */
+  expectedFailure: boolean;
+}
+
 /** Result of matching a single step assertion against the event stream. */
 export interface StepAssertionResult {
   /** The assertion that was evaluated */
@@ -103,6 +118,76 @@ export interface CommandSequenceResult {
   errors: CapturedError[];
   /** Artifact working sets captured from step_entered events */
   artifactEntries: CapturedArtifactEntry[];
+  /** Per-command timing records captured during execution */
+  commandTimings: CommandTiming[];
+}
+
+/** Options passed to a command executor. */
+export interface CommandExecutionOptions {
+  /** Working directory for execution. */
+  cwd: string;
+  /** Whether to suppress stdout/stderr passthrough. */
+  quiet: boolean;
+  /** Path to the CLI entry point for subprocess rd fallback. */
+  cliPath: string;
+  /** Optional environment variables merged into command env. */
+  env?: Record<string, string | undefined>;
+}
+
+/** Result returned by a command executor. */
+export interface CommandExecutionResult {
+  /** Captured stdout. */
+  stdout: string;
+  /** Captured stderr. */
+  stderr: string;
+  /** Process-style exit code. */
+  exitCode: number;
+}
+
+/** Optional command execution injection seam for scenario runners. */
+export interface CommandSequenceExecutor {
+  /** Execute a parsed rd/rundown command. */
+  runRd?: (args: string[], options: CommandExecutionOptions) => Promise<CommandExecutionResult>;
+  /** Execute a shell command. Defaults to subprocess execution when omitted. */
+  runShell?: (cmd: string, options: CommandExecutionOptions) => Promise<CommandExecutionResult>;
+}
+
+/**
+ * Callable used to execute the CLI inside the current Node.js process.
+ *
+ * @param input - In-process CLI invocation details.
+ * @returns Captured process-style command output.
+ */
+export type InProcessCliRunner = (input: {
+  /** Arguments passed to the Rundown CLI, excluding the executable name. */
+  args: string[];
+  /** Working directory for execution. */
+  cwd: string;
+  /** Optional environment variables merged into the invocation environment. */
+  env?: Record<string, string | undefined>;
+}) => Promise<CommandExecutionResult>;
+
+/**
+ * Create the shared in-process scenario command executor when enabled.
+ *
+ * @param runCliInProcess - Callable that executes the CLI in-process.
+ * @returns A command sequence executor when `RUNDOWN_SCENARIO_IN_PROCESS=1`, otherwise undefined.
+ */
+export function createInProcessCommandExecutor(
+  runCliInProcess: InProcessCliRunner,
+): CommandSequenceExecutor | undefined {
+  if (process.env.RUNDOWN_SCENARIO_IN_PROCESS !== '1') {
+    return undefined;
+  }
+
+  return {
+    runRd: (args, options) =>
+      runCliInProcess({
+        args,
+        cwd: options.cwd,
+        env: options.env,
+      }),
+  };
 }
 
 /** Options for command sequence execution. */
@@ -119,6 +204,10 @@ export interface CommandSequenceOptions {
   onCommandStart?: (command: string) => void;
   /** Optional environment variables merged into spawn env (overrides process.env) */
   env?: Record<string, string | undefined>;
+  /** Optional callback invoked after each command completes */
+  onCommandComplete?: (timing: CommandTiming) => void;
+  /** Optional executor for rd and shell commands. */
+  commandExecutor?: CommandSequenceExecutor;
 }
 
 /** Parsed `rd` command with command-scoped environment assignments. */
@@ -130,6 +219,27 @@ export interface ParsedRdCommand {
 }
 
 const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=.*/;
+
+/**
+ * Whether detailed scenario timing diagnostics are enabled.
+ *
+ * @returns True when detailed timing records should be emitted.
+ */
+export function isScenarioTimingEnabled(): boolean {
+  return process.env.RUNDOWN_SCENARIO_COMMAND_TIMINGS === '1';
+}
+
+/**
+ * Emit a scenario timing record to stderr when detailed timing is enabled.
+ *
+ * @param record - JSON-serializable timing record to emit.
+ */
+export function emitScenarioTiming(record: Record<string, unknown>): void {
+  if (!isScenarioTimingEnabled()) {
+    return;
+  }
+  process.stderr.write(`SCENARIO_TIMING ${JSON.stringify(record)}\n`);
+}
 
 function findExecutableAfterEnvAssignments(shellArgs: Array<string | object>): string | null {
   for (const entry of shellArgs) {
@@ -278,13 +388,34 @@ export function captureClaimIdFromJsonObject(value: unknown, capturedClaimIds: s
  */
 async function runCommandWithTee(
   command: { kind: 'rd'; args: string[] } | { kind: 'shell'; cmd: string },
-  options: {
-    cwd: string;
-    quiet: boolean;
-    cliPath: string;
-    env?: Record<string, string | undefined>;
-  },
-): Promise<{ stdout: string; exitCode: number }> {
+  options: CommandExecutionOptions & { commandExecutor?: CommandSequenceExecutor },
+): Promise<CommandExecutionResult> {
+  if (command.kind === 'rd' && options.commandExecutor?.runRd) {
+    const result = await options.commandExecutor.runRd(command.args, options);
+    if (!options.quiet) {
+      if (result.stdout) {
+        process.stdout.write(result.stdout);
+      }
+      if (result.stderr) {
+        process.stderr.write(result.stderr);
+      }
+    }
+    return result;
+  }
+
+  if (command.kind === 'shell' && options.commandExecutor?.runShell) {
+    const result = await options.commandExecutor.runShell(command.cmd, options);
+    if (!options.quiet) {
+      if (result.stdout) {
+        process.stdout.write(result.stdout);
+      }
+      if (result.stderr) {
+        process.stderr.write(result.stderr);
+      }
+    }
+    return result;
+  }
+
   return new Promise((resolve, reject) => {
     let child: ReturnType<typeof spawn>;
     const spawnEnv = { ...process.env, ...(options.env ?? {}), RUNDOWN_LOG: '0' };
@@ -304,6 +435,7 @@ async function runCommandWithTee(
     }
 
     const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
 
     child.stdout?.on('data', (chunk: Buffer) => {
       stdoutChunks.push(chunk);
@@ -313,13 +445,18 @@ async function runCommandWithTee(
     });
 
     child.stderr?.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
       if (!options.quiet) {
         process.stderr.write(chunk);
       }
     });
 
     child.on('close', (code) => {
-      resolve({ stdout: Buffer.concat(stdoutChunks).toString('utf-8'), exitCode: code ?? 1 });
+      resolve({
+        stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+        exitCode: code ?? 1,
+      });
     });
 
     child.on('error', (err) => {
@@ -910,9 +1047,28 @@ export async function executeCommandSequence(
   const errors: CapturedError[] = [];
   const transitions: CapturedTransition[] = [];
   const artifactEntries: CapturedArtifactEntry[] = [];
+  const commandTimings: CommandTiming[] = [];
   let terminalResult: 'COMPLETE' | 'STOP' | 'UNKNOWN' = 'UNKNOWN';
 
-  const { commands, cwd, cliPath, quiet, env } = options;
+  const { commands, cwd, cliPath, quiet, env, commandExecutor } = options;
+
+  const recordTiming = (
+    command: string,
+    kind: CommandTiming['kind'],
+    start: number,
+    exitCode: number,
+    expectedFailure: boolean,
+  ): void => {
+    const timing: CommandTiming = {
+      command,
+      kind,
+      durationMs: Math.round(performance.now() - start),
+      exitCode,
+      expectedFailure,
+    };
+    commandTimings.push(timing);
+    options.onCommandComplete?.(timing);
+  };
 
   for (const rawCmd of commands) {
     const trimmedRaw = rawCmd.trimStart();
@@ -930,10 +1086,12 @@ export async function executeCommandSequence(
     if (rdCommand) {
       // rd command — parse args (JSON is the default output format)
       const commandEnv = { ...env, ...rdCommand.env };
+      const commandStart = performance.now();
       const result = await runCommandWithTee(
         { kind: 'rd', args: rdCommand.args },
-        { cwd, quiet, cliPath, env: commandEnv },
+        { cwd, quiet, cliPath, env: commandEnv, commandExecutor },
       );
+      recordTiming(cmd, 'rd', commandStart, result.exitCode, expectsFailure);
       stdout = result.stdout;
 
       // Parse JSON output to extract transitions, terminal state, and tokens
@@ -958,7 +1116,12 @@ export async function executeCommandSequence(
       }
     } else {
       // Shell command — execute directly
-      const result = await runCommandWithTee({ kind: 'shell', cmd }, { cwd, quiet, cliPath, env });
+      const commandStart = performance.now();
+      const result = await runCommandWithTee(
+        { kind: 'shell', cmd },
+        { cwd, quiet, cliPath, env, commandExecutor },
+      );
+      recordTiming(cmd, 'shell', commandStart, result.exitCode, expectsFailure);
       stdout = result.stdout;
 
       // Parse JSON output from shell commands as well (e.g., shell scripts that wrap rd commands)
@@ -983,5 +1146,13 @@ export async function executeCommandSequence(
     }
   }
 
-  return { terminalResult, transitions, capturedTokens, capturedClaimIds, errors, artifactEntries };
+  return {
+    terminalResult,
+    transitions,
+    capturedTokens,
+    capturedClaimIds,
+    errors,
+    artifactEntries,
+    commandTimings,
+  };
 }

--- a/packages/cli/src/helpers/scenario-workflow.ts
+++ b/packages/cli/src/helpers/scenario-workflow.ts
@@ -23,7 +23,9 @@ import { resolveRunbookFile } from './resolve-runbook.js';
 import { extractFrontmatter } from '@rundown-org/parser';
 import type { OutputEmitter } from '../services/output-emitter.js';
 import {
+  createInProcessCommandExecutor,
   executeCommandSequence,
+  emitScenarioTiming,
   extractRunbookReferences,
   extractInputFileReferences,
   matchErrorAssertions,
@@ -33,6 +35,7 @@ import {
   type ErrorAssertionResult,
   type StepAssertionResult,
 } from './command-sequence.js';
+import { runCliInProcess } from '../services/in-process-cli-runner.js';
 
 /**
  * A loaded runbook with its scenarios.
@@ -307,6 +310,10 @@ export async function executeScenario(
             output.message(`$ ${cmd}`, 'info');
             output.message('', 'info');
           },
+      onCommandComplete: (timing) => {
+        emitScenarioTiming({ scope: 'command', ...timing });
+      },
+      commandExecutor: createInProcessCommandExecutor(runCliInProcess),
     });
 
     const actualResult = seqResult.terminalResult;

--- a/packages/cli/src/services/in-process-cli-runner.ts
+++ b/packages/cli/src/services/in-process-cli-runner.ts
@@ -1,0 +1,191 @@
+import { CommanderError } from 'commander';
+import { ConsoleWriter, getErrorMessage, resetColorCache, setWriter } from '@rundown-org/core';
+import { resetPolicyContext } from './policy-context.js';
+
+/** Result of running the CLI in the current Node process. */
+export interface InProcessCliRunResult {
+  /** Captured stdout. */
+  stdout: string;
+  /** Captured stderr. */
+  stderr: string;
+  /** Exit code observed from Commander, process.exit, or process.exitCode. */
+  exitCode: number;
+  /** Whether process.exit was intercepted during the invocation. */
+  exitIntercepted?: boolean;
+}
+
+/** Options for running the CLI in the current Node process. */
+export interface InProcessCliRunOptions {
+  /** CLI arguments, excluding the executable name. */
+  args: readonly string[];
+  /** Working directory visible via process.cwd() during invocation. */
+  cwd: string;
+  /** Per-invocation environment overrides, restored after the command finishes. */
+  env?: Readonly<Record<string, string | undefined>>;
+}
+
+/** Sentinel error thrown when a command calls process.exit() in-process. */
+class ExitSignal extends Error {
+  constructor(public readonly code: number) {
+    super(`process.exit(${String(code)})`);
+    this.name = 'ExitSignal';
+  }
+}
+
+/**
+ * Strip in-process process.exit interception artefacts from a captured buffer.
+ *
+ * @param buf - Captured stdout or stderr buffer.
+ * @returns The buffer with end-of-buffer artefacts removed.
+ */
+export function stripExitArtefact(buf: string): string {
+  const artefactPattern =
+    /(^|\n)\{\s*"error":\s*"process\.exit\(\d+\)",\s*"kind":\s*"error",\s*"code":\s*"UNKNOWN_ERROR"(?:,\s*"command":\s*"[^"]+")?\s*\}\s*$/;
+  let out = buf.replace(artefactPattern, '$1');
+  out = out.replace(/\s*process\.exit\(\d+\)\s*$/, '');
+  return out;
+}
+
+function appendChunk(buffer: string, chunk: unknown): string {
+  if (typeof chunk === 'string') {
+    return buffer + chunk;
+  }
+  if (chunk instanceof Uint8Array) {
+    return buffer + new TextDecoder().decode(chunk);
+  }
+  return buffer + String(chunk);
+}
+
+function restoreEnv(originalEnv: Readonly<Record<string, string | undefined>>): void {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+/**
+ * Run the Rundown CLI in this Node process while capturing stdout/stderr.
+ *
+ * This exists for scenario execution in environments where nested process
+ * spawning is expensive or unavailable. It mutates process globals during the
+ * invocation and restores them before returning.
+ *
+ * @param options - Arguments, cwd, and environment for this invocation.
+ * @returns Captured output and exit code.
+ */
+export async function runCliInProcess(
+  options: InProcessCliRunOptions,
+): Promise<InProcessCliRunResult> {
+  const extraEnv = options.env ?? {};
+  const envKeys = new Set([
+    'NO_COLOR',
+    'RUNDOWN_LOG',
+    'CLAUDE_PLUGIN_ROOT',
+    'PATH',
+    'FORCE_COLOR',
+    ...Object.keys(extraEnv),
+  ]);
+  const originalEnv = Object.fromEntries(
+    [...envKeys].map((key) => [key, process.env[key]]),
+  ) as Record<string, string | undefined>;
+
+  const originalCwd = process.cwd();
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const originalExit = process.exit.bind(process);
+  const originalConsoleError = console.error.bind(console);
+  const originalConsoleLog = console.log.bind(console);
+
+  let stdoutBuf = '';
+  let stderrBuf = '';
+  let exitCode = 0;
+  const exit = { signalled: false };
+
+  try {
+    resetPolicyContext();
+    resetColorCache();
+
+    process.chdir(options.cwd);
+    process.env.NO_COLOR = '1';
+    process.env.RUNDOWN_LOG = '0';
+    delete process.env.FORCE_COLOR;
+    for (const [key, value] of Object.entries(extraEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+
+    process.stdout.write = (chunk: unknown, ...rest: unknown[]): boolean => {
+      stdoutBuf = appendChunk(stdoutBuf, chunk);
+      const cb = rest.find((arg) => typeof arg === 'function') as
+        | ((err?: Error | null) => void)
+        | undefined;
+      cb?.();
+      return true;
+    };
+    process.stderr.write = (chunk: unknown, ...rest: unknown[]): boolean => {
+      stderrBuf = appendChunk(stderrBuf, chunk);
+      const cb = rest.find((arg) => typeof arg === 'function') as
+        | ((err?: Error | null) => void)
+        | undefined;
+      cb?.();
+      return true;
+    };
+
+    setWriter(new ConsoleWriter());
+
+    console.error = (...args: unknown[]) => {
+      stderrBuf += `${args.map(String).join(' ')}\n`;
+    };
+    console.log = (...args: unknown[]) => {
+      stdoutBuf += `${args.map(String).join(' ')}\n`;
+    };
+
+    process.exit = (code?: number) => {
+      exit.signalled = true;
+      throw new ExitSignal(code ?? 0);
+    };
+
+    const { createProgram } = await import('../cli.js');
+    const program = createProgram();
+    program.exitOverride();
+    await program.parseAsync([...options.args], { from: 'user' });
+
+    exitCode = Number(process.exitCode ?? 0);
+    process.exitCode = undefined;
+  } catch (err: unknown) {
+    if (err instanceof ExitSignal) {
+      exitCode = err.code;
+    } else if (err instanceof CommanderError) {
+      exitCode = err.exitCode;
+    } else {
+      exitCode = 1;
+      stderrBuf += getErrorMessage(err);
+    }
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    process.exit = originalExit;
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+    process.exitCode = undefined;
+    process.chdir(originalCwd);
+    restoreEnv(originalEnv);
+
+    resetPolicyContext();
+    resetColorCache();
+    setWriter(new ConsoleWriter());
+  }
+
+  if (exit.signalled) {
+    stdoutBuf = stripExitArtefact(stdoutBuf);
+    stderrBuf = stripExitArtefact(stderrBuf);
+  }
+
+  return { stdout: stdoutBuf, stderr: stderrBuf, exitCode, exitIntercepted: exit.signalled };
+}

--- a/scripts/__tests__/scenario-script-timings.test.mjs
+++ b/scripts/__tests__/scenario-script-timings.test.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+
+async function makeWorkspace() {
+  const cwd = await mkdtemp(join(tmpdir(), 'rd-script-test-'));
+  await mkdir(join(cwd, 'runbooks'), { recursive: true });
+  await mkdir(join(cwd, 'packages/cli/dist'), { recursive: true });
+  await mkdir(join(cwd, 'packages/claude-code-plugin'), { recursive: true });
+
+  await writeFile(
+    join(cwd, 'runbooks/example.runbook.md'),
+    [
+      '---',
+      'name: example',
+      'scenarios:',
+      '  happy:',
+      '    commands:',
+      '      - rd run example.runbook.md',
+      '    result: COMPLETE',
+      '---',
+      '# Example',
+      '',
+    ].join('\n'),
+  );
+  await writeFile(
+    join(cwd, 'runbooks/scenario-suite.yaml'),
+    'cases:\n  happy:\n    commands: []\n',
+  );
+  await writeFile(
+    join(cwd, 'packages/claude-code-plugin/plugin.scenario-suite.yaml'),
+    'cases:\n  plugin:\n    commands: []\n',
+  );
+
+  await writeFile(
+    join(cwd, 'packages/cli/dist/cli.js'),
+    [
+      '#!/usr/bin/env node',
+      'const args = process.argv.slice(2);',
+      "if (args[0] === 'scenario' && args[1] === 'ls') {",
+      "  console.error('scenario ls should not be used by the raw runner');",
+      '  process.exit(99);',
+      '}',
+      "if (args[0] === 'scenario' && args[1] === 'run') {",
+      "  if (process.env.RUNDOWN_SCENARIO_COMMAND_TIMINGS === '1') {",
+      '    console.error(\'SCENARIO_TIMING {"scope":"command","kind":"rd","exitCode":0,"durationMs":12,"expectedFailure":false,"command":"rd run example.runbook.md"}\');',
+      '  }',
+      '  process.exit(0);',
+      '}',
+      "if (args[0] === 'scenario-suite' && args[1] === 'run') {",
+      "  if (process.env.RUNDOWN_SCENARIO_COMMAND_TIMINGS === '1') {",
+      '    console.error(\'SCENARIO_TIMING {"scope":"case","case":"plugin","durationMs":34}\');',
+      '  }',
+      '  process.exit(0);',
+      '}',
+      'process.exit(1);',
+      '',
+    ].join('\n'),
+    { mode: 0o755 },
+  );
+
+  return cwd;
+}
+
+test('frontmatter scenario raw script reports per-runbook and total timings', async () => {
+  const cwd = await makeWorkspace();
+
+  const result = spawnSync('node', [join(repoRoot, 'scripts/test-scenarios.mjs')], {
+    cwd,
+    encoding: 'utf-8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /runbooks\/example\.runbook\.md: 1 passed, 0 failed \(\d+ms\)/);
+  assert.match(result.stdout, /1 passed, 0 failed \(\d+ms total\)/);
+});
+
+test('frontmatter scenario raw script discovers scenarios without scenario ls subprocess', async () => {
+  const cwd = await makeWorkspace();
+
+  const result = spawnSync('node', [join(repoRoot, 'scripts/test-scenarios.mjs')], {
+    cwd,
+    encoding: 'utf-8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stderr, /scenario ls should not be used/);
+});
+
+test('frontmatter scenario raw script reports frontmatter diagnostics', async () => {
+  const cwd = await makeWorkspace();
+  await writeFile(
+    join(cwd, 'runbooks/invalid.runbook.md'),
+    [
+      '---',
+      'name: invalid',
+      'inputs:',
+      '  - 42',
+      'scenarios:',
+      '  broken:',
+      '    commands: []',
+      '---',
+      '# Invalid',
+      '',
+    ].join('\n'),
+  );
+
+  const result = spawnSync('node', [join(repoRoot, 'scripts/test-scenarios.mjs')], {
+    cwd,
+    encoding: 'utf-8',
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Invalid frontmatter in runbooks\/invalid\.runbook\.md/);
+  assert.match(result.stderr, /Frontmatter "inputs\[0\]" must be a string identifier/);
+});
+
+test('scenario suite raw script reports per-suite and total timings', async () => {
+  const cwd = await makeWorkspace();
+
+  const result = spawnSync('node', [join(repoRoot, 'scripts/test-scenario-suites.mjs')], {
+    cwd,
+    encoding: 'utf-8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /packages\/claude-code-plugin\/plugin\.scenario-suite\.yaml: passed \(\d+ms\)/,
+  );
+  assert.match(result.stdout, /runbooks\/scenario-suite\.yaml: passed \(\d+ms\)/);
+  assert.match(result.stdout, /2 suites passed, 0 failed \(\d+ms total\)/);
+});
+
+test('raw scripts forward detailed timings when enabled', async () => {
+  const cwd = await makeWorkspace();
+
+  const scenarios = spawnSync('node', [join(repoRoot, 'scripts/test-scenarios.mjs')], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, RUNDOWN_SCENARIO_COMMAND_TIMINGS: '1' },
+  });
+  assert.equal(scenarios.status, 0, scenarios.stderr);
+  assert.match(scenarios.stderr, /SCENARIO_TIMING .*"scope":"command"/);
+
+  const suites = spawnSync('node', [join(repoRoot, 'scripts/test-scenario-suites.mjs')], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, RUNDOWN_SCENARIO_COMMAND_TIMINGS: '1' },
+  });
+  assert.equal(suites.status, 0, suites.stderr);
+  assert.match(suites.stderr, /SCENARIO_TIMING .*"scope":"case"/);
+});
+
+test('CI scenarios job uses raw scripts after downloading build artifacts', async () => {
+  const workflow = await readFile(join(repoRoot, '.github/workflows/ci.yml'), 'utf-8');
+
+  assert.match(workflow, /run: npm run test:scenarios:raw/);
+  assert.match(workflow, /run: npm run test:scenario-suites:raw/);
+});

--- a/scripts/test-scenario-suites.mjs
+++ b/scripts/test-scenario-suites.mjs
@@ -3,9 +3,18 @@
 import { spawnSync } from 'node:child_process';
 import { globSync } from 'glob';
 import process from 'node:process';
+import { performance } from 'node:perf_hooks';
 
 let passed = 0;
 let failures = 0;
+
+function formatDuration(start) {
+  return `${Math.round(performance.now() - start).toString()}ms`;
+}
+
+const totalStart = performance.now();
+
+const detailedTimingsEnabled = process.env.RUNDOWN_SCENARIO_COMMAND_TIMINGS === '1';
 
 // Find all scenario suite files. The root runbook pattern suite predates the
 // `*.scenario-suite.yaml` naming convention, so keep it explicitly in CI.
@@ -27,29 +36,35 @@ if (suites.length === 0) {
 
 // Run each scenario suite
 for (const suite of suites) {
+  const suiteStart = performance.now();
   console.log(`=== ${suite} ===`);
 
-  const result = spawnSync('node', [
-    'packages/cli/dist/cli.js',
-    'scenario-suite',
-    'run',
-    suite,
-    '--all',
-    '--quiet',
-  ]);
+  const result = spawnSync(
+    'node',
+    ['packages/cli/dist/cli.js', 'scenario-suite', 'run', suite, '--all', '--quiet'],
+    {
+      encoding: 'utf-8',
+    },
+  );
+
+  if (detailedTimingsEnabled && result.stderr) {
+    process.stderr.write(result.stderr);
+  }
 
   if (result.error) {
     console.error(`Failed to spawn process for ${suite}:`, result.error.message);
     failures += 1;
   } else if (result.status === 0) {
     passed += 1;
+    console.log(`${suite}: passed (${formatDuration(suiteStart)})`);
   } else {
     console.log(`FAIL: ${suite}`);
     failures += 1;
+    console.log(`${suite}: failed (${formatDuration(suiteStart)})`);
   }
 
   console.log('');
 }
 
-console.log(`${passed} suites passed, ${failures} failed`);
+console.log(`${passed} suites passed, ${failures} failed (${formatDuration(totalStart)} total)`);
 process.exit(failures === 0 ? 0 : 1);

--- a/scripts/test-scenarios.mjs
+++ b/scripts/test-scenarios.mjs
@@ -4,9 +4,50 @@ import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { globSync } from 'glob';
 import process from 'node:process';
+import { performance } from 'node:perf_hooks';
+import { extractFrontmatter } from '../packages/parser/dist/index.js';
+import { parseScenarios } from '../packages/cli/dist/schemas/scenarios.js';
 
 let passed = 0;
 let failures = 0;
+
+function formatDuration(start) {
+  return `${Math.round(performance.now() - start).toString()}ms`;
+}
+
+function formatDiagnostics(diagnostics) {
+  return diagnostics
+    .map((diagnostic) => {
+      const location = diagnostic.line === undefined ? '' : `line ${diagnostic.line.toString()}: `;
+      return `${diagnostic.severity}: ${location}${diagnostic.message}`;
+    })
+    .join('; ');
+}
+
+const totalStart = performance.now();
+
+const detailedTimingsEnabled = process.env.RUNDOWN_SCENARIO_COMMAND_TIMINGS === '1';
+
+function listScenarioNames(runbook) {
+  const content = readFileSync(runbook, 'utf-8');
+  const { frontmatter, diagnostics } = extractFrontmatter(content);
+  if (diagnostics.length > 0) {
+    throw new Error(`Invalid frontmatter in ${runbook}: ${formatDiagnostics(diagnostics)}`);
+  }
+  if (!frontmatter) {
+    throw new Error(`No frontmatter found in ${runbook}`);
+  }
+
+  const { scenarios, errors } = parseScenarios(frontmatter);
+  if (errors.length > 0) {
+    throw new Error(`Invalid scenarios in ${runbook}: ${errors.join('; ')}`);
+  }
+  if (!scenarios || Object.keys(scenarios).length === 0) {
+    throw new Error(`No scenarios defined in ${runbook}`);
+  }
+
+  return Object.keys(scenarios);
+}
 
 // Find all runbooks with scenarios in frontmatter
 const runbooks = globSync('runbooks/**/*.runbook.md').filter((file) => {
@@ -25,40 +66,39 @@ if (runbooks.length === 0) {
 
 // For each runbook, list and run its scenarios
 for (const runbook of runbooks) {
+  const runbookStart = performance.now();
+  let runbookPassed = 0;
+  let runbookFailures = 0;
+
   try {
-    const listResult = spawnSync('node', ['packages/cli/dist/cli.js', 'scenario', 'ls', runbook], {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    });
-    if (listResult.error) {
-      throw listResult.error;
-    }
-    if (listResult.status !== 0) {
-      throw new Error(`scenario ls failed for ${runbook}: ${listResult.stderr ?? ''}`.trim());
-    }
-    const scenarios = JSON.parse(listResult.stdout);
+    const scenarios = listScenarioNames(runbook);
 
     for (const scenario of scenarios) {
-      const result = spawnSync('node', [
-        'packages/cli/dist/cli.js',
-        'scenario',
-        'run',
-        runbook,
-        scenario.name,
-        '--quiet',
-      ]);
+      const result = spawnSync(
+        'node',
+        ['packages/cli/dist/cli.js', 'scenario', 'run', runbook, scenario, '--quiet'],
+        {
+          encoding: 'utf-8',
+        },
+      );
 
       if (result.error) {
         console.error(
-          `Failed to spawn process for ${runbook} :: ${scenario.name}:`,
+          `Failed to spawn process for ${runbook} :: ${scenario}:`,
           result.error.message,
         );
         failures += 1;
+        runbookFailures += 1;
       } else if (result.status === 0) {
         passed += 1;
+        runbookPassed += 1;
       } else {
-        console.log(`FAIL: ${runbook} :: ${scenario.name}`);
+        console.log(`FAIL: ${runbook} :: ${scenario}`);
         failures += 1;
+        runbookFailures += 1;
+      }
+      if (detailedTimingsEnabled && result.stderr) {
+        process.stderr.write(result.stderr);
       }
     }
   } catch (error) {
@@ -67,9 +107,14 @@ for (const runbook of runbooks) {
       error instanceof Error ? error.message : String(error),
     );
     failures += 1;
+    runbookFailures += 1;
   }
+
+  console.log(
+    `${runbook}: ${runbookPassed.toString()} passed, ${runbookFailures.toString()} failed (${formatDuration(runbookStart)})`,
+  );
 }
 
 console.log('');
-console.log(`${passed} passed, ${failures} failed`);
+console.log(`${passed} passed, ${failures} failed (${formatDuration(totalStart)} total)`);
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
- add opt-in in-process execution for scenario rd/rundown commands via RUNDOWN_SCENARIO_IN_PROCESS=1
- keep shell commands on subprocess execution and preserve the default subprocess path
- add scenario timing instrumentation and raw-script timing summaries

## Validation
- npm run test:unit -w packages/cli -- --runTestsByPath __tests__/services/in-process-cli-runner.test.ts __tests__/helpers/command-sequence.test.ts __tests__/commands/scenario-suite.test.ts __tests__/commands/scenarios.test.ts __tests__/helpers/scenario-workflow.test.ts __tests__/helpers/test-utils.test.ts
- node --test scripts/__tests__/scenario-script-timings.test.mjs
- npm run check:types -w packages/cli
- npx biome check --formatter-enabled=true --linter-enabled=false <touched files>
- npx biome lint <touched files>
- npm run check:lint:typed
- npm run build -w packages/parser -w packages/core -w packages/cli
- RUNDOWN_SCENARIO_IN_PROCESS=1 npm run test:scenarios:raw
- RUNDOWN_SCENARIO_IN_PROCESS=1 npm run test:scenario-suites:raw

## Timing
- scenarios raw: 250.2s -> 76.2s
- scenario suites raw: 87.7s -> 7.3s
- combined: 337.9s -> 83.6s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command- and case-level timing telemetry for scenario runs; optional in-process scenario execution.

* **Tests**
  * Expanded integration and unit tests for timings, in-process runner, command sequencing, and raw runner scripts.

* **Chores**
  * CI reorganized to use a local Node setup action, separate Node 24/25 build artifacts, and split coverage jobs.
  * Test runners now report per-runbook/suite and total durations, stream detailed timing output when enabled, and improve scenario discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->