### PR TITLE
Support cross-run ARTIFACTS shorthand selectors

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -242,3 +242,4 @@ xstate
 zod
 redir
 gitevil
+desugars

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -114,11 +114,11 @@ artifacts_directive    ::= "- ARTIFACTS" newline artifact_list
 artifact_list          ::= ( ws "- " artifact_entry newline )+
 artifact_entry         ::= variable_name [ ws quoted_artifact_token ]
 quoted_artifact_token  ::= '"' artifact_token '"'
-artifact_token         ::= artifact_key | uri_artifact_token | file_artifact_token
-artifact_key           ::= exact_artifact_key | wildcard_artifact_key
+artifact_token         ::= [ "*/" ] selector_artifact_key | uri_artifact_token | file_artifact_token
+selector_artifact_key  ::= exact_artifact_key | wildcard_artifact_key
 exact_artifact_key     ::= [A-Za-z0-9._-]+
 wildcard_artifact_key  ::= [A-Za-z0-9._*?-]+
-uri_artifact_token     ::= "rd://artifacts/" ctx_ref "/" run_segment "/" exact_artifact_key
+uri_artifact_token     ::= "rd://artifacts/" ctx_ref "/" run_segment "/" selector_artifact_key
 file_artifact_token    ::= relative_file_ref | absolute_file_ref
 relative_file_ref      ::= safe_path_segment "/" safe_path_segment ( "/" safe_path_segment )*
 absolute_file_ref      ::= "/" safe_path_segment ( "/" safe_path_segment )*
@@ -140,7 +140,7 @@ A step or substep may declare at most one `ARTIFACTS` directive and at most one 
 
 `ARTIFACTS` declares the current execution unit's artifact working set. Each entry maps a variable name to an optional quoted artifact token. The variable name must match `variable_name` and must not be a [reserved variable name](#reserved-variable-names). Duplicate names in one `ARTIFACTS` block are syntax errors.
 
-Artifact entries take four forms: (1) **naked** — a bare `variable_name` with no token, asserting the name is already bound as an artifact reference; (2) **quoted managed key** — `"plan.json"` or `"review-*.json"`; (3) **quoted file reference** — `"schemas/review.schema.json"` or an explicit absolute path; (4) **quoted URI literal** — `"rd://artifacts/<ctx>/<run>/<key>"` or selector form with `*` in the run segment. Quoted tokens are template-expanded BEFORE classification, so `"{{ContextId}}-plan.json"` is valid. After expansion, exact managed keys use `exact_artifact_key`; wildcard managed keys use `wildcard_artifact_key` and contain `*` or `?`. File references are quoted relative or absolute paths, are not glob selectors, and must resolve to an existing contained file through the runtime search/read-policy rules. Empty managed keys, `.`, `..`, traversal, and recursive `**` are invalid. The full URI grammar — including selector form, scheme registration, and component constraints — is normatively defined in [docs/spec/uri.md §4](uri.md#4-grammar-ebnf). Naked-form semantics are defined in [docs/spec/language.md §10.1.2](language.md#1012-naked-declaration-assertion-form).
+Artifact entries take four forms: (1) **naked** — a bare `variable_name` with no token, asserting the name is already bound as an artifact reference; (2) **quoted shorthand key** — a managed artifact key, optionally with a leading `*/` cross-run prefix, e.g. `"plan.json"`, `"review-*.json"`, or `"*/review.json"`; (3) **quoted file reference** — `"schemas/review.schema.json"` or an explicit absolute path; (4) **quoted URI literal** — `"rd://artifacts/<ctx>/<run>/<key>"` or selector form with `*` in the run segment. Quoted tokens are template-expanded BEFORE classification, so `"{{ContextId}}-plan.json"` is valid. After expansion, exact managed keys use `exact_artifact_key`; wildcard managed keys use `wildcard_artifact_key` and contain `*` or `?`. File references are quoted relative or absolute paths, are not glob selectors, and must resolve to an existing contained file through the runtime search/read-policy rules. Empty managed keys, `.`, `..`, traversal, and recursive `**` are invalid. The full URI grammar — including selector form, scheme registration, and component constraints — is normatively defined in [docs/spec/uri.md §4](uri.md#4-grammar-ebnf). Naked-form semantics are defined in [docs/spec/language.md §10.1.2](language.md#1012-naked-declaration-assertion-form).
 
 `OUTPUTS` at step/substep level declares name-only command output channels. Expression-form step/substep `OUTPUTS` entries are parse errors. Naked entries activate a file-backed channel: Rundown creates an empty file whose path is composed from the active scope tiers (step id, optional substep id, optional FOR iteration index) followed by `<VarName>` and exports its absolute path as `RD_OUTPUTS_<VarName>` to the spawned command. The three possible paths are:
 

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -452,22 +452,53 @@ The quoted token in a declaration is template-expanded before parsing. Any in-sc
 
 After expansion, the parser classifies the token:
 
-| Form | Example | Expands to | Manifest write |
-|------|---------|------------|----------------|
-| Bare key (no glob) | `"plan.json"` | `rd://artifacts/{{ContextId}}/{{RunId}}/plan.json` (exact, current ctx + current run) | YES — appends row for the URI |
-| Relative file reference | `"schemas/review.schema.json"` | canonical `file:///.../schemas/review.schema.json` found via project, plugin, then bundled search roots | YES — appends row for the file URI |
-| Absolute file reference | `"/abs/path/review.schema.json"` | canonical `file:///abs/path/review.schema.json` when read policy allows it | YES — appends row for the file URI |
-| Bare key with glob | `"review-*.json"` | selector — current ctx, wildcard run, key glob `review-*.json` matched against `record.key` (no URI is materialized; URI key segments are exact per `uri.md` §5.3) | NO — read-only discovery |
-| URI literal (exact, current ctx + current run) | `"rd://artifacts/<currentCtx>/<currentRun>/<key>"` | itself | YES — appends row for the URI |
-| URI literal (selector) | `"rd://artifacts/<ctx>/*/<key>"` | itself | NO — read-only query |
-| URI literal (exact, current ctx + other run) | `"rd://artifacts/<currentCtx>/<otherRun>/<key>"` | itself | NO — read-only reference |
-| URI literal (cross-context) | `"rd://artifacts/<otherCtx>/<run>/<key>"` | rejected | NO |
+| Form | Example | Desugars to | Resolved kind | Manifest write |
+|------|---------|-------------|---------------|----------------|
+| Shorthand, bare exact key | `"plan.json"` | `rd://artifacts/{{ContextId}}/{{RunId}}/plan.json` | exact | YES — produces (current run) |
+| Shorthand, bare wildcard key | `"plan-*.json"` | `rd://artifacts/{{ContextId}}/{{RunId}}/plan-*.json` | selector | NO — query, current run |
+| Shorthand, cross-run exact key | `"*/plan.json"` | `rd://artifacts/{{ContextId}}/*/plan.json` | selector | NO — query, all runs in context |
+| Shorthand, cross-run wildcard key | `"*/plan-*.json"` | `rd://artifacts/{{ContextId}}/*/plan-*.json` | selector | NO — query, all runs in context |
+| Relative file reference | `"schemas/review.schema.json"` | canonical `file:///.../schemas/review.schema.json` found via project, plugin, then bundled search roots | file | YES — appends row for the file URI |
+| Absolute file reference | `"/abs/path/review.schema.json"` | canonical `file:///abs/path/review.schema.json` when read policy allows it | file | YES — appends row for the file URI |
+| URI literal (exact, current ctx + current run) | `"rd://artifacts/<currentCtx>/<currentRun>/<key>"` | itself | exact | YES — produces |
+| URI literal (selector) | `"rd://artifacts/<ctx>/*/<key>"` | itself | selector | NO — read-only query |
+| URI literal (exact, current ctx + other run) | `"rd://artifacts/<currentCtx>/<otherRun>/<key>"` | itself | exact | NO — read-only reference |
+| URI literal (cross-context) | `"rd://artifacts/<otherCtx>/<run>/<key>"` | rejected | — | NO |
 
-The bare key is syntactic sugar:
+A quoted shorthand token is syntactic sugar for an `rd://artifacts/` URI. The
+token is the tail of the URI path; omitted leading segments default — the
+context segment to the current `ContextId`, the run segment to the current
+`RunId`. The token forms collapse into one concept; every shorthand desugars
+to a URI and routes through the single URI resolver path.
 
-- **Without glob and with no file match** — exact URI for the current context and current run. The resolver creates a manifest entry; the agent writes the artifact file.
-- **Path-like file reference** — existing files are resolved before managed artifact fallback. Relative paths search project, plugin, then bundled roots. Explicit absolute paths require read-policy approval. Missing path-like references fail instead of becoming managed artifact keys.
-- **With glob characters** (`*` or `?`) — selector form for the current context with a wildcard run; the glob token is matched against each manifest record's `key` field (URI key segments stay exact per `uri.md` §5.3, so the glob is not lifted into a URI string). Read-only discovery; resolves to `ArtifactRecord` or `ArtifactRecord[]`. Discovering and finding artifacts across sibling runs in the same context is a first-class capability of the bare-key form.
+- **Bare exact key** (`"plan.json"`) — produces. Desugars to an exact URI for
+  the current context and current run. The resolver appends a manifest entry;
+  the agent writes the artifact file. This shorthand is one of the operations
+  that writes a manifest row, alongside file references and exact URI literals
+  for the current context and run.
+- **Bare wildcard key** (`"plan-*.json"`) — queries the current run. Desugars
+  to a selector URI whose run segment is the current run and whose key carries
+  the glob. Read-only discovery within the current run's artifacts.
+- **Cross-run prefix** (`"*/plan.json"`, `"*/plan-*.json"`) — queries all runs
+  in the current context. A leading `*/` overrides the run segment to the
+  selector wildcard `*`. The key may be exact (collect a known filename across
+  sibling runs) or carry globs. Read-only discovery. Discovering and finding
+  artifacts across sibling runs in the same context is a first-class capability
+  of the cross-run shorthand.
+- **Path-like file reference** (`"schemas/review.schema.json"`) — a token
+  containing a path separator that is NOT the `*/` cross-run prefix is a file
+  reference. Existing files are resolved before any managed-artifact
+  interpretation. Relative paths search project, plugin, then bundled roots;
+  explicit absolute paths require read-policy approval. A path-like token that
+  also carries glob characters is rejected — it is neither a valid shorthand
+  key nor a file reference. Missing path-like references fail.
+
+**Produce vs query.** A shorthand token *produces* (writes a manifest row)
+exactly when it is a bare exact key — no `*/` prefix and no `*`/`?` in the key.
+Every other shorthand form *queries* (read-only). The `*` is the universal
+"search" signal: a `*/` prefix searches across runs, and a glob in the key
+searches across names. Producing is the terse default because it is the common
+operation and the only one that structurally cannot be a query.
 
 Manifest writes use the identity tuple defined in [uri.md §8](./uri.md#8-manifest-record); appending a row for an identity that already exists is idempotent under the coalescing rule ([uri.md §10](./uri.md#10-coalescing)).
 

--- a/docs/spec/uri.md
+++ b/docs/spec/uri.md
@@ -94,17 +94,21 @@ artifact_uri        ::= exact_artifact_uri | selector_artifact_uri
 exact_artifact_uri  ::= "rd://artifacts/" context_segment "/" run_segment "/" key_segment
 
 selector_artifact_uri
-                    ::= "rd://artifacts/" context_segment "/" run_selector "/" key_segment
+                    ::= "rd://artifacts/" context_segment "/" run_selector "/" selector_key_segment
 
 context_segment     ::= pct_encoded_safe_id   /* decoded value MUST satisfy ctx_ref */
 run_segment         ::= pct_encoded_run_id    /* decoded value MUST match RUN_ID_PATTERN */
 run_selector        ::= run_segment | "*"
 key_segment         ::= pct_encoded_artifact_key  /* decoded value MUST satisfy exact_artifact_key */
+selector_key_segment
+                    ::= pct_encoded_selector_key  /* decoded value MUST satisfy selector_artifact_key */
 
 pct_encoded_safe_id ::= (* RFC 3986 percent-encoded segment whose decoded value matches [A-Za-z0-9._-]+ *)
 pct_encoded_run_id  ::= (* RFC 3986 percent-encoded segment whose decoded value matches RUN_ID_PATTERN *)
 pct_encoded_artifact_key
                     ::= (* RFC 3986 percent-encoded segment whose decoded value matches exact_artifact_key *)
+pct_encoded_selector_key
+                    ::= (* RFC 3986 percent-encoded segment whose decoded value matches selector_artifact_key *)
 ```
 
 The scheme prefix `rd://artifacts/` is fixed and case-sensitive. Each
@@ -121,6 +125,12 @@ hexadecimal characters. The canonical source for this pattern is
 [docs/spec/grammar.md §Lexical Rules](grammar.md#lexical-rules). They share the
 same character class (`[A-Za-z0-9._-]+`) and reject `.`, `..`, empty values,
 slashes, traversal, and recursive `**`.
+`selector_artifact_key` is the union of `exact_artifact_key` and a wildcard
+form: it permits `*` and `?` glob characters in addition to the exact
+character class (`[A-Za-z0-9._*?-]+`), while still rejecting `.`, `..`, empty
+values, slashes, traversal, and recursive `**`. A literal `?` written in a
+hand-authored URI key MUST be percent-encoded (`%3F`) so it is not parsed as
+the URI query-string delimiter.
 
 ## 5. Components
 
@@ -148,9 +158,29 @@ and MUST be rejected, as are unresolved `{{template}}` markers.
 
 ### 5.3 key
 
-The `key` is the final path segment. Its decoded value MUST satisfy
-`exact_artifact_key` (`[A-Za-z0-9._-]+`, with `.` and `..` rejected, slashes
-rejected, traversal rejected, recursive `**` rejected, and empty rejected).
+The `key` is the final path segment. Its validation depends on the URI form
+(§6):
+
+- In an **exact** URI, the decoded key MUST satisfy `exact_artifact_key`
+  (`[A-Za-z0-9._-]+`, with `.` and `..` rejected, slashes rejected, traversal
+  rejected, recursive `**` rejected, empty rejected). An exact URI addresses
+  exactly one artifact file, so its key MUST NOT carry `*` or `?`.
+- In a **selector** URI, the decoded key MUST satisfy `selector_artifact_key`
+  — the same character class extended with `*` and `?` glob characters
+  (`[A-Za-z0-9._*?-]+`), with the same rejections (`.`, `..`, slashes,
+  traversal, recursive `**`, empty). A selector key MAY be exact OR carry
+  globs; an exact selector key simply matches one literal name across the
+  selected runs.
+
+A glob key (`*` or `?`) makes a URI a **selector** even when its run segment
+is concrete (§6): the URI is then a selector scoped to that single run. A
+glob key therefore never appears in an **exact** URI — the exact form is the
+producer surface and addresses exactly one file, so its key MUST be exact.
+`parseArtifactUri` classifies any glob-keyed URI as a selector; the exact-URI
+builder is what rejects a glob key.
+
+A literal `?` in a hand-written selector key MUST be percent-encoded (`%3F`);
+an unencoded `?` is parsed as the URI query-string delimiter.
 
 **Length:** No normative length cap is currently enforced. Implementations MAY
 enforce a reasonable filesystem-compatible cap on key length (for example 255
@@ -160,10 +190,12 @@ keys solely on length grounds below an obvious filesystem limit.
 
 ## 6. Forms
 
-A URI is either exact or selector. The discriminator is structural: an
-implementation MUST classify a URI as a selector when its `runId` segment is
-`*`. Otherwise the URI is exact. URIs MUST NOT carry a query string;
-implementations MUST reject URIs containing one.
+A URI is either exact or selector. The discriminator is structural: a URI is
+**exact** iff its `runId` segment is concrete (matches `RUN_ID_PATTERN`), its
+`key` segment is exact (no `*`/`?`), and it carries no query string. Any
+wildcard in the `runId` or `key` segment, or any query string, makes the URI a
+**selector**. Implementations MUST classify accordingly. A query string is
+permitted only on selector URIs; an exact URI MUST NOT carry one.
 
 ### 6.1 Exact form
 
@@ -178,15 +210,18 @@ references exactly one identity tuple (§8) in the owning manifest.
 ### 6.2 Selector form
 
 ```text
-rd://artifacts/<contextId>/*/<key>
+rd://artifacts/<contextId>/<run_selector>/<selector_key>
 ```
 
-A selector URI is the read-only query form. Its `runId` segment is the literal
-`*`; all other segments are concrete. It is produced by `ARTIFACTS`
-declarations that name an explicit selector URI (see
-[language.md §10.1.1](./language.md#1011-expansion-rules)) and consumed by
-manifest selector resolution. A selector URI resolves to zero or more
-`ArtifactRecord` values and never writes a manifest row.
+A selector URI is the read-only query form. It is a selector when its `runId`
+segment is the literal `*`, OR its `key` segment carries `*`/`?` globs, OR it
+carries a query string. The `contextId` segment is always concrete. It is
+produced by `ARTIFACTS` declarations — by the shorthand forms (a bare token,
+or a token with a leading `*/` cross-run prefix; see
+[language.md §10.1.1](./language.md#1011-expansion-rules)) and by explicit
+selector URI literals — and consumed by manifest selector resolution. A
+selector URI resolves to zero or more `ArtifactRecord` values and never writes
+a manifest row.
 
 Selectors have no opinion on arity: the resolved value is an `ArtifactRecord`
 when the manifest yields exactly one matching row, an `ArtifactRecord[]` when
@@ -194,11 +229,12 @@ it yields many, or an empty array when none. The runbook's structure
 determines the expected number of records. Empty selector results are
 meaningful and MUST NOT be collapsed to absence.
 
-The exact form (§6.1), by contrast, is the producer surface: the bare-key
-`ARTIFACTS` shortcut expands to an exact URI for the current context and
-current run, and the resolver appends a manifest row for that identity at
-directive evaluation. The artifact file itself is written by the agent, not
-the resolver.
+The exact form (§6.1), by contrast, is the producer surface: the shorthand
+`ARTIFACTS` form with an exact key and no `*/` prefix expands to an exact URI
+for the current context and current run, and the resolver appends a manifest
+row for that identity at directive evaluation. The artifact file itself is
+written by the agent, not the resolver. A glob key can never be a producer:
+structurally, a glob key forces selector classification.
 
 ## 7. Storage layout (mapping rules)
 

--- a/packages/claude-code-plugin/runbooks/meta/planning.runbook.md
+++ b/packages/claude-code-plugin/runbooks/meta/planning.runbook.md
@@ -1,0 +1,61 @@
+---
+name: End-to-End Test
+description: Run multiple runbooks and test the end-to-end process.
+---
+
+# End-to-End Test
+
+Run multiple runbooks, reviewing and testing the end-to-end process.
+
+
+## 1. Read the output schema
+- PASS CONTINUE
+- FAIL STOP
+
+```prompt
+{{ CLAUDE_PLUGIN_ROOT }}/schemas/review.schema.json
+```
+
+## 2. Write Plan
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- planning/write-plan.runbook.md
+
+
+## 3. Review Plan
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- planning/review-plan.runbook.md
+
+
+## 4. Write the review of the end-to-end Rundown workflow
+- PASS CONTINUE
+- FAIL STOP
+
+Write the review to the output path as JSON.
+Follow the review output schema.
+
+```bash
+OUTPUT_PATH="$(rdpath --dir {{ WorkPath }} --ctx {{ ContextId }} --file end-to-end-test-review.json)"
+cat > "$OUTPUT_PATH" <<'JSON'
+{
+  "$schema": "https://rundown.org/schemas/review.schema.json",
+  "meta": {
+    "version": "1.0.0"
+  },
+  "items": []
+}
+JSON
+```
+
+
+## 5. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 4
+
+```bash
+rdx "$(rdpath --dir {{ WorkPath }} --ctx {{ ContextId }} --file end-to-end-test-review.json)" --validate
+```

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -688,7 +688,7 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
         runId: CURRENT_RUN,
         runbook: RUNBOOK,
       }),
-    ).rejects.toThrow(/wildcard_artifact_key|invalid key/);
+    ).rejects.toThrow(/selector_artifact_key|invalid|shorthand/);
   });
 
   it('matches both current-run records and completed sibling-run records in the same context', async () => {
@@ -709,7 +709,7 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
     await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, otherContext);
     await Promise.all([current, completedChild, otherContext].map((r) => touchArtifact(cwd, r)));
 
-    const result = await resolveArtifactDeclarations([decl('Reviews', 'review-plan-*.json')], {
+    const result = await resolveArtifactDeclarations([decl('Reviews', '*/review-plan-*.json')], {
       cwd,
       workPath: WORK_PATH,
       contextId: CONTEXT_ID,
@@ -866,6 +866,105 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
     });
 
     expect(result).toEqual({});
+  });
+});
+
+describe('resolveArtifactDeclarations — cross-run shorthand (*/key)', () => {
+  it('resolves an exact-named artifact across runs in the current context', async () => {
+    const cwd = await tempCwd();
+    const parentRow = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'end-to-end-test-review.json',
+    });
+    const childRow = record({
+      runId: CHILD_RUN,
+      runbook: CHILD_RUNBOOK,
+      key: 'end-to-end-test-review.json',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, parentRow);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, childRow);
+    await Promise.all([parentRow, childRow].map((r) => touchArtifact(cwd, r)));
+
+    const result = await resolveArtifactDeclarations(
+      [decl('Reviews', '*/end-to-end-test-review.json')],
+      { cwd, workPath: WORK_PATH, contextId: CONTEXT_ID, runId: CURRENT_RUN, runbook: RUNBOOK },
+    );
+
+    expect(result.Reviews).toEqual(
+      [parentRow, childRow].sort((l, r) => l.uri.localeCompare(r.uri)),
+    );
+  });
+
+  it('returns identical records to the equivalent rd:// selector URI form', async () => {
+    const cwd = await tempCwd();
+    const parentRow = record({
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+      key: 'end-to-end-test-review.json',
+    });
+    const childRow = record({
+      runId: CHILD_RUN,
+      runbook: CHILD_RUNBOOK,
+      key: 'end-to-end-test-review.json',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, parentRow);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, childRow);
+    await Promise.all([parentRow, childRow].map((r) => touchArtifact(cwd, r)));
+
+    const options = {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+    };
+    const shorthand = await resolveArtifactDeclarations(
+      [decl('Reviews', '*/end-to-end-test-review.json')],
+      options,
+    );
+    const uriForm = await resolveArtifactDeclarations(
+      [decl('Reviews', `rd://artifacts/${CONTEXT_ID}/*/end-to-end-test-review.json`)],
+      options,
+    );
+
+    expect(shorthand.Reviews).toEqual(uriForm.Reviews);
+  });
+
+  it('does NOT write a manifest row for a cross-run shorthand', async () => {
+    const cwd = await tempCwd();
+    const before = await readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
+    expect(before).toHaveLength(0);
+
+    await resolveArtifactDeclarations([decl('Reviews', '*/review.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+    });
+
+    const after = await readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
+    expect(after).toHaveLength(0);
+  });
+
+  it('matches a cross-run wildcard-key shorthand (*/review-*.json)', async () => {
+    const cwd = await tempCwd();
+    const a = record({ runId: CURRENT_RUN, runbook: RUNBOOK, key: 'review-a.json' });
+    const b = record({ runId: CHILD_RUN, runbook: CHILD_RUNBOOK, key: 'review-b.json' });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, a);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, b);
+    await Promise.all([a, b].map((r) => touchArtifact(cwd, r)));
+
+    const result = await resolveArtifactDeclarations([decl('Reviews', '*/review-*.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+    });
+
+    expect(result.Reviews).toEqual([a, b].sort((l, r) => l.uri.localeCompare(r.uri)));
   });
 });
 

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -632,6 +632,35 @@ describe('resolveArtifactDeclarations — bare key with glob (selector form)', (
     expect(result.Reviews).toEqual(row);
   });
 
+  it('limits an unprefixed wildcard shorthand to current-run manifest rows', async () => {
+    const cwd = await tempCwd();
+    const current = record({ runId: CURRENT_RUN, runbook: RUNBOOK, key: 'review-current.json' });
+    const child = record({ runId: CHILD_RUN, runbook: CHILD_RUNBOOK, key: 'review-child.json' });
+    const otherContext = record({
+      runId: OTHER_CONTEXT_RUN,
+      contextId: 'ctx2',
+      key: 'review-other.json',
+    });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, current);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, child);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, otherContext);
+    await Promise.all([current, child, otherContext].map((r) => touchArtifact(cwd, r)));
+
+    const result = await resolveArtifactDeclarations([decl('Reviews', 'review-*.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+    });
+
+    expect(result.Reviews).toEqual(current);
+    const manifest = await readArtifactManifest({ cwd, workPath: WORK_PATH }, CONTEXT_ID);
+    expect(manifest).toEqual(
+      [current, child].sort((left, right) => left.uri.localeCompare(right.uri)),
+    );
+  });
+
   it('returns an empty array when no manifest row matches the glob', async () => {
     const cwd = await tempCwd();
 

--- a/packages/core/__tests__/runbook/artifact-uri.test.ts
+++ b/packages/core/__tests__/runbook/artifact-uri.test.ts
@@ -64,6 +64,64 @@ describe('artifact URI utilities', () => {
     });
   });
 
+  it('parses a selector URI with a wildcard key', () => {
+    expect(parseArtifactUri('rd://artifacts/ctx1/*/review-*.json')).toEqual({
+      kind: 'selector',
+      contextId: 'ctx1',
+      runId: '*',
+      key: 'review-*.json',
+      query: {},
+    });
+  });
+
+  it('parses a selector URI with a wildcard run and an exact key', () => {
+    expect(parseArtifactUri('rd://artifacts/ctx1/*/end-to-end-test-review.json')).toEqual({
+      kind: 'selector',
+      contextId: 'ctx1',
+      runId: '*',
+      key: 'end-to-end-test-review.json',
+      query: {},
+    });
+  });
+
+  it('parses a wildcard-key selector with a percent-encoded question mark', () => {
+    expect(parseArtifactUri('rd://artifacts/ctx1/*/review-%3F.json')).toEqual({
+      kind: 'selector',
+      contextId: 'ctx1',
+      runId: '*',
+      key: 'review-?.json',
+      query: {},
+    });
+  });
+
+  it('parses a concrete-run URI with a wildcard key as a selector', () => {
+    expect(parseArtifactUri(`rd://artifacts/ctx1/${RUN_ID}/review-*.json`)).toEqual({
+      kind: 'selector',
+      contextId: 'ctx1',
+      runId: RUN_ID,
+      key: 'review-*.json',
+      query: {},
+    });
+  });
+
+  it('rejects a glob key passed to the exact-URI builder', () => {
+    expect(() =>
+      buildArtifactUri({ contextId: 'ctx1', runId: RUN_ID, key: 'review-*.json' }),
+    ).toThrow(ARTIFACT_ERROR_TEXT.GLOB_KEY_IN_EXACT_URI);
+  });
+
+  it('keeps rejecting recursive wildcard keys in selector URIs', () => {
+    expect(() => parseArtifactUri('rd://artifacts/ctx1/*/review-**.json')).toThrow(
+      ARTIFACT_ERROR_TEXT.RECURSIVE_WILDCARD,
+    );
+  });
+
+  it('keeps rejecting an unsafe selector key (path separator after decode)', () => {
+    expect(() => parseArtifactUri('rd://artifacts/ctx1/*/with%2F' + 'space.json')).toThrow(
+      /Invalid ArtifactKey|path shape/,
+    );
+  });
+
   it('classifies a concrete run id with a query string as a selector', () => {
     expect(parseArtifactUri(`${EXACT_URI}?status=any`)).toMatchObject({
       kind: 'selector',

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -26,7 +26,6 @@ import {
 } from './artifact-schema.js';
 import {
   artifactUriToPath,
-  buildArtifactUri,
   parseArtifactUri,
   type ArtifactPathOptions,
   type ArtifactRef,
@@ -90,19 +89,18 @@ export interface ResolveArtifactDeclarationsOptions extends ArtifactPathOptions 
  * Each quoted declaration token is expanded once, classified with the
  * parser-owned ARTIFACTS token classifier, then dispatched by token kind:
  *
- * - **Bare key shortcut** — non-URI quoted token, e.g. `"plan.json"`. Per
- *   spec §10.1.1, this is syntactic sugar for an exact URI in the current
- *   context and current run. The parser classifier has already validated
- *   exact-key syntax; the resolver builds the exact URI, **appends a
- *   manifest row** for the producer identity tuple, and returns the resulting
- *   {@link ArtifactRecord}.
- * - **Bare key selector** — wildcard key token, e.g. `"review-*.json"`.
- *   The parser classifier has already validated wildcard-key syntax. The
- *   resolver builds the implicit same-context selector and resolves it
- *   read-only against the manifest.
+ * - **Shorthand** — non-URI, non-path quoted token, e.g. `"plan.json"` or
+ *   `"review-*.json"`, optionally with a leading cross-run prefix (an asterisk
+ *   then a slash). Per spec §10.1.1, a shorthand token is sugar for an
+ *   `rd://artifacts/` URI: the context segment defaults to the current
+ *   context; the run segment is the current run (`runScope: 'current'`) or the
+ *   selector wildcard `*` (`runScope: 'any'`, set by the cross-run prefix).
+ *   The resolver builds the URI and routes it through the same code path as a
+ *   `rd://` URI literal. An exact key with the current run produces (appends a
+ *   manifest row); a wildcard key or the cross-run prefix queries read-only.
  * - **URI literal exact (current ctx + current run)** — `rawToken` parses
  *   as an exact URI whose `runId` equals the current run. Behaves identically
- *   to the bare-key form: appends a manifest row and returns the
+ *   to the shorthand producer form: appends a manifest row and returns the
  *   {@link ArtifactRecord}.
  * - **URI literal exact (current ctx + other run)** — read-only reference to
  *   an existing manifest row. The resolver looks up the identity-tuple match
@@ -121,9 +119,10 @@ export interface ResolveArtifactDeclarationsOptions extends ArtifactPathOptions 
  *   reasons (`unbound`, `not-an-artifact`, `unresolvable-uri`,
  *   `partial-resolve`). No manifest writes.
  *
- * Bare-key and exact-URI-current-run declarations are the producer surface
- * and create manifest entries. The directive does NOT write the artifact
- * file itself; the agent writes the file at the path mapped from the URI.
+ * Shorthand exact-key-current-run and exact-URI-current-run declarations are
+ * the producer surface and create manifest entries. The directive does NOT
+ * write the artifact file itself; the agent writes the file at the path
+ * mapped from the URI.
  *
  * @param declarations - Parser-owned artifact declarations from one execution unit
  * @param options - Current run identity and path options
@@ -178,9 +177,19 @@ export async function resolveArtifactDeclarations(
           invalidateManifestCache,
         );
         break;
-      case 'wildcard-key': {
-        const selector = buildImplicitBareKeySelector(classification.token.key, options.contextId);
-        result[declaration.name] = resolveSelector(selector, options, await readManifest());
+      case 'shorthand': {
+        // A shorthand token is sugar for an `rd://artifacts/` URI. Build the
+        // URI and route it through the single URI-literal code path:
+        // `runScope: 'current'` + exact key parses as an exact producer URI;
+        // a wildcard key or `runScope: 'any'` parses as a selector URI.
+        const uri = buildShorthandUri(classification.token, options);
+        result[declaration.name] = await resolveUriLiteralDeclaration(
+          declaration.name,
+          uri,
+          options,
+          readManifest,
+          invalidateManifestCache,
+        );
         break;
       }
       case 'abs-path':
@@ -194,14 +203,6 @@ export async function resolveArtifactDeclarations(
         result[declaration.name] = fileRecord;
         break;
       }
-      case 'bare-key':
-        result[declaration.name] = await resolveBareKeyProducer(
-          declaration.name,
-          classification.token.key,
-          options,
-          invalidateManifestCache,
-        );
-        break;
     }
   }
 
@@ -366,38 +367,43 @@ export function toStateArtifactRecord(record: ManagedArtifactManifestRecord): Ar
 }
 
 /**
- * Build the implicit selector reference for a bare-key declaration that
- * carries glob characters (`*` or `?`).
+ * Build the canonical `rd://artifacts/` URI string for a shorthand ARTIFACTS
+ * token.
  *
- * Per spec §10.1.1, a bare key with glob characters expands to a selector URI
- * targeting the current context, any run, and the original token as a key
- * glob: `rd://artifacts/<currentCtx>/*\/<rawToken>`. The selector pathway in
- * {@link resolveSelector} matches the `key` field of each record using
- * picomatch, so this helper just stitches together a {@link SelectorArtifactRef}
- * with the raw token as the key glob — there is no need to materialize the
- * URI string.
+ * Per spec §10.1.1, a shorthand token is sugar for an artifact URI: the
+ * context segment defaults to the current `ContextId`; the run segment is the
+ * current `RunId` when `runScope` is `current`, or the selector wildcard `*`
+ * when `runScope` is `any`. The key is the shorthand key, which may be exact
+ * (producer or current-run query) or carry `*`/`?` globs (selector).
  *
- * @param rawToken - Bare-key token (post template expansion) carrying `*` or `?`
- * @param contextId - Current context identifier the selector is scoped to
- * @returns Selector reference suitable for {@link resolveSelector}
+ * Each segment is percent-encoded with {@link encodeURIComponent}. Encoding
+ * the key is required, not optional: a literal `?` in a wildcard key would
+ * otherwise be parsed as the URI query-string delimiter. The run segment `*`
+ * is intentionally NOT encoded — it is the selector wildcard, a structural URI
+ * token, not data.
+ *
+ * @param token - Shorthand classified token carrying `key` and `runScope`
+ * @param options - Resolver options carrying the current context and run id
+ * @returns Canonical `rd://artifacts/` URI string for the shorthand
  */
-function buildImplicitBareKeySelector(rawToken: string, contextId: string): SelectorArtifactRef {
-  return {
-    kind: 'selector',
-    contextId,
-    runId: '*',
-    key: rawToken,
-    query: {},
-  };
+function buildShorthandUri(
+  token: Extract<ParsedArtifactToken, { kind: 'shorthand' }>,
+  options: ResolveArtifactDeclarationsOptions,
+): string {
+  const contextSegment = encodeURIComponent(options.contextId);
+  const runSegment = token.runScope === 'any' ? '*' : encodeURIComponent(options.runId);
+  const keySegment = encodeURIComponent(token.key);
+  return `rd://artifacts/${contextSegment}/${runSegment}/${keySegment}`;
 }
 
 /**
  * Ensure the parent directory for an exact artifact URI exists on disk.
  *
- * Producer declarations (bare-key without glob, and exact URI literal for the
- * current ctx + current run) write a manifest row but do NOT write the
- * artifact file itself. The agent writes the file at the path mapped from
- * the URI, typically via shell redirection (`echo ... > {{ path Plan }}`).
+ * Producer declarations (shorthand without glob or cross-run prefix, and exact
+ * URI literal for the current ctx + current run) write a manifest row but do
+ * NOT write the artifact file itself. The agent writes the file at the path
+ * mapped from the URI, typically via shell redirection
+ * (`echo ... > {{ path Plan }}`).
  * Without an existing parent directory those redirections fail with ENOENT.
  *
  * Called BEFORE `appendArtifactManifestRecord` so a failing `mkdir` (e.g.
@@ -411,54 +417,6 @@ function buildImplicitBareKeySelector(rawToken: string, contextId: string): Sele
 async function ensureArtifactParentDir(uri: string, options: ArtifactPathOptions): Promise<void> {
   const filePath = artifactUriToPath(uri, options);
   await fsp.mkdir(path.dirname(filePath), { recursive: true });
-}
-
-/**
- * Resolve a bare-key declaration in producer form (no glob characters).
- *
- * Per spec §10.1.1, `Plan "plan.json"` is sugar for the exact URI in the
- * current context and current run. The parser classifier has already
- * validated exact-key syntax; this helper builds the URI, appends a manifest
- * row, and returns the resulting record. `buildArtifactUri` retains its own
- * URI identity validation as defense-in-depth.
- *
- * The caller is responsible for dispatching only `bare-key` classified tokens
- * here; wildcard keys dispatch to the selector pathway upstream.
- *
- * @param name - Variable name being declared
- * @param rawToken - Bare-key token (post template expansion), no glob characters
- * @param options - Resolver options carrying current identity and path config
- * @param invalidateManifestCache - Invalidates the per-pass coalesced read cache
- * @returns The newly-written {@link ArtifactRecord}
- * @throws {Error} If downstream URI identity validation fails
- */
-async function resolveBareKeyProducer(
-  name: string,
-  rawToken: string,
-  options: ResolveArtifactDeclarationsOptions,
-  invalidateManifestCache: () => void,
-): Promise<ArtifactRecord> {
-  const uri = buildArtifactUri({
-    contextId: options.contextId,
-    runId: options.runId,
-    key: rawToken,
-  });
-  // Ensure the parent directory exists so the agent can write the artifact
-  // file via shell redirection. Must precede the manifest write so a failing
-  // mkdir does not leave an orphan manifest row.
-  await ensureArtifactParentDir(uri, options);
-  const record: ArtifactRecord = {
-    kind: 'artifact-record',
-    uri,
-    runId: options.runId,
-    contextId: options.contextId,
-    runbook: options.runbook,
-    key: rawToken,
-    timestamp: new Date().toISOString(),
-  };
-  const canonical = await appendArtifactManifestRecord(options, record);
-  invalidateManifestCache();
-  return projectManagedManifestRow(canonical, name);
 }
 
 /**

--- a/packages/core/src/runbook/artifact-errors.ts
+++ b/packages/core/src/runbook/artifact-errors.ts
@@ -9,6 +9,7 @@ export const ARTIFACT_ERROR_TEXT = {
   BARE_BUILTIN_PLACEHOLDER: 'Artifact URI contains bare built-in placeholder',
   INVALID_RUN_ID: 'Invalid RunId: expected rd_<32 lowercase hex chars>',
   INVALID_URI_FRAGMENT: 'Artifact URI fragments are not supported',
+  GLOB_KEY_IN_EXACT_URI: 'Exact artifact URIs require an exact key; glob keys are selector-only',
   URI_MUST_BE_EXACT: 'uri must be an exact artifact URI',
   URI_CONTEXT_MISMATCH: 'uri contextId does not match contextId',
   URI_RUN_ID_MISMATCH: 'uri runId does not match runId',

--- a/packages/core/src/runbook/artifact-uri.ts
+++ b/packages/core/src/runbook/artifact-uri.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { SELECTOR_ARTIFACT_KEY_PATTERN } from '@rundown-org/parser';
 import { isNodeErrorCode } from '../errors.js';
 import { assertSafeId } from '../paths.js';
 import { ARTIFACT_ERROR_TEXT } from './artifact-errors.js';
@@ -68,13 +69,23 @@ export interface ArtifactPathOptions {
 export function buildArtifactUri(identity: ArtifactIdentity): string {
   assertSafeId(identity.contextId, 'contextId');
   validateConcreteRunId(identity.runId);
-  validateArtifactKey(identity.key);
+  validateExactArtifactKey(identity.key);
 
   return `rd://artifacts/${encodeURIComponent(identity.contextId)}/${encodeURIComponent(identity.runId)}/${encodeURIComponent(identity.key)}`;
 }
 
 /**
  * Parse an artifact URI into an exact reference or selector reference.
+ *
+ * The exact/selector discriminator is structural: a URI is **exact** iff its
+ * run segment is concrete (matches `RUN_ID_PATTERN`), its key segment is an
+ * exact key (no `*`/`?`), and it carries no query string. Any wildcard in the
+ * run or key segment, or any query string, makes the URI a **selector**.
+ *
+ * Key validation is by kind: exact URIs require an exact key
+ * ({@link assertSafeId}); selector URIs accept an exact OR wildcard key
+ * ({@link SELECTOR_ARTIFACT_KEY_PATTERN}). A glob key never yields an exact
+ * ref — it forces the selector branch even when the run segment is concrete.
  *
  * @param uri - Artifact URI to parse
  * @returns Parsed artifact reference
@@ -95,15 +106,18 @@ export function parseArtifactUri(uri: string): ArtifactRef {
   if (runId !== '*') {
     validateConcreteRunId(runId);
   }
-  validateArtifactKey(key);
 
-  return {
-    kind: runId === '*' || hasQuery ? 'selector' : 'exact',
-    contextId,
-    runId,
-    key,
-    query,
-  };
+  const runConcrete = runId !== '*';
+  const keyExact = isExactArtifactKey(key);
+  const kind: ArtifactRef['kind'] = runConcrete && keyExact && !hasQuery ? 'exact' : 'selector';
+
+  if (kind === 'exact') {
+    validateExactArtifactKey(key);
+  } else {
+    validateSelectorArtifactKey(key, runConcrete);
+  }
+
+  return { kind, contextId, runId, key, query };
 }
 
 /**
@@ -248,7 +262,7 @@ function decodePathSegment(segment: string): string {
 
 function validateDecodedSegments(contextId: string, runId: string, key: string): void {
   const identitySegments = [contextId, runId, key];
-  if (identitySegments.includes('**')) {
+  if (identitySegments.some((segment) => segment.includes('**'))) {
     throw new Error(ARTIFACT_ERROR_TEXT.RECURSIVE_WILDCARD);
   }
   if (identitySegments.some((segment) => TEMPLATE_MARKER_PATTERN.test(segment))) {
@@ -283,8 +297,58 @@ export function assertConcreteRunId(runId: string): void {
   validateConcreteRunId(runId);
 }
 
-function validateArtifactKey(key: string): void {
+/**
+ * Test whether a decoded key segment is an exact artifact key — i.e. carries
+ * no `*` or `?` glob characters. The full safe-id check is applied separately
+ * by {@link validateExactArtifactKey}.
+ *
+ * @param key - Decoded key segment
+ * @returns True when the key contains no glob characters
+ */
+function isExactArtifactKey(key: string): boolean {
+  return !key.includes('*') && !key.includes('?');
+}
+
+/**
+ * Validate an exact artifact key segment — the producer-surface key check.
+ *
+ * Reached from the `exact` branch of {@link parseArtifactUri} (where the key is
+ * already glob-free by construction) and from {@link buildArtifactUri}, the
+ * exact-URI producer builder. The glob guard is the live check for builder
+ * callers: a glob key cannot address an exact producer artifact.
+ *
+ * @param key - Candidate exact artifact key segment
+ * @throws {Error} If the key carries glob characters, or is otherwise unsafe
+ *   ({@link assertSafeId})
+ */
+function validateExactArtifactKey(key: string): void {
+  if (!isExactArtifactKey(key)) {
+    throw new Error(ARTIFACT_ERROR_TEXT.GLOB_KEY_IN_EXACT_URI);
+  }
   assertSafeId(key, 'ArtifactKey');
+}
+
+/**
+ * Validate a selector artifact key segment.
+ *
+ * A selector key may be exact or carry `*`/`?` globs. Exact selector keys
+ * additionally satisfy {@link assertSafeId}; wildcard selector keys satisfy
+ * {@link SELECTOR_ARTIFACT_KEY_PATTERN}, which rejects path separators,
+ * whitespace, and recursive `**`.
+ *
+ * @param key - Decoded key segment from a selector URI
+ * @param runConcrete - Whether the run segment is concrete
+ * @throws {Error} If the key fails both the exact and selector key checks
+ */
+function validateSelectorArtifactKey(key: string, runConcrete: boolean): void {
+  void runConcrete;
+  if (isExactArtifactKey(key)) {
+    assertSafeId(key, 'ArtifactKey');
+    return;
+  }
+  if (!SELECTOR_ARTIFACT_KEY_PATTERN.test(key)) {
+    throw new Error(`Invalid ArtifactKey: ${JSON.stringify(key)}`);
+  }
 }
 
 /**

--- a/packages/parser/__tests__/artifact-token.properties.test.ts
+++ b/packages/parser/__tests__/artifact-token.properties.test.ts
@@ -94,10 +94,10 @@ describe('ARTIFACTS token classifier properties', () => {
     );
   });
 
-  it('rejects path-like wildcard hybrids as invalid-wildcard-key', () => {
+  it('rejects path-like wildcard hybrids as invalid-shorthand-key', () => {
     fc.assert(
       fc.property(classifierArb, wildcardPathHybridArb, (classify, raw) => {
-        expect(classify(raw)).toEqual({ ok: false, reason: 'invalid-wildcard-key', raw });
+        expect(classify(raw)).toEqual({ ok: false, reason: 'invalid-shorthand-key', raw });
       }),
     );
   });

--- a/packages/parser/__tests__/artifact-token.test.ts
+++ b/packages/parser/__tests__/artifact-token.test.ts
@@ -8,8 +8,26 @@ import {
 
 describe('classifyRawArtifactToken', () => {
   it.each([
-    ['plan.json', 'bare-key'],
-    ['review-*.json', 'wildcard-key'],
+    ['plan.json', { kind: 'shorthand', key: 'plan.json', runScope: 'current' }],
+    ['review-*.json', { kind: 'shorthand', key: 'review-*.json', runScope: 'current' }],
+    ['*/plan.json', { kind: 'shorthand', key: 'plan.json', runScope: 'any' }],
+    ['*/review-*.json', { kind: 'shorthand', key: 'review-*.json', runScope: 'any' }],
+    [
+      '*/end-to-end-test-review.json',
+      {
+        kind: 'shorthand',
+        key: 'end-to-end-test-review.json',
+        runScope: 'any',
+      },
+    ],
+  ] as const)('classifies %s as shorthand', (raw, token) => {
+    expect(classifyRawArtifactToken(raw)).toEqual({
+      ok: true,
+      token: { ...token, raw },
+    });
+  });
+
+  it.each([
     ['rd://artifacts/ctx1/*/plan.json', 'rd-uri'],
     ['/tmp/plan.json', 'abs-path'],
     ['schemas/review.schema.json', 'rel-path'],
@@ -22,18 +40,23 @@ describe('classifyRawArtifactToken', () => {
 
   it.each([
     ['', 'empty'],
-    ['   ', 'invalid-bare-key'],
+    ['   ', 'invalid-shorthand-key'],
     ['.', 'dot-segment'],
     ['..', 'dot-segment'],
     ['**', 'recursive-wildcard'],
     ['dir/**/plan.json', 'recursive-wildcard'],
     ['a/./b.json', 'dot-segment'],
     ['a/../b.json', 'dot-segment'],
-    ['foo bar', 'invalid-bare-key'],
-    ['foo:bar', 'invalid-bare-key'],
-    ['plan#.json', 'invalid-bare-key'],
-    ['dir/*.json', 'invalid-wildcard-key'],
-    ['review-*.json extra', 'invalid-wildcard-key'],
+    ['foo bar', 'invalid-shorthand-key'],
+    ['foo:bar', 'invalid-shorthand-key'],
+    ['plan#.json', 'invalid-shorthand-key'],
+    ['/tmp/review-*.json', 'invalid-shorthand-key'],
+    ['dir/*.json', 'invalid-shorthand-key'],
+    ['reports/review-*.json', 'invalid-shorthand-key'],
+    ['review-*.json extra', 'invalid-shorthand-key'],
+    ['*/dir/plan.json', 'invalid-shorthand-key'],
+    ['*/plan#.json', 'invalid-shorthand-key'],
+    ['*/', 'invalid-shorthand-key'],
   ] as const)('rejects %s with reason %s', (raw, reason) => {
     expect(classifyRawArtifactToken(raw)).toEqual({ ok: false, reason, raw });
   });
@@ -41,19 +64,30 @@ describe('classifyRawArtifactToken', () => {
   it('accepts raw template tokens before runtime expansion', () => {
     expect(classifyRawArtifactToken('{{ContextId}}-plan.json')).toMatchObject({
       ok: true,
-      token: { kind: 'bare-key', raw: '{{ContextId}}-plan.json' },
+      token: { kind: 'shorthand', key: '{{ContextId}}-plan.json', runScope: 'current' },
+    });
+  });
+
+  it('accepts a raw templated cross-run shorthand before expansion', () => {
+    expect(classifyRawArtifactToken('*/{{Name}}-review.json')).toMatchObject({
+      ok: true,
+      token: { kind: 'shorthand', key: '{{Name}}-review.json', runScope: 'any' },
     });
   });
 
   it('accepts raw templated tokens as advisory before expanded classification', () => {
+    // A templated `/`-shaped token is accepted permissively at raw
+    // classification — its final shape is unknown until expansion. The
+    // advisory kind is `rel-path`; only `.ok` gates declaration acceptance,
+    // and the resolver re-classifies the expanded value.
     expect(classifyRawArtifactToken('{{Dir}}/review-*.json')).toMatchObject({
       ok: true,
-      token: { kind: 'wildcard-key', raw: '{{Dir}}/review-*.json' },
+      token: { kind: 'rel-path', raw: '{{Dir}}/review-*.json', path: '{{Dir}}/review-*.json' },
     });
 
     expect(classifyExpandedArtifactToken('reports/review-*.json')).toEqual({
       ok: false,
-      reason: 'invalid-wildcard-key',
+      reason: 'invalid-shorthand-key',
       raw: 'reports/review-*.json',
     });
   });
@@ -71,7 +105,7 @@ describe('classifyRawArtifactToken', () => {
 });
 
 describe('parseArtifactDeclaration classifier validation', () => {
-  it.each(['foo bar', 'foo:bar'])('rejects invalid exact bare key %s', (rawToken) => {
+  it.each(['foo bar', 'foo:bar'])('rejects invalid exact shorthand key %s', (rawToken) => {
     expect(parseArtifactDeclaration(`Plan "${rawToken}"`)).toBeNull();
   });
 
@@ -80,15 +114,36 @@ describe('parseArtifactDeclaration classifier validation', () => {
     'review-*.json extra',
     '/tmp/*.json',
     '/tmp/review-?.json',
-  ])('rejects invalid wildcard key %s', (rawToken) => {
+  ])('rejects invalid wildcard shorthand key %s', (rawToken) => {
     expect(parseArtifactDeclaration(`Plan "${rawToken}"`)).toBeNull();
+  });
+
+  it.each([
+    '*/plan.json',
+    '*/end-to-end-test-review.json',
+    '*/review-*.json',
+  ])('accepts cross-run shorthand %s', (rawToken) => {
+    expect(parseArtifactDeclaration(`Plan "${rawToken}"`)).toEqual({
+      name: 'Plan',
+      rawToken,
+    });
   });
 });
 
 describe('classifyExpandedArtifactToken', () => {
   it.each([
-    ['plan.json', 'bare-key'],
-    ['review-?.json', 'wildcard-key'],
+    ['plan.json', { kind: 'shorthand', key: 'plan.json', runScope: 'current' }],
+    ['review-?.json', { kind: 'shorthand', key: 'review-?.json', runScope: 'current' }],
+    ['*/plan.json', { kind: 'shorthand', key: 'plan.json', runScope: 'any' }],
+    ['*/review-?.json', { kind: 'shorthand', key: 'review-?.json', runScope: 'any' }],
+  ] as const)('classifies expanded %s as shorthand', (raw, token) => {
+    expect(classifyExpandedArtifactToken(raw)).toEqual({
+      ok: true,
+      token: { ...token, raw },
+    });
+  });
+
+  it.each([
     ['rd://artifacts/ctx1/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json', 'rd-uri'],
     ['/tmp/plan.json', 'abs-path'],
     ['C:\\tmp\\plan.json', 'abs-path'],
@@ -112,6 +167,17 @@ describe('classifyExpandedArtifactToken', () => {
       ok: false,
       reason: 'unresolved-template',
       raw: '{{Name}}-plan.json',
+    });
+  });
+
+  it.each([
+    '/tmp/review-*.json',
+    'C:\\tmp\\review-?.json',
+  ])('rejects expanded absolute glob path %s', (raw) => {
+    expect(classifyExpandedArtifactToken(raw)).toEqual({
+      ok: false,
+      reason: 'invalid-shorthand-key',
+      raw,
     });
   });
 

--- a/packages/parser/__tests__/artifacts.test.ts
+++ b/packages/parser/__tests__/artifacts.test.ts
@@ -27,6 +27,21 @@ describe('parseArtifactDeclaration', () => {
     });
   });
 
+  it.each([
+    '*/plan.json',
+    '*/end-to-end-test-review.json',
+    '*/review-*.json',
+  ])('accepts the cross-run shorthand %s', (token) => {
+    expect(parseArtifactDeclaration(`Plan "${token}"`)).toEqual({
+      name: 'Plan',
+      rawToken: token,
+    });
+  });
+
+  it.each(['*/dir/plan.json', 'dir/*.json'])('rejects a non-shorthand glob path %s', (token) => {
+    expect(parseArtifactDeclaration(`Plan "${token}"`)).toBeNull();
+  });
+
   it('parses a bare key with template markers (expansion deferred to resolver)', () => {
     expect(parseArtifactDeclaration('Plan "{{ContextId}}-plan.json"')).toEqual({
       name: 'Plan',

--- a/packages/parser/src/artifact-token.ts
+++ b/packages/parser/src/artifact-token.ts
@@ -1,4 +1,14 @@
-import { EXACT_ARTIFACT_KEY_PATTERN, WILDCARD_ARTIFACT_KEY_PATTERN } from './schemas.js';
+import { SELECTOR_ARTIFACT_KEY_PATTERN } from './schemas.js';
+
+/**
+ * Run scope for a shorthand ARTIFACTS token.
+ *
+ * - `current` — bare token; the run segment defaults to the current `RunId`.
+ * - `any` — the token carried a leading cross-run prefix (an asterisk then a
+ *   slash); the run segment is the selector wildcard `*` (query across all
+ *   runs in the current context).
+ */
+export type ArtifactRunScope = 'current' | 'any';
 
 /**
  * Typed reason explaining why an ARTIFACTS token was rejected by the parser
@@ -9,26 +19,24 @@ export type ArtifactTokenRejectReason =
   | 'dot-segment'
   | 'recursive-wildcard'
   | 'unresolved-template'
-  | 'invalid-bare-key'
-  | 'invalid-wildcard-key';
+  | 'invalid-shorthand-key';
 
 /** Parsed ARTIFACTS token classified by syntactic dispatch kind. */
 export type ParsedArtifactToken =
   | {
-      /** Exact managed artifact key token. */
-      readonly kind: 'bare-key';
+      /**
+       * Shorthand managed-artifact token. Sugar for an `rd://artifacts/` URI
+       * whose context segment defaults to the current `ContextId`. The run
+       * segment is the current `RunId` when `runScope` is `current` or the
+       * selector wildcard `*` when `runScope` is `any`.
+       */
+      readonly kind: 'shorthand';
       /** Original token text supplied to the classifier. */
       readonly raw: string;
-      /** Artifact key text. */
+      /** Artifact key (exact or wildcard); the URI key segment. */
       readonly key: string;
-    }
-  | {
-      /** Managed artifact wildcard selector key token. */
-      readonly kind: 'wildcard-key';
-      /** Original token text supplied to the classifier. */
-      readonly raw: string;
-      /** Wildcard key pattern text. */
-      readonly key: string;
+      /** Run scope: `current` for produce/current-run query, `any` for cross-run query. */
+      readonly runScope: ArtifactRunScope;
     }
   | {
       /** Rundown artifact URI token. */
@@ -64,6 +72,9 @@ export type ParsedArtifactToken =
 export type ArtifactTokenClassificationResult =
   | { readonly ok: true; readonly token: ParsedArtifactToken }
   | { readonly ok: false; readonly reason: ArtifactTokenRejectReason; readonly raw: string };
+
+/** Prefix that overrides a shorthand token's run scope to query all runs. */
+const CROSS_RUN_PREFIX = '*/';
 
 /**
  * Classify a raw ARTIFACTS token as it appears in the runbook source.
@@ -113,10 +124,8 @@ export function formatArtifactTokenRejectReason(reason: ArtifactTokenRejectReaso
       return "recursive wildcard '**' is not allowed";
     case 'unresolved-template':
       return 'unresolved template marker remains after expansion';
-    case 'invalid-bare-key':
-      return 'bare keys must match exact_artifact_key (alphanumerics, dots, underscores, and hyphens)';
-    case 'invalid-wildcard-key':
-      return "wildcard keys must match wildcard_artifact_key (alphanumerics, dots, underscores, hyphens, '*', and '?')";
+    case 'invalid-shorthand-key':
+      return "shorthand keys must match selector_artifact_key (alphanumerics, dots, underscores, hyphens, '*', and '?'), optionally with a leading '*/' cross-run prefix";
     default: {
       const exhaustive: never = reason;
       return exhaustive;
@@ -131,49 +140,63 @@ function classifyAcceptedArtifactToken(
   const hasTemplates = options.allowTemplateMarkers && hasTemplateMarker(raw);
 
   if (raw.startsWith('rd://')) {
-    return {
-      ok: true,
-      token: {
-        kind: 'rd-uri',
-        raw,
-        uri: raw,
-      },
-    };
-  }
-
-  if (raw.includes('*') || raw.includes('?')) {
-    if (!hasTemplates && !WILDCARD_ARTIFACT_KEY_PATTERN.test(raw)) {
-      return { ok: false, reason: 'invalid-wildcard-key', raw };
-    }
-    return { ok: true, token: { kind: 'wildcard-key', raw, key: raw } };
+    return { ok: true, token: { kind: 'rd-uri', raw, uri: raw } };
   }
 
   if (isAbsoluteArtifactPath(raw)) {
-    return {
-      ok: true,
-      token: {
-        kind: 'abs-path',
-        raw,
-        path: raw,
-      },
-    };
+    if (!hasTemplates && (raw.includes('*') || raw.includes('?'))) {
+      return { ok: false, reason: 'invalid-shorthand-key', raw };
+    }
+    return { ok: true, token: { kind: 'abs-path', raw, path: raw } };
   }
 
+  // Cross-run shorthand: a leading `*/` prefix overrides the run segment to
+  // the selector wildcard. The remainder must be a single key segment (no
+  // further slashes) and must satisfy the selector-key shape.
+  if (raw.startsWith(CROSS_RUN_PREFIX)) {
+    const key = raw.slice(CROSS_RUN_PREFIX.length);
+    if (!isValidShorthandKey(key, hasTemplates)) {
+      return { ok: false, reason: 'invalid-shorthand-key', raw };
+    }
+    return { ok: true, token: { kind: 'shorthand', raw, key, runScope: 'any' } };
+  }
+
+  // A path-shaped token (contains a separator) that is NOT the cross-run
+  // shorthand. A concrete token carrying glob characters is neither a valid
+  // key nor a valid file reference — reject it. A templated token is exempt:
+  // its final shape is unknown until runtime expansion, so raw classification
+  // accepts it permissively and `classifyExpandedArtifactToken` re-checks the
+  // expanded value. Otherwise it is a plain file reference.
   if (raw.includes('/') || raw.includes('\\')) {
-    return {
-      ok: true,
-      token: {
-        kind: 'rel-path',
-        raw,
-        path: raw,
-      },
-    };
+    if (!hasTemplates && (raw.includes('*') || raw.includes('?'))) {
+      return { ok: false, reason: 'invalid-shorthand-key', raw };
+    }
+    return { ok: true, token: { kind: 'rel-path', raw, path: raw } };
   }
 
-  if (!hasTemplates && !EXACT_ARTIFACT_KEY_PATTERN.test(raw)) {
-    return { ok: false, reason: 'invalid-bare-key', raw };
+  // Bare shorthand: no separators. The key may be exact or carry globs; the
+  // run segment defaults to the current run.
+  if (!isValidShorthandKey(raw, hasTemplates)) {
+    return { ok: false, reason: 'invalid-shorthand-key', raw };
   }
-  return { ok: true, token: { kind: 'bare-key', raw, key: raw } };
+  return { ok: true, token: { kind: 'shorthand', raw, key: raw, runScope: 'current' } };
+}
+
+/**
+ * Validate a shorthand key segment.
+ *
+ * Templated keys bypass the regex (they are expanded later); concrete keys
+ * must satisfy {@link SELECTOR_ARTIFACT_KEY_PATTERN} — a single segment with
+ * no separators, optionally carrying `*`/`?` globs.
+ *
+ * @param key - Candidate shorthand key segment
+ * @param hasTemplates - Whether raw classification found template markers
+ * @returns True when the key is acceptable for deferred or concrete shorthand
+ *   classification
+ */
+function isValidShorthandKey(key: string, hasTemplates: boolean): boolean {
+  if (hasTemplates) return true;
+  return SELECTOR_ARTIFACT_KEY_PATTERN.test(key);
 }
 
 function rejectUnsafeArtifactToken(raw: string): ArtifactTokenRejectReason | null {


### PR DESCRIPTION
## Summary
- add parser support for a unified ARTIFACTS shorthand token with current-run and cross-run scopes
- extend artifact URI parsing so selector URIs can use wildcard keys while exact URIs remain producer-only
- route shorthand through canonical rd:// artifact URIs and document the uniform URI-suffix model

## Test Plan
- npm run build
- npm test
- npm run test:property
- npm run verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-run artifact selection via a leading "*/" shorthand; improved shorthand handling.
  * Added end-to-end planning-and-review runbook.

* **Documentation**
  * Clarified artifact grammar, URI rules, and exact vs selector semantics across specs and expansion rules.

* **Tests**
  * Expanded coverage for shorthand/classification, cross-run selectors, and selector-URI parsing.

* **Bug Fixes**
  * Stricter validation and clearer error messaging for glob/wildcard use in exact artifact URIs.

* **Chores**
  * Added new spelling entry to dictionary.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->