### PR TITLE
Add validateSchema runbook helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ rdpath --dir <path> --ctx <id> find <pattern> # Find within context scope
 ```bash
 rdx <file>                        # Render JSON to Markdown (stdout)
 rdx <file> -o, --output <path>    # Write Markdown to file
-rdx <file> --check                # Validate only, no rendering
+rdx <file> --validate             # Validate only, no rendering
 rdx <file> --schema <name>        # Explicit schema for validation
 ```
 

--- a/docs/reference/rdx.md
+++ b/docs/reference/rdx.md
@@ -22,7 +22,7 @@ This specification defines the behavior of the `rdx` binary. It covers:
 - Command-line surface and argument shape.
 - JSON input parsing and the `$schema` discovery contract.
 - Schema name resolution and the registry of recognized schema names.
-- Validation behavior, including `--check` mode.
+- Validation behavior, including `--validate` mode.
 - The structural Markdown rendering algorithm.
 - Output destination semantics for stdout and `--output`.
 - Failure modes, error message format, and exit codes.
@@ -45,7 +45,7 @@ and [docs/reference/runtime.md](runtime.md), respectively.
 | Validator | A module-level `validate(data: unknown)` function exported by a schema module. |
 | Renderer | The structural JSON-to-Markdown algorithm defined in [§7](#7-rendering-rules). |
 | Render mode | Default invocation: `rdx <file>` produces Markdown output. |
-| Check mode | Invocation with `--check`: validates only, no Markdown output. |
+| Validate mode | Invocation with `--validate`: validates only, no Markdown output. |
 
 ## 3. Binary and Invocation
 
@@ -54,7 +54,7 @@ and [docs/reference/runtime.md](runtime.md), respectively.
 | Package | `@rundown-org/claude-code-plugin`. |
 | Binary | `rdx`. |
 | Positional argument | Exactly one path to a JSON file is REQUIRED. |
-| Option `--check` | Validate only; produce no Markdown output. |
+| Option `--validate` | Validate only; produce no Markdown output. |
 | Option `--schema <name>` | Explicit schema name for validation. |
 | Option `-o, --output <path>` | Write Markdown to the given path instead of stdout. |
 
@@ -63,7 +63,7 @@ Synopsis:
 ```text
 rdx <file>                        Render JSON to Markdown on stdout.
 rdx <file> -o, --output <path>    Render JSON to the given Markdown file.
-rdx <file> --check                Validate only; no Markdown output.
+rdx <file> --validate             Validate only; no Markdown output.
 rdx <file> --schema <name>        Validate using the named schema.
 ```
 
@@ -181,7 +181,7 @@ When no schema is selected by either source, behavior depends on mode:
 
 | Mode | Behavior |
 | --- | --- |
-| `--check` | Fail closed with the message `--check requires a schema (use $schema in JSON or --schema flag)`. |
+| `--validate` | Fail closed with the message `--validate requires a schema (use $schema in JSON or --schema flag)`. |
 | Render mode | Emit the warning `warning: no schema found, skipping validation` to stderr and render without validation. |
 
 In render mode, the absence of a schema MUST NOT produce a non-zero exit code
@@ -204,9 +204,9 @@ that returns the validated, typed value or throws on validation failure.
 | Validation result | When validation succeeds, the value returned by `validate` MUST be used as the value passed to the renderer. |
 | Validation failure | When validation throws, `rdx` MUST format and emit the error per [§6.3](#63-validation-error-format) and exit with status `1`. |
 
-### 6.2 Check Mode
+### 6.2 Validate Mode
 
-When `--check` is supplied:
+When `--validate` is supplied:
 
 | Outcome | Behavior |
 | --- | --- |
@@ -214,8 +214,8 @@ When `--check` is supplied:
 | Validation fails | Write the formatted validation error to stderr and exit with status `1`. |
 | No schema discovered | Fail closed per [§5.6](#56-no-schema-discovered). |
 
-In `--check` mode, `rdx` MUST NOT write Markdown to stdout or to a file. The
-`--output` option MUST have no effect when combined with `--check`.
+In `--validate` mode, `rdx` MUST NOT write Markdown to stdout or to a file. The
+`--output` option MUST have no effect when combined with `--validate`.
 
 <a id="63-validation-error-format"></a>
 
@@ -390,13 +390,13 @@ characters.
 | --- | --- | --- |
 | stdout | No `--output` flag in render mode. | Markdown is written to standard output. |
 | File | `-o, --output <path>` in render mode. | Markdown is written to `<path>`. |
-| Stdout (`Valid.`) | `--check` mode after successful validation. | The literal `Valid.\n` is written to standard output. |
+| Stdout (`Valid.`) | `--validate` mode after successful validation. | The literal `Valid.\n` is written to standard output. |
 
 The `--output` path MUST be written using standard file I/O. `rdx` MUST NOT
 create parent directories for `--output` paths; missing parent directories
 cause an I/O error and exit `1`. Existing files MUST be overwritten.
 
-The `--output` flag MUST have no effect in `--check` mode.
+The `--output` flag MUST have no effect in `--validate` mode.
 
 <a id="9-failure-modes"></a>
 
@@ -414,7 +414,7 @@ single-line summary shown below, followed by one or more indented issue lines.
 | Embedded `$schema` value is neither a recognized Rundown schema URI nor a valid bare schema name | `error: unrecognized schema: <raw>` |
 | Resolved schema name not in registry | `error: Unknown schema: <name>` |
 | Schema name fails the format check | `error: Invalid schema name: <name>` |
-| `--check` supplied with no discoverable schema | `error: --check requires a schema (use $schema in JSON or --schema flag)` |
+| `--validate` supplied with no discoverable schema | `error: --validate requires a schema (use $schema in JSON or --schema flag)` |
 | Validation failure | `error: schema validation failed (<schema>)` followed by issue lines indented by two spaces |
 | Output file write failure | `error: <message>` |
 
@@ -436,7 +436,7 @@ without validation. The warning MUST NOT cause a non-zero exit.
 6. If no schema is selected, behave per [§5.6](#56-no-schema-discovered).
 7. If a schema is selected, load the validator from the registry and validate
    the stripped input.
-8. If `--check` was supplied, write `Valid.\n` to stdout and exit `0`.
+8. If `--validate` was supplied, write `Valid.\n` to stdout and exit `0`.
 9. Otherwise, render the validated value (or the stripped input if no schema
    was selected) per [§7](#7-rendering-rules).
 10. Write the rendered Markdown to the destination per [§8](#8-output-destination).
@@ -461,7 +461,7 @@ A conforming `rdx` implementation MUST satisfy these requirements:
    `--schema` flag overrides selection.
 7. Recognize exactly the schema names listed in the registry table in
    [§5.4](#54-schema-registry).
-8. In `--check` mode, fail closed when no schema is discoverable.
+8. In `--validate` mode, fail closed when no schema is discoverable.
 9. In render mode without a schema, emit the no-schema warning and render.
 10. Format Zod validation errors as schema-labeled, JSON-pointer-prefixed
     indented lines.
@@ -469,7 +469,7 @@ A conforming `rdx` implementation MUST satisfy these requirements:
     schema knowledge.
 12. Cap heading depth at H6.
 13. Strip `null` and empty array fields from rendered output.
-14. In `--check` success, write `Valid.\n` to stdout and emit no Markdown.
+14. In `--validate` success, write `Valid.\n` to stdout and emit no Markdown.
 15. Exit with status `0` on success and status `1` on every failure mode in
     [§9](#9-failure-modes).
 16. Never define exit codes other than `0` and `1`.
@@ -486,7 +486,7 @@ rdx plan.json
 rdx plan.json --output plan.md
 
 # Validate without rendering
-rdx plan.json --check
+rdx plan.json --validate
 
 # Validate with an explicit schema
 rdx data.json --schema plan
@@ -586,7 +586,7 @@ export class Widget {}
 ```bash
 # 1. Author plan as JSON (manually or via Claude structured output).
 # 2. Validate.
-rdx plan.json --check
+rdx plan.json --validate
 
 # 3. Render to Markdown.
 rdx plan.json --output plan.md

--- a/packages/claude-code-plugin/__tests__/rdx.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/rdx.integration.test.ts
@@ -33,35 +33,47 @@ const runRdx = (args: string[]): Promise<{ stdout: string; stderr: string; exitC
   });
 };
 
-describe('rdx --check', () => {
-  test('--check without schema errors', async () => {
-    const result = await runRdx(['--check', path.join(fixturesDir, 'no-schema.json')]);
+describe('rdx --validate', () => {
+  test('--validate without schema errors', async () => {
+    const result = await runRdx(['--validate', path.join(fixturesDir, 'no-schema.json')]);
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain('--check requires a schema');
+    expect(result.stderr).toContain('--validate requires a schema');
   });
 
   test('valid plan with $schema field prints Valid', async () => {
-    const result = await runRdx(['--check', path.join(fixturesDir, 'valid-plan.json')]);
+    const result = await runRdx(['--validate', path.join(fixturesDir, 'valid-plan.json')]);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe('Valid.\n');
   });
 
+  test('--validate with --output ignores output flag', async () => {
+    const result = await runRdx([
+      '--validate',
+      '--output',
+      'ignored.out',
+      path.join(fixturesDir, 'valid-plan.json'),
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('Valid.\n');
+    expect(result.stderr).not.toContain('error:');
+  });
+
   test('invalid JSON syntax prints error with filename', async () => {
-    const result = await runRdx(['--check', path.join(fixturesDir, 'invalid-json.txt')]);
+    const result = await runRdx(['--validate', path.join(fixturesDir, 'invalid-json.txt')]);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('invalid JSON in');
     expect(result.stderr).toContain('invalid-json.txt');
   });
 
   test('missing file prints file-not-found error', async () => {
-    const result = await runRdx(['--check', path.join(fixturesDir, 'nonexistent.json')]);
+    const result = await runRdx(['--validate', path.join(fixturesDir, 'nonexistent.json')]);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('file not found');
     expect(result.stderr).toContain('nonexistent.json');
   });
 
   test('valid JSON failing schema prints validation errors and exits 1', async () => {
-    const result = await runRdx(['--check', path.join(fixturesDir, 'invalid-plan.json')]);
+    const result = await runRdx(['--validate', path.join(fixturesDir, 'invalid-plan.json')]);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('schema validation failed');
     expect(result.stderr).toContain('plan');
@@ -70,7 +82,7 @@ describe('rdx --check', () => {
   test('--schema flag overrides $schema field', async () => {
     // valid-plan.json has $schema: "plan", but --schema nonexistent should fail
     const result = await runRdx([
-      '--check',
+      '--validate',
       '--schema',
       'nonexistent',
       path.join(fixturesDir, 'valid-plan.json'),
@@ -80,7 +92,7 @@ describe('rdx --check', () => {
   });
 
   test('unrecognized $schema URI prints error and exits 1', async () => {
-    const result = await runRdx(['--check', path.join(fixturesDir, 'unknown-schema.json')]);
+    const result = await runRdx(['--validate', path.join(fixturesDir, 'unknown-schema.json')]);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('unrecognized schema');
   });
@@ -88,13 +100,19 @@ describe('rdx --check', () => {
   test('--schema flag validates file without $schema field', async () => {
     // no-schema.json has no $schema, but --schema plan should validate (and fail)
     const result = await runRdx([
-      '--check',
+      '--validate',
       '--schema',
       'plan',
       path.join(fixturesDir, 'no-schema.json'),
     ]);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('schema validation failed');
+  });
+
+  test('--check is not accepted', async () => {
+    const result = await runRdx(['--check', path.join(fixturesDir, 'valid-plan.json')]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unknown option');
   });
 });
 

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -68,13 +68,31 @@ describe('Built-in Runbook Validation', () => {
     });
   });
 
-  it('does not double-quote rdx path templates in command blocks', () => {
+  it('does not use removed rdx --check mode', () => {
     const offenders = runbookEntries
       .map(([relativePath, runbookPath]) => ({
         relativePath,
         content: readFileSync(runbookPath, 'utf-8'),
       }))
-      .filter(({ content }) => /rdx --check\s+"{{\s*[^}]+\s*}}"/.test(content))
+      .filter(({ content }) => /rdx --check\b/.test(content))
+      .map(({ relativePath }) => relativePath);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('does not double-quote schema helper templates in command blocks', () => {
+    const shellFence = /```(?:bash|sh|shell)[^\n]*\n([\s\S]*?)\n```/g;
+    const quotedValidateSchema = /"\{\{\s*validateSchema\s+[^}]+\s*\}\}"/;
+    const offenders = runbookEntries
+      .map(([relativePath, runbookPath]) => ({
+        relativePath,
+        content: readFileSync(runbookPath, 'utf-8'),
+      }))
+      .filter(({ content }) =>
+        Array.from(content.matchAll(shellFence)).some((match) =>
+          quotedValidateSchema.test(match[1]),
+        ),
+      )
       .map(({ relativePath }) => relativePath);
 
     expect(offenders).toEqual([]);

--- a/packages/claude-code-plugin/runbooks/meta/end-to-end-test.runbook.md
+++ b/packages/claude-code-plugin/runbooks/meta/end-to-end-test.runbook.md
@@ -32,15 +32,17 @@ Run multiple runbooks, reviewing and testing the end-to-end process.
 
 
 ## 4. Write the review of the end-to-end Rundown workflow
+- ARTIFACTS
+  - EndToEndReviewPath "end-to-end-test-review.json"
+- OUTPUTS
+  - EndToEndReviewPath
 - PASS CONTINUE
 - FAIL STOP
 
 Write the review to the output path as JSON.
 Follow the review output schema.
 
-```bash
-rdpath --file end-to-end-test-review.json
-```
+{{ EndToEndReviewPath }}
 
 
 ## 5. Check Schema
@@ -48,6 +50,5 @@ rdpath --file end-to-end-test-review.json
 - FAIL GOTO 4
 
 ```bash
-rdx --check "$(rdpath --dir {{ WorkPath }} --ctx {{ ContextId }} --file end-to-end-test-review.json)"
+{{ validateSchema EndToEndReviewPath }}
 ```
-

--- a/packages/claude-code-plugin/runbooks/planning/review/review-plan-build-runtime.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/review/review-plan-build-runtime.runbook.md
@@ -63,5 +63,5 @@ Ensure any validation issues have been resolved.
 - FAIL GOTO 5
 
 ```bash
-rdx --check {{ ReviewPath }}
+{{ validateSchema ReviewPath }}
 ```

--- a/packages/claude-code-plugin/runbooks/planning/review/review-plan-collate.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/review/review-plan-collate.runbook.md
@@ -68,5 +68,5 @@ Follow the review output schema.
 - FAIL GOTO 5
 
 ```bash
-rdx --check {{ ReviewPlanPath }}
+{{ validateSchema ReviewPlanPath }}
 ```

--- a/packages/claude-code-plugin/runbooks/planning/review/review-plan-risk-safety.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/review/review-plan-risk-safety.runbook.md
@@ -66,5 +66,5 @@ Ensure any validation issues have been resolved.
 - FAIL GOTO 5
 
 ```bash
-rdx --check {{ ReviewPath }}
+{{ validateSchema ReviewPath }}
 ```

--- a/packages/claude-code-plugin/runbooks/planning/review/review-plan-structural-integrity.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/review/review-plan-structural-integrity.runbook.md
@@ -67,5 +67,5 @@ Ensure any validation issues have been resolved.
 - FAIL GOTO 5
 
 ```bash
-rdx --check {{ ReviewPath }}
+{{ validateSchema ReviewPath }}
 ```

--- a/packages/claude-code-plugin/runbooks/planning/review/review-plan-technical-accuracy.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/review/review-plan-technical-accuracy.runbook.md
@@ -61,5 +61,5 @@ Follow the review output schema.
 - FAIL GOTO 5
 
 ```bash
-rdx --check {{ ReviewPath }}
+{{ validateSchema ReviewPath }}
 ```

--- a/packages/claude-code-plugin/runbooks/planning/write-plan.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/write-plan.runbook.md
@@ -92,7 +92,7 @@ If revising the plan, address the issues identified.
 - FAIL GOTO 8
 
 ```bash
-rdx --check "$(rdpath --dir {{ WorkPath }} --ctx {{ ContextId }} --file plan.json)"
+{{ validateSchema PlanPath }}
 ```
 
 

--- a/packages/claude-code-plugin/src/rdx.ts
+++ b/packages/claude-code-plugin/src/rdx.ts
@@ -25,87 +25,89 @@ program
   .name('rdx')
   .description('Transform JSON to Markdown')
   .argument('<file>', 'JSON file to process')
-  .option('--check', 'Validate without rendering')
+  .option('--validate', 'Validate without rendering')
   .option('--schema <name>', 'Schema name for validation (e.g. "plan")')
   .option('-o, --output <path>', 'Write to file instead of stdout')
-  .action(async (file: string, options: { check?: boolean; schema?: string; output?: string }) => {
-    // Stage 1: Read file
-    let raw: string;
-    try {
-      raw = await fs.readFile(file, 'utf-8');
-    } catch (error) {
-      if (isNodeError(error) && error.code === 'ENOENT') {
-        process.stderr.write(`error: file not found: ${file}\n`);
-      } else {
-        process.stderr.write(`error: cannot read ${file}: ${getErrorMessage(error)}\n`);
-      }
-      process.exitCode = 1;
-      return;
-    }
-
-    // Stage 2: Parse JSON
-    let data: unknown;
-    try {
-      data = JSON.parse(raw);
-    } catch (error) {
-      process.stderr.write(`error: invalid JSON in ${file}: ${getErrorMessage(error)}\n`);
-      process.exitCode = 1;
-      return;
-    }
-
-    // Stage 3: Schema resolution, validation, rendering
-    try {
-      // Extract $schema and prepare clean data
-      const { cleanData, schemaName: dataSchema, rawSchema } = stripSchema(data);
-      const schema = resolveSchemaName(options.schema, dataSchema);
-
-      // Reject unrecognized $schema URIs — don't silently skip validation
-      if (rawSchema && !schema) {
-        process.stderr.write(`error: unrecognized schema: ${rawSchema}\n`);
+  .action(
+    async (file: string, options: { validate?: boolean; schema?: string; output?: string }) => {
+      // Stage 1: Read file
+      let raw: string;
+      try {
+        raw = await fs.readFile(file, 'utf-8');
+      } catch (error) {
+        if (isNodeError(error) && error.code === 'ENOENT') {
+          process.stderr.write(`error: file not found: ${file}\n`);
+        } else {
+          process.stderr.write(`error: cannot read ${file}: ${getErrorMessage(error)}\n`);
+        }
         process.exitCode = 1;
         return;
       }
 
-      // No schema discoverable — error in check mode, warn in render mode
-      if (!schema) {
-        if (options.check) {
-          process.stderr.write(
-            'error: --check requires a schema (use $schema in JSON or --schema flag)\n',
-          );
-          process.exitCode = 1;
-          return;
-        }
-        process.stderr.write('warning: no schema found, skipping validation\n');
-      }
-
-      // Validate against schema when available, capturing typed result
-      let dataToRender: unknown = cleanData;
-      if (schema) {
-        try {
-          const validate = await loadValidator(schema);
-          dataToRender = validate(cleanData);
-        } catch (error) {
-          process.stderr.write(formatValidationErrors(error, schema));
-          process.exitCode = 1;
-          return;
-        }
-      }
-
-      if (options.check) {
-        process.stdout.write('Valid.\n');
+      // Stage 2: Parse JSON
+      let data: unknown;
+      try {
+        data = JSON.parse(raw);
+      } catch (error) {
+        process.stderr.write(`error: invalid JSON in ${file}: ${getErrorMessage(error)}\n`);
+        process.exitCode = 1;
         return;
       }
 
-      const md = renderToMarkdown(dataToRender);
-      if (options.output) {
-        await fs.writeFile(options.output, md);
-      } else {
-        process.stdout.write(md);
+      // Stage 3: Schema resolution, validation, rendering
+      try {
+        // Extract $schema and prepare clean data
+        const { cleanData, schemaName: dataSchema, rawSchema } = stripSchema(data);
+        const schema = resolveSchemaName(options.schema, dataSchema);
+
+        // Reject unrecognized $schema URIs — don't silently skip validation
+        if (rawSchema && !schema) {
+          process.stderr.write(`error: unrecognized schema: ${rawSchema}\n`);
+          process.exitCode = 1;
+          return;
+        }
+
+        // No schema discoverable — error in validate mode, warn in render mode
+        if (!schema) {
+          if (options.validate) {
+            process.stderr.write(
+              'error: --validate requires a schema (use $schema in JSON or --schema flag)\n',
+            );
+            process.exitCode = 1;
+            return;
+          }
+          process.stderr.write('warning: no schema found, skipping validation\n');
+        }
+
+        // Validate against schema when available, capturing typed result
+        let dataToRender: unknown = cleanData;
+        if (schema) {
+          try {
+            const validate = await loadValidator(schema);
+            dataToRender = validate(cleanData);
+          } catch (error) {
+            process.stderr.write(formatValidationErrors(error, schema));
+            process.exitCode = 1;
+            return;
+          }
+        }
+
+        if (options.validate) {
+          process.stdout.write('Valid.\n');
+          return;
+        }
+
+        const md = renderToMarkdown(dataToRender);
+        if (options.output) {
+          await fs.writeFile(options.output, md);
+        } else {
+          process.stdout.write(md);
+        }
+      } catch (error) {
+        process.stderr.write(`error: ${getErrorMessage(error)}\n`);
+        process.exitCode = 1;
       }
-    } catch (error) {
-      process.stderr.write(`error: ${getErrorMessage(error)}\n`);
-      process.exitCode = 1;
-    }
-  });
+    },
+  );
 
 program.parse();

--- a/packages/cli/__tests__/services/helper-registry.test.ts
+++ b/packages/cli/__tests__/services/helper-registry.test.ts
@@ -85,6 +85,16 @@ describe('loadHelperModules', () => {
     warnSpy.mockRestore();
   });
 
+  it('rejects "validateSchema" as a helper name with a warning', async () => {
+    const helperFile = path.join(tmpDir, 'bad-validate-schema.mjs');
+    await fs.writeFile(helperFile, 'export function validateSchema(v) { return v; }');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const registry = await loadHelperModules([helperFile], tmpDir, tmpDir);
+    expect(registry.has('validateSchema')).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"validateSchema" is reserved'));
+    warnSpy.mockRestore();
+  });
+
   it('skips non-function exports with a warning', async () => {
     const helperFile = path.join(tmpDir, 'mixed.mjs');
     await fs.writeFile(

--- a/packages/core/__tests__/runbook/template-renderer.test.ts
+++ b/packages/core/__tests__/runbook/template-renderer.test.ts
@@ -2494,6 +2494,68 @@ describe('substituteText with path helper', () => {
   });
 });
 
+describe('substituteText with validateSchema helper', () => {
+  it('renders an ArtifactRecord as a full rdx validation command', () => {
+    const out = substituteText(
+      '{{ validateSchema PlanPath }}',
+      { PlanPath: PLAN, WorkPath: '.rundown/work' },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out).toContain('rdx --validate ');
+    expect(out).toContain(`.rd-${ARTIFACT_CONTEXT}`);
+    expect(out).toContain(ARTIFACT_RUN_ID);
+    expect(out.endsWith('plan.json')).toBe(true);
+  });
+
+  it('maps an exact artifact URI string to a local path', () => {
+    const out = substituteText(
+      '{{ validateSchema PlanUri }}',
+      { PlanUri: PLAN.uri, WorkPath: '.rundown/work' },
+      undefined,
+      ARTIFACT_HELPER_OPTIONS,
+    );
+    expect(out).toContain('rdx --validate ');
+    expect(out).toContain(`.rd-${ARTIFACT_CONTEXT}`);
+    expect(out).toContain(ARTIFACT_RUN_ID);
+    expect(out.endsWith('plan.json')).toBe(true);
+  });
+
+  it('accepts a path string variable and shell-escapes it as one argument', () => {
+    const out = substituteText('{{ validateSchema ReviewPath }}', {
+      ReviewPath: 'review outputs/-draft plan.json',
+    });
+    expect(out).toBe("rdx --validate 'review outputs/-draft plan.json'");
+  });
+
+  it('accepts a literal path string', () => {
+    expect(substituteText('{{ validateSchema "plan.json" }}', {})).toBe('rdx --validate plan.json');
+  });
+
+  it('preserves an artifact placeholder when runtime path options are unavailable', () => {
+    expect(substituteText('{{ validateSchema PlanPath }}', { PlanPath: PLAN })).toBe(
+      '{{ validateSchema PlanPath }}',
+    );
+  });
+
+  it('throws for artifact arrays because rdx validates one document per invocation', () => {
+    expect(() =>
+      substituteText(
+        '{{ validateSchema Reviews }}',
+        { Reviews: [REVIEW_A], WorkPath: '.rundown/work' },
+        undefined,
+        ARTIFACT_HELPER_OPTIONS,
+      ),
+    ).toThrow(/single schema document/);
+  });
+
+  it('throws for non-string non-artifact values', () => {
+    expect(() => substituteText('{{ validateSchema ReviewPath }}', { ReviewPath: 42 })).toThrow(
+      /ArtifactRecord, artifact URI, or path string/,
+    );
+  });
+});
+
 describe('substituteText with artifact helper', () => {
   // Spec §9.3: `{{ artifact Var }}` renders artifact URI values with the same
   // shape as the direct alias `{{ Var }}` — scalar URI for an ArtifactRecord,

--- a/packages/core/__tests__/runbook/variable-preparation.test.ts
+++ b/packages/core/__tests__/runbook/variable-preparation.test.ts
@@ -21,6 +21,7 @@ describe('template helper semantics', () => {
   it('reserves artifact-producing built-in helper names', () => {
     expect(RESERVED_TEMPLATE_HELPER_NAMES.has('path')).toBe(true);
     expect(RESERVED_TEMPLATE_HELPER_NAMES.has('artifact')).toBe(true);
+    expect(RESERVED_TEMPLATE_HELPER_NAMES.has('validateSchema')).toBe(true);
   });
 
   it('detects user variable names shadowed by registered helpers', () => {

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -47,6 +47,7 @@ import {
   renderLiteralArtifactPath,
   type RenderArtifactOptions,
 } from './renderer/artifact-helper.js';
+import { artifactUriToPath } from './artifact-uri.js';
 import type { StepVariables } from './runtime-frame.js';
 
 /**
@@ -108,6 +109,14 @@ const HELPER_CALL_TEMPLATE_REGEX =
  */
 const PATH_HELPER_TEMPLATE_REGEX =
   /\{\{[ \t\r\n]{0,64}path[ \t\r\n]{1,64}(?:"([^"]*)"|([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*))[ \t\r\n]{0,64}\}\}/g;
+
+/**
+ * Matches the built-in schema-validation helper:
+ *  - `{{ validateSchema "literal-path-or-uri" }}`  (group 1)
+ *  - `{{ validateSchema VarRef }}`                  (group 2; dotted paths permitted)
+ */
+const VALIDATE_SCHEMA_HELPER_TEMPLATE_REGEX =
+  /\{\{[ \t\r\n]{0,64}validateSchema[ \t\r\n]{1,64}(?:"([^"]*)"|([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*))[ \t\r\n]{0,64}\}\}/g;
 
 /**
  * Matches the built-in `artifact` helper in variable-reference form only:
@@ -981,6 +990,77 @@ function resolvePathHelperCall(
   });
 }
 
+function resolveValidateSchemaTarget(
+  value: unknown,
+  variables: Readonly<Record<string, unknown>>,
+  helperOptions: TemplateHelperOptions | undefined,
+  label: string,
+): string | undefined {
+  if (isArtifactRecord(value)) {
+    if (!helperOptions?.cwd) return undefined;
+    return renderArtifactPathValue(value, {
+      cwd: helperOptions.cwd,
+      workPath: requireWorkPath(variables),
+      contextId: value.contextId,
+      runId: value.runId,
+    });
+  }
+
+  if (Array.isArray(value)) {
+    throw new Error(
+      `validateSchema helper expects a single schema document for "${label}", got array`,
+    );
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(
+      `validateSchema helper expects an ArtifactRecord, artifact URI, or path string for "${label}", got ${typeof value}`,
+    );
+  }
+
+  if (value.startsWith('rd://')) {
+    if (!helperOptions?.cwd) return undefined;
+    return artifactUriToPath(value, {
+      cwd: helperOptions.cwd,
+      workPath: requireWorkPath(variables),
+    });
+  }
+
+  return value;
+}
+
+/**
+ * Render `validateSchema` as a complete `rdx --validate <path>` command.
+ *
+ * @param literalValue - Quoted literal path or artifact URI, or undefined
+ * @param varRef - Variable reference to resolve, or undefined
+ * @param variables - Render-frame variables
+ * @param helperOptions - Filesystem options used for artifact URI/path mapping
+ * @param original - Original match text returned when runtime path options are unavailable
+ * @returns Shell command for schema validation, or the original placeholder
+ * @throws {Error} When the input is not a single artifact reference, URI, or path string
+ */
+function resolveValidateSchemaHelperCall(
+  literalValue: string | undefined,
+  varRef: string | undefined,
+  variables: Readonly<Record<string, unknown>>,
+  helperOptions: TemplateHelperOptions | undefined,
+  original: string,
+): string {
+  const value =
+    literalValue ?? (varRef === undefined ? undefined : resolveTemplatePathRaw(varRef, variables));
+  if (value === undefined) return original;
+
+  const target = resolveValidateSchemaTarget(
+    value,
+    variables,
+    helperOptions,
+    varRef ?? literalValue ?? '',
+  );
+  if (target === undefined) return original;
+  return `rdx --validate ${shellEscapeValue(target)}`;
+}
+
 /**
  * Render the `artifact` helper for a variable reference only.
  *
@@ -1092,6 +1172,12 @@ export function substituteText(
       if (raw === match) return match;
       return escapeFn ? escapeFn(raw) : raw;
     },
+  );
+
+  result = result.replace(
+    VALIDATE_SCHEMA_HELPER_TEMPLATE_REGEX,
+    (match, literalValue: string | undefined, varRef: string | undefined) =>
+      resolveValidateSchemaHelperCall(literalValue, varRef, variables, helperOptions, match),
   );
 
   // Pass 3: {{ helperName varRef }} or {{ helperName "literal" }}

--- a/packages/core/src/runbook/variable-preparation.ts
+++ b/packages/core/src/runbook/variable-preparation.ts
@@ -29,7 +29,11 @@ import {
   type TemplateVarValue,
 } from './types.js';
 
-export const RESERVED_TEMPLATE_HELPER_NAMES: ReadonlySet<string> = new Set(['artifact', 'path']);
+export const RESERVED_TEMPLATE_HELPER_NAMES: ReadonlySet<string> = new Set([
+  'artifact',
+  'path',
+  'validateSchema',
+]);
 
 /**
  * Detect template variables whose names collide with registered helpers.

--- a/scripts/e2e-entrypoint.sh
+++ b/scripts/e2e-entrypoint.sh
@@ -149,7 +149,7 @@ if [ -n "$PLAN_FILE" ]; then
 
   # Schema validation
   set +e
-  rdx --check "$PLAN_FILE" 2>&1 | tee -a "$LOG_FILE"
+  rdx --validate "$PLAN_FILE" 2>&1 | tee -a "$LOG_FILE"
   RDX_EXIT=${PIPESTATUS[0]}
   set -e
   if [ "$RDX_EXIT" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- add built-in `{{ validateSchema ... }}` helper for ArtifactRecord, exact artifact URI, and path string inputs
- rename `rdx --check` to `rdx --validate` with no compatibility alias
- update plugin runbooks, rdx docs, e2e script, root instructions, and tests to use validation naming

## Verification
- `npm run test:unit -w packages/core -- template-renderer.test.ts variable-preparation.test.ts`
- `npx jest __tests__/services/helper-registry.test.ts --maxWorkers=2 --testPathIgnorePatterns='integration'`
- `npx jest __tests__/rdx.integration.test.ts --maxWorkers=2`
- `npm run test:unit -w packages/claude-code-plugin -- runbooks/validation.test.ts`
- `npm run build -w packages/claude-code-plugin`
- `npm run check:format`
- `git diff --check`

## Note
This replaces PR #335, which was accidentally merged into `scenario-speedup` after that branch had already merged into `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `validateSchema` template helper for simplified schema validation in runbooks.

* **Documentation**
  * Renamed validation flag from `--check` to `--validate` in CLI documentation and reference specifications.
  * Updated runbook templates to use the new `validateSchema` helper for schema validation.

* **Tests**
  * Updated test coverage to verify `--validate` flag behavior and new helper functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->