### PR TITLE
feat(core,cli)!: fail closed by default when the OS sandbox is unavailable (#423)

### DIFF
--- a/docs/reference/cli-help.md
+++ b/docs/reference/cli-help.md
@@ -71,8 +71,10 @@ Policy options:
   --non-interactive             Non-interactive mode (no prompts, CI-friendly)
   --sandbox                     Enable OS-level sandbox for file access
                                 enforcement
-  --no-sandbox                  Disable sandbox enforcement (trust mode)
-  --sandbox-strict              Fail if sandbox is unavailable (strict mode)
+  --no-sandbox                  Disable sandbox enforcement (trust mode); the
+                                explicit opt-out when the sandbox is unavailable
+  --sandbox-strict              Fail if sandbox is unavailable (default;
+                                explicit affirmation of fail-closed)
   --helpers <paths>             Helper module paths to load (comma-separated,
                                 relative to project root)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -131,9 +131,9 @@ Rundown enforces a security policy layer to control what commands runbooks can e
 | `--policy <file>` | Use custom policy file |
 | `--trust-js-policy` | Trust an explicitly selected JS policy file and helper modules declared by policy config |
 | `--helpers <paths>` | Helper module paths to load (comma-separated, relative to project root) |
-| `--sandbox` | Enable OS-level filesystem sandbox |
-| `--no-sandbox` | Disable sandbox enforcement |
-| `--sandbox-strict` | Fail if sandbox is unavailable |
+| `--sandbox` | Enable OS-level filesystem sandbox (default) |
+| `--no-sandbox` | Disable sandbox enforcement; the explicit opt-out when the sandbox is unavailable |
+| `--sandbox-strict` | Fail if sandbox is unavailable (default; explicit affirmation of fail-closed) |
 
 Policy discovery is data-only by default: `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, or the `rundown` field in `package.json`. Executable `rundown.config.js/.cjs/.mjs` files are only loaded when passed via `--policy` together with `--trust-js-policy`.
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -277,9 +277,11 @@ The sandbox MUST be enabled by default unless `--no-sandbox` or `--allow-all` is
 
 `--allow-all` MUST disable sandboxing.
 
-When sandboxing is enabled but unavailable, Rundown MUST warn and execute unsandboxed unless `--sandbox-strict` is supplied.
+When sandboxing is enabled but unavailable, Rundown MUST fail closed: it MUST NOT execute the command and MUST report that file-access policy cannot be enforced. This is the default because the OS sandbox is the only layer that enforces file policy on a shelled-out command step, so an unavailable sandbox means the policy is enforced by nothing (fail-safe defaults; CWE-636).
 
-With `--sandbox-strict`, unavailable sandboxing MUST fail closed and MUST NOT execute the command.
+The explicit, per-run opt-outs are `--no-sandbox` (disable OS-level enforcement) and `--allow-all` (trust mode). Both disable the sandbox loudly; there is no silent fallback to unsandboxed execution.
+
+`--sandbox-strict` remains accepted and is now the default; supplying it is an explicit, no-op affirmation of the fail-closed posture.
 
 When the Linux sandbox backend cannot safely represent effective deny-path rules, Rundown MUST fail closed instead of silently weakening policy.
 
@@ -363,8 +365,9 @@ When `--non-interactive` is supplied, or when the process is detected as non-int
 | Unlisted operation in interactive prompted mode | Prompt. |
 | Unlisted operation requiring prompt in non-interactive mode | Fail closed. |
 | `--allow-all` and `--deny-all` both supplied | `--deny-all` wins. |
-| Sandbox unavailable with default sandboxing | Warn and run unsandboxed. |
-| Sandbox unavailable with `--sandbox-strict` | Fail closed. |
+| Sandbox unavailable with default sandboxing | Fail closed (the default). Use `--no-sandbox` to run unsandboxed. |
+| Sandbox unavailable with `--sandbox-strict` | Fail closed (explicit affirmation of the default). |
+| Sandbox unavailable with `--no-sandbox` | Run unsandboxed (explicit, loud opt-out). |
 | Linux deny-path rules cannot be safely represented | Fail closed. |
 | Missing data source file | Fail visibly. |
 | Denied data source file | Fail visibly. |
@@ -539,9 +542,12 @@ which sandbox-exec
 
 | Scenario | Behavior |
 |----------|----------|
-| `--sandbox` or default sandboxing | Falls back to unsandboxed execution with a warning when the sandbox is unavailable. |
-| `--sandbox-strict` | Fails with an error and does not execute the command when the sandbox is unavailable. |
-| `--no-sandbox` | Executes without sandboxing and does not warn about sandbox availability. |
+| `--sandbox` or default sandboxing | Fails closed (the default): does not execute the command when the sandbox is unavailable, and reports that file policy cannot be enforced. |
+| `--sandbox-strict` | Same as the default — explicitly affirms the fail-closed posture. |
+| `--no-sandbox` | Executes without sandboxing and does not warn about sandbox availability. Trusted runs only. |
+| `--allow-all` | Trust mode: disables the sandbox and the policy evaluator entirely. |
+
+Affected hosts: the fail-closed default blocks command steps on platforms with no sandbox backend (Windows), on Linux without `landrun`, and on Linux where seccomp blocks the `landlock_*` syscall. macOS ships Seatbelt, so it is unaffected. To run on an un-provisioned host, either install the sandbox backend or pass `--no-sandbox` for that run.
 
 Linux deny-path note: if the effective policy contains deny-path rules that the Linux backend cannot enforce safely, Rundown blocks execution instead of silently weakening policy. For trusted runs only, disable sandboxing with `--no-sandbox`.
 

--- a/packages/cli/__tests__/services/policy-context.test.ts
+++ b/packages/cli/__tests__/services/policy-context.test.ts
@@ -225,11 +225,12 @@ describe('policy context service', () => {
   });
 
   describe('getSandboxOptions', () => {
-    it('returns defaults', () => {
+    it('returns defaults (fail-closed: sandbox on, strict on)', () => {
       getPolicyContext();
       const opts = getSandboxOptions();
       expect(opts.sandbox).toBe(true);
-      expect(opts.sandboxStrict).toBe(false);
+      // Fail closed by default — strict is on unless --no-sandbox/--allow-all opt out.
+      expect(opts.sandboxStrict).toBe(true);
     });
 
     it('returns true for sandbox when initialized with empty options', async () => {
@@ -248,6 +249,8 @@ describe('policy context service', () => {
       await initializePolicyContext({ noSandbox: true });
       const opts = getSandboxOptions();
       expect(opts.sandbox).toBe(false);
+      // The explicit opt-out also clears strict so it does not fail closed.
+      expect(opts.sandboxStrict).toBe(false);
     });
 
     it('returns false for sandbox if allowAll is true', async () => {
@@ -257,6 +260,7 @@ describe('policy context service', () => {
       await initializePolicyContext({ allowAll: true });
       const opts = getSandboxOptions();
       expect(opts.sandbox).toBe(false);
+      expect(opts.sandboxStrict).toBe(false);
     });
 
     it('respects sandboxStrict', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -132,14 +132,16 @@ export function createProgram(): Command {
       ),
     )
     .addOption(
-      new Option('--no-sandbox', 'Disable sandbox enforcement (trust mode)').helpGroup(
-        'Policy options:',
-      ),
+      new Option(
+        '--no-sandbox',
+        'Disable sandbox enforcement (trust mode); the explicit opt-out when the sandbox is unavailable',
+      ).helpGroup('Policy options:'),
     )
     .addOption(
-      new Option('--sandbox-strict', 'Fail if sandbox is unavailable (strict mode)').helpGroup(
-        'Policy options:',
-      ),
+      new Option(
+        '--sandbox-strict',
+        'Fail if sandbox is unavailable (default; explicit affirmation of fail-closed)',
+      ).helpGroup('Policy options:'),
     )
     .addOption(
       new Option(

--- a/packages/cli/src/services/policy-context.ts
+++ b/packages/cli/src/services/policy-context.ts
@@ -277,7 +277,11 @@ export function getSandboxOptions(): { sandbox: boolean; sandboxStrict: boolean 
   return {
     // Default to true (enable sandbox) unless explicitly disabled
     sandbox: opts.sandbox !== false,
-    sandboxStrict: opts.sandboxStrict ?? false,
+    // Fail closed by default: when the sandbox is enabled but unavailable on the
+    // host, refuse the command rather than silently running it unconfined. The
+    // OS sandbox is the only layer that enforces file policy on a command step.
+    // The loud, explicit opt-outs are --no-sandbox and --allow-all (handled above).
+    sandboxStrict: opts.sandboxStrict ?? true,
   };
 }
 

--- a/packages/core/__tests__/runbook/executor.test.ts
+++ b/packages/core/__tests__/runbook/executor.test.ts
@@ -214,6 +214,27 @@ describe('executeCommandWithPolicy', () => {
     }
   });
 
+  it('fails closed by default (sandboxStrict omitted) when sandbox unavailable', async () => {
+    const evaluator = new PolicyEvaluator({
+      ...DEFAULT_POLICY,
+      default: { ...DEFAULT_POLICY.default, mode: 'execute', run: { allow: ['*'], deny: [] } },
+    });
+
+    // No sandboxStrict supplied — the default is now fail-closed.
+    const result = await executeCommandWithPolicy('node -e "process.exit(0)"', process.cwd(), {
+      evaluator,
+      sandbox: true,
+    });
+
+    // On a host without a sandbox backend this must deny rather than run unconfined.
+    // On macOS/Linux with the sandbox available it runs sandboxed instead.
+    if (!result.sandboxed) {
+      expect(result.policyDenied).toBe(true);
+      expect(result.denialReason).toContain('Sandbox unavailable');
+      expect(result.denialReason).toContain('--no-sandbox');
+    }
+  });
+
   it('falls back to unsandboxed execution with warning when sandbox unavailable and not strict', async () => {
     const evaluator = new PolicyEvaluator({
       ...DEFAULT_POLICY,

--- a/packages/core/src/runbook/executor.ts
+++ b/packages/core/src/runbook/executor.ts
@@ -36,7 +36,17 @@ export interface PolicyExecutionOptions {
   rdInjected?: Record<string, string>;
   /** Enable OS-level sandbox for file access enforcement (default: true on supported platforms) */
   sandbox?: boolean;
-  /** Fail if sandbox is unavailable (default: false, falls back to unsandboxed) */
+  /**
+   * Require the OS sandbox: fail closed when sandboxing is enabled but
+   * unavailable instead of running unsandboxed (default: true).
+   *
+   * Because Rundown shells out to child processes, the OS sandbox is the only
+   * layer that can enforce file-access policy on a command step. "Sandbox
+   * unavailable" therefore means "the file policy is enforced by nothing", so
+   * the secure default is to refuse the command rather than silently run it
+   * unconfined (fail-safe defaults; CWE-636). Pass `false` to opt into
+   * best-effort execution (warn, then run unsandboxed) for trusted runs.
+   */
   sandboxStrict?: boolean;
 }
 
@@ -168,7 +178,7 @@ export async function executeCommandWithPolicy(
   cwd: string,
   options: PolicyExecutionOptions = {},
 ): Promise<ExecutionResult> {
-  const { evaluator, prompter, env, rdInjected, sandbox = true, sandboxStrict = false } = options;
+  const { evaluator, prompter, env, rdInjected, sandbox = true, sandboxStrict = true } = options;
 
   // If no evaluator, execute without policy checks
   if (!evaluator) {
@@ -236,19 +246,22 @@ export async function executeCommandWithPolicy(
       };
     }
 
-    // Sandbox not available
+    // Sandbox not available. Fail closed by default: the OS sandbox is the only
+    // layer that enforces file-access policy on a shelled-out command step, so
+    // "unavailable" means "unenforced". Refuse rather than run unconfined.
     if (sandboxStrict) {
       return {
         success: false,
         exitCode: POLICY_DENIED_EXIT_CODE,
         denialReason:
-          'Sandbox unavailable and --sandbox-strict set. File policies cannot be enforced.',
+          'Sandbox unavailable: file-access policy cannot be enforced for this command. ' +
+          'Re-run with --no-sandbox to execute without OS-level enforcement (trusted runbooks only).',
         policyDenied: true,
         sandboxed: false,
       };
     }
 
-    // Fall through to unsandboxed execution with warning
+    // Best-effort opt-out (sandboxStrict: false): run unsandboxed with a warning.
     console.warn('Warning: Sandbox unavailable. File access policies will not be enforced.');
   }
 


### PR DESCRIPTION
Closes #423.

## Problem

When the OS sandbox is enabled but **unavailable** on the host, Rundown previously **failed open**: it warned and ran the command step unsandboxed (`sandboxStrict` defaulted to `false`).

Because Rundown shells out to child processes, the OS sandbox is the **only** layer that can enforce file-access policy on a command step (the policy evaluator cannot intercept a child's syscalls). So "sandbox unavailable" ≡ "the file policy is enforced by nothing", and the warning gave a false sense of security — the CWE-636 "Failing Open" anti-pattern; violates fail-safe defaults (Saltzer & Schroeder).

This is the *availability fallback* axis, distinct from #418 (the *shape* of the default policy under an allow-list sandbox, resolved by Option 4). The two compose.

## Change

Make **fail-closed the default**:

- **`packages/core/src/runbook/executor.ts`** — `sandboxStrict` default `false → true`. Any core API consumer (MCP, plugin, tests) that enables the sandbox but omits the flag now fails closed too (fail-safe by construction). The denial reason is reworded to be actionable (points at `--no-sandbox`) instead of referencing a flag that is now the default; rationale documented on the option.
- **`packages/cli/src/services/policy-context.ts`** — `getSandboxOptions()` default `sandboxStrict ?? false → ?? true`. `--no-sandbox` / `--allow-all` still clear strict and remain the **loud, explicit, per-run opt-outs**. No soft middle ground (`--no-sandbox-strict` deliberately not added), no silent fallback.

Mirrors the closest analogs — landrun (`--best-effort` is the opt-out), OpenAI Codex CLI (never silently downgrades), Chrome (`--no-sandbox` is the discouraged escape) — and aligns with Claude Code's `sandbox.failIfUnavailable` security gate.

## Blast radius

Command steps now block until `--no-sandbox` on:
- **Windows** (no sandbox backend)
- **Linux without `landrun`**
- **Linux where seccomp blocks the `landlock_*` syscall**

**macOS is unaffected** (Seatbelt ships with the OS). Composes with #418 / Option 4: Linux+landrun → sandboxed; un-provisioned hosts → blocked-until-`--no-sandbox`.

## Docs

- `security.md` — normative §10 (mandates fail-closed, names the opt-outs and affected hosts) + §13 / §16.3 fallback tables.
- `cli.md`, generated `cli-help.md`, and `cli.ts` flag help — note the new default.

## Tests

- **core** `executor.test.ts` — new test: `sandboxStrict` omitted + sandbox unavailable → `policy_denied` with the `--no-sandbox` hint.
- **CLI** `policy-context.test.ts` — default now asserts `sandboxStrict: true`; `--no-sandbox` / `--allow-all` pin `sandboxStrict: false`.

## Verification

- Build (parser → core → cli) clean.
- core unit **3261 passed**, cli unit **2563 passed**; sandbox + execution-loop suites green.
- `check:spell` clean, `check:docs:cli-help` no drift, biome format/lint clean on the changeset.

> [!NOTE]
> Marked `!` (breaking) — this changes default behavior on sandbox-less hosts. The recovery path is always explicit: install the backend or pass `--no-sandbox` for that run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated CLI help, security policy documentation, and reference guides with enhanced descriptions clarifying sandbox enforcement modes, default behaviors, and explicit opt-out options.

* **Bug Fixes**
  * Sandbox enforcement now defaults to fail-closed when OS-level sandboxing is unavailable, denying command execution rather than proceeding with an unsandboxed fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->