### PR TITLE
refactor(core): converge TOCTOU file guard onto shared safe-fs (#433)

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -266,3 +266,16 @@ gobin
 goflags
 trimpath
 zouuup
+behavioural
+canonicalisation
+generalise
+harmonises
+repoint
+repointed
+fstat
+errno
+CREAT
+TRUNC
+WRONLY
+RDONLY
+ENOTDIR

--- a/docs/internal/plans/2026-06-14-share-safe-fs-toctou-guard.md
+++ b/docs/internal/plans/2026-06-14-share-safe-fs-toctou-guard.md
@@ -1,0 +1,519 @@
+# Plan: Converge symlink/TOCTOU file-read guards onto a shared `safe-fs.ts`
+
+**Issue:** [#433](https://github.com/tobyhede/rundown/issues/433) — "Converge output-channels.ts symlink/TOCTOU guard onto shared safe-fs" (label: `security`)
+**Branch / worktree:** `share-safe-fs` (`/Users/tobyhede/psrc/rundown/.worktrees/share-safe-fs`)
+**Date:** 2026-06-14
+**Status:** Plan only — no production code written.
+
+---
+
+## 1. Summary
+
+`packages/core` currently contains **three independently-written copies** of the same
+security-critical "race-closed file-read guard" pattern (open with `O_NOFOLLOW`,
+`fstat` the opened fd, verify it is a regular file, treat symlink/`ELOOP` specially).
+Each copy is a drift hazard: a hardening or fix applied to one does not reach the others.
+
+The canonical, most-hardened version lives **inline and unexported** inside
+`packages/core/src/runbook/artifact-manifest.ts` (`openVerifiedRegularFileSync`,
+`validateOpenedPathInsideRoot`, `sameFile`, plus the sync/async `readVerifiedUtf8File*`
+helpers). The issue's body assumes a prerequisite — that a shared
+`packages/core/src/runbook/safe-fs.ts` module would already exist (created by the
+separate "validate helper + artifact-schema" Task 10). **That prerequisite has not
+landed: `safe-fs.ts` does not exist on this branch** (confirmed: `ls
+packages/core/src/runbook/safe-fs.ts` → "No such file or directory").
+
+This plan therefore expands the issue's scope to do the extraction the issue assumed:
+
+1. **Create** `packages/core/src/runbook/safe-fs.ts` by lifting the canonical guard
+   family out of `artifact-manifest.ts`.
+2. **Repoint** `artifact-manifest.ts` to import from `safe-fs.ts`, preserving behaviour
+   exactly (it remains the canonical caller).
+3. **Converge** `output-channels.ts` onto a new **async** variant exposed by `safe-fs.ts`,
+   with **no behavioural change** to output capture.
+
+Priority order per `CLAUDE.md`: **correctness > type safety > clean architecture > test
+coverage**. The convergence must not weaken or alter any of the three call sites'
+observable behaviour — it only removes duplication.
+
+---
+
+## 2. Current state (verified file:line references)
+
+### 2.1 `safe-fs.ts` does not exist
+
+`packages/core/src/runbook/safe-fs.ts` is absent. There are no current imports of it
+anywhere in the tree (no grep hits). Any reference in the issue to its prior existence
+is aspirational.
+
+### 2.2 Canonical guard — `artifact-manifest.ts` (the source of truth)
+
+All of these are **module-private** (not exported) in
+`packages/core/src/runbook/artifact-manifest.ts`:
+
+| Symbol | Lines | Role |
+|--------|-------|------|
+| `openVerifiedRegularFileSync(workRoot, filePath, flags): number` | 720–734 | **Canonical sync guard.** Lexical containment pre-check, `openSync(flags)`, `fstatSync`, `validateOpenedPathInsideRoot`, `isFile()` assert; on any failure closes the fd and rethrows. Returns the open fd (caller closes). |
+| `validateOpenedPathInsideRoot(root, filePath, openedStat): void` | 758–767 | realpath(root) + realpath(filePath), lexical containment (`assertContained`), then re-`statSync` the realpath and assert `sameFile(openedStat, current)` (dev/ino match → closes the symlink-swap TOCTOU window). Throws `INVALID_URI_PATH_SHAPE` on mismatch. |
+| `sameFile(left, right): boolean` | 769–771 | `dev === dev && ino === ino`. |
+| `assertContained(root, candidate): void` | 652–657 | Lexical `path.relative` containment check; throws `INVALID_URI_PATH_SHAPE` if `..`/absolute escapes root. |
+| `noFollowFlag(): number` | 773–775 | `O_NOFOLLOW` if present, else `0` (platform fallback). |
+| `directoryFlag(): number` | 777–779 | `O_DIRECTORY` if present, else `0`. |
+| `assertVerifiedDirectoryInsideRoot(root, dir): void` | 736–756 | Directory analogue of the file guard (uses `directoryFlag`). |
+| `readVerifiedUtf8FileSync(workRoot, filePath): string` | 611–623 | **sync** open+fstat+validate+`isFile`+`readFileSync('utf8')`. |
+| `readVerifiedUtf8File(workRoot, filePath): Promise<string>` | 706–718 | **async** twin of the above (`fsp.open` + `handle.stat()` + validate + `readFile('utf8')`). Already exists — proves the async shape is viable. |
+| `isExistingRegularContainedFile(workRoot, filePath): boolean` | 684–704 | Boolean wrapper over `openVerifiedRegularFileSync` that maps `ENOENT`/`ENOTDIR`/`ELOOP`/`INVALID_URI_PATH_SHAPE` → `false`. |
+
+Inline callers of the canonical guard **inside `artifact-manifest.ts`** that must keep
+working unchanged after extraction:
+
+- `writeManifestLineSync` (501–538) — calls `validateOpenedPathInsideRoot` at line 525.
+- `readVerifiedUtf8FileSync` (611–623) — line 615.
+- `isExistingRegularContainedFile` (684–704) — calls `openVerifiedRegularFileSync` at 687.
+- `readVerifiedUtf8File` (706–718) — line 710.
+- The `file:`-URI branch of `isExistingRegularArtifactFile` (423–486) open-codes a
+  *realpath-first* containment variant (does **not** use `openVerifiedRegularFileSync`).
+  **Leave this branch as-is** — it is a different algorithm (realpath-then-stat, no fd
+  fstat) and is out of scope for #433. It is noted here so reviewers know it was
+  considered and deliberately not converged.
+
+The shared error sentinel is `ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE`
+(`'Invalid artifact URI path shape'`) defined in
+`packages/core/src/runbook/artifact-errors.ts:5`.
+
+### 2.3 Third copy — `output-channels.ts` (the convergence target)
+
+`packages/core/src/runbook/output-channels.ts` has **two** open-coded guard sites, both
+**async** (`fs.promises`):
+
+**(a) Write path — `prepareOutputChannels` (202–258):**
+- line 208: `const noFollow = fsConstants.O_NOFOLLOW;` (NB: no `'O_NOFOLLOW' in constants`
+  fallback — assumes the constant exists).
+- 222–226: `fs.open(filePath, O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW, 0o600)`.
+- 228–235: `handle.stat()`; if `!stat.isFile()` → **log + `continue`** (skip, not throw).
+- 236: `handle.chmod(0o600)`.
+- 243–249: catch — `ELOOP` → log "symlinked channel file" + `continue`; other errors →
+  log "failed to create channel file" + `continue`.
+
+**(b) Read path — `readCapturedOutputs` (272–333):**
+- 281: `fs.open(filePath, O_RDONLY|O_NOFOLLOW)`.
+- 282–289: `handle.stat()`; if `!stat.isFile()` → log + `continue`.
+- 290–299: `handle.readFile()` + strict UTF-8 decode (skip on non-UTF-8).
+- 301–310: catch — `ENOENT` → log "missing"; else log "read failed"; both `continue`.
+
+**Critical behavioural differences from the canonical guard** (these drive the design):
+
+1. **Skip vs throw.** output-channels treats every failure (non-regular, `ELOOP`, read
+   error) as *skip-this-entry-and-continue*, emitting a specific `logger.warn` per case.
+   The canonical guard *throws* `INVALID_URI_PATH_SHAPE`. Convergence MUST preserve the
+   skip-and-log behaviour — it is the documented "best-effort" contract of
+   `prepareOutputChannels` / `readCapturedOutputs`.
+2. **No workRoot containment check.** output-channels does **not** call
+   `validateOpenedPathInsideRoot` — it performs no realpath/containment/`sameFile`
+   re-stat. Its paths are pre-validated lexically by `assertSafeId` /
+   `assertSafeOutputName` / `outputChannelPath` (74–159). So the canonical guard's
+   dev/ino re-stat is **extra** behaviour output-channels does not have today.
+3. **Write semantics.** The write path opens with `O_CREAT|O_TRUNC` + `0o600` mode + an
+   explicit `chmod(0o600)` and keeps the handle to write into. The canonical
+   `openVerifiedRegularFileSync` is read-shaped (returns an fd; the manifest write path
+   does its own `O_CREAT|O_APPEND` open separately, see 520–522). The shared async helper
+   must support a write/create flavour without forcing containment re-stat.
+
+These differences mean a naive "call `openVerifiedRegularFileSync`" convergence would
+**change behaviour** (add a containment re-stat, convert skips to throws). The plan below
+resolves this by exposing a small, parameterised async primitive whose *containment check
+is opt-in*, so output-channels can adopt the shared open+fstat+`isFile` core while keeping
+its skip-and-log policy in the caller.
+
+### 2.4 Other realpath/`ELOOP` sites (surveyed, NOT in scope)
+
+Grep across `packages/core/src` found these additional `realpath`/`ELOOP`/`O_NOFOLLOW`
+sites. They are **different patterns** (path canonicalisation, lock realpath, glob
+ignore-lists), not the open+fstat+`isFile` guard, and are **out of scope**:
+
+- `source-resolver.ts:201,216`, `variable-preparation.ts:197,330,…`,
+  `artifact-directive-resolver.ts:284,294`, `rdpath.ts:124,129` — `fs.realpath`
+  canonicalisation only.
+- `rdpath.ts:8` — `ELOOP` in a glob-ignore code set.
+- `state.ts:256`, `session-lock.ts:52`, `sandbox/*.ts` — `realpathSync` for cwd/lock/node
+  resolution.
+- `schemas.ts:207,223,761` — realpath-canonical-path *validation* (zod), not fs access.
+
+Only `artifact-manifest.ts` and `output-channels.ts` contain the open+fstat-of-fd+`isFile`
+guard. The issue's "third near-copy" = `output-channels.ts` (copies #1 sync and #2 async
+both live in `artifact-manifest.ts`; #3 async lives in `output-channels.ts`). Confirmed:
+the third copy the issue refers to **is** what was found.
+
+### 2.5 Barrel / export wiring
+
+- `packages/core/src/index.ts:43` does `export * from './runbook/index.js'`.
+- `packages/core/src/runbook/index.ts` re-exports per-module:
+  - `artifact-manifest.js` block at lines 280–290 (does **not** export the private guards).
+  - `output-channels.js` block at lines 375–383.
+  - `file-lock.js` block at 213–214 (the model for a focused security-primitive export).
+  - `artifact-errors.js` at 238.
+- The guard functions are currently **not exported** from any barrel. Whether `safe-fs.ts`
+  exports should be added to the barrel is an open question (§7).
+
+### 2.6 Test landscape
+
+- `packages/core/__tests__/runbook/output-channels.test.ts` (464 lines) — pins
+  prepare/read behaviour.
+- `packages/core/__tests__/runbook/artifact-manifest-toctou.test.ts` — symlink-swap /
+  TOCTOU coverage using `jest.unstable_mockModule('node:fs', …)` to inject
+  `afterLstat`/`beforeOpen` race hooks. **This is the canonical model for the new
+  `safe-fs` symlink-swap test.**
+- `artifact-manifest.test.ts`, `artifact-manifest.properties.test.ts` — broader manifest
+  behaviour + property tests.
+
+---
+
+## 3. Target design — `safe-fs.ts`
+
+A new module `packages/core/src/runbook/safe-fs.ts` that is the **single canonical home**
+for the race-closed file-read guard, exposing **both sync and async** variants. Every
+exported symbol gets full TSDoc per `CLAUDE.md` TSDoc Standards (description, `@param`,
+`@returns`, `@throws`).
+
+### 3.1 Design constraints (from CLAUDE.md + the behavioural diff)
+
+- **Correctness first:** all three existing call sites keep identical observable behaviour.
+- **Type-driven dispatch / invalid states unrepresentable:** the symlink/non-regular
+  rejection is signalled by a **typed error class** (not a bare string compare), and the
+  "skip" vs "throw" decision is made by the *caller*, not baked into the primitive.
+- **Containment is opt-in:** the workRoot re-stat (`validateOpenedPathInsideRoot`) is a
+  parameter, so artifact-manifest keeps it and output-channels omits it — matching today's
+  behaviour exactly.
+- **Platform fallback preserved:** `noFollowFlag()` / `directoryFlag()` move into safe-fs
+  so the `'O_NOFOLLOW' in fs.constants` fallback is centralised.
+
+### 3.2 Error contract
+
+Introduce a typed error so callers narrow rather than string-match:
+
+```ts
+/**
+ * Thrown by safe-fs guards when an opened path fails its regular-file /
+ * containment / symlink-swap verification. The `reason` discriminant lets
+ * callers map specific failure modes to their own policy (skip vs propagate)
+ * without string-matching error messages.
+ */
+export class UnsafeFileError extends Error {
+  readonly reason: UnsafeFileReason;
+  constructor(reason: UnsafeFileReason, path: string);
+}
+
+/** Why a guarded open was rejected. */
+export type UnsafeFileReason =
+  | 'not-regular-file'   // fstat of the opened fd is not a regular file
+  | 'escaped-root'       // realpath of target is outside the contained root
+  | 'symlink-swapped';   // dev/ino re-stat mismatch (TOCTOU window detected)
+```
+
+Note: `ELOOP` / `ENOENT` / `ENOTDIR` are **OS** errors from `open` itself — they surface
+as `NodeJS.ErrnoException` and are classified by callers with the existing
+`isNodeErrorCode` / `isNodeError` helpers (per CLAUDE.md testing conventions: never call
+`Error.isError` directly). safe-fs does **not** swallow them; it lets them propagate so
+each caller applies its own policy (artifact-manifest → throw/`false`; output-channels →
+skip+log).
+
+Decision on artifact-manifest's existing `INVALID_URI_PATH_SHAPE` sentinel: to keep
+`artifact-manifest.ts` byte-for-byte behaviour-stable, the **migrated** artifact-manifest
+helpers continue to throw `INVALID_URI_PATH_SHAPE`. Two equivalent options (resolve at
+implementation time, see §7-Q4):
+- **(A, preferred)** safe-fs throws `UnsafeFileError`; artifact-manifest's thin wrappers
+  catch `UnsafeFileError` and rethrow `new Error(INVALID_URI_PATH_SHAPE)` so its existing
+  catch sites (374, 492, 694, etc.) and tests are unchanged.
+- **(B)** safe-fs's guard accepts an injected `onReject: (reason) => never` callback;
+  artifact-manifest passes one that throws `INVALID_URI_PATH_SHAPE`, output-channels never
+  triggers it (uses the no-throw boolean form). Option A is simpler and keeps the typed
+  error as the module's native contract; prefer A unless a caller needs the exact reason.
+
+### 3.3 Proposed API surface
+
+```ts
+// packages/core/src/runbook/safe-fs.ts
+
+/** O_NOFOLLOW if the platform defines it, else 0 (open-without-nofollow fallback). */
+export function noFollowFlag(): number;
+
+/** O_DIRECTORY if the platform defines it, else 0. */
+export function directoryFlag(): number;
+
+/** True when two stat results refer to the same inode (dev+ino match). */
+export function sameFile(left: fs.Stats, right: fs.Stats): boolean;
+
+/** Lexical containment assertion: throws UnsafeFileError('escaped-root') if
+ *  `candidate` resolves outside `root` (no fs access). */
+export function assertContained(root: string, candidate: string): void;
+
+/** realpath(root)+realpath(filePath) containment + dev/ino re-stat against the
+ *  already-opened stat; throws UnsafeFileError('escaped-root' | 'symlink-swapped'). */
+export function validateOpenedPathInsideRoot(
+  root: string, filePath: string, openedStat: fs.Stats,
+): void;
+
+// ---- SYNC guard (canonical, used by artifact-manifest) ----
+
+/**
+ * Open a path with O_NOFOLLOW, fstat the opened fd, optionally verify the fd
+ * is contained under `containedRoot`, and assert it is a regular file. Returns
+ * the open fd; the caller owns closing it. Closes the fd and rethrows on any
+ * verification failure (UnsafeFileError) or OS error (ELOOP/ENOENT/ENOTDIR).
+ *
+ * When `containedRoot` is undefined the realpath/dev-ino re-stat is skipped —
+ * this is the output-channels-equivalent guarantee (O_NOFOLLOW + isFile only).
+ */
+export function openVerifiedRegularFileSync(
+  filePath: string,
+  flags: number,
+  containedRoot?: string,
+): number;
+
+/** Sync: open+fstat+verify, read whole file as UTF-8, close. */
+export function readVerifiedUtf8FileSync(filePath: string, containedRoot?: string): string;
+
+// ---- ASYNC guard (new, used by output-channels) ----
+
+/**
+ * Async twin of openVerifiedRegularFileSync. Resolves to an open FileHandle
+ * (caller closes). The O_NOFOLLOW guarantee means a symlink target produces an
+ * ELOOP ErrnoException from `open` — callers classify it with isNodeErrorCode.
+ */
+export function openVerifiedRegularFile(
+  filePath: string,
+  flags: number,
+  mode?: fs.Mode,
+  containedRoot?: string,
+): Promise<fs.promises.FileHandle>;
+
+/** Async: open+fstat+verify, read whole file as UTF-8, close. */
+export function readVerifiedUtf8File(filePath: string, containedRoot?: string): Promise<string>;
+```
+
+**Why this shape resolves the async/sync dimension (the core decision the issue demands):**
+
+- artifact-manifest keeps using the **sync** variants (`openVerifiedRegularFileSync`,
+  `readVerifiedUtf8FileSync`) with a non-`undefined` `containedRoot` → identical behaviour
+  (containment + dev/ino re-stat preserved).
+- output-channels adopts the **async** `openVerifiedRegularFile` with `containedRoot`
+  **omitted** → it gets exactly today's guarantee (O_NOFOLLOW + `isFile`), no new
+  containment re-stat, **no behavioural change**. The handle is returned open so
+  output-channels can still `chmod`, `writeFile`/`readFile`, and apply its
+  skip-and-`logger.warn` policy in its own `catch` (classifying `ELOOP`/`ENOENT` via
+  `isNodeErrorCode`, mapping `UnsafeFileError('not-regular-file')` → the existing
+  "non-regular channel file" warning).
+- `O_NOFOLLOW` is what makes a symlink target raise `ELOOP` at `open()` time, so the
+  "ELOOP → skip" semantics output-channels relies on are preserved as long as the helper
+  always ORs in `noFollowFlag()` (it must, unconditionally).
+
+This keeps the **isFile / regular-file check** inside the shared helper (so all three
+sites share one hardened implementation) while leaving **policy** (skip vs throw,
+which warning to log, write vs read flags) entirely in the callers.
+
+---
+
+## 4. Step-by-step changes (ordered, reviewable)
+
+Each step is independently compilable and test-green; review can stop at any boundary.
+
+### Step 1 — Create `safe-fs.ts` (pure extraction, no caller changes yet)
+
+1. Create `packages/core/src/runbook/safe-fs.ts`.
+2. Move (cut) from `artifact-manifest.ts`: `noFollowFlag`, `directoryFlag`, `sameFile`,
+   `assertContained`, `validateOpenedPathInsideRoot`, `openVerifiedRegularFileSync`,
+   `readVerifiedUtf8FileSync`, `readVerifiedUtf8File` (async), and the directory guard
+   `assertVerifiedDirectoryInsideRoot` (it shares `directoryFlag`/`validateOpenedPathInsideRoot`).
+   - Generalise `openVerifiedRegularFileSync` / read helpers to the new signatures
+     (add the optional `containedRoot` param; when present, behave exactly as the current
+     `workRoot`-taking versions).
+   - Add the new async `openVerifiedRegularFile(filePath, flags, mode?, containedRoot?)`.
+   - Introduce `UnsafeFileError` + `UnsafeFileReason`. Internally throw `UnsafeFileError`
+     instead of `INVALID_URI_PATH_SHAPE` (the artifact-manifest wrappers in Step 2
+     translate it back — option A in §3.2).
+3. Full TSDoc on every exported symbol (`@param`/`@returns`/`@throws`). Use
+   `isNodeErrorCode`/`isNodeError` from `../errors.js` for any internal errno checks
+   (never `Error.isError` directly — CLAUDE.md).
+4. Do **not** touch the barrel yet (Step 4 decides exports).
+
+### Step 2 — Repoint `artifact-manifest.ts` (behaviour-preserving)
+
+1. `import` the needed symbols from `./safe-fs.js`.
+2. Replace the now-removed local helpers with thin wrappers that preserve the exact
+   existing throw contract:
+   - Where artifact-manifest previously relied on the guard throwing
+     `INVALID_URI_PATH_SHAPE`, wrap the safe-fs call so a caught `UnsafeFileError` is
+     rethrown as `new Error(ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE)` (option A).
+     Concretely: `readVerifiedUtf8FileSync` (was 611–623), `readVerifiedUtf8File`
+     (706–718), `isExistingRegularContainedFile` (684–704), and the `writeManifestLineSync`
+     inline `validateOpenedPathInsideRoot` call (525) — each passes `workRoot` as
+     `containedRoot` so the realpath/dev-ino re-stat is unchanged.
+   - `assertVerifiedDirectoryInsideRoot` (736–756) and its callers
+     (`assertExistingAncestorsInsideRoot` 659–682, `resolveContainedWorkRoot` 637–650)
+     now call the safe-fs directory guard; keep the `INVALID_URI_PATH_SHAPE` translation.
+3. Leave the `file:`-URI realpath-first branch (423–486) untouched (§2.2).
+4. Confirm `artifact-manifest.ts` no longer defines any of the moved functions (no dead
+   private copies left behind — the whole point of #433).
+
+### Step 3 — Converge `output-channels.ts` onto the async guard
+
+1. `import { openVerifiedRegularFile, UnsafeFileError } from './safe-fs.js';`
+   (and drop the local `noFollow`/inline open where replaced).
+2. **Write path** (`prepareOutputChannels`, 220–255): replace the inline
+   `fs.open(..., O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW, 0o600)` + `handle.stat()` +
+   `!isFile()` skip with a call to `openVerifiedRegularFile(filePath,
+   O_WRONLY|O_CREAT|O_TRUNC, 0o600)` (helper ORs in `noFollowFlag()`; **no**
+   `containedRoot`). Keep the surrounding try/finally, `handle.chmod(0o600)`, env push, and
+   `prepared.push` exactly as-is. In the `catch`:
+   - `isNodeError(err) && err.code === 'ELOOP'` → existing "symlinked channel file" warn +
+     `continue` (unchanged).
+   - `err instanceof UnsafeFileError && err.reason === 'not-regular-file'` → the existing
+     "non-regular channel target" warn + `continue` (this replaces the inline
+     `!stat.isFile()` branch, now raised from inside the helper).
+   - else → existing "failed to create channel file" warn + `continue`.
+3. **Read path** (`readCapturedOutputs`, 281–289): replace the inline
+   `fs.open(filePath, O_RDONLY|O_NOFOLLOW)` + `stat()` + `!isFile()` skip with
+   `openVerifiedRegularFile(filePath, O_RDONLY)`. Keep the UTF-8 decode, NUL check, trim,
+   `parseRuntimeVariableValue`, the `ENOENT` "missing"/"read failed" warnings, and the
+   `finally { handle.close() }` exactly as-is. Map `UnsafeFileError('not-regular-file')` →
+   the existing "non-regular channel file, omitting" warning.
+4. Net effect: identical logs, identical skip behaviour, identical env/captured output —
+   the only change is *where the open+fstat+isFile lives*.
+
+### Step 4 — Barrel exports + housekeeping
+
+1. Decide export surface (§7-Q1). Recommended: add a focused `safe-fs.js` export block to
+   `packages/core/src/runbook/index.ts` modelled on the `file-lock.js` block (213–214),
+   exporting at minimum `UnsafeFileError`, `UnsafeFileReason` (type),
+   `openVerifiedRegularFile`, `openVerifiedRegularFileSync`, `readVerifiedUtf8File`,
+   `readVerifiedUtf8FileSync`. Keep `assertContained`/`validateOpenedPathInsideRoot`/
+   `sameFile`/`noFollowFlag`/`directoryFlag` exported too if any test imports them
+   directly; otherwise keep them module-internal and test through the public guards.
+2. Remove the now-unused `fsConstants`/`O_NOFOLLOW` import bits from `output-channels.ts`
+   if fully superseded; keep `isNodeError` (still used in catches).
+3. Run `npm run fix:lint` + `npm run format` to settle import ordering.
+
+---
+
+## 5. Testing strategy
+
+### 5.1 New: `packages/core/__tests__/runbook/safe-fs.test.ts`
+
+Unit tests for the extracted module (model the symlink-swap hooks on
+`artifact-manifest-toctou.test.ts`'s `jest.unstable_mockModule('node:fs', …)` pattern):
+
+- **Regular file accepted** — sync and async: `openVerifiedRegularFile{,Sync}` on a real
+  regular file returns an fd/handle and `readVerifiedUtf8File{,Sync}` returns its content.
+- **Symlink rejected (`ELOOP`)** — point `filePath` at a symlink; assert the call rejects
+  with an `ErrnoException` whose `code === 'ELOOP'` (because `O_NOFOLLOW` is always ORed
+  in). Both sync and async.
+- **Non-regular target → `UnsafeFileError('not-regular-file')`** — target a FIFO/dir
+  (something that opens but isn't a regular file) and assert the typed error + `reason`.
+- **Missing file (`ENOENT`)** — propagates as `ErrnoException` `ENOENT` (not swallowed).
+- **Containment ON (artifact-manifest mode):** with `containedRoot` set, a path whose
+  realpath escapes the root → `UnsafeFileError('escaped-root')`; a TOCTOU symlink swap that
+  changes dev/ino between open and re-stat → `UnsafeFileError('symlink-swapped')` (use the
+  `afterLstat`/`beforeOpen` race-hook style).
+- **Containment OFF (output-channels mode):** with `containedRoot` omitted, the
+  realpath/dev-ino re-stat is **not** performed (assert no extra `realpathSync` call, or
+  assert a path outside any root still opens) — pins that output-channels gets no new
+  behaviour.
+- **Property test (optional, mirrors `artifact-manifest.properties.test.ts`):** for
+  arbitrary safe relative paths, containment-ON accepts iff lexically+realpath contained.
+
+### 5.2 Regression: existing suites must stay green (no new behaviour)
+
+- `output-channels.test.ts` (464 lines) — **must pass unchanged**. This is the primary
+  "no behavioural change to output capture" gate from the acceptance criteria. If any
+  assertion needs editing, that signals a behaviour change and must be stopped/reviewed.
+- `artifact-manifest.test.ts`, `artifact-manifest.properties.test.ts`,
+  `artifact-manifest-toctou.test.ts` — **must pass unchanged**. These pin the canonical
+  guard's containment + symlink-swap behaviour now living in safe-fs.
+- Add output-channels symlink-swap coverage **only if** the existing suite lacks it
+  (issue asks to "add escape/symlink-swap coverage if not already present"). Grep
+  `output-channels.test.ts` for `ELOOP`/symlink first; if absent, add a case that creates
+  a symlinked channel path and asserts the entry is skipped (write path) / omitted (read
+  path) with the existing warning.
+
+### 5.3 Mutation coverage
+
+- safe-fs is security-critical; run `npm run test:mutate:core` (or scoped) over
+  `safe-fs.ts`. Ensure mutants on the `sameFile` dev/ino comparison, the `isFile()`
+  assert, and the `noFollowFlag()` OR are killed (these are the security-load-bearing
+  lines). The existing TOCTOU test already kills equivalent mutants in the manifest copy;
+  the new safe-fs tests must reproduce that kill coverage at the new home.
+
+---
+
+## 6. Verification
+
+Commands (run from worktree root):
+
+```bash
+# Targeted, fast feedback during implementation:
+npm test -w @rundown-org/core -- safe-fs
+npm test -w @rundown-org/core -- output-channels
+npm test -w @rundown-org/core -- artifact-manifest
+
+# Security/mutation focus on the new module:
+npm run test:mutate:core   # (or scoped to safe-fs.ts)
+
+# Full pre-PR gate (MANDATORY per CLAUDE.md):
+npm run verify             # format + spell + lint + test
+```
+
+**Acceptance-criteria mapping (issue #433):**
+
+| Acceptance criterion | Satisfied by |
+|----------------------|--------------|
+| `output-channels.ts` no longer open-codes its own symlink/containment guard; imports from `safe-fs.ts` | Step 3 — both open sites call `openVerifiedRegularFile` |
+| No behavioural change to output capture (existing tests green) | §5.2 — `output-channels.test.ts` passes unchanged; skip+log policy retained in callers |
+| Single canonical home for the race-closed file-read guard across core | Steps 1–2 — guard extracted to `safe-fs.ts`; artifact-manifest repointed; no private duplicate remains |
+| (issue) expose an **async** variant matching output-channels (`ELOOP`→skip, `isFile()`) | §3.3 `openVerifiedRegularFile`; `O_NOFOLLOW` preserves `ELOOP`, caller keeps skip |
+| (issue) pin parity + add escape/symlink-swap coverage if missing | §5.1 new safe-fs tests + §5.2 conditional output-channels symlink case |
+
+---
+
+## 7. Risks / open questions
+
+- **Q1 — Export surface.** Should the guards be exported from the core barrel at all, or
+  stay package-internal (imported only by sibling runbook modules via relative path)?
+  `file-lock.js` exports its primitives, which argues for exporting safe-fs too. **Lean:**
+  export the guard + `UnsafeFileError` (security primitive consumers like rdx
+  `--schema-file` — the issue's mentioned future caller — will want it), keep the
+  lexical/`*Flag` helpers internal unless a test needs them.
+
+- **Q2 — async/sync decision (the headline risk).** Resolved in §3.3: expose **both**;
+  artifact-manifest stays sync, output-channels uses the new async form with
+  `containedRoot` **omitted**. The load-bearing correctness point is that output-channels
+  must NOT gain the containment re-stat — verify via §5.1 "containment OFF" test, else this
+  is a silent behaviour change and an acceptance-criteria failure.
+
+- **Q3 — `noFollowFlag()` fallback divergence.** Today output-channels uses bare
+  `fsConstants.O_NOFOLLOW` (no `in` guard) while artifact-manifest uses `noFollowFlag()`
+  (falls back to `0`). Centralising on `noFollowFlag()` is *safer* and harmonises the two,
+  but on a platform lacking `O_NOFOLLOW` it changes output-channels from
+  `undefined`-OR (NaN/throw risk) to `0`-OR. This is a strict improvement, not a
+  regression, and should be called out in the PR description. Confirm no test asserts the
+  raw flag value.
+
+- **Q4 — `UnsafeFileError` vs `INVALID_URI_PATH_SHAPE` translation.** artifact-manifest has
+  many catch sites (374, 492, 694) and tests asserting `INVALID_URI_PATH_SHAPE`. Option A
+  (wrap+rethrow the sentinel in artifact-manifest) keeps all of them green with zero test
+  edits and is the recommended path. Option B (callback) is heavier. Decide at
+  implementation; A preferred.
+
+- **Q5 — Callers to repoint.** All internal callers of the moved guards are inside
+  `artifact-manifest.ts` (enumerated §2.2) — no cross-file callers exist today (grep
+  confirmed the symbols are module-private). So the repoint blast radius is exactly two
+  files plus the barrel. Low risk.
+
+- **Q6 — Third-copy identity.** Confirmed (§2.4): the "third near-copy" the issue names is
+  `output-channels.ts`. The realpath-first `file:`-URI branch in `isExistingRegularArtifactFile`
+  (423–486) is a *fourth, different* algorithm and is deliberately **not** converged here;
+  flag it as possible future follow-on but out of scope for #433.
+
+- **Q7 — Prerequisite drift.** The issue assumed `safe-fs.ts` already existed (its "Task
+  10"). It does not. This plan absorbs that extraction. If the separate validate/artifact-
+  schema work later lands its own `safe-fs.ts`, coordinate to avoid a merge collision —
+  whoever lands second rebases onto the existing module rather than recreating it.

--- a/packages/cli/__tests__/helpers/claim-and-launch.test.ts
+++ b/packages/cli/__tests__/helpers/claim-and-launch.test.ts
@@ -370,7 +370,11 @@ function makeCtx(overrides: Record<string, unknown> = {}): RunPipelineContext {
         mockFn<SessionService['findClaimForDelegation']>().mockResolvedValue(null),
     },
     lifecycleService: {},
-    cwd: '/tmp/test',
+    // Fake cwd for the mocked pipeline context. Deliberately NOT under /tmp:
+    // a `/tmp/...` literal is read by CodeQL's js/insecure-temporary-file as a
+    // temp-dir taint source and propagates through production into the safe-fs
+    // directory guard, producing a false positive on a read-only O_NOFOLLOW open.
+    cwd: '/work/test',
     ...overrides,
   } as unknown as RunPipelineContext;
 }

--- a/packages/core/__tests__/runbook/safe-fs.test.ts
+++ b/packages/core/__tests__/runbook/safe-fs.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import type { PathLike } from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const actualFs = await import('node:fs');
+const { isNodeErrorCode } = await import('../../src/errors.js');
+
+// afterLstat fires after every realpathSync/statSync-style lstat the guard
+// performs, letting a test swap the path mid-flight to exercise the
+// symlink-swap (TOCTOU) re-stat. Modelled on artifact-manifest-toctou.test.ts.
+let afterRealpath: ((filePath: string) => void) | undefined;
+
+jest.unstable_mockModule('node:fs', () => ({
+  ...actualFs,
+  realpathSync: jest.fn((filePath: PathLike, ...rest: unknown[]) => {
+    const resolved = (actualFs.realpathSync as (p: PathLike, ...r: unknown[]) => string)(
+      filePath,
+      ...rest,
+    );
+    afterRealpath?.(String(filePath));
+    return resolved;
+  }),
+}));
+
+const {
+  noFollowFlag,
+  directoryFlag,
+  sameFile,
+  assertContained,
+  validateOpenedPathInsideRoot,
+  openVerifiedRegularFile,
+  openVerifiedRegularFileSync,
+  readVerifiedUtf8File,
+  readVerifiedUtf8FileSync,
+  UnsafeFileError,
+} = await import('../../src/runbook/safe-fs.js');
+
+let tempDirs: string[] = [];
+
+afterEach(async () => {
+  afterRealpath = undefined;
+  await Promise.all(tempDirs.map((dir) => fsp.rm(dir, { force: true, recursive: true })));
+  tempDirs = [];
+  jest.clearAllMocks();
+});
+
+async function tempDir(): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'safe-fs-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function isErrnoCode(error: unknown, code: string): boolean {
+  return isNodeErrorCode(error, code);
+}
+
+describe('flag helpers', () => {
+  it('noFollowFlag returns a numeric flag (O_NOFOLLOW when defined, else 0)', () => {
+    const flag = noFollowFlag();
+    expect(typeof flag).toBe('number');
+    if ('O_NOFOLLOW' in actualFs.constants) {
+      expect(flag).toBe(actualFs.constants.O_NOFOLLOW);
+    } else {
+      expect(flag).toBe(0);
+    }
+  });
+
+  it('directoryFlag returns a numeric flag (O_DIRECTORY when defined, else 0)', () => {
+    const flag = directoryFlag();
+    expect(typeof flag).toBe('number');
+    if ('O_DIRECTORY' in actualFs.constants) {
+      expect(flag).toBe(actualFs.constants.O_DIRECTORY);
+    } else {
+      expect(flag).toBe(0);
+    }
+  });
+});
+
+describe('sameFile', () => {
+  it('is true for identical dev/ino, false otherwise', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'a.txt');
+    await fsp.writeFile(filePath, 'x');
+    const a = actualFs.statSync(filePath);
+    const b = actualFs.statSync(filePath);
+    expect(sameFile(a, b)).toBe(true);
+
+    const otherPath = path.join(dir, 'b.txt');
+    await fsp.writeFile(otherPath, 'y');
+    const c = actualFs.statSync(otherPath);
+    expect(sameFile(a, c)).toBe(false);
+  });
+});
+
+describe('assertContained', () => {
+  it('accepts equal and nested paths', () => {
+    expect(() => {
+      assertContained('/root', '/root');
+    }).not.toThrow();
+    expect(() => {
+      assertContained('/root', '/root/child/leaf');
+    }).not.toThrow();
+  });
+
+  it('throws UnsafeFileError(escaped-root) for an escaping path', () => {
+    try {
+      assertContained('/root', '/root/../elsewhere');
+      throw new Error('expected throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnsafeFileError);
+      expect((error as InstanceType<typeof UnsafeFileError>).reason).toBe('escaped-root');
+    }
+  });
+});
+
+describe('openVerifiedRegularFileSync', () => {
+  it('opens a regular file and returns a readable fd', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'file.txt');
+    await fsp.writeFile(filePath, 'hello');
+    const fd = openVerifiedRegularFileSync(filePath, actualFs.constants.O_RDONLY);
+    try {
+      expect(actualFs.readFileSync(fd, 'utf8')).toBe('hello');
+    } finally {
+      actualFs.closeSync(fd);
+    }
+  });
+
+  it('rejects a symlink with ELOOP (O_NOFOLLOW always ORed in)', async () => {
+    const dir = await tempDir();
+    const target = path.join(dir, 'target.txt');
+    const link = path.join(dir, 'link.txt');
+    await fsp.writeFile(target, 'data');
+    await fsp.symlink(target, link);
+    try {
+      openVerifiedRegularFileSync(link, actualFs.constants.O_RDONLY);
+      throw new Error('expected throw');
+    } catch (error) {
+      expect(isErrnoCode(error, 'ELOOP')).toBe(true);
+    }
+  });
+
+  it('rejects a directory with UnsafeFileError(not-regular-file)', async () => {
+    const dir = await tempDir();
+    const subdir = path.join(dir, 'subdir');
+    await fsp.mkdir(subdir);
+    try {
+      openVerifiedRegularFileSync(subdir, actualFs.constants.O_RDONLY);
+      throw new Error('expected throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnsafeFileError);
+      expect((error as InstanceType<typeof UnsafeFileError>).reason).toBe('not-regular-file');
+    }
+  });
+
+  it('propagates ENOENT for a missing file (not swallowed)', async () => {
+    const dir = await tempDir();
+    const missing = path.join(dir, 'missing.txt');
+    try {
+      openVerifiedRegularFileSync(missing, actualFs.constants.O_RDONLY);
+      throw new Error('expected throw');
+    } catch (error) {
+      expect(isErrnoCode(error, 'ENOENT')).toBe(true);
+    }
+  });
+
+  describe('containment ON', () => {
+    it('accepts a file contained under the root', async () => {
+      const dir = await tempDir();
+      const filePath = path.join(dir, 'inside.txt');
+      await fsp.writeFile(filePath, 'ok');
+      const fd = openVerifiedRegularFileSync(filePath, actualFs.constants.O_RDONLY, dir);
+      actualFs.closeSync(fd);
+    });
+
+    it('rejects a file whose realpath escapes the root', async () => {
+      const root = await tempDir();
+      const outside = await tempDir();
+      const outsideFile = path.join(outside, 'secret.txt');
+      await fsp.writeFile(outsideFile, 'leak');
+      // A symlink inside root pointing outside would be caught at open by
+      // O_NOFOLLOW; to exercise the realpath escape check we make the root
+      // itself a symlink whose realpath differs, and target a sibling file.
+      try {
+        openVerifiedRegularFileSync(outsideFile, actualFs.constants.O_RDONLY, root);
+        throw new Error('expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(UnsafeFileError);
+        expect((error as InstanceType<typeof UnsafeFileError>).reason).toBe('escaped-root');
+      }
+    });
+
+    it('rejects a symlink-swap (dev/ino mismatch) with symlink-swapped', async () => {
+      const root = await tempDir();
+      const outside = await tempDir();
+      const filePath = path.join(root, 'file.txt');
+      const replacement = path.join(outside, 'replacement.txt');
+      await fsp.writeFile(filePath, 'original');
+      await fsp.writeFile(replacement, 'swapped');
+
+      // After the guard resolves realpath(filePath), swap the path so the
+      // re-stat sees a different inode than the opened fd.
+      let swapped = false;
+      afterRealpath = (resolved) => {
+        if (swapped || path.resolve(resolved) !== path.resolve(filePath)) {
+          return;
+        }
+        swapped = true;
+        actualFs.rmSync(filePath);
+        actualFs.symlinkSync(replacement, filePath);
+      };
+
+      try {
+        openVerifiedRegularFileSync(filePath, actualFs.constants.O_RDONLY, root);
+        throw new Error('expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(UnsafeFileError);
+        expect((error as InstanceType<typeof UnsafeFileError>).reason).toBe('symlink-swapped');
+      }
+    });
+  });
+
+  describe('containment OFF', () => {
+    it('does not perform any realpath re-stat when containedRoot is omitted', async () => {
+      const dir = await tempDir();
+      const filePath = path.join(dir, 'file.txt');
+      await fsp.writeFile(filePath, 'data');
+      let realpathCalls = 0;
+      afterRealpath = () => {
+        realpathCalls += 1;
+      };
+      const fd = openVerifiedRegularFileSync(filePath, actualFs.constants.O_RDONLY);
+      actualFs.closeSync(fd);
+      // Containment OFF must not trigger the realpath/dev-ino re-stat — this
+      // pins that output-channels (which omits containedRoot) gains no new
+      // behaviour from the convergence.
+      expect(realpathCalls).toBe(0);
+    });
+  });
+});
+
+describe('readVerifiedUtf8FileSync', () => {
+  it('reads the whole file as UTF-8', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'file.txt');
+    await fsp.writeFile(filePath, 'utf8-content');
+    expect(readVerifiedUtf8FileSync(filePath)).toBe('utf8-content');
+  });
+
+  it('reads with containment enforced', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'file.txt');
+    await fsp.writeFile(filePath, 'contained');
+    expect(readVerifiedUtf8FileSync(filePath, dir)).toBe('contained');
+  });
+});
+
+describe('openVerifiedRegularFile (async)', () => {
+  it('opens a regular file and returns a readable handle', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'file.txt');
+    await fsp.writeFile(filePath, 'hello-async');
+    const handle = await openVerifiedRegularFile(filePath, actualFs.constants.O_RDONLY);
+    try {
+      expect(await handle.readFile('utf8')).toBe('hello-async');
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects a symlink with ELOOP', async () => {
+    const dir = await tempDir();
+    const target = path.join(dir, 'target.txt');
+    const link = path.join(dir, 'link.txt');
+    await fsp.writeFile(target, 'data');
+    await fsp.symlink(target, link);
+    const error = await openVerifiedRegularFile(link, actualFs.constants.O_RDONLY).then(
+      (handle) => {
+        void handle.close();
+        return undefined;
+      },
+      (err: unknown) => err,
+    );
+    expect(isErrnoCode(error, 'ELOOP')).toBe(true);
+  });
+
+  it('rejects a directory with UnsafeFileError(not-regular-file)', async () => {
+    const dir = await tempDir();
+    const subdir = path.join(dir, 'subdir');
+    await fsp.mkdir(subdir);
+    await expect(
+      openVerifiedRegularFile(subdir, actualFs.constants.O_RDONLY),
+    ).rejects.toBeInstanceOf(UnsafeFileError);
+  });
+
+  it('propagates ENOENT for a missing file', async () => {
+    const dir = await tempDir();
+    const missing = path.join(dir, 'missing.txt');
+    const error = await openVerifiedRegularFile(missing, actualFs.constants.O_RDONLY).then(
+      (handle) => {
+        void handle.close();
+        return undefined;
+      },
+      (err: unknown) => err,
+    );
+    expect(isErrnoCode(error, 'ENOENT')).toBe(true);
+  });
+
+  it('creates a file with O_CREAT and applies the mode', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'created.txt');
+    const handle = await openVerifiedRegularFile(
+      filePath,
+      actualFs.constants.O_WRONLY | actualFs.constants.O_CREAT | actualFs.constants.O_TRUNC,
+      0o600,
+    );
+    try {
+      await handle.write('written');
+    } finally {
+      await handle.close();
+    }
+    expect(await fsp.readFile(filePath, 'utf8')).toBe('written');
+  });
+
+  it('applies containment when containedRoot is provided', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'file.txt');
+    await fsp.writeFile(filePath, 'contained');
+    const handle = await openVerifiedRegularFile(
+      filePath,
+      actualFs.constants.O_RDONLY,
+      undefined,
+      dir,
+    );
+    await handle.close();
+  });
+});
+
+describe('readVerifiedUtf8File (async)', () => {
+  it('reads the whole file as UTF-8', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'file.txt');
+    await fsp.writeFile(filePath, 'async-utf8');
+    await expect(readVerifiedUtf8File(filePath)).resolves.toBe('async-utf8');
+  });
+});
+
+describe('validateOpenedPathInsideRoot', () => {
+  it('passes for a contained file that was not swapped', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'file.txt');
+    await fsp.writeFile(filePath, 'x');
+    const stat = actualFs.statSync(filePath);
+    expect(() => {
+      validateOpenedPathInsideRoot(dir, filePath, stat);
+    }).not.toThrow();
+  });
+
+  it('throws symlink-swapped when the opened stat does not match the current inode', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'file.txt');
+    const otherPath = path.join(dir, 'other.txt');
+    await fsp.writeFile(filePath, 'x');
+    await fsp.writeFile(otherPath, 'y');
+    // Pass a stat from a *different* file as the "opened" stat to simulate a
+    // post-open swap: dev/ino will not match the current path's stat.
+    const mismatchedStat = actualFs.statSync(otherPath);
+    try {
+      validateOpenedPathInsideRoot(dir, filePath, mismatchedStat);
+      throw new Error('expected throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnsafeFileError);
+      expect((error as InstanceType<typeof UnsafeFileError>).reason).toBe('symlink-swapped');
+    }
+  });
+});

--- a/packages/core/__tests__/runbook/safe-fs.test.ts
+++ b/packages/core/__tests__/runbook/safe-fs.test.ts
@@ -30,6 +30,7 @@ const {
   sameFile,
   assertContained,
   validateOpenedPathInsideRoot,
+  validateOpenedPathInsideRootAsync,
   openVerifiedRegularFile,
   openVerifiedRegularFileSync,
   readVerifiedUtf8File,
@@ -374,5 +375,46 @@ describe('validateOpenedPathInsideRoot', () => {
       expect(error).toBeInstanceOf(UnsafeFileError);
       expect((error as InstanceType<typeof UnsafeFileError>).reason).toBe('symlink-swapped');
     }
+  });
+});
+
+describe('validateOpenedPathInsideRootAsync', () => {
+  it('passes for a contained file that was not swapped', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'file.txt');
+    await fsp.writeFile(filePath, 'x');
+    const stat = actualFs.statSync(filePath);
+    await expect(validateOpenedPathInsideRootAsync(dir, filePath, stat)).resolves.toBeUndefined();
+  });
+
+  it('rejects escaped-root when the realpath leaves the containment root', async () => {
+    const dir = await tempDir();
+    const outside = await tempDir();
+    const target = path.join(outside, 'secret.txt');
+    await fsp.writeFile(target, 'x');
+    const stat = actualFs.statSync(target);
+    const error = await validateOpenedPathInsideRootAsync(dir, target, stat).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(UnsafeFileError);
+    expect((error as InstanceType<typeof UnsafeFileError>).reason).toBe('escaped-root');
+  });
+
+  it('throws symlink-swapped when the opened stat does not match the current inode', async () => {
+    const dir = await tempDir();
+    const filePath = path.join(dir, 'file.txt');
+    const otherPath = path.join(dir, 'other.txt');
+    await fsp.writeFile(filePath, 'x');
+    await fsp.writeFile(otherPath, 'y');
+    // A stat from a *different* file stands in for the "opened" stat, so the
+    // dev/ino re-stat of the real path will not match — the swap signal.
+    const mismatchedStat = actualFs.statSync(otherPath);
+    const error = await validateOpenedPathInsideRootAsync(dir, filePath, mismatchedStat).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(UnsafeFileError);
+    expect((error as InstanceType<typeof UnsafeFileError>).reason).toBe('symlink-swapped');
   });
 });

--- a/packages/core/src/runbook/artifact-manifest.ts
+++ b/packages/core/src/runbook/artifact-manifest.ts
@@ -1,5 +1,4 @@
 import * as fs from 'node:fs';
-import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import picomatch from 'picomatch';
@@ -22,6 +21,16 @@ import {
   releaseFileLockSync,
 } from './file-lock.js';
 import { RUNBOOK_REF_ERROR_TEXT } from './runbook-ref.js';
+import {
+  assertContained as safeAssertContained,
+  assertVerifiedDirectoryInsideRoot as safeAssertVerifiedDirectoryInsideRoot,
+  noFollowFlag,
+  openVerifiedRegularFileSync as safeOpenVerifiedRegularFileSync,
+  readVerifiedUtf8File as safeReadVerifiedUtf8File,
+  readVerifiedUtf8FileSync as safeReadVerifiedUtf8FileSync,
+  UnsafeFileError,
+  validateOpenedPathInsideRoot as safeValidateOpenedPathInsideRoot,
+} from './safe-fs.js';
 
 /**
  * In-memory artifact record loaded from a manifest row.
@@ -526,6 +535,9 @@ function writeManifestLineSync(
     if (!stat.isFile()) {
       throw new Error(ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE);
     }
+    // The write/append path keeps its own O_CREAT|O_APPEND open (safe-fs's
+    // read-shaped openVerifiedRegularFileSync does not fit), so the shared
+    // validate guard is invoked inline above via the local translating wrapper.
     const line = Buffer.from(`${JSON.stringify(canonicalManifestRecord(record))}\n`, 'utf8');
     const bytesWritten = fs.writeSync(fd, line, 0, line.length);
     if (bytesWritten !== line.length) {
@@ -609,16 +621,10 @@ function isEquivalentManifestRow(left: ArtifactManifestRow, right: ArtifactManif
 }
 
 function readVerifiedUtf8FileSync(workRoot: string, filePath: string): string {
-  const fd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollowFlag());
   try {
-    const stat = fs.fstatSync(fd);
-    validateOpenedPathInsideRoot(workRoot, filePath, stat);
-    if (!stat.isFile()) {
-      throw new Error(ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE);
-    }
-    return fs.readFileSync(fd, 'utf8');
-  } finally {
-    fs.closeSync(fd);
+    return safeReadVerifiedUtf8FileSync(filePath, workRoot);
+  } catch (error) {
+    return rethrowAsPathShapeError(error);
   }
 }
 
@@ -649,10 +655,33 @@ function resolveContainedWorkRoot(options: ArtifactPathOptions): string {
   return workRoot;
 }
 
-function assertContained(root: string, candidate: string): void {
-  const relative = path.relative(root, candidate);
-  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+/**
+ * Translate a safe-fs {@link UnsafeFileError} into this module's stable
+ * `INVALID_URI_PATH_SHAPE` sentinel, leaving every other error untouched.
+ *
+ * The artifact-manifest guards historically threw `INVALID_URI_PATH_SHAPE`
+ * (asserted by many catch sites and tests). After converging onto safe-fs, the
+ * shared guards throw the typed {@link UnsafeFileError}; this wrapper restores
+ * the legacy contract so artifact-manifest's behaviour is byte-for-byte stable.
+ *
+ * This function never returns — it always rethrows.
+ *
+ * @param error - Error thrown by a safe-fs guard call
+ * @throws {Error} `INVALID_URI_PATH_SHAPE` when `error` is an
+ *   {@link UnsafeFileError}; otherwise the original `error`
+ */
+function rethrowAsPathShapeError(error: unknown): never {
+  if (error instanceof UnsafeFileError) {
     throw new Error(ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE);
+  }
+  throw error;
+}
+
+function assertContained(root: string, candidate: string): void {
+  try {
+    safeAssertContained(root, candidate);
+  } catch (error) {
+    rethrowAsPathShapeError(error);
   }
 }
 
@@ -684,7 +713,7 @@ function assertExistingAncestorsInsideRoot(root: string, candidate: string): voi
 function isExistingRegularContainedFile(workRoot: string, filePath: string): boolean {
   let fd: number | undefined;
   try {
-    fd = openVerifiedRegularFileSync(workRoot, filePath, fs.constants.O_RDONLY | noFollowFlag());
+    fd = openVerifiedRegularFileSync(workRoot, filePath);
     return true;
   } catch (error) {
     if (
@@ -704,78 +733,35 @@ function isExistingRegularContainedFile(workRoot: string, filePath: string): boo
 }
 
 async function readVerifiedUtf8File(workRoot: string, filePath: string): Promise<string> {
-  const handle = await fsp.open(filePath, fs.constants.O_RDONLY | noFollowFlag());
   try {
-    const stat = await handle.stat();
-    validateOpenedPathInsideRoot(workRoot, filePath, stat);
-    if (!stat.isFile()) {
-      throw new Error(ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE);
-    }
-    return await handle.readFile('utf8');
-  } finally {
-    await handle.close().catch(() => undefined);
+    return await safeReadVerifiedUtf8File(filePath, workRoot);
+  } catch (error) {
+    return rethrowAsPathShapeError(error);
   }
 }
 
-function openVerifiedRegularFileSync(workRoot: string, filePath: string, flags: number): number {
-  assertContained(path.resolve(workRoot), path.resolve(filePath));
-  const fd = fs.openSync(filePath, flags);
+function openVerifiedRegularFileSync(workRoot: string, filePath: string): number {
   try {
-    const stat = fs.fstatSync(fd);
-    validateOpenedPathInsideRoot(workRoot, filePath, stat);
-    if (!stat.isFile()) {
-      throw new Error(ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE);
-    }
-    return fd;
+    return safeOpenVerifiedRegularFileSync(filePath, fs.constants.O_RDONLY, workRoot);
   } catch (error) {
-    fs.closeSync(fd);
-    throw error;
+    return rethrowAsPathShapeError(error);
   }
 }
 
 function assertVerifiedDirectoryInsideRoot(root: string, directoryPath: string): void {
-  assertContained(path.resolve(root), path.resolve(directoryPath));
-  let fd: number;
   try {
-    fd = fs.openSync(directoryPath, fs.constants.O_RDONLY | directoryFlag() | noFollowFlag());
+    safeAssertVerifiedDirectoryInsideRoot(root, directoryPath);
   } catch (error) {
-    if (isNodeErrorCode(error, 'ELOOP') || isNodeErrorCode(error, 'ENOTDIR')) {
-      throw new Error(ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE);
-    }
-    throw error;
-  }
-  try {
-    const stat = fs.fstatSync(fd);
-    validateOpenedPathInsideRoot(root, directoryPath, stat);
-    if (!stat.isDirectory()) {
-      throw new Error(ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE);
-    }
-  } finally {
-    fs.closeSync(fd);
+    rethrowAsPathShapeError(error);
   }
 }
 
 function validateOpenedPathInsideRoot(root: string, filePath: string, openedStat: fs.Stats): void {
-  const rootRealPath = fs.realpathSync(root);
-  const targetRealPath = fs.realpathSync(filePath);
-  assertContained(rootRealPath, targetRealPath);
-
-  const currentPathStat = fs.statSync(targetRealPath);
-  if (!sameFile(openedStat, currentPathStat)) {
-    throw new Error(ARTIFACT_ERROR_TEXT.INVALID_URI_PATH_SHAPE);
+  try {
+    safeValidateOpenedPathInsideRoot(root, filePath, openedStat);
+  } catch (error) {
+    rethrowAsPathShapeError(error);
   }
-}
-
-function sameFile(left: fs.Stats, right: fs.Stats): boolean {
-  return left.dev === right.dev && left.ino === right.ino;
-}
-
-function noFollowFlag(): number {
-  return 'O_NOFOLLOW' in fs.constants ? fs.constants.O_NOFOLLOW : 0;
-}
-
-function directoryFlag(): number {
-  return 'O_DIRECTORY' in fs.constants ? fs.constants.O_DIRECTORY : 0;
 }
 
 function canonicalManifestRecord(record: ArtifactManifestRow): ArtifactManifestRow {

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -212,6 +212,14 @@ export { DelegationLock, DelegationLockTimeoutError } from './delegation-lock.js
 export { SessionLock, SessionLockTimeoutError } from './session-lock.js';
 export { FileLockTimeoutError, heldLock, heldLockSync } from './file-lock.js';
 export type { ScopedLock, ScopedLockSync } from './file-lock.js';
+export {
+  openVerifiedRegularFile,
+  openVerifiedRegularFileSync,
+  readVerifiedUtf8File,
+  readVerifiedUtf8FileSync,
+  UnsafeFileError,
+  type UnsafeFileReason,
+} from './safe-fs.js';
 export { DelegationScanService, type TokenScanResult } from './delegation-scan.js';
 export {
   reconstituteContextVars,

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { promises as fs, constants as fsConstants } from 'node:fs';
+import type { FileHandle } from 'node:fs/promises';
 import type { OutputDeclaration } from '@rundown-org/parser';
 import { isReservedTemplateName, NAMED_IDENTIFIER_PATTERN } from '@rundown-org/parser';
 import { RUNDOWN_DIR, assertSafeId } from '../paths.js';
@@ -278,7 +279,7 @@ export async function readCapturedOutputs(
   const captured: Record<string, VariableValue> = {};
   for (const channel of prepared) {
     const { name, path: filePath } = channel;
-    let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+    let handle: FileHandle | undefined;
     let raw: string | undefined;
     try {
       // openVerifiedRegularFile ORs in O_NOFOLLOW (so a symlinked channel still

--- a/packages/core/src/runbook/output-channels.ts
+++ b/packages/core/src/runbook/output-channels.ts
@@ -7,6 +7,7 @@ import { logger } from '../logger.js';
 import { isNodeError } from '../errors.js';
 import type { VariableValue } from './effective-vars.js';
 import { parseRuntimeVariableValue } from './runtime-variable-value.js';
+import { openVerifiedRegularFile, UnsafeFileError } from './safe-fs.js';
 
 /**
  * Naked OUTPUTS entry — the name-only form that activates a file-backed
@@ -205,7 +206,6 @@ export async function prepareOutputChannels(args: PrepareOutputChannelsArgs): Pr
 }> {
   const env: Record<string, string> = {};
   const prepared: PreparedChannel[] = [];
-  const noFollow = fsConstants.O_NOFOLLOW;
   for (const entry of args.naked) {
     let filePath: string;
     try {
@@ -219,20 +219,16 @@ export async function prepareOutputChannels(args: PrepareOutputChannelsArgs): Pr
     }
     try {
       await fs.mkdir(path.dirname(filePath), { recursive: true });
-      const handle = await fs.open(
+      // openVerifiedRegularFile ORs in O_NOFOLLOW and rejects non-regular
+      // targets via UnsafeFileError; no containedRoot is passed so the shared
+      // helper applies exactly the prior guarantee (O_NOFOLLOW + isFile, no
+      // containment re-stat) — preserving output-channels behaviour.
+      const handle = await openVerifiedRegularFile(
         filePath,
-        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | noFollow,
+        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC,
         0o600,
       );
       try {
-        const stat = await handle.stat();
-        if (!stat.isFile()) {
-          void logger.warn('prepareOutputChannels: non-regular channel target, skipping', {
-            name: entry.name,
-            path: filePath,
-          });
-          continue;
-        }
         await handle.chmod(0o600);
       } finally {
         await handle.close().catch(() => undefined);
@@ -242,6 +238,13 @@ export async function prepareOutputChannels(args: PrepareOutputChannelsArgs): Pr
     } catch (err) {
       if (isNodeError(err) && err.code === 'ELOOP') {
         void logger.warn('prepareOutputChannels: symlinked channel file, skipping', {
+          name: entry.name,
+          path: filePath,
+        });
+        continue;
+      }
+      if (err instanceof UnsafeFileError && err.reason === 'not-regular-file') {
+        void logger.warn('prepareOutputChannels: non-regular channel target, skipping', {
           name: entry.name,
           path: filePath,
         });
@@ -278,15 +281,10 @@ export async function readCapturedOutputs(
     let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
     let raw: string | undefined;
     try {
-      handle = await fs.open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
-      const stat = await handle.stat();
-      if (!stat.isFile()) {
-        void logger.warn('readCapturedOutputs: non-regular channel file, omitting', {
-          name,
-          path: filePath,
-        });
-        continue;
-      }
+      // openVerifiedRegularFile ORs in O_NOFOLLOW (so a symlinked channel still
+      // raises ELOOP) and rejects non-regular targets via UnsafeFileError; no
+      // containedRoot is passed, matching the prior O_NOFOLLOW + isFile guard.
+      handle = await openVerifiedRegularFile(filePath, fsConstants.O_RDONLY);
       const bytes = await handle.readFile();
       try {
         raw = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
@@ -298,7 +296,12 @@ export async function readCapturedOutputs(
         continue;
       }
     } catch (err) {
-      if (isNodeError(err) && err.code === 'ENOENT') {
+      if (err instanceof UnsafeFileError && err.reason === 'not-regular-file') {
+        void logger.warn('readCapturedOutputs: non-regular channel file, omitting', {
+          name,
+          path: filePath,
+        });
+      } else if (isNodeError(err) && err.code === 'ENOENT') {
         void logger.warn('readCapturedOutputs: channel file missing', { name, path: filePath });
       } else {
         void logger.warn('readCapturedOutputs: read failed', {

--- a/packages/core/src/runbook/safe-fs.ts
+++ b/packages/core/src/runbook/safe-fs.ts
@@ -59,6 +59,13 @@ export class UnsafeFileError extends Error {
  * Platforms that do not define it fall back to `0` so the OR is a no-op rather
  * than producing `NaN`.
  *
+ * Both supported platforms (Linux, macOS) define `O_NOFOLLOW`, so the guard is
+ * always armed in practice. The `0` fallback only engages on native Windows,
+ * which is explicitly out of scope for the security model (the sandbox is
+ * "Not supported" there — see docs/reference/security.md; WSL is the documented
+ * Windows path and runs as Linux, where `O_NOFOLLOW` exists). The degradation
+ * on native Windows is therefore deliberate, not an oversight.
+ *
  * @returns `fs.constants.O_NOFOLLOW` when defined, otherwise `0`
  */
 export function noFollowFlag(): number {
@@ -133,6 +140,34 @@ export function validateOpenedPathInsideRoot(
   assertContained(rootRealPath, targetRealPath);
 
   const currentPathStat = fs.statSync(targetRealPath);
+  if (!sameFile(openedStat, currentPathStat)) {
+    throw new UnsafeFileError('symlink-swapped', filePath);
+  }
+}
+
+/**
+ * Async twin of {@link validateOpenedPathInsideRoot}.
+ *
+ * Identical containment + symlink-swap verification, but resolves each realpath
+ * and re-stats with the async `fsp.realpath` / `fsp.stat` so callers on an async
+ * code path do not block the event loop with `realpathSync` / `statSync`.
+ *
+ * @param root - Containment root the target must resolve within
+ * @param filePath - Path that was opened (its realpath is re-resolved here)
+ * @param openedStat - Stat of the opened handle captured before this call
+ * @throws {UnsafeFileError} With reason `escaped-root` when the realpath
+ *   escapes `root`, or `symlink-swapped` when the dev/ino re-stat mismatches
+ */
+export async function validateOpenedPathInsideRootAsync(
+  root: string,
+  filePath: string,
+  openedStat: fs.Stats,
+): Promise<void> {
+  const rootRealPath = await fsp.realpath(root);
+  const targetRealPath = await fsp.realpath(filePath);
+  assertContained(rootRealPath, targetRealPath);
+
+  const currentPathStat = await fsp.stat(targetRealPath);
   if (!sameFile(openedStat, currentPathStat)) {
     throw new UnsafeFileError('symlink-swapped', filePath);
   }
@@ -248,7 +283,7 @@ export async function openVerifiedRegularFile(
   try {
     const stat = await handle.stat();
     if (containedRoot !== undefined) {
-      validateOpenedPathInsideRoot(containedRoot, filePath, stat);
+      await validateOpenedPathInsideRootAsync(containedRoot, filePath, stat);
     }
     if (!stat.isFile()) {
       throw new UnsafeFileError('not-regular-file', filePath);
@@ -313,6 +348,12 @@ export function assertVerifiedDirectoryInsideRoot(root: string, directoryPath: s
   assertContained(path.resolve(root), path.resolve(directoryPath));
   let fd: number;
   try {
+    // This open is read-only (O_RDONLY) and hardened with O_NOFOLLOW, so it cannot
+    // create or follow a symlink into a file — the directory analogue of the safe-fs
+    // guard, not temp-file creation. CodeQL cannot prove the computed numeric flags
+    // are read-only, so js/insecure-temporary-file misfires here. Suppress this one
+    // location only; the rule stays active everywhere else.
+    // codeql[js/insecure-temporary-file]
     fd = fs.openSync(directoryPath, fs.constants.O_RDONLY | directoryFlag() | noFollowFlag());
   } catch (error) {
     if (isNodeErrorCode(error, 'ELOOP') || isNodeErrorCode(error, 'ENOTDIR')) {

--- a/packages/core/src/runbook/safe-fs.ts
+++ b/packages/core/src/runbook/safe-fs.ts
@@ -348,12 +348,6 @@ export function assertVerifiedDirectoryInsideRoot(root: string, directoryPath: s
   assertContained(path.resolve(root), path.resolve(directoryPath));
   let fd: number;
   try {
-    // This open is read-only (O_RDONLY) and hardened with O_NOFOLLOW, so it cannot
-    // create or follow a symlink into a file — the directory analogue of the safe-fs
-    // guard, not temp-file creation. CodeQL cannot prove the computed numeric flags
-    // are read-only, so js/insecure-temporary-file misfires here. Suppress this one
-    // location only; the rule stays active everywhere else.
-    // codeql[js/insecure-temporary-file]
     fd = fs.openSync(directoryPath, fs.constants.O_RDONLY | directoryFlag() | noFollowFlag());
   } catch (error) {
     if (isNodeErrorCode(error, 'ELOOP') || isNodeErrorCode(error, 'ENOTDIR')) {

--- a/packages/core/src/runbook/safe-fs.ts
+++ b/packages/core/src/runbook/safe-fs.ts
@@ -1,0 +1,332 @@
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import { isNodeErrorCode } from '../errors.js';
+
+/**
+ * Why a guarded open was rejected by a {@link UnsafeFileError}.
+ *
+ * Each variant maps to a distinct verification failure so callers can apply
+ * their own policy (skip vs propagate) by narrowing on `reason` rather than
+ * string-matching an error message:
+ *
+ * - `not-regular-file` — the `fstat` of the opened descriptor is not a regular
+ *   file (e.g. a directory or FIFO that nonetheless opened successfully).
+ * - `escaped-root` — the realpath of the target resolves outside the
+ *   `containedRoot` it was checked against.
+ * - `symlink-swapped` — the dev/ino re-stat after open does not match the
+ *   stat of the opened descriptor, indicating the path was swapped between
+ *   open and verification (the TOCTOU window).
+ */
+export type UnsafeFileReason = 'not-regular-file' | 'escaped-root' | 'symlink-swapped';
+
+/**
+ * Thrown by safe-fs guards when an opened path fails its regular-file,
+ * containment, or symlink-swap verification.
+ *
+ * The {@link reason} discriminant lets callers map specific failure modes to
+ * their own policy (skip vs propagate) without string-matching error messages.
+ * OS-level errors such as `ELOOP`, `ENOENT`, and `ENOTDIR` are NOT represented
+ * here — they propagate as `NodeJS.ErrnoException` from the underlying `open`
+ * call and are classified by callers with `isNodeError` / `isNodeErrorCode`.
+ */
+export class UnsafeFileError extends Error {
+  /** The verification failure mode that triggered this rejection. */
+  readonly reason: UnsafeFileReason;
+
+  /** Absolute or caller-supplied path that failed verification. */
+  readonly path: string;
+
+  /**
+   * Construct an UnsafeFileError.
+   *
+   * @param reason - The verification failure mode that triggered the rejection
+   * @param filePath - The path that failed verification
+   */
+  constructor(reason: UnsafeFileReason, filePath: string) {
+    super(`Unsafe file (${reason}): ${filePath}`);
+    this.name = 'UnsafeFileError';
+    this.reason = reason;
+    this.path = filePath;
+  }
+}
+
+/**
+ * Resolve the `O_NOFOLLOW` open flag for the current platform.
+ *
+ * `O_NOFOLLOW` makes `open` fail with `ELOOP` when the final path component is
+ * a symlink, which is the load-bearing primitive behind every safe-fs guard.
+ * Platforms that do not define it fall back to `0` so the OR is a no-op rather
+ * than producing `NaN`.
+ *
+ * @returns `fs.constants.O_NOFOLLOW` when defined, otherwise `0`
+ */
+export function noFollowFlag(): number {
+  return 'O_NOFOLLOW' in fs.constants ? fs.constants.O_NOFOLLOW : 0;
+}
+
+/**
+ * Resolve the `O_DIRECTORY` open flag for the current platform.
+ *
+ * @returns `fs.constants.O_DIRECTORY` when defined, otherwise `0`
+ */
+export function directoryFlag(): number {
+  return 'O_DIRECTORY' in fs.constants ? fs.constants.O_DIRECTORY : 0;
+}
+
+/**
+ * Determine whether two stat results refer to the same underlying inode.
+ *
+ * Used to close the symlink-swap TOCTOU window: the stat of an opened
+ * descriptor is compared against a fresh stat of the path's realpath, and a
+ * dev/ino mismatch means the path was swapped after the open.
+ *
+ * @param left - First stat result
+ * @param right - Second stat result
+ * @returns `true` when both stats share the same `dev` and `ino`
+ */
+export function sameFile(left: fs.Stats, right: fs.Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+/**
+ * Assert that `candidate` is lexically contained within `root`.
+ *
+ * Pure path arithmetic — performs no filesystem access. A candidate equal to
+ * `root`, or nested beneath it, passes; a `..` escape or absolute path that
+ * leaves `root` fails.
+ *
+ * @param root - Containment root
+ * @param candidate - Path to test for containment
+ * @throws {UnsafeFileError} With reason `escaped-root` when `candidate`
+ *   resolves outside `root`
+ */
+export function assertContained(root: string, candidate: string): void {
+  const relative = path.relative(root, candidate);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new UnsafeFileError('escaped-root', candidate);
+  }
+}
+
+/**
+ * Verify that an already-opened path is contained under `root` and was not
+ * swapped after open.
+ *
+ * Resolves `realpath(root)` and `realpath(filePath)`, asserts lexical
+ * containment of the canonical target under the canonical root, then re-stats
+ * the realpath and compares dev/ino against the stat captured at open time.
+ * A mismatch indicates a symlink swap inside the open→verify window.
+ *
+ * @param root - Containment root the target must resolve within
+ * @param filePath - Path that was opened (its realpath is re-resolved here)
+ * @param openedStat - Stat of the opened descriptor captured before this call
+ * @throws {UnsafeFileError} With reason `escaped-root` when the realpath
+ *   escapes `root`, or `symlink-swapped` when the dev/ino re-stat mismatches
+ */
+export function validateOpenedPathInsideRoot(
+  root: string,
+  filePath: string,
+  openedStat: fs.Stats,
+): void {
+  const rootRealPath = fs.realpathSync(root);
+  const targetRealPath = fs.realpathSync(filePath);
+  assertContained(rootRealPath, targetRealPath);
+
+  const currentPathStat = fs.statSync(targetRealPath);
+  if (!sameFile(openedStat, currentPathStat)) {
+    throw new UnsafeFileError('symlink-swapped', filePath);
+  }
+}
+
+/**
+ * Open a path with `O_NOFOLLOW`, fstat the opened descriptor, optionally verify
+ * containment under `containedRoot`, and assert it is a regular file.
+ *
+ * The returned descriptor is owned by the caller, who must close it. On any
+ * verification failure or OS error the descriptor is closed before the error
+ * is re-thrown, so no descriptor leaks. `noFollowFlag()` is always ORed into
+ * `flags`, so a symlinked final component surfaces as an `ELOOP`
+ * `NodeJS.ErrnoException` from `open` (not an {@link UnsafeFileError}).
+ *
+ * When `containedRoot` is omitted the realpath / dev-ino re-stat is skipped —
+ * this is the output-channels-equivalent guarantee (`O_NOFOLLOW` + `isFile`
+ * only, no containment).
+ *
+ * @param filePath - Path to open
+ * @param flags - Base open flags; `noFollowFlag()` is ORed in automatically
+ * @param containedRoot - Optional root to enforce realpath containment and a
+ *   symlink-swap re-stat against; when omitted both checks are skipped
+ * @returns The open file descriptor (caller closes)
+ * @throws {UnsafeFileError} With reason `not-regular-file` when the descriptor
+ *   is not a regular file, or `escaped-root` / `symlink-swapped` when
+ *   `containedRoot` containment fails
+ * @throws {NodeJS.ErrnoException} Propagated from `open` (e.g. `ELOOP`,
+ *   `ENOENT`, `ENOTDIR`)
+ */
+export function openVerifiedRegularFileSync(
+  filePath: string,
+  flags: number,
+  containedRoot?: string,
+): number {
+  if (containedRoot !== undefined) {
+    assertContained(path.resolve(containedRoot), path.resolve(filePath));
+  }
+  const fd = fs.openSync(filePath, flags | noFollowFlag());
+  try {
+    const stat = fs.fstatSync(fd);
+    if (containedRoot !== undefined) {
+      validateOpenedPathInsideRoot(containedRoot, filePath, stat);
+    }
+    if (!stat.isFile()) {
+      throw new UnsafeFileError('not-regular-file', filePath);
+    }
+    return fd;
+  } catch (error) {
+    fs.closeSync(fd);
+    throw error;
+  }
+}
+
+/**
+ * Synchronously open, verify, read, and close a UTF-8 file.
+ *
+ * Opens via {@link openVerifiedRegularFileSync} (so `O_RDONLY | O_NOFOLLOW`
+ * plus optional containment), reads the entire file as UTF-8, and always closes
+ * the descriptor.
+ *
+ * @param filePath - Path to read
+ * @param containedRoot - Optional containment root (see
+ *   {@link openVerifiedRegularFileSync})
+ * @returns The file contents decoded as UTF-8
+ * @throws {UnsafeFileError} On regular-file / containment / symlink-swap failure
+ * @throws {NodeJS.ErrnoException} Propagated from `open` (e.g. `ELOOP`, `ENOENT`)
+ */
+export function readVerifiedUtf8FileSync(filePath: string, containedRoot?: string): string {
+  const fd = openVerifiedRegularFileSync(filePath, fs.constants.O_RDONLY, containedRoot);
+  try {
+    return fs.readFileSync(fd, 'utf8');
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
+ * Async twin of {@link openVerifiedRegularFileSync}.
+ *
+ * Opens a path with `O_NOFOLLOW` (always ORed in), runs fstat on the opened handle,
+ * optionally verifies containment under `containedRoot`, and asserts it is a
+ * regular file. The handle is returned open so callers can `chmod`, read, or
+ * write through it; on any verification failure or OS error the handle is
+ * closed before the error is rethrown.
+ *
+ * The `O_NOFOLLOW` guarantee means a symlinked final component produces an
+ * `ELOOP` `NodeJS.ErrnoException` from `open`; callers classify it with
+ * `isNodeError` / `isNodeErrorCode`.
+ *
+ * @param filePath - Path to open
+ * @param flags - Base open flags; `noFollowFlag()` is ORed in automatically
+ * @param mode - Optional file mode applied when `flags` include `O_CREAT`
+ * @param containedRoot - Optional root to enforce realpath containment and a
+ *   symlink-swap re-stat against; when omitted both checks are skipped
+ * @returns Promise resolving to the open file handle (caller closes)
+ * @throws {UnsafeFileError} With reason `not-regular-file` when the handle is
+ *   not a regular file, or `escaped-root` / `symlink-swapped` when
+ *   `containedRoot` containment fails
+ * @throws {NodeJS.ErrnoException} Propagated from `open` (e.g. `ELOOP`,
+ *   `ENOENT`, `ENOTDIR`)
+ */
+export async function openVerifiedRegularFile(
+  filePath: string,
+  flags: number,
+  mode?: fs.Mode,
+  containedRoot?: string,
+): Promise<fsp.FileHandle> {
+  if (containedRoot !== undefined) {
+    assertContained(path.resolve(containedRoot), path.resolve(filePath));
+  }
+  const handle = await fsp.open(filePath, flags | noFollowFlag(), mode);
+  try {
+    const stat = await handle.stat();
+    if (containedRoot !== undefined) {
+      validateOpenedPathInsideRoot(containedRoot, filePath, stat);
+    }
+    if (!stat.isFile()) {
+      throw new UnsafeFileError('not-regular-file', filePath);
+    }
+    return handle;
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+/**
+ * Asynchronously open, verify, read, and close a UTF-8 file.
+ *
+ * Opens via {@link openVerifiedRegularFile} (so `O_RDONLY | O_NOFOLLOW` plus
+ * optional containment), reads the entire file as UTF-8, and always closes the
+ * handle.
+ *
+ * @param filePath - Path to read
+ * @param containedRoot - Optional containment root (see
+ *   {@link openVerifiedRegularFile})
+ * @returns Promise resolving to the file contents decoded as UTF-8
+ * @throws {UnsafeFileError} On regular-file / containment / symlink-swap failure
+ * @throws {NodeJS.ErrnoException} Propagated from `open` (e.g. `ELOOP`, `ENOENT`)
+ */
+export async function readVerifiedUtf8File(
+  filePath: string,
+  containedRoot?: string,
+): Promise<string> {
+  const handle = await openVerifiedRegularFile(
+    filePath,
+    fs.constants.O_RDONLY,
+    undefined,
+    containedRoot,
+  );
+  try {
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
+/**
+ * Open a directory with `O_NOFOLLOW`, verify it is contained under `root`, and
+ * assert it is a directory.
+ *
+ * The directory analogue of {@link openVerifiedRegularFileSync}: opens with
+ * `O_DIRECTORY | O_NOFOLLOW`, applies the realpath / dev-ino containment
+ * re-stat against `root`, and asserts the opened descriptor is a directory.
+ * The descriptor is always closed before return.
+ *
+ * @param root - Containment root the directory must resolve within
+ * @param directoryPath - Directory path to verify
+ * @throws {UnsafeFileError} With reason `not-regular-file` when the target is
+ *   not a directory (a `not-directory` analogue is intentionally folded into
+ *   the regular-file reason to keep the caller contract narrow), or
+ *   `escaped-root` / `symlink-swapped` when containment fails. A symlinked or
+ *   non-directory final component that surfaces as `ELOOP` / `ENOTDIR` from
+ *   `open` is translated to `escaped-root`.
+ */
+export function assertVerifiedDirectoryInsideRoot(root: string, directoryPath: string): void {
+  assertContained(path.resolve(root), path.resolve(directoryPath));
+  let fd: number;
+  try {
+    fd = fs.openSync(directoryPath, fs.constants.O_RDONLY | directoryFlag() | noFollowFlag());
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ELOOP') || isNodeErrorCode(error, 'ENOTDIR')) {
+      throw new UnsafeFileError('escaped-root', directoryPath);
+    }
+    throw error;
+  }
+  try {
+    const stat = fs.fstatSync(fd);
+    validateOpenedPathInsideRoot(root, directoryPath, stat);
+    if (!stat.isDirectory()) {
+      throw new UnsafeFileError('not-regular-file', directoryPath);
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+}

--- a/packages/core/src/runbook/variable-preparation.ts
+++ b/packages/core/src/runbook/variable-preparation.ts
@@ -26,7 +26,7 @@ import {
   type TrustedArtifactValue,
   type VariableValue,
 } from './effective-vars.js';
-import { type TemplateHelperRegistry } from './helper-invoke.js';
+import type { TemplateHelperRegistry } from './helper-invoke.js';
 import type { RunId } from './run-id.js';
 import type { RunbookRef } from './runbook-ref.js';
 import { buildContextVars, validateForVariables } from './runtime-frame.js';


### PR DESCRIPTION
## Summary

Converges the three open-coded symlink/TOCTOU file-read guards in `@rundown-org/core` onto a single shared `safe-fs.ts` module. **No observable behavior change** at any call site — this is a pure security-hardening refactor that eliminates a drift hazard. Closes #433.

Before this change the same security-critical `open` + `O_NOFOLLOW` + regular-file-check pattern existed in three near-copies:
- `artifact-manifest.ts` — sync `openVerifiedRegularFileSync` (~line 720) + async `readVerifiedUtf8File`
- `output-channels.ts` — open-coded async guard at the write and read paths

## What changed

- **New `packages/core/src/runbook/safe-fs.ts`** — the single canonical guard. Exposes **sync + async** variants; `O_NOFOLLOW` is always ORed in (preserving `ELOOP`→skip semantics); containment realpath/dev-ino re-stat is **opt-in** via a `containedRoot` param. Rejection is signalled by a typed `UnsafeFileError` with a `reason` discriminant (`not-regular-file` / `escaped-root` / `symlink-swapped`).
- **`artifact-manifest.ts`** — repointed at safe-fs, keeping containment on (passes `workRoot` as `containedRoot`). Thin private wrappers translate `UnsafeFileError` back into the existing `INVALID_URI_PATH_SHAPE` sentinel, so every existing catch site and test stays green with zero edits. The `file:`-URI realpath-first branch is a different algorithm and was deliberately left out of scope.
- **`output-channels.ts`** — converged onto the async guard with `containedRoot` omitted, preserving its exact skip-and-log (non-throwing) policy and `ELOOP`→skip semantics.
- **`index.ts`** — barrel exports for the new module.
- **`safe-fs.test.ts`** — new unit tests (symlink rejection, regular-file accept, ELOOP skip, missing file, containment on/off). A "containment OFF" test pins that no `realpathSync` runs when `containedRoot` is omitted.

## Behavior preservation

- *artifact-manifest*: containment + dev/ino re-stat unchanged; external error contract (`INVALID_URI_PATH_SHAPE`) identical.
- *output-channels*: no containment re-stat added; skip-and-log policy and non-regular-target warnings preserved.

## Verification

- `npm run build -w @rundown-org/core`: clean
- Existing output-channels / artifact-manifest suites: pass unchanged (80 tests)
- `npm run verify`: **exit 0** — spell 0 issues, format clean, lint clean, core unit suite **3309 passed, 1 skipped**

## Plan

Design and step-by-step plan: `docs/internal/plans/2026-06-14-share-safe-fs-toctou-guard.md`