### PR TITLE
[codex] Reset reopened substep state

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -250,3 +250,5 @@ zod
 redir
 gitevil
 desugars
+generalising
+nondelegated

--- a/docs/internal/plans/substep-reopen-plan.md
+++ b/docs/internal/plans/substep-reopen-plan.md
@@ -1,0 +1,857 @@
+# Substep `reset-on-reopen` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a RETRY or intra-frame GOTO re-opens a substep, reset the re-opened substep rows (`status -> 'pending'`, `result -> undefined`) in the active frame so the persisted `substepStates` projection cannot show a stale `done` from a prior attempt.
+
+**Architecture:** Add one pure core helper, `resetReopenedSubsteps`, and call it from the two machine seams that re-open substeps inside the same `frameKey`: the RETRY hook (generalising the existing delegated-only reset to all substeps) and the intra-frame substep-GOTO assign in the compiler. Once both seams reset, collapse the reader-side duplicate guard back to a plain `status === 'done'` check. An optional later phase adds a `resolvedAtEntry` entry stamp to the `done` variant to make stale `done` unrepresentable by construction.
+
+**Tech Stack:** TypeScript, XState v5 (`5.32.0`), Zod, Jest. All production code lives in `@rundown-org/core` (`packages/core/src/runbook`), except the reader collapse in `@rundown-org/cli`. The reset is **Category B** (pure computation over context) per `CLAUDE.md` § Side-effect categorisation — it belongs in the machine via `runbookSetup.assign(...)`, never in `actor-service` or the CLI.
+
+---
+
+## Source-of-truth reference (verified against the current tree, 2026-06-05)
+
+Line numbers in the design doc (`docs/internal/substep-reopen-design.md`) were re-verified. Drift found and corrected below; cite **these** locations when implementing.
+
+| Symbol | Design says | Actual (current tree) | Status |
+|---|---|---|---|
+| `SubstepState` interface | `types.ts:602-609` | `packages/core/src/runbook/types.ts:602-609` | matches |
+| `RunbookState.activeEntry` | `types.ts:962` | `packages/core/src/runbook/types.ts:962` | matches |
+| `ResolvedCompletion.targetEntry` | `types.ts:629` | `packages/core/src/runbook/types.ts:629` | matches |
+| Both `SubstepState` Zod schemas | `schemas.ts:481-488` and `:951-960` | **`packages/core/src/schemas.ts`** `481-488` (`SubstepStateSchema`, status enum :484) and `951-960` (`makeSubstepStateSchema`, status enum :955) | line numbers match; **path drift** — the file is `packages/core/src/schemas.ts`, not `packages/core/src/runbook/schemas.ts` |
+| `retrySingleSubstep` delegated reset | `retry-hook.ts:168-171` | `packages/core/src/runbook/retry-hook.ts:168-172` | matches |
+| `retrySingleSubstep` delegation gate | `retry-hook.ts:153` | `packages/core/src/runbook/retry-hook.ts:153` (`if (!ss.delegation) return { status: 'skipped' }`) | matches |
+| `buildSimpleGotoAssign` | `compiler.ts:1261-1290` | `packages/core/src/runbook/compiler.ts:1261-1290` | matches |
+| Static GOTO call site | (implied) | `packages/core/src/runbook/compiler.ts:2819` (inside `buildGotoTransition`) | located |
+| **Live event-driven GOTO call site** | (implied) | `packages/core/src/runbook/compiler.ts:3948` (inside `buildGotoTransitionsForState`, the `forStepForTarget ? … : buildSimpleGotoAssign(…)` branch starting :3866) | located — this is the seam that fires on `rd goto` |
+| `findNextStateId` substep advance | `compiler.ts:1370` | `packages/core/src/runbook/compiler.ts:1370` | matches |
+| `isLastSubstepOfStep` aggregation | `compiler.ts:957-958` | `packages/core/src/runbook/compiler.ts:948-959` (the `lastSubstepId` compare is :957-958) | matches |
+| `initializeActiveSubsteps` | `actor-service.ts:948` | `packages/core/src/runbook/actor-service.ts:948` | matches |
+| `buildConsumedCompletionPatch` (delete on consume) | `actor-service.ts:898-915`, delete `:913` | `packages/core/src/runbook/actor-service.ts:898-915`, delete `:913` | matches |
+| Same-frame row preservation | `state.ts:707-717` | **`packages/core/src/runbook/state.ts:761-786`** (`initializeSubsteps`; same-frame preserve at :772-784) | **drift** — `state.ts:707-717` is now `loadSession`, unrelated |
+| `recordManualCompletion` `done` write | `completion-service.ts:425` | `packages/core/src/runbook/completion-service.ts:425` (inside `recordManualCompletionUnlocked`, upsert :421-426) | matches |
+| `completion-service` duplicate guard | "(unmerged, PR #383)" — `substepStates.status === 'done'` gate | **Not present on current tree.** The live duplicate guard is `findExistingCompletion`-based (`recordManualCompletionUnlocked`, `completion-service.ts:400-404`), checking `resolvedCompletions`, **not** `substepStates.status`. No `isActiveCursorTarget` symbol exists in the tree. | **drift** — PR #383's gate is genuinely unmerged; see "PR #383 note" below |
+| `delegation-inference` reader | `delegation-inference.ts:111` `isSubstepDone` | `packages/core/src/runbook/delegation-inference.ts:104-112` (`status === 'done'` at :111) | matches |
+| `run.ts` delegation pre-check | `run.ts:421` + self-guard `:427-439` | `packages/cli/src/commands/run.ts:420-444` (`status === 'done'` at :421; cursor-advance self-guard :427-444) | matches |
+| `collect.ts` all-resolved check | `collect.ts:231` | `packages/cli/src/commands/collect.ts:226-237` (`findSubstepState` :230, status check :231) | matches |
+| `completeSubstep` (no prod caller) | "test/repair only" | `packages/core/src/runbook/state.ts:832` — only definition; no production caller found | matches |
+| `CURRENT_SCHEMA_VERSION` | (entry-stamp phase) | `packages/core/src/runbook/state.ts:52` (`= 1`); checked at `state.ts:405-408`; `schemaVersion` Zod at `schemas.ts:721` | located |
+
+**Helper exports the new code composes with** (all in `packages/core/src/runbook/targeting.ts`):
+- `FrameKey` (branded string) — `targeting.ts:20`
+- `buildFrameKey(step, iteration?)` — `targeting.ts:167`
+- `findSubstepState(substepStates, substepId, frameKey)` — `targeting.ts:325`
+- `upsertSubstepState(substepStates, substepId, frameKey, patch)` — `targeting.ts:361` (an explicit `result: undefined` in the patch removes the field; see `applySubstepStatePatch` :337-345)
+
+**`ResolvedStep` / substep guard:** `resolvedStepHasSubsteps(step)` and `ResolvedStepHavingSubsteps` are imported from `./types.js` (used throughout `compiler.ts` and `retry-hook.ts`).
+
+### PR #383 note (sequencing)
+
+Design §7.1 says "land PR #383 first" and §7.2.4 says "revert #383's gate atomically." On the **current tree PR #383 is not merged** and its `substepStates.status === 'done'` cursor gate does not exist. Two consequences for this plan:
+
+1. **Phase 0 (land #383) is treated as a pre-condition, not a task in this plan.** If #383 lands before this work starts, Phase 4 (the gate-revert) applies as written. If #383 does **not** land first, Phase 4 becomes a no-op verification step (there is no cursor gate to revert) — but the regression scenarios in Phase 4 still MUST run and stay green, because they are the gate that proves the source-side reset is sufficient.
+2. The plan does not depend on #383's code being present. Each phase below is self-contained against the current tree.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `packages/core/src/runbook/substep-reset.ts` | New module: the pure `resetReopenedSubsteps` helper. One responsibility, no machine/service/CLI awareness. | Create |
+| `packages/core/__tests__/runbook/substep-reset.test.ts` | Unit tests for the pure helper. | Create |
+| `packages/core/src/runbook/retry-hook.ts` | RETRY seam: lift the status mutation out of the delegation-only branch into the shared helper; reset all re-opened substeps; preserve #382's delegation re-issue / `in_flight` coordination. | Modify (`retrySingleSubstep` :137-216; `runRetryHook` :244-368) |
+| `packages/core/__tests__/runbook/retry-single-substep.test.ts` | Pin RETRY reset of non-delegated substeps. | Modify |
+| `packages/core/src/runbook/compiler.ts` | GOTO seam: reset `substepStates` for intra-frame substep targets (`index >= N`, active `frameKey`) in the live event-driven GOTO assign (:3866-3955) and the static GOTO assign (:2819). | Modify |
+| `packages/core/__tests__/runbook/substep-reopen-machine.test.ts` | New machine-level pure `transition()` tests for RETRY + GOTO reset (the primary tests per design §8). | Create |
+| `runbooks/for-loops/`, `runbooks/goto/`, `runbooks/transitions/` | New scenario fixtures: RETRY/GOTO over a non-delegated substep that carried a prior result. | Create |
+| `packages/cli/src/commands/run.ts` (+ `collect.ts`, `completion-service.ts` if #383 landed) | Phase 4: collapse the cursor gate (if present) back to plain `status === 'done'`. | Modify (conditional) |
+| `packages/core/src/runbook/types.ts`, `packages/core/src/schemas.ts`, readers | Phase 5 (optional follow-up): entry stamp. | Modify |
+
+---
+
+## Phase 1: The pure `resetReopenedSubsteps` helper
+
+The shared reset both seams call. Pure: takes the active step, frame key, an inclusive "from" substep id, and the current `substepStates`; returns a new array with frame-scoped rows at `index >= N` reset to pending. Per design §5: reset **N through end-of-frame**, scoped to the active `frameKey`; leave earlier substeps and other frames untouched.
+
+### Task 1: `resetReopenedSubsteps`
+
+**Files:**
+- Create: `packages/core/src/runbook/substep-reset.ts`
+- Test: `packages/core/__tests__/runbook/substep-reset.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/core/__tests__/runbook/substep-reset.test.ts
+import { describe, expect, it } from '@jest/globals';
+import { resetReopenedSubsteps } from '../../src/runbook/substep-reset.js';
+import { buildFrameKey } from '../../src/runbook/targeting.js';
+import type { ResolvedStep, SubstepState } from '../../src/runbook/types.js';
+
+const step: ResolvedStep = {
+  name: '1',
+  description: 'Step 1',
+  kind: 'plain',
+  transitions: {
+    pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+    fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+  },
+  substeps: [
+    { id: 'a', description: 'A', transitions: { pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } }, fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } } } },
+    { id: 'b', description: 'B', transitions: { pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } }, fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } } } },
+    { id: 'c', description: 'C', transitions: { pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } }, fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } } } },
+  ],
+} as unknown as ResolvedStep;
+
+const frame = buildFrameKey('1');
+
+function done(id: string, result: 'pass' | 'fail'): SubstepState {
+  return { id, frameKey: frame, status: 'done', result };
+}
+
+describe('resetReopenedSubsteps', () => {
+  it('resets the from-substep and all later substeps in the active frame to pending, clearing result', () => {
+    const before: SubstepState[] = [done('a', 'pass'), done('b', 'fail'), done('c', 'pass')];
+    const after = resetReopenedSubsteps(step, frame, 'b', before);
+    expect(after).toEqual([
+      done('a', 'pass'),
+      { id: 'b', frameKey: frame, status: 'pending' },
+      { id: 'c', frameKey: frame, status: 'pending' },
+    ]);
+  });
+
+  it('leaves substeps before N untouched', () => {
+    const before: SubstepState[] = [done('a', 'pass'), done('b', 'fail'), done('c', 'pass')];
+    const after = resetReopenedSubsteps(step, frame, 'b', before);
+    expect(after[0]).toEqual(done('a', 'pass'));
+  });
+
+  it('resets only the from-substep when it is last (self-loop on last)', () => {
+    const before: SubstepState[] = [done('a', 'pass'), done('b', 'pass'), done('c', 'pass')];
+    const after = resetReopenedSubsteps(step, frame, 'c', before);
+    expect(after).toEqual([done('a', 'pass'), done('b', 'pass'), { id: 'c', frameKey: frame, status: 'pending' }]);
+  });
+
+  it('leaves rows in other frames untouched', () => {
+    const otherFrame = buildFrameKey('1', 2);
+    const before: SubstepState[] = [
+      done('a', 'pass'),
+      { id: 'b', frameKey: otherFrame, status: 'done', result: 'pass' },
+    ];
+    const after = resetReopenedSubsteps(step, frame, 'a', before);
+    expect(after).toEqual([
+      { id: 'a', frameKey: frame, status: 'pending' },
+      { id: 'b', frameKey: otherFrame, status: 'done', result: 'pass' },
+    ]);
+  });
+
+  it('preserves a delegation record on a reset row (status/result reset only)', () => {
+    const before: SubstepState[] = [
+      { id: 'a', frameKey: frame, status: 'done', result: 'pass', delegation: { token: 't' } as never },
+    ];
+    const after = resetReopenedSubsteps(step, frame, 'a', before);
+    expect(after[0]).toEqual({ id: 'a', frameKey: frame, status: 'pending', delegation: { token: 't' } });
+  });
+
+  it('returns the input unchanged when fromSubstepId is not a declared substep', () => {
+    const before: SubstepState[] = [done('a', 'pass')];
+    const after = resetReopenedSubsteps(step, frame, 'zzz', before);
+    expect(after).toEqual(before);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test --workspace @rundown-org/core -- substep-reset`
+Expected: FAIL — `resetReopenedSubsteps is not a function` / module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// packages/core/src/runbook/substep-reset.ts
+/**
+ * Pure reset of re-opened substep rows for the "reset-on-reopen" behaviour.
+ *
+ * @module
+ */
+
+import { resolvedStepHasSubsteps, type ResolvedStep, type SubstepState } from './types.js';
+import type { FrameKey } from './targeting.js';
+
+/**
+ * Reset a re-opened substep — and every later substep in the same frame — to a
+ * clean `pending` slate.
+ *
+ * On RETRY or intra-frame GOTO the machine resumes at `fromSubstepId` and walks
+ * forward, re-prompting that substep through the last substep of the step. This
+ * helper makes the persisted projection match that forward walk: every row in
+ * the active `frameKey` whose substep index is `>= index(fromSubstepId)` is
+ * reset to `{ status: 'pending' }` with any prior `result` removed. Rows in
+ * other frames, and rows before `fromSubstepId`, are returned untouched.
+ * Non-status/result fields (notably `delegation`, `inline`) are preserved.
+ *
+ * Pure: no machine, service, or CLI awareness. Category B (computation over
+ * context) per `CLAUDE.md`.
+ *
+ * @param step - The active step whose substeps are being re-walked.
+ * @param frameKey - The active frame key scoping the reset (FOR iteration aware).
+ * @param fromSubstepId - Inclusive start substep id; this row and all later
+ *   same-frame rows are reset.
+ * @param substepStates - Current substep states.
+ * @returns A new array with the re-opened rows reset; the input array is never
+ *   mutated. If `fromSubstepId` is not a declared substep of `step`, or `step`
+ *   has no substeps, the input is returned unchanged.
+ */
+export function resetReopenedSubsteps(
+  step: ResolvedStep,
+  frameKey: FrameKey,
+  fromSubstepId: string,
+  substepStates: readonly SubstepState[],
+): readonly SubstepState[] {
+  if (!resolvedStepHasSubsteps(step)) return substepStates;
+  const orderedIds = step.substeps.map((substep) => substep.id);
+  const fromIndex = orderedIds.indexOf(fromSubstepId);
+  if (fromIndex === -1) return substepStates;
+  const reopened = new Set(orderedIds.slice(fromIndex));
+
+  return substepStates.map((ss) => {
+    if (ss.frameKey !== frameKey || !reopened.has(ss.id)) return ss;
+    if (ss.status === 'pending' && ss.result === undefined) return ss;
+    const { result, ...rest } = ss;
+    void result;
+    return { ...rest, status: 'pending' as const };
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test --workspace @rundown-org/core -- substep-reset`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Verify lint/format/types**
+
+Run: `npm run check:lint:fast --workspace @rundown-org/core && npm run check:format`
+Expected: clean. Confirm TSDoc is present on the exported function (CLAUDE.md TSDoc standard).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/runbook/substep-reset.ts packages/core/__tests__/runbook/substep-reset.test.ts
+git commit -m "feat(core): add pure resetReopenedSubsteps helper for substep reset-on-reopen"
+```
+
+---
+
+## Phase 2: RETRY seam — reset all re-opened substeps
+
+Today `retrySingleSubstep` (`retry-hook.ts:137`) resets a substep only when it carries a `delegation` record (gated at :153 `if (!ss.delegation) return { status: 'skipped' }`; reset at :168-172). The shared reset must cover **non-delegated** substeps too, while leaving #382's delegation re-issue / `in_flight` / RD-823 coordination exactly where it is.
+
+**Design constraint (§4.1, §6, §9):** lift the *status mutation* into the shared helper; keep the delegation re-issue logic in place. The cleanest seam is `runRetryHook` (`retry-hook.ts:244`), which already owns the active `frameKey` (derived :255-259) and the parent step (`parentStep`). Apply the shared reset there over **all** of the parent's substeps for the active frame, then run the existing per-substep delegation loop. The per-substep delegated reset at :168-172 becomes redundant once the frame is reset up front, but leave the delegation re-issue (the `retryDelegation` call and frontier assembly) untouched.
+
+### Task 2: Reset non-delegated substeps on RETRY
+
+**Files:**
+- Modify: `packages/core/src/runbook/retry-hook.ts` (`runRetryHook` :244-368; `retrySingleSubstep` reset :164-194)
+- Test: `packages/core/__tests__/runbook/retry-single-substep.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/core/__tests__/runbook/retry-single-substep.test.ts` (or a new `retry-hook-reset.test.ts` if the existing file is delegation-only — check its imports first). This test calls `runRetryHook` directly with a non-delegated `done` substep in the active frame and asserts it is reset.
+
+```typescript
+import { describe, expect, it } from '@jest/globals';
+import { runRetryHook } from '../../src/runbook/retry-hook.js';
+import { buildFrameKey } from '../../src/runbook/targeting.js';
+import type { RunbookContext } from '../../src/runbook/compiler.js';
+import type { ResolvedStepHavingSubsteps, ResolvedStep, SubstepState } from '../../src/runbook/types.js';
+
+// A parent step with two NON-delegated substeps.
+const parentStep = {
+  name: '1',
+  description: 'Parent',
+  kind: 'plain',
+  transitions: {
+    pass: { kind: 'pass', retry: 1, action: { type: 'CONTINUE' } },
+    fail: { kind: 'fail', retry: 1, action: { type: 'RETRY' } },
+  },
+  substeps: [
+    { id: 'a', description: 'A', transitions: { pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } }, fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } } } },
+    { id: 'b', description: 'B', transitions: { pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } }, fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } } } },
+  ],
+} as unknown as ResolvedStepHavingSubsteps;
+
+const frame = buildFrameKey('1');
+
+describe('runRetryHook reset-on-reopen (non-delegated)', () => {
+  it('resets non-delegated done substeps in the active frame to pending', () => {
+    const substepStates: SubstepState[] = [
+      { id: 'a', frameKey: frame, status: 'done', result: 'fail' },
+      { id: 'b', frameKey: frame, status: 'done', result: 'pass' },
+    ];
+    const context = { substepStates, forStack: [], templateVars: {}, variables: {} } as unknown as RunbookContext;
+    const result = runRetryHook(context, parentStep, [parentStep as unknown as ResolvedStep]);
+    expect(result.status).toBe('success');
+    if (result.status !== 'success') return;
+    expect(result.substepStates).toEqual([
+      { id: 'a', frameKey: frame, status: 'pending' },
+      { id: 'b', frameKey: frame, status: 'pending' },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test --workspace @rundown-org/core -- retry-single-substep`
+Expected: FAIL — `result.substepStates` still shows `status: 'done'` for the non-delegated substeps (current code skips them at :153).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `runRetryHook` (`retry-hook.ts:244`), after the `working` object is built (:272-279) and before the delegation loop (:306), reset the whole active frame using the shared helper. Add the import at the top of the file (alongside the existing `./targeting.js` import :24):
+
+```typescript
+import { resetReopenedSubsteps } from './substep-reset.js';
+```
+
+Then in `runRetryHook`, change the `working.substepStates` seed to the reset array. The active frame is re-opened from its first substep on RETRY (the whole iteration re-walks), so reset from `parentStep.substeps[0].id`:
+
+**Why reset from `substeps[0]` (whole frame), not from a single substep:** a parent-step RETRY re-walks the entire iteration — the existing delegation re-issue loop already iterates **all** of `parentStep.substeps` (`retry-hook.ts:306`), so every substep in the active frame is re-opened, not just a failed one. Resetting from index 0 therefore matches the machine's re-entry exactly. (This is the one place the plan deviates from design §4.1's `fromSubstepId`-scoped framing; the wider scope is correct here because RETRY's scope *is* the whole frame, unlike GOTO which lands at an arbitrary N.)
+
+```typescript
+  // Reset the whole active frame to pending before re-issuing delegations.
+  // RETRY re-walks ALL of the parent's substeps (the loop at :306 iterates
+  // every substep), so the whole frame is re-opened; the persisted projection
+  // must match (design §4.1, §5). Non-delegated substeps are now reset here;
+  // the delegation re-issue loop below preserves #382's in_flight / RD-823
+  // coordination unchanged.
+  const resetStates =
+    parentStep.substeps.length > 0
+      ? resetReopenedSubsteps(parentStep, activeFrameKey, parentStep.substeps[0].id, substepStates)
+      : substepStates;
+
+  let working: RetryWorkingState = {
+    step: parentStep.name,
+    substepStates: resetStates,
+    templateVars: brandInitialTemplateVars(asTemplateVars(context.templateVars)),
+    forStack: context.forStack,
+    activeFrameKey,
+    variables: brandStoredOutputs(context.variables),
+  };
+```
+
+Note: the orphan-delegation guard (:289-304) reads the original `substepStates` (status-agnostic — it checks `delegation !== undefined`), so it is unaffected by the reset. The per-substep delegated reset at :168-172 in `retrySingleSubstep` is now redundant but harmless (it re-resets an already-pending row); leave it in place this task to keep the delegation branch's diff minimal, or remove it as a follow-up cleanup. Do **not** touch the `retryDelegation` call, the frontier assembly, or the `in_flight` handling.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test --workspace @rundown-org/core -- retry-single-substep`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full retry/delegation suite for regressions**
+
+Run: `npm test --workspace @rundown-org/core -- retry-hook retry-single-substep retry-delegation`
+Expected: PASS — the #382 delegation re-issue tests still green (no change to delegation coordination).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/runbook/retry-hook.ts packages/core/__tests__/runbook/retry-single-substep.test.ts
+git commit -m "feat(core): reset non-delegated substeps on RETRY via shared helper"
+```
+
+---
+
+## Phase 3: GOTO seam — reset intra-frame substep targets
+
+Add a `substepStates` reset to the intra-frame substep-GOTO assign. Per design §4.1 / §5: gate to **intra-frame substep targets only** — a cross-step GOTO lands in a different frame handled by `initializeActiveSubsteps` (`actor-service.ts:948`) and must reset nothing. Scope: reset `index >= N` within the active `frameKey`.
+
+The live, event-driven seam is `buildGotoTransitionsForState` in `compiler.ts:3866-3955`. Each target's `actions` is either a FOR-step assign (`forStepForTarget ? runbookSetup.assign({…})` :3892) or `buildSimpleGotoAssign({…})` (:3948). The substep target id is `target.substepId` (and the event may override via `event.target.substep`). The reset must be added to **both** branches because an intra-frame GOTO can land on a FOR-step substep (FOR branch) or a plain-step substep (simple branch).
+
+**Frame key at GOTO time:** for a self/backward GOTO that stays in the same frame, the active frame key is derived from `context.forStack` + the target step name (same logic as `runRetryHook` :255-259). Because the reset must only fire when the target frame equals the *current* frame (intra-frame), compute the candidate target frame and the current frame inside the assign and reset only when they match. Add a `substepStates` key to the assign whose resolver:
+
+1. reads `context.substepStates`, `context.forStack`;
+2. determines the target step + substep from the event (`event.type === 'GOTO' ? event.target : …`) falling back to the build-time `target`;
+3. derives `targetFrameKey = buildFrameKey(targetStepName, activeIteration?)` and `currentFrameKey` from `context.forStack`;
+4. if `targetStepName !== config.stepName` (cross-step) OR `targetFrameKey !== currentFrameKey`, returns `context.substepStates` unchanged;
+5. otherwise returns `resetReopenedSubsteps(targetStep, currentFrameKey, resolvedSubstepId, context.substepStates)`.
+
+Keep this as a **named/parameterised assign helper**, not a `switch(event.type)` inside one shared action (design §4.1; xstate-patterns.md anti-pattern "`switch(event.type)` inside actions"). Concretely: write a small builder `buildSubstepGotoResetAssignValue({ step, stepName, fallbackSubstepId })` that returns the resolver function, used as the `substepStates` value in both the FOR-branch `runbookSetup.assign({…})` and inside `buildSimpleGotoAssign`.
+
+> **Type note (do NOT reuse `GotoAssignValue`).** The existing `GotoAssignValue<T> = T | ((args: { event: RunbookEvent }) => T)` (`compiler.ts:1246`) supplies **only `event`** to its function form. This resolver needs **`context`** as well (it reads `context.substepStates` and `context.forStack` to derive the active `frameKey` and scope the reset). Typing the new option as `GotoAssignValue<readonly SubstepState[]>` is a compile error: calling it with the fresh literal `{ context, event }` fails excess-property checking against `(args: { event }) => T`. Give the option its own context-bearing type instead:
+>
+> ```typescript
+> type SubstepGotoResetAssignValue = (
+>   args: { context: RunbookContext; event: RunbookEvent },
+> ) => readonly SubstepState[];
+> ```
+>
+> The FOR-branch `runbookSetup.assign({ substepStates: ({ context, event }) => … })` form is unaffected — XState assign resolvers receive the full `{ context, event }` natively; the typing constraint is isolated to routing the value through `buildSimpleGotoAssign`'s option.
+
+### Task 3: GOTO intra-frame substep reset
+
+**Files:**
+- Modify: `packages/core/src/runbook/compiler.ts` (`buildSimpleGotoAssign` :1261-1290; `buildGotoTransitionsForState` :3866-3955; static `buildGotoTransition` simple branch :2804-2826)
+- Test: `packages/core/__tests__/runbook/substep-reopen-machine.test.ts` (created in Phase 3b below; the GOTO assertions are added here)
+
+- [ ] **Step 1: Write the failing machine-level test**
+
+Create `packages/core/__tests__/runbook/substep-reopen-machine.test.ts`. Use the pure `transition()` API per design §8 and xstate-patterns.md § transition(). Build a machine with a plain step `1` having substeps `a`, `b`, `c`, drive `a` and `b` to `done` via PASS, then send a backward `GOTO` to `1.a` and assert all three same-frame rows are reset.
+
+```typescript
+import { describe, expect, it } from '@jest/globals';
+import { createActor, transition } from 'xstate';
+import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
+import { buildFrameKey } from '../../src/runbook/targeting.js';
+import type { ResolvedStep, SubstepState } from '../../src/runbook/types.js';
+
+const sub = (id: string): ResolvedStep['substeps'][number] =>
+  ({
+    id,
+    description: id,
+    transitions: {
+      pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+      fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+    },
+  }) as never;
+
+const steps: ResolvedStep[] = [
+  {
+    name: '1',
+    description: 'Step 1',
+    kind: 'plain',
+    transitions: {
+      pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+      fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+    },
+    substeps: [sub('a'), sub('b'), sub('c')],
+  },
+  {
+    name: '2',
+    description: 'Step 2',
+    kind: 'plain',
+    transitions: {
+      pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+      fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+    },
+  },
+] as unknown as ResolvedStep[];
+
+const frame = buildFrameKey('1');
+
+function seedDoneRows(): SubstepState[] {
+  return [
+    { id: 'a', frameKey: frame, status: 'done', result: 'pass' },
+    { id: 'b', frameKey: frame, status: 'done', result: 'pass' },
+    { id: 'c', frameKey: frame, status: 'pending' },
+  ];
+}
+
+describe('substep reset-on-reopen (machine-level, pure transition)', () => {
+  it('GOTO backward to an earlier substep resets that substep and all later same-frame rows', () => {
+    const machine = compileRunbookToMachine(steps);
+    // Position the actor at substep 1.c with a/b marked done, then snapshot.
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'PASS' }); // a -> b
+    actor.send({ type: 'PASS' }); // b -> c
+    const atC = actor.getSnapshot();
+    actor.stop();
+
+    // Inject the stale done rows the readers would see (the machine tracks
+    // position, not substepStates, so seed them onto the snapshot context).
+    const seeded = {
+      ...atC,
+      context: { ...atC.context, substepStates: seedDoneRows() },
+    } as typeof atC;
+
+    const [next] = transition(machine, seeded, {
+      type: 'GOTO',
+      target: { step: '1', substep: 'a' },
+    });
+
+    expect(next.context.substepStates).toEqual([
+      { id: 'a', frameKey: frame, status: 'pending' },
+      { id: 'b', frameKey: frame, status: 'pending' },
+      { id: 'c', frameKey: frame, status: 'pending' },
+    ]);
+  });
+
+  it('cross-step GOTO does not reset substepStates of the previous frame', () => {
+    const machine = compileRunbookToMachine(steps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'PASS' });
+    const atB = actor.getSnapshot();
+    actor.stop();
+
+    const seeded = {
+      ...atB,
+      context: {
+        ...atB.context,
+        substepStates: [
+          { id: 'a', frameKey: frame, status: 'done', result: 'pass' },
+        ] as SubstepState[],
+      },
+    } as typeof atB;
+
+    const [next] = transition(machine, seeded, { type: 'GOTO', target: { step: '2' } });
+    expect(next.context.substepStates).toEqual([
+      { id: 'a', frameKey: frame, status: 'done', result: 'pass' },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test --workspace @rundown-org/core -- substep-reopen-machine`
+Expected: FAIL on the first test — `substepStates` still shows `a`/`b` as `done` (GOTO assign does not touch `substepStates` today). The cross-step test should already pass (cross-step GOTO touches nothing) — that confirms the gating direction before implementation.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `compiler.ts`:
+
+1. Import the helper near the top (with the other `./` imports):
+
+```typescript
+import { resetReopenedSubsteps } from './substep-reset.js';
+```
+
+2. Add a builder that returns the `substepStates` assign resolver (place it near `buildSimpleGotoAssign`, ~:1245):
+
+```typescript
+/**
+ * Build the `substepStates` assign value for an intra-frame substep GOTO.
+ *
+ * Returns a resolver that resets the target substep and all later same-frame
+ * substeps to `pending` when the GOTO lands within the current frame; returns
+ * the context's substepStates unchanged for cross-step or cross-frame targets
+ * (those frames are handled by `initializeActiveSubsteps`). Design §4.1/§5.
+ *
+ * @param step - The GOTO target step (must have substeps).
+ * @param currentStepName - The state's own step name (for intra-frame gating).
+ * @param fallbackSubstepId - Build-time substep id used when the event omits one.
+ * @returns A resolver `({ context, event }) => readonly SubstepState[]`.
+ */
+function buildSubstepGotoResetAssignValue(
+  step: ResolvedStep,
+  currentStepName: string,
+  fallbackSubstepId: string | undefined,
+) {
+  return ({
+    context,
+    event,
+  }: {
+    context: RunbookContext;
+    event: RunbookEvent;
+  }): readonly SubstepState[] => {
+    const substepStates = context.substepStates ?? [];
+    if (event.type !== 'GOTO') return substepStates;
+    const targetStepName = event.target.step;
+    // Intra-frame only: cross-step targets land in a different frame.
+    if (targetStepName !== currentStepName) return substepStates;
+    const resolvedSubstepId = event.target.substep ?? fallbackSubstepId;
+    if (!resolvedSubstepId) return substepStates;
+    // Current frame derives from forStack (FOR-iteration aware), matching
+    // the runRetryHook derivation (retry-hook.ts:255-259).
+    const top = peekForStack(context.forStack);
+    const frameKey = buildFrameKey(
+      currentStepName,
+      top && !top.implicit ? top.iteration : undefined,
+    );
+    return resetReopenedSubsteps(step, frameKey, resolvedSubstepId, substepStates);
+  };
+}
+```
+
+3. Wire it into the **simple** branch by extending `buildSimpleGotoAssign` options (:1261-1290) with `resetSubstepStates?: SubstepGotoResetAssignValue` (the context-bearing type defined above — **not** `GotoAssignValue`) and adding it to the returned assign object. The option is always a resolver function, so no `typeof`/literal-value branch is needed:
+
+```typescript
+    substep: options.resolvedSubstepId,
+    ...(options.resetSubstepStates
+      ? {
+          substepStates: ({ context, event }: { context: RunbookContext; event: RunbookEvent }) =>
+            options.resetSubstepStates!({ context, event }),
+        }
+      : {}),
+```
+
+4. At the live event-driven simple-branch call site (:3948), pass `resetSubstepStates` only when `forStepForTarget` is falsy (plain step) **and** the target is a substep of the current step. `target.stepName`/`target.substepId` are known at build time here:
+
+```typescript
+          : buildSimpleGotoAssign({
+              lastAction: buildGotoLastActionFromEvent(target.substepId),
+              resolvedSubstepId: ({ event }: { event: RunbookEvent }) =>
+                event.type === 'GOTO' ? (event.target.substep ?? target.substepId) : undefined,
+              isGotoToSelf,
+              preserveParentRetryCount: isGotoToSelf,
+              resetSubstepStates:
+                target.substepId !== undefined
+                  ? buildSubstepGotoResetAssignValue(
+                      steps.find((s) => s.name === target.stepName) ?? config /* fallback */,
+                      config.stepName,
+                      target.substepId,
+                    )
+                  : undefined,
+            }),
+```
+
+   (Resolve the target step from `steps`; the `buildSubstepGotoResetAssignValue` resolver itself re-checks `event.target.step === currentStepName`, so a non-substep or cross-step target is a no-op.)
+
+   > **Confirm the current-step-name local.** The pseudocode above passes `config.stepName` as `currentStepName`. Verify the actual binding in scope at `buildGotoTransitionsForState` (:3866-3955) before relying on the name — the verified in-scope locals are `target.stepName`, `target.substepId`, and `steps`; the enclosing state's own step-name local was not separately confirmed. If it is not `config.stepName`, substitute whatever names the current state's step (the static branch at :2819 uses a `stepName` **parameter** — the event-driven branch's equivalent local is what to confirm).
+
+5. In the **FOR** branch (:3892-3947), add a `substepStates` key to the `runbookSetup.assign({…})` object using the same builder, resolving the FOR step via `forStepForTarget.step`:
+
+```typescript
+              substepStates: buildSubstepGotoResetAssignValue(
+                forStepForTarget.step,
+                config.stepName,
+                target.substepId,
+              ),
+```
+
+6. Mirror the `resetSubstepStates` wiring in the **static** `buildGotoTransition` simple branch (:2804-2826) for completeness, so a compiler-resolved GOTO (action `{ type: 'GOTO', target }`) resets too. The static branch knows `targetStepObj` and `resolvedSubstepId`; pass `resetSubstepStates: resolvedSubstepId !== undefined && targetStepObj.name === stepName ? buildSubstepGotoResetAssignValue(targetStepObj, stepName, resolvedSubstepId) : undefined`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test --workspace @rundown-org/core -- substep-reopen-machine`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Run the GOTO + compiler suites for regressions**
+
+Run: `npm test --workspace @rundown-org/core -- goto compiler`
+Expected: PASS — `goto-self`, `goto-transition.properties`, `compiler` unaffected (retryCount and FOR semantics unchanged; only `substepStates` is added).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/runbook/compiler.ts packages/core/__tests__/runbook/substep-reopen-machine.test.ts
+git commit -m "feat(core): reset intra-frame substepStates on substep GOTO"
+```
+
+### Task 3b: Self-loop and FOR-iteration machine coverage
+
+**Files:**
+- Test: `packages/core/__tests__/runbook/substep-reopen-machine.test.ts` (extend)
+
+- [ ] **Step 1: Add self-loop and FOR-frame-isolation tests**
+
+```typescript
+  it('self-loop GOTO N->N resets only N when N is last; resets N..end otherwise', () => {
+    // GOTO 1.b -> 1.b with a,b done, c pending: reset b and c, leave a done.
+    const machine = compileRunbookToMachine(steps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'PASS' }); // a -> b
+    const atB = actor.getSnapshot();
+    actor.stop();
+    const seeded = {
+      ...atB,
+      context: {
+        ...atB.context,
+        substepStates: [
+          { id: 'a', frameKey: frame, status: 'done', result: 'pass' },
+          { id: 'b', frameKey: frame, status: 'done', result: 'fail' },
+          { id: 'c', frameKey: frame, status: 'pending' },
+        ] as SubstepState[],
+      },
+    } as typeof atB;
+    const [next] = transition(machine, seeded, { type: 'GOTO', target: { step: '1', substep: 'b' } });
+    expect(next.context.substepStates).toEqual([
+      { id: 'a', frameKey: frame, status: 'done', result: 'pass' },
+      { id: 'b', frameKey: frame, status: 'pending' },
+      { id: 'c', frameKey: frame, status: 'pending' },
+    ]);
+  });
+```
+
+For the FOR-iteration case, build a FOR machine (`kind: 'for'`, `forClause: { start: 1, end: 2 }`) and assert a GOTO within iteration 2 resets only the `1|2` frame rows, leaving `1|1` (`buildFrameKey('1', 1)`) rows untouched. Model the fixture on the FOR machines already used in `compiler.test.ts` / `goto-self.test.ts`.
+
+- [ ] **Step 2: Run, verify pass, commit**
+
+Run: `npm test --workspace @rundown-org/core -- substep-reopen-machine`
+Expected: PASS.
+
+```bash
+git add packages/core/__tests__/runbook/substep-reopen-machine.test.ts
+git commit -m "test(core): cover self-loop and FOR-iteration GOTO reset isolation"
+```
+
+---
+
+## Phase 4: Scenario fixtures + atomic gate-revert (HIGHEST RISK)
+
+> **This is the highest-risk step (design §9).** The gate-revert is only safe once **both** reset seams (non-delegated RETRY *and* GOTO) are in place (Phases 2 + 3) and the goto/retry scenarios pass without any cursor gate. On the current tree there is no cursor gate to revert (PR #383 unmerged) — so the "revert" reduces to verifying the plain `status === 'done'` readers behave correctly end-to-end with the source-side reset. If #383 *did* land first, this phase reverts its `isActiveCursorTarget` gate back to the plain check, atomically with the scenarios green.
+
+### Task 4: End-to-end scenario fixtures
+
+**Files:**
+- Create: `runbooks/goto/goto-reopen-nondelegated.runbook.md`
+- Create: `runbooks/for-loops/for-retry-reopen-nondelegated.runbook.md`
+- Create: `runbooks/transitions/<one more, if a transitions-dir case is warranted>`
+
+These guard the `run.ts` / `collect.ts` / `delegation-inference.ts` reader exposures end-to-end: a RETRY/GOTO over a **non-delegated** substep that carried a prior `done` result, asserting it re-executes rather than being skipped (design §8).
+
+- [ ] **Step 1: Write a GOTO scenario fixture**
+
+Model on `runbooks/for-loops/for-retry-succeeds.runbook.md` (frontmatter `scenarios:` with `commands:` and `result:`). Author a runbook where a substep is resolved, then a backward GOTO re-opens it and it is re-resolved to `COMPLETE`. The scenario `commands` sequence must drive the re-walk; `result: COMPLETE` is the assertion.
+
+```markdown
+---
+name: goto-reopen-nondelegated
+description: Backward GOTO re-opens a resolved non-delegated substep; it re-executes
+scenarios:
+  reopen-and-complete:
+    commands:
+      - rd run --prompted goto-reopen-nondelegated.runbook.md
+      - rd pass            # 1.1 done
+      - rd fail            # 1.2 FAIL GOTO 1.1 — re-opens 1.1
+      - rd pass            # 1.1 again
+      - rd pass            # 1.2 again -> CONTINUE
+      - rd pass            # 2 -> COMPLETE
+    result: COMPLETE
+---
+# GOTO re-open
+
+## 1. Work
+### 1.1 First
+- PASS CONTINUE
+- FAIL STOP
+Do first.
+
+### 1.2 Second
+- PASS CONTINUE
+- FAIL GOTO 1.1
+Do second.
+
+## 2. Done
+- PASS COMPLETE
+All done.
+```
+
+- [ ] **Step 2: Write a RETRY scenario fixture**
+
+Create `runbooks/for-loops/for-retry-reopen-nondelegated.runbook.md` — a FOR step whose non-delegated substeps fail once, trigger RETRY, and pass on the retry, asserting the prior `done`/`fail` rows were reset so the retry re-walk reaches `COMPLETE`. Model on `for-retry-succeeds.runbook.md`.
+
+- [ ] **Step 3: Run the scenario runner**
+
+Run: `npm run build && npm run test:integration --workspace @rundown-org/cli -- scenario-runner`
+Expected: the new scenarios execute and reach their declared `result: COMPLETE`. (The scenario runner discovers runbooks from the repo-root `runbooks/` dir — see `packages/cli/__tests__/integration/scenario-runner.test.ts:60`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add runbooks/goto/goto-reopen-nondelegated.runbook.md runbooks/for-loops/for-retry-reopen-nondelegated.runbook.md
+git commit -m "test(scenarios): cover non-delegated substep re-open via GOTO and RETRY"
+```
+
+### Task 5: Atomic gate collapse / reader verification
+
+**Files:**
+- Modify (only if PR #383's gate is present): `packages/cli/src/commands/run.ts`, `packages/cli/src/commands/collect.ts`, `packages/core/src/runbook/completion-service.ts`
+- Verify (always): `packages/core/__tests__/runbook/completion-service.test.ts`
+
+- [ ] **Step 1: Determine whether the cursor gate exists**
+
+Run: `grep -rn "isActiveCursorTarget" packages/`
+- If **zero matches** (current tree): there is no gate to revert. Skip to Step 3 (verification only). The readers already use plain `status === 'done'` (`run.ts:421`, `collect.ts:231`, `delegation-inference.ts:111`), which is now correct because the reset clears stale `done`.
+- If **matches exist** (PR #383 landed): proceed to Step 2.
+
+- [ ] **Step 2: Collapse the gate (only if present)**
+
+Replace each `isActiveCursorTarget`-guarded `status === 'done'` check with the plain `status === 'done'` check, removing the gate helper. The plain check is still required for the double-pass case (because `resolvedCompletions` is consumed on apply — `buildConsumedCompletionPatch` delete at `actor-service.ts:913`). Do this in **one commit** together with confirming Phases 2 + 3 are present and the scenarios from Task 4 pass.
+
+- [ ] **Step 3: Run the gate-proving regression**
+
+Run: `npm test --workspace @rundown-org/core -- completion-service && npm run build && npm run test:integration --workspace @rundown-org/cli -- scenario-runner`
+Expected: PASS. The goto/retry scenarios staying green **without** a cursor gate is the proof that the source-side reset replaces the reader-side workaround (design §8 "Regression"). Per design §8, any cursor-gate-specific completion-service test cases relocate to the machine-level reset tests in Phase 3 — verify no completion-service test still asserts the gate's behaviour; if one does, move its intent to `substep-reopen-machine.test.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: collapse cursor gate to plain done check, proven by reset-on-reopen scenarios"
+```
+
+### Phase 4 verification gate (run before declaring core deliverable complete)
+
+- [ ] Run: `npm run verify`
+- [ ] Expected: format, spell, lint, and the full unit suite pass. Per `CLAUDE.md`, `npm run verify` MUST pass before push.
+
+---
+
+## Phase 5 (OPTIONAL FOLLOW-UP): Entry stamp — make stale `done` unrepresentable
+
+> **Separate, later increment (design §4.2, §7.3).** Phases 1-4 close the live exposure by convention. The entry stamp makes a forgotten reset *unrepresentable*: a `done` row carries `resolvedAtEntry`, and readers gate on `status === 'done' && resolvedAtEntry === state.activeEntry`. This **changes the persisted `SubstepState` shape**, so it requires a `schemaVersion` bump and rejects old state — per `CLAUDE.md`'s no-migration policy, breaking active runs is acceptable and preferred over shims. Do NOT start this phase until Phases 1-4 are merged and stable.
+
+This mirrors the existing `ResolvedCompletion.targetEntry` (`types.ts:629`) + `RunbookState.activeEntry` (`types.ts:962`) precedent.
+
+### Task 6: Add `resolvedAtEntry` to the `done` variant
+
+**Files:**
+- Modify: `packages/core/src/runbook/types.ts:602-609` (`SubstepState`)
+- Modify: `packages/core/src/schemas.ts:481-488` (`SubstepStateSchema`) and `:951-960` (`makeSubstepStateSchema`)
+- Modify: `packages/core/src/runbook/state.ts:52` (`CURRENT_SCHEMA_VERSION` bump from `1`)
+- Test: `packages/core/__tests__/runbook/substep-reset.test.ts`, `substep-reopen-machine.test.ts`
+
+- [ ] **Step 1: Write the failing schema/type test**
+
+Assert that the `done` variant carries `resolvedAtEntry: number` and that `pending`/`running` rows do not; assert both Zod schemas validate the stamped `done` shape and reject a `done` row missing `resolvedAtEntry`.
+
+- [ ] **Step 2: Make `SubstepState` a discriminated union on `status`**
+
+```typescript
+export type SubstepState =
+  | { readonly id: string; readonly frameKey: FrameKey; readonly status: 'pending'; readonly delegation?: StepDelegation; readonly inline?: StepInlineChild }
+  | { readonly id: string; readonly frameKey: FrameKey; readonly status: 'running'; readonly delegation?: StepDelegation; readonly inline?: StepInlineChild }
+  | { readonly id: string; readonly frameKey: FrameKey; readonly status: 'done'; readonly result: 'pass' | 'fail'; readonly resolvedAtEntry: number; readonly delegation?: StepDelegation; readonly inline?: StepInlineChild };
+```
+
+Update `upsertSubstepState` / `applySubstepStatePatch` (`targeting.ts:333-375`) to require `resolvedAtEntry` when patching to `done`, and `resetReopenedSubsteps` (which already drops `result` on reset — extend it to drop `resolvedAtEntry` too via the existing rest-spread).
+
+- [ ] **Step 3: Bump `CURRENT_SCHEMA_VERSION` and update both Zod schemas**
+
+Add `resolvedAtEntry: z.number().int().nonnegative()` to the `done` branch of both schemas (use a Zod discriminated union or refinement keyed on `status`). Bump `CURRENT_SCHEMA_VERSION` (`state.ts:52`). The existing rejection path (`state.ts:405-408`) handles old state with no migration.
+
+- [ ] **Step 4: Stamp at the write site and gate at the readers**
+
+- Write: `recordManualCompletion` upsert (`completion-service.ts:421-426`) sets `resolvedAtEntry: <activeEntry>` (the service already has `state.activeEntry` in scope — see :484).
+- Readers: `delegation-inference.ts:111`, `run.ts:421`, `collect.ts:231` gate on `status === 'done' && resolvedAtEntry === activeEntry`.
+
+- [ ] **Step 5: Run, verify, commit**
+
+Run: `npm run verify`
+Expected: PASS. Commit:
+
+```bash
+git add -A
+git commit -m "feat(core): stamp resolvedAtEntry on done substeps; gate readers on activeEntry (schemaVersion bump)"
+```
+
+---
+
+## Out of scope (track separately)
+
+- **Forward-skip GOTO** (`at 1.1, GOTO 1.3` skips 1.2, which stays `pending` forever) — pre-existing quirk independent of reset (design §5, §9). Reset N..end neither fixes nor worsens it.
+- **`evaluateSubstepAggregation` dead code** (`transition-handler.ts`) — test-only, no production caller (design §3.3); not touched here.
+- **`SubstepState.result` readers** — none live (design §3.3); the reset clears `result` but no live reader depends on it.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §4.1 behavioral reset → Phase 1 (helper), Phase 2 (RETRY seam), Phase 3 (GOTO seam). ✓
+- §4.2 entry stamp → Phase 5 (optional, separated). ✓
+- §5 GOTO frame-scope (N..end, intra-frame, FOR isolation) → Task 3, Task 3b. ✓
+- §6/§7.1 PR #383 → addressed via the "PR #383 note" + Task 5 conditional. ✓
+- §7 sequencing → Phases 1→2→3→4(scenarios+gate)→5. ✓
+- §8 test plan: machine-level pure `transition()` primary → Phase 3/3b; scenario fixtures → Task 4; regression (scenarios green without gate) → Task 5 Step 3; existing completion-service tests → Task 5 Step 3. ✓
+- §9 highest risk (atomic gate-revert) → called out at Phase 4 header and Task 5. ✓
+
+**Type consistency:** `resetReopenedSubsteps(step, frameKey, fromSubstepId, substepStates)` signature is identical across Phase 1 definition and all call sites (Phase 2 `runRetryHook`, Phase 3 `buildSubstepGotoResetAssignValue`). `FrameKey`, `findSubstepState`, `upsertSubstepState`, `buildFrameKey` all referenced from `targeting.ts` as exported. `buildSimpleGotoAssign`'s new option `resetSubstepStates` is typed with the **context-bearing** `SubstepGotoResetAssignValue = (args: { context: RunbookContext; event: RunbookEvent }) => readonly SubstepState[]` — **not** the existing event-only `GotoAssignValue<T>` (which omits `context` and would not compile; see the Phase 3 "Type note"). The resolver requires `context` for `substepStates` + `forStack`.
+
+**Placeholder scan:** No TBD/TODO. The one "fallback `/* fallback */`" in Task 3 Step 3 is a defensive default with the resolver re-checking the target — acceptable, the resolver no-ops on mismatch.

--- a/docs/internal/substep-reopen-design.md
+++ b/docs/internal/substep-reopen-design.md
@@ -1,0 +1,291 @@
+# Design Proposal: Substep `reset-on-reopen`
+
+> Status: **Draft proposal** (not yet scheduled). Authored from an investigation +
+> dual independent agent verification on 2026-06-05.
+> Audience: contributors to `packages/core/src/runbook` (the XState compiler and
+> completion/substep machinery).
+
+## 1. Summary
+
+A substep's persisted lifecycle status (`SubstepState.status: 'pending' | 'running' | 'done'`)
+is **never reset when a RETRY or intra-frame GOTO re-opens the substep**. The prior
+attempt's `done` status (and its `result`) stay in place. This is not an execution
+bug — the state machine re-walks and re-prompts re-opened substeps correctly — but it
+leaves the **persisted projection stale**, which a handful of out-of-band readers
+(CLI commands, a duplicate guard) can act on incorrectly.
+
+The proposal: make a re-opened substep's status reflect that it is re-opened, so
+`done` unambiguously means "resolved in the current attempt." This is done in **two
+machine seams** (RETRY and GOTO) via a shared reset, optionally hardened with a
+type-level entry stamp so a forgotten reset cannot lie.
+
+## 2. Background — why this is subtle
+
+Three facts combine to create the trap:
+
+1. **Substep rows are created once per frame and never reset.**
+   `initializeActiveSubsteps` (`packages/core/src/runbook/actor-service.ts:948`) is the
+   only producer of substep rows. It is gated by `frameKey` (`alreadyInitialized`,
+   ~`:967`) and skips re-initialization once a frame has rows. Even if it were
+   re-invoked, `state.ts:707-717` *preserves* existing same-frame rows. So nothing
+   walks a `done` row back to `pending` except an explicit reset.
+
+2. **RETRY and intra-frame GOTO stay in the same `frameKey`.** A RETRY of FOR
+   iteration 1 keeps `frameKey = 1|1`; a self-loop / backward GOTO keeps the parent
+   frame. So the re-opened substep's `done` row from the *previous* attempt survives.
+   (A *new* FOR iteration gets a fresh `frameKey` and a clean `pending` slate — which
+   is why iterations work cleanly and retries do not.)
+
+3. **Resolved completions are deleted on consume.** `buildConsumedCompletionPatch`
+   (`actor-service.ts:898-915`, delete at `:913`) removes a completion once the actor
+   applies it. After a substep resolves, `resolvedCompletions` is empty for it, so
+   `substepStates.status` is the **only durable record** that the substep was ever
+   resolved. That is why downstream code reads `status === 'done'` at all.
+
+The live `done` write for a manual `rd pass` / `rd fail` flows through
+`recordManualCompletion` → `upsertSubstepState(..., {status:'done', result})`
+(`completion-service.ts:425`). (`state.ts completeSubstep` exists but has **no
+production caller** on the current tree — test/repair only.)
+
+## 3. Verified findings
+
+These were confirmed by two independent agents, including empirical state dumps.
+
+### 3.1 The machine is already correct on re-open (this is *not* an execution bug)
+
+Substep progression is **positional, not status-driven**:
+
+- CONTINUE advances by index: `nextSubstep = currentStep.substeps[currentIndex + 1]`
+  (`compiler.ts:1370`); parent-advance guards key on `substepCompletedCount`/position,
+  not status.
+- Aggregation fires **structurally** when the last substep resolves
+  (`isLastSubstep`, `compiler.ts:957-958`).
+- There is **no "skip if already done" guard** on substep nodes; each leaf state simply
+  waits for a fresh `PASS`/`FAIL`/`RETRY`/`GOTO`.
+
+Empirically confirmed: after a backward GOTO onto a stale-`done` substep, the machine
+re-prompts it, accepts a fresh result, and **overwrites** the stale row. So the stale
+`done` never corrupts execution — it only affects readers that inspect the persisted
+projection *between* transitions.
+
+### 3.2 A partial reset already exists (delegated RETRY only)
+
+`retrySingleSubstep` (`retry-hook.ts`) already resets a re-opened substep to
+`{status:'pending', result:undefined}` (`:168-171`) — **but only when the substep
+carries a `delegation` record** (gated at `:153` `if (!ss.delegation) return {status:'skipped'}`).
+Non-delegated substeps are skipped ("the cursor-re-entry machinery handles their
+re-execution"). The GOTO path resets nothing: `buildSimpleGotoAssign`
+(`compiler.ts:1261-1290`) reassigns the cursor + retry counters but never touches
+`substepStates`.
+
+So "reset-on-reopen" is **completing a half-built mechanism**, not greenfield.
+
+### 3.3 The readers (smaller than first thought)
+
+Live readers of `SubstepState.status` that a stale `done` can affect:
+
+| # | Reader | Affected by stale `done`? |
+|---|--------|---------------------------|
+| 1 | `delegation-inference.ts:111` `isSubstepDone` | Yes — could mis-infer "already done" for delegate targeting |
+| 2 | `packages/cli/src/commands/run.ts:421` delegation pre-check | Yes, but **partially self-guarded** by a cursor-advance check (`run.ts:427-439`) |
+| 3 | `packages/cli/src/commands/collect.ts:231` all-resolved check | Yes — could treat a re-opened substep as resolved |
+| 4 | `completion-service.ts` duplicate guard (**unmerged**, PR #383) | Yes — the original symptom; see §6 |
+
+Corrections to earlier framing discovered during verification:
+
+- `evaluateSubstepAggregation` (`transition-handler.ts:158/164`) is **dead code**
+  (test-only; no production caller). The live ALL/ANY aggregation runs off
+  `deferredResults` (`compiler.ts:678`), **not** `substepStates`.
+- Consequently **`SubstepState.result` has zero live readers.**
+- `snapshot-utils.ts:21,33` (`snapshot.status === 'done'`) is the **XState actor**
+  status, not `SubstepState` — a false positive in any grep.
+
+Net: the genuine live exposure is `delegation-inference` and `collect` (with `run.ts`
+partially self-guarded), plus the unmerged #383 duplicate guard.
+
+### 3.4 Data model
+
+`SubstepState` (`types.ts:602-609`):
+
+```ts
+interface SubstepState {
+  readonly id: string;
+  readonly frameKey: FrameKey;     // buildFrameKey(step, iteration?)
+  readonly status: 'pending' | 'running' | 'done';
+  readonly result?: 'pass' | 'fail';
+  readonly delegation?: StepDelegation;
+  readonly inline?: StepInlineChild;
+}
+```
+
+No entry/attempt stamp — so a `done` from a prior attempt is structurally
+indistinguishable from a `done` in the current attempt within the same frame. The
+precedent for an entry stamp already exists elsewhere: `ResolvedCompletion.targetEntry`
+(`types.ts:629`) + `RunbookState.activeEntry` (`types.ts:962`). Two Zod schemas validate
+`SubstepState`: `schemas.ts:481-488` and `schemas.ts:951-960`.
+
+## 4. The design
+
+### 4.1 Behavioral reset (required)
+
+On **re-open**, reset the affected substep rows to `{status:'pending', result:undefined}`,
+scoped to the active `frameKey`, via a single shared helper:
+
+```ts
+// pseudocode — lives in core, called from the machine assigns
+function resetReopenedSubsteps(
+  step: ResolvedStep,
+  frameKey: FrameKey,
+  fromSubstepId: string,            // inclusive
+  substepStates: readonly SubstepState[],
+): readonly SubstepState[]
+```
+
+Two call sites:
+
+- **RETRY** — generalize the existing reset in `retrySingleSubstep` so it covers
+  *non-delegated* substeps too, while preserving PR #382's delegated-path coordination
+  (`allowLinkedChildRun` / `in_flight` / RD-823). Practically: lift the `substepStates`
+  mutation out of the delegation branch into the shared helper; keep the delegation
+  re-issue logic where it is.
+- **GOTO** — add a `substepStates` assign to the intra-frame substep-GOTO path
+  (around `buildSimpleGotoAssign`, `compiler.ts:1261`). Gate it to intra-frame substep
+  targets only (cross-step GOTO lands in a different frame handled by
+  `initializeActiveSubsteps`).
+
+Reset is **pure computation over context** (Category B in `CLAUDE.md`), so it belongs in
+the machine via `runbookSetup.assign(...)` — not in `actor-service` (a mirror) or the
+CLI. Use a named/parameterized assign (target id + frameKey via dynamic `params`); do
+**not** `switch(event.type)` inside one shared action.
+
+### 4.2 Entry stamp (optional, for a by-construction guarantee)
+
+The behavioral reset alone fixes the bug **by convention**: if a future re-open path
+forgets to call the reset, a stale `done` is still perfectly well-typed and the readers
+silently consume it. To make stale-`done` **unrepresentable**, add an entry stamp to the
+resolved variant and have readers compare it to the live cursor:
+
+```ts
+type SubstepState =
+  | { id; frameKey; status: 'pending'; ... }
+  | { id; frameKey; status: 'running'; ... }
+  | { id; frameKey; status: 'done'; result: 'pass' | 'fail'; resolvedAtEntry: number };
+// readers gate on: status === 'done' && resolvedAtEntry === state.activeEntry
+```
+
+This mirrors the existing `ResolvedCompletion.targetEntry` pattern. A stale `done`
+carries a stale `resolvedAtEntry` and fails the comparison, so a forgotten reset cannot
+produce a false positive. Cost: changes the persisted `SubstepState` shape (both Zod
+schemas) → a `schemaVersion` bump. Per `CLAUDE.md`'s no-migration policy, breaking active
+runs is acceptable and preferred over compatibility shims.
+
+Recommendation: ship §4.1 first (it closes the live exposure and consolidates the
+existing partial reset); treat §4.2 as a follow-up hardening increment.
+
+## 5. GOTO frame-scope semantics (the decision)
+
+When an intra-frame GOTO lands on substep **N**, reset **N through end-of-frame**
+(`index ≥ N`), scoped to the active `frameKey`. Leave substeps before N untouched. Leave
+other frames untouched.
+
+Rationale: the machine resumes at N and walks *forward*, re-prompting N, N+1, …, last.
+Resetting only N would leave N+1..last showing stale `done` to out-of-band readers in the
+window before they are re-resolved — a projection state **no execution path produces**
+(the machine never resumes at N while treating N+1 as final). Resetting N..end keeps the
+projection consistent with the machine's positional forward-walk, which is the entire
+justification for doing the reset.
+
+Cases:
+
+| Case | Behavior |
+|------|----------|
+| Self-loop `GOTO N→N` | reset N..end (just N if N is last) |
+| Backward `at 1.3, GOTO 1.1` | reset 1.1,1.2,1.3 — full re-walk |
+| FOR iteration | reset only the active frame's N..end; sibling iterations untouched |
+| Cross-step GOTO | **no substep reset** — different frame; reset gated to intra-frame substep targets |
+
+Out of scope: **forward GOTO** (`at 1.1, GOTO 1.3`) skips 1.2, which stays `pending`
+forever — a pre-existing forward-skip quirk independent of reset. Reset N..end neither
+fixes nor worsens it. Track separately.
+
+## 6. Interaction with in-flight work
+
+- **PR #382** (`codex/issue-374-retry-linked-child-guard`, **merged into `main`**):
+  adds `allowLinkedChildRun` + an `in_flight`/RD-823 path to the **delegation** re-issue
+  in `retrySingleSubstep`. It does **not** touch the substepStates reset. Interaction is
+  **textual only** (shared function): the §4.1 RETRY refactor must factor the status
+  mutation out while leaving #382's delegation coordination intact.
+
+- **PR #383** (`codex/issue-375-error-envelope-registry`, **unmerged**): the tactical
+  fix that started this thread. It wraps the original `substepStates.status === 'done'`
+  duplicate guard in an `isActiveCursorTarget` gate (so the check is skipped when the
+  cursor is *on* the target — the retry/goto re-open case). This is a **reader-side
+  workaround for the exact stale-`done` that reset fixes at the source.** With
+  reset-on-reopen, a re-opened substep is no longer `done`, so the gate becomes
+  redundant and the guard collapses back to the **plain** `status === 'done'` check
+  (still required for the double-pass case, since `resolvedCompletions` is consumed).
+  Reset **subsumes** #383's gate; the two are layered fixes for one bug, not conflicting.
+
+## 7. Implementation plan (sequenced)
+
+1. **Land PR #383 first.** It fixes live CI failures; the gate is correct and
+   self-contained. Do not block it on this design.
+2. **reset-on-reopen** (single change, on `main` after #383 merges):
+   1. Add `resetReopenedSubsteps(step, frameKey, fromSubstepId, substepStates)` helper
+      in core (pure).
+   2. **RETRY seam:** call it from `retrySingleSubstep` for all substeps (not only
+      delegated); preserve #382's delegation re-issue/`in_flight` handling.
+   3. **GOTO seam:** call it from the intra-frame substep-GOTO assign
+      (`buildSimpleGotoAssign` path), scope `index ≥ N` within the active `frameKey`,
+      gated to intra-frame substep targets.
+   4. **Revert #383's gate** back to the plain `status === 'done'` duplicate guard —
+      **atomically** with 2.2 + 2.3 landing and the scenario suite green (see §9 risk).
+3. **(Optional follow-up) Entry stamp** (§4.2): add `resolvedAtEntry` to the `done`
+   variant, update both Zod schemas, bump `schemaVersion`, switch the readers to compare
+   against `activeEntry`.
+
+## 8. Test plan
+
+- **Machine-level (primary), pure `transition()`** — per `docs/internal/xstate-patterns.md`
+  Testing: send `RETRY` / `GOTO` into a compiled machine and assert
+  `nextSnapshot.context.substepStates` has the re-opened entries reset to
+  `{status:'pending', result:undefined}` and earlier-than-N / other-frame entries
+  untouched. No actor, no persistence round-trip.
+- **New scenario fixtures** under `runbooks/for-loops/*retry*`, `runbooks/goto/*`,
+  `runbooks/transitions/*`: a RETRY/GOTO over a **non-delegated** substep that carried a
+  prior `done` result, asserting it re-executes rather than being skipped — these guard
+  the `run.ts` / `collect.ts` exposures end-to-end.
+- **Regression:** the goto/retry scenario suite must stay green **after the gate-revert**
+  (step 2.4) — this is the gate that proves the source-side reset replaces the
+  reader-side workaround.
+- **Existing:** `packages/core/__tests__/runbook/completion-service.test.ts` (the
+  retry-vs-duplicate tests that pin the discriminator) — once the gate is reverted, the
+  cursor-gate-specific cases relocate to the machine-level reset tests.
+
+## 9. Risks & open decisions
+
+- **Atomic gate-revert (highest risk).** Step 2.4 is only safe once **both** reset seams
+  (non-delegated RETRY *and* GOTO) are in place and the goto/retry scenarios pass without
+  the cursor-gate. Revert with only the RETRY seam reset and GOTO re-opens re-expose the
+  exact "suppress legitimate re-completion" bug #383 fixed.
+- **GOTO frame-scope** (decided in §5: N..end) — confirm no consumer wants
+  "patch N, keep N+1's result"; none found.
+- **#382 shared function.** Keep the delegation re-issue/`in_flight` logic intact when
+  factoring the status mutation out of `retrySingleSubstep`.
+- **No-migration.** Only the entry-stamp increment (§4.2) changes persisted shape; bump
+  `schemaVersion`, reject old state, no shim. The behavioral reset (§4.1) changes field
+  *values* within the existing shape — no migration concern.
+- **Forward-skip GOTO** quirk (§5) is pre-existing and out of scope; track separately.
+
+## 10. Alternatives considered
+
+- **Keep `substepStates` as a result-log; readers consult the cursor.** This is what
+  PR #383's gate does. Legitimate under the documented "`substepStates` is a mirror;
+  cursor is source-of-truth" contract, and cheaper — but the contract stays *implicit*,
+  so the next reader added repeats the bug (which is exactly how #383's regression
+  arose). Acceptable only paired with loud documentation at the `status` type and each
+  reader.
+- **Add a `'reopened'` status variant.** Buys little: the readers are `=== 'done'`
+  equality checks, not exhaustive switches, so a new member just evaluates `false`
+  silently while still leaving stale `done` representable. More surface for less safety
+  than the entry stamp.

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -332,6 +332,21 @@ interface RetryHandlerOptions {
   output: OutputEmitter;
 }
 
+interface RetryDelegationInFlightLike {
+  readonly status: 'in_flight';
+  readonly error: unknown;
+}
+
+function isRetryDelegationInFlightLike(result: unknown): result is RetryDelegationInFlightLike {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'status' in result &&
+    (result as { readonly status?: unknown }).status === 'in_flight' &&
+    'error' in result
+  );
+}
+
 /**
  * Result of resolving a `rd delegate --retry` invocation to a concrete target.
  *
@@ -559,11 +574,12 @@ async function executeRetry(target: ResolvedTarget, args: RetryHandlerOptions): 
     },
     targetSteps,
   );
+  const maybeInFlight: unknown = result;
+  if (isRetryDelegationInFlightLike(maybeInFlight)) throw maybeInFlight.error;
 
   switch (result.status) {
     case 'not_found':
     case 'not_current':
-    case 'in_flight':
     case 'error':
       // Rethrow so withErrorHandling's toRundownError -> stderr envelope
       // fires with the inner RundownError's code (RD-801 / RD-802 / inner

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -576,8 +576,9 @@ async function executeRetry(target: ResolvedTarget, args: RetryHandlerOptions): 
   );
   const maybeInFlight: unknown = result;
   if (isRetryDelegationInFlightLike(maybeInFlight)) throw maybeInFlight.error;
+  const retryResult = result as Exclude<typeof result, RetryDelegationInFlightLike>;
 
-  switch (result.status) {
+  switch (retryResult.status) {
     case 'not_found':
     case 'not_current':
     case 'error':
@@ -587,7 +588,7 @@ async function executeRetry(target: ResolvedTarget, args: RetryHandlerOptions): 
       // `throw result.error` pattern. M3 widened all three variants to
       // carry `error: RundownError`, so the dispatch collapses to a single
       // arm.
-      throw result.error;
+      throw retryResult.error;
     case 'retried':
       break;
     default: {
@@ -596,14 +597,14 @@ async function executeRetry(target: ResolvedTarget, args: RetryHandlerOptions): 
       // resolved value, so this compiles even though handleRetry is
       // declared as Promise<void>. Matches the create-path sibling at
       // line ~223 and the abort.ts / execution.ts patterns.
-      const _exhaustive: never = result;
+      const _exhaustive: never = retryResult;
       return _exhaustive;
     }
   }
 
   // 8. Persist updated substepStates.
   await manager.update(target.state.id, {
-    substepStates: result.updatedSubstepStates,
+    substepStates: retryResult.updatedSubstepStates,
   });
 
   // 9. Emit output.
@@ -612,16 +613,18 @@ async function executeRetry(target: ResolvedTarget, args: RetryHandlerOptions): 
       kind: 'delegate',
       action: 'retried',
       step: target.stepLabel,
-      runbook: result.delegation.childRunbookPath,
-      token: result.token,
-      token_hash: result.tokenHash,
+      runbook: retryResult.delegation.childRunbookPath,
+      token: retryResult.token,
+      token_hash: retryResult.tokenHash,
       parent_run_id: target.state.id,
     });
   } else {
-    output.message(`RETRIED    step ${target.stepLabel} -> ${result.delegation.childRunbookPath}`);
-    output.message(`Token:     ${result.token}`);
+    output.message(
+      `RETRIED    step ${target.stepLabel} -> ${retryResult.delegation.childRunbookPath}`,
+    );
+    output.message(`Token:     ${retryResult.token}`);
     output.message('');
-    output.message(`RD_CLAIM_TOKEN=${result.token}`);
+    output.message(`RD_CLAIM_TOKEN=${retryResult.token}`);
   }
 }
 

--- a/packages/core/__tests__/runbook/compiler.test.ts
+++ b/packages/core/__tests__/runbook/compiler.test.ts
@@ -12449,15 +12449,13 @@ echo ok
       expect(post3?.status).toBe('pending');
       expect(post3?.result).toBeUndefined();
 
-      // 1.2 has no delegation — it's skipped by the hook. Its state is
-      // preserved byte-for-byte from the prepared snapshot; the cursor-re-entry
-      // machinery handles it separately. A regression that touched non-delegated
-      // substeps would flip status or clear result here.
-      const pre2 = preparedSubsteps.find((ss) => ss.id === '2');
+      // 1.2 has no delegation — it's skipped for delegation re-issue, but the
+      // active frame is still re-opened. Its projection is reset so the
+      // cursor-re-entry machinery cannot see a stale done/result row.
       const post2 = ctx.substepStates?.find((ss) => ss.id === '2');
       expect(post2?.delegation).toBeUndefined();
-      expect(post2?.status).toBe(pre2?.status);
-      expect(post2?.result).toBe(pre2?.result);
+      expect(post2?.status).toBe('pending');
+      expect(post2?.result).toBeUndefined();
 
       actor.stop();
     });

--- a/packages/core/__tests__/runbook/retry-single-substep.test.ts
+++ b/packages/core/__tests__/runbook/retry-single-substep.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import type {
+  ResolvedStepHavingSubsteps,
   ResolvedStep,
   Substep,
   SubstepState,
   StepDelegation,
 } from '../../src/runbook/types.js';
+import type { RunbookContext } from '../../src/runbook/compiler.js';
 // TDD red state: RetryWorkingState WILL FAIL to import until Task 4 exports it.
 import type { RetryWorkingState } from '../../src/runbook/retry-hook.js';
 import { assertDelegationTokenHash } from '../../src/runbook/delegation-token.js';
@@ -19,7 +21,7 @@ jest.unstable_mockModule('../../src/runbook/delegation-service.js', () => ({
 
 const { retryDelegation } = await import('../../src/runbook/delegation-service.js');
 // TDD red state: retrySingleSubstep WILL FAIL to import until Task 4 exports it.
-const { retrySingleSubstep } = await import('../../src/runbook/retry-hook.js');
+const { retrySingleSubstep, runRetryHook } = await import('../../src/runbook/retry-hook.js');
 
 const mockedRetryDelegation = retryDelegation as jest.MockedFunction<typeof retryDelegation>;
 const HASH_TEST = assertDelegationTokenHash(`sha256:${'a'.repeat(64)}`);
@@ -303,5 +305,53 @@ describe('retrySingleSubstep', () => {
 
     // Input working must be unchanged (immutability)
     expect(working).toEqual(snapshot);
+  });
+});
+
+describe('runRetryHook reset-on-reopen (non-delegated)', () => {
+  beforeEach(() => {
+    mockedRetryDelegation.mockReset();
+  });
+
+  it('resets non-delegated done substeps in the active frame to pending', () => {
+    const substepTransitions = {
+      pass: { kind: 'pass' as const, retry: 0, action: { type: 'CONTINUE' as const } },
+      fail: { kind: 'fail' as const, retry: 0, action: { type: 'STOP' as const } },
+    };
+    const parentStep = {
+      name: '1',
+      description: 'Parent',
+      kind: 'substeps',
+      transitions: {
+        pass: { kind: 'pass' as const, retry: 1, action: { type: 'CONTINUE' as const } },
+        fail: { kind: 'fail' as const, retry: 1, action: { type: 'RETRY' as const } },
+      },
+      aggregation: { strategy: 'ALL' as const },
+      substeps: [
+        { kind: 'base' as const, id: 'a', description: 'A', transitions: substepTransitions },
+        { kind: 'base' as const, id: 'b', description: 'B', transitions: substepTransitions },
+      ],
+    } as unknown as ResolvedStepHavingSubsteps;
+    const frameKey = buildFrameKey('1');
+    const substepStates: SubstepState[] = [
+      { id: 'a', frameKey, status: 'done', result: 'fail' },
+      { id: 'b', frameKey, status: 'done', result: 'pass' },
+    ];
+    const context = {
+      substepStates,
+      forStack: [],
+      templateVars: {},
+      variables: {},
+    } as unknown as RunbookContext;
+
+    const result = runRetryHook(context, parentStep, [parentStep]);
+
+    expect(result.status).toBe('success');
+    if (result.status !== 'success') return;
+    expect(mockedRetryDelegation).not.toHaveBeenCalled();
+    expect(result.substepStates).toEqual([
+      { id: 'a', frameKey, status: 'pending' },
+      { id: 'b', frameKey, status: 'pending' },
+    ]);
   });
 });

--- a/packages/core/__tests__/runbook/substep-reopen-machine.test.ts
+++ b/packages/core/__tests__/runbook/substep-reopen-machine.test.ts
@@ -4,16 +4,14 @@ import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
 import { buildFrameKey } from '../../src/runbook/targeting.js';
 import type { ResolvedStep, Substep, SubstepState } from '../../src/runbook/types.js';
 
-const sub = (id: string): Substep =>
-  ({
-    kind: 'base',
-    id,
-    description: id,
-    transitions: {
-      pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
-      fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
-    },
-  }) as Substep;
+const sub = (id: string): Substep => ({
+  id,
+  description: id,
+  transitions: {
+    pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+    fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+  },
+});
 
 const steps = [
   {
@@ -30,13 +28,13 @@ const steps = [
   {
     name: '2',
     description: 'Step 2',
-    kind: 'plain',
+    kind: 'base',
     transitions: {
       pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
       fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
     },
   },
-] as unknown as ResolvedStep[];
+] satisfies ResolvedStep[];
 
 const frame = buildFrameKey('1');
 const frameOne = buildFrameKey('1', 1);
@@ -148,13 +146,13 @@ describe('substep reset-on-reopen (machine-level, pure transition)', () => {
       {
         name: '2',
         description: 'Done',
-        kind: 'plain',
+        kind: 'base',
         transitions: {
           pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
           fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
         },
       },
-    ] as unknown as ResolvedStep[];
+    ] satisfies ResolvedStep[];
     const machine = compileRunbookToMachine(forSteps);
     const actor = createActor(machine);
     actor.start();
@@ -180,6 +178,66 @@ describe('substep reset-on-reopen (machine-level, pure transition)', () => {
     const [next] = transition(machine, seeded, {
       type: 'GOTO',
       target: { step: '1', substep: 'a' },
+    });
+
+    expect(next.context.substepStates).toEqual([
+      { id: 'a', frameKey: frameOne, status: 'done', result: 'pass' },
+      { id: 'b', frameKey: frameOne, status: 'done', result: 'pass' },
+      { id: 'a', frameKey: frameTwo, status: 'pending' },
+      { id: 'b', frameKey: frameTwo, status: 'pending' },
+    ]);
+  });
+
+  it('intra-loop GOTO carrying an explicit `at` resets the active frame, not the `at` frame', () => {
+    const forSteps = [
+      {
+        name: '1',
+        description: 'Loop',
+        kind: 'for',
+        forClause: { start: 1, end: 2 },
+        transitions: {
+          pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+          fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+        },
+        substeps: [sub('a'), sub('b')],
+      },
+      {
+        name: '2',
+        description: 'Done',
+        kind: 'base',
+        transitions: {
+          pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+        },
+      },
+    ] satisfies ResolvedStep[];
+    const machine = compileRunbookToMachine(forSteps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'PASS' });
+    actor.send({ type: 'PASS' });
+    actor.send({ type: 'PASS' });
+    const atIterationTwoB = actor.getSnapshot();
+    actor.stop();
+
+    const seeded = {
+      ...atIterationTwoB,
+      context: {
+        ...atIterationTwoB.context,
+        substepStates: [
+          { id: 'a', frameKey: frameOne, status: 'done', result: 'pass' },
+          { id: 'b', frameKey: frameOne, status: 'done', result: 'pass' },
+          { id: 'a', frameKey: frameTwo, status: 'done', result: 'fail' },
+          { id: 'b', frameKey: frameTwo, status: 'done', result: 'pass' },
+        ],
+      },
+    } as typeof atIterationTwoB;
+
+    // initForStack ignores `at` for an intra-loop GOTO and stays on iteration 2,
+    // so the reset must target frame two regardless of the `at: 1` qualifier.
+    const [next] = transition(machine, seeded, {
+      type: 'GOTO',
+      target: { step: '1', substep: 'a', at: 1 },
     });
 
     expect(next.context.substepStates).toEqual([

--- a/packages/core/__tests__/runbook/substep-reopen-machine.test.ts
+++ b/packages/core/__tests__/runbook/substep-reopen-machine.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from '@jest/globals';
+import { createActor, transition } from 'xstate';
+import { compileRunbookToMachine } from '../../src/runbook/compiler.js';
+import { buildFrameKey } from '../../src/runbook/targeting.js';
+import type { ResolvedStep, Substep, SubstepState } from '../../src/runbook/types.js';
+
+const sub = (id: string): Substep =>
+  ({
+    kind: 'base',
+    id,
+    description: id,
+    transitions: {
+      pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+      fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+    },
+  }) as Substep;
+
+const steps = [
+  {
+    name: '1',
+    description: 'Step 1',
+    kind: 'substeps',
+    transitions: {
+      pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+      fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+    },
+    aggregation: { strategy: 'ALL' },
+    substeps: [sub('a'), sub('b'), sub('c')],
+  },
+  {
+    name: '2',
+    description: 'Step 2',
+    kind: 'plain',
+    transitions: {
+      pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+      fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+    },
+  },
+] as unknown as ResolvedStep[];
+
+const frame = buildFrameKey('1');
+
+function seedDoneRows(): SubstepState[] {
+  return [
+    { id: 'a', frameKey: frame, status: 'done', result: 'pass' },
+    { id: 'b', frameKey: frame, status: 'done', result: 'pass' },
+    { id: 'c', frameKey: frame, status: 'pending' },
+  ];
+}
+
+describe('substep reset-on-reopen (machine-level, pure transition)', () => {
+  it('GOTO backward to an earlier substep resets that substep and all later same-frame rows', () => {
+    const machine = compileRunbookToMachine(steps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'PASS' });
+    actor.send({ type: 'PASS' });
+    const atC = actor.getSnapshot();
+    actor.stop();
+
+    const seeded = {
+      ...atC,
+      context: { ...atC.context, substepStates: seedDoneRows() },
+    } as typeof atC;
+
+    const [next] = transition(machine, seeded, {
+      type: 'GOTO',
+      target: { step: '1', substep: 'a' },
+    });
+
+    expect(next.context.substepStates).toEqual([
+      { id: 'a', frameKey: frame, status: 'pending' },
+      { id: 'b', frameKey: frame, status: 'pending' },
+      { id: 'c', frameKey: frame, status: 'pending' },
+    ]);
+  });
+
+  it('cross-step GOTO does not reset substepStates of the previous frame', () => {
+    const machine = compileRunbookToMachine(steps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'PASS' });
+    const atB = actor.getSnapshot();
+    actor.stop();
+
+    const seeded = {
+      ...atB,
+      context: {
+        ...atB.context,
+        substepStates: [{ id: 'a', frameKey: frame, status: 'done', result: 'pass' }],
+      },
+    } as typeof atB;
+
+    const [next] = transition(machine, seeded, { type: 'GOTO', target: { step: '2' } });
+
+    expect(next.context.substepStates).toEqual([
+      { id: 'a', frameKey: frame, status: 'done', result: 'pass' },
+    ]);
+  });
+});

--- a/packages/core/__tests__/runbook/substep-reopen-machine.test.ts
+++ b/packages/core/__tests__/runbook/substep-reopen-machine.test.ts
@@ -39,6 +39,8 @@ const steps = [
 ] as unknown as ResolvedStep[];
 
 const frame = buildFrameKey('1');
+const frameOne = buildFrameKey('1', 1);
+const frameTwo = buildFrameKey('1', 2);
 
 function seedDoneRows(): SubstepState[] {
   return [
@@ -95,6 +97,96 @@ describe('substep reset-on-reopen (machine-level, pure transition)', () => {
 
     expect(next.context.substepStates).toEqual([
       { id: 'a', frameKey: frame, status: 'done', result: 'pass' },
+    ]);
+  });
+
+  it('self-loop GOTO resets the target substep and later rows while preserving earlier rows', () => {
+    const machine = compileRunbookToMachine(steps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'PASS' });
+    const atB = actor.getSnapshot();
+    actor.stop();
+
+    const seeded = {
+      ...atB,
+      context: {
+        ...atB.context,
+        substepStates: [
+          { id: 'a', frameKey: frame, status: 'done', result: 'pass' },
+          { id: 'b', frameKey: frame, status: 'done', result: 'fail' },
+          { id: 'c', frameKey: frame, status: 'pending' },
+        ],
+      },
+    } as typeof atB;
+
+    const [next] = transition(machine, seeded, {
+      type: 'GOTO',
+      target: { step: '1', substep: 'b' },
+    });
+
+    expect(next.context.substepStates).toEqual([
+      { id: 'a', frameKey: frame, status: 'done', result: 'pass' },
+      { id: 'b', frameKey: frame, status: 'pending' },
+      { id: 'c', frameKey: frame, status: 'pending' },
+    ]);
+  });
+
+  it('GOTO inside a FOR iteration resets only the active iteration frame', () => {
+    const forSteps = [
+      {
+        name: '1',
+        description: 'Loop',
+        kind: 'for',
+        forClause: { start: 1, end: 2 },
+        transitions: {
+          pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+          fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+        },
+        substeps: [sub('a'), sub('b')],
+      },
+      {
+        name: '2',
+        description: 'Done',
+        kind: 'plain',
+        transitions: {
+          pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
+          fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+        },
+      },
+    ] as unknown as ResolvedStep[];
+    const machine = compileRunbookToMachine(forSteps);
+    const actor = createActor(machine);
+    actor.start();
+    actor.send({ type: 'PASS' });
+    actor.send({ type: 'PASS' });
+    actor.send({ type: 'PASS' });
+    const atIterationTwoB = actor.getSnapshot();
+    actor.stop();
+
+    const seeded = {
+      ...atIterationTwoB,
+      context: {
+        ...atIterationTwoB.context,
+        substepStates: [
+          { id: 'a', frameKey: frameOne, status: 'done', result: 'pass' },
+          { id: 'b', frameKey: frameOne, status: 'done', result: 'pass' },
+          { id: 'a', frameKey: frameTwo, status: 'done', result: 'fail' },
+          { id: 'b', frameKey: frameTwo, status: 'done', result: 'pass' },
+        ],
+      },
+    } as typeof atIterationTwoB;
+
+    const [next] = transition(machine, seeded, {
+      type: 'GOTO',
+      target: { step: '1', substep: 'a' },
+    });
+
+    expect(next.context.substepStates).toEqual([
+      { id: 'a', frameKey: frameOne, status: 'done', result: 'pass' },
+      { id: 'b', frameKey: frameOne, status: 'done', result: 'pass' },
+      { id: 'a', frameKey: frameTwo, status: 'pending' },
+      { id: 'b', frameKey: frameTwo, status: 'pending' },
     ]);
   });
 });

--- a/packages/core/__tests__/runbook/substep-reset.test.ts
+++ b/packages/core/__tests__/runbook/substep-reset.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from '@jest/globals';
+import { resetReopenedSubsteps } from '../../src/runbook/substep-reset.js';
+import { buildFrameKey } from '../../src/runbook/targeting.js';
+import type { ResolvedStep, SubstepState } from '../../src/runbook/types.js';
+
+const step: ResolvedStep = {
+  name: '1',
+  description: 'Step 1',
+  kind: 'substeps',
+  transitions: {
+    pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+    fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+  },
+  substeps: [
+    {
+      id: 'a',
+      description: 'A',
+      transitions: {
+        pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+        fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+      },
+    },
+    {
+      id: 'b',
+      description: 'B',
+      transitions: {
+        pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+        fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+      },
+    },
+    {
+      id: 'c',
+      description: 'C',
+      transitions: {
+        pass: { kind: 'pass', retry: 0, action: { type: 'CONTINUE' } },
+        fail: { kind: 'fail', retry: 0, action: { type: 'STOP' } },
+      },
+    },
+  ],
+} as unknown as ResolvedStep;
+
+const frame = buildFrameKey('1');
+
+function done(id: string, result: 'pass' | 'fail'): SubstepState {
+  return { id, frameKey: frame, status: 'done', result };
+}
+
+describe('resetReopenedSubsteps', () => {
+  it('resets the from-substep and all later substeps in the active frame to pending, clearing result', () => {
+    const before: SubstepState[] = [done('a', 'pass'), done('b', 'fail'), done('c', 'pass')];
+    const after = resetReopenedSubsteps(step, frame, 'b', before);
+    expect(after).toEqual([
+      done('a', 'pass'),
+      { id: 'b', frameKey: frame, status: 'pending' },
+      { id: 'c', frameKey: frame, status: 'pending' },
+    ]);
+  });
+
+  it('leaves substeps before N untouched', () => {
+    const before: SubstepState[] = [done('a', 'pass'), done('b', 'fail'), done('c', 'pass')];
+    const after = resetReopenedSubsteps(step, frame, 'b', before);
+    expect(after[0]).toEqual(done('a', 'pass'));
+  });
+
+  it('resets only the from-substep when it is last (self-loop on last)', () => {
+    const before: SubstepState[] = [done('a', 'pass'), done('b', 'pass'), done('c', 'pass')];
+    const after = resetReopenedSubsteps(step, frame, 'c', before);
+    expect(after).toEqual([
+      done('a', 'pass'),
+      done('b', 'pass'),
+      { id: 'c', frameKey: frame, status: 'pending' },
+    ]);
+  });
+
+  it('leaves rows in other frames untouched', () => {
+    const otherFrame = buildFrameKey('1', 2);
+    const before: SubstepState[] = [
+      done('a', 'pass'),
+      { id: 'b', frameKey: otherFrame, status: 'done', result: 'pass' },
+    ];
+    const after = resetReopenedSubsteps(step, frame, 'a', before);
+    expect(after).toEqual([
+      { id: 'a', frameKey: frame, status: 'pending' },
+      { id: 'b', frameKey: otherFrame, status: 'done', result: 'pass' },
+    ]);
+  });
+
+  it('preserves a delegation record on a reset row (status/result reset only)', () => {
+    const before: SubstepState[] = [
+      {
+        id: 'a',
+        frameKey: frame,
+        status: 'done',
+        result: 'pass',
+        delegation: { token: 't' } as never,
+      },
+    ];
+    const after = resetReopenedSubsteps(step, frame, 'a', before);
+    expect(after[0]).toEqual({
+      id: 'a',
+      frameKey: frame,
+      status: 'pending',
+      delegation: { token: 't' },
+    });
+  });
+
+  it('returns the input unchanged when fromSubstepId is not a declared substep', () => {
+    const before: SubstepState[] = [done('a', 'pass')];
+    const after = resetReopenedSubsteps(step, frame, 'zzz', before);
+    expect(after).toEqual(before);
+  });
+});

--- a/packages/core/__tests__/runbook/substep-reset.test.ts
+++ b/packages/core/__tests__/runbook/substep-reset.test.ts
@@ -107,6 +107,6 @@ describe('resetReopenedSubsteps', () => {
   it('returns the input unchanged when fromSubstepId is not a declared substep', () => {
     const before: SubstepState[] = [done('a', 'pass')];
     const after = resetReopenedSubsteps(step, frame, 'zzz', before);
-    expect(after).toEqual(before);
+    expect(after).toBe(before);
   });
 });

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -77,6 +77,7 @@ import type { MachineExecutionObserver } from '../events/execution-observation.j
 import { buildFrameKey, deriveExecutionAt, findSubstepState, type FrameKey } from './targeting.js';
 import { runRetryHook } from './retry-hook.js';
 import { asTemplateVars } from './template-vars.js';
+import { resetReopenedSubsteps } from './substep-reset.js';
 import { getErrorMessage } from '../errors.js';
 import { assertRunId } from './run-id.js';
 import { generateRunId } from './state.js';
@@ -1244,6 +1245,50 @@ function getStepForSubstep(
 }
 
 type GotoAssignValue<T> = T | ((args: { event: RunbookEvent }) => T);
+type SubstepGotoResetAssignValue = (args: {
+  context: RunbookContext;
+  event: RunbookEvent;
+}) => readonly SubstepState[];
+
+/**
+ * Build the `substepStates` assign value for an intra-frame substep GOTO.
+ *
+ * The resolver resets the target substep and all later same-frame substeps to
+ * `pending` when GOTO re-enters the current frame. Cross-step and cross-frame
+ * targets are left unchanged; their target frames are initialized elsewhere.
+ *
+ * @param step - The GOTO target step.
+ * @param currentStepName - The current state's step name.
+ * @param fallbackSubstepId - Build-time substep id used when the event omits one.
+ * @returns Context-bearing assign resolver for substep state reset.
+ */
+function buildSubstepGotoResetAssignValue(
+  step: ResolvedStep,
+  currentStepName: string,
+  fallbackSubstepId: string | undefined,
+): SubstepGotoResetAssignValue {
+  return ({ context, event }): readonly SubstepState[] => {
+    const substepStates = context.substepStates ?? [];
+    const isGotoEvent = event.type === 'GOTO';
+    const targetStepName = isGotoEvent ? event.target.step : step.name;
+    if (targetStepName !== currentStepName) return substepStates;
+
+    const resolvedSubstepId = isGotoEvent
+      ? (event.target.substep ?? fallbackSubstepId)
+      : fallbackSubstepId;
+    if (!resolvedSubstepId) return substepStates;
+
+    const top = peekForStack(context.forStack);
+    const currentIteration = top && !top.implicit ? top.iteration : undefined;
+    const targetIteration =
+      isGotoEvent && typeof event.target.at === 'number' ? event.target.at : currentIteration;
+    const currentFrameKey = buildFrameKey(currentStepName, currentIteration);
+    const targetFrameKey = buildFrameKey(targetStepName, targetIteration);
+    if (targetFrameKey !== currentFrameKey) return substepStates;
+
+    return resetReopenedSubsteps(step, currentFrameKey, resolvedSubstepId, substepStates);
+  };
+}
 
 /**
  * Build assign action for simple GOTO transitions.
@@ -1256,6 +1301,7 @@ type GotoAssignValue<T> = T | ((args: { event: RunbookEvent }) => T);
  * @param options.isGotoToSelf - Whether this GOTO targets the current state
  * @param options.preserveForContext - Whether to preserve the FOR context stack
  * @param options.preserveParentRetryCount - Whether to preserve the parent retry counter
+ * @param options.resetSubstepStates - Optional reset resolver for intra-frame substep GOTO
  * @returns XState assign action
  */
 function buildSimpleGotoAssign(options: {
@@ -1264,7 +1310,9 @@ function buildSimpleGotoAssign(options: {
   isGotoToSelf: boolean;
   preserveForContext?: boolean;
   preserveParentRetryCount?: boolean;
+  resetSubstepStates?: SubstepGotoResetAssignValue;
 }): ReturnType<typeof runbookSetup.assign> {
+  const resetSubstepStates = options.resetSubstepStates;
   return runbookSetup.assign({
     lastAction: ({ event }: { event: RunbookEvent }) => {
       return typeof options.lastAction === 'function'
@@ -1279,6 +1327,17 @@ function buildSimpleGotoAssign(options: {
       : 0,
     retryMax: undefined,
     substep: options.resolvedSubstepId,
+    ...(resetSubstepStates
+      ? {
+          substepStates: ({
+            context,
+            event,
+          }: {
+            context: RunbookContext;
+            event: RunbookEvent;
+          }): readonly SubstepState[] => resetSubstepStates({ context, event }),
+        }
+      : {}),
     ...(options.preserveForContext
       ? {}
       : {
@@ -2783,6 +2842,7 @@ function buildGotoTransition(
         retryMax: undefined,
         iterationRetryCount: 0,
         substep: resolvedSubstepId,
+        substepStates: buildSubstepGotoResetAssignValue(targetStepObj, stepName, resolvedSubstepId),
         substepCompletedCount: !isImplicit
           ? ({ context }: { context: RunbookContext }): number => {
               const top = peekForStack(context.forStack);
@@ -2822,6 +2882,10 @@ function buildGotoTransition(
       isGotoToSelf,
       preserveForContext: isIntraLoopGoto,
       preserveParentRetryCount: isGotoToSelf || isIntraLoopGoto,
+      resetSubstepStates:
+        resolvedSubstepId !== undefined
+          ? buildSubstepGotoResetAssignValue(targetStepObj, stepName, resolvedSubstepId)
+          : undefined,
     }),
   };
 }
@@ -3869,6 +3933,7 @@ export function compileRunbookToMachine(
 
       // Check if this target is ANY substep of a FOR step (widened from first-only)
       const forStepForTarget = getStepForSubstep(target.id, steps);
+      const targetStepForReset = steps.find((step) => step.name === target.stepName);
       const routedTarget = routeThroughParentArtifactsIfNeeded(target.id, steps);
 
       return {
@@ -3929,6 +3994,11 @@ export function compileRunbookToMachine(
               iterationRetryCount: 0,
               substep: ({ event }: { event: RunbookEvent }) =>
                 event.type === 'GOTO' ? (event.target.substep ?? target.substepId) : undefined,
+              substepStates: buildSubstepGotoResetAssignValue(
+                forStepForTarget.step,
+                config.stepName,
+                target.substepId,
+              ),
               substepCompletedCount: !forStepForTarget.implicit
                 ? ({ context }: { context: RunbookContext }): number => {
                     const top = peekForStack(context.forStack);
@@ -3951,6 +4021,14 @@ export function compileRunbookToMachine(
                 event.type === 'GOTO' ? (event.target.substep ?? target.substepId) : undefined,
               isGotoToSelf,
               preserveParentRetryCount: isGotoToSelf,
+              resetSubstepStates:
+                target.substepId !== undefined && targetStepForReset !== undefined
+                  ? buildSubstepGotoResetAssignValue(
+                      targetStepForReset,
+                      config.stepName,
+                      target.substepId,
+                    )
+                  : undefined,
             }),
       };
     });

--- a/packages/core/src/runbook/compiler.ts
+++ b/packages/core/src/runbook/compiler.ts
@@ -1280,8 +1280,17 @@ function buildSubstepGotoResetAssignValue(
 
     const top = peekForStack(context.forStack);
     const currentIteration = top && !top.implicit ? top.iteration : undefined;
+    // A same-step substep GOTO is an intra-loop re-entry: initForStack preserves
+    // the active FOR frame and discards event.target.at. Mirror that here so the
+    // reset scopes to the frame the transition actually lands on, rather than a
+    // numeric `at` that would be ignored — otherwise the current frame's done
+    // rows are left stale.
     const targetIteration =
-      isGotoEvent && typeof event.target.at === 'number' ? event.target.at : currentIteration;
+      top?.stepId === targetStepName
+        ? currentIteration
+        : isGotoEvent && typeof event.target.at === 'number'
+          ? event.target.at
+          : currentIteration;
     const currentFrameKey = buildFrameKey(currentStepName, currentIteration);
     const targetFrameKey = buildFrameKey(targetStepName, targetIteration);
     if (targetFrameKey !== currentFrameKey) return substepStates;

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -166,6 +166,7 @@ export {
   type RetryDelegationRetriedResult,
   type RetryDelegationNotFoundResult,
   type RetryDelegationNotCurrentResult,
+  type RetryDelegationInFlightResult,
   type RetryDelegationErrorResult,
   readConsumedDelegationClosure,
   readConsumedDelegationClosureForCwd,

--- a/packages/core/src/runbook/retry-hook.ts
+++ b/packages/core/src/runbook/retry-hook.ts
@@ -25,6 +25,7 @@ import { buildFrameKey, findSubstepState, type FrameKey } from './targeting.js';
 import { brandInitialTemplateVars, brandStoredOutputs } from './effective-vars.js';
 import { Errors } from '../errors/factory.js';
 import { asTemplateVars } from './template-vars.js';
+import { resetReopenedSubsteps } from './substep-reset.js';
 
 /**
  * Discriminated success variant of {@link RetryHookResult}.
@@ -269,9 +270,18 @@ export function runRetryHook(
   // delegation path the value is only spread into contextSnapshot.vars — the
   // actual runtime values originate from `flattenTemplateVars` at hydration
   // and are always TemplateVarValue-compatible.
+  // Reset the whole active frame to pending before re-issuing delegations.
+  // RETRY re-walks every parent substep, so the persisted projection must
+  // match the machine's first-substep re-entry. Error paths below continue
+  // returning the original substepStates to preserve rollback semantics.
+  const resetStates =
+    parentStep.substeps.length > 0
+      ? resetReopenedSubsteps(parentStep, activeFrameKey, parentStep.substeps[0].id, substepStates)
+      : substepStates;
+
   let working: RetryWorkingState = {
     step: parentStep.name,
-    substepStates,
+    substepStates: resetStates,
     templateVars: brandInitialTemplateVars(asTemplateVars(context.templateVars)),
     forStack: context.forStack,
     activeFrameKey,

--- a/packages/core/src/runbook/substep-reset.ts
+++ b/packages/core/src/runbook/substep-reset.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure reset of re-opened substep rows for the "reset-on-reopen" behaviour.
+ *
+ * @module
+ */
+
+import { resolvedStepHasSubsteps } from '@rundown-org/parser';
+import type { ResolvedStep, SubstepState } from './types.js';
+import type { FrameKey } from './targeting.js';
+
+/**
+ * Reset a re-opened substep — and every later substep in the same frame — to a
+ * clean `pending` slate.
+ *
+ * On RETRY or intra-frame GOTO the machine resumes at `fromSubstepId` and walks
+ * forward, re-prompting that substep through the last substep of the step. This
+ * helper makes the persisted projection match that forward walk: every row in
+ * the active `frameKey` whose substep index is `>= index(fromSubstepId)` is
+ * reset to `{ status: 'pending' }` with any prior `result` removed. Rows in
+ * other frames, and rows before `fromSubstepId`, are returned untouched.
+ * Non-status/result fields (notably `delegation`, `inline`) are preserved.
+ *
+ * Pure: no machine, service, or CLI awareness. Category B (computation over
+ * context) per `CLAUDE.md`.
+ *
+ * @param step - The active step whose substeps are being re-walked.
+ * @param frameKey - The active frame key scoping the reset (FOR iteration aware).
+ * @param fromSubstepId - Inclusive start substep id; this row and all later
+ *   same-frame rows are reset.
+ * @param substepStates - Current substep states.
+ * @returns A new array with the re-opened rows reset; the input array is never
+ *   mutated. If `fromSubstepId` is not a declared substep of `step`, or `step`
+ *   has no substeps, the input is returned unchanged.
+ */
+export function resetReopenedSubsteps(
+  step: ResolvedStep,
+  frameKey: FrameKey,
+  fromSubstepId: string,
+  substepStates: readonly SubstepState[],
+): readonly SubstepState[] {
+  if (!resolvedStepHasSubsteps(step)) return substepStates;
+  const orderedIds = step.substeps.map((substep) => substep.id);
+  const fromIndex = orderedIds.indexOf(fromSubstepId);
+  if (fromIndex === -1) return substepStates;
+  const reopened = new Set(orderedIds.slice(fromIndex));
+
+  return substepStates.map((ss) => {
+    if (ss.frameKey !== frameKey || !reopened.has(ss.id)) return ss;
+    if (ss.status === 'pending' && ss.result === undefined) return ss;
+    const { result, ...rest } = ss;
+    void result;
+    return { ...rest, status: 'pending' as const };
+  });
+}

--- a/runbooks/for-loops/for-retry-reopen-nondelegated.runbook.md
+++ b/runbooks/for-loops/for-retry-reopen-nondelegated.runbook.md
@@ -1,0 +1,48 @@
+---
+name: for-retry-reopen-nondelegated
+description: RETRY re-opens resolved non-delegated FOR substeps before completing
+tags:
+  - for
+  - retry
+  - substeps
+scenarios:
+  retry-reopens-and-completes:
+    commands:
+      - rd run --prompted for-retry-reopen-nondelegated.runbook.md
+      - rd pass
+      - rd fail
+      - rd pass
+    result: COMPLETE
+---
+
+# FOR RETRY Re-open
+
+Parent RETRY re-opens non-delegated substeps in the active FOR frame.
+
+## 1. Process item
+
+- FOR item IN 1 TO 1
+  - PASS ALL CONTINUE
+  - FAIL ANY RETRY 1 STOP
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 First check
+
+- PASS DEFER
+- FAIL DEFER
+
+Check first.
+
+### 1.2 Second check
+
+- PASS DEFER
+- FAIL BREAK
+
+Check second.
+
+## 2. Done
+
+- PASS COMPLETE
+
+All done.

--- a/runbooks/goto/goto-reopen-nondelegated.runbook.md
+++ b/runbooks/goto/goto-reopen-nondelegated.runbook.md
@@ -1,0 +1,43 @@
+---
+name: goto-reopen-nondelegated
+description: Backward GOTO re-opens a resolved non-delegated substep; it re-executes
+tags:
+  - goto
+  - substeps
+scenarios:
+  reopen-and-complete:
+    commands:
+      - rd run --prompted goto-reopen-nondelegated.runbook.md
+      - rd pass
+      - rd fail
+      - rd pass
+      - rd pass
+      - rd pass
+    result: COMPLETE
+---
+
+# GOTO Re-open
+
+Backward GOTO re-opens a substep that already carried a result.
+
+## 1. Work
+
+### 1.1 First
+
+- PASS CONTINUE
+- FAIL STOP
+
+Do first.
+
+### 1.2 Second
+
+- PASS CONTINUE
+- FAIL GOTO 1.1
+
+Do second.
+
+## 2. Done
+
+- PASS COMPLETE
+
+All done.


### PR DESCRIPTION
## Summary
- add source-side reset of reopened substep rows for parent RETRY and intra-frame substep GOTO
- cover backward GOTO, self-loop GOTO, FOR-frame isolation, and non-delegated RETRY/GOTO scenarios
- preserve manual delegation retry handling for in-flight child runs while keeping CLI type-check green

## Validation
- npm test
- npm run build && npm run test:integration --workspace @rundown-org/cli -- scenario-runner
- npm test --workspace @rundown-org/core -- completion-service
- npm test --workspace @rundown-org/cli -- delegate
- npm run check:types:core
- npm run check:types:cli
- npm run check:lint:fast
- npm run check:lint:typed
- npm run check:format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic reset of re-opened substeps to pending during RETRY and intra-frame GOTO, including non-delegated cases.
  * Improved retry behavior to surface accurate retry results and output after reopen.

* **Bug Fixes**
  * Prevented stale "done" states from persisting after substep reopen.

* **Tests**
  * Added broad tests covering RETRY, GOTO, loops, and edge scenarios.

* **Documentation**
  * Added design, implementation plan, and example runbooks for reopen/reset behavior.

* **Chores**
  * Minor spell-check dictionary additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->