### PR TITLE
[codex] Add artifact token classifier property tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18538,6 +18538,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^25.8.0",
+        "fast-check": "^4.8.0",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.9",
         "typescript": "^6.0.3"

--- a/packages/parser/__tests__/artifact-token.properties.test.ts
+++ b/packages/parser/__tests__/artifact-token.properties.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fc from 'fast-check';
+import {
+  classifyExpandedArtifactToken,
+  classifyRawArtifactToken,
+  type ArtifactTokenClassificationResult,
+} from '../src/index.js';
+
+const plainSegmentArb = fc.stringMatching(/^[A-Za-z0-9_-]{1,8}$/);
+const dottedNameSegmentArb = fc.stringMatching(/^[A-Za-z0-9_-]{1,6}\.[A-Za-z0-9_-]{1,6}$/);
+const safeSegmentArb = fc.oneof(plainSegmentArb, dottedNameSegmentArb);
+const separatorArb = fc.constantFrom('/', '\\');
+const classifierArb = fc.constantFrom(classifyRawArtifactToken, classifyExpandedArtifactToken);
+
+function joinPathSegments(segments: readonly string[], separator: string): string {
+  return segments.join(separator);
+}
+
+function containsForbiddenDotSegment(raw: string): boolean {
+  return raw
+    .split(/[\\/]+/)
+    .filter(Boolean)
+    .some((segment) => segment === '.' || segment === '..');
+}
+
+const dotSegmentTokenArb = fc
+  .tuple(
+    fc.array(safeSegmentArb, { maxLength: 3 }),
+    fc.constantFrom('.', '..'),
+    fc.array(safeSegmentArb, { maxLength: 3 }),
+    separatorArb,
+  )
+  .map(([before, dotSegment, after, separator]) =>
+    joinPathSegments([...before, dotSegment, ...after], separator),
+  );
+
+const recursiveWildcardTokenArb = fc
+  .tuple(
+    fc.array(safeSegmentArb, { maxLength: 3 }),
+    fc.constant('**'),
+    fc.array(safeSegmentArb, { maxLength: 3 }),
+    separatorArb,
+  )
+  .map(([before, recursiveWildcard, after, separator]) =>
+    joinPathSegments([...before, recursiveWildcard, ...after], separator),
+  );
+
+const wildcardPathHybridArb = fc
+  .tuple(
+    fc.array(safeSegmentArb, { minLength: 1, maxLength: 3 }),
+    fc.constantFrom('*.json', 'review-?.json'),
+    separatorArb,
+  )
+  .map(([dirs, filename, separator]) => joinPathSegments([...dirs, filename], separator));
+
+const pathLikeTokenArb = fc
+  .tuple(
+    fc.constantFrom('', '/', 'C:\\', '\\\\server\\share\\'),
+    fc.array(fc.oneof(safeSegmentArb, fc.constant('.'), fc.constant('..'), fc.constant('**')), {
+      minLength: 2,
+      maxLength: 5,
+    }),
+    separatorArb,
+  )
+  .map(([prefix, segments, separator]) => `${prefix}${joinPathSegments(segments, separator)}`);
+
+function isAcceptedPath(result: ArtifactTokenClassificationResult): result is Extract<
+  ArtifactTokenClassificationResult,
+  { ok: true }
+> & {
+  readonly token: { readonly kind: 'abs-path' | 'rel-path'; readonly raw: string };
+} {
+  return result.ok && (result.token.kind === 'abs-path' || result.token.kind === 'rel-path');
+}
+
+describe('ARTIFACTS token classifier properties', () => {
+  it('rejects raw and expanded tokens with dot path segments as dot-segment', () => {
+    fc.assert(
+      fc.property(classifierArb, dotSegmentTokenArb, (classify, raw) => {
+        expect(classify(raw)).toEqual({ ok: false, reason: 'dot-segment', raw });
+      }),
+    );
+  });
+
+  it('rejects raw and expanded tokens with recursive wildcards as recursive-wildcard', () => {
+    fc.assert(
+      fc.property(classifierArb, recursiveWildcardTokenArb, (classify, raw) => {
+        expect(classify(raw)).toEqual({ ok: false, reason: 'recursive-wildcard', raw });
+      }),
+    );
+  });
+
+  it('rejects path-like wildcard hybrids as invalid-wildcard-key', () => {
+    fc.assert(
+      fc.property(classifierArb, wildcardPathHybridArb, (classify, raw) => {
+        expect(classify(raw)).toEqual({ ok: false, reason: 'invalid-wildcard-key', raw });
+      }),
+    );
+  });
+
+  it('never accepts expanded relative or absolute paths with forbidden segments or recursive wildcards', () => {
+    fc.assert(
+      fc.property(pathLikeTokenArb, (raw) => {
+        const result = classifyExpandedArtifactToken(raw);
+        if (!isAcceptedPath(result)) return;
+
+        expect(containsForbiddenDotSegment(result.token.raw)).toBe(false);
+        expect(result.token.raw.includes('**')).toBe(false);
+      }),
+    );
+  });
+});

--- a/packages/parser/__tests__/artifact-token.properties.test.ts
+++ b/packages/parser/__tests__/artifact-token.properties.test.ts
@@ -47,11 +47,15 @@ const recursiveWildcardTokenArb = fc
 
 const wildcardPathHybridArb = fc
   .tuple(
+    fc.constantFrom('', '/', 'C:\\', '\\\\server\\share\\'),
     fc.array(safeSegmentArb, { minLength: 1, maxLength: 3 }),
     fc.constantFrom('*.json', 'review-?.json'),
     separatorArb,
   )
-  .map(([dirs, filename, separator]) => joinPathSegments([...dirs, filename], separator));
+  .map(
+    ([prefix, dirs, filename, separator]) =>
+      `${prefix}${joinPathSegments([...dirs, filename], separator)}`,
+  );
 
 const pathLikeTokenArb = fc
   .tuple(

--- a/packages/parser/__tests__/artifact-token.test.ts
+++ b/packages/parser/__tests__/artifact-token.test.ts
@@ -75,7 +75,12 @@ describe('parseArtifactDeclaration classifier validation', () => {
     expect(parseArtifactDeclaration(`Plan "${rawToken}"`)).toBeNull();
   });
 
-  it.each(['dir/*.json', 'review-*.json extra'])('rejects invalid wildcard key %s', (rawToken) => {
+  it.each([
+    'dir/*.json',
+    'review-*.json extra',
+    '/tmp/*.json',
+    '/tmp/review-?.json',
+  ])('rejects invalid wildcard key %s', (rawToken) => {
     expect(parseArtifactDeclaration(`Plan "${rawToken}"`)).toBeNull();
   });
 });

--- a/packages/parser/__tests__/artifact-token.test.ts
+++ b/packages/parser/__tests__/artifact-token.test.ts
@@ -149,6 +149,10 @@ describe('SELECTOR_ARTIFACT_KEY_PATTERN', () => {
     expect(SELECTOR_ARTIFACT_KEY_PATTERN.test(key)).toBe(true);
   });
 
+  it.each(['.', '..'])('accepts dot-segment key %s', (key) => {
+    expect(SELECTOR_ARTIFACT_KEY_PATTERN.test(key)).toBe(true);
+  });
+
   // `.` and `..` are intentionally NOT rejected by this pattern — it
   // mirrors EXACT_ARTIFACT_KEY_PATTERN, which also accepts them. Dot-segment
   // safety is the caller's job (`rejectUnsafeArtifactToken` / `assertSafeId`).

--- a/packages/parser/__tests__/artifact-token.test.ts
+++ b/packages/parser/__tests__/artifact-token.test.ts
@@ -3,6 +3,7 @@ import {
   classifyExpandedArtifactToken,
   classifyRawArtifactToken,
   parseArtifactDeclaration,
+  SELECTOR_ARTIFACT_KEY_PATTERN,
 } from '../src/index.js';
 
 describe('classifyRawArtifactToken', () => {
@@ -122,5 +123,37 @@ describe('classifyExpandedArtifactToken', () => {
         uri: 'rd://artifacts/ctx1/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
       },
     });
+  });
+});
+
+describe('SELECTOR_ARTIFACT_KEY_PATTERN', () => {
+  it.each([
+    'plan.json',
+    'review-plan-a.json',
+    'end-to-end-test-review.json',
+  ])('accepts exact key %s', (key) => {
+    expect(SELECTOR_ARTIFACT_KEY_PATTERN.test(key)).toBe(true);
+  });
+
+  it.each([
+    'plan-*.json',
+    'review-?.json',
+    '*.json',
+    'a*b?c.json',
+  ])('accepts wildcard key %s', (key) => {
+    expect(SELECTOR_ARTIFACT_KEY_PATTERN.test(key)).toBe(true);
+  });
+
+  // `.` and `..` are intentionally NOT rejected by this pattern — it
+  // mirrors EXACT_ARTIFACT_KEY_PATTERN, which also accepts them. Dot-segment
+  // safety is the caller's job (`rejectUnsafeArtifactToken` / `assertSafeId`).
+  it.each([
+    '',
+    'nested/plan.json',
+    'with space.json',
+    'plan#.json',
+    '**',
+  ])('rejects unsafe key %s', (key) => {
+    expect(SELECTOR_ARTIFACT_KEY_PATTERN.test(key)).toBe(false);
   });
 });

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^25.8.0",
+    "fast-check": "^4.8.0",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.9",
     "typescript": "^6.0.3"

--- a/packages/parser/src/schemas.ts
+++ b/packages/parser/src/schemas.ts
@@ -315,6 +315,19 @@ export const EXACT_ARTIFACT_KEY_PATTERN = /^[A-Za-z0-9._-]+$/;
 export const WILDCARD_ARTIFACT_KEY_PATTERN = /^(?=.*[*?])[A-Za-z0-9._*?-]+$/;
 
 /**
+ * Shape of a selector artifact key — `[A-Za-z0-9._*?-]+`. This is the union of
+ * {@link EXACT_ARTIFACT_KEY_PATTERN} and {@link WILDCARD_ARTIFACT_KEY_PATTERN}:
+ * a selector key MAY be exact OR carry `*`/`?` glob characters. Mirrors
+ * `selector_artifact_key` in docs/spec/grammar.md and the selector-URI key
+ * segment in docs/spec/uri.md §5.3.
+ *
+ * The leading negative lookahead rejects any token containing `**` (recursive
+ * wildcards are not supported); `.` and `..` dot-segments are rejected
+ * separately by the caller's reject-first safety checks.
+ */
+export const SELECTOR_ARTIFACT_KEY_PATTERN = /^(?!.*\*\*)[A-Za-z0-9._*?-]+$/;
+
+/**
  * Valid transition kinds
  */
 export const TransitionKindSchema = z.enum(['pass', 'fail', 'yes', 'no']);


### PR DESCRIPTION
## Summary

Adds parser-owned property tests for the ARTIFACTS token classifier introduced for issue #331.

The tests pin the safety invariants that motivated the classifier refactor:
- dot path segments reject before dispatch
- recursive wildcards reject before dispatch
- wildcard/path hybrids reject as invalid wildcard keys instead of falling through as file paths
- accepted expanded path tokens do not contain forbidden dot segments or recursive wildcards

Also adds fast-check to the parser package dev dependencies, matching the existing repo version used by core/plugin tests.

## Validation

- npm test -- -w packages/parser artifact-token.test.ts artifact-token.properties.test.ts
- npm run check:types -w packages/parser
- npm run verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a validated artifact-key pattern that accepts exact keys and common wildcard forms while rejecting unsafe constructs (path separators, dot-segments, recursive wildcards, and invalid wildcard hybrids).

* **Tests**
  * Added unit and property-based tests to verify artifact token classification and the artifact-key pattern, expanding invalid-case coverage to catch additional unsafe patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->