### PR TITLE
[codex] Sync runbook skill docs

### DIFF
--- a/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
@@ -94,7 +94,9 @@ Skill(skill: "rundown:running-runbooks")
 
 ### 3. Child claims and executes
 
-The child agent runs `rd claim <token>`, which starts the delegated runbook. The child then follows normal [runbook execution](../running-runbooks/SKILL.md) — follow steps, pass/fail.
+The plugin normally detects `RD_CLAIM_TOKEN=rdtk_...` in the child prompt and injects the claim instructions automatically. If automatic token injection is unavailable, or you are recovering manually, the child can run `rd claim <token>` to start the delegated runbook.
+
+After claiming, the child follows normal [runbook execution](../running-runbooks/SKILL.md) — follow steps, pass/fail.
 
 ```bash
 rd claim <token>
@@ -133,18 +135,20 @@ rd abort <token> --force   # Cancel already-claimed delegation
 
 ## Variable Pass-Through
 
-When the parent issues a delegation, the child is launched with the parent's full user-level variable space passed in as `--input` flags. That includes built-ins like `ContextId`, `WorkPath`, and any keys the parent has accumulated from earlier step OUTPUTS. Each child gets its own `RunId`; `ContextId` stays stable across the tree so paths from `{{ path "..." }}` resolve into the same `.rd-<ContextId>/` directory in parent and child. Override with `--input ContextId=sprint-42` only when you want a meaningful identifier.
+Delegated runbooks automatically inherit available parent variables. Do not manually pass every variable as `--input`; add explicit inputs only when you intentionally want to change or add a value for the child.
+
+Each child gets its own `RunId`. `ContextId` stays stable across the delegation tree so shared paths and correlation IDs continue to line up, including paths created with `{{ path "..." }}` under the same `.rd-<ContextId>/` directory. Override with `--input ContextId=sprint-42` only when you want a meaningful new shared context identifier.
+
+Explicit inputs override inherited values:
+
+```bash
+rd delegate --step 2.1 --input environment=staging
+rd delegate --step 2.1 --input-json config='{"debug":true}'
+```
 
 ## Context Passing (OUTPUTS)
 
-Data flows from a producing runbook to a consuming runbook through two coordinated mechanisms.
-
-**How it works:**
-1. A step in the producing runbook declares step-level `OUTPUTS`. On PASS, the values merge into the run's live `state.variables`.
-2. The producing runbook declares frontmatter `OUTPUTS:` listing which of those variables to export. At terminal completion, those names are read from `state.variables` and written to `state.finalVars`.
-3. The runtime forwards the child's `finalVars` into the parent delegation's `state.variables` via a `SET_VARIABLES` event when the child completes.
-4. When the parent later delegates to a sibling runbook, the inherited variables are passed to the sibling as `--input` flags automatically.
-5. The sibling declares the values it needs in `REQUIRED:` (frontmatter), and they're satisfied from the inherited inputs.
+Outputs exported by a completed child become available as inherited inputs to later delegated children. Use this for handoffs such as "write a plan, then delegate review of that plan" without manually copying paths or values between delegations.
 
 **Example — write-plan produces PlanPath, review-plan consumes it:**
 
@@ -188,22 +192,13 @@ Read the plan from `{{ PlanPath }}`.
 
 When the parent delegates `write-plan` at step 2 and `review-plan` at step 3 (with the same `ContextId`), `PlanPath` flows through automatically — no `--input PlanPath=...` needed at the parent.
 
-**Key rules:**
-- Step OUTPUTS are evaluated on every step transition, independent of PASS/FAIL. Values land in `state.variables`.
-- Frontmatter `OUTPUTS:` are evaluated at terminal completion (`COMPLETE` or `STOPPED`). Values land in `state.finalVars` and forward to the parent.
-- Frontmatter `INPUTS:` is a YAML sequence of variable names the runbook accepts (declarations only — entries do not carry values). Defaults live in config / `--input-file` / env, not in frontmatter.
-- `REQUIRED:` must be a subset of `INPUTS:` — names in `REQUIRED:` must also appear in `INPUTS:`, otherwise the parser rejects the frontmatter.
-- Variable resolution precedence (highest → lowest): CLI `--input-json` > `--input` > `--input-file`, `RD_INPUT_*` env, parent-forwarded variables, project `.rundown/config.yaml`, built-in defaults.
-- `REQUIRED:` causes a hard error if the variable is missing from all sources.
+**Authoring notes:**
+- Export values with `OUTPUTS` in the producing runbook.
+- Declare required inherited values with frontmatter `INPUTS` and `REQUIRED` in the consuming runbook.
+- Missing required values fail before work starts.
+- Explicit inputs on `rd delegate` or `rd claim` override inherited values.
 
-### Frontmatter casing convention
-
-| Casing | Fields | Reason |
-|--------|--------|--------|
-| **UPPERCASE** | `INPUTS`, `OUTPUTS`, `REQUIRED` | Load-bearing runtime parameters; mirrors the step-level `- OUTPUTS`/`- FOR` directive style |
-| **lowercase** | `name`, `description`, `version`, `author`, `tags`, `skill` | Static metadata |
-
-The parser case-normalizes known keys, so both forms parse identically — the convention is purely for human readability.
+See [Template Variables](../../../../CLAUDE.md#template-variables) and [Context Passing](../../../../docs/spec/language.md#10-context-passing) for detailed syntax and precedence.
 
 ## Patterns
 

--- a/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
@@ -36,7 +36,7 @@ Default transitions:
 - **PASS** → advance to next step
 - **FAIL** → stop execution
 
-The runbook may override these (e.g., FAIL retries, GOTO a recovery step). **Trust the output unconditionally** — it tells you what happened and what's next. Do not second-guess or work around the runbook's transition logic, even if the result seems unexpected.
+The runbook may override these (e.g., FAIL retries, GOTO a recovery step). **Trust Rundown for execution state and transitions** — it tells you what happened and what's next. Do not second-guess or work around the runbook's transition logic, even if the result seems unexpected. Still apply normal safety, permission, and policy checks before running commands or taking external actions.
 
 ## Substeps
 
@@ -56,15 +56,13 @@ rd pass --step 2.1 --index 3    # Pass substep 2.1 at iteration 3
 rd fail --step 2.1 --index 3    # Fail substep 2.1 at iteration 3
 ```
 
-## Nested Runbooks (Inline Linkage)
+## Nested Runbooks
 
-**Inline linkage** is the default for runbook-list entries: no `- DELEGATE`, no token, the parent walks the child in-session. When you advance the parent into a step whose substep references a nested runbook, the child launches **automatically** — no command required. The parent emits the launch on entering the substep, runs the child, and resumes when it completes:
+Follow the output you receive. Inline child runbooks launch automatically when the parent advances into a substep that references a nested runbook — no manual `rd run` command required:
 
 ```bash
 rd pass    # advancing into the step that holds the inline substep auto-launches the child
 ```
-
-If you instead want an out-of-process subagent to execute the child, add `- DELEGATE` and follow the [delegating-runbooks](../delegating-runbooks/SKILL.md) skill.
 
 The child:
 - Auto-starts and executes command steps
@@ -72,57 +70,25 @@ The child:
 - Automatically propagates its result to the parent substep on completion
 - Parent advances to the next step without manual `rd pass`
 
+If the output provides a delegation token or tells you to delegate work, follow the token flow below or the [delegating-runbooks](../delegating-runbooks/SKILL.md) skill as directed.
+
 ## Context Passing (OUTPUTS)
 
-Steps and runbooks may declare OUTPUTS to flow data forward — between steps in the same run, and from a child runbook back to its parent.
+Outputs declared by steps or child runbooks become available automatically to later steps. When a later step references a value such as `{{ PlanPath }}`, trust that Rundown has carried the declared output forward.
 
-**Step OUTPUTS** — evaluated on every step transition (independent of PASS/FAIL), merged into the run's live variable space:
-```markdown
-## 7. Output Path
-- ARTIFACTS
-  - PlanPath "plan.json"
-- OUTPUTS
-  - PlanPath
-- PASS CONTINUE
-- FAIL STOP
+Do not manually copy, forward, or re-enter output values unless the runbook output explicitly asks you to do so. Your job as a runner is to follow the CLI output and step instructions, not to manage variable plumbing.
+
+If `rd run` or `rd claim` reports missing required inputs, supply them operationally:
+
+```bash
+rd run <file> --input key=value
+rd run <file> --input-json key=json
+rd run <file> --input-file <path>
+
+rd claim <token> --input key=value
+rd claim <token> --input-json key=json
+rd claim <token> --input-file <path>
 ```
-On the completing step's transition, `PlanPath` is added to `state.variables` and is visible to every later step in the same run via `{{ PlanPath }}`. Step OUTPUTS apply to both H2 steps and H3 substeps.
-
-**Frontmatter `OUTPUTS:`** — evaluated at terminal completion (`COMPLETE` or `STOPPED`), exported to the parent:
-```yaml
----
-name: write-plan
-OUTPUTS:
-  - PlanPath
----
-```
-At terminal completion, listed names are read from the merged variable space and written to `state.finalVars`. When the runbook completes as a child of a delegation, those `finalVars` are forwarded into the parent's `state.variables` via a `SET_VARIABLES` event — so the parent's later steps see `{{ PlanPath }}` automatically. No CLI plumbing required.
-
-**Receiving inputs** — declare what a runbook needs in frontmatter:
-
-```yaml
----
-name: review-plan
-INPUTS:
-  - PlanPath
-  - environment
-REQUIRED:
-  - PlanPath
----
-```
-
-`INPUTS:` is a YAML sequence of variable names the runbook accepts (declarations only, no values). `REQUIRED:` must be a subset of `INPUTS:` — names listed in `REQUIRED:` must also appear in `INPUTS:`, otherwise the parser rejects the frontmatter. `REQUIRED:` causes a hard error at startup if the variable isn't supplied by any source: CLI `--input`, `--input-file`, or `--input-json`; environment variables via `RD_INPUT_*`; parent forwarding; or project `.rundown/config.yaml`. Inside the runbook, just reference `{{ PlanPath }}`.
-
-Defaults do not live in frontmatter. Supply them via `.rundown/config.yaml`, `--input`, `--input-file`, `--input-json`, or `RD_INPUT_*` env.
-
-### Frontmatter casing convention
-
-| Casing | Fields | Reason |
-|--------|--------|--------|
-| **UPPERCASE** | `INPUTS`, `OUTPUTS`, `REQUIRED` | Load-bearing runtime parameters; mirrors the step-level `- OUTPUTS`/`- FOR` directive style |
-| **lowercase** | `name`, `description`, `version`, `author`, `tags`, `skill` | Static metadata |
-
-The parser case-normalizes known keys, so both forms parse identically — the convention is purely for human readability.
 
 ## Claiming Delegated Work
 

--- a/packages/claude-code-plugin/skills/writing-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-runbooks/SKILL.md
@@ -51,36 +51,58 @@ All frontmatter fields are optional (open schema). Place project runbooks in `.r
 | **UPPERCASE** | `INPUTS`, `OUTPUTS`, `REQUIRED` | Load-bearing runtime parameters; mirrors the step-level `- OUTPUTS`/`- FOR` directive style |
 | **lowercase** | `name`, `description`, `version`, `author`, `tags`, `skill` | Static metadata |
 
-The parser case-normalizes known keys, so both forms parse identically — the convention is purely for human readability.
-
 Validate with: `rd check <file>` and `rd resolve <file>`
 
 ## Steps
 
 ### Identifiers
 
-| Format | Type | Usage |
-|--------|------|-------|
-| `## 1` | Static | Sequential execution. Must start at 1. |
-| `## ErrorHandler` | Named | GOTO target. Skipped by default flow. |
+Prefer numeric step IDs for ordinary sequential workflows:
 
-Named identifiers must match `/^[A-Za-z_][A-Za-z0-9_]*$/`. Reserved words cannot be used as identifiers: `ALL`, `ANY`, `AT`, `BREAK`, `COMPLETE`, `CONTINUE`, `DEFER`, `FAIL`, `FOR`, `GOTO`, `IN`, `NEXT`, `NO`, `PASS`, `RETRY`, `STOP`, `TO`, `YES`. Case-sensitive: `NEXT` is reserved but `Next` is valid. `OF` is a contextual keyword but NOT reserved.
+```markdown
+## 1. Install dependencies
+## 2. Run tests
+```
 
-Separators between ID and title are flexible: `.`, `:`, `-`, `)`, space, em dash, right arrow.
+Use named IDs when a step is mainly a `GOTO` target:
+
+```markdown
+## FixFailure. Repair failing checks
+- PASS GOTO 2
+- FAIL STOP
+```
+
+Avoid transition and action words as IDs (`PASS`, `FAIL`, `CONTINUE`, `STOP`, `GOTO`, `RETRY`, etc.). Run `rd check <file>` after editing; it catches invalid IDs and malformed transitions.
+
+Separators between ID and title are flexible: `.`, `:`, `-`, `)`, or space.
 
 ### Content Order (strict)
 
-````
-## ID. Title
-- OUTPUTS             (optional, must precede FOR / transitions)
-  - Key value-expr
-- FOR clause          (optional, after OUTPUTS)
-- Transition rules    (optional, must precede body)
-Prompt text           (instructions)
-```bash              (OR substeps — not both)
-command
+Within a step, put directives before the body:
+
+````markdown
+## 1. Produce a plan
+- OUTPUTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+```bash
+printf '%s\n' "plan.md" > "$RD_OUTPUTS_PlanPath"
 ```
 ````
+
+FOR steps put iteration transitions under the `FOR` directive and use substeps:
+
+```markdown
+## 2. Review files
+- FOR file IN {{ files }}
+  - PASS DEFER
+  - FAIL DEFER
+
+### 2.1 Review current file
+Review {{ file }}.
+```
 
 ### Step Types
 
@@ -92,32 +114,36 @@ command
 
 ## Context Passing (OUTPUTS)
 
-Data flows forward through two coordinated mechanisms — between steps in the same run, and from a child runbook back to its parent in a delegation tree.
+Data flows forward by author contract:
+
+1. Declare the output name on the producing step.
+2. The command writes the value to `RD_OUTPUTS_<Name>`.
+3. Later steps read it with `{{ Name }}`.
+4. Frontmatter `OUTPUTS:` exports selected values to a parent/delegating runbook.
 
 ### Step-level OUTPUTS
 
-Declares values to publish into the run's live variable space after a step PASSes. Applies to both H2 steps and H3 substeps. FAIL skips OUTPUTS evaluation entirely.
+Declares values a step or substep will publish for later steps. Step and substep `OUTPUTS` are name-only.
 
-```markdown
-## 7. Output Path
-- ARTIFACTS
-  - PlanPath "plan.json"
+````markdown
+## 7. Write plan path
 - OUTPUTS
   - PlanPath
 - PASS CONTINUE
 - FAIL STOP
+
+```bash
+printf '%s\n' "plan.json" > "$RD_OUTPUTS_PlanPath"
 ```
+````
 
-After PASS, `PlanPath` is added to `state.variables` and is available to every later step in the same run as `{{ PlanPath }}`.
+After the step passes or fails, later steps can use `{{ PlanPath }}`.
 
-At step/substep level, `OUTPUTS` is name-only:
-- **Naked form (file-backed channel)**: `PlanPath` — pre-creates a file at `.rundown/runs/<runId>/outputs/<stepId>/<VarName>` and exports its absolute path as `RD_OUTPUTS_<VarName>` to the spawned shell. The command writes the value into that file; on exit, Rundown reads, trims, and merges it.
-
-Use `ARTIFACTS` to declare structured artifact paths/keys (for example: `PlanPath "plan.json"`), then list the alias in `OUTPUTS`.
+Use `ARTIFACTS` when the runbook should declare file artifacts separately, then list the exported variable name in `OUTPUTS`.
 
 ### Frontmatter `OUTPUTS:` — exporting to the parent
 
-Declares which variables the runbook exports at terminal completion. The listed names are read from `state.variables`, written to `state.finalVars`, and forwarded into the parent delegation's variable space via `SET_VARIABLES`.
+Declares which values the runbook exports when it completes. A parent or delegating runbook can receive these values and use them as variables.
 
 ```yaml
 ---
@@ -127,7 +153,7 @@ OUTPUTS:
 ---
 ```
 
-Combine with a step-level OUTPUTS so the value lands in `state.variables` first, then exports at completion.
+Combine frontmatter `OUTPUTS:` with a step-level `OUTPUTS` declaration so the runbook produces the value before completion.
 
 ### Frontmatter `INPUTS:` and `REQUIRED:` — declaring what a runbook needs
 
@@ -142,8 +168,8 @@ REQUIRED:
 ---
 ```
 
-- `INPUTS:` is a YAML sequence of variable names the runbook accepts. Declarations only — entries do not carry values. Names must match `/^[a-zA-Z_][a-zA-Z0-9_]*$/` and must not collide with reserved/built-in names.
-- `REQUIRED:` is a subset of `INPUTS:`. Every name in `REQUIRED:` must also appear in `INPUTS:` — mismatch is a parse-time error. Missing values trigger a hard `MISSING_REQUIRED_VARS` error at resolution.
+- `INPUTS:` is a YAML sequence of variable names the runbook accepts. Declarations only — entries do not carry values.
+- `REQUIRED:` is a subset of `INPUTS:`. `rd check <file>` reports a required name that is not declared as an input. `rd resolve <file>` reports required inputs that do not have values.
 
 Defaults are not carried in frontmatter. Provide values via `--input`, `--input-json`, `--input-file`, `RD_INPUT_*` env, parent-forwarded variables (from a parent runbook's `OUTPUTS:`), or project `.rundown/config.yaml`.
 
@@ -196,8 +222,8 @@ Verify test coverage.
 
 | Modifier | Meaning |
 |----------|---------|
-| `PASS ALL` / `FAIL ANY` | Pessimistic — any failure stops (default) |
-| `PASS ANY` / `FAIL ALL` | Optimistic — only total failure stops |
+| `PASS ALL` / `FAIL ANY` | Every substep must pass; any failed substep makes the parent fail (default) |
+| `PASS ANY` / `FAIL ALL` | One successful substep is enough; the parent fails only if every substep fails |
 
 Standalone `- DEFER` shorthand expands to `- PASS DEFER` + `- FAIL DEFER`.
 
@@ -255,6 +281,5 @@ Key authoring notes:
 ## Reference
 
 - [Rundown specification](../../../../docs/spec/language.md)
-- [Format grammar (EBNF)](../../../../docs/spec/grammar.md)
 - [Runbook patterns and examples](../../../../runbooks/README.md)
 - [Template variables](../../../../CLAUDE.md#template-variables)


### PR DESCRIPTION
## Summary
- align runbook skill docs with current OUTPUTS behavior and resolved-completion propagation
- clarify SET_VARIABLES as a general variable merge event, not child completion propagation
- remove stale XState internal line reference and raise the Node floor to match npm-run-all2@9.0.1

## Validation
- npm test -w packages/claude-code-plugin -- --runInBand commands/manifest.test.ts gates/on-skill-start.test.ts
- metadata check for engines.node, .nvmrc, and npm-run-all2 lockfile engine
- stale phrase rg check across affected docs/skills
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified delegation flow: automatic claim injection with a documented manual fallback.
  * Simplified context-passing guidance: parent variables flow to children; explicit inputs override inherited values.
  * Streamlined output semantics: declared step/child outputs are available to later steps without manual forwarding.
  * Improved runner guidance on transitions and nested runbook behavior.
  * Updated authoring best practices for step IDs, inputs/outputs, and substep aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->