### PR TITLE
[codex] recover PR #438 onto main

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -287,3 +287,4 @@ cwds
 Hermeticity
 Trailmark
 chokepoint
+Fors

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -230,6 +230,8 @@ turboshovel
 typename
 typestates
 ultrathink
+undercounted
+undercounting
 unasserted
 unclaimable
 unist

--- a/docs/guides/composing-runbooks.md
+++ b/docs/guides/composing-runbooks.md
@@ -35,12 +35,18 @@ A thin parent that sequences pipeline stages with explicit aggregation (`- PASS 
 
 A delegated child inherits the shared **artifacts** (e.g. `PlanPath`) and persisted **template variables**. This is the handoff to reach for: produce an artifact upstream, declare it `REQUIRED` in the child, rehydrate it with a naked `ARTIFACTS` alias. `execute-plan` hands the whole plan to `implement-plan` this way and nothing else crosses.
 
-## Future work — iterate-and-delegate (FOR + DELEGATE per item)
+## Pattern 6 — iterate-and-delegate (FOR + DELEGATE per item)
 
-The intuitive "loop a data source, delegate one worker per item" has two sharp edges, both validated against the engine. Until there is a first-class pattern for them, the planning pipeline deliberately keeps the per-task walk inside the agent + the [executing-plans](../../packages/claude-code-plugin/skills/executing-plans/SKILL.md) skill rather than expressing it as `FOR`.
+Loop a data source and delegate one worker per item, in a single runbook. The canonical example is the pair under [`packages/claude-code-plugin/runbooks/patterns/`](../../packages/claude-code-plugin/runbooks/patterns/): `iterate-and-delegate.runbook.md` produces a work list in step 1 (`OUTPUTS`, which needs no seed), then a step-2 `FOR item IN {{ Items }}` `DELEGATE`s `process-one-item.runbook.md` once per item. The leaf declares the loop variable in frontmatter `inputs` / `required`:
 
-1. **A `FOR` source must resolve at the launch of the runbook that contains the `FOR`.** Launch-time validation rejects a `FOR` over a variable or artifact the same runbook produces in an earlier step (`VALIDATION_ERROR: FOR loop references undefined variable`); a frontmatter `inputs:` declaration is not a value. The workaround is to have a *parent* populate the source (via `OUTPUTS`, which needs no seed) and compose a child that iterates the inherited, already-populated source.
+```yaml
+inputs:
+  - item
+required:
+  - item
+```
 
-2. **The loop variable and `Index` do not cross the delegation boundary.** A delegated child inherits the whole array (and supports index-in like `{{ Tasks.0.name }}`) but not the per-iteration loop variable or `Index`. Passing per-item data to a delegated child therefore needs explicit `--input` forwarding or a per-iteration artifact.
+so each delegated child receives that iteration's item — plus `Index` — automatically, with no manual `--input` plumbing. The two engine constraints that previously blocked this are now resolved (#435):
 
-The syntax for `FOR` + `DELEGATE` lives in the parser/core fixtures under `runbooks/for-loops/` and `runbooks/delegation/`.
+- **Self-produced `FOR` source.** A data source is resolved at the `FOR` step's **entry**, not at launch, so a `FOR` may iterate a value the same runbook produced earlier via `OUTPUTS` (or a name-binding `ARTIFACTS` alias). Launch validation defers such a source rather than rejecting it. See [language spec §8.2](../spec/language.md#82-data-source-resolution-timing).
+- **Per-iteration handoff.** The loop variable and `Index` cross the delegation boundary: `Index` is inherited unconditionally; the loop variable is inherited **only when the child declares it in `inputs`**, and ranks below an explicit `--input` override. The binding is keyed to the iteration, not the reference — a `FOR` that delegates more than one reference per iteration shares the same item across them (`rd check` warns), so use a single delegated reference per `FOR` for one-worker-per-item. See [language spec §10.4](../spec/language.md#104-delegation-inheritance).

--- a/docs/internal/composing-runbooks-design.md
+++ b/docs/internal/composing-runbooks-design.md
@@ -146,22 +146,21 @@ explicitly and threading `PlanPath` through the shared context:
 This makes the leaf-delegate / orchestrator-compose discipline visible in one file:
 step 1 delegates (leaf); steps 2–3 compose (orchestrators).
 
-## Mechanism constraints (validated)
+## FOR + delegation semantics (validated)
 
-Two constraints were confirmed by live spikes against the built CLI; they shaped the
-no-`FOR` execute design and are documented in the guide:
+Two mechanisms were confirmed by live spikes against the built CLI and are now
+exercised by the `iterate-and-delegate` pattern:
 
-1. **A `FOR` source must resolve at the launch of the runbook containing the `FOR`.**
-   Launch-time validation rejects a `FOR` over a variable/artifact the same runbook
-   produces in an earlier step (`VALIDATION_ERROR: FOR loop references undefined
-   variable`); frontmatter `inputs:` declaration does not satisfy it. A parent may
-   populate the source (via `OUTPUTS`, no seed needed) and compose a child that
-   iterates it — the child inherits a populated source and validates.
-2. **Loop variable and `Index` do not cross the delegation boundary.** A delegated
-   child inherits shared artifacts and persisted template vars (e.g. the whole `Tasks`
-   array, with index-in like `{{ Tasks.0.name }}`), but **not** the per-iteration loop
-   variable or `Index`. Passing per-item data to a delegated child requires explicit
-   `--input` forwarding or a per-iteration artifact.
+1. **A `FOR` source resolves at step entry, not at launch.** A runbook may
+   `FOR`-iterate a data source it produces itself in an earlier step; the source is
+   resolved when the `FOR` step is entered, so no upstream seed or parent populate is
+   required. (`runbooks/patterns/iterate-and-delegate.runbook.md` captures `Items`
+   via `OUTPUTS` in step 1 and loops it in step 2.)
+2. **Iteration bindings cross the delegation boundary.** Within a `FOR` step a
+   delegated child inherits `Index` unconditionally, and the loop variable when the
+   child declares that name in its frontmatter `inputs` (language spec §10.4); an
+   explicit `--input` of the same name still overrides the inherited binding. A child
+   that does not declare the loop variable does not receive it.
 
 ## Data flow
 

--- a/docs/internal/plans/composing-runbooks-plan.md
+++ b/docs/internal/plans/composing-runbooks-plan.md
@@ -1007,13 +1007,13 @@ A thin parent that sequences pipeline stages with explicit aggregation (`- PASS 
 
 A delegated child inherits the shared **artifacts** (e.g. `PlanPath`) and persisted **template variables**. This is the handoff to reach for: produce an artifact upstream, declare it `REQUIRED` in the child, rehydrate it with a naked `ARTIFACTS` alias. `execute-plan` hands the whole plan to `implement-plan` this way and nothing else crosses.
 
-## Future work — iterate-and-delegate (FOR + DELEGATE per item)
+## iterate-and-delegate (FOR + DELEGATE per item)
 
-The intuitive "loop a data source, delegate one worker per item" has two sharp edges, both validated against the engine. Until there is a first-class pattern for them, the planning pipeline deliberately keeps the per-task walk inside the agent + the [executing-plans](../../packages/claude-code-plugin/skills/executing-plans/SKILL.md) skill rather than expressing it as `FOR`.
+"Loop a data source, delegate one worker per item" is a first-class pattern, captured in `runbooks/patterns/iterate-and-delegate.runbook.md`. Two mechanisms make it work, both validated against the engine:
 
-1. **A `FOR` source must resolve at the launch of the runbook that contains the `FOR`.** Launch-time validation rejects a `FOR` over a variable or artifact the same runbook produces in an earlier step (`VALIDATION_ERROR: FOR loop references undefined variable`); a frontmatter `inputs:` declaration is not a value. The workaround is to have a *parent* populate the source (via `OUTPUTS`, which needs no seed) and compose a child that iterates the inherited, already-populated source.
+1. **A `FOR` source resolves at step entry, not at launch.** A runbook may `FOR`-iterate a data source it produces itself in an earlier step; the source is resolved when the `FOR` step is entered, so no seed or parent populate is required (the pattern captures `Items` via `OUTPUTS`, then loops it).
 
-2. **The loop variable and `Index` do not cross the delegation boundary.** A delegated child inherits the whole array (and supports index-in like `{{ Tasks.0.name }}`) but not the per-iteration loop variable or `Index`. Passing per-item data to a delegated child therefore needs explicit `--input` forwarding or a per-iteration artifact.
+2. **Iteration bindings cross the delegation boundary.** Within a `FOR` step a delegated child inherits `Index` unconditionally, and the loop variable when the child declares that name in its frontmatter `inputs`; an explicit `--input` of the same name still overrides the inherited binding.
 
 The syntax for `FOR` + `DELEGATE` lives in the parser/core fixtures under `runbooks/for-loops/` and `runbooks/delegation/`.
 ```

--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -123,6 +123,12 @@ The runtime MUST expand loop and location variables against the active frame.
 Dynamic variables MUST NOT be overridden by user input, config, environment, or
 delegation inheritance.
 
+`Index` is the 1-based iteration number of the active `FOR` step. It is
+available in the step's substeps and, when a delegation is issued inside the
+loop, is inherited by the delegated child as the delegating iteration's index
+(language spec §10.4). A non-looping child does not re-derive `Index`, so the
+inherited value persists for the child's duration.
+
 ### 5.3 Iteration Actions
 
 Substep actions inside a `FOR` step affect the current iteration. Nested

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -291,10 +291,12 @@ Rules:
 | Limits | Numeric bounds exceeding `MAX_FOR_BOUND` (10,000) are rejected at parse time by Zod validation — not silently capped. Open-ended data-source iteration is capped at runtime by `MAX_FILE_ITERATIONS` (10,000); iteration stops once the cap is reached. See [runtime.md §5.1](../reference/runtime.md#51-loop-state). |
 | Data-source variable | Data-source iteration MUST use a named variable; `FOR {{source}}` is invalid. |
 | Data-source reference | `{{source}}` names a defined runtime data source and is not template-expanded. |
+| Source resolution | A data source is resolved at step **entry**, not at launch. A source produced by an earlier step in the same run (via `OUTPUTS` or a name-binding `ARTIFACTS` alias) is valid. See §8.2. |
 | Template bounds | Bounds such as `{{Max}}` are expanded before parsing. |
 | Unresolved bounds | Step becomes `prompted-for`; original `FOR` text is preserved as prompt. |
 | Body | `FOR` MUST have substeps; runbook-list shorthand qualifies. |
 | Scope | Named loop variable is available in substeps as `{{var}}`. |
+| Delegation scope | Within an iteration, the loop variable and `Index` are inheritable by delegated children, per §10.4. |
 
 Data sources are runtime arrays or file-backed JSON/JSONL sources. `file:` paths
 MUST remain inside the project root after symlink resolution. `.jsonl` sources
@@ -319,6 +321,25 @@ Nested bullets under `FOR` MUST be transitions. Allowed actions are `CONTINUE`,
 Default iteration-level action is `DEFER`. Iteration-level `RETRY` is evaluated
 before the exhausted fallback action and applies to the iteration result, not
 the substep action.
+
+### 8.2 Data-Source Resolution Timing
+
+A data source is resolved against the effective variable space when its `FOR`
+step is entered, using the rendering merge order (`templateVars < variables <
+extraVars`, §10.4). A source MAY therefore be produced by an earlier step in the
+same run; iterating a value the runbook itself produces is valid.
+
+The *produced set* is the union of every step and substep `OUTPUTS` name and
+every **name-binding** `ARTIFACTS` alias. A naked `ARTIFACTS` assertion (`- Name`
+with no token, §10.1.2) asserts an existing binding and publishes no new name, so
+it is **not** in the produced set. Launch validation and static analysis MUST
+derive this set identically.
+
+| Phase | Requirement |
+| --- | --- |
+| Launch (`rd run`, `rd resolve`) | A data source that is neither available at launch (input, config, `--input`, `RD_INPUT_*`, or delegation inheritance) nor in the produced set MUST be rejected (`VALIDATION_ERROR`). A source in the produced set MUST be deferred to step entry and MUST NOT be rejected at launch. |
+| Step entry | The source MUST resolve to an iterable value (runtime array, `.json` array, or `.jsonl` stream). A missing or non-iterable source fails the step with a typed resolution error; it is not silently skipped. |
+| Static (`rd check`) | Parser-tier validation does not resolve variables. An implementation SHOULD warn when a data source is neither a declared `inputs` name nor in the produced set, and MUST NOT raise it as an error — the source may be supplied at runtime. |
 
 ## 9. Templating
 
@@ -606,13 +627,38 @@ Results are written to final run state and forwarded from child runbooks to pare
 
 ### 10.4 Delegation Inheritance
 
-Delegated children inherit the parent's `ContextId` and non-context template variables. They do not inherit the parent's `RunId` or `RunbookRef`.
+Delegated children inherit the parent's `ContextId`, the parent's non-context
+template variables, and — within a `FOR` step — the iteration bindings defined
+below. They do not inherit the parent's `RunId` or `RunbookRef`.
 
 Effective delegation variables use the same merge order as rendering:
 
 ```text
 templateVars < variables < extraVars
 ```
+
+**Iteration bindings.** When a delegation is issued from within a `FOR` step,
+the parent's active iteration contributes two inherited values:
+
+- **`Index`** — the 1-based iteration number — is inherited unconditionally.
+- **The loop variable** — the iteration's current value (the data-source item,
+  or the iteration number for a numeric range) — is inherited **only when the
+  delegated child declares that name in its frontmatter `inputs`**. A child that
+  does not declare the loop variable does not receive it; a child that lists it
+  in `required` fails to launch when the binding is absent (for example, when
+  delegated outside a `FOR`). Both values enter the child through the inherited
+  variable layer, which ranks **below** explicit `--input`, so an override
+  (`--input` on `delegate` or `claim`) for the same name still wins.
+
+**Per-iteration scope.** An iteration binding is keyed to the parent step's
+active iteration, not to the individual delegated reference. When a `FOR` step
+delegates more than one reference per iteration, every reference delegated in
+iteration *N* inherits the **same** loop value and `Index`. References are never
+paired to data-source positions. A data-source `FOR` (`FOR var IN {{source}}`)
+with more than one delegated reference SHOULD be reported by `rd check` as a
+shared-binding warning; numeric-range `FOR` (a pass counter) is unaffected.
+Authors requiring one worker per item MUST use a single delegated reference per
+`FOR` step.
 
 Step `OUTPUTS` and step `ARTIFACTS` both accumulate during execution in the unified `state.variables` map (typed via `VariableValueSchema`). Terminal frontmatter `outputs` propagate selected values through string-only `finalVars`; artifact records cross this boundary as URI strings or JSON URI-array strings and can be rehydrated by naked `ARTIFACTS` declarations in the receiver.
 

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -296,7 +296,7 @@ Rules:
 | Unresolved bounds | Step becomes `prompted-for`; original `FOR` text is preserved as prompt. |
 | Body | `FOR` MUST have substeps; runbook-list shorthand qualifies. |
 | Scope | Named loop variable is available in substeps as `{{var}}`. |
-| Delegation scope | Within an iteration, the loop variable and `Index` are inheritable by delegated children, per §10.4. |
+| Delegation scope | Within an iteration, `Index` is inherited by delegated children unconditionally; the loop variable is inherited only when the child declares it in `inputs`. See §10.4. |
 
 Data sources are runtime arrays or file-backed JSON/JSONL sources. `file:` paths
 MUST remain inside the project root after symlink resolution. `.jsonl` sources

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -395,9 +395,7 @@ describe('Built-in Runbook Validation', () => {
       expect(isSourced(forStep.forClause)).toBe(true);
       if (!isSourced(forStep.forClause)) throw new Error('expected a data-source FOR clause');
       expect(forStep.forClause.source).toBe('Items');
-      const refs = forStep.substeps.filter((s) => (s.runbooks?.length ?? 0) > 0);
-      expect(refs).toHaveLength(1);
-      expect(refs[0]?.runbooks?.[0]).toBe('process-one-item.runbook.md');
+      expectSubstepRunbook(forStep, ['process-one-item.runbook.md'], true);
     });
 
     it('process-one-item requires the inherited item', () => {

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -384,13 +384,17 @@ describe('Built-in Runbook Validation', () => {
       const rb = readRunbook('patterns/iterate-and-delegate.runbook.md');
       const forStep = rb.steps.find((s) => s.name === '2');
       expect(forStep?.kind).toBe('for');
-      // Narrow via the parser guard rather than casting.
+      // Narrow via the parser guards rather than casting; assert each guard
+      // separately so a failure points at the specific clause expectation.
+      // The guards must run in order: isResolvedForClause narrows
+      // ParsedForClause -> ForClause, which isSourced then requires.
       if (forStep?.kind !== 'for') throw new Error('expected a FOR step');
-      expect(
-        isResolvedForClause(forStep.forClause) &&
-          isSourced(forStep.forClause) &&
-          forStep.forClause.source,
-      ).toBe('Items');
+      expect(isResolvedForClause(forStep.forClause)).toBe(true);
+      if (!isResolvedForClause(forStep.forClause))
+        throw new Error('expected a resolved FOR clause');
+      expect(isSourced(forStep.forClause)).toBe(true);
+      if (!isSourced(forStep.forClause)) throw new Error('expected a data-source FOR clause');
+      expect(forStep.forClause.source).toBe('Items');
       const refs = forStep.substeps.filter((s) => (s.runbooks?.length ?? 0) > 0);
       expect(refs).toHaveLength(1);
       expect(refs[0]?.runbooks?.[0]).toBe('process-one-item.runbook.md');

--- a/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/validation.test.ts
@@ -7,7 +7,12 @@ import { describe, it, expect } from '@jest/globals';
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseRunbookDocument, stepHasSubsteps } from '@rundown-org/parser';
+import {
+  isResolvedForClause,
+  isSourced,
+  parseRunbookDocument,
+  stepHasSubsteps,
+} from '@rundown-org/parser';
 import type { ArtifactDeclaration, Step } from '@rundown-org/parser';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -371,6 +376,30 @@ describe('Built-in Runbook Validation', () => {
         'utf-8',
       );
       expect(houseStyle).toMatch(/composing-runbooks\.md/);
+    });
+  });
+
+  describe('patterns/iterate-and-delegate (#435)', () => {
+    it('iterate-and-delegate: step 2 is a data-source FOR delegating a single leaf', () => {
+      const rb = readRunbook('patterns/iterate-and-delegate.runbook.md');
+      const forStep = rb.steps.find((s) => s.name === '2');
+      expect(forStep?.kind).toBe('for');
+      // Narrow via the parser guard rather than casting.
+      if (forStep?.kind !== 'for') throw new Error('expected a FOR step');
+      expect(
+        isResolvedForClause(forStep.forClause) &&
+          isSourced(forStep.forClause) &&
+          forStep.forClause.source,
+      ).toBe('Items');
+      const refs = forStep.substeps.filter((s) => (s.runbooks?.length ?? 0) > 0);
+      expect(refs).toHaveLength(1);
+      expect(refs[0]?.runbooks?.[0]).toBe('process-one-item.runbook.md');
+    });
+
+    it('process-one-item requires the inherited item', () => {
+      const runbookPath = join(runbooksDir, 'patterns/process-one-item.runbook.md');
+      const { frontmatter } = parseRunbookDocument(readFileSync(runbookPath, 'utf-8'), runbookPath);
+      expect(frontmatter?.required).toContain('item');
     });
   });
 });

--- a/packages/claude-code-plugin/runbooks/patterns/iterate-and-delegate.runbook.md
+++ b/packages/claude-code-plugin/runbooks/patterns/iterate-and-delegate.runbook.md
@@ -1,0 +1,28 @@
+---
+name: iterate-and-delegate
+description: Extract a work list, then delegate one worker per item.
+tags:
+  - patterns
+---
+
+# Iterate and Delegate
+
+## 1. Extract items
+- OUTPUTS
+  - Items
+- PASS CONTINUE
+- FAIL STOP
+
+```sh
+printf '["left","right"]' > "$RD_OUTPUTS_Items"
+```
+
+## 2. Process each item
+- FOR item IN {{ Items }}
+  - PASS DEFER
+  - FAIL BREAK
+- DELEGATE
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+- process-one-item.runbook.md

--- a/packages/claude-code-plugin/runbooks/patterns/process-one-item.runbook.md
+++ b/packages/claude-code-plugin/runbooks/patterns/process-one-item.runbook.md
@@ -1,0 +1,18 @@
+---
+name: process-one-item
+description: Process a single item handed down from the loop.
+tags:
+  - patterns
+inputs:
+  - item
+required:
+  - item
+---
+
+# Process One Item
+
+## 1. Do the work
+- PASS COMPLETE
+- FAIL STOP
+
+Process item **{{ item }}** (iteration {{ Index }}).

--- a/packages/cli/__tests__/check.test.ts
+++ b/packages/cli/__tests__/check.test.ts
@@ -220,4 +220,35 @@ Hello.
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('PASS:');
   });
+
+  it('warns on a FOR source that is neither declared nor produced', async () => {
+    const runbookPath = path.join(workspace.cwd, 'check-warn.runbook.md');
+    fs.writeFileSync(
+      runbookPath,
+      [
+        '# Check Warn',
+        '## 1. Iterate',
+        '- FOR item IN {{ Missing }}',
+        '- PASS ALL COMPLETE',
+        '- FAIL ANY STOP',
+        '',
+        '### 1.1 Check',
+        '- PASS CONTINUE',
+        '- FAIL STOP',
+        '',
+        'do work',
+        '',
+      ].join('\n'),
+    );
+
+    const res = await runCliInProcess(['check', runbookPath], workspace);
+    const json = JSON.parse(res.stdout);
+    expect(json.valid).toBe(true);
+    expect(json.warnings).toContainEqual(
+      expect.objectContaining({
+        message:
+          'Step 1: FOR source "Missing" is neither a declared input nor produced by a step — ensure it is provided at runtime.',
+      }),
+    );
+  });
 });

--- a/packages/cli/__tests__/check.test.ts
+++ b/packages/cli/__tests__/check.test.ts
@@ -243,6 +243,7 @@ Hello.
 
     const res = await runCliInProcess(['check', runbookPath], workspace);
     const json = JSON.parse(res.stdout);
+    expect(res.exitCode).toBe(0);
     expect(json.valid).toBe(true);
     expect(json.warnings).toContainEqual(
       expect.objectContaining({
@@ -280,6 +281,7 @@ Hello.
 
     const res = await runCliInProcess(['check', runbookPath], workspace);
     const json = JSON.parse(res.stdout);
+    expect(res.exitCode).toBe(0);
     expect(json.valid).toBe(true);
     expect(json.warnings).toContainEqual(
       expect.objectContaining({

--- a/packages/cli/__tests__/check.test.ts
+++ b/packages/cli/__tests__/check.test.ts
@@ -251,4 +251,47 @@ Hello.
       }),
     );
   });
+
+  it('warns on a data-source FOR with multiple delegated refs (shared binding)', async () => {
+    const runbookPath = path.join(workspace.cwd, 'check-multi-ref.runbook.md');
+    fs.writeFileSync(
+      runbookPath,
+      [
+        '---',
+        'inputs:',
+        '  - Tasks',
+        '---',
+        '# Check Multi Ref',
+        '## 1. Iterate',
+        '- FOR item IN {{ Tasks }}',
+        '- PASS ALL COMPLETE',
+        '- FAIL ANY STOP',
+        '',
+        '### 1.1 First',
+        '- DELEGATE',
+        '- child-a.runbook.md',
+        '',
+        '### 1.2 Second',
+        '- DELEGATE',
+        '- child-b.runbook.md',
+        '',
+      ].join('\n'),
+    );
+
+    const res = await runCliInProcess(['check', runbookPath], workspace);
+    const json = JSON.parse(res.stdout);
+    expect(json.valid).toBe(true);
+    expect(json.warnings).toContainEqual(
+      expect.objectContaining({
+        message:
+          'Step 1: FOR "Tasks" delegates 2 references per iteration; the loop item is shared across all of them (not paired). Use a single delegated reference for per-item-per-worker.',
+      }),
+    );
+    // `Tasks` is a declared input, so the unsatisfiable-source warning must not co-fire.
+    expect(json.warnings).not.toContainEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('is neither a declared input nor produced'),
+      }),
+    );
+  });
 });

--- a/packages/cli/__tests__/integration/delegation-claim-inheritance.test.ts
+++ b/packages/cli/__tests__/integration/delegation-claim-inheritance.test.ts
@@ -276,4 +276,144 @@ describe('delegation claim inheritance integration', () => {
     expect(childState!.templateVars?.Plan).toBe('literal');
     expect(childState!.variables).not.toHaveProperty('Plan');
   });
+
+  // #435 C2 — FOR iteration binding surfaced into a delegated child.
+  // The parent fans out over a data-source FOR and delegates one child per
+  // iteration; the delegation snapshot captures the iteration's item + Index.
+  const FOR_DELEGATE_PARENT = (childRef: string): string =>
+    [
+      '# Parent',
+      '',
+      '## 1. Fan out',
+      '',
+      '- FOR task IN {{ Tasks }}',
+      '  - PASS DEFER',
+      '  - FAIL BREAK',
+      '- DELEGATE',
+      '- PASS ALL COMPLETE',
+      '- FAIL ANY STOP',
+      '',
+      `### 1.1 Process {{ task }}`,
+      '',
+      `- ${childRef}`,
+      '',
+    ].join('\n');
+
+  // Token extraction mirrors the sibling tests: the per-iteration delegation
+  // lands on the first persisted substep state.
+  const tokenFor = async (): Promise<string> => {
+    const parentState = await getActiveState(workspace);
+    const token = parentState?.substepStates?.[0]?.delegation?.token;
+    expect(token).toEqual(expect.stringMatching(/^rdtk_/));
+    return token!;
+  };
+
+  it('surfaces the FOR item to a declaring child (#435)', async () => {
+    const declares = [
+      '---',
+      'name: declares',
+      'inputs: [task]',
+      'required: [task]',
+      '---',
+      '# Declares',
+      '## 1. Report',
+      '- PASS COMPLETE',
+      '- FAIL STOP',
+      '',
+      'Got {{ task }} at index {{ Index }}.',
+      '',
+    ].join('\n');
+    await writeFile(
+      join(workspace.cwd, 'parent.runbook.md'),
+      FOR_DELEGATE_PARENT('declares.runbook.md'),
+    );
+    await writeFile(join(workspace.cwd, 'declares.runbook.md'), declares);
+
+    const run = await runCliInProcess(
+      ['run', '--prompted', 'parent.runbook.md', '--input-json', 'Tasks=[{"name":"alpha"}]'],
+      workspace,
+    );
+    expect(run.exitCode).toBe(0);
+
+    const claim = await runCliInProcess(['claim', await tokenFor()], workspace);
+    expect(claim.exitCode).toBe(0);
+    const out = findActionOutput<{ run_id: string }>(claim.stdout);
+    expect(out).not.toBeNull();
+    const childState = await readRunbookState(workspace, out!.run_id);
+    expect(childState!.templateVars).toMatchObject({ task: { name: 'alpha' }, Index: '1' });
+  });
+
+  it('withholds the loop var from a non-declaring child; Index still flows (#435)', async () => {
+    const silent = [
+      '---',
+      'name: silent',
+      '---',
+      '# Silent',
+      '## 1. Report',
+      '- PASS COMPLETE',
+      '- FAIL STOP',
+      '',
+      'No declared inputs here.',
+      '',
+    ].join('\n');
+    await writeFile(
+      join(workspace.cwd, 'parent.runbook.md'),
+      FOR_DELEGATE_PARENT('silent.runbook.md'),
+    );
+    await writeFile(join(workspace.cwd, 'silent.runbook.md'), silent);
+
+    const run = await runCliInProcess(
+      ['run', '--prompted', 'parent.runbook.md', '--input-json', 'Tasks=[{"name":"alpha"}]'],
+      workspace,
+    );
+    expect(run.exitCode).toBe(0);
+
+    const claim = await runCliInProcess(['claim', await tokenFor()], workspace);
+    expect(claim.exitCode).toBe(0);
+    const out = findActionOutput<{ run_id: string }>(claim.stdout);
+    expect(out).not.toBeNull();
+    const childState = await readRunbookState(workspace, out!.run_id);
+    expect(childState!.templateVars).not.toHaveProperty('task'); // var withheld
+    expect(childState!.templateVars).toMatchObject({ Index: '1' }); // Index still flows
+  });
+
+  it('an explicit --input on claim overrides the surfaced loop var (#435 precedence)', async () => {
+    const declares = [
+      '---',
+      'name: declares',
+      'inputs: [task]',
+      'required: [task]',
+      '---',
+      '# Declares',
+      '## 1. Report',
+      '- PASS COMPLETE',
+      '- FAIL STOP',
+      '',
+      'Got {{ task }}.',
+      '',
+    ].join('\n');
+    await writeFile(
+      join(workspace.cwd, 'parent.runbook.md'),
+      FOR_DELEGATE_PARENT('declares.runbook.md'),
+    );
+    await writeFile(join(workspace.cwd, 'declares.runbook.md'), declares);
+
+    const run = await runCliInProcess(
+      ['run', '--prompted', 'parent.runbook.md', '--input-json', 'Tasks=[{"name":"alpha"}]'],
+      workspace,
+    );
+    expect(run.exitCode).toBe(0);
+
+    const claim = await runCliInProcess(
+      ['claim', await tokenFor(), '--input-json', 'task={"name":"override"}'],
+      workspace,
+    );
+    expect(claim.exitCode).toBe(0);
+    const out = findActionOutput<{ run_id: string }>(claim.stdout);
+    expect(out).not.toBeNull();
+    const childState = await readRunbookState(workspace, out!.run_id);
+    // Surfacing routes the loop value through inheritedUserVars (below --input),
+    // so the explicit override wins.
+    expect(childState!.templateVars).toMatchObject({ task: { name: 'override' } });
+  });
 });

--- a/packages/cli/__tests__/integration/for-self-produced-source.test.ts
+++ b/packages/cli/__tests__/integration/for-self-produced-source.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createTestWorkspace, runCliInProcess, type TestWorkspace } from '../helpers/test-utils.js';
+// Mirror the sibling integration tests' harness: createTestWorkspace +
+// runCliInProcess(args, workspace), with beforeEach/afterEach for setup/cleanup.
+
+describe('FOR over a self-produced source (#435 C1)', () => {
+  let workspace: TestWorkspace;
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('launches without a seed and iterates the produced array', async () => {
+    const rb = [
+      '# Self Produced',
+      '## 1. Capture items',
+      '- OUTPUTS',
+      '  - Items',
+      '- PASS CONTINUE',
+      '- FAIL STOP',
+      '```sh',
+      `printf '["left","right"]' > "$RD_OUTPUTS_Items"`,
+      '```',
+      '',
+      '## 2. Iterate',
+      '- FOR item IN {{ Items }}',
+      '- PASS ALL COMPLETE',
+      '- FAIL ANY STOP',
+      '',
+      '### 2.1 Check',
+      '- PASS CONTINUE',
+      '- FAIL STOP',
+      '```sh',
+      'rd echo "{{ Index }}:{{ item }}"',
+      '```',
+      '',
+    ].join('\n');
+    await writeFile(join(workspace.cwd, 'self-produced.runbook.md'), rb);
+    // run WITHOUT any --input seed:
+    const res = await runCliInProcess(
+      ['run', '--allow-all', 'self-produced.runbook.md'],
+      workspace,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain('1:left');
+    expect(res.stdout).toContain('2:right');
+  });
+});

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { analyzeForSources, forSourceWarnings } from '@rundown-org/core';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { loadAndParseRunbook } from '../helpers/runbook-pipeline.js';
 
@@ -33,6 +34,15 @@ export function registerCheckCommand(program: Command): void {
       const { diagnostics, stats } = result;
       const errors = diagnostics.filter((d) => d.severity === 'error');
       const warnings = diagnostics.filter((d) => d.severity === 'warning');
+
+      // SHOULD-level FOR-source diagnostics (language spec §8.2, §10.4): an
+      // unsatisfiable source (neither declared nor produced) and a multi-ref
+      // shared-binding warning. Derived from the same produced-name analysis as
+      // the C1 launch deferral so the two tiers cannot disagree.
+      const forWarnings = forSourceWarnings(
+        analyzeForSources(result.runbook.steps, result.frontmatter),
+      ).map((message) => ({ severity: 'warning' as const, message }));
+      warnings.push(...forWarnings);
 
       if (errors.length > 0) {
         output.detail(

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -19,6 +19,7 @@ import {
   extractInheritedUserVars,
   Errors,
   type InlineLinkage,
+  type IterationBinding,
   type ParentLinkage,
   type RunbookState,
   type VariableValue,
@@ -147,6 +148,7 @@ export function registerRunCommand(program: Command): void {
               | {
                   inheritedContextVars?: Readonly<Record<string, VariableValue>>;
                   inheritedUserVars?: Readonly<Record<string, VariableValue>>;
+                  iterationBinding?: IterationBinding;
                 }
               | undefined;
 
@@ -158,6 +160,7 @@ export function registerRunCommand(program: Command): void {
               inheritedOptions = {
                 inheritedContextVars: reconstituteContextVars(snapshot),
                 inheritedUserVars: extractInheritedUserVars(snapshot),
+                iterationBinding: snapshot.iterationBinding,
               };
             }
 

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -35,6 +35,7 @@ import {
   truncateDelegationToken,
   ErrorCodes,
   getErrorMessage,
+  type IterationBinding,
   type TemplateVarValue,
   type VariableValue,
   type RoutedVariableValue,
@@ -273,6 +274,12 @@ export interface PrepareRunbookOptions {
   readonly inheritedContextVars?: Readonly<Record<string, VariableValue>>;
   /** User variables inherited from a parent delegation. */
   readonly inheritedUserVars?: Readonly<Record<string, VariableValue>>;
+  /**
+   * Typed FOR iteration binding inherited from the delegating parent
+   * (language spec §10.4). Forwarded to `prepareParsedRunbook`, which surfaces
+   * it into the child gated on the child's declared `inputs`.
+   */
+  readonly iterationBinding?: IterationBinding;
   /** Optional execution identity supplied by a parent inline launch intent. */
   readonly runId?: RunId;
 }
@@ -731,6 +738,7 @@ async function prepareLoadedRunbook(
     runtimeVars: { ...partitions.runtimeVars, ...contextPartitions.runtimeVars },
     providedKeys,
     inheritedContextVars: contextPartitions.templateVars,
+    iterationBinding: options?.iterationBinding,
     runbookRef,
     helperRegistry: getHelperRegistry(),
     identity:
@@ -1547,6 +1555,7 @@ export async function claimAndLaunch(
       {
         inheritedContextVars,
         inheritedUserVars,
+        iterationBinding: freshDelegation.contextSnapshot.iterationBinding,
       },
     );
     if (!prepResult.ok) {

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -597,6 +597,7 @@ async function launchInlineChildFromIntent({
         runId: childRunId,
         inheritedContextVars,
         inheritedUserVars,
+        iterationBinding: intent.contextSnapshot.iterationBinding,
       },
     );
     if (!prepared.ok) {

--- a/packages/core/__tests__/runbook/delegation-context.test.ts
+++ b/packages/core/__tests__/runbook/delegation-context.test.ts
@@ -9,6 +9,7 @@ import {
   MAX_ANCESTOR_DEPTH,
 } from '../../src/runbook/delegation-context.js';
 import { isTrustedArtifactArray, mergeEffectiveVars } from '../../src/runbook/effective-vars.js';
+import { buildFrameKey } from '../../src/runbook/targeting.js';
 import { RunbookStateSchema } from '../../src/schemas.js';
 import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
 import type {
@@ -673,16 +674,16 @@ describe('buildContextSnapshot', () => {
 
 function stateInForLoop(fc: ForContext): DelegationParentState {
   return {
-    id: 'rd_parent',
+    id: brandRunIdForTest(`rd_${'7'.repeat(32)}`),
     step: '2',
     substep: '1',
-    substepStates: {},
-    activeFrameKey: '2|1',
+    substepStates: [],
+    activeFrameKey: buildFrameKey('2', 1),
     parentLinkage: undefined,
-    templateVars: { Tasks: [{ name: 'alpha' }, { name: 'beta' }] },
+    templateVars: brandInitialTemplateVarsForTest({ Tasks: [{ name: 'alpha' }, { name: 'beta' }] }),
     variables: {},
     forStack: [fc],
-  } as unknown as DelegationParentState;
+  };
 }
 
 describe('buildContextSnapshot — typed iteration binding (#435 C2)', () => {

--- a/packages/core/__tests__/runbook/delegation-context.test.ts
+++ b/packages/core/__tests__/runbook/delegation-context.test.ts
@@ -13,6 +13,8 @@ import type { ArtifactRecord } from '../../src/runbook/artifact-schema.js';
 import type {
   AncestorSnapshot,
   ContextSnapshot,
+  DelegationParentState,
+  ForContext,
   RunbookState,
   RunId,
 } from '../../src/runbook/types.js';
@@ -664,5 +666,68 @@ describe('buildContextSnapshot', () => {
     });
 
     expect(isTrustedArtifactArray(snapshot.vars.Plans)).toBe(true);
+  });
+});
+
+function stateInForLoop(fc: ForContext): DelegationParentState {
+  return {
+    id: 'rd_parent',
+    step: '2',
+    substep: '1',
+    substepStates: {},
+    activeFrameKey: '2|1',
+    parentLinkage: undefined,
+    templateVars: { Tasks: [{ name: 'alpha' }, { name: 'beta' }] },
+    variables: {},
+    forStack: [fc],
+  } as unknown as DelegationParentState;
+}
+
+describe('buildContextSnapshot — typed iteration binding (#435 C2)', () => {
+  it('captures an item binding for a data-source loop (not folded into vars)', () => {
+    const fc: ForContext = {
+      stepId: '2',
+      start: 1,
+      iteration: 1,
+      variable: 'task',
+      source: { kind: 'variable', name: 'Tasks' },
+      currentValue: { name: 'alpha' },
+      implicit: false,
+    };
+    const snap = buildContextSnapshot(stateInForLoop(fc), '1');
+    expect(snap.iterationBinding).toEqual({
+      kind: 'item',
+      index: 1,
+      variable: 'task',
+      value: { name: 'alpha' },
+    });
+    // The binding is NOT pre-folded into vars; surfacing happens at claim time.
+    expect(snap.vars.task).toBeUndefined();
+    expect(snap.vars.Index).toBeUndefined();
+  });
+
+  it('captures a range binding (variable optional)', () => {
+    const fc: ForContext = {
+      stepId: '2',
+      start: 1,
+      iteration: 3,
+      variable: 'pass',
+      source: { kind: 'range' },
+      implicit: false,
+    };
+    const snap = buildContextSnapshot(stateInForLoop(fc), '1');
+    expect(snap.iterationBinding).toEqual({ kind: 'range', index: 3, variable: 'pass' });
+  });
+
+  it('omits the binding for an implicit (non-FOR) frame', () => {
+    const fc: ForContext = {
+      stepId: '2',
+      start: 1,
+      iteration: 1,
+      source: { kind: 'range' },
+      implicit: true,
+    };
+    const snap = buildContextSnapshot(stateInForLoop(fc), '1');
+    expect(snap.iterationBinding).toBeUndefined();
   });
 });

--- a/packages/core/__tests__/runbook/delegation-context.test.ts
+++ b/packages/core/__tests__/runbook/delegation-context.test.ts
@@ -5,6 +5,7 @@ import {
   extractInheritedUserVars,
   rebrandContextSnapshotArtifacts,
   reconstituteContextVars,
+  surfaceIterationBinding,
   MAX_ANCESTOR_DEPTH,
 } from '../../src/runbook/delegation-context.js';
 import { isTrustedArtifactArray, mergeEffectiveVars } from '../../src/runbook/effective-vars.js';
@@ -15,6 +16,7 @@ import type {
   ContextSnapshot,
   DelegationParentState,
   ForContext,
+  IterationBinding,
   RunbookState,
   RunId,
 } from '../../src/runbook/types.js';
@@ -729,5 +731,36 @@ describe('buildContextSnapshot — typed iteration binding (#435 C2)', () => {
     };
     const snap = buildContextSnapshot(stateInForLoop(fc), '1');
     expect(snap.iterationBinding).toBeUndefined();
+  });
+});
+
+describe('surfaceIterationBinding — child-inputs gate (#435 C2)', () => {
+  const item: IterationBinding = {
+    kind: 'item',
+    index: 1,
+    variable: 'task',
+    value: { name: 'alpha' },
+  };
+
+  it('surfaces Index unconditionally and the loop var when declared', () => {
+    expect(surfaceIterationBinding(item, ['task'])).toEqual({
+      Index: '1',
+      index: '1',
+      task: { name: 'alpha' },
+    });
+  });
+
+  it('withholds the loop var when the child does not declare it; Index still flows', () => {
+    expect(surfaceIterationBinding(item, [])).toEqual({ Index: '1', index: '1' });
+    expect(surfaceIterationBinding(item, undefined)).toEqual({ Index: '1', index: '1' });
+  });
+
+  it('surfaces a range value as the iteration number when declared', () => {
+    const range: IterationBinding = { kind: 'range', index: 3, variable: 'pass' };
+    expect(surfaceIterationBinding(range, ['pass'])).toEqual({ Index: '3', index: '3', pass: '3' });
+  });
+
+  it('returns nothing for an absent binding', () => {
+    expect(surfaceIterationBinding(undefined, ['task'])).toEqual({});
   });
 });

--- a/packages/core/__tests__/runbook/delegation-schemas.test.ts
+++ b/packages/core/__tests__/runbook/delegation-schemas.test.ts
@@ -179,6 +179,57 @@ describe('ContextSnapshotSchema', () => {
   });
 });
 
+// IterationBindingSchema is not exported; it is exercised through the
+// `iterationBinding` field of ContextSnapshotSchema — the persisted-snapshot
+// validation seam (language spec §10.4). These pin the discriminated-union
+// rejection paths directly, not just the happy-path integration coverage.
+describe('ContextSnapshotSchema iterationBinding', () => {
+  it('accepts a range iteration binding', () => {
+    const result = ContextSnapshotSchema.safeParse({
+      vars: {},
+      ancestors: [],
+      iterationBinding: { kind: 'range', index: 2, variable: 'i' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an item iteration binding with a resolved value', () => {
+    const result = ContextSnapshotSchema.safeParse({
+      vars: {},
+      ancestors: [],
+      iterationBinding: { kind: 'item', index: 1, variable: 'item', value: { name: 'a' } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an item iteration binding missing its value', () => {
+    const result = ContextSnapshotSchema.safeParse({
+      vars: {},
+      ancestors: [],
+      iterationBinding: { kind: 'item', index: 1, variable: 'item' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an iteration binding with a non-positive index', () => {
+    const result = ContextSnapshotSchema.safeParse({
+      vars: {},
+      ancestors: [],
+      iterationBinding: { kind: 'range', index: 0, variable: 'i' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an iteration binding with an unknown kind', () => {
+    const result = ContextSnapshotSchema.safeParse({
+      vars: {},
+      ancestors: [],
+      iterationBinding: { kind: 'sequence', index: 1, variable: 'i' },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe('StepDelegationSchema', () => {
   const validDelegation = {
     tokenHash: `sha256:${'a'.repeat(64)}`,

--- a/packages/core/__tests__/runbook/for-source-analysis.test.ts
+++ b/packages/core/__tests__/runbook/for-source-analysis.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from '@jest/globals';
+import type { RunbookFrontmatter, Step } from '@rundown-org/parser';
+import {
+  analyzeForSources,
+  collectProducedNames,
+  forSourceWarnings,
+} from '../../src/runbook/for-source-analysis.js';
+
+// Fixtures are parser-tier `Step` objects (what `rd check` passes). The minimal
+// `as unknown as Step` keeps the literals terse — these are test-only doubles,
+// not the production traversal (which is fully cast-free).
+const forStep = (source: string, refs: number): Step =>
+  ({
+    kind: 'for',
+    name: '2',
+    description: 'Loop',
+    forClause: { variable: 'task', start: 1, end: 2, source },
+    substeps: Array.from({ length: refs }, (_unused, i) => ({
+      id: String(i + 1),
+      description: `Runbook: child-${String(i)}.runbook.md`,
+      delegate: true,
+      runbooks: [`child-${String(i)}.runbook.md`],
+    })),
+  }) as unknown as Step;
+
+// A pure numeric-range FOR (no `source`): must never appear in sourcedFors.
+const rangeForStep = (refs: number): Step =>
+  ({
+    kind: 'for',
+    name: '3',
+    description: 'Pass counter',
+    forClause: { variable: 'pass', start: 1, end: 3 },
+    substeps: Array.from({ length: refs }, (_unused, i) => ({
+      id: String(i + 1),
+      description: `Runbook: child-${String(i)}.runbook.md`,
+      delegate: true,
+      runbooks: [`child-${String(i)}.runbook.md`],
+    })),
+  }) as unknown as Step;
+
+const producerStep = (name: string): Step =>
+  ({
+    kind: 'command',
+    name: '1',
+    description: 'Produce',
+    outputs: [{ name }],
+  }) as unknown as Step;
+
+const fm = (inputs: string[]): RunbookFrontmatter => ({ inputs }) as unknown as RunbookFrontmatter;
+
+describe('analyzeForSources', () => {
+  it('collects produced names from step OUTPUTS', () => {
+    expect([...collectProducedNames([producerStep('Tasks'), forStep('Tasks', 1)])]).toEqual([
+      'Tasks',
+    ]);
+  });
+
+  it('excludes naked ARTIFACTS assertions (rawToken null binds no name)', () => {
+    const step = {
+      kind: 'command',
+      name: '1',
+      description: 'Mixed',
+      outputs: [{ name: 'Bound' }],
+      artifacts: [
+        { name: 'NamedArtifact', rawToken: 'plan.json' },
+        { name: 'NakedAssertion', rawToken: null },
+      ],
+    } as unknown as Step;
+    expect([...collectProducedNames([step])].sort()).toEqual(['Bound', 'NamedArtifact']);
+  });
+
+  it('collects sourced FOR facts with delegated ref counts', () => {
+    const facts = analyzeForSources([producerStep('Tasks'), forStep('Tasks', 2)], fm([]));
+    expect(facts.sourcedFors).toEqual([{ stepName: '2', source: 'Tasks', delegatedRefCount: 2 }]);
+    expect(facts.producedNames.has('Tasks')).toBe(true);
+  });
+
+  it('tolerates null frontmatter (rd check supplies RunbookFrontmatter | null)', () => {
+    const facts = analyzeForSources([forStep('Tasks', 1)], null);
+    expect(facts.declaredInputs.size).toBe(0);
+    expect(forSourceWarnings(facts)).toContain(
+      'Step 2: FOR source "Tasks" is neither a declared input nor produced by a step — ensure it is provided at runtime.',
+    );
+  });
+
+  it('warns when a FOR source is neither declared nor produced', () => {
+    const facts = analyzeForSources([forStep('Tasks', 1)], fm([]));
+    expect(forSourceWarnings(facts)).toEqual([
+      'Step 2: FOR source "Tasks" is neither a declared input nor produced by a step — ensure it is provided at runtime.',
+    ]);
+  });
+
+  it('does not warn when the source is produced by a step', () => {
+    const facts = analyzeForSources([producerStep('Tasks'), forStep('Tasks', 1)], fm([]));
+    expect(forSourceWarnings(facts)).toEqual([]);
+  });
+
+  it('does not warn when the source is a declared input (suppression branch)', () => {
+    const facts = analyzeForSources([forStep('Tasks', 1)], fm(['Tasks']));
+    expect(facts.declaredInputs.has('Tasks')).toBe(true);
+    expect(forSourceWarnings(facts)).toEqual([]);
+  });
+
+  it('warns on a data-source FOR with multiple delegated refs (shared binding)', () => {
+    const facts = analyzeForSources([producerStep('Tasks'), forStep('Tasks', 2)], fm([]));
+    expect(forSourceWarnings(facts)).toContain(
+      'Step 2: FOR "Tasks" delegates 2 references per iteration; the loop item is shared across all of them (not paired). Use a single delegated reference for per-item-per-worker.',
+    );
+  });
+
+  it('never warns on a numeric-range FOR, even with multiple delegated refs', () => {
+    // Pins the spec/impl agreement: a range FOR has no source, so it is never a
+    // sourcedFor and the shared-binding warning cannot fire (language spec §10.4).
+    const facts = analyzeForSources([rangeForStep(3)], fm([]));
+    expect(facts.sourcedFors).toEqual([]);
+    expect(forSourceWarnings(facts)).toEqual([]);
+  });
+});

--- a/packages/core/__tests__/runbook/for-source-analysis.test.ts
+++ b/packages/core/__tests__/runbook/for-source-analysis.test.ts
@@ -46,7 +46,7 @@ const producerStep = (name: string): Step =>
     outputs: [{ name }],
   }) as unknown as Step;
 
-const fm = (inputs: string[]): RunbookFrontmatter => ({ inputs }) as unknown as RunbookFrontmatter;
+const fm = (inputs: string[]): RunbookFrontmatter => ({ inputs });
 
 describe('analyzeForSources', () => {
   it('collects produced names from step OUTPUTS', () => {

--- a/packages/core/__tests__/runbook/for-source-analysis.test.ts
+++ b/packages/core/__tests__/runbook/for-source-analysis.test.ts
@@ -23,6 +23,26 @@ const forStep = (source: string, refs: number): Step =>
     })),
   }) as unknown as Step;
 
+// A data-source FOR whose single delegating substep references `refs` runbooks.
+// Distinct from `forStep`, which spreads each ref across its own substep; this
+// pins that `delegatedRefCount` counts runbook references, not substeps, so a
+// single multi-ref substep is not undercounted.
+const forStepMultiRefSubstep = (source: string, refs: number): Step =>
+  ({
+    kind: 'for',
+    name: '2',
+    description: 'Loop',
+    forClause: { variable: 'task', start: 1, end: 2, source },
+    substeps: [
+      {
+        id: '1',
+        description: 'Fan out to several runbooks',
+        delegate: true,
+        runbooks: Array.from({ length: refs }, (_unused, i) => `child-${String(i)}.runbook.md`),
+      },
+    ],
+  }) as unknown as Step;
+
 // A pure numeric-range FOR (no `source`): must never appear in sourcedFors.
 const rangeForStep = (refs: number): Step =>
   ({
@@ -105,6 +125,20 @@ describe('analyzeForSources', () => {
     const facts = analyzeForSources([producerStep('Tasks'), forStep('Tasks', 2)], fm([]));
     expect(forSourceWarnings(facts)).toContain(
       'Step 2: FOR "Tasks" delegates 2 references per iteration; the loop item is shared across all of them (not paired). Use a single delegated reference for per-item-per-worker.',
+    );
+  });
+
+  it('counts every runbook reference in a single delegating substep (not just the substep)', () => {
+    // Regression: a lone substep that fans out to 3 runbooks is 3 references,
+    // so delegatedRefCount must be 3 — undercounting to 1 would suppress the
+    // shared-binding warning for multi-reference fan-out in one substep.
+    const facts = analyzeForSources(
+      [producerStep('Tasks'), forStepMultiRefSubstep('Tasks', 3)],
+      fm([]),
+    );
+    expect(facts.sourcedFors).toEqual([{ stepName: '2', source: 'Tasks', delegatedRefCount: 3 }]);
+    expect(forSourceWarnings(facts)).toContain(
+      'Step 2: FOR "Tasks" delegates 3 references per iteration; the loop item is shared across all of them (not paired). Use a single delegated reference for per-item-per-worker.',
     );
   });
 

--- a/packages/core/__tests__/runbook/runtime-frame.test.ts
+++ b/packages/core/__tests__/runbook/runtime-frame.test.ts
@@ -99,4 +99,43 @@ describe('runtime frame construction', () => {
       validateForVariables(steps, {});
     }).toThrow('FOR loop references undefined variable "{{items}}"');
   });
+
+  it('defers a FOR source produced by an earlier step (does not reject at launch)', () => {
+    const steps = [
+      {
+        kind: 'command',
+        name: '1',
+        description: 'Produce',
+        outputs: [{ name: 'Tasks' }],
+      },
+      {
+        kind: 'for',
+        name: '2',
+        description: 'Loop',
+        forClause: { variable: 'task', start: 1, end: 2, source: 'Tasks' },
+        substeps: [],
+      },
+    ] as unknown as readonly ResolvedStep[];
+
+    // Tasks is absent from launch vars but produced by step 1 → must NOT throw.
+    expect(() => {
+      validateForVariables(steps, {});
+    }).not.toThrow();
+  });
+
+  it('still rejects a FOR source that is neither provided nor produced (typo)', () => {
+    const steps = [
+      {
+        kind: 'for',
+        name: '1',
+        description: 'Loop',
+        forClause: { variable: 'task', start: 1, end: 2, source: 'Taks' },
+        substeps: [],
+      },
+    ] as unknown as readonly ResolvedStep[];
+
+    expect(() => {
+      validateForVariables(steps, {});
+    }).toThrow('FOR loop references undefined variable "{{Taks}}"');
+  });
 });

--- a/packages/core/__tests__/runbook/runtime-frame.test.ts
+++ b/packages/core/__tests__/runbook/runtime-frame.test.ts
@@ -123,6 +123,30 @@ describe('runtime frame construction', () => {
     }).not.toThrow();
   });
 
+  it('rejects a FOR source produced only by a later step (deferral is earlier-step only)', () => {
+    const steps = [
+      {
+        kind: 'for',
+        name: '1',
+        description: 'Loop',
+        forClause: { variable: 'task', start: 1, end: 2, source: 'Tasks' },
+        substeps: [],
+      },
+      {
+        kind: 'command',
+        name: '2',
+        description: 'Produce',
+        outputs: [{ name: 'Tasks' }],
+      },
+    ] as unknown as readonly ResolvedStep[];
+
+    // Tasks is produced only by the later step 2, so it cannot be available when
+    // the step 1 FOR runs → must reject at launch rather than defer.
+    expect(() => {
+      validateForVariables(steps, {});
+    }).toThrow('FOR loop references undefined variable "{{Tasks}}"');
+  });
+
   it('still rejects a FOR source that is neither provided nor produced (typo)', () => {
     // cspell:ignore Taks -- deliberate misspelling exercising the rejection path
     const steps = [

--- a/packages/core/__tests__/runbook/runtime-frame.test.ts
+++ b/packages/core/__tests__/runbook/runtime-frame.test.ts
@@ -124,6 +124,7 @@ describe('runtime frame construction', () => {
   });
 
   it('still rejects a FOR source that is neither provided nor produced (typo)', () => {
+    // cspell:ignore Taks -- deliberate misspelling exercising the rejection path
     const steps = [
       {
         kind: 'for',

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -210,14 +210,6 @@ export type RunbookEventV1 =
   | (EventEnvelope & { type: 'ERROR_OCCURRED'; payload: ErrorOccurredPayload });
 
 /**
- * Extract payload type for a given event type.
- */
-export type PayloadFor<T extends RunbookEventV1['type']> = Extract<
-  RunbookEventV1,
-  { type: T }
->['payload'];
-
-/**
  * Pre-correlated `{ type, payload }` input pair accepted by the event emitter.
  *
  * Derived directly from {@link RunbookEventV1} (the single source of truth for

--- a/packages/core/src/runbook/delegation-context.ts
+++ b/packages/core/src/runbook/delegation-context.ts
@@ -12,6 +12,7 @@ import type {
   ContextSnapshotVarValue,
   ForContext,
   IterationBinding,
+  JsonValue,
   TemplateVarValue,
 } from './types.js';
 import { getActiveForContext, deriveExecutionAt } from './targeting.js';
@@ -243,6 +244,60 @@ function toIterationBinding(fc: ForContext | undefined): IterationBinding | unde
   // mid-resolution (currentValue still undefined) simply contributes nothing.
   if (fc.variable === undefined || fc.currentValue === undefined) return undefined;
   return { kind: 'item', index: fc.iteration, variable: fc.variable, value: fc.currentValue };
+}
+
+/**
+ * Normalise a FOR data-source item value into the child's input-variable space.
+ *
+ * A data-source item is a {@link JsonValue}; the inherited-variable layer the
+ * child receives is {@link TemplateVarValue}-typed (the declared-input space,
+ * which excludes the bare `boolean`/`null` primitives a `.jsonl` line may
+ * carry). Objects, arrays, strings, and numbers pass through unchanged; a
+ * `boolean` or `null` item is serialised to its JSON string, matching the
+ * documented `{{item}}` serialized-JSON-string rendering convention.
+ *
+ * @param value - The resolved data-source item from the iteration binding
+ * @returns The item as a template-variable value
+ */
+function itemValueToTemplateVar(value: JsonValue): TemplateVarValue {
+  return typeof value === 'boolean' || value === null ? JSON.stringify(value) : value;
+}
+
+/**
+ * Surface a typed iteration binding into a flat inherited-var map for a child.
+ *
+ * `Index`/`index` are surfaced unconditionally; the loop variable is surfaced
+ * only when the child declares it in frontmatter `inputs` (the contract gate —
+ * language spec §10.4). Applied at claim/prepare time, where the child's
+ * `inputs` are known. The result is {@link TemplateVarValue}-typed so it
+ * composes directly with the inherited-user-var layer in
+ * `prepareParsedRunbook`, which ranks below explicit `--input`.
+ *
+ * @param binding - Typed iteration binding from the snapshot (may be undefined)
+ * @param childInputs - The child runbook's declared `inputs` names
+ * @returns Inherited-var additions (empty when there is no binding)
+ */
+export function surfaceIterationBinding(
+  binding: IterationBinding | undefined,
+  childInputs: readonly string[] | undefined,
+): Record<string, TemplateVarValue> {
+  if (binding === undefined) return {};
+  // Both casings are surfaced deliberately: `Index` is the documented built-in
+  // (language spec §10.4), and lower-case `index` mirrors the snapshot/CLI field
+  // used by the `--index` flag so templates referencing either resolve.
+  const surfaced: Record<string, TemplateVarValue> = {
+    Index: String(binding.index),
+    index: String(binding.index),
+  };
+  const declares = (name: string): boolean => childInputs?.includes(name) ?? false;
+  if (binding.kind === 'range') {
+    if (binding.variable !== undefined && declares(binding.variable)) {
+      surfaced[binding.variable] = String(binding.index);
+    }
+  } else if (declares(binding.variable)) {
+    surfaced[binding.variable] = itemValueToTemplateVar(binding.value);
+  }
+  return surfaced;
 }
 
 /**

--- a/packages/core/src/runbook/delegation-context.ts
+++ b/packages/core/src/runbook/delegation-context.ts
@@ -10,6 +10,8 @@ import type {
   ContextSnapshot,
   DelegationParentState,
   ContextSnapshotVarValue,
+  ForContext,
+  IterationBinding,
   TemplateVarValue,
 } from './types.js';
 import { getActiveForContext, deriveExecutionAt } from './targeting.js';
@@ -206,6 +208,7 @@ export function buildContextSnapshot(
   const vars = rebrandContextSnapshotVars(mergeEffectiveVars(state, options?.extraVars));
   const activeFor = getActiveForContext(state.forStack, state.step);
   const iteration = options?.iterationOverride ?? activeFor?.iteration;
+  const iterationBinding = toIterationBinding(activeFor);
   const at = deriveExecutionAt(state.step, substep, iteration);
 
   return {
@@ -215,7 +218,31 @@ export function buildContextSnapshot(
     substep,
     at,
     ...(iteration !== undefined ? { index: iteration } : {}),
+    ...(iterationBinding !== undefined ? { iterationBinding } : {}),
   };
+}
+
+/**
+ * Build a typed iteration binding from the active FOR context, or `undefined`
+ * when there is no current named/data-source iteration. An item binding is
+ * produced only for a resolved data-source value, keeping the `item` variant's
+ * non-optional `value` invariant true by construction.
+ *
+ * @param fc - Active FOR context (already excludes implicit / non-current frames)
+ * @returns Typed iteration binding, or undefined
+ */
+function toIterationBinding(fc: ForContext | undefined): IterationBinding | undefined {
+  if (fc === undefined) return undefined;
+  if (fc.source.kind === 'range') {
+    return fc.variable !== undefined
+      ? { kind: 'range', index: fc.iteration, variable: fc.variable }
+      : { kind: 'range', index: fc.iteration };
+  }
+  // No variable or no resolved value → no item binding. This keeps the `item`
+  // variant's non-optional `value` true by construction; a data-source frame
+  // mid-resolution (currentValue still undefined) simply contributes nothing.
+  if (fc.variable === undefined || fc.currentValue === undefined) return undefined;
+  return { kind: 'item', index: fc.iteration, variable: fc.variable, value: fc.currentValue };
 }
 
 /**

--- a/packages/core/src/runbook/for-source-analysis.ts
+++ b/packages/core/src/runbook/for-source-analysis.ts
@@ -1,0 +1,118 @@
+import type { ResolvedStep, RunbookFrontmatter, Step } from '@rundown-org/parser';
+import { isResolvedForClause, isSourced } from '@rundown-org/parser';
+
+/** Facts about a single data-sourced FOR step. */
+export interface SourcedForFact {
+  /** Owning step name (e.g. "2"). */
+  readonly stepName: string;
+  /** FOR data-source variable name (e.g. "Tasks"). */
+  readonly source: string;
+  /** Number of delegated runbook references in the step (per iteration). */
+  readonly delegatedRefCount: number;
+}
+
+/** Static FOR-source analysis shared by launch validation and `rd check`. */
+export interface ForSourceFacts {
+  /** Variable names produced by any step/substep OUTPUTS or name-binding ARTIFACTS. */
+  readonly producedNames: ReadonlySet<string>;
+  /** Names declared in frontmatter `inputs`. */
+  readonly declaredInputs: ReadonlySet<string>;
+  /** One entry per data-sourced FOR step. */
+  readonly sourcedFors: readonly SourcedForFact[];
+}
+
+/**
+ * Collect every variable name a runbook binds via step/substep OUTPUTS or
+ * name-binding ARTIFACTS. Naked ARTIFACTS assertions (`rawToken === null`)
+ * re-assert an existing binding and publish no new name, so they are excluded
+ * (matching `artifact-reference-extractor.ts`). This is the deferral set for
+ * FOR-source launch validation and the suppression set for the `rd check`
+ * FOR-source warning — both MUST use this function so they cannot disagree
+ * (language spec §8.2).
+ *
+ * Accepts the parser-tier `Step` (from `rd check`, which holds an unresolved
+ * AST) or `ResolvedStep` (from launch validation). Both expose OUTPUTS/ARTIFACTS
+ * via the shared `ContextDirectiveFields`, and substeps are reached through the
+ * `kind` discriminant — no casts. Neither union is a subtype of the other
+ * (`ResolvedStep` has a `prompted-for` variant; `Step`'s FOR clause is the wider
+ * `ParsedForClause`), so the parameter is their union.
+ *
+ * @param steps - Parsed or resolved runbook steps
+ * @returns Set of produced variable names
+ */
+export function collectProducedNames(steps: readonly (Step | ResolvedStep)[]): Set<string> {
+  const names = new Set<string>();
+  for (const step of steps) {
+    for (const o of step.outputs ?? []) names.add(o.name);
+    for (const a of step.artifacts ?? []) if (a.rawToken !== null) names.add(a.name);
+    if (step.kind === 'substeps' || step.kind === 'for' || step.kind === 'prompted-for') {
+      for (const sub of step.substeps) {
+        for (const o of sub.outputs ?? []) names.add(o.name);
+        for (const a of sub.artifacts ?? []) if (a.rawToken !== null) names.add(a.name);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Analyze a runbook's FOR data sources for launch validation and static checks.
+ *
+ * Only data-sourced FOR steps (`FOR x IN {{source}}`) contribute facts; a pure
+ * numeric-range FOR has no `source` (the `ForClause` union is discriminated on
+ * it) and is intentionally excluded, so the shared-binding warning can never
+ * fire for one — matching the spec's "numeric-range FOR is unaffected" rule
+ * (language spec §10.4).
+ *
+ * @param steps - Parsed or resolved runbook steps
+ * @param frontmatter - Parsed frontmatter for declared `inputs`; `null`/`undefined` tolerated
+ *   (the `rd check` call site supplies `RunbookFrontmatter | null`)
+ * @returns Static FOR-source facts
+ */
+export function analyzeForSources(
+  steps: readonly (Step | ResolvedStep)[],
+  frontmatter: RunbookFrontmatter | null | undefined,
+): ForSourceFacts {
+  const sourcedFors: SourcedForFact[] = [];
+  for (const step of steps) {
+    if (step.kind !== 'for') continue;
+    // isResolvedForClause narrows ParsedForClause → ForClause (a no-op on the
+    // already-resolved tier); isSourced then narrows to a data source.
+    if (!isResolvedForClause(step.forClause) || !isSourced(step.forClause)) continue;
+    let delegatedRefCount = 0;
+    for (const sub of step.substeps) {
+      if (sub.delegate === true && (sub.runbooks?.length ?? 0) > 0) delegatedRefCount += 1;
+    }
+    sourcedFors.push({ stepName: step.name, source: step.forClause.source, delegatedRefCount });
+  }
+  return {
+    producedNames: collectProducedNames(steps),
+    declaredInputs: new Set(frontmatter?.inputs ?? []),
+    sourcedFors,
+  };
+}
+
+/**
+ * Derive non-fatal diagnostics from FOR-source facts: an unsatisfiable-source
+ * warning and a shared-binding warning for multi-ref data-source FOR steps
+ * (language spec §8.2, §10.4). These are SHOULD-level (`rd check`), never errors.
+ *
+ * @param facts - FOR-source facts from {@link analyzeForSources}
+ * @returns Warning messages (empty when nothing to report)
+ */
+export function forSourceWarnings(facts: ForSourceFacts): string[] {
+  const out: string[] = [];
+  for (const f of facts.sourcedFors) {
+    if (!facts.declaredInputs.has(f.source) && !facts.producedNames.has(f.source)) {
+      out.push(
+        `Step ${f.stepName}: FOR source "${f.source}" is neither a declared input nor produced by a step — ensure it is provided at runtime.`,
+      );
+    }
+    if (f.delegatedRefCount > 1) {
+      out.push(
+        `Step ${f.stepName}: FOR "${f.source}" delegates ${String(f.delegatedRefCount)} references per iteration; the loop item is shared across all of them (not paired). Use a single delegated reference for per-item-per-worker.`,
+      );
+    }
+  }
+  return out;
+}

--- a/packages/core/src/runbook/for-source-analysis.ts
+++ b/packages/core/src/runbook/for-source-analysis.ts
@@ -81,7 +81,7 @@ export function analyzeForSources(
     if (!isResolvedForClause(step.forClause) || !isSourced(step.forClause)) continue;
     let delegatedRefCount = 0;
     for (const sub of step.substeps) {
-      if (sub.delegate === true && (sub.runbooks?.length ?? 0) > 0) delegatedRefCount += 1;
+      if (sub.delegate === true) delegatedRefCount += sub.runbooks?.length ?? 0;
     }
     sourcedFors.push({ stepName: step.name, source: step.forClause.source, delegatedRefCount });
   }

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -381,3 +381,10 @@ export {
   type PrepareOutputChannelsArgs,
   type PreparedChannel,
 } from './output-channels.js';
+export {
+  analyzeForSources,
+  collectProducedNames,
+  forSourceWarnings,
+  type ForSourceFacts,
+  type SourcedForFact,
+} from './for-source-analysis.js';

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -217,6 +217,7 @@ export {
   reconstituteContextVars,
   buildContextSnapshot,
   extractInheritedUserVars,
+  surfaceIterationBinding,
   MAX_ANCESTOR_DEPTH,
 } from './delegation-context.js';
 export {

--- a/packages/core/src/runbook/runtime-frame.ts
+++ b/packages/core/src/runbook/runtime-frame.ts
@@ -1,4 +1,5 @@
 import { isSourced, type ForClause, type ResolvedStep } from '@rundown-org/parser';
+import { collectProducedNames } from './for-source-analysis.js';
 import { deriveExecutionAt } from './targeting.js';
 import {
   assertResolvedVariableForContext,
@@ -119,6 +120,10 @@ export function buildStepVariables(input: BuildStepVariablesInput): StepVariable
 /**
  * Validate that sourced FOR loops reference iterable variables.
  *
+ * @remarks A FOR source produced by an earlier step's OUTPUTS or name-binding
+ * ARTIFACTS is deferred to step-entry resolution and not validated here
+ * (language spec §8.2).
+ *
  * @param steps - Resolved steps to validate
  * @param vars - Template variables available to the runbook
  * @throws {Error} if a FOR source variable is missing or non-iterable
@@ -127,9 +132,13 @@ export function validateForVariables(
   steps: readonly ResolvedStep[],
   vars: Readonly<Partial<Record<string, VariableValue>>>,
 ): void {
+  const produced = collectProducedNames(steps);
   for (const step of steps) {
     if (step.kind === 'for' && isSourced(step.forClause)) {
       const name = step.forClause.source;
+      // A source produced by an earlier step in this run resolves at step
+      // entry (language spec §8.2); defer it rather than rejecting at launch.
+      if (produced.has(name)) continue;
       const value = vars[name];
       if (value === undefined) {
         throw new Error(

--- a/packages/core/src/runbook/runtime-frame.ts
+++ b/packages/core/src/runbook/runtime-frame.ts
@@ -132,13 +132,15 @@ export function validateForVariables(
   steps: readonly ResolvedStep[],
   vars: Readonly<Partial<Record<string, VariableValue>>>,
 ): void {
-  const produced = collectProducedNames(steps);
+  const producedSoFar = new Set<string>();
   for (const step of steps) {
     if (step.kind === 'for' && isSourced(step.forClause)) {
       const name = step.forClause.source;
       // A source produced by an earlier step in this run resolves at step
       // entry (language spec §8.2); defer it rather than rejecting at launch.
-      if (produced.has(name)) continue;
+      // Only earlier steps count: a source produced solely by a later step
+      // cannot be available when this FOR runs, so it stays validated here.
+      if (producedSoFar.has(name)) continue;
       const value = vars[name];
       if (value === undefined) {
         throw new Error(
@@ -150,6 +152,9 @@ export function validateForVariables(
           `FOR loop variable "{{${name}}}" is not iterable (got ${typeof value}). Define "${name}" as an array in .rundown/config.yaml or pass --input-file with an array value.`,
         );
       }
+    }
+    for (const producedName of collectProducedNames([step])) {
+      producedSoFar.add(producedName);
     }
   }
 }

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -678,6 +678,24 @@ export interface StepInlineChild {
   readonly startedAt: string | null;
 }
 
+/**
+ * Typed per-iteration binding captured at delegation time so a delegated child
+ * can receive the parent's loop value and `Index` (language spec §10.4).
+ *
+ * Discriminated on the FOR source kind. A range loop yields the iteration
+ * number; a data-source loop yields the resolved item. The `item` variant's
+ * `variable` and `value` are non-optional, so an item binding cannot exist
+ * without a resolved value — invalid states are unrepresentable.
+ */
+export type IterationBinding =
+  | { readonly kind: 'range'; readonly index: number; readonly variable?: string }
+  | {
+      readonly kind: 'item';
+      readonly index: number;
+      readonly variable: string;
+      readonly value: JsonValue;
+    };
+
 /** Snapshot of execution context at delegation time. */
 export interface ContextSnapshot {
   /**
@@ -700,6 +718,8 @@ export interface ContextSnapshot {
   readonly at?: string;
   /** FOR loop iteration number at delegation time (1-based). */
   readonly index?: number;
+  /** Typed active-FOR iteration binding at delegation time (language spec §10.4). */
+  readonly iterationBinding?: IterationBinding;
 }
 
 /** Single ancestor in the runbook lineage snapshot. */

--- a/packages/core/src/runbook/variable-preparation.ts
+++ b/packages/core/src/runbook/variable-preparation.ts
@@ -29,6 +29,7 @@ import {
 import { type TemplateHelperRegistry } from './helper-invoke.js';
 import type { RunId } from './run-id.js';
 import type { RunbookRef } from './runbook-ref.js';
+import { surfaceIterationBinding } from './delegation-context.js';
 import { buildContextVars, validateForVariables } from './runtime-frame.js';
 import {
   collectUnresolvedRunbookVariables,
@@ -38,6 +39,7 @@ import {
 import {
   createJsonArrayStream,
   isJsonValue,
+  type IterationBinding,
   type JsonArray,
   type JsonObject,
   type TemplateVarValue,
@@ -636,6 +638,12 @@ export interface PrepareParsedRunbookInput {
   readonly providedKeys: ReadonlySet<string>;
   readonly inheritedUserVars?: Readonly<Record<string, TemplateVarValue>>;
   readonly inheritedContextVars?: Readonly<Record<string, TemplateVarValue>>;
+  /**
+   * Typed FOR iteration binding inherited from the delegating parent
+   * (language spec §10.4). Surfaced into the inherited-user-var layer gated on
+   * this runbook's declared `inputs`; ranks below explicit `--input`.
+   */
+  readonly iterationBinding?: IterationBinding;
   readonly runbookRef: RunbookRef;
   readonly helperRegistry: TemplateHelperRegistry;
   readonly identity: PrepareParsedRunbookIdentity;
@@ -736,8 +744,28 @@ export function withRunnableVariables(
 export function prepareParsedRunbook(input: PrepareParsedRunbookInput): PrepareParsedRunbookResult {
   const warnings: string[] = [];
   const runtimeVars = input.runtimeVars ?? {};
+  // The surfaced iteration binding overlays inherited parent vars of the same
+  // name (mirroring parent render semantics, where the loop var overlays) but
+  // still ranks below explicit `--input` (`input.templateVars`), which layers
+  // on top in both merge paths below.
+  const surfacedIterationVars = surfaceIterationBinding(
+    input.iterationBinding,
+    input.frontmatter?.inputs,
+  );
+  const inheritedUserVars: Readonly<Record<string, TemplateVarValue>> = {
+    ...(input.inheritedUserVars ?? {}),
+    ...surfacedIterationVars,
+  };
+  // A surfaced binding is a provided value (inherited from the parent's active
+  // iteration), so its names satisfy the child's `required` contract below —
+  // the same way an explicit `--input` or a prior OUTPUTS would.
+  const surfacedKeys = Object.keys(surfacedIterationVars);
+  const providedKeys =
+    surfacedKeys.length > 0
+      ? new Set<string>([...input.providedKeys, ...surfacedKeys])
+      : input.providedKeys;
   const baseTemplateVars = buildTemplateVars(input.templateVars, {
-    inheritedUserVars: input.inheritedUserVars,
+    inheritedUserVars,
     inheritedContextVars: input.inheritedContextVars,
   });
   const preparedTemplateVars = withPreparedVariables(baseTemplateVars, input.runbookRef);
@@ -775,7 +803,7 @@ export function prepareParsedRunbook(input: PrepareParsedRunbookInput): PrepareP
         };
   const effectiveUserVars = mergeEffectiveVars<VariableValue>({
     templateVars: {
-      ...(input.inheritedUserVars ?? {}),
+      ...inheritedUserVars,
       ...input.templateVars,
     },
     variables: runtimeVars,
@@ -807,7 +835,7 @@ export function prepareParsedRunbook(input: PrepareParsedRunbookInput): PrepareP
 
   const requiredVars = input.frontmatter?.required;
   if (requiredVars && requiredVars.length > 0) {
-    const missing = requiredVars.filter((name) => !input.providedKeys.has(name));
+    const missing = requiredVars.filter((name) => !providedKeys.has(name));
     if (missing.length > 0) {
       const names = missing.map((name) => `"${name}"`).join(', ');
       return {

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -402,6 +402,27 @@ function makeContextVarValueSchema(
 const ContextSnapshotVarValueSchema = makeContextVarValueSchema();
 
 /**
+ * Zod schema for the typed FOR iteration binding captured on a delegation
+ * snapshot (language spec §10.4). Discriminated on `kind`; the `item` variant
+ * requires a resolved value so an item binding cannot lack one. Shared by the
+ * static {@link ContextSnapshotSchema} and the path-validated
+ * {@link makeContextSnapshotSchema} so the two cannot drift.
+ */
+const IterationBindingSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('range'),
+    index: z.number().int().positive(),
+    variable: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal('item'),
+    index: z.number().int().positive(),
+    variable: z.string(),
+    value: JsonValueSchema,
+  }),
+]);
+
+/**
  * Zod schema for a single ancestor in the runbook lineage snapshot.
  */
 export const AncestorSnapshotSchema = z.object({
@@ -425,6 +446,7 @@ export const ContextSnapshotSchema = z
     substep: z.string().optional(),
     at: z.string().optional(),
     index: z.number().int().positive().optional(),
+    iterationBinding: IterationBindingSchema.optional(),
   })
   .loose()
   .superRefine((val, ctx) => {
@@ -875,6 +897,7 @@ function makeContextSnapshotSchema(projectRoot: string): z.ZodType {
       substep: z.string().optional(),
       at: z.string().optional(),
       index: z.number().int().positive().optional(),
+      iterationBinding: IterationBindingSchema.optional(),
     })
     .loose()
     .superRefine((val, ctx) => {


### PR DESCRIPTION
## Summary

Reopens the work from PR #438 against main after it was accidentally merged into feat/composing-runbooks instead of main.

This branch points at the original misplaced commit series from origin/feat/iterate-and-delegate, excluding the confusing merge commit that advanced origin/feat/composing-runbooks after PR #434 was already merged.

## Context

- PR #434 merged feat/composing-runbooks into main.
- PR #438 then used feat/composing-runbooks as its base and merged there.
- As a result, the iterate-and-delegate work did not land on main.

## Validation

Not rerun in this recovery step; this PR republishes the existing commit series for review against main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FOR loops now resolve data sources at step entry, enabling iteration over data produced by earlier steps in the same runbook
  * Delegated child runbooks within FOR loops inherit iteration binding (loop variable and `Index`); children declare needed variables via frontmatter `inputs`
  * Added `check` command warnings for unresolved FOR sources and multi-delegation patterns
  * New documented `iterate-and-delegate` pattern for processing collections

* **Documentation**
  * Expanded runtime and language specifications for FOR iteration semantics and delegation inheritance behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->