### PR TITLE
fix(parser): take ARTIFACTS literal tokens verbatim from source (#451)

### DIFF
--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -3,7 +3,7 @@ import * as fsp from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { ArtifactDeclaration } from '@rundown-org/parser';
+import { type ArtifactDeclaration, parseRunbookDocument } from '@rundown-org/parser';
 import {
   appendArtifactManifestRecord,
   readArtifactManifest,
@@ -994,6 +994,43 @@ describe('resolveArtifactDeclarations — cross-run shorthand (*/key)', () => {
     await Promise.all([a, b].map((r) => touchArtifact(cwd, r)));
 
     const result = await resolveArtifactDeclarations([decl('Reviews', '*/review-*.json')], {
+      cwd,
+      workPath: WORK_PATH,
+      contextId: CONTEXT_ID,
+      runId: CURRENT_RUN,
+      runbook: RUNBOOK,
+    });
+
+    expect(result.Reviews).toEqual([a, b].sort((l, r) => l.uri.localeCompare(r.uri)));
+  });
+
+  it('resolves a two-`*` selector authored in an ARTIFACTS directive (issue #451, end-to-end)', async () => {
+    // Regression for #451 across the full markdown→parse→resolve path. The
+    // selector URI carries two `*` (cross-run wildcard + key glob). Before the
+    // fix, the parser interpreted `*/review-*` as markdown emphasis and stripped
+    // both asterisks, so the resolver received a malformed URI and threw. Author
+    // the directive as real markdown and resolve the parsed declaration verbatim.
+    const cwd = await tempCwd();
+    const a = record({ runId: CURRENT_RUN, runbook: RUNBOOK, key: 'review-a.json' });
+    const b = record({ runId: CHILD_RUN, runbook: CHILD_RUNBOOK, key: 'review-b.json' });
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, a);
+    await appendArtifactManifestRecord({ cwd, workPath: WORK_PATH }, b);
+    await Promise.all([a, b].map((r) => touchArtifact(cwd, r)));
+
+    const md = `## 1. Consume
+- ARTIFACTS
+  - Reviews "rd://artifacts/${CONTEXT_ID}/*/review-*.json"
+- PASS COMPLETE
+- FAIL STOP
+`;
+    const { runbook, diagnostics } = parseRunbookDocument(md);
+    expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const declarations = runbook.steps[0].artifacts;
+    expect(declarations).toEqual([
+      { name: 'Reviews', rawToken: `rd://artifacts/${CONTEXT_ID}/*/review-*.json` },
+    ]);
+
+    const result = await resolveArtifactDeclarations(declarations ?? [], {
       cwd,
       workPath: WORK_PATH,
       contextId: CONTEXT_ID,

--- a/packages/parser/__tests__/artifacts.test.ts
+++ b/packages/parser/__tests__/artifacts.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from '@jest/globals';
+import * as fc from 'fast-check';
 import {
   parseArtifactDeclaration,
   parseRunbookDocument,
   RunbookSyntaxError,
 } from '../src/index.js';
+// `rawNodeText` is a parser internal (not part of the public package barrel);
+// the missing-offsets invariant is exercised directly via the deep import.
+import { rawNodeText } from '../src/parser.js';
 
 describe('parseArtifactDeclaration', () => {
   it('parses a bare key into rawToken (classification deferred to resolver)', () => {
@@ -226,6 +230,63 @@ describe('parseRunbookDocument with ARTIFACTS directive', () => {
     expect(runbook.steps[0].artifacts).toEqual([{ name: 'Plan', rawToken }]);
   });
 
+  it('takes any quoted selector token verbatim from source, regardless of markdown inline syntax (#451 property)', () => {
+    // The hand-picked it.each above is an approximation of one invariant: for
+    // ANY quoted token, the parsed `rawToken` equals the exact source substring
+    // between the quotes — no markdown inline interpretation is applied. The
+    // generator deliberately seeds emphasis (`*`/`_`), strikethrough (`~`), code
+    // (backtick), and link (`[](...)`) delimiters, the constructs that the old
+    // `extractText` path would have consumed. `rd://` URIs are classified
+    // verbatim, so the only constraints are the artifact-token safety rules
+    // (no `**`, no `.`/`..` path segments).
+    const tokenCharArb = fc.constantFrom(
+      ...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'.split(''),
+      '-',
+      '_',
+      '.',
+      '*',
+      '?',
+      '~',
+      '`',
+      '[',
+      ']',
+      '(',
+      ')',
+    );
+    const segmentArb = fc
+      .array(tokenCharArb, { minLength: 1, maxLength: 10 })
+      .map((chars) => chars.join(''))
+      .filter((segment) => segment !== '.' && segment !== '..');
+    const selectorTokenArb = fc
+      .record({
+        template: fc.constantFrom('{{ ContextId }}', '{{ContextId}}', 'ctx-fixed'),
+        segments: fc.array(segmentArb, { minLength: 1, maxLength: 4 }),
+        query: fc.constantFrom('', '?source=project', '?source=child', '?run=*'),
+      })
+      .map(
+        ({ template, segments, query }) =>
+          `rd://artifacts/${template}/${segments.join('/')}${query}`,
+      )
+      // A single segment of random characters can still contain `**`, which the
+      // classifier rejects as a recursive wildcard; drop those samples.
+      .filter((token) => !token.includes('**'));
+
+    fc.assert(
+      fc.property(selectorTokenArb, (rawToken) => {
+        const md = `## 1. Consume
+- ARTIFACTS
+  - Plan "${rawToken}"
+- PASS COMPLETE
+- FAIL STOP
+`;
+        const { runbook, diagnostics } = parseRunbookDocument(md);
+        expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+        expect(runbook.steps[0].artifacts).toEqual([{ name: 'Plan', rawToken }]);
+      }),
+      { numRuns: 500 },
+    );
+  });
+
   it('parses bare key with template through the document parser', () => {
     const md = `## 1. Templated
 - ARTIFACTS
@@ -420,5 +481,24 @@ Some prompt text first.
     // retain `artifacts === undefined` because they declared none of their own.
     expect(step.substeps[0].artifacts).toBeUndefined();
     expect(step.substeps[1].artifacts).toBeUndefined();
+  });
+});
+
+describe('rawNodeText missing-offsets invariant', () => {
+  // `fromMarkdown` always populates byte offsets, so this guard is unreachable
+  // through normal parsing. It is pinned directly so a mutation that drops the
+  // guard — replacing the throw with a `source.slice(undefined, undefined)`
+  // fallback that silently returns lossy text — cannot survive (#451).
+  it('throws when the node carries no position rather than returning lossy text', () => {
+    expect(() => rawNodeText({}, 'rd://artifacts/ctx/*/review-*.json')).toThrow(RunbookSyntaxError);
+  });
+
+  it('throws when the position exists but the start offset is absent', () => {
+    expect(() =>
+      rawNodeText(
+        { position: { start: { line: 1, column: 1 }, end: { line: 1, column: 7, offset: 6 } } },
+        'rd://artifacts/ctx/*/review-*.json',
+      ),
+    ).toThrow(RunbookSyntaxError);
   });
 });

--- a/packages/parser/__tests__/artifacts.test.ts
+++ b/packages/parser/__tests__/artifacts.test.ts
@@ -189,6 +189,43 @@ describe('parseRunbookDocument with ARTIFACTS directive', () => {
     ]);
   });
 
+  it('preserves paired `*` in a selector URI (markdown emphasis must not be applied)', () => {
+    // Regression for #451: `*/plan-*` was parsed as markdown emphasis and both
+    // asterisks were stripped, yielding `//plan-.json`. The quoted token is a
+    // literal and must be taken verbatim from the source.
+    const md = `## 1. Consume
+- ARTIFACTS
+  - Reviews "rd://artifacts/{{ ContextId }}/*/plan-*.json?source=project"
+- PASS COMPLETE
+- FAIL STOP
+`;
+    const { runbook, diagnostics } = parseRunbookDocument(md);
+    expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expect(runbook.steps[0].artifacts).toEqual([
+      {
+        name: 'Reviews',
+        rawToken: 'rd://artifacts/{{ ContextId }}/*/plan-*.json?source=project',
+      },
+    ]);
+  });
+
+  it.each([
+    ['multiple `*` emphasis pairs', '*/a-*-*-*.json'],
+    ['`*`-pair wrapping underscores', '*/plan_v_*.json'],
+    ['`_`-delimited emphasis', '*/_v_-*.json'],
+    ['single `*` (control — never an emphasis pair)', '*/plan.json'],
+  ])('preserves literal token verbatim through the document parser: %s', (_label, rawToken) => {
+    const md = `## 1. Consume
+- ARTIFACTS
+  - Plan "${rawToken}"
+- PASS COMPLETE
+- FAIL STOP
+`;
+    const { runbook, diagnostics } = parseRunbookDocument(md);
+    expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expect(runbook.steps[0].artifacts).toEqual([{ name: 'Plan', rawToken }]);
+  });
+
   it('parses bare key with template through the document parser', () => {
     const md = `## 1. Templated
 - ARTIFACTS

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -115,7 +115,7 @@ function extractText(node: PhrasingContent | Heading | Paragraph | ListItem): st
 }
 
 /** An mdast node carrying source byte offsets (populated by `fromMarkdown`). */
-interface OffsetPositioned {
+export interface OffsetPositioned {
   /** Source position whose `start.offset`/`end.offset` index into the parsed content. */
   position?: Position;
 }
@@ -143,7 +143,7 @@ interface OffsetPositioned {
  *   rather than falling back to lossy extraction, which would silently
  *   reintroduce the delimiter-stripping corruption.
  */
-function rawNodeText(node: OffsetPositioned, source: string): string {
+export function rawNodeText(node: OffsetPositioned, source: string): string {
   const start = node.position?.start.offset;
   const end = node.position?.end.offset;
   if (start === undefined || end === undefined) {

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -1,6 +1,6 @@
 import { fromMarkdown } from 'mdast-util-from-markdown';
 import { visit, SKIP } from 'unist-util-visit';
-import type { Node } from 'unist';
+import type { Node, Position } from 'unist';
 import type { Code, Heading, List, ListItem, Paragraph, PhrasingContent } from 'mdast';
 import type {
   Step,
@@ -114,6 +114,46 @@ function extractText(node: PhrasingContent | Heading | Paragraph | ListItem): st
   return '';
 }
 
+/** An mdast node carrying source byte offsets (populated by `fromMarkdown`). */
+interface OffsetPositioned {
+  /** Source position whose `start.offset`/`end.offset` index into the parsed content. */
+  position?: Position;
+}
+
+/**
+ * Extract the verbatim source text spanned by a positioned node.
+ *
+ * Unlike {@link extractText} — which reconstructs text from the rendered mdast
+ * tree and therefore drops inline-markup delimiters (the `*`/`_` of an
+ * `emphasis`/`strong` node are consumed by the markdown parser and never
+ * re-emitted) — this returns the exact source bytes the author wrote. Use it for
+ * directive tokens that are quoted literals (URIs, globs, templates), which must
+ * not be subject to markdown inline interpretation. See issue #451: a selector
+ * URI whose path contained a run wildcard followed by a key glob (asterisk,
+ * slash, then a hyphenated key glob) was parsed as emphasis and both asterisks
+ * were stripped, yielding a malformed path.
+ *
+ * @param node - A positioned mdast node whose byte offsets are populated by
+ *   `fromMarkdown`
+ * @param source - The markdown source the node's offsets index into (the
+ *   post-frontmatter content passed to `fromMarkdown`)
+ * @returns The exact source substring spanned by the node
+ * @throws {RunbookSyntaxError} When the node lacks byte offsets. This is a parser
+ *   invariant violation — `fromMarkdown` always populates offsets — and is raised
+ *   rather than falling back to lossy extraction, which would silently
+ *   reintroduce the delimiter-stripping corruption.
+ */
+function rawNodeText(node: OffsetPositioned, source: string): string {
+  const start = node.position?.start.offset;
+  const end = node.position?.end.offset;
+  if (start === undefined || end === undefined) {
+    throw new RunbookSyntaxError(
+      'Internal parser error: node is missing source offsets; cannot extract verbatim declaration text',
+    );
+  }
+  return source.slice(start, end);
+}
+
 interface SubstepBuilder {
   id: string;
   description: string;
@@ -191,6 +231,13 @@ interface VisitorContext {
   implicitText: string;
   inPreamble: boolean;
   diagnostics: ValidationDiagnostic[];
+  /**
+   * The markdown source the mdast tree was parsed from (post-frontmatter
+   * `content`, so node byte offsets index directly into it). Threaded so
+   * directive handlers can recover verbatim literal tokens via {@link rawNodeText}
+   * instead of the lossy {@link extractText} reconstruction (issue #451).
+   */
+  readonly source: string;
 }
 
 /** Narrowed context where a step is active. Handlers that require currentStep take this. */
@@ -699,7 +746,11 @@ function handleArtifactsDirective(node: ListItem, ctx: ActiveStepContext): typeo
         `Invalid ARTIFACTS declaration in ${targetLabel}${formatLineNum(item)}: expected \`Name\` or \`Name "<token>"\``,
       );
     }
-    const text = extractText(paragraph);
+    // The ARTIFACTS token is a quoted literal (URI, glob, template) and must be
+    // taken verbatim from source — markdown inline interpretation would corrupt
+    // it (e.g. paired `*` parsed as emphasis, issue #451). Use the raw source
+    // span, not the rendered-tree reconstruction.
+    const text = rawNodeText(paragraph, ctx.source);
     const decl = parseArtifactDeclaration(text);
     if (!decl) {
       throw new RunbookSyntaxError(
@@ -1117,6 +1168,7 @@ export function parseRunbookDocument(markdown: string, basename?: string): Parse
     implicitText: '',
     inPreamble: true,
     diagnostics: [],
+    source: content,
   };
 
   visit(tree, (node: Node, _index, parent: Node | undefined) => visitNode(node, parent, ctx));


### PR DESCRIPTION
## Summary

Fixes #451. ARTIFACTS selector tokens are quoted literals (URIs, globs, templates) but were extracted via `extractText()`, which rebuilds text from the rendered mdast tree — so a token like `rd://artifacts/{{ContextId}}/*/review-*.json` had its `*/review-*` parsed as markdown emphasis and the `*` delimiters stripped, yielding a malformed URI.

The fix recovers the verbatim source span instead of trusting the rendered tree:

- `rawNodeText(node, source)` (`parser.ts`) slices the exact source substring from the node's `position` byte offsets. It throws a `RunbookSyntaxError` if offsets are missing rather than falling back to lossy extraction.
- The post-frontmatter content is threaded into `VisitorContext.source` so offsets index into the right string.
- `handleArtifactsDirective` swaps its one `extractText` call site over to `rawNodeText`.

ARTIFACTS is the only directive surface carrying quoted literal tokens — sibling directives (OUTPUTS, FOR, transitions) are name-only or keyword grammar, so the fix is complete, not partial.

## Tests

- **Unit** (`parser/__tests__/artifacts.test.ts`): targeted regression + `it.each` over multiple `*`/`_`/control token shapes; exact-equality assertions on `rawToken`.
- **Property** (`fast-check`): for any quoted selector token, parsed `rawToken` equals the exact source substring — generators seed emphasis/strikethrough/code/link delimiters, the constructs the old path would have consumed (500 runs).
- **Invariant**: `rawNodeText`'s missing-offsets guard is pinned so a mutation dropping the throw cannot silently return lossy text.
- **End-to-end** (`core/__tests__/runbook/artifact-directive-resolver.test.ts`): real manifest records, two-`*` cross-run selector authored as markdown → parse → resolve.

## Verification

- `npm run build` — exit 0, all 23 runbooks validate
- parser full suite — 1685/1685 pass
- core `artifact-directive-resolver.test.ts` — 96/96 pass
- `npm run lint` / `check:format` / `check:spell` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed artifact selector parsing to correctly preserve literal wildcard (`*`) and underscore (`_`) characters in runbook artifact directives. Markdown emphasis processing no longer corrupts artifact selector URIs during parsing.

* **Tests**
  * Added comprehensive test coverage for artifact token handling and selector URI parsing with special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->