### PR TITLE
fix(plugin): correct e2e/writing skill artifact + claim-id guidance, add e2e runtime coverage

### DIFF
--- a/packages/claude-code-plugin/__tests__/runbooks/end-to-end-test-runtime.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/end-to-end-test-runtime.integration.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Runtime integration coverage for the bundled end-to-end-test workflow.
+ *
+ * Unlike `workflow.integration.test.ts` (which mostly validates parser/AST shape
+ * and `rd check`), this suite drives the *real* runtime transitions of
+ * `end-to-end-test/end-to-end-test.runbook.md` and its delegated
+ * `review-and-collate.runbook.md` children:
+ *
+ * - inline launch of the local `write-file` and `review-and-collate` children,
+ * - delegation-token issue at each `DELEGATE` substep,
+ * - `rd claim` launching the delegated `review-file` child,
+ * - claim-id-targeted `rd pass` advancing a prompted claimed child,
+ * - auto-resolution of the parent substep and auto-advance on child completion,
+ * - artifact alias handoff (the `PlanPath` produced by `write-file` flows into
+ *   the delegated `review-file` child, and direct/`path` aliases render as
+ *   local filesystem paths, never `rd://` URIs).
+ *
+ * Pattern: follows `workflow.integration.test.ts` (subprocess `runCli`, a temp
+ * cwd, and `CLAUDE_PLUGIN_ROOT` pointed at the plugin so `rundown:` and bundled
+ * schema artifacts resolve).
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdir, rm } from 'node:fs/promises';
+import { mkdtempSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { runCli } from '../helpers/test-utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pluginRoot = join(__dirname, '..', '..');
+
+type JsonEvent = Record<string, unknown>;
+
+/** Parse mixed CLI stdout, ignoring blank lines and non-JSON diagnostic text. */
+function parseJsonEvents(stdout: string): JsonEvent[] {
+  const events: JsonEvent[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        events.push(parsed as JsonEvent);
+      }
+    } catch {}
+  }
+  return events;
+}
+
+function eventRunbookPath(event: JsonEvent): string {
+  const runbook = event.runbook as { readonly path?: unknown } | undefined;
+  return typeof runbook?.path === 'string' ? runbook.path : '';
+}
+
+function eventPromptText(event: JsonEvent): string {
+  if (typeof event.prompt === 'string') return event.prompt;
+  return typeof event.commandCode === 'string' ? event.commandCode : '';
+}
+
+function enteredStep(
+  events: JsonEvent[],
+  runbookSuffix: string,
+  current: string,
+): JsonEvent | undefined {
+  return events.find(
+    (event) =>
+      event.type === 'step_entered' &&
+      eventRunbookPath(event).endsWith(runbookSuffix) &&
+      (event.position as { current?: string } | undefined)?.current === current,
+  );
+}
+
+interface StatusResponse {
+  readonly file?: string;
+  readonly position?: { readonly current?: string };
+  readonly delegations?: ReadonlyArray<{
+    readonly substep: string;
+    readonly state: string;
+    readonly token: string;
+    readonly runbook: string;
+  }>;
+}
+
+describe('end-to-end-test runtime delegation + artifact handoff', () => {
+  let tempDir: string;
+  let previousPluginRoot: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'rd-e2e-runtime-'));
+    await mkdir(join(tempDir, '.claude', 'rundown', 'runs'), { recursive: true });
+    previousPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+    process.env.CLAUDE_PLUGIN_ROOT = pluginRoot;
+  });
+
+  afterEach(async () => {
+    if (previousPluginRoot === undefined) {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    } else {
+      process.env.CLAUDE_PLUGIN_ROOT = previousPluginRoot;
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  /** Advance the active runbook with a bare `rd pass` and collect its events. */
+  function pass(): JsonEvent[] {
+    const result = runCli(['pass'], tempDir);
+    return parseJsonEvents(result.stdout);
+  }
+
+  function status(): StatusResponse {
+    const result = runCli(['status'], tempDir);
+    expect(result.exitCode).toBe(0);
+    return JSON.parse(result.stdout) as StatusResponse;
+  }
+
+  /**
+   * Drive the bundled workflow in prompted mode until `review-and-collate`
+   * reaches its first DELEGATE substep, returning the auto-issued token and the
+   * accumulated events. Bounded so a flow regression fails loudly instead of
+   * hanging.
+   */
+  function driveToReviewDelegate(): { token: string; events: JsonEvent[] } {
+    const start = runCli(['run', '--prompted', 'rundown:end-to-end-test'], tempDir);
+    expect(start.exitCode).toBe(0);
+    const events = parseJsonEvents(start.stdout);
+
+    for (let i = 0; i < 12; i += 1) {
+      const current = status();
+      const pending = current.delegations?.find(
+        (d) => d.state === 'pending' && d.runbook.endsWith('review-file.runbook.md'),
+      );
+      if (
+        pending &&
+        current.file?.endsWith('review-and-collate.runbook.md') &&
+        current.position?.current === '1'
+      ) {
+        return { token: pending.token, events };
+      }
+      events.push(...pass());
+    }
+    throw new Error('Did not reach review-and-collate DELEGATE step');
+  }
+
+  it('inline-launches write-file and review-and-collate from the parent', () => {
+    const { events } = driveToReviewDelegate();
+
+    expect(enteredStep(events, 'end-to-end-test/write-file.runbook.md', '1')).toBeDefined();
+    expect(enteredStep(events, 'end-to-end-test/review-and-collate.runbook.md', '1')).toBeDefined();
+  });
+
+  it('auto-issues a review-file delegation token at the DELEGATE substep', () => {
+    const { token } = driveToReviewDelegate();
+    expect(token).toEqual(expect.stringMatching(/^rdtk_/));
+  });
+
+  it('hands PlanPath through to the delegated review child as a local path', () => {
+    const { token } = driveToReviewDelegate();
+
+    const claim = runCli(['claim', token], tempDir);
+    expect(claim.exitCode).toBe(0);
+    const claimEvents = parseJsonEvents(claim.stdout);
+    const claimResult = claimEvents.find((event) => event.kind === 'claim') as
+      | { claim_id?: string }
+      | undefined;
+    const claimId = claimResult?.claim_id;
+    expect(claimId).toEqual(expect.stringMatching(/^rdclm_/));
+
+    // The claim launches the review-file child at step 1.
+    expect(enteredStep(claimEvents, 'review-file.runbook.md', '1')).toBeDefined();
+
+    // Step 2 of review-file rehydrates the inherited PlanPath artifact, proving
+    // the alias produced by write-file was handed across the delegation.
+    const advance2 = parseJsonEvents(runCli(['pass', '--claim-id', claimId!], tempDir).stdout);
+    const reviewStep2 = enteredStep(advance2, 'review-file.runbook.md', '2');
+    expect(reviewStep2).toBeDefined();
+    const step2Artifacts = reviewStep2!.artifacts as Record<string, unknown> | undefined;
+    expect(step2Artifacts).toBeDefined();
+    expect(Object.keys(step2Artifacts!)).toContain('PlanPath');
+
+    // Step 3 writes ReviewPath; its prompt renders `{{ path ReviewPath }}` as a
+    // local work-dir path, never an rd:// URI (direct/path alias semantics).
+    const advance3 = parseJsonEvents(runCli(['pass', '--claim-id', claimId!], tempDir).stdout);
+    const reviewStep3 = enteredStep(advance3, 'review-file.runbook.md', '3');
+    expect(reviewStep3).toBeDefined();
+    expect(eventPromptText(reviewStep3!)).toMatch(
+      /\.rundown\/work\/.*\/rd_[a-f0-9]{32}\/end-to-end-test-review\.json/,
+    );
+    expect(eventPromptText(reviewStep3!)).not.toContain('rd://artifacts/');
+  });
+
+  it('advances a claimed child via claim-id and auto-aggregates into the parent', () => {
+    const { token } = driveToReviewDelegate();
+
+    const claim = runCli(['claim', token], tempDir);
+    expect(claim.exitCode).toBe(0);
+    const claimId = (
+      parseJsonEvents(claim.stdout).find((event) => event.kind === 'claim') as {
+        claim_id?: string;
+      }
+    ).claim_id;
+    expect(claimId).toEqual(expect.stringMatching(/^rdclm_/));
+
+    // review-file has four steps; drive all of them with claim-id transitions.
+    let lastEvents: JsonEvent[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      const result = runCli(['pass', '--claim-id', claimId!], tempDir);
+      expect(result.exitCode).toBe(0);
+      lastEvents = parseJsonEvents(result.stdout);
+    }
+
+    // On the child's final pass the parent auto-resolves substep 1 and the
+    // review-and-collate parent advances to its second DELEGATE step (collate).
+    expect(
+      lastEvents.some(
+        (event) =>
+          event.type === 'step_entered' &&
+          eventRunbookPath(event).endsWith('review-and-collate.runbook.md') &&
+          (event.position as { current?: string } | undefined)?.current === '2',
+      ),
+    ).toBe(true);
+
+    // The parent is now at its second DELEGATE substep with a fresh collate token.
+    const after = status();
+    expect(after.file).toMatch(/review-and-collate\.runbook\.md$/);
+    expect(after.position?.current).toBe('2');
+    const collate = after.delegations?.find((d) => d.runbook.endsWith('collate-files.runbook.md'));
+    expect(collate?.state).toBe('pending');
+    expect(collate?.token).toEqual(expect.stringMatching(/^rdtk_/));
+  });
+});

--- a/packages/claude-code-plugin/__tests__/runbooks/end-to-end-test-runtime.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/end-to-end-test-runtime.integration.test.ts
@@ -30,6 +30,11 @@ import { runCli } from '../helpers/test-utils.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const pluginRoot = path.join(__dirname, '..', '..');
+// Production injects CLAUDE_PLUGIN_ROOT slash-terminated (see
+// `deriveClaudePluginRoot` in cli/src/helpers/runbook-pipeline.ts, which returns
+// `${pluginRoot}/`). Mirror that exact form so this runtime test exercises the
+// same path/schema/artifact resolution as production.
+const pluginRootEnv = `${pluginRoot}/`;
 
 type JsonEvent = Record<string, unknown>;
 
@@ -94,7 +99,7 @@ describe('end-to-end-test runtime delegation + artifact handoff', () => {
     tempDir = mkdtempSync(path.join(tmpdir(), 'rd-e2e-runtime-'));
     await mkdir(path.join(tempDir, '.claude', 'rundown', 'runs'), { recursive: true });
     previousPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
-    process.env.CLAUDE_PLUGIN_ROOT = pluginRoot;
+    process.env.CLAUDE_PLUGIN_ROOT = pluginRootEnv;
   });
 
   afterEach(async () => {

--- a/packages/claude-code-plugin/__tests__/runbooks/end-to-end-test-runtime.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/end-to-end-test-runtime.integration.test.ts
@@ -22,14 +22,14 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { mkdir, rm } from 'node:fs/promises';
 import { mkdtempSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import * as path from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { runCli } from '../helpers/test-utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const pluginRoot = join(__dirname, '..', '..');
+const __dirname = path.dirname(__filename);
+const pluginRoot = path.join(__dirname, '..', '..');
 
 type JsonEvent = Record<string, unknown>;
 
@@ -45,7 +45,9 @@ function parseJsonEvents(stdout: string): JsonEvent[] {
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         events.push(parsed as JsonEvent);
       }
-    } catch {}
+    } catch {
+      // Skip non-JSON lines (e.g., diagnostic output)
+    }
   }
   return events;
 }
@@ -89,8 +91,8 @@ describe('end-to-end-test runtime delegation + artifact handoff', () => {
   let previousPluginRoot: string | undefined;
 
   beforeEach(async () => {
-    tempDir = mkdtempSync(join(tmpdir(), 'rd-e2e-runtime-'));
-    await mkdir(join(tempDir, '.claude', 'rundown', 'runs'), { recursive: true });
+    tempDir = mkdtempSync(path.join(tmpdir(), 'rd-e2e-runtime-'));
+    await mkdir(path.join(tempDir, '.claude', 'rundown', 'runs'), { recursive: true });
     previousPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
     process.env.CLAUDE_PLUGIN_ROOT = pluginRoot;
   });

--- a/packages/claude-code-plugin/__tests__/skills/end-to-end-testing.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/end-to-end-testing.test.ts
@@ -30,18 +30,27 @@ describe('end-to-end-testing skill', () => {
     expect(skill).not.toMatch(/npm install|npm run build|installation|Local Setup/i);
   });
 
-  it('describes the idempotent delegation flow', () => {
+  it('describes the claimed-child delegation flow', () => {
     const skill = readSkill();
 
     // The DELEGATE step auto-issues the token; the agent claims it directly.
     expect(skill).toContain('rd claim <token>');
     expect(skill).toMatch(/auto-issues a claim token/i);
-    // A self-completing child auto-resolves and the parent auto-aggregates,
-    // so the manual driver commands are not required for the happy path.
-    expect(skill).toMatch(/auto-resolves/i);
-    expect(skill).toMatch(/auto-aggregates and advances/i);
-    // pass/fail --claim-id is reserved for stopped children and is idempotent.
-    expect(skill).toMatch(/idempotent/i);
+  });
+
+  it('directs claimed children to advance with claim-id-targeted transitions', () => {
+    const skill = readSkill();
+
+    // Claimed children — including prompted ones — advance and report their
+    // result with claim-id-targeted transitions, matching running-runbooks.
+    expect(skill).toContain('rd pass --claim-id <claim_id>');
+    expect(skill).toContain('rd fail --claim-id <claim_id>');
+    // It must NOT claim that claim-id targeting is only for early-stopped
+    // children — prompted claimed children need it to advance at all.
+    expect(skill).not.toMatch(/only for a child you stop early/i);
+    expect(skill).not.toMatch(/reserved for stopped children/i);
+    // A bare pass/fail targets the parent, not the claimed child.
+    expect(skill).toMatch(/bare `rd pass`\/`rd fail` targets the parent/i);
   });
 
   it('uses transition output as the normal agent context', () => {

--- a/packages/claude-code-plugin/__tests__/skills/writing-runbooks-artifacts.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/writing-runbooks-artifacts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const skillPath = path.join(__dirname, '..', '..', 'skills', 'writing-runbooks', 'SKILL.md');
+
+function readSkill(): string {
+  return readFileSync(skillPath, 'utf-8');
+}
+
+/**
+ * These assertions pin the documented artifact-rendering behaviour to what the
+ * core renderer actually does (see
+ * `packages/core/src/runbook/renderer/artifact-helper.ts`):
+ *
+ * - direct alias `{{ Alias }}` -> `renderArtifactValue` -> local path
+ * - `{{ path Alias }}` -> `renderArtifactPathValue` -> local path
+ * - `{{ artifact Alias }}` -> `renderArtifactRecordValue` -> artifact URI
+ *
+ * The historical docs incorrectly described `{{ Alias }}` as rendering the URI.
+ */
+describe('writing-runbooks skill artifact rendering guidance', () => {
+  it('documents direct alias and path helper as local-path renderings', () => {
+    const skill = readSkill();
+
+    // The rendering-helpers table row for the direct alias must say "local"
+    // path, not "URI".
+    expect(skill).toMatch(/\|\s*`\{\{ Alias \}\}`\s*\|\s*Local[^|]*path/i);
+    expect(skill).toMatch(/\|\s*`\{\{ path Alias \}\}`\s*\|\s*Local[^|]*path/i);
+  });
+
+  it('documents the artifact helper as the URI rendering', () => {
+    const skill = readSkill();
+
+    expect(skill).toMatch(/\|\s*`\{\{ artifact Alias \}\}`\s*\|\s*Artifact URI/i);
+  });
+
+  it('does not claim the direct alias renders an artifact URI', () => {
+    const skill = readSkill();
+
+    // The bug was the direct-alias row reading "Artifact URI value(s)".
+    expect(skill).not.toMatch(/`\{\{ Alias \}\}`\s*\|\s*Artifact URI/);
+    // The common-mistakes guidance must not say `{{ Alias }}` renders a URI.
+    expect(skill).not.toMatch(/`\{\{ Alias \}\}` and `\{\{ artifact Alias \}\}` render URI/);
+  });
+});

--- a/packages/claude-code-plugin/skills/end-to-end-testing/SKILL.md
+++ b/packages/claude-code-plugin/skills/end-to-end-testing/SKILL.md
@@ -5,9 +5,7 @@ description: Use when running the Rundown end-to-end test runbook and reporting 
 
 # End-to-End Testing
 
-Run the end-to-end test through Rundown state. Do not improvise.
-
-Start:
+Run the end-to-end test through Rundown state. Do not improvise. Start:
 
 ```bash
 rd run rundown:end-to-end-test
@@ -15,31 +13,28 @@ rd run rundown:end-to-end-test
 
 ## Flow
 
-- Parent runs in the current context.
-- `end-to-end-test/write-file.runbook.md` and `end-to-end-test/review-and-collate.runbook.md` run locally.
+- Parent, final feedback, `end-to-end-test/write-file.runbook.md`, and `end-to-end-test/review-and-collate.runbook.md` run locally.
 - `end-to-end-test/review-file.runbook.md` and `end-to-end-test/collate-files.runbook.md` are delegated by the review wrapper.
-- Final feedback written locally.
 
 Only nested review and collation runbooks are delegated. If the wrapper completes before collate, report a defect; never delegate collation from the parent.
 
 ## Operating Rules
 
-- Follow the active prompt.
-- Use default JSON output. Do not pass `--text` unless debugging.
+- Follow the active prompt. Use default JSON output; pass `--text` only when debugging.
 - Treat `rd run`, `rd pass`, `rd fail`, `rd claim`, and `rd collect` output as the next context.
 - Use `rd status` only to recover orientation after an error or interruption.
 - Pass only after the current step is complete; fail when it cannot be completed as written.
 - Preserve state on errors. Do not prune, clear, or delete `.rundown`.
 
-The DELEGATE step auto-issues a claim token (see `delegations` in `rd status`). Claim it:
+The DELEGATE step auto-issues a claim token (`delegations` in `rd status`). Claim it:
 
 ```bash
 rd claim <token>                  # returns claim_id; dispatch the child to a subagent
 ```
 
-The subagent passes the claim id to every child command (`rd status/pass/fail --claim-id <claim_id>`). A bare `rd pass`/`rd fail` targets the parent; core refuses it while a claimed child is open (`OPEN_DELEGATED_CHILDREN`) — rerun with the child `--claim-id`.
+Drive the claimed child like any runbook: advance each step with `rd pass --claim-id <claim_id>` / `rd fail --claim-id <claim_id>`. Prompted child steps need this claim-id transition to advance. A bare `rd pass`/`rd fail` targets the parent; core refuses it while a claimed child is open (`OPEN_DELEGATED_CHILDREN`).
 
-A child that completes auto-resolves its parent substep; the parent auto-aggregates and advances. Use `rd pass/fail --claim-id <claim_id>` only for a child you stop early; idempotent (no-op if resolved, error if contradicting).
+When the child's final step completes it auto-resolves its parent substep and the parent auto-aggregates and advances. `rd pass/fail --claim-id` is idempotent on a resolved child, so it also confirms or overrides a child you stop early.
 
 ## Artifacts
 
@@ -58,8 +53,6 @@ Do not rediscover paths or add artifact-only steps. Missing/wrong variables and 
 
 ## Feedback
 
-Feedback must be JSON matching `review.schema.json`.
+Feedback must be JSON matching `review.schema.json`. Use empty `items` when there are no findings.
 
 Capture only concrete issues: unclear prompts, wrong delegation boundary, missing/wrong artifact variables, schema mismatches, required manual inference, failed commands with observed output.
-
-Use an empty `items` array when there are no findings.

--- a/packages/claude-code-plugin/skills/writing-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-runbooks/SKILL.md
@@ -151,9 +151,9 @@ Artifact rendering helpers:
 
 | Template | Renders |
 |----------|---------|
-| `{{ Alias }}` | Artifact URI value(s) |
-| `{{ artifact Alias }}` | Artifact URI value(s) |
+| `{{ Alias }}` | Local filesystem path value(s) (direct alias) |
 | `{{ path Alias }}` | Local filesystem path value(s) |
+| `{{ artifact Alias }}` | Artifact URI value(s) |
 | `{{ path "file.json" }}` | Local path only; does not create a manifest row |
 
 For wildcard aliases that resolve to arrays, `{{ path Reviews }}` renders a JSON array of paths. Arrays can be used as `FOR` data sources when that matches the workflow.
@@ -345,7 +345,7 @@ Key authoring notes:
 | Using naked `ARTIFACTS` as creation (`- PlanPath`) | Naked `ARTIFACTS` asserts/rehydrates an already-bound artifact reference. Use `- PlanPath "plan.json"` to create a managed artifact record. |
 | Assuming `FOR` works on substeps | `FOR` is valid only on H2 steps. Put iteration on the parent step and work inside H3 substeps. |
 | Writing `DELEGATE value` | Use bare `- DELEGATE`; the target is resolved from the delegated step/substep context. |
-| Confusing artifact URI and path rendering | `{{ Alias }}` and `{{ artifact Alias }}` render URI values; `{{ path Alias }}` renders local filesystem paths. |
+| Confusing artifact URI and path rendering | `{{ Alias }}` (direct) and `{{ path Alias }}` render local filesystem paths; only `{{ artifact Alias }}` renders artifact URI values. |
 | Broken fenced examples inside fenced docs | When documenting a runbook inside a code fence, use a longer outer fence, such as four backticks around examples containing triple-backtick command blocks. |
 | Reserved word as step ID | `PASS`, `FAIL`, `CONTINUE`, etc. are reserved |
 | `INPUTS:` written as a key→default map (`VarName: default`) | `INPUTS:` is a YAML sequence of bare names (`- VarName`). Defaults live in config / `--input-file` / `--input-json` / env, not in frontmatter. |


### PR DESCRIPTION
Fixes two related issues in the Claude Code plugin skills / end-to-end runbook testing domain.

## Issue #399 — Claimed-child guidance in the E2E skill

`skills/end-to-end-testing/SKILL.md` previously implied `rd pass --claim-id` / `rd fail --claim-id` were only needed for children stopped early. That is wrong for prompted claimed children, which need claim-id-targeted transitions to advance at all.

- Corrected the skill to direct agents to drive a claimed child like any runbook: advance each step with `rd pass --claim-id <claim_id>` / `rd fail --claim-id <claim_id>`; prompted child steps need this transition to advance. A bare `rd pass`/`rd fail` targets the parent (core refuses it while a claimed child is open, `OPEN_DELEGATED_CHILDREN`).
- Clarified that on the child's final step the parent auto-resolves the substep and auto-aggregates/advances, and that `--claim-id` is also the idempotent command to confirm/override an early-stopped child.
- Now consistent with `skills/running-runbooks/SKILL.md` (and the existing `claim-guidance.test.ts`).
- Updated `__tests__/skills/end-to-end-testing.test.ts` (TDD) to pin the corrected guidance instead of the old "no claim-id needed" wording. Skill stays within the 350-word agent budget.

## Issue #398 — E2E workflow and artifact guidance coverage

**(a) Artifact alias guidance, verified empirically against the renderer**

Source of truth: `packages/core/src/runbook/renderer/artifact-helper.ts` + `template-renderer.ts`.

- `{{ Alias }}` (direct) renders the **local filesystem path** (`renderArtifactValue` -> `renderArtifactPathValue`).
- `{{ path Alias }}` renders the **local filesystem path** (`renderArtifactPathValue`).
- `{{ artifact Alias }}` renders the **artifact URI** (`renderArtifactRecordValue`).

`skills/writing-runbooks/SKILL.md` wrongly listed `{{ Alias }}` (and grouped it with `{{ artifact Alias }}`) as a URI rendering. Corrected the rendering-helpers table and the common-mistakes row, and added `__tests__/skills/writing-runbooks-artifacts.test.ts` to pin the corrected wording so the docs can't silently regress.

**(b) Runtime coverage for the E2E workflow**

Added `__tests__/runbooks/end-to-end-test-runtime.integration.test.ts`, which drives the bundled `end-to-end-test` workflow through the real runtime (not just parser/`rd check`):

- inline launch of the local `write-file` and `review-and-collate` children,
- delegation-token issue at the `DELEGATE` substeps,
- `rd claim` launching the delegated `review-file` child,
- claim-id-targeted `rd pass` advancing a prompted claimed child,
- auto-resolution of the parent substep and auto-advance on child completion (parent reaches the second `collate` DELEGATE step with a fresh token),
- artifact alias handoff: `PlanPath` produced by `write-file` rehydrates in the delegated `review-file` child, and `{{ path ReviewPath }}` renders as a local work-dir path, never an `rd://` URI.

## Verification

`npm run verify` passes cleanly (format, spell, lint, build, types, docs, tests). Full plugin unit + integration suites pass, including the new runtime suite.

Closes #398
Closes #399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added runtime integration tests exercising end-to-end workflows, delegation issuance, and claimed-child advancement.
  * Updated skill tests to validate claim-token behavior and claim-id-targeted pass/fail semantics.
  * Added tests ensuring documentation accurately describes artifact-rendering behavior.

* **Documentation**
  * Clarified artifact rendering: `{{ Alias }}` and `{{ path Alias }}` → local paths; `{{ artifact Alias }}` → artifact URIs.
  * Updated end-to-end testing guidance for delegation, claiming, and claim-id-driven child advancement.
  * Tightened feedback validation requirements and guidance for concrete issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->