### PR TITLE
fix(core): make the Linux Landlock sandbox actually usable (env, /dev/null, missing paths, write surface)

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -61,6 +61,7 @@ changeset
 changesets
 cipherpowers
 cjs
+cmdline
 codecov
 codeql
 coderabbit

--- a/packages/core/__tests__/paths.test.ts
+++ b/packages/core/__tests__/paths.test.ts
@@ -1,10 +1,18 @@
 // packages/core/__tests__/paths.test.ts
 
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   completionLockPath,
+  CONTEXTS_DIR,
   delegationLockPath,
+  ensureStateDirs,
+  LOCKS_DIR,
   runStateLockPath,
+  RUNS_DIR,
   statePath,
+  WORK_DIR,
 } from '../src/paths.js';
 
 describe('assertSafeId (via path builders)', () => {
@@ -29,6 +37,31 @@ describe('assertSafeId (via path builders)', () => {
           expect(() => build(bad)).toThrow(/Invalid/);
         });
       }
+    }
+  });
+});
+
+describe('ensureStateDirs', () => {
+  it('creates the rundown state directories under the project root', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rd-paths-state-'));
+    try {
+      await ensureStateDirs(dir);
+      for (const sub of [RUNS_DIR, LOCKS_DIR, CONTEXTS_DIR, WORK_DIR]) {
+        expect(existsSync(join(dir, sub))).toBe(true);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('is idempotent when the directories already exist', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rd-paths-state-'));
+    try {
+      await ensureStateDirs(dir);
+      await expect(ensureStateDirs(dir)).resolves.toBeUndefined();
+      expect(existsSync(join(dir, WORK_DIR))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/core/__tests__/policy/schema.test.ts
+++ b/packages/core/__tests__/policy/schema.test.ts
@@ -191,6 +191,20 @@ describe('Policy Schema', () => {
       // runbooks/ contains user-authored sources, not generated state — must NOT be writable by default
       expect(allowedWrites).not.toContain('{repo}/.rundown/runbooks/**');
     });
+
+    it('does not grant write to build-output directories by default', () => {
+      // Build dirs are unused by Rundown-managed runbooks and, on Linux (allow-
+      // list only), would be unguarded blast radius. Build-writing runbooks must
+      // opt in via --allow-write. .claude/** is retained for the plugin's session
+      // state, and {tmp}/** is retained for scratch space.
+      const allowedWrites = DEFAULT_POLICY.default.write.allow;
+      expect(allowedWrites).not.toContain('{repo}/node_modules/**');
+      expect(allowedWrites).not.toContain('{repo}/dist/**');
+      expect(allowedWrites).not.toContain('{repo}/build/**');
+      expect(allowedWrites).not.toContain('{repo}/.next/**');
+      expect(allowedWrites).toContain('{repo}/.claude/**');
+      expect(allowedWrites).toContain('{tmp}/**');
+    });
   });
 
   describe('DEFAULT_POLICY_LINUX', () => {

--- a/packages/core/__tests__/sandbox/linux.test.ts
+++ b/packages/core/__tests__/sandbox/linux.test.ts
@@ -237,6 +237,86 @@ describe('LandlockSandbox', () => {
       expect(argv.slice(-3)).toEqual(['/bin/sh', '-c', 'echo hi']);
     });
 
+    it('forwards the sandbox environment to landrun via --env pass-through', async () => {
+      configureSpawnSync({ wrapperFound: true, positiveStatus: 0, deniedStatus: 1 });
+      const fakeChild = {
+        on: (event: string, cb: (arg: number) => void) => {
+          if (event === 'close') cb(0);
+        },
+      };
+      (spawn as jest.Mock).mockReturnValue(fakeChild);
+
+      await new LandlockSandbox().execute('echo hi', {
+        ...mockSandboxOptions,
+        env: { HOME: '/home/test', RD_RUN_ID: 'run-123' },
+        denyPaths: [],
+      });
+
+      const [, argv, spawnOpts] = (spawn as jest.Mock).mock.calls[0] as [
+        string,
+        string[],
+        { env: Record<string, string> },
+      ];
+
+      // Each key is forwarded as a `--env KEY` pass-through flag (the value
+      // following every `--env`), so PATH reaches `#!/usr/bin/env node` shebangs.
+      const forwarded = argv.filter((_, i) => argv[i - 1] === '--env');
+      expect(forwarded).toEqual(expect.arrayContaining(['HOME', 'RD_RUN_ID', 'PATH']));
+
+      // Values must NOT appear in argv (would be world-visible via /proc/<pid>/cmdline).
+      expect(argv).not.toContain('/home/test');
+      expect(argv).not.toContain('run-123');
+      expect(argv.some((a) => a.includes('='))).toBe(false);
+
+      // The values ARE placed in landrun's own env, where pass-through reads them.
+      expect(spawnOpts.env.HOME).toBe('/home/test');
+      expect(spawnOpts.env.RD_RUN_ID).toBe('run-123');
+      // PATH is enhanced with the project-local node_modules/.bin.
+      expect(spawnOpts.env.PATH).toContain('/test/cwd/node_modules/.bin');
+
+      // Env flags precede the `/bin/sh -c <command>` triple.
+      expect(argv.slice(-3)).toEqual(['/bin/sh', '-c', 'echo hi']);
+    });
+
+    it('grants device nodes read-write so redirects like > /dev/null work', async () => {
+      configureSpawnSync({ wrapperFound: true, positiveStatus: 0, deniedStatus: 1 });
+      const fakeChild = {
+        on: (event: string, cb: (arg: number) => void) => {
+          if (event === 'close') cb(0);
+        },
+      };
+      (spawn as jest.Mock).mockReturnValue(fakeChild);
+
+      await new LandlockSandbox().execute('echo hi', { ...mockSandboxOptions, denyPaths: [] });
+
+      const [, argv] = (spawn as jest.Mock).mock.calls[0] as [string, string[]];
+      // /dev/null is granted --rw (shells open it for *writing* on `> /dev/null`).
+      const devNullIdx = argv.indexOf('/dev/null');
+      expect(devNullIdx).toBeGreaterThan(0);
+      expect(argv[devNullIdx - 1]).toBe('--rw');
+    });
+
+    it('filters absent device nodes from grants', async () => {
+      // /dev/random and /dev/urandom missing; /dev/null present.
+      (existsSync as jest.Mock).mockImplementation(
+        (p: unknown) => p !== '/dev/random' && p !== '/dev/urandom',
+      );
+      configureSpawnSync({ wrapperFound: true, positiveStatus: 0, deniedStatus: 1 });
+      const fakeChild = {
+        on: (event: string, cb: (arg: number) => void) => {
+          if (event === 'close') cb(0);
+        },
+      };
+      (spawn as jest.Mock).mockReturnValue(fakeChild);
+
+      await new LandlockSandbox().execute('echo hi', { ...mockSandboxOptions, denyPaths: [] });
+
+      const [, argv] = (spawn as jest.Mock).mock.calls[0] as [string, string[]];
+      expect(argv).toContain('/dev/null');
+      expect(argv).not.toContain('/dev/random');
+      expect(argv).not.toContain('/dev/urandom');
+    });
+
     it('honors a cached unavailable result and does not run the wrapper', async () => {
       // Regression for the wrapperPath-as-gate bug: the wrapper is found (so
       // wrapperPath is set) but the enforcement probe fails (unavailable). A

--- a/packages/core/__tests__/sandbox/linux.test.ts
+++ b/packages/core/__tests__/sandbox/linux.test.ts
@@ -317,6 +317,36 @@ describe('LandlockSandbox', () => {
       expect(argv).not.toContain('/dev/urandom');
     });
 
+    it('filters non-existent policy grant paths (landrun aborts on missing paths)', async () => {
+      // /test/read and /test/write exist; the *-missing paths do not. System and
+      // device paths exist so the availability probe still passes.
+      (existsSync as jest.Mock).mockImplementation(
+        (p: unknown) => p !== '/test/missing-ro' && p !== '/test/missing-rw',
+      );
+      configureSpawnSync({ wrapperFound: true, positiveStatus: 0, deniedStatus: 1 });
+      const fakeChild = {
+        on: (event: string, cb: (arg: number) => void) => {
+          if (event === 'close') cb(0);
+        },
+      };
+      (spawn as jest.Mock).mockReturnValue(fakeChild);
+
+      await new LandlockSandbox().execute('echo hi', {
+        ...mockSandboxOptions,
+        readOnlyPaths: ['/test/read', '/test/missing-ro'],
+        readWritePaths: ['/test/write', '/test/missing-rw'],
+        denyPaths: [],
+      });
+
+      const [, argv] = (spawn as jest.Mock).mock.calls[0] as [string, string[]];
+      // Existing grant paths are passed through...
+      expect(argv).toContain('/test/read');
+      expect(argv).toContain('/test/write');
+      // ...non-existent ones are dropped rather than aborting landrun's ruleset.
+      expect(argv).not.toContain('/test/missing-ro');
+      expect(argv).not.toContain('/test/missing-rw');
+    });
+
     it('honors a cached unavailable result and does not run the wrapper', async () => {
       // Regression for the wrapperPath-as-gate bug: the wrapper is found (so
       // wrapperPath is set) but the enforcement probe fails (unavailable). A

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,4 +1,5 @@
 // packages/core/src/paths.ts
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 /**
@@ -107,6 +108,31 @@ export const workDir = (cwd: string): string => path.join(cwd, WORK_DIR);
  * @returns Path to `.rundown/contexts/`
  */
 export const contextsDir = (cwd: string): string => path.join(cwd, CONTEXTS_DIR);
+
+/**
+ * Ensure the Rundown-owned state directories exist under the project root.
+ *
+ * Creates `.rundown/{runs,locks,contexts,work}` if absent. `runs` and `locks`
+ * are normally created on first state-save / lock-acquire, but `contexts` and
+ * `work` are otherwise created lazily on first artifact/OUTPUTS write — which is
+ * too late for the OS sandbox: the Landlock backend grants these directories to
+ * the sandboxed command up front, and the `landrun` wrapper aborts ruleset
+ * construction on any grant path that does not yet exist. Ensuring the base
+ * directories exist before sandbox setup keeps the grants valid and lets a
+ * command write its OUTPUTS into `work`/`contexts` on a fresh run.
+ *
+ * Idempotent: uses recursive mkdir, so existing directories are left untouched.
+ *
+ * @param cwd - Project root directory (repo root the sandbox grants resolve against)
+ * @returns Resolves once all four directories exist
+ */
+export const ensureStateDirs = async (cwd: string): Promise<void> => {
+  await Promise.all(
+    [RUNS_DIR, LOCKS_DIR, CONTEXTS_DIR, WORK_DIR].map((dir) =>
+      fs.mkdir(path.join(cwd, dir), { recursive: true }),
+    ),
+  );
+};
 
 /**
  * Absolute path to a specific runbook state file.

--- a/packages/core/src/policy/schema.ts
+++ b/packages/core/src/policy/schema.ts
@@ -238,11 +238,15 @@ export const DEFAULT_POLICY: PolicyConfig = {
         // Single-file entries: update this list when new top-level .rundown/*.json artifacts are introduced
         `{repo}/${SESSION_FILE}`,
         `{repo}/${WORK_DIR}/**`,
-        '{repo}/node_modules/**',
-        '{repo}/dist/**',
-        '{repo}/build/**',
-        '{repo}/.next/**',
         '{tmp}/**',
+        // NOTE: build-output directories (node_modules, dist, build, .next) are
+        // deliberately NOT writable by default. No Rundown-managed runbook writes
+        // to them, and on Linux the default is allow-list-only (toAllowListOnly
+        // strips write denies because Landlock cannot enforce subtractive denies),
+        // so every entry here is unguarded blast radius. Runbooks that build
+        // (e.g. `npm run build` -> dist/) must opt in via `--allow-write dist`.
+        // `.claude/**` is retained: the Claude Code plugin persists session state
+        // under .claude/session/ (packages/claude-code-plugin/src/session.ts).
       ],
       deny: [
         '**/.env',

--- a/packages/core/src/runbook/executor.ts
+++ b/packages/core/src/runbook/executor.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import * as path from 'node:path';
+import { ensureStateDirs } from '../paths.js';
 import type { PolicyEvaluator, PolicyPrompter, PolicyDecision } from '../policy/index.js';
 import { executeWithSandbox, isSandboxAvailable } from '../sandbox/index.js';
 import { policyToSandboxOptions } from '../sandbox/policy-mapper.js';
@@ -227,6 +228,12 @@ export async function executeCommandWithPolicy(
     const sandboxAvailable = await isSandboxAvailable();
 
     if (sandboxAvailable) {
+      // The Landlock backend grants Rundown's own state directories to the
+      // sandboxed command, and landrun aborts if a grant path does not exist.
+      // `contexts`/`work` are otherwise created lazily on first write, so ensure
+      // the base directories exist before building the ruleset.
+      await ensureStateDirs(evaluator.getRepoRoot());
+
       const sandboxOptions = policyToSandboxOptions(evaluator, {
         cwd,
         repoRoot: evaluator.getRepoRoot(),

--- a/packages/core/src/sandbox/linux.ts
+++ b/packages/core/src/sandbox/linux.ts
@@ -15,6 +15,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { logger } from '../logger.js';
 import type {
   SandboxOptions,
   SandboxExecutionResult,
@@ -82,6 +83,36 @@ function buildDevicePathArgs(): string[] {
   for (const path of DEVICE_RW_PATHS) {
     if (existsSync(path)) {
       args.push('--rw', path);
+    }
+  }
+  return args;
+}
+
+/**
+ * Build landrun grant flags for caller-supplied policy paths, filtered to those
+ * that exist on this host.
+ *
+ * landrun aborts ruleset construction on any grant path that does not exist
+ * (the same constraint that {@link buildSystemPathArgs} handles for system
+ * paths). A policy may resolve write-allow globs to concrete paths that have not
+ * been created yet (e.g. an opted-in `dist/` before the first build, or
+ * `.claude/` in a project that does not use the Claude Code plugin), so those
+ * are dropped rather than passed through. Dropping is safe: the repo root is
+ * granted read-only, so a sandboxed command could not create such a path
+ * regardless of the grant. Rundown's own state directories are ensured to exist
+ * before sandbox setup (see `ensureStateDirs`), so they are never dropped here.
+ *
+ * @param flag - landrun access flag (`--ro` for read-only, `--rw` for read-write)
+ * @param paths - Candidate paths to grant
+ * @returns Ordered landrun args for the paths that exist, e.g. `['--rw', '/a']`
+ */
+function buildGrantArgs(flag: '--ro' | '--rw', paths: string[]): string[] {
+  const args: string[] = [];
+  for (const path of paths) {
+    if (existsSync(path)) {
+      args.push(flag, path);
+    } else {
+      void logger.debug('sandbox: skipping non-existent grant path', { flag, path });
     }
   }
   return args;
@@ -338,15 +369,10 @@ export class LandlockSandbox implements SandboxImplementation {
       // us to an unsandboxed run that still reports as sandboxed.
       const args: string[] = ['--best-effort'];
 
-      // Add read-only paths
-      for (const path of options.readOnlyPaths) {
-        args.push('--ro', path);
-      }
-
-      // Add read-write paths
-      for (const path of options.readWritePaths) {
-        args.push('--rw', path);
-      }
+      // Add read-only and read-write policy paths, filtered to those that exist
+      // (landrun aborts ruleset construction on a non-existent grant path).
+      args.push(...buildGrantArgs('--ro', options.readOnlyPaths));
+      args.push(...buildGrantArgs('--rw', options.readWritePaths));
 
       // Add the system paths needed to exec the interpreter and load libraries
       // (granted --rox), filtered to those present on this host.

--- a/packages/core/src/sandbox/linux.ts
+++ b/packages/core/src/sandbox/linux.ts
@@ -37,6 +37,16 @@ const SYSTEM_EXEC_PATHS = ['/usr', '/bin', '/sbin', '/lib', '/lib64'];
 const SYSTEM_READ_PATHS = ['/etc'];
 
 /**
+ * Device nodes a sandboxed command opens directly. `/dev/null` is the common
+ * case: a shell opens it *for writing* on every `> /dev/null` redirect, so a
+ * read-only grant is insufficient — without a read-write grant the redirect
+ * fails with `cannot create /dev/null: Permission denied`. landrun 0.1.x has no
+ * dedicated device flag, so these are granted as individual read-write
+ * filesystem nodes with `--rw`, filtered to those present on the host.
+ */
+const DEVICE_RW_PATHS = ['/dev/null', '/dev/zero', '/dev/random', '/dev/urandom'];
+
+/**
  * Build the landrun grant flags for the standard system paths, filtered to
  * those that actually exist on this host. Filtering matters because landrun
  * fails to build a ruleset for a non-existent path (e.g. `/lib64` is absent on
@@ -55,6 +65,23 @@ function buildSystemPathArgs(): string[] {
   for (const path of SYSTEM_READ_PATHS) {
     if (existsSync(path)) {
       args.push('--ro', path);
+    }
+  }
+  return args;
+}
+
+/**
+ * Build the landrun `--rw` grants for the device nodes a sandboxed command may
+ * open directly (e.g. `/dev/null` on a `> /dev/null` redirect), filtered to
+ * those that exist on this host.
+ *
+ * @returns Ordered landrun args, e.g. `['--rw', '/dev/null', '--rw', '/dev/zero']`
+ */
+function buildDevicePathArgs(): string[] {
+  const args: string[] = [];
+  for (const path of DEVICE_RW_PATHS) {
+    if (existsSync(path)) {
+      args.push('--rw', path);
     }
   }
   return args;
@@ -325,14 +352,32 @@ export class LandlockSandbox implements SandboxImplementation {
       // (granted --rox), filtered to those present on this host.
       args.push(...buildSystemPathArgs());
 
-      // Execute the command
-      args.push('--', '/bin/sh', '-c', command);
+      // Grant the device nodes a command opens directly (e.g. /dev/null).
+      args.push(...buildDevicePathArgs());
 
-      // Enhance PATH to include node_modules/.bin for local package binaries
+      // Enhance PATH to include node_modules/.bin for local package binaries.
       const enhancedEnv = {
         ...options.env,
         PATH: buildEnhancedPathFromEnv(options.cwd, options.env),
       };
+
+      // landrun runs the sandboxed command with an EMPTY environment unless each
+      // variable is explicitly forwarded. Without this, PATH never reaches the
+      // command and `#!/usr/bin/env node` shebangs (rdx, rd, npm — all under
+      // /usr/local/bin) fail with exit 127 because /usr/local/bin is absent from
+      // glibc's fallback PATH. Use the `--env KEY` pass-through form (not
+      // `--env KEY=VALUE`) so values are read from landrun's own environment
+      // (set on spawn below) rather than placed in argv, where they would be
+      // world-visible via /proc/<pid>/cmdline. The env reaching here is already
+      // policy-filtered by the executor, so forwarding every key leaks nothing
+      // the policy means to block.
+      for (const key of Object.keys(enhancedEnv)) {
+        args.push('--env', key);
+      }
+
+      // Execute the command. Keep '/bin/sh -c <command>' as the final three argv
+      // elements (after the `--` delimiter); env/grant flags must precede them.
+      args.push('--', '/bin/sh', '-c', command);
 
       // wrapperPath is guaranteed to be set at this point (checked at start of execute method)
 


### PR DESCRIPTION
## Summary

The Linux Landlock sandbox (`landrun` backend) was effectively unusable for real runbooks. Diagnosed and fixed while running the end-to-end Docker test, where the write-file runbook's step-3 schema gate (`rdx … --validate --schema plan`) looped step 3 → step 2 forever. Four distinct issues, all in `@rundown-org/core`:

### 1. Environment was never forwarded into the sandbox
`landrun` runs the sandboxed command with an **empty environment** unless each variable is forwarded with `--env`. `executeWithLandrun` built `enhancedEnv` (with the correct PATH) but only handed it to the *landrun process*, never into the sandbox. The command ran with **no PATH**. `node` still worked (dash substitutes a built-in default PATH for its own lookups), but every `#!/usr/bin/env node` shebang — `rdx`, `rdpath`, **and `rd`/`rundown`/`npm` themselves** — died with `env: 'node': No such file or directory` (exit 127). That was the real cause of the step 3 → step 2 loop.

Fix: forward each `enhancedEnv` key via landrun's `--env KEY` **pass-through** form (not `KEY=VALUE`), so values come from landrun's own environment rather than argv (where they'd be world-visible via `/proc/<pid>/cmdline`). The env is already policy-filtered by the executor, so forwarding every key leaks nothing the policy blocks.

### 2. `/dev/null` was not granted
A shell opens `/dev/null` **for writing** on every `> /dev/null` redirect; without a grant it failed with `cannot create /dev/null: Permission denied`. Now granted `--rw` (plus `/dev/zero`, `/dev/random`, `/dev/urandom`), existence-filtered.

### 3. Sandbox crashed on non-existent grant paths
`landrun` aborts ruleset construction on any grant path that doesn't exist (the constraint `buildSystemPathArgs` already handles for system paths), but policy-derived read/write grants were passed through **unfiltered**. On a fresh run this failed *before the command ran*: `.rundown/{contexts,work}` are created lazily on first write, and `.claude/` is absent in non-plugin projects.

Fix: (a) ensure rd's own `.rundown/{runs,locks,contexts,work}` exist before sandbox init (`paths.ensureStateDirs`, called from the executor) — keeps grants valid and lets commands write OUTPUTS into `work/` on a fresh run; (b) existence-filter the grant paths in the Landlock backend, logging dropped paths at debug. Dropping is safe — the repo root is read-only, so a sandboxed command couldn't create a missing path anyway.

### 4. Over-broad default write surface
`DEFAULT_POLICY.write.allow` granted write to `node_modules/`, `dist/`, `build/`, `.next/`. No Rundown-managed runbook writes there, and on Linux the default is **allow-list-only** (`toAllowListOnly` strips write denies because Landlock can't enforce subtractive denies), so every entry is unguarded blast radius. Removed — build-writing runbooks opt in via `--allow-write dist`. `.claude/**` retained (plugin session state); `{tmp}/**` retained.

> macOS (Seatbelt) was unaffected throughout: it inherits the spawned env directly and already permits `/dev/null`.

## Commits
1. `forward env into the Landlock sandbox and grant /dev/null`
2. `drop build-output dirs from the default sandbox write surface`
3. `make the Landlock sandbox tolerate missing grant paths`

## Verification
- `npm run verify` green (format, spell, lint, types, docs, full suite incl. new unit tests in `linux.test.ts`, `schema.test.ts`, `paths.test.ts`).
- **End-to-end in the e2e container, from a fresh tree (`rm -rf .rundown`, no `dist/build/.next`):** a runbook step running `rdpath` (node-shebang) with a `> /dev/null` redirect and a write into `.rundown/work` now runs under the **default** Landlock sandbox → step **PASS / COMPLETE**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build and output directories (`node_modules`, `dist`, `build`, `.next`) are now protected by default and no longer writable without explicit permission.

* **Tests**
  * Added comprehensive test coverage for sandbox behavior, policy validation, and directory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->