### PR TITLE
feat(plugin): plan→review→execute pipeline + composing-runbooks patterns

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -49,6 +49,7 @@ bashisms
 behaviour
 biome
 biomejs
+bisectable
 callsite
 callsites
 canonicalises
@@ -77,6 +78,7 @@ deserialized
 dirfd
 documentational
 dogfood
+dogfooded
 dogfoods
 dogfooding
 dotdot

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -79,8 +79,8 @@ dirfd
 documentational
 dogfood
 dogfooded
-dogfoods
 dogfooding
+dogfoods
 dotdot
 émoji
 env
@@ -105,7 +105,9 @@ initialisation
 initialise
 initialised
 initialises
+jmespath
 jsdoc
+jsonata
 jsonl
 killall
 landlock

--- a/docs/guides/composing-runbooks.md
+++ b/docs/guides/composing-runbooks.md
@@ -1,0 +1,44 @@
+# Composing Runbooks
+
+How independent, single-artifact runbooks combine into multi-stage workflows. This guide covers *inter*-runbook composition; for *intra*-runbook conventions see [writing-runbooks/house-style.md](../../packages/claude-code-plugin/skills/writing-runbooks/house-style.md), and for delegation mechanics see [agent-orchestration.md](agent-orchestration.md).
+
+The worked example throughout is the planning pipeline: `planning.runbook.md` composes `write-plan` → `review-plan` → `execute-plan`.
+
+## Pattern 1 — Workflow pipeline (artifact handoff)
+
+Stages run in sequence in a shared `ContextId`. Each stage declares what it publishes via frontmatter `OUTPUTS`; the next declares `INPUTS` / `REQUIRED` and rehydrates a naked `ARTIFACTS` alias. `write-plan` publishes `PlanPath`; `review-plan` and `execute-plan` consume it. Never re-derive a child's output path in the parent — consume its declared `OUTPUTS`.
+
+## Pattern 2 — Leaf-delegate, orchestrator-compose (the RD-819 discipline)
+
+A delegated (claimed) child cannot delegate further (`RD-819 DELEGATION_NESTED_FORBIDDEN`). So **delegate only leaves; compose any stage that itself delegates or fans out.** Decision test: *does this child delegate? → compose it (list it inline / `rd run`). Is it a terminal worker? → delegate it (`- DELEGATE`).* In `planning.runbook.md` this is visible in one file: step 1 delegates `write-plan` (a leaf); steps 2–3 compose `review-plan` and `execute-plan` (both delegate internally).
+
+## Pattern 3 — Fan-out + collate
+
+A composed stage delegates N sibling analysis runbooks, then delegates a collation runbook that gathers them with a wildcard artifact or `rdpath find`, deduplicates, and validates against the shared schema. `review-plan` delegates four reviewers then `review-plan-collate`. Never collate from the parent.
+
+## Pattern 4 — Gate loop (iterate-until-clean)
+
+A composed stage runs a **machine-checkable** gate and `FAIL GOTO`s a focused fix step until the gate is met. The runbook's value here is *refusing to advance* on dirty work — enforcement an agent prompt cannot reliably self-impose. `execute-plan` does this twice:
+
+- **Review-clean gate:** a `jq` step counts `level == "error"` items in the code review; clean jumps ahead, dirty falls to the fix step.
+- **Verify gate:** `npm run verify`; red sends work to the same fix step.
+
+Both `GOTO` a single dedicated fix leaf (`address-review`), so each iteration is small and convergent. `GOTO` loops have no engine-level iteration cap — the fix step's body tells the agent when to escalate rather than spin.
+
+## Pattern 5 — Top-level workflow runbook
+
+A thin parent that sequences pipeline stages with explicit aggregation (`- PASS ALL ...` / `- FAIL ANY ...`) and terminates when the final stage completes. `planning.runbook.md` is four frontmatter lines plus three composition steps; all the work lives in the leaves it composes.
+
+## Passing data to a delegated child
+
+A delegated child inherits the shared **artifacts** (e.g. `PlanPath`) and persisted **template variables**. This is the handoff to reach for: produce an artifact upstream, declare it `REQUIRED` in the child, rehydrate it with a naked `ARTIFACTS` alias. `execute-plan` hands the whole plan to `implement-plan` this way and nothing else crosses.
+
+## Future work — iterate-and-delegate (FOR + DELEGATE per item)
+
+The intuitive "loop a data source, delegate one worker per item" has two sharp edges, both validated against the engine. Until there is a first-class pattern for them, the planning pipeline deliberately keeps the per-task walk inside the agent + the [executing-plans](../../packages/claude-code-plugin/skills/executing-plans/SKILL.md) skill rather than expressing it as `FOR`.
+
+1. **A `FOR` source must resolve at the launch of the runbook that contains the `FOR`.** Launch-time validation rejects a `FOR` over a variable or artifact the same runbook produces in an earlier step (`VALIDATION_ERROR: FOR loop references undefined variable`); a frontmatter `inputs:` declaration is not a value. The workaround is to have a *parent* populate the source (via `OUTPUTS`, which needs no seed) and compose a child that iterates the inherited, already-populated source.
+
+2. **The loop variable and `Index` do not cross the delegation boundary.** A delegated child inherits the whole array (and supports index-in like `{{ Tasks.0.name }}`) but not the per-iteration loop variable or `Index`. Passing per-item data to a delegated child therefore needs explicit `--input` forwarding or a per-iteration artifact.
+
+The syntax for `FOR` + `DELEGATE` lives in the parser/core fixtures under `runbooks/for-loops/` and `runbooks/delegation/`.

--- a/docs/guides/composing-runbooks.md
+++ b/docs/guides/composing-runbooks.md
@@ -18,12 +18,14 @@ A composed stage delegates N sibling analysis runbooks, then delegates a collati
 
 ## Pattern 4 — Gate loop (iterate-until-clean)
 
-A composed stage runs a **machine-checkable** gate and `FAIL GOTO`s a focused fix step until the gate is met. The runbook's value here is *refusing to advance* on dirty work — enforcement an agent prompt cannot reliably self-impose. `execute-plan` does this twice:
+A composed stage holds work behind a gate and `FAIL GOTO`s a focused fix step until the gate is met. The runbook's value here is the **loop shape** — *refusing to advance* until a step renders a passing verdict, and routing every failure to one small, convergent fix step. What that verdict *is* is the author's choice; the gate can be machine-checkable or agent-judged:
 
-- **Review-clean gate:** a `jq` step counts `level == "error"` items in the code review; clean jumps ahead, dirty falls to the fix step.
-- **Verify gate:** `npm run verify`; red sends work to the same fix step.
+- **Command gate (machine-checkable):** a step runs a command and its exit code is the verdict — e.g. `execute-plan`'s **verify gate** (`npm run verify`; red routes to the fix step). Use this when the gate is mechanically decidable and you want enforcement an agent prompt cannot soften.
+- **Verdict gate (agent-judged):** a delegated child *owns its own verdict* and reports it as its terminal status — `COMPLETE` → `pass`, `STOP` → `fail`. `execute-plan`'s **review gate** is this: `code-review` ends in a prompted step where the agent judges its recorded review and passes (clean) or stops (blocking findings). The parent reads only the delegation result — `PASS ALL GOTO` verify, `FAIL ANY` falls to the fix step — and never inspects the review JSON. The trade-off is deliberate: an agent *can* rationalize a pass, so reach for a verdict gate when the judgment is inherently qualitative (code review, design sign-off) and a command gate when it isn't.
 
-Both `GOTO` a single dedicated fix leaf (`address-review`), so each iteration is small and convergent. `GOTO` loops have no engine-level iteration cap — the fix step's body tells the agent when to escalate rather than spin.
+Both gates `GOTO` a single dedicated fix leaf (`address-review`), so each iteration is small and convergent. `GOTO` loops have no engine-level iteration cap — the fix step's body tells the agent when to escalate rather than spin.
+
+The verdict-gate form leans on the engine's child-status mapping (a delegated child's `COMPLETE`/`STOP` becomes the parent's `pass`/`fail`). Keeping the verdict *inside* the child — rather than re-deriving it in the parent — also keeps the encapsulation rule of "never re-derive a child's output in the parent" intact: the review owns both its artifact and its verdict.
 
 ## Pattern 5 — Top-level workflow runbook
 

--- a/docs/internal/composing-runbooks-design.md
+++ b/docs/internal/composing-runbooks-design.md
@@ -100,10 +100,14 @@ Use the `converting-skills-to-runbooks` skill to distill the superpowers
   4. **Review-clean gate** — a `jq` step over `CodeReviewPath` counting `level == "error"`
      items; `PASS CONTINUE` / `FAIL GOTO` step 5. Machine-checkable, so "loop until
      clean" has teeth.
-  5. **Address findings** — `- DELEGATE` a fix subagent (given `PlanPath` +
-     `CodeReviewPath`); the `GOTO` target. Loops back to step 3 (re-review).
+  5. **Address findings** — `- DELEGATE address-review.runbook.md` (the dedicated fix
+     leaf, given `PlanPath` + `CodeReviewPath`); the `GOTO` target. Loops back to step 3
+     (re-review). A dedicated leaf — not a re-run of `implement-plan` — so a fix touches
+     only the findings, and no runbook carries an optional/unbound `CodeReviewPath`.
   6. **Verify** — `npm run verify`; `PASS COMPLETE` / `FAIL GOTO` step 5 until green.
-  7. Validate `CodeReviewPath`; `COMPLETE`.
+
+  `CodeReviewPath` is produced (and schema-validated) by the delegated `code-review`
+  leaf and re-exported via `execute-plan`'s frontmatter `OUTPUTS`.
 - **`implement-plan.runbook.md`** (`runbooks/planning/`, delegated leaf) —
   `INPUTS:[PlanPath]` / `REQUIRED:[PlanPath]`: invoke the `executing-plans` skill, read
   `{{ path PlanPath }}`, walk every task per the skill (committing per task as the
@@ -113,6 +117,11 @@ Use the `converting-skills-to-runbooks` skill to distill the superpowers
   implemented changes against the plan, write `CodeReviewPath` validated against
   `review.schema.json` (produce → validate → retry). Single reviewer for the first
   pass; dimension fan-out (mirroring `review-plan`) is future work.
+- **`address-review.runbook.md`** (`runbooks/planning/`, delegated leaf) —
+  `skill: executing-plans`, `INPUTS:[PlanPath, CodeReviewPath]` /
+  `REQUIRED:[PlanPath, CodeReviewPath]`: read the recorded `error`-level findings and
+  resolve them, committing the fix. The `GOTO` target of the review-clean and verify
+  gates. A claimed child, so it **cannot delegate**.
 
 The plan task shape is fixed by `schemas/plan.schema.json`: each task is
 `{ name, files, subtasks, commit }`; the implementer reads them directly from the plan.
@@ -208,8 +217,8 @@ review-clean gate + `npm run verify` loops (`FAIL GOTO` address-findings) → `C
    the documented-not-dogfooded iterate-and-delegate with its two constraints) and is
    cross-linked from `writing-runbooks/house-style.md`.
 2. `executing-plans` skill + `execute-plan.runbook.md` + `implement-plan.runbook.md` +
-   `code-review.runbook.md` exist, follow house style, and pass `rd check` + the
-   conversion checklist.
+   `code-review.runbook.md` + `address-review.runbook.md` exist, follow house style, and
+   pass `rd check` + the conversion checklist.
 3. `planning.runbook.md` is a correct `write → review → execute` pipeline (no stub
    frontmatter/body) with explicit aggregation and `PlanPath` threading; the verify gate
    lives inside `execute-plan`.

--- a/docs/internal/composing-runbooks-design.md
+++ b/docs/internal/composing-runbooks-design.md
@@ -79,7 +79,7 @@ Use the `converting-skills-to-runbooks` skill to distill the superpowers
   TDD cycle, commit discipline, review gates, when to escalate. Cross-links, does not
   restate, `writing-runbooks` / `running-runbooks` / `delegating-runbooks`.
 - **`execute-plan.runbook.md`** (`runbooks/planning/`) — `skill: executing-plans`,
-  `INPUTS:[PlanPath]` / `REQUIRED:[PlanPath]`, `OUTPUTS:[ExecReviewPath]`:
+  `INPUTS:[PlanPath]` / `REQUIRED:[PlanPath]`, `OUTPUTS:[CodeReviewPath]`:
   1. Invoke & read the `executing-plans` skill.
   2. Bind the plan schema read-only.
   3. **Extract tasks** — read `{{ path PlanPath }}`, write `.tasks` to a `TasksPath`
@@ -89,7 +89,7 @@ Use the `converting-skills-to-runbooks` skill to distill the superpowers
      sequentially (ordering preserved); each is delegated to a fresh subagent.
   5. **Review at end** — one review/verify stage after the loop (composed; may itself
      fan out across review dimensions since `execute-plan` is composed, not delegated),
-     writing `ExecReviewPath` validated against `review.schema.json`.
+     writing `CodeReviewPath` validated against `review.schema.json`.
   6. **Verify gate** — build/tests pass (`PASS COMPLETE` / `FAIL GOTO` the review step).
 - **`implement-task.runbook.md`** (`runbooks/planning/`) — the delegated leaf,
   `INPUTS` for the task fields it needs: TDD a single task (write failing test → run →
@@ -103,7 +103,7 @@ The plan task shape is fixed by `schemas/plan.schema.json`: each task is
 ### 3. Rebuilt `planning.runbook.md` (the worked example)
 
 Replace the stub with the true pipeline. Frontmatter declares the contract
-(`OUTPUTS:[PlanPath, ExecReviewPath]` as applicable). Steps, each stating aggregation
+(`OUTPUTS:[PlanPath, ReviewPlanPath, CodeReviewPath]` as applicable). Steps, each stating aggregation
 explicitly and threading `PlanPath` through the shared context:
 
 1. **Write plan** — `- DELEGATE` (leaf), `planning/write-plan.runbook.md`.
@@ -121,9 +121,9 @@ step 1 delegates (leaf); steps 2–3 compose (orchestrators).
 `write-plan` [delegated] writes `PlanPath` artifact in C, exports via frontmatter
 `OUTPUTS` →
 `review-plan` [composed] rehydrates `PlanPath`, fan-out reviewers → collate →
-`ExecReviewPath`/`ReviewPlanPath` →
+`ReviewPlanPath` →
 `execute-plan` [composed] rehydrates `PlanPath`, extracts `TasksPath`, `FOR task` →
-`implement-task` [delegated] per task → end review → verify.
+`implement-task` [delegated] per task → end code review → `CodeReviewPath` → verify.
 
 ## Error handling
 

--- a/docs/internal/composing-runbooks-design.md
+++ b/docs/internal/composing-runbooks-design.md
@@ -66,7 +66,7 @@ canonical worked examples.
 | 1 | **Workflow pipeline (artifact handoff)** | Stages run in sequence; each stage's frontmatter `OUTPUTS` forwards into the shared `ContextId`; the next stage declares `INPUTS`/`REQUIRED` and rehydrates. `write-plan → PlanPath → review-plan / execute-plan`. |
 | 2 | **Leaf-delegate, orchestrator-compose** (the RD-819 discipline) | Delegate only terminal work-doing runbooks; compose any stage that itself fans out or delegates. Decision test: *does this child delegate? → compose it. Is it a leaf? → delegate it.* |
 | 3 | **Fan-out + collate** | A composed stage delegates N sibling analysis runbooks, then a collation runbook (`review-plan`). |
-| 4 | **Gate loop / iterate-until-clean** | A composed stage runs a machine-checkable gate and `FAIL GOTO`s a focused fix step until the gate is met — the runbook's enforcement value is in *refusing to advance* on a dirty review or red verify. `execute-plan`'s review-clean (`jq` error-count) and `npm run verify` loops. |
+| 4 | **Gate loop / iterate-until-clean** | A composed stage holds work behind a gate and `FAIL GOTO`s a focused fix step until the gate is met — the runbook's value is the loop shape: *refusing to advance* until a passing verdict. The gate may be a **command** (exit code is the verdict — `execute-plan`'s `npm run verify`) or a **delegated verdict** (a child owns its verdict and reports it as terminal status; `COMPLETE`→pass, `STOP`→fail — `execute-plan`'s `code-review`, which ends in a prompted gate the agent judges). The parent reads the delegation result, not the review JSON. |
 | 5 | **Top-level workflow runbook** | A thin parent that sequences pipeline stages with explicit aggregation (`planning.runbook.md`). |
 | — | *Documented, not yet dogfooded:* **iterate-and-delegate** (FOR + DELEGATE per item) | The intuitive "loop a data source, delegate one worker per item" has two sharp edges validated by spike (see [Mechanism constraints](#mechanism-constraints-validated)): a `FOR` source must resolve at the **launch** of the runbook that contains the `FOR` (a runbook cannot iterate data it produces itself), and the loop variable + `Index` **do not cross the delegation boundary** (only inherited artifacts/template vars do). The guide documents the pattern, both constraints, and the orchestrator-extracts / explicit-`--input`-forward workarounds, flagged future work and pointing at the root `runbooks/for-loops/` + `runbooks/delegation/` fixtures. The first-pass execute stage deliberately avoids it. |
 
@@ -96,15 +96,17 @@ Use the `converting-skills-to-runbooks` skill to distill the superpowers
   2. **Implement** — `- DELEGATE implement-plan.runbook.md`. The delegated leaf walks
      all tasks. The only data crossing the boundary is the `PlanPath` artifact — the
      exact, proven handoff the e2e runtime test already exercises.
-  3. **Code review** — `- DELEGATE code-review.runbook.md` → `CodeReviewPath`.
-  4. **Review-clean gate** — a `jq` step over `CodeReviewPath` counting `level == "error"`
-     items; `PASS CONTINUE` / `FAIL GOTO` step 5. Machine-checkable, so "loop until
-     clean" has teeth.
-  5. **Address findings** — `- DELEGATE address-review.runbook.md` (the dedicated fix
-     leaf, given `PlanPath` + `CodeReviewPath`); the `GOTO` target. Loops back to step 3
-     (re-review). A dedicated leaf — not a re-run of `implement-plan` — so a fix touches
-     only the findings, and no runbook carries an optional/unbound `CodeReviewPath`.
-  6. **Verify** — `npm run verify`; `PASS COMPLETE` / `FAIL GOTO` step 5 until green.
+  3. **Code review** — `- DELEGATE code-review.runbook.md` → `CodeReviewPath`. The
+     review owns its verdict: a clean review `COMPLETE`s (→ parent `pass`) and jumps to
+     Verify; a review with blocking findings `STOP`s (→ parent `fail`) and falls through
+     to Address. `PASS ALL GOTO` step 5 (verify) / `FAIL ANY CONTINUE`. The parent reads
+     only the delegation result — it never inspects the review JSON.
+  4. **Address findings** — `- DELEGATE address-review.runbook.md` (the dedicated fix
+     leaf, given `PlanPath` + `CodeReviewPath`). Loops back to step 3 (re-review) on
+     success; `FAIL ANY STOP` if it cannot resolve in scope. A dedicated leaf — not a
+     re-run of `implement-plan` — so a fix touches only the findings, and no runbook
+     carries an optional/unbound `CodeReviewPath`.
+  5. **Verify** — `npm run verify`; `PASS COMPLETE` / `FAIL GOTO` step 4 until green.
 
   `CodeReviewPath` is produced (and schema-validated) by the delegated `code-review`
   leaf and re-exported via `execute-plan`'s frontmatter `OUTPUTS`.
@@ -115,13 +117,16 @@ Use the `converting-skills-to-runbooks` skill to distill the superpowers
 - **`code-review.runbook.md`** (`runbooks/planning/`, delegated leaf) —
   `INPUTS:[PlanPath]` / `REQUIRED:[PlanPath]`, `OUTPUTS:[CodeReviewPath]`: review the
   implemented changes against the plan, write `CodeReviewPath` validated against
-  `review.schema.json` (produce → validate → retry). Single reviewer for the first
-  pass; dimension fan-out (mirroring `review-plan`) is future work.
+  `review.schema.json` (produce → validate → retry), then **own the verdict** in a final
+  prompted gate — `PASS COMPLETE` (clean) / `FAIL STOP` (blocking findings). The verdict
+  is agent judgment over the recorded review, not a machine count, so the review carries
+  both its artifact and its pass/fail signal across the delegation boundary. Single
+  reviewer for the first pass; dimension fan-out (mirroring `review-plan`) is future work.
 - **`address-review.runbook.md`** (`runbooks/planning/`, delegated leaf) —
   `skill: executing-plans`, `INPUTS:[PlanPath, CodeReviewPath]` /
   `REQUIRED:[PlanPath, CodeReviewPath]`: read the recorded `error`-level findings and
-  resolve them, committing the fix. The `GOTO` target of the review-clean and verify
-  gates. A claimed child, so it **cannot delegate**.
+  resolve them, committing the fix. The `GOTO` target of the code-review verdict and the
+  verify gate. A claimed child, so it **cannot delegate**.
 
 The plan task shape is fixed by `schemas/plan.schema.json`: each task is
 `{ name, files, subtasks, commit }`; the implementer reads them directly from the plan.
@@ -166,14 +171,15 @@ no-`FOR` execute design and are documented in the guide:
 `review-plan` [composed] rehydrates `PlanPath`, fan-out reviewers → collate →
 `ReviewPlanPath` →
 `execute-plan` [composed] rehydrates `PlanPath` → `implement-plan` [delegated] reads
-`PlanPath`, walks tasks → `code-review` [delegated] → `CodeReviewPath` →
-review-clean gate + `npm run verify` loops (`FAIL GOTO` address-findings) → `COMPLETE`.
+`PlanPath`, walks tasks → `code-review` [delegated] writes `CodeReviewPath` and reports
+its own verdict (`COMPLETE`/`STOP`) → that verdict + `npm run verify` loops
+(`FAIL GOTO` address-findings) → `COMPLETE`.
 
 ## Error handling
 
 - Each artifact-producing runbook keeps its produce → validate → retry loop
   (`FAIL GOTO <write-step>`).
-- `execute-plan`'s review-clean and verify gates `FAIL GOTO` a focused **address-findings**
+- `execute-plan`'s code-review verdict and verify gate `FAIL GOTO` a focused **address-findings**
   step (never back to implement), so each loop iteration is small and convergent.
   `GOTO` loops have no engine-level max-iteration cap — the step body instructs the
   agent when to escalate rather than spin.
@@ -186,8 +192,8 @@ review-clean gate + `npm run verify` loops (`FAIL GOTO` address-findings) → `C
   `__tests__/runbooks/validation.test.ts` to pin the rebuilt `planning.runbook.md`
   structure (it currently asserts nothing about it) and the `execute-plan` /
   `implement-plan` / `code-review` contracts (`INPUTS`/`OUTPUTS`, the delegate frontiers
-  on implement + review, and that the review-clean and verify gates `GOTO` the
-  address-findings step).
+  on implement + review + address, that the code-review verdict and verify gate `GOTO`
+  the address-findings step, and that `code-review` ends in a prompted verdict gate).
 - **Mechanic / runtime.** A small fixture plan JSON → drive `execute-plan` in prompted
   mode and assert it (a) issues a delegation token for `implement-plan` carrying the
   inherited `PlanPath`, (b) issues a token for `code-review`, and (c) the review-clean /

--- a/docs/internal/composing-runbooks-design.md
+++ b/docs/internal/composing-runbooks-design.md
@@ -64,56 +64,90 @@ canonical worked examples.
 | # | Pattern | Rule / example |
 |---|---------|----------------|
 | 1 | **Workflow pipeline (artifact handoff)** | Stages run in sequence; each stage's frontmatter `OUTPUTS` forwards into the shared `ContextId`; the next stage declares `INPUTS`/`REQUIRED` and rehydrates. `write-plan → PlanPath → review-plan / execute-plan`. |
-| 2 | **Leaf-delegate, orchestrator-compose** (the RD-819 discipline) | Delegate only terminal work-doing runbooks; compose any stage that itself fans out. Decision test: *does this child delegate? → compose it. Is it a leaf? → delegate it.* |
+| 2 | **Leaf-delegate, orchestrator-compose** (the RD-819 discipline) | Delegate only terminal work-doing runbooks; compose any stage that itself fans out or delegates. Decision test: *does this child delegate? → compose it. Is it a leaf? → delegate it.* |
 | 3 | **Fan-out + collate** | A composed stage delegates N sibling analysis runbooks, then a collation runbook (`review-plan`). |
-| 4 | **Iterate-and-delegate** (FOR + DELEGATE per item) | Loop a data source, delegate one worker runbook per iteration, aggregate, then a terminal review (`execute-plan`). |
-| 5 | **Top-level workflow runbook** | A thin parent that sequences pipeline stages with explicit aggregation and terminates in a verify (`planning.runbook.md`). |
-| — | *Supporting:* **data-source extraction** | Turn a structured artifact (plan JSON object) into a FOR data source (`tasks.jsonl`) with an extraction step. |
+| 4 | **Gate loop / iterate-until-clean** | A composed stage runs a machine-checkable gate and `FAIL GOTO`s a focused fix step until the gate is met — the runbook's enforcement value is in *refusing to advance* on a dirty review or red verify. `execute-plan`'s review-clean (`jq` error-count) and `npm run verify` loops. |
+| 5 | **Top-level workflow runbook** | A thin parent that sequences pipeline stages with explicit aggregation (`planning.runbook.md`). |
+| — | *Documented, not yet dogfooded:* **iterate-and-delegate** (FOR + DELEGATE per item) | The intuitive "loop a data source, delegate one worker per item" has two sharp edges validated by spike (see [Mechanism constraints](#mechanism-constraints-validated)): a `FOR` source must resolve at the **launch** of the runbook that contains the `FOR` (a runbook cannot iterate data it produces itself), and the loop variable + `Index` **do not cross the delegation boundary** (only inherited artifacts/template vars do). The guide documents the pattern, both constraints, and the orchestrator-extracts / explicit-`--input`-forward workarounds, flagged future work and pointing at the root `runbooks/for-loops/` + `runbooks/delegation/` fixtures. The first-pass execute stage deliberately avoids it. |
 
 ### 2. The execute stage (dogfood-converted from superpowers)
+
+The task walk stays in the agent + skill; Rundown owns the **gates**. The agent is
+already good at "for each task, do the steps" (the superpowers `executing-plans` skill
+*is* that prompt). What an agent is bad at is stopping too early — declaring work done
+on a dirty review or red tests. `execute-plan` therefore does **not** re-encode the
+task iteration as `FOR`; it delegates the whole implementation, then loops review and
+verify gates until they pass. This sidesteps both mechanism constraints above and
+relies only on proven mechanisms (compose, delegate-fan-out-collate, `FAIL GOTO`, and
+artifact inheritance across delegation).
 
 Use the `converting-skills-to-runbooks` skill to distill the superpowers
 `executing-plans` + `subagent-driven-development` skills into:
 
-- **`executing-plans` skill** (`skills/executing-plans/`) — the *context*: per-task
-  TDD cycle, commit discipline, review gates, when to escalate. Cross-links, does not
-  restate, `writing-runbooks` / `running-runbooks` / `delegating-runbooks`.
-- **`execute-plan.runbook.md`** (`runbooks/planning/`) — `skill: executing-plans`,
-  `INPUTS:[PlanPath]` / `REQUIRED:[PlanPath]`, `OUTPUTS:[CodeReviewPath]`:
-  1. Invoke & read the `executing-plans` skill.
-  2. Bind the plan schema read-only.
-  3. **Extract tasks** — read `{{ path PlanPath }}`, write `.tasks` to a `TasksPath`
-     `tasks.jsonl` artifact (one task object per line) via a bash/jq step.
-  4. **`FOR task IN {{ TasksPath }}`** with a single `### implement-task` substep
-     marked `- DELEGATE`; iteration transitions `PASS DEFER` / `FAIL DEFER`. Tasks run
-     sequentially (ordering preserved); each is delegated to a fresh subagent.
-  5. **Review at end** — one review/verify stage after the loop (composed; may itself
-     fan out across review dimensions since `execute-plan` is composed, not delegated),
-     writing `CodeReviewPath` validated against `review.schema.json`.
-  6. **Verify gate** — build/tests pass (`PASS COMPLETE` / `FAIL GOTO` the review step).
-- **`implement-task.runbook.md`** (`runbooks/planning/`) — the delegated leaf,
-  `INPUTS` for the task fields it needs: TDD a single task (write failing test → run →
-  implement → run → commit). It is a claimed child, so it **cannot delegate**; any
-  internal review uses `rd run` composition.
+- **`executing-plans` skill** (`skills/executing-plans/`) — the *context*: the per-task
+  walk (mark in-progress → follow the plan's bite-sized steps → run verifications →
+  commit → mark complete), commit discipline, and when to escalate. Cross-links, does
+  not restate, `writing-runbooks` / `running-runbooks` / `delegating-runbooks`.
+- **`execute-plan.runbook.md`** (`runbooks/planning/`, composed orchestrator) —
+  `skill: executing-plans`, `INPUTS:[PlanPath]` / `REQUIRED:[PlanPath]`,
+  `OUTPUTS:[CodeReviewPath]`:
+  1. Invoke & read the `executing-plans` skill; bind the review schema read-only;
+     rehydrate `PlanPath`.
+  2. **Implement** — `- DELEGATE implement-plan.runbook.md`. The delegated leaf walks
+     all tasks. The only data crossing the boundary is the `PlanPath` artifact — the
+     exact, proven handoff the e2e runtime test already exercises.
+  3. **Code review** — `- DELEGATE code-review.runbook.md` → `CodeReviewPath`.
+  4. **Review-clean gate** — a `jq` step over `CodeReviewPath` counting `level == "error"`
+     items; `PASS CONTINUE` / `FAIL GOTO` step 5. Machine-checkable, so "loop until
+     clean" has teeth.
+  5. **Address findings** — `- DELEGATE` a fix subagent (given `PlanPath` +
+     `CodeReviewPath`); the `GOTO` target. Loops back to step 3 (re-review).
+  6. **Verify** — `npm run verify`; `PASS COMPLETE` / `FAIL GOTO` step 5 until green.
+  7. Validate `CodeReviewPath`; `COMPLETE`.
+- **`implement-plan.runbook.md`** (`runbooks/planning/`, delegated leaf) —
+  `INPUTS:[PlanPath]` / `REQUIRED:[PlanPath]`: invoke the `executing-plans` skill, read
+  `{{ path PlanPath }}`, walk every task per the skill (committing per task as the
+  plan's `commit` blocks direct). A claimed child, so it **cannot delegate**.
+- **`code-review.runbook.md`** (`runbooks/planning/`, delegated leaf) —
+  `INPUTS:[PlanPath]` / `REQUIRED:[PlanPath]`, `OUTPUTS:[CodeReviewPath]`: review the
+  implemented changes against the plan, write `CodeReviewPath` validated against
+  `review.schema.json` (produce → validate → retry). Single reviewer for the first
+  pass; dimension fan-out (mirroring `review-plan`) is future work.
 
 The plan task shape is fixed by `schemas/plan.schema.json`: each task is
-`{ name, files, subtasks, commit }`; dotted access (`{{ task.name }}`) works because
-`.jsonl` items parse as JSON objects.
+`{ name, files, subtasks, commit }`; the implementer reads them directly from the plan.
 
 ### 3. Rebuilt `planning.runbook.md` (the worked example)
 
 Replace the stub with the true pipeline. Frontmatter declares the contract
-(`OUTPUTS:[PlanPath, ReviewPlanPath, CodeReviewPath]` as applicable). Steps, each stating aggregation
+(`OUTPUTS:[PlanPath, ReviewPlanPath, CodeReviewPath]`). Steps, each stating aggregation
 explicitly and threading `PlanPath` through the shared context:
 
 1. **Write plan** — `- DELEGATE` (leaf), `planning/write-plan.runbook.md`.
 2. **Review plan** — composed inline (it fans out), `planning/review-plan.runbook.md`.
-3. **Execute plan** — composed inline (it iterates + delegates),
-   `planning/execute-plan.runbook.md`.
-4. **Verify** — build/tests pass; terminal.
+3. **Execute plan** — composed inline (it delegates + loops gates),
+   `planning/execute-plan.runbook.md`. The `npm run verify` gate lives inside
+   `execute-plan`, so the pipeline terminates on execute completion.
 
 This makes the leaf-delegate / orchestrator-compose discipline visible in one file:
 step 1 delegates (leaf); steps 2–3 compose (orchestrators).
+
+## Mechanism constraints (validated)
+
+Two constraints were confirmed by live spikes against the built CLI; they shaped the
+no-`FOR` execute design and are documented in the guide:
+
+1. **A `FOR` source must resolve at the launch of the runbook containing the `FOR`.**
+   Launch-time validation rejects a `FOR` over a variable/artifact the same runbook
+   produces in an earlier step (`VALIDATION_ERROR: FOR loop references undefined
+   variable`); frontmatter `inputs:` declaration does not satisfy it. A parent may
+   populate the source (via `OUTPUTS`, no seed needed) and compose a child that
+   iterates it — the child inherits a populated source and validates.
+2. **Loop variable and `Index` do not cross the delegation boundary.** A delegated
+   child inherits shared artifacts and persisted template vars (e.g. the whole `Tasks`
+   array, with index-in like `{{ Tasks.0.name }}`), but **not** the per-iteration loop
+   variable or `Index`. Passing per-item data to a delegated child requires explicit
+   `--input` forwarding or a per-iteration artifact.
 
 ## Data flow
 
@@ -122,15 +156,18 @@ step 1 delegates (leaf); steps 2–3 compose (orchestrators).
 `OUTPUTS` →
 `review-plan` [composed] rehydrates `PlanPath`, fan-out reviewers → collate →
 `ReviewPlanPath` →
-`execute-plan` [composed] rehydrates `PlanPath`, extracts `TasksPath`, `FOR task` →
-`implement-task` [delegated] per task → end code review → `CodeReviewPath` → verify.
+`execute-plan` [composed] rehydrates `PlanPath` → `implement-plan` [delegated] reads
+`PlanPath`, walks tasks → `code-review` [delegated] → `CodeReviewPath` →
+review-clean gate + `npm run verify` loops (`FAIL GOTO` address-findings) → `COMPLETE`.
 
 ## Error handling
 
 - Each artifact-producing runbook keeps its produce → validate → retry loop
   (`FAIL GOTO <write-step>`).
-- `FOR`+`DELEGATE` iteration transitions use `DEFER`; aggregation resolves on the
-  parent step. Per-iteration retry budgets apply (existing engine behaviour).
+- `execute-plan`'s review-clean and verify gates `FAIL GOTO` a focused **address-findings**
+  step (never back to implement), so each loop iteration is small and convergent.
+  `GOTO` loops have no engine-level max-iteration cap — the step body instructs the
+  agent when to escalate rather than spin.
 - Stage failures propagate as themselves (`STOP`) — no silent downgrade.
 - No new core/CLI delegation semantics; patterns operate within today's RD-819 model.
 
@@ -139,12 +176,14 @@ step 1 delegates (leaf); steps 2–3 compose (orchestrators).
 - **Static.** `rd check` every new/changed runbook. Extend
   `__tests__/runbooks/validation.test.ts` to pin the rebuilt `planning.runbook.md`
   structure (it currently asserts nothing about it) and the `execute-plan` /
-  `implement-task` contracts (`INPUTS`/`OUTPUTS`, the `FOR`+`DELEGATE` frontier, the
-  extraction step).
-- **Mechanic / runtime.** A small fixture plan JSON → run `execute-plan` and assert the
-  extraction produces `tasks.jsonl` and the `FOR` emits a `delegateFrontier` record per
-  task — a runtime integration test alongside the existing `end-to-end-test-runtime`
-  integration test.
+  `implement-plan` / `code-review` contracts (`INPUTS`/`OUTPUTS`, the delegate frontiers
+  on implement + review, and that the review-clean and verify gates `GOTO` the
+  address-findings step).
+- **Mechanic / runtime.** A small fixture plan JSON → drive `execute-plan` in prompted
+  mode and assert it (a) issues a delegation token for `implement-plan` carrying the
+  inherited `PlanPath`, (b) issues a token for `code-review`, and (c) the review-clean /
+  verify gate steps resolve their `GOTO` targets — a runtime integration test alongside
+  the existing `end-to-end-test-runtime` integration test.
 - **Dogfood validation.** The converted `executing-plans` skill + runbooks pass
   `rd check` and the `converting-skills-to-runbooks` checklist (backbone coverage,
   no-duplication scan, contract consistency).
@@ -154,22 +193,28 @@ step 1 delegates (leaf); steps 2–3 compose (orchestrators).
 
 - No changes to `@rundown-org/core`, `cli`, or `parser` delegation/FOR semantics — the
   patterns work within today's RD-819 single-level model.
-- No new retry/resume policy beyond what `FOR`+`DELEGATE` already provides.
+- **No `FOR`-based per-task delegation in the execute stage** — the task walk lives in
+  the agent + skill for the first pass. Iterate-and-delegate is documented (with its two
+  validated constraints) but not dogfooded; per-task isolation and per-task review
+  checkpoints are future work.
+- No code-review dimension fan-out yet — `code-review` is a single delegated reviewer;
+  the `review-plan`-style fan-out + collate is future work.
 - Not converting every superpowers skill — only `executing-plans` /
   `subagent-driven-development` for the execute stage.
-- The execute stage delegates per task but does not parallelize tasks (ordering deps);
-  parallel task execution is future work.
 
 ## Success criteria
 
-1. `docs/guides/composing-runbooks.md` documents the five patterns with examples and
-   is cross-linked from `writing-runbooks/house-style.md`.
-2. `executing-plans` skill + `execute-plan.runbook.md` + `implement-task.runbook.md`
-   exist, follow house style, and pass `rd check` + the conversion checklist.
-3. `planning.runbook.md` is a correct `write → review → execute → verify` pipeline
-   (no stub frontmatter/body) with explicit aggregation and `PlanPath` threading.
+1. `docs/guides/composing-runbooks.md` documents the patterns (incl. the gate loop and
+   the documented-not-dogfooded iterate-and-delegate with its two constraints) and is
+   cross-linked from `writing-runbooks/house-style.md`.
+2. `executing-plans` skill + `execute-plan.runbook.md` + `implement-plan.runbook.md` +
+   `code-review.runbook.md` exist, follow house style, and pass `rd check` + the
+   conversion checklist.
+3. `planning.runbook.md` is a correct `write → review → execute` pipeline (no stub
+   frontmatter/body) with explicit aggregation and `PlanPath` threading; the verify gate
+   lives inside `execute-plan`.
 4. `validation.test.ts` pins the new/rebuilt runbook structures; a runtime test
-   exercises the `execute-plan` extraction + `FOR`/`DELEGATE` frontier.
+   exercises `execute-plan`'s delegate-implement + code-review + gate-loop wiring.
 5. `npm run verify` passes.
 
 ## Dependencies

--- a/docs/internal/composing-runbooks-design.md
+++ b/docs/internal/composing-runbooks-design.md
@@ -1,0 +1,179 @@
+# Composing Runbooks — Design
+
+**Date:** 2026-06-11
+**Status:** Approved (brainstorming)
+**Author:** Toby Hede
+
+## Goal
+
+Establish reusable **composition patterns** for Rundown runbooks, and prove them by
+building the full **plan → review → execute → verify** workflow. Today `write-plan`
+and `review-plan` exist, but there is no execute stage and `planning.runbook.md` is a
+broken stub. This work codifies how runbooks compose into multi-stage workflows and
+delivers the missing execute capability as the worked example.
+
+Rundown's purpose is orchestrating workflow. Composition is how independent,
+single-artifact runbooks combine into a larger flow without re-deriving each other's
+internals — the patterns make that combination consistent and correct.
+
+## Background — what exists today
+
+- **List composition.** A parent step lists child runbook paths; they run inline, or
+  with `- DELEGATE` they fan out to subagents.
+- **Fan-out + collate.** `review-plan.runbook.md` delegates four reviewer runbooks
+  (step 3) then a collation runbook (step 4).
+- **Artifact handoff.** A child's frontmatter `OUTPUTS` forwards into the shared
+  `ContextId`; the next stage declares `INPUTS`/`REQUIRED` and rehydrates
+  (`write-plan` → `PlanPath` → `review-plan`).
+
+### The constraint that governs composition — RD-819 (single-level delegation)
+
+A *delegated* (claimed) child runbook may not delegate further (`createDelegation`
+refuses with `RD-819 DELEGATION_NESTED_FORBIDDEN`). When a claimed child needs another
+runbook it must **compose** via `rd run` in a substep body — composition is
+unrestricted; delegation is single-level.
+
+This is already implicit in `planning.runbook.md`: `write-plan` uses `- DELEGATE`, but
+`review-plan` is composed inline — it *has* to be, because `review-plan` itself
+delegates its four reviewers. The undocumented discipline:
+
+> **Delegate leaves; compose orchestrators.** Only terminal work-doing runbooks get
+> `- DELEGATE`. Any stage that itself fans out must be composed (inline list / `rd
+> run`), never delegated.
+
+### The gaps
+
+1. `planning.runbook.md` is a stub — frontmatter `name: End-to-End Test`, body copied
+   from the e2e test; not a plan→review→execute flow, no `INPUTS`/`OUTPUTS` contract.
+2. No execute stage — no `execute-plan` runbook and no `executing-plans` skill (the
+   superpowers flow has `executing-plans` + `subagent-driven-development`; rundown
+   stops at plan + review).
+3. The composition patterns are written down nowhere — `writing-runbooks/house-style.md`
+   covers *intra*-runbook artifact pipelines; *inter*-runbook composition is not codified.
+
+## Components
+
+### 1. Composition patterns guide — `docs/guides/composing-runbooks.md`
+
+A new guide (sibling to `docs/guides/agent-orchestration.md`, which already holds the
+delegation *mechanics*), cross-linked from `writing-runbooks/house-style.md`. It
+documents five patterns, each with a minimal example and the rule behind it. The
+guide cites the rebuilt `planning.runbook.md` and the execute-stage runbooks as the
+canonical worked examples.
+
+| # | Pattern | Rule / example |
+|---|---------|----------------|
+| 1 | **Workflow pipeline (artifact handoff)** | Stages run in sequence; each stage's frontmatter `OUTPUTS` forwards into the shared `ContextId`; the next stage declares `INPUTS`/`REQUIRED` and rehydrates. `write-plan → PlanPath → review-plan / execute-plan`. |
+| 2 | **Leaf-delegate, orchestrator-compose** (the RD-819 discipline) | Delegate only terminal work-doing runbooks; compose any stage that itself fans out. Decision test: *does this child delegate? → compose it. Is it a leaf? → delegate it.* |
+| 3 | **Fan-out + collate** | A composed stage delegates N sibling analysis runbooks, then a collation runbook (`review-plan`). |
+| 4 | **Iterate-and-delegate** (FOR + DELEGATE per item) | Loop a data source, delegate one worker runbook per iteration, aggregate, then a terminal review (`execute-plan`). |
+| 5 | **Top-level workflow runbook** | A thin parent that sequences pipeline stages with explicit aggregation and terminates in a verify (`planning.runbook.md`). |
+| — | *Supporting:* **data-source extraction** | Turn a structured artifact (plan JSON object) into a FOR data source (`tasks.jsonl`) with an extraction step. |
+
+### 2. The execute stage (dogfood-converted from superpowers)
+
+Use the `converting-skills-to-runbooks` skill to distill the superpowers
+`executing-plans` + `subagent-driven-development` skills into:
+
+- **`executing-plans` skill** (`skills/executing-plans/`) — the *context*: per-task
+  TDD cycle, commit discipline, review gates, when to escalate. Cross-links, does not
+  restate, `writing-runbooks` / `running-runbooks` / `delegating-runbooks`.
+- **`execute-plan.runbook.md`** (`runbooks/planning/`) — `skill: executing-plans`,
+  `INPUTS:[PlanPath]` / `REQUIRED:[PlanPath]`, `OUTPUTS:[ExecReviewPath]`:
+  1. Invoke & read the `executing-plans` skill.
+  2. Bind the plan schema read-only.
+  3. **Extract tasks** — read `{{ path PlanPath }}`, write `.tasks` to a `TasksPath`
+     `tasks.jsonl` artifact (one task object per line) via a bash/jq step.
+  4. **`FOR task IN {{ TasksPath }}`** with a single `### implement-task` substep
+     marked `- DELEGATE`; iteration transitions `PASS DEFER` / `FAIL DEFER`. Tasks run
+     sequentially (ordering preserved); each is delegated to a fresh subagent.
+  5. **Review at end** — one review/verify stage after the loop (composed; may itself
+     fan out across review dimensions since `execute-plan` is composed, not delegated),
+     writing `ExecReviewPath` validated against `review.schema.json`.
+  6. **Verify gate** — build/tests pass (`PASS COMPLETE` / `FAIL GOTO` the review step).
+- **`implement-task.runbook.md`** (`runbooks/planning/`) — the delegated leaf,
+  `INPUTS` for the task fields it needs: TDD a single task (write failing test → run →
+  implement → run → commit). It is a claimed child, so it **cannot delegate**; any
+  internal review uses `rd run` composition.
+
+The plan task shape is fixed by `schemas/plan.schema.json`: each task is
+`{ name, files, subtasks, commit }`; dotted access (`{{ task.name }}`) works because
+`.jsonl` items parse as JSON objects.
+
+### 3. Rebuilt `planning.runbook.md` (the worked example)
+
+Replace the stub with the true pipeline. Frontmatter declares the contract
+(`OUTPUTS:[PlanPath, ExecReviewPath]` as applicable). Steps, each stating aggregation
+explicitly and threading `PlanPath` through the shared context:
+
+1. **Write plan** — `- DELEGATE` (leaf), `planning/write-plan.runbook.md`.
+2. **Review plan** — composed inline (it fans out), `planning/review-plan.runbook.md`.
+3. **Execute plan** — composed inline (it iterates + delegates),
+   `planning/execute-plan.runbook.md`.
+4. **Verify** — build/tests pass; terminal.
+
+This makes the leaf-delegate / orchestrator-compose discipline visible in one file:
+step 1 delegates (leaf); steps 2–3 compose (orchestrators).
+
+## Data flow
+
+`planning` (context C) →
+`write-plan` [delegated] writes `PlanPath` artifact in C, exports via frontmatter
+`OUTPUTS` →
+`review-plan` [composed] rehydrates `PlanPath`, fan-out reviewers → collate →
+`ExecReviewPath`/`ReviewPlanPath` →
+`execute-plan` [composed] rehydrates `PlanPath`, extracts `TasksPath`, `FOR task` →
+`implement-task` [delegated] per task → end review → verify.
+
+## Error handling
+
+- Each artifact-producing runbook keeps its produce → validate → retry loop
+  (`FAIL GOTO <write-step>`).
+- `FOR`+`DELEGATE` iteration transitions use `DEFER`; aggregation resolves on the
+  parent step. Per-iteration retry budgets apply (existing engine behaviour).
+- Stage failures propagate as themselves (`STOP`) — no silent downgrade.
+- No new core/CLI delegation semantics; patterns operate within today's RD-819 model.
+
+## Testing
+
+- **Static.** `rd check` every new/changed runbook. Extend
+  `__tests__/runbooks/validation.test.ts` to pin the rebuilt `planning.runbook.md`
+  structure (it currently asserts nothing about it) and the `execute-plan` /
+  `implement-task` contracts (`INPUTS`/`OUTPUTS`, the `FOR`+`DELEGATE` frontier, the
+  extraction step).
+- **Mechanic / runtime.** A small fixture plan JSON → run `execute-plan` and assert the
+  extraction produces `tasks.jsonl` and the `FOR` emits a `delegateFrontier` record per
+  task — a runtime integration test alongside the existing `end-to-end-test-runtime`
+  integration test.
+- **Dogfood validation.** The converted `executing-plans` skill + runbooks pass
+  `rd check` and the `converting-skills-to-runbooks` checklist (backbone coverage,
+  no-duplication scan, contract consistency).
+- `npm run verify` passes (format, spell, lint, test).
+
+## Out of scope (YAGNI)
+
+- No changes to `@rundown-org/core`, `cli`, or `parser` delegation/FOR semantics — the
+  patterns work within today's RD-819 single-level model.
+- No new retry/resume policy beyond what `FOR`+`DELEGATE` already provides.
+- Not converting every superpowers skill — only `executing-plans` /
+  `subagent-driven-development` for the execute stage.
+- The execute stage delegates per task but does not parallelize tasks (ordering deps);
+  parallel task execution is future work.
+
+## Success criteria
+
+1. `docs/guides/composing-runbooks.md` documents the five patterns with examples and
+   is cross-linked from `writing-runbooks/house-style.md`.
+2. `executing-plans` skill + `execute-plan.runbook.md` + `implement-task.runbook.md`
+   exist, follow house style, and pass `rd check` + the conversion checklist.
+3. `planning.runbook.md` is a correct `write → review → execute → verify` pipeline
+   (no stub frontmatter/body) with explicit aggregation and `PlanPath` threading.
+4. `validation.test.ts` pins the new/rebuilt runbook structures; a runtime test
+   exercises the `execute-plan` extraction + `FOR`/`DELEGATE` frontier.
+5. `npm run verify` passes.
+
+## Dependencies
+
+Builds on the `converting-skills-to-runbooks` skill (PR #432, branch
+`feat/converting-skills-to-runbooks`). This work branches from it; rebase onto `main`
+after #432 merges.

--- a/docs/internal/planning-pipeline-flow.md
+++ b/docs/internal/planning-pipeline-flow.md
@@ -1,0 +1,150 @@
+# Planning Pipeline Flow
+
+The `planning` runbook is a three-stage pipeline — **write the plan**, **review the plan**, **execute the plan** — composed from smaller runbooks under `packages/claude-code-plugin/runbooks/planning/` (with the four reviewer runbooks and the collator under the `planning/review/` subdirectory). The discipline is consistent: the top-level orchestrator (`meta/planning.runbook.md`) and `execute-plan` push real work to **delegated children** (a `- DELEGATE` step hands a child runbook to a separate agent/context, whose terminal lifecycle maps back to the parent's result — child `COMPLETE` → parent `pass`, child `STOP` → parent `fail`), while orchestration runbooks that simply sequence other runbooks **compose** them (a substep list with no `- DELEGATE` marker runs inline in the same context). A delegated step that lists a single child is a *leaf delegate*; a fan-out step lists several children and aggregates them with `PASS ALL` / `FAIL ANY`.
+
+The gates worth tracking are all in `execute-plan`: the **code-review verdict loop** (code review fails → address findings → re-review) and the **verify loop** (verify fails → address findings → re-review → re-verify). The code-review child owns its own verdict via a final prompted gate step; there is no separate `jq` gate in `execute-plan`.
+
+## Legend
+
+```mermaid
+flowchart LR
+  D["DELEGATE child<br/>(separate context)"]:::delegate
+  C["composed stage<br/>(inline)"]:::compose
+  G["command / prompt gate"]:::gate
+  T(["terminal: COMPLETE / STOP"]):::terminal
+  A["step n"] -. "GOTO back-edge" .-> B["step m"]
+
+  classDef delegate fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+  classDef compose fill:#dcfce7,stroke:#16a34a,color:#14532d;
+  classDef gate fill:#fef9c3,stroke:#ca8a04,color:#713f12;
+  classDef terminal fill:#f3e8ff,stroke:#9333ea,color:#581c87;
+```
+
+- **DELEGATE child** (blue): step hands a child runbook to a separate agent/context; the child's terminal status maps back to the parent — `COMPLETE` → parent `pass`, `STOP` → parent `fail`.
+- **composed stage** (green): substep list runs inline in the current context.
+- **command / prompt gate** (yellow): a step whose result comes from a shell command or a prompted human/agent verdict.
+- **GOTO back-edge** (dotted): a `GOTO <n>` jump, usually looping backward.
+- **terminal** (purple, stadium): `COMPLETE` (success) or `STOP` (failure) ends the runbook.
+
+## 1. Top-level: `planning` (write → review → execute)
+
+`meta/planning.runbook.md`. Step 1 is a leaf DELEGATE; steps 2 and 3 compose their stage runbooks inline. Every step stops the pipeline on failure (`FAIL ANY STOP`); the final stage completes it (`PASS ALL COMPLETE`).
+
+```mermaid
+flowchart TD
+  start([planning]) --> s1
+
+  s1["1. Write the plan<br/>(DELEGATE write-plan)"]:::delegate
+  s2["2. Review the plan<br/>(composes review-plan)"]:::compose
+  s3["3. Execute the plan<br/>(composes execute-plan)"]:::compose
+
+  s1 -- "PASS ALL→CONTINUE" --> s2
+  s1 -- "FAIL ANY→STOP" --> stop1(["STOP"]):::terminal
+
+  s2 -- "PASS ALL→CONTINUE" --> s3
+  s2 -- "FAIL ANY→STOP" --> stop2(["STOP"]):::terminal
+
+  s3 -- "PASS ALL→COMPLETE" --> done(["COMPLETE"]):::terminal
+  s3 -- "FAIL ANY→STOP" --> stop3(["STOP"]):::terminal
+
+  classDef delegate fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+  classDef compose fill:#dcfce7,stroke:#16a34a,color:#14532d;
+  classDef terminal fill:#f3e8ff,stroke:#9333ea,color:#581c87;
+```
+
+## 2. Review stage: `review-plan` (fan-out + collate)
+
+`planning/review-plan.runbook.md`. Steps 1–2 are inline find/context checks. Step 3 is a DELEGATE **fan-out** to four reviewer runbooks, aggregated `PASS ALL CONTINUE` / `FAIL ANY STOP`. Step 4 is a leaf DELEGATE to the collator, which completes the stage.
+
+```mermaid
+flowchart TD
+  start([review-plan]) --> r1
+
+  r1["1. Find plan<br/>(read PlanPath)"]:::gate
+  r2["2. Context and scope"]:::gate
+  r1 -- "PASS→CONTINUE" --> r2
+  r1 -- "FAIL→STOP" --> stopA(["STOP"]):::terminal
+  r2 -- "PASS→CONTINUE" --> r3
+  r2 -- "FAIL→STOP" --> stopB(["STOP"]):::terminal
+
+  r3["3. Delegate subagents to review<br/>(DELEGATE × 4, fan-out)"]:::delegate
+
+  r3 --> ra["review-plan-technical-accuracy"]:::delegate
+  r3 --> rb["review-plan-structural-integrity"]:::delegate
+  r3 --> rc["review-plan-build-runtime"]:::delegate
+  r3 --> rd["review-plan-risk-safety"]:::delegate
+
+  r3 -- "FAIL ANY→STOP" --> stopC(["STOP"]):::terminal
+  r3 -- "PASS ALL→CONTINUE" --> r4
+
+  r4["4. Collate review findings<br/>(DELEGATE review-plan-collate)"]:::delegate
+  r4 -- "PASS ALL→COMPLETE" --> doneR(["COMPLETE"]):::terminal
+  r4 -- "FAIL ANY→STOP" --> stopD(["STOP"]):::terminal
+
+  classDef delegate fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+  classDef gate fill:#fef9c3,stroke:#ca8a04,color:#713f12;
+  classDef terminal fill:#f3e8ff,stroke:#9333ea,color:#581c87;
+```
+
+Each reviewer runbook writes a `*-review-plan-*-*.json` file and self-completes; the four findings flagged in their step 3 use `FAIL CONTINUE` so a finding records into the JSON rather than failing the reviewer — a reviewer only `STOP`s on operational failure (e.g. missing schema). `review-plan-collate` merges and deduplicates those files into `ReviewPlanPath`.
+
+## 3. Execute stage: `execute-plan` (review loop + verify loop)
+
+`planning/execute-plan.runbook.md`. Step 1 reads the skill inline. Steps 2–4 are DELEGATE children; step 5 is a shell-command gate. Two loops:
+
+- **Code-review verdict loop:** step 3 delegates `code-review`. Its child's terminal status *is* the verdict (its step 7 prompted gate: clean → `COMPLETE`, blocking findings → `STOP`). Child `COMPLETE` → step 3 `pass` → `GOTO 5` (skip straight to verify). Child `STOP` → step 3 `fail` → `CONTINUE` to step 4 (address). Step 4 (`address-review`) on success loops `GOTO 3` to re-review.
+- **Verify loop:** step 5 runs `npm run verify`. Pass → `COMPLETE`. Fail → `GOTO 4` to address the verify failure, which re-reviews (`GOTO 3`) and re-verifies.
+
+```mermaid
+flowchart TD
+  start([execute-plan]) --> e1
+
+  e1["1. Invoke executing-plans skill"]:::gate
+  e1 -- "PASS→CONTINUE" --> e2
+  e1 -- "FAIL→STOP" --> stopE1(["STOP"]):::terminal
+
+  e2["2. Implement the plan<br/>(DELEGATE implement-plan)"]:::delegate
+  e2 -- "PASS ALL→CONTINUE" --> e3
+  e2 -- "FAIL ANY→STOP" --> stopE2(["STOP"]):::terminal
+
+  e3["3. Code review<br/>(DELEGATE code-review)"]:::delegate
+  e4["4. Address review findings<br/>(DELEGATE address-review)"]:::delegate
+  e5["5. Verify<br/>(npm run verify)"]:::gate
+
+  e3 -- "PASS ALL→GOTO 5<br/>(review clean)" --> e5
+  e3 -- "FAIL ANY→CONTINUE<br/>(blocking findings)" --> e4
+
+  e4 -- "PASS ALL→GOTO 3<br/>(re-review)" -.-> e3
+  e4 -- "FAIL ANY→STOP" --> stopE4(["STOP"]):::terminal
+
+  e5 -- "PASS→COMPLETE" --> doneE(["COMPLETE"]):::terminal
+  e5 -- "FAIL→GOTO 4<br/>(fix & re-verify)" -.-> e4
+
+  classDef delegate fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+  classDef gate fill:#fef9c3,stroke:#ca8a04,color:#713f12;
+  classDef terminal fill:#f3e8ff,stroke:#9333ea,color:#581c87;
+```
+
+### How `code-review`'s verdict drives execute-plan step 3
+
+`planning/code-review.runbook.md` records findings then renders the verdict in its **final prompted gate** (step 7), which is what the parent reads:
+
+```mermaid
+flowchart TD
+  start([code-review]) --> c1
+  c1["1. Read review schema"]:::gate --> c2["2. Read the plan"]:::gate
+  c2 --> c3["3. Review changes<br/>(FAIL CONTINUE — record, don't gate)"]:::gate
+  c3 --> c4["4. Output path"]:::gate
+  c4 --> c5["5. Write the review (JSON)"]:::gate
+  c5 --> c6["6. Check schema<br/>(FAIL→GOTO 5)"]:::gate
+  c6 -. "FAIL→GOTO 5" .-> c5
+  c6 --> c7["7. Gate the review (PROMPTED verdict)"]:::gate
+
+  c7 -- "PASS→COMPLETE<br/>(clean → parent step 3 pass → GOTO 5)" --> doneC(["COMPLETE"]):::terminal
+  c7 -- "FAIL→STOP<br/>(blocking → parent step 3 fail → CONTINUE)" --> stopC(["STOP"]):::terminal
+
+  classDef gate fill:#fef9c3,stroke:#ca8a04,color:#713f12;
+  classDef terminal fill:#f3e8ff,stroke:#9333ea,color:#581c87;
+```
+
+`implement-plan` (step 2 child) and `address-review` (step 4 child) are both straightforward executing-plans children: read the plan (and, for `address-review`, the recorded findings), do the work committing per task, then `COMPLETE` on success or `STOP` when blocked.

--- a/docs/internal/plans/composing-runbooks-plan.md
+++ b/docs/internal/plans/composing-runbooks-plan.md
@@ -1,0 +1,1103 @@
+# Composing Runbooks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the plan → review → execute pipeline as the worked example of Rundown composition patterns, with the execute stage built as a delegated implementer behind looping code-review and `npm run verify` gates (no `FOR`).
+
+**Architecture:** The task walk lives in the agent + a converted `executing-plans` skill; Rundown owns the gates. `execute-plan` delegates one `implement-plan` leaf (only `PlanPath` crosses the delegation boundary — the proven artifact handoff), delegates a `code-review` leaf, then loops a machine-checkable review-clean gate (`jq` error count) and `npm run verify`, each `FAIL GOTO` a dedicated `address-review` fix leaf. `planning.runbook.md` composes write (delegate) → review (compose) → execute (compose). A new guide documents the patterns, including the two `FOR`/delegation constraints validated by spike.
+
+**Tech Stack:** Rundown runbooks (markdown), Claude plugin skill (markdown), Jest + `@rundown-org/parser` (static structure tests), subprocess CLI integration test (`runCli` harness), `jq`.
+
+**Spec:** `docs/internal/composing-runbooks-design.md`. The five runbook bodies in Tasks 2–6 are pre-validated: each passes `rd check` and parses to the structure the tests assert.
+
+**Conventions (read once):**
+- Runbooks live under `packages/claude-code-plugin/runbooks/`. New planning runbooks go in `runbooks/planning/`.
+- House style: blank line after the `## N. Heading`, the directive block, a blank line, then the prose body; **two** blank lines between steps. Reference artifacts as `{{ path Alias }}` — never hardcode. State aggregation explicitly on compose/delegate steps (`- PASS ALL CONTINUE` / `- FAIL ANY STOP`).
+- Build is current (`packages/cli/dist/cli.js` exists). The CLI is invoked as `node packages/cli/dist/cli.js` in this repo (`rd` is shell-aliased to `rmdir` on this machine). All commands below assume CWD = the worktree root `/Users/tobyhede/psrc/rundown/.worktrees/composing-runbooks` unless noted.
+- Run the plugin Jest suite with: `npm test -w @rundown-org/claude-code-plugin -- <path-or-pattern>` (there is no root `--selectProjects` config).
+
+---
+
+### Task 1: Convert the `executing-plans` skill
+
+Dogfood the `converting-skills-to-runbooks` skill: distill superpowers `executing-plans` + `subagent-driven-development` into the **context** for the task walk. The skill holds the per-task cycle, commit discipline, and escalation; it cross-links rather than restates, and it explicitly cedes the *sequence and gates* to the `execute-plan` runbook.
+
+**Files:**
+- Create: `packages/claude-code-plugin/skills/executing-plans/SKILL.md`
+- Test: `packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts`
+
+- [ ] **Step 1: Write the failing skill test**
+
+Create `packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts`:
+
+```typescript
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const skillPath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'skills',
+  'executing-plans',
+  'SKILL.md',
+);
+
+function readSkill(): string {
+  return readFileSync(skillPath, 'utf-8');
+}
+
+describe('executing-plans skill', () => {
+  it('declares kebab-case name and a description', () => {
+    const skill = readSkill();
+    expect(skill).toMatch(/^name:\s*executing-plans\s*$/m);
+    expect(skill).toMatch(/^description:\s*\S+/m);
+  });
+
+  it('describes the per-task cycle as the context, not the sequence', () => {
+    const skill = readSkill();
+    expect(skill).toMatch(/per-task/i);
+    expect(skill).toMatch(/commit/i);
+    // Cedes the sequence + gates to the runbook rather than restating them.
+    expect(skill).toMatch(/execute-plan/);
+  });
+
+  it('cross-links related skills instead of restating them', () => {
+    const skill = readSkill();
+    expect(skill).toMatch(/writing-plans/);
+    expect(skill).toMatch(/running-runbooks/);
+    expect(skill).toMatch(/delegating-runbooks/);
+  });
+
+  it('tells the implementer when to stop and escalate', () => {
+    const skill = readSkill();
+    expect(skill).toMatch(/escalat|stop/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- executing-plans.test.ts`
+Expected: FAIL — `ENOENT` / `SKILL.md` does not exist.
+
+- [ ] **Step 3: Write the skill**
+
+Create `packages/claude-code-plugin/skills/executing-plans/SKILL.md`:
+
+```markdown
+---
+name: executing-plans
+description: Use when implementing a written plan task-by-task — the per-task cycle, commit discipline, and escalation rules that an execute-plan runbook orchestrates around.
+---
+
+# Executing Plans
+
+Implement a written plan one task at a time, holding each task to its own tests and committing as you go. This skill is the **context** an execution runbook orchestrates: how to do each task well. The [`execute-plan`](../../runbooks/planning/execute-plan.runbook.md) runbook owns the *sequence* (implement → review → verify) and the *gates*; this skill owns the *craft* of a single task.
+
+Rundown orchestrates workflow; it does not store craft. Keep the cycle here, not in the runbook.
+
+## When to Use
+
+- Implementing a plan produced by [writing-plans](../writing-plans/SKILL.md), whether driven by the `execute-plan` runbook or by hand.
+- Resolving review findings against an already-implemented plan.
+
+## When NOT to Use
+
+- Writing the plan — use [writing-plans](../writing-plans/SKILL.md).
+- Authoring or sequencing the runbook that drives execution — use [writing-runbooks](../writing-runbooks/SKILL.md) and [delegating-runbooks](../delegating-runbooks/SKILL.md).
+
+## The Per-Task Cycle
+
+Work the plan's tasks in order. For each task:
+
+1. **Follow its bite-sized steps exactly.** A well-written task is TDD-shaped: write the failing test, run it red, implement the minimum, run it green.
+2. **Run the verifications the task specifies.** Do not skip them.
+3. **Commit per the task's `commit` block** before starting the next task.
+4. **Keep moving.** Do not pause between tasks to check in — execute the whole plan. Stop only to escalate (below).
+
+## Commit Discipline
+
+One commit per task, staging exactly the files the task's `commit.files` lists, with the task's `commit.message`. Frequent, atomic commits keep the work bisectable and give the review and verify gates a clean history to act on.
+
+## Review and Verify Gates
+
+The `execute-plan` runbook reviews the implemented changes and runs `npm run verify` after implementation, looping a fix step until both are clean. Your responsibility is to make those gates *reachable*: leave the tree building, tests passing for the work you did, and changes scoped to the plan. When a gate sends work back (via `address-review`), resolve the recorded `error`-level findings without expanding scope.
+
+## When to Stop and Escalate
+
+Stop and ask rather than guess when:
+
+- A dependency, file, or symbol the plan references does not exist.
+- A task's instruction is ambiguous or contradicts the codebase.
+- A verification fails repeatedly and the fix is unclear.
+- The plan has a gap that prevents starting a task.
+
+Never start implementation on `main`/`master` without explicit consent.
+
+## Reference
+
+- [writing-plans](../writing-plans/SKILL.md) — produces the plan this skill executes
+- [running-runbooks](../running-runbooks/SKILL.md) — executing the driving runbook
+- [delegating-runbooks](../delegating-runbooks/SKILL.md) — parent-side delegation of the implementer
+- [composing-runbooks.md](../../../../docs/guides/composing-runbooks.md) — how execute-plan composes the leaves
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- executing-plans.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/claude-code-plugin/skills/executing-plans/SKILL.md packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts
+git commit -m "feat(plugin): add executing-plans skill (converted context for the task walk)"
+```
+
+---
+
+### Task 2: `implement-plan` runbook (delegated leaf)
+
+The leaf that walks every task in the plan. Inherits only `PlanPath`. Pure leaf — no substeps, cannot delegate.
+
+**Files:**
+- Create: `packages/claude-code-plugin/runbooks/planning/implement-plan.runbook.md`
+- Modify (add a `describe` block): `packages/claude-code-plugin/__tests__/runbooks/validation.test.ts`
+
+- [ ] **Step 1: Write the failing structure test**
+
+In `packages/claude-code-plugin/__tests__/runbooks/validation.test.ts`, add this block inside the top-level `describe('Built-in Runbook Validation', ...)` (after the existing `describe('end-to-end test workflow', ...)` block), reusing the file's existing helpers (`readRunbook`, `frontmatterOutputNames`):
+
+```typescript
+  describe('planning execute pipeline', () => {
+    function frontmatterText(relativePath: string): string {
+      return readFileSync(join(runbooksDir, relativePath), 'utf-8');
+    }
+
+    it('implement-plan is a delegated leaf that invokes the executing-plans skill', () => {
+      const rel = 'planning/implement-plan.runbook.md';
+      const runbook = readRunbook(rel);
+      expect(runbook.name).toBe('implement-plan');
+      // Leaf: no substeps anywhere (cannot delegate).
+      expect(runbook.steps.every((step) => !stepHasSubsteps(step))).toBe(true);
+      expect(runbook.steps.map((step) => step.description)).toEqual([
+        'Invoke the Executing Plans skill',
+        'Read the plan',
+        'Implement every task',
+      ]);
+      expect(frontmatterText(rel)).toMatch(/^skill:\s*executing-plans\s*$/m);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: FAIL — `readRunbook` throws `ENOENT` for `planning/implement-plan.runbook.md`.
+
+- [ ] **Step 3: Write the runbook**
+
+Create `packages/claude-code-plugin/runbooks/planning/implement-plan.runbook.md` exactly (this content passes `rd check`):
+
+```markdown
+---
+name: implement-plan
+description: Implement every task in a plan via the executing-plans skill, committing per task.
+skill: executing-plans
+tags:
+  - planning
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+---
+
+# Implement Plan
+
+Execute every task in the plan, following the executing-plans skill.
+
+## 1. Invoke the Executing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the executing-plans skill. Internalize the per-task cycle, commit discipline, and when to stop and escalate.
+
+Skill: `rundown:executing-plans`
+
+
+## 2. Read the plan
+- ARTIFACTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan at `{{ path PlanPath }}`. Review it critically before starting; if it has gaps that prevent starting, stop and escalate.
+
+
+## 3. Implement every task
+- PASS COMPLETE
+- FAIL STOP
+
+Work through the plan's tasks in order. For each task: follow its bite-sized steps exactly, run the verifications it specifies, and make its commit before the next task. Do not pause between tasks; stop only when blocked or when every task is complete.
+```
+
+- [ ] **Step 4: Verify the runbook checks and the test passes**
+
+Run: `node packages/cli/dist/cli.js check packages/claude-code-plugin/runbooks/planning/implement-plan.runbook.md --text`
+Expected: `PASS: 3 steps`
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: PASS (the new `implement-plan` test plus the generic parse/validate/metadata/steps assertions auto-applied to the new file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/claude-code-plugin/runbooks/planning/implement-plan.runbook.md packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+git commit -m "feat(plugin): add implement-plan delegated leaf runbook"
+```
+
+---
+
+### Task 3: `code-review` runbook (delegated leaf)
+
+Reviews the implemented changes against the plan and writes `CodeReviewPath` (produce → validate → retry). Records findings (`FAIL CONTINUE`), does not gate.
+
+**Files:**
+- Create: `packages/claude-code-plugin/runbooks/planning/code-review.runbook.md`
+- Modify: `packages/claude-code-plugin/__tests__/runbooks/validation.test.ts`
+
+- [ ] **Step 1: Write the failing structure test**
+
+Add to the `describe('planning execute pipeline', ...)` block:
+
+```typescript
+    it('code-review is a leaf producing a validated CodeReviewPath', () => {
+      const rel = 'planning/code-review.runbook.md';
+      const runbook = readRunbook(rel);
+      expect(runbook.name).toBe('code-review');
+      expect(runbook.steps.every((step) => !stepHasSubsteps(step))).toBe(true);
+      expect(frontmatterOutputNames(rel)).toEqual(['CodeReviewPath']);
+      // Final step validates the produced artifact and loops back on failure.
+      expect(artifactNamesForStep(rel, '4')).toEqual(['CodeReviewPath']);
+      const writeStep = readRunbook(rel).steps.find((s) => s.name === '5');
+      expect(writeStep?.description).toBe('Write the review');
+      // The review step records rather than gates.
+      const reviewStep = readRunbook(rel).steps.find((s) => s.name === '3');
+      expect(reviewStep?.description).toBe('Review the implemented changes');
+    });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: FAIL — `ENOENT` for `planning/code-review.runbook.md`.
+
+- [ ] **Step 3: Write the runbook**
+
+Create `packages/claude-code-plugin/runbooks/planning/code-review.runbook.md` exactly:
+
+```markdown
+---
+name: code-review
+description: Review implemented changes against the plan and record findings as a review document.
+tags:
+  - planning
+  - review
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+OUTPUTS:
+  - CodeReviewPath
+---
+
+# Code Review
+
+Review the implemented changes against the plan and record findings.
+
+## 1. Read the output schema
+- ARTIFACTS
+  - ReviewSchemaPath "schemas/review.schema.json"
+- PASS CONTINUE
+- FAIL STOP
+
+The schema defines the expected review output structure.
+
+
+## 2. Read the plan
+- ARTIFACTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan at `{{ path PlanPath }}`. It defines the intended changes to review against.
+
+
+## 3. Review the implemented changes
+- PASS CONTINUE
+- FAIL CONTINUE
+
+Review the working-tree changes against the plan:
+
+- Each planned task is implemented and matches its intent.
+- No unplanned or out-of-scope changes.
+- Tests cover the new behaviour and code follows project conventions.
+
+Record findings; do not gate here.
+
+
+## 4. Output Path
+- ARTIFACTS
+  - CodeReviewPath "code-review.json"
+- PASS CONTINUE
+- FAIL STOP
+
+{{ CodeReviewPath }}
+
+
+## 5. Write the review
+- ARTIFACTS
+  - PlanPath
+  - ReviewSchemaPath
+  - CodeReviewPath
+- PASS CONTINUE
+- FAIL STOP
+
+Write the review to `{{ path CodeReviewPath }}` as JSON, following the schema from `{{ path ReviewSchemaPath }}`. Use `level: "error"` for findings that must block, `warning` or `note` otherwise. An empty `items` array records a clean review.
+
+
+## 6. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 5
+
+```bash
+{{ validateSchema CodeReviewPath }}
+```
+```
+
+- [ ] **Step 4: Verify the runbook checks and the test passes**
+
+Run: `node packages/cli/dist/cli.js check packages/claude-code-plugin/runbooks/planning/code-review.runbook.md --text`
+Expected: `PASS: 6 steps`
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/claude-code-plugin/runbooks/planning/code-review.runbook.md packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+git commit -m "feat(plugin): add code-review delegated leaf runbook"
+```
+
+---
+
+### Task 4: `address-review` runbook (delegated fix leaf)
+
+The `GOTO` target of both gates. Inherits `PlanPath` + `CodeReviewPath`, resolves `error`-level findings, commits. Leaf — cannot delegate.
+
+**Files:**
+- Create: `packages/claude-code-plugin/runbooks/planning/address-review.runbook.md`
+- Modify: `packages/claude-code-plugin/__tests__/runbooks/validation.test.ts`
+
+- [ ] **Step 1: Write the failing structure test**
+
+Add to the `describe('planning execute pipeline', ...)` block:
+
+```typescript
+    it('address-review is a leaf requiring the plan and the recorded review', () => {
+      const rel = 'planning/address-review.runbook.md';
+      const runbook = readRunbook(rel);
+      expect(runbook.name).toBe('address-review');
+      expect(runbook.steps.every((step) => !stepHasSubsteps(step))).toBe(true);
+      const fm = frontmatterText(rel);
+      expect(fm).toMatch(/^skill:\s*executing-plans\s*$/m);
+      // Requires both the plan and the review it must resolve.
+      expect(fm).toMatch(/REQUIRED:[\s\S]*?-\s*PlanPath/);
+      expect(fm).toMatch(/REQUIRED:[\s\S]*?-\s*CodeReviewPath/);
+    });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: FAIL — `ENOENT` for `planning/address-review.runbook.md`.
+
+- [ ] **Step 3: Write the runbook**
+
+Create `packages/claude-code-plugin/runbooks/planning/address-review.runbook.md` exactly:
+
+```markdown
+---
+name: address-review
+description: Resolve the error-level findings recorded by a code review, committing the fix.
+skill: executing-plans
+tags:
+  - planning
+INPUTS:
+  - PlanPath
+  - CodeReviewPath
+REQUIRED:
+  - PlanPath
+  - CodeReviewPath
+---
+
+# Address Review Findings
+
+Resolve the blocking findings from the code review.
+
+## 1. Invoke the Executing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the executing-plans skill. Internalize the per-task cycle and commit discipline.
+
+Skill: `rundown:executing-plans`
+
+
+## 2. Read the review and plan
+- ARTIFACTS
+  - PlanPath
+  - CodeReviewPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the recorded findings at `{{ path CodeReviewPath }}` and the plan at `{{ path PlanPath }}`.
+
+
+## 3. Resolve the findings
+- PASS COMPLETE
+- FAIL STOP
+
+Resolve every `error`-level finding, staying within the plan's intent. Add or update tests as needed, then commit the fix. Stop and escalate if a finding cannot be resolved within scope.
+```
+
+- [ ] **Step 4: Verify the runbook checks and the test passes**
+
+Run: `node packages/cli/dist/cli.js check packages/claude-code-plugin/runbooks/planning/address-review.runbook.md --text`
+Expected: `PASS: 3 steps`
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/claude-code-plugin/runbooks/planning/address-review.runbook.md packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+git commit -m "feat(plugin): add address-review fix leaf runbook"
+```
+
+---
+
+### Task 5: `execute-plan` runbook (composed orchestrator)
+
+Delegates implement (step 2) and code-review (step 3), then loops the review-clean gate (step 4) and `npm run verify` (step 6) through the `address-review` fix step (step 5). Composed, not delegated — so it is *allowed* to delegate.
+
+**Files:**
+- Create: `packages/claude-code-plugin/runbooks/planning/execute-plan.runbook.md`
+- Modify: `packages/claude-code-plugin/__tests__/runbooks/validation.test.ts`
+
+- [ ] **Step 1: Write the failing structure test**
+
+Add to the `describe('planning execute pipeline', ...)` block:
+
+```typescript
+    it('execute-plan delegates implement/review/fix and loops the gates', () => {
+      const rel = 'planning/execute-plan.runbook.md';
+      const runbook = readRunbook(rel);
+      expect(runbook.name).toBe('execute-plan');
+      expect(runbook.steps.map((step) => step.description)).toEqual([
+        'Invoke the Executing Plans skill',
+        'Implement the plan',
+        'Code review',
+        'Is the review clean?',
+        'Address review findings',
+        'Verify',
+      ]);
+      expect(frontmatterOutputNames(rel)).toEqual(['CodeReviewPath']);
+
+      const byId = (id: string) => runbook.steps.find((s) => s.name === id)!;
+      // The three delegate frontiers.
+      expectSubstepRunbook(byId('2'), ['implement-plan.runbook.md'], true);
+      expectSubstepRunbook(byId('3'), ['code-review.runbook.md'], true);
+      expectSubstepRunbook(byId('5'), ['address-review.runbook.md'], true);
+      // Gate + verify steps carry no substeps (they are command gates).
+      expect(stepHasSubsteps(byId('4'))).toBe(false);
+      expect(stepHasSubsteps(byId('6'))).toBe(false);
+    });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: FAIL — `ENOENT` for `planning/execute-plan.runbook.md`.
+
+- [ ] **Step 3: Write the runbook**
+
+Create `packages/claude-code-plugin/runbooks/planning/execute-plan.runbook.md` exactly (passes `rd check`: `6 steps, 3 substeps`):
+
+````markdown
+---
+name: execute-plan
+description: Execute a reviewed plan — delegate implementation, then loop code review and verify gates until clean.
+skill: executing-plans
+tags:
+  - planning
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+OUTPUTS:
+  - CodeReviewPath
+---
+
+# Execute Plan
+
+Execute the plan, then hold the work to the review and verify gates.
+
+## 1. Invoke the Executing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the executing-plans skill. Internalize how implementation, review, and verification fit together.
+
+Skill: `rundown:executing-plans`
+
+
+## 2. Implement the plan
+- ARTIFACTS
+  - PlanPath
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- implement-plan.runbook.md
+
+
+## 3. Code review
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- code-review.runbook.md
+
+
+## 4. Is the review clean?
+- ARTIFACTS
+  - CodeReviewPath
+- PASS GOTO 6
+- FAIL CONTINUE
+
+```bash
+test "$(jq '[.items[] | select(.level == "error")] | length' "{{ path CodeReviewPath }}")" -eq 0
+```
+
+
+## 5. Address review findings
+- DELEGATE
+- PASS ALL GOTO 3
+- FAIL ANY STOP
+
+- address-review.runbook.md
+
+
+## 6. Verify
+- PASS COMPLETE
+- FAIL GOTO 5
+
+```bash
+npm run verify
+```
+````
+
+Loop semantics: step 4 jumps to verify when the review has no `error` items (`PASS GOTO 6`), otherwise falls through to the fix (`FAIL CONTINUE` → step 5). Step 5 re-reviews after a fix (`PASS ALL GOTO 3`). Step 6 sends a red verify back to the fix (`FAIL GOTO 5`), which re-reviews, re-verifies — converging. `address-review` is the single `GOTO` target, so each loop iteration is focused, not a full re-implement.
+
+- [ ] **Step 4: Verify the runbook checks and the test passes**
+
+Run: `node packages/cli/dist/cli.js check packages/claude-code-plugin/runbooks/planning/execute-plan.runbook.md --text`
+Expected: `PASS: 6 steps, 3 substeps`
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/claude-code-plugin/runbooks/planning/execute-plan.runbook.md packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+git commit -m "feat(plugin): add execute-plan orchestrator with gate loops"
+```
+
+---
+
+### Task 6: Rebuild `planning.runbook.md`
+
+Replace the broken `End-to-End Test` stub with the real pipeline: write (delegate leaf) → review (compose) → execute (compose). The verify gate lives inside `execute-plan`, so the pipeline terminates on execute completion (`PASS ALL COMPLETE`).
+
+**Files:**
+- Overwrite: `packages/claude-code-plugin/runbooks/meta/planning.runbook.md`
+- Modify: `packages/claude-code-plugin/__tests__/runbooks/validation.test.ts`
+
+- [ ] **Step 1: Write the failing structure test**
+
+Add to the `describe('planning execute pipeline', ...)` block:
+
+```typescript
+    it('planning composes write(delegate) -> review -> execute', () => {
+      const rel = 'meta/planning.runbook.md';
+      const runbook = readRunbook(rel);
+      expect(runbook.name).toBe('planning');
+      expect(runbook.steps.map((step) => step.description)).toEqual([
+        'Write the plan',
+        'Review the plan',
+        'Execute the plan',
+      ]);
+      // Leaf-delegate, orchestrator-compose: write delegates, review + execute compose.
+      expectSubstepRunbook(runbook.steps[0], ['planning/write-plan.runbook.md'], true);
+      expectSubstepRunbook(runbook.steps[1], ['planning/review-plan.runbook.md'], false);
+      expectSubstepRunbook(runbook.steps[2], ['planning/execute-plan.runbook.md'], false);
+      expect(frontmatterOutputNames(rel)).toEqual([
+        'PlanPath',
+        'ReviewPlanPath',
+        'CodeReviewPath',
+      ]);
+    });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: FAIL — current `meta/planning.runbook.md` has name `End-to-End Test` and the wrong steps.
+
+- [ ] **Step 3: Overwrite the runbook**
+
+Replace the entire contents of `packages/claude-code-plugin/runbooks/meta/planning.runbook.md` with (passes `rd check`: `3 steps, 3 substeps`):
+
+```markdown
+---
+name: planning
+description: Plan, review, and execute a body of work — write the plan, review it, then implement it behind review and verify gates.
+tags:
+  - planning
+OUTPUTS:
+  - PlanPath
+  - ReviewPlanPath
+  - CodeReviewPath
+---
+
+# Planning
+
+Plan a body of work, review the plan, then execute it.
+
+## 1. Write the plan
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- planning/write-plan.runbook.md
+
+
+## 2. Review the plan
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- planning/review-plan.runbook.md
+
+
+## 3. Execute the plan
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+- planning/execute-plan.runbook.md
+```
+
+- [ ] **Step 4: Verify the runbook checks and the test passes**
+
+Run: `node packages/cli/dist/cli.js check packages/claude-code-plugin/runbooks/meta/planning.runbook.md --text`
+Expected: `PASS: 3 steps, 3 substeps`
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/claude-code-plugin/runbooks/meta/planning.runbook.md packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+git commit -m "feat(plugin): rebuild planning.runbook.md as write/review/execute pipeline"
+```
+
+---
+
+### Task 7: Runtime integration test for `execute-plan`
+
+Drive the real `execute-plan` from a project-local harness that produces `PlanPath`, and assert the runtime facts: `execute-plan` issues an `implement-plan` delegation token, and the claimed child inherits `PlanPath` as a local path. This mirrors `end-to-end-test-runtime.integration.test.ts` (subprocess `runCli`, temp cwd, `CLAUDE_PLUGIN_ROOT` at the plugin). Pattern proven against the built CLI: harness → `execute-plan` step 2 → `implement-plan` token → claimed child step 2 has `PlanPath` in `artifacts`.
+
+**Files:**
+- Create: `packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts`:
+
+```typescript
+/**
+ * Runtime integration coverage for the execute-plan orchestrator.
+ *
+ * A project-local harness produces a `PlanPath` artifact (the proven
+ * parent-produces-artifact pattern), then composes the bundled
+ * `planning/execute-plan.runbook.md`. We assert the runtime facts that static
+ * structure tests cannot: execute-plan issues an `implement-plan` delegation
+ * token, and the claimed child inherits `PlanPath` across the delegation
+ * boundary (rendered as a local work-dir path, never an rd:// URI).
+ *
+ * Pattern: follows `end-to-end-test-runtime.integration.test.ts`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtempSync } from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { runCli } from '../helpers/test-utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const pluginRoot = path.join(__dirname, '..', '..');
+const pluginRootEnv = `${pluginRoot}/`;
+
+type JsonEvent = Record<string, unknown>;
+
+function parseJsonEvents(stdout: string): JsonEvent[] {
+  const events: JsonEvent[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        events.push(parsed as JsonEvent);
+      }
+    } catch {
+      // skip non-JSON diagnostic lines
+    }
+  }
+  return events;
+}
+
+function eventRunbookPath(event: JsonEvent): string {
+  const runbook = event.runbook as { readonly path?: unknown } | undefined;
+  return typeof runbook?.path === 'string' ? runbook.path : '';
+}
+
+function enteredStep(
+  events: JsonEvent[],
+  runbookSuffix: string,
+  current: string,
+): JsonEvent | undefined {
+  return events.find(
+    (event) =>
+      event.type === 'step_entered' &&
+      eventRunbookPath(event).endsWith(runbookSuffix) &&
+      (event.position as { current?: string } | undefined)?.current === current,
+  );
+}
+
+interface StatusResponse {
+  readonly file?: string;
+  readonly position?: { readonly current?: string };
+  readonly delegations?: ReadonlyArray<{
+    readonly state: string;
+    readonly token: string;
+    readonly runbook: string;
+  }>;
+}
+
+const HARNESS = `---
+name: exec-plan-harness
+OUTPUTS:
+  - PlanPath
+---
+# Exec Plan Harness
+
+## 1. Seed plan
+- ARTIFACTS
+  - PlanPath "plan.json"
+- PASS CONTINUE
+- FAIL STOP
+
+\`\`\`bash
+cat > "{{ path PlanPath }}" <<'JSON'
+{"$schema":"https://rundown.org/schemas/plan.schema.json","name":"fixture","meta":{"version":"1.0.0"},"goal":"g","architecture_and_approach":"a","constraints_and_assumptions":"c","files":[{"path":"src/x.ts","action":"create"}],"tasks":[{"name":"t1","files":[],"subtasks":[{"name":"s1"}]}]}
+JSON
+\`\`\`
+
+## 2. Execute
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+- planning/execute-plan.runbook.md
+`;
+
+describe('execute-plan runtime delegation + artifact handoff', () => {
+  let tempDir: string;
+  let previousPluginRoot: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'rd-exec-runtime-'));
+    await mkdir(path.join(tempDir, '.rundown', 'runs'), { recursive: true });
+    await mkdir(path.join(tempDir, '.rundown', 'runbooks'), { recursive: true });
+    await writeFile(
+      path.join(tempDir, '.rundown', 'runbooks', 'exec-plan-harness.runbook.md'),
+      HARNESS,
+    );
+    previousPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+    process.env.CLAUDE_PLUGIN_ROOT = pluginRootEnv;
+  });
+
+  afterEach(async () => {
+    if (previousPluginRoot === undefined) {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    } else {
+      process.env.CLAUDE_PLUGIN_ROOT = previousPluginRoot;
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  function status(): StatusResponse {
+    const result = runCli(['status'], tempDir);
+    expect(result.exitCode).toBe(0);
+    return JSON.parse(result.stdout) as StatusResponse;
+  }
+
+  function driveToImplementDelegate(): { token: string } {
+    const start = runCli(['run', '--prompted', '--allow-all', 'exec-plan-harness'], tempDir);
+    expect(start.exitCode).toBe(0);
+    for (let i = 0; i < 12; i += 1) {
+      const current = status();
+      const pending = current.delegations?.find(
+        (d) => d.state === 'pending' && d.runbook.endsWith('implement-plan.runbook.md'),
+      );
+      if (
+        pending &&
+        current.file?.endsWith('execute-plan.runbook.md') &&
+        current.position?.current === '2'
+      ) {
+        return { token: pending.token };
+      }
+      runCli(['pass'], tempDir);
+    }
+    throw new Error('Did not reach execute-plan implement DELEGATE step');
+  }
+
+  it('issues an implement-plan delegation token at execute-plan step 2', () => {
+    const { token } = driveToImplementDelegate();
+    expect(token).toEqual(expect.stringMatching(/^rdtk_/));
+  });
+
+  it('hands PlanPath through to the delegated implement-plan child as a local path', () => {
+    const { token } = driveToImplementDelegate();
+
+    const claim = runCli(['claim', token], tempDir);
+    expect(claim.exitCode).toBe(0);
+    const claimId = (
+      parseJsonEvents(claim.stdout).find((event) => event.kind === 'claim') as {
+        claim_id?: string;
+      }
+    ).claim_id;
+    expect(claimId).toEqual(expect.stringMatching(/^rdclm_/));
+
+    expect(enteredStep(parseJsonEvents(claim.stdout), 'implement-plan.runbook.md', '1')).toBeDefined();
+
+    // Step 2 of implement-plan rehydrates the inherited PlanPath artifact.
+    const advance2 = parseJsonEvents(runCli(['pass', '--claim-id', claimId!], tempDir).stdout);
+    const step2 = enteredStep(advance2, 'implement-plan.runbook.md', '2');
+    expect(step2).toBeDefined();
+    const step2Artifacts = step2!.artifacts as Record<string, unknown> | undefined;
+    expect(Object.keys(step2Artifacts ?? {})).toContain('PlanPath');
+    const prompt = typeof step2!.prompt === 'string' ? step2!.prompt : '';
+    expect(prompt).toMatch(/\.rundown\/work\/.*plan\.json/);
+    expect(prompt).not.toContain('rd://artifacts/');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- execute-plan-runtime.integration.test.ts`
+Expected: PASS (2 tests). (Integration tests run a built CLI subprocess; the worktree is already built. If the helper reports a stale build, run `npm run build` first.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts
+git commit -m "test(plugin): runtime coverage for execute-plan delegation + PlanPath handoff"
+```
+
+---
+
+### Task 8: Composition patterns guide + cross-link
+
+Write the guide documenting the patterns (lead with the gate loop; document iterate-and-delegate with its two validated constraints as future work), cross-link it from `house-style.md`, and add new terms to the spell dictionary.
+
+**Files:**
+- Create: `docs/guides/composing-runbooks.md`
+- Modify: `packages/claude-code-plugin/skills/writing-runbooks/house-style.md`
+- Modify: `cspell-dictionary.txt` (repo root, alphabetical)
+- Modify: `packages/claude-code-plugin/__tests__/runbooks/validation.test.ts`
+
+- [ ] **Step 1: Write the failing cross-link test**
+
+Add to the `describe('planning execute pipeline', ...)` block:
+
+```typescript
+    it('house-style links to the composing-runbooks guide', () => {
+      const houseStyle = readFileSync(
+        join(projectRoot, 'skills', 'writing-runbooks', 'house-style.md'),
+        'utf-8',
+      );
+      expect(houseStyle).toMatch(/composing-runbooks\.md/);
+    });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: FAIL — `house-style.md` does not yet reference the guide.
+
+- [ ] **Step 3: Write the guide**
+
+Create `docs/guides/composing-runbooks.md`:
+
+```markdown
+# Composing Runbooks
+
+How independent, single-artifact runbooks combine into multi-stage workflows. This guide covers *inter*-runbook composition; for *intra*-runbook conventions see [writing-runbooks/house-style.md](../../packages/claude-code-plugin/skills/writing-runbooks/house-style.md), and for delegation mechanics see [agent-orchestration.md](agent-orchestration.md).
+
+The worked example throughout is the planning pipeline: `planning.runbook.md` composes `write-plan` → `review-plan` → `execute-plan`.
+
+## Pattern 1 — Workflow pipeline (artifact handoff)
+
+Stages run in sequence in a shared `ContextId`. Each stage declares what it publishes via frontmatter `OUTPUTS`; the next declares `INPUTS` / `REQUIRED` and rehydrates a naked `ARTIFACTS` alias. `write-plan` publishes `PlanPath`; `review-plan` and `execute-plan` consume it. Never re-derive a child's output path in the parent — consume its declared `OUTPUTS`.
+
+## Pattern 2 — Leaf-delegate, orchestrator-compose (the RD-819 discipline)
+
+A delegated (claimed) child cannot delegate further (`RD-819 DELEGATION_NESTED_FORBIDDEN`). So **delegate only leaves; compose any stage that itself delegates or fans out.** Decision test: *does this child delegate? → compose it (list it inline / `rd run`). Is it a terminal worker? → delegate it (`- DELEGATE`).* In `planning.runbook.md` this is visible in one file: step 1 delegates `write-plan` (a leaf); steps 2–3 compose `review-plan` and `execute-plan` (both delegate internally).
+
+## Pattern 3 — Fan-out + collate
+
+A composed stage delegates N sibling analysis runbooks, then delegates a collation runbook that gathers them with a wildcard artifact or `rdpath find`, deduplicates, and validates against the shared schema. `review-plan` delegates four reviewers then `review-plan-collate`. Never collate from the parent.
+
+## Pattern 4 — Gate loop (iterate-until-clean)
+
+A composed stage runs a **machine-checkable** gate and `FAIL GOTO`s a focused fix step until the gate is met. The runbook's value here is *refusing to advance* on dirty work — enforcement an agent prompt cannot reliably self-impose. `execute-plan` does this twice:
+
+- **Review-clean gate:** a `jq` step counts `level == "error"` items in the code review; clean jumps ahead, dirty falls to the fix step.
+- **Verify gate:** `npm run verify`; red sends work to the same fix step.
+
+Both `GOTO` a single dedicated fix leaf (`address-review`), so each iteration is small and convergent. `GOTO` loops have no engine-level iteration cap — the fix step's body tells the agent when to escalate rather than spin.
+
+## Pattern 5 — Top-level workflow runbook
+
+A thin parent that sequences pipeline stages with explicit aggregation (`- PASS ALL ...` / `- FAIL ANY ...`) and terminates when the final stage completes. `planning.runbook.md` is four-frontmatter-lines plus three composition steps; all the work lives in the leaves it composes.
+
+## Passing data to a delegated child
+
+A delegated child inherits the shared **artifacts** (e.g. `PlanPath`) and persisted **template variables**. This is the handoff to reach for: produce an artifact upstream, declare it `REQUIRED` in the child, rehydrate it with a naked `ARTIFACTS` alias. `execute-plan` hands the whole plan to `implement-plan` this way and nothing else crosses.
+
+## Future work — iterate-and-delegate (FOR + DELEGATE per item)
+
+The intuitive "loop a data source, delegate one worker per item" has two sharp edges, both validated against the engine. Until there is a first-class pattern for them, the planning pipeline deliberately keeps the per-task walk inside the agent + the [executing-plans](../../packages/claude-code-plugin/skills/executing-plans/SKILL.md) skill rather than expressing it as `FOR`.
+
+1. **A `FOR` source must resolve at the launch of the runbook that contains the `FOR`.** Launch-time validation rejects a `FOR` over a variable or artifact the same runbook produces in an earlier step (`VALIDATION_ERROR: FOR loop references undefined variable`); a frontmatter `inputs:` declaration is not a value. The workaround is to have a *parent* populate the source (via `OUTPUTS`, which needs no seed) and compose a child that iterates the inherited, already-populated source.
+
+2. **The loop variable and `Index` do not cross the delegation boundary.** A delegated child inherits the whole array (and supports index-in like `{{ Tasks.0.name }}`) but not the per-iteration loop variable or `Index`. Passing per-item data to a delegated child therefore needs explicit `--input` forwarding or a per-iteration artifact.
+
+The syntax for `FOR` + `DELEGATE` lives in the parser/core fixtures under `runbooks/for-loops/` and `runbooks/delegation/`.
+```
+
+- [ ] **Step 4: Cross-link from house-style.md**
+
+In `packages/claude-code-plugin/skills/writing-runbooks/house-style.md`, the intro paragraph (lines 1–6) ends by telling authors to match sibling runbooks. Append one sentence to that intro paragraph:
+
+Find:
+```markdown
+`SKILL.md` documents the *syntax* of each directive. This guide documents how the pieces *combine* — the patterns to reach for first when authoring a new runbook. When in doubt, open a sibling runbook in those directories and match it.
+```
+
+Replace with:
+```markdown
+`SKILL.md` documents the *syntax* of each directive. This guide documents how the pieces *combine* — the patterns to reach for first when authoring a new runbook. When in doubt, open a sibling runbook in those directories and match it. For *inter*-runbook composition (pipelines, gate loops, the leaf-delegate / orchestrator-compose discipline) see [docs/guides/composing-runbooks.md](../../../../docs/guides/composing-runbooks.md).
+```
+
+- [ ] **Step 5: Add new terms to the spell dictionary**
+
+Confirm spelling first:
+
+Run: `npm run check:spell`
+If it flags terms, add any missing ones (e.g. `rdtk`, `rdclm`) to `cspell-dictionary.txt` at the repo root, keeping the file alphabetical. (Most domain terms — `runbook`, `delegate`, `jq` — are already present.)
+
+- [ ] **Step 6: Verify cross-link test passes**
+
+Run: `npm test -w @rundown-org/claude-code-plugin -- validation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/guides/composing-runbooks.md packages/claude-code-plugin/skills/writing-runbooks/house-style.md cspell-dictionary.txt packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+git commit -m "docs: add composing-runbooks guide and cross-link from house-style"
+```
+
+---
+
+### Task 9: Full verification
+
+Run the repo's pre-PR gate and the conversion checklist.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the converted-skill checklist**
+
+Verify the new runbooks against the `converting-skills-to-runbooks` checklist (`packages/claude-code-plugin/skills/converting-skills-to-runbooks/references/checklist.md`): step 1 invokes the skill (`skill:` set on `execute-plan` / `implement-plan` / `address-review`), every load-bearing phase maps to a step, no step body restates skill context, artifacts use `{{ path Alias }}`, `INPUTS`/`OUTPUTS`/`REQUIRED` consistent, and the produce → validate → retry loop is present in `code-review`. Fix any gaps and re-commit.
+
+- [ ] **Step 2: `rd check` every new/changed runbook**
+
+```bash
+for f in implement-plan code-review address-review execute-plan; do
+  node packages/cli/dist/cli.js check "packages/claude-code-plugin/runbooks/planning/$f.runbook.md" --text
+done
+node packages/cli/dist/cli.js check packages/claude-code-plugin/runbooks/meta/planning.runbook.md --text
+```
+Expected: all `PASS`.
+
+- [ ] **Step 3: Run the full plugin test suite**
+
+Run: `npm test -w @rundown-org/claude-code-plugin`
+Expected: PASS, including the new `executing-plans`, `planning execute pipeline`, and `execute-plan runtime` tests.
+
+- [ ] **Step 4: Run the pre-PR gate**
+
+Run: `npm run verify`
+Expected: format, spell, lint, and test all pass. Fix any issues and re-commit.
+
+- [ ] **Step 5: Finish the branch**
+
+Use superpowers:finishing-a-development-branch to verify tests, then push and open the PR (this work branches from `feat/converting-skills-to-runbooks`; rebase onto `main` after PR #432 merges, per the spec's Dependencies section).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Guide with patterns + the two `FOR`/delegation constraints, cross-linked from house-style → Task 8 (SC #1). ✅
+- `executing-plans` skill + `execute-plan` + `implement-plan` + `code-review` + `address-review`, house style, `rd check` → Tasks 1–5, 9 (SC #2). ✅
+- `planning.runbook.md` as write → review → execute, no stub, `PlanPath` threading, verify inside execute → Task 6 (SC #3). ✅
+- `validation.test.ts` pins structures; runtime test exercises delegate-implement + code-review + gate wiring → Tasks 2–7 (SC #4). ✅
+- `npm run verify` → Task 9 (SC #5). ✅
+
+**Placeholder scan:** All five runbook bodies are verbatim and `rd check`-verified; all test code is complete; all commands are exact. No "TBD"/"similar to". The runtime harness and the implement-plan/PlanPath inheritance assertion were proven against the built CLI before writing.
+
+**Type/name consistency:** Artifact aliases (`PlanPath`, `ReviewPlanPath`, `CodeReviewPath`, `ReviewSchemaPath`) and runbook names (`execute-plan`, `implement-plan`, `code-review`, `address-review`, `planning`) are used identically across runbooks and tests. Substep reference strings in the tests (`implement-plan.runbook.md`, `planning/execute-plan.runbook.md`, etc.) match the exact strings in the runbook bodies, confirmed via the parser. `stepHasSubsteps` and the helpers (`readRunbook`, `expectSubstepRunbook`, `artifactNamesForStep`, `frontmatterOutputNames`) already exist in `validation.test.ts`; the added `frontmatterText` local helper and the `readFileSync`/`join`/`projectRoot` references it relies on are already imported/defined at the top of that file.

--- a/docs/internal/plans/composing-runbooks-plan.md
+++ b/docs/internal/plans/composing-runbooks-plan.md
@@ -75,7 +75,7 @@ describe('executing-plans skill', () => {
 
   it('tells the implementer when to stop and escalate', () => {
     const skill = readSkill();
-    expect(skill).toMatch(/escalat|stop/i);
+    expect(skill).toMatch(/escalate|stop/i);
   });
 });
 ```

--- a/docs/internal/plans/composing-runbooks-plan.md
+++ b/docs/internal/plans/composing-runbooks-plan.md
@@ -18,7 +18,7 @@
 
 ---
 
-### Task 1: Convert the `executing-plans` skill
+## Task 1: Convert the `executing-plans` skill
 
 Dogfood the `converting-skills-to-runbooks` skill: distill superpowers `executing-plans` + `subagent-driven-development` into the **context** for the task walk. The skill holds the per-task cycle, commit discipline, and escalation; it cross-links rather than restates, and it explicitly cedes the *sequence and gates* to the `execute-plan` runbook.
 
@@ -161,7 +161,7 @@ git commit -m "feat(plugin): add executing-plans skill (converted context for th
 
 ---
 
-### Task 2: `implement-plan` runbook (delegated leaf)
+## Task 2: `implement-plan` runbook (delegated leaf)
 
 The leaf that walks every task in the plan. Inherits only `PlanPath`. Pure leaf — no substeps, cannot delegate.
 
@@ -263,7 +263,7 @@ git commit -m "feat(plugin): add implement-plan delegated leaf runbook"
 
 ---
 
-### Task 3: `code-review` runbook (delegated leaf)
+## Task 3: `code-review` runbook (delegated leaf)
 
 Reviews the implemented changes against the plan and writes `CodeReviewPath` (produce → validate → retry). Records findings (`FAIL CONTINUE`), does not gate.
 
@@ -301,7 +301,7 @@ Expected: FAIL — `ENOENT` for `planning/code-review.runbook.md`.
 
 Create `packages/claude-code-plugin/runbooks/planning/code-review.runbook.md` exactly:
 
-```markdown
+````markdown
 ---
 name: code-review
 description: Review implemented changes against the plan and record findings as a review document.
@@ -378,7 +378,7 @@ Write the review to `{{ path CodeReviewPath }}` as JSON, following the schema fr
 ```bash
 {{ validateSchema CodeReviewPath }}
 ```
-```
+````
 
 - [ ] **Step 4: Verify the runbook checks and the test passes**
 
@@ -397,7 +397,7 @@ git commit -m "feat(plugin): add code-review delegated leaf runbook"
 
 ---
 
-### Task 4: `address-review` runbook (delegated fix leaf)
+## Task 4: `address-review` runbook (delegated fix leaf)
 
 The `GOTO` target of both gates. Inherits `PlanPath` + `CodeReviewPath`, resolves `error`-level findings, commits. Leaf — cannot delegate.
 
@@ -494,7 +494,7 @@ git commit -m "feat(plugin): add address-review fix leaf runbook"
 
 ---
 
-### Task 5: `execute-plan` runbook (composed orchestrator)
+## Task 5: `execute-plan` runbook (composed orchestrator)
 
 Delegates implement (step 2) and code-review (step 3), then loops the review-clean gate (step 4) and `npm run verify` (step 6) through the `address-review` fix step (step 5). Composed, not delegated — so it is *allowed* to delegate.
 
@@ -634,7 +634,7 @@ git commit -m "feat(plugin): add execute-plan orchestrator with gate loops"
 
 ---
 
-### Task 6: Rebuild `planning.runbook.md`
+## Task 6: Rebuild `planning.runbook.md`
 
 Replace the broken `End-to-End Test` stub with the real pipeline: write (delegate leaf) → review (compose) → execute (compose). The verify gate lives inside `execute-plan`, so the pipeline terminates on execute completion (`PASS ALL COMPLETE`).
 
@@ -732,7 +732,7 @@ git commit -m "feat(plugin): rebuild planning.runbook.md as write/review/execute
 
 ---
 
-### Task 7: Runtime integration test for `execute-plan`
+## Task 7: Runtime integration test for `execute-plan`
 
 Drive the real `execute-plan` from a project-local harness that produces `PlanPath`, and assert the runtime facts: `execute-plan` issues an `implement-plan` delegation token, and the claimed child inherits `PlanPath` as a local path. This mirrors `end-to-end-test-runtime.integration.test.ts` (subprocess `runCli`, temp cwd, `CLAUDE_PLUGIN_ROOT` at the plugin). Pattern proven against the built CLI: harness → `execute-plan` step 2 → `implement-plan` token → claimed child step 2 has `PlanPath` in `artifacts`.
 
@@ -938,7 +938,7 @@ git commit -m "test(plugin): runtime coverage for execute-plan delegation + Plan
 
 ---
 
-### Task 8: Composition patterns guide + cross-link
+## Task 8: Composition patterns guide + cross-link
 
 Write the guide documenting the patterns (lead with the gate loop; document iterate-and-delegate with its two validated constraints as future work), cross-link it from `house-style.md`, and add new terms to the spell dictionary.
 
@@ -1053,7 +1053,7 @@ git commit -m "docs: add composing-runbooks guide and cross-link from house-styl
 
 ---
 
-### Task 9: Full verification
+## Task 9: Full verification
 
 Run the repo's pre-PR gate and the conversion checklist.
 

--- a/docs/internal/plans/composing-runbooks-plan.md
+++ b/docs/internal/plans/composing-runbooks-plan.md
@@ -13,7 +13,7 @@
 **Conventions (read once):**
 - Runbooks live under `packages/claude-code-plugin/runbooks/`. New planning runbooks go in `runbooks/planning/`.
 - House style: blank line after the `## N. Heading`, the directive block, a blank line, then the prose body; **two** blank lines between steps. Reference artifacts as `{{ path Alias }}` — never hardcode. State aggregation explicitly on compose/delegate steps (`- PASS ALL CONTINUE` / `- FAIL ANY STOP`).
-- Build is current (`packages/cli/dist/cli.js` exists). The CLI is invoked as `node packages/cli/dist/cli.js` in this repo (`rd` is shell-aliased to `rmdir` on this machine). All commands below assume CWD = the worktree root `/Users/tobyhede/psrc/rundown/.worktrees/composing-runbooks` unless noted.
+- Build is current (`packages/cli/dist/cli.js` exists). Invoke the CLI as `node packages/cli/dist/cli.js`. Run commands from the repository root unless a task says otherwise.
 - Run the plugin Jest suite with: `npm test -w @rundown-org/claude-code-plugin -- <path-or-pattern>` (there is no root `--selectProjects` config).
 
 ---

--- a/packages/claude-code-plugin/__tests__/runbooks/convert-skill-runbook.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/convert-skill-runbook.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it } from '@jest/globals';
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseRunbookDocument } from '@rundown-org/parser';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const runbookPath = join(__dirname, '..', '..', 'runbooks', 'meta', 'convert-skill.runbook.md');
+const __dirname = path.dirname(__filename);
+const runbookPath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'runbooks',
+  'meta',
+  'convert-skill.runbook.md',
+);
 
 const content = readFileSync(runbookPath, 'utf-8');
 const { runbook, diagnostics, frontmatter } = parseRunbookDocument(content, runbookPath);

--- a/packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts
@@ -156,11 +156,11 @@ describe('execute-plan runtime delegation + artifact handoff', () => {
 
     const claim = runCli(['claim', token], tempDir);
     expect(claim.exitCode).toBe(0);
-    const claimId = (
-      parseJsonEvents(claim.stdout).find((event) => event.kind === 'claim') as {
-        claim_id?: string;
-      }
-    ).claim_id;
+    const claimEvent = parseJsonEvents(claim.stdout).find((event) => event.kind === 'claim') as
+      | { claim_id?: string }
+      | undefined;
+    expect(claimEvent).toBeDefined();
+    const claimId = claimEvent?.claim_id;
     expect(claimId).toEqual(expect.stringMatching(/^rdclm_/));
 
     expect(

--- a/packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Runtime integration coverage for the execute-plan orchestrator.
+ *
+ * A project-local harness produces a `PlanPath` artifact (the proven
+ * parent-produces-artifact pattern), then composes the bundled
+ * `planning/execute-plan.runbook.md`. We assert the runtime facts that static
+ * structure tests cannot: execute-plan issues an `implement-plan` delegation
+ * token, and the claimed child inherits `PlanPath` across the delegation
+ * boundary (rendered as a local work-dir path, never an rd:// URI).
+ *
+ * Pattern: follows `end-to-end-test-runtime.integration.test.ts`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtempSync } from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { runCli } from '../helpers/test-utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const pluginRoot = path.join(__dirname, '..', '..');
+const pluginRootEnv = `${pluginRoot}/`;
+
+type JsonEvent = Record<string, unknown>;
+
+function parseJsonEvents(stdout: string): JsonEvent[] {
+  const events: JsonEvent[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        events.push(parsed as JsonEvent);
+      }
+    } catch {
+      // skip non-JSON diagnostic lines
+    }
+  }
+  return events;
+}
+
+function eventRunbookPath(event: JsonEvent): string {
+  const runbook = event.runbook as { readonly path?: unknown } | undefined;
+  return typeof runbook?.path === 'string' ? runbook.path : '';
+}
+
+function enteredStep(
+  events: JsonEvent[],
+  runbookSuffix: string,
+  current: string,
+): JsonEvent | undefined {
+  return events.find(
+    (event) =>
+      event.type === 'step_entered' &&
+      eventRunbookPath(event).endsWith(runbookSuffix) &&
+      (event.position as { current?: string } | undefined)?.current === current,
+  );
+}
+
+interface StatusResponse {
+  readonly file?: string;
+  readonly position?: { readonly current?: string };
+  readonly delegations?: ReadonlyArray<{
+    readonly state: string;
+    readonly token: string;
+    readonly runbook: string;
+  }>;
+}
+
+const HARNESS = `---
+name: exec-plan-harness
+OUTPUTS:
+  - PlanPath
+---
+# Exec Plan Harness
+
+## 1. Seed plan
+- ARTIFACTS
+  - PlanPath "plan.json"
+- PASS CONTINUE
+- FAIL STOP
+
+\`\`\`bash
+cat > "{{ path PlanPath }}" <<'JSON'
+{"$schema":"https://rundown.org/schemas/plan.schema.json","name":"fixture","meta":{"version":"1.0.0"},"goal":"g","architecture_and_approach":"a","constraints_and_assumptions":"c","files":[{"path":"src/x.ts","action":"create"}],"tasks":[{"name":"t1","files":[],"subtasks":[{"name":"s1"}]}]}
+JSON
+\`\`\`
+
+## 2. Execute
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+- planning/execute-plan.runbook.md
+`;
+
+describe('execute-plan runtime delegation + artifact handoff', () => {
+  let tempDir: string;
+  let previousPluginRoot: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'rd-exec-runtime-'));
+    await mkdir(path.join(tempDir, '.rundown', 'runs'), { recursive: true });
+    await mkdir(path.join(tempDir, '.rundown', 'runbooks'), { recursive: true });
+    await writeFile(
+      path.join(tempDir, '.rundown', 'runbooks', 'exec-plan-harness.runbook.md'),
+      HARNESS,
+    );
+    previousPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+    process.env.CLAUDE_PLUGIN_ROOT = pluginRootEnv;
+  });
+
+  afterEach(async () => {
+    if (previousPluginRoot === undefined) {
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+    } else {
+      process.env.CLAUDE_PLUGIN_ROOT = previousPluginRoot;
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  function status(): StatusResponse {
+    const result = runCli(['status'], tempDir);
+    expect(result.exitCode).toBe(0);
+    return JSON.parse(result.stdout) as StatusResponse;
+  }
+
+  function driveToImplementDelegate(): { token: string } {
+    const start = runCli(['run', '--prompted', '--allow-all', 'exec-plan-harness'], tempDir);
+    expect(start.exitCode).toBe(0);
+    for (let i = 0; i < 12; i += 1) {
+      const current = status();
+      const pending = current.delegations?.find(
+        (d) => d.state === 'pending' && d.runbook.endsWith('implement-plan.runbook.md'),
+      );
+      if (
+        pending &&
+        current.file?.endsWith('execute-plan.runbook.md') &&
+        current.position?.current === '2'
+      ) {
+        return { token: pending.token };
+      }
+      runCli(['pass'], tempDir);
+    }
+    throw new Error('Did not reach execute-plan implement DELEGATE step');
+  }
+
+  it('issues an implement-plan delegation token at execute-plan step 2', () => {
+    const { token } = driveToImplementDelegate();
+    expect(token).toEqual(expect.stringMatching(/^rdtk_/));
+  });
+
+  it('hands PlanPath through to the delegated implement-plan child as a local path', () => {
+    const { token } = driveToImplementDelegate();
+
+    const claim = runCli(['claim', token], tempDir);
+    expect(claim.exitCode).toBe(0);
+    const claimId = (
+      parseJsonEvents(claim.stdout).find((event) => event.kind === 'claim') as {
+        claim_id?: string;
+      }
+    ).claim_id;
+    expect(claimId).toEqual(expect.stringMatching(/^rdclm_/));
+
+    expect(
+      enteredStep(parseJsonEvents(claim.stdout), 'implement-plan.runbook.md', '1'),
+    ).toBeDefined();
+
+    // Step 2 of implement-plan rehydrates the inherited PlanPath artifact.
+    const advance2 = parseJsonEvents(runCli(['pass', '--claim-id', claimId!], tempDir).stdout);
+    const step2 = enteredStep(advance2, 'implement-plan.runbook.md', '2');
+    expect(step2).toBeDefined();
+    const step2Artifacts = step2!.artifacts as Record<string, unknown> | undefined;
+    expect(Object.keys(step2Artifacts ?? {})).toContain('PlanPath');
+    const prompt = typeof step2!.prompt === 'string' ? step2!.prompt : '';
+    expect(prompt).toMatch(/\.rundown\/work\/.*plan\.json/);
+    expect(prompt).not.toContain('rd://artifacts/');
+  });
+});

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -254,6 +254,39 @@ describe('Built-in Runbook Validation', () => {
       );
     });
 
+    it('code-review owns its verdict via a final prompted gate (no jq)', () => {
+      const rel = 'planning/code-review.runbook.md';
+      const runbook = readRunbook(rel);
+
+      const byId = (id: string) => {
+        const step = runbook.steps.find((s) => s.name === id);
+        if (!step) throw new Error(`expected step ${id}`);
+        return step;
+      };
+
+      // Schema check no longer terminates the runbook — it continues to the gate.
+      const schemaCheck = byId('6');
+      expect(schemaCheck.kind).toBe('command');
+      expect(schemaCheck.transitions.pass.action).toEqual({ type: 'CONTINUE' });
+      expect(schemaCheck.transitions.fail.action).toMatchObject({
+        type: 'GOTO',
+        target: { step: '5' },
+      });
+
+      // The final step is a prompted (agent-judgment) gate, not a command.
+      // A clean review COMPLETEs the runbook (-> parent pass); a dirty review
+      // STOPs it (-> parent fail), so the review owns its own verdict.
+      const gate = byId('7');
+      expect(gate.kind).toBe('base');
+      expect(gate.transitions.pass.action).toEqual({ type: 'COMPLETE' });
+      expect(gate.transitions.fail.action).toEqual({ type: 'STOP' });
+      // The gate rehydrates the recorded review so the agent can judge it.
+      expect(artifactNamesForStep(rel, '7')).toEqual(['CodeReviewPath']);
+
+      // The verdict is agent judgment, not a machine count — no jq anywhere.
+      expect(readFileSync(join(runbooksDir, rel), 'utf-8')).not.toMatch(/\bjq\b/);
+    });
+
     it('address-review is a leaf requiring the plan and the recorded review', () => {
       const rel = 'planning/address-review.runbook.md';
       const runbook = readRunbook(rel);
@@ -266,7 +299,7 @@ describe('Built-in Runbook Validation', () => {
       expect(fm).toMatch(/REQUIRED:[\s\S]*?-\s*CodeReviewPath/);
     });
 
-    it('execute-plan delegates implement/review/fix and loops the gates', () => {
+    it('execute-plan delegates implement/review and loops the review-verdict gate', () => {
       const rel = 'planning/execute-plan.runbook.md';
       const runbook = readRunbook(rel);
       expect(runbook.name).toBe('execute-plan');
@@ -274,7 +307,6 @@ describe('Built-in Runbook Validation', () => {
         'Invoke the Executing Plans skill',
         'Implement the plan',
         'Code review',
-        'Is the review clean?',
         'Address review findings',
         'Verify',
       ]);
@@ -288,10 +320,33 @@ describe('Built-in Runbook Validation', () => {
       // The three delegate frontiers.
       expectSubstepRunbook(byId('2'), ['implement-plan.runbook.md'], true);
       expectSubstepRunbook(byId('3'), ['code-review.runbook.md'], true);
-      expectSubstepRunbook(byId('5'), ['address-review.runbook.md'], true);
-      // Gate + verify steps carry no substeps (they are command gates).
-      expect(stepHasSubsteps(byId('4'))).toBe(false);
-      expect(stepHasSubsteps(byId('6'))).toBe(false);
+      expectSubstepRunbook(byId('4'), ['address-review.runbook.md'], true);
+      // Verify is a command gate with no substeps.
+      expect(stepHasSubsteps(byId('5'))).toBe(false);
+
+      // The code-review verdict drives flow directly — there is no jq gate step
+      // in the parent. A clean review (child COMPLETE -> pass) jumps to Verify;
+      // a dirty review (child STOP -> fail) falls through to Address.
+      expect(byId('3').transitions.pass.action).toMatchObject({
+        type: 'GOTO',
+        target: { step: '5' },
+      });
+      expect(byId('3').transitions.fail.action).toEqual({ type: 'CONTINUE' });
+      // Address loops back to re-review on success; stops if it cannot resolve.
+      expect(byId('4').transitions.pass.action).toMatchObject({
+        type: 'GOTO',
+        target: { step: '3' },
+      });
+      expect(byId('4').transitions.fail.action).toEqual({ type: 'STOP' });
+      // Verify completes the workflow when green; red routes back to Address.
+      expect(byId('5').transitions.pass.action).toEqual({ type: 'COMPLETE' });
+      expect(byId('5').transitions.fail.action).toMatchObject({
+        type: 'GOTO',
+        target: { step: '4' },
+      });
+
+      // The whole point of the change: the parent never inspects the review JSON.
+      expect(readFileSync(join(runbooksDir, rel), 'utf-8')).not.toMatch(/\bjq\b/);
     });
 
     it('planning composes write(delegate) -> review -> execute', () => {

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -253,5 +253,17 @@ describe('Built-in Runbook Validation', () => {
         'Review the implemented changes',
       );
     });
+
+    it('address-review is a leaf requiring the plan and the recorded review', () => {
+      const rel = 'planning/address-review.runbook.md';
+      const runbook = readRunbook(rel);
+      expect(runbook.name).toBe('address-review');
+      expect(runbook.steps.every((step) => !stepHasSubsteps(step))).toBe(true);
+      const fm = frontmatterText(rel);
+      expect(fm).toMatch(/^skill:\s*executing-plans\s*$/m);
+      // Requires both the plan and the review it must resolve.
+      expect(fm).toMatch(/REQUIRED:[\s\S]*?-\s*PlanPath/);
+      expect(fm).toMatch(/REQUIRED:[\s\S]*?-\s*CodeReviewPath/);
+    });
   });
 });

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -238,5 +238,20 @@ describe('Built-in Runbook Validation', () => {
       ]);
       expect(frontmatterText(rel)).toMatch(/^skill:\s*executing-plans\s*$/m);
     });
+
+    it('code-review is a leaf producing a validated CodeReviewPath', () => {
+      const rel = 'planning/code-review.runbook.md';
+      const runbook = readRunbook(rel);
+      expect(runbook.name).toBe('code-review');
+      expect(runbook.steps.every((step) => !stepHasSubsteps(step))).toBe(true);
+      expect(frontmatterOutputNames(rel)).toEqual(['CodeReviewPath']);
+      // Output path step binds the managed artifact; write step precedes validate.
+      expect(artifactNamesForStep(rel, '4')).toEqual(['CodeReviewPath']);
+      expect(runbook.steps.find((s) => s.name === '5')?.description).toBe('Write the review');
+      // The review step records rather than gates.
+      expect(runbook.steps.find((s) => s.name === '3')?.description).toBe(
+        'Review the implemented changes',
+      );
+    });
   });
 });

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -219,4 +219,24 @@ describe('Built-in Runbook Validation', () => {
       ]);
     });
   });
+
+  describe('planning execute pipeline', () => {
+    function frontmatterText(relativePath: string): string {
+      return readFileSync(join(runbooksDir, relativePath), 'utf-8');
+    }
+
+    it('implement-plan is a delegated leaf that invokes the executing-plans skill', () => {
+      const rel = 'planning/implement-plan.runbook.md';
+      const runbook = readRunbook(rel);
+      expect(runbook.name).toBe('implement-plan');
+      // Leaf: no substeps anywhere (cannot delegate).
+      expect(runbook.steps.every((step) => !stepHasSubsteps(step))).toBe(true);
+      expect(runbook.steps.map((step) => step.description)).toEqual([
+        'Invoke the Executing Plans skill',
+        'Read the plan',
+        'Implement every task',
+      ]);
+      expect(frontmatterText(rel)).toMatch(/^skill:\s*executing-plans\s*$/m);
+    });
+  });
 });

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -265,5 +265,33 @@ describe('Built-in Runbook Validation', () => {
       expect(fm).toMatch(/REQUIRED:[\s\S]*?-\s*PlanPath/);
       expect(fm).toMatch(/REQUIRED:[\s\S]*?-\s*CodeReviewPath/);
     });
+
+    it('execute-plan delegates implement/review/fix and loops the gates', () => {
+      const rel = 'planning/execute-plan.runbook.md';
+      const runbook = readRunbook(rel);
+      expect(runbook.name).toBe('execute-plan');
+      expect(runbook.steps.map((step) => step.description)).toEqual([
+        'Invoke the Executing Plans skill',
+        'Implement the plan',
+        'Code review',
+        'Is the review clean?',
+        'Address review findings',
+        'Verify',
+      ]);
+      expect(frontmatterOutputNames(rel)).toEqual(['CodeReviewPath']);
+
+      const byId = (id: string) => {
+        const step = runbook.steps.find((s) => s.name === id);
+        if (!step) throw new Error(`expected step ${id}`);
+        return step;
+      };
+      // The three delegate frontiers.
+      expectSubstepRunbook(byId('2'), ['implement-plan.runbook.md'], true);
+      expectSubstepRunbook(byId('3'), ['code-review.runbook.md'], true);
+      expectSubstepRunbook(byId('5'), ['address-review.runbook.md'], true);
+      // Gate + verify steps carry no substeps (they are command gates).
+      expect(stepHasSubsteps(byId('4'))).toBe(false);
+      expect(stepHasSubsteps(byId('6'))).toBe(false);
+    });
   });
 });

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -309,5 +309,13 @@ describe('Built-in Runbook Validation', () => {
       expectSubstepRunbook(runbook.steps[2], ['planning/execute-plan.runbook.md'], false);
       expect(frontmatterOutputNames(rel)).toEqual(['PlanPath', 'ReviewPlanPath', 'CodeReviewPath']);
     });
+
+    it('house-style links to the composing-runbooks guide', () => {
+      const houseStyle = readFileSync(
+        join(projectRoot, 'skills', 'writing-runbooks', 'house-style.md'),
+        'utf-8',
+      );
+      expect(houseStyle).toMatch(/composing-runbooks\.md/);
+    });
   });
 });

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -293,5 +293,21 @@ describe('Built-in Runbook Validation', () => {
       expect(stepHasSubsteps(byId('4'))).toBe(false);
       expect(stepHasSubsteps(byId('6'))).toBe(false);
     });
+
+    it('planning composes write(delegate) -> review -> execute', () => {
+      const rel = 'meta/planning.runbook.md';
+      const runbook = readRunbook(rel);
+      expect(runbook.name).toBe('planning');
+      expect(runbook.steps.map((step) => step.description)).toEqual([
+        'Write the plan',
+        'Review the plan',
+        'Execute the plan',
+      ]);
+      // Leaf-delegate, orchestrator-compose: write delegates, review + execute compose.
+      expectSubstepRunbook(runbook.steps[0], ['planning/write-plan.runbook.md'], true);
+      expectSubstepRunbook(runbook.steps[1], ['planning/review-plan.runbook.md'], false);
+      expectSubstepRunbook(runbook.steps[2], ['planning/execute-plan.runbook.md'], false);
+      expect(frontmatterOutputNames(rel)).toEqual(['PlanPath', 'ReviewPlanPath', 'CodeReviewPath']);
+    });
   });
 });

--- a/packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts
@@ -35,6 +35,6 @@ describe('executing-plans skill', () => {
 
   it('tells the implementer when to stop and escalate', () => {
     const skill = readSkill();
-    expect(skill).toMatch(/escalat|stop/i);
+    expect(skill).toMatch(/escalate|stop/i);
   });
 });

--- a/packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const skillPath = path.join(__dirname, '..', '..', 'skills', 'executing-plans', 'SKILL.md');
+
+function readSkill(): string {
+  return readFileSync(skillPath, 'utf-8');
+}
+
+describe('executing-plans skill', () => {
+  it('declares kebab-case name and a description', () => {
+    const skill = readSkill();
+    expect(skill).toMatch(/^name:\s*executing-plans\s*$/m);
+    expect(skill).toMatch(/^description:\s*\S+/m);
+  });
+
+  it('describes the per-task cycle as the context, not the sequence', () => {
+    const skill = readSkill();
+    expect(skill).toMatch(/per-task/i);
+    expect(skill).toMatch(/commit/i);
+    // Cedes the sequence + gates to the runbook rather than restating them.
+    expect(skill).toMatch(/execute-plan/);
+  });
+
+  it('cross-links related skills instead of restating them', () => {
+    const skill = readSkill();
+    expect(skill).toMatch(/writing-plans/);
+    expect(skill).toMatch(/running-runbooks/);
+    expect(skill).toMatch(/delegating-runbooks/);
+  });
+
+  it('tells the implementer when to stop and escalate', () => {
+    const skill = readSkill();
+    expect(skill).toMatch(/escalat|stop/i);
+  });
+});

--- a/packages/claude-code-plugin/runbooks/meta/planning.runbook.md
+++ b/packages/claude-code-plugin/runbooks/meta/planning.runbook.md
@@ -1,22 +1,19 @@
 ---
-name: End-to-End Test
-description: Run multiple runbooks and test the end-to-end process.
+name: planning
+description: Plan, review, and execute a body of work — write the plan, review it, then implement it behind review and verify gates.
+tags:
+  - planning
+OUTPUTS:
+  - PlanPath
+  - ReviewPlanPath
+  - CodeReviewPath
 ---
 
-# End-to-End Test
+# Planning
 
-Run multiple runbooks, reviewing and testing the end-to-end process.
+Plan a body of work, review the plan, then execute it.
 
-
-## 1. Read the output schema
-- PASS CONTINUE
-- FAIL STOP
-
-```prompt
-{{ CLAUDE_PLUGIN_ROOT }}/schemas/review.schema.json
-```
-
-## 2. Write Plan
+## 1. Write the plan
 - DELEGATE
 - PASS ALL CONTINUE
 - FAIL ANY STOP
@@ -24,38 +21,15 @@ Run multiple runbooks, reviewing and testing the end-to-end process.
 - planning/write-plan.runbook.md
 
 
-## 3. Review Plan
+## 2. Review the plan
 - PASS ALL CONTINUE
 - FAIL ANY STOP
 
 - planning/review-plan.runbook.md
 
 
-## 4. Write the review of the end-to-end Rundown workflow
-- PASS CONTINUE
-- FAIL STOP
+## 3. Execute the plan
+- PASS ALL COMPLETE
+- FAIL ANY STOP
 
-Write the review to the output path as JSON.
-Follow the review output schema.
-
-```bash
-OUTPUT_PATH="$(rdpath --dir {{ WorkPath }} --ctx {{ ContextId }} --file end-to-end-test-review.json)"
-cat > "$OUTPUT_PATH" <<'JSON'
-{
-  "$schema": "https://rundown.org/schemas/review.schema.json",
-  "meta": {
-    "version": "1.0.0"
-  },
-  "items": []
-}
-JSON
-```
-
-
-## 5. Check Schema
-- PASS COMPLETE
-- FAIL GOTO 4
-
-```bash
-rdx "$(rdpath --dir {{ WorkPath }} --ctx {{ ContextId }} --file end-to-end-test-review.json)" --validate
-```
+- planning/execute-plan.runbook.md

--- a/packages/claude-code-plugin/runbooks/planning/address-review.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/address-review.runbook.md
@@ -1,0 +1,42 @@
+---
+name: address-review
+description: Resolve the error-level findings recorded by a code review, committing the fix.
+skill: executing-plans
+tags:
+  - planning
+INPUTS:
+  - PlanPath
+  - CodeReviewPath
+REQUIRED:
+  - PlanPath
+  - CodeReviewPath
+---
+
+# Address Review Findings
+
+Resolve the blocking findings from the code review.
+
+## 1. Invoke the Executing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the executing-plans skill. Internalize the per-task cycle and commit discipline.
+
+Skill: `rundown:executing-plans`
+
+
+## 2. Read the review and plan
+- ARTIFACTS
+  - PlanPath
+  - CodeReviewPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the recorded findings at `{{ path CodeReviewPath }}` and the plan at `{{ path PlanPath }}`.
+
+
+## 3. Resolve the findings
+- PASS COMPLETE
+- FAIL STOP
+
+Resolve every `error`-level finding, staying within the plan's intent. Add or update tests as needed, then commit the fix. Stop and escalate if a finding cannot be resolved within scope.

--- a/packages/claude-code-plugin/runbooks/planning/code-review.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/code-review.runbook.md
@@ -1,0 +1,76 @@
+---
+name: code-review
+description: Review implemented changes against the plan and record findings as a review document.
+tags:
+  - planning
+  - review
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+OUTPUTS:
+  - CodeReviewPath
+---
+
+# Code Review
+
+Review the implemented changes against the plan and record findings.
+
+## 1. Read the output schema
+- ARTIFACTS
+  - ReviewSchemaPath "schemas/review.schema.json"
+- PASS CONTINUE
+- FAIL STOP
+
+The schema defines the expected review output structure.
+
+
+## 2. Read the plan
+- ARTIFACTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan at `{{ path PlanPath }}`. It defines the intended changes to review against.
+
+
+## 3. Review the implemented changes
+- PASS CONTINUE
+- FAIL CONTINUE
+
+Review the working-tree changes against the plan:
+
+- Each planned task is implemented and matches its intent.
+- No unplanned or out-of-scope changes.
+- Tests cover the new behaviour and code follows project conventions.
+
+Record findings; do not gate here.
+
+
+## 4. Output Path
+- ARTIFACTS
+  - CodeReviewPath "code-review.json"
+- PASS CONTINUE
+- FAIL STOP
+
+{{ CodeReviewPath }}
+
+
+## 5. Write the review
+- ARTIFACTS
+  - PlanPath
+  - ReviewSchemaPath
+  - CodeReviewPath
+- PASS CONTINUE
+- FAIL STOP
+
+Write the review to `{{ path CodeReviewPath }}` as JSON, following the schema from `{{ path ReviewSchemaPath }}`. Use `level: "error"` for findings that must block, `warning` or `note` otherwise. An empty `items` array records a clean review.
+
+
+## 6. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 5
+
+```bash
+{{ validateSchema CodeReviewPath }}
+```

--- a/packages/claude-code-plugin/runbooks/planning/code-review.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/code-review.runbook.md
@@ -68,9 +68,22 @@ Write the review to `{{ path CodeReviewPath }}` as JSON, following the schema fr
 
 
 ## 6. Check Schema
-- PASS COMPLETE
+- PASS CONTINUE
 - FAIL GOTO 5
 
 ```bash
 {{ validateSchema CodeReviewPath }}
 ```
+
+
+## 7. Gate the review
+- ARTIFACTS
+  - CodeReviewPath
+- PASS COMPLETE
+- FAIL STOP
+
+You recorded the review at `{{ path CodeReviewPath }}`. Render the verdict.
+
+Pass the gate when the review is clean — no findings that must block the work. Fail the gate when it holds blocking (`error`-level) findings the work must address before it can advance.
+
+A review that records blocking findings is a failing review. The verdict is yours to make from the recorded review; do not soften it to keep the work moving.

--- a/packages/claude-code-plugin/runbooks/planning/execute-plan.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/execute-plan.runbook.md
@@ -1,0 +1,71 @@
+---
+name: execute-plan
+description: Execute a reviewed plan — delegate implementation, then loop code review and verify gates until clean.
+skill: executing-plans
+tags:
+  - planning
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+OUTPUTS:
+  - CodeReviewPath
+---
+
+# Execute Plan
+
+Execute the plan, then hold the work to the review and verify gates.
+
+## 1. Invoke the Executing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the executing-plans skill. Internalize how implementation, review, and verification fit together.
+
+Skill: `rundown:executing-plans`
+
+
+## 2. Implement the plan
+- ARTIFACTS
+  - PlanPath
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- implement-plan.runbook.md
+
+
+## 3. Code review
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- code-review.runbook.md
+
+
+## 4. Is the review clean?
+- ARTIFACTS
+  - CodeReviewPath
+- PASS GOTO 6
+- FAIL CONTINUE
+
+```bash
+test "$(jq '[.items[] | select(.level == "error")] | length' "{{ path CodeReviewPath }}")" -eq 0
+```
+
+
+## 5. Address review findings
+- DELEGATE
+- PASS ALL GOTO 3
+- FAIL ANY STOP
+
+- address-review.runbook.md
+
+
+## 6. Verify
+- PASS COMPLETE
+- FAIL GOTO 5
+
+```bash
+npm run verify
+```

--- a/packages/claude-code-plugin/runbooks/planning/execute-plan.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/execute-plan.runbook.md
@@ -37,24 +37,13 @@ Skill: `rundown:executing-plans`
 
 ## 3. Code review
 - DELEGATE
-- PASS ALL CONTINUE
-- FAIL ANY STOP
+- PASS ALL GOTO 5
+- FAIL ANY CONTINUE
 
 - code-review.runbook.md
 
 
-## 4. Is the review clean?
-- ARTIFACTS
-  - CodeReviewPath
-- PASS GOTO 6
-- FAIL CONTINUE
-
-```bash
-test "$(jq '[.items[] | select(.level == "error")] | length' "{{ path CodeReviewPath }}")" -eq 0
-```
-
-
-## 5. Address review findings
+## 4. Address review findings
 - DELEGATE
 - PASS ALL GOTO 3
 - FAIL ANY STOP
@@ -62,9 +51,9 @@ test "$(jq '[.items[] | select(.level == "error")] | length' "{{ path CodeReview
 - address-review.runbook.md
 
 
-## 6. Verify
+## 5. Verify
 - PASS COMPLETE
-- FAIL GOTO 5
+- FAIL GOTO 4
 
 ```bash
 npm run verify

--- a/packages/claude-code-plugin/runbooks/planning/implement-plan.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/implement-plan.runbook.md
@@ -1,0 +1,39 @@
+---
+name: implement-plan
+description: Implement every task in a plan via the executing-plans skill, committing per task.
+skill: executing-plans
+tags:
+  - planning
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+---
+
+# Implement Plan
+
+Execute every task in the plan, following the executing-plans skill.
+
+## 1. Invoke the Executing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the executing-plans skill. Internalize the per-task cycle, commit discipline, and when to stop and escalate.
+
+Skill: `rundown:executing-plans`
+
+
+## 2. Read the plan
+- ARTIFACTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan at `{{ path PlanPath }}`. Review it critically before starting; if it has gaps that prevent starting, stop and escalate.
+
+
+## 3. Implement every task
+- PASS COMPLETE
+- FAIL STOP
+
+Work through the plan's tasks in order. For each task: follow its bite-sized steps exactly, run the verifications it specifies, and make its commit before the next task. Do not pause between tasks; stop only when blocked or when every task is complete.

--- a/packages/claude-code-plugin/skills/converting-skills-to-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/converting-skills-to-runbooks/SKILL.md
@@ -45,7 +45,7 @@ Every `SKILL.md` holds two kinds of content. Conversion separates them.
 
 ## Worked Example
 
-The superpowers `writing-plans` skill (~200 lines of guidance) distills to `runbooks/planning/write-plan.runbook.md` (~112 lines). Its step 1 is the move this skill generalizes:
+The superpowers `writing-plans` skill distills to `runbooks/planning/write-plan.runbook.md`. Its step 1 is the move this skill generalizes:
 
 ```markdown
 ## 1. Invoke the Writing Plans skill

--- a/packages/claude-code-plugin/skills/converting-skills-to-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/converting-skills-to-runbooks/SKILL.md
@@ -45,7 +45,7 @@ Every `SKILL.md` holds two kinds of content. Conversion separates them.
 
 ## Worked Example
 
-The superpowers `writing-plans` skill (~200 lines of guidance) distills to `runbooks/planning/write-plan.runbook.md` (~40 lines of backbone). Its step 1 is the move this skill generalizes:
+The superpowers `writing-plans` skill (~200 lines of guidance) distills to `runbooks/planning/write-plan.runbook.md` (~112 lines). Its step 1 is the move this skill generalizes:
 
 ```markdown
 ## 1. Invoke the Writing Plans skill

--- a/packages/claude-code-plugin/skills/executing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/executing-plans/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: executing-plans
+description: Use when implementing a written plan task-by-task — the per-task cycle, commit discipline, and escalation rules that an execute-plan runbook orchestrates around.
+---
+
+# Executing Plans
+
+Implement a written plan one task at a time, holding each task to its own tests and committing as you go. This skill is the **context** an execution runbook orchestrates: how to do each task well. The [`execute-plan`](../../runbooks/planning/execute-plan.runbook.md) runbook owns the *sequence* (implement → review → verify) and the *gates*; this skill owns the *craft* of a single task.
+
+Rundown orchestrates workflow; it does not store craft. Keep the cycle here, not in the runbook.
+
+## When to Use
+
+- Implementing a plan produced by [writing-plans](../writing-plans/SKILL.md), whether driven by the `execute-plan` runbook or by hand.
+- Resolving review findings against an already-implemented plan.
+
+## When NOT to Use
+
+- Writing the plan — use [writing-plans](../writing-plans/SKILL.md).
+- Authoring or sequencing the runbook that drives execution — use [writing-runbooks](../writing-runbooks/SKILL.md) and [delegating-runbooks](../delegating-runbooks/SKILL.md).
+
+## The Per-Task Cycle
+
+Work the plan's tasks in order. For each task:
+
+1. **Follow its bite-sized steps exactly.** A well-written task is TDD-shaped: write the failing test, run it red, implement the minimum, run it green.
+2. **Run the verifications the task specifies.** Do not skip them.
+3. **Commit per the task's `commit` block** before starting the next task.
+4. **Keep moving.** Do not pause between tasks to check in — execute the whole plan. Stop only to escalate (below).
+
+## Commit Discipline
+
+One commit per task, staging exactly the files the task's `commit.files` lists, with the task's `commit.message`. Frequent, atomic commits keep the work bisectable and give the review and verify gates a clean history to act on.
+
+## Review and Verify Gates
+
+The `execute-plan` runbook reviews the implemented changes and runs `npm run verify` after implementation, looping a fix step until both are clean. Your responsibility is to make those gates *reachable*: leave the tree building, tests passing for the work you did, and changes scoped to the plan. When a gate sends work back (via `address-review`), resolve the recorded `error`-level findings without expanding scope.
+
+## When to Stop and Escalate
+
+Stop and ask rather than guess when:
+
+- A dependency, file, or symbol the plan references does not exist.
+- A task's instruction is ambiguous or contradicts the codebase.
+- A verification fails repeatedly and the fix is unclear.
+- The plan has a gap that prevents starting a task.
+
+Never start implementation on `main`/`master` without explicit consent.
+
+## Reference
+
+- [writing-plans](../writing-plans/SKILL.md) — produces the plan this skill executes
+- [running-runbooks](../running-runbooks/SKILL.md) — executing the driving runbook
+- [delegating-runbooks](../delegating-runbooks/SKILL.md) — parent-side delegation of the implementer
+- [composing-runbooks.md](../../../../docs/guides/composing-runbooks.md) — how execute-plan composes the leaves

--- a/packages/claude-code-plugin/skills/writing-runbooks/house-style.md
+++ b/packages/claude-code-plugin/skills/writing-runbooks/house-style.md
@@ -2,7 +2,7 @@
 
 Idiomatic conventions distilled from the canonical plugin runbooks — `packages/claude-code-plugin/runbooks/end-to-end-test/*` and `packages/claude-code-plugin/runbooks/planning/*`. These runbooks are the reference style; mirror them.
 
-`SKILL.md` documents the *syntax* of each directive. This guide documents how the pieces *combine* — the patterns to reach for first when authoring a new runbook. When in doubt, open a sibling runbook in those directories and match it.
+`SKILL.md` documents the *syntax* of each directive. This guide documents how the pieces *combine* — the patterns to reach for first when authoring a new runbook. When in doubt, open a sibling runbook in those directories and match it. For *inter*-runbook composition (pipelines, gate loops, the leaf-delegate / orchestrator-compose discipline) see [docs/guides/composing-runbooks.md](../../../../docs/guides/composing-runbooks.md).
 
 ## The core idiom: schema-first artifact pipeline
 


### PR DESCRIPTION
## Summary

Delivers the plan → review → execute workflow as the worked example of Rundown **composition patterns**, and documents those patterns. Builds on the `converting-skills-to-runbooks` skill (#432, now merged).

The execute stage is a **first pass** that deliberately avoids `FOR`: the task walk lives in the agent + a converted `executing-plans` skill, and Rundown owns the **gates**. `execute-plan` delegates one `implement-plan` leaf (only `PlanPath` crosses the delegation boundary — the proven artifact handoff), delegates a `code-review` leaf, then loops a machine-checkable review-clean gate (`jq` error count) and `npm run verify`, each `FAIL GOTO` a dedicated `address-review` fix leaf.

### What's added
- **`executing-plans` skill** — converted context for the per-task walk (dogfooded from superpowers `executing-plans` + `subagent-driven-development`).
- **`implement-plan` / `code-review` / `address-review`** — three delegated leaves.
- **`execute-plan`** — composed orchestrator with the two gate loops.
- **`planning.runbook.md`** — rebuilt from a broken `End-to-End Test` stub into write(delegate) → review(compose) → execute(compose).
- **`docs/guides/composing-runbooks.md`** — five patterns (pipeline, leaf-delegate/orchestrator-compose, fan-out+collate, gate loop, top-level workflow) plus the two `FOR`/delegation constraints found by spike, documented as future work. Cross-linked from house-style.

### Design notes
Live spikes against the built CLI surfaced two constraints that reshaped the design away from `FOR`-per-task delegation: a `FOR` source must resolve at the launch of the runbook containing it, and the loop variable + `Index` do not cross the delegation boundary. Both are now documented rather than latent. Design + plan: `docs/internal/composing-runbooks-design.md`, `docs/internal/plans/composing-runbooks-plan.md`.

## Test Plan
- [x] All five runbooks pass `rd check`
- [x] `validation.test.ts` pins runbook structures (delegate frontiers, gate steps, leaf-vs-compose discipline)
- [x] Runtime integration test: harness → `execute-plan` → `implement-plan` delegation + `PlanPath` inheritance
- [x] Full plugin suite: 990 passing
- [x] `npm run verify` (format, spell, lint, test) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an executing-plans skill and a three-phase planning workflow (write → review → execute) with new runbooks: implement-plan, code-review, execute-plan, and address-review.

* **Documentation**
  * New public guide on composing multi-stage runbooks plus extensive internal design, plan, flow, and skill docs and house-style updates with examples and cross-links.

* **Tests**
  * Added integration and validation tests for the planning pipeline, delegation/artifact handoff, and runbook/frontmatter semantics.

* **Chores**
  * Updated spell dictionary (added/split a few terms).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->