### PR TITLE
chore(scripts): add plugin:dev launcher for --plugin-dir loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,6 +377,9 @@ pnpm run test:mutate:plugin  # Mutation testing for plugin only
 pnpm run test:mutate:cli -- --mutate <file> --testFiles <test>  # Scoped CLI Stryker run
 pnpm run test:property # Property-based tests
 pnpm run test:perf     # Performance benchmarks
+pnpm run plugin:dev       # Build + launch Claude Code with the local plugin via --plugin-dir
+pnpm run plugin:dev -- --no-build              # Skip rebuild (faster iteration)
+pnpm run plugin:dev -- -- --debug hooks,plugins # Forward flags to claude
 pnpm run verify:claude    # Docker: verify CLI+plugin install (local build)
 pnpm run verify:claude:npm  # Docker: verify install from npm registry
 pnpm run test:e2e                              # Docker: E2E plugin workflow test

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "version": "changeset version",
     "release": "changeset publish",
     "prepare": "husky || true",
+    "plugin:dev": "./scripts/plugin-dev.sh",
     "verify:claude": "./scripts/verify-install.sh local",
     "verify:claude:npm": "./scripts/verify-install.sh npm",
     "test:e2e": "./scripts/run-e2e.sh",

--- a/scripts/__tests__/plugin-dev.test.mjs
+++ b/scripts/__tests__/plugin-dev.test.mjs
@@ -1,0 +1,135 @@
+import { spawnSync } from 'node:child_process';
+import assert from 'node:assert/strict';
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+
+/**
+ * Run scripts/plugin-dev.sh inside an isolated ROOT_DIR containing a fake plugin
+ * manifest, with `npm` and (optionally) `rd`/`claude` stubbed on a pruned PATH so
+ * the wrapper reaches its final `exec claude` without a real build or Claude Code.
+ *
+ * PATH is set to the stub bin dir plus only /usr/bin:/bin — this excludes the
+ * developer's real npm/rd/claude so the wrapper's behavior is observed against
+ * stubs, not whatever happens to be installed. The claude stub prints its argv,
+ * and the npm stub appends its argv to npm.log, so the test asserts real flag
+ * BEHAVIOR (what reaches claude, whether build/link ran) rather than string-
+ * matching the script source.
+ *
+ * @param args - arguments passed to plugin-dev.sh
+ * @param opts - control which stubs exist on PATH
+ * @param opts.rd - whether an `rd` stub is on PATH (default true)
+ * @param opts.claude - whether a `claude` stub is on PATH (default true)
+ * @param opts.manifest - whether the plugin manifest exists (default true)
+ * @returns spawnSync result plus the captured npm invocation log
+ */
+async function runPluginDev(args, opts = {}) {
+  const { rd = true, claude = true, manifest = true } = opts;
+  const work = await mkdtemp(join(tmpdir(), 'plugin-dev-'));
+  try {
+    const scriptsDir = join(work, 'scripts');
+    const binDir = join(work, 'bin');
+    const manifestDir = join(work, 'packages/claude-code-plugin/.claude-plugin');
+    await mkdir(scriptsDir, { recursive: true });
+    await mkdir(binDir, { recursive: true });
+    if (manifest) {
+      await mkdir(manifestDir, { recursive: true });
+      await writeFile(join(manifestDir, 'plugin.json'), '{"name":"rundown"}\n');
+    }
+
+    const script = join(scriptsDir, 'plugin-dev.sh');
+    await copyFile(join(repoRoot, 'scripts/plugin-dev.sh'), script);
+    await chmod(script, 0o755);
+
+    const npmLog = join(work, 'npm.log');
+    // npm stub records every invocation; `npm run build` and `npm link` both no-op.
+    const npmStub = join(binDir, 'npm');
+    await writeFile(
+      npmStub,
+      `#!/usr/bin/env bash\nprintf '%s ' "$@" >> ${JSON.stringify(npmLog)}\nprintf '\\n' >> ${JSON.stringify(npmLog)}\nexit 0\n`,
+    );
+    await chmod(npmStub, 0o755);
+
+    if (rd) {
+      const rdStub = join(binDir, 'rd');
+      await writeFile(rdStub, '#!/usr/bin/env bash\nexit 0\n');
+      await chmod(rdStub, 0o755);
+    }
+    if (claude) {
+      // Prints argv so the test can assert what the wrapper forwarded.
+      const claudeStub = join(binDir, 'claude');
+      await writeFile(claudeStub, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$@"\n');
+      await chmod(claudeStub, 0o755);
+    }
+
+    const result = spawnSync('bash', [script, ...args], {
+      env: { ...process.env, PATH: `${binDir}:/usr/bin:/bin` },
+      encoding: 'utf-8',
+    });
+    const npmCalls = existsSync(npmLog) ? await readFile(npmLog, 'utf-8') : '';
+    return { ...result, npmCalls, pluginDir: join(work, 'packages/claude-code-plugin') };
+  } finally {
+    await rm(work, { recursive: true, force: true });
+  }
+}
+
+test('launches claude with --plugin-dir pointing at the plugin package', async () => {
+  const r = await runPluginDev(['--no-build']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /--plugin-dir/);
+  assert.ok(
+    r.stdout.includes(r.pluginDir),
+    `expected plugin dir ${r.pluginDir} in argv:\n${r.stdout}`,
+  );
+});
+
+test('--no-build skips the build; default builds', async () => {
+  const skipped = await runPluginDev(['--no-build']);
+  assert.equal(skipped.status, 0, skipped.stderr);
+  assert.doesNotMatch(skipped.npmCalls, /run build/);
+
+  const built = await runPluginDev([]);
+  assert.equal(built.status, 0, built.stderr);
+  assert.match(built.npmCalls, /run build/);
+});
+
+test('forwards args after -- to claude', async () => {
+  const r = await runPluginDev(['--no-build', '--', '--debug', 'hooks,plugins']);
+  assert.equal(r.status, 0, r.stderr);
+  const lines = r.stdout.trim().split('\n');
+  // The forwarded flags must arrive after --plugin-dir <dir>, in order.
+  assert.deepEqual(lines.slice(-2), ['--debug', 'hooks,plugins']);
+});
+
+test('links the local CLI when rd is absent, skips link when present', async () => {
+  const absent = await runPluginDev(['--no-build'], { rd: false });
+  assert.equal(absent.status, 0, absent.stderr);
+  assert.match(absent.npmCalls, /link -w packages\/cli/);
+
+  const present = await runPluginDev(['--no-build'], { rd: true });
+  assert.equal(present.status, 0, present.stderr);
+  assert.doesNotMatch(present.npmCalls, /link/);
+});
+
+test('fails when claude is not installed', async () => {
+  const r = await runPluginDev(['--no-build'], { claude: false });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /claude.*not found/i);
+});
+
+test('fails on an unknown argument', async () => {
+  const r = await runPluginDev(['--nope']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unknown argument/i);
+});
+
+test('fails when the plugin manifest is missing', async () => {
+  const r = await runPluginDev(['--no-build'], { manifest: false });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /manifest not found/i);
+});

--- a/scripts/__tests__/plugin-dev.test.mjs
+++ b/scripts/__tests__/plugin-dev.test.mjs
@@ -26,10 +26,12 @@ const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
  * @param opts.rd - whether an `rd` stub is on PATH (default true)
  * @param opts.claude - whether a `claude` stub is on PATH (default true)
  * @param opts.manifest - whether the plugin manifest exists (default true)
+ * @param opts.linkProvidesRd - whether `npm link` puts `rd` on PATH (default true).
+ *   Set false to simulate a link that succeeds but leaves the npm global bin off PATH.
  * @returns spawnSync result plus the captured npm invocation log
  */
 async function runPluginDev(args, opts = {}) {
-  const { rd = true, claude = true, manifest = true } = opts;
+  const { rd = true, claude = true, manifest = true, linkProvidesRd = true } = opts;
   const work = await mkdtemp(join(tmpdir(), 'plugin-dev-'));
   try {
     const scriptsDir = join(work, 'scripts');
@@ -47,16 +49,21 @@ async function runPluginDev(args, opts = {}) {
     await chmod(script, 0o755);
 
     const npmLog = join(work, 'npm.log');
-    // npm stub records every invocation; `npm run build` and `npm link` both no-op.
+    const rdStub = join(binDir, 'rd');
+    // npm stub records every invocation; `npm run build` no-ops. `npm link` no-ops
+    // too, except that — when linkProvidesRd — it drops an `rd` stub on PATH to model
+    // a link that makes the CLI resolvable, mirroring the script's post-link recheck.
     const npmStub = join(binDir, 'npm');
+    const linkBody = linkProvidesRd
+      ? `if [ "$1" = link ]; then printf '#!/usr/bin/env bash\\nexit 0\\n' > ${JSON.stringify(rdStub)}; chmod 0755 ${JSON.stringify(rdStub)}; fi\n`
+      : '';
     await writeFile(
       npmStub,
-      `#!/usr/bin/env bash\nprintf '%s ' "$@" >> ${JSON.stringify(npmLog)}\nprintf '\\n' >> ${JSON.stringify(npmLog)}\nexit 0\n`,
+      `#!/usr/bin/env bash\nprintf '%s ' "$@" >> ${JSON.stringify(npmLog)}\nprintf '\\n' >> ${JSON.stringify(npmLog)}\n${linkBody}exit 0\n`,
     );
     await chmod(npmStub, 0o755);
 
     if (rd) {
-      const rdStub = join(binDir, 'rd');
       await writeFile(rdStub, '#!/usr/bin/env bash\nexit 0\n');
       await chmod(rdStub, 0o755);
     }
@@ -114,6 +121,13 @@ test('links the local CLI when rd is absent, skips link when present', async () 
   const present = await runPluginDev(['--no-build'], { rd: true });
   assert.equal(present.status, 0, present.stderr);
   assert.doesNotMatch(present.npmCalls, /link/);
+});
+
+test('fails fast when rd is still absent after npm link', async () => {
+  const r = await runPluginDev(['--no-build'], { rd: false, linkProvidesRd: false });
+  assert.match(r.npmCalls, /link -w packages\/cli/);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /still not on PATH after npm link/i);
 });
 
 test('fails when claude is not installed', async () => {

--- a/scripts/__tests__/plugin-dev.test.mjs
+++ b/scripts/__tests__/plugin-dev.test.mjs
@@ -109,8 +109,10 @@ test('forwards args after -- to claude', async () => {
   const r = await runPluginDev(['--no-build', '--', '--debug', 'hooks,plugins']);
   assert.equal(r.status, 0, r.stderr);
   const lines = r.stdout.trim().split('\n');
-  // The forwarded flags must arrive after --plugin-dir <dir>, in order.
-  assert.deepEqual(lines.slice(-2), ['--debug', 'hooks,plugins']);
+  // The forwarded flags must arrive after --plugin-dir <dir>, in order. Assert the
+  // full claude argv (the trailing lines after the script's diagnostics) so a
+  // dropped or reordered --plugin-dir is caught, not just the forwarded tail.
+  assert.deepEqual(lines.slice(-4), ['--plugin-dir', r.pluginDir, '--debug', 'hooks,plugins']);
 });
 
 test('links the local CLI when rd is absent, skips link when present', async () => {

--- a/scripts/__tests__/plugin-dev.test.mjs
+++ b/scripts/__tests__/plugin-dev.test.mjs
@@ -88,11 +88,10 @@ async function runPluginDev(args, opts = {}) {
 test('launches claude with --plugin-dir pointing at the plugin package', async () => {
   const r = await runPluginDev(['--no-build']);
   assert.equal(r.status, 0, r.stderr);
-  assert.match(r.stdout, /--plugin-dir/);
-  assert.ok(
-    r.stdout.includes(r.pluginDir),
-    `expected plugin dir ${r.pluginDir} in argv:\n${r.stdout}`,
-  );
+  // Assert the exact trailing argv pair reaches claude, not just that the dir name
+  // appears somewhere in stdout (which a launcher diagnostic could satisfy).
+  const lines = r.stdout.trim().split('\n');
+  assert.deepEqual(lines.slice(-2), ['--plugin-dir', r.pluginDir]);
 });
 
 test('--no-build skips the build; default builds', async () => {

--- a/scripts/plugin-dev.sh
+++ b/scripts/plugin-dev.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# plugin-dev.sh — Launch Claude Code with the local Rundown plugin loaded in-place.
+#
+# Loads packages/claude-code-plugin via Claude Code's --plugin-dir flag. This is
+# the dev loop: per-session, no caching, edits picked up on /reload-plugins. It is
+# NOT the install path — for persistent/shared use add a marketplace instead.
+#
+# Because the plugin's hooks shell out to `rd`/`rundown` (the @rundown-org/cli
+# package), this also ensures that CLI is resolvable on PATH, linking the local
+# build if it is not.
+#
+# Usage:
+#   ./scripts/plugin-dev.sh                              # build, ensure CLI, launch
+#   ./scripts/plugin-dev.sh --no-build                   # skip rebuild (faster iteration)
+#   ./scripts/plugin-dev.sh -- --debug "hooks,plugins"   # forward flags to claude
+#
+# After editing plugin files mid-session, run /reload-plugins inside Claude Code.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+PLUGIN_DIR="$ROOT_DIR/packages/claude-code-plugin"
+
+# ── Parse arguments ──────────────────────────────────────────────────────────
+
+SKIP_BUILD=false
+FORWARDED=()
+
+while [ "$#" -gt 0 ]; do
+  arg="$1"
+  case "$arg" in
+    --no-build)
+      SKIP_BUILD=true
+      ;;
+    --)
+      shift
+      FORWARDED=("$@")
+      break
+      ;;
+    *)
+      echo "[plugin-dev] ERROR: unknown argument '$arg' (use -- to forward flags to claude)" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+
+if [ ! -f "$PLUGIN_DIR/.claude-plugin/plugin.json" ]; then
+  echo "[plugin-dev] ERROR: plugin manifest not found at $PLUGIN_DIR/.claude-plugin/plugin.json" >&2
+  exit 1
+fi
+
+# ── Build (unless skipped) ───────────────────────────────────────────────────
+
+if [ "$SKIP_BUILD" = false ]; then
+  echo "[plugin-dev] Building workspace..."
+  npm run build
+else
+  echo "[plugin-dev] Skipping build (--no-build)"
+fi
+
+# ── Ensure the rd/rundown CLI the plugin hooks call is on PATH ────────────────
+
+if command -v rd >/dev/null 2>&1; then
+  echo "[plugin-dev] Using rd: $(command -v rd)"
+else
+  echo "[plugin-dev] rd not found on PATH — linking local CLI (one-time)..." >&2
+  npm link -w packages/cli
+fi
+
+# ── Launch ───────────────────────────────────────────────────────────────────
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "[plugin-dev] ERROR: 'claude' CLI not found on PATH. Install Claude Code first." >&2
+  exit 1
+fi
+
+echo "[plugin-dev] Launching Claude Code with plugin: $PLUGIN_DIR"
+# ${arr[@]+...} keeps the empty-array expansion safe under set -u on bash 3.2.
+exec claude --plugin-dir "$PLUGIN_DIR" ${FORWARDED[@]+"${FORWARDED[@]}"}

--- a/scripts/plugin-dev.sh
+++ b/scripts/plugin-dev.sh
@@ -70,6 +70,10 @@ if command -v rd >/dev/null 2>&1; then
 else
   echo "[plugin-dev] rd not found on PATH — linking local CLI (one-time)..." >&2
   npm link -w packages/cli
+  if ! command -v rd >/dev/null 2>&1; then
+    echo "[plugin-dev] ERROR: 'rd' is still not on PATH after npm link. Add the npm global bin to PATH, or install @rundown-org/cli." >&2
+    exit 1
+  fi
 fi
 
 # ── Launch ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds an `npm run plugin:dev` task (backed by `scripts/plugin-dev.sh`) for the local plugin development loop: loads `packages/claude-code-plugin` into Claude Code via the `--plugin-dir` flag.

This is the **dev loop** — per-session, no caching, edits picked up via `/reload-plugins`. It is not the install path; persistent/shared use is still a marketplace.

## Why

`--plugin-dir` is the documented way to iterate on the plugin (it's how the repo's own e2e/docker entrypoints wire it), but doing it by hand has a footgun: the plugin's hooks shell out to `rd`/`rundown` (the `@rundown-org/cli` package), which must be on `PATH`. The script handles that.

## Behavior

- Builds the workspace (skip with `--no-build`).
- Ensures `rd` resolves on `PATH`; links the local CLI build (`npm link -w packages/cli`) only if absent.
- `exec claude --plugin-dir packages/claude-code-plugin`, forwarding any flags after `--`.
- Fails fast on: missing plugin manifest, missing `claude` CLI, unknown args.

## Usage

```bash
npm run plugin:dev                                # build, ensure CLI, launch
npm run plugin:dev -- --no-build                  # skip rebuild
npm run plugin:dev -- -- --debug "hooks,plugins"  # forward flags to claude
```

## Tests

`scripts/__tests__/plugin-dev.test.mjs` — 7 behavior tests following the `e2e-codex-harness` pattern: stub `claude`/`npm`/`rd` on a pruned `PATH` and assert what reaches `claude` (forwarded args, build/link behavior, failure modes), rather than string-matching the script source. Runs under `/bin/bash` (bash 3.2), exercising the `set -u`-safe empty-array expansion.

## Scope

Three files only: `scripts/plugin-dev.sh`, `scripts/__tests__/plugin-dev.test.mjs`, `package.json`. No docs change — flag if you want a line added to CLAUDE.md's Development Commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `npm run plugin:dev` to launch Claude Code with the local plugin loaded.
  * Supports `--no-build`, validates the plugin manifest, ensures the required local CLI is available, and forwards additional flags after `--`.
* **Documentation**
  * Updated `CLAUDE.md` with new `plugin:dev` command variants.
* **Tests**
  * Added a Node-based test suite covering the dev launcher, including argument forwarding and expected failure scenarios (unknown args, missing manifest, missing tools).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->