### PR TITLE
[codex] Guard retry with linked child

### DIFF
--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -765,6 +765,37 @@ describe('delegate command', () => {
       expect(retryOutput.token).not.toBe(originalToken);
     });
 
+    it('refuses retry when the delegation has a linked child run', async () => {
+      await setupDelegation();
+
+      const first = await runCliInProcess(
+        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        workspace,
+      );
+      expect(first.exitCode).toBe(0);
+      const firstOutput = parseCliJsonObject(first.stdout);
+      const token = firstOutput.token as string;
+
+      const claim = await runCliInProcess(['claim', token], workspace);
+      expect(claim.exitCode).toBe(0);
+
+      const retry = await runCliInProcess(['delegate', '--retry', token], workspace);
+
+      expect(retry.exitCode).not.toBe(0);
+      const envelope = parseCliJsonObject(retry.stdout || retry.stderr);
+      expect(envelope).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-823' }));
+      expect(JSON.stringify(envelope)).toContain('abort');
+      expect(JSON.stringify(envelope)).toContain('--force');
+
+      const state = await getActiveState(workspace);
+      const substepStates = state?.substepStates as Array<Record<string, unknown>> | undefined;
+      const delegation = substepStates?.find((ss) => ss.id === '1')?.delegation as
+        | Record<string, unknown>
+        | undefined;
+      expect(delegation?.tokenHash).toBe(firstOutput.token_hash);
+      expect(delegation?.childRunId).not.toBeNull();
+    });
+
     it('rejects ambiguity: token + --step both provided', async () => {
       await setupDelegation();
 

--- a/packages/cli/__tests__/integration/delegate-workflow.test.ts
+++ b/packages/cli/__tests__/integration/delegate-workflow.test.ts
@@ -7,6 +7,7 @@ import {
   runCliInProcess,
   getActiveState,
   readRunbookState,
+  parseCliJsonObject,
   parseConcatenatedJson,
   findActionOutput,
   type TestWorkspace,
@@ -903,11 +904,9 @@ describe('DELEGATE re-entry and retry', () => {
   // has a fresh token, cancelledAt null, childRunId null, same childRunbookPath).
   // ---------------------------------------------------------------------------
   it('rd delegate --retry CLI forms (token, --step, inferred) all produce equivalent state (spec §8.1 Test 5)', async () => {
-    // Helper: build a parent + child, start the parent, and run claim on ss2
-    // (so it's in a claimed-but-not-yet-resolved state suitable for retry).
-    // Under reverted Route A, claimed children are NOT pushed onto
-    // defaultStack — the parent remains at session top after `rd claim`.
-    async function setupClaimed(): Promise<{
+    // Helper: build a parent + child, resolve ss1, and leave ss2 pending
+    // (token issued but childRunId still null) so it is suitable for retry.
+    async function setupPendingSecond(): Promise<{
       parentRunId: string;
       token2: string;
       priorDelegation: Record<string, unknown>;
@@ -923,21 +922,18 @@ describe('DELEGATE re-entry and retry', () => {
       const claimId1 = String(claim1!.claim_id);
       r = await runCliInProcess(['pass', '--claim-id', claimId1], workspace);
       expect(r.exitCode).toBe(0);
-      // Claim ss2 but don't pass/fail yet — leaves the delegation in
-      // claimed-but-unresolved state for retry tests.
-      r = await runCliInProcess(`claim ${token2}`, workspace);
-      expect(r.exitCode).toBe(0);
       const state = await readRunbookState(workspace, parentRunId);
       const substeps = state?.substepStates as Array<Record<string, unknown>> | undefined;
       const ss = substeps?.find((s) => s.id === '2');
       const priorDelegation = ss?.delegation as Record<string, unknown>;
+      expect(priorDelegation.childRunId).toBeNull();
       return { parentRunId, token2, priorDelegation };
     }
 
     // Form 1: token positional. Token-form resolves by tokenHash regardless
     // of active session top (parent is looked up via scan).
     {
-      const { parentRunId, token2, priorDelegation } = await setupClaimed();
+      const { parentRunId, token2, priorDelegation } = await setupPendingSecond();
       const retry = await runCliInProcess(['delegate', '--retry', token2], workspace);
       expect(retry.exitCode).toBe(0);
       const out = JSON.parse(retry.stdout) as Record<string, unknown>;
@@ -964,7 +960,7 @@ describe('DELEGATE re-entry and retry', () => {
     // (claimed children are not pushed onto defaultStack), so no session
     // manipulation is needed.
     {
-      const { parentRunId, priorDelegation } = await setupClaimed();
+      const { parentRunId, priorDelegation } = await setupPendingSecond();
       const retry = await runCliInProcess(['delegate', '--retry', '--step', '1.2'], workspace);
       expect(retry.exitCode).toBe(0);
       const out = JSON.parse(retry.stdout) as Record<string, unknown>;
@@ -985,7 +981,7 @@ describe('DELEGATE re-entry and retry', () => {
     // Form 3: inferred (no args) — infers from active substep. Under reverted
     // Route A, parent is already at session top after `rd claim`.
     {
-      const { parentRunId, priorDelegation } = await setupClaimed();
+      const { parentRunId, priorDelegation } = await setupPendingSecond();
       const retry = await runCliInProcess(['delegate', '--retry'], workspace);
       expect(retry.exitCode).toBe(0);
       const out = JSON.parse(retry.stdout) as Record<string, unknown>;
@@ -1003,7 +999,7 @@ describe('DELEGATE re-entry and retry', () => {
     // Ambiguity rejection: token + --step is an error.
     await workspace.cleanup();
     workspace = await createTestWorkspace();
-    const { token2 } = await setupClaimed();
+    const { token2 } = await setupPendingSecond();
     const ambiguous = await runCliInProcess(
       ['delegate', '--retry', token2, '--step', '1.2'],
       workspace,
@@ -1329,10 +1325,9 @@ describe('DELEGATE re-entry and retry', () => {
   // ---------------------------------------------------------------------------
   // Task 11 additional test — result-agnostic CLI retry (spec §4.4).
   //
-  // `rd delegate --retry` accepts retry regardless of substep result. We
-  // exercise three states: pending (unclaimed), claimed (childRunId set but
-  // no result recorded), and passed (result='pass'). All three must succeed
-  // and mint a fresh token.
+  // `rd delegate --retry` accepts retry regardless of substep result only
+  // when no child run remains linked. A linked childRunId must be force-
+  // aborted first so retry does not abandon an in-flight or completed child.
   // ---------------------------------------------------------------------------
   it('rd delegate --retry accepts delegations regardless of substep result (spec §4.4)', async () => {
     // State 1: PENDING (unclaimed). Start runbook; do not claim ss2.
@@ -1379,19 +1374,31 @@ describe('DELEGATE re-entry and retry', () => {
       const preSs = preSubsteps?.find((s) => s.id === '2');
       const preDel = preSs?.delegation as Record<string, unknown>;
       expect(preDel.childRunId).not.toBeNull();
+      const priorHash = preDel.tokenHash;
+      const childRunId = preDel.childRunId;
 
       const retry = await runCliInProcess(['delegate', '--retry', token2], workspace);
-      expect(retry.exitCode).toBe(0);
-      const out = JSON.parse(retry.stdout) as Record<string, unknown>;
-      expect(out.action).toBe('retried');
-      expect(out.token).not.toBe(token2);
+      expect(retry.exitCode).not.toBe(0);
+      const out = parseCliJsonObject(retry.stdout || retry.stderr);
+      expect(out).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-823' }));
+      expect(JSON.stringify(out)).toContain(String(childRunId));
+
+      const postState = await readRunbookState(workspace, parentRunId);
+      const postSubsteps = postState?.substepStates as Array<Record<string, unknown>> | undefined;
+      const postDel = postSubsteps?.find((s) => s.id === '2')?.delegation as Record<
+        string,
+        unknown
+      >;
+      expect(postDel.tokenHash).toBe(priorHash);
+      expect(postDel.childRunId).toBe(childRunId);
     }
     await workspace.cleanup();
     workspace = await createTestWorkspace();
 
-    // State 3: PASSED. Claim ss1 + pass. Retry ss1's delegation even though
-    // it already recorded a pass result. Cursor hasn't moved past step 1
-    // (ss2 is still pending), so ss1 is still on the active frontier.
+    // State 3: PASSED but still linked. Claim ss1 + pass. The propagated
+    // result is present, but childRunId remains linked until collection/abort
+    // clears the ownership path, so retry must refuse rather than discard the
+    // recorded result.
     {
       const { parentRunId, token1 } = await setupRetryParent();
       let r = await runCliInProcess(`claim ${token1}`, workspace);
@@ -1410,14 +1417,23 @@ describe('DELEGATE re-entry and retry', () => {
       expect(preSs?.result).toBe('pass');
       const preDel = preSs?.delegation as Record<string, unknown>;
       const priorHash = preDel.tokenHash;
+      const childRunId = preDel.childRunId;
+      expect(childRunId).not.toBeNull();
 
-      // Retry the passed delegation. CLI is permissive (§4.4).
       const retry = await runCliInProcess(['delegate', '--retry', token1], workspace);
-      expect(retry.exitCode).toBe(0);
-      const out = JSON.parse(retry.stdout) as Record<string, unknown>;
-      expect(out.action).toBe('retried');
-      expect(out.token).not.toBe(token1);
-      expect(out.token_hash).not.toBe(priorHash);
+      expect(retry.exitCode).not.toBe(0);
+      const out = parseCliJsonObject(retry.stdout || retry.stderr);
+      expect(out).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-823' }));
+      expect(JSON.stringify(out)).toContain(String(childRunId));
+
+      const postState = await readRunbookState(workspace, parentRunId);
+      const postSubsteps = postState?.substepStates as Array<Record<string, unknown>> | undefined;
+      const postDel = postSubsteps?.find((s) => s.id === '1')?.delegation as Record<
+        string,
+        unknown
+      >;
+      expect(postDel.tokenHash).toBe(priorHash);
+      expect(postDel.childRunId).toBe(childRunId);
     }
   }, 60_000);
 

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -563,6 +563,7 @@ async function executeRetry(target: ResolvedTarget, args: RetryHandlerOptions): 
   switch (result.status) {
     case 'not_found':
     case 'not_current':
+    case 'in_flight':
     case 'error':
       // Rethrow so withErrorHandling's toRundownError -> stderr envelope
       // fires with the inner RundownError's code (RD-801 / RD-802 / inner

--- a/packages/core/__tests__/runbook/retry-delegation.test.ts
+++ b/packages/core/__tests__/runbook/retry-delegation.test.ts
@@ -151,7 +151,7 @@ describe('retryDelegation', () => {
     });
   });
 
-  it('returns { status: "retried" } when the existing delegation is claimed (force-style)', () => {
+  it('returns { status: "in_flight" } when the existing delegation is claimed', () => {
     const baseState = makeState();
     const steps = makeSteps();
     const initial = createDelegation(
@@ -189,7 +189,10 @@ describe('retryDelegation', () => {
       steps,
     );
 
-    expect(result.status).toBe('retried');
+    expect(result.status).toBe('in_flight');
+    if (result.status !== 'in_flight') return;
+    expect(result.childRunId).toBe(CHILD_RUN_ID);
+    expect(result.error.code).toBe('RD-823');
   });
 
   it('returns { status: "not_found" } when the substep has no delegation', () => {

--- a/packages/core/src/errors/codes.ts
+++ b/packages/core/src/errors/codes.ts
@@ -363,6 +363,14 @@ export const ErrorCodes = {
       'The requested child runbook does not match the runbook authored on the DELEGATE substep.',
     docSlug: 'delegation-runbook-mismatch',
   },
+  DELEGATION_IN_FLIGHT: {
+    code: 'RD-823',
+    category: ErrorCategory.DELEGATION,
+    title: 'Delegation child run in flight',
+    description:
+      'Cannot retry a delegation while its child run is still linked. Use `rd abort <token> --force` first to stop and record the child failure before retrying.',
+    docSlug: 'delegation-in-flight',
+  },
   // Retry hook (9xx) — sub-range of ErrorCategory.EXECUTION reserved for
   // retry-hook lifecycle failures (delegation re-issuance, frame-key invariants,
   // canonical-at requirements). Kept as EXECUTION rather than a dedicated

--- a/packages/core/src/errors/factory.ts
+++ b/packages/core/src/errors/factory.ts
@@ -109,6 +109,13 @@ export const Errors = {
   delegationAlreadyClaimed: (step: string, childRunId: string): RundownError =>
     new RundownError('DELEGATION_ALREADY_CLAIMED', { step, childRunId }),
 
+  delegationInFlight: (step: string, childRunId: string): RundownError =>
+    new RundownError('DELEGATION_IN_FLIGHT', {
+      step,
+      childRunId,
+      message: `child run ${childRunId} is still linked; run "rd abort <token> --force" before retrying`,
+    }),
+
   delegationAlreadyResolved: (step: string): RundownError =>
     new RundownError('DELEGATION_ALREADY_RESOLVED', { step }),
 

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -71,6 +71,8 @@ export const CLIErrorCodes = {
   CLAIM_INVARIANT_VIOLATED: 'RD-820',
   /** Requested child runbook does not match the authored DELEGATE target */
   DELEGATION_RUNBOOK_MISMATCH: 'RD-822',
+  /** Retry refused because a child run is still linked */
+  DELEGATION_IN_FLIGHT: 'RD-823',
   /** Scenario not found */
   SCENARIO_NOT_FOUND: 'SCENARIO_NOT_FOUND',
   /** File system operation failed */
@@ -114,6 +116,7 @@ export const ErrorCodeSchema = z
     'LAUNCH_FAILED',
     'RD-820',
     'RD-822',
+    'RD-823',
     'SCENARIO_NOT_FOUND',
     'FILE_ERROR',
     'UNKNOWN_ERROR',

--- a/packages/core/src/runbook/delegation-service.ts
+++ b/packages/core/src/runbook/delegation-service.ts
@@ -709,6 +709,14 @@ export interface RetryDelegationOptions {
   readonly frameKey: FrameKey;
   /** Variables that override inherited extraVars; unspecified keys inherit verbatim. */
   readonly overrides?: Readonly<Record<string, TemplateVarValue>>;
+  /**
+   * Allow retry when the delegation still has a childRunId.
+   *
+   * Intended only for machine-owned retry hooks that run after child completion
+   * has already been recorded into the parent. Manual CLI retry leaves this
+   * false so linked child runs must go through abort --force teardown first.
+   */
+  readonly allowLinkedChildRun?: boolean;
 }
 
 /**
@@ -770,6 +778,21 @@ export interface RetryDelegationErrorResult {
 }
 
 /**
+ * Existing delegation has a linked child run.
+ *
+ * Retrying would replace the parent delegation record without stopping the
+ * child run, releasing the claim tombstone, or recording a fail completion.
+ * Callers must route through the force-abort flow before reissuing.
+ */
+export interface RetryDelegationInFlightResult {
+  readonly status: 'in_flight';
+  /** Linked child run that must be force-aborted before retry. */
+  readonly childRunId: string;
+  /** Wrapped RundownError (RD-823) for callers that re-surface the message. */
+  readonly error: RundownError;
+}
+
+/**
  * Retry succeeded: the existing delegation has been force-cancelled and a
  * fresh one minted under a new token. The contract mirrors
  * {@link CreateDelegationCreatedResult} — every field a caller needs to
@@ -800,6 +823,7 @@ export type RetryDelegationResult =
   | RetryDelegationRetriedResult
   | RetryDelegationNotFoundResult
   | RetryDelegationNotCurrentResult
+  | RetryDelegationInFlightResult
   | RetryDelegationErrorResult;
 
 /**
@@ -830,7 +854,7 @@ export function retryDelegation(
   options: RetryDelegationOptions,
   steps: readonly ResolvedStep[],
 ): RetryDelegationResult {
-  const { state, substepId, frameKey, overrides } = options;
+  const { state, substepId, frameKey, overrides, allowLinkedChildRun = false } = options;
 
   // 1. Locate the existing delegation.
   const existingStates = state.substepStates ?? [];
@@ -862,13 +886,30 @@ export function retryDelegation(
     };
   }
 
-  // 3. Compose inherited + override extraVars.
+  // 3. A linked, non-cancelled child run must be force-aborted before manual
+  // retry. retryDelegation is a pure core primitive, so it cannot perform the
+  // full abort --force teardown: delete/release child state, clear session
+  // claim tombstones, and record fail completion. The retry hook opts out only
+  // after the machine has already recorded child completion.
+  if (
+    existingDelegation.childRunId !== null &&
+    existingDelegation.cancelledAt === null &&
+    !allowLinkedChildRun
+  ) {
+    return {
+      status: 'in_flight',
+      childRunId: existingDelegation.childRunId,
+      error: Errors.delegationInFlight(substepId, existingDelegation.childRunId),
+    };
+  }
+
+  // 4. Compose inherited + override extraVars.
   const mergedExtraVars: Record<string, TemplateVarValue> | undefined =
     existingDelegation.extraVars || overrides
       ? { ...(existingDelegation.extraVars ?? {}), ...(overrides ?? {}) }
       : undefined;
 
-  // 4. Force-cancel the existing delegation. Idempotent on already-cancelled.
+  // 5. Force-cancel the existing delegation. Idempotent on already-cancelled.
   const abortResult = abortDelegation({
     parentState: state,
     substepId,
@@ -917,7 +958,7 @@ export function retryDelegation(
     }
   }
 
-  // 5. Mint a fresh delegation. createDelegation returns a Result variant;
+  // 6. Mint a fresh delegation. createDelegation returns a Result variant;
   //    translate any non-created outcome into this function's `error` variant
   //    so the state-machine caller has a single uniform shape to discriminate.
   //    Bare-step delegations are stored with substepState.id === step.name

--- a/packages/core/src/runbook/retry-hook.ts
+++ b/packages/core/src/runbook/retry-hook.ts
@@ -114,8 +114,9 @@ function peekForStack(stack: readonly ForContext[] | undefined): ForContext | un
  *   `{ status: 'pending', result: undefined }`) and a frontier entry.
  * - `error` — surface codes:
  *   - Wrapped `RundownError` from `retryDelegation` returning
- *     `not_found` / `not_current` (e.g. RD-801 / RD-802) propagated
- *     verbatim — state and delegation-service views have diverged.
+ *     `not_found` / `not_current` / `in_flight` (e.g. RD-801 / RD-802 /
+ *     RD-823) propagated verbatim — state and delegation-service views have
+ *     diverged, or a linked child must be force-aborted before retry.
  *   - `RD-904` from a fresh retried delegation missing
  *     `contextSnapshot.at` (frontier id would lose FOR-iteration context).
  *   - Otherwise the code + message from `result.error` are propagated.
@@ -157,6 +158,7 @@ export function retrySingleSubstep(
       state: working as RunbookState,
       substepId: substep.id,
       frameKey: activeFrameKey,
+      allowLinkedChildRun: true,
     },
     steps,
   );
@@ -202,12 +204,10 @@ export function retrySingleSubstep(
     };
   }
 
-  // not_found / not_current: the delegation-service view and the substep
-  // state have diverged. The caller already filtered on `ss.delegation`
-  // being present and `activeFrameKey` matching, so silent skip would
-  // consume the retry transition without re-issuing a token. Both variants
-  // now carry a `RundownError` (parallel to CreateDelegation), so the hook
-  // surfaces the structured code/message verbatim and rolls back.
+  // not_found / not_current / in_flight: the delegation-service view and the
+  // substep state have diverged, or a linked child must be force-aborted before
+  // retry. These variants carry a RundownError, so the hook surfaces the
+  // structured code/message verbatim and rolls back.
   return {
     status: 'error',
     code: result.error.code,


### PR DESCRIPTION
## Summary
- refuse delegate --retry when an existing delegation still has a linked child run
- surface RD-823 / DELEGATION_IN_FLIGHT with guidance to use abort --force first
- keep retry-hook behavior explicit for already-recorded child completion paths

## Issue
Fixes #374.

## Validation
- npm test -w packages/core -- --runInBand retry-delegation retry-hook retry-single-substep
- npm run check:types -w packages/core
- npm run build -w packages/core
- npm test -w packages/cli -- --runInBand delegate.test.ts delegate-workflow.test.ts
- npm run check:types -w packages/cli


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error code `RD-823` for delegation retry attempts when the target delegation is still linked to an active child run.
  * Enhanced error messaging to guide users to abort the linked child run with `--force` before retrying a delegation.

* **Tests**
  * Added test coverage for delegation retry validation with linked child runs.
  * Updated integration tests for delegation workflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->