### PR TITLE
docs: fix --text drift, consolidate CLI surface, and load runbook protocol before rd run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,105 +76,17 @@ npm install -g @rundown-org/cli
 
 ## Commands
 
-```bash
-rundown run [file]       # Run a runbook (JSON output by default)
-rundown run [file] --text # Output execution events as human-readable text
-rundown run [file] --input key=value  # Set template variable (repeatable, omit =value to inherit from env)
-rundown run [file] --input-json key=json  # Set variable with JSON value (repeatable)
-rundown run [file] --input-file path  # Load variables from YAML file (repeatable)
-rundown run [file] --prompted  # Show commands without auto-executing
-rundown run [file] --step <stepId>   # Link child to parent substep (inline nested execution)
-rundown run [file] --step <stepId> --prompted  # Jump to step after starting (goto)
-rundown run [file] --step <stepId> --index <number>  # FOR loop iteration to target
-rundown pass             # Mark current step as passed (aliases: yes, ok)
-rundown pass --step <stepId>         # Target specific substep
-rundown pass --index <number>        # FOR loop iteration (requires --step)
-rundown fail             # Mark current step as failed (alias: no)
-rundown fail --step <stepId>         # Target specific substep
-rundown fail --index <number>        # FOR loop iteration (requires --step)
-rundown goto <step>      # Jump to step (e.g., '3', '3.1' for substep)
-rundown goto <step> --index <number> # FOR loop iteration to target
-rundown status           # Show current state
-rundown stop [message]   # Abort runbook with optional message
-rundown complete [message] # Force early completion (runbooks auto-complete on final step)
-rundown stash            # Pause enforcement (stash active runbook)
-rundown pop              # Resume enforcement (restore stashed runbook)
-# --claim-id <claimId> targets a claimed delegated child runbook;
-# accepted by goto, status, stop, complete, stash, pop, and collect
-# (pass/fail also accept --claim-id — see below)
-rundown ls               # List active runbooks
-rundown ls --all         # List available runbook files
-rundown ls --all --tags <tags>  # Filter by comma-separated tags
-rundown check <file>     # Check runbook for errors
-rundown resolve <file>   # Resolve and validate variables and data sources
-rundown echo             # Test helper: echo with configurable result
-rundown echo -r pass     # Configure result (pass|fail, repeatable — sequences through results)
-rundown prune            # Remove runbook state (default: completed + stopped)
-rundown prune --dry-run  # Show what would be removed without deleting
-rundown prune --completed # Prune successfully completed runbook state
-rundown prune --stopped  # Prune stopped (aborted/failed) runbook state
-rundown prune --active   # Prune active runbook state
-rundown prune --inactive # Prune inactive (orphaned) runbook state
-rundown prune --all      # Prune all runbook state
-rundown scenario ls <file>           # List scenarios in a runbook
-rundown scenario show <file> <name>  # Show scenario details
-rundown scenario run <file> <name>   # Run a scenario
-rundown scenario run <file> <name> -q, --quiet  # Run scenario (suppress output)
-rundown scenario-suite ls <suite-file>           # List cases in a scenario suite
-rundown scenario-suite show <suite-file> <case>  # Show case details
-rundown scenario-suite run <suite-file> [case]   # Run a case (or all with --all)
-rundown prompt <content> # Output content in markdown fences
-rundown delegate                        # Infer substep and runbook from state
-rundown delegate --step <id>            # Infer runbook from substep reference
-rundown delegate <runbook> --step <id>  # Explicit delegation
-rundown delegate <runbook> --step <id> --input key=value  # With variables (repeatable)
-rundown delegate <runbook> --step <id> --input-json key=json  # With JSON variables
-rundown delegate <runbook> --step <id> --input-file path  # Load variables from YAML file (repeatable)
-rundown delegate --step <id> --index <number>  # FOR loop iteration to target
-rundown delegate --retry <token>                         # Retry delegation by token
-rundown delegate --retry --step <id>                     # Retry delegation on substep
-rundown delegate --retry --step <id> --index <n>         # Retry delegation in FOR iteration
-rundown delegate --retry                                 # Retry inferred from active substep
-rundown delegate --retry --step <id> --input key=value   # Retry with var overrides
-rundown claim <token>                   # Claim a delegation token and launch child
-rundown claim <token> --input key=value   # Claim with variables (repeatable)
-rundown claim <token> --input-json key=json  # Claim with JSON variables
-rundown claim <token> --input-file path   # Load variables from YAML file (repeatable)
-rundown abort <token>                   # Cancel a delegation token
-rundown abort <token> --force           # Force cancel even if delegation is claimed (stops child run)
-rundown collect                         # Aggregate current DELEGATE step and fire transition
-rundown collect --step <id>             # Target a specific substep scope
-rundown collect --claim-id <claimId>    # Collect within a claimed child runbook scope
-```
+`@rundown-org/cli` ships two equivalent binaries — `rundown` and its alias `rd`. Output is **JSON by default** on every command; that is the agent-facing format. `--text` is human-readable output for humans/debugging only — **agents must not add it.** Appending `--text` to an agent-driven command (such as starting a runbook) is exactly the drift this surface must not invite.
 
-The `rd` command is an alias for `rundown`.
+The full command and flag surface is canonical in the reference docs — **do not duplicate or reconstruct it here.** When stepping through a runbook, follow the `running-runbooks` skill for the execution protocol (when to `rd pass`/`rd fail`, claim/delegate, JSON vs `--text`) rather than the raw flag list.
 
-### rdpath (Path Assembly Tool)
+- [docs/reference/cli.md](docs/reference/cli.md) — every `rundown`/`rd` command (run, pass/fail, goto, status, stop, complete, stash/pop, ls, check, resolve, echo, prune, scenario, scenario-suite, prompt, delegate, claim, abort, collect) with flags and `--step` / `--index` / `--claim-id` semantics
+- [docs/spec/cli-output.md](docs/spec/cli-output.md) — `--schema` JSON-output schemas for programmatic validation
+- [docs/reference/security.md](docs/reference/security.md) — policy flags (`--allow-*`, `--deny-all`, `--sandbox*`, `--trust-js-policy`, `--helpers`) and policy-file discovery
 
-> **Note:** `rdpath` and `rdx` are bin entries of the `@rundown-org/claude-code-plugin` package, not the `@rundown-org/cli` package. The CLI package ships only `rundown` and `rd`.
+### Sibling tools: rdpath, rdx
 
-```bash
-rdpath --dir <path>                           # Assemble base path (default subcommand)
-rdpath --dir <path> --ctx <id>                # With context scope (.rd-<id>/)
-rdpath --dir <path> --file <name>             # With date-prefixed filename
-rdpath --dir <path> --ctx <id> --file <name>  # With date-prefixed filename in context
-rdpath --dir <path> find <pattern>            # Find files matching glob pattern
-rdpath --dir <path> --ctx <id> find <pattern> # Find within context scope
-rdpath --dir <path> find <pattern> --allow-empty # Exit 0 when zero files match (default: exit 1)
-```
-
-### rdx (JSON-to-Markdown CLI)
-
-`rdx` is also a bin entry of `@rundown-org/claude-code-plugin`, not `@rundown-org/cli`.
-
-```bash
-rdx <file>                        # Render JSON to Markdown (stdout)
-rdx <file> -o, --output <path>    # Write Markdown to file
-rdx <file> --validate             # Validate only, no rendering
-rdx <file> --schema <name>        # Explicit schema for validation
-```
-
-Schema validation is automatic when the JSON includes `"$schema": "https://rundown.org/schemas/<name>.schema.json"`. See [docs/reference/rdx.md](docs/reference/rdx.md) for full reference.
+Minor bins of the plugin package (`@rundown-org/claude-code-plugin`) — **not** part of the CLI package, and of decreasing importance as their functionality moves into artifacts. Reach for them only when a runbook explicitly invokes them. See [rdpath.md](docs/reference/rdpath.md) and [rdx.md](docs/reference/rdx.md).
 
 ## Template Variables
 
@@ -243,18 +155,6 @@ Data sources are referenced in FOR clauses: `FOR item IN {{ items }}`.
 
 **Note:** The `scenarios` frontmatter field is an internal testing/demo feature, not part of the public Rundown format specification. See [docs/internal/scenarios.md](docs/internal/scenarios.md).
 
-## Schema Output
-
-The `--schema` flag outputs the JSON Schema for a command's JSON output (supported by all commands with JSON output):
-
-```bash
-rd status --schema           # Status response schema
-rd check --schema            # Check response schema
-rd scenario ls --schema      # Scenario list schema
-```
-
-This enables programmatic validation of CLI output against the schema.
-
 ## State Persistence
 
 State persists in `.rundown/runs/` (execution state) and `.rundown/session.json` (active runbook tracking). Runbook source files are discovered from multiple locations (see [Runbook Discovery](#runbook-discovery)). State files persist across context clears.
@@ -308,33 +208,11 @@ rd ls --all                    # List all discoverable runbooks with source
 
 Output shows NAME, SOURCE, DESCRIPTION, and TAGS columns. The SOURCE column indicates where each runbook was found (project, plugin, or bundled).
 
-## Policy Options
+## Policy
 
-These options are registered at the program level and can be used with any subcommand:
+Policy flags (`--allow-run`, `--allow-read`, `--allow-write`, `--allow-env`, `--allow-all`, `--deny-all`, `--policy`, `--sandbox` / `--no-sandbox` / `--sandbox-strict`, `--trust-js-policy`, `--helpers`) are registered at the program level and usable with any subcommand. Policy files are auto-discovered from `.rundownrc{,.json,.yaml,.yml}` and `package.json`; JavaScript config files (`.js`, `.cjs`, `.mjs`) require explicit `--policy <path>` with `--trust-js-policy`.
 
-```bash
-rundown run [file] --allow-run git,npm    # Allow specific commands
-rundown run [file] --allow-read /path     # Allow reading specific paths
-rundown run [file] --allow-write /path    # Allow writing to specific paths
-rundown run [file] --allow-env VAR        # Allow specific environment variables
-rundown run [file] --allow-all            # Bypass policy (trust mode)
-rundown run [file] --deny-all             # Block all commands
-rundown run [file] -y, --yes              # Skip confirmation prompts
-rundown run [file] --non-interactive      # CI mode (auto-deny)
-rundown run [file] --no-color             # Disable colored output
-rundown run [file] --policy ./policy.yaml # Custom policy file
-rundown run [file] --sandbox              # Enable OS-level sandbox (default)
-rundown run [file] --no-sandbox           # Disable sandbox (trust mode)
-rundown run [file] --sandbox-strict       # Fail if sandbox unavailable
-rundown run [file] --trust-js-policy      # Trust executable JS policy configs and config-declared helpers
-rundown run [file] --helpers ./helpers.js # Helper module paths to load (comma-separated, relative to project root)
-```
-
-## Policy Configuration
-
-Policy files are auto-discovered from: `.rundownrc`, `.rundownrc.json`, `.rundownrc.yaml`, `.rundownrc.yml`, `package.json` (rundown field). JavaScript config files (`.js`, `.cjs`, `.mjs`) are not auto-discovered — they require explicit `--policy <path>` with `--trust-js-policy`. Helper modules declared by policy config are skipped unless `--trust-js-policy` is set; `--helpers` remains an explicit CLI opt-in.
-
-See [docs/reference/security.md](docs/reference/security.md) for full security policy documentation.
+See [docs/reference/security.md](docs/reference/security.md) for the full policy model, flag reference, and discovery rules.
 
 ## Environment Variables
 

--- a/packages/claude-code-plugin/__tests__/skills/converting-skills-to-runbooks.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/converting-skills-to-runbooks.test.ts
@@ -20,7 +20,7 @@ describe('converting-skills-to-runbooks skill', () => {
 
   it('declares the runbook entrypoint and running-runbooks invocation', () => {
     const skill = readSkill();
-    expect(skill).toMatch(/Start the runbook:\s*`rd run rundown:convert-skill --input SkillPath=/);
+    expect(skill).toMatch(/`rd run rundown:convert-skill --input SkillPath=/);
     expect(skill).toMatch(/Skill\(skill:\s*"rundown:running-runbooks"\)/);
   });
 

--- a/packages/claude-code-plugin/__tests__/skills/planning.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/planning.test.ts
@@ -20,7 +20,7 @@ describe('planning skill', () => {
 
   it('declares the runbook entrypoint and running-runbooks invocation', () => {
     const skill = readSkill();
-    expect(skill).toMatch(/Start the runbook:\s*`rd run rundown:planning`/);
+    expect(skill).toMatch(/`rd run rundown:planning`/);
     expect(skill).toMatch(/Skill\(skill:\s*"rundown:running-runbooks"\)/);
   });
 

--- a/packages/claude-code-plugin/__tests__/skills/planning.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/planning.test.ts
@@ -22,6 +22,10 @@ describe('planning skill', () => {
     const skill = readSkill();
     expect(skill).toMatch(/`rd run rundown:planning`/);
     expect(skill).toMatch(/Skill\(skill:\s*"rundown:running-runbooks"\)/);
+    // Lock the no-added-flags contract: the start command must never carry
+    // --text (or any other flag) in the example, even as the skill prose
+    // elsewhere explains why --text is human/debug-only.
+    expect(skill).not.toMatch(/rd run rundown:planning\s+--/);
   });
 
   it('cross-links the stage skills instead of restating them', () => {

--- a/packages/claude-code-plugin/__tests__/skills/writing-runbooks-bootstrap.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/writing-runbooks-bootstrap.test.ts
@@ -29,7 +29,7 @@ describe('writing-runbooks companion bootstrap skill guidance', () => {
 
   it('describes the agent-driven model: the agent runs rd run', () => {
     const section = bootstrapSection();
-    expect(section).toMatch(/Start the runbook:\s*`rd run <runbook-name>`/);
+    expect(section).toMatch(/`rd run <runbook-name>`/);
     expect(section).toMatch(/Skill\(skill:\s*"rundown:running-runbooks"\)/);
   });
 

--- a/packages/claude-code-plugin/skills/converting-skills-to-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/converting-skills-to-runbooks/SKILL.md
@@ -7,8 +7,10 @@ description: Use when converting an existing Claude skill (SKILL.md) into a rund
 
 <important>
 ## Runbook-Orchestrated Skill
-Start the runbook: `rd run rundown:convert-skill --input SkillPath=<path-to-SKILL.md>`
-Then invoke the running-runbooks skill: `Skill(skill: "rundown:running-runbooks")`
+Load the execution protocol *before* starting the runbook:
+
+1. `Skill(skill: "rundown:running-runbooks")`
+2. Then start it: `rd run rundown:convert-skill --input SkillPath=<path-to-SKILL.md>`
 </important>
 
 Distill a Claude skill into a rundown runbook that **orchestrates** its workflow. The runbook captures the high-level sequence of steps and coordinates the artifacts that flow between them. The skill keeps the context. The runbook references the skill; it does not restate it.

--- a/packages/claude-code-plugin/skills/executing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/executing-plans/SKILL.md
@@ -8,9 +8,12 @@ description: Use when implementing a written plan task-by-task — the per-task 
 <important>
 ## Runbook-Orchestrated Skill
 This runbook requires the path to the plan to execute. Resolve `PlanPath` first
-(ask the user if it is not already known), then start the runbook with it:
-`rd run rundown:execute-plan --input PlanPath=<path-to-plan>`
-Then invoke the running-runbooks skill: `Skill(skill: "rundown:running-runbooks")`
+(ask the user if it is not already known). Load the execution protocol *before*
+starting, so you can handle delegated tasks the moment they appear:
+
+1. `Skill(skill: "rundown:running-runbooks")`
+2. `Skill(skill: "rundown:delegating-runbooks")` — this runbook delegates
+3. Then start it: `rd run rundown:execute-plan --input PlanPath=<path-to-plan>`
 </important>
 
 Implement a written plan one task at a time, holding each task to its own tests and committing as you go. This skill is the **context** an execution runbook orchestrates: how to do each task well. The [`execute-plan`](../../runbooks/planning/execute-plan.runbook.md) runbook owns the *sequence* (implement → review → verify) and the *gates*; this skill owns the *craft* of a single task.

--- a/packages/claude-code-plugin/skills/planning/SKILL.md
+++ b/packages/claude-code-plugin/skills/planning/SKILL.md
@@ -8,7 +8,8 @@ use_when: Driving a body of work from a spec through to merged implementation.
 
 <important>
 ## Runbook-Orchestrated Skill
-Start the runbook: `rd run rundown:planning`
+Start the runbook with exactly this command, no added flags: `rd run rundown:planning`
+JSON is the agent-facing default; `--text` is for humans/debugging only — do not add it here.
 Then invoke the running-runbooks skill: `Skill(skill: "rundown:running-runbooks")`
 </important>
 

--- a/packages/claude-code-plugin/skills/planning/SKILL.md
+++ b/packages/claude-code-plugin/skills/planning/SKILL.md
@@ -8,9 +8,14 @@ use_when: Driving a body of work from a spec through to merged implementation.
 
 <important>
 ## Runbook-Orchestrated Skill
-Start the runbook with exactly this command, no added flags: `rd run rundown:planning`
+Load the execution protocol *before* starting, so you can handle step 1 (a
+delegation) the moment it appears:
+
+1. `Skill(skill: "rundown:running-runbooks")`
+2. `Skill(skill: "rundown:delegating-runbooks")` — step 1 delegates
+3. Then start the runbook with exactly this command, no added flags: `rd run rundown:planning`
+
 JSON is the agent-facing default; `--text` is for humans/debugging only — do not add it here.
-Then invoke the running-runbooks skill: `Skill(skill: "rundown:running-runbooks")`
 </important>
 
 
@@ -43,3 +48,4 @@ Every stage stops the pipeline on failure (`FAIL ANY STOP`); the final stage com
 - [writing-plans](../writing-plans/SKILL.md) — stage 1 craft: authoring the plan
 - [executing-plans](../executing-plans/SKILL.md) — stage 3 craft: implementing the plan
 - [running-runbooks](../running-runbooks/SKILL.md) — executing the driving runbook
+- [delegating-runbooks](../delegating-runbooks/SKILL.md) — parent-side delegation (step 1 delegates)

--- a/packages/claude-code-plugin/skills/rundown/SKILL.md
+++ b/packages/claude-code-plugin/skills/rundown/SKILL.md
@@ -36,7 +36,22 @@ contain the protocol itself.
    source). A bare name resolves via the priority chain (project → plugin →
    bundled).
 
-2. **Start it.**
+2. **Load the execution protocol — before starting.** So you are ready to
+   interpret the first step's output (including a delegation) the moment it
+   appears, rather than scrambling for the protocol after `rd run` has fired:
+
+   ```text
+   Skill(skill: "rundown:running-runbooks")
+   ```
+
+   If the runbook contains a `- DELEGATE` step, also load the delegation
+   protocol:
+
+   ```text
+   Skill(skill: "rundown:delegating-runbooks")
+   ```
+
+3. **Start it.**
 
    ```bash
    rd run <name>
@@ -50,7 +65,7 @@ contain the protocol itself.
 
    If `rd run` reports missing required inputs, supply them and re-run.
 
-3. **Hand off.** Once the runbook is active, follow the
+4. **Execute.** Follow the loaded
    [running-runbooks](../running-runbooks/SKILL.md) protocol: respond to each
    step with `rd pass` / `rd fail` and trust Rundown for transitions.
 

--- a/packages/claude-code-plugin/skills/writing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-plans/SKILL.md
@@ -9,8 +9,10 @@ template: ${CLAUDE_PLUGIN_ROOT}/templates/planning/plan.template.md
 
 <important>
 ## Runbook-Orchestrated Skill
-Start the runbook: `rd run rundown:write-plan`
-Then invoke the running-runbooks skill: `Skill(skill: "rundown:running-runbooks")`
+Load the execution protocol *before* starting the runbook:
+
+1. `Skill(skill: "rundown:running-runbooks")`
+2. Then start it: `rd run rundown:write-plan`
 </important>
 
 

--- a/packages/claude-code-plugin/skills/writing-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/writing-runbooks/SKILL.md
@@ -381,8 +381,12 @@ intent the runbook serves. The skill is a pre-bound variant of the generic
 `rundown` launcher: its body tells the orchestrating agent to start *this*
 runbook and hand off to `running-runbooks`.
 
-The orchestrating agent always starts the runbook — the skill instructs, the
-agent runs `rd run`. Nothing auto-starts a runbook behind the agent's back.
+The orchestrating agent loads the execution protocol *first*, then starts the
+runbook — the skill instructs, the agent runs `rd run`. Loading the protocol
+before the run is deliberate: the agent must be ready to interpret the first
+step's output (including a delegation) the moment it appears, not scramble for
+the protocol after `rd run` has already fired. Nothing auto-starts a runbook
+behind the agent's back.
 
 Create one for common, named runbooks (e.g. `planning`). One-off project
 runbooks don't need their own skill — the generic `rundown` launcher starts any
@@ -402,8 +406,11 @@ description: Use when <the user need this runbook serves, in trigger terms>.
 
 <important>
 ## Runbook-Orchestrated Skill
-Start the runbook: `rd run <runbook-name>`
-Then invoke the running-runbooks skill: `Skill(skill: "rundown:running-runbooks")`
+Load the execution protocol *before* starting the runbook:
+
+1. `Skill(skill: "rundown:running-runbooks")` — always.
+2. `Skill(skill: "rundown:delegating-runbooks")` — only if this runbook contains a `- DELEGATE` step.
+3. Then start it: `rd run <runbook-name>`
 </important>
 
 <One or two sentences: what this runbook does and when to reach for it.>


### PR DESCRIPTION
Two related fixes from reviewing a `/rundown:planning` test run where the agent (a) appended `--text` to the first command and (b) ran the runbook before loading the execution/delegation protocol.

## Part 1 — `--text` drift + CLAUDE.md consolidation

**Root cause:** `--text` is instructed nowhere in the skill chain. The agent appended it at cold start, sourced from `CLAUDE.md`'s command table, where `--text` was listed as a co-equal run form with no agent-facing guard.

- `skills/planning/SKILL.md`: start command takes no flags; JSON is the agent default, `--text` is human/debug-only.
- `CLAUDE.md` (−133 lines): replace the duplicated CLI command/flag surface with a compact orientation pointing to canonical refs (`cli.md`, `cli-output.md`, `security.md`), stating the JSON-default / no-`--text` rule once. Demote `rdpath`/`rdx` to a short subsection (minor plugin bins moving into artifacts). Remove redundant Schema Output; collapse Policy Options + Configuration into one Policy pointer.
- Kept `Environment Variables` (`RUNDOWN_LOG*` documented only here) and `Template Variables` (linked by skills). No anchors broke.

## Part 2 — load the protocol before `rd run`

**Root cause:** the baseline companion-bootstrap pattern (`writing-runbooks`) instructed run-first, protocol-second. An agent running `rundown:planning` fired `rd run` and immediately hit a delegation-shaped step 1 with neither `running-runbooks` nor `delegating-runbooks` loaded — and `planning` never referenced `delegating-runbooks` despite step 1 being `- DELEGATE`.

- `writing-runbooks`: invert the canonical bootstrap template + prose — load `running-runbooks` first (plus `delegating-runbooks` if the runbook has a `- DELEGATE` step), then `rd run`.
- `planning`, `writing-plans`, `executing-plans`, `converting-skills-to-runbooks`: apply the inverted template.
- `rundown` launcher: add a "load the protocol — before starting" step ahead of `rd run`.
- Add the missing `delegating-runbooks` reference to `planning` (bootstrap steps + Reference). `executing-plans` and `converting-skills-to-runbooks` already referenced it.

## Verification

- Every removed CLAUDE.md command is covered in `cli.md` / `cli-output.md` / `security.md`.
- Spell check passes on all changed files; biome (the repo formatter) does not process markdown.
- Delegating refs added only where the runbook actually delegates (planning: 1, execute-plan: 3); write-plan and convert-skill don't delegate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked CLI docs to highlight `rundown`/`rd`, make JSON output the default, and direct readers to canonical reference/output-schema resources; simplified policy guidance and removed verbose schema examples.
  * Updated multiple runbook/skill instructions to load the execution protocol before starting, corrected orchestration order, standardized run commands, and clarified that agent-driven commands should not use `--text`.
* **Tests**
  * Adjusted documentation assertions to match the updated command snippets, formatting, and required/forbidden flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->