### PR TITLE
refactor(core): typed helper-registry dispatch (#385)

### DIFF
--- a/packages/core/__tests__/runbook/template-renderer.test.ts
+++ b/packages/core/__tests__/runbook/template-renderer.test.ts
@@ -3,8 +3,10 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import {
+  BUILTIN_RENDER_HELPERS,
   createJsonArrayStream,
   assertRunId,
+  isBuiltinRenderHelper,
   readArtifactManifest,
   resetHelperInvokeWarnings,
   type ArtifactRecord,
@@ -2762,5 +2764,60 @@ describe('substituteRunbookVariables with ArtifactRecord direct-alias', () => {
       ARTIFACT_HELPER_OPTIONS,
     );
     expect(result.title).toBe(ARTIFACT_PLAN_PATH);
+  });
+});
+
+describe('built-in helper registry (issue #385)', () => {
+  it('derives the built-in name set from exactly three registry entries', () => {
+    expect([...BUILTIN_RENDER_HELPERS].sort()).toEqual(['artifact', 'path', 'validateSchema']);
+  });
+
+  it('recognizes built-ins and rejects user-helper names', () => {
+    expect(isBuiltinRenderHelper('artifact')).toBe(true);
+    expect(isBuiltinRenderHelper('path')).toBe(true);
+    expect(isBuiltinRenderHelper('validateSchema')).toBe(true);
+    expect(isBuiltinRenderHelper('upper')).toBe(false);
+  });
+
+  it('artifact is var-only: a literal key is a hard error', () => {
+    expect(() => substituteText('{{ artifact "plan.json" }}', {})).toThrow(/literal key/);
+  });
+
+  it('path requires render context: preserved when absent', () => {
+    expect(substituteText('{{ path "plan.json" }}', {})).toBe('{{ path "plan.json" }}');
+  });
+
+  it('validateSchema needs no context for a literal path and is not shell-escaped', () => {
+    expect(substituteText('{{ validateSchema "plan.json" }}', {}, shellEscapeValue)).toBe(
+      'rdx --validate plan.json',
+    );
+  });
+});
+
+describe('unified helper dispatch routing (issue #385)', () => {
+  it('routes built-in names to the built-in resolver even when a same-named user helper is supplied', () => {
+    // A user registry that (hypothetically) carries a built-in name must never
+    // shadow the built-in: the registry lookup wins before user dispatch.
+    const helpers = new Map<string, (value: string) => string>([
+      ['path', () => 'USER_PATH_SHOULD_NOT_RUN'],
+    ]);
+    // No render context -> `path` (needsContext) preserves the token; it must
+    // NOT fall through to the user helper.
+    expect(substituteText('{{ path "plan.json" }}', {}, undefined, { helpers })).toBe(
+      '{{ path "plan.json" }}',
+    );
+  });
+
+  it('falls through unknown names to the user-helper registry', () => {
+    const helpers = new Map<string, (value: string) => string>([
+      ['upper', (value) => value.toUpperCase()],
+    ]);
+    expect(substituteText('{{ upper "abc" }}', {}, undefined, { helpers })).toBe('ABC');
+  });
+
+  it('preserves an unknown helper name with no matching user helper', () => {
+    expect(substituteText('{{ mystery "abc" }}', {}, undefined, { helpers: new Map() })).toBe(
+      '{{ mystery "abc" }}',
+    );
   });
 });

--- a/packages/core/__tests__/runbook/variable-preparation.test.ts
+++ b/packages/core/__tests__/runbook/variable-preparation.test.ts
@@ -59,19 +59,19 @@ describe('template helper semantics', () => {
     expect(isBuiltinRenderHelper('upper')).toBe(false);
   });
 
-  it('resolveTemplateHelperCall leaves built-in helper tokens untouched for their dedicated passes', () => {
+  it('resolveTemplateHelperCall returns the original for any name absent from the user registry', () => {
     const registry = new Map<string, (value: string) => string>([
       ['upper', (value) => value.toUpperCase()],
     ]);
-    // Built-ins are owned by dedicated render passes; the generic registry
-    // dispatcher must never process them, even if a same-named user helper
-    // were registered.
+    // Built-in names are never registered as user helpers (reserved at load
+    // time) and are dispatched by the typed registry in substituteText, not
+    // here — so this user-helper resolver simply misses and preserves them.
     for (const name of BUILTIN_RENDER_HELPERS) {
       expect(resolveTemplateHelperCall(registry, name, 'arg', `{{ ${name} arg }}`)).toBe(
         `{{ ${name} arg }}`,
       );
     }
-    // Genuine user helpers still resolve through the generic path.
+    // Genuine user helpers still resolve.
     expect(resolveTemplateHelperCall(registry, 'upper', 'arg', '{{ upper arg }}')).toBe('ARG');
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,14 +51,19 @@ export {
 } from './runbook/types.js';
 export { isRunId } from './runbook/run-id.js';
 export {
-  BUILTIN_RENDER_HELPERS,
   invokeHelperSafely,
-  isBuiltinRenderHelper,
   resetHelperInvokeWarnings,
   resolveTemplateHelperCall,
+  type HelperArity,
+  type HelperKind,
   type TemplateHelper,
   type TemplateHelperRegistry,
 } from './runbook/helper-invoke.js';
+export {
+  BUILTIN_RENDER_HELPERS,
+  isBuiltinRenderHelper,
+  type HelperDescriptor,
+} from './runbook/template-renderer.js';
 export {
   RESERVED_TEMPLATE_HELPER_NAMES,
   detectTemplateHelperCollisions,

--- a/packages/core/src/runbook/helper-invoke.ts
+++ b/packages/core/src/runbook/helper-invoke.ts
@@ -24,32 +24,16 @@ export type TemplateHelper = (value: string) => string;
 /** Registry of template helpers keyed by helper name. */
 export type TemplateHelperRegistry = ReadonlyMap<string, TemplateHelper>;
 
-/**
- * Names of the built-in render helpers (`artifact`, `path`, `validateSchema`).
- *
- * These are NOT user-registry helpers: each has a dedicated render pass that
- * reads typed artifact values and the render context, with its own argument
- * grammar. They are the single source of truth for "this name is a built-in",
- * so the generic helper-dispatch paths can exclude them rather than re-deriving
- * the set from scattered string comparisons. See issue #385 for the typed
- * registry that will replace this skip-set entirely.
- */
-export const BUILTIN_RENDER_HELPERS: ReadonlySet<string> = new Set([
-  'artifact',
-  'path',
-  'validateSchema',
-]);
+/** Whether a helper is a render built-in or a user-registered helper. */
+export type HelperKind = 'builtin' | 'user';
 
 /**
- * Test whether a helper name refers to a built-in render helper.
- *
- * @param helperName - Helper name parsed from a `{{ name arg }}` placeholder
- * @returns `true` when the name is a built-in render helper handled by its own
- *   dedicated render pass rather than the generic user-helper registry
+ * Legal argument forms a helper accepts.
+ * - `var`: variable reference only (`{{ name Var }}`)
+ * - `literal`: quoted literal only (`{{ name "x" }}`)
+ * - `both`: either form
  */
-export function isBuiltinRenderHelper(helperName: string): boolean {
-  return BUILTIN_RENDER_HELPERS.has(helperName);
-}
+export type HelperArity = 'var' | 'literal' | 'both';
 
 /**
  * Reset the per-process "already warned" set.
@@ -141,9 +125,6 @@ export function resolveTemplateHelperCall(
   argValue: string,
   original: string,
 ): string {
-  if (isBuiltinRenderHelper(helperName)) {
-    return original;
-  }
   const helper = helpers?.get(helperName);
   if (!helper) return original;
   return invokeHelperSafely(helperName, helper, argValue) ?? original;

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -22,19 +22,24 @@ export {
   type TemplateVariables,
 } from './runtime-frame.js';
 export {
+  BUILTIN_RENDER_HELPERS,
   collectUnresolvedRunbookVariables,
   collectUnresolvedVariables,
   expandLoopVariables,
   expandLoopVariablesForCommand,
+  isBuiltinRenderHelper,
   resolveForBounds,
   shellEscapeValue,
   substituteRunbookVariables,
   substituteText,
   warnUnresolvedRunbookVariables,
+  type HelperDescriptor,
   type TemplateRenderContext,
   type TemplateRenderOptions,
 } from './template-renderer.js';
 export type {
+  HelperArity,
+  HelperKind,
   TemplateHelper,
   TemplateHelperRegistry,
 } from './helper-invoke.js';
@@ -296,9 +301,7 @@ export {
   type OutputVars,
 } from './output-evaluator.js';
 export {
-  BUILTIN_RENDER_HELPERS,
   invokeHelperSafely,
-  isBuiltinRenderHelper,
   resetHelperInvokeWarnings,
   resolveTemplateHelperCall,
 } from './helper-invoke.js';

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -154,7 +154,15 @@ export interface BuiltinHelperResolveArgs {
   readonly original: string;
 }
 
-/** Render-only resolver for a built-in helper. No manifest writes, no mkdir. */
+/**
+ * Render-only resolver for a built-in helper. No manifest writes, no mkdir.
+ *
+ * @param args - Parsed helper-call inputs ({@link BuiltinHelperResolveArgs}):
+ * the literal/varRef argument, render-frame variables, helper options, and the
+ * original match text for soft misses.
+ * @returns The rendered helper output, or the original `{{ ... }}` token on a
+ * soft miss.
+ */
 export type BuiltinHelperResolver = (args: BuiltinHelperResolveArgs) => string;
 
 /**
@@ -1176,11 +1184,18 @@ export function substituteText(
     (match, helperName: string, varRef: string | undefined, literal: string | undefined) => {
       const descriptor = BUILTIN_HELPER_REGISTRY.get(helperName);
       if (descriptor) {
-        // Arity gate: a var-only built-in (artifact) given a literal key is a
-        // hard error — declare it via ARTIFACTS and pass the alias instead.
-        if (literal !== undefined && descriptor.arity === 'var') {
+        // Arity gate: enforce both sides of the descriptor's arity. A var-only
+        // built-in (e.g. artifact) given a literal key is a hard error — declare
+        // it via ARTIFACTS and pass the alias instead; a literal-only built-in
+        // given a variable reference is the symmetric error.
+        if (
+          (literal !== undefined && descriptor.arity === 'var') ||
+          (varRef !== undefined && descriptor.arity === 'literal')
+        ) {
           throw new Error(
-            `${descriptor.name} helper does not accept a literal key (${match}); declare it via ARTIFACTS and pass the alias.`,
+            descriptor.arity === 'var'
+              ? `${descriptor.name} helper does not accept a literal key (${match}); declare it via ARTIFACTS and pass the alias.`
+              : `${descriptor.name} helper does not accept a variable reference (${match}); pass a quoted literal.`,
           );
         }
         // Context gate: hard-context built-ins preserve the token when no render

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -100,46 +100,12 @@ const EXPLICIT_VAR_TEMPLATE_REGEX =
  * Matches `{{ helperName varRef }}` or `{{ helperName "literal" }}`.
  * Group 1: helperName, Group 2: varRef (or undefined), Group 3: literal (or undefined).
  *
- * Intercepts any two-token `{{ identifier arg }}` expression in pass 2. Future
- * template built-ins that use this syntax must be added to `RESERVED_HELPER_NAMES`
- * in `helper-registry.ts`; otherwise a same-named user helper will take priority.
+ * The single matcher for all two-token helper calls. Dispatch (built-in vs
+ * user) is decided by BUILTIN_HELPER_REGISTRY membership in `substituteText`,
+ * not by this regex. New built-ins are registry entries, not new regexes.
  */
 const HELPER_CALL_TEMPLATE_REGEX =
   /\{\{[ \t\r\n]{0,64}([a-zA-Z_][a-zA-Z0-9_]*)[ \t\r\n]{1,64}(?:([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)|"([^"]*)")[ \t\r\n]{0,64}\}\}/g;
-
-/**
- * Matches the built-in `path` helper in either form:
- *  - `{{ path "literal-key" }}`  (group 1)
- *  - `{{ path VarRef }}`          (group 2; dotted paths permitted)
- */
-const PATH_HELPER_TEMPLATE_REGEX =
-  /\{\{[ \t\r\n]{0,64}path[ \t\r\n]{1,64}(?:"([^"]*)"|([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*))[ \t\r\n]{0,64}\}\}/g;
-
-/**
- * Matches the built-in schema-validation helper:
- *  - `{{ validateSchema "literal-path-or-uri" }}`  (group 1)
- *  - `{{ validateSchema VarRef }}`                  (group 2; dotted paths permitted)
- */
-const VALIDATE_SCHEMA_HELPER_TEMPLATE_REGEX =
-  /\{\{[ \t\r\n]{0,64}validateSchema[ \t\r\n]{1,64}(?:"([^"]*)"|([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*))[ \t\r\n]{0,64}\}\}/g;
-
-/**
- * Matches the built-in `artifact` helper in variable-reference form only:
- *  - `{{ artifact VarRef }}`      (group 1)
- *
- * The literal-key form `{{ artifact "key" }}` is intentionally NOT matched
- * here. It is rejected separately so the runtime never silently produces a
- * record-shaped projection from a literal key (spec §327).
- */
-const ARTIFACT_HELPER_TEMPLATE_REGEX =
-  /\{\{[ \t\r\n]{0,64}artifact[ \t\r\n]{1,64}([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)[ \t\r\n]{0,64}\}\}/g;
-
-/**
- * Matches the explicitly-rejected literal `artifact` helper form, so we can
- * raise a hard error rather than fall through to the generic helper dispatch.
- */
-const LITERAL_ARTIFACT_HELPER_REGEX =
-  /\{\{[ \t\r\n]{0,64}artifact[ \t\r\n]{1,64}"([^"]*)"[ \t\r\n]{0,64}\}\}/g;
 
 /** Context available to template helpers during render. */
 export type TemplateRenderContext =
@@ -1166,19 +1132,18 @@ export function isBuiltinRenderHelper(helperName: string): boolean {
 /**
  * Substitute placeholders in text with optional escaping.
  *
- * Supports four placeholder forms (processed in order):
- * 1. `{{ ./VarName }}` — explicit variable lookup, bypasses helper registry
- * 2. `{{ artifact "file.json" }}` / `{{ path "file.json" }}` — built-in artifact helpers
- * 3. `{{ helperName varRef }}` or `{{ helperName "literal" }}` — helper call
- * 4. `{{ identifier }}` — standard variable substitution
+ * Supports three placeholder forms (processed in order):
+ * 1. `{{ ./VarName }}` — explicit variable lookup, bypasses helper dispatch
+ * 2. `{{ name arg }}` — unified helper dispatch (built-in or user) via the typed registry
+ * 3. `{{ identifier }}` — standard variable substitution
  *
  * Pass isolation: each pass operates on the full result string produced by the
- * previous pass. A variable value that itself contains `{{ helperName arg }}`
- * syntax will be processed by pass 3 after being substituted by pass 1. This is
- * benign in practice — variable values rarely contain helper call syntax — but
- * callers should be aware that variable values are not isolated from later passes.
+ * previous pass. A variable value that itself contains `{{ name arg }}` syntax
+ * will be processed by pass 2 after being substituted by pass 1. This is benign
+ * in practice — variable values rarely contain helper call syntax — but callers
+ * should be aware that variable values are not isolated from later passes.
  * Similarly, a value returned by a helper that contains `{{ VarName }}` syntax
- * will be processed by pass 4.
+ * will be processed by pass 3.
  *
  * @param text - Input text containing placeholders
  * @param variables - Variable map for substitution
@@ -1199,50 +1164,45 @@ export function substituteText(
     return escapeFn ? escapeFn(value) : value;
   });
 
-  // Pass 2: built-in artifact-producing helpers — pure render-only projection.
-  // The literal `artifact` form is rejected before any other dispatch so a
-  // misuse fails fast, even if the input also contains valid helper calls.
-  result = result.replace(LITERAL_ARTIFACT_HELPER_REGEX, (match, _key: string) => {
-    throw new Error(
-      `artifact helper does not accept a literal key (${match}); declare it via ARTIFACTS and pass the alias.`,
-    );
-  });
-
-  result = result.replace(ARTIFACT_HELPER_TEMPLATE_REGEX, (match, varRef: string) => {
-    const raw = resolveArtifactHelperCall(varRef, variables, match);
-    if (raw === match) return match;
-    return escapeFn ? escapeFn(raw) : raw;
-  });
-
-  result = result.replace(
-    PATH_HELPER_TEMPLATE_REGEX,
-    (match, literalKey: string | undefined, varRef: string | undefined) => {
-      const raw = resolvePathHelperCall(literalKey, varRef, variables, helperOptions, match);
-      if (raw === match) return match;
-      return escapeFn ? escapeFn(raw) : raw;
-    },
-  );
-
-  result = result.replace(
-    VALIDATE_SCHEMA_HELPER_TEMPLATE_REGEX,
-    (match, literalValue: string | undefined, varRef: string | undefined) =>
-      resolveValidateSchemaHelperCall(literalValue, varRef, variables, helperOptions, match),
-  );
-
-  // Pass 3: {{ helperName varRef }} or {{ helperName "literal" }}
+  // Pass 2: unified helper dispatch. Every two-token `{{ name arg }}` call —
+  // built-in or user — routes through one registry lookup. Built-in identity is
+  // a descriptor in BUILTIN_HELPER_REGISTRY (not an ordered pass); unknown names
+  // fall through to the user-helper registry; unresolved names are preserved as
+  // literal text.
   result = result.replace(
     HELPER_CALL_TEMPLATE_REGEX,
     (match, helperName: string, varRef: string | undefined, literal: string | undefined) => {
-      if (isBuiltinRenderHelper(helperName)) {
-        return match;
+      const descriptor = BUILTIN_HELPER_REGISTRY.get(helperName);
+      if (descriptor) {
+        // Arity gate: a var-only built-in (artifact) given a literal key is a
+        // hard error — declare it via ARTIFACTS and pass the alias instead.
+        if (literal !== undefined && descriptor.arity === 'var') {
+          throw new Error(
+            `${descriptor.name} helper does not accept a literal key (${match}); declare it via ARTIFACTS and pass the alias.`,
+          );
+        }
+        // Context gate: hard-context built-ins preserve the token when no render
+        // context exists (AST-walk / preparation phase).
+        if (descriptor.needsContext && getRenderContext(helperOptions) === undefined) {
+          return match;
+        }
+        const raw = descriptor.resolve({
+          literal,
+          varRef,
+          variables,
+          helperOptions,
+          original: match,
+        });
+        if (raw === match) return match;
+        return descriptor.escapeOutput && escapeFn ? escapeFn(raw) : raw;
       }
+
+      // User helper: resolve the argument, then dispatch through the user registry.
       let argValue: string;
       if (varRef !== undefined) {
         const resolved = resolveTemplatePath(varRef, variables, helperOptions);
         // Preserve the original placeholder when the variable arg is unresolved.
-        // `resolveTemplatePath` already maps the artifact-no-options sentinel to
-        // `undefined`, so this single branch covers both. Silently substituting
-        // `''` would corrupt downstream output (CLAUDE.md "No silent mapping").
+        // Silently substituting '' would corrupt output (CLAUDE.md "No silent mapping").
         if (resolved === undefined) return match;
         argValue = resolved;
       } else {
@@ -1254,7 +1214,7 @@ export function substituteText(
     },
   );
 
-  // Pass 4: {{ identifier }} standard variable substitution
+  // Pass 3: {{ identifier }} standard variable substitution
   result = result.replace(TEMPLATE_PATH_REGEX, (match, path: string) => {
     const value = resolveTemplatePathRaw(path, variables);
     if (value === undefined) return match;

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -157,13 +157,13 @@ export interface BuiltinHelperResolveArgs {
 /**
  * Render-only resolver for a built-in helper. No manifest writes, no mkdir.
  *
- * `@param` args - Parsed helper-call inputs ({`@link` BuiltinHelperResolveArgs}):
+ * @param args - Parsed helper-call inputs ({@link BuiltinHelperResolveArgs}):
  * the literal/varRef argument, render-frame variables, helper options, and the
  * original match text for soft misses.
- * `@returns` The rendered helper output, or the original `{{ ... }}` token on a
+ * @returns The rendered helper output, or the original `{{ ... }}` token on a
  * soft miss.
- * `@throws` {Error} When a built-in resolver rejects an invalid argument shape or
- * resolved value.
+ * @throws {Error} When a built-in resolver rejects its input (e.g. an unknown
+ * artifact alias or an invalid path argument).
  */
 export type BuiltinHelperResolver = (args: BuiltinHelperResolveArgs) => string;
 

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -1083,8 +1083,10 @@ const BUILTIN_HELPER_REGISTRY: ReadonlyMap<string, HelperDescriptor> = new Map(
         escapeOutput: true,
         // The literal form is rejected by the arity gate before resolve runs,
         // so `varRef` is always defined here.
+        // The arity 'var' gate rejects the literal form before resolve runs, so
+        // varRef is defined here; narrow explicitly rather than assert.
         resolve: ({ varRef, variables, original }) =>
-          resolveArtifactHelperCall(varRef as string, variables, original),
+          varRef === undefined ? original : resolveArtifactHelperCall(varRef, variables, original),
       },
       {
         name: 'path',

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -38,8 +38,9 @@ import {
   RunbookSyntaxError,
 } from '@rundown-org/parser';
 import {
-  isBuiltinRenderHelper,
   resolveTemplateHelperCall,
+  type HelperArity,
+  type HelperKind,
   type TemplateHelperRegistry,
 } from './helper-invoke.js';
 import { isArtifactRecord, type ArtifactRecord } from './artifact-schema.js';
@@ -172,6 +173,53 @@ export interface TemplateRenderOptions {
 }
 
 type TemplateHelperOptions = TemplateRenderOptions;
+
+/** Arguments handed to a built-in helper resolver at dispatch time. */
+export interface BuiltinHelperResolveArgs {
+  /** Quoted literal argument (`{{ name "x" }}`), or undefined for the var form. */
+  readonly literal: string | undefined;
+  /** Variable-reference argument (`{{ name Var }}`), or undefined for the literal form. */
+  readonly varRef: string | undefined;
+  /** Render-frame variables. */
+  readonly variables: Readonly<Record<string, unknown>>;
+  /** Render/helper options carrying the render context. */
+  readonly helperOptions: TemplateHelperOptions | undefined;
+  /** Original `{{ ... }}` match text, returned on a soft miss. */
+  readonly original: string;
+}
+
+/** Render-only resolver for a built-in helper. No manifest writes, no mkdir. */
+export type BuiltinHelperResolver = (args: BuiltinHelperResolveArgs) => string;
+
+/**
+ * Typed descriptor for a built-in render helper. The dispatcher in
+ * {@link substituteText} reads `arity`, `needsContext`, and `escapeOutput` as
+ * data; built-in identity itself is membership in {@link BUILTIN_HELPER_REGISTRY},
+ * not pass ordering.
+ */
+export interface HelperDescriptor {
+  /** Helper name as written in `{{ name arg }}`. */
+  readonly name: string;
+  /** Render built-in vs user-registered. Every registry entry is `builtin`. */
+  readonly kind: HelperKind;
+  /** Legal argument forms; illegal forms are rejected during dispatch. */
+  readonly arity: HelperArity;
+  /**
+   * When true, the token is preserved verbatim if no render context is present
+   * (AST-walk / preparation phase). Encodes a built-in's hard context
+   * requirement as data rather than a branch inside `substituteText`.
+   */
+  readonly needsContext: boolean;
+  /**
+   * When true, the resolver output is passed through the caller's `escapeFn`
+   * (shell escaping). `validateSchema` sets this false: it returns a complete
+   * `rdx --validate <path>` command whose path is already escaped and must not
+   * be re-escaped as a whole.
+   */
+  readonly escapeOutput: boolean;
+  /** Render-only resolver. */
+  readonly resolve: BuiltinHelperResolver;
+}
 
 /**
  * Resolve a dotted path in an object using own-property traversal.
@@ -1046,6 +1094,73 @@ export function shellEscapeValue(value: string): string {
   if (value === '') return "''";
   if (SAFE_SHELL_VALUE.test(value)) return value;
   return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Single typed source of truth for the built-in render helpers.
+ *
+ * Every `{{ name arg }}` token routes through one dispatcher in
+ * {@link substituteText}; built-in identity is a lookup in this map, not an
+ * ordered sequence of regex passes plus a name-based exclusion. Adding a
+ * built-in is a single entry here — `BUILTIN_RENDER_HELPERS` and
+ * `isBuiltinRenderHelper` are derived from it, so the reserved-name set cannot
+ * drift out of sync (issue #385).
+ */
+const BUILTIN_HELPER_REGISTRY: ReadonlyMap<string, HelperDescriptor> = new Map(
+  (
+    [
+      {
+        name: 'artifact',
+        kind: 'builtin',
+        arity: 'var',
+        needsContext: false,
+        escapeOutput: true,
+        // The literal form is rejected by the arity gate before resolve runs,
+        // so `varRef` is always defined here.
+        resolve: ({ varRef, variables, original }) =>
+          resolveArtifactHelperCall(varRef as string, variables, original),
+      },
+      {
+        name: 'path',
+        kind: 'builtin',
+        arity: 'both',
+        needsContext: true,
+        escapeOutput: true,
+        resolve: ({ literal, varRef, variables, helperOptions, original }) =>
+          resolvePathHelperCall(literal, varRef, variables, helperOptions, original),
+      },
+      {
+        name: 'validateSchema',
+        kind: 'builtin',
+        arity: 'both',
+        // Plain path/URI literals resolve without a render context
+        // (`{{ validateSchema "plan.json" }}` -> `rdx --validate plan.json`),
+        // so this built-in does not hard-require context.
+        needsContext: false,
+        // Output is a full `rdx --validate <path>` command with the path already
+        // escaped; the whole command must not be re-escaped.
+        escapeOutput: false,
+        resolve: ({ literal, varRef, variables, helperOptions, original }) =>
+          resolveValidateSchemaHelperCall(literal, varRef, variables, helperOptions, original),
+      },
+    ] satisfies readonly HelperDescriptor[]
+  ).map((descriptor): [string, HelperDescriptor] => [descriptor.name, descriptor]),
+);
+
+/**
+ * Names of all built-in render helpers, derived from {@link BUILTIN_HELPER_REGISTRY}.
+ * Single source of truth for "this name is a built-in".
+ */
+export const BUILTIN_RENDER_HELPERS: ReadonlySet<string> = new Set(BUILTIN_HELPER_REGISTRY.keys());
+
+/**
+ * Test whether a helper name refers to a built-in render helper.
+ *
+ * @param helperName - Helper name parsed from a `{{ name arg }}` placeholder
+ * @returns `true` when the name has a descriptor in {@link BUILTIN_HELPER_REGISTRY}
+ */
+export function isBuiltinRenderHelper(helperName: string): boolean {
+  return BUILTIN_HELPER_REGISTRY.has(helperName);
 }
 
 /**

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -157,11 +157,13 @@ export interface BuiltinHelperResolveArgs {
 /**
  * Render-only resolver for a built-in helper. No manifest writes, no mkdir.
  *
- * @param args - Parsed helper-call inputs ({@link BuiltinHelperResolveArgs}):
+ * `@param` args - Parsed helper-call inputs ({`@link` BuiltinHelperResolveArgs}):
  * the literal/varRef argument, render-frame variables, helper options, and the
  * original match text for soft misses.
- * @returns The rendered helper output, or the original `{{ ... }}` token on a
+ * `@returns` The rendered helper output, or the original `{{ ... }}` token on a
  * soft miss.
+ * `@throws` {Error} When a built-in resolver rejects an invalid argument shape or
+ * resolved value.
  */
 export type BuiltinHelperResolver = (args: BuiltinHelperResolveArgs) => string;
 

--- a/packages/core/src/runbook/variable-preparation.ts
+++ b/packages/core/src/runbook/variable-preparation.ts
@@ -25,11 +25,12 @@ import {
   type TrustedArtifactValue,
   type VariableValue,
 } from './effective-vars.js';
-import { BUILTIN_RENDER_HELPERS, type TemplateHelperRegistry } from './helper-invoke.js';
+import { type TemplateHelperRegistry } from './helper-invoke.js';
 import type { RunId } from './run-id.js';
 import type { RunbookRef } from './runbook-ref.js';
 import { buildContextVars, validateForVariables } from './runtime-frame.js';
 import {
+  BUILTIN_RENDER_HELPERS,
   collectUnresolvedRunbookVariables,
   resolveForBounds,
   substituteRunbookVariables,


### PR DESCRIPTION
## Summary

Routes all helper dispatch through a single typed registry pass, making the
three built-in render helpers (`artifact`, `path`, `validateSchema`)
single-sourced and type-driven rather than scattered string checks. Closes #385.

## Changes

- **Single-source built-in helpers via typed registry** — the built-in render
  helper set is derived from one registry, exposed via `BUILTIN_RENDER_HELPERS`
  / `isBuiltinRenderHelper`.
- **Route helper dispatch through one typed registry pass** — dispatch narrows
  on typed registry entries instead of branching on raw helper-name strings.
- **Narrow artifact `varRef` instead of asserting** — replaces a type assertion
  with proper narrowing on the artifact path.
- **Tests** — pins the typed helper-registry contract and dispatch routing,
  including that built-ins bypass shell-escaping even when an escape fn is
  supplied.

## Testing

`npm run verify` passes (format, spell, lint, full test suite — exit 0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying built-in helpers are recognized, take precedence over same-named user helpers, and that unresolved helper tokens are preserved as literals.
  * Enhanced validation of helper resolution and routing between built-in and user helpers.

* **Refactor**
  * Unified helper dispatch via a centralized built-in registry for consistent resolution.
  * Introduced clearer helper classification and arity handling to improve validation, error handling, and output escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->