### PR TITLE
Move built-in template helper identity to parser

### DIFF
--- a/packages/cli/__tests__/services/helper-registry.test.ts
+++ b/packages/cli/__tests__/services/helper-registry.test.ts
@@ -11,6 +11,7 @@ import {
   detectHelperCollisions,
   type HelperRegistry,
 } from '../../src/services/helper-registry.js';
+import { BUILTIN_TEMPLATE_HELPER_NAMES } from '@rundown-org/parser';
 import { createTestWorkspace, runCliInProcess } from '../helpers/test-utils.js';
 
 describe('validateHelperPath', () => {
@@ -65,33 +66,15 @@ describe('loadHelperModules', () => {
     expect(registry.size).toBe(0);
   });
 
-  it('rejects "path" as a helper name with a warning', async () => {
-    const helperFile = path.join(tmpDir, 'bad.mjs');
-    await fs.writeFile(helperFile, 'export function path(v) { return v; }');
+  it.each(
+    BUILTIN_TEMPLATE_HELPER_NAMES,
+  )('rejects "%s" as a reserved helper name with a warning', async (name) => {
+    const helperFile = path.join(tmpDir, `bad-${name}.mjs`);
+    await fs.writeFile(helperFile, `export function ${name}(v) { return v; }`);
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const registry = await loadHelperModules([helperFile], tmpDir, tmpDir);
-    expect(registry.has('path')).toBe(false);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"path" is reserved'));
-    warnSpy.mockRestore();
-  });
-
-  it('rejects "artifact" as a helper name with a warning', async () => {
-    const helperFile = path.join(tmpDir, 'bad-artifact.mjs');
-    await fs.writeFile(helperFile, 'export function artifact(v) { return v; }');
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    const registry = await loadHelperModules([helperFile], tmpDir, tmpDir);
-    expect(registry.has('artifact')).toBe(false);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"artifact" is reserved'));
-    warnSpy.mockRestore();
-  });
-
-  it('rejects "validateSchema" as a helper name with a warning', async () => {
-    const helperFile = path.join(tmpDir, 'bad-validate-schema.mjs');
-    await fs.writeFile(helperFile, 'export function validateSchema(v) { return v; }');
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    const registry = await loadHelperModules([helperFile], tmpDir, tmpDir);
-    expect(registry.has('validateSchema')).toBe(false);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"validateSchema" is reserved'));
+    expect(registry.has(name)).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(`"${name}" is reserved`));
     warnSpy.mockRestore();
   });
 

--- a/packages/core/__tests__/runbook/template-renderer.test.ts
+++ b/packages/core/__tests__/runbook/template-renderer.test.ts
@@ -24,6 +24,7 @@ import type {
   Substep,
 } from '@rundown-org/parser';
 import { RunbookSyntaxError } from '@rundown-org/parser';
+import { BUILTIN_TEMPLATE_HELPER_NAMES } from '@rundown-org/parser';
 import { parseRunbookDocument } from '@rundown-org/parser';
 import {
   expandLoopVariables as coreExpandLoopVariables,
@@ -2790,6 +2791,39 @@ describe('built-in helper registry (issue #385)', () => {
   it('validateSchema needs no context for a literal path and is not shell-escaped', () => {
     expect(substituteText('{{ validateSchema "plan.json" }}', {}, shellEscapeValue)).toBe(
       'rdx --validate plan.json',
+    );
+  });
+
+  it('recognizes every parser-owned built-in name', () => {
+    for (const name of BUILTIN_TEMPLATE_HELPER_NAMES) {
+      expect(isBuiltinRenderHelper(name)).toBe(true);
+    }
+  });
+
+  it('routes built-in names before same-named user helpers with valid helper forms', () => {
+    const helpers = new Map<string, (value: string) => string>([
+      ['artifact', () => 'USER_ARTIFACT_SHOULD_NOT_RUN'],
+      ['path', () => 'USER_PATH_SHOULD_NOT_RUN'],
+      ['validateSchema', () => 'USER_VALIDATE_SHOULD_NOT_RUN'],
+    ]);
+
+    expect(() =>
+      substituteText('{{ artifact Plan }}', { Plan: 'not-an-artifact' }, undefined, { helpers }),
+    ).toThrow(/ArtifactRecord/);
+    expect(substituteText('{{ path "plan.json" }}', {}, undefined, { helpers })).toBe(
+      '{{ path "plan.json" }}',
+    );
+    expect(substituteText('{{ validateSchema "plan.json" }}', {}, undefined, { helpers })).toBe(
+      'rdx --validate plan.json',
+    );
+  });
+
+  it('rejects literal artifact helper arguments before same-named user helpers', () => {
+    const helpers = new Map<string, (value: string) => string>([
+      ['artifact', () => 'USER_ARTIFACT_SHOULD_NOT_RUN'],
+    ]);
+    expect(() => substituteText('{{ artifact "plan.json" }}', {}, undefined, { helpers })).toThrow(
+      /literal key/,
     );
   });
 });

--- a/packages/core/__tests__/runbook/template-renderer.test.ts
+++ b/packages/core/__tests__/runbook/template-renderer.test.ts
@@ -2794,9 +2794,20 @@ describe('built-in helper registry (issue #385)', () => {
     );
   });
 
-  it('recognizes every parser-owned built-in name', () => {
+  it('never dispatches to a same-named user helper for any built-in name', () => {
+    // Drift guard: every parser-owned built-in name must resolve through the
+    // built-in registry, never the user-helper registry. If a name lacked a
+    // descriptor, dispatch would fall through and invoke this user helper.
     for (const name of BUILTIN_TEMPLATE_HELPER_NAMES) {
-      expect(isBuiltinRenderHelper(name)).toBe(true);
+      const userHelper = jest.fn(() => 'USER_SHOULD_NOT_RUN');
+      const helpers = new Map([[name, userHelper]]);
+      try {
+        substituteText(`{{ ${name} someVar }}`, { someVar: 'x' }, undefined, { helpers });
+      } catch {
+        // A built-in may reject the arg form (e.g. artifact on a non-artifact
+        // ref); the throw still proves the built-in, not the user helper, ran.
+      }
+      expect(userHelper).not.toHaveBeenCalled();
     }
   });
 

--- a/packages/core/__tests__/runbook/variable-preparation.test.ts
+++ b/packages/core/__tests__/runbook/variable-preparation.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { BUILTIN_TEMPLATE_HELPER_NAME_SET } from '@rundown-org/parser';
 import { parseRunbookDocument } from '@rundown-org/parser';
 import {
   BUILTIN_RENDER_HELPERS,
@@ -44,11 +45,13 @@ describe('template helper semantics', () => {
     expect(RESERVED_TEMPLATE_HELPER_NAMES.has('validateSchema')).toBe(true);
   });
 
-  it('single-sources the built-in render-helper set across reserved names and dispatch', () => {
-    // Reserved-name collision detection and the dispatch skip-set must be the
-    // same set, so a new built-in cannot be added to one and forgotten in the
-    // other (issue #385).
-    expect(RESERVED_TEMPLATE_HELPER_NAMES).toBe(BUILTIN_RENDER_HELPERS);
+  it('aliases reserved template helper names to the parser-owned helper set', () => {
+    expect(RESERVED_TEMPLATE_HELPER_NAMES).toBe(BUILTIN_TEMPLATE_HELPER_NAME_SET);
+    expect([...RESERVED_TEMPLATE_HELPER_NAMES].sort()).toEqual([
+      'artifact',
+      'path',
+      'validateSchema',
+    ]);
     expect([...BUILTIN_RENDER_HELPERS].sort()).toEqual(['artifact', 'path', 'validateSchema']);
   });
 

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -36,6 +36,9 @@ import {
   MAX_FOR_BOUND,
   stepIdToString,
   RunbookSyntaxError,
+  BUILTIN_TEMPLATE_HELPER_NAME_SET,
+  isBuiltinTemplateHelperName,
+  type BuiltinTemplateHelperName,
 } from '@rundown-org/parser';
 import {
   resolveTemplateHelperCall,
@@ -175,7 +178,7 @@ export type BuiltinHelperResolver = (args: BuiltinHelperResolveArgs) => string;
  */
 export interface HelperDescriptor {
   /** Helper name as written in `{{ name arg }}`. */
-  readonly name: string;
+  readonly name: BuiltinTemplateHelperName;
   /** Render built-in vs user-registered. Every registry entry is `builtin`. */
   readonly kind: HelperKind;
   /** Legal argument forms; illegal forms are rejected during dispatch. */
@@ -1073,16 +1076,16 @@ export function shellEscapeValue(value: string): string {
 }
 
 /**
- * Single typed source of truth for the built-in render helpers.
+ * Single typed source of truth for built-in render helper behavior.
  *
  * Every `{{ name arg }}` token routes through one dispatcher in
  * {@link substituteText}; built-in identity is a lookup in this map, not an
- * ordered sequence of regex passes plus a name-based exclusion. Adding a
- * built-in is a single entry here — `BUILTIN_RENDER_HELPERS` and
- * `isBuiltinRenderHelper` are derived from it, so the reserved-name set cannot
- * drift out of sync (issue #385).
+ * ordered sequence of regex passes plus a name-based exclusion. Parser owns the
+ * reserved names ({@link BUILTIN_TEMPLATE_HELPER_NAME_SET}); this map keys its
+ * behavior by those names, so the `BuiltinTemplateHelperName` key type forces
+ * the reserved-name set and the behavior registry to stay in sync (issue #385).
  */
-const BUILTIN_HELPER_REGISTRY: ReadonlyMap<string, HelperDescriptor> = new Map(
+const BUILTIN_HELPER_REGISTRY: ReadonlyMap<BuiltinTemplateHelperName, HelperDescriptor> = new Map(
   (
     [
       {
@@ -1122,23 +1125,29 @@ const BUILTIN_HELPER_REGISTRY: ReadonlyMap<string, HelperDescriptor> = new Map(
           resolveValidateSchemaHelperCall(literal, varRef, variables, helperOptions, original),
       },
     ] satisfies readonly HelperDescriptor[]
-  ).map((descriptor): [string, HelperDescriptor] => [descriptor.name, descriptor]),
+  ).map((descriptor): [BuiltinTemplateHelperName, HelperDescriptor] => [
+    descriptor.name,
+    descriptor,
+  ]),
 );
 
 /**
- * Names of all built-in render helpers, derived from {@link BUILTIN_HELPER_REGISTRY}.
- * Single source of truth for "this name is a built-in".
+ * Names of all built-in render helpers.
+ *
+ * Compatibility alias over parser-owned helper identity. Core owns helper
+ * behavior in {@link BUILTIN_HELPER_REGISTRY}; parser owns the reserved names.
  */
-export const BUILTIN_RENDER_HELPERS: ReadonlySet<string> = new Set(BUILTIN_HELPER_REGISTRY.keys());
+export const BUILTIN_RENDER_HELPERS: ReadonlySet<BuiltinTemplateHelperName> =
+  BUILTIN_TEMPLATE_HELPER_NAME_SET;
 
 /**
  * Test whether a helper name refers to a built-in render helper.
  *
  * @param helperName - Helper name parsed from a `{{ name arg }}` placeholder
- * @returns `true` when the name has a descriptor in {@link BUILTIN_HELPER_REGISTRY}
+ * @returns `true` when parser reserves the name for a built-in render helper
  */
-export function isBuiltinRenderHelper(helperName: string): boolean {
-  return BUILTIN_HELPER_REGISTRY.has(helperName);
+export function isBuiltinRenderHelper(helperName: string): helperName is BuiltinTemplateHelperName {
+  return isBuiltinTemplateHelperName(helperName);
 }
 
 /**
@@ -1184,7 +1193,9 @@ export function substituteText(
   result = result.replace(
     HELPER_CALL_TEMPLATE_REGEX,
     (match, helperName: string, varRef: string | undefined, literal: string | undefined) => {
-      const descriptor = BUILTIN_HELPER_REGISTRY.get(helperName);
+      const descriptor = isBuiltinRenderHelper(helperName)
+        ? BUILTIN_HELPER_REGISTRY.get(helperName)
+        : undefined;
       if (descriptor) {
         // Arity gate: enforce both sides of the descriptor's arity. A var-only
         // built-in (e.g. artifact) given a literal key is a hard error — declare

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -36,6 +36,7 @@ import {
   MAX_FOR_BOUND,
   stepIdToString,
   RunbookSyntaxError,
+  BUILTIN_TEMPLATE_HELPER_NAMES,
   BUILTIN_TEMPLATE_HELPER_NAME_SET,
   isBuiltinTemplateHelperName,
   type BuiltinTemplateHelperName,
@@ -177,8 +178,6 @@ export type BuiltinHelperResolver = (args: BuiltinHelperResolveArgs) => string;
  * not pass ordering.
  */
 export interface HelperDescriptor {
-  /** Helper name as written in `{{ name arg }}`. */
-  readonly name: BuiltinTemplateHelperName;
   /** Render built-in vs user-registered. Every registry entry is `builtin`. */
   readonly kind: HelperKind;
   /** Legal argument forms; illegal forms are rejected during dispatch. */
@@ -1076,58 +1075,58 @@ export function shellEscapeValue(value: string): string {
 }
 
 /**
- * Single typed source of truth for built-in render helper behavior.
+ * Behavior for each built-in render helper, keyed by parser-owned name.
  *
- * Every `{{ name arg }}` token routes through one dispatcher in
- * {@link substituteText}; built-in identity is a lookup in this map, not an
- * ordered sequence of regex passes plus a name-based exclusion. Parser owns the
- * reserved names ({@link BUILTIN_TEMPLATE_HELPER_NAME_SET}); this map keys its
- * behavior by those names, so the `BuiltinTemplateHelperName` key type forces
- * the reserved-name set and the behavior registry to stay in sync (issue #385).
+ * `satisfies Record<BuiltinTemplateHelperName, HelperDescriptor>` requires one
+ * descriptor per reserved name, so a name added to the parser tuple without a
+ * descriptor here (or a descriptor whose name is not reserved) is a compile
+ * error. That is what keeps the reserved-name set and the behavior registry in
+ * sync — drift cannot reach runtime (issue #385).
+ */
+const BUILTIN_HELPER_DESCRIPTORS = {
+  artifact: {
+    kind: 'builtin',
+    arity: 'var',
+    needsContext: false,
+    escapeOutput: true,
+    // The arity 'var' gate rejects the literal form before resolve runs, so
+    // varRef is defined here; narrow explicitly rather than assert.
+    resolve: ({ varRef, variables, original }) =>
+      varRef === undefined ? original : resolveArtifactHelperCall(varRef, variables, original),
+  },
+  path: {
+    kind: 'builtin',
+    arity: 'both',
+    needsContext: true,
+    escapeOutput: true,
+    resolve: ({ literal, varRef, variables, helperOptions, original }) =>
+      resolvePathHelperCall(literal, varRef, variables, helperOptions, original),
+  },
+  validateSchema: {
+    kind: 'builtin',
+    arity: 'both',
+    // Plain path/URI literals resolve without a render context
+    // (`{{ validateSchema "plan.json" }}` -> `rdx --validate plan.json`),
+    // so this built-in does not hard-require context.
+    needsContext: false,
+    // Output is a full `rdx --validate <path>` command with the path already
+    // escaped; the whole command must not be re-escaped.
+    escapeOutput: false,
+    resolve: ({ literal, varRef, variables, helperOptions, original }) =>
+      resolveValidateSchemaHelperCall(literal, varRef, variables, helperOptions, original),
+  },
+} satisfies Record<BuiltinTemplateHelperName, HelperDescriptor>;
+
+/**
+ * Built-in render helper behavior keyed by name. Every `{{ name arg }}` token
+ * routes through one lookup here in {@link substituteText}; built-in identity is
+ * map membership, not an ordered sequence of regex passes. The map is built by
+ * walking the parser-owned name tuple so the keys are exactly the reserved names.
  */
 const BUILTIN_HELPER_REGISTRY: ReadonlyMap<BuiltinTemplateHelperName, HelperDescriptor> = new Map(
-  (
-    [
-      {
-        name: 'artifact',
-        kind: 'builtin',
-        arity: 'var',
-        needsContext: false,
-        escapeOutput: true,
-        // The literal form is rejected by the arity gate before resolve runs,
-        // so `varRef` is always defined here.
-        // The arity 'var' gate rejects the literal form before resolve runs, so
-        // varRef is defined here; narrow explicitly rather than assert.
-        resolve: ({ varRef, variables, original }) =>
-          varRef === undefined ? original : resolveArtifactHelperCall(varRef, variables, original),
-      },
-      {
-        name: 'path',
-        kind: 'builtin',
-        arity: 'both',
-        needsContext: true,
-        escapeOutput: true,
-        resolve: ({ literal, varRef, variables, helperOptions, original }) =>
-          resolvePathHelperCall(literal, varRef, variables, helperOptions, original),
-      },
-      {
-        name: 'validateSchema',
-        kind: 'builtin',
-        arity: 'both',
-        // Plain path/URI literals resolve without a render context
-        // (`{{ validateSchema "plan.json" }}` -> `rdx --validate plan.json`),
-        // so this built-in does not hard-require context.
-        needsContext: false,
-        // Output is a full `rdx --validate <path>` command with the path already
-        // escaped; the whole command must not be re-escaped.
-        escapeOutput: false,
-        resolve: ({ literal, varRef, variables, helperOptions, original }) =>
-          resolveValidateSchemaHelperCall(literal, varRef, variables, helperOptions, original),
-      },
-    ] satisfies readonly HelperDescriptor[]
-  ).map((descriptor): [BuiltinTemplateHelperName, HelperDescriptor] => [
-    descriptor.name,
-    descriptor,
+  BUILTIN_TEMPLATE_HELPER_NAMES.map((name): [BuiltinTemplateHelperName, HelperDescriptor] => [
+    name,
+    BUILTIN_HELPER_DESCRIPTORS[name],
   ]),
 );
 
@@ -1207,8 +1206,8 @@ export function substituteText(
         ) {
           throw new Error(
             descriptor.arity === 'var'
-              ? `${descriptor.name} helper does not accept a literal key (${match}); declare it via ARTIFACTS and pass the alias.`
-              : `${descriptor.name} helper does not accept a variable reference (${match}); pass a quoted literal.`,
+              ? `${helperName} helper does not accept a literal key (${match}); declare it via ARTIFACTS and pass the alias.`
+              : `${helperName} helper does not accept a variable reference (${match}); pass a quoted literal.`,
           );
         }
         // Context gate: hard-context built-ins preserve the token when no render

--- a/packages/core/src/runbook/variable-preparation.ts
+++ b/packages/core/src/runbook/variable-preparation.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import {
+  BUILTIN_TEMPLATE_HELPER_NAME_SET,
   RESERVED_TEMPLATE_NAMES as PARSER_RESERVED_TEMPLATE_NAMES,
   isReservedTemplateName,
   type Runbook,
@@ -30,7 +31,6 @@ import type { RunId } from './run-id.js';
 import type { RunbookRef } from './runbook-ref.js';
 import { buildContextVars, validateForVariables } from './runtime-frame.js';
 import {
-  BUILTIN_RENDER_HELPERS,
   collectUnresolvedRunbookVariables,
   resolveForBounds,
   substituteRunbookVariables,
@@ -45,10 +45,9 @@ import {
 
 /**
  * Names reserved for built-in render helpers, used to detect variable-name
- * collisions. Aliases {@link BUILTIN_RENDER_HELPERS} so the reserved set and the
- * dispatch skip-set stay single-sourced. See issue #385.
+ * collisions. Parser owns the names; core owns their behavior.
  */
-export const RESERVED_TEMPLATE_HELPER_NAMES: ReadonlySet<string> = BUILTIN_RENDER_HELPERS;
+export const RESERVED_TEMPLATE_HELPER_NAMES: ReadonlySet<string> = BUILTIN_TEMPLATE_HELPER_NAME_SET;
 
 /**
  * Detect template variables whose names collide with registered helpers.

--- a/packages/parser/__tests__/reserved.test.ts
+++ b/packages/parser/__tests__/reserved.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  BUILTIN_TEMPLATE_HELPER_NAMES,
+  BUILTIN_TEMPLATE_HELPER_NAME_SET,
+  isBuiltinTemplateHelperName,
+} from '../src/reserved.js';
+
+describe('built-in template helper names', () => {
+  it('contains exactly the built-in render helper names', () => {
+    expect([...BUILTIN_TEMPLATE_HELPER_NAMES]).toEqual(['artifact', 'path', 'validateSchema']);
+    expect([...BUILTIN_TEMPLATE_HELPER_NAME_SET].sort()).toEqual([
+      'artifact',
+      'path',
+      'validateSchema',
+    ]);
+  });
+
+  it('is case-sensitive', () => {
+    expect(isBuiltinTemplateHelperName('artifact')).toBe(true);
+    expect(isBuiltinTemplateHelperName('path')).toBe(true);
+    expect(isBuiltinTemplateHelperName('validateSchema')).toBe(true);
+    expect(isBuiltinTemplateHelperName('Artifact')).toBe(false);
+    expect(isBuiltinTemplateHelperName('validateschema')).toBe(false); // cspell:disable-line
+    expect(isBuiltinTemplateHelperName('upper')).toBe(false);
+  });
+});

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -61,7 +61,11 @@ export {
   IDENTITY_OWNED_BUILTINS,
   RESERVED_TEMPLATE_NAMES,
   isReservedTemplateName,
+  BUILTIN_TEMPLATE_HELPER_NAMES,
+  BUILTIN_TEMPLATE_HELPER_NAME_SET,
+  isBuiltinTemplateHelperName,
 } from './reserved.js';
+export type { BuiltinTemplateHelperName } from './reserved.js';
 export type { ParseStepIdOptions } from './step-id.js';
 export {
   extractFrontmatter,

--- a/packages/parser/src/reserved.ts
+++ b/packages/parser/src/reserved.ts
@@ -53,3 +53,33 @@ export function formatReservedTemplateNames(): string {
 export function isReservedTemplateName(name: string): boolean {
   return RESERVED_TEMPLATE_NAMES.has(name.toLowerCase());
 }
+
+/**
+ * Built-in template helper names reserved for core render helpers.
+ *
+ * Parser owns helper identity so validation and front-end packages can share
+ * one name source without importing core render semantics. Core owns behavior.
+ */
+export const BUILTIN_TEMPLATE_HELPER_NAMES = ['artifact', 'path', 'validateSchema'] as const;
+
+/** Built-in template helper name. */
+export type BuiltinTemplateHelperName = (typeof BUILTIN_TEMPLATE_HELPER_NAMES)[number];
+
+/**
+ * Set view of {@link BUILTIN_TEMPLATE_HELPER_NAMES}.
+ *
+ * Case-sensitive: helper calls match literal helper spelling.
+ */
+export const BUILTIN_TEMPLATE_HELPER_NAME_SET: ReadonlySet<BuiltinTemplateHelperName> = new Set(
+  BUILTIN_TEMPLATE_HELPER_NAMES,
+);
+
+/**
+ * Test whether a name is reserved for a built-in template helper.
+ *
+ * @param name - Candidate helper name
+ * @returns `true` when the name is one of the built-in template helpers
+ */
+export function isBuiltinTemplateHelperName(name: string): name is BuiltinTemplateHelperName {
+  return BUILTIN_TEMPLATE_HELPER_NAME_SET.has(name as BuiltinTemplateHelperName);
+}

--- a/packages/parser/src/reserved.ts
+++ b/packages/parser/src/reserved.ts
@@ -62,7 +62,7 @@ export function isReservedTemplateName(name: string): boolean {
  */
 export const BUILTIN_TEMPLATE_HELPER_NAMES = ['artifact', 'path', 'validateSchema'] as const;
 
-/** Built-in template helper name. */
+/** Union of built-in template helper names, derived from {@link BUILTIN_TEMPLATE_HELPER_NAMES}. */
 export type BuiltinTemplateHelperName = (typeof BUILTIN_TEMPLATE_HELPER_NAMES)[number];
 
 /**


### PR DESCRIPTION
## Summary
- Parser now owns built-in template helper-name identity (`artifact`, `path`, `validateSchema`) via `BUILTIN_TEMPLATE_HELPER_NAMES`, `BUILTIN_TEMPLATE_HELPER_NAME_SET`, and `isBuiltinTemplateHelperName`, so validation and front ends share one source of truth.
- Core keeps all helper behavior in `template-renderer.ts`: the typed `BUILTIN_HELPER_REGISTRY` is now keyed by the parser-owned `BuiltinTemplateHelperName`, and `BUILTIN_RENDER_HELPERS` / `isBuiltinRenderHelper` become compatibility aliases over parser identity. `variable-preparation.ts` aliases `RESERVED_TEMPLATE_HELPER_NAMES` to the parser set.
- `helper-invoke.ts` is unchanged (no built-in skip guard re-added). CLI reserved-helper registration tests are now driven by `BUILTIN_TEMPLATE_HELPER_NAMES`.
- No behavior change — this PR only moves helper-name identity.

## Test Plan
- [x] `npm test --workspace @rundown-org/parser -- reserved.test.ts`
- [x] `npm test --workspace @rundown-org/core -- variable-preparation.test.ts template-renderer.test.ts`
- [x] `npm test --workspace @rundown-org/cli -- helper-registry.test.ts`
- [x] `npm run build` for parser, core, and cli
- [x] `npm run verify` (format, spell, lint, typed-lint, build, types, docs, full test suite) — all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage to ensure built-in template helpers are consistently recognized and take precedence over same-named user helpers, preventing regressions.

* **Chores**
  * Centralized the canonical list of built-in template helper names and tightened related typing to improve consistency and reliability across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->