### PR TITLE
[codex] Reconcile CLI error envelopes

### DIFF
--- a/packages/cli/__tests__/commands/schema-validation.test.ts
+++ b/packages/cli/__tests__/commands/schema-validation.test.ts
@@ -8,7 +8,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { createTestWorkspace, runCliInProcess, type TestWorkspace } from '../helpers/test-utils.js';
+import {
+  createRunbook,
+  createTestWorkspace,
+  runCliInProcess,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
 import {
   validateActionOutput,
   validateStatusOutput,
@@ -357,6 +362,42 @@ echo done
 
       const validation = validateWarningOutput(output);
       expect(validation.valid).toBe(true);
+    });
+
+    it('validates already-resolved substep output', async () => {
+      const runbookPath = path.join(workspace.cwd, 'substeps.runbook.md');
+      fs.writeFileSync(
+        runbookPath,
+        createRunbook({
+          name: 'substeps',
+          steps: [
+            {
+              title: 'Parent Step',
+              pass: 'CONTINUE',
+              substeps: [
+                { title: 'First', content: 'Resolve once.' },
+                { title: 'Second', content: 'Keep parent unresolved.' },
+              ],
+            },
+            { title: 'Done', pass: 'COMPLETE', content: 'Finished.' },
+          ],
+        }),
+      );
+      await runCliInProcess('run --prompted substeps.runbook.md --text', workspace);
+      await runCliInProcess('pass --step 1.1', workspace);
+
+      const result = await runCliInProcess('pass --step 1.1', workspace);
+      expect(result).toMatchObject({ exitCode: 0 });
+      const output = parseJsonOutput(result.stdout);
+
+      expect(output).toMatchObject({
+        kind: 'action',
+        action: 'pass',
+        status: 'already-resolved',
+      });
+      const validation = validateActionOutput(output);
+      expect(validation.valid).toBe(true);
+      expect(validation.errors).toEqual([]);
     });
   });
 

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -773,11 +773,11 @@ describe('executeTransition with ExplicitTarget', () => {
 
     // Should NOT write a new completion (sentinel already covers it)
     expect(ctx.lifecycleService.upsertResolvedCompletion).not.toHaveBeenCalled();
-    // Should emit duplicate status
+    // Should emit the reconciled already-resolved envelope under the command name
     expect(ctx.output.status).toHaveBeenCalledWith(
-      'completion_duplicate',
+      config.commandName,
       expect.any(String),
-      expect.any(Object),
+      expect.objectContaining({ status: 'already-resolved' }),
     );
   });
 

--- a/packages/cli/__tests__/helpers/wrapper.test.ts
+++ b/packages/cli/__tests__/helpers/wrapper.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import { Errors } from '@rundown-org/core';
+import { ErrorResponseSchema, Errors } from '@rundown-org/core';
 import { RunbookSyntaxError } from '@rundown-org/parser';
 
 const { withErrorHandling } = await import('../../src/helpers/wrapper.js');
@@ -9,17 +9,30 @@ describe('withErrorHandling', () => {
   const originalExit = process.exit;
   let mockExit: jest.Mock;
   let errorSpy: jest.SpiedFunction<typeof console.error>;
+  let stdoutWriteSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let stderrWriteSpy: jest.SpiedFunction<typeof process.stderr.write>;
 
   beforeEach(() => {
     mockExit = jest.fn();
     process.exit = mockExit as unknown as typeof process.exit;
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    stdoutWriteSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
     process.exit = originalExit;
     errorSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
   });
+
+  function parseStdoutJson(): Record<string, unknown> {
+    return JSON.parse(stdoutWriteSpy.mock.calls.map((call) => String(call[0])).join('')) as Record<
+      string,
+      unknown
+    >;
+  }
 
   it('executes fn successfully without calling exit', async () => {
     await withErrorHandling(async () => {});
@@ -37,8 +50,9 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const output = errorSpy.mock.calls[0]?.[0] as string;
-    const parsed = JSON.parse(output);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(stderrWriteSpy).not.toHaveBeenCalled();
+    const parsed = parseStdoutJson();
     expect(parsed.kind).toBe('error');
     expect(parsed.error).toBe(error.message);
     expect(parsed.code).toBe(error.code);
@@ -47,6 +61,7 @@ describe('withErrorHandling', () => {
       category: error.errorCode.category,
       title: error.errorCode.title,
     });
+    expect(ErrorResponseSchema.safeParse(parsed).success).toBe(true);
   });
 
   it('includes the command field when options.command is provided', async () => {
@@ -59,7 +74,7 @@ describe('withErrorHandling', () => {
       { command: 'run' },
     );
 
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.command).toBe('run');
   });
 
@@ -89,7 +104,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.fileNotFound('x').code);
   });
 
@@ -104,7 +119,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.fileNotReadable('x').code);
   });
 
@@ -119,7 +134,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.fileNotReadable('x').code);
   });
 
@@ -131,7 +146,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.syntaxError('x').code);
   });
 
@@ -141,7 +156,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.unknown('x').code);
   });
 
@@ -152,7 +167,7 @@ describe('withErrorHandling', () => {
     });
 
     expect(mockExit).toHaveBeenCalledWith(1);
-    const parsed = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    const parsed = parseStdoutJson();
     expect(parsed.code).toBe(Errors.unknown('x').code);
   });
 

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -448,7 +448,8 @@ export async function executeTransition(
       agentId: 'manual',
     });
     if (recorded.status === 'duplicate') {
-      output.status('completion_duplicate', `Completion already recorded for ${cursor.at}`, {
+      output.status(config.commandName, `Completion already recorded for ${cursor.at}`, {
+        status: 'already-resolved',
         at: cursor.at,
         frameKey: cursor.frame.frameKey,
         entry: completionEntryForFrame(cursor.frame),

--- a/packages/cli/src/helpers/wrapper.ts
+++ b/packages/cli/src/helpers/wrapper.ts
@@ -1,4 +1,11 @@
-import { isNodeError, isError, getErrorMessage, RundownError, Errors } from '@rundown-org/core';
+import {
+  isNodeError,
+  isError,
+  getErrorMessage,
+  RundownError,
+  Errors,
+  getWriter,
+} from '@rundown-org/core';
 import { RunbookSyntaxError } from '@rundown-org/parser';
 
 /**
@@ -89,7 +96,7 @@ export async function withErrorHandling(
         context: rundownError.context,
         docsUrl: rundownError.docsUrl,
       };
-      console.error(JSON.stringify(envelope, null, 2));
+      getWriter().writeJson(envelope);
     }
 
     process.exit(1);

--- a/packages/core/__tests__/output/schema.test.ts
+++ b/packages/core/__tests__/output/schema.test.ts
@@ -13,6 +13,7 @@ import {
   CheckResponseSchema,
   ResolveResponseSchema,
   ScenarioRunResponseSchema,
+  ErrorResponseSchema,
   CLIErrorCodes,
   ErrorCodeSchema,
   WarningCodeSchema,
@@ -211,6 +212,38 @@ describe('isWarningResponse type guard', () => {
 describe('ErrorCodeSchema code registry', () => {
   it('registers RD-813 for non-delegatable delegation targets', () => {
     expect(CLIErrorCodes.DELEGATION_NO_DELEGATABLE_SUBSTEP).toBe('RD-813');
+  });
+
+  it('accepts emitted RundownError RD codes in error envelopes', () => {
+    for (const code of ['RD-301', 'RD-403', 'RD-501', 'RD-812', 'RD-816', 'RD-819', 'RD-999']) {
+      expect(
+        ErrorResponseSchema.safeParse({
+          kind: 'error',
+          error: 'Rundown error',
+          code,
+        }).success,
+      ).toBe(true);
+    }
+  });
+
+  it('accepts direct CLI symbolic codes and rejects dead symbolic aliases', () => {
+    for (const code of [
+      'INVALID_STEP',
+      'INVALID_INDEX',
+      'NOT_DELEGATE_STEP',
+      'SUBSTEPS_NOT_RESOLVED',
+      'DELEGATION_ALREADY_RESOLVED',
+      'DELEGATION_ALREADY_EXISTS',
+      'CONFLICTING_INDEX',
+      'ENGINE_INIT_FAILED',
+      'INVALID_AT_TARGET',
+    ]) {
+      expect(ErrorCodeSchema.safeParse(code).success).toBe(true);
+    }
+
+    for (const code of ['FILE_ERROR', 'LAUNCH_FAILED', 'DELEGATION_NESTED_FORBIDDEN']) {
+      expect(ErrorCodeSchema.safeParse(code).success).toBe(false);
+    }
   });
 
   it('accepts every registered CLI error code', () => {

--- a/packages/core/__tests__/runbook/completion-service.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.test.ts
@@ -913,6 +913,63 @@ describe('RunbookCompletionService', () => {
       );
     });
 
+    it('treats a done substep the cursor has moved past as a duplicate (no resolved row left)', async () => {
+      // Cursor has advanced to substep '2'; substep '1' is already done with no
+      // resolved-completion row remaining (the actor consumed it on sync). A
+      // caller re-resolving the passed-over substep '1' is a genuine duplicate.
+      const current = state({
+        substep: '2',
+        substepStates: [
+          { id: '1', frameKey: buildFrameKey('1'), status: 'done', result: 'pass' },
+          { id: '2', frameKey: buildFrameKey('1'), status: 'pending' },
+        ],
+      });
+      await manager.save(current);
+
+      const result = await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
+        result: 'pass',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:01.000Z',
+      });
+
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      expect(result).toEqual({ status: 'duplicate', key });
+    });
+
+    it('records a re-completion when a retry re-opens the active cursor onto a done substep', async () => {
+      // A RETRY re-opened substep '1' (cursor is back on it) but left its prior
+      // `done` status from the failed attempt in place. Resolving the now-active
+      // cursor is a legitimate re-completion, not a duplicate.
+      const current = state({
+        substep: '1',
+        retryCount: 1,
+        substepStates: [
+          { id: '1', frameKey: buildFrameKey('1'), status: 'done', result: 'fail' },
+          { id: '2', frameKey: buildFrameKey('1'), status: 'done', result: 'fail' },
+        ],
+      });
+      await manager.save(current);
+
+      const result = await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
+        result: 'pass',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:01.000Z',
+      });
+
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      expect(result).toEqual({ status: 'recorded', key });
+    });
+
     it('inactive manual completion detects an existing exact row for the same frame and substep', async () => {
       const current = state({ activeFrameKey: buildFrameKey('1', 2) });
       await manager.save(current);

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -20,25 +20,67 @@ import { CLAIM_ID_PATTERN } from '../runbook/claim-id.js';
 import { DELEGATION_TOKEN_PATTERN } from '../runbook/delegation-token.js';
 import { ArtifactManifestRecordSchema } from '../runbook/artifact-schema.js';
 import { RunbookRefSchema } from '../runbook/runbook-ref.js';
+import { ErrorCodes } from '../errors/codes.js';
 
 // ============================================================================
 // CLI Error Codes
 // ============================================================================
 
+const RundownErrorCodeValues = Object.values(ErrorCodes).map((code) => code.code) as [
+  string,
+  ...string[],
+];
+
+const CLISymbolicErrorCodeValues = [
+  'RUNBOOK_NOT_FOUND',
+  'STEP_NOT_FOUND',
+  'INVALID_SYNTAX',
+  'VALIDATION_ERROR',
+  'ALREADY_STASHED',
+  'NO_STASHED_RUNBOOK',
+  'INVALID_CLAIM_ID',
+  'CLAIMED_RUNBOOK_UNAVAILABLE',
+  'CHILD_RUN_MISSING',
+  'CHILD_LINKAGE_MISMATCH',
+  'INVALID_TOKEN',
+  'TOKEN_NOT_FOUND',
+  'DELEGATION_CANCELLED',
+  'DELEGATION_LOCK_TIMEOUT',
+  'INVALID_STEP',
+  'INVALID_INDEX',
+  'NOT_DELEGATE_STEP',
+  'SUBSTEPS_NOT_RESOLVED',
+  'DELEGATION_ALREADY_RESOLVED',
+  'DELEGATION_ALREADY_EXISTS',
+  'CONFLICTING_INDEX',
+  'ENGINE_INIT_FAILED',
+  'INVALID_AT_TARGET',
+  'SCENARIO_NOT_FOUND',
+  'UNKNOWN_ERROR',
+] as const;
+
+/**
+ * CLI-only symbolic error codes emitted outside the RundownError factory path.
+ */
+export const CLISymbolicErrorCodes = Object.fromEntries(
+  CLISymbolicErrorCodeValues.map((code) => [code, code]),
+) as { readonly [Code in (typeof CLISymbolicErrorCodeValues)[number]]: Code };
+
 /**
  * Machine-readable error codes for CLI JSON output.
  *
- * These codes enable programmatic error handling without parsing error messages.
+ * Thrown RundownError envelopes use RD-NNN values from ErrorCodes. Some
+ * command validation paths still emit CLI-only symbolic codes directly.
  */
 export const CLIErrorCodes = {
   /** No runbook is currently active */
-  NO_ACTIVE_RUNBOOK: 'NO_ACTIVE_RUNBOOK',
+  NO_ACTIVE_RUNBOOK: ErrorCodes.NO_ACTIVE_RUNBOOK.code,
   /** Specified runbook file doesn't exist */
-  RUNBOOK_NOT_FOUND: 'RUNBOOK_NOT_FOUND',
+  RUNBOOK_NOT_FOUND: ErrorCodes.FILE_NOT_FOUND.code,
   /** Target step doesn't exist */
-  STEP_NOT_FOUND: 'STEP_NOT_FOUND',
+  STEP_NOT_FOUND: ErrorCodes.DELEGATION_STEP_NOT_FOUND.code,
   /** Runbook has syntax errors */
-  INVALID_SYNTAX: 'INVALID_SYNTAX',
+  INVALID_SYNTAX: ErrorCodes.SYNTAX_ERROR.code,
   /** Input validation failed */
   VALIDATION_ERROR: 'VALIDATION_ERROR',
   /** A runbook is already stashed */
@@ -54,31 +96,29 @@ export const CLIErrorCodes = {
   /** Child runbook's persisted parentLinkage diverges from the freshly token-validated linkage (state corruption — operator intervention required) */
   CHILD_LINKAGE_MISMATCH: 'CHILD_LINKAGE_MISMATCH',
   /** Delegation token format is invalid */
-  INVALID_TOKEN: 'INVALID_TOKEN',
+  INVALID_TOKEN: ErrorCodes.INVALID_TOKEN.code,
   /** Delegation token was not found */
-  TOKEN_NOT_FOUND: 'TOKEN_NOT_FOUND',
+  TOKEN_NOT_FOUND: ErrorCodes.TOKEN_NOT_FOUND.code,
   /** Delegation token was cancelled */
-  DELEGATION_CANCELLED: 'DELEGATION_CANCELLED',
+  DELEGATION_CANCELLED: ErrorCodes.TOKEN_CANCELLED.code,
   /** Delegation lock could not be acquired */
-  DELEGATION_LOCK_TIMEOUT: 'DELEGATION_LOCK_TIMEOUT',
+  DELEGATION_LOCK_TIMEOUT: ErrorCodes.DELEGATION_LOCK_TIMEOUT.code,
   /** Nested delegation forbidden (claimed child cannot delegate further) */
-  DELEGATION_NESTED_FORBIDDEN: 'DELEGATION_NESTED_FORBIDDEN',
+  DELEGATION_NESTED_FORBIDDEN: ErrorCodes.DELEGATION_NESTED_FORBIDDEN.code,
   /** Targeted step has no substep marked DELEGATE */
-  DELEGATION_NO_DELEGATABLE_SUBSTEP: 'RD-813',
+  DELEGATION_NO_DELEGATABLE_SUBSTEP: ErrorCodes.DELEGATION_NO_DELEGATABLE_SUBSTEP.code,
   /** Runbook launch failed */
-  LAUNCH_FAILED: 'LAUNCH_FAILED',
+  LAUNCH_FAILED: ErrorCodes.LAUNCH_FAILED.code,
   /** Fresh claim launch violated write-side invariants */
-  CLAIM_INVARIANT_VIOLATED: 'RD-820',
+  CLAIM_INVARIANT_VIOLATED: ErrorCodes.CLAIM_INVARIANT_VIOLATED.code,
   /** Requested child runbook does not match the authored DELEGATE target */
-  DELEGATION_RUNBOOK_MISMATCH: 'RD-822',
+  DELEGATION_RUNBOOK_MISMATCH: ErrorCodes.DELEGATION_RUNBOOK_MISMATCH.code,
   /** Retry refused because a child run is still linked */
-  DELEGATION_IN_FLIGHT: 'RD-823',
+  DELEGATION_IN_FLIGHT: ErrorCodes.DELEGATION_IN_FLIGHT.code,
   /** Scenario not found */
-  SCENARIO_NOT_FOUND: 'SCENARIO_NOT_FOUND',
-  /** File system operation failed */
-  FILE_ERROR: 'FILE_ERROR',
+  SCENARIO_NOT_FOUND: ErrorCodes.SCENARIO_NOT_FOUND.code,
   /** Unknown or unexpected error */
-  UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+  UNKNOWN_ERROR: ErrorCodes.UNKNOWN_ERROR.code,
 } as const;
 
 /**
@@ -95,32 +135,7 @@ export const CLIWarningCodes = {
  * Zod schema for error codes.
  */
 export const ErrorCodeSchema = z
-  .enum([
-    'NO_ACTIVE_RUNBOOK',
-    'RUNBOOK_NOT_FOUND',
-    'STEP_NOT_FOUND',
-    'INVALID_SYNTAX',
-    'VALIDATION_ERROR',
-    'ALREADY_STASHED',
-    'NO_STASHED_RUNBOOK',
-    'INVALID_CLAIM_ID',
-    'CLAIMED_RUNBOOK_UNAVAILABLE',
-    'CHILD_RUN_MISSING',
-    'CHILD_LINKAGE_MISMATCH',
-    'INVALID_TOKEN',
-    'TOKEN_NOT_FOUND',
-    'DELEGATION_CANCELLED',
-    'DELEGATION_LOCK_TIMEOUT',
-    'DELEGATION_NESTED_FORBIDDEN',
-    'RD-813',
-    'LAUNCH_FAILED',
-    'RD-820',
-    'RD-822',
-    'RD-823',
-    'SCENARIO_NOT_FOUND',
-    'FILE_ERROR',
-    'UNKNOWN_ERROR',
-  ])
+  .enum([...RundownErrorCodeValues, ...CLISymbolicErrorCodeValues] as [string, ...string[]])
   .describe('Error code identifying the type of error that occurred');
 
 /**
@@ -133,7 +148,9 @@ export const WarningCodeSchema = z
 /**
  * Union type of all valid CLI error codes.
  */
-export type CLIErrorCode = (typeof CLIErrorCodes)[keyof typeof CLIErrorCodes];
+export type CLIErrorCode =
+  | (typeof CLIErrorCodes)[keyof typeof CLIErrorCodes]
+  | (typeof CLISymbolicErrorCodes)[keyof typeof CLISymbolicErrorCodes];
 
 /**
  * Union type of all valid CLI warning codes.
@@ -315,6 +332,8 @@ export const ActionResponseSchema = z
     state: z.string().optional().describe('Runbook state after action'),
     prompted: z.boolean().optional().describe('Whether awaiting user input'),
     message: z.string().optional().describe('Status message from the action'),
+    /** Idempotency status for action-family responses */
+    status: z.enum(['already-resolved']).optional().describe('Idempotency status'),
     position: PositionSchema.optional().describe('Current position after action'),
   })
   .describe('Response from a step action command')

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -403,6 +403,19 @@ export class RunbookCompletionService {
     });
     if (existingKey) return { status: 'duplicate', key: existingKey };
 
+    const freshState = await this.manager.load(args.runbookId);
+    const existingSubstepState = findSubstepState(
+      freshState?.substepStates ?? args.currentState.substepStates ?? [],
+      args.targetSubstep,
+      args.targetFrame.frameKey,
+    );
+    if (existingSubstepState?.status === 'done') {
+      return {
+        status: 'duplicate',
+        key: buildCompletionKey(args.targetFrame, args.targetSubstep),
+      };
+    }
+
     const key = buildCompletionKey(args.targetFrame, args.targetSubstep);
     const completion = buildResolvedCompletion({
       agentId: args.agentId,

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -403,17 +403,32 @@ export class RunbookCompletionService {
     });
     if (existingKey) return { status: 'duplicate', key: existingKey };
 
+    // A consumed completion leaves no resolved-completion row behind (the actor
+    // deletes it on sync), so `substepStates` is the only persistent record that
+    // a substep was already resolved. Use it to detect a genuine duplicate — a
+    // caller resolving a substep the cursor has already moved past.
+    //
+    // This must NOT fire when the cursor is currently positioned on the target
+    // substep: a RETRY/GOTO that re-opens a substep leaves its prior `done`
+    // status in place (the machine does not reset it), and the next resolution
+    // of the now-active cursor is a legitimate re-completion, not a duplicate.
     const freshState = await this.manager.load(args.runbookId);
-    const existingSubstepState = findSubstepState(
-      freshState?.substepStates ?? args.currentState.substepStates ?? [],
-      args.targetSubstep,
-      args.targetFrame.frameKey,
-    );
-    if (existingSubstepState?.status === 'done') {
-      return {
-        status: 'duplicate',
-        key: buildCompletionKey(args.targetFrame, args.targetSubstep),
-      };
+    const cursorState = freshState ?? args.currentState;
+    const activeFrameKey = cursorState.activeFrameKey ?? deriveActiveFrame(cursorState).frameKey;
+    const isActiveCursorTarget =
+      args.targetSubstep === cursorState.substep && args.targetFrame.frameKey === activeFrameKey;
+    if (!isActiveCursorTarget) {
+      const existingSubstepState = findSubstepState(
+        freshState?.substepStates ?? args.currentState.substepStates ?? [],
+        args.targetSubstep,
+        args.targetFrame.frameKey,
+      );
+      if (existingSubstepState?.status === 'done') {
+        return {
+          status: 'duplicate',
+          key: buildCompletionKey(args.targetFrame, args.targetSubstep),
+        };
+      }
     }
 
     const key = buildCompletionKey(args.targetFrame, args.targetSubstep);


### PR DESCRIPTION
## Summary
- accept emitted RD-NNN errors and CLI symbolic validation codes in the schema
- route wrapper JSON errors through the same stdout writer path as OutputEmitter JSON errors
- make already-resolved pass/fail emit an action-family schema-valid payload

## Issue
Fixes #375.

## Validation
- npm run check:types -w packages/core
- npm test -w packages/core -- output/schema.test.ts runbook/completion-service.test.ts --runInBand
- npm run build -w packages/core
- npm test -w packages/cli -- helpers/wrapper.test.ts services/schema-coverage.test.ts commands/schema-validation.test.ts --runInBand
- npm run check:types -w packages/cli


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of duplicate completion attempts for already-resolved steps.
  * Enhanced error output handling to use proper JSON envelopes instead of console logging.

* **New Features**
  * Added `already-resolved` status field to action responses for idempotent completion operations.

* **Tests**
  * Expanded test coverage for error code validation, completion service behavior, and duplicate detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->