### PR TITLE
docs(plugin): document automatic inline runbook launch as default

### DIFF
--- a/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
@@ -58,10 +58,10 @@ rd fail --step 2.1 --index 3    # Fail substep 2.1 at iteration 3
 
 ## Nested Runbooks (Inline Linkage)
 
-**Inline linkage** is the default for runbook-list entries: no `- DELEGATE`, no token, the parent walks the child in-session. When a step has a substep with a nested runbook reference, run the child with `--step` pointing at the parent substep:
+**Inline linkage** is the default for runbook-list entries: no `- DELEGATE`, no token, the parent walks the child in-session. When you advance the parent into a step whose substep references a nested runbook, the child launches **automatically** — no command required. The parent emits the launch on entering the substep, runs the child, and resumes when it completes:
 
 ```bash
-rd run <child-runbook> --step 1.1
+rd pass    # advancing into the step that holds the inline substep auto-launches the child
 ```
 
 If you instead want an out-of-process subagent to execute the child, add `- DELEGATE` and follow the [delegating-runbooks](../delegating-runbooks/SKILL.md) skill.
@@ -71,12 +71,6 @@ The child:
 - Presents prompted steps for you to follow
 - Automatically propagates its result to the parent substep on completion
 - Parent advances to the next step without manual `rd pass`
-
-For FOR loop iterations, add `--index`:
-
-```bash
-rd run <child-runbook> --step 1.1 --index 3
-```
 
 ## Context Passing (OUTPUTS)
 
@@ -149,12 +143,6 @@ rd claim <token> --input-file <path>
 
 For orchestrating delegation from the parent side, see [delegating-runbooks](../delegating-runbooks/SKILL.md).
 
-## Prompted
-
-With `--prompted`, command steps do NOT auto-execute — you see the command and manually advance. Use `--step 3` to jump (requires `--prompted`).
-
-Note: auto-execution is `default` behaviour and the typical usage.
-
 ## State Management
 
 ```bash
@@ -196,3 +184,21 @@ rd status --text    # Human-readable text output
 - [Runbook patterns and examples](../../../../runbooks/README.md)
 - [Rundown specification](../../../../docs/spec/language.md)
 - [CLI reference](../../../../CLAUDE.md)
+
+## Prompted Mode
+
+> Included for completeness. **Automatic execution is the default and the typical usage** — reach for `--prompted` only when you explicitly need to step through manually. Nothing above requires it.
+
+`--prompted` suppresses auto-execution: command steps do NOT run automatically — you see the command and advance manually with `rd pass` / `rd fail`. Use `--step <n>` to jump (requires `--prompted`).
+
+**Nested runbooks under `--prompted`.** Because auto-launch is suppressed, launch an inline child explicitly with `--step` pointing at the parent substep:
+
+```bash
+rd run <child-runbook> --step 1.1
+```
+
+For a FOR loop iteration, add `--index`:
+
+```bash
+rd run <child-runbook> --step 1.1 --index 3
+```


### PR DESCRIPTION
## Summary

Updates the `running-runbooks` skill so it reflects the current inline-linkage launch semantics. The skill previously documented inline children as launched via `rd run <child> --step 1.1` — but that is only the **prompted-mode** mechanism. In normal (non-prompted) execution, inline children launch **automatically** when the parent enters the substep (`STEP_ENTERED` → `inlineLaunch` intent → `launchInlineChildFromIntent`).

- **Nested Runbooks (Inline Linkage)** now documents automatic-on-entry as the single default path (`rd pass` advances into the substep, child auto-launches).
- All `--prompted` guidance — auto-execution suppression, `--step <n>` jumps, and explicit inline-child launch (`rd run <child> --step`, plus `--index`) — is collated into one **Prompted Mode** section at the end, flagged as *included for completeness*, not offered as an equal option in the body.
- Removed the old mid-document `## Prompted` stub.

## Context (verification of #341)

Issue #341 reported `rd run <child> --step` failing 100% with RD-816 against plugin v1.0.0. Investigation confirmed:

- **RD-816 is obsolete** — it was `LAUNCH_FAILED` wrapping an `InvalidRunbookStateError` on the v1.0.0 `run --step` path, which has since been replaced by the automatic-launch architecture. The original symptom does not reproduce on current `main`.
- The `rd prune --all` suffix that contradicted the end-to-end-testing skill's "preserve state" rule was already removed from the schema-validation error message.
- `rd run --step` is **not** broken — it remains the prompted-mode launch path and is covered by `inline-linkage.test.ts` (30+ passing cases); automatic launch is covered by `inline-child-launch.test.ts`. The remaining defect was purely documentation, addressed here.

Closes #341.

## Test plan

- Docs-only change to a plugin skill markdown file.
- `npm run check:spell` passes (906 files, 0 issues).
- No code paths touched; existing `inline-child-launch.test.ts` and `inline-linkage.test.ts` already pin both launch behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Clarified nested runbook auto-launch behavior: child runbooks now execute in-session automatically when a parent advances into a substep referencing them, with the parent resuming automatically upon completion.
* Updated guidance on `--prompted` mode to explain how it suppresses auto-execution and how to explicitly launch nested runbooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->