### PR TITLE
[codex] Parse OUTPUTS template tokens once

### DIFF
--- a/packages/core/src/runbook/output-evaluator.ts
+++ b/packages/core/src/runbook/output-evaluator.ts
@@ -1,9 +1,9 @@
 import {
   parseOutputExpression,
-  tokenizeTemplate,
   type OutputDeclaration,
   type OutputExpression,
   type OutputExpressionRejectReason,
+  type TemplateToken,
 } from '@rundown-org/parser';
 import { isArtifactRecord } from './artifact-schema.js';
 import { mergeEffectiveVars, type VariableValue } from './effective-vars.js';
@@ -165,13 +165,16 @@ interface OutputTemplateExpansion {
  * choose whether an unresolved reference is fatal (template text throws; the
  * legacy `ctx=` path lets {@link VALID_CTX} reject the leftover token instead).
  *
- * @param text - Template text to expand
+ * @param tokens - Parser-owned template tokens to expand
  * @param variables - Variable frame for resolution
  * @returns Expanded text plus the list of unresolved bare variable paths
  */
-function expandOutputTemplate(text: string, variables: OutputVars): OutputTemplateExpansion {
+function expandOutputTemplate(
+  tokens: readonly TemplateToken[],
+  variables: OutputVars,
+): OutputTemplateExpansion {
   const unresolved: string[] = [];
-  const expanded = tokenizeTemplate(text)
+  const expanded = tokens
     .map((token) => {
       if (token.kind === 'literal') return token.text;
       if (token.kind !== 'variable' || token.explicit) return token.raw;
@@ -192,14 +195,18 @@ function expandOutputTemplate(text: string, variables: OutputVars): OutputTempla
  * Shared by the `templateText` and `quotedLiteral` evaluation branches, which
  * require every embedded `{{ var }}` to resolve.
  *
- * @param text - Template text to expand
+ * @param tokens - Parser-owned template tokens to expand
  * @param raw - Original expression text used in the error message
  * @param variables - Variable frame for resolution
  * @returns Fully expanded text
  * @throws {Error} When the text contains one or more unresolved bare references
  */
-function expandOutputTemplateOrThrow(text: string, raw: string, variables: OutputVars): string {
-  const { text: expanded, unresolved } = expandOutputTemplate(text, variables);
+function expandOutputTemplateOrThrow(
+  tokens: readonly TemplateToken[],
+  raw: string,
+  variables: OutputVars,
+): string {
+  const { text: expanded, unresolved } = expandOutputTemplate(tokens, variables);
   if (unresolved.length > 0) {
     throw new Error(
       `evaluateOutputExpression: template reference has unresolved variables: "${raw}"`,
@@ -291,13 +298,14 @@ export function applyRunArtifactHelper(
 function resolveLegacyCtxPathHelper(
   filename: string,
   ctxExpr: string,
+  ctxTokens: readonly TemplateToken[] | undefined,
   variables: OutputVars,
 ): string {
   const workPath = requireOutputString('WorkPath', variables);
   // Unresolved refs intentionally stay as their raw `{{ ref }}` token; the
   // VALID_CTX guard below rejects them with a ctx-specific error.
-  const expandedContextId = ctxExpr.trim().startsWith('{{')
-    ? expandOutputTemplate(ctxExpr.trim(), variables).text
+  const expandedContextId = ctxTokens
+    ? expandOutputTemplate(ctxTokens, variables).text
     : ctxExpr.trim();
 
   if (!VALID_CTX.test(expandedContextId)) {
@@ -394,7 +402,12 @@ export function evaluateOutputExpression(
     }
     case 'outputPathHelper': {
       if (expression.ctx !== undefined) {
-        return resolveLegacyCtxPathHelper(expression.arg.value, expression.ctx, variables);
+        return resolveLegacyCtxPathHelper(
+          expression.arg.value,
+          expression.ctx,
+          expression.ctxTokens,
+          variables,
+        );
       }
       return applyRunArtifactHelper(
         expression.name,
@@ -416,11 +429,13 @@ export function evaluateOutputExpression(
       return expression.raw;
     }
     case 'quotedLiteral': {
-      if (!expression.containsTemplates) return expression.value;
-      return expandOutputTemplateOrThrow(expression.value, expression.raw, variables);
+      if (!expression.containsTemplates) {
+        return expandOutputTemplate(expression.tokens, variables).text;
+      }
+      return expandOutputTemplateOrThrow(expression.tokens, expression.raw, variables);
     }
     case 'templateText': {
-      return expandOutputTemplateOrThrow(expression.text, expression.raw, variables);
+      return expandOutputTemplateOrThrow(expression.tokens, expression.raw, variables);
     }
     case 'bareIdentifier': {
       const resolved = resolveOutputPath(expression.name, variables);

--- a/packages/parser/__tests__/output-expression.test.ts
+++ b/packages/parser/__tests__/output-expression.test.ts
@@ -43,6 +43,14 @@ describe('parseOutputExpression', () => {
         name: 'path',
         arg: { kind: 'literal', value: 'file.json' },
         ctx: '{{ ChildContext }}',
+        ctxTokens: [
+          {
+            kind: 'variable',
+            name: 'ChildContext',
+            explicit: false,
+            raw: '{{ ChildContext }}',
+          },
+        ],
         raw: '{{ path "file.json" ctx={{ ChildContext }} }}',
       },
     });
@@ -51,7 +59,7 @@ describe('parseOutputExpression', () => {
       ok: true,
       expression: {
         kind: 'templateText',
-        text: '{{ artifact "file.json" ctx=child }}',
+        tokens: [{ kind: 'literal', text: '{{ artifact "file.json" ctx=child }}' }],
         raw: '{{ artifact "file.json" ctx=child }}',
       },
     });
@@ -71,7 +79,7 @@ describe('parseOutputExpression', () => {
       ok: true,
       expression: {
         kind: 'templateText',
-        text: '{{ PlanPath }}',
+        tokens: [{ kind: 'variable', name: 'PlanPath', explicit: false, raw: '{{ PlanPath }}' }],
         raw: '{{ PlanPath }}',
       },
     });
@@ -100,7 +108,10 @@ describe('parseOutputExpression', () => {
       ok: true,
       expression: {
         kind: 'quotedLiteral',
-        value: 'quoted {{ Step }}',
+        tokens: [
+          { kind: 'literal', text: 'quoted ' },
+          { kind: 'variable', name: 'Step', explicit: false, raw: '{{ Step }}' },
+        ],
         containsTemplates: true,
         raw: '"quoted {{ Step }}"',
       },
@@ -110,7 +121,7 @@ describe('parseOutputExpression', () => {
       ok: true,
       expression: {
         kind: 'quotedLiteral',
-        value: 'quoted literal',
+        tokens: [{ kind: 'literal', text: 'quoted literal' }],
         containsTemplates: false,
         raw: '"quoted literal"',
       },
@@ -123,7 +134,14 @@ describe('parseOutputExpression', () => {
 
     expect(parseOutputExpression('at {{ Step }}')).toEqual({
       ok: true,
-      expression: { kind: 'templateText', text: 'at {{ Step }}', raw: 'at {{ Step }}' },
+      expression: {
+        kind: 'templateText',
+        tokens: [
+          { kind: 'literal', text: 'at ' },
+          { kind: 'variable', name: 'Step', explicit: false, raw: '{{ Step }}' },
+        ],
+        raw: 'at {{ Step }}',
+      },
     });
   });
 
@@ -145,7 +163,7 @@ describe('parseOutputExpression', () => {
       ok: true,
       expression: {
         kind: 'templateText',
-        text: '{{ ./bad-path }}',
+        tokens: [{ kind: 'literal', text: '{{ ./bad-path }}' }],
         raw: '{{ ./bad-path }}',
       },
     });

--- a/packages/parser/src/output-expression.ts
+++ b/packages/parser/src/output-expression.ts
@@ -6,9 +6,13 @@
  * template text, `{{ ./Var }}` is explicit lookup, and legacy `ctx=` is legal
  * only for the `path` helper.
  */
-import type { TemplateArg } from './template.js';
 import type { BuiltinTemplateHelperName } from './reserved.js';
-import { TEMPLATE_PATH_PATTERN } from './template.js';
+import {
+  TEMPLATE_PATH_PATTERN,
+  tokenizeTemplate,
+  type TemplateArg,
+  type TemplateToken,
+} from './template.js';
 import {
   GRAMMAR_IDENTIFIER,
   GRAMMAR_PATH,
@@ -56,6 +60,8 @@ export type OutputExpression =
       readonly arg: Extract<TemplateArg, { kind: 'literal' }>;
       /** Optional legacy context expression. May be a literal context id or `{{ Var }}` template. */
       readonly ctx?: string;
+      /** Tokenized legacy context expression when `ctx` is a template. */
+      readonly ctxTokens?: readonly TemplateToken[];
       /** Original trimmed expression text. */
       readonly raw: string;
     }
@@ -80,8 +86,8 @@ export type OutputExpression =
   /** Quoted literal expression, optionally containing template references. */
   | {
       readonly kind: 'quotedLiteral';
-      /** Unquoted literal value. */
-      readonly value: string;
+      /** Tokenized unquoted literal value. */
+      readonly tokens: readonly TemplateToken[];
       /** Whether the literal contains `{{ ... }}` spans that core must expand. */
       readonly containsTemplates: boolean;
       /** Original trimmed expression text. */
@@ -90,8 +96,8 @@ export type OutputExpression =
   /** Template-containing text, including bare `{{ Var }}` and mixed strings. */
   | {
       readonly kind: 'templateText';
-      /** Text core expands against the OUTPUTS frame. */
-      readonly text: string;
+      /** Tokens core expands against the OUTPUTS frame. */
+      readonly tokens: readonly TemplateToken[];
       /** Original trimmed expression text. */
       readonly raw: string;
     }
@@ -175,13 +181,15 @@ export function parseOutputExpression(text: string): ParseOutputExpressionResult
 
   const legacyCtxPathMatch = LEGACY_CTX_PATH_HELPER_REGEX.exec(trimmed);
   if (legacyCtxPathMatch) {
+    const ctx = legacyCtxPathMatch[2];
     return {
       ok: true,
       expression: {
         kind: 'outputPathHelper',
         name: 'path',
         arg: { kind: 'literal', value: legacyCtxPathMatch[1] },
-        ctx: legacyCtxPathMatch[2],
+        ctx,
+        ...(ctx.trim().startsWith('{{') ? { ctxTokens: tokenizeTemplate(ctx.trim()) } : {}),
         raw: trimmed,
       },
     };
@@ -234,7 +242,7 @@ export function parseOutputExpression(text: string): ParseOutputExpressionResult
       ok: true,
       expression: {
         kind: 'quotedLiteral',
-        value,
+        tokens: tokenizeTemplate(value),
         containsTemplates: value.includes('{{'),
         raw: trimmed,
       },
@@ -244,7 +252,7 @@ export function parseOutputExpression(text: string): ParseOutputExpressionResult
   if (trimmed.includes('{{')) {
     return {
       ok: true,
-      expression: { kind: 'templateText', text: trimmed, raw: trimmed },
+      expression: { kind: 'templateText', tokens: tokenizeTemplate(trimmed), raw: trimmed },
     };
   }
 


### PR DESCRIPTION
## Summary
- have parseOutputExpression return parser-owned tokens for templateText and quotedLiteral OUTPUTS expressions
- carry tokenized legacy ctx templates for path helpers
- update core OUTPUTS evaluation to consume parser-provided tokens instead of re-tokenizing

Closes #411.

## Validation
- npm test -w packages/parser -- --runInBand output-expression
- npm test -w packages/core -- --runInBand output-evaluator
- npm run check:types -w packages/parser
- npm run build -w packages/parser
- npm run check:types -w packages/core
- npx biome check --formatter-enabled=true --linter-enabled=false packages/parser/src/output-expression.ts packages/parser/__tests__/output-expression.test.ts packages/core/src/runbook/output-evaluator.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal template expression parsing and evaluation by restructuring how template tokens are processed and resolved, enhancing efficiency and maintainability of output expression handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->