### PR TITLE
refactor(core): align remaining locks with scoped-disposable strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,14 +45,22 @@ A side effect that lives in the CLI but classifies as B or C is architectural de
 
 When multiple CLI processes may mutate the same file (e.g., `.rundown/session.json`, run state, artifact manifest), use **file-based exclusive locks** with process-aware stale lock reclamation:
 
-**Pattern:** Use `acquireFileLock` / `releaseFileLock` from `packages/core/src/runbook/file-lock.ts`.
+**Pattern:** Acquire the lock, then scope its release with `await using` so the lock is released deterministically on every exit path — including early `return` and `throw` — without a hand-rolled `try/finally`:
+
+```typescript
+await lock.acquire(id);
+await using _guard = lock.held(id); // or: await using _guard = await lock.scope(id);
+return await doWork(); // a failed release can never mask this committed result (RD-102)
+```
+
+`acquireFileLock` / `releaseFileLock` (and the `*Sync` variants) in `packages/core/src/runbook/file-lock.ts` are the underlying primitives; `heldLock` / `heldLockSync` (returning `ScopedLock` / `ScopedLockSync`) are the consumer-facing wrappers that own the best-effort, non-masking release policy. Domain locks expose `scope()` / `held()` built on them.
 
 - **Lock mechanism:** Atomic file creation (`fs.open(..., 'wx')`) on `.rundown/locks/<name>.lock`
 - **Stale detection:** Kill signal check (`kill(pid, 0)`) — never age-based expiration
 - **Retry:** Jittered backoff (50–100ms) bounded to 5 seconds
-- **Release:** Idempotent unlink; safe to call multiple times
+- **Release:** Best-effort and idempotent. A failed unlink only leaks a self-healing lock (reclaimed by the next acquirer via PID-aware stale detection) and is **never propagated** by the disposer, so it cannot mask the committed outcome of the protected work. Never release a domain lock from a bare `finally` — that is the RD-102 masking defect.
 
-**Examples:** `SessionLock` (`packages/core/src/runbook/session-lock.ts` — class at line 36, `acquire`/`release` at lines 59-77), `DelegationLock` (`packages/core/src/runbook/delegation-lock.ts` line 38-87), and fixture tests (`packages/core/__tests__/runbook/session-lock.test.ts`).
+**Examples:** `CompletionLock`, `DelegationLock`, and `SessionLock` (`packages/core/src/runbook/{completion,delegation,session}-lock.ts`) all expose `acquire` + `scope()` / `held()`. `RunStateLock` (`run-state-lock.ts`) is the exception: it is consumed through the narrow `RunStateLockLike` DI interface (acquire/release only, so test fakes stay trivial), so its caller — `RunbookStateManager.withRunStateLock` in `state.ts` — wraps `heldLock` inline rather than calling a `held()` method. See the lock fixture tests under `packages/core/__tests__/runbook/` (`*-lock.test.ts`).
 
 **For manifest writes:** Wrap `findEquivalentManifestRow` + append in a lock (e.g., `sessionLockPath(cwd)` if manifest is per-project, or derive a manifest-specific lock path from `manifestPath(cwd)` + `.lock`).
 

--- a/packages/core/__tests__/runbook/completion-lock.test.ts
+++ b/packages/core/__tests__/runbook/completion-lock.test.ts
@@ -20,6 +20,7 @@ function findDeadPid(): number {
 }
 
 describe('CompletionLock', () => {
+  const filePermissionsSupported = process.platform !== 'win32';
   let tmpDir: string;
   let lock: CompletionLock;
 
@@ -120,4 +121,82 @@ describe('CompletionLock', () => {
     await lock.release('run-a');
     await lock.release('run-b');
   });
+
+  it('scope() propagates the typed timeout when held by an alive process', async () => {
+    await lock.acquire('run-scope-timeout');
+    const lock2 = new CompletionLock(tmpDir);
+
+    await expect(lock2.scope('run-scope-timeout')).rejects.toBeInstanceOf(
+      CompletionLockTimeoutError,
+    );
+
+    await lock.release('run-scope-timeout');
+  }, 10_000);
+
+  it('scope() releases the lock at await using scope exit', async () => {
+    const lockPath = completionLockPath(tmpDir, 'run-scope');
+    {
+      await using _guard = await lock.scope('run-scope');
+      // Lock is held inside the block.
+      const content = JSON.parse(await fs.readFile(lockPath, 'utf8'));
+      expect(content.pid).toBe(process.pid);
+    }
+    // Released on block exit.
+    await expect(fs.access(lockPath)).rejects.toThrow();
+  });
+
+  it('held() disposal does not mask the committed outcome when unlink is denied (RD-102 regression)', async () => {
+    // Impact-level regression for the RD-102 bug: a caller commits its work,
+    // buffers a successful return value, and lets the `await using` guard
+    // release the lock at scope exit. If the unlink fails (here a transient
+    // EACCES forced by a read-only locks directory), the best-effort disposer
+    // must swallow it — never propagate and replace the already-committed
+    // return value. Goes RED if the guard disposer rethrows. (No effect as
+    // root, where release succeeds and the assertion still holds trivially.)
+    const lockDir = locksDir(tmpDir);
+
+    async function commitThenScopedRelease(): Promise<{ ok: true; recorded: boolean }> {
+      await lock.acquire('run-scoped-release');
+      await using _guard = lock.held('run-scoped-release');
+      // ... committing work already done; the caller has a successful result.
+      if (filePermissionsSupported) {
+        await fs.chmod(lockDir, 0o500);
+      }
+      return { ok: true, recorded: true };
+    }
+
+    try {
+      await expect(commitThenScopedRelease()).resolves.toEqual({
+        ok: true,
+        recorded: true,
+      });
+    } finally {
+      // Restore write permission so afterEach cleanup can remove the temp dir.
+      if (filePermissionsSupported) {
+        await fs.chmod(lockDir, 0o700);
+      }
+    }
+  });
+
+  (filePermissionsSupported ? it : it.skip)(
+    'release() propagates a real (non-ENOENT) failure — honest by contract',
+    async () => {
+      // The guard owns the best-effort policy; release() itself stays honest so
+      // genuine I/O failures remain diagnosable. Skipped as root, where the
+      // read-only directory does not deny unlink.
+      if (process.getuid?.() === 0) {
+        return;
+      }
+      await lock.acquire('run-honest-release');
+      const lockDir = locksDir(tmpDir);
+      await fs.chmod(lockDir, 0o500);
+      try {
+        await expect(lock.release('run-honest-release')).rejects.toMatchObject({
+          code: expect.stringMatching(/^(EACCES|EPERM)$/),
+        });
+      } finally {
+        await fs.chmod(lockDir, 0o700);
+      }
+    },
+  );
 });

--- a/packages/core/__tests__/runbook/delegation-lock.test.ts
+++ b/packages/core/__tests__/runbook/delegation-lock.test.ts
@@ -19,6 +19,7 @@ function findDeadPid(): number {
 }
 
 describe('DelegationLock', () => {
+  const filePermissionsSupported = process.platform !== 'win32';
   let tmpDir: string;
   let lock: DelegationLock;
 
@@ -88,6 +89,17 @@ describe('DelegationLock', () => {
     await expect(lock.release('nonexistent-run')).resolves.toBeUndefined();
   });
 
+  it('scope() propagates the typed timeout when held by an alive process', async () => {
+    await lock.acquire('run-scope-timeout');
+    const lock2 = new DelegationLock(tmpDir);
+
+    await expect(lock2.scope('run-scope-timeout')).rejects.toBeInstanceOf(
+      DelegationLockTimeoutError,
+    );
+
+    await lock.release('run-scope-timeout');
+  }, 10_000);
+
   it('scope() releases the lock at await using scope exit', async () => {
     const lockPath = delegationLockPath(tmpDir, 'run-scope');
     {
@@ -133,24 +145,27 @@ describe('DelegationLock', () => {
     }
   });
 
-  it('release() propagates a real (non-ENOENT) failure — honest by contract', async () => {
-    // The guard owns the best-effort policy; release() itself stays honest so
-    // genuine I/O failures remain diagnosable. Skipped as root, where the
-    // read-only directory does not deny unlink.
-    if (process.getuid?.() === 0) {
-      return;
-    }
-    await lock.acquire('run-honest-release');
-    const lockDir = locksDir(tmpDir);
-    await fs.chmod(lockDir, 0o500);
-    try {
-      await expect(lock.release('run-honest-release')).rejects.toMatchObject({
-        code: expect.stringMatching(/^(EACCES|EPERM)$/),
-      });
-    } finally {
-      await fs.chmod(lockDir, 0o700);
-    }
-  });
+  (filePermissionsSupported ? it : it.skip)(
+    'release() propagates a real (non-ENOENT) failure — honest by contract',
+    async () => {
+      // The guard owns the best-effort policy; release() itself stays honest so
+      // genuine I/O failures remain diagnosable. Skipped as root, where the
+      // read-only directory does not deny unlink.
+      if (process.getuid?.() === 0) {
+        return;
+      }
+      await lock.acquire('run-honest-release');
+      const lockDir = locksDir(tmpDir);
+      await fs.chmod(lockDir, 0o500);
+      try {
+        await expect(lock.release('run-honest-release')).rejects.toMatchObject({
+          code: expect.stringMatching(/^(EACCES|EPERM)$/),
+        });
+      } finally {
+        await fs.chmod(lockDir, 0o700);
+      }
+    },
+  );
 
   it('reclaims stale lock from dead PID', async () => {
     // Manually write a lock file with a dead PID

--- a/packages/core/__tests__/runbook/session-lock.test.ts
+++ b/packages/core/__tests__/runbook/session-lock.test.ts
@@ -133,4 +133,81 @@ describe('SessionLock', () => {
 
     await expect(fs.access(sessionLockPath(tmpDir))).rejects.toThrow();
   });
+
+  it('scope() propagates the typed timeout when held by an alive process', async () => {
+    await lock.acquire();
+    const lock2 = new SessionLock(tmpDir);
+
+    await expect(lock2.scope()).rejects.toBeInstanceOf(SessionLockTimeoutError);
+
+    await lock.release();
+  }, 10_000);
+
+  it('scope() releases the lock at await using scope exit', async () => {
+    const lockPath = await canonicalSessionLockPath(tmpDir);
+    {
+      await using _guard = await lock.scope();
+      // Lock is held inside the block.
+      const content = JSON.parse(await fs.readFile(lockPath, 'utf8'));
+      expect(content.pid).toBe(process.pid);
+    }
+    // Released on block exit.
+    await expect(fs.access(lockPath)).rejects.toThrow();
+  });
+
+  it('held() disposal does not mask the committed outcome when unlink is denied (RD-102 regression)', async () => {
+    // Impact-level regression for the RD-102 bug: a caller commits its work,
+    // buffers a successful return value, and lets the `await using` guard
+    // release the lock at scope exit. If the unlink fails (here a transient
+    // EACCES forced by a read-only locks directory), the best-effort disposer
+    // must swallow it — never propagate and replace the already-committed
+    // return value. Goes RED if the guard disposer rethrows. On platforms
+    // without enforced permissions (Windows) the chmod is a no-op and the
+    // release simply succeeds, so the assertion still holds trivially.
+    const lockDir = locksDir(tmpDir);
+
+    async function commitThenScopedRelease(): Promise<{ ok: true; sessionId: string }> {
+      await lock.acquire();
+      await using _guard = lock.held();
+      // ... committing work already done; the caller has a successful result.
+      if (filePermissionsSupported) {
+        await fs.chmod(lockDir, 0o500);
+      }
+      return { ok: true, sessionId: 'committed_session_id_0001' };
+    }
+
+    try {
+      await expect(commitThenScopedRelease()).resolves.toEqual({
+        ok: true,
+        sessionId: 'committed_session_id_0001',
+      });
+    } finally {
+      // Restore write permission so afterEach cleanup can remove the temp dir.
+      if (filePermissionsSupported) {
+        await fs.chmod(lockDir, 0o700);
+      }
+    }
+  });
+
+  (filePermissionsSupported ? it : it.skip)(
+    'release() propagates a real (non-ENOENT) failure — honest by contract',
+    async () => {
+      // The guard owns the best-effort policy; release() itself stays honest so
+      // genuine I/O failures remain diagnosable. Skipped as root, where the
+      // read-only directory does not deny unlink.
+      if (process.getuid?.() === 0) {
+        return;
+      }
+      await lock.acquire();
+      const lockDir = locksDir(tmpDir);
+      await fs.chmod(lockDir, 0o500);
+      try {
+        await expect(lock.release()).rejects.toMatchObject({
+          code: expect.stringMatching(/^(EACCES|EPERM)$/),
+        });
+      } finally {
+        await fs.chmod(lockDir, 0o700);
+      }
+    },
+  );
 });

--- a/packages/core/src/runbook/completion-lock.ts
+++ b/packages/core/src/runbook/completion-lock.ts
@@ -75,9 +75,12 @@ export class CompletionLock {
   /**
    * Release an exclusive resolved-completion lock for the given run ID.
    *
-   * Honest by contract (idempotent on ENOENT, propagates real I/O failures).
-   * Prefer {@link scope} / {@link held} with `await using` so the disposer owns
-   * the best-effort, non-masking release policy.
+   * Honest by contract: idempotent on `ENOENT` (does not throw if the lock file
+   * is already gone) but propagates real I/O failures (`EACCES`/`EPERM`/`EIO`).
+   * Callers must not release from a bare `finally` — a propagated error would
+   * mask the operation's already-committed outcome (the RD-102 defect). Use
+   * {@link scope} / {@link held} with `await using` instead: the disposer owns
+   * the best-effort, non-masking policy while this method stays diagnosable.
    *
    * @param runId - Run ID to unlock
    * @throws {Error} Propagates non-ENOENT failures from `releaseFileLock`.

--- a/packages/core/src/runbook/file-lock.ts
+++ b/packages/core/src/runbook/file-lock.ts
@@ -5,7 +5,8 @@
  * `.rundown/locks/` directory. Uses `O_CREAT | O_EXCL` (`'wx'` flag) for
  * atomic acquisition with retry-jitter and stale-lock reclaim.
  *
- * Used by `DelegationLock` (delegation mutations).
+ * Used by the completion, delegation, session, and run-state locks, and by the
+ * artifact-manifest append paths (sync and async).
  *
  * @module runbook/file-lock
  */

--- a/packages/core/src/runbook/session-lock.ts
+++ b/packages/core/src/runbook/session-lock.ts
@@ -1,6 +1,12 @@
 import { realpathSync } from 'node:fs';
 import { locksDir, sessionLockPath as _sessionLockPath } from '../paths.js';
-import { acquireFileLock, FileLockTimeoutError, releaseFileLock } from './file-lock.js';
+import {
+  acquireFileLock,
+  FileLockTimeoutError,
+  heldLock,
+  releaseFileLock,
+  type ScopedLock,
+} from './file-lock.js';
 
 /**
  * Thrown when {@link SessionLock.acquire} cannot acquire the lock within the
@@ -70,9 +76,45 @@ export class SessionLock {
   /**
    * Release the session lock.
    *
-   * Idempotent — does not throw if the lock file does not exist.
+   * Honest by contract: idempotent on `ENOENT` (does not throw if the lock file
+   * is already gone) but propagates real I/O failures (`EACCES`/`EPERM`/`EIO`).
+   * Callers must not release from a bare `finally` — a propagated error would
+   * mask the operation's already-committed outcome (the RD-102 defect). Use
+   * {@link scope} / {@link held} with `await using` instead: the disposer owns
+   * the best-effort, non-masking policy while this method stays diagnosable.
+   *
+   * @throws {Error} Propagates non-ENOENT failures from `releaseFileLock`.
    */
   async release(): Promise<void> {
     await releaseFileLock(this.lockFile);
+  }
+
+  /**
+   * Acquire the lock and return a best-effort {@link ScopedLock} for `await using`.
+   *
+   * `acquire` may throw {@link SessionLockTimeoutError}; callers that map the
+   * timeout to a typed result (rather than letting it propagate through the
+   * `await using` declaration) should call {@link acquire} then {@link held}.
+   *
+   * @returns A disposable scope that releases the lock on exit
+   * @throws {SessionLockTimeoutError} When the lock cannot be acquired within the deadline
+   */
+  async scope(): Promise<ScopedLock> {
+    await this.acquire();
+    return this.held();
+  }
+
+  /**
+   * Wrap the already-held lock as a best-effort {@link ScopedLock} without
+   * acquiring. Disposal (or an explicit `release()`) runs at most once and never
+   * throws — a leaked lock self-heals via PID-aware stale reclaim.
+   *
+   * @returns A disposable scope that releases the lock on exit
+   */
+  held(): ScopedLock {
+    return heldLock(
+      () => this.release(),
+      () => ({ lock: 'session', lockFile: this.lockFile }),
+    );
   }
 }

--- a/packages/core/src/runbook/session-service.ts
+++ b/packages/core/src/runbook/session-service.ts
@@ -13,7 +13,6 @@
 import type { RunbookStateManager } from './state.js';
 import type { RunId } from './run-id.js';
 import { SessionLock } from './session-lock.js';
-import { heldLock } from './file-lock.js';
 import {
   createClaimRecord,
   generateClaimId,
@@ -144,10 +143,7 @@ export class SessionService {
     await this.lock.acquire();
     // Best-effort scoped release: a failed unlink only leaks a self-healing lock
     // and must never mask the committed session mutation that `fn()` returns.
-    await using _guard = heldLock(
-      () => this.lock.release(),
-      () => ({ lock: 'session' }),
-    );
+    await using _guard = this.lock.held();
     return await fn();
   }
 

--- a/packages/core/src/runbook/state.ts
+++ b/packages/core/src/runbook/state.ts
@@ -291,6 +291,11 @@ export class RunbookStateManager {
     await lock.acquire(id);
     // Best-effort scoped release: a failed unlink only leaks a self-healing lock
     // and must never mask the committed state mutation that `fn()` returns.
+    //
+    // Unlike the completion/delegation/session locks, this lock is consumed
+    // through the narrow `RunStateLockLike` DI interface (acquire/release only,
+    // so test fakes stay trivial), so there is no `held()`/`scope()` method to
+    // call here — wrapping `heldLock` inline is the correct adaptation.
     await using _guard = heldLock(
       () => lock.release(id),
       () => ({ lock: 'run-state', runId: id }),


### PR DESCRIPTION
## Summary

Closes the internal inconsistencies left by the `await using` scoped-disposable lock migration (RD-102 fix), so the locking strategy is uniform and the prescribed pattern is the one new code copies.

RD-102: a thrown lock release inside a bare `try/finally` could mask the already-committed result of the work the lock protected (e.g. discarding a successful claim's `claim_id` and surfacing a spurious error + non-zero exit). The fix added best-effort, non-propagating disposers (`heldLock`/`heldLockSync` → `ScopedLock`/`ScopedLockSync`) and `scope()`/`held()` methods on `CompletionLock` and `DelegationLock`. This PR brings the remaining locks and docs in line.

## Changes

- **`SessionLock` gains `scope()`/`held()`** mirroring `CompletionLock`/`DelegationLock`; `SessionService.withLock` now uses `await using _guard = this.lock.held()` (and the now-unused `heldLock` import is dropped). `release()` TSDoc upgraded to the shared "honest by contract" wording.
- **`CompletionLock` direct tests** — added `scope()` release-on-exit, the RD-102 non-masking regression (a denied unlink must not replace the committed result), `release()` honest-by-contract, and `scope()` typed-timeout propagation.
- **`SessionLock` tests** — the same set, adapted to the parameterless signature.
- **`CLAUDE.md`** "Concurrent write synchronization" rewritten to prescribe `acquire` + `await using lock.held()/scope()` over bare `try/finally`, with the best-effort/non-propagating release contract spelled out.
- **`file-lock.ts`** stale module comment fixed to list all lock consumers.
- **`RunStateLock`** intentionally **not** changed — it's consumed via the narrow `RunStateLockLike` DI interface (so test fakes stay trivial), so its caller wraps `heldLock` inline. A comment in `state.ts` documents this exception.

## Review

Reviewed across architecture, code quality, and test coverage. All review findings (scope-timeout tests, Windows guard symmetry, TSDoc alignment, test path canonicalization) were addressed in-PR. The RD-102 regression tests were sanity-checked by temporarily making the disposer rethrow — all three (completion/delegation/session) go RED — confirming they pin the non-masking behaviour. Tests run as non-root, so the denied-unlink path is genuinely exercised.

## Test plan

- [x] `npx tsc -p packages/core/tsconfig.test.json --noEmit` — clean
- [x] Lock suites green: `file-lock`, `completion-lock`, `delegation-lock`, `session-lock`, `run-state-lock`, `session-service` (41 in the three core lock suites)
- [x] `npm run verify` (format, spell, lint, full test suite) — exit 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `scope()` and `held()` methods for safer lock acquisition and disposal with `await using` support, ensuring deterministic lock release on all code paths.

* **Documentation**
  * Enhanced concurrent write synchronization guidance with updated lock usage patterns, failure-handling semantics, and best-practice examples.

* **Tests**
  * Expanded test coverage for lock timeout scenarios, error propagation, and platform-specific permission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->