### PR TITLE
docs: sync core docs with the codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ When multiple CLI processes may mutate the same file (e.g., `.rundown/session.js
 - **Retry:** Jittered backoff (50–100ms) bounded to 5 seconds
 - **Release:** Idempotent unlink; safe to call multiple times
 
-**Examples:** `SessionLock` (`packages/core/src/runbook/session-lock.ts` line 122-129), `DelegationLock` (`packages/core/src/runbook/delegation-lock.ts` line 38-87), and fixture tests (`packages/core/__tests__/runbook/session-lock.test.ts`).
+**Examples:** `SessionLock` (`packages/core/src/runbook/session-lock.ts` — class at line 36, `acquire`/`release` at lines 59-77), `DelegationLock` (`packages/core/src/runbook/delegation-lock.ts` line 38-87), and fixture tests (`packages/core/__tests__/runbook/session-lock.test.ts`).
 
 **For manifest writes:** Wrap `findEquivalentManifestRow` + append in a lock (e.g., `sessionLockPath(cwd)` if manifest is per-project, or derive a manifest-specific lock path from `manifestPath(cwd)` + `.lock`).
 
@@ -91,6 +91,9 @@ rundown stop [message]   # Abort runbook with optional message
 rundown complete [message] # Force early completion (runbooks auto-complete on final step)
 rundown stash            # Pause enforcement (stash active runbook)
 rundown pop              # Resume enforcement (restore stashed runbook)
+# --claim-id <claimId> targets a claimed delegated child runbook;
+# accepted by goto, status, stop, complete, stash, pop, and collect
+# (pass/fail also accept --claim-id — see below)
 rundown ls               # List active runbooks
 rundown ls --all         # List available runbook files
 rundown ls --all --tags <tags>  # Filter by comma-separated tags
@@ -124,19 +127,23 @@ rundown delegate --retry <token>                         # Retry delegation by t
 rundown delegate --retry --step <id>                     # Retry delegation on substep
 rundown delegate --retry --step <id> --index <n>         # Retry delegation in FOR iteration
 rundown delegate --retry                                 # Retry inferred from active substep
-rundown delegate --retry --step <id> --var key=value     # Retry with var overrides
+rundown delegate --retry --step <id> --input key=value   # Retry with var overrides
 rundown claim <token>                   # Claim a delegation token and launch child
 rundown claim <token> --input key=value   # Claim with variables (repeatable)
 rundown claim <token> --input-json key=json  # Claim with JSON variables
 rundown claim <token> --input-file path   # Load variables from YAML file (repeatable)
-rundown abort <token>                   # Cancel a delegation token (--force for claimed)
+rundown abort <token>                   # Cancel a delegation token
+rundown abort <token> --force           # Force cancel even if delegation is claimed (stops child run)
 rundown collect                         # Aggregate current DELEGATE step and fire transition
 rundown collect --step <id>             # Target a specific substep scope
+rundown collect --claim-id <claimId>    # Collect within a claimed child runbook scope
 ```
 
 The `rd` command is an alias for `rundown`.
 
 ### rdpath (Path Assembly Tool)
+
+> **Note:** `rdpath` and `rdx` are bin entries of the `@rundown-org/claude-code-plugin` package, not the `@rundown-org/cli` package. The CLI package ships only `rundown` and `rd`.
 
 ```bash
 rdpath --dir <path>                           # Assemble base path (default subcommand)
@@ -145,9 +152,12 @@ rdpath --dir <path> --file <name>             # With date-prefixed filename
 rdpath --dir <path> --ctx <id> --file <name>  # With date-prefixed filename in context
 rdpath --dir <path> find <pattern>            # Find files matching glob pattern
 rdpath --dir <path> --ctx <id> find <pattern> # Find within context scope
+rdpath --dir <path> find <pattern> --allow-empty # Exit 0 when zero files match (default: exit 1)
 ```
 
 ### rdx (JSON-to-Markdown CLI)
+
+`rdx` is also a bin entry of `@rundown-org/claude-code-plugin`, not `@rundown-org/cli`.
 
 ```bash
 rdx <file>                        # Render JSON to Markdown (stdout)
@@ -162,9 +172,9 @@ Schema validation is automatic when the JSON includes `"$schema": "https://rundo
 
 Template variables use Handlebars syntax `{{variableName}}` and are expanded at run time. The full precedence table, built-in variables list, and context-passing semantics live in the specification:
 
-- [docs/spec/language.md §6 Templating](docs/spec/language.md#6-templating) — precedence order, reserved keys, required variables
+- [docs/spec/language.md §9 Templating](docs/spec/language.md#9-templating) — precedence order, reserved keys, required variables
 - [docs/reference/runtime.md Built-in Variables](docs/reference/runtime.md#built-in-variables) — `Date`, `Branch`, `WorkPath`, `RunId`, `ContextId`, `Step`, `Index`, `context.current.*`, plus plugin variables (`CLAUDE_PLUGIN_ROOT`)
-- [docs/spec/language.md §7 Context Passing](docs/spec/language.md#7-context-passing-outputs) — OUTPUTS directives and frontmatter `outputs:` / `inputs:` fields
+- [docs/spec/language.md §10 Context Passing](docs/spec/language.md#10-context-passing) — OUTPUTS directives and frontmatter `outputs:` / `inputs:` fields
 
 **CLI Example:**
 ```bash
@@ -309,6 +319,7 @@ rundown run [file] --sandbox              # Enable OS-level sandbox (default)
 rundown run [file] --no-sandbox           # Disable sandbox (trust mode)
 rundown run [file] --sandbox-strict       # Fail if sandbox unavailable
 rundown run [file] --trust-js-policy      # Trust executable JS policy configs and config-declared helpers
+rundown run [file] --helpers ./helpers.js # Helper module paths to load (comma-separated, relative to project root)
 ```
 
 ## Policy Configuration

--- a/docs/guides/agent-orchestration.md
+++ b/docs/guides/agent-orchestration.md
@@ -80,7 +80,7 @@ rd pass --claim-id <claim_id>   # or: rd fail --claim-id <claim_id>
 
 `- DELEGATE` is a structural bullet annotation that marks substeps for delegation. When the parent step is entered, the execution engine auto-issues a delegation token for each marked substep, so the orchestrating agent does not need to call `rd delegate` per substep. This is the recommended flow for any step that delegates more than one substep to subagents.
 
-See [docs/spec/language.md §4.3](../spec/language.md#43-delegate) for the full format specification and [docs/spec/grammar.md](../spec/grammar.md#delegate-annotation) for the grammar.
+See [docs/spec/language.md §7](../spec/language.md#7-delegation) for the full format specification and [docs/spec/grammar.md](../spec/grammar.md#delegate-annotation) for the grammar.
 
 ### Three equivalent forms
 
@@ -221,7 +221,7 @@ The plugin never destroys child runbook state. Incomplete delegations preserve t
 
 **Data flow between parent and child:** Delegated runbooks exchange values through context passing — a parent step's `- OUTPUTS` directive writes values into the live machine variable space when that step transition completes, and frontmatter `outputs:` writes terminal values into `state.finalVars`. Children inherit the parent's `ContextId` via `--input`, and parent/child hand-off happens through forwarded live vars and `finalVars`, not through a shared `outputs.json` file.
 
-See [Section 4: Control Flow](../spec/language.md#4-control-flow) for transition semantics.
+See [Section 6: Transitions and Actions](../spec/language.md#6-transitions-and-actions) for transition semantics.
 
 ---
 

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -36,25 +36,15 @@ The CLI is an orchestration and control interface. Claude executes the actual wo
 
 ### Typed `lastAction` discriminants
 
-Machine-internal failures and step outcomes are signalled via the typed `LastAction` discriminated union, never via string-prefixed `lastMessage` parsing or other stringly-typed channels. Variants are defined in `packages/core/src/runbook/types.ts`: `START`, `CONTINUE`, `DEFER`, `GOTO`, `COMPLETE`, `STOP`, `RETRY`, `NEXT`, `BREAK`, and `RETRY_ERROR`. (`lastMessage` itself remains a legitimate diagnostic carrier for free-form context — what is forbidden is *type discrimination* via string parsing of it.)
+Machine-internal failures and step outcomes are signalled via the typed `LastAction` discriminated union, never via string-prefixed `lastMessage` parsing or other stringly-typed channels. The union is defined in `packages/core/src/runbook/types.ts`. Its members are the transition-action variants `START`, `CONTINUE`, `DEFER`, `GOTO`, `COMPLETE`, `STOP`, `RETRY`, `NEXT`, `BREAK`; the policy variant `POLICY_DENIED`; and the `InternalFailureLastAction` sub-union — `RETRY_ERROR`, `OUTPUT_CAPTURE_FAILED`, `ARTIFACT_RESOLUTION_FAILED`, `FOR_RESOLUTION_FAILED`, `COMMAND_EXECUTION_FAILED`, and `DELEGATION_ISSUANCE_FAILED`. (`lastMessage` itself remains a legitimate diagnostic carrier for free-form context — what is forbidden is *type discrimination* via string parsing of it.)
 
-When the CLI needs to react to a specific variant (typically to route to an `ERROR_OCCURRED` or `RUNBOOK_STOPPED { reason }` emission), it does so through a narrowing helper. The canonical example is `extractRetryError` in `packages/cli/src/services/execution.ts:375`:
+Narrowing into observer events (`ERROR_OCCURRED`, `RUNBOOK_STOPPED { reason }`) happens in **core**, not the CLI — `packages/core/src/events/transition-observation.ts` builds those events from a terminal snapshot. The internal-failure variants are handled collectively, not per-variant:
 
-```ts
-function extractRetryError(snapshot: unknown): { code: string; message: string } | undefined {
-  if (typeof snapshot !== 'object' || snapshot === null) return undefined;
-  const ctx = (snapshot as { context?: unknown }).context;
-  if (typeof ctx !== 'object' || ctx === null) return undefined;
-  const lastAction = (ctx as { lastAction?: unknown }).lastAction;
-  if (typeof lastAction !== 'object' || lastAction === null) return undefined;
-  const record = lastAction as { type?: unknown; code?: unknown; message?: unknown };
-  if (record.type !== 'RETRY_ERROR') return undefined;
-  if (typeof record.code !== 'string' || typeof record.message !== 'string') return undefined;
-  return { code: record.code, message: record.message };
-}
-```
+- `isInternalFailureLastAction(lastAction)` — a single type guard that narrows any `LastAction` to the `InternalFailureLastAction` sub-union (defined in `packages/core/src/runbook/transition-kernel.ts`).
+- `extractInternalFailureMessage(lastAction)` — pulls the diagnostic message off whichever internal-failure variant is present.
+- `deriveStoppedReason(lastAction)` — maps a terminal `lastAction` to the `RUNBOOK_STOPPED` reason.
 
-Each helper narrows on `lastAction.type`, returns the variant-specific fields as a typed record, and is the only call site that touches the variant. New `LastAction` variants come with a corresponding extraction helper following the same shape.
+There is no per-variant extraction helper. New internal-failure variants are added to the `InternalFailureLastAction` union and are then covered by the existing guard and extractors without any new narrowing code. The CLI's `transition-orchestrator.ts` consumes the already-built observer events; it does not narrow `lastAction` itself.
 
 ---
 
@@ -87,7 +77,7 @@ The state machine responds to these input events:
 | `GOTO` | `rundown goto N` or GOTO action | Jump to step N |
 | `RETRY` | FAIL + RETRY action | Increment retryCount, stay in state |
 
-These input events are distinct from the action output recorded as `lastAction.type` after a transition resolves. The primary `LastAction` action variants are `START`, `CONTINUE`, `DEFER`, `GOTO`, `COMPLETE`, `STOP`, `RETRY`, `NEXT`, and `BREAK`; retry exhaustion may also surface the `RETRY_ERROR` variant (see `packages/core/src/runbook/types.ts`).
+These input events are distinct from the action output recorded as `lastAction.type` after a transition resolves. The transition-action `LastAction` variants are `START`, `CONTINUE`, `DEFER`, `GOTO`, `COMPLETE`, `STOP`, `RETRY`, `NEXT`, and `BREAK`. Beyond those, the union also carries `POLICY_DENIED` and the `InternalFailureLastAction` sub-union (`RETRY_ERROR`, `OUTPUT_CAPTURE_FAILED`, `ARTIFACT_RESOLUTION_FAILED`, `FOR_RESOLUTION_FAILED`, `COMMAND_EXECUTION_FAILED`, `DELEGATION_ISSUANCE_FAILED`) — see `packages/core/src/runbook/types.ts` and [§ Typed `lastAction` discriminants](#typed-lastaction-discriminants).
 
 ### Transitions
 
@@ -119,6 +109,10 @@ Nested FOR support remains intentionally out of scope for this actor shape: `for
 
 Leaves with ARTIFACTS use `__resolve-artifacts` after iteration resolution. This ordering means ARTIFACTS templates may reference the loop variable for the current iteration.
 
+A fourth side-effect child, `__issue-delegations`, runs after `__resolve-artifacts` when the leaf has delegations to issue: `afterArtifactsTarget = shouldIssueDelegations ? '__issue-delegations' : 'idle'`. It invokes `delegationIssueActor` (wired via `buildDelegationIssueInvokeBlock`) to create delegation tokens for the step's child runbooks before the leaf reaches `idle`.
+
+The leaf also invokes `commandExecActor` directly to execute the step's command; that actor's completion produces the `COMMAND_RESULT` event the capture flow consumes (see [§ CLI ↔ Core Event Boundary](#cli--core-event-boundary)).
+
 On `COMMAND_RESULT` the leaf transitions to its relative child (`target: '.__capture'`). `__capture` invokes `outputCaptureActor`; its `input` carries `{ channels, result }` read from the entering event. The actor reads channel files into `variables` and returns `{ variables, result }` — `result` is opaque to the actor and passes through unchanged. `onDone` merges `event.output.variables` into context and `raise`s `{ type: 'PASS' | 'FAIL' }` with **no `target`**; the raised event bubbles up XState's active state chain to the leaf's own `PASS`/`FAIL` handler. `onError` targets `#STOPPED`.
 
 Because the leaf stays active throughout the capture cycle, `entryActions` (notably FOR-first-substep `initForStack`) are never re-run by capture. No context field stores the result discriminant — it lives in the actor's typed output and bubbles out as a typed event.
@@ -147,8 +141,8 @@ Worked example — ARTIFACTS resolution (`::__resolve-artifacts` substate):
 | `workPath` | Event | `context.templateVars.WorkPath` (read in factory) |
 | `contextId` | Event | `context.templateVars.ContextId` (read in factory) |
 | `runId` | Event | `context.templateVars.RunId` (read in factory; branded with `assertRunId`) |
-| `runbook` | Event | `context.templateVars.RunbookRef` (read in factory; validated with `RunbookRefSchema.parse`) |
-| `scopeVars` | Event | `{ ...context.templateVars, ...context.variables }` (merged at fire time) |
+| `runbook` | Event | `context.templateVars.RunbookRef` (read in factory; validated with `RunbookRefSchema.safeParse` via the `requireRunbookRef` helper, which throws a wrapped error on failure) |
+| `scopeVars` | Event | `mergeEffectiveVars({ templateVars, variables })` with the `buildArtifactRuntimeScope` overlay layered on top (FOR-loop `Step`, `Index`, loop variable, `context.current.*`) |
 
 The canonical implementation site is `compileMachineFromState` in `packages/core/src/runbook/actor-service.ts`, where `flattenTemplateVars(state.templateVars)` and `evaluationOptions.cwd` are passed into `compileRunbookToMachine` and threaded into every per-state `invoke.input` closure. FOR iteration resolution additionally receives the unflattened initial template-variable seed through the same compile-time closure so file-backed `JsonArrayStream` sources never need to live in persisted XState context.
 
@@ -180,7 +174,7 @@ The CLI subscribes to actor state changes and translates them into observer even
 | `RUNBOOK_STOPPED { reason, message }` | Final state, lifecycle = `'stopped'`. `reason` is narrowed from a typed `lastAction` variant where applicable. Payload shape defined in `packages/core/src/events/types.ts`. |
 | `RUNBOOK_COMPLETED` | Final state, lifecycle = `'completed'` |
 | `ERROR_OCCURRED { code, message }` | When a typed `lastAction` variant indicates a machine-internal failure (e.g. `RETRY_ERROR`). See [Typed `lastAction` Discriminants](#typed-lastaction-discriminants). |
-| `COMMAND_STARTED` / `COMMAND_COMPLETED` / `POLICY_DENIED` | Currently emitted directly by the CLI execution loop; will move into the machine when command execution becomes a Category C actor. |
+| `COMMAND_STARTED` / `COMMAND_COMPLETED` / `POLICY_DENIED` | Machine-owned. Command execution is the Category C actor `commandExecActor` (`packages/core/src/runbook/actors/command-exec-actor.ts`), wired into every leaf in `compiler.ts`. These observations flow through the `MachineExecutionObserver` effect collector in core (`packages/core/src/events/execution-observation.ts`); the CLI supplies the `runExternalCommand` services that the actor calls but does not emit the events. |
 
 The narrowing layer between snapshot context and observer events uses the typed `lastAction` discriminant convention — never `lastMessage` string parsing.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,7 +72,7 @@ rundown run simple.runbook.md
 The CLI resolves runbook paths in this order:
 1. Absolute path (used as-is)
 2. Relative to current working directory
-3. Relative to `.rundown/runbooks/` in the project root
+3. By name via the discovery chain: project (`.rundown/runbooks/`), then plugin (`$CLAUDE_PLUGIN_ROOT/runbooks/`), then bundled (CLI package `dist/runbooks/`) — see [Runbook Discovery](#runbook-discovery) below for the full priority table
 
 ### Runbook Discovery
 
@@ -129,6 +129,7 @@ Rundown enforces a security policy layer to control what commands runbooks can e
 | `--non-interactive` | CI mode (auto-deny unlisted commands) |
 | `--policy <file>` | Use custom policy file |
 | `--trust-js-policy` | Trust an explicitly selected JS policy file and helper modules declared by policy config |
+| `--helpers <paths>` | Helper module paths to load (comma-separated, relative to project root) |
 | `--sandbox` | Enable OS-level filesystem sandbox |
 | `--no-sandbox` | Disable sandbox enforcement |
 | `--sandbox-strict` | Fail if sandbox is unavailable |
@@ -156,9 +157,21 @@ Start a new runbook from a runbook file.
 ```bash
 rundown run my-runbook.runbook.md
 rundown run my-runbook.runbook.md --prompted  # Disable automatic execution
+rundown run my-runbook.runbook.md --text      # Emit execution events as human-readable text
 rundown run my-runbook.runbook.md --input key=value  # Set template variable (repeatable)
-rundown run my-runbook.runbook.md --input-file vars.yaml  # Load variables from YAML file
+rundown run my-runbook.runbook.md --input-json 'items=["a","b"]'  # Set variable with JSON value (repeatable)
+rundown run my-runbook.runbook.md --input-file vars.yaml  # Load variables from YAML file (repeatable)
+rundown run my-runbook.runbook.md --step 2.1  # Link this run as a child of parent substep 2.1
+rundown run my-runbook.runbook.md --step 2.1 --prompted  # Jump to step 2.1 after starting (goto)
+rundown run my-runbook.runbook.md --step 2.1 --index 3  # Target FOR iteration 3 of step 2.1
 ```
+
+**Flags:**
+- `--prompted` — Show commands without auto-executing.
+- `--text` — Output execution events as human-readable text (JSON is the default).
+- `--input <key=value>` / `--input-json <key=json>` / `--input-file <path>` — Set template variables (all repeatable). `--input-json` carries JSON array/object values.
+- `--step <stepId>` — Link this run to a parent substep for inline nested execution; with `--prompted`, jumps to the step after starting.
+- `--index <number>` — FOR loop iteration to target (requires `--step`).
 
 **Behavior:**
 1. Parse runbook file
@@ -279,7 +292,7 @@ rundown goto 3 --index 2      # Jump to step 3 and enter FOR iteration 2
 
 | Target | Valid From | Description |
 |--------|------------|-------------|
-| `GOTO N` | Any step | Jump to step N (if FOR step, AT defaults per [spec §4.2](../spec/language.md#42-actions)) |
+| `GOTO N` | Any step | Jump to step N (if FOR step, AT defaults per [spec §6](../spec/language.md#6-transitions-and-actions)) |
 | `GOTO N.M` | Any step | Jump to substep M of step N |
 | `GOTO Name` | Any step | Jump to named step |
 | `GOTO Name.M` | Any step | Jump to substep M of named step |
@@ -287,7 +300,7 @@ rundown goto 3 --index 2      # Jump to step 3 and enter FOR iteration 2
 | `GOTO N.M AT I` | Any step | Jump to substep M of FOR step N at iteration I |
 | `GOTO Name AT I` | Any step | Enter named FOR step at iteration I |
 
-The `AT` qualifier is only valid when the target is a step with a FOR annotation. See [docs/spec/language.md §4.2](../spec/language.md#42-actions) for the authoritative AT default rule. See [docs/spec/language.md Actions](../spec/language.md#42-actions) for full details.
+The `AT` qualifier is only valid when the target is a step with a FOR annotation. See [docs/spec/language.md §6](../spec/language.md#6-transitions-and-actions) for the authoritative AT default rule. See [docs/spec/language.md Actions](../spec/language.md#6-transitions-and-actions) for full details.
 
 ### Status Commands
 
@@ -296,10 +309,13 @@ The `AT` qualifier is only valid when the target is a step with a FOR annotation
 Display active runbook information.
 
 ```bash
-rundown status
+rundown status          # JSON output by default
+rundown status --text   # Human-readable text output
 ```
 
-**Output:**
+`status` emits JSON by default. Pass `--text` for the human-readable layout shown below.
+
+**Output (`--text`):**
 ```text
 File:     my-runbook.runbook.md
 State:    .rundown/runs/rd_0123456789abcdef0123456789abcdef.json
@@ -360,10 +376,13 @@ Restores stashed runbook to active stack.
 Check a runbook file for syntax errors.
 
 ```bash
-rundown check my-runbook.runbook.md
+rundown check my-runbook.runbook.md          # JSON output by default
+rundown check my-runbook.runbook.md --text   # Human-readable text output
 ```
 
-**Output:**
+`check` emits JSON by default. Pass `--text` for the human-readable layout shown below.
+
+**Output (`--text`):**
 
 ```text
 PASS: 5 steps, 3 substeps
@@ -413,7 +432,11 @@ Resolve and validate template variables and data sources for a runbook without e
 ```bash
 rundown resolve my-runbook.runbook.md
 rundown resolve my-runbook.runbook.md --input environment=staging
+rundown resolve my-runbook.runbook.md --input-json 'items=["a","b"]'  # JSON value
+rundown resolve my-runbook.runbook.md --input-file vars.yaml          # YAML file
 ```
+
+`--input`, `--input-json`, and `--input-file` are all repeatable.
 
 Useful for verifying that required variables are satisfied and data sources resolve before running.
 
@@ -469,10 +492,17 @@ Two companion CLIs ship alongside `rundown`:
 
 | Command | Description |
 |---------|-------------|
-| `rd delegate <runbook> --step <id>` | Delegate substep to child runbook |
-| `rd delegate <runbook> --step <id> --input key=value` | Delegate with variables |
+| `rd delegate` | Infer both child runbook and substep from runbook state |
+| `rd delegate --step <id>` | Infer child runbook from the substep's `runbooks:` field |
+| `rd delegate <runbook> --step <id>` | Delegate substep to an explicit child runbook |
+| `rd delegate <runbook> --step <id> --input key=value` | Delegate with variables (`--input`/`--input-json`/`--input-file`, all repeatable) |
+| `rd delegate --retry <token>` | Retry a delegation: cancel and re-issue with a fresh token |
+| `rd delegate --retry --step <id>` | Retry the delegation on a substep |
+| `rd delegate --retry --step <id> --index <n>` | Retry a delegation within a FOR iteration |
+| `rd delegate --retry` | Retry the delegation inferred from the active substep |
+| `rd delegate --retry --step <id> --input key=value` | Retry with variable overrides |
 | `rd claim <token>` | Claim a delegation token, launch child, and return `claim_id` |
-| `rd claim <token> --input key=value` | Claim with variables |
+| `rd claim <token> --input key=value` | Claim with variables (`--input`/`--input-json`/`--input-file`, all repeatable) |
 | `rd pass --claim-id <claim_id>` | Complete a claimed child with PASS |
 | `rd fail --claim-id <claim_id>` | Complete a claimed child with FAIL |
 | `rd status --claim-id <claim_id>` | Inspect a claimed child runbook |
@@ -486,7 +516,8 @@ Two companion CLIs ship alongside `rundown`:
 | `rd abort <token> --force` | Cancel a claimed delegation |
 
 Delegation semantics:
-- `delegate` requires a child runbook as a positional argument and `--step` to identify the target substep.
+- `delegate` infers the child runbook and target substep from runbook state. The `[runbook]` positional and `--step` are both optional and inferred when omitted: with neither, both are inferred via the active substep; with `--step` only, the runbook is read from the substep's `runbooks:` field; with the runbook only, the substep is inferred.
+- `delegate --retry` cancels an existing delegation and re-issues it with a fresh token. The target is resolved from a token positional, from `--step` (optionally with `--index` for a FOR iteration), or inferred from the active substep. `--input`/`--input-json`/`--input-file` supply variable overrides on the re-issued delegation.
 - `claim` uses the delegation token (printed by `delegate`) to launch the child runbook and returns a stable `claim_id`.
 - Child runbook uses `rd pass --claim-id <claim_id>` / `rd fail --claim-id <claim_id>` to report its outcome. Other claim-targeted lifecycle commands use the same explicit child routing.
 - Completion routing is frame + entry aware (`frame + entry + substep`) to prevent stale re-entry completions from being applied.
@@ -619,7 +650,7 @@ rd pass --claim-id <claim_id>    # or: rd fail --claim-id <claim_id>
 ```
 
 **Key points:**
-- `delegate` requires the child runbook as a positional argument and `--step` to identify the target substep
+- `delegate` infers the child runbook and target substep from runbook state; the runbook positional and `--step` are optional and inferred when omitted
 - The delegation token printed by `delegate` is passed to `claim` by the subagent
 - The `claim_id` printed by `claim` is passed to every child-targeting command
 - Child uses `rd pass --claim-id <claim_id>` / `rd fail --claim-id <claim_id>`
@@ -829,7 +860,11 @@ rdpath --dir <path>          # Path assembly tool (see docs/reference/rdpath.md)
 rdx <file>                   # Render JSON to Markdown (see docs/reference/rdx.md)
 
 # Delegation
-rd delegate <runbook> --step <id>  # Delegate substep to child runbook
+rd delegate                        # Infer child runbook + substep from state
+rd delegate --step <id>            # Infer child runbook from substep
+rd delegate <runbook> --step <id>  # Delegate substep to explicit child runbook
+rd delegate --retry <token>        # Retry delegation: cancel and re-issue
+rd delegate --retry --step <id>    # Retry delegation on a substep
 rd claim <token>                   # Claim delegation token and return claim_id
 rd status --claim-id <claim_id>    # Inspect claimed child
 rd pass --claim-id <claim_id>      # Complete claimed child with PASS

--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -100,8 +100,14 @@ For an active loop, runtime state MUST track:
 | Current value | Current data element for array/file-backed sources. |
 | Iteration results | Recorded `PASS`/`FAIL` outcomes used for parent aggregation. |
 
-Numeric bounds and open-ended data-source iteration are capped at 10,000
-iterations.
+Two distinct 10,000-iteration limits apply, enforced by different mechanisms:
+
+- **Numeric `FOR` bounds** are rejected at **parse time**. A `FOR` range whose
+  bound exceeds `MAX_FOR_BOUND` (10,000) fails Zod validation as a parse error —
+  it is not a silently capped loop.
+- **Open-ended data-source iteration** (file- or variable-backed sources) is
+  capped at **runtime** by `MAX_FILE_ITERATIONS` (10,000); iteration stops once
+  the cap is reached.
 
 ### 5.2 Dynamic Loop Variables
 
@@ -226,6 +232,7 @@ The session tracks top-level runs and delegated children separately.
       "tokenHash": "sha256:...",
       "parentRunId": "rd_11111111111111111111111111111111",
       "parentStepId": "1.1",
+      "parentStep": "Process item",
       "parentFrameKey": "1|",
       "parentEntry": 1,
       "claimedAt": "2026-04-28T00:00:00.000Z",
@@ -313,8 +320,15 @@ Each run state file stores enough information to resume deterministically.
   "iterationResults": ["pass"],
   "lastResult": "pass",
   "lastAction": { "type": "CONTINUE" },
+  "startedAt": "2026-04-28T00:00:00.000Z",
+  "updatedAt": "2026-04-28T00:01:00.000Z",
+  "parentLinkage": null,
+  "frontmatterOutputs": [],
+  "finalVars": {},
+  "lifecycle": "running",
   "runbookSrc": "---\nname: my-runbook\n---\n# My Runbook\n...",
-  "snapshot": {}
+  "snapshot": {},
+  "schemaVersion": 1
 }
 ```
 
@@ -333,8 +347,14 @@ Each run state file stores enough information to resume deterministically.
 | `resolvedCompletions` | Completion records keyed by frame, entry, and substep. |
 | `frameEntries`, `activeFrameKey`, `activeEntry` | Re-entry-safe identity for stale-completion rejection. |
 | `lastResult`, `lastAction` | Last result signal and resolved action. |
+| `startedAt`, `updatedAt` | ISO timestamps for run creation and last state write. |
+| `parentLinkage` | Linkage describing how a child run was attached to its parent (absent for top-level runs). |
+| `frontmatterOutputs` | Frontmatter `outputs:` declarations parsed at startup, seeded into the machine on every actor creation. |
+| `finalVars` | Evaluated frontmatter output values at runbook termination; read by parent delegation completion. |
+| `lifecycle` | Run lifecycle state: `running` during execution, `completed` or `stopped` once terminal. |
 | `runbookSrc` | Raw source content with template placeholders preserved. |
 | `snapshot` | Opaque XState persisted snapshot. |
+| `schemaVersion` | Persisted state schema version. Current v1 state writes numeric `1`. |
 
 The runtime MUST treat `snapshot` as persisted state subject to the no-migration
 rule.
@@ -350,17 +370,24 @@ in [docs/spec/language.md §9](../spec/language.md#9-templating).
 
 ### 8.1 Variable Sources
 
-Variables are collected with this precedence, highest first:
+Variables are resolved by layering five sources. Each layer overrides every
+layer below it; the table lists them from lowest to highest precedence:
 
-| Priority | Source | Rule |
+| Layer | Source | Rule |
 | --- | --- | --- |
-| 1 | Explicit invocation inputs | `--input-file`, `--input`, and `--input-json`; highest priority. |
-| 2 | Plugin variables | Injected only when resolving plugin runbooks. |
-| 3 | `RD_INPUT_*` environment variables | Prefix stripped. |
-| 4 | Inherited delegation variables | Parent runtime variable space passed to child. |
-| 5 | `.rundown/config.yaml` | Auto-discovered from cwd upward. |
-| 6 | Built-in defaults | Runtime-provided static defaults. |
-| 7 | Context-output inputs | Fill gaps only; MUST NOT override existing values. |
+| `builtins` (lowest) | Built-in defaults | Runtime-provided static built-ins (`Date`, `Branch`, `WorkPath`, `ContextId`, …). |
+| `config` | `.rundown/config.yaml` | Auto-discovered from cwd upward. |
+| `inherited` | Inherited delegation variables | Parent runtime variable space passed to a child, including inherited step `OUTPUTS`. Overrides `config` and `builtins`. |
+| `env` | `RD_INPUT_*` environment variables | Prefix stripped. |
+| `cli` (highest) | Explicit invocation inputs | `--input`, `--input-json`, and `--input-file`. |
+
+Within the `cli` layer, `--input-json` overrides `--input`, which overrides
+`--input-file`. Inherited step `OUTPUTS` ride the `inherited` layer — they are
+not a separate gap-fill tier and **do** override `config` and `builtins`.
+
+Plugin variables are not a precedence layer. `CLAUDE_PLUGIN_ROOT` is injected
+post-resolution for plugin-sourced runbooks only, and only when the key is
+absent — see §8.6.
 
 Frontmatter `inputs` declares accepted names only. It is not a value layer.
 
@@ -426,8 +453,13 @@ dynamic current-frame values but remain reserved for user input.
 | `context.vars.NAME` | Current variable namespace. |
 
 Static built-ins MAY be overridden by higher-precedence sources. Dynamic
-built-ins MUST NOT be overridden. Plugin runbooks MAY receive upper-snake-case
-plugin variables such as `CLAUDE_PLUGIN_ROOT`.
+built-ins MUST NOT be overridden.
+
+Plugin runbooks MAY receive the upper-snake-case `CLAUDE_PLUGIN_ROOT` variable.
+It is not part of the §8.1 precedence layers: it is injected after variable
+resolution completes, for plugin-sourced runbooks only, and only when no
+resolved layer already provided the key. It is therefore a plugin-only default
+that any explicit input (`--input`, `RD_INPUT_*`, config, inherited) preempts.
 
 The default `WorkPath` value is shared at the project level and does not include
 a branch, run, or checkout suffix. Use `ContextId` with `{{ path "..." }}` or

--- a/docs/spec/cli-output.md
+++ b/docs/spec/cli-output.md
@@ -6,18 +6,36 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Response Type Detection
 
-| Type | Format | Detection |
-|------|--------|-----------|
-| **Error** | `{ "error": "msg", "code": "CODE" }` | `error` field exists |
-| **Warning** | `{ "kind": "warning", "message": "msg", "code": "CODE" }` | `kind === "warning"` |
-| **Workflow** | `{ "action": "...", ... }` | `action` field exists |
-| **List** | `[...]` | `Array.isArray()` |
+Every non-list JSON response carries a `kind` discriminant as its first-class, authoritative type tag. Consumers MUST detect the response type by reading `kind`; field-presence heuristics are non-normative and MUST NOT be relied upon. List responses are raw JSON arrays and carry no `kind`.
+
+| `kind` | Response type | Emitted by |
+|--------|---------------|------------|
+| `error` | Error response | any command on failure |
+| `warning` | Warning (non-error, exit 0) | any command (e.g. "No active runbook") |
+| `action` | Step action / lifecycle response | `pass`, `fail`, `goto`, `stop`, `complete` |
+| `status` | Status response | `status` |
+| `check` | Validation response | `check` |
+| `resolve` | Variable/source resolution response | `resolve` |
+| `echo` | Echo response | `echo` |
+| `prompt` | Prompt response | `prompt` |
+| `stash` | Stash response | `stash` |
+| `pop` | Pop response | `pop` |
+| `scenario_run` | Scenario run result | `scenario run` |
+| `scenario_suite_run` | Scenario suite aggregate result | `scenario-suite run` |
+| `run` | Run command execution summary | `run` (final terminal object) |
+| `delegate` | Delegate response | `delegate` |
+| `claim` | Claim response | `claim` |
+| `abort` | Abort response | `abort` |
+| `collect` | Collect response | `collect` |
+
+List responses (`ls`, `prune`, `scenario ls`, `scenario-suite ls`) are detected by `Array.isArray()` and carry no `kind` field.
 
 ### Key Conventions
 
-- **Lists**: Raw arrays `[...]` (no wrapper object)
+- **Discriminant**: All non-list responses carry a `kind` literal. It is the primary, authoritative type discriminant.
+- **Lists**: Raw arrays `[...]` (no wrapper object, no `kind`)
 - **Workflow commands**: Include `action` field. Transition commands (`pass`, `fail`, `goto`) use transition text; lifecycle/session commands (`run`, `stop`, `complete`, `stash`, `pop`) use command-name actions.
-- **Errors**: `{ "error": "message", "code": "CODE" }`
+- **Errors**: `{ "kind": "error", "error": "message", "code": "CODE" }`. The `command` field names the CLI command that triggered the error when known.
 - **Warnings**: `{ "kind": "warning", "message": "message", "code": "CODE" }`
 - **Success/failure**: Workflow commands use exit code, not a `result` field
 - **Position**: `{ "current": string, "total": number }`
@@ -25,7 +43,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Schema Reference
 
-Authoritative TypeScript types: `packages/core/src/output/schema.ts`
+Authoritative response schemas: `packages/core/src/output/zod-schemas.ts`. These Zod schemas are the single source of truth; the TypeScript response types are derived from them via `z.infer<>`. The `packages/core/src/output/schema.ts` module is a re-export barrel of those derived types plus type guards.
+
+The `--schema` flag's command-to-schema map lives in `packages/cli/src/schemas/output-schemas.ts` (`COMMAND_SCHEMAS`).
 
 ### Unified Types
 
@@ -162,18 +182,18 @@ Step description here.
 **JSON:**
 ```json
 {
+  "kind": "status",
   "active": true,
   "stashed": false,
   "file": "runbooks/deploy.runbook.md",
   "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
   "prompted": true,
   "position": { "current": "1", "total": 3 },
-  "step": { "name": "1", "description": "First Step" },
-  "artifacts": {}
+  "step": { "name": "1", "description": "First Step" }
 }
 ```
 
-`artifacts` is required for active status responses and contains the active step/substep working set. It is `{}` when the active execution unit has no artifacts. Accumulated artifact records live in the unified `state.variables` map alongside other variables and are surfaced through `vars` rather than a separate field.
+Active status responses always include `lastAction`. They include `vars` when scalar variables are present (it is omitted when there are none), and additionally include `delegations` and `parentLinkage` when present. Accumulated artifact records live in the unified `state.variables` map alongside other variables and are surfaced through `vars` rather than a separate field.
 
 ### `rd status` (no active runbook)
 
@@ -185,12 +205,13 @@ No active runbook.
 **JSON:**
 ```json
 {
+  "kind": "status",
   "active": false,
   "stashed": false
 }
 ```
 
-Inactive status responses omit `artifacts`.
+Inactive status responses carry only `kind`, `active`, and `stashed`.
 
 ### `rd status --claim-id <claim_id>`
 
@@ -261,6 +282,7 @@ CLAIMED: Claimed rdtk_abcd... -> child.runbook.md
 **JSON:**
 ```json
 {
+  "kind": "claim",
   "action": "claimed",
   "token": "rdtk_abcd...",
   "claim_id": "rdclm_F3J3n3d_f8fo0a0b1B2c3Q",
@@ -300,13 +322,16 @@ Next step description.
 **JSON:**
 ```json
 {
+  "kind": "action",
   "action": "CONTINUE",
   "file": "runbooks/deploy.runbook.md",
   "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
-  "from": { "current": "1", "total": 3 },
-  "to": { "current": "2", "total": 3 }
+  "from": "1",
+  "at": "2"
 }
 ```
+
+`from` and `at` are plain qualified step-ID strings (the step before the transition, and the step after). There is no `to` field.
 
 ### `rd pass --claim-id <claim_id>`
 
@@ -336,10 +361,11 @@ Step description.
 **JSON:**
 ```json
 {
+  "kind": "action",
   "action": "RETRY (1/3)",
   "file": "runbooks/deploy.runbook.md",
   "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
-  "to": { "current": "1", "total": 3 }
+  "at": "1"
 }
 ```
 
@@ -356,6 +382,7 @@ Runbook:  STOP
 **JSON:**
 ```json
 {
+  "kind": "action",
   "action": "STOP",
   "file": "runbooks/deploy.runbook.md",
   "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
@@ -394,11 +421,12 @@ Step description.
 **JSON:**
 ```json
 {
+  "kind": "action",
   "action": "GOTO 3",
   "file": "runbooks/deploy.runbook.md",
   "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
-  "from": { "current": "1", "total": 5 },
-  "to": { "current": "3", "total": 5 }
+  "from": "1",
+  "at": "3"
 }
 ```
 
@@ -421,7 +449,9 @@ Runbook:  STOP
 **JSON:**
 ```json
 {
+  "kind": "action",
   "action": "stop",
+  "stopped": true,
   "message": "User requested stop",
   "file": "runbooks/deploy.runbook.md",
   "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json"
@@ -445,7 +475,9 @@ Runbook:  COMPLETE
 **JSON:**
 ```json
 {
+  "kind": "action",
   "action": "complete",
+  "complete": true,
   "message": "Deployment finished",
   "file": "runbooks/deploy.runbook.md",
   "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json"
@@ -474,6 +506,7 @@ Runbook:  STASHED
 **JSON:**
 ```json
 {
+  "kind": "stash",
   "action": "stash",
   "file": "runbooks/deploy.runbook.md",
   "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
@@ -511,6 +544,7 @@ Step description.
 **JSON:**
 ```json
 {
+  "kind": "pop",
   "action": "pop",
   "file": "runbooks/deploy.runbook.md",
   "state": ".rundown/runs/rd_0123456789abcdef0123456789abcdef.json",
@@ -534,8 +568,10 @@ No stashed runbook to restore.
 **JSON:**
 ```json
 {
+  "kind": "error",
   "error": "No stashed runbook to restore",
-  "code": "NO_STASHED_RUNBOOK"
+  "code": "NO_STASHED_RUNBOOK",
+  "command": "pop"
 }
 ```
 
@@ -614,11 +650,15 @@ PASS: 3 steps, 2 substeps
 **JSON:**
 ```json
 {
+  "kind": "check",
   "valid": true,
   "errors": [],
+  "warnings": [],
   "stats": { "steps": 3, "substeps": 2 }
 }
 ```
+
+The `warnings` array is optional. When present, each entry has a `message` and an optional `line` and `kind`.
 
 ### `rd check <file>` (invalid)
 
@@ -632,14 +672,17 @@ Line 22: Missing command in step
 **JSON:**
 ```json
 {
+  "kind": "check",
   "valid": false,
   "errors": [
     { "line": 15, "message": "Unknown transition target \"step4\"" },
     { "line": 22, "message": "Missing command in step" }
   ],
-  "stats": { "steps": 3, "substeps": 0 }
+  "warnings": []
 }
 ```
+
+`stats` is present only when the runbook is structurally valid.
 
 ---
 
@@ -704,8 +747,10 @@ Available: success, failure
 **JSON:**
 ```json
 {
+  "kind": "error",
   "error": "Scenario \"unknown\" not found",
   "code": "SCENARIO_NOT_FOUND",
+  "command": "scenario show",
   "details": {
     "available": ["success", "failure"]
   }
@@ -718,7 +763,7 @@ Available: success, failure
 
 ### `rd scenario run <file> <name>`
 
-Uses `passed` to indicate scenario outcome (not `result` - this is scenario verification, not workflow).
+Uses `result` (a boolean) to indicate scenario outcome. This is scenario verification, not workflow — the boolean is the verification verdict, not a step result.
 
 **Text:**
 ```text
@@ -737,10 +782,11 @@ Scenario: COMPLETE
 **JSON:**
 ```json
 {
+  "kind": "scenario_run",
+  "result": true,
   "scenario": "success",
   "expected": "COMPLETE",
-  "actual": "COMPLETE",
-  "passed": true
+  "actual": "COMPLETE"
 }
 ```
 
@@ -758,6 +804,7 @@ npm install
 **JSON:**
 ```json
 {
+  "kind": "echo",
   "result": true,
   "output": "npm install",
   "exitCode": 0
@@ -774,6 +821,7 @@ npm install
 **JSON:**
 ```json
 {
+  "kind": "echo",
   "result": false,
   "exitCode": 1
 }
@@ -793,6 +841,7 @@ Hello world
 **JSON:**
 ```json
 {
+  "kind": "prompt",
   "output": "Hello world"
 }
 ```
@@ -801,7 +850,7 @@ Hello world
 
 ## Error Output (all commands)
 
-Error responses include `error` and `code` fields. A non-zero exit code indicates failure.
+Error responses carry `kind: "error"` along with `error` and `code` fields. When the triggering command is known, a `command` field names it. A non-zero exit code indicates failure.
 
 ### No active runbook
 
@@ -831,7 +880,9 @@ Error: Runbook file not found: missing.runbook.md
 **JSON:**
 ```json
 {
-  "error": "Runbook file not found: missing.runbook.md",
-  "code": "RUNBOOK_NOT_FOUND"
+  "kind": "error",
+  "error": "Runbook not found: missing.runbook.md",
+  "code": "RUNBOOK_NOT_FOUND",
+  "command": "run"
 }
 ```

--- a/docs/spec/deferred.md
+++ b/docs/spec/deferred.md
@@ -15,7 +15,7 @@ This document collects spec language that describes intended-but-not-yet-impleme
 
 - **Parser:** `parseArtifactUri` in `packages/core/src/runbook/artifact-uri.ts` accepts the four supported keys (`status`, `runbook`, `source`, `latest`) and rejects any other key.
 - **Resolver:** `resolveSelector` in `packages/core/src/runbook/artifact-directive-resolver.ts` IGNORES `selector.query` and returns unfiltered selector results — every coalesced manifest row that matches `(contextId, runId, key)` plus the per-row file-existence check.
-- **Why deferred:** Scope of Batch 2 was the entry-time machine wiring for ARTIFACTS resolution; selector filtering requires additional manifest-level state (per-run lifecycle / source tracking integration) that is not yet wired through the resolver path.
+- **Why deferred:** The filtering engine itself already exists — `findArtifactMatches` in `packages/core/src/runbook/artifact-manifest.ts` fully implements all four query keys (`status`, `runbook`, `source`, `latest`) and the sibling-run lifecycle filter, and is covered by tests. What is deferred is wiring that engine into the ARTIFACTS directive path: `resolveSelector` in `packages/core/src/runbook/artifact-directive-resolver.ts` does not call `findArtifactMatches`, so `findArtifactMatches` currently has no production caller.
 
 ### Acceptance criteria for the future implementation
 

--- a/docs/spec/grammar.md
+++ b/docs/spec/grammar.md
@@ -62,6 +62,11 @@ output_fm_list   ::= ( ws "- " quoted_output_fm_entry newline
                      | ws "- " output_fm_entry newline )+
 output_fm_entry  ::= variable_name ( ws output_value )?
 quoted_output_fm_entry ::= quoted_string
+
+output_value      ::= helper_call | template_variable | quoted_string | variable_name
+helper_call       ::= "{{" ws? variable_name ( ws helper_argument )+ ws? "}}"
+helper_argument   ::= quoted_string | variable_path | keyed_argument
+keyed_argument    ::= variable_name "=" ( quoted_string | variable_path | ctx_ref )
 ```
 
 Public frontmatter keys are case-insensitive (`inputs:`, `INPUTS:`, and `Inputs:` are equivalent); unknown keys are preserved with their original casing. All fields are optional.
@@ -83,29 +88,32 @@ Frontmatter `outputs:` is separate from step/substep `OUTPUTS`. Frontmatter expr
 ```ebnf
 step ::= "## " step_id separator? text? newline
          artifacts_directive?
-         outputs_directive?
-         for_clause?
-         delegate_annotation?
-         transition*
+         step_directives
          prompt?
          body?
+
+step_directives ::= transition* outputs_directive? transition*
+                  | outputs_directive?
+                    ( for_clause delegate_annotation? | delegate_annotation )
+                    transition*
 ```
 
-Content must appear in the order shown: ARTIFACTS, OUTPUTS, FOR, DELEGATE, transitions, prompt, body.
+Content must appear in the order: ARTIFACTS, OUTPUTS, FOR, DELEGATE, transitions, prompt, body. The two `step_directives` alternatives encode one exception for `OUTPUTS`. When a step has neither a FOR clause nor a DELEGATE annotation (the first alternative), `outputs_directive` is interchangeable with `transition` — the `OUTPUTS` directive may appear before, after, or interleaved with transitions. When a FOR clause or DELEGATE annotation is present (the second alternative), `OUTPUTS` must precede it and every transition follows it. `ARTIFACTS` must always precede `OUTPUTS`, and a step may declare at most one `OUTPUTS` directive regardless of where it appears.
 
 ## Substeps
 
 ```ebnf
 substep ::= "### " substep_id separator? text? newline
             artifacts_directive?
-            outputs_directive?
-            delegate_annotation?
-            transition*
+            substep_directives
             prompt?
             ( code_block | runbook_list )?
+
+substep_directives ::= transition* outputs_directive? transition*
+                     | outputs_directive? delegate_annotation transition*
 ```
 
-Substeps cannot contain nested substeps. See [docs/spec/language.md §1.1](language.md) for the heading hierarchy rules.
+Substep directive ordering mirrors `step_directives` but has no FOR clause: when no DELEGATE annotation is present, `OUTPUTS` is interchangeable with transitions; when DELEGATE is present, `OUTPUTS` must precede it and transitions follow. Substeps cannot contain nested substeps. See [docs/spec/language.md §1.1](language.md) for the heading hierarchy rules.
 
 ## Context Directives
 
@@ -129,11 +137,6 @@ run_segment            ::= [A-Za-z0-9_-]+ | "*"
 outputs_directive ::= "- OUTPUTS" newline output_list
 output_list       ::= ( ws "- " output_entry newline )+
 output_entry      ::= variable_name
-
-output_value      ::= helper_call | template_variable | quoted_string | variable_name
-helper_call       ::= "{{" ws? variable_name ( ws helper_argument )+ ws? "}}"
-helper_argument   ::= quoted_string | variable_path | keyed_argument
-keyed_argument    ::= variable_name "=" ( quoted_string | variable_path | ctx_ref )
 ```
 
 A step or substep may declare at most one `ARTIFACTS` directive and at most one `OUTPUTS` directive. Duplicate directives on the same target are rejected. `ARTIFACTS` is valid only on steps and substeps; it is not a frontmatter field.
@@ -141,6 +144,8 @@ A step or substep may declare at most one `ARTIFACTS` directive and at most one 
 `ARTIFACTS` declares the current execution unit's artifact working set. Each entry maps a variable name to an optional quoted artifact token. The variable name must match `variable_name` and must not be a [reserved variable name](#reserved-variable-names). Duplicate names in one `ARTIFACTS` block are syntax errors.
 
 Artifact entries take four forms: (1) **naked** — a bare `variable_name` with no token, asserting the name is already bound as an artifact reference; (2) **quoted shorthand key** — a managed artifact key, optionally with a leading `*/` cross-run prefix, e.g. `"plan.json"`, `"review-*.json"`, or `"*/review.json"`; (3) **quoted file reference** — `"schemas/review.schema.json"` or an explicit absolute path; (4) **quoted URI literal** — `"rd://artifacts/<ctx>/<run>/<key>"` or selector form with `*` in the run segment. Quoted tokens are template-expanded BEFORE classification, so `"{{ContextId}}-plan.json"` is valid. After expansion, exact managed keys use `exact_artifact_key`; wildcard managed keys use `wildcard_artifact_key` and contain `*` or `?`. File references are quoted relative or absolute paths, are not glob selectors, and must resolve to an existing contained file through the runtime search/read-policy rules. Empty managed keys, `.`, `..`, traversal, and recursive `**` are invalid. The full URI grammar — including selector form, scheme registration, and component constraints — is normatively defined in [docs/spec/uri.md §4](uri.md#4-grammar-ebnf). Naked-form semantics are defined in [docs/spec/language.md §10.1.2](language.md#1012-naked-declaration-assertion-form).
+
+The `safe_path_chars` character class (`[A-Za-z0-9._-]+`) in the `safe_path_segment` production is a **runtime path-resolution constraint, not a parse-time terminal**. At parse time the artifact-token classifier rejects only empty segments, `.`/`..` segments, and recursive `**`; a file-reference token whose path segments contain other characters (for example a space) is accepted by the parser and the stricter character-class restriction is enforced later by runtime read-policy and path resolution.
 
 `OUTPUTS` at step/substep level declares name-only command output channels. Expression-form step/substep `OUTPUTS` entries are parse errors. Naked entries activate a file-backed channel: Rundown creates an empty file whose path is composed from the active scope tiers (step id, optional substep id, optional FOR iteration index) followed by `<VarName>` and exports its absolute path as `RD_OUTPUTS_<VarName>` to the spawned command. The three possible paths are:
 
@@ -150,7 +155,7 @@ Artifact entries take four forms: (1) **naked** — a bare `variable_name` with 
 | Substep | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<VarName>` |
 | FOR iteration (in substep) | `.rundown/runs/<runId>/outputs/<stepId>/<substepId>/<iteration>/<VarName>` |
 
-See [docs/spec/language.md §10.1](language.md#101-step-outputs).
+See [docs/spec/language.md §10.2](language.md#102-step-outputs).
 
 The `path` helper call `{{ path "file.json" }}` is valid in frontmatter `outputs:` and rendered content. For literal filenames it is syntactic sugar for the CLI form `rdpath --dir WorkPath --ctx ContextId --file file.json`. The optional `ctx=` argument (`{{ path "file.json" ctx=alt-ctx }}`) overrides the default `ContextId`. Filenames must match the [`filename`](#lexical-rules) production; context identifiers must match [`ctx_ref`](#lexical-rules). See [docs/reference/rdpath.md](../reference/rdpath.md) for the full path-assembly contract.
 
@@ -217,7 +222,7 @@ A step may contain at most one FOR clause. The FOR clause must appear before tra
 delegate_annotation ::= "- DELEGATE" newline
 ```
 
-`DELEGATE` is bare — it takes no arguments. On an H2 step it propagates to every H3 substep; on an H3 substep or runbook-list entry it applies only to that target. DELEGATE precedes transitions within the step's or substep's bullet block; when a FOR clause is present, FOR precedes DELEGATE. A DELEGATE substep must resolve to a runbook reference. See [docs/spec/language.md §4.3](language.md#43-delegate) for execution semantics.
+`DELEGATE` is bare — it takes no arguments. On an H2 step it propagates to every H3 substep; on an H3 substep or runbook-list entry it applies only to that target. DELEGATE precedes transitions within the step's or substep's bullet block; when a FOR clause is present, FOR precedes DELEGATE. A DELEGATE substep must resolve to a runbook reference. See [docs/spec/language.md §7](language.md#7-delegation) for execution semantics.
 
 ## Transitions
 
@@ -239,6 +244,8 @@ Aggregation modifiers must pair complementarily: `PASS ALL` + `FAIL ANY` (pessim
 **Default transitions:** When no transitions are authored, the parser supplies `PASS CONTINUE`, `FAIL STOP`. Substeps under aggregation or with runbook delegation default to `PASS DEFER`, `FAIL DEFER`.
 
 **Disambiguation:** A `-`-prefixed bullet inside a step is resolved by priority: (1) `ARTIFACTS` directive (`- ARTIFACTS` as exact, case-sensitive list-item text with no trailing content), (2) `OUTPUTS` directive (`- OUTPUTS` as exact, case-sensitive list-item text with no trailing content), (3) FOR clause (`FOR` keyword), (4) DELEGATE annotation (`- DELEGATE` as exact, case-sensitive list-item text with no trailing content), (5) transition (`PASS`, `FAIL`, `YES`, `NO`, or standalone `DEFER`), (6) runbook reference (`.runbook.md` suffix), (7) prompt text. A bullet whose text merely contains `ARTIFACTS`, `OUTPUTS`, or `DELEGATE` inside prose, or uses a different case (for example `Artifacts`, `Outputs`, `delegate`), falls through to normal list semantics.
+
+A bare `- INPUTS` bullet does not fall through to prompt text. `INPUTS` step directives are invalid: the parser special-cases an exact `- INPUTS` bullet and rejects it with an error directing the author to the frontmatter `inputs:` field. See [docs/spec/language.md §11](language.md#11-conformance) rule 15.
 
 ## Actions
 

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -168,8 +168,6 @@ Canonical runtime identity is `step + substep + iteration`. Display notation
 such as `1.2.1` (`STEP.INDEX.SUBSTEP` inside `FOR`) is not authoring syntax and
 is not canonical.
 
-<a id="4-control-flow"></a>
-
 ## 6. Transitions and Actions
 
 Transition syntax:
@@ -206,8 +204,6 @@ Defaults:
 | Neither | `PASS CONTINUE`, `FAIL STOP` |
 | Substeps under aggregation or delegation | `PASS DEFER`, `FAIL DEFER` |
 
-<a id="42-actions"></a>
-
 ### 6.2 Actions
 
 | Action | Valid context | Rule |
@@ -233,8 +229,6 @@ When `GOTO target` targets a `FOR` step and omits `AT`, execution enters the
 target at the loop's start value: `1` for `FOR 1 TO 10`, `5` for `FOR 5 TO 1`,
 and so on. `GOTO target AT {{Index}}` re-enters the target at the current
 iteration value.
-
-<a id="43-delegate"></a>
 
 ## 7. Delegation
 
@@ -272,8 +266,6 @@ an orchestrated workflow failure. Terminal failure is reserved for cases where
 there is no parent linkage or the parent's propagation also resolves to a
 terminal stopped state.
 
-<a id="5-iteration-for"></a>
-
 ## 8. Iteration
 
 A `FOR` directive repeats a step's substeps.
@@ -296,7 +288,7 @@ Rules:
 | --- | --- |
 | Direction | `start > end` descends by `1`; otherwise ascends by `1`. |
 | Single-number shorthand | Always ascends from `1`. |
-| Limits | Numeric bounds and open-ended data sources are capped at 10,000 iterations. |
+| Limits | Numeric bounds exceeding `MAX_FOR_BOUND` (10,000) are rejected at parse time by Zod validation — not silently capped. Open-ended data-source iteration is capped at runtime by `MAX_FILE_ITERATIONS` (10,000); iteration stops once the cap is reached. See [runtime.md §5.1](../reference/runtime.md#51-loop-state). |
 | Data-source variable | Data-source iteration MUST use a named variable; `FOR {{source}}` is invalid. |
 | Data-source reference | `{{source}}` names a defined runtime data source and is not template-expanded. |
 | Template bounds | Bounds such as `{{Max}}` are expanded before parsing. |
@@ -328,8 +320,6 @@ Default iteration-level action is `DEFER`. Iteration-level `RETRY` is evaluated
 before the exhausted fallback action and applies to the iteration result, not
 the substep action.
 
-<a id="6-templating"></a>
-
 ## 9. Templating
 
 Variables use Handlebars syntax: `{{variable}}`. Dotted paths are supported,
@@ -340,6 +330,11 @@ undefined variable.
 Global variables expand once. Dynamic step, substep, and iteration variables
 expand against the current runtime frame.
 
+Beyond the `path` and `artifact` artifact helpers documented in §9.3, the
+renderer also provides the built-in `validateSchema` helper and a
+user-extensible helper registry. §9.3 is not an exhaustive list of available
+helpers.
+
 ### 9.1 Variable Names and Precedence
 
 `step`, `index`, `context`, `runid`, and `runbookref` are reserved
@@ -348,21 +343,23 @@ are rejected in frontmatter `inputs`, frontmatter `required`, explicit
 invocation inputs, input files, and configuration files. Reserved `RD_INPUT_*`
 environment variables are skipped with a warning.
 
-Precedence, highest first:
+Resolution builds five variable layers. Precedence, highest first:
 
-1. Explicit invocation inputs: files, scalar inputs, JSON inputs.
-2. Plugin variables, when resolving a plugin runbook.
-3. `RD_INPUT_*` environment variables, prefix stripped.
-4. Inherited delegation variables.
-5. `.rundown/config.yaml`, discovered from cwd upward.
-6. Built-in defaults.
-7. Context-output inputs, which fill gaps only.
+1. CLI inputs: `--input-json` > `--input` > `--input-file` (within-layer tie-break; see [runtime.md §8.1](../reference/runtime.md#81-variable-sources)).
+2. `RD_INPUT_*` environment variables, prefix stripped.
+3. Inherited delegation variables, including inherited step `OUTPUTS`.
+4. `.rundown/config.yaml`, discovered from cwd upward.
+5. Built-in defaults.
+
+Inherited step `OUTPUTS` ride the inherited-delegation layer and override
+configuration and built-in defaults; they are not a separate gap-fill layer.
+`CLAUDE_PLUGIN_ROOT` is not a precedence layer: it is a plugin-only default
+injected after resolution only when the variable is absent, and any explicit
+input takes precedence over it.
 
 Frontmatter `inputs` declares accepted names; it is not a value layer. Missing
 frontmatter `required` variables produce a hard resolution error
 (`MISSING_REQUIRED_VARS`).
-
-<a id="61-built-in-variables"></a>
 
 ### 9.2 Built-In Variables
 
@@ -402,7 +399,9 @@ Helpers are render-only. The `path` and `artifact` helpers MUST NOT append manif
 
 Rendering an `ArtifactRecord` directly yields its `uri`. Rendering an `ArtifactRecord[]` directly yields a JSON array of artifact URIs. An empty artifact array renders as `[]`.
 
-`{{ path ArtifactName }}` renders the contained local filesystem path for an `ArtifactRecord`. Managed `rd://artifacts/...` records render under `WorkPath`; file-backed `file:///...` records render to the referenced local path. For an `ArtifactRecord[]`, it renders a JSON array of contained local filesystem paths. `{{ artifact ArtifactName }}` renders artifact URI values with the same scalar or array shape.
+The `path` helper accepts two forms. The **variable-reference form** `{{ path ArtifactName }}` renders the contained local filesystem path for an `ArtifactRecord`. Managed `rd://artifacts/...` records render under `WorkPath`; file-backed `file:///...` records render to the referenced local path. For an `ArtifactRecord[]`, it renders a JSON array of contained local filesystem paths. The **literal-key form** `{{ path "key" }}` renders a single local filesystem path for the quoted key under the current `WorkPath`, `ContextId`, and `RunId` — it does not require an artifact binding.
+
+`{{ artifact ArtifactName }}` renders artifact URI values with the same scalar or array shape as the `path` variable-reference form. The `artifact` helper accepts only the variable-reference form and rejects the literal-key form `{{ artifact "key" }}`.
 
 Runtime command rendering MUST render command text once per execution and reuse that exact rendered string for both `STEP_ENTERED.commandCode` and actual execution.
 
@@ -413,9 +412,6 @@ Executable shell blocks receive `RD_WORK_PATH`, `RD_CONTEXT_ID`, `RD_RUN_ID`,
 `RunbookRef.path`, and `RunbookRef.source`. These variables are injected after
 policy environment filtering and use Rundown-wins semantics. The `RD_` prefix is
 reserved for Rundown-injected variables.
-
-<a id="7-context-passing-outputs"></a>
-<a id="7-context-passing-inputs--outputs"></a>
 
 ## 10. Context Passing
 
@@ -556,8 +552,6 @@ templateVars < variables < extraVars
 `state.variables` carries mixed values (typed via `VariableValueSchema`): string command `OUTPUTS` and structured `ArtifactRecord` / `ArtifactRecord[]` from `ARTIFACTS`. Effective rendering and delegation contexts merge `templateVars`, `variables`, and `extraVars` in the order shown.
 
 Same-name `ARTIFACTS` and `OUTPUTS` declarations are allowed. `ARTIFACTS` writes a structured value at step/substep entry. `OUTPUTS` writes a string value after command completion and overwrites the entry under the same name in `state.variables`. The legacy `artifactVars` field is rejected by `RunbookStateSchema` via `superRefine`.
-
-<a id="71-outputs"></a>
 
 ### 10.2 Step OUTPUTS
 

--- a/docs/spec/uri.md
+++ b/docs/spec/uri.md
@@ -24,6 +24,11 @@ registration, key/component constraints, on-disk storage layout, the manifest
 record shape, manifest scoping, and the coalescing rule. Where other Rundown
 specifications mention URIs or manifests, they refer to terms defined here.
 
+This document governs only the `rd:` *URI* scheme. It is unrelated to the
+`namespace:name` runbook-discovery syntax (for example `rundown:write-plan`),
+which selects a runbook *source* and is a separate mechanism documented under
+Runbook Discovery; that syntax is not an `rd:` URI and is out of scope here.
+
 **Run-scoping invariant.** Every artifact is owned by exactly one run,
 identified by the producer's `runId`. The grammar (§4) and storage layout
 (§7) reflect this: a URI identifies a `(contextId, runId, key)` triple, and
@@ -32,6 +37,11 @@ segment. Same-context delegation makes artifacts produced by sibling runs
 visible through the shared manifest (§9), but ownership stays with the
 producer. There is no artifact namespace under a context that exists
 outside a run.
+
+This invariant, and the `rd:` URI grammar in §3–§7 and §11, govern *managed*
+artifacts. The manifest (§8) may also contain *file-reference* rows whose
+`uri` field is a `file:` URI pointing at a pre-existing local file; those rows
+are a separate record class, are not `rd:` URIs, and are specified in §8.
 
 Non-normative cross-references:
 
@@ -78,6 +88,11 @@ and required. Implementations MUST reject URIs whose scheme is not exactly
 
 All other hostnames are reserved for future use. Implementations MUST reject
 URIs whose hostname is not a currently registered namespace.
+
+The `rd:` URI namespaces in this table are distinct from the `namespace:name`
+runbook-discovery syntax (for example `rundown:write-plan`): that syntax is a
+runbook-*source* selector, not an `rd:` URI, and is governed by Runbook
+Discovery rather than by this document.
 
 URI fragments are invalid in any namespace and MUST be rejected.
 
@@ -265,46 +280,119 @@ Each context owns exactly one manifest file:
 ```
 
 The manifest is append-only JSON Lines (one JSON value per line). Each line
-encodes one `ArtifactRecord` (§8). Implementations MUST open the manifest with
-append semantics (e.g. `O_APPEND` on POSIX) so that concurrent writers do not
-overwrite earlier rows.
+encodes one `ArtifactManifestRecord` (§8) — a managed row or a file-reference
+row. Implementations MUST open the manifest with append semantics (e.g.
+`O_APPEND` on POSIX) so that concurrent writers do not overwrite earlier rows.
 
 ## 8. Manifest record
 
-The single structured artifact value is the `ArtifactRecord`. One manifest
-line MUST encode exactly one `ArtifactRecord`.
+A manifest line encodes one `ArtifactManifestRecord`. The record type is a
+**union of two record classes** discriminated by the presence of a `kind`
+field in the manifest:
 
-The required field set is:
+- **Managed rows** — `rd://` artifacts produced and addressed by this URI
+  scheme. A managed row has no `kind` field in the manifest.
+- **File-reference rows** — references to a pre-existing local file declared
+  by an `ARTIFACTS` directive. A file-reference row carries a persisted
+  `kind: "file-artifact-record"` field.
+
+One manifest line MUST encode exactly one record of either class. Readers MUST
+classify a row by the presence of the manifest `kind` field before applying
+the class-specific rules below. When a manifest row is loaded into the
+runtime `ArtifactRecord` type, managed rows are tagged with
+`kind: "artifact-record"` so the runtime union discriminates on `kind`; this
+tag is added by the loader and is never written back to the manifest.
+
+### 8.1 Managed rows
+
+A managed manifest row has the following required field set, and MUST NOT carry
+a `kind` field:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `uri` | string | Canonical exact artifact URI (§6.1, §11). |
+| `uri` | string | Canonical exact `rd://artifacts/...` artifact URI (§6.1, §11). |
 | `runId` | string | Concrete run id; MUST match `RUN_ID_PATTERN`. |
 | `contextId` | string | Owning context id; MUST satisfy `ctx_ref`. |
 | `runbook` | object | `{ source, path }` runbook reference. |
 | `key` | string | Artifact key; MUST satisfy `exact_artifact_key`. |
 | `timestamp` | string | RFC 3339 / ISO 8601 datetime. |
 
-All fields are required. The manifest record is intentionally limited to these
-six fields; the `kind` discriminator used by in-memory `state.variables` values
-is added by the loader and is NOT persisted in the manifest.
+All six fields are required. The managed row is intentionally limited to these
+six fields; the `kind` discriminator (`artifact-record`) used by in-memory
+`state.variables` values is added by the loader and is NOT persisted for
+managed rows.
 
-**Canonical write order.** Manifest writers MUST emit the JSON object keys in
-the order shown above (`uri`, `runId`, `contextId`, `runbook`, `key`,
-`timestamp`) so manifest output is byte-stable across runs.
+**Canonical write order.** Writers MUST emit the JSON object keys in the order
+shown above (`uri`, `runId`, `contextId`, `runbook`, `key`, `timestamp`) so
+manifest output is byte-stable across runs.
 
-**Cross-field validation.** Manifest readers MUST validate that the URI's
-decoded `contextId`, `runId`, and `key` segments equal the record's
-corresponding structured fields, and MUST reject mismatched rows.
+**Cross-field validation.** Readers MUST validate that the managed row's URI,
+when parsed, has decoded `contextId`, `runId`, and `key` segments equal to the
+record's corresponding structured fields, and MUST reject mismatched rows.
 
 **Identity tuple.** The identity used for coalescing (§10) and de-duplication
-is:
+of a managed row is the five-tuple:
 
 ```text
 (contextId, runId, runbook.source, runbook.path, key)
 ```
 
-Two records share an identity when all five components are equal.
+Two managed rows share an identity when all five components are equal. `uri` is
+omitted because it is deterministic given `(contextId, runId, key)` and adds no
+discrimination.
+
+### 8.2 File-reference rows
+
+A file-reference manifest row references a pre-existing local file declared by
+an `ARTIFACTS` directive (see [language.md §10](language.md#10-context-passing)).
+It is a deliberately separate record class — a `file:` URI is not an `rd:`
+URI, so the `rd:` URI invariants of §1 and §3–§7 do not govern these rows.
+
+A file-reference row has the following required field set:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `kind` | string | The literal `"file-artifact-record"`. Persisted on disk. |
+| `uri` | string | Canonical `file:///...` URI (`pathToFileURL` form) for the referenced local file. |
+| `runId` | string | Concrete run id of the run that made the declaration; MUST match `RUN_ID_PATTERN`. |
+| `contextId` | string | Owning context id; MUST satisfy `ctx_ref`. |
+| `runbook` | object | `{ source, path }` runbook reference. |
+| `key` | string | Raw `ARTIFACTS` declaration token; a non-empty string. NOT an `exact_artifact_key`. |
+| `timestamp` | string | RFC 3339 / ISO 8601 datetime. |
+
+The differences from a managed row are normative:
+
+- **`kind` is persisted.** Unlike a managed row, the `kind` field
+  (`"file-artifact-record"`) is written to disk and is part of the on-disk
+  record. Readers use it to classify the row.
+- **`uri` is a `file:` URI.** It is a canonical `file:///...` URI, not an
+  `rd://artifacts/...` URI. It does not satisfy the `rd:` URI grammar of §4
+  and is not subject to the §7.1 `WorkPath` path-mapping rule.
+- **`key` is a declaration token, not an artifact key.** It holds the raw
+  token written in the `ARTIFACTS` declaration. It MAY contain slashes and
+  other path-shaped characters; it MUST NOT be required to satisfy
+  `exact_artifact_key`. It is not selector-addressable.
+- **No URI/`key` cross-validation.** The §8.1 cross-field validation rule does
+  NOT apply: a file-reference row's `file:` URI has no decoded `key` segment to
+  compare against, and the row's `key` is a declaration token. Readers MUST NOT
+  reject a file-reference row on URI/`key` mismatch grounds.
+
+**Canonical write order.** Writers MUST emit `kind` first, followed by the
+managed-row key order (`uri`, `runId`, `contextId`, `runbook`, `key`,
+`timestamp`).
+
+**Identity tuple.** The identity used for coalescing (§10) and de-duplication
+of a file-reference row is the six-component tuple — the managed five-tuple
+**plus `uri`**:
+
+```text
+(contextId, runId, runbook.source, runbook.path, key, uri)
+```
+
+Two file-reference rows share an identity when all six components are equal.
+`uri` is part of the identity because the row's `key` is a raw declaration
+token rather than a content-addressable identifier, so the canonical file
+target is needed to distinguish rows.
 
 ## 9. Manifest scoping
 
@@ -323,7 +411,10 @@ shared manifest.
 ## 10. Coalescing
 
 When the manifest is read for resolution, repeated rows MUST be coalesced by
-the identity tuple defined in §8.
+the identity tuple defined in §8. The identity tuple is kind-dependent:
+managed rows (§8.1) use the five-tuple `(contextId, runId, runbook.source,
+runbook.path, key)`; file-reference rows (§8.2) use the six-component tuple
+that adds `uri`. Rows of different classes never share an identity.
 
 **Selection rule:** the row with the newest `timestamp` wins.
 
@@ -353,27 +444,35 @@ properties.
    - contain a fragment (`#...`),
    - use a scheme other than `rd:` or a hostname other than a registered
      namespace.
-4. **Manifest URI consistency.** Manifest rows whose `uri` field, when parsed,
-   yields different `contextId`, `runId`, or `key` values than the row's
-   structured fields MUST be rejected.
+4. **Manifest URI consistency.** Managed manifest rows (§8.1) whose `uri`
+   field, when parsed, yields different `contextId`, `runId`, or `key` values
+   than the row's structured fields MUST be rejected. File-reference rows
+   (§8.2) are exempt: their `uri` is a `file:` URI with no decoded `key`
+   segment, and their `key` is a declaration token.
 
 ## 12. Verified against
 
 This specification has been verified against the following implementation
-sources. The line ranges identify the canonical algorithms and constants that
-back each section.
+sources. Each entry names the canonical symbols (functions, schemas, constants)
+that back the cited sections; symbol names are used in preference to line
+numbers, which drift as the files change.
 
 - `packages/core/src/runbook/artifact-uri.ts` — URI builder, parser, and
   filesystem mapping. Sections §3, §4, §5, §6, §7.1, §11.
-  <!-- verified against artifact-uri.ts:10,68-109,121-178,225-243,253-304 -->
+  Symbols: `buildArtifactUri`, `parseArtifactUri`, `parseExactArtifactUriParts`,
+  `artifactUriToPath`, `assertConcreteRunId`.
 - `packages/core/src/runbook/artifact-manifest.ts` — manifest read scoping,
-  canonical write order, and coalescing.
-  Sections §7.2, §8, §9, §10.
-  <!-- verified against artifact-manifest.ts:53-60,160-168,178-213,344-354,500-509 -->
-- `packages/core/src/runbook/artifact-schema.ts` — `ArtifactRecord` field set
-  and cross-field validation. Section §8.
-  <!-- verified against artifact-schema.ts:56-115 -->
-- `packages/core/src/runbook/run-id.ts` — `RUN_ID_PATTERN`. Section §4, §5.2.
+  canonical write order, and coalescing. Sections §7.2, §8, §9, §10.
+  Symbols: `manifestPathForContext`, `readArtifactManifest`,
+  `appendArtifactManifestRecord`, `writeManifestLineSync`,
+  `canonicalManifestRecord`, `coalesceManifestRecords`, `manifestRowIdentity`.
+- `packages/core/src/runbook/artifact-schema.ts` — the two-class manifest
+  record union and cross-field validation. Section §8.
+  Symbols: `ArtifactManifestRecordSchema` (union of
+  `ManagedArtifactManifestRecordSchema` and `FileArtifactRecordSchema`),
+  `FileUriSchema`, `validateArtifactRecordIdentity`.
+- `packages/core/src/runbook/artifact-directive-resolver.ts` — construction of
+  file-reference rows. Section §8.2. Symbol: `resolveFileReferenceDeclaration`.
+- `packages/core/src/runbook/run-id.ts` — `RUN_ID_PATTERN`. Sections §4, §5.2.
 - `packages/core/src/paths.ts` — `SAFE_ID_PATTERN` and `assertSafeId`.
   Sections §5.1, §5.3.
-  <!-- verified against paths.ts:18,33-40 -->

--- a/packages/cli/__tests__/commands/claim.test.ts
+++ b/packages/cli/__tests__/commands/claim.test.ts
@@ -356,6 +356,7 @@ describe('claim command', () => {
 
       const jsonLines = result.stdout.trim().split('\n');
       const output = JSON.parse(jsonLines[jsonLines.length - 1]);
+      expect(output.kind).toBe('claim');
       expect(output.action).toBe('claimed');
       expect(output.token).toMatch(/^rdtk_.{3}\.\.\..{4}$/);
       expect(typeof output.claim_id).toBe('string');
@@ -387,7 +388,8 @@ describe('claim command', () => {
       const output = JSON.parse(jsonLines[jsonLines.length - 1]);
 
       // Verify all required fields
-      expect(output).toHaveProperty('action');
+      expect(output).toHaveProperty('kind', 'claim');
+      expect(output).toHaveProperty('action', 'claimed');
       expect(output).toHaveProperty('token');
       expect(output).toHaveProperty('claim_id');
       expect(output).toHaveProperty('run_id');

--- a/packages/cli/__tests__/commands/json-output.test.ts
+++ b/packages/cli/__tests__/commands/json-output.test.ts
@@ -49,6 +49,32 @@ prompt: Wait
       expect(output[0]).not.toHaveProperty('_status');
     });
 
+    it('emits only the documented ActiveRunbookEntry fields, not raw RunbookState', async () => {
+      // ls JSON entries must match ActiveRunbookEntrySchema (id, runbook, step,
+      // status, total, title) — internal RunbookState fields must not leak.
+      const runbookPath = path.join(workspace.cwd, 'test.runbook.md');
+      fs.writeFileSync(
+        runbookPath,
+        `---
+name: test-runbook
+---
+## Step 1
+prompt: Wait
+`,
+      );
+      await runCliInProcess('run --prompted test.runbook.md --text', workspace);
+
+      const result = await runCliInProcess('ls', workspace);
+      const output = JSON.parse(result.stdout);
+      const allowed = ['id', 'runbook', 'step', 'status', 'total', 'title'];
+      const leakedKeys = Object.keys(output[0]).filter((k) => !allowed.includes(k));
+      expect(leakedKeys).toEqual([]);
+      expect(output[0]).not.toHaveProperty('snapshot');
+      expect(output[0]).not.toHaveProperty('variables');
+      expect(output[0]).not.toHaveProperty('lifecycle');
+      expect(output[0]).not.toHaveProperty('schemaVersion');
+    });
+
     it('outputs array of available runbooks with --all', async () => {
       // discovery requires runbooks to be in specific dirs
       const runbooksDirPath = workspace.runbooksDir();

--- a/packages/cli/__tests__/commands/prune.test.ts
+++ b/packages/cli/__tests__/commands/prune.test.ts
@@ -53,6 +53,23 @@ describe('prune command', () => {
       expect(statesAfter.length).toBe(0);
     });
 
+    it('emits only the documented ActiveRunbookEntry fields in JSON, not raw RunbookState', async () => {
+      // prune JSON uses PruneResponseSchema (= ActiveRunbookListSchema), so
+      // entries must not leak internal RunbookState fields.
+      await runCliInProcess('run runbooks/simple.runbook.md --text', workspace);
+
+      const result = await runCliInProcess('prune', workspace);
+
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.stdout);
+      expect(output.length).toBeGreaterThan(0);
+      const allowed = ['id', 'runbook', 'step', 'status', 'total', 'title'];
+      const leakedKeys = Object.keys(output[0]).filter((k) => !allowed.includes(k));
+      expect(leakedKeys).toEqual([]);
+      expect(output[0]).not.toHaveProperty('snapshot');
+      expect(output[0]).not.toHaveProperty('variables');
+    });
+
     it('removes artifact-bearing variables when pruning a completed run', async () => {
       await runCliInProcess('run runbooks/simple.runbook.md --text', workspace);
       const statesBefore = await listRunbookStates(workspace);

--- a/packages/cli/__tests__/helpers/wrapper.test.ts
+++ b/packages/cli/__tests__/helpers/wrapper.test.ts
@@ -27,7 +27,9 @@ describe('withErrorHandling', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it('outputs JSON and exits on RundownError by default', async () => {
+  it('outputs the documented error envelope and exits on RundownError by default', async () => {
+    // Documented envelope (docs/spec/cli-output.md § Key Conventions):
+    // { kind: "error", error, code, command?, details? }.
     const error = Errors.fileNotFound('missing.md');
 
     await withErrorHandling(async () => {
@@ -37,8 +39,28 @@ describe('withErrorHandling', () => {
     expect(mockExit).toHaveBeenCalledWith(1);
     const output = errorSpy.mock.calls[0]?.[0] as string;
     const parsed = JSON.parse(output);
+    expect(parsed.kind).toBe('error');
+    expect(parsed.error).toBe(error.message);
     expect(parsed.code).toBe(error.code);
-    expect(parsed.message).toBe(error.message);
+    expect(parsed.command).toBeUndefined();
+    expect(parsed.details).toMatchObject({
+      category: error.errorCode.category,
+      title: error.errorCode.title,
+    });
+  });
+
+  it('includes the command field when options.command is provided', async () => {
+    const error = Errors.fileNotFound('missing.md');
+
+    await withErrorHandling(
+      async () => {
+        throw error;
+      },
+      { command: 'run' },
+    );
+
+    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    expect(parsed.command).toBe('run');
   });
 
   it('outputs CLI string and exits on RundownError when text=true', async () => {

--- a/packages/cli/__tests__/integration/__snapshots__/scenario-snapshots.test.ts.snap
+++ b/packages/cli/__tests__/integration/__snapshots__/scenario-snapshots.test.ts.snap
@@ -23,7 +23,7 @@ exports[`scenario output snapshots delegation-outputs JSON 1`] = `
 === command: rd claim <token> ===
 {"type":"runbook_started","title":"Snapshot Child","prompted":false,"statePath":".rundown/runs/<runbookId>.json","timestamp":"<timestamp>","runbookId":"<runbookId>","runbook":{"source":"project","path":".rundown/runbooks/snapshot-child.runbook.md"},"seq":1}
 {"type":"step_entered","position":{"current":"1","total":1},"stepName":"1","description":"Child step","prompt":"The message is: hello from snapshot parent","hasCommand":false,"isSubstep":false,"prompted":false,"artifacts":{},"timestamp":"<timestamp>","runbookId":"<runbookId>","runbook":{"source":"project","path":".rundown/runbooks/snapshot-child.runbook.md"},"seq":2}
-{"action":"claimed","message":"Claimed <token> -> <workdir>/.rundown/runbooks/snapshot-child.runbook.md","token":"<token>","claim_id":"<claimId>","run_id":"<runbookId>","runbook":"<workdir>/.rundown/runbooks/snapshot-child.runbook.md","parent_run_id":"<runbookId>","parent_step":"2.1","kind":"action"}
+{"action":"claimed","message":"Claimed <token> -> <workdir>/.rundown/runbooks/snapshot-child.runbook.md","token":"<token>","claim_id":"<claimId>","run_id":"<runbookId>","runbook":"<workdir>/.rundown/runbooks/snapshot-child.runbook.md","parent_run_id":"<runbookId>","parent_step":"2.1","kind":"claim"}
 "
 `;
 

--- a/packages/cli/__tests__/integration/delegation-claim.test.ts
+++ b/packages/cli/__tests__/integration/delegation-claim.test.ts
@@ -114,9 +114,11 @@ describe('Delegation claim integration', () => {
 
     const outputLines = result.stdout.trim().split('\n');
     const claimOutput = JSON.parse(outputLines[outputLines.length - 1]) as {
+      kind?: string;
       action?: string;
       runbook?: string;
     };
+    expect(claimOutput.kind).toBe('claim');
     expect(claimOutput.action).toBe('claimed');
     expect(claimOutput.runbook).toContain('delegation-child-pass.runbook.md');
   });
@@ -165,6 +167,7 @@ describe('Delegation claim integration', () => {
     // Parse last JSON line — claim output follows child-run JSON events
     const jsonLines = result.stdout.trim().split('\n');
     const claimOutput = JSON.parse(jsonLines[jsonLines.length - 1]);
+    expect(claimOutput.kind).toBe('claim');
     expect(claimOutput.action).toBe('claimed');
     expect(claimOutput.token).toMatch(/^rdtk_.{3}\.\.\..{4}$/);
     expect(typeof claimOutput.run_id).toBe('string');
@@ -207,6 +210,7 @@ Task uses {{ myVar }}.
     // Parse last JSON line for claimed output
     const jsonLines = result.stdout.trim().split('\n');
     const claimOutput = JSON.parse(jsonLines[jsonLines.length - 1]);
+    expect(claimOutput.kind).toBe('claim');
     expect(claimOutput.action).toBe('claimed');
   });
 

--- a/packages/cli/__tests__/services/renderers/json-renderer.properties.test.ts
+++ b/packages/cli/__tests__/services/renderers/json-renderer.properties.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from '@jest/globals';
+import * as fc from 'fast-check';
+import { JSONRenderer } from '../../../src/services/renderers/json-renderer.js';
+import type { OutputWriter, StatusOutput } from '@rundown-org/core';
+
+function createMockWriter(): OutputWriter & { lines: string[] } {
+  const lines: string[] = [];
+  return {
+    lines,
+    write: (text: string) => {
+      lines.push(text);
+    },
+    writeLine: (text?: string) => {
+      lines.push(text ?? '');
+    },
+    writeLines: (textLines: string[]) => {
+      lines.push(...textLines);
+    },
+    writeError: (text: string) => {
+      lines.push(text);
+    },
+    writeJson: (data: unknown, pretty?: boolean) => {
+      lines.push(JSON.stringify(data, null, pretty ? 2 : undefined));
+    },
+  };
+}
+
+// Canonical mapping defined alongside the renderer's status-event handler in
+// packages/cli/src/services/renderers/json-renderer.ts. `stash`, `pop`, and
+// `claimed` carry distinct lifecycle payloads and get their own `kind`
+// discriminants (matching the schemas in
+// packages/core/src/output/zod-schemas.ts). Everything else folds into the
+// action family.
+const KIND_BY_ACTION: Record<string, string> = {
+  stash: 'stash',
+  pop: 'pop',
+  claimed: 'claim',
+};
+
+function expectedKindFor(action: string): string {
+  return KIND_BY_ACTION[action] ?? 'action';
+}
+
+function renderStatus(action: string, message?: string, data?: Record<string, unknown>): string {
+  const writer = createMockWriter();
+  const renderer = new JSONRenderer({ writer });
+  const event: StatusOutput = { type: 'status', action, message, data };
+  renderer.render(event);
+  renderer.flush();
+  const parsed = JSON.parse(writer.lines[0]) as Record<string, unknown>;
+  return parsed.kind as string;
+}
+
+describe('JSONRenderer status-action → kind mapping (property)', () => {
+  it('matches the canonical mapping for the three special discriminants', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('stash', 'pop', 'claimed'), (action) => {
+        expect(renderStatus(action)).toBe(expectedKindFor(action));
+      }),
+    );
+  });
+
+  it('folds any other action into the "action" family', () => {
+    // Generate arbitrary action strings excluding the three special cases.
+    // Restrict to identifier-ish strings so the renderer's JSON output stays
+    // well-formed; the discriminant logic doesn't depend on character set.
+    const otherActionArb = fc
+      .stringMatching(/^[A-Za-z][A-Za-z0-9_-]{0,32}$/)
+      .filter((s) => s !== 'stash' && s !== 'pop' && s !== 'claimed');
+    fc.assert(
+      fc.property(otherActionArb, (action) => {
+        expect(renderStatus(action)).toBe('action');
+      }),
+    );
+  });
+
+  it('the mapping is unaffected by message and data payload contents', () => {
+    // The renderer derives kind purely from `event.action`; carrying arbitrary
+    // message/data must not change which kind is emitted.
+    const allActions = fc.constantFrom('stash', 'pop', 'claimed', 'CONTINUE', 'STOP', 'completed');
+    fc.assert(
+      fc.property(
+        allActions,
+        fc.option(fc.string({ maxLength: 64 }), { nil: undefined }),
+        fc.option(
+          fc.dictionary(
+            fc.stringMatching(/^[a-z][a-z0-9_]{0,20}$/),
+            fc.oneof(fc.string({ maxLength: 64 }), fc.integer(), fc.boolean()),
+          ),
+          { nil: undefined },
+        ),
+        (action, message, data) => {
+          expect(renderStatus(action, message, data)).toBe(expectedKindFor(action));
+        },
+      ),
+    );
+  });
+});

--- a/packages/cli/__tests__/services/renderers/json-renderer.test.ts
+++ b/packages/cli/__tests__/services/renderers/json-renderer.test.ts
@@ -5,6 +5,7 @@ import type {
   DetailOutput,
   ExecutionEventOutput,
   RunbookEventV1,
+  StatusOutput,
 } from '@rundown-org/core';
 
 function createMockWriter(): OutputWriter & { lines: string[] } {
@@ -92,7 +93,7 @@ describe('JSONRenderer', () => {
       const detail: DetailOutput = {
         type: 'detail',
         format: 'custom',
-        data: { action: 'claimed', token: 'rdtk_xyz', kind: 'action' },
+        data: { action: 'claimed', token: 'rdtk_xyz', kind: 'claim' },
       };
 
       renderer.render(executionEvent(started));
@@ -125,6 +126,48 @@ describe('JSONRenderer', () => {
       const parsed = JSON.parse(writer.lines[0]) as Record<string, unknown>;
       expect(parsed.kind).toBe('status');
       expect(parsed.message).toBe('hello');
+    });
+  });
+
+  describe('status-action → kind mapping', () => {
+    // Each StatusOutput action carries a distinct lifecycle payload and the
+    // renderer assigns the appropriate `kind` discriminant. stash, pop, and
+    // claimed have their own kinds; everything else folds into the action
+    // family. See packages/cli/src/services/renderers/json-renderer.ts case
+    // 'status' and the corresponding schemas in
+    // packages/core/src/output/zod-schemas.ts.
+    function renderStatusKind(action: string): string {
+      const writer = createMockWriter();
+      const renderer = new JSONRenderer({ writer });
+      const event: StatusOutput = { type: 'status', action };
+      renderer.render(event);
+      renderer.flush();
+      const parsed = JSON.parse(writer.lines[0]) as Record<string, unknown>;
+      return parsed.kind as string;
+    }
+
+    it('maps "claimed" → kind: "claim"', () => {
+      expect(renderStatusKind('claimed')).toBe('claim');
+    });
+
+    it('maps "stash" → kind: "stash"', () => {
+      expect(renderStatusKind('stash')).toBe('stash');
+    });
+
+    it('maps "pop" → kind: "pop"', () => {
+      expect(renderStatusKind('pop')).toBe('pop');
+    });
+
+    it('maps "complete" → kind: "action" (action family default)', () => {
+      expect(renderStatusKind('complete')).toBe('action');
+    });
+
+    it('maps "stop" → kind: "action" (action family default)', () => {
+      expect(renderStatusKind('stop')).toBe('action');
+    });
+
+    it('maps an unknown action → kind: "action" (action family default)', () => {
+      expect(renderStatusKind('something-else')).toBe('action');
     });
   });
 });

--- a/packages/cli/src/commands/ls.ts
+++ b/packages/cli/src/commands/ls.ts
@@ -113,16 +113,17 @@ export function registerLsCommand(program: Command): void {
             {
               emptyMessage:
                 'No active runbooks.\nRun "rundown ls --all" to see available runbooks.',
-              jsonMapper: (s) => {
-                // Include status, step, total per docs/spec/cli-output.md
-                const { _status, _displayStep: _, _step, _total, ...original } = s;
-                return {
-                  ...original,
-                  status: _status,
-                  step: _step,
-                  total: _total,
-                };
-              },
+              jsonMapper: (s) => ({
+                // Emit only the documented ActiveRunbookEntry fields
+                // (docs/spec/cli-output.md). Spreading the enriched state
+                // would leak internal RunbookState fields into JSON output.
+                id: s.id,
+                runbook: s.runbook,
+                step: s._step,
+                status: s._status,
+                total: s._total,
+                title: s.title,
+              }),
             },
           );
           output.flush();

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -129,11 +129,18 @@ export function registerPruneCommand(program: Command): void {
             { header: 'TITLE', key: (item: PruneRow) => (item.title ? `[${item.title}]` : '') },
           ];
 
-          // JSON mapper to clean internal fields
-          const jsonMapper = (item: PruneRow): Record<string, unknown> => {
-            const { _status, ...rest } = item as Record<string, unknown>;
-            return { ...rest, status: _status };
-          };
+          // Emit only the documented ActiveRunbookEntry fields
+          // (PruneResponseSchema = ActiveRunbookListSchema). Spreading the
+          // enriched row would leak internal RunbookState fields into JSON.
+          // `step`/`total` are intentionally omitted: prune rows are not
+          // enriched with step counts (unlike `ls`); both are optional in
+          // ActiveRunbookEntrySchema.
+          const jsonMapper = (item: PruneRow): Record<string, unknown> => ({
+            id: item.id,
+            runbook: item.runbook,
+            status: item._status,
+            title: item.title,
+          });
 
           if (allItems.length === 0) {
             // Use output.list() for consistency - outputs raw array in JSON mode

--- a/packages/cli/src/helpers/wrapper.ts
+++ b/packages/cli/src/helpers/wrapper.ts
@@ -9,6 +9,8 @@ interface ErrorHandlingOptions {
   verbose?: boolean;
   /** Output error as human-readable text instead of JSON (JSON is the default) */
   text?: boolean;
+  /** CLI command name to include in the error envelope when known. */
+  command?: string;
 }
 
 /**
@@ -64,7 +66,30 @@ export async function withErrorHandling(
     if (options.text) {
       console.error(rundownError.toCliString(options.verbose));
     } else {
-      console.error(JSON.stringify(rundownError.toJSON(), null, 2));
+      // Emit the documented error envelope (see docs/spec/cli-output.md
+      // § Key Conventions): { kind: "error", error, code, command?, details? }.
+      // This matches the shape OutputEmitter.error / JSONRenderer produce so
+      // consumers see one consistent error JSON across all paths. The
+      // RundownError-specific fields (category, title, context, docsUrl) ride
+      // in `details` so no information is lost.
+      const envelope: Record<string, unknown> = {
+        kind: 'error',
+        error: rundownError.message,
+        code: rundownError.code,
+      };
+      if (options.command !== undefined) {
+        envelope.command = options.command;
+      }
+      // RundownError-specific metadata travels in `details` so the documented
+      // envelope is preserved while no information from RundownError.toJSON()
+      // is lost.
+      envelope.details = {
+        category: rundownError.errorCode.category,
+        title: rundownError.errorCode.title,
+        context: rundownError.context,
+        docsUrl: rundownError.docsUrl,
+      };
+      console.error(JSON.stringify(envelope, null, 2));
     }
 
     process.exit(1);

--- a/packages/cli/src/services/renderers/json-renderer.ts
+++ b/packages/cli/src/services/renderers/json-renderer.ts
@@ -115,11 +115,16 @@ export class JSONRenderer implements OutputRenderer {
         if (event.data) {
           Object.assign(this.output, event.data);
         }
-        // Derive kind from status action
+        // Derive kind from status action. `stash`, `pop`, and `claimed` carry
+        // distinct lifecycle payloads and get their own discriminants
+        // (matching the schemas in packages/core/src/output/zod-schemas.ts).
+        // All other status actions are part of the action family.
         if (event.action === 'stash') {
           this.output.kind = 'stash';
         } else if (event.action === 'pop') {
           this.output.kind = 'pop';
+        } else if (event.action === 'claimed') {
+          this.output.kind = 'claim';
         } else {
           this.output.kind = 'action';
         }

--- a/packages/core/__tests__/output/claim-schema.properties.test.ts
+++ b/packages/core/__tests__/output/claim-schema.properties.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from '@jest/globals';
+import * as fc from 'fast-check';
+import { ClaimResponseSchema } from '../../src/output/zod-schemas.js';
+import { isClaimResponse, isActionResponse } from '../../src/output/schema.js';
+import type { CLIResponse } from '../../src/output/schema.js';
+
+// Mirrors CLAIM_ID_PATTERN at packages/core/src/runbook/claim-id.ts:16
+// (^rdclm_[A-Za-z0-9_-]{22}$). Regex arbitraries via fc.stringMatching
+// aren't supported in this fast-check version; a deterministic generator
+// over the alphabet is sufficient. The alphabet is ASCII-only so iterating
+// via Array.from is safe.
+const CLAIM_ID_ALPHABET = Array.from(
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-',
+);
+const claimIdArb: fc.Arbitrary<string> = fc
+  .array(fc.constantFrom(...CLAIM_ID_ALPHABET), { minLength: 22, maxLength: 22 })
+  .map((chars) => `rdclm_${chars.join('')}`);
+
+const validClaimPayloadArb = fc.record({
+  kind: fc.constant('claim' as const),
+  action: fc.constant('claimed' as const),
+  token: fc.string({ minLength: 1, maxLength: 64 }),
+  claim_id: claimIdArb,
+  run_id: fc.string({ minLength: 1, maxLength: 64 }),
+  runbook: fc.string({ minLength: 1, maxLength: 128 }),
+  parent_run_id: fc.string({ minLength: 1, maxLength: 64 }),
+  parent_step: fc.option(fc.string({ minLength: 1, maxLength: 32 }), { nil: undefined }),
+});
+
+describe('ClaimResponseSchema property tests', () => {
+  it('round-trips: every generated valid payload parses successfully', () => {
+    fc.assert(
+      fc.property(validClaimPayloadArb, (payload) => {
+        const result = ClaimResponseSchema.safeParse(payload);
+        expect(result.success).toBe(true);
+      }),
+    );
+  });
+
+  it('rejects payloads with a non-"claim" kind discriminant', () => {
+    fc.assert(
+      fc.property(
+        validClaimPayloadArb,
+        fc.constantFrom('action', 'status', 'stash', 'pop', 'error', 'warning'),
+        (payload, badKind) => {
+          const result = ClaimResponseSchema.safeParse({ ...payload, kind: badKind });
+          expect(result.success).toBe(false);
+        },
+      ),
+    );
+  });
+
+  it('rejects payloads with a non-"claimed" action literal', () => {
+    fc.assert(
+      fc.property(
+        validClaimPayloadArb,
+        fc.constantFrom('CONTINUE', 'STOP', 'stash', 'pop', 'started', 'completed'),
+        (payload, badAction) => {
+          const result = ClaimResponseSchema.safeParse({ ...payload, action: badAction });
+          expect(result.success).toBe(false);
+        },
+      ),
+    );
+  });
+
+  it('rejects payloads with a malformed claim_id', () => {
+    // Any string that doesn't match CLAIM_ID_PATTERN should be rejected.
+    const badClaimIdArb = fc.oneof(
+      fc.constant(''),
+      fc.constant('rdclm_'),
+      fc.constant('rdclm_short'),
+      fc.constant('wrong_prefix_aaaaaaaaaaaaaaaaaaaaaa'),
+      fc.string({ minLength: 0, maxLength: 10 }),
+    );
+    fc.assert(
+      fc.property(validClaimPayloadArb, badClaimIdArb, (payload, badId) => {
+        const result = ClaimResponseSchema.safeParse({ ...payload, claim_id: badId });
+        expect(result.success).toBe(false);
+      }),
+    );
+  });
+
+  it('rejects payloads missing the required token field', () => {
+    fc.assert(
+      fc.property(validClaimPayloadArb, (payload) => {
+        const { token: _token, ...withoutToken } = payload;
+        const result = ClaimResponseSchema.safeParse(withoutToken);
+        expect(result.success).toBe(false);
+      }),
+    );
+  });
+
+  it('accepts payloads with parent_step omitted (bare-step delegations)', () => {
+    fc.assert(
+      fc.property(validClaimPayloadArb, (payload) => {
+        const { parent_step: _ps, ...withoutParentStep } = payload;
+        const result = ClaimResponseSchema.safeParse(withoutParentStep);
+        expect(result.success).toBe(true);
+      }),
+    );
+  });
+});
+
+describe('claim-vs-action guard exclusivity (property)', () => {
+  it('every valid claim payload satisfies isClaimResponse and fails isActionResponse', () => {
+    fc.assert(
+      fc.property(validClaimPayloadArb, (payload) => {
+        const response = payload as unknown as CLIResponse;
+        expect(isClaimResponse(response)).toBe(true);
+        expect(isActionResponse(response)).toBe(false);
+      }),
+    );
+  });
+});

--- a/packages/core/__tests__/output/schema.test.ts
+++ b/packages/core/__tests__/output/schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import {
   isActionResponse,
+  isClaimResponse,
   isCheckResponse,
   isResolveResponse,
   isErrorResponse,
@@ -17,12 +18,26 @@ import {
 } from '../../src/output/zod-schemas.js';
 import type {
   ActionResponse,
+  ClaimResponse,
   ErrorResponse,
   WarningResponse,
   StashResponse,
   PopResponse,
   CLIResponse,
 } from '../../src/output/schema.js';
+
+function makeClaimResponse(): ClaimResponse {
+  return {
+    kind: 'claim',
+    action: 'claimed',
+    token: 'rdtk_abcdef0123456789abcdef',
+    claim_id: 'rdclm_F3J3n3d_f8fo0a0b1B2c3Q',
+    run_id: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    runbook: 'child.runbook.md',
+    parent_run_id: 'rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    parent_step: '1.1',
+  };
+}
 
 describe('isActionResponse type guard', () => {
   describe('correctly identifies ActionResponse', () => {
@@ -70,7 +85,7 @@ describe('isActionResponse type guard', () => {
     });
   });
 
-  describe('correctly rejects StashResponse and PopResponse', () => {
+  describe('correctly rejects StashResponse, PopResponse, and ClaimResponse', () => {
     it('returns false for StashResponse', () => {
       const response: StashResponse = {
         kind: 'stash',
@@ -94,6 +109,55 @@ describe('isActionResponse type guard', () => {
       // PopResponse has kind='pop', not 'action'
       expect(isActionResponse(response as CLIResponse)).toBe(false);
     });
+
+    it('returns false for ClaimResponse', () => {
+      // ClaimResponse has kind='claim', not 'action' — see isClaimResponse
+      expect(isActionResponse(makeClaimResponse() as CLIResponse)).toBe(false);
+    });
+  });
+});
+
+describe('isClaimResponse type guard', () => {
+  it('returns true for ClaimResponse', () => {
+    expect(isClaimResponse(makeClaimResponse() as CLIResponse)).toBe(true);
+  });
+
+  it('returns true for a ClaimResponse with parent_step omitted', () => {
+    // parent_step is optional for bare-step delegations.
+    const response = makeClaimResponse();
+    delete (response as Record<string, unknown>).parent_step;
+    expect(isClaimResponse(response as CLIResponse)).toBe(true);
+  });
+
+  it('returns false for ActionResponse (kind: "action")', () => {
+    const response: ActionResponse = {
+      kind: 'action',
+      action: 'CONTINUE',
+      command: 'pass',
+      from: '1',
+      at: '2',
+    };
+    expect(isClaimResponse(response)).toBe(false);
+  });
+
+  it('returns false for StashResponse', () => {
+    const response: StashResponse = {
+      kind: 'stash',
+      action: 'stash',
+      stashedId: 'abc-123',
+      runbook: { file: 'test.md', state: 'test-state.json' },
+    };
+    expect(isClaimResponse(response as CLIResponse)).toBe(false);
+  });
+
+  it('returns false for PopResponse', () => {
+    const response: PopResponse = {
+      kind: 'pop',
+      action: 'pop',
+      restoredId: 'abc-123',
+      runbook: { file: 'test.md', state: 'test-state.json' },
+    };
+    expect(isClaimResponse(response as CLIResponse)).toBe(false);
   });
 });
 

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -10630,11 +10630,11 @@ echo ok
       // transition IS a parent-exit and DOES carry outputs — that's the
       // parent-step completion, distinct from the BREAK signal itself.
       const steps = createRunbook(`## 1. Loop
+- OUTPUTS
+  - LoopVar
 - FOR i IN 1 TO 2
 - PASS CONTINUE
 - FAIL STOP
-- OUTPUTS
-  - LoopVar
 
 ### 1.1 Inside
 - PASS CONTINUE
@@ -10721,15 +10721,15 @@ echo ok
       // This is distinct from the structural test asserting that the self-targeting
       // BREAK transition does not carry storeStepOutputs.
       const steps = createRunbook(`## 1. Loop
-- FOR i IN 1 TO 2
-- PASS CONTINUE
-- FAIL STOP
 - OUTPUTS
   - LoopResult
   - StepCursor
   - SubstepCursor
   - IterCursor
   - LoopCursor
+- FOR i IN 1 TO 2
+- PASS CONTINUE
+- FAIL STOP
 
 ### 1.1 Inside
 - PASS CONTINUE
@@ -10788,12 +10788,12 @@ echo ok
 
     it('[P2] keeps naked parent OUTPUTS inert on BREAK-origin substep cursor exit', () => {
       const steps = createRunbook(`## 1. Loop
-- FOR i IN 1 TO 2
-- PASS COMPLETE
-- FAIL STOP
 - OUTPUTS
   - StepCursor
   - SubstepCursor
+- FOR i IN 1 TO 2
+- PASS COMPLETE
+- FAIL STOP
 
 ### 1.1 Breaker
 - PASS CONTINUE
@@ -10820,15 +10820,15 @@ echo ok
 
     it('keeps naked parent OUTPUTS inert against the completed FOR frame on BREAK exit', () => {
       const steps = createRunbook(`## 1. Loop
-- FOR i IN 1 TO 3
-- PASS COMPLETE
-- FAIL STOP
 - OUTPUTS
   - StepCursor
   - SubstepCursor
   - AtCursor
   - IndexCursor
   - LoopValue
+- FOR i IN 1 TO 3
+- PASS COMPLETE
+- FAIL STOP
 
 ### 1.1 Breaker
 - PASS CONTINUE
@@ -10854,14 +10854,14 @@ echo ok
 
     it('keeps naked parent OUTPUTS inert against the completed FOR frame on NEXT-exhausted loop exit', () => {
       const steps = createRunbook(`## 1. Loop
-- FOR i IN 1 TO 2
-- PASS COMPLETE
-- FAIL STOP
 - OUTPUTS
   - StepCursor
   - AtCursor
   - IndexCursor
   - LoopValue
+- FOR i IN 1 TO 2
+- PASS COMPLETE
+- FAIL STOP
 
 ### 1.1 Walker
 - PASS NEXT
@@ -10889,11 +10889,11 @@ echo ok
       // parent and are intentionally NOT decorated. This test is structural;
       // value capture is covered by CLI integration tests.
       const steps = createRunbook(`## 1. Loop
+- OUTPUTS
+  - Value
 - FOR i IN 1 TO 2
 - PASS CONTINUE
 - FAIL STOP
-- OUTPUTS
-  - Value
 
 ### 1.1 Inside
 - PASS CONTINUE
@@ -10915,11 +10915,11 @@ echo ok
       // Naked OUTPUTS require executor-created channel files; the compiler
       // action alone does not derive values from the FOR frame.
       const steps = createRunbook(`## 1. Loop
+- OUTPUTS
+  - Value
 - FOR i IN 1 TO 2
 - PASS CONTINUE
 - FAIL STOP
-- OUTPUTS
-  - Value
 
 ### 1.1 Inside
 - PASS CONTINUE
@@ -11119,15 +11119,15 @@ echo ok
       // resolvedStepHasSubsteps returns true for FOR steps, so the exitsParent
       // guard applies equally — the FOR parent's outputs must fire.
       const steps = createRunbook(`## 1. Loop
-- FOR i IN 1 TO 2
-- PASS CONTINUE
-- FAIL STOP
 - OUTPUTS
   - LoopVar
   - StepCursor
   - SubstepCursor
   - IterCursor
   - LoopCursor
+- FOR i IN 1 TO 2
+- PASS CONTINUE
+- FAIL STOP
 
 ### 1.1 Inside
 - PASS COMPLETE
@@ -11148,15 +11148,15 @@ echo ok
 
     it('does not synthesize naked parent OUTPUTS when FOR loop substep fires STOP directly', () => {
       const steps = createRunbook(`## 1. Loop
-- FOR i IN 1 TO 2
-- PASS CONTINUE
-- FAIL STOP
 - OUTPUTS
   - LoopVar
   - StepCursor
   - SubstepCursor
   - IterCursor
   - LoopCursor
+- FOR i IN 1 TO 2
+- PASS CONTINUE
+- FAIL STOP
 
 ### 1.1 Inside
 - PASS CONTINUE

--- a/packages/core/src/output/index.ts
+++ b/packages/core/src/output/index.ts
@@ -209,6 +209,7 @@ export {
   isErrorResponse,
   isWarningResponse,
   isActionResponse,
+  isClaimResponse,
   isStatusResponse as isSchemaStatusResponse,
   isCheckResponse,
   isResolveResponse,

--- a/packages/core/src/output/schema.ts
+++ b/packages/core/src/output/schema.ts
@@ -137,6 +137,7 @@ import type {
   ErrorResponse,
   WarningResponse,
   ActionResponse,
+  ClaimResponse,
   StatusResponse,
   CheckResponse,
   ResolveResponse,
@@ -170,6 +171,20 @@ export function isWarningResponse(response: CLIResponse): response is WarningRes
  */
 export function isActionResponse(response: CLIResponse): response is ActionResponse {
   return 'kind' in response && response.kind === 'action';
+}
+
+/**
+ * Type guard to check if a response is a claim response.
+ *
+ * `rd claim` carries a distinct lifecycle payload (claim_id, run_id, parent
+ * linkage) and gets its own `kind: "claim"` discriminant, alongside `stash`
+ * and `pop`. A ClaimResponse never satisfies `isActionResponse`.
+ *
+ * @param response - The response to check
+ * @returns True if the response is a ClaimResponse
+ */
+export function isClaimResponse(response: CLIResponse): response is ClaimResponse {
+  return 'kind' in response && response.kind === 'claim';
 }
 
 /**

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -1150,27 +1150,33 @@ export const DelegateResponseSchema = z
 /**
  * Claim response schema.
  *
- * Output from `rd claim <token>` command. The claim command launches a child
- * runbook, so the response extends the execution summary with claim-specific fields.
+ * Output from `rd claim <token>` command. Claim launches a child runbook and
+ * returns the `claim_id` used for subsequent child-targeting commands; the
+ * child does not (in general) run to completion at claim time, so this is its
+ * own response type rather than an execution summary. `kind: "claim"` is the
+ * primary discriminant — consistent with `stash` / `pop` which also carry
+ * distinct lifecycle payloads.
  */
-export const ClaimResponseSchema = ExecutionSummarySchema.extend({
-  /** Response kind discriminant (overrides base execution_summary) */
-  kind: z.literal('claim').describe('Response type discriminant'),
-  /** Action performed */
-  action: z.literal('claimed').describe('Action type'),
-  /** Truncated delegation token */
-  token: z.string().describe('Truncated delegation token'),
-  /** Claim ID for explicit child targeting */
-  claim_id: z.string().regex(CLAIM_ID_PATTERN).describe('Claim ID for explicit child targeting'),
-  /** Child run ID */
-  run_id: z.string().describe('Child run ID'),
-  /** Child runbook path */
-  runbook: z.string().describe('Child runbook path'),
-  /** Parent run ID */
-  parent_run_id: z.string().describe('Parent run ID'),
-  /** Parent step identifier */
-  parent_step: z.string().describe('Parent step identifier'),
-}).describe('Response from the claim command');
+export const ClaimResponseSchema = z
+  .object({
+    /** Response kind discriminant */
+    kind: z.literal('claim').describe('Response type discriminant'),
+    /** Action performed */
+    action: z.literal('claimed').describe('Action type'),
+    /** Truncated delegation token */
+    token: z.string().describe('Truncated delegation token'),
+    /** Claim ID for explicit child targeting */
+    claim_id: z.string().regex(CLAIM_ID_PATTERN).describe('Claim ID for explicit child targeting'),
+    /** Child run ID */
+    run_id: z.string().describe('Child run ID'),
+    /** Child runbook path */
+    runbook: z.string().describe('Child runbook path'),
+    /** Parent run ID */
+    parent_run_id: z.string().describe('Parent run ID'),
+    /** Parent step identifier; omitted for bare-step delegations without an at-qualifier */
+    parent_step: z.string().optional().describe('Parent step identifier (optional)'),
+  })
+  .describe('Response from the claim command');
 
 // ============================================================================
 // Derived TypeScript Types

--- a/packages/core/src/runbook/artifact-manifest.ts
+++ b/packages/core/src/runbook/artifact-manifest.ts
@@ -315,6 +315,14 @@ function manifestRowIdentity(record: ArtifactManifestRecord | ArtifactManifestRo
  * Exact artifact URIs are rejected; callers must pass a selector URI with a
  * wildcard run id or query string. By default only completed runs are returned.
  *
+ * @experimental Staged but not yet wired into the runbook pipeline. This is the
+ * query engine for selector query-parameter filtering (`status`, `runbook`,
+ * `source`, `latest`) and sibling-run lifecycle filtering. The ARTIFACTS
+ * directive path (`resolveSelector` in `artifact-directive-resolver.ts`) does
+ * not yet call it — see `docs/spec/deferred.md` "Selector URI query
+ * parameters" for the re-promotion gate. Covered by tests; no production
+ * caller. Do not rely on it in the directive path until that wiring lands.
+ *
  * @param selectorUri - Artifact selector URI
  * @param options - Path resolution and run state loading options
  * @returns Matching artifacts sorted by canonical artifact URI

--- a/packages/parser/__tests__/outputs-inputs.test.ts
+++ b/packages/parser/__tests__/outputs-inputs.test.ts
@@ -248,6 +248,88 @@ describe('parseRunbookDocument with OUTPUTS directive', () => {
     }
     expect(step.substeps[0].outputs).toEqual([{ name: 'ChildPath' }]);
   });
+
+  it('rejects a step-level OUTPUTS directive that appears after a FOR clause', () => {
+    // Grammar (docs/spec/grammar.md § Steps) mandates OUTPUTS before FOR.
+    // handleArtifactsDirective enforces ARTIFACTS-before-FOR; OUTPUTS must too.
+    const md = `## 1. Process items
+- FOR item IN 1 TO 3
+- OUTPUTS
+  - ResultPath
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Handle item
+Do the work.
+`;
+    expect(() => parseRunbookDocument(md)).toThrow(RunbookSyntaxError);
+    expect(() => parseRunbookDocument(md)).toThrow(/OUTPUTS directive.*must appear before FOR/i);
+  });
+
+  it('accepts a step-level OUTPUTS directive that appears before a FOR clause', () => {
+    const md = `## 1. Process items
+- OUTPUTS
+  - ResultPath
+- FOR item IN 1 TO 3
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Handle item
+Do the work.
+`;
+    const { runbook } = parseRunbookDocument(md);
+    expect(runbook.steps[0].outputs).toEqual([{ name: 'ResultPath' }]);
+  });
+
+  it('accepts a substep OUTPUTS directive even though the parent step has a FOR clause', () => {
+    // A step-level FOR is structurally before its substeps, so a substep
+    // OUTPUTS after the parent FOR is legal — the gate must not over-fire.
+    const md = `## 1. Process items
+- FOR item IN 1 TO 3
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Handle item
+- OUTPUTS
+  - ItemPath
+`;
+    const { runbook } = parseRunbookDocument(md);
+    const step = runbook.steps[0];
+    expect(step.kind).toBe('for');
+    if (step.kind !== 'for') {
+      throw new Error('expected for step');
+    }
+    expect(step.substeps[0].outputs).toEqual([{ name: 'ItemPath' }]);
+  });
+
+  it('rejects a step-level OUTPUTS directive that appears after a DELEGATE annotation', () => {
+    // Grammar (docs/spec/grammar.md § Steps) mandates OUTPUTS before DELEGATE.
+    const md = `## 1. Dispatch work
+- DELEGATE
+- OUTPUTS
+  - ResultPath
+- PASS CONTINUE
+- FAIL STOP
+`;
+    expect(() => parseRunbookDocument(md)).toThrow(RunbookSyntaxError);
+    expect(() => parseRunbookDocument(md)).toThrow(
+      /OUTPUTS directive.*must appear before DELEGATE/i,
+    );
+  });
+
+  it('accepts a step-level OUTPUTS directive interleaved with transitions', () => {
+    // OUTPUTS is intentionally interchangeable with transitions — the parser
+    // does not enforce OUTPUTS-before-transitions. See the "must not
+    // over-reach" describe block in parser.test.ts.
+    const md = `## 1. Capture result
+- PASS CONTINUE
+- OUTPUTS
+  - ResultPath
+- FAIL STOP
+`;
+    const { runbook } = parseRunbookDocument(md);
+    expect(runbook.steps[0].outputs).toEqual([{ name: 'ResultPath' }]);
+  });
 });
 
 describe('parseRunbookDocument frontmatter.inputs', () => {

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -743,6 +743,24 @@ function handleOutputsDirective(node: ListItem, ctx: ActiveStepContext): typeof 
   const target = getDirectiveTarget(ctx);
   const targetLabel = formatDirectiveTarget(ctx);
 
+  // OUTPUTS must precede FOR, DELEGATE, and body content. It is intentionally
+  // interchangeable with transitions — see the "must not over-reach" test in
+  // parser.test.ts, so there is deliberately no hasSeenTransitions gate here.
+  // These gates mirror the before-FOR / before-DELEGATE checks in
+  // handleArtifactsDirective. The FOR clause is step-level, so its gate only
+  // constrains a step-level OUTPUTS; a substep OUTPUTS is structurally after
+  // the parent FOR and is exempt.
+  if (!ctx.currentStep.pendingSubstep && ctx.currentStep.hasSeenForClause) {
+    throw new RunbookSyntaxError(
+      `OUTPUTS directive in ${targetLabel}${formatLineNum(node)}: must appear before FOR`,
+    );
+  }
+  if (target.hasSeenDelegate) {
+    throw new RunbookSyntaxError(
+      `OUTPUTS directive in ${targetLabel}${formatLineNum(node)}: must appear before DELEGATE`,
+    );
+  }
+
   // Gate mirrors handleDelegateAnnotation: on a pending substep, runbook-list
   // entries alone do not block subsequent structural directives on the same
   // synthesized substep. Only prose prompt text and non-runbook body content

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -119,7 +119,7 @@ Three equivalent forms are available. Pick whichever reads best for the step:
   - DELEGATE
 ```
 
-Worked examples for each form live in `delegation/delegate-keyword-*.runbook.md` (e.g., `delegate-keyword-h2-propagation.runbook.md`, `delegate-keyword-h3-explicit.runbook.md`, `delegate-keyword-runbook-shorthand.runbook.md`). See [docs/spec/language.md §4.3](../docs/spec/language.md#43-delegate) for syntax rules and [docs/guides/agent-orchestration.md](../docs/guides/agent-orchestration.md#delegate-annotation) for the auto-issuance lifecycle and `rd collect`.
+Worked examples for each form live in `delegation/delegate-keyword-*.runbook.md` (e.g., `delegate-keyword-h2-propagation.runbook.md`, `delegate-keyword-h3-explicit.runbook.md`, `delegate-keyword-runbook-shorthand.runbook.md`). See [docs/spec/language.md §7](../docs/spec/language.md#7-delegation) for syntax rules and [docs/guides/agent-orchestration.md](../docs/guides/agent-orchestration.md#delegate-annotation) for the auto-issuance lifecycle and `rd collect`.
 
 For `RETRY` + DELEGATE examples, see `delegation/delegate-keyword-retry-recovers.runbook.md` and `delegation/delegate-keyword-retry-exhausts.runbook.md`. `delegation/delegation-child-fail-once.runbook.md` uses a filesystem marker pattern for stateful fail-then-pass behavior; see its description for details.
 


### PR DESCRIPTION
## Summary

Audit-driven sync of the core documentation set against the current codebase. Nine docs were audited claim-by-claim against the implementation; the audit surfaced **two genuine code-vs-doc divergences** (fixed here) alongside the documentation corrections.

## Code fixes

- **parser** — `handleOutputsDirective` now enforces OUTPUTS-before-FOR and OUTPUTS-before-DELEGATE, mirroring `handleArtifactsDirective`. The parser previously accepted these orderings silently, despite the grammar forbidding them. OUTPUTS remains intentionally interchangeable with transitions (no transitions gate). 9 FOR-step fixtures in `compiler.test.ts` were reordered to OUTPUTS-before-FOR — grammar-compliant, identical AST.
- **cli** — `ls`/`prune` `jsonMapper`s spread the entire `RunbookState` into JSON output, leaking internal fields (`snapshot`, `variables`, `forStack`, …) far beyond the documented `ActiveRunbookEntrySchema`. Both now emit only the six documented `ActiveRunbookEntry` fields.

## Documentation

- **cli-output.md** — document the `kind` response discriminant as the primary type discriminant; correct `pass`/`fail`/`goto` to string `from`/`at` (no `to`); drop the non-existent active-status `artifacts` field; `scenario run` uses `result` not `passed`; add `complete`/`stop` lifecycle flags.
- **uri.md** — rewrite the manifest record model as a two-class union: managed `rd://` rows and file-reference `file://` rows (persisted `kind`, raw-token `key`, 6-component identity).
- **grammar.md** — split the `step`/`substep` productions into `step_directives` / `substep_directives` so the EBNF matches the parser exactly: OUTPUTS interleaves with transitions only when no FOR/DELEGATE is present, and strictly precedes them otherwise.
- **language.md** — prune stale-numbered section anchors; 5-layer variable precedence; `path` literal-key form; `validateSchema` helper.
- **runtime.md / cli.md / architecture.md / CLAUDE.md** — 5-layer precedence, `CLAUDE_PLUGIN_ROOT` semantics, `RunbookState` fields, CLI flags, replace the fabricated `extractRetryError` reference, repair inbound anchor links.
- **deferred.md** — correct the "why deferred" rationale; mark `findArtifactMatches` `@experimental` (staged, no production caller).

## Test plan

- Full unit suites green: parser 1628, core 2825, cli 2345; mcp + plugin pass.
- All packages build (`npm run build`).
- biome, eslint, and cspell clean on every changed file.
- Both change sets passed independent code + doc review; all review findings applied.

## Follow-ups (not in this PR)

- **Claim response code-vs-schema divergence** — `ClaimResponseSchema` / `COMMAND_SCHEMAS` declare `rd claim` returns `kind: "claim"` + an execution summary, but the runtime emits `kind: "action"`. `cli-output.md` documents the real shape; resolving the schema-vs-renderer mismatch needs a separate decision.
- External bookmarks to the pruned `language.md` section anchors are now dead — accepted consequence of the anchor cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified many docs: templating helpers, helper-module opt‑in, iteration-cap rules, variable precedence, manifest/URI canonicalization, delegation and language spec updates.
* **CLI**
  * New/updated flags and variants: helpers opt‑in, --claim-id, claim/abort (with --force), delegation retry/input syntax, step/index targeting, clearer examples.
* **CLI Output**
  * JSON responses adopt a top-level kind discriminator; standardized error/warning envelope with optional command field.
* **Bug Fixes / Tests**
  * Prevented leaking internal fields from ls/prune JSON outputs; added tests; parser now enforces OUTPUTS ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->