### PR TITLE
chore: add `npm run worktree` helper to scaffold worktrees with deps

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -303,3 +303,6 @@ Hermeticity
 Trailmark
 chokepoint
 Fors
+typechecks
+unbuilt
+toplevel

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "site"
   ],
   "scripts": {
+    "worktree": "bash scripts/worktree.sh",
     "build": "npm run build -w packages/parser && npm run build -w packages/core && npm run build -w packages/cli && npm run build -w packages/claude-code-plugin && npm run build -w packages/mcp",
     "build:site": "npm run build -w site",
     "build:all": "npm run build && npm run build -w site",

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# worktree.sh — Create a git worktree under .worktrees/ with deps installed
+# Usage: ./scripts/worktree.sh <name> [base-ref]
+#        npm run worktree -- <name> [base-ref]
+#
+# Creates .worktrees/<name> on a new branch <name>, branched from [base-ref]
+# (default: main), then runs `npm install` inside it so the workspace is
+# immediately buildable/testable.
+#
+# A fresh `git worktree add` checks out only git-tracked files — node_modules
+# is gitignored, so a new worktree has no dependencies until installed. Skipping
+# that step makes `npm run build`/tests fail with confusing cross-package type
+# errors (the worktree typechecks against an unbuilt/absent core). This wrapper
+# removes that footgun. Idempotent-ish: re-running with an existing name fails
+# fast on the `git worktree add` step rather than clobbering anything.
+set -euo pipefail
+
+name="${1:-}"
+base="${2:-main}"
+
+if [[ -z "$name" ]]; then
+  echo "Usage: $0 <name> [base-ref]" >&2
+  echo "  e.g. $0 my-feature        # branch 'my-feature' from main" >&2
+  echo "       $0 my-fix release-1  # branch 'my-fix' from release-1" >&2
+  exit 1
+fi
+
+# Resolve repo root so the script works from any CWD.
+root="$(git rev-parse --show-toplevel)"
+dir="$root/.worktrees/$name"
+
+echo "→ Creating worktree '$name' (branch '$name' from '$base') at $dir"
+git -C "$root" worktree add -b "$name" "$dir" "$base"
+
+echo "→ Installing dependencies in $dir"
+npm --prefix "$dir" install
+
+echo "✓ Worktree ready: $dir"
+echo "  cd $dir && npm run build"


### PR DESCRIPTION
## What

Adds `scripts/worktree.sh` and an `npm run worktree` alias that creates a git worktree under `.worktrees/` **with dependencies installed**:

```bash
npm run worktree -- <name> [base-ref]   # default base: main
```

It runs `git worktree add -b <name> .worktrees/<name> <base>` followed by `npm install` in the new worktree.

## Why

A fresh `git worktree add` checks out only git-tracked files, so a new worktree has **no `node_modules`** until installed. Skipping that step makes `npm run build`/tests fail with confusing cross-package `TS2554`-style errors (the worktree typechecks against an absent/unbuilt `@rundown-org/core`), which reads as a real build break when it's just a missing install. This wrapper removes that footgun.

It does **not** address the per-worktree disk/install tax (~446 MB each) — that's tracked separately in #446 (pnpm migration). This helper is the correctness fix; pnpm is the optimization tier.

## Testing

Verified end-to-end: created a throwaway worktree via `npm run worktree`, confirmed `node_modules` installed and `packages/parser` built clean, then removed the worktree + branch. Usage guard (no args) prints help and exits non-zero.

Refs #446