### PR TITLE
[codex] Scope file locks as await-using disposables

### DIFF
--- a/packages/claude-code-plugin/tsconfig.json
+++ b/packages/claude-code-plugin/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "ESNext.Error"],
+    "lib": ["ES2022", "ESNext.Error", "ESNext.Disposable"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "declaration": true,

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -13,6 +13,7 @@ import type {
   RunbookStateManager,
   RunnableTemplateVariables,
   RunbookState,
+  ScopedLock,
   SessionService,
   TemplateVarValue,
   StepDelegation,
@@ -423,8 +424,11 @@ function mockScanService(result: FindByTokenResult, orphan?: FindOrphanedChildRe
 /**
  * Configure `core.DelegationLock` with the given acquire/release mocks.
  *
- * Partial mock is intentional: production code only invokes `acquire` and
- * `release`. The cast surfaces the full instance shape without forcing
+ * Production takes the lock via the disposable scope API (`scope`/`held`,
+ * returning an `AsyncDisposable`), so the mock implements those too. Both
+ * delegate disposal to the supplied `release` mock so `toHaveBeenCalledWith`
+ * assertions on `release` still observe the scope-exit unlink. The cast
+ * surfaces the full instance shape without forcing the private
  * `cwd` / `lockDir` / `lockPath` fields onto the literal.
  *
  * `release` accepts an optional `runId` argument in production (the lock
@@ -435,11 +439,24 @@ function mockDelegationLock(
   acquire: jest.Mock<(...args: unknown[]) => Promise<void>>,
   release: jest.Mock<(...args: unknown[]) => Promise<void>>,
 ): void {
+  const held = (runId?: string): ScopedLock => {
+    let released = false;
+    const run = async (): Promise<void> => {
+      if (released) return;
+      released = true;
+      await release(runId);
+    };
+    return { release: run, [Symbol.asyncDispose]: run };
+  };
+  const scope = async (runId?: string): Promise<ScopedLock> => {
+    await acquire(runId);
+    return held(runId);
+  };
   jest
     .mocked(core.DelegationLock)
     .mockImplementation(
       () =>
-        ({ acquire, release }) as unknown as jest.MockedObject<
+        ({ acquire, release, held, scope }) as unknown as jest.MockedObject<
           InstanceType<typeof core.DelegationLock>
         >,
     );

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -17,6 +17,7 @@ import type {
   RunbookRef,
   RunId,
   RunnableTemplateVariables,
+  ScopedLock,
   TemplateVarValue,
 } from '@rundown-org/core';
 import type {
@@ -383,6 +384,36 @@ const {
 const { setHelperRegistry, resetHelperRegistry } = await import(
   '../../src/services/helper-registry.js'
 );
+
+/**
+ * Install a fully-successful `core.DelegationLock` mock.
+ *
+ * Production takes the lock via the disposable scope API (`scope`/`held`,
+ * returning an `AsyncDisposable`), so the mock implements those and delegates
+ * disposal to an always-resolving `release`. Centralised so the many
+ * startRunbook/claim tests that just need the lock to succeed stay in lock-step
+ * with the lock's API.
+ */
+function installHappyDelegationLockMock(): void {
+  jest.mocked(core.DelegationLock).mockImplementation(() => {
+    const acquire = mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined);
+    const release = mockFn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined);
+    const held = (runId?: string): ScopedLock => {
+      let released = false;
+      const run = async (): Promise<void> => {
+        if (released) return;
+        released = true;
+        await release(runId);
+      };
+      return { release: run, [Symbol.asyncDispose]: run };
+    };
+    const scope = async (runId?: string): Promise<ScopedLock> => {
+      await acquire(runId);
+      return held(runId);
+    };
+    return { acquire, release, held, scope } as unknown as jest.MockedObject<DelegationLock>;
+  });
+}
 
 function makeState(id: RunId, overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -2117,13 +2148,7 @@ describe('claimAndLaunch', () => {
       .mocked(core.RunbookStateManager)
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     const claimSpy = mockClaimRunbookSuccess();
     const ctx = {
@@ -2180,13 +2205,7 @@ describe('claimAndLaunch', () => {
       .mocked(core.RunbookStateManager)
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     const claimSpy = mockClaimRunbookSuccess();
     const ctx = {
@@ -2251,13 +2270,7 @@ describe('claimAndLaunch', () => {
       .mocked(core.RunbookStateManager)
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     const ctx = {
       output: {} as unknown as OutputEmitter,
@@ -2333,13 +2346,7 @@ describe('claimAndLaunch', () => {
       .mocked(core.RunbookStateManager)
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     const claimSpy = mockClaimRunbookSuccess();
     const ctx = {
@@ -2402,13 +2409,7 @@ describe('claimAndLaunch', () => {
       .mocked(core.RunbookStateManager)
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     const claimSpy = mockClaimRunbookSuccess();
     const mockSessionService = {
@@ -2491,13 +2492,7 @@ describe('claimAndLaunch', () => {
       .mocked(core.RunbookStateManager)
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     const claimSpy = mockFn<SessionService['claimRunbook']>().mockResolvedValue({
       status: 'linkage-mismatch',
@@ -2602,13 +2597,7 @@ describe('claimAndLaunch', () => {
       .mocked(core.RunbookStateManager)
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     jest.mocked(runExecutionLoop).mockResolvedValue('waiting');
 
@@ -2730,13 +2719,7 @@ describe('claimAndLaunch', () => {
       .mocked(core.RunbookStateManager)
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     jest.mocked(runExecutionLoop).mockResolvedValue('waiting');
 
@@ -2863,13 +2846,7 @@ describe('claimAndLaunch', () => {
       .mocked(core.RunbookStateManager)
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     jest.mocked(runExecutionLoop).mockResolvedValue('waiting');
 
@@ -2959,13 +2936,7 @@ describe('claimAndLaunch', () => {
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
     jest.mocked(core.reconstituteContextVars).mockReturnValue({});
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     const ctx = {
       output: {} as unknown as OutputEmitter,
@@ -3051,13 +3022,7 @@ describe('claimAndLaunch', () => {
       .mocked(core.RunbookStateManager)
       .mockImplementation(() => mockManager as unknown as jest.MockedObject<RunbookStateManager>);
 
-    jest.mocked(core.DelegationLock).mockImplementation(
-      () =>
-        ({
-          acquire: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-          release: mockFn<() => Promise<void>>().mockResolvedValue(undefined),
-        }) as unknown as jest.MockedObject<DelegationLock>,
-    );
+    installHappyDelegationLockMock();
 
     jest.mocked(runExecutionLoop).mockResolvedValue('waiting');
 

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -178,8 +178,12 @@ export function registerAbortCommand(program: Command): void {
           const targetSubstepId = substepId ?? scanResult.stepId;
           const lock = new DelegationLock(cwd);
 
-          // 3. Acquire delegation lock
+          // 3. Acquire delegation lock. Scoped with `await using` as a
+          //    best-effort safety net (released explicitly below, before the
+          //    post-lock propagation work); a failed release can never mask the
+          //    committed abort.
           await lock.acquire(parentState.id);
+          await using _lockGuard = lock.held(parentState.id);
 
           let abortResult: ReturnType<typeof abortDelegation>;
           let freshParent: RunbookState | null = null;
@@ -223,7 +227,7 @@ export function registerAbortCommand(program: Command): void {
             );
           }
 
-          try {
+          {
             // 4. Re-load parent state under lock
             freshParent = await manager.load(parentState.id);
             if (!freshParent) {
@@ -363,10 +367,12 @@ export function registerAbortCommand(program: Command): void {
                 });
               }
             }
-          } finally {
-            // 10. Release lock
-            await lock.release(parentState.id);
           }
+
+          // 10. Release the lock before the post-lock propagation work below.
+          //     (The `await using` guard above re-releases idempotently if an
+          //     early throw skips this.)
+          await _lockGuard.release();
 
           // 11. If force + childRunId: propagate failure through parent (outside lock)
           if (options.force && childRunId) {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -187,21 +187,17 @@ export function registerRunCommand(program: Command): void {
                 // be stale by the time afterInit runs (another child may have
                 // modified substepStates in between).
                 const lock = new DelegationLock(cwd);
-                await lock.acquire(link.parentRunId);
-                try {
-                  const fresh = await manager.load(link.parentRunId);
-                  if (!fresh) return;
-                  const substeps = fresh.substepStates ?? [];
-                  const updated = upsertSubstepState(
-                    substeps,
-                    link.parentStepId,
-                    link.parentFrameKey,
-                    { status: 'running' as const },
-                  );
-                  await manager.update(link.parentRunId, { substepStates: updated });
-                } finally {
-                  await lock.release(link.parentRunId);
-                }
+                await using _guard = await lock.scope(link.parentRunId);
+                const fresh = await manager.load(link.parentRunId);
+                if (!fresh) return;
+                const substeps = fresh.substepStates ?? [];
+                const updated = upsertSubstepState(
+                  substeps,
+                  link.parentStepId,
+                  link.parentFrameKey,
+                  { status: 'running' as const },
+                );
+                await manager.update(link.parentRunId, { substepStates: updated });
               };
             }
 

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -1299,7 +1299,10 @@ export async function claimAndLaunch(
   const { parentState, stepId, substepId, delegation: _delegation } = scanResult;
   const lock = new DelegationLock(cwd);
 
-  // 3. Acquire delegation lock
+  // 3. Acquire delegation lock. The timeout is mapped to a typed result, so
+  //    acquire stays an explicit try/catch; the held lock is then scoped with
+  //    `await using` so a best-effort release can never mask the committed
+  //    claim result (the RD-102 defect this method originally exhibited).
   try {
     await lock.acquire(parentState.id);
   } catch (err) {
@@ -1314,8 +1317,9 @@ export async function claimAndLaunch(
     }
     throw err;
   }
+  await using _lockGuard = lock.held(parentState.id);
 
-  try {
+  {
     // 4a. Re-load parent state (freshness check)
     const freshParent = await manager.load(parentState.id);
     if (!freshParent) {
@@ -1682,8 +1686,6 @@ export async function claimAndLaunch(
       parentStepAt: freshDelegation.contextSnapshot.at,
       loopResult: launchResult.loopResult,
     });
-  } finally {
-    // 5. Always release lock
-    await lock.release(parentState.id);
   }
+  // Lock released by `_lockGuard`'s disposer on scope exit (best-effort).
 }

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -38,6 +38,7 @@ import {
   type DelegateFrontierEntry,
   DelegationLock,
   DelegationLockTimeoutError,
+  type ScopedLock,
   reconstituteContextVars,
   extractInheritedUserVars,
   ErrorCodes,
@@ -438,16 +439,20 @@ async function launchInlineChildFromIntent({
   };
   const childRunId = assertRunId(intent.childRunId);
   const lock = new DelegationLock(cwd);
-  let lockHeld = false;
+  // This site deliberately releases the lock *before* the child execution loop
+  // and from several branches, so a block-scoped `await using` is the wrong
+  // shape. Instead route the existing idempotent release closure through the
+  // best-effort `ScopedLock` guard: release runs at most once and never throws,
+  // so a failed unlink can never mask the committed result at the safety-net
+  // `finally` below (the RD-102 masking defect).
+  let guard: ScopedLock | undefined;
   const releaseLock = async (): Promise<void> => {
-    if (!lockHeld) return;
-    lockHeld = false;
-    await lock.release(parentLinkage.parentRunId);
+    await guard?.release();
   };
 
   try {
     await lock.acquire(parentLinkage.parentRunId);
-    lockHeld = true;
+    guard = lock.held(parentLinkage.parentRunId);
   } catch (err) {
     if (err instanceof DelegationLockTimeoutError) {
       emitter.emit('ERROR_OCCURRED', {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "ESNext.Error"],
+    "lib": ["ES2022", "ESNext.Error", "ESNext.Disposable"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "declaration": true,

--- a/packages/core/__tests__/runbook/delegation-lock.test.ts
+++ b/packages/core/__tests__/runbook/delegation-lock.test.ts
@@ -88,6 +88,70 @@ describe('DelegationLock', () => {
     await expect(lock.release('nonexistent-run')).resolves.toBeUndefined();
   });
 
+  it('scope() releases the lock at await using scope exit', async () => {
+    const lockPath = delegationLockPath(tmpDir, 'run-scope');
+    {
+      await using _guard = await lock.scope('run-scope');
+      // Lock is held inside the block.
+      const content = JSON.parse(await fs.readFile(lockPath, 'utf8'));
+      expect(content.pid).toBe(process.pid);
+    }
+    // Released on block exit.
+    await expect(fs.access(lockPath)).rejects.toThrow();
+  });
+
+  it('held() disposal does not mask the committed outcome when unlink is denied (RD-102 regression)', async () => {
+    // Impact-level regression for the RD-102 bug: a caller commits its work,
+    // buffers a successful return value, and lets the `await using` guard
+    // release the lock at scope exit. If the unlink fails (here a transient
+    // EACCES forced by a read-only locks directory), the best-effort disposer
+    // must swallow it — never propagate and replace the already-committed
+    // return value (which discarded a successful claim's `claim_id` and
+    // surfaced a spurious RD-102 + non-zero exit). Goes RED if the guard
+    // disposer rethrows.
+    const lockDir = locksDir(tmpDir);
+
+    async function commitThenScopedRelease(): Promise<{ ok: true; claimId: string }> {
+      await lock.acquire('run-scoped-release');
+      await using _guard = lock.held('run-scoped-release');
+      // ... committing work already done; the caller has a successful result.
+      // Deny the unlink by removing write permission on the lock directory.
+      // (No effect as root, where release succeeds and the assertion still
+      // holds trivially — non-root CI reproduces the denied unlink.)
+      await fs.chmod(lockDir, 0o500);
+      return { ok: true, claimId: 'rdclm_committed_claim_id_0001' };
+    }
+
+    try {
+      await expect(commitThenScopedRelease()).resolves.toEqual({
+        ok: true,
+        claimId: 'rdclm_committed_claim_id_0001',
+      });
+    } finally {
+      // Restore write permission so afterEach cleanup can remove the temp dir.
+      await fs.chmod(lockDir, 0o700);
+    }
+  });
+
+  it('release() propagates a real (non-ENOENT) failure — honest by contract', async () => {
+    // The guard owns the best-effort policy; release() itself stays honest so
+    // genuine I/O failures remain diagnosable. Skipped as root, where the
+    // read-only directory does not deny unlink.
+    if (process.getuid?.() === 0) {
+      return;
+    }
+    await lock.acquire('run-honest-release');
+    const lockDir = locksDir(tmpDir);
+    await fs.chmod(lockDir, 0o500);
+    try {
+      await expect(lock.release('run-honest-release')).rejects.toMatchObject({
+        code: expect.stringMatching(/^(EACCES|EPERM)$/),
+      });
+    } finally {
+      await fs.chmod(lockDir, 0o700);
+    }
+  });
+
   it('reclaims stale lock from dead PID', async () => {
     // Manually write a lock file with a dead PID
     const lockDir = locksDir(tmpDir);

--- a/packages/core/__tests__/runbook/file-lock.test.ts
+++ b/packages/core/__tests__/runbook/file-lock.test.ts
@@ -9,6 +9,8 @@ import {
   acquireFileLock,
   acquireFileLockSync,
   FileLockTimeoutError,
+  heldLock,
+  heldLockSync,
   isLockContent,
   isProcessAlive,
   releaseFileLock,
@@ -359,6 +361,81 @@ describe('file-lock', () => {
       } finally {
         releaseFileLockSync(lockFile);
       }
+    });
+  });
+
+  describe('heldLock (scoped async-disposable)', () => {
+    it('releases exactly once at scope exit via await using', async () => {
+      let count = 0;
+      {
+        await using _guard = heldLock(
+          async () => {
+            count += 1;
+          },
+          () => ({}),
+        );
+        expect(count).toBe(0);
+      }
+      expect(count).toBe(1);
+    });
+
+    it('explicit release() disarms the automatic disposal (released at most once)', async () => {
+      let count = 0;
+      {
+        await using guard = heldLock(
+          async () => {
+            count += 1;
+          },
+          () => ({}),
+        );
+        await guard.release();
+        expect(count).toBe(1);
+      }
+      // The scope-exit dispose must be a no-op after an explicit release.
+      expect(count).toBe(1);
+    });
+
+    it('disposal is best-effort: a throwing release neither propagates nor masks the result', async () => {
+      const run = async (): Promise<string> => {
+        await using _guard = heldLock(
+          async () => {
+            throw new Error('unlink denied');
+          },
+          () => ({}),
+        );
+        return 'committed-result';
+      };
+      // The committed result survives; the throwing disposer is swallowed.
+      await expect(run()).resolves.toBe('committed-result');
+    });
+  });
+
+  describe('heldLockSync (scoped disposable)', () => {
+    it('releases exactly once at scope exit via using', () => {
+      let count = 0;
+      {
+        using _guard = heldLockSync(
+          () => {
+            count += 1;
+          },
+          () => ({}),
+        );
+        expect(count).toBe(0);
+      }
+      expect(count).toBe(1);
+    });
+
+    it('disposal is best-effort: a throwing release does not propagate', () => {
+      const run = (): string => {
+        using _guard = heldLockSync(
+          () => {
+            throw new Error('unlink denied');
+          },
+          () => ({}),
+        );
+        return 'committed-result';
+      };
+      expect(run()).toBe('committed-result');
     });
   });
 });

--- a/packages/core/src/runbook/artifact-manifest.ts
+++ b/packages/core/src/runbook/artifact-manifest.ts
@@ -16,6 +16,8 @@ import { artifactUriToPath, parseArtifactUri, type ArtifactPathOptions } from '.
 import {
   acquireFileLock,
   acquireFileLockSync,
+  heldLock,
+  heldLockSync,
   releaseFileLock,
   releaseFileLockSync,
 } from './file-lock.js';
@@ -116,11 +118,15 @@ export function appendArtifactManifestRecordSync(
   const lockFile = path.resolve(locksDir, `.rd-${parsed.contextId}.manifest.lock`);
 
   acquireFileLockSync(lockFile, locksDir);
-  try {
-    return writeManifestLineSync(workRoot, location.manifestPath, parsed);
-  } finally {
-    releaseFileLockSync(lockFile);
-  }
+  // Best-effort scoped release: a failed unlink only leaks a self-healing lock
+  // and must never mask the committed manifest append.
+  using _guard = heldLockSync(
+    () => {
+      releaseFileLockSync(lockFile);
+    },
+    () => ({ lock: 'manifest', contextId: parsed.contextId, lockFile }),
+  );
+  return writeManifestLineSync(workRoot, location.manifestPath, parsed);
 }
 
 /**
@@ -151,11 +157,13 @@ export async function appendArtifactManifestRecord(
   const lockFile = path.resolve(locksDir, `.rd-${parsed.contextId}.manifest.lock`);
 
   await acquireFileLock(lockFile, locksDir);
-  try {
-    return writeManifestLineSync(workRoot, location.manifestPath, parsed);
-  } finally {
-    await releaseFileLock(lockFile);
-  }
+  // Best-effort scoped release: a failed unlink only leaks a self-healing lock
+  // and must never mask the committed manifest append.
+  await using _guard = heldLock(
+    () => releaseFileLock(lockFile),
+    () => ({ lock: 'manifest', contextId: parsed.contextId, lockFile }),
+  );
+  return writeManifestLineSync(workRoot, location.manifestPath, parsed);
 }
 
 /**

--- a/packages/core/src/runbook/completion-lock.ts
+++ b/packages/core/src/runbook/completion-lock.ts
@@ -91,6 +91,7 @@ export class CompletionLock {
    *
    * @param runId - Run ID to lock
    * @returns A disposable scope that releases the lock on exit
+   * @throws {CompletionLockTimeoutError} When the lock cannot be acquired within the deadline
    */
   async scope(runId: string): Promise<ScopedLock> {
     await this.acquire(runId);

--- a/packages/core/src/runbook/completion-lock.ts
+++ b/packages/core/src/runbook/completion-lock.ts
@@ -1,5 +1,11 @@
 import { locksDir, completionLockPath as _completionLockPath } from '../paths.js';
-import { acquireFileLock, FileLockTimeoutError, releaseFileLock } from './file-lock.js';
+import {
+  acquireFileLock,
+  FileLockTimeoutError,
+  heldLock,
+  releaseFileLock,
+  type ScopedLock,
+} from './file-lock.js';
 
 /**
  * Thrown when {@link CompletionLock.acquire} cannot acquire the lock within
@@ -69,11 +75,39 @@ export class CompletionLock {
   /**
    * Release an exclusive resolved-completion lock for the given run ID.
    *
+   * Honest by contract (idempotent on ENOENT, propagates real I/O failures).
+   * Prefer {@link scope} / {@link held} with `await using` so the disposer owns
+   * the best-effort, non-masking release policy.
+   *
    * @param runId - Run ID to unlock
-   * @throws {Error} Propagates errors from `releaseFileLock(this.lockPath(runId))`,
-   *   such as I/O or permission failures while resolving or releasing the lock path
+   * @throws {Error} Propagates non-ENOENT failures from `releaseFileLock`.
    */
   async release(runId: string): Promise<void> {
     await releaseFileLock(this.lockPath(runId));
+  }
+
+  /**
+   * Acquire the lock and return a best-effort {@link ScopedLock} for `await using`.
+   *
+   * @param runId - Run ID to lock
+   * @returns A disposable scope that releases the lock on exit
+   */
+  async scope(runId: string): Promise<ScopedLock> {
+    await this.acquire(runId);
+    return this.held(runId);
+  }
+
+  /**
+   * Wrap the already-held lock as a best-effort {@link ScopedLock} without
+   * acquiring.
+   *
+   * @param runId - Run ID whose held lock to wrap
+   * @returns A disposable scope that releases the lock on exit
+   */
+  held(runId: string): ScopedLock {
+    return heldLock(
+      () => this.release(runId),
+      () => ({ lock: 'completion', runId, lockFile: this.lockPath(runId) }),
+    );
   }
 }

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -396,12 +396,8 @@ export class RunbookCompletionService {
    */
   async recordManualCompletion(args: RecordManualCompletionArgs): Promise<RecordCompletionResult> {
     const lock = new CompletionLock(this.manager.cwd);
-    await lock.acquire(args.runbookId);
-    try {
-      return await this.recordManualCompletionUnlocked(args);
-    } finally {
-      await lock.release(args.runbookId);
-    }
+    await using _guard = await lock.scope(args.runbookId);
+    return await this.recordManualCompletionUnlocked(args);
   }
 
   /**
@@ -499,12 +495,8 @@ export class RunbookCompletionService {
     assertCompleteParentLinkage(args.childState);
 
     const lock = new DelegationLock(this.manager.cwd);
-    await lock.acquire(linkage.parentRunId);
-    try {
-      return await this.recordChildCompletionUnlocked(args);
-    } finally {
-      await lock.release(linkage.parentRunId);
-    }
+    await using _guard = await lock.scope(linkage.parentRunId);
+    return await this.recordChildCompletionUnlocked(args);
   }
 
   /**
@@ -577,113 +569,108 @@ export class RunbookCompletionService {
     const applied: AppliedResolvedCompletion[] = [];
     const lock = new CompletionLock(this.manager.cwd);
 
-    await lock.acquire(args.runbookId);
-    try {
-      for (;;) {
-        const currentStep = findStepOrThrow(args.steps, state.step);
-        if (!resolvedStepHasSubsteps(currentStep) || !state.substep) {
+    await using _guard = await lock.scope(args.runbookId);
+    for (;;) {
+      const currentStep = findStepOrThrow(args.steps, state.step);
+      if (!resolvedStepHasSubsteps(currentStep) || !state.substep) {
+        return { status: 'continue', state, unresolved: 0, applied };
+      }
+      const ensured = await this.lifecycleService.ensureActiveEntry(
+        args.runbookId,
+        undefined,
+        state,
+      );
+      state = ensured.state;
+      const activeFrameKey = state.activeFrameKey ?? ensured.frameKey;
+      const requestedFrame = args.frameOverride;
+      if (requestedFrame && requestedFrame.frameKey !== activeFrameKey) {
+        // The cursor has moved off the override frame. Two cases:
+        //
+        // 1. Initial mismatch (`applied.length === 0`): the override targets a
+        //    frame other than the current cursor — drain is observation-only.
+        //    Return `not_active` so the caller knows nothing was applied.
+        //
+        // 2. Subsequent mismatch (`applied.length > 0`): we already drained
+        //    the override frame, and the apply itself advanced the cursor to
+        //    a new frame (e.g., a FOR loop-back into the next iteration). We
+        //    must NOT discard the applied entries — the CLI still needs to
+        //    observe them so STEP_TRANSITIONED is emitted. Stop draining here
+        //    and return `continue` with what we have; the next iteration's
+        //    frame belongs to a different delegation/claim flow.
+        if (applied.length > 0) {
           return { status: 'continue', state, unresolved: 0, applied };
         }
-        const ensured = await this.lifecycleService.ensureActiveEntry(
+        const overrideResolvedSubsteps = await this.observedSubstepsForFrame(
           args.runbookId,
-          undefined,
-          state,
-        );
-        state = ensured.state;
-        const activeFrameKey = state.activeFrameKey ?? ensured.frameKey;
-        const requestedFrame = args.frameOverride;
-        if (requestedFrame && requestedFrame.frameKey !== activeFrameKey) {
-          // The cursor has moved off the override frame. Two cases:
-          //
-          // 1. Initial mismatch (`applied.length === 0`): the override targets a
-          //    frame other than the current cursor — drain is observation-only.
-          //    Return `not_active` so the caller knows nothing was applied.
-          //
-          // 2. Subsequent mismatch (`applied.length > 0`): we already drained
-          //    the override frame, and the apply itself advanced the cursor to
-          //    a new frame (e.g., a FOR loop-back into the next iteration). We
-          //    must NOT discard the applied entries — the CLI still needs to
-          //    observe them so STEP_TRANSITIONED is emitted. Stop draining here
-          //    and return `continue` with what we have; the next iteration's
-          //    frame belongs to a different delegation/claim flow.
-          if (applied.length > 0) {
-            return { status: 'continue', state, unresolved: 0, applied };
-          }
-          const overrideResolvedSubsteps = await this.observedSubstepsForFrame(
-            args.runbookId,
-            requestedFrame.frameKey,
-          );
-          const unresolved = currentStep.substeps.filter(
-            (substep) => !overrideResolvedSubsteps.has(substep.id),
-          ).length;
-          return {
-            status: 'not_active',
-            frameKey: requestedFrame.frameKey,
-            activeFrameKey,
-            unresolved,
-            applied: [],
-          };
-        }
-
-        const entry = state.activeEntry ?? ensured.entry;
-        const activeTargetFrame = activeFrame(activeFrameKey, entry);
-        const resolved = await this.lifecycleService.listResolvedCompletions(
-          args.runbookId,
-          activeTargetFrame,
-        );
-        const resolvedBySubstep = new Map(
-          resolved
-            .filter(({ completion }) => completion.targetSubstep !== undefined)
-            .map(({ completion }) => [completion.targetSubstep, completion]),
+          requestedFrame.frameKey,
         );
         const unresolved = currentStep.substeps.filter(
-          (substep) => !resolvedBySubstep.has(substep.id),
+          (substep) => !overrideResolvedSubsteps.has(substep.id),
         ).length;
-        const currentKey = buildCompletionKey(activeTargetFrame, state.substep);
-        const current =
-          resolved.find(({ key }) => key === currentKey) ??
-          resolved.find(
-            ({ key, completion }) =>
-              key === buildCompletionKey(inactiveFrame(activeFrameKey), state.substep) ||
-              completion.targetSubstep === state.substep,
-          );
-        if (!current) {
-          return { status: 'continue', state, unresolved, applied };
-        }
-
-        const validated = this.resolveAgainstCurrentCursor(state, current.completion, ensured);
-        if (!(currentCursorValidatedBrand in validated))
-          return { ...validated, unresolved, applied };
-
-        const result = await this.actorService.sendAndSync(args.runbookId, args.steps, {
-          type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
-          completionKey: current.key,
-          completion: validated,
-        });
-        if (!result) {
-          return { status: 'continue', state, unresolved, applied };
-        }
-        applied.push({
-          key: current.key,
-          completion: validated,
-          stateBefore: state,
-          stateAfter: result.state,
-          snapshot: result.snapshot,
-        });
-        const terminal = terminalStatus(result);
-        if (terminal) return { status: terminal, unresolved: 0, applied };
-        if (args.maxApplied !== undefined && applied.length >= args.maxApplied) {
-          const remaining = await this.countUnresolvedForState(
-            args.runbookId,
-            args.steps,
-            result.state,
-          );
-          return { status: 'continue', state: result.state, unresolved: remaining, applied };
-        }
-        state = result.state;
+        return {
+          status: 'not_active',
+          frameKey: requestedFrame.frameKey,
+          activeFrameKey,
+          unresolved,
+          applied: [],
+        };
       }
-    } finally {
-      await lock.release(args.runbookId);
+
+      const entry = state.activeEntry ?? ensured.entry;
+      const activeTargetFrame = activeFrame(activeFrameKey, entry);
+      const resolved = await this.lifecycleService.listResolvedCompletions(
+        args.runbookId,
+        activeTargetFrame,
+      );
+      const resolvedBySubstep = new Map(
+        resolved
+          .filter(({ completion }) => completion.targetSubstep !== undefined)
+          .map(({ completion }) => [completion.targetSubstep, completion]),
+      );
+      const unresolved = currentStep.substeps.filter(
+        (substep) => !resolvedBySubstep.has(substep.id),
+      ).length;
+      const currentKey = buildCompletionKey(activeTargetFrame, state.substep);
+      const current =
+        resolved.find(({ key }) => key === currentKey) ??
+        resolved.find(
+          ({ key, completion }) =>
+            key === buildCompletionKey(inactiveFrame(activeFrameKey), state.substep) ||
+            completion.targetSubstep === state.substep,
+        );
+      if (!current) {
+        return { status: 'continue', state, unresolved, applied };
+      }
+
+      const validated = this.resolveAgainstCurrentCursor(state, current.completion, ensured);
+      if (!(currentCursorValidatedBrand in validated)) return { ...validated, unresolved, applied };
+
+      const result = await this.actorService.sendAndSync(args.runbookId, args.steps, {
+        type: 'APPLY_CURRENT_RESOLVED_COMPLETION',
+        completionKey: current.key,
+        completion: validated,
+      });
+      if (!result) {
+        return { status: 'continue', state, unresolved, applied };
+      }
+      applied.push({
+        key: current.key,
+        completion: validated,
+        stateBefore: state,
+        stateAfter: result.state,
+        snapshot: result.snapshot,
+      });
+      const terminal = terminalStatus(result);
+      if (terminal) return { status: terminal, unresolved: 0, applied };
+      if (args.maxApplied !== undefined && applied.length >= args.maxApplied) {
+        const remaining = await this.countUnresolvedForState(
+          args.runbookId,
+          args.steps,
+          result.state,
+        );
+        return { status: 'continue', state: result.state, unresolved: remaining, applied };
+      }
+      state = result.state;
     }
   }
 }

--- a/packages/core/src/runbook/delegation-lock.ts
+++ b/packages/core/src/runbook/delegation-lock.ts
@@ -106,6 +106,7 @@ export class DelegationLock {
    *
    * @param parentRunId - The parent run ID to lock
    * @returns A disposable scope that releases the lock on exit
+   * @throws {DelegationLockTimeoutError} When the lock cannot be acquired within the deadline
    */
   async scope(parentRunId: string): Promise<ScopedLock> {
     await this.acquire(parentRunId);

--- a/packages/core/src/runbook/delegation-lock.ts
+++ b/packages/core/src/runbook/delegation-lock.ts
@@ -1,7 +1,13 @@
 // Lock-file naming convention and directory layout are defined in ../paths.ts
 // (`delegationLockPath`, `locksDir`).
 import { locksDir, delegationLockPath as _delegationLockPath } from '../paths.js';
-import { acquireFileLock, FileLockTimeoutError, releaseFileLock } from './file-lock.js';
+import {
+  acquireFileLock,
+  FileLockTimeoutError,
+  heldLock,
+  releaseFileLock,
+  type ScopedLock,
+} from './file-lock.js';
 
 /**
  * Thrown when {@link DelegationLock.acquire} cannot acquire the lock
@@ -77,11 +83,47 @@ export class DelegationLock {
   /**
    * Release an exclusive lock for the given parent run ID.
    *
-   * Idempotent — does not throw if the lock file does not exist.
+   * Honest by contract: idempotent on `ENOENT` (does not throw if the lock file
+   * is already gone) but propagates real I/O failures (`EACCES`/`EPERM`/`EIO`).
+   * Callers must not release from a bare `finally` — a propagated error would
+   * mask the operation's already-committed outcome (the RD-102 defect). Use
+   * {@link scope} / {@link held} with `await using` instead: the disposer owns
+   * the best-effort, non-masking policy while this method stays diagnosable.
    *
    * @param parentRunId - The parent run ID to unlock
+   * @throws {Error} Propagates non-ENOENT failures from `releaseFileLock`.
    */
   async release(parentRunId: string): Promise<void> {
     await releaseFileLock(this.lockPath(parentRunId));
+  }
+
+  /**
+   * Acquire the lock and return a best-effort {@link ScopedLock} for `await using`.
+   *
+   * `acquire` may throw {@link DelegationLockTimeoutError}; callers that map the
+   * timeout to a typed result (rather than letting it propagate through the
+   * `await using` declaration) should call {@link acquire} then {@link held}.
+   *
+   * @param parentRunId - The parent run ID to lock
+   * @returns A disposable scope that releases the lock on exit
+   */
+  async scope(parentRunId: string): Promise<ScopedLock> {
+    await this.acquire(parentRunId);
+    return this.held(parentRunId);
+  }
+
+  /**
+   * Wrap the already-held lock as a best-effort {@link ScopedLock} without
+   * acquiring. Disposal (or an explicit `release()`) runs at most once and never
+   * throws — a leaked lock self-heals via PID-aware stale reclaim.
+   *
+   * @param parentRunId - The parent run ID whose held lock to wrap
+   * @returns A disposable scope that releases the lock on exit
+   */
+  held(parentRunId: string): ScopedLock {
+    return heldLock(
+      () => this.release(parentRunId),
+      () => ({ lock: 'delegation', parentRunId, lockFile: this.lockPath(parentRunId) }),
+    );
   }
 }

--- a/packages/core/src/runbook/file-lock.ts
+++ b/packages/core/src/runbook/file-lock.ts
@@ -12,7 +12,8 @@
 
 import * as fs from 'node:fs/promises';
 import * as fsSync from 'node:fs';
-import { isError, isNodeError } from '../errors.js';
+import { isError, isNodeError, getErrorMessage } from '../errors.js';
+import { logger } from '../logger.js';
 
 const LOCK_DEADLINE_MS = 5_000;
 const RETRY_MIN_MS = 50;
@@ -231,6 +232,100 @@ export async function releaseFileLock(lockFile: string): Promise<void> {
       throw err;
     }
   }
+}
+
+/**
+ * An acquired file lock exposed as an async-disposable scope.
+ *
+ * Used with `await using` so the lock is released deterministically when the
+ * enclosing block exits — including on early `return` or `throw` — without a
+ * hand-rolled `try/finally`. Disposal is **best-effort**: a failed unlink only
+ * leaks a self-healing lock (the owning process exits, so the next acquirer
+ * reclaims it via PID-aware stale detection in {@link acquireFileLock}), so a
+ * release failure must never escape the disposer and mask the already-committed
+ * outcome of the work the lock protected — the defect behind RD-102. `release()`
+ * is idempotent and disarms the automatic disposal, for callers that must drop
+ * the lock before later work (e.g. before a long-running child execution loop).
+ */
+export interface ScopedLock extends AsyncDisposable {
+  /** Release now; the automatic `Symbol.asyncDispose` becomes a no-op. */
+  release(): Promise<void>;
+}
+
+/**
+ * Wrap the release of an already-acquired lock as a best-effort
+ * {@link ScopedLock}.
+ *
+ * The release runs at most once across an explicit `release()` call and the
+ * `await using` scope-exit disposal. A thrown release is logged and swallowed —
+ * never propagated — so it cannot mask the protected operation's result. The
+ * `release` thunk is expected to perform the underlying (possibly throwing)
+ * unlink; keeping it throwing preserves the primitive's honest error contract
+ * while this wrapper owns the non-masking policy.
+ *
+ * @param release  - Thunk performing the underlying release (may reject)
+ * @param describe - Returns structured log context identifying the lock
+ * @returns A best-effort, idempotent async-disposable lock scope
+ */
+export function heldLock(
+  release: () => Promise<void>,
+  describe: () => Record<string, unknown>,
+): ScopedLock {
+  let released = false;
+  const run = async (): Promise<void> => {
+    if (released) {
+      return;
+    }
+    released = true;
+    try {
+      await release();
+    } catch (err) {
+      void logger.warn('lock release failed (leaked, self-healing)', {
+        ...describe(),
+        error: getErrorMessage(err),
+      });
+    }
+  };
+  return { release: run, [Symbol.asyncDispose]: run };
+}
+
+/**
+ * Synchronous counterpart to {@link ScopedLock}, for the sync manifest-append
+ * path that cannot `await`. Used with `using`. Same best-effort, idempotent
+ * disposal contract as {@link heldLock}.
+ */
+export interface ScopedLockSync extends Disposable {
+  /** Release now; the automatic `Symbol.dispose` becomes a no-op. */
+  release(): void;
+}
+
+/**
+ * Synchronous counterpart to {@link heldLock}.
+ *
+ * @param release  - Thunk performing the underlying sync release (may throw)
+ * @param describe - Returns structured log context identifying the lock
+ * @returns A best-effort, idempotent disposable lock scope
+ */
+export function heldLockSync(
+  release: () => void,
+  describe: () => Record<string, unknown>,
+): ScopedLockSync {
+  let released = false;
+  const run = (): void => {
+    if (released) {
+      return;
+    }
+    released = true;
+    try {
+      release();
+    } catch (err) {
+      void logger.warn('lock release failed (leaked, self-healing)', {
+        ...describe(),
+        error: getErrorMessage(err),
+      });
+    }
+  };
+  return { release: run, [Symbol.dispose]: run };
 }
 
 // Module-scoped TypedArray used to block the current thread without spinning

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -210,7 +210,8 @@ export {
 } from './delegation-token.js';
 export { DelegationLock, DelegationLockTimeoutError } from './delegation-lock.js';
 export { SessionLock, SessionLockTimeoutError } from './session-lock.js';
-export { FileLockTimeoutError } from './file-lock.js';
+export { FileLockTimeoutError, heldLock, heldLockSync } from './file-lock.js';
+export type { ScopedLock, ScopedLockSync } from './file-lock.js';
 export { DelegationScanService, type TokenScanResult } from './delegation-scan.js';
 export {
   reconstituteContextVars,

--- a/packages/core/src/runbook/session-service.ts
+++ b/packages/core/src/runbook/session-service.ts
@@ -13,6 +13,7 @@
 import type { RunbookStateManager } from './state.js';
 import type { RunId } from './run-id.js';
 import { SessionLock } from './session-lock.js';
+import { heldLock } from './file-lock.js';
 import {
   createClaimRecord,
   generateClaimId,
@@ -141,11 +142,13 @@ export class SessionService {
    */
   private async withLock<T>(fn: () => Promise<T>): Promise<T> {
     await this.lock.acquire();
-    try {
-      return await fn();
-    } finally {
-      await this.lock.release();
-    }
+    // Best-effort scoped release: a failed unlink only leaks a self-healing lock
+    // and must never mask the committed session mutation that `fn()` returns.
+    await using _guard = heldLock(
+      () => this.lock.release(),
+      () => ({ lock: 'session' }),
+    );
+    return await fn();
   }
 
   private findClaimByChildRunId(

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -47,6 +47,7 @@ import {
   type RunStateLockFactory,
   type RunStateLockLike,
 } from './run-state-lock.js';
+import { heldLock } from './file-lock.js';
 
 /** Current persisted state schema version for the v1 release. */
 const CURRENT_SCHEMA_VERSION = 1;
@@ -288,11 +289,13 @@ export class RunbookStateManager {
   private async withRunStateLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
     const lock: RunStateLockLike = this.lockFactory(this.cwd);
     await lock.acquire(id);
-    try {
-      return await fn();
-    } finally {
-      await lock.release(id);
-    }
+    // Best-effort scoped release: a failed unlink only leaks a self-healing lock
+    // and must never mask the committed state mutation that `fn()` returns.
+    await using _guard = heldLock(
+      () => lock.release(id),
+      () => ({ lock: 'run-state', runId: id }),
+    );
+    return await fn();
   }
 
   /** Emit a process-wide one-time warning when legacy `.claude/rundown/` state is detected. */

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "ESNext.Error"],
+    "lib": ["ES2022", "ESNext.Error", "ESNext.Disposable"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "declaration": true,

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "ESNext.Error", "DOM"],
+    "lib": ["ES2022", "ESNext.Error", "ESNext.Disposable", "DOM"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "outDir": "./dist",

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "ESNext.Error"],
+    "lib": ["ES2022", "ESNext.Error", "ESNext.Disposable"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "declaration": true,

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,7 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2022",
-    "lib": ["ES2022", "ESNext.Error"],
+    "lib": ["ES2022", "ESNext.Error", "ESNext.Disposable"],
     "types": ["node"],
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

- Add best-effort `heldLock` / `heldLockSync` disposable guards for acquired file locks.
- Migrate core and CLI lock release sites to `await using` / `using` where scope-shaped, while keeping explicit early release in the inline execution path.
- Keep primitive lock release APIs honest so real release failures remain diagnosable outside guarded cleanup.
- Add regression coverage for non-masking lock disposal and update delegation lock mocks to the scoped API.

## Why

`rd claim <token>` could commit a claim successfully, then lose the successful `claim_id` output if a best-effort lock unlink failed in a `finally` block. The release error escaped after the mutation had committed, causing the CLI wrapper to surface a misleading RD-102 file-read error instead of the committed result.

This change centralizes the non-masking cleanup policy in disposable guards: leaked advisory locks self-heal through PID-aware stale lock reclamation, so cleanup failures are logged and swallowed by scoped disposal rather than replacing the protected operation's result.

## Validation

- `npm test -w packages/core -- runbook/file-lock.test.ts runbook/delegation-lock.test.ts`
- `npm test -w packages/cli -- helpers/claim-and-launch.test.ts helpers/runbook-pipeline.test.ts`
- `npm run verify`

`npm run verify` completed successfully. The existing Biome `useImportType` warning in `packages/core/src/runbook/variable-preparation.ts:29` remains non-blocking and unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delegation and file lock handling to avoid leaked locks, ensure releases don’t mask operation results, and make cleanup more robust on errors.

* **Chores**
  * Enabled modern disposable/RAII typings in TypeScript configs to support scoped async resource management.

* **Tests**
  * Added coverage and regression tests validating scoped lock/disposer behavior and release idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->