### PR TITLE
fix(core): artifact-array discriminant + #384 review follow-ups

### DIFF
--- a/docs/spec/cli-output.md
+++ b/docs/spec/cli-output.md
@@ -279,6 +279,12 @@ they only list, inspect, or project artifact aliases and URIs.
 `rd artifact path --text` and `rd artifact uri --text` are the only concise
 projection outputs.
 
+Non-list artifact responses (`path`, `uri`, `inspect`) carry a `kind`
+discriminant: scalar entries reuse the record's own `kind` (`artifact-record` /
+`file-artifact-record`), while an alias bound to multiple records is tagged
+`artifact-array`. `ls` returns a raw array whose elements carry the same
+discriminants. Authoritative shapes live in `packages/core/src/output/zod-schemas.ts`.
+
 ---
 
 ## claim

--- a/packages/cli/__tests__/commands/artifact.test.ts
+++ b/packages/cli/__tests__/commands/artifact.test.ts
@@ -282,6 +282,66 @@ describe('artifact command', () => {
     expect(text.stdout).toContain('2 paths');
   });
 
+  it('ls JSON output carries kind: artifact-array for array-bound aliases', async () => {
+    await seedActiveArrayArtifact();
+    const result = await runCliInProcess(['artifact', 'ls'], workspace);
+    expect(result.exitCode).toBe(0);
+    const rows = JSON.parse(result.stdout) as Array<{ alias: string; kind: string }>;
+    const reviews = rows.find((row) => row.alias === 'Reviews');
+    expect(reviews).toBeDefined();
+    expect(reviews?.kind).toBe('artifact-array');
+  });
+
+  it('ls JSON output carries kind: artifact-record for scalar aliases', async () => {
+    await seedActiveArtifact();
+    const result = await runCliInProcess(['artifact', 'ls'], workspace);
+    expect(result.exitCode).toBe(0);
+    const rows = JSON.parse(result.stdout) as Array<{ alias: string; kind: string }>;
+    const planEntry = rows.find((row) => row.alias === 'PlanPath');
+    expect(planEntry).toBeDefined();
+    expect(planEntry?.kind).toBe('artifact-record');
+  });
+
+  it('ls --text KIND column shows artifact-array for array aliases', async () => {
+    await seedActiveArrayArtifact();
+    const result = await runCliInProcess(['artifact', 'ls', '--text'], workspace);
+    expect(result.exitCode).toBe(0);
+    // The KIND column should contain 'artifact-array' for the Reviews alias
+    expect(result.stdout).toContain('artifact-array');
+  });
+
+  it('ls --text KIND column shows artifact-record for scalar aliases', async () => {
+    await seedActiveArtifact();
+    const result = await runCliInProcess(['artifact', 'ls', '--text'], workspace);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('artifact-record');
+  });
+
+  it('path JSON output carries kind: artifact-array for array-bound aliases', async () => {
+    await seedActiveArrayArtifact();
+    const result = await runCliInProcess(['artifact', 'path', 'Reviews'], workspace);
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.stdout) as { kind: string; items?: unknown[] };
+    expect(data.kind).toBe('artifact-array');
+    expect(data.items).toHaveLength(2);
+  });
+
+  it('uri JSON output carries kind: artifact-array for array-bound aliases', async () => {
+    await seedActiveArrayArtifact();
+    const result = await runCliInProcess(['artifact', 'uri', 'Reviews'], workspace);
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.stdout) as { kind: string; items?: unknown[] };
+    expect(data.kind).toBe('artifact-array');
+  });
+
+  it('inspect JSON output carries kind: artifact-array for array-bound aliases', async () => {
+    await seedActiveArrayArtifact();
+    const result = await runCliInProcess(['artifact', 'inspect', 'Reviews'], workspace);
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.stdout) as { kind: string; items?: unknown[] };
+    expect(data.kind).toBe('artifact-array');
+  });
+
   it('projects an array-bound alias to newline-joined paths and uris in text mode', async () => {
     const uris = await seedActiveArrayArtifact();
     const paths = await runCliInProcess(['artifact', 'path', 'Reviews', '--text'], workspace);

--- a/packages/cli/__tests__/helpers/status-builder.test.ts
+++ b/packages/cli/__tests__/helpers/status-builder.test.ts
@@ -532,6 +532,66 @@ describe('vars field', () => {
     });
   });
 
+  it('renders artifact path using record contextId and runId, not hardcoded values', () => {
+    const otherRunId = brandRunIdForTest(`rd_${'d'.repeat(32)}`);
+    const artifact = brandTrustedArtifactRecordForTest({
+      kind: 'artifact-record',
+      uri: `rd://artifacts/ctx-b/${otherRunId}/output.json`,
+      runId: otherRunId,
+      contextId: 'ctx-b',
+      runbook: { source: 'project', path: 'other.runbook.md' },
+      key: 'output.json',
+      timestamp: '2026-05-25T00:00:00.000Z',
+    });
+    const state = makeState({
+      variables: brandStoredOutputsForTest({ OutputPath: artifact }),
+    });
+
+    const result = buildActiveStatus(state, '/project');
+
+    expect(result.vars?.OutputPath).toBe(
+      `/project/.rundown/work/.rd-ctx-b/${otherRunId}/output.json`,
+    );
+    expect(result.vars?.OutputPath).not.toContain('ctx-a');
+    expect(result.vars?.OutputPath).not.toContain(String(ARTIFACT_RUN_ID));
+  });
+
+  it('renders artifact paths for two records from different contexts independently', () => {
+    const runIdA = brandRunIdForTest(`rd_${'e'.repeat(32)}`);
+    const runIdB = brandRunIdForTest(`rd_${'f'.repeat(32)}`);
+    const artifactA = brandTrustedArtifactRecordForTest({
+      kind: 'artifact-record',
+      uri: `rd://artifacts/ctx-x/${runIdA}/a.json`,
+      runId: runIdA,
+      contextId: 'ctx-x',
+      runbook: { source: 'project', path: 'a.runbook.md' },
+      key: 'a.json',
+      timestamp: '2026-05-25T00:00:00.000Z',
+    });
+    const artifactB = brandTrustedArtifactRecordForTest({
+      kind: 'artifact-record',
+      uri: `rd://artifacts/ctx-y/${runIdB}/b.json`,
+      runId: runIdB,
+      contextId: 'ctx-y',
+      runbook: { source: 'project', path: 'b.runbook.md' },
+      key: 'b.json',
+      timestamp: '2026-05-25T00:00:00.000Z',
+    });
+    const state = makeState({
+      variables: brandStoredOutputsForTest({ ArtA: artifactA, ArtB: artifactB }),
+    });
+
+    const result = buildActiveStatus(state, '/project');
+
+    expect(result.vars?.ArtA).toContain('ctx-x');
+    expect(result.vars?.ArtA).toContain(runIdA);
+    expect(result.vars?.ArtB).toContain('ctx-y');
+    expect(result.vars?.ArtB).toContain(runIdB);
+    // Ensure cross-contamination does not occur
+    expect(result.vars?.ArtA).not.toContain('ctx-y');
+    expect(result.vars?.ArtB).not.toContain('ctx-x');
+  });
+
   it('renders artifact-record arrays as JSON path arrays and exposes structured projections', () => {
     const first = brandTrustedArtifactRecordForTest({
       kind: 'artifact-record',

--- a/packages/cli/__tests__/helpers/status-builder.test.ts
+++ b/packages/cli/__tests__/helpers/status-builder.test.ts
@@ -60,10 +60,17 @@ jest.unstable_mockModule('@rundown-org/core', () => {
     }),
     WORK_DIR: '.rundown/work',
     renderArtifactValue: jest.fn((value: unknown, options?: { cwd: string; workPath: string }) => {
-      const renderOne = (record: { key: string; kind: string }) =>
+      const renderOne = (record: {
+        key: string;
+        kind: string;
+        contextId?: string;
+        runId?: string;
+      }) =>
         record.kind === 'file-artifact-record'
           ? '/tmp/project/schemas/review.schema.json'
-          : `${options?.cwd ?? '/test'}/${options?.workPath ?? '.rundown/work'}/.rd-ctx-a/${ARTIFACT_RUN_ID}/${record.key}`;
+          : `${options?.cwd ?? '/test'}/${options?.workPath ?? '.rundown/work'}/.rd-${String(
+              record.contextId,
+            )}/${String(record.runId)}/${record.key}`;
       if (Array.isArray(value)) {
         return JSON.stringify(value.map(renderOne));
       }
@@ -411,7 +418,18 @@ describe('parentLinkage projection', () => {
         parentEntry: 1,
       },
       templateVars: brandInitialTemplateVarsForTest({ secret: 'inherited-from-parent' }),
-      variables: brandStoredOutputsForTest({ output_value: 'child-output' }),
+      variables: brandStoredOutputsForTest({
+        output_value: 'child-output',
+        PlanPath: brandTrustedArtifactRecordForTest({
+          kind: 'artifact-record',
+          uri: `rd://artifacts/ctx-a/${ARTIFACT_RUN_ID}/plan.json`,
+          runId: ARTIFACT_RUN_ID,
+          contextId: 'ctx-a',
+          runbook: { source: 'project', path: 'producer.runbook.md' },
+          key: 'plan.json',
+          timestamp: '2026-05-25T00:00:00.000Z',
+        }),
+      }),
     });
 
     const result = buildStashedStatus(state, '/test');
@@ -425,8 +443,9 @@ describe('parentLinkage projection', () => {
       parentFrameKey: brandFrameKeyForTest('2'),
       parentEntry: 1,
     });
-    // Caller-scoped (parentLinkage set) → vars must be redacted from stashed status.
+    // Caller-scoped (parentLinkage set) → vars and artifacts must be redacted from stashed status.
     expect(result.vars).toBeUndefined();
+    expect(result.artifacts).toBeUndefined();
   });
 
   it('surfaces vars in stashed status when no parentLinkage is set', () => {

--- a/packages/cli/src/commands/artifact.ts
+++ b/packages/cli/src/commands/artifact.ts
@@ -123,7 +123,7 @@ export function registerArtifactCommand(program: Command): void {
         const rows = listArtifactAliases(state, artifactPathOptions);
         output.list(rows, [
           { header: 'ALIAS', key: 'alias' },
-          { header: 'KIND', key: (row) => ('items' in row ? 'artifact-array' : row.kind) },
+          { header: 'KIND', key: (row) => row.kind },
           {
             header: 'URI',
             key: (row) => ('items' in row ? `${String(row.items.length)} artifacts` : row.uri),

--- a/packages/core/__tests__/output/artifact-response-schemas.test.ts
+++ b/packages/core/__tests__/output/artifact-response-schemas.test.ts
@@ -24,7 +24,7 @@ const managed = {
 };
 
 const aliasEntry = { ...managed, alias: 'PlanPath' };
-const arrayEntry = { alias: 'Reviews', items: [managed] };
+const arrayEntry = { kind: 'artifact-array', alias: 'Reviews', items: [managed] };
 
 describe('artifact response schemas', () => {
   describe('ArtifactAliasEntrySchema', () => {
@@ -49,9 +49,17 @@ describe('artifact response schemas', () => {
 
     it('rejects items that are not public records', () => {
       expect(
-        ArtifactAliasArrayEntrySchema.safeParse({ alias: 'Reviews', items: [{ alias: 'x' }] })
-          .success,
+        ArtifactAliasArrayEntrySchema.safeParse({
+          kind: 'artifact-array',
+          alias: 'Reviews',
+          items: [{ alias: 'x' }],
+        }).success,
       ).toBe(false);
+    });
+
+    it('rejects an array entry missing the kind discriminant', () => {
+      const { kind: _omitted, ...withoutKind } = arrayEntry;
+      expect(ArtifactAliasArrayEntrySchema.safeParse(withoutKind).success).toBe(false);
     });
   });
 

--- a/packages/core/__tests__/output/artifact-response-schemas.test.ts
+++ b/packages/core/__tests__/output/artifact-response-schemas.test.ts
@@ -95,7 +95,10 @@ describe('artifact response schemas', () => {
         ArtifactAliasArrayEntrySchema.safeParse({
           kind: 'artifact-array',
           alias: 'Reviews',
-          items: [managed, { ...managed, key: 'review.json', uri: `rd://artifacts/ctx1/${RUN_ID}/review.json` }],
+          items: [
+            managed,
+            { ...managed, key: 'review.json', uri: `rd://artifacts/ctx1/${RUN_ID}/review.json` },
+          ],
         }).success,
       ).toBe(true);
     });

--- a/packages/core/__tests__/output/artifact-response-schemas.test.ts
+++ b/packages/core/__tests__/output/artifact-response-schemas.test.ts
@@ -61,6 +61,54 @@ describe('artifact response schemas', () => {
       const { kind: _omitted, ...withoutKind } = arrayEntry;
       expect(ArtifactAliasArrayEntrySchema.safeParse(withoutKind).success).toBe(false);
     });
+
+    it('rejects an array entry with wrong kind value', () => {
+      expect(
+        ArtifactAliasArrayEntrySchema.safeParse({
+          ...arrayEntry,
+          kind: 'artifact-record',
+        }).success,
+      ).toBe(false);
+    });
+
+    it('rejects an array entry with kind: file-artifact-record', () => {
+      expect(
+        ArtifactAliasArrayEntrySchema.safeParse({
+          ...arrayEntry,
+          kind: 'file-artifact-record',
+        }).success,
+      ).toBe(false);
+    });
+
+    it('accepts an entry with an empty items array', () => {
+      expect(
+        ArtifactAliasArrayEntrySchema.safeParse({
+          kind: 'artifact-array',
+          alias: 'Empty',
+          items: [],
+        }).success,
+      ).toBe(true);
+    });
+
+    it('accepts an entry with multiple valid items', () => {
+      expect(
+        ArtifactAliasArrayEntrySchema.safeParse({
+          kind: 'artifact-array',
+          alias: 'Reviews',
+          items: [managed, { ...managed, key: 'review.json', uri: `rd://artifacts/ctx1/${RUN_ID}/review.json` }],
+        }).success,
+      ).toBe(true);
+    });
+
+    it('rejects an entry missing the alias field', () => {
+      const { alias: _omitted, ...withoutAlias } = arrayEntry;
+      expect(ArtifactAliasArrayEntrySchema.safeParse(withoutAlias).success).toBe(false);
+    });
+
+    it('rejects an entry missing the items field', () => {
+      const { items: _omitted, ...withoutItems } = arrayEntry;
+      expect(ArtifactAliasArrayEntrySchema.safeParse(withoutItems).success).toBe(false);
+    });
   });
 
   describe('ArtifactLsResponseSchema', () => {
@@ -70,6 +118,27 @@ describe('artifact response schemas', () => {
 
     it('rejects a non-array payload', () => {
       expect(ArtifactLsResponseSchema.safeParse(aliasEntry).success).toBe(false);
+    });
+
+    it('accepts an empty list', () => {
+      expect(ArtifactLsResponseSchema.safeParse([]).success).toBe(true);
+    });
+
+    it('accepts a scalar-only list', () => {
+      expect(ArtifactLsResponseSchema.safeParse([aliasEntry]).success).toBe(true);
+    });
+
+    it('accepts an array-only list', () => {
+      expect(ArtifactLsResponseSchema.safeParse([arrayEntry]).success).toBe(true);
+    });
+
+    it('rejects a list containing a bare record without alias', () => {
+      expect(ArtifactLsResponseSchema.safeParse([managed]).success).toBe(false);
+    });
+
+    it('rejects a list containing an array entry missing kind', () => {
+      const { kind: _omitted, ...withoutKind } = arrayEntry;
+      expect(ArtifactLsResponseSchema.safeParse([withoutKind]).success).toBe(false);
     });
   });
 
@@ -86,6 +155,31 @@ describe('artifact response schemas', () => {
       const { kind: _omitted, ...withoutKind } = managed;
       expect(ArtifactPathResponseSchema.safeParse(withoutKind).success).toBe(false);
     });
+
+    it('accept an array entry and preserve its kind: artifact-array discriminant', () => {
+      for (const schema of [ArtifactPathResponseSchema, ArtifactInspectResponseSchema]) {
+        const result = schema.safeParse(arrayEntry);
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data).toHaveProperty('kind', 'artifact-array');
+        }
+      }
+    });
+
+    it('accept a scalar alias entry with its record kind preserved', () => {
+      for (const schema of [ArtifactPathResponseSchema, ArtifactInspectResponseSchema]) {
+        const result = schema.safeParse(aliasEntry);
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data).toHaveProperty('kind', 'artifact-record');
+        }
+      }
+    });
+
+    it('ArtifactInspectResponseSchema rejects an array entry missing kind', () => {
+      const { kind: _omitted, ...withoutKind } = arrayEntry;
+      expect(ArtifactInspectResponseSchema.safeParse(withoutKind).success).toBe(false);
+    });
   });
 
   describe('ArtifactUriResponseSchema', () => {
@@ -96,6 +190,19 @@ describe('artifact response schemas', () => {
 
     it('rejects a bare record without an alias', () => {
       expect(ArtifactUriResponseSchema.safeParse(managed).success).toBe(false);
+    });
+
+    it('accepts an array entry and its kind discriminant is artifact-array', () => {
+      const result = ArtifactUriResponseSchema.safeParse(arrayEntry);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toHaveProperty('kind', 'artifact-array');
+      }
+    });
+
+    it('rejects an array entry missing its kind discriminant', () => {
+      const { kind: _omitted, ...withoutKind } = arrayEntry;
+      expect(ArtifactUriResponseSchema.safeParse(withoutKind).success).toBe(false);
     });
   });
 

--- a/packages/core/__tests__/runbook/artifact-service.test.ts
+++ b/packages/core/__tests__/runbook/artifact-service.test.ts
@@ -199,7 +199,7 @@ describe('artifact service', () => {
         PlanPath: artifact,
         Reviews: [artifact, secondArtifact],
       },
-    } as unknown as (typeof state);
+    } as unknown as typeof state;
 
     const entries = listArtifactAliases(mixedState, { cwd, workPath });
     const planEntry = entries.find((e) => e.alias === 'PlanPath');

--- a/packages/core/__tests__/runbook/artifact-service.test.ts
+++ b/packages/core/__tests__/runbook/artifact-service.test.ts
@@ -171,6 +171,7 @@ describe('artifact service', () => {
   it('lists an array-bound alias as items', () => {
     expect(listArtifactAliases(arrayState, { cwd, workPath })).toEqual([
       {
+        kind: 'artifact-array',
         alias: 'Reviews',
         items: [
           expect.objectContaining({ uri: artifact.uri, path: expectedPath() }),
@@ -180,8 +181,14 @@ describe('artifact service', () => {
     ]);
   });
 
+  it('tags an array-bound alias with the artifact-array discriminant', () => {
+    const [entry] = listArtifactAliases(arrayState, { cwd, workPath });
+    expect(entry).toHaveProperty('kind', 'artifact-array');
+  });
+
   it('gets an array-bound alias by name', () => {
     expect(getArtifactByAlias(arrayState, 'Reviews', { cwd, workPath })).toEqual({
+      kind: 'artifact-array',
       alias: 'Reviews',
       items: [
         expect.objectContaining({ uri: artifact.uri }),
@@ -192,6 +199,7 @@ describe('artifact service', () => {
 
   it('projects an array-bound alias to items for path and uri', async () => {
     const expected = {
+      kind: 'artifact-array',
       alias: 'Reviews',
       items: [
         expect.objectContaining({ uri: artifact.uri, path: expectedPath() }),

--- a/packages/core/__tests__/runbook/artifact-service.test.ts
+++ b/packages/core/__tests__/runbook/artifact-service.test.ts
@@ -186,6 +186,29 @@ describe('artifact service', () => {
     expect(entry).toHaveProperty('kind', 'artifact-array');
   });
 
+  it('tags a scalar alias with the underlying record kind, not artifact-array', () => {
+    const [entry] = listArtifactAliases(state, { cwd, workPath });
+    expect(entry).toHaveProperty('kind', 'artifact-record');
+    expect(entry.kind).not.toBe('artifact-array');
+  });
+
+  it('listArtifactAliases returns kind: artifact-array only for array-bound entries', () => {
+    const mixedState = {
+      templateVars: { WorkPath: workPath },
+      variables: {
+        PlanPath: artifact,
+        Reviews: [artifact, secondArtifact],
+      },
+    } as unknown as (typeof state);
+
+    const entries = listArtifactAliases(mixedState, { cwd, workPath });
+    const planEntry = entries.find((e) => e.alias === 'PlanPath');
+    const reviewsEntry = entries.find((e) => e.alias === 'Reviews');
+
+    expect(planEntry).toHaveProperty('kind', 'artifact-record');
+    expect(reviewsEntry).toHaveProperty('kind', 'artifact-array');
+  });
+
   it('gets an array-bound alias by name', () => {
     expect(getArtifactByAlias(arrayState, 'Reviews', { cwd, workPath })).toEqual({
       kind: 'artifact-array',
@@ -195,6 +218,22 @@ describe('artifact service', () => {
         expect.objectContaining({ uri: secondArtifact.uri }),
       ],
     });
+  });
+
+  it('getArtifactByAlias returns null for a missing alias', () => {
+    expect(getArtifactByAlias(state, 'NonExistent', { cwd, workPath })).toBeNull();
+  });
+
+  it('getArtifactByAlias for array-bound alias carries kind: artifact-array', () => {
+    const entry = getArtifactByAlias(arrayState, 'Reviews', { cwd, workPath });
+    expect(entry).not.toBeNull();
+    expect(entry?.kind).toBe('artifact-array');
+  });
+
+  it('getArtifactByAlias for scalar alias carries the record kind', () => {
+    const entry = getArtifactByAlias(state, 'PlanPath', { cwd, workPath });
+    expect(entry).not.toBeNull();
+    expect(entry?.kind).toBe('artifact-record');
   });
 
   it('projects an array-bound alias to items for path and uri', async () => {
@@ -210,5 +249,33 @@ describe('artifact service', () => {
       expected,
     );
     expect(projectArtifactUri(arrayState, 'Reviews', { cwd, workPath })).toEqual(expected);
+  });
+
+  it('projectArtifactPath for array-bound alias returns kind: artifact-array', async () => {
+    const result = await projectArtifactPath(arrayState, 'Reviews', { cwd, workPath });
+    expect(result).toHaveProperty('kind', 'artifact-array');
+  });
+
+  it('projectArtifactUri for array-bound alias returns kind: artifact-array', () => {
+    const result = projectArtifactUri(arrayState, 'Reviews', { cwd, workPath });
+    expect(result).toHaveProperty('kind', 'artifact-array');
+  });
+
+  it('projectArtifactPath for scalar alias returns the record kind', async () => {
+    const result = await projectArtifactPath(state, 'PlanPath', { cwd, workPath });
+    expect(result).toHaveProperty('kind', 'artifact-record');
+  });
+
+  it('projectArtifactUri for scalar alias returns the record kind', () => {
+    const result = projectArtifactUri(state, 'PlanPath', { cwd, workPath });
+    expect(result).toHaveProperty('kind', 'artifact-record');
+  });
+
+  it('kind discriminant is present on every entry returned by listArtifactAliases', () => {
+    const entries = listArtifactAliases(arrayState, { cwd, workPath });
+    for (const entry of entries) {
+      expect(entry).toHaveProperty('kind');
+      expect(typeof entry.kind).toBe('string');
+    }
   });
 });

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -483,6 +483,13 @@ export const StatusResponseSchema = z
   .describe('Response from the status command')
   .loose();
 
+/**
+ * One artifact alias bound to a single record, projected for CLI output.
+ *
+ * Intersects {@link PublicArtifactRecordSchema} with the resolving `alias`, so
+ * the entry's `kind` (`artifact-record` / `file-artifact-record`) comes from the
+ * underlying record and doubles as its response discriminant.
+ */
 export const ArtifactAliasEntrySchema = z.intersection(
   PublicArtifactRecordSchema,
   z.object({
@@ -490,26 +497,55 @@ export const ArtifactAliasEntrySchema = z.intersection(
   }),
 );
 
+/**
+ * One artifact alias bound to multiple records, projected for CLI output.
+ *
+ * Array entries carry a dedicated `kind: 'artifact-array'` discriminant (scalar
+ * entries borrow the record's own `kind`) so every non-list artifact response
+ * can be narrowed by `kind` alone, per docs/spec/cli-output.md.
+ */
 export const ArtifactAliasArrayEntrySchema = z.object({
+  kind: z.literal('artifact-array').describe('Response discriminant for array-bound aliases'),
   alias: z.string().describe('Artifact alias from the effective variable map'),
   items: z.array(PublicArtifactRecordSchema).describe('Artifacts bound to this alias'),
 });
 
+/**
+ * Response for `rd artifact ls`: a raw array of scalar and array alias entries.
+ *
+ * List responses carry no top-level `kind`; each element is self-describing via
+ * its own discriminant ({@link ArtifactAliasEntrySchema} /
+ * {@link ArtifactAliasArrayEntrySchema}).
+ */
 export const ArtifactLsResponseSchema = z.array(
   z.union([ArtifactAliasEntrySchema, ArtifactAliasArrayEntrySchema]),
 );
 
+/**
+ * Response for `rd artifact path`: an alias entry (scalar or array) or a bare
+ * manifest-backed record when an exact `rd://` URI is projected. Every member
+ * carries a `kind` discriminant.
+ */
 export const ArtifactPathResponseSchema = z.union([
   ArtifactAliasEntrySchema,
   ArtifactAliasArrayEntrySchema,
   PublicArtifactRecordSchema,
 ]);
 
+/**
+ * Response for `rd artifact uri`: an alias entry (scalar or array). Bare records
+ * are not produced because the command always resolves through an alias.
+ */
 export const ArtifactUriResponseSchema = z.union([
   ArtifactAliasEntrySchema,
   ArtifactAliasArrayEntrySchema,
 ]);
 
+/**
+ * Response for `rd artifact inspect`: an alias entry (scalar or array) or a bare
+ * manifest-backed record for an exact `rd://` URI. Every member carries a `kind`
+ * discriminant.
+ */
 export const ArtifactInspectResponseSchema = z.union([
   ArtifactAliasEntrySchema,
   ArtifactAliasArrayEntrySchema,

--- a/packages/core/src/runbook/artifact-service.ts
+++ b/packages/core/src/runbook/artifact-service.ts
@@ -21,6 +21,13 @@ export type ArtifactAliasEntry = PublicArtifactRecord & {
  * Public projection for one artifact alias bound to multiple artifact records.
  */
 export interface ArtifactAliasArrayEntry {
+  /**
+   * Response-type discriminant for array-bound alias projections. Scalar alias
+   * entries reuse the underlying record's `kind` (`artifact-record` /
+   * `file-artifact-record`); array entries carry their own tag so non-list
+   * artifact responses can be narrowed by `kind` alone.
+   */
+  readonly kind: 'artifact-array';
   /** Artifact alias from the effective variable map. */
   readonly alias: string;
   /** Public artifact records bound to the alias. */
@@ -48,7 +55,11 @@ export function listArtifactAliases(
     if (!isArtifactValue(value)) continue;
     const projected = toPublicArtifactVarValue(value, options);
     if (Array.isArray(projected)) {
-      entries.push({ alias, items: projected as readonly PublicArtifactRecord[] });
+      entries.push({
+        kind: 'artifact-array',
+        alias,
+        items: projected as readonly PublicArtifactRecord[],
+      });
     } else {
       entries.push({ alias, ...(projected as PublicArtifactRecord) });
     }


### PR DESCRIPTION
## Summary
Follow-up to the merged #384, resolving the four CodeRabbit review threads that were still open when that PR merged. Branched off the post-merge `main`.

| Finding | Fix |
|---------|-----|
| **D** — `ArtifactAliasArrayEntry` lacked a `kind` discriminant (non-list responses must carry `kind` per `docs/spec/cli-output.md`) | Added `kind: 'artifact-array'` to the core type, the `listArtifactAliases` build site, and `ArtifactAliasArrayEntrySchema`. `path`/`uri`/`inspect` unions are now narrowable by `kind` alone. Simplified the `artifact ls` KIND column from an `'items' in row` heuristic to `row.kind`. |
| **C** — six exported artifact schemas missing TSDoc | Documented all six (`ArtifactAliasEntrySchema`, `ArtifactAliasArrayEntrySchema`, and the four response schemas). |
| **A** — status-builder artifact mock hardcoded `.rd-ctx-a`/`ARTIFACT_RUN_ID` | Mock now derives `contextId`/`runId` from the record, mirroring the sibling `toPublicArtifactVarValue` mock, so it no longer masks projection regressions. |
| **B** — caller-scoped stashed test asserted `vars` redaction but not `artifacts` | Seeded an artifact into that state and added `expect(result.artifacts).toBeUndefined()`, a genuine paired guard. |

Also documented the new artifact response discriminants in `docs/spec/cli-output.md`.

## Approach
TDD: for finding D (the behavioral change) tests were written first and confirmed RED for the right reason, then implemented to GREEN, then the CLI heuristic refactored.

## Validation
- `npm test -w packages/core` (3033 passed) and `npm test -w packages/cli` (2497 passed)
- `npm run check:types` for core + cli
- biome lint + format, typed eslint (the TSDoc gate)
- cspell on the changed files (note: `check:spell` no-ops inside a `.worktrees/` checkout because `.worktrees` is in `ignorePaths`)

## Notes
No persisted-state shape changed; the manifest row shape is untouched. `kind` is added only to the public CLI-output projection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI artifact responses (`ls`, `path`, `uri`, `inspect`) now include a `kind` discriminant; array-bound aliases use `kind: 'artifact-array'` and scalar aliases retain their record kind.

* **Bug Fixes**
  * Artifact path rendering now uses each artifact’s context/run identifiers so printed paths reflect the originating record.

* **Documentation**
  * CLI output spec clarified `kind` usage and discriminant behavior.

* **Tests**
  * Expanded coverage to assert `kind` presence and correct behavior across outputs and alias/array scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->