### PR TITLE
Render templates in a single terminal pass

### DIFF
--- a/packages/cli/__tests__/services/template-renderer.test.ts
+++ b/packages/cli/__tests__/services/template-renderer.test.ts
@@ -2111,13 +2111,16 @@ describe('substituteText with HelperRegistry', () => {
   });
 
   it('preserves legacy path helper ctx template override as literal text', () => {
+    // Single-pass terminal rendering (B13): the unsupported `ctx={{ ... }}` form
+    // is one token whose inner `}}` ends the span, so the whole placeholder is
+    // preserved literally without a second pass expanding the nested marker.
     expect(
       substituteText('{{ path "review.json" ctx={{ childCtx }} }}', {
         WorkPath: '.rundown/work/demo',
         ContextId: 'parent',
         childCtx: 'child-123',
       }),
-    ).toBe('{{ path "review.json" ctx=child-123 }}');
+    ).toBe('{{ path "review.json" ctx={{ childCtx }} }}');
   });
 
   it('preserves legacy path helper bare ctx override as literal text', () => {
@@ -2617,6 +2620,24 @@ describe('substituteRunbookVariables with ArtifactRecord direct-alias', () => {
         ARTIFACT_RUN_ID,
         'plan.json',
       ),
+    );
+  });
+});
+
+describe('CLI template renderer terminal rendering', () => {
+  afterEach(() => {
+    resetHelperRegistry();
+  });
+
+  it('does not re-expand helper output containing template syntax', () => {
+    setHelperRegistry(new Map([['braces', (value: string) => `{{ ${value} }}`]]));
+
+    expect(substituteText('{{ braces "Name" }}', { Name: 'final' })).toBe('{{ Name }}');
+  });
+
+  it('does not re-expand variable output containing template syntax', () => {
+    expect(substituteText('{{ Name }}', { Name: '{{ Later }}', Later: 'final' })).toBe(
+      '{{ Later }}',
     );
   });
 });

--- a/packages/core/__tests__/runbook/template-nodes.test.ts
+++ b/packages/core/__tests__/runbook/template-nodes.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals';
+import { isBuiltinName, type TemplateNode } from '../../src/runbook/template/nodes.js';
+
+describe('TemplateNode', () => {
+  it('recognizes parser-owned built-in names', () => {
+    expect(isBuiltinName('artifact')).toBe(true);
+    expect(isBuiltinName('path')).toBe(true);
+    expect(isBuiltinName('validateSchema')).toBe(true);
+    expect(isBuiltinName('upper')).toBe(false);
+  });
+
+  it('supports exhaustive kind switching', () => {
+    const render = (node: TemplateNode): string => {
+      switch (node.kind) {
+        case 'literal':
+          return node.text;
+        case 'variable':
+          return node.name;
+        case 'userHelper':
+          return node.name;
+        case 'builtinHelper':
+          return node.name;
+      }
+    };
+    expect(render({ kind: 'literal', text: 'x' })).toBe('x');
+  });
+});

--- a/packages/core/__tests__/runbook/template-renderer.test.ts
+++ b/packages/core/__tests__/runbook/template-renderer.test.ts
@@ -2205,13 +2205,16 @@ describe('substituteText with HelperRegistry', () => {
   });
 
   it('preserves legacy path helper ctx template override as literal text', () => {
+    // Single-pass terminal rendering (B13): the unsupported `ctx={{ ... }}` form
+    // is one token whose inner `}}` ends the span, so the whole placeholder is
+    // preserved literally without a second pass expanding the nested marker.
     expect(
       substituteText('{{ path "review.json" ctx={{ childCtx }} }}', {
         WorkPath: '.rundown/work/demo',
         ContextId: 'parent',
         childCtx: 'child-123',
       }),
-    ).toBe('{{ path "review.json" ctx=child-123 }}');
+    ).toBe('{{ path "review.json" ctx={{ childCtx }} }}');
   });
 
   it('preserves legacy path helper bare ctx override as literal text', () => {
@@ -2864,5 +2867,34 @@ describe('unified helper dispatch routing (issue #385)', () => {
     expect(substituteText('{{ mystery "abc" }}', {}, undefined, { helpers: new Map() })).toBe(
       '{{ mystery "abc" }}',
     );
+  });
+});
+
+describe('substituteText terminal rendering', () => {
+  it('does not re-parse an explicit variable value that contains template syntax', () => {
+    expect(substituteText('{{ ./A }}', { A: '{{ B }}', B: 'final' })).toBe('{{ B }}');
+  });
+
+  it('does not re-parse a bare variable value that contains template syntax', () => {
+    expect(substituteText('{{ A }}', { A: '{{ B }}', B: 'final' })).toBe('{{ B }}');
+  });
+
+  it('does not re-parse a user-helper result that contains template syntax', () => {
+    const helpers = new Map<string, (value: string) => string>([
+      ['wrap', (value) => `{{ ${value} }}`],
+    ]);
+    expect(substituteText('{{ wrap "B" }}', { B: 'final' }, undefined, { helpers })).toBe(
+      '{{ B }}',
+    );
+  });
+
+  it('does not re-parse a built-in helper result as another template pass', () => {
+    expect(substituteText('{{ validateSchema "plan.json" }}', { plan: 'ignored' })).toBe(
+      'rdx --validate plan.json',
+    );
+  });
+
+  it('still resolves independent source tokens once', () => {
+    expect(substituteText('{{ A }} {{ B }}', { A: '{{ B }}', B: 'final' })).toBe('{{ B }} final');
   });
 });

--- a/packages/core/__tests__/runbook/template-tokenizer.properties.test.ts
+++ b/packages/core/__tests__/runbook/template-tokenizer.properties.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from '@jest/globals';
+import fc from 'fast-check';
+import { tokenizeTemplate } from '../../src/runbook/template/tokenizer.js';
+
+describe('tokenizeTemplate properties', () => {
+  it('reconstructs the original input from literal text and token raw text', () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        const reconstructed = tokenizeTemplate(input)
+          .map((node) => (node.kind === 'literal' ? node.text : node.raw))
+          .join('');
+        expect(reconstructed).toBe(input);
+      }),
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/template-tokenizer.test.ts
+++ b/packages/core/__tests__/runbook/template-tokenizer.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from '@jest/globals';
+import { tokenizeTemplate } from '../../src/runbook/template/tokenizer.js';
+
+describe('tokenizeTemplate', () => {
+  it('returns one literal node for plain text', () => {
+    expect(tokenizeTemplate('hello')).toEqual([{ kind: 'literal', text: 'hello' }]);
+  });
+
+  it('classifies plain and explicit variables', () => {
+    expect(tokenizeTemplate('a {{ Name }} {{ ./path.0.value }}')).toEqual([
+      { kind: 'literal', text: 'a ' },
+      { kind: 'variable', name: 'Name', explicit: false, raw: '{{ Name }}' },
+      { kind: 'literal', text: ' ' },
+      { kind: 'variable', name: 'path.0.value', explicit: true, raw: '{{ ./path.0.value }}' },
+    ]);
+  });
+
+  it('classifies built-in and user helpers', () => {
+    expect(tokenizeTemplate('{{ path Plan }} {{ upper "abc" }}')).toEqual([
+      {
+        kind: 'builtinHelper',
+        name: 'path',
+        arg: { kind: 'ref', name: 'Plan' },
+        raw: '{{ path Plan }}',
+      },
+      { kind: 'literal', text: ' ' },
+      {
+        kind: 'userHelper',
+        name: 'upper',
+        arg: { kind: 'literal', value: 'abc' },
+        raw: '{{ upper "abc" }}',
+      },
+    ]);
+  });
+
+  it('preserves unsupported expressions as literal text', () => {
+    expect(tokenizeTemplate('{{ }} {{ outer (inner x) }}')).toEqual([
+      { kind: 'literal', text: '{{ }} {{ outer (inner x) }}' },
+    ]);
+  });
+
+  it('preserves unsupported spans while still tokenizing later valid spans', () => {
+    expect(tokenizeTemplate('x {{ }} y {{ A }}')).toEqual([
+      { kind: 'literal', text: 'x {{ }} y ' },
+      { kind: 'variable', name: 'A', explicit: false, raw: '{{ A }}' },
+    ]);
+  });
+
+  it('handles adjacent tokens without inserting empty literals', () => {
+    expect(tokenizeTemplate('{{ A }}{{ upper "b" }}')).toEqual([
+      { kind: 'variable', name: 'A', explicit: false, raw: '{{ A }}' },
+      {
+        kind: 'userHelper',
+        name: 'upper',
+        arg: { kind: 'literal', value: 'b' },
+        raw: '{{ upper "b" }}',
+      },
+    ]);
+  });
+
+  it('treats quoted literals containing closing braces as unsupported literal text', () => {
+    expect(tokenizeTemplate('{{ validateSchema "a}}b" }}')).toEqual([
+      { kind: 'literal', text: '{{ validateSchema "a}}b" }}' },
+    ]);
+  });
+
+  it('preserves placeholders padded with excessive whitespace as literal text', () => {
+    const raw = `{{${' '.repeat(256)}name}}`;
+    expect(tokenizeTemplate(raw)).toEqual([{ kind: 'literal', text: raw }]);
+  });
+
+  it('classifies placeholders padded with whitespace within the edge bound', () => {
+    const raw = `{{${' '.repeat(64)}name${' '.repeat(64)}}}`;
+    expect(tokenizeTemplate(raw)).toEqual([
+      { kind: 'variable', name: 'name', explicit: false, raw },
+    ]);
+  });
+});

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -95,24 +95,6 @@ function buildResolvedForStep(
 const TEMPLATE_PATH_REGEX =
   /{{[ \t\r\n]{0,64}([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)[ \t\r\n]{0,64}}}/g;
 
-/**
- * Matches `{{ ./VarName }}` — explicit variable lookup, bypasses helper registry.
- * Capture group 1: full dotted path after `./` (identifier or numeric segments).
- */
-const EXPLICIT_VAR_TEMPLATE_REGEX =
-  /\{\{[ \t\r\n]{0,64}\.\/((?:[a-zA-Z_][a-zA-Z0-9_]*)(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)[ \t\r\n]{0,64}\}\}/g;
-
-/**
- * Matches `{{ helperName varRef }}` or `{{ helperName "literal" }}`.
- * Group 1: helperName, Group 2: varRef (or undefined), Group 3: literal (or undefined).
- *
- * The single matcher for all two-token helper calls. Dispatch (built-in vs
- * user) is decided by BUILTIN_HELPER_REGISTRY membership in `substituteText`,
- * not by this regex. New built-ins are registry entries, not new regexes.
- */
-const HELPER_CALL_TEMPLATE_REGEX =
-  /\{\{[ \t\r\n]{0,64}([a-zA-Z_][a-zA-Z0-9_]*)[ \t\r\n]{1,64}(?:([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)|"([^"]*)")[ \t\r\n]{0,64}\}\}/g;
-
 /** Context available to template helpers during render. */
 export type TemplateRenderContext =
   | {
@@ -1154,23 +1136,14 @@ export function isBuiltinRenderHelper(helperName: string): helperName is Builtin
 /**
  * Substitute placeholders in text with optional escaping.
  *
- * Supports three placeholder forms (processed in order):
- * 1. `{{ ./VarName }}` — explicit variable lookup, bypasses helper dispatch
- * 2. `{{ name arg }}` — unified helper dispatch (built-in or user) via the typed registry
- * 3. `{{ identifier }}` — standard variable substitution
- *
- * Pass isolation: each pass operates on the full result string produced by the
- * previous pass. A variable value that itself contains `{{ name arg }}` syntax
- * will be processed by pass 2 after being substituted by pass 1. This is benign
- * in practice — variable values rarely contain helper call syntax — but callers
- * should be aware that variable values are not isolated from later passes.
- * Similarly, a value returned by a helper that contains `{{ VarName }}` syntax
- * will be processed by pass 3.
+ * Rendering is single-pass: the source string is tokenized once, each token is
+ * classified once, and resolved output is appended as terminal data. Resolved
+ * values or helper outputs containing `{{ ... }}` are not re-parsed.
  *
  * @param text - Input text containing placeholders
  * @param variables - Variable map for substitution
  * @param escapeFn - Optional escape function for resolved values
- * @param helperOptions - Filesystem options for artifact-producing helpers
+ * @param helperOptions - Render options for helpers and artifact-producing built-ins
  * @returns Text with resolved placeholders substituted
  */
 export function substituteText(

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -1166,6 +1166,8 @@ export function substituteText(
  * @param escapeFn - Optional escape function for resolved values
  * @param helperOptions - Render options for helpers and artifact-producing built-ins
  * @returns Rendered string
+ * @throws {Error} When a built-in helper's argument form violates its arity, or
+ *   when a node has an unhandled kind (exhaustiveness guard)
  */
 function renderTemplateNodes(
   nodes: readonly TemplateNode[],
@@ -1188,6 +1190,13 @@ function renderTemplateNodes(
       case 'builtinHelper':
         result += renderBuiltinHelperNode(node, variables, escapeFn, helperOptions);
         break;
+      default: {
+        // Exhaustiveness guard: a new TemplateNode kind must add a case above.
+        const _exhaustive: never = node;
+        throw new Error(
+          `Unhandled template node kind: ${String((_exhaustive as { kind: unknown }).kind)}`,
+        );
+      }
     }
   }
   return result;

--- a/packages/core/src/runbook/template-renderer.ts
+++ b/packages/core/src/runbook/template-renderer.ts
@@ -56,6 +56,8 @@ import {
   renderLiteralArtifactPath,
 } from './renderer/artifact-helper.js';
 import { artifactUriToPath } from './artifact-uri.js';
+import { tokenizeTemplate } from './template/tokenizer.js';
+import type { TemplateNode } from './template/nodes.js';
 import type { StepVariables } from './runtime-frame.js';
 import type { RunId } from './run-id.js';
 
@@ -1177,81 +1179,158 @@ export function substituteText(
   escapeFn?: (value: string) => string,
   helperOptions?: TemplateHelperOptions,
 ): string {
-  // Pass 1: {{ ./VarName }} explicit variable lookup, bypasses helper registry
-  let result = text.replace(EXPLICIT_VAR_TEMPLATE_REGEX, (match, varPath: string) => {
-    const value = resolveTemplatePath(varPath, variables, helperOptions);
-    if (value === undefined) return match;
-    return escapeFn ? escapeFn(value) : value;
-  });
+  return renderTemplateNodes(tokenizeTemplate(text), variables, escapeFn, helperOptions);
+}
 
-  // Pass 2: unified helper dispatch. Every two-token `{{ name arg }}` call —
-  // built-in or user — routes through one registry lookup. Built-in identity is
-  // a descriptor in BUILTIN_HELPER_REGISTRY (not an ordered pass); unknown names
-  // fall through to the user-helper registry; unresolved names are preserved as
-  // literal text.
-  result = result.replace(
-    HELPER_CALL_TEMPLATE_REGEX,
-    (match, helperName: string, varRef: string | undefined, literal: string | undefined) => {
-      const descriptor = isBuiltinRenderHelper(helperName)
-        ? BUILTIN_HELPER_REGISTRY.get(helperName)
-        : undefined;
-      if (descriptor) {
-        // Arity gate: enforce both sides of the descriptor's arity. A var-only
-        // built-in (e.g. artifact) given a literal key is a hard error — declare
-        // it via ARTIFACTS and pass the alias instead; a literal-only built-in
-        // given a variable reference is the symmetric error.
-        if (
-          (literal !== undefined && descriptor.arity === 'var') ||
-          (varRef !== undefined && descriptor.arity === 'literal')
-        ) {
-          throw new Error(
-            descriptor.arity === 'var'
-              ? `${helperName} helper does not accept a literal key (${match}); declare it via ARTIFACTS and pass the alias.`
-              : `${helperName} helper does not accept a variable reference (${match}); pass a quoted literal.`,
-          );
-        }
-        // Context gate: hard-context built-ins preserve the token when no render
-        // context exists (AST-walk / preparation phase).
-        if (descriptor.needsContext && getRenderContext(helperOptions) === undefined) {
-          return match;
-        }
-        const raw = descriptor.resolve({
-          literal,
-          varRef,
-          variables,
-          helperOptions,
-          original: match,
-        });
-        if (raw === match) return match;
-        return descriptor.escapeOutput && escapeFn ? escapeFn(raw) : raw;
-      }
-
-      // User helper: resolve the argument, then dispatch through the user registry.
-      let argValue: string;
-      if (varRef !== undefined) {
-        const resolved = resolveTemplatePath(varRef, variables, helperOptions);
-        // Preserve the original placeholder when the variable arg is unresolved.
-        // Silently substituting '' would corrupt output (CLAUDE.md "No silent mapping").
-        if (resolved === undefined) return match;
-        argValue = resolved;
-      } else {
-        argValue = literal ?? '';
-      }
-      const raw = resolveHelperCall(helperName, argValue, match, helperOptions);
-      if (raw === match) return match;
-      return escapeFn ? escapeFn(raw) : raw;
-    },
-  );
-
-  // Pass 3: {{ identifier }} standard variable substitution
-  result = result.replace(TEMPLATE_PATH_REGEX, (match, path: string) => {
-    const value = resolveTemplatePathRaw(path, variables);
-    if (value === undefined) return match;
-    const rendered = renderTemplateValue(value, variables, helperOptions);
-    return escapeFn ? escapeFn(rendered) : rendered;
-  });
-
+/**
+ * Render tokenized template nodes into terminal output.
+ *
+ * Each node resolves once and its output is appended as terminal data; resolved
+ * values are never re-tokenized.
+ *
+ * @param nodes - Ephemeral token nodes for one render call
+ * @param variables - Variable map for substitution
+ * @param escapeFn - Optional escape function for resolved values
+ * @param helperOptions - Render options for helpers and artifact-producing built-ins
+ * @returns Rendered string
+ */
+function renderTemplateNodes(
+  nodes: readonly TemplateNode[],
+  variables: Readonly<Record<string, unknown>>,
+  escapeFn: ((value: string) => string) | undefined,
+  helperOptions: TemplateHelperOptions | undefined,
+): string {
+  let result = '';
+  for (const node of nodes) {
+    switch (node.kind) {
+      case 'literal':
+        result += node.text;
+        break;
+      case 'variable':
+        result += renderVariableNode(node, variables, escapeFn, helperOptions);
+        break;
+      case 'userHelper':
+        result += renderUserHelperNode(node, variables, escapeFn, helperOptions);
+        break;
+      case 'builtinHelper':
+        result += renderBuiltinHelperNode(node, variables, escapeFn, helperOptions);
+        break;
+    }
+  }
   return result;
+}
+
+/**
+ * Render a variable node, preserving the original token when unresolved.
+ *
+ * @param node - Variable token node
+ * @param variables - Variable map for substitution
+ * @param escapeFn - Optional escape function for the resolved value
+ * @param helperOptions - Render options forwarded to the value projector
+ * @returns Resolved value or the original raw token
+ */
+function renderVariableNode(
+  node: Extract<TemplateNode, { kind: 'variable' }>,
+  variables: Readonly<Record<string, unknown>>,
+  escapeFn: ((value: string) => string) | undefined,
+  helperOptions: TemplateHelperOptions | undefined,
+): string {
+  const rendered = node.explicit
+    ? resolveTemplatePath(node.name, variables, helperOptions)
+    : renderRawTemplatePath(node.name, variables, helperOptions);
+  if (rendered === undefined) return node.raw;
+  return escapeFn ? escapeFn(rendered) : rendered;
+}
+
+/**
+ * Resolve a bare variable reference and project its raw value to a string.
+ *
+ * @param path - Dotted variable path
+ * @param variables - Variable map for substitution
+ * @param helperOptions - Render options forwarded to the value projector
+ * @returns Projected value, or undefined when the variable is unresolved
+ */
+function renderRawTemplatePath(
+  path: string,
+  variables: Readonly<Record<string, unknown>>,
+  helperOptions: TemplateHelperOptions | undefined,
+): string | undefined {
+  const value = resolveTemplatePathRaw(path, variables);
+  if (value === undefined) return undefined;
+  return renderTemplateValue(value, variables, helperOptions);
+}
+
+/**
+ * Render a user-helper node, preserving the original token on a soft miss.
+ *
+ * @param node - User-helper token node
+ * @param variables - Variable map for substitution
+ * @param escapeFn - Optional escape function for the resolved value
+ * @param helperOptions - Render options carrying the user-helper registry
+ * @returns Helper output or the original raw token
+ */
+function renderUserHelperNode(
+  node: Extract<TemplateNode, { kind: 'userHelper' }>,
+  variables: Readonly<Record<string, unknown>>,
+  escapeFn: ((value: string) => string) | undefined,
+  helperOptions: TemplateHelperOptions | undefined,
+): string {
+  const argValue =
+    node.arg.kind === 'literal'
+      ? node.arg.value
+      : resolveTemplatePath(node.arg.name, variables, helperOptions);
+  if (argValue === undefined) return node.raw;
+
+  const rendered = resolveHelperCall(node.name, argValue, node.raw, helperOptions);
+  if (rendered === node.raw) return node.raw;
+  return escapeFn ? escapeFn(rendered) : rendered;
+}
+
+/**
+ * Render a built-in helper node by reusing its registry descriptor.
+ *
+ * @param node - Built-in helper token node
+ * @param variables - Variable map for substitution
+ * @param escapeFn - Optional escape function for the resolved value
+ * @param helperOptions - Render options carrying context and registry
+ * @returns Built-in output or the original raw token
+ * @throws {Error} When the argument form violates the descriptor's arity
+ */
+function renderBuiltinHelperNode(
+  node: Extract<TemplateNode, { kind: 'builtinHelper' }>,
+  variables: Readonly<Record<string, unknown>>,
+  escapeFn: ((value: string) => string) | undefined,
+  helperOptions: TemplateHelperOptions | undefined,
+): string {
+  const descriptor = BUILTIN_HELPER_REGISTRY.get(node.name);
+  if (!descriptor) return node.raw;
+
+  const literal = node.arg.kind === 'literal' ? node.arg.value : undefined;
+  const varRef = node.arg.kind === 'ref' ? node.arg.name : undefined;
+  if (
+    (literal !== undefined && descriptor.arity === 'var') ||
+    (varRef !== undefined && descriptor.arity === 'literal')
+  ) {
+    throw new Error(
+      descriptor.arity === 'var'
+        ? `${node.name} helper does not accept a literal key (${node.raw}); declare it via ARTIFACTS and pass the alias.`
+        : `${node.name} helper does not accept a variable reference (${node.raw}); pass a quoted literal.`,
+    );
+  }
+
+  if (descriptor.needsContext && getRenderContext(helperOptions) === undefined) {
+    return node.raw;
+  }
+
+  const rendered = descriptor.resolve({
+    literal,
+    varRef,
+    variables,
+    helperOptions,
+    original: node.raw,
+  });
+  if (rendered === node.raw) return node.raw;
+  return descriptor.escapeOutput && escapeFn ? escapeFn(rendered) : rendered;
 }
 
 /**

--- a/packages/core/src/runbook/template/nodes.ts
+++ b/packages/core/src/runbook/template/nodes.ts
@@ -1,0 +1,46 @@
+import { isBuiltinTemplateHelperName, type BuiltinTemplateHelperName } from '@rundown-org/parser';
+
+/** Built-in helper name, parser-owned and core-rendered. */
+export type BuiltinName = BuiltinTemplateHelperName;
+
+/** Template helper argument. */
+export type TemplateArg =
+  | { readonly kind: 'ref'; readonly name: string }
+  | { readonly kind: 'literal'; readonly value: string };
+
+/**
+ * Ephemeral template node produced for a single render call.
+ *
+ * Never persist this type into RunbookState, RunbookContext, or XState
+ * snapshots.
+ */
+export type TemplateNode =
+  | { readonly kind: 'literal'; readonly text: string }
+  | {
+      readonly kind: 'variable';
+      readonly name: string;
+      readonly explicit: boolean;
+      readonly raw: string;
+    }
+  | {
+      readonly kind: 'userHelper';
+      readonly name: string;
+      readonly arg: TemplateArg;
+      readonly raw: string;
+    }
+  | {
+      readonly kind: 'builtinHelper';
+      readonly name: BuiltinName;
+      readonly arg: TemplateArg;
+      readonly raw: string;
+    };
+
+/**
+ * Check whether a helper name is built-in.
+ *
+ * @param name - Candidate helper name
+ * @returns `true` when parser reserves the name for a built-in helper
+ */
+export function isBuiltinName(name: string): name is BuiltinName {
+  return isBuiltinTemplateHelperName(name);
+}

--- a/packages/core/src/runbook/template/nodes.ts
+++ b/packages/core/src/runbook/template/nodes.ts
@@ -19,19 +19,26 @@ export type TemplateNode =
   | {
       readonly kind: 'variable';
       readonly name: string;
+      /**
+       * Explicit reference (`{{ ./Var }}`) versus a bare reference (`{{ Var }}`).
+       * Explicit references bypass the helper registry and resolve as variables.
+       */
       readonly explicit: boolean;
+      /** Original placeholder token, preserved for soft-miss fallback and debugging. */
       readonly raw: string;
     }
   | {
       readonly kind: 'userHelper';
       readonly name: string;
       readonly arg: TemplateArg;
+      /** Original placeholder token, preserved for soft-miss fallback and debugging. */
       readonly raw: string;
     }
   | {
       readonly kind: 'builtinHelper';
       readonly name: BuiltinName;
       readonly arg: TemplateArg;
+      /** Original placeholder token, preserved for soft-miss fallback and debugging. */
       readonly raw: string;
     };
 

--- a/packages/core/src/runbook/template/tokenizer.ts
+++ b/packages/core/src/runbook/template/tokenizer.ts
@@ -1,0 +1,110 @@
+import type { TemplateArg, TemplateNode } from './nodes.js';
+import { isBuiltinName } from './nodes.js';
+
+/**
+ * Maximum interior whitespace, per side, accepted between `{{`/`}}` and the
+ * token body. Mirrors the bound the prior pass-order regexes enforced so
+ * malformed placeholders padded with excessive whitespace stay literal.
+ */
+const MAX_EDGE_WHITESPACE = 64;
+
+const PATH_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*$/;
+const HELPER_PATTERN =
+  /^([a-zA-Z_][a-zA-Z0-9_]*)[ \t\r\n]{1,64}((?:[a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)|"[^"]*")$/;
+
+/**
+ * Tokenize a template string in a single source scan.
+ *
+ * Invalid or unsupported `{{ ... }}` forms are left as literal text because
+ * current rendering preserves unknown placeholders. Quoted helper literals
+ * containing `}}` are unsupported and are preserved literally by design.
+ *
+ * @param text - Template text
+ * @returns Ephemeral token nodes for one render call
+ */
+export function tokenizeTemplate(text: string): TemplateNode[] {
+  const nodes: TemplateNode[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const open = text.indexOf('{{', cursor);
+    if (open === -1) {
+      pushLiteral(nodes, text.slice(cursor));
+      break;
+    }
+
+    const close = text.indexOf('}}', open + 2);
+    if (close === -1) {
+      pushLiteral(nodes, text.slice(cursor));
+      break;
+    }
+
+    if (open > cursor) {
+      pushLiteral(nodes, text.slice(cursor, open));
+    }
+
+    const raw = text.slice(open, close + 2);
+    const node = classify(raw);
+    if (node) {
+      nodes.push(node);
+    } else {
+      pushLiteral(nodes, raw);
+    }
+
+    cursor = close + 2;
+  }
+
+  return nodes;
+}
+
+function pushLiteral(nodes: TemplateNode[], text: string): void {
+  if (text === '') return;
+  if (nodes.length > 0) {
+    const previous = nodes[nodes.length - 1];
+    if (previous.kind === 'literal') {
+      nodes[nodes.length - 1] = { kind: 'literal', text: previous.text + text };
+      return;
+    }
+  }
+  nodes.push({ kind: 'literal', text });
+}
+
+function classify(raw: string): TemplateNode | undefined {
+  const interior = raw.slice(2, -2);
+  // Preserve malformed placeholders padded with excessive whitespace literally,
+  // matching the prior regex bound; the trim below is otherwise unbounded.
+  if (
+    interior.length - interior.trimStart().length > MAX_EDGE_WHITESPACE ||
+    interior.length - interior.trimEnd().length > MAX_EDGE_WHITESPACE
+  ) {
+    return undefined;
+  }
+
+  const inner = interior.trim();
+  if (inner.startsWith('./')) {
+    const explicit = inner.slice(2).trim();
+    if (!PATH_PATTERN.test(explicit)) return undefined;
+    return { kind: 'variable', name: explicit, explicit: true, raw };
+  }
+
+  if (PATH_PATTERN.test(inner)) {
+    return { kind: 'variable', name: inner, explicit: false, raw };
+  }
+
+  const helperMatch = HELPER_PATTERN.exec(inner);
+  if (!helperMatch) return undefined;
+
+  const [, helperName, rawArg] = helperMatch;
+  const arg = parseArg(rawArg);
+  if (isBuiltinName(helperName)) {
+    return { kind: 'builtinHelper', name: helperName, arg, raw };
+  }
+  return { kind: 'userHelper', name: helperName, arg, raw };
+}
+
+function parseArg(rawArg: string): TemplateArg {
+  if (rawArg.startsWith('"') && rawArg.endsWith('"')) {
+    return { kind: 'literal', value: rawArg.slice(1, -1) };
+  }
+  return { kind: 'ref', name: rawArg };
+}


### PR DESCRIPTION
> Stacked on #394 (PR1: parser-owned helper identity). Base = `template-helper-dispatch-plan`; retarget to `main` once #394 merges.

## Summary
- Replaces the pass-order template renderer with a core-owned single-pass renderer: each source string is tokenized once, classified once, dispatched once, and resolved output is appended as terminal data.
- New ephemeral, never-persisted node types (`packages/core/src/runbook/template/nodes.ts`) and a single-scan tokenizer (`.../template/tokenizer.ts`) that preserves unsupported `{{ ... }}` spans literally.
- `substituteText` now routes through the tokenizer + an inline node renderer that **reuses the existing `BUILTIN_HELPER_REGISTRY` descriptor data** (arity / needsContext / escapeOutput) — no separate dispatch module, renderer wrapper, result wrapper, or resolver layer. Removed the now-unused `EXPLICIT_VAR_TEMPLATE_REGEX` / `HELPER_CALL_TEMPLATE_REGEX`; kept `TEMPLATE_PATH_REGEX` (still used by unresolved-variable collection).

## Behavior change (B13, intentional)
Resolved variable values and helper outputs that themselves contain `{{ ... }}` are now **terminal** — they are not re-parsed by a second pass. Two existing tests pinned the old re-entrant behavior (`{{ path "review.json" ctx={{ childCtx }} }}` expanding the nested marker) and were updated to the terminal output, in both the core and CLI service renderer test suites. All other behaviors are unchanged.

## Parity guard preserved
The tokenizer keeps the prior 64-char interior-whitespace bound so malformed placeholders padded with excessive whitespace stay literal (the old regexes enforced this; the naive `.trim()` would have resolved them). Pinned with tokenizer tests.

## Pre-flight (Task 0)
No shipped runbook or registered helper intentionally stores/emits `{{ ... }}` for a second render pass — matches were two independent tokens on one line, doc comments, or undefined-variable warning strings.

## Test Plan
- [x] `npm test` core: tokenizer, tokenizer properties (input reconstruction), nodes, renderer (incl. terminal-rendering), artifacts — 262 passing
- [x] CLI service renderer + artifacts suites — 223 passing
- [x] Full unit suite, all packages (core 3153, cli 1985, …)
- [x] `npm run build`
- [x] `npm run verify` — all gates green (format, spell, lint, typed-lint, types, docs, tests)

## Known pre-existing issues (not caused by this change; reproduce on the base branch)
- `npm run test:integration`: `scenario-runner.test.ts` / `for-loop-outputs.test.ts` intermittently exceed the 15s per-test timeout under load (a `process.chdir` cascade then amplifies the count). Reproduces identically on the untouched base; passes in isolation.
- Scoped mutation testing could not run: Stryker's per-package sandbox can't resolve the repo-root `jest.config.base.js` imported by `packages/core/jest.config.js` (`ERR_MODULE_NOT_FOUND`). Reproduces on the base even when mutating an unrelated file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template rendering is now single-pass and preserves literal placeholders to avoid unintended re-expansion.

* **New Features**
  * Added a tokenized template parser that accurately classifies variables, user and built-in helpers, and preserves unsupported/edge-case syntax.
  * Rendering now enforces terminal semantics (resolved outputs are not re-parsed).

* **Tests**
  * New tests cover tokenization, terminal-rendering semantics, helper/variable edge cases, and property-based tokenizer validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->