### PR TITLE
[codex] Write run state atomically

### DIFF
--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -860,6 +860,35 @@ describe('RunbookStateManager', () => {
       await expect(manager.update('nonexistent', { step: '2' })).rejects.toThrow('not found');
     });
 
+    it('preserves existing run state when the temp write fails', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      const stateFilePath = _statePath(testDir, state.id);
+      const originalContent = await readFile(stateFilePath, 'utf8');
+      await mkdir(`${stateFilePath}.tmp`);
+
+      await expect(manager.save({ ...state, step: 'changed' })).rejects.toThrow();
+
+      await expect(readFile(stateFilePath, 'utf8')).resolves.toBe(originalContent);
+    });
+
+    it('preserves existing session data when the temp write fails', async () => {
+      const sessionPath = join(testDir, '.rundown', 'session.json');
+      await manager.saveSession({ defaultStack: [], claims: {} });
+      const originalContent = await readFile(sessionPath, 'utf8');
+      await mkdir(`${sessionPath}.tmp`);
+
+      await expect(
+        manager.saveSession({
+          defaultStack: [assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')],
+          claims: {},
+        }),
+      ).rejects.toThrow();
+
+      await expect(readFile(sessionPath, 'utf8')).resolves.toBe(originalContent);
+    });
+
     it('rejects legacy targetPath fields instead of stripping them on save', async () => {
       const state = await manager.create({ source: 'project', path: 'legacy.md' }, mockRunbook, {
         runbookPath: 'legacy.md',

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -106,6 +106,24 @@ function assertTrustedResolvedCompletions(
   return completions;
 }
 
+async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<void> {
+  const tempPath = `${filePath}.tmp`;
+  const content = JSON.stringify(value, null, 2);
+
+  try {
+    await fs.writeFile(tempPath, content, { encoding: 'utf8', mode: 0o600 });
+    await fs.chmod(tempPath, 0o600);
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    try {
+      await fs.unlink(tempPath);
+    } catch {
+      // Best effort cleanup only. The caller-visible error is the failed write/rename.
+    }
+    throw error;
+  }
+}
+
 /**
  * Thrown when a persisted state file does not match the current schema contract.
  */
@@ -359,8 +377,7 @@ export class RunbookStateManager {
       schemaVersion: CURRENT_SCHEMA_VERSION,
       updatedAt: new Date().toISOString(),
     };
-    const content = JSON.stringify(updated, null, 2);
-    await fs.writeFile(this.statePath(state.id), content, { mode: 0o600 }); // Owner read/write only
+    await writeJsonFileAtomic(this.statePath(state.id), updated);
   }
 
   /**
@@ -566,10 +583,7 @@ export class RunbookStateManager {
    */
   async saveSession(session: SessionData): Promise<void> {
     await fs.mkdir(path.dirname(this.sessionPath), { recursive: true });
-    await fs.writeFile(this.sessionPath, JSON.stringify(session, null, 2), {
-      encoding: 'utf-8',
-      mode: 0o600,
-    });
+    await writeJsonFileAtomic(this.sessionPath, session);
   }
 
   /**


### PR DESCRIPTION
## Summary
- write run-state files through temp file plus rename
- write session.json through the same atomic helper
- add regression coverage that temp-write failure preserves existing JSON

## Issue
Fixes #371.

## Validation
- npm test -w packages/core -- --runInBand state.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases to verify that runbook state and session persistence maintain integrity when write operations fail.

* **Bug Fixes**
  * Enhanced the durability and reliability of state and session data persistence to better protect against data loss and corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->