### PR TITLE
Codex/issue 371 atomic state writes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2151,6 +2151,70 @@
         "node": ">=10"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
@@ -2162,6 +2226,342 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -2370,6 +2770,28 @@
         "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
@@ -2382,6 +2804,402 @@
       "os": [
         "darwin"
       ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4586,6 +5404,23 @@
         "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
@@ -4598,6 +5433,189 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 20"
@@ -5076,6 +6094,34 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
@@ -5088,6 +6134,233 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@vitejs/plugin-react": {
@@ -10615,6 +11888,26 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
@@ -10626,6 +11919,186 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -14581,6 +16054,70 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
@@ -14592,6 +16129,342 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -16707,1879 +18580,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
-      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
-      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
-      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
-      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
-      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
-      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
-      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.10.0",
-        "@emnapi/runtime": "^1.10.0",
-        "@emnapi/wasi-threads": "^1.2.1",
-        "@napi-rs/wasm-runtime": "^1.1.4",
-        "@tybys/wasm-util": "^0.10.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     }
   }

--- a/packages/core/__tests__/helpers/resolved-completion-seed.ts
+++ b/packages/core/__tests__/helpers/resolved-completion-seed.ts
@@ -1,0 +1,30 @@
+import type { RunbookStateManager } from '../../src/runbook/state.js';
+import { merge } from '../../src/runbook/state-update-ops.js';
+import type { ResolvedCompletion } from '../../src/runbook/types.js';
+
+/**
+ * Seed a resolved-completion record directly into persisted state for tests.
+ *
+ * Production writes resolved completions only through
+ * `RunbookCompletionService.recordManualCompletion`, which records the
+ * completion atomically alongside its mirrored substep state. The read-side
+ * lifecycle API (`getResolvedCompletion` / `consumeResolvedCompletion` /
+ * `listResolvedCompletions`) therefore needs a fixture seam to establish the
+ * precondition without dragging in substep state. This helper performs the
+ * minimal locked write of just the `resolvedCompletions` map.
+ *
+ * @param manager - The state manager bound to the test workspace.
+ * @param id - The runbook state ID to seed.
+ * @param key - Canonical completion key (`frame|entry|substep`).
+ * @param completion - Resolved completion payload to store.
+ */
+export async function seedResolvedCompletion(
+  manager: RunbookStateManager,
+  id: string,
+  key: string,
+  completion: ResolvedCompletion,
+): Promise<void> {
+  await manager.update(id, {
+    resolvedCompletions: merge({ [key]: completion }),
+  });
+}

--- a/packages/core/__tests__/paths.test.ts
+++ b/packages/core/__tests__/paths.test.ts
@@ -1,6 +1,11 @@
 // packages/core/__tests__/paths.test.ts
 
-import { completionLockPath, delegationLockPath, statePath } from '../src/paths.js';
+import {
+  completionLockPath,
+  delegationLockPath,
+  runStateLockPath,
+  statePath,
+} from '../src/paths.js';
 
 describe('assertSafeId (via path builders)', () => {
   const cwd = '/tmp/project';
@@ -12,6 +17,7 @@ describe('assertSafeId (via path builders)', () => {
     }> = [
       { name: 'completionLockPath', build: (id) => completionLockPath(cwd, id) },
       { name: 'delegationLockPath', build: (id) => delegationLockPath(cwd, id) },
+      { name: 'runStateLockPath', build: (id) => runStateLockPath(cwd, id) },
       { name: 'statePath', build: (id) => statePath(cwd, id) },
     ];
 

--- a/packages/core/__tests__/runbook/completion-service.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.test.ts
@@ -25,6 +25,7 @@ import {
   brandRunIdForTest,
   brandStoredOutputsForTest,
 } from '../../src/testing/effective-vars.js';
+import { seedResolvedCompletion } from '../helpers/resolved-completion-seed.js';
 
 describe('RunbookCompletionService', () => {
   const runbookId = brandRunIdForTest('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
@@ -881,10 +882,10 @@ describe('RunbookCompletionService', () => {
       await manager.save(current);
 
       // recordManualCompletion must persist both the resolved completion row and
-      // the mirrored substep state under one lock acquisition. The separate
-      // upsertResolvedCompletion path (manager.update) must not be used, so a
-      // concurrent reader can never observe a resolved row without its 'done'
-      // substep state and vice versa.
+      // the mirrored substep state under one lock acquisition (a single
+      // updateWithState), never as two separate writes, so a concurrent reader
+      // can never observe a resolved row without its 'done' substep state and
+      // vice versa.
       const updateSpy = jest.spyOn(manager, 'update');
       const updateWithStateSpy = jest.spyOn(manager, 'updateWithState');
 
@@ -922,7 +923,8 @@ describe('RunbookCompletionService', () => {
       await manager.save(current);
 
       const firstKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
-      await lifecycleService.upsertResolvedCompletion(
+      await seedResolvedCompletion(
+        manager,
         runbookId,
         firstKey,
         buildResolvedCompletion({
@@ -959,7 +961,8 @@ describe('RunbookCompletionService', () => {
       await manager.save(current);
 
       const exactKey = buildCompletionKey(exactFrame(buildFrameKey('1'), 4), '1');
-      await lifecycleService.upsertResolvedCompletion(
+      await seedResolvedCompletion(
+        manager,
         runbookId,
         exactKey,
         buildResolvedCompletion({
@@ -1110,7 +1113,8 @@ describe('RunbookCompletionService', () => {
       await manager.save(current);
 
       const exactKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
-      await lifecycleService.upsertResolvedCompletion(
+      await seedResolvedCompletion(
+        manager,
         runbookId,
         exactKey,
         buildResolvedCompletion({

--- a/packages/core/__tests__/runbook/completion-service.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.test.ts
@@ -874,6 +874,47 @@ describe('RunbookCompletionService', () => {
       );
     });
 
+    it('writes the resolved row and substep state in a single atomic update', async () => {
+      const current = state({
+        substepStates: [{ id: '1', frameKey: buildFrameKey('1'), status: 'running' }],
+      });
+      await manager.save(current);
+
+      // recordManualCompletion must persist both the resolved completion row and
+      // the mirrored substep state under one lock acquisition. The separate
+      // upsertResolvedCompletion path (manager.update) must not be used, so a
+      // concurrent reader can never observe a resolved row without its 'done'
+      // substep state and vice versa.
+      const updateSpy = jest.spyOn(manager, 'update');
+      const updateWithStateSpy = jest.spyOn(manager, 'updateWithState');
+
+      await service.recordManualCompletion({
+        runbookId,
+        currentState: current,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
+        result: 'pass',
+        agentId: 'manual',
+        completedAt: '2026-01-01T00:00:00.000Z',
+      });
+
+      expect(updateWithStateSpy).toHaveBeenCalledTimes(1);
+      expect(updateSpy).not.toHaveBeenCalled();
+
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      const persisted = await manager.load(runbookId);
+      expect(persisted?.resolvedCompletions?.[key]).toEqual(
+        expect.objectContaining({ result: 'pass', targetEntry: 1 }),
+      );
+      expect(persisted?.substepStates).toEqual([
+        expect.objectContaining({ id: '1', status: 'done', result: 'pass' }),
+      ]);
+
+      updateSpy.mockRestore();
+      updateWithStateSpy.mockRestore();
+    });
+
     it('duplicate manual completion returns before changing substep state', async () => {
       const current = state({
         substepStates: [{ id: '1', frameKey: buildFrameKey('1'), status: 'done', result: 'pass' }],

--- a/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
+++ b/packages/core/__tests__/runbook/execution-lifecycle-service.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../src/runbook/targeting.js';
 import type { Runbook, Step } from '../../src/runbook/types.js';
 import { makeBaseStep } from '../helpers/step-factories.js';
+import { seedResolvedCompletion } from '../helpers/resolved-completion-seed.js';
 
 const mockSteps: Step[] = [
   makeBaseStep({ name: '1', description: 'Step 1' }),
@@ -178,7 +179,7 @@ describe('ExecutionLifecycleService', () => {
     });
   });
 
-  describe('upsertResolvedCompletion', () => {
+  describe('resolved completion persistence', () => {
     it('stores a new completion', async () => {
       const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
         runbookPath: 'test.md',
@@ -193,7 +194,7 @@ describe('ExecutionLifecycleService', () => {
         completedAt: new Date().toISOString(),
       };
 
-      await service.upsertResolvedCompletion(state.id, '1||1|', completion);
+      await seedResolvedCompletion(manager, state.id, '1||1|', completion);
 
       const retrieved = await service.getResolvedCompletion(state.id, '1||1|');
       expect(retrieved).toEqual(completion);
@@ -223,8 +224,8 @@ describe('ExecutionLifecycleService', () => {
       };
 
       const key = '1||1|';
-      await service.upsertResolvedCompletion(state.id, key, completion1);
-      await service.upsertResolvedCompletion(state.id, key, completion2);
+      await seedResolvedCompletion(manager, state.id, key, completion1);
+      await seedResolvedCompletion(manager, state.id, key, completion2);
 
       const retrieved = await service.getResolvedCompletion(state.id, key);
       expect(retrieved).toEqual(completion2);
@@ -244,7 +245,7 @@ describe('ExecutionLifecycleService', () => {
         completedAt: new Date().toISOString(),
       };
 
-      await service.upsertResolvedCompletion(state.id, '1||1|', completion);
+      await seedResolvedCompletion(manager, state.id, '1||1|', completion);
 
       // Verify via fresh service instance
       const newService = new ExecutionLifecycleService(manager);
@@ -285,7 +286,7 @@ describe('ExecutionLifecycleService', () => {
       };
 
       const key = '1||1|';
-      await service.upsertResolvedCompletion(state.id, key, completion);
+      await seedResolvedCompletion(manager, state.id, key, completion);
 
       const consumed = await service.consumeResolvedCompletion(state.id, key);
       expect(consumed).toEqual(completion);
@@ -324,7 +325,7 @@ describe('ExecutionLifecycleService', () => {
       };
 
       const key = '1||1|';
-      await service.upsertResolvedCompletion(state.id, key, completion);
+      await seedResolvedCompletion(manager, state.id, key, completion);
       await service.consumeResolvedCompletion(state.id, key);
 
       // Verify via fresh service instance
@@ -364,8 +365,8 @@ describe('ExecutionLifecycleService', () => {
       // Keys use format: frameKey|entry|substep
       const key1 = `${frameKey}|${String(entry)}|sub1`;
       const key2 = `${frameKey}|${String(entry)}|sub2`;
-      await service.upsertResolvedCompletion(state.id, key1, completion1);
-      await service.upsertResolvedCompletion(state.id, key2, completion2);
+      await seedResolvedCompletion(manager, state.id, key1, completion1);
+      await seedResolvedCompletion(manager, state.id, key2, completion2);
 
       const listed = await service.listResolvedCompletions(state.id, activeFrame(frameKey, entry));
       expect(listed).toHaveLength(2);
@@ -395,8 +396,8 @@ describe('ExecutionLifecycleService', () => {
         completedAt: new Date().toISOString(),
       };
 
-      await service.upsertResolvedCompletion(state.id, '1||1|sub1', completion1);
-      await service.upsertResolvedCompletion(state.id, '2||2|sub1', completion2);
+      await seedResolvedCompletion(manager, state.id, '1||1|sub1', completion1);
+      await seedResolvedCompletion(manager, state.id, '2||2|sub1', completion2);
 
       const listed = await service.listResolvedCompletions(
         state.id,
@@ -431,7 +432,8 @@ describe('ExecutionLifecycleService', () => {
         runbookPath: 'test.md',
       });
       const frameKey = buildFrameKey('1', 5);
-      await service.upsertResolvedCompletion(
+      await seedResolvedCompletion(
+        manager,
         state.id,
         buildCompletionKey(exactFrame(frameKey, 4), 'sub1'),
         {
@@ -444,7 +446,8 @@ describe('ExecutionLifecycleService', () => {
           completedAt: new Date().toISOString(),
         },
       );
-      await service.upsertResolvedCompletion(
+      await seedResolvedCompletion(
+        manager,
         state.id,
         buildCompletionKey(inactiveFrame(frameKey), 'sub2'),
         {
@@ -489,8 +492,8 @@ describe('ExecutionLifecycleService', () => {
       };
 
       // Store sentinel (entry=0) and exact (entry=2)
-      await service.upsertResolvedCompletion(state.id, `${frameKey}|0|sub1`, sentinelCompletion);
-      await service.upsertResolvedCompletion(state.id, `${frameKey}|2|sub2`, exactCompletion);
+      await seedResolvedCompletion(manager, state.id, `${frameKey}|0|sub1`, sentinelCompletion);
+      await seedResolvedCompletion(manager, state.id, `${frameKey}|2|sub2`, exactCompletion);
 
       // List with entry=2 should return both sentinel and exact
       const listed = await service.listResolvedCompletions(state.id, activeFrame(frameKey, 2));
@@ -507,7 +510,7 @@ describe('ExecutionLifecycleService', () => {
       });
 
       const frameKey = buildFrameKey('1');
-      await service.upsertResolvedCompletion(state.id, `${frameKey}|0|sub1`, {
+      await seedResolvedCompletion(manager, state.id, `${frameKey}|0|sub1`, {
         agentId: 'agent-sentinel',
         result: 'pass',
         targetStep: '1',
@@ -515,7 +518,7 @@ describe('ExecutionLifecycleService', () => {
         targetEntry: SENTINEL_ENTRY,
         completedAt: new Date().toISOString(),
       });
-      await service.upsertResolvedCompletion(state.id, `${frameKey}|2|sub2`, {
+      await seedResolvedCompletion(manager, state.id, `${frameKey}|2|sub2`, {
         agentId: 'agent-exact',
         result: 'pass',
         targetStep: '1',
@@ -534,7 +537,8 @@ describe('ExecutionLifecycleService', () => {
         runbookPath: 'test.md',
       });
       const frameKey = buildFrameKey('1', 5);
-      await service.upsertResolvedCompletion(
+      await seedResolvedCompletion(
+        manager,
         state.id,
         buildCompletionKey(exactFrame(frameKey, 4), 'sub1'),
         {
@@ -547,7 +551,8 @@ describe('ExecutionLifecycleService', () => {
           completedAt: new Date().toISOString(),
         },
       );
-      await service.upsertResolvedCompletion(
+      await seedResolvedCompletion(
+        manager,
         state.id,
         buildCompletionKey(inactiveFrame(frameKey), 'sub2'),
         {
@@ -587,7 +592,7 @@ describe('ExecutionLifecycleService', () => {
       };
 
       // Store at sentinel key (entry=0)
-      await service.upsertResolvedCompletion(state.id, `${frameKey}|0|sub1`, sentinelCompletion);
+      await seedResolvedCompletion(manager, state.id, `${frameKey}|0|sub1`, sentinelCompletion);
 
       // Try consuming with exact key (entry=3) — should fall back to sentinel
       const consumed = await service.consumeResolvedCompletion(state.id, `${frameKey}|3|sub1`);

--- a/packages/core/__tests__/runbook/file-lock.test.ts
+++ b/packages/core/__tests__/runbook/file-lock.test.ts
@@ -1,5 +1,6 @@
 // packages/core/__tests__/runbook/file-lock.test.ts
 
+import { jest } from '@jest/globals';
 import * as fs from 'node:fs/promises';
 import * as fsSync from 'node:fs';
 import * as path from 'node:path';
@@ -9,6 +10,7 @@ import {
   acquireFileLockSync,
   FileLockTimeoutError,
   isLockContent,
+  isProcessAlive,
   releaseFileLock,
   releaseFileLockSync,
 } from '../../src/runbook/file-lock.js';
@@ -280,6 +282,11 @@ describe('file-lock', () => {
       ['null pid', { pid: null, created_at: 'x' }],
       ['NaN pid', { pid: Number.NaN, created_at: 'x' }],
       ['infinite pid', { pid: Number.POSITIVE_INFINITY, created_at: 'x' }],
+      // pid 0 / negatives are process-GROUP targets for process.kill — must be
+      // rejected so they are reclaimed instead of mis-read as a live process.
+      ['zero pid', { pid: 0, created_at: 'x' }],
+      ['negative pid', { pid: -5, created_at: 'x' }],
+      ['non-integer pid', { pid: 1.5, created_at: 'x' }],
       ['missing pid', { created_at: 'x' }],
       ['non-string created_at', { pid: 1, created_at: 123 }],
       ['missing created_at', { pid: 1 }],
@@ -288,6 +295,38 @@ describe('file-lock', () => {
       ['string value', 'nope'],
     ])('rejects %s so it is never trusted as a live pid', (_label, value) => {
       expect(isLockContent(value)).toBe(false);
+    });
+  });
+
+  describe('isProcessAlive error mapping', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('reports alive when kill(pid, 0) succeeds', () => {
+      jest.spyOn(process, 'kill').mockReturnValue(true);
+      expect(isProcessAlive(4242)).toBe(true);
+    });
+
+    it('reports dead only on ESRCH (no such process)', () => {
+      jest.spyOn(process, 'kill').mockImplementation(() => {
+        throw Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
+      });
+      expect(isProcessAlive(4242)).toBe(false);
+    });
+
+    it('treats EPERM as alive — the process exists but we may not signal it', () => {
+      jest.spyOn(process, 'kill').mockImplementation(() => {
+        throw Object.assign(new Error('kill EPERM'), { code: 'EPERM' });
+      });
+      expect(isProcessAlive(4242)).toBe(true);
+    });
+
+    it('treats unexpected errors conservatively as alive', () => {
+      jest.spyOn(process, 'kill').mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(isProcessAlive(4242)).toBe(true);
     });
   });
 

--- a/packages/core/__tests__/runbook/file-lock.test.ts
+++ b/packages/core/__tests__/runbook/file-lock.test.ts
@@ -8,6 +8,7 @@ import {
   acquireFileLock,
   acquireFileLockSync,
   FileLockTimeoutError,
+  isLockContent,
   releaseFileLock,
   releaseFileLockSync,
 } from '../../src/runbook/file-lock.js';
@@ -266,6 +267,57 @@ describe('file-lock', () => {
       expect(() => {
         releaseFileLockSync(lockFile);
       }).not.toThrow();
+    });
+  });
+
+  describe('isLockContent shape guard', () => {
+    it('accepts well-formed lock content', () => {
+      expect(isLockContent({ pid: process.pid, created_at: new Date().toISOString() })).toBe(true);
+    });
+
+    it.each([
+      ['non-numeric pid', { pid: 'not-a-pid', created_at: 'x' }],
+      ['null pid', { pid: null, created_at: 'x' }],
+      ['NaN pid', { pid: Number.NaN, created_at: 'x' }],
+      ['infinite pid', { pid: Number.POSITIVE_INFINITY, created_at: 'x' }],
+      ['missing pid', { created_at: 'x' }],
+      ['non-string created_at', { pid: 1, created_at: 123 }],
+      ['missing created_at', { pid: 1 }],
+      ['null value', null],
+      ['array value', []],
+      ['string value', 'nope'],
+    ])('rejects %s so it is never trusted as a live pid', (_label, value) => {
+      expect(isLockContent(value)).toBe(false);
+    });
+  });
+
+  describe('shape-invalid lock content reclaim (end-to-end)', () => {
+    it('async acquire reclaims a lock whose pid is not a number', async () => {
+      // Valid JSON, invalid shape: a non-numeric pid must never reach
+      // process.kill — it is as untrustworthy as corrupted JSON.
+      await fs.mkdir(lockDir, { recursive: true });
+      await fs.writeFile(lockFile, JSON.stringify({ pid: 'not-a-pid', created_at: 'x' }), 'utf8');
+
+      await expect(acquireFileLock(lockFile, lockDir)).resolves.toBeUndefined();
+      try {
+        const reclaimed = JSON.parse(await fs.readFile(lockFile, 'utf8')) as LockContent;
+        expect(reclaimed.pid).toBe(process.pid);
+      } finally {
+        await releaseFileLock(lockFile);
+      }
+    });
+
+    it('sync acquire reclaims a lock whose pid is null', async () => {
+      await fs.mkdir(lockDir, { recursive: true });
+      await fs.writeFile(lockFile, JSON.stringify({ pid: null, created_at: 'x' }), 'utf8');
+
+      expect(() => acquireFileLockSync(lockFile, lockDir)).not.toThrow();
+      try {
+        const reclaimed = JSON.parse(fsSync.readFileSync(lockFile, 'utf8')) as LockContent;
+        expect(reclaimed.pid).toBe(process.pid);
+      } finally {
+        releaseFileLockSync(lockFile);
+      }
     });
   });
 });

--- a/packages/core/__tests__/runbook/file-lock.test.ts
+++ b/packages/core/__tests__/runbook/file-lock.test.ts
@@ -311,7 +311,9 @@ describe('file-lock', () => {
       await fs.mkdir(lockDir, { recursive: true });
       await fs.writeFile(lockFile, JSON.stringify({ pid: null, created_at: 'x' }), 'utf8');
 
-      expect(() => acquireFileLockSync(lockFile, lockDir)).not.toThrow();
+      expect(() => {
+        acquireFileLockSync(lockFile, lockDir);
+      }).not.toThrow();
       try {
         const reclaimed = JSON.parse(fsSync.readFileSync(lockFile, 'utf8')) as LockContent;
         expect(reclaimed.pid).toBe(process.pid);

--- a/packages/core/__tests__/runbook/run-state-lock.test.ts
+++ b/packages/core/__tests__/runbook/run-state-lock.test.ts
@@ -7,6 +7,7 @@ import { FileLockTimeoutError } from '../../src/runbook/file-lock.js';
 import { RunStateLock, RunStateLockTimeoutError } from '../../src/runbook/run-state-lock.js';
 
 describe('RunStateLock', () => {
+  const filePermissionsSupported = process.platform !== 'win32';
   let tmpDir: string;
   let lock: RunStateLock;
 
@@ -35,14 +36,17 @@ describe('RunStateLock', () => {
     await expect(fs.access(lockPath)).rejects.toThrow();
   });
 
-  it('creates lock file and directory with owner-only permissions', async () => {
-    await lock.acquire('run-perms');
+  (filePermissionsSupported ? it : it.skip)(
+    'creates lock file and directory with owner-only permissions',
+    async () => {
+      await lock.acquire('run-perms');
 
-    expect((await fs.stat(runStateLockPath(tmpDir, 'run-perms'))).mode & 0o777).toBe(0o600);
-    expect((await fs.stat(locksDir(tmpDir))).mode & 0o777).toBe(0o700);
+      expect((await fs.stat(runStateLockPath(tmpDir, 'run-perms'))).mode & 0o777).toBe(0o600);
+      expect((await fs.stat(locksDir(tmpDir))).mode & 0o777).toBe(0o700);
 
-    await lock.release('run-perms');
-  });
+      await lock.release('run-perms');
+    },
+  );
 
   it('release is idempotent', async () => {
     await expect(lock.release('missing-run')).resolves.toBeUndefined();

--- a/packages/core/__tests__/runbook/run-state-lock.test.ts
+++ b/packages/core/__tests__/runbook/run-state-lock.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { locksDir, runStateLockPath } from '../../src/paths.js';
+import { FileLockTimeoutError } from '../../src/runbook/file-lock.js';
+import { RunStateLock, RunStateLockTimeoutError } from '../../src/runbook/run-state-lock.js';
+
+describe('RunStateLock', () => {
+  let tmpDir: string;
+  let lock: RunStateLock;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'run-state-lock-'));
+    lock = new RunStateLock(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('acquires and releases a lock', async () => {
+    await lock.acquire('run-1');
+
+    const lockPath = runStateLockPath(tmpDir, 'run-1');
+    const content = JSON.parse(await fs.readFile(lockPath, 'utf8')) as {
+      pid: number;
+      created_at: string;
+    };
+    expect(content.pid).toBe(process.pid);
+    expect(content.created_at).toBeDefined();
+
+    await lock.release('run-1');
+
+    await expect(fs.access(lockPath)).rejects.toThrow();
+  });
+
+  it('creates lock file and directory with owner-only permissions', async () => {
+    await lock.acquire('run-perms');
+
+    expect((await fs.stat(runStateLockPath(tmpDir, 'run-perms'))).mode & 0o777).toBe(0o600);
+    expect((await fs.stat(locksDir(tmpDir))).mode & 0o777).toBe(0o700);
+
+    await lock.release('run-perms');
+  });
+
+  it('release is idempotent', async () => {
+    await expect(lock.release('missing-run')).resolves.toBeUndefined();
+  });
+
+  it('times out with typed RunStateLockTimeoutError when held by an alive process', async () => {
+    await lock.acquire('run-timeout');
+    const lock2 = new RunStateLock(tmpDir);
+
+    let captured: unknown;
+    try {
+      await lock2.acquire('run-timeout');
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(RunStateLockTimeoutError);
+    expect(captured).toBeInstanceOf(FileLockTimeoutError);
+    if (captured instanceof RunStateLockTimeoutError) {
+      expect(captured.runId).toBe('run-timeout');
+      expect(captured.lockFile).toBe(runStateLockPath(tmpDir, 'run-timeout'));
+      expect(captured.message).toMatch(/Run-state lock timeout for run run-timeout/);
+    }
+
+    await lock.release('run-timeout');
+  }, 10_000);
+
+  it('different run IDs have independent locks', async () => {
+    await lock.acquire('run-a');
+    await lock.acquire('run-b');
+
+    await expect(fs.access(runStateLockPath(tmpDir, 'run-a'))).resolves.toBeUndefined();
+    await expect(fs.access(runStateLockPath(tmpDir, 'run-b'))).resolves.toBeUndefined();
+
+    await lock.release('run-a');
+    await lock.release('run-b');
+  });
+});

--- a/packages/core/__tests__/runbook/session-lock.test.ts
+++ b/packages/core/__tests__/runbook/session-lock.test.ts
@@ -7,6 +7,7 @@ import { FileLockTimeoutError } from '../../src/runbook/file-lock.js';
 import { locksDir, sessionLockPath } from '../../src/paths.js';
 
 describe('SessionLock', () => {
+  const filePermissionsSupported = process.platform !== 'win32';
   let tmpDir: string;
   let lock: SessionLock;
 
@@ -36,24 +37,30 @@ describe('SessionLock', () => {
     await expect(fs.access(lockPath)).rejects.toThrow();
   });
 
-  it('creates lock file with owner-only permissions (0o600)', async () => {
-    await lock.acquire();
+  (filePermissionsSupported ? it : it.skip)(
+    'creates lock file with owner-only permissions (0o600)',
+    async () => {
+      await lock.acquire();
 
-    const lockPath = sessionLockPath(tmpDir);
-    const stat = await fs.stat(lockPath);
-    expect(stat.mode & 0o777).toBe(0o600);
+      const lockPath = sessionLockPath(tmpDir);
+      const stat = await fs.stat(lockPath);
+      expect(stat.mode & 0o777).toBe(0o600);
 
-    await lock.release();
-  });
+      await lock.release();
+    },
+  );
 
-  it('creates lock directory with owner-only permissions (0o700)', async () => {
-    await lock.acquire();
+  (filePermissionsSupported ? it : it.skip)(
+    'creates lock directory with owner-only permissions (0o700)',
+    async () => {
+      await lock.acquire();
 
-    const stat = await fs.stat(locksDir(tmpDir));
-    expect(stat.mode & 0o777).toBe(0o700);
+      const stat = await fs.stat(locksDir(tmpDir));
+      expect(stat.mode & 0o777).toBe(0o700);
 
-    await lock.release();
-  });
+      await lock.release();
+    },
+  );
 
   it('second acquire blocks then succeeds after release', async () => {
     await lock.acquire();

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -929,6 +929,18 @@ describe('RunbookStateManager', () => {
       },
     );
 
+    // NOTE: Cross-process serialization of run-state writes is intentionally
+    // pinned at the IN-PROCESS layer (the two tests below) rather than by a
+    // multi-process spawn test. An automated test that spawns concurrent CLI
+    // processes was investigated and deliberately NOT added: process startup
+    // dwarfs the load→save critical section, so the spawned processes never
+    // reliably overlap inside the lock window and the test cannot dependably
+    // trigger the lost-update race it would claim to cover. A test that cannot
+    // fail when the lock is removed is worse than no test. The lock's
+    // correctness is therefore pinned here: the real-lock contention test
+    // proves the lock serializes overlapping read-modify-write cycles, and the
+    // injected-factory test proves every manager write actually routes through
+    // the lock. Do NOT add a flaky cross-process spawn test in their place.
     it('serializes concurrent update read-modify-write cycles without losing merged fields', async () => {
       // Exercises the REAL run-state lock: two concurrent same-process updates
       // both kick off their async load before either write lands, so without

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { isError } from '../../src/errors.js';
@@ -8,7 +19,7 @@ import { RunStateLock } from '../../src/runbook/run-state-lock.js';
 import type { RunStateLockFactory, RunStateLockLike } from '../../src/runbook/run-state-lock.js';
 import { merge, replace } from '../../src/runbook/state-update-ops.js';
 import { partitionVariables } from '../../src/runbook/variable-preparation.js';
-import { runStateLockPath, statePath as _statePath } from '../../src/paths.js';
+import { runsDir, runStateLockPath, statePath as _statePath } from '../../src/paths.js';
 import { SessionService } from '../../src/runbook/session-service.js';
 import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
 import { makeAggregationLastAction } from '../../src/runbook/last-action.js';
@@ -862,18 +873,61 @@ describe('RunbookStateManager', () => {
       await expect(manager.update('nonexistent', { step: '2' })).rejects.toThrow('not found');
     });
 
-    it('preserves existing run state when the temp write fails', async () => {
+    it('is not blocked by an obstruction at the old fixed-suffix .tmp path', async () => {
       const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
         runbookPath: 'test.md',
       });
       const stateFilePath = _statePath(testDir, state.id);
-      const originalContent = await readFile(stateFilePath, 'utf8');
+
+      // A directory at the OLD fixed temp name blocked the previous fixed-suffix
+      // implementation (EISDIR on the temp write). With a randomized per-write
+      // suffix it must no longer interfere.
       await mkdir(`${stateFilePath}.tmp`);
 
-      await expect(manager.save({ ...state, step: 'changed' })).rejects.toThrow();
+      await expect(manager.save({ ...state, step: 'changed' })).resolves.toBeUndefined();
 
-      await expect(readFile(stateFilePath, 'utf8')).resolves.toBe(originalContent);
+      const reloaded = await manager.load(state.id);
+      expect(reloaded?.step).toBe('changed');
     });
+
+    it('leaves no temp files behind after a successful write', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+
+      await manager.update(state.id, { variables: merge({ A: '1' }) });
+
+      const entries = await readdir(runsDir(testDir));
+      expect(entries.some((name) => name.includes('.tmp'))).toBe(false);
+    });
+
+    // The atomic-write failure path is forced by making the runs directory
+    // read-only (so the temp write fails with EACCES). This is skipped on
+    // Windows and when running as root, where directory mode is not enforced.
+    const writeFailureEnforced = process.platform !== 'win32' && (process.getuid?.() ?? 0) !== 0;
+
+    (writeFailureEnforced ? it : it.skip)(
+      'preserves existing run state when the atomic write fails',
+      async () => {
+        const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+          runbookPath: 'test.md',
+        });
+        const stateFilePath = _statePath(testDir, state.id);
+        const originalContent = await readFile(stateFilePath, 'utf8');
+
+        const dir = runsDir(testDir);
+        await chmod(dir, 0o500);
+        try {
+          await expect(manager.save({ ...state, step: 'changed' })).rejects.toThrow();
+        } finally {
+          await chmod(dir, 0o700);
+        }
+
+        await expect(readFile(stateFilePath, 'utf8')).resolves.toBe(originalContent);
+        const entries = await readdir(dir);
+        expect(entries.some((name) => name.includes('.tmp'))).toBe(false);
+      },
+    );
 
     it('serializes concurrent update read-modify-write cycles without losing merged fields', async () => {
       // Exercises the REAL run-state lock: two concurrent same-process updates
@@ -948,21 +1002,29 @@ describe('RunbookStateManager', () => {
       expect(reloaded?.variables).toEqual({ A: '1', B: '2' });
     });
 
-    it('preserves existing session data when the temp write fails', async () => {
-      const sessionPath = join(testDir, '.rundown', 'session.json');
-      await manager.saveSession({ defaultStack: [], claims: {} });
-      const originalContent = await readFile(sessionPath, 'utf8');
-      await mkdir(`${sessionPath}.tmp`);
+    (writeFailureEnforced ? it : it.skip)(
+      'preserves existing session data when the atomic write fails',
+      async () => {
+        const rundownDir = join(testDir, '.rundown');
+        const sessionPath = join(rundownDir, 'session.json');
+        await manager.saveSession({ defaultStack: [], claims: {} });
+        const originalContent = await readFile(sessionPath, 'utf8');
 
-      await expect(
-        manager.saveSession({
-          defaultStack: [assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')],
-          claims: {},
-        }),
-      ).rejects.toThrow();
+        await chmod(rundownDir, 0o500);
+        try {
+          await expect(
+            manager.saveSession({
+              defaultStack: [assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')],
+              claims: {},
+            }),
+          ).rejects.toThrow();
+        } finally {
+          await chmod(rundownDir, 0o700);
+        }
 
-      await expect(readFile(sessionPath, 'utf8')).resolves.toBe(originalContent);
-    });
+        await expect(readFile(sessionPath, 'utf8')).resolves.toBe(originalContent);
+      },
+    );
 
     it('rejects legacy targetPath fields instead of stripping them on save', async () => {
       const state = await manager.create({ source: 'project', path: 'legacy.md' }, mockRunbook, {

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { isError } from '../../src/errors.js';
 import { generateRunId, RunbookStateManager } from '../../src/runbook/state.js';
 import { RunStateLock } from '../../src/runbook/run-state-lock.js';
+import type { RunStateLockFactory, RunStateLockLike } from '../../src/runbook/run-state-lock.js';
 import { merge, replace } from '../../src/runbook/state-update-ops.js';
 import { partitionVariables } from '../../src/runbook/variable-preparation.js';
 import { runStateLockPath, statePath as _statePath } from '../../src/paths.js';
@@ -875,28 +876,12 @@ describe('RunbookStateManager', () => {
     });
 
     it('serializes concurrent update read-modify-write cycles without losing merged fields', async () => {
+      // Exercises the REAL run-state lock: two concurrent same-process updates
+      // both kick off their async load before either write lands, so without
+      // serialization the second would clobber the first (lost update). The
+      // file lock forces them to run one at a time. No wall-clock dependency.
       const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
         runbookPath: 'test.md',
-      });
-      const originalLoad = manager.load.bind(manager);
-      let matchingLoads = 0;
-      let releaseFirstRead: (() => void) | undefined;
-      const firstReadDelay = new Promise<void>((resolve) => {
-        releaseFirstRead = resolve;
-      });
-
-      jest.spyOn(manager, 'load').mockImplementation(async (id: string) => {
-        const loaded = await originalLoad(id);
-        if (id !== state.id || !loaded) return loaded;
-
-        matchingLoads += 1;
-        if (matchingLoads === 1) {
-          setTimeout(() => releaseFirstRead?.(), 75);
-          await firstReadDelay;
-        } else {
-          releaseFirstRead?.();
-        }
-        return loaded;
       });
 
       await Promise.all([
@@ -904,9 +889,63 @@ describe('RunbookStateManager', () => {
         manager.update(state.id, { variables: merge({ B: '2' }) }),
       ]);
 
-      const updated = await originalLoad(state.id);
+      const updated = await manager.load(state.id);
       expect(updated?.variables).toEqual({ A: '1', B: '2' });
+      // Lock file is released and removed once both updates complete.
       await expect(readFile(runStateLockPath(testDir, state.id), 'utf8')).rejects.toThrow();
+    });
+
+    it('serializes manager writes through the injected lock factory deterministically', async () => {
+      const events: string[] = [];
+      // Single shared mutex across every lock instance the factory hands out, so
+      // the test asserts true serialization without any wall-clock timing.
+      let chain: Promise<void> = Promise.resolve();
+      const releasers: Array<() => void> = [];
+      const factory: RunStateLockFactory = (): RunStateLockLike => ({
+        acquire: async (runId) => {
+          let release!: () => void;
+          const next = new Promise<void>((resolve) => {
+            release = resolve;
+          });
+          const prior = chain;
+          chain = chain.then(() => next);
+          releasers.push(release);
+          await prior;
+          events.push(`acquire:${runId}`);
+        },
+        release: async (runId) => {
+          events.push(`release:${runId}`);
+          releasers.shift()?.();
+        },
+      });
+
+      const lockedManager = new RunbookStateManager(testDir, { lockFactory: factory });
+      const state = await lockedManager.create(
+        { source: 'project', path: 'test.md' },
+        mockRunbook,
+        { runbookPath: 'test.md' },
+      );
+      events.length = 0;
+
+      await Promise.all([
+        lockedManager.update(state.id, { variables: merge({ A: '1' }) }),
+        lockedManager.update(state.id, { variables: merge({ B: '2' }) }),
+      ]);
+
+      // The injected factory must actually be used: two updates → two
+      // acquire/release pairs. (A vacuously-empty log would mean the factory
+      // was ignored and the real lock ran instead.)
+      expect(events).toHaveLength(4);
+
+      // Every acquire is immediately followed by its matching release before the
+      // next acquire: writes were serialized, not interleaved.
+      for (let i = 0; i < events.length; i += 2) {
+        expect(events[i]).toMatch(/^acquire:/);
+        expect(events[i + 1]).toMatch(/^release:/);
+      }
+
+      const reloaded = await lockedManager.load(state.id);
+      expect(reloaded?.variables).toEqual({ A: '1', B: '2' });
     });
 
     it('preserves existing session data when the temp write fails', async () => {

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -1268,4 +1268,85 @@ describe('RunbookStateManager', () => {
       await expect(manager.delete(state.id)).resolves.toBeUndefined();
     });
   });
+
+  describe('updateWithState', () => {
+    it('applies the patch derived from the locked current state', async () => {
+      const state = await manager.create(
+        { source: 'project', path: 'test.runbook.md' },
+        mockRunbook,
+        { runbookPath: 'test.runbook.md' },
+      );
+
+      const updated = await manager.updateWithState(state.id, (current) => ({
+        stepName: `derived from ${current.step}`,
+      }));
+
+      expect(updated.stepName).toBe('derived from 1');
+      const loaded = await manager.load(state.id);
+      expect(loaded?.stepName).toBe('derived from 1');
+    });
+
+    it('leaves state unchanged and returns current state when callback returns null', async () => {
+      const state = await manager.create(
+        { source: 'project', path: 'test.runbook.md' },
+        mockRunbook,
+        { runbookPath: 'test.runbook.md' },
+      );
+
+      const result = await manager.updateWithState(state.id, () => null);
+
+      expect(result.id).toBe(state.id);
+      expect(result.stepName).toBe(state.stepName);
+    });
+
+    it('throws when the runbook does not exist', async () => {
+      const buildUpdates = jest.fn(() => ({ stepName: 'unreachable' }));
+
+      await expect(manager.updateWithState('rd_missing', buildUpdates)).rejects.toThrow(
+        'Runbook rd_missing not found',
+      );
+      // Callback must never run for a missing runbook.
+      expect(buildUpdates).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateWithStateIfExists', () => {
+    it('applies the patch derived from the locked current state', async () => {
+      const state = await manager.create(
+        { source: 'project', path: 'test.runbook.md' },
+        mockRunbook,
+        { runbookPath: 'test.runbook.md' },
+      );
+
+      const updated = await manager.updateWithStateIfExists(state.id, (current) => ({
+        stepName: `derived from ${current.step}`,
+      }));
+
+      expect(updated?.stepName).toBe('derived from 1');
+      const loaded = await manager.load(state.id);
+      expect(loaded?.stepName).toBe('derived from 1');
+    });
+
+    it('returns current state unchanged when callback returns null', async () => {
+      const state = await manager.create(
+        { source: 'project', path: 'test.runbook.md' },
+        mockRunbook,
+        { runbookPath: 'test.runbook.md' },
+      );
+
+      const result = await manager.updateWithStateIfExists(state.id, () => null);
+
+      expect(result?.id).toBe(state.id);
+      expect(result?.stepName).toBe(state.stepName);
+    });
+
+    it('returns null without invoking the callback when the runbook does not exist', async () => {
+      const buildUpdates = jest.fn(() => ({ stepName: 'unreachable' }));
+
+      const result = await manager.updateWithStateIfExists('rd_missing', buildUpdates);
+
+      expect(result).toBeNull();
+      expect(buildUpdates).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -1380,4 +1380,54 @@ describe('RunbookStateManager', () => {
       expect(buildUpdates).not.toHaveBeenCalled();
     });
   });
+
+  describe('updateWithStateReturning', () => {
+    it('flows a typed value out alongside the patch', async () => {
+      const state = await manager.create(
+        { source: 'project', path: 'test.runbook.md' },
+        mockRunbook,
+        { runbookPath: 'test.runbook.md' },
+      );
+
+      const result = await manager.updateWithStateReturning(state.id, (current) => ({
+        updates: { stepName: `derived from ${current.step}` },
+        value: `seen:${current.step}`,
+      }));
+
+      expect(result.value).toBe(`seen:${state.step}`);
+      expect(result.state?.stepName).toBe('derived from 1');
+
+      const reloaded = await manager.load(state.id);
+      expect(reloaded?.stepName).toBe('derived from 1');
+    });
+
+    it('returns the current state and value unchanged when callback updates are null', async () => {
+      const state = await manager.create(
+        { source: 'project', path: 'test.runbook.md' },
+        mockRunbook,
+        { runbookPath: 'test.runbook.md' },
+      );
+
+      const result = await manager.updateWithStateReturning(state.id, () => ({
+        updates: null,
+        value: 'reported',
+      }));
+
+      expect(result.state?.id).toBe(state.id);
+      expect(result.value).toBe('reported');
+    });
+
+    it('returns null state and value without invoking the callback when the runbook is missing', async () => {
+      const buildResult = jest.fn(() => ({
+        updates: { stepName: 'unreachable' },
+        value: 'unused',
+      }));
+
+      const result = await manager.updateWithStateReturning('rd_missing', buildResult);
+
+      expect(result.state).toBeNull();
+      expect(result.value).toBeNull();
+      expect(buildResult).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { isError } from '../../src/errors.js';
 import { generateRunId, RunbookStateManager } from '../../src/runbook/state.js';
+import { RunStateLock } from '../../src/runbook/run-state-lock.js';
 import { merge, replace } from '../../src/runbook/state-update-ops.js';
 import { partitionVariables } from '../../src/runbook/variable-preparation.js';
 import { runStateLockPath, statePath as _statePath } from '../../src/paths.js';
@@ -1266,6 +1267,36 @@ describe('RunbookStateManager', () => {
       );
       // No outputs dir created — delete must still succeed
       await expect(manager.delete(state.id)).resolves.toBeUndefined();
+    });
+
+    it('waits for the run-state lock before removing state', async () => {
+      const state = await manager.create(
+        { source: 'project', path: 'demo.runbook.md' },
+        mockRunbook,
+        { runbookPath: '/abs/demo.runbook.md' },
+      );
+      const statePath = join(testDir, '.rundown', 'runs', `${state.id}.json`);
+
+      // Hold the per-run lock from a separate lock instance (live process), so
+      // delete cannot reclaim it as stale and must wait for release.
+      const lock = new RunStateLock(testDir);
+      await lock.acquire(state.id);
+
+      let settled = false;
+      const deletion = manager.delete(state.id).then(() => {
+        settled = true;
+      });
+
+      // While the lock is held, delete blocks and the state file survives.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(settled).toBe(false);
+      await expect(readFile(statePath, 'utf8')).resolves.toBeDefined();
+
+      await lock.release(state.id);
+      await deletion;
+
+      expect(settled).toBe(true);
+      await expect(readFile(statePath, 'utf8')).rejects.toThrow();
     });
   });
 

--- a/packages/core/__tests__/runbook/state.test.ts
+++ b/packages/core/__tests__/runbook/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -6,7 +6,7 @@ import { isError } from '../../src/errors.js';
 import { generateRunId, RunbookStateManager } from '../../src/runbook/state.js';
 import { merge, replace } from '../../src/runbook/state-update-ops.js';
 import { partitionVariables } from '../../src/runbook/variable-preparation.js';
-import { statePath as _statePath } from '../../src/paths.js';
+import { runStateLockPath, statePath as _statePath } from '../../src/paths.js';
 import { SessionService } from '../../src/runbook/session-service.js';
 import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
 import { makeAggregationLastAction } from '../../src/runbook/last-action.js';
@@ -871,6 +871,41 @@ describe('RunbookStateManager', () => {
       await expect(manager.save({ ...state, step: 'changed' })).rejects.toThrow();
 
       await expect(readFile(stateFilePath, 'utf8')).resolves.toBe(originalContent);
+    });
+
+    it('serializes concurrent update read-modify-write cycles without losing merged fields', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      const originalLoad = manager.load.bind(manager);
+      let matchingLoads = 0;
+      let releaseFirstRead: (() => void) | undefined;
+      const firstReadDelay = new Promise<void>((resolve) => {
+        releaseFirstRead = resolve;
+      });
+
+      jest.spyOn(manager, 'load').mockImplementation(async (id: string) => {
+        const loaded = await originalLoad(id);
+        if (id !== state.id || !loaded) return loaded;
+
+        matchingLoads += 1;
+        if (matchingLoads === 1) {
+          setTimeout(() => releaseFirstRead?.(), 75);
+          await firstReadDelay;
+        } else {
+          releaseFirstRead?.();
+        }
+        return loaded;
+      });
+
+      await Promise.all([
+        manager.update(state.id, { variables: merge({ A: '1' }) }),
+        manager.update(state.id, { variables: merge({ B: '2' }) }),
+      ]);
+
+      const updated = await originalLoad(state.id);
+      expect(updated?.variables).toEqual({ A: '1', B: '2' });
+      await expect(readFile(runStateLockPath(testDir, state.id), 'utf8')).rejects.toThrow();
     });
 
     it('preserves existing session data when the temp write fails', async () => {

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -159,6 +159,21 @@ export const completionLockPath = (cwd: string, runId: string): string => {
 };
 
 /**
+ * Absolute path to a run-state lock file.
+ *
+ * Lock path: `.rundown/locks/run-<runId>.state.lock`
+ *
+ * @param cwd - Project root directory
+ * @param runId - Run ID to lock (must match `[A-Za-z0-9._-]+`)
+ * @returns Path to the run-state lock file
+ * @throws {Error} If `runId` contains path separators, `..`, or is otherwise unsafe
+ */
+export const runStateLockPath = (cwd: string, runId: string): string => {
+  assertSafeId(runId, 'runId');
+  return path.join(cwd, LOCKS_DIR, `run-${runId}.state.lock`);
+};
+
+/**
  * Absolute path to the workspace-wide session lock file.
  *
  * One lock per project root serializes load-modify-save cycles on

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -416,17 +416,16 @@ export class RunbookCompletionService {
     });
     await this.lifecycleService.upsertResolvedCompletion(args.runbookId, key, completion);
 
-    const freshParent = await this.manager.load(args.runbookId);
-    if (freshParent) {
-      await this.manager.update(args.runbookId, {
+    await this.manager.updateWithState(args.runbookId, (freshParent) => {
+      return {
         substepStates: upsertSubstepState(
           freshParent.substepStates ?? [],
           args.targetSubstep,
           args.targetFrame.frameKey,
           { status: 'done', result: args.result },
         ),
-      });
-    }
+      };
+    });
 
     return { status: 'recorded', key };
   }

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -3,6 +3,7 @@ import { CompletionLock } from './completion-lock.js';
 import { DelegationLock } from './delegation-lock.js';
 import type { ExecutionLifecycleService } from './execution-lifecycle-service.js';
 import type { RunbookActorService, ActorSyncResult } from './actor-service.js';
+import { merge } from './state-update-ops.js';
 import type { RunbookStateManager } from './state.js';
 import {
   SENTINEL_ENTRY,
@@ -414,10 +415,17 @@ export class RunbookCompletionService {
       finalVars: args.finalVars,
       completedAt: args.completedAt,
     });
-    await this.lifecycleService.upsertResolvedCompletion(args.runbookId, key, completion);
 
+    // Persist the resolved completion row and its mirrored substep state in a
+    // single locked read-modify-write. Splitting these into two writes (e.g. via
+    // upsertResolvedCompletion + a separate updateWithState) opens a window in
+    // which a concurrent reader observes a resolved row without its matching
+    // `done` substep state, and a concurrent delete between them flips the
+    // missing-parent behavior. updateWithState throws if the parent is gone,
+    // which is the intended fail-closed semantics for recording a completion.
     await this.manager.updateWithState(args.runbookId, (freshParent) => {
       return {
+        resolvedCompletions: merge({ [key]: completion }),
         substepStates: upsertSubstepState(
           freshParent.substepStates ?? [],
           args.targetSubstep,

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -188,9 +188,7 @@ export class ExecutionLifecycleService {
   async consumeResolvedCompletion(id: string, key: string): Promise<ResolvedCompletion | null> {
     let consumed: ResolvedCompletion | null = null;
 
-    await this.manager.updateWithState(id, (state) => {
-      if (!state) return null;
-
+    await this.manager.updateWithStateIfExists(id, (state) => {
       let existing = state.resolvedCompletions?.[key];
       let actualKey = key;
 

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -160,9 +160,6 @@ export class ExecutionLifecycleService {
     key: string,
     completion: ResolvedCompletion,
   ): Promise<void> {
-    const state = await this.manager.load(id);
-    if (!state) throw new Error(`Runbook ${id} not found`);
-
     await this.manager.update(id, {
       resolvedCompletions: merge({ [key]: completion }),
     });
@@ -189,33 +186,38 @@ export class ExecutionLifecycleService {
    * @returns The resolved completion if present, otherwise null
    */
   async consumeResolvedCompletion(id: string, key: string): Promise<ResolvedCompletion | null> {
-    const state = await this.manager.load(id);
-    if (!state) return null;
+    if (!(await this.manager.load(id))) return null;
 
-    let existing = state.resolvedCompletions?.[key];
-    let actualKey = key;
+    let consumed: ResolvedCompletion | null = null;
 
-    // Fall back to sentinel entry if exact key not found
-    if (!existing) {
-      const parsed = parseCompletionKey(key);
-      if (parsed && parsed.entry !== SENTINEL_ENTRY) {
-        const sentinelKey = buildCompletionKey(inactiveFrame(parsed.frameKey), parsed.substep);
-        const sentinelMatch = state.resolvedCompletions?.[sentinelKey];
-        if (sentinelMatch) {
-          existing = sentinelMatch;
-          actualKey = sentinelKey;
+    await this.manager.updateWithState(id, (state) => {
+      let existing = state.resolvedCompletions?.[key];
+      let actualKey = key;
+
+      // Fall back to sentinel entry if exact key not found
+      if (!existing) {
+        const parsed = parseCompletionKey(key);
+        if (parsed && parsed.entry !== SENTINEL_ENTRY) {
+          const sentinelKey = buildCompletionKey(inactiveFrame(parsed.frameKey), parsed.substep);
+          const sentinelMatch = state.resolvedCompletions?.[sentinelKey];
+          if (sentinelMatch) {
+            existing = sentinelMatch;
+            actualKey = sentinelKey;
+          }
         }
       }
-    }
 
-    if (!existing) return null;
+      if (!existing) return null;
 
-    const next = { ...(state.resolvedCompletions ?? {}) };
-    delete next[actualKey];
-    await this.manager.update(id, {
-      resolvedCompletions: replace(next),
+      consumed = existing;
+      const next = { ...(state.resolvedCompletions ?? {}) };
+      delete next[actualKey];
+      return {
+        resolvedCompletions: replace(next),
+      };
     });
-    return existing;
+
+    return consumed;
   }
 
   /**

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -186,11 +186,11 @@ export class ExecutionLifecycleService {
    * @returns The resolved completion if present, otherwise null
    */
   async consumeResolvedCompletion(id: string, key: string): Promise<ResolvedCompletion | null> {
-    if (!(await this.manager.load(id))) return null;
-
     let consumed: ResolvedCompletion | null = null;
 
     await this.manager.updateWithState(id, (state) => {
+      if (!state) return null;
+
       let existing = state.resolvedCompletions?.[key];
       let actualKey = key;
 

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -186,36 +186,39 @@ export class ExecutionLifecycleService {
    * @returns The resolved completion if present, otherwise null
    */
   async consumeResolvedCompletion(id: string, key: string): Promise<ResolvedCompletion | null> {
-    let consumed: ResolvedCompletion | null = null;
+    const { value } = await this.manager.updateWithStateReturning<ResolvedCompletion | null>(
+      id,
+      (state) => {
+        let existing = state.resolvedCompletions?.[key];
+        let actualKey = key;
 
-    await this.manager.updateWithStateIfExists(id, (state) => {
-      let existing = state.resolvedCompletions?.[key];
-      let actualKey = key;
-
-      // Fall back to sentinel entry if exact key not found
-      if (!existing) {
-        const parsed = parseCompletionKey(key);
-        if (parsed && parsed.entry !== SENTINEL_ENTRY) {
-          const sentinelKey = buildCompletionKey(inactiveFrame(parsed.frameKey), parsed.substep);
-          const sentinelMatch = state.resolvedCompletions?.[sentinelKey];
-          if (sentinelMatch) {
-            existing = sentinelMatch;
-            actualKey = sentinelKey;
+        // Fall back to sentinel entry if exact key not found
+        if (!existing) {
+          const parsed = parseCompletionKey(key);
+          if (parsed && parsed.entry !== SENTINEL_ENTRY) {
+            const sentinelKey = buildCompletionKey(inactiveFrame(parsed.frameKey), parsed.substep);
+            const sentinelMatch = state.resolvedCompletions?.[sentinelKey];
+            if (sentinelMatch) {
+              existing = sentinelMatch;
+              actualKey = sentinelKey;
+            }
           }
         }
-      }
 
-      if (!existing) return null;
+        if (!existing) {
+          return { updates: null, value: null };
+        }
 
-      consumed = existing;
-      const next = { ...(state.resolvedCompletions ?? {}) };
-      delete next[actualKey];
-      return {
-        resolvedCompletions: replace(next),
-      };
-    });
+        const next = { ...(state.resolvedCompletions ?? {}) };
+        delete next[actualKey];
+        return {
+          updates: { resolvedCompletions: replace(next) },
+          value: existing,
+        };
+      },
+    );
 
-    return consumed;
+    return value;
   }
 
   /**

--- a/packages/core/src/runbook/execution-lifecycle-service.ts
+++ b/packages/core/src/runbook/execution-lifecycle-service.ts
@@ -1,6 +1,6 @@
 // src/runbook/execution-lifecycle-service.ts
 import type { RunbookStateManager } from './state.js';
-import { merge, replace } from './state-update-ops.js';
+import { replace } from './state-update-ops.js';
 import {
   SENTINEL_ENTRY,
   activeFrame,
@@ -145,24 +145,6 @@ export class ExecutionLifecycleService {
     });
 
     return { state: updated, frameKey: toFrameKey, entry };
-  }
-
-  /**
-   * Store or replace a resolved completion keyed by canonical completion key.
-   *
-   * @param id - The runbook state ID
-   * @param key - Canonical completion key (`frame|entry|substep`)
-   * @param completion - Resolved completion payload
-   * @throws {Error} If the runbook with the given ID is not found
-   */
-  async upsertResolvedCompletion(
-    id: string,
-    key: string,
-    completion: ResolvedCompletion,
-  ): Promise<void> {
-    await this.manager.update(id, {
-      resolvedCompletions: merge({ [key]: completion }),
-    });
   }
 
   /**

--- a/packages/core/src/runbook/file-lock.ts
+++ b/packages/core/src/runbook/file-lock.ts
@@ -24,6 +24,30 @@ interface LockContent {
 }
 
 /**
+ * Type guard validating that parsed lock-file JSON matches {@link LockContent}.
+ *
+ * Shape-valid JSON with a non-numeric `pid` (or a missing/non-string
+ * `created_at`) must never reach `process.kill`, so callers treat a `false`
+ * result the same as corrupted JSON and reclaim the lock. Exported so the
+ * predicate can be unit-tested directly, which is where its behaviour is pinned
+ * (the end-to-end reclaim path coincides with `process.kill` throwing on
+ * malformed input on POSIX, so only a direct test distinguishes the guard).
+ *
+ * @param value - Parsed (but unvalidated) lock-file content.
+ * @returns A type predicate narrowing `value` to {@link LockContent} when it has
+ *   a finite numeric `pid` and a string `created_at`.
+ */
+export function isLockContent(value: unknown): value is LockContent {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { pid?: unknown }).pid === 'number' &&
+    Number.isFinite((value as { pid: number }).pid) &&
+    typeof (value as { created_at?: unknown }).created_at === 'string'
+  );
+}
+
+/**
  * Thrown when {@link acquireFileLock} cannot acquire a lock within
  * {@link LOCK_DEADLINE_MS}. Subclasses (e.g. `DelegationLockTimeoutError`)
  * let callers preserve a typed error contract while reusing this primitive.
@@ -74,9 +98,22 @@ function isProcessAlive(pid: number): boolean {
 async function tryReclaimStale(lockFile: string): Promise<boolean> {
   try {
     const raw = await fs.readFile(lockFile, 'utf8');
-    const content = JSON.parse(raw) as LockContent;
+    const parsed = JSON.parse(raw) as unknown;
 
-    if (!isProcessAlive(content.pid)) {
+    // Shape-invalid lock content is as untrustworthy as corrupted JSON: never
+    // pass a non-numeric pid to process.kill. Unlink and reclaim.
+    if (!isLockContent(parsed)) {
+      try {
+        await fs.unlink(lockFile);
+      } catch (unlinkErr: unknown) {
+        if (!isNodeError(unlinkErr) || unlinkErr.code !== 'ENOENT') {
+          throw unlinkErr;
+        }
+      }
+      return true;
+    }
+
+    if (!isProcessAlive(parsed.pid)) {
       await fs.unlink(lockFile);
       // Between this unlink and the next open('wx') attempt, another process may
       // create the lock. That's fine — the caller retries on EEXIST.
@@ -215,9 +252,20 @@ function sleepSync(ms: number): void {
 function tryReclaimStaleSync(lockFile: string): boolean {
   try {
     const raw = fsSync.readFileSync(lockFile, 'utf8');
-    const content = JSON.parse(raw) as LockContent;
+    const parsed = JSON.parse(raw) as unknown;
 
-    if (!isProcessAlive(content.pid)) {
+    if (!isLockContent(parsed)) {
+      try {
+        fsSync.unlinkSync(lockFile);
+      } catch (unlinkErr: unknown) {
+        if (!isNodeError(unlinkErr) || unlinkErr.code !== 'ENOENT') {
+          throw unlinkErr;
+        }
+      }
+      return true;
+    }
+
+    if (!isProcessAlive(parsed.pid)) {
       fsSync.unlinkSync(lockFile);
       return true;
     }

--- a/packages/core/src/runbook/file-lock.ts
+++ b/packages/core/src/runbook/file-lock.ts
@@ -26,23 +26,28 @@ interface LockContent {
 /**
  * Type guard validating that parsed lock-file JSON matches {@link LockContent}.
  *
- * Shape-valid JSON with a non-numeric `pid` (or a missing/non-string
+ * Shape-valid JSON with an invalid `pid` (or a missing/non-string
  * `created_at`) must never reach `process.kill`, so callers treat a `false`
- * result the same as corrupted JSON and reclaim the lock. Exported so the
- * predicate can be unit-tested directly, which is where its behaviour is pinned
- * (the end-to-end reclaim path coincides with `process.kill` throwing on
- * malformed input on POSIX, so only a direct test distinguishes the guard).
+ * result the same as corrupted JSON and reclaim the lock. `pid` must be a
+ * positive safe integer: `process.kill` interprets `0` and negative values as
+ * process-*group* targets, so a lock claiming `pid: 0`/`-1` would otherwise be
+ * mis-read as "live" and never reclaimed. Exported so the predicate can be
+ * unit-tested directly, which is where its behaviour is pinned (the end-to-end
+ * reclaim path coincides with `process.kill` throwing on malformed input on
+ * POSIX, so only a direct test distinguishes the guard).
  *
  * @param value - Parsed (but unvalidated) lock-file content.
  * @returns A type predicate narrowing `value` to {@link LockContent} when it has
- *   a finite numeric `pid` and a string `created_at`.
+ *   a positive integer `pid` and a string `created_at`.
  */
 export function isLockContent(value: unknown): value is LockContent {
+  const pid = (value as { pid?: unknown } | null)?.pid;
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as { pid?: unknown }).pid === 'number' &&
-    Number.isFinite((value as { pid: number }).pid) &&
+    typeof pid === 'number' &&
+    Number.isSafeInteger(pid) &&
+    pid > 0 &&
     typeof (value as { created_at?: unknown }).created_at === 'string'
   );
 }
@@ -71,15 +76,26 @@ export class FileLockTimeoutError extends Error {
 /**
  * Check if a process is alive using `kill(pid, 0)`.
  *
+ * Only `ESRCH` ("no such process") proves the holder is dead and its lock is
+ * reclaimable. `EPERM` means a process with that pid exists but belongs to
+ * another user we may not signal — it is alive, so the lock must NOT be stolen.
+ * Any other unexpected error is treated conservatively as alive so a lock is
+ * never reclaimed without proof the owner is gone.
+ *
+ * Exported for direct unit testing of this error mapping.
+ *
  * @param pid - Process ID to check
- * @returns `true` if the process exists and is reachable
+ * @returns `true` if the process exists (or its liveness can't be disproven)
  */
-function isProcessAlive(pid: number): boolean {
+export function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (err: unknown) {
+    if (isNodeError(err) && err.code === 'ESRCH') {
+      return false;
+    }
+    return true;
   }
 }
 

--- a/packages/core/src/runbook/run-state-lock.ts
+++ b/packages/core/src/runbook/run-state-lock.ts
@@ -1,0 +1,83 @@
+import { locksDir, runStateLockPath as _runStateLockPath } from '../paths.js';
+import { acquireFileLock, FileLockTimeoutError, releaseFileLock } from './file-lock.js';
+
+/**
+ * Thrown when {@link RunStateLock.acquire} cannot acquire the lock within
+ * the {@link FileLockTimeoutError} deadline.
+ */
+export class RunStateLockTimeoutError extends FileLockTimeoutError {
+  /** Run id whose state lock timed out. */
+  readonly runId: string;
+
+  /**
+   * Construct a typed timeout error tagged with the run id.
+   *
+   * @param runId - Identifier of the run whose state lock timed out
+   * @param lockFile - Absolute path to the underlying lock file
+   */
+  constructor(runId: string, lockFile: string) {
+    super(
+      lockFile,
+      `Run-state lock timeout for run ${runId}: ${lockFile}. Another operation may be writing run state.`,
+    );
+    this.name = 'RunStateLockTimeoutError';
+    this.runId = runId;
+  }
+}
+
+/**
+ * File-based exclusive lock for serializing writes to a single run-state file.
+ *
+ * Lock path: `.rundown/locks/run-<runId>.state.lock`.
+ *
+ * Lock ordering: higher-level domain locks such as `CompletionLock` and
+ * `DelegationLock` may be acquired before this lock, then call into
+ * `RunbookStateManager`. This lock must not acquire those domain locks.
+ */
+export class RunStateLock {
+  private readonly cwd: string;
+  private readonly lockDir: string;
+
+  /**
+   * Create a new RunStateLock.
+   *
+   * @param cwd - Project root directory
+   */
+  constructor(cwd: string) {
+    this.cwd = cwd;
+    this.lockDir = locksDir(cwd);
+  }
+
+  private lockPath(runId: string): string {
+    return _runStateLockPath(this.cwd, runId);
+  }
+
+  /**
+   * Acquire an exclusive run-state lock for the given run ID.
+   *
+   * @param runId - Run ID to lock
+   * @throws {RunStateLockTimeoutError} When the lock cannot be acquired
+   */
+  async acquire(runId: string): Promise<void> {
+    const lockFile = this.lockPath(runId);
+    try {
+      await acquireFileLock(lockFile, this.lockDir);
+    } catch (err) {
+      if (err instanceof FileLockTimeoutError) {
+        throw new RunStateLockTimeoutError(runId, lockFile);
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Release an exclusive run-state lock for the given run ID.
+   *
+   * Idempotent — does not throw if the lock file does not exist.
+   *
+   * @param runId - Run ID to unlock
+   */
+  async release(runId: string): Promise<void> {
+    await releaseFileLock(this.lockPath(runId));
+  }
+}

--- a/packages/core/src/runbook/run-state-lock.ts
+++ b/packages/core/src/runbook/run-state-lock.ts
@@ -89,3 +89,39 @@ export class RunStateLock {
     await releaseFileLock(this.lockPath(runId));
   }
 }
+
+/**
+ * Minimal acquire/release contract the state manager depends on, so tests can
+ * inject a deterministic fake lock without a real filesystem mutex.
+ */
+export interface RunStateLockLike {
+  /**
+   * Acquire an exclusive lock for the given run ID.
+   *
+   * @param runId - Run ID to lock.
+   */
+  acquire(runId: string): Promise<void>;
+  /**
+   * Release the lock for the given run ID. Must be idempotent.
+   *
+   * @param runId - Run ID to unlock.
+   */
+  release(runId: string): Promise<void>;
+}
+
+/**
+ * Factory that produces a {@link RunStateLockLike} for a project root.
+ *
+ * @param cwd - Project root directory.
+ * @returns A lock instance scoped to that project root.
+ */
+export type RunStateLockFactory = (cwd: string) => RunStateLockLike;
+
+/**
+ * Default factory used by {@link RunbookStateManager} when no override is
+ * supplied: constructs the real filesystem-backed {@link RunStateLock}.
+ *
+ * @param cwd - Project root directory.
+ * @returns A real {@link RunStateLock}.
+ */
+export const defaultRunStateLockFactory: RunStateLockFactory = (cwd) => new RunStateLock(cwd);

--- a/packages/core/src/runbook/run-state-lock.ts
+++ b/packages/core/src/runbook/run-state-lock.ts
@@ -55,8 +55,14 @@ export class RunStateLock {
   /**
    * Acquire an exclusive run-state lock for the given run ID.
    *
+   * Retries with bounded jitter up to a 5-second deadline. Reclaims the lock
+   * only when the owning process is no longer alive.
+   *
    * @param runId - Run ID to lock
-   * @throws {RunStateLockTimeoutError} When the lock cannot be acquired
+   * @throws {RunStateLockTimeoutError} When the lock cannot be acquired within
+   *   the deadline
+   * @throws {Error} Propagates non-timeout failures from `acquireFileLock`,
+   *   such as I/O or permission errors while creating the lock file
    */
   async acquire(runId: string): Promise<void> {
     const lockFile = this.lockPath(runId);
@@ -76,6 +82,8 @@ export class RunStateLock {
    * Idempotent — does not throw if the lock file does not exist.
    *
    * @param runId - Run ID to unlock
+   * @throws {Error} Propagates non-ENOENT failures from `releaseFileLock`,
+   *   such as I/O or permission errors while removing the lock file
    */
   async release(runId: string): Promise<void> {
     await releaseFileLock(this.lockPath(runId));

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -513,6 +513,48 @@ export class RunbookStateManager {
     });
   }
 
+  /**
+   * Like {@link updateWithStateIfExists}, but the callback additionally returns
+   * a typed value that flows out through the result instead of through a
+   * captured closure variable.
+   *
+   * Use this for locked read-modify-write operations that must also report
+   * something they computed from the locked current state (for example,
+   * consuming and returning a resolved completion). The patch and the reported
+   * value are derived in the same callback under the same lock, so the reported
+   * value is always consistent with the persisted patch.
+   *
+   * When the runbook does not exist the callback never runs; the result is
+   * `{ state: null, value: null }`.
+   *
+   * @typeParam R - Type of the value the callback reports.
+   * @param id - The runbook state ID to update.
+   * @param buildResult - Callback deriving `{ updates, value }` from current state.
+   * @returns The updated state (or `null` when missing) and the reported value
+   *   (or `null` when the runbook does not exist).
+   */
+  async updateWithStateReturning<R>(
+    id: string,
+    buildResult: (
+      current: RunbookState,
+    ) =>
+      | { updates: RunbookStateUpdate | null; value: R }
+      | Promise<{ updates: RunbookStateUpdate | null; value: R }>,
+  ): Promise<{ state: RunbookState | null; value: R | null }> {
+    return await this.withRunStateLock(id, async () => {
+      const existing = await this.load(id);
+      if (!existing) {
+        return { state: null, value: null };
+      }
+      const { updates, value } = await buildResult(existing);
+      if (updates === null) {
+        return { state: existing, value };
+      }
+      const state = await this.updateUnlockedFromExisting(existing, updates);
+      return { state, value };
+    });
+  }
+
   private async updateUnlocked(id: string, updates: RunbookStateUpdate): Promise<RunbookState> {
     const existing = await this.load(id);
     if (!existing) {

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -582,26 +582,31 @@ export class RunbookStateManager {
    * `.rundown/runs/<id>/` if it exists. Silently ignores errors when either
    * path is absent — `delete` must be idempotent.
    *
+   * Held under the per-run state lock so a concurrent `save`/`update` cannot
+   * recreate the state file or write into the outputs directory mid-removal.
+   *
    * @param id - The runbook state ID to delete
    */
   async delete(id: string): Promise<void> {
-    try {
-      await fs.unlink(this.statePath(id));
-    } catch (error) {
-      if (!isNodeError(error) || error.code !== 'ENOENT') {
-        throw error;
+    await this.withRunStateLock(id, async () => {
+      try {
+        await fs.unlink(this.statePath(id));
+      } catch (error) {
+        if (!isNodeError(error) || error.code !== 'ENOENT') {
+          throw error;
+        }
       }
-    }
-    try {
-      // The per-run outputs directory shares the run id with the state file.
-      // Use rm -rf semantics so a non-empty directory is removed cleanly.
-      const runDir = this.statePath(id).replace(/\.json$/, '');
-      await fs.rm(runDir, { recursive: true, force: true });
-    } catch (error) {
-      if (!isNodeError(error) || error.code !== 'ENOENT') {
-        throw error;
+      try {
+        // The per-run outputs directory shares the run id with the state file.
+        // Use rm -rf semantics so a non-empty directory is removed cleanly.
+        const runDir = this.statePath(id).replace(/\.json$/, '');
+        await fs.rm(runDir, { recursive: true, force: true });
+      } catch (error) {
+        if (!isNodeError(error) || error.code !== 'ENOENT') {
+          throw error;
+        }
       }
-    }
+    });
   }
 
   /**

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -744,6 +744,16 @@ export class RunbookStateManager {
   /**
    * Persist session data to disk.
    *
+   * @remarks
+   * The write uses {@link writeJsonFileAtomic} (temp file + atomic rename), so a
+   * concurrent reader never observes a torn or partially written
+   * `session.json`. This atomicity does NOT serialize read-modify-write across
+   * processes: this method is not protected by the per-run `withRunStateLock`
+   * (that lock guards a single run-state file, not the shared session file), so
+   * two processes that load, mutate, and save the session concurrently can still
+   * lose updates. Callers that mutate session state concurrently must hold the
+   * higher-level `SessionLock` (`packages/core/src/runbook/session-lock.ts`).
+   *
    * @param session - The session data to write
    */
   async saveSession(session: SessionData): Promise<void> {

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -112,7 +112,12 @@ function assertTrustedResolvedCompletions(
 }
 
 async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<void> {
-  const tempPath = `${filePath}.tmp`;
+  // Unique per-write temp name so concurrent writers targeting the same final
+  // path never collide on the temp file; atomicity of the rename then does not
+  // depend on an external lock for collision-freedom. `randomBytes` (not
+  // `Math.random`) is a robust uniqueness source available on every runtime we
+  // support, including WebContainer's Node 22.x.
+  const tempPath = `${filePath}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
   const content = JSON.stringify(value, null, 2);
 
   try {

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -117,7 +117,7 @@ async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<vo
   // depend on an external lock for collision-freedom. `randomBytes` (not
   // `Math.random`) is a robust uniqueness source available on every runtime we
   // support, including WebContainer's Node 22.x.
-  const tempPath = `${filePath}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
+  const tempPath = `${filePath}.${String(process.pid)}.${randomBytes(6).toString('hex')}.tmp`;
   const content = JSON.stringify(value, null, 2);
 
   try {
@@ -550,7 +550,7 @@ export class RunbookStateManager {
    * When the runbook does not exist the callback never runs; the result is
    * `{ state: null, value: null }`.
    *
-   * @typeParam R - Type of the value the callback reports.
+   * @template R - Type of the value the callback reports.
    * @param id - The runbook state ID to update.
    * @param buildResult - Callback deriving `{ updates, value }` from current state.
    * @returns The updated state (or `null` when missing) and the reported value

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -42,6 +42,7 @@ import {
   statePath as _statePath,
   LEGACY_SESSION_FILE,
 } from '../paths.js';
+import { RunStateLock } from './run-state-lock.js';
 
 /** Current persisted state schema version for the v1 release. */
 const CURRENT_SCHEMA_VERSION = 1;
@@ -162,6 +163,35 @@ export interface SessionData {
   claims: Record<string, ClaimRecord>;
 }
 
+/**
+ * Typed patch accepted by {@link RunbookStateManager.update}.
+ *
+ * Record-shaped fields use tagged operations so callers must choose merge or
+ * replacement semantics explicitly.
+ */
+export type RunbookStateUpdate = Partial<
+  Omit<
+    RunbookState,
+    | 'id'
+    | 'startedAt'
+    | 'updatedAt'
+    | 'schemaVersion'
+    | 'variables'
+    | 'templateVars'
+    | 'resolvedCompletions'
+    | 'frameEntries'
+  >
+> & {
+  /** Merge or replace persisted runtime variables. */
+  readonly variables?: VariablesOp;
+  /** Replace initial template variables. */
+  readonly templateVars?: TemplateVarsOp;
+  /** Merge or replace resolved completion records. */
+  readonly resolvedCompletions?: ResolvedCompletionsOp;
+  /** Replace per-frame entry counters. */
+  readonly frameEntries?: FrameEntriesOp;
+};
+
 interface CreateOptions {
   readonly runbookPath: string;
   readonly runId?: RunId;
@@ -230,6 +260,16 @@ export class RunbookStateManager {
 
   private statePath(id: string): string {
     return _statePath(this.cwd, id);
+  }
+
+  private async withRunStateLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+    const lock = new RunStateLock(this.cwd);
+    await lock.acquire(id);
+    try {
+      return await fn();
+    } finally {
+      await lock.release(id);
+    }
   }
 
   /** Emit a process-wide one-time warning when legacy `.claude/rundown/` state is detected. */
@@ -371,6 +411,12 @@ export class RunbookStateManager {
    * @param state - The runbook state to persist
    */
   async save(state: RunbookState): Promise<void> {
+    await this.withRunStateLock(state.id, async () => {
+      await this.saveUnlocked(state);
+    });
+  }
+
+  private async saveUnlocked(state: RunbookState): Promise<void> {
     await fs.mkdir(this.stateDir, { recursive: true });
     const updated: RunbookState = {
       ...state,
@@ -401,36 +447,58 @@ export class RunbookStateManager {
    * @returns The updated runbook state
    * @throws {Error} If the runbook with the given ID is not found
    */
-  async update(
+  async update(id: string, updates: RunbookStateUpdate): Promise<RunbookState> {
+    return await this.withRunStateLock(id, async () => this.updateUnlocked(id, updates));
+  }
+
+  /**
+   * Update an existing runbook state with a patch computed from the locked
+   * current state.
+   *
+   * Use this for read-modify-write operations that replace whole fields such
+   * as `substepStates` or `resolvedCompletions`. The callback runs while the
+   * per-run state lock is held, so concurrent writers cannot compute from the
+   * same stale snapshot and overwrite each other.
+   *
+   * Returning `null` leaves the current state unchanged and releases the lock.
+   *
+   * @param id - The runbook state ID to update
+   * @param buildUpdates - Callback that derives a patch from current state
+   * @returns The updated state, or current state when the callback returns `null`
+   * @throws {Error} If the runbook with the given ID is not found
+   */
+  async updateWithState(
     id: string,
-    updates: Partial<
-      Omit<
-        RunbookState,
-        | 'id'
-        | 'startedAt'
-        | 'updatedAt'
-        | 'schemaVersion'
-        | 'variables'
-        | 'templateVars'
-        | 'resolvedCompletions'
-        | 'frameEntries'
-      >
-    > & {
-      // Tagged ops on record-shaped fields make merge-vs-replace intent
-      // visible at the call site. Internal callers (actor-service sync,
-      // compiler reducers) hold the unbranded XState context shape; the
-      // manager re-mints persistence brands inside the dispatch below.
-      readonly variables?: VariablesOp;
-      readonly templateVars?: TemplateVarsOp;
-      readonly resolvedCompletions?: ResolvedCompletionsOp;
-      readonly frameEntries?: FrameEntriesOp;
-    },
+    buildUpdates: (
+      current: RunbookState,
+    ) => RunbookStateUpdate | null | Promise<RunbookStateUpdate | null>,
   ): Promise<RunbookState> {
+    return await this.withRunStateLock(id, async () => {
+      const existing = await this.load(id);
+      if (!existing) {
+        throw new Error(`Runbook ${id} not found`);
+      }
+      const updates = await buildUpdates(existing);
+      if (updates === null) {
+        return existing;
+      }
+      return await this.updateUnlockedFromExisting(existing, updates);
+    });
+  }
+
+  private async updateUnlocked(id: string, updates: RunbookStateUpdate): Promise<RunbookState> {
     const existing = await this.load(id);
     if (!existing) {
       throw new Error(`Runbook ${id} not found`);
     }
 
+    return await this.updateUnlockedFromExisting(existing, updates);
+  }
+
+  private async updateUnlockedFromExisting(
+    existing: RunbookState,
+    updates: RunbookStateUpdate,
+  ): Promise<RunbookState> {
     // Pull tagged-op fields out of updates so the subsequent `...updates`
     // spread does not leak the wrapper shapes into the strictly-typed
     // RunbookState literal.
@@ -476,7 +544,7 @@ export class RunbookStateManager {
       updatedAt: new Date().toISOString(),
     };
 
-    await this.save(updated);
+    await this.saveUnlocked(updated);
     return updated;
   }
 
@@ -603,24 +671,26 @@ export class RunbookStateManager {
     substeps: readonly Substep[],
     frameKey: FrameKey,
   ): Promise<void> {
-    const state = await this.load(id);
-    if (!state) throw new Error(`Runbook ${id} not found`);
+    await this.withRunStateLock(id, async () => {
+      const state = await this.load(id);
+      if (!state) throw new Error(`Runbook ${id} not found`);
 
-    const existing = state.substepStates ?? [];
-    const authoredIds = new Set(substeps.map((substep) => substep.id));
-    const preserved = existing.filter(
-      (substepState) => substepState.frameKey !== frameKey || authoredIds.has(substepState.id),
-    );
-    const existingSameFrameIds = new Set(
-      preserved
-        .filter((substepState) => substepState.frameKey === frameKey)
-        .map((substepState) => substepState.id),
-    );
-    const initialized: SubstepState[] = substeps
-      .filter((substep) => !existingSameFrameIds.has(substep.id))
-      .map((substep) => ({ id: substep.id, frameKey, status: 'pending' }));
+      const existing = state.substepStates ?? [];
+      const authoredIds = new Set(substeps.map((substep) => substep.id));
+      const preserved = existing.filter(
+        (substepState) => substepState.frameKey !== frameKey || authoredIds.has(substepState.id),
+      );
+      const existingSameFrameIds = new Set(
+        preserved
+          .filter((substepState) => substepState.frameKey === frameKey)
+          .map((substepState) => substepState.id),
+      );
+      const initialized: SubstepState[] = substeps
+        .filter((substep) => !existingSameFrameIds.has(substep.id))
+        .map((substep) => ({ id: substep.id, frameKey, status: 'pending' }));
 
-    await this.update(id, { substepStates: [...preserved, ...initialized] });
+      await this.updateUnlocked(id, { substepStates: [...preserved, ...initialized] });
+    });
   }
 
   /**
@@ -637,21 +707,23 @@ export class RunbookStateManager {
    * @throws {Error} If the runbook with the given ID is not found
    */
   async updateForContext(id: string, forStack: ForContext[]): Promise<RunbookState> {
-    const state = await this.load(id);
-    if (!state) {
-      throw new Error(`Runbook ${id} not found`);
-    }
+    return await this.withRunStateLock(id, async () => {
+      const state = await this.load(id);
+      if (!state) {
+        throw new Error(`Runbook ${id} not found`);
+      }
 
-    const snapshot = state.snapshot as Record<string, unknown> | undefined;
-    const patchedSnapshot =
-      snapshot && typeof snapshot === 'object' && 'context' in snapshot
-        ? {
-            ...snapshot,
-            context: { ...(snapshot.context as Record<string, unknown>), forStack },
-          }
-        : snapshot;
+      const snapshot = state.snapshot as Record<string, unknown> | undefined;
+      const patchedSnapshot =
+        snapshot && typeof snapshot === 'object' && 'context' in snapshot
+          ? {
+              ...snapshot,
+              context: { ...(snapshot.context as Record<string, unknown>), forStack },
+            }
+          : snapshot;
 
-    return await this.update(id, { forStack, snapshot: patchedSnapshot });
+      return await this.updateUnlocked(id, { forStack, snapshot: patchedSnapshot });
+    });
   }
 
   /**
@@ -671,14 +743,18 @@ export class RunbookStateManager {
     result: 'pass' | 'fail',
     frameKey: FrameKey,
   ): Promise<void> {
-    const state = await this.load(runbookId);
-    if (!state) throw new Error(`Runbook ${runbookId} not found`);
+    await this.withRunStateLock(runbookId, async () => {
+      const state = await this.load(runbookId);
+      if (!state) throw new Error(`Runbook ${runbookId} not found`);
 
-    const substepStates = state.substepStates ?? [];
-    const updated = substepStates.map((s) =>
-      s.id === substepId && s.frameKey === frameKey ? { ...s, status: 'done' as const, result } : s,
-    );
+      const substepStates = state.substepStates ?? [];
+      const updated = substepStates.map((s) =>
+        s.id === substepId && s.frameKey === frameKey
+          ? { ...s, status: 'done' as const, result }
+          : s,
+      );
 
-    await this.update(runbookId, { substepStates: updated });
+      await this.updateUnlocked(runbookId, { substepStates: updated });
+    });
   }
 }

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -473,10 +473,37 @@ export class RunbookStateManager {
       current: RunbookState,
     ) => RunbookStateUpdate | null | Promise<RunbookStateUpdate | null>,
   ): Promise<RunbookState> {
+    const updated = await this.updateWithStateIfExists(id, buildUpdates);
+    if (updated === null) {
+      throw new Error(`Runbook ${id} not found`);
+    }
+    return updated;
+  }
+
+  /**
+   * Like {@link updateWithState}, but returns `null` when the runbook does not
+   * exist instead of throwing.
+   *
+   * Use this for locked read-modify-write operations where a missing runbook is
+   * a legitimate "nothing to do" outcome rather than an error (for example,
+   * consuming a resolved completion). The callback only runs when the runbook
+   * exists, so it always receives a non-null {@link RunbookState}.
+   *
+   * @param id - The runbook state ID to update
+   * @param buildUpdates - Callback that derives a patch from current state
+   * @returns The updated state, the current state when the callback returns
+   *   `null`, or `null` when the runbook does not exist
+   */
+  async updateWithStateIfExists(
+    id: string,
+    buildUpdates: (
+      current: RunbookState,
+    ) => RunbookStateUpdate | null | Promise<RunbookStateUpdate | null>,
+  ): Promise<RunbookState | null> {
     return await this.withRunStateLock(id, async () => {
       const existing = await this.load(id);
       if (!existing) {
-        throw new Error(`Runbook ${id} not found`);
+        return null;
       }
       const updates = await buildUpdates(existing);
       if (updates === null) {

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -42,7 +42,11 @@ import {
   statePath as _statePath,
   LEGACY_SESSION_FILE,
 } from '../paths.js';
-import { RunStateLock } from './run-state-lock.js';
+import {
+  defaultRunStateLockFactory,
+  type RunStateLockFactory,
+  type RunStateLockLike,
+} from './run-state-lock.js';
 
 /** Current persisted state schema version for the v1 release. */
 const CURRENT_SCHEMA_VERSION = 1;
@@ -208,6 +212,17 @@ interface CreateOptions {
 }
 
 /**
+ * Construction options for {@link RunbookStateManager}.
+ */
+export interface RunbookStateManagerOptions {
+  /**
+   * Factory producing the per-run state lock. Defaults to the real
+   * filesystem-backed lock; tests inject a deterministic fake.
+   */
+  readonly lockFactory?: RunStateLockFactory;
+}
+
+/**
  * Manager for runbook state persistence and lifecycle.
  *
  * Handles creating, loading, saving, and updating runbook state.
@@ -221,13 +236,16 @@ export class RunbookStateManager {
    */
   private static legacyWarningEmitted = false;
   private readonly _cwd: string;
+  private readonly lockFactory: RunStateLockFactory;
 
   /**
    * Create a new RunbookStateManager.
    *
    * @param cwd - The working directory (project root) for state file paths
+   * @param options - Optional overrides, including an injectable lock factory
    */
-  constructor(cwd: string) {
+  constructor(cwd: string, options: RunbookStateManagerOptions = {}) {
+    this.lockFactory = options.lockFactory ?? defaultRunStateLockFactory;
     try {
       this._cwd = fsSync.realpathSync(cwd);
     } catch (err) {
@@ -263,7 +281,7 @@ export class RunbookStateManager {
   }
 
   private async withRunStateLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
-    const lock = new RunStateLock(this.cwd);
+    const lock: RunStateLockLike = this.lockFactory(this.cwd);
     await lock.acquire(id);
     try {
       return await fn();


### PR DESCRIPTION
# Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added per-run file locking to serialize state writes and prevent races.
  * Switched state mutation paths to always use per-run locks and injectable lock implementations.
  * Atomic writes now use unique temp files to avoid collisions.

* **Bug Fixes**
  * Improved idempotent lock release and surfaced typed timeout errors for competing writers.
  * Robustified completion/resolved-completion updates under concurrency.
  * Validate and reclaim malformed lock files; preserved state on atomic-write failures.

* **Tests**
  * Expanded tests for locking, permissions, timeouts, atomic-writes, and concurrent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- [ ] `npm run verify`

Targeted tests or checks:

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`, `docs/spec/grammar.md`, and
      runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the no-migration rule.
- [ ] Security policy, sandbox, path resolution, or command execution changed; traversal,
      symlink escape, deny precedence, env leakage, and fail-closed behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.
