### PR TITLE
refactor(events): remove unsafe `buildEvent` type assertion

### DIFF
--- a/docs/internal/event-emitter-type-safety-design.md
+++ b/docs/internal/event-emitter-type-safety-design.md
@@ -1,0 +1,239 @@
+# Design Note: Removing the `buildEvent` type assertion in the event emitter
+
+> Status: **Draft proposal** (not yet scheduled). Authored from an investigation +
+> empirical compile-verification of each candidate against the repo's `strict`
+> config on 2026-06-11.
+> Audience: contributors to `packages/core/src/events` and the CLI/JSON event
+> subscribers that consume `RunbookEventV1`.
+
+## 1. Summary
+
+`RunbookEventEmitter.buildEvent` (`packages/core/src/events/emitter.ts:91-120`)
+constructs each lifecycle event with an **unsafe type assertion**:
+
+```typescript
+return {
+  v: '1', type, ts: new Date().toISOString(),
+  runbookId: this.runbookId, runbook: this.runbook, seq: this.seq, payload,
+} as Extract<RunbookEventV1, { type: T }>;
+```
+
+The assertion bypasses static checking of the `type`/`payload` correlation. To
+compensate, a runtime guard `validatePayload` (`emitter.ts:130-158`) runs behind a
+`if (process.env.NODE_ENV !== 'production')` gate (`emitter.ts:107`) — a dev-only
+band-aid for the hole the assertion opens.
+
+This note documents **why the hole exists**, the **constraints any fix must
+satisfy**, and the **trade-offs of four candidate designs**. The recommended
+design (Candidate D) removes the assertion entirely and lets `validatePayload`
+and its `NODE_ENV` gate be deleted.
+
+## 2. Root cause — why TypeScript cannot verify it today
+
+`RunbookEventV1` (`types.ts:201-210`) is a discriminated union whose members are
+`EventEnvelope & { type: 'X'; payload: XPayload }`. `PayloadFor<T>`
+(`types.ts:215-218`) is `Extract<RunbookEventV1, { type: T }>['payload']`.
+
+Inside `buildEvent<T extends RunbookEventV1['type']>`, the object literal is built
+from **two independent generic expressions** — `type: T` and `payload: PayloadFor<T>`.
+TypeScript types the literal as `{ …; type: T; payload: PayloadFor<T> }` but will
+not prove this is assignable to `Extract<RunbookEventV1, { type: T }>` while `T` is
+an unresolved type parameter: it does not distribute the union member-by-member
+over an open type variable and re-correlate `type` with `payload`. This is
+[microsoft/TypeScript#14094](https://github.com/microsoft/TypeScript/issues/14094).
+
+The hole is real, not gratuitous: removing the `as` and returning `RunbookEventV1`
+directly produces `TS2322` (`'RUNBOOK_STARTED' is not assignable to 'ERROR_OCCURRED'…`).
+Given the *current* two-argument signature shape, some assertion is unavoidable.
+
+## 3. Constraints any fix must satisfy
+
+A redesign is only valid if it preserves all of the following:
+
+1. **Two call-site classes must keep type-checking.**
+   - **Concrete-literal sites (25):** `emit('TYPE', { …payload })` throughout
+     `packages/cli/src/services/execution.ts` and elsewhere. These must keep
+     precise per-type payload checking.
+   - **Union-source sites (2):** `emitter.emit(effect.event.type, effect.event.payload)`
+     at `execution.ts:1205` and `:1302`, where `effect.event` is the already-correlated
+     union `ExecutionObservationEvent` (`execution-observation.ts:24-28`). A fix that
+     only handles concrete literals but rejects a union argument is a regression.
+
+2. **The public event contract must not change.** `RunbookEventV1` and the
+   `EventSubscriber` callback shape (`subscriber: (event: RunbookEventV1) => void`)
+   are consumed by `subscribers/cli.ts`, `subscribers/json.ts`, and the output layer
+   (`output/types.ts:205-209`). Only the *input* side of `emit`/`buildEvent` is in
+   scope to change.
+
+3. **No new runtime cost on the emit hot path.** Events fire on every step
+   transition and command start/complete; a fix must not add per-event work.
+
+4. **Single source of truth for the event taxonomy.** Any new input type should be
+   *derived from* `RunbookEventV1`, not hand-maintained in parallel (a second list
+   drifts — the same failure mode that already weakened `validatePayload`; see §6).
+
+## 4. Candidate designs and trade-offs
+
+All four were compiled against the repo's `strict` config. Verdicts are empirical.
+
+### Candidate A — Generic interface envelope (`RunbookEvent<T>`)
+
+```typescript
+interface RunbookEvent<T extends RunbookEventV1['type']> extends EventEnvelope {
+  readonly type: T;
+  readonly payload: PayloadFor<T>;
+}
+function buildEvent<T extends RunbookEventV1['type']>(
+  type: T, payload: PayloadFor<T>,
+): RunbookEvent<T> {
+  return { v: '1', type, ts, runbookId, runbook, seq, payload }; // no assertion
+}
+```
+
+- **What it fixes:** the `buildEvent` body compiles assertion-free.
+- **Constraint it breaks:** **relocates the hole, doesn't remove it.** `emit` must
+  hand the result to a `(event: RunbookEventV1) => void` subscriber. When `T` is
+  instantiated as the *union* (the `execution.ts:1205` site), `RunbookEvent<'A'|'B'|'C'>`
+  is a single object with a **decorrelated** union `type`/`payload` and is **not**
+  assignable to `RunbookEventV1` (`TS2345`). You need an assertion again at the
+  `subscriber(event)` boundary, or you must forbid union-typed `T`.
+- **Verdict:** ❌ contains/relocates the hole. Violates constraint 1 (union sites).
+
+### Candidate B — Builder record (`Record<EventType, builder>`)
+
+```typescript
+const builders: {
+  [K in RunbookEventV1['type']]: (p: PayloadFor<K>) => Extract<RunbookEventV1, { type: K }>;
+} = {
+  RUNBOOK_STARTED: (payload) => ({ v: '1', type: 'RUNBOOK_STARTED', ts, runbookId, runbook, seq, payload }),
+  STEP_ENTERED:    (payload) => ({ v: '1', type: 'STEP_ENTERED',    ts, runbookId, runbook, seq, payload }),
+  // …one entry per event type
+};
+function buildEvent<T extends RunbookEventV1['type']>(type: T, payload: PayloadFor<T>): RunbookEventV1 {
+  const make = builders[type] as (p: PayloadFor<T>) => RunbookEventV1; // re-correlation cast
+  return make(payload);
+}
+```
+
+- **What it fixes:** each builder *body* is concrete (literal `type:`), so every
+  envelope literal is fully type-checked with no assertion. The record is
+  **exhaustive** — a missing event type is a compile error — which subsumes the
+  exhaustiveness role of `validatePayload`.
+- **Residual hole:** indexing the mapped type with a generic `T` (`builders[type]`)
+  yields a union of function types; calling it with `PayloadFor<T>` needs the cast
+  on the lookup line. The hole shrinks to **one narrow lookup cast**.
+- **Cost:** ~9 near-identical builder closures to maintain.
+- **Ergonomics:** preserves the existing two-argument `emit('TYPE', {…})` call shape.
+- **Verdict:** 🟡 contains the hole (one lookup cast) but improves checking and
+  keeps caller ergonomics. Satisfies constraints 1–4. The pragmatic choice *if*
+  two-arg call sites must stay untouched.
+
+### Candidate C — Per-type overloads
+
+A set of `emit('RUNBOOK_STARTED', p: RunbookStartedPayload): void;` … overloads over
+a private union-typed implementation.
+
+- **What it fixes:** callers at concrete sites get precise checking.
+- **Constraints it breaks:** the implementation signature still builds the union
+  generically and **still needs an internal assertion**. Worse, an overload set
+  **rejects a union first argument**, so the `execution.ts:1205/1302` union sites no
+  longer type-check.
+- **Verdict:** ❌ doesn't remove the hole and regresses the union sites. Violates
+  constraint 1. Not recommended.
+
+### Candidate D — Pre-correlated pair input + envelope spread ★
+
+Accept the `{ type, payload }` pair as a single argument (a discriminated-union
+*value*) and spread it into the envelope:
+
+```typescript
+// Derived from RunbookEventV1 — single source of truth (constraint 4):
+type RunbookEventInput =
+  { [E in RunbookEventV1 as E['type']]: { type: E['type']; payload: E['payload'] } }[RunbookEventV1['type']];
+
+function buildEvent(input: RunbookEventInput): RunbookEventV1 {
+  return { v: '1', ts, runbookId, runbook, seq, ...input }; // no assertion
+}
+emit(input: RunbookEventInput): void {
+  this.seq++;
+  const event = this.buildEvent(input);
+  for (const s of this.subscribers) s(event);
+}
+```
+
+Why it works where the generic fails: the `type`/`payload` correlation already
+lives **in the value being spread**, so TypeScript never has to re-correlate an
+open `T`. Spreading a discriminated-union value preserves the correlation, and TS
+distributes the envelope intersection over the union member-by-member.
+
+Empirically verified end-to-end:
+
+- Internal `{ …envelope, ...input }: RunbookEventV1` — compiles with **no assertion**.
+- Concrete call `emit({ type: 'STEP_ENTERED', payload: {…} })` — OK.
+- Union-source call `emit(effect.event)` — OK, and *simpler* than today (the pair is
+  already in hand; no `.type`/`.payload` destructuring).
+- Mismatched pair `emit({ type: 'ERROR_OCCURRED', payload: { position … } })` —
+  correctly **rejected** (`TS2345`).
+
+- **Verdict:** ✅ **removes the hole entirely** — no assertion in `buildEvent`, none
+  at the subscriber boundary, none at the union sites. Satisfies all constraints.
+
+## 5. Comparison
+
+| Design | Assertion in `buildEvent` | Union sites (1205/1302) | Per-type checking | Caller ergonomics | `validatePayload` deletable |
+|--------|---------------------------|-------------------------|-------------------|-------------------|-----------------------------|
+| **A** Generic interface | none here, **needed at subscriber boundary** | ❌ breaks | full | unchanged (2-arg) | no |
+| **B** Builder record | **1 lookup cast** | ✅ works | full + exhaustive | unchanged (2-arg) | yes (via exhaustive record) |
+| **C** Overloads | **still needed** | ❌ breaks | full at call site | unchanged (2-arg) | no |
+| **D** Pair + spread ★ | **none** | ✅ works (simpler) | full | **changes to 1-arg** | **yes** |
+
+## 6. Recommendation
+
+**Candidate D (pre-correlated pair + envelope spread).** It is the only design that
+eliminates *every* assertion and keeps both call-site classes sound, because it
+never asks TypeScript to re-correlate an open `T` — the correlation lives in the
+`{ type, payload }` value being spread. It also aligns the emitter with the shape
+the codebase already uses for machine-owned effects (`ExecutionObservationEvent`,
+`execution-observation.ts:24-28`, whose members are exactly `{ type, payload }`
+pairs), so the union sites simplify to `emitter.emit(effect.event)`.
+
+### Trade-offs of choosing D
+
+- **Caller migration (the main cost):** the 25 concrete sites change from
+  `emit('TYPE', { … })` to `emit({ type: 'TYPE', payload: { … } })` — mechanical but
+  more verbose. The 2 union sites get *simpler*. If two-arg ergonomics must be
+  preserved, a thin two-arg overload can wrap D, but that re-imports a small cast
+  into the glue — prefer migrating the sites over keeping the overload.
+- **Runtime cost:** none (one object spread instead of an explicit literal).
+- **External consumers:** unaffected — `RunbookEventV1` and `EventSubscriber` are
+  unchanged. Only `emit`'s input shape changes; `RunbookEventInput` is a new
+  *exported, derived* type.
+
+If the caller-migration cost is judged too high for now, **Candidate B** is the
+fallback: it keeps two-arg ergonomics and contains the hole to a single, clearly
+commented lookup cast, at the price of ~9 builder closures.
+
+### Can `validatePayload` and the `NODE_ENV` gate be deleted?
+
+**Yes, under D (and under B).** `validatePayload` (`emitter.ts:130-158`) exists
+solely to catch payload/type mismatches that the `as Extract<…>` assertion
+bypasses. With no assertion (D) the compiler rejects mismatched pairs at every call
+site, so the runtime guard protects nothing the type system doesn't already
+guarantee — delete both the method and the `if (process.env.NODE_ENV !== 'production')`
+block (`emitter.ts:104-109`).
+
+Note the existing guard was already *weaker* than the types: its `requiredFields`
+record (`emitter.ts:132-142`) is not field-exhaustive (e.g. it omits
+`STEP_ENTERED.artifacts`), so removing it loses no real coverage. Under B, the
+exhaustive `builders` record subsumes its taxonomy-exhaustiveness role instead.
+
+## 7. Files referenced
+
+- `packages/core/src/events/emitter.ts` — `emit` (63-77), `buildEvent` (91-120),
+  the assertion (`:119`), the `NODE_ENV` gate (`:107`), `validatePayload` (130-158).
+- `packages/core/src/events/types.ts` — `EventEnvelope` (14-31), `RunbookEventV1`
+  (201-210), `PayloadFor` (215-218).
+- `packages/core/src/events/execution-observation.ts` — `ExecutionObservationEvent`
+  (24-28), the existing `{ type, payload }`-pair shape.
+- `packages/cli/src/services/execution.ts` — union-source call sites (`:1205`, `:1302`).
+- `packages/core/src/output/types.ts` — downstream consumer (205-209).

--- a/docs/internal/event-emitter-type-safety-design.md
+++ b/docs/internal/event-emitter-type-safety-design.md
@@ -6,7 +6,7 @@
 > Audience: contributors to `packages/core/src/events` and the CLI/JSON event
 > subscribers that consume `RunbookEventV1`.
 >
-> This note is retained as the design rationale: §2–§6 describe the problem **as
+> This note is retained as the design rationale: §1–§6 describe the problem **as
 > it existed before the refactor** (the `as Extract<…>` assertion and the
 > `validatePayload` runtime guard) and why Candidate D was chosen. For the current
 > emitter, see `packages/core/src/events/emitter.ts` (`emit`/`buildEvent` take a

--- a/docs/internal/event-emitter-type-safety-design.md
+++ b/docs/internal/event-emitter-type-safety-design.md
@@ -1,10 +1,18 @@
 # Design Note: Removing the `buildEvent` type assertion in the event emitter
 
-> Status: **Draft proposal** (not yet scheduled). Authored from an investigation +
+> Status: **Implemented** (Candidate D, PR #431). Authored from an investigation +
 > empirical compile-verification of each candidate against the repo's `strict`
 > config on 2026-06-11.
 > Audience: contributors to `packages/core/src/events` and the CLI/JSON event
 > subscribers that consume `RunbookEventV1`.
+>
+> This note is retained as the design rationale: §2–§6 describe the problem **as
+> it existed before the refactor** (the `as Extract<…>` assertion and the
+> `validatePayload` runtime guard) and why Candidate D was chosen. For the current
+> emitter, see `packages/core/src/events/emitter.ts` (`emit`/`buildEvent` take a
+> `RunbookEventInput` pair and spread it into the envelope — no assertion, no
+> runtime payload guard) and the `RunbookEventV1` union in
+> `packages/core/src/events/types.ts`.
 
 ## 1. Summary
 
@@ -94,7 +102,7 @@ function buildEvent<T extends RunbookEventV1['type']>(
 - **Constraint it breaks:** **relocates the hole, doesn't remove it.** `emit` must
   hand the result to a `(event: RunbookEventV1) => void` subscriber. When `T` is
   instantiated as the *union* (the `execution.ts:1205` site), `RunbookEvent<'A'|'B'|'C'>`
-  is a single object with a **decorrelated** union `type`/`payload` and is **not**
+  is a single object whose union `type`/`payload` are **no longer correlated** and is **not**
   assignable to `RunbookEventV1` (`TS2345`). You need an assertion again at the
   `subscriber(event)` boundary, or you must forbid union-typed `T`.
 - **Verdict:** ❌ contains/relocates the hole. Violates constraint 1 (union sites).
@@ -229,11 +237,22 @@ exhaustive `builders` record subsumes its taxonomy-exhaustiveness role instead.
 
 ## 7. Files referenced
 
-- `packages/core/src/events/emitter.ts` — `emit` (63-77), `buildEvent` (91-120),
-  the assertion (`:119`), the `NODE_ENV` gate (`:107`), `validatePayload` (130-158).
-- `packages/core/src/events/types.ts` — `EventEnvelope` (14-31), `RunbookEventV1`
-  (201-210), `PayloadFor` (215-218).
-- `packages/core/src/events/execution-observation.ts` — `ExecutionObservationEvent`
-  (24-28), the existing `{ type, payload }`-pair shape.
-- `packages/cli/src/services/execution.ts` — union-source call sites (`:1205`, `:1302`).
-- `packages/core/src/output/types.ts` — downstream consumer (205-209).
+Line numbers below are pre-refactor anchors for the §2–§6 narrative; the
+emitter has since been migrated to Candidate D (see the status banner). For the
+current implementation, read the files directly rather than relying on these
+line numbers.
+
+- `packages/core/src/events/emitter.ts` — `ExecutionEventEmitter`, the
+  `emit`/`buildEvent` runtime code. **Post-refactor:** both take a
+  `RunbookEventInput` pair and spread it into the envelope; the `as Extract<…>`
+  assertion, the `NODE_ENV !== 'production'` gate, and the `validatePayload`
+  runtime guard have all been removed — the compiler now enforces the
+  `type`/`payload` correlation at every call site.
+- `packages/core/src/events/types.ts` — `EventEnvelope`, the `RunbookEventV1`
+  union (the produced/consumed event contract), `PayloadFor`, and the
+  `RunbookEventInput` input pair added by this change.
+- `packages/core/src/events/execution-observation.ts` — `ExecutionObservationEvent`,
+  the `{ type, payload }`-pair shape the union-source call sites reuse.
+- `packages/cli/src/services/execution.ts` — union-source call sites
+  (`emit(effect.event)`) plus the migrated concrete `emit({ type, payload })` sites.
+- `packages/core/src/output/types.ts` — downstream consumer of `RunbookEventV1`.

--- a/packages/cli/__tests__/helpers/execution-emitter.test.ts
+++ b/packages/cli/__tests__/helpers/execution-emitter.test.ts
@@ -58,10 +58,13 @@ describe('createBridgedEmitter', () => {
     const { output, executionEventFn } = makeOutput();
     const emitter = createBridgedEmitter(makeState(), output as unknown as OutputEmitter);
 
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        title: 'Test',
+        prompted: false,
+        statePath: '.rundown/runs/wf-test.json',
+      },
     });
 
     expect(executionEventFn).toHaveBeenCalledTimes(1);
@@ -78,10 +81,13 @@ describe('createBridgedEmitter', () => {
     });
     const emitter = createBridgedEmitter(state, output as unknown as OutputEmitter);
 
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        title: 'Test',
+        prompted: false,
+        statePath: '.rundown/runs/wf-test.json',
+      },
     });
 
     const event = executionEventFn.mock.calls[0]?.[0];
@@ -96,10 +102,13 @@ describe('createBridgedEmitter', () => {
     });
     const emitter = createBridgedEmitter(state, output as unknown as OutputEmitter);
 
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        title: 'Test',
+        prompted: false,
+        statePath: '.rundown/runs/wf-test.json',
+      },
     });
 
     const event = executionEventFn.mock.calls[0]?.[0];
@@ -114,10 +123,13 @@ describe('createBridgedEmitter', () => {
     });
     const emitter = createBridgedEmitter(state, output as unknown as OutputEmitter);
 
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        title: 'Test',
+        prompted: false,
+        statePath: '.rundown/runs/wf-test.json',
+      },
     });
 
     const event = executionEventFn.mock.calls[0]?.[0];

--- a/packages/cli/__tests__/integration/events.test.ts
+++ b/packages/cli/__tests__/integration/events.test.ts
@@ -12,40 +12,58 @@ describe('event output integration', () => {
     emitter.subscribe(subscriber.handle);
 
     // Simulate execution sequence
-    emitter.emit('RUNBOOK_STARTED', {
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        prompted: false,
+        statePath: '.rundown/runs/wf-test.json',
+      },
     });
-    emitter.emit('STEP_ENTERED', {
-      position: { current: '1', total: 1 },
-      stepName: '1',
-      description: 'Test step',
-      hasCommand: true,
-      commandCode: 'echo test',
-      commandLang: 'bash',
-      isSubstep: false,
-      prompted: false,
-      artifacts: {},
+    emitter.emit({
+      type: 'STEP_ENTERED',
+      payload: {
+        position: { current: '1', total: 1 },
+        stepName: '1',
+        description: 'Test step',
+        hasCommand: true,
+        commandCode: 'echo test',
+        commandLang: 'bash',
+        isSubstep: false,
+        prompted: false,
+        artifacts: {},
+      },
     });
-    emitter.emit('COMMAND_STARTED', {
-      command: 'echo test',
-      displayCommand: 'echo test',
-      position: { current: '1', total: 1 },
+    emitter.emit({
+      type: 'COMMAND_STARTED',
+      payload: {
+        command: 'echo test',
+        displayCommand: 'echo test',
+        position: { current: '1', total: 1 },
+      },
     });
-    emitter.emit('COMMAND_COMPLETED', {
-      command: 'echo test',
-      success: true,
-      exitCode: 0,
-      position: { current: '1', total: 1 },
+    emitter.emit({
+      type: 'COMMAND_COMPLETED',
+      payload: {
+        command: 'echo test',
+        success: true,
+        exitCode: 0,
+        position: { current: '1', total: 1 },
+      },
     });
-    emitter.emit('STEP_TRANSITIONED', {
-      action: 'COMPLETE',
-      from: '1',
-      at: '1',
-      result: 'PASS',
+    emitter.emit({
+      type: 'STEP_TRANSITIONED',
+      payload: {
+        action: 'COMPLETE',
+        from: '1',
+        at: '1',
+        result: 'PASS',
+      },
     });
-    emitter.emit('RUNBOOK_COMPLETED', {
-      finalPosition: { current: '1', total: 1 },
+    emitter.emit({
+      type: 'RUNBOOK_COMPLETED',
+      payload: {
+        finalPosition: { current: '1', total: 1 },
+      },
     });
 
     const summary = subscriber.getSummary();
@@ -71,19 +89,28 @@ describe('event output integration', () => {
     const subscriber = new JSONSubscriber();
     emitter.subscribe(subscriber.handle);
 
-    emitter.emit('RUNBOOK_STARTED', {
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        prompted: false,
+        statePath: '.rundown/runs/wf-test.json',
+      },
     });
-    emitter.emit('COMMAND_COMPLETED', {
-      command: 'exit 1',
-      success: false,
-      exitCode: 1,
-      position: { current: '1', total: 1 },
+    emitter.emit({
+      type: 'COMMAND_COMPLETED',
+      payload: {
+        command: 'exit 1',
+        success: false,
+        exitCode: 1,
+        position: { current: '1', total: 1 },
+      },
     });
-    emitter.emit('RUNBOOK_STOPPED', {
-      position: { current: '1', total: 1 },
-      reason: 'fail_transition',
+    emitter.emit({
+      type: 'RUNBOOK_STOPPED',
+      payload: {
+        position: { current: '1', total: 1 },
+        reason: 'fail_transition',
+      },
     });
 
     const summary = subscriber.getSummary();
@@ -100,21 +127,30 @@ describe('event output integration', () => {
     const subscriber = new JSONSubscriber();
     emitter.subscribe(subscriber.handle);
 
-    emitter.emit('RUNBOOK_STARTED', {
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        prompted: false,
+        statePath: '.rundown/runs/wf-test.json',
+      },
     });
-    emitter.emit('COMMAND_COMPLETED', {
-      command: 'rm -rf /',
-      success: false,
-      exitCode: 126,
-      position: { current: '1', total: 1 },
-      policyDenied: true,
-      denialReason: 'Dangerous command',
+    emitter.emit({
+      type: 'COMMAND_COMPLETED',
+      payload: {
+        command: 'rm -rf /',
+        success: false,
+        exitCode: 126,
+        position: { current: '1', total: 1 },
+        policyDenied: true,
+        denialReason: 'Dangerous command',
+      },
     });
-    emitter.emit('RUNBOOK_STOPPED', {
-      position: { current: '1', total: 1 },
-      reason: 'policy_denied',
+    emitter.emit({
+      type: 'RUNBOOK_STOPPED',
+      payload: {
+        position: { current: '1', total: 1 },
+        reason: 'policy_denied',
+      },
     });
 
     const summary = subscriber.getSummary();
@@ -134,18 +170,24 @@ describe('event output integration', () => {
     const subscriber = new JSONSubscriber();
     emitter.subscribe(subscriber.handle);
 
-    emitter.emit('RUNBOOK_STARTED', {
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        prompted: false,
+        statePath: '.rundown/runs/wf-test.json',
+      },
     });
-    emitter.emit('STEP_ENTERED', {
-      position: { current: '1', total: 1 },
-      stepName: '1',
-      description: 'Test',
-      hasCommand: false,
-      isSubstep: false,
-      prompted: false,
-      artifacts: {},
+    emitter.emit({
+      type: 'STEP_ENTERED',
+      payload: {
+        position: { current: '1', total: 1 },
+        stepName: '1',
+        description: 'Test',
+        hasCommand: false,
+        isSubstep: false,
+        prompted: false,
+        artifacts: {},
+      },
     });
 
     const events = subscriber.getEvents();
@@ -161,9 +203,12 @@ describe('event output integration', () => {
     const subscriber = new JSONSubscriber();
     emitter.subscribe(subscriber.handle);
 
-    emitter.emit('RUNBOOK_STARTED', {
-      prompted: false,
-      statePath: '.rundown/runs/wf-test.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        prompted: false,
+        statePath: '.rundown/runs/wf-test.json',
+      },
     });
 
     const event = subscriber.getEvents()[0];

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -166,7 +166,7 @@ type ResolvedStepType = ResolvedStep;
 // the test in line with what `runExecutionLoop` actually inspects.
 type LoadFn = jest.Mock<(id: string) => Promise<Record<string, unknown> | null>>;
 type UpdateFn = jest.Mock<(id: string, patch: Record<string, unknown>) => Promise<void>>;
-type EmitFn = jest.Mock<(event: string, payload?: unknown) => void>;
+type EmitFn = jest.Mock<(input: { type: string; payload?: unknown }) => void>;
 type MockManagerLike = {
   cwd: string;
   load: LoadFn;
@@ -414,7 +414,7 @@ describe('runExecutionLoop', () => {
     );
 
     mockEmitter = {
-      emit: mockFn<(event: string, payload?: unknown) => void>(),
+      emit: mockFn<(input: { type: string; payload?: unknown }) => void>(),
     };
     mockSessionService.getActive.mockReset();
     mockSessionService.getActive.mockResolvedValue(null);
@@ -776,14 +776,14 @@ describe('runExecutionLoop', () => {
     );
 
     expect(result).toBe('done');
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'RUNBOOK_COMPLETED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'RUNBOOK_COMPLETED',
+      payload: expect.objectContaining({
         message: 'Success',
         finalPosition: { current: '2', total: 2 },
       }),
-    );
-    const emittedEvents = mockEmitter.emit.mock.calls.map(([event]) => event);
+    });
+    const emittedEvents = mockEmitter.emit.mock.calls.map(([event]) => event.type);
     expect(emittedEvents).not.toContain('STEP_ENTERED');
     expect(emittedEvents).not.toContain('COMMAND_STARTED');
     expect(emittedEvents).not.toContain('COMMAND_COMPLETED');
@@ -804,13 +804,13 @@ describe('runExecutionLoop', () => {
     );
 
     expect(result).toBe('waiting');
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'STEP_ENTERED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'STEP_ENTERED',
+      payload: expect.objectContaining({
         stepName: '1',
         prompted: true,
       }),
-    );
+    });
   });
 
   it('emits STEP_ENTERED.artifacts from the actor snapshot working set', async () => {
@@ -837,8 +837,8 @@ describe('runExecutionLoop', () => {
       asEmitter(mockEmitter),
     );
 
-    const stepEntered = mockEmitter.emit.mock.calls.find((call) => call[0] === 'STEP_ENTERED');
-    expect(stepEntered?.[1]).toEqual(
+    const stepEntered = mockEmitter.emit.mock.calls.find((call) => call[0].type === 'STEP_ENTERED');
+    expect(stepEntered?.[0]?.payload).toEqual(
       expect.objectContaining({
         artifacts: {
           PlanPath: expect.objectContaining({
@@ -868,8 +868,8 @@ describe('runExecutionLoop', () => {
       asEmitter(mockEmitter),
     );
 
-    const stepEntered = mockEmitter.emit.mock.calls.find((call) => call[0] === 'STEP_ENTERED');
-    expect(stepEntered?.[1]).toEqual(expect.objectContaining({ artifacts: {} }));
+    const stepEntered = mockEmitter.emit.mock.calls.find((call) => call[0].type === 'STEP_ENTERED');
+    expect(stepEntered?.[0]?.payload).toEqual(expect.objectContaining({ artifacts: {} }));
   });
 
   it('returns waiting if step has no command', async () => {
@@ -1082,12 +1082,12 @@ describe('runExecutionLoop', () => {
     );
 
     expect(result).toBe('stopped');
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'POLICY_DENIED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'POLICY_DENIED',
+      payload: expect.objectContaining({
         reason: 'Not allowed',
       }),
-    );
+    });
   });
 
   it('emits COMMAND_STARTED then COMMAND_COMPLETED from effects when executing a command', async () => {
@@ -1118,18 +1118,18 @@ describe('runExecutionLoop', () => {
       asEmitter(mockEmitter),
     );
 
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'COMMAND_STARTED',
-      expect.objectContaining({ command: 'echo hello', displayCommand: 'echo hello' }),
-    );
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'COMMAND_COMPLETED',
-      expect.objectContaining({ command: 'echo hello', success: true, exitCode: 0 }),
-    );
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'COMMAND_STARTED',
+      payload: expect.objectContaining({ command: 'echo hello', displayCommand: 'echo hello' }),
+    });
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'COMMAND_COMPLETED',
+      payload: expect.objectContaining({ command: 'echo hello', success: true, exitCode: 0 }),
+    });
 
     const emitCalls = mockEmitter.emit.mock.calls;
-    const startedIdx = emitCalls.findIndex((c) => c[0] === 'COMMAND_STARTED');
-    const completedIdx = emitCalls.findIndex((c) => c[0] === 'COMMAND_COMPLETED');
+    const startedIdx = emitCalls.findIndex((c) => c[0].type === 'COMMAND_STARTED');
+    const completedIdx = emitCalls.findIndex((c) => c[0].type === 'COMMAND_COMPLETED');
     expect(startedIdx).toBeGreaterThanOrEqual(0);
     expect(completedIdx).toBeGreaterThan(startedIdx);
   });
@@ -1164,12 +1164,12 @@ describe('runExecutionLoop', () => {
     );
 
     expect(result).toBe('done');
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'RUNBOOK_COMPLETED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'RUNBOOK_COMPLETED',
+      payload: expect.objectContaining({
         message: 'Success',
       }),
-    );
+    });
     expect(mockSessionService.releaseRunbook).toHaveBeenCalledWith(runbookId, {
       retainClaimsAsTerminal: true,
     });
@@ -1221,25 +1221,25 @@ describe('runExecutionLoop', () => {
     expect(result).toBe('stopped');
 
     // ERROR_OCCURRED is emitted with the RETRY_ERROR lastAction payload fields.
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'ERROR_OCCURRED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'ERROR_OCCURRED',
+      payload: expect.objectContaining({
         code: 'RD-902',
         message: 'hook failed: createDelegation returned step_not_found',
       }),
-    );
+    });
 
     // RUNBOOK_STOPPED still fires afterwards with a reason distinct from an
     // author-configured FAIL STOP transition.
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'RUNBOOK_STOPPED',
-      expect.objectContaining({ reason: 'retry_error_failed' }),
-    );
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'RUNBOOK_STOPPED',
+      payload: expect.objectContaining({ reason: 'retry_error_failed' }),
+    });
 
     // Ordering: ERROR_OCCURRED precedes RUNBOOK_STOPPED.
     const emitCalls = mockEmitter.emit.mock.calls;
-    const errorIdx = emitCalls.findIndex((c: any[]) => c[0] === 'ERROR_OCCURRED');
-    const stoppedIdx = emitCalls.findIndex((c: any[]) => c[0] === 'RUNBOOK_STOPPED');
+    const errorIdx = emitCalls.findIndex((c) => c[0].type === 'ERROR_OCCURRED');
+    const stoppedIdx = emitCalls.findIndex((c) => c[0].type === 'RUNBOOK_STOPPED');
     expect(errorIdx).toBeGreaterThanOrEqual(0);
     expect(stoppedIdx).toBeGreaterThanOrEqual(0);
     expect(errorIdx).toBeLessThan(stoppedIdx);
@@ -1249,9 +1249,9 @@ describe('runExecutionLoop', () => {
     // ERROR_OCCURRED + RUNBOOK_STOPPED; leaking it through STEP_TRANSITIONED
     // would widen the public action enum beyond the scenario schema
     // (CONTINUE/DEFER/GOTO/STOP/COMPLETE/RETRY/BREAK/NEXT).
-    const stepTransitionedCalls = emitCalls.filter((c) => c[0] === 'STEP_TRANSITIONED');
+    const stepTransitionedCalls = emitCalls.filter((c) => c[0].type === 'STEP_TRANSITIONED');
     for (const call of stepTransitionedCalls) {
-      const payload = call[1] as { action?: string } | undefined;
+      const payload = call[0].payload as { action?: string } | undefined;
       expect(payload?.action).not.toBe('RETRY_ERROR');
     }
   });
@@ -1296,20 +1296,23 @@ describe('runExecutionLoop', () => {
     expect(result).toBe('stopped');
 
     // ERROR_OCCURRED is emitted with the OUTPUT_CAPTURE_FAILED message.
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'ERROR_OCCURRED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'ERROR_OCCURRED',
+      payload: expect.objectContaining({
         message: 'failed to read channel file: /tmp/outputs/Foo',
       }),
-    );
+    });
 
     // RUNBOOK_STOPPED still fires afterwards so terminal state is reported.
-    expect(mockEmitter.emit).toHaveBeenCalledWith('RUNBOOK_STOPPED', expect.any(Object));
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'RUNBOOK_STOPPED',
+      payload: expect.any(Object),
+    });
 
     // Ordering: ERROR_OCCURRED precedes RUNBOOK_STOPPED.
     const emitCalls = mockEmitter.emit.mock.calls;
-    const errorIdx = emitCalls.findIndex((c: any[]) => c[0] === 'ERROR_OCCURRED');
-    const stoppedIdx = emitCalls.findIndex((c: any[]) => c[0] === 'RUNBOOK_STOPPED');
+    const errorIdx = emitCalls.findIndex((c) => c[0].type === 'ERROR_OCCURRED');
+    const stoppedIdx = emitCalls.findIndex((c) => c[0].type === 'RUNBOOK_STOPPED');
     expect(errorIdx).toBeGreaterThanOrEqual(0);
     expect(stoppedIdx).toBeGreaterThanOrEqual(0);
     expect(errorIdx).toBeLessThan(stoppedIdx);
@@ -1351,27 +1354,27 @@ describe('runExecutionLoop', () => {
     expect(result).toBe('stopped');
     expect(mockActorService.sendAndSync).not.toHaveBeenCalled();
 
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'ERROR_OCCURRED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'ERROR_OCCURRED',
+      payload: expect.objectContaining({
         message: 'artifact "PlanPath" failed to resolve',
       }),
-    );
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'RUNBOOK_STOPPED',
-      expect.objectContaining({
+    });
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'RUNBOOK_STOPPED',
+      payload: expect.objectContaining({
         message: 'artifact "PlanPath" failed to resolve',
         reason: 'artifact_resolution_failed',
       }),
-    );
+    });
 
     const emitCalls = mockEmitter.emit.mock.calls;
-    const errorIdx = emitCalls.findIndex((c: any[]) => c[0] === 'ERROR_OCCURRED');
-    const stoppedIdx = emitCalls.findIndex((c: any[]) => c[0] === 'RUNBOOK_STOPPED');
+    const errorIdx = emitCalls.findIndex((c) => c[0].type === 'ERROR_OCCURRED');
+    const stoppedIdx = emitCalls.findIndex((c) => c[0].type === 'RUNBOOK_STOPPED');
     expect(errorIdx).toBeGreaterThanOrEqual(0);
     expect(stoppedIdx).toBeGreaterThan(errorIdx);
 
-    const stepTransitionedCalls = emitCalls.filter((c) => c[0] === 'STEP_TRANSITIONED');
+    const stepTransitionedCalls = emitCalls.filter((c) => c[0].type === 'STEP_TRANSITIONED');
     expect(stepTransitionedCalls).toHaveLength(0);
   });
 
@@ -1403,13 +1406,16 @@ describe('runExecutionLoop', () => {
 
     expect(result).toBe('stopped');
     expect(mockActorService.sendAndSync).not.toHaveBeenCalled();
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'RUNBOOK_STOPPED',
-      expect.objectContaining({ position: expect.any(Object), reason: expect.any(String) }),
-    );
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'RUNBOOK_STOPPED',
+      payload: expect.objectContaining({
+        position: expect.any(Object),
+        reason: expect.any(String),
+      }),
+    });
     expect(
       (mockEmitter.emit as jest.Mock).mock.calls.filter(
-        (c: unknown[]) => c[0] === 'STEP_TRANSITIONED',
+        (c) => (c[0] as { type?: string } | undefined)?.type === 'STEP_TRANSITIONED',
       ),
     ).toHaveLength(0);
   });
@@ -1432,13 +1438,13 @@ describe('runExecutionLoop', () => {
     );
 
     expect(result).toBe('stopped');
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'RUNBOOK_STOPPED',
-      expect.objectContaining({ position: expect.any(Object) }),
-    );
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'RUNBOOK_STOPPED',
+      payload: expect.objectContaining({ position: expect.any(Object) }),
+    });
     expect(
       (mockEmitter.emit as jest.Mock).mock.calls.filter(
-        (c: unknown[]) => c[0] === 'STEP_TRANSITIONED',
+        (c) => (c[0] as { type?: string } | undefined)?.type === 'STEP_TRANSITIONED',
       ),
     ).toHaveLength(0);
   });
@@ -1506,12 +1512,12 @@ describe('runExecutionLoop', () => {
       asEmitter(mockEmitter),
     );
 
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'STEP_ENTERED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'STEP_ENTERED',
+      payload: expect.objectContaining({
         prompted: true,
       }),
-    );
+    });
   });
 
   it('prompted-for step falls back to step-level prompt', async () => {
@@ -1545,12 +1551,12 @@ describe('runExecutionLoop', () => {
       asEmitter(mockEmitter),
     );
 
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'STEP_ENTERED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'STEP_ENTERED',
+      payload: expect.objectContaining({
         prompt: 'FOR item IN 1 TO {{N}}',
       }),
-    );
+    });
   });
 
   it('prompted-for step does not inject loop variables', async () => {
@@ -1584,13 +1590,13 @@ describe('runExecutionLoop', () => {
     );
 
     // {{item}} should stay literal since no forClause drives variable injection
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'STEP_ENTERED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'STEP_ENTERED',
+      payload: expect.objectContaining({
         description: 'Handle {{item}}',
         commandCode: 'rd echo item={{item}}',
       }),
-    );
+    });
   });
 
   it('emits expanded command text in STEP_ENTERED payload for prompted mode', async () => {
@@ -1624,14 +1630,14 @@ describe('runExecutionLoop', () => {
     );
 
     expect(result).toBe('waiting');
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'STEP_ENTERED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'STEP_ENTERED',
+      payload: expect.objectContaining({
         description: 'Handle 1',
         commandCode: 'rd echo item=1',
         prompted: true,
       }),
-    );
+    });
   });
 
   describe('machine-driven auto-execution does not break on a step declaring OUTPUTS', () => {
@@ -1822,12 +1828,14 @@ describe('runExecutionLoop', () => {
     );
 
     // STEP_ENTERED should have been emitted with delegateFrontier
-    const stepEnteredCall = mockEmitter.emit.mock.calls.find((call) => call[0] === 'STEP_ENTERED');
+    const stepEnteredCall = mockEmitter.emit.mock.calls.find(
+      (call) => call[0].type === 'STEP_ENTERED',
+    );
     expect(stepEnteredCall).toBeDefined();
     // STEP_ENTERED payload shape is the test contract — mockEmitter.emit's
     // `payload?: unknown` parameter is intentionally permissive, so this
     // narrows to the fields the test actually asserts on.
-    const payload = stepEnteredCall![1] as {
+    const payload = stepEnteredCall![0].payload as {
       delegateFrontier?: { id: string; runbook: string; token: string }[];
     };
 
@@ -1900,9 +1908,11 @@ describe('runExecutionLoop', () => {
     );
 
     // STEP_ENTERED payload should carry the pre-issued frontier
-    const stepEnteredCall = mockEmitter.emit.mock.calls.find((call) => call[0] === 'STEP_ENTERED');
+    const stepEnteredCall = mockEmitter.emit.mock.calls.find(
+      (call) => call[0].type === 'STEP_ENTERED',
+    );
     expect(stepEnteredCall).toBeDefined();
-    const payload = stepEnteredCall![1] as { delegateFrontier?: unknown };
+    const payload = stepEnteredCall![0].payload as { delegateFrontier?: unknown };
 
     expect(payload.delegateFrontier).toEqual(preIssued);
 
@@ -2026,13 +2036,13 @@ describe('runExecutionLoop', () => {
     expect(mockSessionService.popRunbook).toHaveBeenCalledWith();
     expect(mockSessionService.releaseRunbook).not.toHaveBeenCalledWith(childRunId);
     expect(mockManager.delete).not.toHaveBeenCalledWith(childRunId);
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'ERROR_OCCURRED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'ERROR_OCCURRED',
+      payload: expect.objectContaining({
         code: core.ErrorCodes.LAUNCH_FAILED.code,
         message: expect.stringContaining('consume failed'),
       }),
-    );
+    });
     expect(mockActorService.sendAndSync).toHaveBeenNthCalledWith(
       1,
       runbookId,
@@ -2399,9 +2409,11 @@ describe('runExecutionLoop', () => {
       asEmitter(mockEmitter),
     );
 
-    const stepEnteredCall = mockEmitter.emit.mock.calls.find((call) => call[0] === 'STEP_ENTERED');
+    const stepEnteredCall = mockEmitter.emit.mock.calls.find(
+      (call) => call[0].type === 'STEP_ENTERED',
+    );
     expect(stepEnteredCall).toBeDefined();
-    const payload = stepEnteredCall![1] as { delegateFrontier?: unknown };
+    const payload = stepEnteredCall![0].payload as { delegateFrontier?: unknown };
     expect(payload.delegateFrontier).toEqual([
       { id: '1.1', runbook: 'child-a.runbook.md', token: 'rdtk_retry_a' },
     ]);
@@ -2443,9 +2455,11 @@ describe('runExecutionLoop', () => {
       asEmitter(mockEmitter),
     );
 
-    const stepEnteredCall = mockEmitter.emit.mock.calls.find((call) => call[0] === 'STEP_ENTERED');
+    const stepEnteredCall = mockEmitter.emit.mock.calls.find(
+      (call) => call[0].type === 'STEP_ENTERED',
+    );
     expect(stepEnteredCall).toBeDefined();
-    const payload = stepEnteredCall![1] as { delegateFrontier?: unknown };
+    const payload = stepEnteredCall![0].payload as { delegateFrontier?: unknown };
     expect(payload.delegateFrontier).toBeUndefined();
     expect(delegateInference.inferAllDelegateSubsteps).not.toHaveBeenCalled();
     expect(core.createDelegation).not.toHaveBeenCalled();
@@ -2503,18 +2517,18 @@ describe('runExecutionLoop', () => {
 
     // RUNBOOK_STOPPED carries the discriminated reason — not the generic
     // 'delegation_resolution_failed' fallback.
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'ERROR_OCCURRED',
-      expect.objectContaining({
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'ERROR_OCCURRED',
+      payload: expect.objectContaining({
         message: 'Nested delegation forbidden',
       }),
-    );
-    expect(mockEmitter.emit).toHaveBeenCalledWith(
-      'RUNBOOK_STOPPED',
-      expect.objectContaining({
+    });
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'RUNBOOK_STOPPED',
+      payload: expect.objectContaining({
         reason: 'nested_delegation_forbidden',
       }),
-    );
+    });
   });
 });
 

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -256,11 +256,14 @@ function emitRunbookStarted(
   runbookState: RunbookState,
   prompted: boolean,
 ): void {
-  emitter.emit('RUNBOOK_STARTED', {
-    title: runbookState.title,
-    description: runbookState.description,
-    prompted,
-    statePath: `${RUNS_DIR}/${runbookState.id}.json`,
+  emitter.emit({
+    type: 'RUNBOOK_STARTED',
+    payload: {
+      title: runbookState.title,
+      description: runbookState.description,
+      prompted,
+      statePath: `${RUNS_DIR}/${runbookState.id}.json`,
+    },
   });
 }
 

--- a/packages/cli/src/helpers/transition-orchestrator.ts
+++ b/packages/cli/src/helpers/transition-orchestrator.ts
@@ -49,16 +49,16 @@ export function transitionSinkFromEmitter(
 ): TransitionEventSink {
   return {
     onErrorOccurred: (payload) => {
-      emitter.emit('ERROR_OCCURRED', payload);
+      emitter.emit({ type: 'ERROR_OCCURRED', payload });
     },
     onStepTransitioned: (payload) => {
-      emitter.emit('STEP_TRANSITIONED', payload);
+      emitter.emit({ type: 'STEP_TRANSITIONED', payload });
     },
     onRunbookCompleted: (payload) => {
-      emitter.emit('RUNBOOK_COMPLETED', payload);
+      emitter.emit({ type: 'RUNBOOK_COMPLETED', payload });
     },
     onRunbookStopped: (payload) => {
-      emitter.emit('RUNBOOK_STOPPED', payload);
+      emitter.emit({ type: 'RUNBOOK_STOPPED', payload });
     },
   };
 }

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -455,9 +455,12 @@ async function launchInlineChildFromIntent({
     guard = lock.held(parentLinkage.parentRunId);
   } catch (err) {
     if (err instanceof DelegationLockTimeoutError) {
-      emitter.emit('ERROR_OCCURRED', {
-        message: `Could not acquire delegation lock for inline parent ${parentLinkage.parentRunId}`,
-        code: ErrorCodes.DELEGATION_LOCK_TIMEOUT.code,
+      emitter.emit({
+        type: 'ERROR_OCCURRED',
+        payload: {
+          message: `Could not acquire delegation lock for inline parent ${parentLinkage.parentRunId}`,
+          code: ErrorCodes.DELEGATION_LOCK_TIMEOUT.code,
+        },
       });
       return 'stopped';
     }
@@ -467,9 +470,12 @@ async function launchInlineChildFromIntent({
   try {
     const parent = await manager.load(parentLinkage.parentRunId);
     if (!parent || parent.lifecycle === 'completed' || parent.lifecycle === 'stopped') {
-      emitter.emit('ERROR_OCCURRED', {
-        message: `Inline parent run ${parentLinkage.parentRunId} is not active`,
-        code: ErrorCodes.LAUNCH_FAILED.code,
+      emitter.emit({
+        type: 'ERROR_OCCURRED',
+        payload: {
+          message: `Inline parent run ${parentLinkage.parentRunId} is not active`,
+          code: ErrorCodes.LAUNCH_FAILED.code,
+        },
       });
       return 'stopped';
     }
@@ -480,9 +486,12 @@ async function launchInlineChildFromIntent({
     const existingChild = await manager.load(childRunId);
     if (existingChild) {
       if (!parentLinkagesEqual(existingChild.parentLinkage, parentLinkage)) {
-        emitter.emit('ERROR_OCCURRED', {
-          message: `Inline child ${childRunId} has conflicting parent linkage`,
-          code: 'INLINE_CHILD_LINKAGE_MISMATCH',
+        emitter.emit({
+          type: 'ERROR_OCCURRED',
+          payload: {
+            message: `Inline child ${childRunId} has conflicting parent linkage`,
+            code: 'INLINE_CHILD_LINKAGE_MISMATCH',
+          },
         });
         return 'stopped';
       }
@@ -512,9 +521,12 @@ async function launchInlineChildFromIntent({
           steps,
         });
       } catch (error) {
-        emitter.emit('ERROR_OCCURRED', {
-          message: `Inline child launch failed: ${getErrorMessage(error)}`,
-          code: ErrorCodes.LAUNCH_FAILED.code,
+        emitter.emit({
+          type: 'ERROR_OCCURRED',
+          payload: {
+            message: `Inline child launch failed: ${getErrorMessage(error)}`,
+            code: ErrorCodes.LAUNCH_FAILED.code,
+          },
         });
         if (pushedExistingInlineChild) {
           try {
@@ -555,12 +567,15 @@ async function launchInlineChildFromIntent({
         childResolution.reason === 'plugin-context-missing'
           ? `Plugin runbook context is unavailable for ${intent.childRunbookRef.source}:${intent.childRunbookRef.path}. Set CLAUDE_PLUGIN_ROOT or install the Rundown Claude Code plugin alongside the CLI.`
           : `Runbook not found: ${intent.childRunbookRef.source}:${intent.childRunbookRef.path}`;
-      emitter.emit('ERROR_OCCURRED', {
-        message,
-        code:
-          childResolution.reason === 'plugin-context-missing'
-            ? 'RUNBOOK_REF_RESOLUTION_ERROR'
-            : 'RUNBOOK_NOT_FOUND',
+      emitter.emit({
+        type: 'ERROR_OCCURRED',
+        payload: {
+          message,
+          code:
+            childResolution.reason === 'plugin-context-missing'
+              ? 'RUNBOOK_REF_RESOLUTION_ERROR'
+              : 'RUNBOOK_NOT_FOUND',
+        },
       });
       return 'stopped';
     }
@@ -585,9 +600,12 @@ async function launchInlineChildFromIntent({
       },
     );
     if (!prepared.ok) {
-      emitter.emit('ERROR_OCCURRED', {
-        message: prepared.error,
-        code: prepared.code,
+      emitter.emit({
+        type: 'ERROR_OCCURRED',
+        payload: {
+          message: prepared.error,
+          code: prepared.code,
+        },
       });
       return 'stopped';
     }
@@ -637,9 +655,12 @@ async function launchInlineChildFromIntent({
     );
 
     if (!launchResult.ok) {
-      emitter.emit('ERROR_OCCURRED', {
-        message: launchResult.error,
-        code: launchResult.code,
+      emitter.emit({
+        type: 'ERROR_OCCURRED',
+        payload: {
+          message: launchResult.error,
+          code: launchResult.code,
+        },
       });
       return 'stopped';
     }
@@ -719,13 +740,13 @@ function renderTerminalObservationFromCoreState({
   for (const event of observation.events) {
     switch (event.type) {
       case 'ERROR_OCCURRED':
-        emitter.emit('ERROR_OCCURRED', event.payload);
+        emitter.emit({ type: 'ERROR_OCCURRED', payload: event.payload });
         break;
       case 'RUNBOOK_STOPPED':
-        emitter.emit('RUNBOOK_STOPPED', event.payload);
+        emitter.emit({ type: 'RUNBOOK_STOPPED', payload: event.payload });
         break;
       case 'RUNBOOK_COMPLETED':
-        emitter.emit('RUNBOOK_COMPLETED', event.payload);
+        emitter.emit({ type: 'RUNBOOK_COMPLETED', payload: event.payload });
         break;
       case 'STEP_TRANSITIONED':
         break;
@@ -1000,10 +1021,10 @@ export async function runExecutionLoop(
       for (const event of observation.events) {
         switch (event.type) {
           case 'ERROR_OCCURRED':
-            emitter.emit('ERROR_OCCURRED', event.payload);
+            emitter.emit({ type: 'ERROR_OCCURRED', payload: event.payload });
             break;
           case 'RUNBOOK_STOPPED':
-            emitter.emit('RUNBOOK_STOPPED', event.payload);
+            emitter.emit({ type: 'RUNBOOK_STOPPED', payload: event.payload });
             break;
           case 'STEP_TRANSITIONED':
           case 'RUNBOOK_COMPLETED':
@@ -1027,10 +1048,13 @@ export async function runExecutionLoop(
         currentState.forStack,
       );
       const message = extractLastMessage(currentState.snapshot);
-      emitter.emit('RUNBOOK_STOPPED', {
-        position,
-        reason: 'fail_transition',
-        message,
+      emitter.emit({
+        type: 'RUNBOOK_STOPPED',
+        payload: {
+          position,
+          reason: 'fail_transition',
+          message,
+        },
       });
     }
 
@@ -1056,7 +1080,7 @@ export async function runExecutionLoop(
       for (const event of observation.events) {
         switch (event.type) {
           case 'RUNBOOK_COMPLETED':
-            emitter.emit('RUNBOOK_COMPLETED', event.payload);
+            emitter.emit({ type: 'RUNBOOK_COMPLETED', payload: event.payload });
             break;
           case 'STEP_TRANSITIONED':
           case 'ERROR_OCCURRED':
@@ -1069,14 +1093,17 @@ export async function runExecutionLoop(
         }
       }
     } else {
-      emitter.emit('RUNBOOK_COMPLETED', {
-        message: extractLastMessage(currentState.snapshot),
-        finalPosition: buildStepPosition(
-          currentState.step,
-          countNumberedSteps(steps),
-          currentState.substep,
-          currentState.forStack,
-        ),
+      emitter.emit({
+        type: 'RUNBOOK_COMPLETED',
+        payload: {
+          message: extractLastMessage(currentState.snapshot),
+          finalPosition: buildStepPosition(
+            currentState.step,
+            countNumberedSteps(steps),
+            currentState.substep,
+            currentState.forStack,
+          ),
+        },
       });
     }
     await applyExecutionTerminalRelease(sessionService, runbookId, terminalReleaseMode);
@@ -1202,7 +1229,7 @@ export async function runExecutionLoop(
       delegateFrontier,
     });
     for (const effect of entryEffects) {
-      emitter.emit(effect.event.type, effect.event.payload);
+      emitter.emit(effect.event);
     }
 
     const inlineLaunch = entryEffects
@@ -1216,12 +1243,18 @@ export async function runExecutionLoop(
         type: 'DELEGATE_FRONTIER_CONSUMED',
       });
       if (!consumeSync) {
-        emitter.emit('ERROR_OCCURRED', {
-          message: 'Failed to consume delegation frontier after STEP_ENTERED',
+        emitter.emit({
+          type: 'ERROR_OCCURRED',
+          payload: {
+            message: 'Failed to consume delegation frontier after STEP_ENTERED',
+          },
         });
-        emitter.emit('RUNBOOK_STOPPED', {
-          position: stepPosition,
-          message: 'Runbook state synchronization failed',
+        emitter.emit({
+          type: 'RUNBOOK_STOPPED',
+          payload: {
+            position: stepPosition,
+            message: 'Runbook state synchronization failed',
+          },
         });
         await applyExecutionTerminalRelease(sessionService, runbookId, terminalReleaseMode);
         return 'stopped';
@@ -1231,9 +1264,12 @@ export async function runExecutionLoop(
 
     if (!delegateFrontier && inlineLaunch) {
       if (!options.output) {
-        emitter.emit('ERROR_OCCURRED', {
-          message: 'Inline launch requires an output emitter',
-          code: ErrorCodes.LAUNCH_FAILED.code,
+        emitter.emit({
+          type: 'ERROR_OCCURRED',
+          payload: {
+            message: 'Inline launch requires an output emitter',
+            code: ErrorCodes.LAUNCH_FAILED.code,
+          },
         });
         return 'stopped';
       }
@@ -1287,19 +1323,25 @@ export async function runExecutionLoop(
       rdInjected,
     });
     if (!cmdSync) {
-      emitter.emit('ERROR_OCCURRED', {
-        message: 'Failed to synchronize runbook state after EXECUTE_COMMAND',
+      emitter.emit({
+        type: 'ERROR_OCCURRED',
+        payload: {
+          message: 'Failed to synchronize runbook state after EXECUTE_COMMAND',
+        },
       });
-      emitter.emit('RUNBOOK_STOPPED', {
-        position: stepPosition,
-        message: 'Runbook state synchronization failed',
+      emitter.emit({
+        type: 'RUNBOOK_STOPPED',
+        payload: {
+          position: stepPosition,
+          message: 'Runbook state synchronization failed',
+        },
       });
       await applyExecutionTerminalRelease(sessionService, runbookId, terminalReleaseMode);
       return 'stopped';
     }
     const syncEffects = cmdSync.effects;
     for (const effect of syncEffects) {
-      emitter.emit(effect.event.type, effect.event.payload);
+      emitter.emit(effect.event);
     }
 
     const commandOutput = syncEffects.find(

--- a/packages/core/__tests__/events/emitter.test.ts
+++ b/packages/core/__tests__/events/emitter.test.ts
@@ -14,10 +14,13 @@ describe('ExecutionEventEmitter', () => {
     const received: RunbookEventV1[] = [];
     emitter.subscribe((event) => received.push(event));
 
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test-123.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        title: 'Test',
+        prompted: false,
+        statePath: '.rundown/runs/wf-test-123.json',
+      },
     });
 
     expect(received).toHaveLength(1);
@@ -29,19 +32,25 @@ describe('ExecutionEventEmitter', () => {
     const received: RunbookEventV1[] = [];
     emitter.subscribe((event) => received.push(event));
 
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test-123.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        title: 'Test',
+        prompted: false,
+        statePath: '.rundown/runs/wf-test-123.json',
+      },
     });
-    emitter.emit('STEP_ENTERED', {
-      position: { current: '1', total: 5 },
-      stepName: '1',
-      description: 'Test step',
-      hasCommand: true,
-      isSubstep: false,
-      prompted: false,
-      artifacts: {},
+    emitter.emit({
+      type: 'STEP_ENTERED',
+      payload: {
+        position: { current: '1', total: 5 },
+        stepName: '1',
+        description: 'Test step',
+        hasCommand: true,
+        isSubstep: false,
+        prompted: false,
+        artifacts: {},
+      },
     });
 
     expect(received[0].seq).toBe(1);
@@ -52,10 +61,13 @@ describe('ExecutionEventEmitter', () => {
     const received: RunbookEventV1[] = [];
     emitter.subscribe((event) => received.push(event));
 
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test-123.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        title: 'Test',
+        prompted: false,
+        statePath: '.rundown/runs/wf-test-123.json',
+      },
     });
 
     expect(received[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
@@ -65,14 +77,20 @@ describe('ExecutionEventEmitter', () => {
     const received: RunbookEventV1[] = [];
     const unsub = emitter.subscribe((event) => received.push(event));
 
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test-123.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        title: 'Test',
+        prompted: false,
+        statePath: '.rundown/runs/wf-test-123.json',
+      },
     });
     unsub();
-    emitter.emit('RUNBOOK_COMPLETED', {
-      finalPosition: { current: '1', total: 1 },
+    emitter.emit({
+      type: 'RUNBOOK_COMPLETED',
+      payload: {
+        finalPosition: { current: '1', total: 1 },
+      },
     });
 
     expect(received).toHaveLength(1);
@@ -83,10 +101,13 @@ describe('ExecutionEventEmitter', () => {
     emitter.subscribe((event) => received.push(event));
 
     emitter.clear();
-    emitter.emit('RUNBOOK_STARTED', {
-      title: 'Test',
-      prompted: false,
-      statePath: '.rundown/runs/wf-test-123.json',
+    emitter.emit({
+      type: 'RUNBOOK_STARTED',
+      payload: {
+        title: 'Test',
+        prompted: false,
+        statePath: '.rundown/runs/wf-test-123.json',
+      },
     });
 
     expect(received).toHaveLength(0);

--- a/packages/core/__tests__/events/subscribers/method-binding.test.ts
+++ b/packages/core/__tests__/events/subscribers/method-binding.test.ts
@@ -28,9 +28,12 @@ describe('Subscriber method binding', () => {
       // Pass handle directly as callback - this is how fail.ts uses it
       emitter.subscribe(jsonSubscriber.handle);
 
-      emitter.emit('RUNBOOK_STARTED', {
-        prompted: false,
-        statePath: '.rundown/runs/wf-test.json',
+      emitter.emit({
+        type: 'RUNBOOK_STARTED',
+        payload: {
+          prompted: false,
+          statePath: '.rundown/runs/wf-test.json',
+        },
       });
 
       // If handle lost its this binding, this would be empty or throw
@@ -47,18 +50,27 @@ describe('Subscriber method binding', () => {
 
       emitter.subscribe(jsonSubscriber.handle);
 
-      emitter.emit('RUNBOOK_STARTED', {
-        prompted: false,
-        statePath: '.rundown/runs/wf-test.json',
+      emitter.emit({
+        type: 'RUNBOOK_STARTED',
+        payload: {
+          prompted: false,
+          statePath: '.rundown/runs/wf-test.json',
+        },
       });
-      emitter.emit('STEP_TRANSITIONED', {
-        action: 'CONTINUE',
-        from: '1',
-        at: '2',
-        result: 'PASS',
+      emitter.emit({
+        type: 'STEP_TRANSITIONED',
+        payload: {
+          action: 'CONTINUE',
+          from: '1',
+          at: '2',
+          result: 'PASS',
+        },
       });
-      emitter.emit('RUNBOOK_COMPLETED', {
-        finalPosition: { current: '2', total: 2 },
+      emitter.emit({
+        type: 'RUNBOOK_COMPLETED',
+        payload: {
+          finalPosition: { current: '2', total: 2 },
+        },
       });
 
       const summary = jsonSubscriber.getSummary();
@@ -102,9 +114,12 @@ describe('Subscriber method binding', () => {
       // If handle lost its this binding, this would throw
       // "Cannot read properties of undefined (reading 'handleRunbookStarted')"
       expect(() => {
-        emitter.emit('RUNBOOK_STARTED', {
-          prompted: false,
-          statePath: '.rundown/runs/wf-test.json',
+        emitter.emit({
+          type: 'RUNBOOK_STARTED',
+          payload: {
+            prompted: false,
+            statePath: '.rundown/runs/wf-test.json',
+          },
         });
       }).not.toThrow();
 
@@ -140,27 +155,39 @@ describe('Subscriber method binding', () => {
       emitter.subscribe(cliSubscriber.handle);
 
       // Emit various events - each calls different this.handleXxx methods
-      emitter.emit('RUNBOOK_STARTED', {
-        prompted: false,
-        statePath: '.rundown/runs/wf-test.json',
+      emitter.emit({
+        type: 'RUNBOOK_STARTED',
+        payload: {
+          prompted: false,
+          statePath: '.rundown/runs/wf-test.json',
+        },
       });
-      emitter.emit('STEP_ENTERED', {
-        position: { current: '1', total: 2 },
-        stepName: '1',
-        description: 'Test step',
-        hasCommand: true,
-        isSubstep: false,
-        prompted: false,
-        artifacts: {},
+      emitter.emit({
+        type: 'STEP_ENTERED',
+        payload: {
+          position: { current: '1', total: 2 },
+          stepName: '1',
+          description: 'Test step',
+          hasCommand: true,
+          isSubstep: false,
+          prompted: false,
+          artifacts: {},
+        },
       });
-      emitter.emit('COMMAND_STARTED', {
-        command: 'echo test',
-        displayCommand: 'echo test',
-        position: { current: '1', total: 2 },
+      emitter.emit({
+        type: 'COMMAND_STARTED',
+        payload: {
+          command: 'echo test',
+          displayCommand: 'echo test',
+          position: { current: '1', total: 2 },
+        },
       });
-      emitter.emit('RUNBOOK_COMPLETED', {
-        finalPosition: { current: '2', total: 2 },
-        message: 'Done',
+      emitter.emit({
+        type: 'RUNBOOK_COMPLETED',
+        payload: {
+          finalPosition: { current: '2', total: 2 },
+          message: 'Done',
+        },
       });
 
       // If any handler lost this context, we would have thrown

--- a/packages/core/src/events/emitter.ts
+++ b/packages/core/src/events/emitter.ts
@@ -1,4 +1,4 @@
-import type { RunbookEventV1, RunbookRef, PayloadFor } from './types.js';
+import type { RunbookEventV1, RunbookRef, RunbookEventInput } from './types.js';
 
 /**
  * Subscriber callback type for event emissions.
@@ -9,8 +9,9 @@ export type EventSubscriber = (event: RunbookEventV1) => void;
  * Synchronous event emitter for runbook execution events.
  *
  * Automatically populates envelope fields (v, ts, seq) and routes
- * events to all subscribed listeners. Provides type-safe emit() with
- * payload inference based on event type.
+ * events to all subscribed listeners. Accepts a pre-correlated
+ * `{ type, payload }` pair so the type/payload relationship is checked at
+ * every call site without a type assertion.
  *
  * @example
  * ```typescript
@@ -20,10 +21,13 @@ export type EventSubscriber = (event: RunbookEventV1) => void;
  * });
  * const unsub = emitter.subscribe((event) => console.log(event.type));
  *
- * emitter.emit('RUNBOOK_STARTED', {
- *   title: 'My Runbook',
- *   prompted: false,
- *   statePath: '.rundown/runs/wf-123.json'
+ * emitter.emit({
+ *   type: 'RUNBOOK_STARTED',
+ *   payload: {
+ *     title: 'My Runbook',
+ *     prompted: false,
+ *     statePath: '.rundown/runs/wf-123.json',
+ *   },
  * });
  *
  * unsub(); // Stop listening
@@ -56,20 +60,12 @@ export class ExecutionEventEmitter {
    * - runbookId: the runbook execution ID
    * - runbook: the runbook reference
    *
-   * @param type - Event type discriminator
-   * @param payload - Event-specific payload (type-inferred)
-   * @template T - Event type literal
+   * @param input - Pre-correlated `{ type, payload }` event pair
    */
-  emit<T extends RunbookEventV1['type']>(type: T, payload: PayloadFor<T>): void {
+  emit(input: RunbookEventInput): void {
     this.seq++;
 
-    // Build event using type-safe helper to satisfy discriminated union.
-    // The helper ensures payload matches the type discriminant at runtime,
-    // which TypeScript cannot verify in this generic context due to limitations
-    // with discriminated unions in generic functions. The helper's structure
-    // ensures both type and payload are assigned together atomically, making
-    // the union assignment type-safe.
-    const event = this.buildEvent(type, payload);
+    const event = this.buildEvent(input);
 
     for (const subscriber of this.subscribers) {
       subscriber(event);
@@ -77,84 +73,26 @@ export class ExecutionEventEmitter {
   }
 
   /**
-   * Type-safe event builder.
+   * Build a complete event by spreading the pre-correlated input pair into the
+   * envelope.
    *
-   * This helper function properly constructs a discriminated union event
-   * object. By building in a separate context, TypeScript can verify the
-   * relationship between type and payload without needing a type assertion.
+   * The `type`/`payload` correlation already lives in the {@link RunbookEventInput}
+   * value, so spreading it preserves the discriminated-union relationship and
+   * TypeScript proves assignability to {@link RunbookEventV1} member-by-member
+   * with no type assertion.
    *
-   * @param type - Event type discriminator
-   * @param payload - Event-specific payload
+   * @param input - Pre-correlated `{ type, payload }` event pair
    * @returns Complete RunbookEventV1 event object
-   * @template T - Event type literal
    */
-  private buildEvent<T extends RunbookEventV1['type']>(
-    type: T,
-    payload: PayloadFor<T>,
-  ): RunbookEventV1 {
-    // This function separates the event construction from the generic emit() method.
-    // By using a type assertion here instead of in emit(), we achieve better
-    // separation of concerns: emit() remains focused on subscriber management
-    // while buildEvent() handles the type-casting complexity in one focused location.
-    // The assertion is necessary because TypeScript cannot statically verify that
-    // the provided payload matches the type discriminant, even though our generic
-    // constraints guarantee they match at runtime. See:
-    // https://github.com/microsoft/TypeScript/issues/14094 (discriminated unions in generics)
-
-    // Development-mode validation: verify payload has required fields for event type.
-    // This catches type mismatches that the 'as Extract<...>' assertion bypasses.
-    // Zero cost in production since the entire block is tree-shaken.
-    if (process.env.NODE_ENV !== 'production') {
-      this.validatePayload(type, payload);
-    }
-
+  private buildEvent(input: RunbookEventInput): RunbookEventV1 {
     return {
       v: '1',
-      type,
       ts: new Date().toISOString(),
       runbookId: this.runbookId,
       runbook: this.runbook,
       seq: this.seq,
-      payload,
-    } as Extract<RunbookEventV1, { type: T }>;
-  }
-
-  /**
-   * Validate that payload contains required fields for the given event type.
-   * Only called in development mode. Throws if validation fails.
-   *
-   * @param type - Event type discriminator
-   * @param payload - Payload to validate
-   * @throws {Error} If payload is missing required fields for the event type
-   */
-  private validatePayload<T extends RunbookEventV1['type']>(type: T, payload: PayloadFor<T>): void {
-    // Define required fields for each event type
-    const requiredFields: Record<RunbookEventV1['type'], string[]> = {
-      RUNBOOK_STARTED: ['prompted', 'statePath'],
-      STEP_ENTERED: ['position', 'stepName', 'hasCommand', 'isSubstep', 'prompted'],
-      COMMAND_STARTED: ['command', 'displayCommand', 'position'],
-      COMMAND_COMPLETED: ['command', 'success', 'exitCode', 'position'],
-      STEP_TRANSITIONED: ['action', 'from', 'at', 'result'],
-      POLICY_DENIED: ['command', 'reason', 'position'],
-      RUNBOOK_COMPLETED: ['finalPosition'],
-      RUNBOOK_STOPPED: ['position'],
-      ERROR_OCCURRED: ['message'],
+      ...input,
     };
-
-    // TypeScript guarantees `required` is defined via Record<RunbookEventV1['type'], string[]>.
-    // All event types must be keys in requiredFields - adding a new event type without
-    // updating this record causes a compile-time error.
-    const required = requiredFields[type];
-    const payloadObj = payload as unknown as Record<string, unknown>;
-    const missing = required.filter(
-      (field) => !(field in payloadObj) || payloadObj[field] === undefined,
-    );
-
-    if (missing.length > 0) {
-      throw new Error(
-        `Invalid payload for ${type}: missing required fields: ${missing.join(', ')}`,
-      );
-    }
   }
 
   /**

--- a/packages/core/src/events/emitter.ts
+++ b/packages/core/src/events/emitter.ts
@@ -60,7 +60,13 @@ export class ExecutionEventEmitter {
    * - runbookId: the runbook execution ID
    * - runbook: the runbook reference
    *
+   * Subscribers are invoked synchronously in registration order. Exceptions
+   * thrown by a subscriber callback are not caught and propagate to the caller
+   * of `emit` (a throwing subscriber also prevents later subscribers from
+   * running); callers that cannot tolerate this must guard their subscribers.
+   *
    * @param input - Pre-correlated `{ type, payload }` event pair
+   * @throws Re-throws any error thrown by a subscriber callback
    */
   emit(input: RunbookEventInput): void {
     this.seq++;

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -216,3 +216,18 @@ export type PayloadFor<T extends RunbookEventV1['type']> = Extract<
   RunbookEventV1,
   { type: T }
 >['payload'];
+
+/**
+ * Pre-correlated `{ type, payload }` input pair accepted by the event emitter.
+ *
+ * Derived directly from {@link RunbookEventV1} (the single source of truth for
+ * the event taxonomy), so adding or changing an event member automatically
+ * updates the accepted input shape with no parallel list to maintain. Each
+ * union member pairs an event `type` discriminant with its matching `payload`,
+ * keeping the correlation inside the value. The emitter spreads this pair into
+ * the envelope, so TypeScript verifies the type/payload correlation at every
+ * call site without a type assertion.
+ */
+export type RunbookEventInput = {
+  [E in RunbookEventV1 as E['type']]: { type: E['type']; payload: E['payload'] };
+}[RunbookEventV1['type']];


### PR DESCRIPTION
Closes #430.

## What

Eliminates the unsafe `as Extract<RunbookEventV1, { type: T }>` assertion in `ExecutionEventEmitter.buildEvent` and the runtime `validatePayload` band-aid it required.

The emitter now accepts a **pre-correlated `{ type, payload }` pair** (`RunbookEventInput`, derived from `RunbookEventV1`) and spreads it into the envelope. The type/payload correlation lives in the value rather than an open type variable `T`, so TypeScript verifies it statically — no assertion (this is **Candidate D** from the design note).

## Why

`buildEvent<T>` built `type: T` and `payload: PayloadFor<T>` as two independent generic expressions; TS won't distribute the union over an open `T` to re-correlate them ([microsoft/TypeScript#14094](https://github.com/microsoft/TypeScript/issues/14094)). The assertion papered over that, and a `NODE_ENV !== 'production'`-gated `validatePayload` was the dev-only runtime guard. With the correlation now carried by the value, the compiler enforces it at every call site and both the assertion and the guard are gone.

## Changes

- `packages/core/src/events/types.ts` — add exported, derived `RunbookEventInput`
- `packages/core/src/events/emitter.ts` — `emit`/`buildEvent` take `RunbookEventInput`; spread into envelope; **delete `validatePayload` + the `NODE_ENV` gate**
- Migrate **29 src call sites** (27 concrete `emit('TYPE', {…})` → `emit({ type, payload })`; 2 union-source → `emit(effect.event)`) across `execution.ts`, `transition-orchestrator.ts`, `runbook-pipeline.ts`
- Migrate event emit calls + assertions in core & cli tests
- `docs/internal/event-emitter-type-safety-design.md` — design note (root cause, constraints, four candidates with trade-offs, recommendation)

The public `RunbookEventV1` union and `EventSubscriber` callback shape are unchanged — only the *input* side of `emit` changes.

## Verification

- `npm run build` (parser/core/cli) — pass
- `tsc --noEmit` on src + test configs — exit 0 (proves the assertion-free path type-checks)
- `npm run test:unit` — core **3276 passed** (1 skipped), cli **2003 passed**
- biome + eslint on all changed files — clean

## Note

The class is `ExecutionEventEmitter` (the issue/design note referred to it as `RunbookEventEmitter`); the implementation works against the real symbol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Event emitter API now accepts pre-correlated {type, payload} event objects, replacing the prior type+payload call form and removing the runtime payload validation.
* **Documentation**
  * Added an internal design note explaining the new event shape, the type-safety approach, and the chosen solution.
* **Tests**
  * Updated event-related tests and mocks to emit and assert the new object-shaped events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->