### PR TITLE
[codex] Reject conflicting policy flags

### DIFF
--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { createTestWorkspace, runCli, type TestWorkspace } from './helpers/test-utils.js';
+import {
+  createTestWorkspace,
+  runCli,
+  runCliInProcess,
+  type TestWorkspace,
+} from './helpers/test-utils.js';
 
 describe('CLI program', () => {
   let workspace: TestWorkspace;
@@ -166,6 +171,25 @@ describe('CLI program', () => {
       const result = runCli('status --sandbox-strict --text', workspace);
       // May succeed or fail based on sandbox availability
       expect([0, 1]).toContain(result.exitCode);
+    });
+
+    it('rejects conflicting --allow-all and --deny-all flags', async () => {
+      const result = await runCliInProcess('status --allow-all --deny-all --text', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        'Conflicting policy options: --allow-all and --deny-all cannot be used together.',
+      );
+    });
+
+    it('rejects conflicting --no-sandbox and --sandbox-strict flags', async () => {
+      const result = await runCliInProcess(
+        'status --no-sandbox --sandbox-strict --text',
+        workspace,
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        'Conflicting policy options: --no-sandbox and --sandbox-strict cannot be used together.',
+      );
     });
   });
 

--- a/packages/cli/__tests__/services/policy-context.test.ts
+++ b/packages/cli/__tests__/services/policy-context.test.ts
@@ -16,6 +16,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
 // Dynamic imports are needed after mocking
 const core = await import('@rundown-org/core');
 const {
+  PolicyCliOptionConflictError,
   initializePolicyContext,
   getPolicyContext,
   getPolicyEvaluator,
@@ -75,6 +76,18 @@ describe('policy context service', () => {
     it('handles sandbox flags', () => {
       expect(parsePolicyCliOptions({ sandbox: true }).sandbox).toBe(true);
       expect(parsePolicyCliOptions({ sandbox: false }).sandbox).toBe(false);
+    });
+
+    it('rejects conflicting allow-all and deny-all flags', () => {
+      expect(() => parsePolicyCliOptions({ allowAll: true, denyAll: true })).toThrow(
+        PolicyCliOptionConflictError,
+      );
+    });
+
+    it('rejects no-sandbox with sandbox-strict', () => {
+      expect(() => parsePolicyCliOptions({ sandbox: false, sandboxStrict: true })).toThrow(
+        PolicyCliOptionConflictError,
+      );
     });
 
     it('parses trustJsPolicy flag', () => {

--- a/packages/cli/src/services/policy-context.ts
+++ b/packages/cli/src/services/policy-context.ts
@@ -52,6 +52,25 @@ export interface PolicyCliOptions {
 }
 
 /**
+ * Error thrown when mutually exclusive CLI policy flags are provided together.
+ */
+export class PolicyCliOptionConflictError extends Error {
+  /** CLI flags that cannot be used together. */
+  readonly flags: readonly string[];
+
+  /**
+   * Create a policy CLI option conflict error.
+   *
+   * @param flags - Conflicting CLI flags.
+   */
+  constructor(flags: readonly string[]) {
+    super(`Conflicting policy options: ${flags.join(' and ')} cannot be used together.`);
+    this.name = 'PolicyCliOptionConflictError';
+    this.flags = flags;
+  }
+}
+
+/**
  * Global policy context.
  *
  * Holds the loaded policy, evaluator, and prompter for the current CLI session.
@@ -83,11 +102,14 @@ let policyContext: PolicyContext | null = null;
  * @param options - CLI options for policy configuration
  * @param cwd - Current working directory (for config search and path resolution)
  * @returns Initialized policy context
+ * @throws {PolicyCliOptionConflictError} When mutually exclusive policy flags are present
  */
 export async function initializePolicyContext(
   options: PolicyCliOptions = {},
   cwd: string = process.cwd(),
 ): Promise<PolicyContext> {
+  assertValidPolicyCliOptions(options);
+
   // Load policy from file or defaults
   const { policy, filepath, isDefault, warnings } = await loadPolicy({
     cwd,
@@ -209,9 +231,10 @@ export function resetPolicyContext(): void {
  *
  * @param opts - Raw options from commander
  * @returns Parsed policy CLI options
+ * @throws {PolicyCliOptionConflictError} When mutually exclusive policy flags are present
  */
 export function parsePolicyCliOptions(opts: Record<string, unknown>): PolicyCliOptions {
-  return {
+  const parsed = {
     allowRun: parseStringArray(opts.allowRun),
     allowRead: parseStringArray(opts.allowRead),
     allowWrite: parseStringArray(opts.allowWrite),
@@ -224,9 +247,11 @@ export function parsePolicyCliOptions(opts: Record<string, unknown>): PolicyCliO
     nonInteractive: opts.nonInteractive === true,
     sandbox: typeof opts.sandbox === 'boolean' ? opts.sandbox : undefined,
     sandboxStrict: opts.sandboxStrict === true,
-    noSandbox: opts.noSandbox === true,
+    noSandbox: opts.noSandbox === true || opts.sandbox === false,
     helpers: parseStringArray(opts.helpers),
   };
+  assertValidPolicyCliOptions(parsed);
+  return parsed;
 }
 
 /**
@@ -273,4 +298,20 @@ function parseStringArray(value: unknown): string[] | undefined {
     return value.filter((v): v is string => typeof v === 'string');
   }
   return undefined;
+}
+
+/**
+ * Validate policy CLI option combinations.
+ *
+ * @param options - Parsed CLI policy options.
+ * @throws {PolicyCliOptionConflictError} When mutually exclusive policy flags are present
+ */
+function assertValidPolicyCliOptions(options: PolicyCliOptions): void {
+  if (options.allowAll && options.denyAll) {
+    throw new PolicyCliOptionConflictError(['--allow-all', '--deny-all']);
+  }
+
+  if (options.noSandbox && options.sandboxStrict) {
+    throw new PolicyCliOptionConflictError(['--no-sandbox', '--sandbox-strict']);
+  }
 }


### PR DESCRIPTION
## Summary
- reject mutually exclusive policy/sandbox CLI flag combinations before command execution
- add parser-level and user-visible CLI regression coverage

## Issue
Fixes #369.

## Validation
- npm test -w packages/cli -- --runInBand policy-context cli.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now validates and rejects mutually exclusive policy flags: `--allow-all` cannot be combined with `--deny-all`, and `--no-sandbox` cannot be combined with `--sandbox-strict`. Invalid flag combinations will exit with an error message.

* **Tests**
  * Added test coverage for policy flag validation and conflict detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->