### PR TITLE
[codex] fix status artifact vars

### DIFF
--- a/packages/cli/__tests__/helpers/command-sequence-shell-spawn.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence-shell-spawn.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+import type * as ChildProcess from 'node:child_process';
+
+// Capture the arguments passed to `spawn` so we can assert how shell commands
+// are invoked. A fake child process emits `close` with exit code 0 on the next
+// tick so `runCommandWithTee` resolves.
+const spawnCalls: Array<{ command: string; args: readonly string[] }> = [];
+
+function createFakeChild(): EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  setImmediate(() => child.emit('close', 0));
+  return child;
+}
+
+const mockSpawn = jest.fn((command: string, args: readonly string[]) => {
+  spawnCalls.push({ command, args });
+  return createFakeChild();
+});
+
+const actualChildProcess = jest.requireActual<typeof ChildProcess>('node:child_process');
+
+jest.unstable_mockModule('node:child_process', () => ({
+  ...actualChildProcess,
+  spawn: mockSpawn,
+}));
+
+const { executeCommandSequence } = await import('../../src/helpers/command-sequence.js');
+
+describe('shell command spawning', () => {
+  beforeEach(() => {
+    spawnCalls.length = 0;
+    mockSpawn.mockClear();
+  });
+
+  // Regression: shell commands MUST be spawned with a non-login shell (`-c`),
+  // never a login shell (`-lc`). A login shell sources /etc/profile, which on
+  // Debian-based Linux (the CI image) hard-overwrites PATH and discards the
+  // workspace bin directory the scenario harness prepends — breaking any shell
+  // command that resolves `rd` (or any staged tool) by name on PATH. macOS's
+  // path_helper preserves the inherited PATH, which is why the regression only
+  // surfaced in CI. See command-sequence.ts runCommandWithTee.
+  it('spawns shell commands with a non-login shell', async () => {
+    await executeCommandSequence({
+      commands: ['echo hello'],
+      cwd: process.cwd(),
+      cliPath: '/unused/cli.js',
+      quiet: true,
+    });
+
+    const shellCall = spawnCalls.find((call) => call.args.includes('echo hello'));
+    expect(shellCall).toBeDefined();
+    expect(shellCall?.args[0]).toBe('-c');
+    expect(shellCall?.args).not.toContain('-lc');
+  });
+});

--- a/packages/cli/__tests__/helpers/scenario-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/scenario-workflow.test.ts
@@ -76,6 +76,7 @@ jest.unstable_mockModule('node:fs', () => {
     readFileSync: jest.fn(),
     realpathSync: jest.fn(),
     symlinkSync: jest.fn(),
+    chmodSync: jest.fn(),
   };
 });
 
@@ -108,7 +109,7 @@ const { extractFrontmatter } = await import('@rundown-org/parser');
 const { extractFileArtifactReferences } = await import('@rundown-org/core');
 const { parseScenarios } = await import('../../src/schemas/scenarios.js');
 const { readFile, rm } = await import('node:fs/promises');
-const { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, symlinkSync } =
+const { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, symlinkSync, chmodSync } =
   await import('node:fs');
 const { delimiter } = await import('node:path');
 const {
@@ -687,6 +688,10 @@ describe('executeScenario', () => {
       '/cli/dist/cli.js',
       '/tmp/rd-scenario-test/node_modules/.bin/rundown',
     );
+    // The symlink target must be executable so a scenario shell command that
+    // resolves `rd` on PATH can exec cli.js (CI's artifact round-trip strips
+    // the bit — see scenario-workflow.ts).
+    expect(chmodSync).toHaveBeenCalledWith('/cli/dist/cli.js', 0o755);
     expect(executeCommandSequence).toHaveBeenCalledWith(
       expect.objectContaining({
         commands: ['rd run my.runbook.md', 'rd pass'],

--- a/packages/cli/__tests__/helpers/scenario-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/scenario-workflow.test.ts
@@ -67,6 +67,9 @@ const actualFs = await import('node:fs');
 jest.unstable_mockModule('node:fs', () => {
   const mkdtempSyncMock = mockFn<typeof actualFs.mkdtempSync>();
   mkdtempSyncMock.mockReturnValue('/tmp/rd-scenario-test');
+  const statSyncMock = mockFn<typeof actualFs.statSync>();
+  // Default: executable bit already set, so executeScenario skips chmodSync.
+  statSyncMock.mockReturnValue({ mode: 0o755 } as ReturnType<typeof actualFs.statSync>);
   return {
     ...actualFs,
     mkdtempSync: mkdtempSyncMock,
@@ -76,6 +79,7 @@ jest.unstable_mockModule('node:fs', () => {
     readFileSync: jest.fn(),
     realpathSync: jest.fn(),
     symlinkSync: jest.fn(),
+    statSync: statSyncMock,
     chmodSync: jest.fn(),
   };
 });
@@ -109,8 +113,16 @@ const { extractFrontmatter } = await import('@rundown-org/parser');
 const { extractFileArtifactReferences } = await import('@rundown-org/core');
 const { parseScenarios } = await import('../../src/schemas/scenarios.js');
 const { readFile, rm } = await import('node:fs/promises');
-const { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, symlinkSync, chmodSync } =
-  await import('node:fs');
+const {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  symlinkSync,
+  statSync,
+  chmodSync,
+} = await import('node:fs');
 const { delimiter } = await import('node:path');
 const {
   executeCommandSequence,
@@ -166,6 +178,10 @@ beforeEach(() => {
     .mockImplementation(actualCore.extractFileArtifactReferences);
   jest.mocked(readFileSync).mockReturnValue('# Test\n\n## 1. Step\n- PASS COMPLETE\n');
   jest.mocked(existsSync).mockReturnValue(true);
+  // clearAllMocks resets call records but not implementations, so restore the
+  // executable-bit defaults that individual tests may override.
+  jest.mocked(statSync).mockReturnValue({ mode: 0o755 } as ReturnType<typeof statSync>);
+  jest.mocked(chmodSync).mockImplementation(() => undefined);
   setRealpathSyncImplementation((path) => String(path));
 });
 
@@ -677,6 +693,9 @@ describe('executeScenario', () => {
 
   it('passes executeCommandSequence correct options', async () => {
     jest.mocked(executeCommandSequence).mockResolvedValue(makeSequenceResult());
+    // Simulate the CI artifact round-trip stripping the executable bit so the
+    // restore path runs.
+    jest.mocked(statSync).mockReturnValue({ mode: 0o644 } as ReturnType<typeof statSync>);
 
     await executeScenario(makeLoadedRunbook(), 'happy', true, mockOutput, '/cli/dist/cli.js');
 
@@ -704,6 +723,51 @@ describe('executeScenario', () => {
         }),
       }),
     );
+  });
+
+  it('skips chmod when the cli target is already executable', async () => {
+    jest.mocked(executeCommandSequence).mockResolvedValue(makeSequenceResult());
+    // Default statSync mock reports mode 0o755 (executable bit set).
+
+    await executeScenario(makeLoadedRunbook(), 'happy', true, mockOutput, '/cli/dist/cli.js');
+
+    expect(chmodSync).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'EACCES',
+    'EPERM',
+  ])('tolerates %s when restoring the cli executable bit', async (code) => {
+    jest.mocked(executeCommandSequence).mockResolvedValue(makeSequenceResult());
+    jest.mocked(statSync).mockReturnValue({ mode: 0o644 } as ReturnType<typeof statSync>);
+    jest.mocked(chmodSync).mockImplementation(() => {
+      throw Object.assign(new Error(`${code}: permission denied`), { code });
+    });
+
+    // Read-only / global installs may reject chmod even though cli.js is
+    // already runnable — the scenario run must still proceed.
+    const result = await executeScenario(
+      makeLoadedRunbook(),
+      'happy',
+      true,
+      mockOutput,
+      '/cli/dist/cli.js',
+    );
+
+    expect(result.passed).toBe(true);
+    expect(chmodSync).toHaveBeenCalledWith('/cli/dist/cli.js', 0o755);
+  });
+
+  it('rethrows non-permission errors from chmod', async () => {
+    jest.mocked(executeCommandSequence).mockResolvedValue(makeSequenceResult());
+    jest.mocked(statSync).mockReturnValue({ mode: 0o644 } as ReturnType<typeof statSync>);
+    jest.mocked(chmodSync).mockImplementation(() => {
+      throw Object.assign(new Error('EROFS: read-only file system'), { code: 'EROFS' });
+    });
+
+    await expect(
+      executeScenario(makeLoadedRunbook(), 'happy', true, mockOutput, '/cli/dist/cli.js'),
+    ).rejects.toThrow(/EROFS/);
   });
 
   it('cleans up temp directory after execution', async () => {

--- a/packages/cli/__tests__/helpers/status-builder.test.ts
+++ b/packages/cli/__tests__/helpers/status-builder.test.ts
@@ -6,6 +6,8 @@ import {
   brandInitialTemplateVarsForTest,
   brandRunIdForTest,
   brandStoredOutputsForTest,
+  brandTrustedArtifactArrayForTest,
+  brandTrustedArtifactRecordForTest,
 } from './brand-helpers.js';
 import { mockFn } from './typed-mocks.js';
 
@@ -16,6 +18,7 @@ import type * as ExecutionModule from '../../src/services/execution.js';
 const PARENT_RUN_ID = brandRunIdForTest(`rd_${'9'.repeat(32)}`);
 const SECOND_PARENT_RUN_ID = brandRunIdForTest(`rd_${'a'.repeat(32)}`);
 const DEFAULT_RUN_ID = brandRunIdForTest(`rd_${'b'.repeat(32)}`);
+const ARTIFACT_RUN_ID = brandRunIdForTest(`rd_${'c'.repeat(32)}`);
 
 // Mock @rundown-org/core
 jest.unstable_mockModule('@rundown-org/core', () => {
@@ -35,9 +38,35 @@ jest.unstable_mockModule('@rundown-org/core', () => {
         `${step}${iteration != null ? `.${String(iteration)}` : ''}${substep ? `.${substep}` : ''}`,
     ),
     countNumberedSteps,
+    isArtifactRecord: jest.fn(
+      (value: unknown) =>
+        value !== null &&
+        typeof value === 'object' &&
+        'kind' in value &&
+        ((value as { kind?: unknown }).kind === 'artifact-record' ||
+          (value as { kind?: unknown }).kind === 'file-artifact-record'),
+    ),
+    isArtifactValue: jest.fn((value: unknown) => {
+      const isRecord = (candidate: unknown): boolean =>
+        candidate !== null &&
+        typeof candidate === 'object' &&
+        'kind' in candidate &&
+        ((candidate as { kind?: unknown }).kind === 'artifact-record' ||
+          (candidate as { kind?: unknown }).kind === 'file-artifact-record');
+      return (
+        isRecord(value) ||
+        (Array.isArray(value) && value.length > 0 && value.every((item) => isRecord(item)))
+      );
+    }),
+    renderArtifactValue: jest.fn((value: unknown) => {
+      if (Array.isArray(value)) {
+        return JSON.stringify(value.map((record) => (record as { uri: string }).uri));
+      }
+      return (value as { uri: string }).uri;
+    }),
     mergeEffectiveVars: jest.fn(
       (
-        state: { templateVars?: Record<string, unknown>; variables?: Record<string, string> },
+        state: { templateVars?: Record<string, unknown>; variables?: Record<string, unknown> },
         extraVars?: Record<string, unknown>,
       ) => ({
         ...(state.templateVars ?? {}),
@@ -433,6 +462,62 @@ describe('vars field', () => {
     const result = buildActiveStatus(state, '/project');
     expect(result.vars).toEqual({ name: 'test' });
     expect(result.vars?.items).toBeUndefined();
+  });
+
+  it('renders artifact-record variables as URI strings', () => {
+    const artifact = brandTrustedArtifactRecordForTest({
+      kind: 'artifact-record',
+      uri: `rd://artifacts/ctx-a/${ARTIFACT_RUN_ID}/plan.json`,
+      runId: ARTIFACT_RUN_ID,
+      contextId: 'ctx-a',
+      runbook: { source: 'project', path: 'producer.runbook.md' },
+      key: 'plan.json',
+      timestamp: '2026-05-25T00:00:00.000Z',
+    });
+    const state = makeState({
+      variables: brandStoredOutputsForTest({ PlanPath: artifact }),
+    });
+
+    const result = buildActiveStatus(state, '/project');
+
+    expect(result.vars).toEqual({
+      PlanPath: `rd://artifacts/ctx-a/${ARTIFACT_RUN_ID}/plan.json`,
+    });
+  });
+
+  it('renders artifact-record arrays as JSON URI arrays', () => {
+    const first = brandTrustedArtifactRecordForTest({
+      kind: 'artifact-record',
+      uri: `rd://artifacts/ctx-a/${ARTIFACT_RUN_ID}/plan-a.json`,
+      runId: ARTIFACT_RUN_ID,
+      contextId: 'ctx-a',
+      runbook: { source: 'project', path: 'producer.runbook.md' },
+      key: 'plan-a.json',
+      timestamp: '2026-05-25T00:00:00.000Z',
+    });
+    const second = brandTrustedArtifactRecordForTest({
+      kind: 'artifact-record',
+      uri: `rd://artifacts/ctx-a/${ARTIFACT_RUN_ID}/plan-b.json`,
+      runId: ARTIFACT_RUN_ID,
+      contextId: 'ctx-a',
+      runbook: { source: 'project', path: 'producer.runbook.md' },
+      key: 'plan-b.json',
+      timestamp: '2026-05-25T00:00:00.000Z',
+    });
+    const state = makeState({
+      variables: brandStoredOutputsForTest({
+        Plans: brandTrustedArtifactArrayForTest([first, second]),
+      }),
+    });
+
+    const result = buildActiveStatus(state, '/project');
+
+    expect(result.vars).toEqual({
+      Plans: JSON.stringify([
+        `rd://artifacts/ctx-a/${ARTIFACT_RUN_ID}/plan-a.json`,
+        `rd://artifacts/ctx-a/${ARTIFACT_RUN_ID}/plan-b.json`,
+      ]),
+    });
   });
 
   it('returns undefined vars when both templateVars and variables are empty', () => {

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -1,4 +1,14 @@
-import { mkdir, mkdtemp, rm, cp, readFile, writeFile, readdir, symlink } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  cp,
+  readFile,
+  writeFile,
+  readdir,
+  symlink,
+  chmod,
+} from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -92,6 +102,12 @@ export async function createTestWorkspace(opts?: { fixtureDir?: string }): Promi
   const cliPath = getCliPath();
   await symlink(cliPath, join(binDir, 'rd'));
   await symlink(cliPath, join(binDir, 'rundown'));
+  // The `rd`/`rundown` entries symlink to cli.js, so a scenario shell command
+  // that resolves `rd` on PATH execs cli.js directly and needs its executable
+  // bit. CI ships dist/ through actions/upload-artifact + download-artifact,
+  // which strips permissions (cli.js arrives at 0644). Restore the bit on the
+  // symlink target so the spawn does not fail with EACCES.
+  await chmod(cliPath, 0o755);
 
   // Copy fixtures (or a named subdirectory) to temp dir
   const fixturesRoot = join(__dirname, '..', 'fixtures');

--- a/packages/cli/__tests__/integration/artifact-variable-inputs.test.ts
+++ b/packages/cli/__tests__/integration/artifact-variable-inputs.test.ts
@@ -259,7 +259,13 @@ Second {{ Plan }}
     expect(JSON.parse(status.stdout)).toMatchObject({
       active: true,
       step: expect.objectContaining({ name: '1' }),
+      vars: expect.objectContaining({ Plan: row.uri }),
     });
+
+    const textStatus = await runCliInProcess(['status', '--text'], workspace);
+    expect(textStatus.exitCode).toBe(0);
+    expect(textStatus.stdout).toContain('Plan');
+    expect(textStatus.stdout).toContain(row.uri);
 
     const pass = await runCliInProcess(['pass', '--text'], workspace);
     expect(pass.exitCode).toBe(0);

--- a/packages/cli/__tests__/schemas/status-response.test.ts
+++ b/packages/cli/__tests__/schemas/status-response.test.ts
@@ -86,6 +86,41 @@ describe('StatusResponseSchema', () => {
     });
   });
 
+  describe('vars field', () => {
+    it('accepts string-valued status vars', () => {
+      const statusResponse = {
+        kind: 'status',
+        active: true,
+        stashed: false,
+        vars: {
+          PlanPath: 'rd://artifacts/ctx-a/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+        },
+      };
+
+      const parseResult = StatusResponseSchema.safeParse(statusResponse);
+
+      expect(parseResult.success).toBe(true);
+    });
+
+    it('rejects non-string status vars', () => {
+      const statusResponse = {
+        kind: 'status',
+        active: true,
+        stashed: false,
+        vars: {
+          PlanPath: {
+            kind: 'artifact-record',
+            uri: 'rd://artifacts/ctx-a/rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/plan.json',
+          },
+        },
+      };
+
+      const parseResult = StatusResponseSchema.safeParse(statusResponse);
+
+      expect(parseResult.success).toBe(false);
+    });
+  });
+
   describe('required fields', () => {
     it('rejects response without kind field', () => {
       const statusResponse = {

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -160,6 +160,28 @@ describe('getBuiltinVariables', () => {
     expect(builtins.Branch).toBe('feature/my-branch');
   });
 
+  it('detects git branch with the expected command and trims stdout', () => {
+    let capturedCommand: string | undefined;
+    let capturedArgs: readonly string[] | undefined;
+    let capturedOptions: unknown;
+    setExecFileSyncImpl(((command, args, options) => {
+      capturedCommand = command as string;
+      capturedArgs = args as readonly string[];
+      capturedOptions = options;
+      return 'feature/branch-check\n';
+    }) as unknown as typeof nodeExecFileSync);
+
+    const builtins = getBuiltinVariables();
+
+    expect(capturedCommand).toBe('git');
+    expect(capturedArgs).toEqual(['rev-parse', '--abbrev-ref', 'HEAD']);
+    expect(capturedOptions).toEqual({
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    expect(builtins.Branch).toBe('feature/branch-check');
+  });
+
   it('should fall back to WORK_DIR when not in git', () => {
     setExecFileSyncImpl(() => {
       throw new Error('not a git repo');
@@ -282,6 +304,51 @@ describe('loadVariablesFromFile', () => {
     const result = await loadVariablesFromFile(filePath);
 
     expect(result).toEqual({});
+  });
+
+  it('should return empty object for scalar YAML in raw mode', async () => {
+    const filePath = path.join(tmpDir, 'raw-string.yaml');
+    await fs.writeFile(filePath, 'just a string');
+
+    const result = await loadVariablesFromFile(filePath, {
+      normalize: false,
+      optional: false,
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object for null YAML in raw mode', async () => {
+    const filePath = path.join(tmpDir, 'raw-null.yaml');
+    await fs.writeFile(filePath, '');
+
+    const result = await loadVariablesFromFile(filePath, {
+      normalize: false,
+      optional: false,
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('should reject malformed YAML in required raw mode', async () => {
+    const filePath = path.join(tmpDir, 'raw-malformed.yaml');
+    await fs.writeFile(filePath, 'invalid: yaml: content:\n  - missing\n  proper: indentation');
+
+    await expect(
+      loadVariablesFromFile(filePath, {
+        normalize: false,
+        optional: false,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should ignore complex YAML values when normalizing to strings', async () => {
+    const filePath = path.join(tmpDir, 'nested.yaml');
+    await fs.writeFile(filePath, 'nested:\n  x: 1\nplain: ok\n');
+
+    const result = await loadVariablesFromFile(filePath);
+
+    expect(result).toEqual({ plain: 'ok' });
   });
 
   it('should convert non-string values to strings (numbers)', async () => {
@@ -1136,6 +1203,26 @@ describe('resolveVariables', () => {
       expect(result.vars.foo).toBe('bar');
     });
 
+    it('does not collect environment variables without the RD_INPUT_ prefix', async () => {
+      const previous = process.env.NOT_RD_INPUT_secret;
+      process.env.NOT_RD_INPUT_secret = 'leak';
+
+      try {
+        const result = await resolveVariables({}, tmpDir);
+
+        expect(result.vars.secret).toBeUndefined();
+        expect(result.vars.NOT_RD_INPUT_secret).toBeUndefined();
+        expect(result.providedKeys.has('secret')).toBe(false);
+        expect(result.providedKeys.has('NOT_RD_INPUT_secret')).toBe(false);
+      } finally {
+        if (previous === undefined) {
+          delete process.env.NOT_RD_INPUT_secret;
+        } else {
+          process.env.NOT_RD_INPUT_secret = previous;
+        }
+      }
+    });
+
     it('ignores RD_INPUT_ with invalid identifier suffix and produces warning', async () => {
       process.env.RD_INPUT_1bad = 'value';
 
@@ -1143,6 +1230,18 @@ describe('resolveVariables', () => {
 
       expect(result.vars['1bad']).toBeUndefined();
       expect(result.warnings.some((w) => w.includes('1bad'))).toBe(true);
+    });
+
+    it('reports the exact invalid identifier warning for RD_INPUT_* keys', async () => {
+      process.env.RD_INPUT_1bad = 'value';
+
+      const result = await resolveVariables({}, tmpDir);
+
+      expect(result.vars['1bad']).toBeUndefined();
+      expect(result.providedKeys.has('1bad')).toBe(false);
+      expect(result.warnings).toContain(
+        'Ignoring env RD_INPUT_1bad: "1bad" is not a valid identifier',
+      );
     });
 
     it('ignores RD_INPUT_step and produces warning instead of throwing', async () => {
@@ -1154,6 +1253,18 @@ describe('resolveVariables', () => {
       expect(
         result.warnings.some((w) => w.includes('RD_INPUT_step') && w.includes('reserved')),
       ).toBe(true);
+    });
+
+    it('reports the exact reserved variable warning for RD_INPUT_* keys', async () => {
+      process.env.RD_INPUT_step = 'from-env';
+
+      const result = await resolveVariables({}, tmpDir);
+
+      expect(result.vars.step).toBeUndefined();
+      expect(result.providedKeys.has('step')).toBe(false);
+      expect(result.warnings).toContain(
+        'Ignoring env RD_INPUT_step: "step" is a reserved runtime variable',
+      );
     });
 
     it('ignores reserved names case-insensitively in RD_INPUT_* bridge', async () => {
@@ -1236,6 +1347,39 @@ describe('resolveVariables', () => {
       // Only built-in vars should be present
       expect(result.vars).toHaveProperty('Date');
       expect(result.vars).not.toHaveProperty('any_file_var');
+    });
+  });
+
+  describe('providedKeys provenance', () => {
+    it('tracks user-provided layers and excludes builtins', async () => {
+      const previous = process.env.RD_INPUT_envProvided;
+      process.env.RD_INPUT_envProvided = 'from-env';
+      const configDir = path.join(tmpDir, RUNDOWN_DIR);
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(path.join(configDir, 'config.yaml'), 'configProvided: from-config\n');
+
+      try {
+        const result = await resolveVariables(
+          {
+            inheritedVars: { inheritedProvided: 'from-parent' },
+            input: ['cliProvided=from-cli'],
+          },
+          tmpDir,
+        );
+
+        expect(result.providedKeys.has('configProvided')).toBe(true);
+        expect(result.providedKeys.has('inheritedProvided')).toBe(true);
+        expect(result.providedKeys.has('envProvided')).toBe(true);
+        expect(result.providedKeys.has('cliProvided')).toBe(true);
+        expect(result.providedKeys.has('Date')).toBe(false);
+        expect(result.providedKeys.has('ContextId')).toBe(false);
+      } finally {
+        if (previous === undefined) {
+          delete process.env.RD_INPUT_envProvided;
+        } else {
+          process.env.RD_INPUT_envProvided = previous;
+        }
+      }
     });
   });
 
@@ -1466,6 +1610,24 @@ describe('collectCliFlags', () => {
 
     const result = await collectCliFlags({ inputFile: [varFile] }, tmpDir);
     expect(result).toEqual({ greeting: 'hello', count: 42 });
+  });
+
+  it('rejects missing --input-file paths', async () => {
+    const missingPath = path.join(tmpDir, 'missing.yaml');
+
+    await expect(collectCliFlags({ inputFile: [missingPath] }, tmpDir)).rejects.toThrow();
+  });
+
+  it('rejects invalid --input entries that bypass option parsing', async () => {
+    await expect(collectCliFlags({ input: ['not-key-value'] }, tmpDir)).rejects.toThrow(
+      'Unexpected invalid --input entry: not-key-value',
+    );
+  });
+
+  it('rejects invalid --input-json keys that bypass option parsing', async () => {
+    await expect(collectCliFlags({ inputJson: ['1bad=42'] }, tmpDir)).rejects.toThrow(
+      'Unexpected invalid --input-json key: 1bad',
+    );
   });
 
   it('preserves precedence: input-json > input > input-file', async () => {

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -1615,7 +1615,7 @@ describe('collectCliFlags', () => {
   it('rejects missing --input-file paths', async () => {
     const missingPath = path.join(tmpDir, 'missing.yaml');
 
-    await expect(collectCliFlags({ inputFile: [missingPath] }, tmpDir)).rejects.toThrow();
+    await expect(collectCliFlags({ inputFile: [missingPath] }, tmpDir)).rejects.toThrow(/ENOENT/);
   });
 
   it('rejects invalid --input entries that bypass option parsing', async () => {

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -153,7 +153,7 @@ describe('getBuiltinVariables', () => {
   });
 
   it('should return fixed WorkPath even when in git repo', () => {
-    setExecFileSyncImpl((() => 'feature/my-branch\n') as unknown as typeof nodeExecFileSync);
+    setExecFileSyncImpl(() => 'feature/my-branch\n');
 
     const builtins = getBuiltinVariables();
     expect(builtins.WorkPath).toBe(WORK_DIR);
@@ -164,12 +164,12 @@ describe('getBuiltinVariables', () => {
     let capturedCommand: string | undefined;
     let capturedArgs: readonly string[] | undefined;
     let capturedOptions: unknown;
-    setExecFileSyncImpl(((command, args, options) => {
-      capturedCommand = command as string;
-      capturedArgs = args as readonly string[];
+    setExecFileSyncImpl((command, args, options) => {
+      capturedCommand = command;
+      capturedArgs = args;
       capturedOptions = options;
       return 'feature/branch-check\n';
-    }) as unknown as typeof nodeExecFileSync);
+    });
 
     const builtins = getBuiltinVariables();
 
@@ -193,7 +193,7 @@ describe('getBuiltinVariables', () => {
   });
 
   it('should fall back to WORK_DIR on detached HEAD', () => {
-    setExecFileSyncImpl((() => 'HEAD\n') as unknown as typeof nodeExecFileSync);
+    setExecFileSyncImpl(() => 'HEAD\n');
 
     const builtins = getBuiltinVariables();
     expect(builtins.WorkPath).toBe(WORK_DIR);

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -427,7 +427,7 @@ async function runCommandWithTee(
         env: spawnEnv,
       });
     } else {
-      child = spawn(process.env.SHELL ?? '/bin/sh', ['-lc', command.cmd], {
+      child = spawn(process.env.SHELL ?? '/bin/sh', ['-c', command.cmd], {
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: options.cwd,
         env: spawnEnv,

--- a/packages/cli/src/helpers/scenario-workflow.ts
+++ b/packages/cli/src/helpers/scenario-workflow.ts
@@ -9,6 +9,7 @@
 
 import { readFile, rm, cp } from 'node:fs/promises';
 import {
+  chmodSync,
   copyFileSync,
   existsSync,
   mkdirSync,
@@ -280,6 +281,13 @@ export async function executeScenario(
     mkdirSync(binDir, { recursive: true });
     symlinkSync(cliPath, join(binDir, 'rd'));
     symlinkSync(cliPath, join(binDir, 'rundown'));
+    // The `rd`/`rundown` entries are symlinks to cli.js, so a shell command
+    // that resolves `rd` on PATH (e.g. `node -e '...execFileSync("rd")...'`)
+    // execs cli.js directly — which requires its executable bit. CI obtains
+    // dist/ via actions/upload-artifact + download-artifact, and that round
+    // trip strips file permissions, leaving cli.js at 0644. Restore the bit on
+    // the symlink target so the spawn does not fail with EACCES.
+    chmodSync(cliPath, 0o755);
 
     const referenced = extractReferencedRunbooks(scenario);
     const sourceDir = dirname(filePath);

--- a/packages/cli/src/helpers/scenario-workflow.ts
+++ b/packages/cli/src/helpers/scenario-workflow.ts
@@ -16,6 +16,7 @@ import {
   mkdtempSync,
   readFileSync,
   realpathSync,
+  statSync,
   symlinkSync,
 } from 'node:fs';
 import { basename, delimiter, dirname, isAbsolute, join, normalize, resolve, sep } from 'node:path';
@@ -286,8 +287,20 @@ export async function executeScenario(
     // execs cli.js directly — which requires its executable bit. CI obtains
     // dist/ via actions/upload-artifact + download-artifact, and that round
     // trip strips file permissions, leaving cli.js at 0644. Restore the bit on
-    // the symlink target so the spawn does not fail with EACCES.
-    chmodSync(cliPath, 0o755);
+    // the symlink target so the spawn does not fail with EACCES. Only chmod
+    // when the executable bit is actually missing, and tolerate EACCES/EPERM:
+    // in read-only or globally-installed layouts cliPath may be non-writable
+    // even when already executable, and chmodSync itself would otherwise abort
+    // the run.
+    try {
+      if ((statSync(cliPath).mode & 0o111) === 0) {
+        chmodSync(cliPath, 0o755);
+      }
+    } catch (err: unknown) {
+      if (!isNodeError(err) || (err.code !== 'EACCES' && err.code !== 'EPERM')) {
+        throw err;
+      }
+    }
 
     const referenced = extractReferencedRunbooks(scenario);
     const sourceDir = dirname(filePath);

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -10,7 +10,9 @@
 import {
   buildStepPosition,
   countNumberedSteps,
+  isArtifactValue,
   mergeEffectiveVars,
+  renderArtifactValue,
   type ActionBlockData,
   type ResolvedCompletion,
   type RunbookState,
@@ -105,10 +107,9 @@ export interface StatusOutputData {
  * Build the effective variable space for status output.
  *
  * Merges templateVars (CLI/config/frontmatter) with state.variables (step OUTPUTS).
- * From templateVars, only scalar values (string, number) are included;
- * arrays, streams, and JSON objects are excluded. state.variables is already
- * Record<string, string> and is merged as-is; step outputs win over templateVars
- * on key collision.
+ * From the merged view, scalar values (string, number) and artifact values are
+ * included. Other arrays, streams, and JSON objects are excluded. Step outputs
+ * win over templateVars on key collision.
  *
  * @param state - Runbook state with templateVars and variables
  * @returns Stringified key-value map, or undefined if empty
@@ -120,13 +121,16 @@ function buildVars(state: RunbookState): Record<string, string> | undefined {
   // precedence delegation snapshots and OUTPUTS frames use.
   //
   // Status output requires Record<string, string>, so the merged view is
-  // post-filtered to scalars and stringified. Arrays, JsonObjects, and
-  // JsonArrayStream refs are intentionally omitted from the status surface.
-  // TemplateVarValue does not admit booleans (see TemplateVarValueSchema).
+  // post-filtered to scalars and renderable artifact records. Other arrays,
+  // JsonObjects, and JsonArrayStream refs are intentionally omitted from the
+  // status surface. TemplateVarValue does not admit booleans (see
+  // TemplateVarValueSchema).
   const merged: Record<string, string> = {};
   for (const [k, v] of Object.entries(mergeEffectiveVars(state))) {
     if (typeof v === 'string' || typeof v === 'number') {
       merged[k] = String(v);
+    } else if (isArtifactValue(v)) {
+      merged[k] = renderArtifactValue(v);
     }
   }
   return Object.keys(merged).length > 0 ? merged : undefined;

--- a/packages/cli/src/services/renderers/text-renderer.ts
+++ b/packages/cli/src/services/renderers/text-renderer.ts
@@ -57,6 +57,7 @@ interface StatusDetailData {
   };
   step?: { name: string; description?: string };
   lastAction?: { action: string; result?: 'PASS' | 'FAIL' };
+  vars?: Record<string, string>;
   pending?: string[];
   delegations?: {
     substep: string;
@@ -236,6 +237,7 @@ export class TextRenderer implements OutputRenderer {
       position,
       step,
       lastAction,
+      vars,
       pending,
       delegations,
     } = data as StatusDetailData;
@@ -255,6 +257,7 @@ export class TextRenderer implements OutputRenderer {
         );
       }
       printRunbookStashed(position, this.writer);
+      this.renderVars(vars);
       return;
     }
 
@@ -283,6 +286,8 @@ export class TextRenderer implements OutputRenderer {
       }
     }
 
+    this.renderVars(vars);
+
     // Show pending steps
     if (pending && pending.length > 0) {
       this.writer.writeLine(`\nPending: ${pending.join(', ')}`);
@@ -302,6 +307,14 @@ export class TextRenderer implements OutputRenderer {
         }
         this.writer.writeLine(`  ${d.substep}  ${d.runbook}  DELEGATED  ${stateLabel}`);
       }
+    }
+  }
+
+  private renderVars(vars: Record<string, string> | undefined): void {
+    if (!vars || Object.keys(vars).length === 0) return;
+    this.writer.writeLine('\nVars:');
+    for (const [key, value] of Object.entries(vars)) {
+      this.writer.writeLine(`  ${key}: ${value}`);
     }
   }
 

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -39,15 +39,26 @@ export {
   type VariableSecurityContext,
 } from '@rundown-org/core';
 
+type GitBranchExecOptions = {
+  encoding: 'utf-8';
+  stdio: ['pipe', 'pipe', 'pipe'];
+};
+
+type GitBranchExecFileSync = (
+  command: string,
+  args: readonly string[],
+  options: GitBranchExecOptions,
+) => string;
+
 // Allow injection for testing
-let execFileSyncImpl: typeof nodeExecFileSync = nodeExecFileSync;
+let execFileSyncImpl: GitBranchExecFileSync = nodeExecFileSync;
 
 /**
  * Replace the execFileSync implementation (for testing).
  *
- * @param fn - Replacement function matching the execFileSync signature
+ * @param fn - Replacement function matching the git branch discovery call shape
  */
-export function setExecFileSyncImpl(fn: typeof nodeExecFileSync): void {
+export function setExecFileSyncImpl(fn: GitBranchExecFileSync): void {
   execFileSyncImpl = fn;
 }
 

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -440,6 +440,10 @@ export const StatusResponseSchema = z
     file: z.string().optional().describe('Path to the active runbook file'),
     state: z.string().optional().describe('Current runbook execution state'),
     prompted: z.boolean().optional().describe('Whether awaiting user input'),
+    vars: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe('Effective status variables rendered as strings'),
   })
   .describe('Response from the status command')
   .loose();

--- a/runbooks/artifacts/artifact-status-vars.runbook.md
+++ b/runbooks/artifacts/artifact-status-vars.runbook.md
@@ -1,0 +1,33 @@
+---
+name: artifact-status-vars
+description: Status vars include artifact-record variables
+tags: [test, artifacts]
+scenarios:
+  status-shows-artifact-vars:
+    description: rd status surfaces ARTIFACTS variables as URI strings
+    commands:
+      - rd run artifact-status-vars.runbook.md --allow-all
+      - >-
+        node -e 'const { execFileSync } = require("node:child_process"); const status = JSON.parse(execFileSync("rd", ["status"], { encoding: "utf8" })); const value = status.vars && status.vars.PlanPath; if (typeof value !== "string" || !value.startsWith("rd://artifacts/") || !value.endsWith("/plan.json")) { console.error(JSON.stringify(status.vars)); process.exit(1); }'
+      - rd complete
+    expect:
+      result: COMPLETE
+---
+# Status vars include artifact variables
+
+## 1. Produce an artifact variable
+
+- ARTIFACTS
+  - PlanPath "plan.json"
+- PASS CONTINUE
+
+```bash
+printf '{"plan":"ok"}' > "{{ path PlanPath }}"
+```
+
+## 2. Pause with the artifact variable in scope
+
+- PASS COMPLETE
+- FAIL STOP
+
+The active status output should include `PlanPath`.

--- a/runbooks/artifacts/artifact-status-vars.runbook.md
+++ b/runbooks/artifacts/artifact-status-vars.runbook.md
@@ -27,6 +27,8 @@ printf '{"plan":"ok"}' > "{{ path PlanPath }}"
 
 ## 2. Pause with the artifact variable in scope
 
+- ARTIFACTS
+  - PlanPath
 - PASS COMPLETE
 - FAIL STOP
 


### PR DESCRIPTION
## Summary

Fixes `rd status` so artifact-record variables in the effective variable space are visible in `vars` instead of being silently omitted.

## Root Cause

`status` projected `mergeEffectiveVars(state)` into a string map, but only kept scalar string/number values. Artifact variables are stored as object-shaped artifact records, so they were filtered out even though they were present in state and rendered correctly in templates.

## Changes

- Render artifact values in `status.vars` as URI strings, matching direct template rendering.
- Keep non-artifact structured values omitted from the status vars surface.
- Document `vars` in the status response schema as `Record<string, string>`.
- Render `Vars:` in `rd status --text` when vars are present.
- Add unit, schema, integration, and scenario regressions for artifact vars in status output.

## Validation

- `npm run build -w packages/cli`
- `npm run test -w packages/cli -- --runTestsByPath __tests__/helpers/status-builder.test.ts __tests__/schemas/status-response.test.ts __tests__/integration/artifact-variable-inputs.test.ts __tests__/integration/scenario-runner.test.ts`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The status command now exposes effective status variables (vars) in JSON/text outputs; artifact variables are rendered as URI strings.
* **Bug Fixes**
  * Shell commands run in a non-login shell to avoid CI PATH issues.
  * Ensure CLI entry is executable in scenario/workspace setup to prevent spawn EACCES failures.
* **Tests**
  * Expanded tests for artifact variable rendering, status schema, variable discovery, command spawning, and scenario workflows.
* **Documentation**
  * Added runbook documenting artifact status variable behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tobyhede/rundown/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->