### PR TITLE
[codex] Handle terminal claim targets

### DIFF
--- a/packages/cli/__tests__/commands/complete.test.ts
+++ b/packages/cli/__tests__/commands/complete.test.ts
@@ -304,6 +304,58 @@ Do work.
       const session = await readSession(workspace);
       expect(session.defaultStack).toContain(parentId);
     });
+
+    it('releases a terminal claimed child as an idempotent no-op', async () => {
+      const parentRunbook = `## 1. Review
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Child
+- DELEGATE
+
+Do child.
+
+- child-terminal-complete.runbook.md
+`;
+      const childRunbook = `## 1. Child
+- PASS COMPLETE
+
+Do work.
+`;
+      await writeFile(join(workspace.cwd, 'parent-terminal-complete.runbook.md'), parentRunbook);
+      await writeFile(join(workspace.cwd, 'child-terminal-complete.runbook.md'), childRunbook);
+
+      let result = await runCliInProcess(
+        'run --prompted parent-terminal-complete.runbook.md --text',
+        workspace,
+      );
+      expect(result.exitCode).toBe(0);
+      const parentState = await getActiveState(workspace);
+      const token = parentState?.substepStates?.[0]?.delegation?.token;
+      expect(token).toEqual(expect.stringMatching(/^rdtk_/));
+      if (typeof token !== 'string') throw new Error('Expected delegation token');
+      result = await runCliInProcess(`claim ${token}`, workspace);
+      expect(result.exitCode).toBe(0);
+      const claimOutput = findActionOutput(result.stdout);
+      const childRunId = String(claimOutput?.run_id);
+      const claimId = String(claimOutput?.claim_id);
+
+      const childState = await readRunbookState(workspace, childRunId);
+      expect(childState).not.toBeNull();
+      await writeFile(
+        join(workspace.statePath(), `${childRunId}.json`),
+        JSON.stringify({ ...childState, lifecycle: 'completed' }, null, 2),
+      );
+
+      result = await runCliInProcess(['complete', '--claim-id', claimId], workspace);
+
+      expect(result.exitCode).toBe(0);
+      const session = await readSession(workspace);
+      expect(Object.values(session.claims)).not.toContainEqual(
+        expect.objectContaining({ childRunId }),
+      );
+      expect(session.defaultStack).toContain(parentState!.id);
+    });
   });
 
   it('does not propagate to parent or send FORCE_COMPLETE when state is already terminal', async () => {

--- a/packages/cli/__tests__/commands/stash-pop.test.ts
+++ b/packages/cli/__tests__/commands/stash-pop.test.ts
@@ -309,6 +309,13 @@ describe('stash command', () => {
 
     result = await runCliInProcess(['pop', '--claim-id', claimId], workspace);
     expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toEqual(
+      expect.objectContaining({
+        kind: 'error',
+        code: 'CLAIMED_RUNBOOK_UNAVAILABLE',
+        error: expect.stringContaining('missing child state'),
+      }),
+    );
     const session = await readSession(workspace);
     expect(session.stashed).toBe(childRunId);
     expect(Object.values(session.claims)).toContainEqual(expect.objectContaining({ childRunId }));
@@ -369,6 +376,7 @@ describe('stash command', () => {
       expect.objectContaining({
         kind: 'error',
         code: 'CLAIMED_RUNBOOK_UNAVAILABLE',
+        error: expect.stringContaining('parent runbook has completed'),
       }),
     );
 

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -322,6 +322,21 @@ describe('claim-id delegated children', () => {
     );
   });
 
+  it('claim id renders terminal child status instead of unavailable', async () => {
+    const { childRunId, claimId } = await setupOwnedStash();
+    const stateFile = join(workspace.statePath(), `${childRunId}.json`);
+    const state = JSON.parse(await readFile(stateFile, 'utf-8')) as Record<string, unknown>;
+    await writeFile(stateFile, JSON.stringify({ ...state, lifecycle: 'completed' }, null, 2));
+
+    const status = await runCliInProcess(['status', '--claim-id', claimId], workspace);
+    const output = JSON.parse(status.stdout);
+
+    expect(status.exitCode).toBe(0);
+    expect(output.active).toBe(false);
+    expect(output.status).toBe('completed');
+    expect(output.state).toContain(childRunId);
+  });
+
   it('anonymous stash remains visible to plain callers', async () => {
     await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
     await runCliInProcess('stash --text', workspace);

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -381,6 +381,58 @@ Do work.
       expect(session.active).toBe(parentState!.id);
       expect(await readRunbookState(workspace, parentState!.id)).not.toBeNull();
     });
+
+    it('releases a terminal claimed child as an idempotent no-op', async () => {
+      const parentRunbook = `## 1. Review
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Child
+- DELEGATE
+
+Do child.
+
+- child-terminal-stop.runbook.md
+`;
+      const childRunbook = `## 1. Child
+- PASS COMPLETE
+
+Do work.
+`;
+      await writeFile(join(workspace.cwd, 'parent-terminal-stop.runbook.md'), parentRunbook);
+      await writeFile(join(workspace.cwd, 'child-terminal-stop.runbook.md'), childRunbook);
+
+      let result = await runCliInProcess(
+        'run --prompted parent-terminal-stop.runbook.md --text',
+        workspace,
+      );
+      expect(result.exitCode).toBe(0);
+      const parentState = await getActiveState(workspace);
+      const token = parentState?.substepStates?.[0]?.delegation?.token;
+      expect(token).toEqual(expect.stringMatching(/^rdtk_/));
+      if (typeof token !== 'string') throw new Error('Expected delegation token');
+      result = await runCliInProcess(`claim ${token}`, workspace);
+      expect(result.exitCode).toBe(0);
+      const claimOutput = findActionOutput(result.stdout);
+      const childRunId = String(claimOutput?.run_id);
+      const claimId = String(claimOutput?.claim_id);
+
+      const childState = await readRunbookState(workspace, childRunId);
+      expect(childState).not.toBeNull();
+      await writeFile(
+        join(workspace.statePath(), `${childRunId}.json`),
+        JSON.stringify({ ...childState, lifecycle: 'stopped' }, null, 2),
+      );
+
+      result = await runCliInProcess(['stop', '--claim-id', claimId], workspace);
+
+      expect(result.exitCode).toBe(0);
+      const session = await readSession(workspace);
+      expect(Object.values(session.claims)).not.toContainEqual(
+        expect.objectContaining({ childRunId }),
+      );
+      expect(session.defaultStack).toContain(parentState!.id);
+    });
   });
 
   describe('stop with message', () => {

--- a/packages/cli/__tests__/helpers/active-runbook-resolver.test.ts
+++ b/packages/cli/__tests__/helpers/active-runbook-resolver.test.ts
@@ -49,6 +49,37 @@ describe('resolveActiveRunbook', () => {
     }
   });
 
+  it('preserves terminal claim resolution with final child state', async () => {
+    const claimId = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
+    const terminalChild = { ...child, lifecycle: 'completed' } as RunbookState;
+    const sessionService = {
+      getActiveForClaimId: async () => ({
+        status: 'terminal' as const,
+        claim: {
+          kind: 'claim-record',
+          claimId,
+          childRunId: 'child',
+          tokenHash: `sha256:${'a'.repeat(64)}`,
+          parentRunId: 'parent',
+          parentStepId: '1.1',
+          claimedAt: '2026-05-01T00:00:00.000Z',
+          updatedAt: '2026-05-01T00:00:00.000Z',
+        },
+        lifecycle: 'completed' as const,
+        state: terminalChild,
+      }),
+      getActive: async () => parent,
+    } as unknown as SessionService;
+
+    const result = await resolveActiveRunbook(sessionService, { claimId });
+
+    expect(result.kind).toBe('terminal_claim');
+    if (result.kind === 'terminal_claim') {
+      expect(result.lifecycle).toBe('completed');
+      expect(result.state.id).toBe('child');
+    }
+  });
+
   it('resolves default stack when no claim id is supplied', async () => {
     const sessionService = {
       getActive: async () => parent,

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -70,6 +70,7 @@ export function registerCollectCommand(program: Command): void {
                 output.flush();
                 return;
               case 'stale_claim':
+              case 'terminal_claim':
                 output.error(contextResult.message, 'CLAIMED_RUNBOOK_UNAVAILABLE');
                 output.flush();
                 process.exitCode = 1;

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -64,6 +64,9 @@ export function registerCompleteCommand(program: Command): void {
               case 'default':
                 state = active.state;
                 break;
+              case 'terminal_claim':
+                state = active.state;
+                break;
               case 'none':
                 break;
               case 'stale_claim':

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -38,6 +38,7 @@ export function registerGotoCommand(program: Command): void {
                 output.flush();
                 return;
               case 'stale_claim':
+              case 'terminal_claim':
                 output.error(contextResult.message, 'CLAIMED_RUNBOOK_UNAVAILABLE');
                 output.flush();
                 process.exitCode = 1;

--- a/packages/cli/src/commands/pop.ts
+++ b/packages/cli/src/commands/pop.ts
@@ -6,6 +6,9 @@ import {
   SessionService,
   countNumberedSteps,
   type ActionBlockData,
+  type ClaimId,
+  type RunbookState,
+  type UnstashForClaimIdResult,
 } from '@rundown-org/core';
 import { getCwd } from '../helpers/context.js';
 import { getStepRetryMax, buildMetadata, formatActionForDisplay } from '../services/execution.js';
@@ -13,6 +16,32 @@ import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
+
+function claimPopUnavailableMessage(
+  claimId: ClaimId,
+  result: Exclude<UnstashForClaimIdResult, { status: 'restored' }>,
+): string {
+  switch (result.status) {
+    case 'missing-claim':
+      return `Claim id ${claimId} does not exist.`;
+    case 'not-stashed':
+      return `Claim id ${claimId} is not currently stashed.`;
+    case 'missing-child':
+      return `Claim id ${claimId} points at missing child state.`;
+    case 'terminal-child':
+      return `Claim id ${claimId} points at a ${result.lifecycle} child runbook.`;
+    case 'child-linkage-mismatch':
+      return `Claim id ${claimId} is no longer linked to its child runbook.`;
+    case 'parent-missing':
+      return `Claim id ${claimId} parent runbook is missing.`;
+    case 'parent-ended':
+      return `Claim id ${claimId} parent runbook has ${result.lifecycle}.`;
+    default: {
+      const _exhaustive: never = result;
+      return _exhaustive;
+    }
+  }
+}
 
 /**
  * Registers the 'pop' command for resuming stashed runbooks.
@@ -35,18 +64,19 @@ export function registerPopCommand(program: Command): void {
           const claimTarget = parseClaimIdOption(options.claimId, output);
           if (!claimTarget.ok) return;
 
-          let state: Awaited<ReturnType<typeof sessionService.unstash>>;
+          let state: RunbookState | null;
           if (claimTarget.claimId !== undefined) {
-            state = await sessionService.unstashForClaimId(claimTarget.claimId);
-            if (!state) {
+            const unstashed = await sessionService.unstashForClaimId(claimTarget.claimId);
+            if (unstashed.status !== 'restored') {
               output.error(
-                `No stashed runbook is available for claim id ${claimTarget.claimId}.`,
+                claimPopUnavailableMessage(claimTarget.claimId, unstashed),
                 'CLAIMED_RUNBOOK_UNAVAILABLE',
               );
               output.flush();
               process.exitCode = 1;
               return;
             }
+            state = unstashed.state;
           } else {
             state = await sessionService.unstash();
           }

--- a/packages/cli/src/commands/pop.ts
+++ b/packages/cli/src/commands/pop.ts
@@ -66,17 +66,17 @@ export function registerPopCommand(program: Command): void {
 
           let state: RunbookState | null;
           if (claimTarget.claimId !== undefined) {
-            const unstashed = await sessionService.unstashForClaimId(claimTarget.claimId);
-            if (unstashed.status !== 'restored') {
+            const restoreResult = await sessionService.unstashForClaimId(claimTarget.claimId);
+            if (restoreResult.status !== 'restored') {
               output.error(
-                claimPopUnavailableMessage(claimTarget.claimId, unstashed),
+                claimPopUnavailableMessage(claimTarget.claimId, restoreResult),
                 'CLAIMED_RUNBOOK_UNAVAILABLE',
               );
               output.flush();
               process.exitCode = 1;
               return;
             }
-            state = unstashed.state;
+            state = restoreResult.state;
           } else {
             state = await sessionService.unstash();
           }

--- a/packages/cli/src/commands/stash.ts
+++ b/packages/cli/src/commands/stash.ts
@@ -41,6 +41,7 @@ export function registerStashCommand(program: Command): void {
               output.flush();
               return;
             case 'stale_claim':
+            case 'terminal_claim':
               output.error(active.message, 'CLAIMED_RUNBOOK_UNAVAILABLE');
               output.flush();
               process.exitCode = 1;

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -53,6 +53,18 @@ export function registerStatusCommand(program: Command): void {
               );
               output.flush();
               return;
+            case 'terminal_claim':
+              output.detail(
+                buildActiveStatus(
+                  active.state,
+                  cwd,
+                  stashedId ?? undefined,
+                  active.lifecycle,
+                ) as unknown as Record<string, unknown>,
+                'status',
+              );
+              output.flush();
+              return;
             case 'none':
               break;
             case 'stale_claim':

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -55,6 +55,9 @@ export function registerStopCommand(program: Command): void {
               case 'default':
                 state = active.state;
                 break;
+              case 'terminal_claim':
+                state = active.state;
+                break;
               case 'none':
                 break;
               case 'stale_claim':

--- a/packages/cli/src/helpers/active-runbook-resolver.ts
+++ b/packages/cli/src/helpers/active-runbook-resolver.ts
@@ -8,6 +8,14 @@ export type ActiveRunbookResolution =
       readonly claim: ClaimRecord;
       readonly state: RunbookState;
     }
+  | {
+      readonly kind: 'terminal_claim';
+      readonly claimId: ClaimId;
+      readonly claim: ClaimRecord;
+      readonly state: RunbookState;
+      readonly lifecycle: 'completed' | 'stopped';
+      readonly message: string;
+    }
   | { readonly kind: 'default'; readonly state: RunbookState }
   | { readonly kind: 'none' }
   | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string };
@@ -54,8 +62,11 @@ export async function resolveActiveRunbook(
         };
       case 'terminal':
         return {
-          kind: 'stale_claim',
+          kind: 'terminal_claim',
           claimId: options.claimId,
+          claim: claimed.claim,
+          state: claimed.state,
+          lifecycle: claimed.lifecycle,
           message: `Claim id ${options.claimId} points at a ${claimed.lifecycle} child runbook.`,
         };
       case 'unlinked':

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -68,7 +68,7 @@ export type GotoExecutionResult =
 /** Result of resolving the runbook target and building goto execution context. */
 export type BuildGotoContextResult =
   | { readonly kind: 'ready'; readonly ctx: GotoContext }
-  | Extract<ActiveRunbookResolution, { kind: 'none' | 'stale_claim' }>;
+  | Extract<ActiveRunbookResolution, { kind: 'none' | 'stale_claim' | 'terminal_claim' }>;
 
 /**
  * Resolve how terminal execution should remove a specific runbook from session targeting.
@@ -101,8 +101,8 @@ export async function resolveTerminalReleaseModeForRunbook(
  * @param options.claimId - Claim id to resolve instead of the default stack
  * @returns Discriminated union: `{ kind: 'ready'; ctx }` when an active runbook
  *   was resolved and a goto context is available; `{ kind: 'none' }` when no
- *   active runbook exists; or `{ kind: 'stale_claim' }` when the supplied
- *   claim id no longer maps to an active child.
+ *   active runbook exists; or `{ kind: 'stale_claim' | 'terminal_claim' }`
+ *   when the supplied claim id cannot be used as a mutable child target.
  */
 export async function buildGotoContext(
   output: OutputEmitter,
@@ -119,6 +119,7 @@ export async function buildGotoContext(
       break;
     case 'none':
     case 'stale_claim':
+    case 'terminal_claim':
       return active;
     default: {
       const _exhaustive: never = active;

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -244,6 +244,7 @@ export function buildStashedStatus(stashedState: RunbookState, cwd: string): Sta
  * @param activeState - The active runbook state
  * @param cwd - Current working directory (for step resolution)
  * @param stashedId - Optional stashed runbook ID (to indicate stashed flag)
+ * @param lifecycleStatus - Optional terminal lifecycle status override
  * @returns StatusOutputData with full active runbook details
  */
 export function buildActiveStatus(

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -244,7 +244,7 @@ export function buildStashedStatus(stashedState: RunbookState, cwd: string): Sta
  * @param activeState - The active runbook state
  * @param cwd - Current working directory (for step resolution)
  * @param stashedId - Optional stashed runbook ID (to indicate stashed flag)
- * @param lifecycleStatus - Optional terminal lifecycle status override
+ * @param lifecycleStatus - Optional terminal lifecycle status override ('completed' | 'stopped')
  * @returns StatusOutputData with full active runbook details
  */
 export function buildActiveStatus(

--- a/packages/cli/src/helpers/status-builder.ts
+++ b/packages/cli/src/helpers/status-builder.ts
@@ -42,6 +42,8 @@ import { getRunbookFromState } from './runbook-loader.js';
 export interface StatusOutputData {
   /** Whether a runbook is currently active */
   active: boolean;
+  /** Final lifecycle status when the inspected runbook has ended. */
+  status?: 'completed' | 'stopped';
   /** Whether the active runbook is stashed (enforcement paused) */
   stashed: boolean;
   /** Runbook file path (flat, not nested) */
@@ -248,6 +250,7 @@ export function buildActiveStatus(
   activeState: RunbookState,
   cwd: string,
   stashedId?: string,
+  lifecycleStatus?: 'completed' | 'stopped',
 ): StatusOutputData {
   const steps = getRunbookFromState(activeState, cwd);
   const currentStepIndex = steps.findIndex((s) => s.name === activeState.step);
@@ -323,7 +326,8 @@ export function buildActiveStatus(
     }));
 
   return {
-    active: true,
+    active: lifecycleStatus === undefined,
+    ...(lifecycleStatus !== undefined ? { status: lifecycleStatus } : {}),
     stashed: !!stashedId,
     file: metadata.file,
     state: metadata.state,

--- a/packages/cli/src/helpers/transition-command.ts
+++ b/packages/cli/src/helpers/transition-command.ts
@@ -85,6 +85,7 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
                 output.flush();
                 return;
               case 'stale_claim':
+              case 'terminal_claim':
                 output.error(contextResult.message, 'CLAIMED_RUNBOOK_UNAVAILABLE');
                 output.flush();
                 process.exitCode = 1;

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -154,7 +154,7 @@ export interface TransitionContext {
 /** Result of resolving the runbook target and building transition execution context. */
 export type BuildTransitionContextResult =
   | { readonly kind: 'ready'; readonly ctx: TransitionContext }
-  | Extract<ActiveRunbookResolution, { kind: 'none' | 'stale_claim' }>;
+  | Extract<ActiveRunbookResolution, { kind: 'none' | 'stale_claim' | 'terminal_claim' }>;
 
 /**
  * Build full transition context from resolved state.
@@ -186,6 +186,7 @@ export async function buildTransitionContext(
       break;
     case 'none':
     case 'stale_claim':
+    case 'terminal_claim':
       return active;
     default: {
       const _exhaustive: never = active;

--- a/packages/core/__tests__/runbook/session-service.test.ts
+++ b/packages/core/__tests__/runbook/session-service.test.ts
@@ -505,13 +505,88 @@ describe('SessionService', () => {
       }
 
       const restored = await sessionService.unstashForClaimId(claimed.claim.claimId);
-      expect(restored?.id).toBe(child.id);
+      expect(restored.status).toBe('restored');
+      if (restored.status === 'restored') {
+        expect(restored.state.id).toBe(child.id);
+      }
       expect(await sessionService.getStashedRunbookId()).toBeNull();
 
       // After pop the claim is active again.
       expect((await sessionService.getActiveForClaimId(claimed.claim.claimId)).status).toBe(
         'claimed',
       );
+    });
+
+    it('unstashForClaimId distinguishes absent claim from non-stashed claim', async () => {
+      const parent = await manager.create({ source: 'project', path: 'parent.md' }, mockRunbook, {
+        runbookPath: 'parent.md',
+      });
+      const linkage = linkageFor(parent.id, '1');
+      const child = await manager.create({ source: 'project', path: 'child.md' }, mockRunbook, {
+        runbookPath: 'child.md',
+        parentLinkage: linkage,
+      });
+      const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
+
+      const absent = await sessionService.unstashForClaimId(
+        assertClaimId('rdclm_abcdefghijklmnopqrstu1'),
+      );
+      expect(absent.status).toBe('missing-claim');
+
+      const notStashed = await sessionService.unstashForClaimId(claimed.claim.claimId);
+      expect(notStashed.status).toBe('not-stashed');
+      if (notStashed.status === 'not-stashed') {
+        expect(notStashed.claim.childRunId).toBe(child.id);
+      }
+    });
+
+    it('unstashForClaimId distinguishes terminal child and ended parent', async () => {
+      const parent = await manager.create({ source: 'project', path: 'parent.md' }, mockRunbook, {
+        runbookPath: 'parent.md',
+      });
+      const terminalLinkage = linkageFor(parent.id, '1');
+      const terminalChild = await manager.create(
+        { source: 'project', path: 'terminal-child.md' },
+        mockRunbook,
+        {
+          runbookPath: 'terminal-child.md',
+          parentLinkage: terminalLinkage,
+        },
+      );
+      const terminalClaimed = assertClaimed(
+        await sessionService.claimRunbook(terminalChild.id, terminalLinkage),
+      );
+      await sessionService.stashRunbook(terminalChild.id);
+      await manager.update(terminalChild.id, { lifecycle: 'completed' });
+
+      const terminal = await sessionService.unstashForClaimId(terminalClaimed.claim.claimId);
+      expect(terminal.status).toBe('terminal-child');
+      if (terminal.status === 'terminal-child') {
+        expect(terminal.lifecycle).toBe('completed');
+      }
+
+      const endedParent = await manager.create(
+        { source: 'project', path: 'ended-parent.md' },
+        mockRunbook,
+        {
+          runbookPath: 'ended-parent.md',
+        },
+      );
+      const endedLinkage = linkageFor(endedParent.id, '2');
+      const child = await manager.create({ source: 'project', path: 'child.md' }, mockRunbook, {
+        runbookPath: 'child.md',
+        parentLinkage: endedLinkage,
+      });
+      const endedClaimed = assertClaimed(await sessionService.claimRunbook(child.id, endedLinkage));
+      await manager.update(endedParent.id, { lifecycle: 'stopped' });
+      await sessionService.releaseRunbook(terminalChild.id);
+      await sessionService.stashRunbook(child.id);
+
+      const parentEnded = await sessionService.unstashForClaimId(endedClaimed.claim.claimId);
+      expect(parentEnded.status).toBe('parent-ended');
+      if (parentEnded.status === 'parent-ended') {
+        expect(parentEnded.lifecycle).toBe('stopped');
+      }
     });
 
     it('exposes a stashed claimed child read-only via includeStashed', async () => {

--- a/packages/core/src/runbook/claim-id.ts
+++ b/packages/core/src/runbook/claim-id.ts
@@ -83,6 +83,7 @@ export type ClaimIdResolution =
   | {
       readonly status: 'terminal';
       readonly claim: ClaimRecord;
+      readonly state: RunbookState;
       readonly lifecycle: 'completed' | 'stopped';
     }
   | {

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -66,7 +66,11 @@ export {
   type TemplateVarsOp,
   type VariablesOp,
 } from './state-update-ops.js';
-export { SessionService, type ReleaseRunbookResult } from './session-service.js';
+export {
+  SessionService,
+  type ReleaseRunbookResult,
+  type UnstashForClaimIdResult,
+} from './session-service.js';
 export { readActiveRunScope, type ActiveRunScope } from './session-reader.js';
 export { ExecutionLifecycleService } from './execution-lifecycle-service.js';
 export {

--- a/packages/core/src/runbook/session-service.ts
+++ b/packages/core/src/runbook/session-service.ts
@@ -33,6 +33,25 @@ export type ReleaseRunbookResult =
       readonly nextDefaultRunbookId: RunId | null;
     };
 
+/** Result of restoring a stashed delegated child by claim id. */
+export type UnstashForClaimIdResult =
+  | { readonly status: 'restored'; readonly claim: ClaimRecord; readonly state: RunbookState }
+  | { readonly status: 'missing-claim'; readonly claimId: ClaimId }
+  | { readonly status: 'not-stashed'; readonly claim: ClaimRecord }
+  | { readonly status: 'missing-child'; readonly claim: ClaimRecord }
+  | {
+      readonly status: 'terminal-child';
+      readonly claim: ClaimRecord;
+      readonly lifecycle: 'completed' | 'stopped';
+    }
+  | { readonly status: 'child-linkage-mismatch'; readonly claim: ClaimRecord }
+  | { readonly status: 'parent-missing'; readonly claim: ClaimRecord }
+  | {
+      readonly status: 'parent-ended';
+      readonly claim: ClaimRecord;
+      readonly lifecycle: 'completed' | 'stopped';
+    };
+
 /**
  * True when persisted child linkage matches an incoming delegation linkage on the
  * three identifying fields (`parentRunId`, `parentStepId`, `tokenHash`).
@@ -315,7 +334,7 @@ export class SessionService {
       return { status: 'stale', claim, reason: 'missing-state' };
     }
     if (state.lifecycle === 'completed' || state.lifecycle === 'stopped') {
-      return { status: 'terminal', claim, lifecycle: state.lifecycle };
+      return { status: 'terminal', claim, state, lifecycle: state.lifecycle };
     }
     if (!linkageMatchesClaim(state.parentLinkage, claim)) {
       return { status: 'unlinked', claim, reason: 'child-linkage-mismatch' };
@@ -458,39 +477,41 @@ export class SessionService {
    * Restore a stashed delegated runbook by explicit claim id.
    *
    * @param claimId - Claim id for the stashed child runbook
-   * @returns The restored runbook state, or null if no stashed runbook exists
+   * @returns Discriminated restore result describing success or the refusal reason
    */
-  async unstashForClaimId(claimId: ClaimId): Promise<RunbookState | null> {
+  async unstashForClaimId(claimId: ClaimId): Promise<UnstashForClaimIdResult> {
     return this.withLock(async () => {
       const session = await this.manager.loadSession();
       if (!(claimId in session.claims)) {
-        return null;
+        return { status: 'missing-claim', claimId };
       }
       const claim = session.claims[claimId];
       if (session.stashedRunbookId !== claim.childRunId) {
-        return null;
+        return { status: 'not-stashed', claim };
       }
 
       const state = await this.manager.load(claim.childRunId);
-      if (state?.lifecycle !== 'running') {
-        return null;
+      if (!state) {
+        return { status: 'missing-child', claim };
+      }
+      if (state.lifecycle === 'completed' || state.lifecycle === 'stopped') {
+        return { status: 'terminal-child', claim, lifecycle: state.lifecycle };
       }
       if (!linkageMatchesClaim(state.parentLinkage, claim)) {
-        return null;
+        return { status: 'child-linkage-mismatch', claim };
       }
       const parent = await this.manager.load(claim.parentRunId);
-      if (
-        parent?.lifecycle === undefined ||
-        parent.lifecycle === 'completed' ||
-        parent.lifecycle === 'stopped'
-      ) {
-        return null;
+      if (!parent) {
+        return { status: 'parent-missing', claim };
+      }
+      if (parent.lifecycle === 'completed' || parent.lifecycle === 'stopped') {
+        return { status: 'parent-ended', claim, lifecycle: parent.lifecycle };
       }
 
       session.stashedRunbookId = undefined;
       session.claims[claimId] = { ...claim, updatedAt: new Date().toISOString() };
       await this.manager.saveSession(session);
-      return state;
+      return { status: 'restored', claim: session.claims[claimId], state };
     });
   }
 


### PR DESCRIPTION
## Summary
- preserve terminal claim resolutions instead of flattening them to stale claims
- make status/stop/complete claim targets handle terminal children idempotently where appropriate
- return discriminated pop --claim-id outcomes with focused messages

## Issue
Fixes #373.

## Validation
- npm test -w packages/core -- --runInBand session-service
- npm test -w packages/cli -- --runInBand active-runbook-resolver status stop complete stash-pop
- npm run build -w packages/core
- npm run check:types -w packages/cli


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commands now treat terminal (completed/stopped) claimed children as idempotent no-ops and route unavailable claims to consistent error paths with clear exit behavior.
  * Restore/pop error messages now distinguish missing child state vs parent-completed cases.

* **New Features**
  * Status output reports terminal lifecycle (completed/stopped) for claimed children.

* **Tests**
  * Added/expanded tests covering terminal-claim, stash/unstash outcomes, and status/stop/complete behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->