### PR TITLE
[codex] Address GitHub issues 369-375

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -169,7 +169,7 @@ rundown run my-runbook.runbook.md --step 2.1 --index 3  # Target FOR iteration 3
 **Flags:**
 - `--prompted` — Show commands without auto-executing.
 - `--text` — Output execution events as human-readable text (JSON is the default).
-- `--input <key=value>` / `--input-json <key=json>` / `--input-file <path>` — Set template variables (all repeatable). `--input-json` carries JSON array/object values.
+- `--input <key=value>` / `--input-json <key=json>` / `--input-file <path>` — Set template variables (all repeatable). `--input-json` carries JSON array/object values. `--input-file` paths must be project-relative and must remain inside the project directory after symlink resolution; absolute paths and `..` traversal are rejected.
 - `--step <stepId>` — Link this run to a parent substep for inline nested execution; with `--prompted`, jumps to the step after starting.
 - `--index <number>` — FOR loop iteration to target (requires `--step`).
 

--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -384,6 +384,9 @@ layer below it; the table lists them from lowest to highest precedence:
 Within the `cli` layer, `--input-json` overrides `--input`, which overrides
 `--input-file`. Inherited step `OUTPUTS` ride the `inherited` layer — they are
 not a separate gap-fill tier and **do** override `config` and `builtins`.
+`--input-file` paths must be project-relative and must remain inside the
+project directory after symlink resolution; absolute paths and `..` traversal
+are rejected.
 
 Plugin variables are not a precedence layer. `CLAUDE_PLUGIN_ROOT` is injected
 post-resolution for plugin-sourced runbooks only, and only when the key is

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { createTestWorkspace, runCli, type TestWorkspace } from './helpers/test-utils.js';
+import {
+  createTestWorkspace,
+  runCli,
+  runCliInProcess,
+  type TestWorkspace,
+} from './helpers/test-utils.js';
 
 describe('CLI program', () => {
   let workspace: TestWorkspace;
@@ -166,6 +171,25 @@ describe('CLI program', () => {
       const result = runCli('status --sandbox-strict --text', workspace);
       // May succeed or fail based on sandbox availability
       expect([0, 1]).toContain(result.exitCode);
+    });
+
+    it('rejects conflicting --allow-all and --deny-all flags', async () => {
+      const result = await runCliInProcess('status --allow-all --deny-all --text', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        'Conflicting policy options: --allow-all and --deny-all cannot be used together.',
+      );
+    });
+
+    it('rejects conflicting --no-sandbox and --sandbox-strict flags', async () => {
+      const result = await runCliInProcess(
+        'status --no-sandbox --sandbox-strict --text',
+        workspace,
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        'Conflicting policy options: --no-sandbox and --sandbox-strict cannot be used together.',
+      );
     });
   });
 

--- a/packages/cli/__tests__/commands/complete.test.ts
+++ b/packages/cli/__tests__/commands/complete.test.ts
@@ -304,6 +304,58 @@ Do work.
       const session = await readSession(workspace);
       expect(session.defaultStack).toContain(parentId);
     });
+
+    it('releases a terminal claimed child as an idempotent no-op', async () => {
+      const parentRunbook = `## 1. Review
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Child
+- DELEGATE
+
+Do child.
+
+- child-terminal-complete.runbook.md
+`;
+      const childRunbook = `## 1. Child
+- PASS COMPLETE
+
+Do work.
+`;
+      await writeFile(join(workspace.cwd, 'parent-terminal-complete.runbook.md'), parentRunbook);
+      await writeFile(join(workspace.cwd, 'child-terminal-complete.runbook.md'), childRunbook);
+
+      let result = await runCliInProcess(
+        'run --prompted parent-terminal-complete.runbook.md --text',
+        workspace,
+      );
+      expect(result.exitCode).toBe(0);
+      const parentState = await getActiveState(workspace);
+      const token = parentState?.substepStates?.[0]?.delegation?.token;
+      expect(token).toEqual(expect.stringMatching(/^rdtk_/));
+      if (typeof token !== 'string') throw new Error('Expected delegation token');
+      result = await runCliInProcess(`claim ${token}`, workspace);
+      expect(result.exitCode).toBe(0);
+      const claimOutput = findActionOutput(result.stdout);
+      const childRunId = String(claimOutput?.run_id);
+      const claimId = String(claimOutput?.claim_id);
+
+      const childState = await readRunbookState(workspace, childRunId);
+      expect(childState).not.toBeNull();
+      await writeFile(
+        join(workspace.statePath(), `${childRunId}.json`),
+        JSON.stringify({ ...childState, lifecycle: 'completed' }, null, 2),
+      );
+
+      result = await runCliInProcess(['complete', '--claim-id', claimId], workspace);
+
+      expect(result.exitCode).toBe(0);
+      const session = await readSession(workspace);
+      expect(Object.values(session.claims)).not.toContainEqual(
+        expect.objectContaining({ childRunId }),
+      );
+      expect(session.defaultStack).toContain(parentState!.id);
+    });
   });
 
   it('does not propagate to parent or send FORCE_COMPLETE when state is already terminal', async () => {

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -765,6 +765,37 @@ describe('delegate command', () => {
       expect(retryOutput.token).not.toBe(originalToken);
     });
 
+    it('refuses retry when the delegation has a linked child run', async () => {
+      await setupDelegation();
+
+      const first = await runCliInProcess(
+        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        workspace,
+      );
+      expect(first.exitCode).toBe(0);
+      const firstOutput = parseCliJsonObject(first.stdout);
+      const token = firstOutput.token as string;
+
+      const claim = await runCliInProcess(['claim', token], workspace);
+      expect(claim.exitCode).toBe(0);
+
+      const retry = await runCliInProcess(['delegate', '--retry', token], workspace);
+
+      expect(retry.exitCode).not.toBe(0);
+      const envelope = parseCliJsonObject(retry.stdout || retry.stderr);
+      expect(envelope).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-823' }));
+      expect(JSON.stringify(envelope)).toContain('abort');
+      expect(JSON.stringify(envelope)).toContain('--force');
+
+      const state = await getActiveState(workspace);
+      const substepStates = state?.substepStates as Array<Record<string, unknown>> | undefined;
+      const delegation = substepStates?.find((ss) => ss.id === '1')?.delegation as
+        | Record<string, unknown>
+        | undefined;
+      expect(delegation?.tokenHash).toBe(firstOutput.token_hash);
+      expect(delegation?.childRunId).not.toBeNull();
+    });
+
     it('rejects ambiguity: token + --step both provided', async () => {
       await setupDelegation();
 

--- a/packages/cli/__tests__/commands/resolve.test.ts
+++ b/packages/cli/__tests__/commands/resolve.test.ts
@@ -202,7 +202,7 @@ echo {{ item }}
     );
 
     const result = await runCliInProcess(
-      `resolve ${runbookPath} --input-file ${varFile}`,
+      `resolve ${runbookPath} --input-file vars.yaml`,
       workspace,
     );
     const output = JSON.parse(result.stdout);
@@ -354,7 +354,7 @@ echo hello
     );
 
     const result = await runCliInProcess(
-      `resolve ${runbookPath} --input-file ${badVarFile}`,
+      `resolve ${runbookPath} --input-file bad-vars.yaml`,
       workspace,
     );
     const output = JSON.parse(result.stdout);
@@ -383,7 +383,7 @@ Say {{ greeting }} to {{ recipient }}.
     );
 
     const result = await runCliInProcess(
-      `resolve ${runbookPath} --input-file ${badVarFile}`,
+      `resolve ${runbookPath} --input-file nonexistent-vars.yaml`,
       workspace,
     );
     const output = JSON.parse(result.stdout);

--- a/packages/cli/__tests__/commands/schema-validation.test.ts
+++ b/packages/cli/__tests__/commands/schema-validation.test.ts
@@ -8,7 +8,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { createTestWorkspace, runCliInProcess, type TestWorkspace } from '../helpers/test-utils.js';
+import {
+  createRunbook,
+  createTestWorkspace,
+  runCliInProcess,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
 import {
   validateActionOutput,
   validateStatusOutput,
@@ -357,6 +362,42 @@ echo done
 
       const validation = validateWarningOutput(output);
       expect(validation.valid).toBe(true);
+    });
+
+    it('validates already-resolved substep output', async () => {
+      const runbookPath = path.join(workspace.cwd, 'substeps.runbook.md');
+      fs.writeFileSync(
+        runbookPath,
+        createRunbook({
+          name: 'substeps',
+          steps: [
+            {
+              title: 'Parent Step',
+              pass: 'CONTINUE',
+              substeps: [
+                { title: 'First', content: 'Resolve once.' },
+                { title: 'Second', content: 'Keep parent unresolved.' },
+              ],
+            },
+            { title: 'Done', pass: 'COMPLETE', content: 'Finished.' },
+          ],
+        }),
+      );
+      await runCliInProcess('run --prompted substeps.runbook.md --text', workspace);
+      await runCliInProcess('pass --step 1.1', workspace);
+
+      const result = await runCliInProcess('pass --step 1.1', workspace);
+      expect(result).toMatchObject({ exitCode: 0 });
+      const output = parseJsonOutput(result.stdout);
+
+      expect(output).toMatchObject({
+        kind: 'action',
+        action: 'pass',
+        status: 'already-resolved',
+      });
+      const validation = validateActionOutput(output);
+      expect(validation.valid).toBe(true);
+      expect(validation.errors).toEqual([]);
     });
   });
 

--- a/packages/cli/__tests__/commands/stash-pop.test.ts
+++ b/packages/cli/__tests__/commands/stash-pop.test.ts
@@ -309,6 +309,13 @@ describe('stash command', () => {
 
     result = await runCliInProcess(['pop', '--claim-id', claimId], workspace);
     expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        code: 'CLAIMED_RUNBOOK_UNAVAILABLE',
+        error: expect.stringContaining('missing child state'),
+      }),
+    );
     const session = await readSession(workspace);
     expect(session.stashed).toBe(childRunId);
     expect(Object.values(session.claims)).toContainEqual(expect.objectContaining({ childRunId }));
@@ -369,6 +376,7 @@ describe('stash command', () => {
       expect.objectContaining({
         kind: 'error',
         code: 'CLAIMED_RUNBOOK_UNAVAILABLE',
+        error: expect.stringContaining('parent runbook has completed'),
       }),
     );
 

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -322,6 +322,21 @@ describe('claim-id delegated children', () => {
     );
   });
 
+  it('claim id renders terminal child status instead of unavailable', async () => {
+    const { childRunId, claimId } = await setupOwnedStash();
+    const stateFile = join(workspace.statePath(), `${childRunId}.json`);
+    const state = JSON.parse(await readFile(stateFile, 'utf-8')) as Record<string, unknown>;
+    await writeFile(stateFile, JSON.stringify({ ...state, lifecycle: 'completed' }, null, 2));
+
+    const status = await runCliInProcess(['status', '--claim-id', claimId], workspace);
+    const output = JSON.parse(status.stdout);
+
+    expect(status.exitCode).toBe(0);
+    expect(output.active).toBe(false);
+    expect(output.status).toBe('completed');
+    expect(output.state).toContain(childRunId);
+  });
+
   it('anonymous stash remains visible to plain callers', async () => {
     await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
     await runCliInProcess('stash --text', workspace);

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -381,6 +381,58 @@ Do work.
       expect(session.active).toBe(parentState!.id);
       expect(await readRunbookState(workspace, parentState!.id)).not.toBeNull();
     });
+
+    it('releases a terminal claimed child as an idempotent no-op', async () => {
+      const parentRunbook = `## 1. Review
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Child
+- DELEGATE
+
+Do child.
+
+- child-terminal-stop.runbook.md
+`;
+      const childRunbook = `## 1. Child
+- PASS COMPLETE
+
+Do work.
+`;
+      await writeFile(join(workspace.cwd, 'parent-terminal-stop.runbook.md'), parentRunbook);
+      await writeFile(join(workspace.cwd, 'child-terminal-stop.runbook.md'), childRunbook);
+
+      let result = await runCliInProcess(
+        'run --prompted parent-terminal-stop.runbook.md --text',
+        workspace,
+      );
+      expect(result.exitCode).toBe(0);
+      const parentState = await getActiveState(workspace);
+      const token = parentState?.substepStates?.[0]?.delegation?.token;
+      expect(token).toEqual(expect.stringMatching(/^rdtk_/));
+      if (typeof token !== 'string') throw new Error('Expected delegation token');
+      result = await runCliInProcess(`claim ${token}`, workspace);
+      expect(result.exitCode).toBe(0);
+      const claimOutput = findActionOutput(result.stdout);
+      const childRunId = String(claimOutput?.run_id);
+      const claimId = String(claimOutput?.claim_id);
+
+      const childState = await readRunbookState(workspace, childRunId);
+      expect(childState).not.toBeNull();
+      await writeFile(
+        join(workspace.statePath(), `${childRunId}.json`),
+        JSON.stringify({ ...childState, lifecycle: 'stopped' }, null, 2),
+      );
+
+      result = await runCliInProcess(['stop', '--claim-id', claimId], workspace);
+
+      expect(result.exitCode).toBe(0);
+      const session = await readSession(workspace);
+      expect(Object.values(session.claims)).not.toContainEqual(
+        expect.objectContaining({ childRunId }),
+      );
+      expect(session.defaultStack).toContain(parentState!.id);
+    });
   });
 
   describe('stop with message', () => {

--- a/packages/cli/__tests__/helpers/active-runbook-resolver.test.ts
+++ b/packages/cli/__tests__/helpers/active-runbook-resolver.test.ts
@@ -49,6 +49,37 @@ describe('resolveActiveRunbook', () => {
     }
   });
 
+  it('preserves terminal claim resolution with final child state', async () => {
+    const claimId = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
+    const terminalChild = { ...child, lifecycle: 'completed' } as RunbookState;
+    const sessionService = {
+      getActiveForClaimId: async () => ({
+        status: 'terminal' as const,
+        claim: {
+          kind: 'claim-record',
+          claimId,
+          childRunId: 'child',
+          tokenHash: `sha256:${'a'.repeat(64)}`,
+          parentRunId: 'parent',
+          parentStepId: '1.1',
+          claimedAt: '2026-05-01T00:00:00.000Z',
+          updatedAt: '2026-05-01T00:00:00.000Z',
+        },
+        lifecycle: 'completed' as const,
+        state: terminalChild,
+      }),
+      getActive: async () => parent,
+    } as unknown as SessionService;
+
+    const result = await resolveActiveRunbook(sessionService, { claimId });
+
+    expect(result.kind).toBe('terminal_claim');
+    if (result.kind === 'terminal_claim') {
+      expect(result.lifecycle).toBe('completed');
+      expect(result.state.id).toBe('child');
+    }
+  });
+
   it('resolves default stack when no claim id is supplied', async () => {
     const sessionService = {
       getActive: async () => parent,

--- a/packages/cli/__tests__/helpers/wrapper.test.ts
+++ b/packages/cli/__tests__/helpers/wrapper.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import { Errors } from '@rundown-org/core';
+import { ErrorResponseSchema, Errors } from '@rundown-org/core';
 import { RunbookSyntaxError } from '@rundown-org/parser';
 
 const { withErrorHandling } = await import('../../src/helpers/wrapper.js');
@@ -9,17 +9,30 @@ describe('withErrorHandling', () => {
   const originalExit = process.exit;
   let mockExit: jest.Mock;
   let errorSpy: jest.SpiedFunction<typeof console.error>;
+  let stdoutWriteSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let stderrWriteSpy: jest.SpiedFunction<typeof process.stderr.write>;
 
   beforeEach(() => {
     mockExit = jest.fn();
     process.exit = mockExit as unknown as typeof process.exit;
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    stdoutWriteSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
     process.exit = originalExit;
     errorSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
   });
+
+  function parseStdoutJson(): Record<string, unknown> {
+    return JSON.parse(stdoutWriteSpy.mock.calls.map((call) => String(call[0])).join('')) as Record<
+      string,
+      unknown
+    >;
+  }
 
   it('executes fn successfully without calling exit', async () => {
     await withErrorHandling(async () => {});
@@ -37,8 +50,9 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const output = errorSpy.mock.calls[0]?.[0] as string;
-    const parsed = JSON.parse(output);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(stderrWriteSpy).not.toHaveBeenCalled();
+    const parsed = parseStdoutJson();
     expect(parsed.kind).toBe('error');
     expect(parsed.error).toBe(error.message);
     expect(parsed.code).toBe(error.code);
@@ -47,6 +61,7 @@ describe('withErrorHandling', () => {
       category: error.errorCode.category,
       title: error.errorCode.title,
     });
+    expect(ErrorResponseSchema.safeParse(parsed).success).toBe(true);
   });
 
   it('includes the command field when options.command is provided', async () => {
@@ -59,7 +74,7 @@ describe('withErrorHandling', () => {
       { command: 'run' },
     );
 
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.command).toBe('run');
   });
 
@@ -89,7 +104,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.fileNotFound('x').code);
   });
 
@@ -104,7 +119,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.fileNotReadable('x').code);
   });
 
@@ -119,7 +134,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.fileNotReadable('x').code);
   });
 
@@ -131,7 +146,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.syntaxError('x').code);
   });
 
@@ -141,7 +156,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.unknown('x').code);
   });
 
@@ -152,7 +167,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.unknown('x').code);
   });
 

--- a/packages/cli/__tests__/integration/delegate-workflow.test.ts
+++ b/packages/cli/__tests__/integration/delegate-workflow.test.ts
@@ -7,6 +7,7 @@ import {
   runCliInProcess,
   getActiveState,
   readRunbookState,
+  parseCliJsonObject,
   parseConcatenatedJson,
   findActionOutput,
   type TestWorkspace,
@@ -903,11 +904,9 @@ describe('DELEGATE re-entry and retry', () => {
   // has a fresh token, cancelledAt null, childRunId null, same childRunbookPath).
   // ---------------------------------------------------------------------------
   it('rd delegate --retry CLI forms (token, --step, inferred) all produce equivalent state (spec §8.1 Test 5)', async () => {
-    // Helper: build a parent + child, start the parent, and run claim on ss2
-    // (so it's in a claimed-but-not-yet-resolved state suitable for retry).
-    // Under reverted Route A, claimed children are NOT pushed onto
-    // defaultStack — the parent remains at session top after `rd claim`.
-    async function setupClaimed(): Promise<{
+    // Helper: build a parent + child, resolve ss1, and leave ss2 pending
+    // (token issued but childRunId still null) so it is suitable for retry.
+    async function setupPendingSecond(): Promise<{
       parentRunId: string;
       token2: string;
       priorDelegation: Record<string, unknown>;
@@ -923,21 +922,18 @@ describe('DELEGATE re-entry and retry', () => {
       const claimId1 = String(claim1!.claim_id);
       r = await runCliInProcess(['pass', '--claim-id', claimId1], workspace);
       expect(r.exitCode).toBe(0);
-      // Claim ss2 but don't pass/fail yet — leaves the delegation in
-      // claimed-but-unresolved state for retry tests.
-      r = await runCliInProcess(`claim ${token2}`, workspace);
-      expect(r.exitCode).toBe(0);
       const state = await readRunbookState(workspace, parentRunId);
       const substeps = state?.substepStates as Array<Record<string, unknown>> | undefined;
       const ss = substeps?.find((s) => s.id === '2');
       const priorDelegation = ss?.delegation as Record<string, unknown>;
+      expect(priorDelegation.childRunId).toBeNull();
       return { parentRunId, token2, priorDelegation };
     }
 
     // Form 1: token positional. Token-form resolves by tokenHash regardless
     // of active session top (parent is looked up via scan).
     {
-      const { parentRunId, token2, priorDelegation } = await setupClaimed();
+      const { parentRunId, token2, priorDelegation } = await setupPendingSecond();
       const retry = await runCliInProcess(['delegate', '--retry', token2], workspace);
       expect(retry.exitCode).toBe(0);
       const out = JSON.parse(retry.stdout) as Record<string, unknown>;
@@ -964,7 +960,7 @@ describe('DELEGATE re-entry and retry', () => {
     // (claimed children are not pushed onto defaultStack), so no session
     // manipulation is needed.
     {
-      const { parentRunId, priorDelegation } = await setupClaimed();
+      const { parentRunId, priorDelegation } = await setupPendingSecond();
       const retry = await runCliInProcess(['delegate', '--retry', '--step', '1.2'], workspace);
       expect(retry.exitCode).toBe(0);
       const out = JSON.parse(retry.stdout) as Record<string, unknown>;
@@ -985,7 +981,7 @@ describe('DELEGATE re-entry and retry', () => {
     // Form 3: inferred (no args) — infers from active substep. Under reverted
     // Route A, parent is already at session top after `rd claim`.
     {
-      const { parentRunId, priorDelegation } = await setupClaimed();
+      const { parentRunId, priorDelegation } = await setupPendingSecond();
       const retry = await runCliInProcess(['delegate', '--retry'], workspace);
       expect(retry.exitCode).toBe(0);
       const out = JSON.parse(retry.stdout) as Record<string, unknown>;
@@ -1003,7 +999,7 @@ describe('DELEGATE re-entry and retry', () => {
     // Ambiguity rejection: token + --step is an error.
     await workspace.cleanup();
     workspace = await createTestWorkspace();
-    const { token2 } = await setupClaimed();
+    const { token2 } = await setupPendingSecond();
     const ambiguous = await runCliInProcess(
       ['delegate', '--retry', token2, '--step', '1.2'],
       workspace,
@@ -1329,10 +1325,9 @@ describe('DELEGATE re-entry and retry', () => {
   // ---------------------------------------------------------------------------
   // Task 11 additional test — result-agnostic CLI retry (spec §4.4).
   //
-  // `rd delegate --retry` accepts retry regardless of substep result. We
-  // exercise three states: pending (unclaimed), claimed (childRunId set but
-  // no result recorded), and passed (result='pass'). All three must succeed
-  // and mint a fresh token.
+  // `rd delegate --retry` accepts retry regardless of substep result only
+  // when no child run remains linked. A linked childRunId must be force-
+  // aborted first so retry does not abandon an in-flight or completed child.
   // ---------------------------------------------------------------------------
   it('rd delegate --retry accepts delegations regardless of substep result (spec §4.4)', async () => {
     // State 1: PENDING (unclaimed). Start runbook; do not claim ss2.
@@ -1379,19 +1374,31 @@ describe('DELEGATE re-entry and retry', () => {
       const preSs = preSubsteps?.find((s) => s.id === '2');
       const preDel = preSs?.delegation as Record<string, unknown>;
       expect(preDel.childRunId).not.toBeNull();
+      const priorHash = preDel.tokenHash;
+      const childRunId = preDel.childRunId;
 
       const retry = await runCliInProcess(['delegate', '--retry', token2], workspace);
-      expect(retry.exitCode).toBe(0);
-      const out = JSON.parse(retry.stdout) as Record<string, unknown>;
-      expect(out.action).toBe('retried');
-      expect(out.token).not.toBe(token2);
+      expect(retry.exitCode).not.toBe(0);
+      const out = parseCliJsonObject(retry.stdout || retry.stderr);
+      expect(out).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-823' }));
+      expect(JSON.stringify(out)).toContain(String(childRunId));
+
+      const postState = await readRunbookState(workspace, parentRunId);
+      const postSubsteps = postState?.substepStates as Array<Record<string, unknown>> | undefined;
+      const postDel = postSubsteps?.find((s) => s.id === '2')?.delegation as Record<
+        string,
+        unknown
+      >;
+      expect(postDel.tokenHash).toBe(priorHash);
+      expect(postDel.childRunId).toBe(childRunId);
     }
     await workspace.cleanup();
     workspace = await createTestWorkspace();
 
-    // State 3: PASSED. Claim ss1 + pass. Retry ss1's delegation even though
-    // it already recorded a pass result. Cursor hasn't moved past step 1
-    // (ss2 is still pending), so ss1 is still on the active frontier.
+    // State 3: PASSED but still linked. Claim ss1 + pass. The propagated
+    // result is present, but childRunId remains linked until collection/abort
+    // clears the ownership path, so retry must refuse rather than discard the
+    // recorded result.
     {
       const { parentRunId, token1 } = await setupRetryParent();
       let r = await runCliInProcess(`claim ${token1}`, workspace);
@@ -1410,14 +1417,23 @@ describe('DELEGATE re-entry and retry', () => {
       expect(preSs?.result).toBe('pass');
       const preDel = preSs?.delegation as Record<string, unknown>;
       const priorHash = preDel.tokenHash;
+      const childRunId = preDel.childRunId;
+      expect(childRunId).not.toBeNull();
 
-      // Retry the passed delegation. CLI is permissive (§4.4).
       const retry = await runCliInProcess(['delegate', '--retry', token1], workspace);
-      expect(retry.exitCode).toBe(0);
-      const out = JSON.parse(retry.stdout) as Record<string, unknown>;
-      expect(out.action).toBe('retried');
-      expect(out.token).not.toBe(token1);
-      expect(out.token_hash).not.toBe(priorHash);
+      expect(retry.exitCode).not.toBe(0);
+      const out = parseCliJsonObject(retry.stdout || retry.stderr);
+      expect(out).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-823' }));
+      expect(JSON.stringify(out)).toContain(String(childRunId));
+
+      const postState = await readRunbookState(workspace, parentRunId);
+      const postSubsteps = postState?.substepStates as Array<Record<string, unknown>> | undefined;
+      const postDel = postSubsteps?.find((s) => s.id === '1')?.delegation as Record<
+        string,
+        unknown
+      >;
+      expect(postDel.tokenHash).toBe(priorHash);
+      expect(postDel.childRunId).toBe(childRunId);
     }
   }, 60_000);
 

--- a/packages/cli/__tests__/services/policy-context.test.ts
+++ b/packages/cli/__tests__/services/policy-context.test.ts
@@ -16,6 +16,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
 // Dynamic imports are needed after mocking
 const core = await import('@rundown-org/core');
 const {
+  PolicyCliOptionConflictError,
   initializePolicyContext,
   getPolicyContext,
   getPolicyEvaluator,
@@ -75,6 +76,18 @@ describe('policy context service', () => {
     it('handles sandbox flags', () => {
       expect(parsePolicyCliOptions({ sandbox: true }).sandbox).toBe(true);
       expect(parsePolicyCliOptions({ sandbox: false }).sandbox).toBe(false);
+    });
+
+    it('rejects conflicting allow-all and deny-all flags', () => {
+      expect(() => parsePolicyCliOptions({ allowAll: true, denyAll: true })).toThrow(
+        PolicyCliOptionConflictError,
+      );
+    });
+
+    it('rejects no-sandbox with sandbox-strict', () => {
+      expect(() => parsePolicyCliOptions({ sandbox: false, sandboxStrict: true })).toThrow(
+        PolicyCliOptionConflictError,
+      );
     });
 
     it('parses trustJsPolicy flag', () => {

--- a/packages/cli/__tests__/services/variable-discovery.test.ts
+++ b/packages/cli/__tests__/services/variable-discovery.test.ts
@@ -615,7 +615,7 @@ describe('resolveVariables', () => {
       const varFile = path.join(tmpDir, `${name}.yaml`);
       await fs.writeFile(varFile, `${name}: shadow\n`);
 
-      await expect(resolveVariables({ inputFile: [varFile] }, tmpDir)).rejects.toThrow(
+      await expect(resolveVariables({ inputFile: [`${name}.yaml`] }, tmpDir)).rejects.toThrow(
         /reserved runtime variable/i,
       );
     });
@@ -723,7 +723,7 @@ describe('resolveVariables', () => {
       const varFile = path.join(tmpDir, 'vars.yaml');
       await fs.writeFile(varFile, 'servers:\n  - alpha\n  - beta\n  - gamma\n');
 
-      const result = await resolveVariables({ inputFile: [varFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['vars.yaml'] }, tmpDir);
       expect(result.vars.servers).toEqual(['alpha', 'beta', 'gamma']);
     });
   });
@@ -733,7 +733,7 @@ describe('resolveVariables', () => {
       const varFile = path.join(tmpDir, 'vars.yaml');
       await fs.writeFile(varFile, 'log: |\n  line1\n  line2\n  line3\n');
 
-      const result = await resolveVariables({ inputFile: [varFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['vars.yaml'] }, tmpDir);
       // YAML block scalar with trailing newline stripped by YAML parser produces "line1\nline2\nline3\n"
       expect(typeof result.vars.log).toBe('string');
       expect((result.vars.log as string).includes('\n')).toBe(true);
@@ -745,7 +745,7 @@ describe('resolveVariables', () => {
       const tmpFile = path.join(tmpDir, 'objects.yaml');
       await fs.writeFile(tmpFile, 'config:\n  host: localhost\n  port: 3000\n');
 
-      const result = await resolveVariables({ inputFile: [tmpFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['objects.yaml'] }, tmpDir);
 
       expect(result.vars.config).toEqual({ host: 'localhost', port: 3000 });
     });
@@ -755,7 +755,7 @@ describe('resolveVariables', () => {
       // YAML parses unquoted timestamps as Date objects
       await fs.writeFile(tmpFile, 'event:\n  name: launch\n  date: 2026-03-20\n');
 
-      const result = await resolveVariables({ inputFile: [tmpFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['date-obj.yaml'] }, tmpDir);
 
       // Date gets parsed by yaml.load() as a JS Date, failing isJsonValue
       expect(typeof result.vars.event).toBe('string');
@@ -769,7 +769,7 @@ describe('resolveVariables', () => {
       // Quoted strings prevent YAML date parsing
       await fs.writeFile(tmpFile, 'config:\n  host: localhost\n  port: 3000\n  debug: true\n');
 
-      const result = await resolveVariables({ inputFile: [tmpFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['normal-obj.yaml'] }, tmpDir);
 
       expect(result.vars.config).toEqual({ host: 'localhost', port: 3000, debug: true });
       expect(result.warnings).toHaveLength(0);
@@ -783,7 +783,7 @@ describe('resolveVariables', () => {
       const varFile = path.join(tmpDir, 'vars.yaml');
       await fs.writeFile(varFile, `items: "file:${dataFile}"\n`);
 
-      const result = await resolveVariables({ inputFile: [varFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['vars.yaml'] }, tmpDir);
       expect(isJsonArrayStream(result.vars.items)).toBe(true);
       expect(result.vars.items).toMatchObject({
         kind: 'json-array-stream',
@@ -848,7 +848,7 @@ describe('resolveVariables', () => {
       await fs.writeFile(varFile, `items: "file:${fileA}"\n`);
 
       const result = await resolveVariables(
-        { inputFile: [varFile], input: [`items=file:${fileB}`] },
+        { inputFile: ['vars.yaml'], input: [`items=file:${fileB}`] },
         tmpDir,
       );
       expect(isJsonArrayStream(result.vars.items)).toBe(true);
@@ -901,7 +901,7 @@ describe('resolveVariables', () => {
         ].join('\n'),
       );
 
-      const result = await resolveVariables({ inputFile: [varFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['vars.yaml'] }, tmpDir);
 
       expect(result.vars.Plan).toEqual({ ...row, kind: 'artifact-record' });
       expect(isTrustedArtifactRecord(result.vars.Plan)).toBe(true);
@@ -966,7 +966,7 @@ describe('resolveVariables', () => {
       await fs.writeFile(varFile, 'servers:\n  - alpha\n  - beta\n');
 
       const result = await resolveVariables(
-        { inputFile: [varFile], input: ['servers=prod'] },
+        { inputFile: ['vars.yaml'], input: ['servers=prod'] },
         tmpDir,
       );
       expect(result.vars.servers).toBe('prod');
@@ -979,7 +979,7 @@ describe('resolveVariables', () => {
       await fs.writeFile(varFile, 'items:\n  - x\n  - y\n');
 
       const result = await resolveVariables(
-        { inputFile: [varFile], input: [`items=file:${dataFile}`] },
+        { inputFile: ['vars.yaml'], input: [`items=file:${dataFile}`] },
         tmpDir,
       );
       expect(isJsonArrayStream(result.vars.items)).toBe(true);
@@ -997,7 +997,7 @@ describe('resolveVariables', () => {
       await fs.mkdir(configDir, { recursive: true });
       await fs.writeFile(path.join(configDir, 'config.yaml'), 'servers: single\n');
 
-      const result = await resolveVariables({ inputFile: [varFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['vars.yaml'] }, tmpDir);
       expect(result.vars.servers).toEqual(['a', 'b']);
     });
 
@@ -1009,7 +1009,7 @@ describe('resolveVariables', () => {
       await fs.mkdir(configDir, { recursive: true });
       await fs.writeFile(path.join(configDir, 'config.yaml'), 'items:\n  - x\n  - "y"\n');
 
-      const result = await resolveVariables({ inputFile: [varFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['vars.yaml'] }, tmpDir);
       expect(result.vars.items).toBe('override');
     });
 
@@ -1018,7 +1018,7 @@ describe('resolveVariables', () => {
       await fs.writeFile(varFile, 'log: |\n  line1\n  line2\n');
 
       const result = await resolveVariables(
-        { inputFile: [varFile], input: ['log=override'] },
+        { inputFile: ['vars.yaml'], input: ['log=override'] },
         tmpDir,
       );
       expect(result.vars.log).toBe('override');
@@ -1283,7 +1283,7 @@ describe('resolveVariables', () => {
       const varFile = path.join(tmpDir, 'vars.yaml');
       await fs.writeFile(varFile, 'message: from-file\n');
 
-      const result = await resolveVariables({ inputFile: [varFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['vars.yaml'] }, tmpDir);
 
       expect(result.vars.message).toBe('from-file');
     });
@@ -1315,7 +1315,7 @@ describe('resolveVariables', () => {
       await fs.writeFile(fileA, 'alpha: one\n');
       await fs.writeFile(fileB, 'beta: two\n');
 
-      const result = await resolveVariables({ inputFile: [fileA, fileB] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['a.yaml', 'b.yaml'] }, tmpDir);
 
       expect(result.vars.alpha).toBe('one');
       expect(result.vars.beta).toBe('two');
@@ -1327,7 +1327,7 @@ describe('resolveVariables', () => {
       await fs.writeFile(fileA, 'shared: from-a\n');
       await fs.writeFile(fileB, 'shared: from-b\n');
 
-      const result = await resolveVariables({ inputFile: [fileA, fileB] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['a.yaml', 'b.yaml'] }, tmpDir);
 
       expect(result.vars.shared).toBe('from-b');
     });
@@ -1336,7 +1336,7 @@ describe('resolveVariables', () => {
       const varFile = path.join(tmpDir, 'vars.yaml');
       await fs.writeFile(varFile, 'greeting: hello\n');
 
-      const result = await resolveVariables({ inputFile: [varFile] }, tmpDir);
+      const result = await resolveVariables({ inputFile: ['vars.yaml'] }, tmpDir);
 
       expect(result.vars.greeting).toBe('hello');
     });
@@ -1608,14 +1608,80 @@ describe('collectCliFlags', () => {
     const varFile = path.join(tmpDir, 'vars.yaml');
     await fs.writeFile(varFile, 'greeting: hello\ncount: 42\n');
 
-    const result = await collectCliFlags({ inputFile: [varFile] }, tmpDir);
+    const result = await collectCliFlags({ inputFile: ['vars.yaml'] }, tmpDir);
     expect(result).toEqual({ greeting: 'hello', count: 42 });
   });
 
-  it('rejects missing --input-file paths', async () => {
-    const missingPath = path.join(tmpDir, 'missing.yaml');
+  it('collects project-relative --input-file contents', async () => {
+    const varFile = path.join(tmpDir, 'vars.yaml');
+    await fs.writeFile(varFile, 'greeting: hello\n');
 
-    await expect(collectCliFlags({ inputFile: [missingPath] }, tmpDir)).rejects.toThrow(/ENOENT/);
+    const result = await collectCliFlags({ inputFile: ['vars.yaml'] }, tmpDir);
+    expect(result).toEqual({ greeting: 'hello' });
+  });
+
+  it('rejects absolute --input-file paths outside the project root', async () => {
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'collect-cli-flags-outside-'));
+    const outsideFile = path.join(outsideDir, 'vars.yaml');
+    await fs.writeFile(outsideFile, 'secret: leaked\n');
+
+    try {
+      await expect(collectCliFlags({ inputFile: [outsideFile] }, tmpDir)).rejects.toThrow(
+        /--input-file path must be relative to the project directory/,
+      );
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects absolute --input-file paths inside the project root', async () => {
+    const varFile = path.join(tmpDir, 'vars.yaml');
+    await fs.writeFile(varFile, 'greeting: hello\n');
+
+    await expect(collectCliFlags({ inputFile: [varFile] }, tmpDir)).rejects.toThrow(
+      /--input-file path must be relative to the project directory/,
+    );
+  });
+
+  it('rejects relative --input-file traversal outside the project root', async () => {
+    const parentFile = path.join(path.dirname(tmpDir), 'vars.yaml');
+    await fs.writeFile(parentFile, 'secret: leaked\n');
+
+    try {
+      await expect(collectCliFlags({ inputFile: ['../vars.yaml'] }, tmpDir)).rejects.toThrow(
+        /--input-file path escapes project directory/,
+      );
+    } finally {
+      await fs.rm(parentFile, { force: true });
+    }
+  });
+
+  it('rejects symlinked --input-file paths that resolve outside the project root', async () => {
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'collect-cli-flags-outside-'));
+    const outsideFile = path.join(outsideDir, 'vars.yaml');
+    const linkPath = path.join(tmpDir, 'linked-vars.yaml');
+    await fs.writeFile(outsideFile, 'secret: leaked\n');
+    await fs.symlink(outsideFile, linkPath);
+
+    try {
+      await expect(collectCliFlags({ inputFile: ['linked-vars.yaml'] }, tmpDir)).rejects.toThrow(
+        /--input-file path escapes project directory/,
+      );
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects missing --input-file paths', async () => {
+    await expect(collectCliFlags({ inputFile: ['missing.yaml'] }, tmpDir)).rejects.toThrow(
+      /ENOENT/,
+    );
+  });
+
+  it('preserves nested project-relative path when --input-file is missing', async () => {
+    await expect(collectCliFlags({ inputFile: ['missing/vars.yaml'] }, tmpDir)).rejects.toThrow(
+      /missing\/vars\.yaml/,
+    );
   });
 
   it('rejects invalid --input entries that bypass option parsing', async () => {
@@ -1635,7 +1701,7 @@ describe('collectCliFlags', () => {
     await fs.writeFile(varFile, 'key: from-file\n');
 
     const result = await collectCliFlags(
-      { inputFile: [varFile], input: ['key=from-var'], inputJson: ['key="from-json"'] },
+      { inputFile: ['vars.yaml'], input: ['key=from-var'], inputJson: ['key="from-json"'] },
       tmpDir,
     );
     expect(result.key).toBe('from-json');

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -70,6 +70,7 @@ export function registerCollectCommand(program: Command): void {
                 output.flush();
                 return;
               case 'stale_claim':
+              case 'terminal_claim':
                 output.error(contextResult.message, 'CLAIMED_RUNBOOK_UNAVAILABLE');
                 output.flush();
                 process.exitCode = 1;

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -64,6 +64,9 @@ export function registerCompleteCommand(program: Command): void {
               case 'default':
                 state = active.state;
                 break;
+              case 'terminal_claim':
+                state = active.state;
+                break;
               case 'none':
                 break;
               case 'stale_claim':

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -563,6 +563,7 @@ async function executeRetry(target: ResolvedTarget, args: RetryHandlerOptions): 
   switch (result.status) {
     case 'not_found':
     case 'not_current':
+    case 'in_flight':
     case 'error':
       // Rethrow so withErrorHandling's toRundownError -> stderr envelope
       // fires with the inner RundownError's code (RD-801 / RD-802 / inner

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -38,6 +38,7 @@ export function registerGotoCommand(program: Command): void {
                 output.flush();
                 return;
               case 'stale_claim':
+              case 'terminal_claim':
                 output.error(contextResult.message, 'CLAIMED_RUNBOOK_UNAVAILABLE');
                 output.flush();
                 process.exitCode = 1;

--- a/packages/cli/src/commands/pop.ts
+++ b/packages/cli/src/commands/pop.ts
@@ -6,6 +6,9 @@ import {
   SessionService,
   countNumberedSteps,
   type ActionBlockData,
+  type ClaimId,
+  type RunbookState,
+  type UnstashForClaimIdResult,
 } from '@rundown-org/core';
 import { getCwd } from '../helpers/context.js';
 import { getStepRetryMax, buildMetadata, formatActionForDisplay } from '../services/execution.js';
@@ -13,6 +16,32 @@ import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
+
+function claimPopUnavailableMessage(
+  claimId: ClaimId,
+  result: Exclude<UnstashForClaimIdResult, { status: 'restored' }>,
+): string {
+  switch (result.status) {
+    case 'missing-claim':
+      return `Claim id ${claimId} does not exist.`;
+    case 'not-stashed':
+      return `Claim id ${claimId} is not currently stashed.`;
+    case 'missing-child':
+      return `Claim id ${claimId} points at missing child state.`;
+    case 'terminal-child':
+      return `Claim id ${claimId} points at a ${result.lifecycle} child runbook.`;
+    case 'child-linkage-mismatch':
+      return `Claim id ${claimId} is no longer linked to its child runbook.`;
+    case 'parent-missing':
+      return `Claim id ${claimId} parent runbook is missing.`;
+    case 'parent-ended':
+      return `Claim id ${claimId} parent runbook has ${result.lifecycle}.`;
+    default: {
+      const _exhaustive: never = result;
+      return _exhaustive;
+    }
+  }
+}
 
 /**
  * Registers the 'pop' command for resuming stashed runbooks.
@@ -35,18 +64,19 @@ export function registerPopCommand(program: Command): void {
           const claimTarget = parseClaimIdOption(options.claimId, output);
           if (!claimTarget.ok) return;
 
-          let state: Awaited<ReturnType<typeof sessionService.unstash>>;
+          let state: RunbookState | null;
           if (claimTarget.claimId !== undefined) {
-            state = await sessionService.unstashForClaimId(claimTarget.claimId);
-            if (!state) {
+            const unstashed = await sessionService.unstashForClaimId(claimTarget.claimId);
+            if (unstashed.status !== 'restored') {
               output.error(
-                `No stashed runbook is available for claim id ${claimTarget.claimId}.`,
+                claimPopUnavailableMessage(claimTarget.claimId, unstashed),
                 'CLAIMED_RUNBOOK_UNAVAILABLE',
               );
               output.flush();
               process.exitCode = 1;
               return;
             }
+            state = unstashed.state;
           } else {
             state = await sessionService.unstash();
           }

--- a/packages/cli/src/commands/stash.ts
+++ b/packages/cli/src/commands/stash.ts
@@ -41,6 +41,7 @@ export function registerStashCommand(program: Command): void {
               output.flush();
               return;
             case 'stale_claim':
+            case 'terminal_claim':
               output.error(active.message, 'CLAIMED_RUNBOOK_UNAVAILABLE');
               output.flush();
               process.exitCode = 1;

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -53,6 +53,18 @@ export function registerStatusCommand(program: Command): void {
               );
               output.flush();
               return;
+            case 'terminal_claim':
+              output.detail(
+                buildActiveStatus(
+                  active.state,
+                  cwd,
+                  stashedId ?? undefined,
+                  active.lifecycle,
+                ) as unknown as Record<string, unknown>,
+                'status',
+              );
+              output.flush();
+              return;
             case 'none':
               break;
             case 'stale_claim':

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -55,6 +55,9 @@ export function registerStopCommand(program: Command): void {
               case 'default':
                 state = active.state;
                 break;
+              case 'terminal_claim':
+                state = active.state;
+                break;
               case 'none':
                 break;
               case 'stale_claim':

--- a/packages/cli/src/helpers/active-runbook-resolver.ts
+++ b/packages/cli/src/helpers/active-runbook-resolver.ts
@@ -8,6 +8,14 @@ export type ActiveRunbookResolution =
       readonly claim: ClaimRecord;
       readonly state: RunbookState;
     }
+  | {
+      readonly kind: 'terminal_claim';
+      readonly claimId: ClaimId;
+      readonly claim: ClaimRecord;
+      readonly state: RunbookState;
+      readonly lifecycle: 'completed' | 'stopped';
+      readonly message: string;
+    }
   | { readonly kind: 'default'; readonly state: RunbookState }
   | { readonly kind: 'none' }
   | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string };
@@ -54,8 +62,11 @@ export async function resolveActiveRunbook(
         };
       case 'terminal':
         return {
-          kind: 'stale_claim',
+          kind: 'terminal_claim',
           claimId: options.claimId,
+          claim: claimed.claim,
+          state: claimed.state,
+          lifecycle: claimed.lifecycle,
           message: `Claim id ${options.claimId} points at a ${claimed.lifecycle} child runbook.`,
         };
       case 'unlinked':

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -68,7 +68,7 @@ export type GotoExecutionResult =
 /** Result of resolving the runbook target and building goto execution context. */
 export type BuildGotoContextResult =
   | { readonly kind: 'ready'; readonly ctx: GotoContext }
-  | Extract<ActiveRunbookResolution, { kind: 'none' | 'stale_claim' }>;
+  | Extract<ActiveRunbookResolution, { kind: 'none' | 'stale_claim' | 'terminal_claim' }>;
 
 /**
  * Resolve how terminal execution should remove a specific runbook from session targeting.
@@ -101,8 +101,8 @@ export async function resolveTerminalReleaseModeForRunbook(
  * @param options.claimId - Claim id to resolve instead of the default stack
  * @returns Discriminated union: `{ kind: 'ready'; ctx }` when an active runbook
  *   was resolved and a goto context is available; `{ kind: 'none' }` when no
- *   active runbook exists; or `{ kind: 'stale_claim' }` when the supplied
- *   claim id no longer maps to an active child.
+ *   active runbook exists; or `{ kind: 'stale_claim' | 'terminal_claim' }`
+ *   when the supplied claim id cannot be used as a mutable child target.
  */
 export async function buildGotoContext(
   output: OutputEmitter,
@@ -119,6 +119,7 @@ export async function buildGotoContext(
       break;
     case 'none':
     case 'stale_claim':
+    case 'terminal_claim':
       return active;
     default: {
       const _exhaustive: never = active;

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -42,6 +42,8 @@ import { getRunbookFromState } from './runbook-loader.js';
 export interface StatusOutputData {
   /** Whether a runbook is currently active */
   active: boolean;
+  /** Final lifecycle status when the inspected runbook has ended. */
+  status?: 'completed' | 'stopped';
   /** Whether the active runbook is stashed (enforcement paused) */
   stashed: boolean;
   /** Runbook file path (flat, not nested) */
@@ -248,6 +250,7 @@ export function buildActiveStatus(
   activeState: RunbookState,
   cwd: string,
   stashedId?: string,
+  lifecycleStatus?: 'completed' | 'stopped',
 ): StatusOutputData {
   const steps = getRunbookFromState(activeState, cwd);
   const currentStepIndex = steps.findIndex((s) => s.name === activeState.step);
@@ -323,7 +326,8 @@ export function buildActiveStatus(
     }));
 
   return {
-    active: true,
+    active: lifecycleStatus === undefined,
+    ...(lifecycleStatus !== undefined ? { status: lifecycleStatus } : {}),
     stashed: !!stashedId,
     file: metadata.file,
     state: metadata.state,

--- a/packages/cli/src/helpers/transition-command.ts
+++ b/packages/cli/src/helpers/transition-command.ts
@@ -85,6 +85,7 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
                 output.flush();
                 return;
               case 'stale_claim':
+              case 'terminal_claim':
                 output.error(contextResult.message, 'CLAIMED_RUNBOOK_UNAVAILABLE');
                 output.flush();
                 process.exitCode = 1;

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -154,7 +154,7 @@ export interface TransitionContext {
 /** Result of resolving the runbook target and building transition execution context. */
 export type BuildTransitionContextResult =
   | { readonly kind: 'ready'; readonly ctx: TransitionContext }
-  | Extract<ActiveRunbookResolution, { kind: 'none' | 'stale_claim' }>;
+  | Extract<ActiveRunbookResolution, { kind: 'none' | 'stale_claim' | 'terminal_claim' }>;
 
 /**
  * Build full transition context from resolved state.
@@ -186,6 +186,7 @@ export async function buildTransitionContext(
       break;
     case 'none':
     case 'stale_claim':
+    case 'terminal_claim':
       return active;
     default: {
       const _exhaustive: never = active;
@@ -448,7 +449,8 @@ export async function executeTransition(
       agentId: 'manual',
     });
     if (recorded.status === 'duplicate') {
-      output.status('completion_duplicate', `Completion already recorded for ${cursor.at}`, {
+      output.status(config.commandName, `Completion already recorded for ${cursor.at}`, {
+        status: 'already-resolved',
         at: cursor.at,
         frameKey: cursor.frame.frameKey,
         entry: completionEntryForFrame(cursor.frame),

--- a/packages/cli/src/helpers/wrapper.ts
+++ b/packages/cli/src/helpers/wrapper.ts
@@ -1,4 +1,11 @@
-import { isNodeError, isError, getErrorMessage, RundownError, Errors } from '@rundown-org/core';
+import {
+  isNodeError,
+  isError,
+  getErrorMessage,
+  RundownError,
+  Errors,
+  getWriter,
+} from '@rundown-org/core';
 import { RunbookSyntaxError } from '@rundown-org/parser';
 
 /**
@@ -89,7 +96,7 @@ export async function withErrorHandling(
         context: rundownError.context,
         docsUrl: rundownError.docsUrl,
       };
-      console.error(JSON.stringify(envelope, null, 2));
+      getWriter().writeJson(envelope);
     }
 
     process.exit(1);

--- a/packages/cli/src/services/policy-context.ts
+++ b/packages/cli/src/services/policy-context.ts
@@ -52,6 +52,25 @@ export interface PolicyCliOptions {
 }
 
 /**
+ * Error thrown when mutually exclusive CLI policy flags are provided together.
+ */
+export class PolicyCliOptionConflictError extends Error {
+  /** CLI flags that cannot be used together. */
+  readonly flags: readonly string[];
+
+  /**
+   * Create a policy CLI option conflict error.
+   *
+   * @param flags - Conflicting CLI flags.
+   */
+  constructor(flags: readonly string[]) {
+    super(`Conflicting policy options: ${flags.join(' and ')} cannot be used together.`);
+    this.name = 'PolicyCliOptionConflictError';
+    this.flags = flags;
+  }
+}
+
+/**
  * Global policy context.
  *
  * Holds the loaded policy, evaluator, and prompter for the current CLI session.
@@ -83,11 +102,14 @@ let policyContext: PolicyContext | null = null;
  * @param options - CLI options for policy configuration
  * @param cwd - Current working directory (for config search and path resolution)
  * @returns Initialized policy context
+ * @throws {PolicyCliOptionConflictError} When mutually exclusive policy flags are present
  */
 export async function initializePolicyContext(
   options: PolicyCliOptions = {},
   cwd: string = process.cwd(),
 ): Promise<PolicyContext> {
+  assertValidPolicyCliOptions(options);
+
   // Load policy from file or defaults
   const { policy, filepath, isDefault, warnings } = await loadPolicy({
     cwd,
@@ -209,9 +231,10 @@ export function resetPolicyContext(): void {
  *
  * @param opts - Raw options from commander
  * @returns Parsed policy CLI options
+ * @throws {PolicyCliOptionConflictError} When mutually exclusive policy flags are present
  */
 export function parsePolicyCliOptions(opts: Record<string, unknown>): PolicyCliOptions {
-  return {
+  const parsed = {
     allowRun: parseStringArray(opts.allowRun),
     allowRead: parseStringArray(opts.allowRead),
     allowWrite: parseStringArray(opts.allowWrite),
@@ -224,9 +247,11 @@ export function parsePolicyCliOptions(opts: Record<string, unknown>): PolicyCliO
     nonInteractive: opts.nonInteractive === true,
     sandbox: typeof opts.sandbox === 'boolean' ? opts.sandbox : undefined,
     sandboxStrict: opts.sandboxStrict === true,
-    noSandbox: opts.noSandbox === true,
+    noSandbox: opts.noSandbox === true || opts.sandbox === false,
     helpers: parseStringArray(opts.helpers),
   };
+  assertValidPolicyCliOptions(parsed);
+  return parsed;
 }
 
 /**
@@ -273,4 +298,20 @@ function parseStringArray(value: unknown): string[] | undefined {
     return value.filter((v): v is string => typeof v === 'string');
   }
   return undefined;
+}
+
+/**
+ * Validate policy CLI option combinations.
+ *
+ * @param options - Parsed CLI policy options.
+ * @throws {PolicyCliOptionConflictError} When mutually exclusive policy flags are present
+ */
+function assertValidPolicyCliOptions(options: PolicyCliOptions): void {
+  if (options.allowAll && options.denyAll) {
+    throw new PolicyCliOptionConflictError(['--allow-all', '--deny-all']);
+  }
+
+  if (options.noSandbox && options.sandboxStrict) {
+    throw new PolicyCliOptionConflictError(['--no-sandbox', '--sandbox-strict']);
+  }
 }

--- a/packages/cli/src/services/variable-discovery.ts
+++ b/packages/cli/src/services/variable-discovery.ts
@@ -26,6 +26,7 @@ import {
   CONFIG_FILE,
   WORK_DIR,
 } from '@rundown-org/core';
+import { assertContainedPath } from '../helpers/path-containment.js';
 
 export {
   BUILTIN_VARIABLES,
@@ -160,6 +161,47 @@ export function parseVarFlag(flag: string): { key: string; value: string } | nul
   return { key, value };
 }
 
+async function realpathOrResolved(filePath: string): Promise<string> {
+  try {
+    return await fs.realpath(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+async function resolveContainedInputFilePath(rawPath: string, cwd: string): Promise<string> {
+  if (path.isAbsolute(rawPath)) {
+    throw new Error(`--input-file path must be relative to the project directory: ${rawPath}`);
+  }
+  const normalized = path.normalize(rawPath);
+  if (normalized === '..' || normalized.startsWith(`..${path.sep}`)) {
+    throw new Error(`--input-file path escapes project directory: ${rawPath}`);
+  }
+
+  const canonicalRoot = await realpathOrResolved(cwd);
+  const resolved = path.resolve(cwd, rawPath);
+  let canonical = resolved;
+  try {
+    canonical = await fs.realpath(resolved);
+  } catch {
+    const resolvedDir = path.dirname(resolved);
+    try {
+      const canonicalDir = await fs.realpath(resolvedDir);
+      canonical = path.join(canonicalDir, path.basename(resolved));
+    } catch {
+      canonical = path.join(canonicalRoot, normalized);
+    }
+  }
+
+  assertContainedPath(
+    canonicalRoot,
+    canonical,
+    `--input-file path escapes project directory: ${rawPath}`,
+  );
+
+  return canonical;
+}
+
 /**
  * Collect CLI flag variables (--input-file, --input, --input-json) into a single dict.
  *
@@ -182,7 +224,7 @@ export async function collectCliFlags(
 
   // input-file(s) — repeatable, later overrides earlier
   for (const vf of options.inputFile ?? []) {
-    const varFilePath = path.isAbsolute(vf) ? vf : path.join(cwd, vf);
+    const varFilePath = await resolveContainedInputFilePath(vf, cwd);
     const fileVars = await loadVariablesFromFile(varFilePath, {
       normalize: false,
       optional: false,

--- a/packages/core/__tests__/output/schema.test.ts
+++ b/packages/core/__tests__/output/schema.test.ts
@@ -13,6 +13,7 @@ import {
   CheckResponseSchema,
   ResolveResponseSchema,
   ScenarioRunResponseSchema,
+  ErrorResponseSchema,
   CLIErrorCodes,
   ErrorCodeSchema,
   WarningCodeSchema,
@@ -211,6 +212,38 @@ describe('isWarningResponse type guard', () => {
 describe('ErrorCodeSchema code registry', () => {
   it('registers RD-813 for non-delegatable delegation targets', () => {
     expect(CLIErrorCodes.DELEGATION_NO_DELEGATABLE_SUBSTEP).toBe('RD-813');
+  });
+
+  it('accepts emitted RundownError RD codes in error envelopes', () => {
+    for (const code of ['RD-301', 'RD-403', 'RD-501', 'RD-812', 'RD-816', 'RD-819', 'RD-999']) {
+      expect(
+        ErrorResponseSchema.safeParse({
+          kind: 'error',
+          error: 'Rundown error',
+          code,
+        }).success,
+      ).toBe(true);
+    }
+  });
+
+  it('accepts direct CLI symbolic codes and rejects dead symbolic aliases', () => {
+    for (const code of [
+      'INVALID_STEP',
+      'INVALID_INDEX',
+      'NOT_DELEGATE_STEP',
+      'SUBSTEPS_NOT_RESOLVED',
+      'DELEGATION_ALREADY_RESOLVED',
+      'DELEGATION_ALREADY_EXISTS',
+      'CONFLICTING_INDEX',
+      'ENGINE_INIT_FAILED',
+      'INVALID_AT_TARGET',
+    ]) {
+      expect(ErrorCodeSchema.safeParse(code).success).toBe(true);
+    }
+
+    for (const code of ['FILE_ERROR', 'LAUNCH_FAILED', 'DELEGATION_NESTED_FORBIDDEN']) {
+      expect(ErrorCodeSchema.safeParse(code).success).toBe(false);
+    }
   });
 
   it('accepts every registered CLI error code', () => {

--- a/packages/core/__tests__/runbook/retry-delegation.test.ts
+++ b/packages/core/__tests__/runbook/retry-delegation.test.ts
@@ -151,7 +151,7 @@ describe('retryDelegation', () => {
     });
   });
 
-  it('returns { status: "retried" } when the existing delegation is claimed (force-style)', () => {
+  it('returns { status: "in_flight" } when the existing delegation is claimed', () => {
     const baseState = makeState();
     const steps = makeSteps();
     const initial = createDelegation(
@@ -189,7 +189,10 @@ describe('retryDelegation', () => {
       steps,
     );
 
-    expect(result.status).toBe('retried');
+    expect(result.status).toBe('in_flight');
+    if (result.status !== 'in_flight') return;
+    expect(result.childRunId).toBe(CHILD_RUN_ID);
+    expect(result.error.code).toBe('RD-823');
   });
 
   it('returns { status: "not_found" } when the substep has no delegation', () => {

--- a/packages/core/__tests__/runbook/run-state-lock.test.ts
+++ b/packages/core/__tests__/runbook/run-state-lock.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { locksDir, runStateLockPath } from '../../src/paths.js';
+import { FileLockTimeoutError } from '../../src/runbook/file-lock.js';
+import { RunStateLock, RunStateLockTimeoutError } from '../../src/runbook/run-state-lock.js';
+
+describe('RunStateLock', () => {
+  let tmpDir: string;
+  let lock: RunStateLock;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'run-state-lock-'));
+    lock = new RunStateLock(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('acquires and releases a lock', async () => {
+    await lock.acquire('run-1');
+
+    const lockPath = runStateLockPath(tmpDir, 'run-1');
+    const content = JSON.parse(await fs.readFile(lockPath, 'utf8')) as {
+      pid: number;
+      created_at: string;
+    };
+    expect(content.pid).toBe(process.pid);
+    expect(content.created_at).toBeDefined();
+
+    await lock.release('run-1');
+
+    await expect(fs.access(lockPath)).rejects.toThrow();
+  });
+
+  it('creates lock file and directory with owner-only permissions', async () => {
+    await lock.acquire('run-perms');
+
+    expect((await fs.stat(runStateLockPath(tmpDir, 'run-perms'))).mode & 0o777).toBe(0o600);
+    expect((await fs.stat(locksDir(tmpDir))).mode & 0o777).toBe(0o700);
+
+    await lock.release('run-perms');
+  });
+
+  it('release is idempotent', async () => {
+    await expect(lock.release('missing-run')).resolves.toBeUndefined();
+  });
+
+  it('times out with typed RunStateLockTimeoutError when held by an alive process', async () => {
+    await lock.acquire('run-timeout');
+    const lock2 = new RunStateLock(tmpDir);
+
+    let captured: unknown;
+    try {
+      await lock2.acquire('run-timeout');
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(RunStateLockTimeoutError);
+    expect(captured).toBeInstanceOf(FileLockTimeoutError);
+    if (captured instanceof RunStateLockTimeoutError) {
+      expect(captured.runId).toBe('run-timeout');
+      expect(captured.lockFile).toBe(runStateLockPath(tmpDir, 'run-timeout'));
+      expect(captured.message).toMatch(/Run-state lock timeout for run run-timeout/);
+    }
+
+    await lock.release('run-timeout');
+  }, 10_000);
+
+  it('different run IDs have independent locks', async () => {
+    await lock.acquire('run-a');
+    await lock.acquire('run-b');
+
+    await expect(fs.access(runStateLockPath(tmpDir, 'run-a'))).resolves.toBeUndefined();
+    await expect(fs.access(runStateLockPath(tmpDir, 'run-b'))).resolves.toBeUndefined();
+
+    await lock.release('run-a');
+    await lock.release('run-b');
+  });
+});

--- a/packages/core/__tests__/runbook/session-service.test.ts
+++ b/packages/core/__tests__/runbook/session-service.test.ts
@@ -505,13 +505,88 @@ describe('SessionService', () => {
       }
 
       const restored = await sessionService.unstashForClaimId(claimed.claim.claimId);
-      expect(restored?.id).toBe(child.id);
+      expect(restored.status).toBe('restored');
+      if (restored.status === 'restored') {
+        expect(restored.state.id).toBe(child.id);
+      }
       expect(await sessionService.getStashedRunbookId()).toBeNull();
 
       // After pop the claim is active again.
       expect((await sessionService.getActiveForClaimId(claimed.claim.claimId)).status).toBe(
         'claimed',
       );
+    });
+
+    it('unstashForClaimId distinguishes absent claim from non-stashed claim', async () => {
+      const parent = await manager.create({ source: 'project', path: 'parent.md' }, mockRunbook, {
+        runbookPath: 'parent.md',
+      });
+      const linkage = linkageFor(parent.id, '1');
+      const child = await manager.create({ source: 'project', path: 'child.md' }, mockRunbook, {
+        runbookPath: 'child.md',
+        parentLinkage: linkage,
+      });
+      const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
+
+      const absent = await sessionService.unstashForClaimId(
+        assertClaimId('rdclm_abcdefghijklmnopqrstu1'),
+      );
+      expect(absent.status).toBe('missing-claim');
+
+      const notStashed = await sessionService.unstashForClaimId(claimed.claim.claimId);
+      expect(notStashed.status).toBe('not-stashed');
+      if (notStashed.status === 'not-stashed') {
+        expect(notStashed.claim.childRunId).toBe(child.id);
+      }
+    });
+
+    it('unstashForClaimId distinguishes terminal child and ended parent', async () => {
+      const parent = await manager.create({ source: 'project', path: 'parent.md' }, mockRunbook, {
+        runbookPath: 'parent.md',
+      });
+      const terminalLinkage = linkageFor(parent.id, '1');
+      const terminalChild = await manager.create(
+        { source: 'project', path: 'terminal-child.md' },
+        mockRunbook,
+        {
+          runbookPath: 'terminal-child.md',
+          parentLinkage: terminalLinkage,
+        },
+      );
+      const terminalClaimed = assertClaimed(
+        await sessionService.claimRunbook(terminalChild.id, terminalLinkage),
+      );
+      await sessionService.stashRunbook(terminalChild.id);
+      await manager.update(terminalChild.id, { lifecycle: 'completed' });
+
+      const terminal = await sessionService.unstashForClaimId(terminalClaimed.claim.claimId);
+      expect(terminal.status).toBe('terminal-child');
+      if (terminal.status === 'terminal-child') {
+        expect(terminal.lifecycle).toBe('completed');
+      }
+
+      const endedParent = await manager.create(
+        { source: 'project', path: 'ended-parent.md' },
+        mockRunbook,
+        {
+          runbookPath: 'ended-parent.md',
+        },
+      );
+      const endedLinkage = linkageFor(endedParent.id, '2');
+      const child = await manager.create({ source: 'project', path: 'child.md' }, mockRunbook, {
+        runbookPath: 'child.md',
+        parentLinkage: endedLinkage,
+      });
+      const endedClaimed = assertClaimed(await sessionService.claimRunbook(child.id, endedLinkage));
+      await manager.update(endedParent.id, { lifecycle: 'stopped' });
+      await sessionService.releaseRunbook(terminalChild.id);
+      await sessionService.stashRunbook(child.id);
+
+      const parentEnded = await sessionService.unstashForClaimId(endedClaimed.claim.claimId);
+      expect(parentEnded.status).toBe('parent-ended');
+      if (parentEnded.status === 'parent-ended') {
+        expect(parentEnded.lifecycle).toBe('stopped');
+      }
     });
 
     it('exposes a stashed claimed child read-only via includeStashed', async () => {

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -6,7 +6,7 @@ import { isError } from '../../src/errors.js';
 import { generateRunId, RunbookStateManager } from '../../src/runbook/state.js';
 import { merge, replace } from '../../src/runbook/state-update-ops.js';
 import { partitionVariables } from '../../src/runbook/variable-preparation.js';
-import { statePath as _statePath } from '../../src/paths.js';
+import { runStateLockPath, statePath as _statePath } from '../../src/paths.js';
 import { SessionService } from '../../src/runbook/session-service.js';
 import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
 import { makeAggregationLastAction } from '../../src/runbook/last-action.js';
@@ -858,6 +858,70 @@ describe('RunbookStateManager', () => {
 
     it('update throws for missing runbook', async () => {
       await expect(manager.update('nonexistent', { step: '2' })).rejects.toThrow('not found');
+    });
+
+    it('preserves existing run state when the temp write fails', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      const stateFilePath = _statePath(testDir, state.id);
+      const originalContent = await readFile(stateFilePath, 'utf8');
+      await mkdir(`${stateFilePath}.tmp`);
+
+      await expect(manager.save({ ...state, step: 'changed' })).rejects.toThrow();
+
+      await expect(readFile(stateFilePath, 'utf8')).resolves.toBe(originalContent);
+    });
+
+    it('serializes concurrent update read-modify-write cycles without losing merged fields', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      const originalLoad = manager.load.bind(manager);
+      let matchingLoads = 0;
+      let releaseFirstRead: (() => void) | undefined;
+      const firstReadDelay = new Promise<void>((resolve) => {
+        releaseFirstRead = resolve;
+      });
+
+      jest.spyOn(manager, 'load').mockImplementation(async (id: string) => {
+        const loaded = await originalLoad(id);
+        if (id !== state.id || !loaded) return loaded;
+
+        matchingLoads += 1;
+        if (matchingLoads === 1) {
+          setTimeout(() => releaseFirstRead?.(), 75);
+          await firstReadDelay;
+        } else {
+          releaseFirstRead?.();
+        }
+        return loaded;
+      });
+
+      await Promise.all([
+        manager.update(state.id, { variables: merge({ A: '1' }) }),
+        manager.update(state.id, { variables: merge({ B: '2' }) }),
+      ]);
+
+      const updated = await originalLoad(state.id);
+      expect(updated?.variables).toEqual({ A: '1', B: '2' });
+      await expect(readFile(runStateLockPath(testDir, state.id), 'utf8')).rejects.toThrow();
+    });
+
+    it('preserves existing session data when the temp write fails', async () => {
+      const sessionPath = join(testDir, '.rundown', 'session.json');
+      await manager.saveSession({ defaultStack: [], claims: {} });
+      const originalContent = await readFile(sessionPath, 'utf8');
+      await mkdir(`${sessionPath}.tmp`);
+
+      await expect(
+        manager.saveSession({
+          defaultStack: [assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')],
+          claims: {},
+        }),
+      ).rejects.toThrow();
+
+      await expect(readFile(sessionPath, 'utf8')).resolves.toBe(originalContent);
     });
 
     it('rejects legacy targetPath fields instead of stripping them on save', async () => {

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -363,6 +363,14 @@ export const ErrorCodes = {
       'The requested child runbook does not match the runbook authored on the DELEGATE substep.',
     docSlug: 'delegation-runbook-mismatch',
   },
+  DELEGATION_IN_FLIGHT: {
+    code: 'RD-823',
+    category: ErrorCategory.DELEGATION,
+    title: 'Delegation child run in flight',
+    description:
+      'Cannot retry a delegation while its child run is still linked. Use `rd abort <token> --force` first to stop and record the child failure before retrying.',
+    docSlug: 'delegation-in-flight',
+  },
   // Retry hook (9xx) — sub-range of ErrorCategory.EXECUTION reserved for
   // retry-hook lifecycle failures (delegation re-issuance, frame-key invariants,
   // canonical-at requirements). Kept as EXECUTION rather than a dedicated

--- a/packages/core/src/errors/factory.ts
+++ b/packages/core/src/errors/factory.ts
@@ -109,6 +109,13 @@ export const Errors = {
   delegationAlreadyClaimed: (step: string, childRunId: string): RundownError =>
     new RundownError('DELEGATION_ALREADY_CLAIMED', { step, childRunId }),
 
+  delegationInFlight: (step: string, childRunId: string): RundownError =>
+    new RundownError('DELEGATION_IN_FLIGHT', {
+      step,
+      childRunId,
+      message: `child run ${childRunId} is still linked; run "rd abort <token> --force" before retrying`,
+    }),
+
   delegationAlreadyResolved: (step: string): RundownError =>
     new RundownError('DELEGATION_ALREADY_RESOLVED', { step }),
 

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -20,25 +20,67 @@ import { CLAIM_ID_PATTERN } from '../runbook/claim-id.js';
 import { DELEGATION_TOKEN_PATTERN } from '../runbook/delegation-token.js';
 import { ArtifactManifestRecordSchema } from '../runbook/artifact-schema.js';
 import { RunbookRefSchema } from '../runbook/runbook-ref.js';
+import { ErrorCodes } from '../errors/codes.js';
 
 // ============================================================================
 // CLI Error Codes
 // ============================================================================
 
+const RundownErrorCodeValues = Object.values(ErrorCodes).map((code) => code.code) as [
+  string,
+  ...string[],
+];
+
+const CLISymbolicErrorCodeValues = [
+  'RUNBOOK_NOT_FOUND',
+  'STEP_NOT_FOUND',
+  'INVALID_SYNTAX',
+  'VALIDATION_ERROR',
+  'ALREADY_STASHED',
+  'NO_STASHED_RUNBOOK',
+  'INVALID_CLAIM_ID',
+  'CLAIMED_RUNBOOK_UNAVAILABLE',
+  'CHILD_RUN_MISSING',
+  'CHILD_LINKAGE_MISMATCH',
+  'INVALID_TOKEN',
+  'TOKEN_NOT_FOUND',
+  'DELEGATION_CANCELLED',
+  'DELEGATION_LOCK_TIMEOUT',
+  'INVALID_STEP',
+  'INVALID_INDEX',
+  'NOT_DELEGATE_STEP',
+  'SUBSTEPS_NOT_RESOLVED',
+  'DELEGATION_ALREADY_RESOLVED',
+  'DELEGATION_ALREADY_EXISTS',
+  'CONFLICTING_INDEX',
+  'ENGINE_INIT_FAILED',
+  'INVALID_AT_TARGET',
+  'SCENARIO_NOT_FOUND',
+  'UNKNOWN_ERROR',
+] as const;
+
+/**
+ * CLI-only symbolic error codes emitted outside the RundownError factory path.
+ */
+export const CLISymbolicErrorCodes = Object.fromEntries(
+  CLISymbolicErrorCodeValues.map((code) => [code, code]),
+) as { readonly [Code in (typeof CLISymbolicErrorCodeValues)[number]]: Code };
+
 /**
  * Machine-readable error codes for CLI JSON output.
  *
- * These codes enable programmatic error handling without parsing error messages.
+ * Thrown RundownError envelopes use RD-NNN values from ErrorCodes. Some
+ * command validation paths still emit CLI-only symbolic codes directly.
  */
 export const CLIErrorCodes = {
   /** No runbook is currently active */
-  NO_ACTIVE_RUNBOOK: 'NO_ACTIVE_RUNBOOK',
+  NO_ACTIVE_RUNBOOK: ErrorCodes.NO_ACTIVE_RUNBOOK.code,
   /** Specified runbook file doesn't exist */
-  RUNBOOK_NOT_FOUND: 'RUNBOOK_NOT_FOUND',
+  RUNBOOK_NOT_FOUND: ErrorCodes.FILE_NOT_FOUND.code,
   /** Target step doesn't exist */
-  STEP_NOT_FOUND: 'STEP_NOT_FOUND',
+  STEP_NOT_FOUND: ErrorCodes.DELEGATION_STEP_NOT_FOUND.code,
   /** Runbook has syntax errors */
-  INVALID_SYNTAX: 'INVALID_SYNTAX',
+  INVALID_SYNTAX: ErrorCodes.SYNTAX_ERROR.code,
   /** Input validation failed */
   VALIDATION_ERROR: 'VALIDATION_ERROR',
   /** A runbook is already stashed */
@@ -54,29 +96,29 @@ export const CLIErrorCodes = {
   /** Child runbook's persisted parentLinkage diverges from the freshly token-validated linkage (state corruption — operator intervention required) */
   CHILD_LINKAGE_MISMATCH: 'CHILD_LINKAGE_MISMATCH',
   /** Delegation token format is invalid */
-  INVALID_TOKEN: 'INVALID_TOKEN',
+  INVALID_TOKEN: ErrorCodes.INVALID_TOKEN.code,
   /** Delegation token was not found */
-  TOKEN_NOT_FOUND: 'TOKEN_NOT_FOUND',
+  TOKEN_NOT_FOUND: ErrorCodes.TOKEN_NOT_FOUND.code,
   /** Delegation token was cancelled */
-  DELEGATION_CANCELLED: 'DELEGATION_CANCELLED',
+  DELEGATION_CANCELLED: ErrorCodes.TOKEN_CANCELLED.code,
   /** Delegation lock could not be acquired */
-  DELEGATION_LOCK_TIMEOUT: 'DELEGATION_LOCK_TIMEOUT',
+  DELEGATION_LOCK_TIMEOUT: ErrorCodes.DELEGATION_LOCK_TIMEOUT.code,
   /** Nested delegation forbidden (claimed child cannot delegate further) */
-  DELEGATION_NESTED_FORBIDDEN: 'DELEGATION_NESTED_FORBIDDEN',
+  DELEGATION_NESTED_FORBIDDEN: ErrorCodes.DELEGATION_NESTED_FORBIDDEN.code,
   /** Targeted step has no substep marked DELEGATE */
-  DELEGATION_NO_DELEGATABLE_SUBSTEP: 'RD-813',
+  DELEGATION_NO_DELEGATABLE_SUBSTEP: ErrorCodes.DELEGATION_NO_DELEGATABLE_SUBSTEP.code,
   /** Runbook launch failed */
-  LAUNCH_FAILED: 'LAUNCH_FAILED',
+  LAUNCH_FAILED: ErrorCodes.LAUNCH_FAILED.code,
   /** Fresh claim launch violated write-side invariants */
-  CLAIM_INVARIANT_VIOLATED: 'RD-820',
+  CLAIM_INVARIANT_VIOLATED: ErrorCodes.CLAIM_INVARIANT_VIOLATED.code,
   /** Requested child runbook does not match the authored DELEGATE target */
-  DELEGATION_RUNBOOK_MISMATCH: 'RD-822',
+  DELEGATION_RUNBOOK_MISMATCH: ErrorCodes.DELEGATION_RUNBOOK_MISMATCH.code,
+  /** Retry refused because a child run is still linked */
+  DELEGATION_IN_FLIGHT: ErrorCodes.DELEGATION_IN_FLIGHT.code,
   /** Scenario not found */
-  SCENARIO_NOT_FOUND: 'SCENARIO_NOT_FOUND',
-  /** File system operation failed */
-  FILE_ERROR: 'FILE_ERROR',
+  SCENARIO_NOT_FOUND: ErrorCodes.SCENARIO_NOT_FOUND.code,
   /** Unknown or unexpected error */
-  UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+  UNKNOWN_ERROR: ErrorCodes.UNKNOWN_ERROR.code,
 } as const;
 
 /**
@@ -93,31 +135,7 @@ export const CLIWarningCodes = {
  * Zod schema for error codes.
  */
 export const ErrorCodeSchema = z
-  .enum([
-    'NO_ACTIVE_RUNBOOK',
-    'RUNBOOK_NOT_FOUND',
-    'STEP_NOT_FOUND',
-    'INVALID_SYNTAX',
-    'VALIDATION_ERROR',
-    'ALREADY_STASHED',
-    'NO_STASHED_RUNBOOK',
-    'INVALID_CLAIM_ID',
-    'CLAIMED_RUNBOOK_UNAVAILABLE',
-    'CHILD_RUN_MISSING',
-    'CHILD_LINKAGE_MISMATCH',
-    'INVALID_TOKEN',
-    'TOKEN_NOT_FOUND',
-    'DELEGATION_CANCELLED',
-    'DELEGATION_LOCK_TIMEOUT',
-    'DELEGATION_NESTED_FORBIDDEN',
-    'RD-813',
-    'LAUNCH_FAILED',
-    'RD-820',
-    'RD-822',
-    'SCENARIO_NOT_FOUND',
-    'FILE_ERROR',
-    'UNKNOWN_ERROR',
-  ])
+  .enum([...RundownErrorCodeValues, ...CLISymbolicErrorCodeValues] as [string, ...string[]])
   .describe('Error code identifying the type of error that occurred');
 
 /**
@@ -130,7 +148,9 @@ export const WarningCodeSchema = z
 /**
  * Union type of all valid CLI error codes.
  */
-export type CLIErrorCode = (typeof CLIErrorCodes)[keyof typeof CLIErrorCodes];
+export type CLIErrorCode =
+  | (typeof CLIErrorCodes)[keyof typeof CLIErrorCodes]
+  | (typeof CLISymbolicErrorCodes)[keyof typeof CLISymbolicErrorCodes];
 
 /**
  * Union type of all valid CLI warning codes.
@@ -312,6 +332,8 @@ export const ActionResponseSchema = z
     state: z.string().optional().describe('Runbook state after action'),
     prompted: z.boolean().optional().describe('Whether awaiting user input'),
     message: z.string().optional().describe('Status message from the action'),
+    /** Idempotency status for action-family responses */
+    status: z.enum(['already-resolved']).optional().describe('Idempotency status'),
     position: PositionSchema.optional().describe('Current position after action'),
   })
   .describe('Response from a step action command')

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -159,6 +159,21 @@ export const completionLockPath = (cwd: string, runId: string): string => {
 };
 
 /**
+ * Absolute path to a run-state lock file.
+ *
+ * Lock path: `.rundown/locks/run-<runId>.state.lock`
+ *
+ * @param cwd - Project root directory
+ * @param runId - Run ID to lock (must match `[A-Za-z0-9._-]+`)
+ * @returns Path to the run-state lock file
+ * @throws {Error} If `runId` contains path separators, `..`, or is otherwise unsafe
+ */
+export const runStateLockPath = (cwd: string, runId: string): string => {
+  assertSafeId(runId, 'runId');
+  return path.join(cwd, LOCKS_DIR, `run-${runId}.state.lock`);
+};
+
+/**
  * Absolute path to the workspace-wide session lock file.
  *
  * One lock per project root serializes load-modify-save cycles on

--- a/packages/core/src/runbook/claim-id.ts
+++ b/packages/core/src/runbook/claim-id.ts
@@ -83,6 +83,7 @@ export type ClaimIdResolution =
   | {
       readonly status: 'terminal';
       readonly claim: ClaimRecord;
+      readonly state: RunbookState;
       readonly lifecycle: 'completed' | 'stopped';
     }
   | {

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -403,6 +403,19 @@ export class RunbookCompletionService {
     });
     if (existingKey) return { status: 'duplicate', key: existingKey };
 
+    const freshState = await this.manager.load(args.runbookId);
+    const existingSubstepState = findSubstepState(
+      freshState?.substepStates ?? args.currentState.substepStates ?? [],
+      args.targetSubstep,
+      args.targetFrame.frameKey,
+    );
+    if (existingSubstepState?.status === 'done') {
+      return {
+        status: 'duplicate',
+        key: buildCompletionKey(args.targetFrame, args.targetSubstep),
+      };
+    }
+
     const key = buildCompletionKey(args.targetFrame, args.targetSubstep);
     const completion = buildResolvedCompletion({
       agentId: args.agentId,
@@ -416,17 +429,16 @@ export class RunbookCompletionService {
     });
     await this.lifecycleService.upsertResolvedCompletion(args.runbookId, key, completion);
 
-    const freshParent = await this.manager.load(args.runbookId);
-    if (freshParent) {
-      await this.manager.update(args.runbookId, {
+    await this.manager.updateWithState(args.runbookId, (freshParent) => {
+      return {
         substepStates: upsertSubstepState(
           freshParent.substepStates ?? [],
           args.targetSubstep,
           args.targetFrame.frameKey,
           { status: 'done', result: args.result },
         ),
-      });
-    }
+      };
+    });
 
     return { status: 'recorded', key };
   }

--- a/packages/core/src/runbook/delegation-service.ts
+++ b/packages/core/src/runbook/delegation-service.ts
@@ -709,6 +709,14 @@ export interface RetryDelegationOptions {
   readonly frameKey: FrameKey;
   /** Variables that override inherited extraVars; unspecified keys inherit verbatim. */
   readonly overrides?: Readonly<Record<string, TemplateVarValue>>;
+  /**
+   * Allow retry when the delegation still has a childRunId.
+   *
+   * Intended only for machine-owned retry hooks that run after child completion
+   * has already been recorded into the parent. Manual CLI retry leaves this
+   * false so linked child runs must go through abort --force teardown first.
+   */
+  readonly allowLinkedChildRun?: boolean;
 }
 
 /**
@@ -770,6 +778,21 @@ export interface RetryDelegationErrorResult {
 }
 
 /**
+ * Existing delegation has a linked child run.
+ *
+ * Retrying would replace the parent delegation record without stopping the
+ * child run, releasing the claim tombstone, or recording a fail completion.
+ * Callers must route through the force-abort flow before reissuing.
+ */
+export interface RetryDelegationInFlightResult {
+  readonly status: 'in_flight';
+  /** Linked child run that must be force-aborted before retry. */
+  readonly childRunId: string;
+  /** Wrapped RundownError (RD-823) for callers that re-surface the message. */
+  readonly error: RundownError;
+}
+
+/**
  * Retry succeeded: the existing delegation has been force-cancelled and a
  * fresh one minted under a new token. The contract mirrors
  * {@link CreateDelegationCreatedResult} — every field a caller needs to
@@ -800,6 +823,7 @@ export type RetryDelegationResult =
   | RetryDelegationRetriedResult
   | RetryDelegationNotFoundResult
   | RetryDelegationNotCurrentResult
+  | RetryDelegationInFlightResult
   | RetryDelegationErrorResult;
 
 /**
@@ -830,7 +854,7 @@ export function retryDelegation(
   options: RetryDelegationOptions,
   steps: readonly ResolvedStep[],
 ): RetryDelegationResult {
-  const { state, substepId, frameKey, overrides } = options;
+  const { state, substepId, frameKey, overrides, allowLinkedChildRun = false } = options;
 
   // 1. Locate the existing delegation.
   const existingStates = state.substepStates ?? [];
@@ -862,13 +886,30 @@ export function retryDelegation(
     };
   }
 
-  // 3. Compose inherited + override extraVars.
+  // 3. A linked, non-cancelled child run must be force-aborted before manual
+  // retry. retryDelegation is a pure core primitive, so it cannot perform the
+  // full abort --force teardown: delete/release child state, clear session
+  // claim tombstones, and record fail completion. The retry hook opts out only
+  // after the machine has already recorded child completion.
+  if (
+    existingDelegation.childRunId !== null &&
+    existingDelegation.cancelledAt === null &&
+    !allowLinkedChildRun
+  ) {
+    return {
+      status: 'in_flight',
+      childRunId: existingDelegation.childRunId,
+      error: Errors.delegationInFlight(substepId, existingDelegation.childRunId),
+    };
+  }
+
+  // 4. Compose inherited + override extraVars.
   const mergedExtraVars: Record<string, TemplateVarValue> | undefined =
     existingDelegation.extraVars || overrides
       ? { ...(existingDelegation.extraVars ?? {}), ...(overrides ?? {}) }
       : undefined;
 
-  // 4. Force-cancel the existing delegation. Idempotent on already-cancelled.
+  // 5. Force-cancel the existing delegation. Idempotent on already-cancelled.
   const abortResult = abortDelegation({
     parentState: state,
     substepId,
@@ -917,7 +958,7 @@ export function retryDelegation(
     }
   }
 
-  // 5. Mint a fresh delegation. createDelegation returns a Result variant;
+  // 6. Mint a fresh delegation. createDelegation returns a Result variant;
   //    translate any non-created outcome into this function's `error` variant
   //    so the state-machine caller has a single uniform shape to discriminate.
   //    Bare-step delegations are stored with substepState.id === step.name

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -160,9 +160,6 @@ export class ExecutionLifecycleService {
     key: string,
     completion: ResolvedCompletion,
   ): Promise<void> {
-    const state = await this.manager.load(id);
-    if (!state) throw new Error(`Runbook ${id} not found`);
-
     await this.manager.update(id, {
       resolvedCompletions: merge({ [key]: completion }),
     });
@@ -189,33 +186,38 @@ export class ExecutionLifecycleService {
    * @returns The resolved completion if present, otherwise null
    */
   async consumeResolvedCompletion(id: string, key: string): Promise<ResolvedCompletion | null> {
-    const state = await this.manager.load(id);
-    if (!state) return null;
+    if (!(await this.manager.load(id))) return null;
 
-    let existing = state.resolvedCompletions?.[key];
-    let actualKey = key;
+    let consumed: ResolvedCompletion | null = null;
 
-    // Fall back to sentinel entry if exact key not found
-    if (!existing) {
-      const parsed = parseCompletionKey(key);
-      if (parsed && parsed.entry !== SENTINEL_ENTRY) {
-        const sentinelKey = buildCompletionKey(inactiveFrame(parsed.frameKey), parsed.substep);
-        const sentinelMatch = state.resolvedCompletions?.[sentinelKey];
-        if (sentinelMatch) {
-          existing = sentinelMatch;
-          actualKey = sentinelKey;
+    await this.manager.updateWithState(id, (state) => {
+      let existing = state.resolvedCompletions?.[key];
+      let actualKey = key;
+
+      // Fall back to sentinel entry if exact key not found
+      if (!existing) {
+        const parsed = parseCompletionKey(key);
+        if (parsed && parsed.entry !== SENTINEL_ENTRY) {
+          const sentinelKey = buildCompletionKey(inactiveFrame(parsed.frameKey), parsed.substep);
+          const sentinelMatch = state.resolvedCompletions?.[sentinelKey];
+          if (sentinelMatch) {
+            existing = sentinelMatch;
+            actualKey = sentinelKey;
+          }
         }
       }
-    }
 
-    if (!existing) return null;
+      if (!existing) return null;
 
-    const next = { ...(state.resolvedCompletions ?? {}) };
-    delete next[actualKey];
-    await this.manager.update(id, {
-      resolvedCompletions: replace(next),
+      consumed = existing;
+      const next = { ...(state.resolvedCompletions ?? {}) };
+      delete next[actualKey];
+      return {
+        resolvedCompletions: replace(next),
+      };
     });
-    return existing;
+
+    return consumed;
   }
 
   /**

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -66,7 +66,11 @@ export {
   type TemplateVarsOp,
   type VariablesOp,
 } from './state-update-ops.js';
-export { SessionService, type ReleaseRunbookResult } from './session-service.js';
+export {
+  SessionService,
+  type ReleaseRunbookResult,
+  type UnstashForClaimIdResult,
+} from './session-service.js';
 export { readActiveRunScope, type ActiveRunScope } from './session-reader.js';
 export { ExecutionLifecycleService } from './execution-lifecycle-service.js';
 export {
@@ -186,6 +190,7 @@ export {
 } from './delegation-token.js';
 export { DelegationLock, DelegationLockTimeoutError } from './delegation-lock.js';
 export { SessionLock, SessionLockTimeoutError } from './session-lock.js';
+export { RunStateLock, RunStateLockTimeoutError } from './run-state-lock.js';
 export { FileLockTimeoutError } from './file-lock.js';
 export { DelegationScanService, type TokenScanResult } from './delegation-scan.js';
 export {

--- a/packages/core/src/runbook/retry-hook.ts
+++ b/packages/core/src/runbook/retry-hook.ts
@@ -114,8 +114,9 @@ function peekForStack(stack: readonly ForContext[] | undefined): ForContext | un
  *   `{ status: 'pending', result: undefined }`) and a frontier entry.
  * - `error` — surface codes:
  *   - Wrapped `RundownError` from `retryDelegation` returning
- *     `not_found` / `not_current` (e.g. RD-801 / RD-802) propagated
- *     verbatim — state and delegation-service views have diverged.
+ *     `not_found` / `not_current` / `in_flight` (e.g. RD-801 / RD-802 /
+ *     RD-823) propagated verbatim — state and delegation-service views have
+ *     diverged, or a linked child must be force-aborted before retry.
  *   - `RD-904` from a fresh retried delegation missing
  *     `contextSnapshot.at` (frontier id would lose FOR-iteration context).
  *   - Otherwise the code + message from `result.error` are propagated.
@@ -157,6 +158,7 @@ export function retrySingleSubstep(
       state: working as RunbookState,
       substepId: substep.id,
       frameKey: activeFrameKey,
+      allowLinkedChildRun: true,
     },
     steps,
   );
@@ -202,12 +204,10 @@ export function retrySingleSubstep(
     };
   }
 
-  // not_found / not_current: the delegation-service view and the substep
-  // state have diverged. The caller already filtered on `ss.delegation`
-  // being present and `activeFrameKey` matching, so silent skip would
-  // consume the retry transition without re-issuing a token. Both variants
-  // now carry a `RundownError` (parallel to CreateDelegation), so the hook
-  // surfaces the structured code/message verbatim and rolls back.
+  // not_found / not_current / in_flight: the delegation-service view and the
+  // substep state have diverged, or a linked child must be force-aborted before
+  // retry. These variants carry a RundownError, so the hook surfaces the
+  // structured code/message verbatim and rolls back.
   return {
     status: 'error',
     code: result.error.code,

--- a/packages/core/src/runbook/run-state-lock.ts
+++ b/packages/core/src/runbook/run-state-lock.ts
@@ -1,0 +1,83 @@
+import { locksDir, runStateLockPath as _runStateLockPath } from '../paths.js';
+import { acquireFileLock, FileLockTimeoutError, releaseFileLock } from './file-lock.js';
+
+/**
+ * Thrown when {@link RunStateLock.acquire} cannot acquire the lock within
+ * the {@link FileLockTimeoutError} deadline.
+ */
+export class RunStateLockTimeoutError extends FileLockTimeoutError {
+  /** Run id whose state lock timed out. */
+  readonly runId: string;
+
+  /**
+   * Construct a typed timeout error tagged with the run id.
+   *
+   * @param runId - Identifier of the run whose state lock timed out
+   * @param lockFile - Absolute path to the underlying lock file
+   */
+  constructor(runId: string, lockFile: string) {
+    super(
+      lockFile,
+      `Run-state lock timeout for run ${runId}: ${lockFile}. Another operation may be writing run state.`,
+    );
+    this.name = 'RunStateLockTimeoutError';
+    this.runId = runId;
+  }
+}
+
+/**
+ * File-based exclusive lock for serializing writes to a single run-state file.
+ *
+ * Lock path: `.rundown/locks/run-<runId>.state.lock`.
+ *
+ * Lock ordering: higher-level domain locks such as `CompletionLock` and
+ * `DelegationLock` may be acquired before this lock, then call into
+ * `RunbookStateManager`. This lock must not acquire those domain locks.
+ */
+export class RunStateLock {
+  private readonly cwd: string;
+  private readonly lockDir: string;
+
+  /**
+   * Create a new RunStateLock.
+   *
+   * @param cwd - Project root directory
+   */
+  constructor(cwd: string) {
+    this.cwd = cwd;
+    this.lockDir = locksDir(cwd);
+  }
+
+  private lockPath(runId: string): string {
+    return _runStateLockPath(this.cwd, runId);
+  }
+
+  /**
+   * Acquire an exclusive run-state lock for the given run ID.
+   *
+   * @param runId - Run ID to lock
+   * @throws {RunStateLockTimeoutError} When the lock cannot be acquired
+   */
+  async acquire(runId: string): Promise<void> {
+    const lockFile = this.lockPath(runId);
+    try {
+      await acquireFileLock(lockFile, this.lockDir);
+    } catch (err) {
+      if (err instanceof FileLockTimeoutError) {
+        throw new RunStateLockTimeoutError(runId, lockFile);
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Release an exclusive run-state lock for the given run ID.
+   *
+   * Idempotent — does not throw if the lock file does not exist.
+   *
+   * @param runId - Run ID to unlock
+   */
+  async release(runId: string): Promise<void> {
+    await releaseFileLock(this.lockPath(runId));
+  }
+}

--- a/packages/core/src/runbook/session-service.ts
+++ b/packages/core/src/runbook/session-service.ts
@@ -33,6 +33,25 @@ export type ReleaseRunbookResult =
       readonly nextDefaultRunbookId: RunId | null;
     };
 
+/** Result of restoring a stashed delegated child by claim id. */
+export type UnstashForClaimIdResult =
+  | { readonly status: 'restored'; readonly claim: ClaimRecord; readonly state: RunbookState }
+  | { readonly status: 'missing-claim'; readonly claimId: ClaimId }
+  | { readonly status: 'not-stashed'; readonly claim: ClaimRecord }
+  | { readonly status: 'missing-child'; readonly claim: ClaimRecord }
+  | {
+      readonly status: 'terminal-child';
+      readonly claim: ClaimRecord;
+      readonly lifecycle: 'completed' | 'stopped';
+    }
+  | { readonly status: 'child-linkage-mismatch'; readonly claim: ClaimRecord }
+  | { readonly status: 'parent-missing'; readonly claim: ClaimRecord }
+  | {
+      readonly status: 'parent-ended';
+      readonly claim: ClaimRecord;
+      readonly lifecycle: 'completed' | 'stopped';
+    };
+
 /**
  * True when persisted child linkage matches an incoming delegation linkage on the
  * three identifying fields (`parentRunId`, `parentStepId`, `tokenHash`).
@@ -315,7 +334,7 @@ export class SessionService {
       return { status: 'stale', claim, reason: 'missing-state' };
     }
     if (state.lifecycle === 'completed' || state.lifecycle === 'stopped') {
-      return { status: 'terminal', claim, lifecycle: state.lifecycle };
+      return { status: 'terminal', claim, state, lifecycle: state.lifecycle };
     }
     if (!linkageMatchesClaim(state.parentLinkage, claim)) {
       return { status: 'unlinked', claim, reason: 'child-linkage-mismatch' };
@@ -458,39 +477,41 @@ export class SessionService {
    * Restore a stashed delegated runbook by explicit claim id.
    *
    * @param claimId - Claim id for the stashed child runbook
-   * @returns The restored runbook state, or null if no stashed runbook exists
+   * @returns Discriminated restore result describing success or the refusal reason
    */
-  async unstashForClaimId(claimId: ClaimId): Promise<RunbookState | null> {
+  async unstashForClaimId(claimId: ClaimId): Promise<UnstashForClaimIdResult> {
     return this.withLock(async () => {
       const session = await this.manager.loadSession();
       if (!(claimId in session.claims)) {
-        return null;
+        return { status: 'missing-claim', claimId };
       }
       const claim = session.claims[claimId];
       if (session.stashedRunbookId !== claim.childRunId) {
-        return null;
+        return { status: 'not-stashed', claim };
       }
 
       const state = await this.manager.load(claim.childRunId);
-      if (state?.lifecycle !== 'running') {
-        return null;
+      if (!state) {
+        return { status: 'missing-child', claim };
+      }
+      if (state.lifecycle === 'completed' || state.lifecycle === 'stopped') {
+        return { status: 'terminal-child', claim, lifecycle: state.lifecycle };
       }
       if (!linkageMatchesClaim(state.parentLinkage, claim)) {
-        return null;
+        return { status: 'child-linkage-mismatch', claim };
       }
       const parent = await this.manager.load(claim.parentRunId);
-      if (
-        parent?.lifecycle === undefined ||
-        parent.lifecycle === 'completed' ||
-        parent.lifecycle === 'stopped'
-      ) {
-        return null;
+      if (!parent) {
+        return { status: 'parent-missing', claim };
+      }
+      if (parent.lifecycle === 'completed' || parent.lifecycle === 'stopped') {
+        return { status: 'parent-ended', claim, lifecycle: parent.lifecycle };
       }
 
       session.stashedRunbookId = undefined;
       session.claims[claimId] = { ...claim, updatedAt: new Date().toISOString() };
       await this.manager.saveSession(session);
-      return state;
+      return { status: 'restored', claim: session.claims[claimId], state };
     });
   }
 

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -42,6 +42,7 @@ import {
   statePath as _statePath,
   LEGACY_SESSION_FILE,
 } from '../paths.js';
+import { RunStateLock } from './run-state-lock.js';
 
 /** Current persisted state schema version for the v1 release. */
 const CURRENT_SCHEMA_VERSION = 1;
@@ -106,6 +107,24 @@ function assertTrustedResolvedCompletions(
   return completions;
 }
 
+async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<void> {
+  const tempPath = `${filePath}.tmp`;
+  const content = JSON.stringify(value, null, 2);
+
+  try {
+    await fs.writeFile(tempPath, content, { encoding: 'utf8', mode: 0o600 });
+    await fs.chmod(tempPath, 0o600);
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    try {
+      await fs.unlink(tempPath);
+    } catch {
+      // Best effort cleanup only. The caller-visible error is the failed write/rename.
+    }
+    throw error;
+  }
+}
+
 /**
  * Thrown when a persisted state file does not match the current schema contract.
  */
@@ -143,6 +162,35 @@ export interface SessionData {
   /** Explicit claim-id records for delegated child runbook targeting. */
   claims: Record<string, ClaimRecord>;
 }
+
+/**
+ * Typed patch accepted by {@link RunbookStateManager.update}.
+ *
+ * Record-shaped fields use tagged operations so callers must choose merge or
+ * replacement semantics explicitly.
+ */
+export type RunbookStateUpdate = Partial<
+  Omit<
+    RunbookState,
+    | 'id'
+    | 'startedAt'
+    | 'updatedAt'
+    | 'schemaVersion'
+    | 'variables'
+    | 'templateVars'
+    | 'resolvedCompletions'
+    | 'frameEntries'
+  >
+> & {
+  /** Merge or replace persisted runtime variables. */
+  readonly variables?: VariablesOp;
+  /** Replace initial template variables. */
+  readonly templateVars?: TemplateVarsOp;
+  /** Merge or replace resolved completion records. */
+  readonly resolvedCompletions?: ResolvedCompletionsOp;
+  /** Replace per-frame entry counters. */
+  readonly frameEntries?: FrameEntriesOp;
+};
 
 interface CreateOptions {
   readonly runbookPath: string;
@@ -212,6 +260,16 @@ export class RunbookStateManager {
 
   private statePath(id: string): string {
     return _statePath(this.cwd, id);
+  }
+
+  private async withRunStateLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+    const lock = new RunStateLock(this.cwd);
+    await lock.acquire(id);
+    try {
+      return await fn();
+    } finally {
+      await lock.release(id);
+    }
   }
 
   /** Emit a process-wide one-time warning when legacy `.claude/rundown/` state is detected. */
@@ -353,14 +411,19 @@ export class RunbookStateManager {
    * @param state - The runbook state to persist
    */
   async save(state: RunbookState): Promise<void> {
+    await this.withRunStateLock(state.id, async () => {
+      await this.saveUnlocked(state);
+    });
+  }
+
+  private async saveUnlocked(state: RunbookState): Promise<void> {
     await fs.mkdir(this.stateDir, { recursive: true });
     const updated: RunbookState = {
       ...state,
       schemaVersion: CURRENT_SCHEMA_VERSION,
       updatedAt: new Date().toISOString(),
     };
-    const content = JSON.stringify(updated, null, 2);
-    await fs.writeFile(this.statePath(state.id), content, { mode: 0o600 }); // Owner read/write only
+    await writeJsonFileAtomic(this.statePath(state.id), updated);
   }
 
   /**
@@ -384,36 +447,58 @@ export class RunbookStateManager {
    * @returns The updated runbook state
    * @throws {Error} If the runbook with the given ID is not found
    */
-  async update(
+  async update(id: string, updates: RunbookStateUpdate): Promise<RunbookState> {
+    return await this.withRunStateLock(id, async () => this.updateUnlocked(id, updates));
+  }
+
+  /**
+   * Update an existing runbook state with a patch computed from the locked
+   * current state.
+   *
+   * Use this for read-modify-write operations that replace whole fields such
+   * as `substepStates` or `resolvedCompletions`. The callback runs while the
+   * per-run state lock is held, so concurrent writers cannot compute from the
+   * same stale snapshot and overwrite each other.
+   *
+   * Returning `null` leaves the current state unchanged and releases the lock.
+   *
+   * @param id - The runbook state ID to update
+   * @param buildUpdates - Callback that derives a patch from current state
+   * @returns The updated state, or current state when the callback returns `null`
+   * @throws {Error} If the runbook with the given ID is not found
+   */
+  async updateWithState(
     id: string,
-    updates: Partial<
-      Omit<
-        RunbookState,
-        | 'id'
-        | 'startedAt'
-        | 'updatedAt'
-        | 'schemaVersion'
-        | 'variables'
-        | 'templateVars'
-        | 'resolvedCompletions'
-        | 'frameEntries'
-      >
-    > & {
-      // Tagged ops on record-shaped fields make merge-vs-replace intent
-      // visible at the call site. Internal callers (actor-service sync,
-      // compiler reducers) hold the unbranded XState context shape; the
-      // manager re-mints persistence brands inside the dispatch below.
-      readonly variables?: VariablesOp;
-      readonly templateVars?: TemplateVarsOp;
-      readonly resolvedCompletions?: ResolvedCompletionsOp;
-      readonly frameEntries?: FrameEntriesOp;
-    },
+    buildUpdates: (
+      current: RunbookState,
+    ) => RunbookStateUpdate | null | Promise<RunbookStateUpdate | null>,
   ): Promise<RunbookState> {
+    return await this.withRunStateLock(id, async () => {
+      const existing = await this.load(id);
+      if (!existing) {
+        throw new Error(`Runbook ${id} not found`);
+      }
+      const updates = await buildUpdates(existing);
+      if (updates === null) {
+        return existing;
+      }
+      return await this.updateUnlockedFromExisting(existing, updates);
+    });
+  }
+
+  private async updateUnlocked(id: string, updates: RunbookStateUpdate): Promise<RunbookState> {
     const existing = await this.load(id);
     if (!existing) {
       throw new Error(`Runbook ${id} not found`);
     }
 
+    return await this.updateUnlockedFromExisting(existing, updates);
+  }
+
+  private async updateUnlockedFromExisting(
+    existing: RunbookState,
+    updates: RunbookStateUpdate,
+  ): Promise<RunbookState> {
     // Pull tagged-op fields out of updates so the subsequent `...updates`
     // spread does not leak the wrapper shapes into the strictly-typed
     // RunbookState literal.
@@ -459,7 +544,7 @@ export class RunbookStateManager {
       updatedAt: new Date().toISOString(),
     };
 
-    await this.save(updated);
+    await this.saveUnlocked(updated);
     return updated;
   }
 
@@ -566,10 +651,7 @@ export class RunbookStateManager {
    */
   async saveSession(session: SessionData): Promise<void> {
     await fs.mkdir(path.dirname(this.sessionPath), { recursive: true });
-    await fs.writeFile(this.sessionPath, JSON.stringify(session, null, 2), {
-      encoding: 'utf-8',
-      mode: 0o600,
-    });
+    await writeJsonFileAtomic(this.sessionPath, session);
   }
 
   /**
@@ -589,24 +671,26 @@ export class RunbookStateManager {
     substeps: readonly Substep[],
     frameKey: FrameKey,
   ): Promise<void> {
-    const state = await this.load(id);
-    if (!state) throw new Error(`Runbook ${id} not found`);
+    await this.withRunStateLock(id, async () => {
+      const state = await this.load(id);
+      if (!state) throw new Error(`Runbook ${id} not found`);
 
-    const existing = state.substepStates ?? [];
-    const authoredIds = new Set(substeps.map((substep) => substep.id));
-    const preserved = existing.filter(
-      (substepState) => substepState.frameKey !== frameKey || authoredIds.has(substepState.id),
-    );
-    const existingSameFrameIds = new Set(
-      preserved
-        .filter((substepState) => substepState.frameKey === frameKey)
-        .map((substepState) => substepState.id),
-    );
-    const initialized: SubstepState[] = substeps
-      .filter((substep) => !existingSameFrameIds.has(substep.id))
-      .map((substep) => ({ id: substep.id, frameKey, status: 'pending' }));
+      const existing = state.substepStates ?? [];
+      const authoredIds = new Set(substeps.map((substep) => substep.id));
+      const preserved = existing.filter(
+        (substepState) => substepState.frameKey !== frameKey || authoredIds.has(substepState.id),
+      );
+      const existingSameFrameIds = new Set(
+        preserved
+          .filter((substepState) => substepState.frameKey === frameKey)
+          .map((substepState) => substepState.id),
+      );
+      const initialized: SubstepState[] = substeps
+        .filter((substep) => !existingSameFrameIds.has(substep.id))
+        .map((substep) => ({ id: substep.id, frameKey, status: 'pending' }));
 
-    await this.update(id, { substepStates: [...preserved, ...initialized] });
+      await this.updateUnlocked(id, { substepStates: [...preserved, ...initialized] });
+    });
   }
 
   /**
@@ -623,21 +707,23 @@ export class RunbookStateManager {
    * @throws {Error} If the runbook with the given ID is not found
    */
   async updateForContext(id: string, forStack: ForContext[]): Promise<RunbookState> {
-    const state = await this.load(id);
-    if (!state) {
-      throw new Error(`Runbook ${id} not found`);
-    }
+    return await this.withRunStateLock(id, async () => {
+      const state = await this.load(id);
+      if (!state) {
+        throw new Error(`Runbook ${id} not found`);
+      }
 
-    const snapshot = state.snapshot as Record<string, unknown> | undefined;
-    const patchedSnapshot =
-      snapshot && typeof snapshot === 'object' && 'context' in snapshot
-        ? {
-            ...snapshot,
-            context: { ...(snapshot.context as Record<string, unknown>), forStack },
-          }
-        : snapshot;
+      const snapshot = state.snapshot as Record<string, unknown> | undefined;
+      const patchedSnapshot =
+        snapshot && typeof snapshot === 'object' && 'context' in snapshot
+          ? {
+              ...snapshot,
+              context: { ...(snapshot.context as Record<string, unknown>), forStack },
+            }
+          : snapshot;
 
-    return await this.update(id, { forStack, snapshot: patchedSnapshot });
+      return await this.updateUnlocked(id, { forStack, snapshot: patchedSnapshot });
+    });
   }
 
   /**
@@ -657,14 +743,18 @@ export class RunbookStateManager {
     result: 'pass' | 'fail',
     frameKey: FrameKey,
   ): Promise<void> {
-    const state = await this.load(runbookId);
-    if (!state) throw new Error(`Runbook ${runbookId} not found`);
+    await this.withRunStateLock(runbookId, async () => {
+      const state = await this.load(runbookId);
+      if (!state) throw new Error(`Runbook ${runbookId} not found`);
 
-    const substepStates = state.substepStates ?? [];
-    const updated = substepStates.map((s) =>
-      s.id === substepId && s.frameKey === frameKey ? { ...s, status: 'done' as const, result } : s,
-    );
+      const substepStates = state.substepStates ?? [];
+      const updated = substepStates.map((s) =>
+        s.id === substepId && s.frameKey === frameKey
+          ? { ...s, status: 'done' as const, result }
+          : s,
+      );
 
-    await this.update(runbookId, { substepStates: updated });
+      await this.updateUnlocked(runbookId, { substepStates: updated });
+    });
   }
 }


### PR DESCRIPTION
## Summary
- reject conflicting policy/sandbox flags and enforce project-root containment for --input-file
- make run-state/session writes atomic and serialize run-state read-modify-write paths with a per-run lock
- extend claim idempotency, guard delegation retry with linked children, and reconcile CLI error schemas/envelopes

## Issues
Addresses #369, #370, #371, #372, #373, #374, and #375.

## Validation
- npm run check:types -w packages/core
- npm run check:types -w packages/cli
- npm test -w packages/core -- --runInBand state.test.ts run-state-lock.test.ts execution-lifecycle-service.test.ts completion-service.test.ts completion-lock.test.ts session-lock.test.ts delegation-lock.test.ts retry-delegation retry-hook retry-single-substep session-service output/schema.test.ts
- npm test -w packages/cli -- --runInBand policy-context cli.test.ts variable-discovery.test.ts resolve.test.ts active-runbook-resolver status stop complete stash-pop delegate.test.ts delegate-workflow.test.ts wrapper.test.ts schema-validation.test.ts

## Notes
This is a combined draft PR for the dispatched issue batch. The #371 atomic-write and #372 run-state-lock work are separate logical sections in the diff, but are currently published together on this branch.
