### PR TITLE
ci: fix mutation.yml startup failure + review cleanups

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -30,27 +30,36 @@ jobs:
             dir: packages/cli
           - package: plugin
             dir: packages/claude-code-plugin
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event.inputs.package == 'all' ||
-      github.event.inputs.package == '${{ matrix.package }}'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # On schedule, run every package. On workflow_dispatch, run the selected
+    # package (or 'all'). This filter lives at the step level via env.RUN_PACKAGE
+    # because the `matrix` context is not available in a job-level `if:`.
+    env:
+      RUN_PACKAGE: >-
+        ${{ github.event_name == 'schedule' ||
+            github.event.inputs.package == 'all' ||
+            github.event.inputs.package == matrix.package }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        if: ${{ env.RUN_PACKAGE == 'true' }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+        if: ${{ env.RUN_PACKAGE == 'true' }}
         with:
           node-version-file: .nvmrc
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ env.RUN_PACKAGE == 'true' }}
         run: npm ci
 
       - name: Build
+        if: ${{ env.RUN_PACKAGE == 'true' }}
         run: npm run build
 
       - name: Restore Stryker incremental cache
+        if: ${{ env.RUN_PACKAGE == 'true' }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ${{ matrix.dir }}/reports/stryker-incremental.json
@@ -58,12 +67,15 @@ jobs:
           restore-keys: stryker-${{ matrix.package }}-
 
       - name: Run mutation tests
+        if: ${{ env.RUN_PACKAGE == 'true' }}
         run: npx stryker run
         working-directory: ${{ matrix.dir }}
 
       - name: Upload mutation report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        if: always()
+        # always() so the report uploads even when the mutation run fails, but
+        # only for packages this dispatch actually ran.
+        if: ${{ always() && env.RUN_PACKAGE == 'true' }}
         with:
           name: mutation-report-${{ matrix.package }}
           path: |

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         if: ${{ env.RUN_PACKAGE == 'true' }}
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         if: ${{ env.RUN_PACKAGE == 'true' }}

--- a/packages/core/__tests__/runbook/safe-fs.test.ts
+++ b/packages/core/__tests__/runbook/safe-fs.test.ts
@@ -7,9 +7,9 @@ import * as path from 'node:path';
 const actualFs = await import('node:fs');
 const { isNodeErrorCode } = await import('../../src/errors.js');
 
-// afterLstat fires after every realpathSync/statSync-style lstat the guard
-// performs, letting a test swap the path mid-flight to exercise the
-// symlink-swap (TOCTOU) re-stat. Modelled on artifact-manifest-toctou.test.ts.
+// afterRealpath fires after every realpathSync the guard performs, letting a
+// test swap the path mid-flight to exercise the symlink-swap (TOCTOU) re-stat.
+// Modelled on artifact-manifest-toctou.test.ts.
 let afterRealpath: ((filePath: string) => void) | undefined;
 
 jest.unstable_mockModule('node:fs', () => ({


### PR DESCRIPTION
## Summary

Fixes the `mutation.yml` workflow startup failure on push, plus small review-driven cleanups surfaced by CodeRabbit.

## Changes

- **`mutation.yml`**: stop `startup_failure` on push, and set `persist-credentials: false` on the checkout step (matches the convention used by all checkout steps in `ci.yml`).
- **`tokenize-shell-differential.properties.test.ts`**: remove an unreachable branch in the head scanner (the inner separator check could never fire).
- **`safe-fs.test.ts`**: correct the realpath hook comment to match the actual implementation (only intercepts `realpathSync`).

## Notes

The branch is behind `main`; the merge-base diff above is the real scope (3 files). Consider rebasing before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated mutation testing workflow with conditional execution logic based on event type and improved step handling.

* **Tests**
  * Updated test documentation comments for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->