### PR TITLE
docs(plugin): improve runbook skill quality (running/delegating/writing)

### DIFF
--- a/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
@@ -7,7 +7,21 @@ description: Use when orchestrating multi-agent work through rundown delegation,
 
 Rundown delegation dispatches substeps to child agents. The parent delegates, a child claims the work, executes it, and reports back. The plugin automates token detection and claim injection.
 
-If you want the parent to walk the child runbook inline instead of dispatching a subagent, omit `- DELEGATE` — see the inline-linkage pattern in [running-runbooks](../running-runbooks/SKILL.md#nested-runbooks-inline-linkage).
+To walk the child runbook inline instead of dispatching a subagent, omit `- DELEGATE` — see the inline-linkage pattern in [running-runbooks](../running-runbooks/SKILL.md#nested-runbooks).
+
+## When to Use
+
+- Orchestrating multi-agent work where substeps are dispatched to separate child agents
+- A runbook step carries `- DELEGATE` and a token (`rdtk_...`) must be issued and dispatched
+- Managing the parent side of delegation: issuing, monitoring, aborting, or aggregating delegated substeps
+- Fanning out independent substeps (or FOR-loop iterations) to run concurrently across agents
+
+## When NOT to Use
+
+- Executing an already-claimed runbook as the child — use the [running-runbooks](../running-runbooks/SKILL.md) skill instead
+- Walking a nested child runbook inline without a subagent — omit `- DELEGATE` (see [running-runbooks](../running-runbooks/SKILL.md#nested-runbooks))
+- Authoring or editing runbook files — use the writing-runbooks skill instead
+- Running unrelated shell commands outside a Rundown-controlled workflow
 
 ## Quick Reference
 
@@ -194,8 +208,8 @@ Read the plan from `{{ PlanPath }}`.
 When the parent delegates `write-plan` at step 2 and `review-plan` at step 3 (with the same `ContextId`), `PlanPath` flows through automatically — no `--input PlanPath=...` needed at the parent.
 
 **Authoring notes:**
-- Export values with `OUTPUTS` in the producing runbook.
-- Declare required inherited values with frontmatter `INPUTS` and `REQUIRED` in the consuming runbook.
+- Export values with frontmatter `OUTPUTS:` in the producing runbook.
+- Declare required inherited values with frontmatter `INPUTS:` and `REQUIRED:` in the consuming runbook.
 - Missing required values fail before work starts.
 - Explicit inputs on `rd delegate` or `rd claim` override inherited values.
 
@@ -228,4 +242,5 @@ rd delegate --step 2.3
 - [Subagent delegation](../../../../docs/guides/agent-orchestration.md)
 - [Delegation patterns](../../../../runbooks/delegation/)
 - [Rundown specification](../../../../docs/spec/language.md)
-- [CLI reference](../../../../CLAUDE.md)
+- [CLI reference](../../../../docs/reference/cli.md)
+- [Project overview and command list](../../../../CLAUDE.md)

--- a/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
@@ -1,11 +1,25 @@
 ---
 name: running-runbooks
-description: Use when a rundown runbook is active, when receiving delegation instructions with a claim token, or when rd/rundown CLI commands appear in step output
+description: Use when a Rundown runbook is active, when receiving delegation instructions with a claim token, or when rd/rundown CLI commands appear in step output
 ---
 
 # Running Runbooks
 
 Rundown executes markdown runbooks step-by-step. The CLI controls progress — you follow the output and respond.
+
+## When to Use
+
+- A Rundown runbook is already active and needs step-by-step execution
+- CLI output from `rd` or `rundown` asks for a pass/fail response, claim, status check, or continuation
+- A delegated task arrives with a claim token and must be accepted, executed, and reported back
+- A prompt or command output references Rundown step IDs, substeps, FOR loop indexes, or claim IDs
+
+## When NOT to Use
+
+- Writing or editing runbook files — use the writing-runbooks skill instead
+- Orchestrating parent-side delegation to other agents — use the delegating-runbooks skill instead
+- Planning work before authoring a runbook — use the writing-plans skill when applicable
+- Running unrelated shell commands that are not part of a Rundown-controlled workflow
 
 ## Quick Reference
 
@@ -145,13 +159,15 @@ rd status --text    # Human-readable text output
 | Verbal "done" instead of CLI | Always `rd pass` or `rd fail` |
 | Skipping steps | Follow every step — runbook controls flow |
 | Bare `rd pass` with substeps active | Use `rd pass --step 2.1` |
+| Bare `rd pass`/`rd fail` in a claimed child | Use `rd pass --claim-id <claim_id>` to report to the parent |
 | Abandoning without `rd stop` | Complete all steps or explicitly stop |
 
 ## Reference
 
 - [Runbook patterns and examples](../../../../runbooks/README.md)
 - [Rundown specification](../../../../docs/spec/language.md)
-- [CLI reference](../../../../CLAUDE.md)
+- [CLI reference](../../../../docs/reference/cli.md)
+- [Project overview and command list](../../../../CLAUDE.md)
 
 ## Prompted Mode
 

--- a/packages/claude-code-plugin/skills/writing-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-runbooks/SKILL.md
@@ -1,12 +1,23 @@
 ---
 name: writing-runbooks
 description: Use when creating, editing, or authoring rundown runbook files (.runbook.md), or when needing runbook format syntax reference
-use_when: Writing, editing, or creating rundown runbook files (.runbook.md). When authoring new runbooks or modifying existing ones.
 ---
 
 # Writing Runbooks
 
 Rundown runbooks are markdown files (`.runbook.md`) that define executable step-by-step workflows. Steps combine human-readable instructions with machine-executable commands and deterministic control flow.
+
+## When to Use
+
+- Creating a new `.runbook.md` file from scratch
+- Editing or refactoring an existing runbook's steps, transitions, `INPUTS`/`OUTPUTS`, `ARTIFACTS`, or FOR loops
+- Looking up Rundown format syntax (directives, transitions, artifacts, delegation, frontmatter)
+
+## When NOT to Use
+
+- Executing or stepping through an active runbook — use the [running-runbooks](../running-runbooks/SKILL.md) skill instead
+- Orchestrating parent-side delegation to child agents — use the [delegating-runbooks](../delegating-runbooks/SKILL.md) skill instead
+- Planning the work before a runbook exists — use the [writing-plans](../writing-plans/SKILL.md) skill when applicable
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary

Quality pass over the three runbook-workflow Claude Code skills using the `skill-reviewer` agent. Each skill was reviewed, fixed, and re-reviewed to a PASS.

### running-runbooks
- Add **When to Use** / **When NOT to Use** sections
- Point the "CLI reference" link at `docs/reference/cli.md` (it pointed at `CLAUDE.md`, the contributor/architecture doc); relabel `CLAUDE.md` as "Project overview and command list"
- Add a Common Mistakes row for the highest-risk delegation error: bare `rd pass`/`rd fail` in a claimed child reports to the wrong runbook → use `--claim-id`

### delegating-runbooks
- **Fix broken anchor**: `#nested-runbooks-inline-linkage` → `#nested-runbooks` (the sibling heading produces the latter)
- Add **When to Use** / **When NOT to Use** sections
- Point the "CLI reference" link at `docs/reference/cli.md`; relabel `CLAUDE.md`
- Clarify authoring notes explicitly reference frontmatter `INPUTS:`/`OUTPUTS:`/`REQUIRED:`

### writing-runbooks
- **Remove deprecated `use_when:` frontmatter field** (only `name`/`description` are loader-recognized; it duplicated `description:` in weaker voice and diverged from sibling skills)
- Add **When to Use** / **When NOT to Use** sections with redirects to the sibling skills

## Notes

- **Frontmatter casing kept UPPERCASE** (`INPUTS:`/`OUTPUTS:`/`REQUIRED:`) per the project's documented house convention (confirmed with the repo owner). Step-level directives remain UPPERCASE; this is the deliberate Rundown style.
- A reviewer initially flagged `docs/guides/agent-orchestration.md` and `runbooks/delegation/` as broken references — both were verified to **exist** (false positives) and left unchanged.

## Out of scope (follow-ups)
- The spec (`docs/spec/language.md`) and `CLAUDE.md` use lowercase frontmatter keys in prose — a separate doc inconsistency vs. the UPPERCASE house convention.
- `writing-plans/SKILL.md` carries the same redundant `use_when:` field if plugin-wide cleanup is wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced guidance for runbook delegation with clearer distinctions between delegation methods and inline execution approaches
* Expanded "when to use" and "when not to use" sections across runbook documentation to help users understand appropriate use cases
* Improved best practices guidance and common mistakes references
* Updated reference links for better resource navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->