### PR TITLE
feat(core): delegation lifecycle read-model foundation

### DIFF
--- a/packages/core/__tests__/output/schema.test.ts
+++ b/packages/core/__tests__/output/schema.test.ts
@@ -271,6 +271,25 @@ describe('ErrorCodeSchema code registry', () => {
     // CLAIMED_RUNBOOK_UNAVAILABLE and DELEGATION_RESULT_CONFLICT.
     expect(CLIErrorCodes.OPEN_DELEGATED_CHILDREN).toBe('OPEN_DELEGATED_CHILDREN');
   });
+
+  it('accepts DELEGATION_COLLECTION_PENDING for the future collection-pending guard', () => {
+    const message =
+      'A delegated claim has reported an outcome that must be collected by the orchestrator.';
+
+    expect(ErrorCodeSchema.safeParse('DELEGATION_COLLECTION_PENDING').success).toBe(true);
+    expect(
+      ErrorResponseSchema.safeParse({
+        kind: 'error',
+        error: message,
+        code: 'DELEGATION_COLLECTION_PENDING',
+        details: {
+          suggestion:
+            'If you are the delegated agent, stop here. If you are the orchestrator, run rd collect.',
+        },
+      }).success,
+    ).toBe(true);
+    expect(CLIErrorCodes.DELEGATION_COLLECTION_PENDING).toBe('DELEGATION_COLLECTION_PENDING');
+  });
 });
 
 describe('WarningResponseSchema code semantics', () => {

--- a/packages/core/__tests__/runbook/completion-service.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
   assertDelegationTokenHash,
+  lifecycleToDelegationOutcome,
   RunbookActorService,
   RunbookCompletionService,
   RunbookStateManager,
@@ -100,6 +101,14 @@ describe('RunbookCompletionService', () => {
 
   afterEach(async () => {
     await rm(tmp, { recursive: true, force: true });
+  });
+
+  it.each([
+    ['completed', 'pass'],
+    ['stopped', 'fail'],
+    ['running', undefined],
+  ] as const)('maps lifecycle %s to delegation outcome %s', (lifecycle, expectedOutcome) => {
+    expect(lifecycleToDelegationOutcome(lifecycle)).toBe(expectedOutcome);
   });
 
   it('records non-active manual completions with sentinel entry and exact/sentinel duplicate detection', async () => {

--- a/packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts
+++ b/packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts
@@ -192,4 +192,39 @@ describe('readDelegationCollectionPending', () => {
       outcomes: [],
     });
   });
+
+  it('narrows the pending variant to expose operator guidance', () => {
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const parent = state({
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    const model = readDelegationCollectionPending(parent);
+
+    if (!model.pending) {
+      throw new Error('expected collection pending');
+    }
+    expect(model.message).toBe(
+      'A delegated claim has reported an outcome that must be collected by the orchestrator.',
+    );
+    expect(model.outcomes[0]?.outcome).toBe('pass');
+  });
+
+  it('narrows the non-pending variant to an empty outcome list', () => {
+    const model = readDelegationCollectionPending(state());
+
+    if (model.pending) {
+      throw new Error('expected no collection pending');
+    }
+    expect(model.outcomes).toEqual([]);
+  });
 });

--- a/packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts
+++ b/packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  readDelegationCollectionPending,
+  readDelegationOutcomeReportedFacts,
+  type RunbookState,
+} from '../../src/runbook/index.js';
+import {
+  activeFrame,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+  exactFrame,
+  inactiveFrame,
+} from '../../src/runbook/targeting.js';
+import { brandRunIdForTest, brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
+
+const runbookId = brandRunIdForTest('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+
+function state(overrides: Partial<RunbookState> = {}): RunbookState {
+  return {
+    id: runbookId,
+    runbook: { source: 'project', path: 'parent.md' },
+    runbookPath: 'parent.md',
+    step: '1',
+    stepName: 'Parent',
+    substep: '1',
+    retryCount: 0,
+    variables: brandStoredOutputsForTest({}),
+    steps: [],
+    resolvedCompletions: {},
+    frameEntries: { [buildFrameKey('1')]: 1 },
+    activeFrameKey: buildFrameKey('1'),
+    activeEntry: 1,
+    startedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    lifecycle: 'running',
+    schemaVersion: 1,
+    frontmatterOutputs: [],
+    ...overrides,
+  };
+}
+
+describe('readDelegationOutcomeReportedFacts', () => {
+  it('maps delegation completion rows to outcome-reported facts', () => {
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const parent = state({
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          finalVars: { ChildValue: 'ready' },
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationOutcomeReportedFacts(parent)).toEqual([
+      {
+        kind: 'delegation-outcome-reported',
+        completionKey: key,
+        parentRunId: runbookId,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrameKey: buildFrameKey('1'),
+        targetEntry: 1,
+        outcome: 'pass',
+        reportedAt: '2026-01-01T00:00:00.000Z',
+        finalVars: { ChildValue: 'ready' },
+      },
+    ]);
+  });
+
+  it('ignores manual and inline resolved completions', () => {
+    const manualKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const inlineKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '2');
+    const parent = state({
+      resolvedCompletions: {
+        [manualKey]: buildResolvedCompletion({
+          agentId: 'manual',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+        [inlineKey]: buildResolvedCompletion({
+          agentId: 'inline',
+          result: 'fail',
+          targetStep: '1',
+          targetSubstep: '2',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:01.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationOutcomeReportedFacts(parent)).toEqual([]);
+  });
+});
+
+describe('readDelegationCollectionPending', () => {
+  it('derives pending state from active-frame delegation outcomes', () => {
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const parent = state({
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationCollectionPending(parent)).toEqual({
+      kind: 'delegation-collection-pending',
+      pending: true,
+      parentRunId: runbookId,
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      outcomes: [
+        {
+          kind: 'delegation-outcome-reported',
+          completionKey: key,
+          parentRunId: runbookId,
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrameKey: buildFrameKey('1'),
+          targetEntry: 1,
+          outcome: 'pass',
+          reportedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      message:
+        'A delegated claim has reported an outcome that must be collected by the orchestrator.',
+    });
+  });
+
+  it('treats sentinel delegation outcomes for the active frame as pending', () => {
+    const key = buildCompletionKey(inactiveFrame(buildFrameKey('1')), '1');
+    const parent = state({
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'fail',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: inactiveFrame(buildFrameKey('1')),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    const pending = readDelegationCollectionPending(parent);
+
+    expect(pending.pending).toBe(true);
+    expect(pending.outcomes).toEqual([
+      expect.objectContaining({
+        completionKey: key,
+        targetEntry: 0,
+        outcome: 'fail',
+      }),
+    ]);
+  });
+
+  it('does not mark collection pending for a different exact entry', () => {
+    const key = buildCompletionKey(exactFrame(buildFrameKey('1'), 2), '1');
+    const parent = state({
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(buildFrameKey('1'), 2),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationCollectionPending(parent)).toEqual({
+      kind: 'delegation-collection-pending',
+      pending: false,
+      parentRunId: runbookId,
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      outcomes: [],
+    });
+  });
+});

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -42,6 +42,7 @@ const CLISymbolicErrorCodeValues = [
   'CLAIMED_RUNBOOK_UNAVAILABLE',
   'DELEGATION_RESULT_CONFLICT',
   'OPEN_DELEGATED_CHILDREN',
+  'DELEGATION_COLLECTION_PENDING',
   'CHILD_RUN_MISSING',
   'CHILD_LINKAGE_MISMATCH',
   'INVALID_TOKEN',
@@ -97,6 +98,8 @@ export const CLIErrorCodes = {
   DELEGATION_RESULT_CONFLICT: 'DELEGATION_RESULT_CONFLICT',
   /** A bare pass/fail was refused because the active parent has open claimed delegated children */
   OPEN_DELEGATED_CHILDREN: 'OPEN_DELEGATED_CHILDREN',
+  /** A delegated outcome has been reported and must be collected before bare parent advancement */
+  DELEGATION_COLLECTION_PENDING: 'DELEGATION_COLLECTION_PENDING',
   /** Child run state file is missing on disk (transient — pruning may help) */
   CHILD_RUN_MISSING: 'CHILD_RUN_MISSING',
   /** Child runbook's persisted parentLinkage diverges from the freshly token-validated linkage (state corruption — operator intervention required) */

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -19,7 +19,13 @@ import {
   type Frame,
   type FrameKey,
 } from './targeting.js';
-import type { ResolvedCompletion, ResolvedStep, RunId, RunbookState } from './types.js';
+import type {
+  DelegationOutcome,
+  ResolvedCompletion,
+  ResolvedStep,
+  RunId,
+  RunbookState,
+} from './types.js';
 import type { VariableValue } from './effective-vars.js';
 
 /**
@@ -64,24 +70,37 @@ export function brandCurrentCursorResolvedCompletionForTest(
 }
 
 /**
- * Map a runbook lifecycle to the pass/fail result it represents.
+ * Map a delegated run lifecycle to the delegation outcome it reports.
  *
- * This is the canonical mapping the machine's aggregation uses to translate a
- * delegated child's terminal lifecycle into the parent substep result. Reuse it
- * anywhere a child lifecycle must be compared to a pass/fail action (e.g. the
- * idempotent `rd pass/fail --claim-id` conflict check) so the translation stays
- * in lock-step with aggregation.
+ * This is the canonical mapping used when projecting a delegated run terminal
+ * state into the delegating run. Reuse it anywhere a delegated lifecycle must be
+ * compared to a pass/fail command so the translation stays in lock-step with
+ * aggregation.
  *
  * @param lifecycle - Runbook lifecycle value.
  * @returns `'pass'` for `completed`, `'fail'` for `stopped`, otherwise
- *   `undefined` (non-terminal lifecycle values have no result).
+ *   `undefined` (non-terminal lifecycle values have no delegation outcome).
  */
-export function lifecycleToResult(
+export function lifecycleToDelegationOutcome(
   lifecycle: RunbookState['lifecycle'],
-): 'pass' | 'fail' | undefined {
+): DelegationOutcome | undefined {
   if (lifecycle === 'completed') return 'pass';
   if (lifecycle === 'stopped') return 'fail';
   return undefined;
+}
+
+/**
+ * Existing-API wrapper for callers that still use generic result terminology.
+ *
+ * New delegation lifecycle code should call {@link lifecycleToDelegationOutcome}.
+ *
+ * @param lifecycle - Runbook lifecycle value.
+ * @returns Delegation outcome for terminal lifecycles, otherwise `undefined`.
+ */
+export function lifecycleToResult(
+  lifecycle: RunbookState['lifecycle'],
+): DelegationOutcome | undefined {
+  return lifecycleToDelegationOutcome(lifecycle);
 }
 
 /** Completion applied to the machine during a drain pass. */

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -95,7 +95,7 @@ export function lifecycleToDelegationOutcome(
  * New delegation lifecycle code should call {@link lifecycleToDelegationOutcome}.
  *
  * @param lifecycle - Runbook lifecycle value.
- * @returns Delegation outcome for terminal lifecycles, otherwise `undefined`.
+ * @returns Delegation outcome for terminal lifecycle values, otherwise `undefined`.
  */
 export function lifecycleToResult(
   lifecycle: RunbookState['lifecycle'],

--- a/packages/core/src/runbook/delegation-lifecycle-read-model.ts
+++ b/packages/core/src/runbook/delegation-lifecycle-read-model.ts
@@ -1,0 +1,162 @@
+import type { VariableValue } from './effective-vars.js';
+import type { RunId } from './run-id.js';
+import { deriveActiveFrame, SENTINEL_ENTRY, type FrameKey } from './targeting.js';
+import type { DelegationOutcome, RunbookState } from './types.js';
+
+const DELEGATION_AGENT_ID = 'delegation';
+
+/** Message paired with the DELEGATION_COLLECTION_PENDING frontend error code. */
+export const DELEGATION_COLLECTION_PENDING_MESSAGE =
+  'A delegated claim has reported an outcome that must be collected by the orchestrator.';
+
+/**
+ * Pure read model for a reported delegation outcome.
+ *
+ * This is derived from existing `resolvedCompletions` rows whose `agentId` is
+ * `delegation`. It intentionally does not introduce a persisted schema field.
+ */
+export interface DelegationOutcomeReportedFact {
+  /** Read-model discriminant. */
+  readonly kind: 'delegation-outcome-reported';
+  /** Completion key under which the reported outcome is currently persisted. */
+  readonly completionKey: string;
+  /** Delegating run that owns the reported outcome row. */
+  readonly parentRunId: RunId;
+  /** Step that owns the delegated substep. */
+  readonly targetStep: string;
+  /** Delegated substep that reported an outcome. */
+  readonly targetSubstep: string;
+  /** FOR iteration for loop-scoped delegation outcomes. */
+  readonly targetIteration?: number;
+  /** Active or historical frame key for the delegated substep. */
+  readonly targetFrameKey: FrameKey;
+  /** Active, exact, or sentinel entry for the delegated substep frame. */
+  readonly targetEntry: number;
+  /** Delegation outcome projected from the delegated run terminal lifecycle. */
+  readonly outcome: DelegationOutcome;
+  /** ISO timestamp when the outcome was reported. */
+  readonly reportedAt: string;
+  /** Final variables produced by the delegated run. */
+  readonly finalVars?: Readonly<Record<string, VariableValue>>;
+}
+
+/** Pure read model for collection-pending state at the delegating run's active scope. */
+export type DelegationCollectionPendingReadModel =
+  | {
+      /** Read-model discriminant. */
+      readonly kind: 'delegation-collection-pending';
+      /** Whether the active scope has unconsumed reported delegation outcomes. */
+      readonly pending: true;
+      /** Delegating run that may need collection. */
+      readonly parentRunId: RunId;
+      /** Active frame key used to derive collection scope. */
+      readonly activeFrameKey: FrameKey;
+      /** Active entry used to derive collection scope. */
+      readonly activeEntry: number;
+      /** Reported outcomes in the active collection scope. */
+      readonly outcomes: readonly DelegationOutcomeReportedFact[];
+      /** Operator-facing guidance for frontend error rendering. */
+      readonly message: typeof DELEGATION_COLLECTION_PENDING_MESSAGE;
+    }
+  | {
+      /** Read-model discriminant. */
+      readonly kind: 'delegation-collection-pending';
+      /** No unconsumed reported delegation outcomes exist in the active scope. */
+      readonly pending: false;
+      /** Delegating run that was inspected. */
+      readonly parentRunId: RunId;
+      /** Active frame key used to derive collection scope. */
+      readonly activeFrameKey: FrameKey;
+      /** Active entry used to derive collection scope. */
+      readonly activeEntry: number;
+      /** Empty when no collection is pending. */
+      readonly outcomes: readonly [];
+    };
+
+/**
+ * Read reported delegation outcomes from existing completion rows.
+ *
+ * @param state - Delegating run state to inspect
+ * @returns Reported delegation outcome facts sorted by persisted completion key
+ */
+export function readDelegationOutcomeReportedFacts(
+  state: RunbookState,
+): readonly DelegationOutcomeReportedFact[] {
+  return Object.entries(state.resolvedCompletions ?? {})
+    .filter(
+      ([, completion]) =>
+        completion.agentId === DELEGATION_AGENT_ID && completion.targetSubstep !== undefined,
+    )
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([completionKey, completion]) => ({
+      kind: 'delegation-outcome-reported',
+      completionKey,
+      parentRunId: state.id,
+      targetStep: completion.targetStep,
+      targetSubstep: completion.targetSubstep as string,
+      ...(completion.targetIteration !== undefined
+        ? { targetIteration: completion.targetIteration }
+        : {}),
+      targetFrameKey: completion.targetFrameKey,
+      targetEntry: completion.targetEntry,
+      outcome: completion.result,
+      reportedAt: completion.completedAt,
+      ...(completion.finalVars ? { finalVars: completion.finalVars } : {}),
+    }));
+}
+
+function activeEntryFor(state: RunbookState, activeFrameKey: FrameKey): number {
+  return state.activeEntry ?? state.frameEntries?.[activeFrameKey] ?? 1;
+}
+
+function belongsToActiveCollectionScope(
+  fact: DelegationOutcomeReportedFact,
+  activeFrameKey: FrameKey,
+  activeEntry: number,
+): boolean {
+  // Provisional Plan 1 scope rule: report all delegation outcomes, but mark
+  // collection pending only for the active cursor frame/entry until the
+  // command-policy plan resolves wider enforcement semantics.
+  return (
+    fact.targetFrameKey === activeFrameKey &&
+    (fact.targetEntry === activeEntry || fact.targetEntry === SENTINEL_ENTRY)
+  );
+}
+
+/**
+ * Derive collection-pending state for the delegating run's active scope.
+ *
+ * @param state - Delegating run state to inspect
+ * @returns Collection-pending read model for the active frame and entry
+ */
+export function readDelegationCollectionPending(
+  state: RunbookState,
+): DelegationCollectionPendingReadModel {
+  const derived = deriveActiveFrame(state);
+  const activeFrameKey = state.activeFrameKey ?? derived.frameKey;
+  const activeEntry = activeEntryFor(state, activeFrameKey);
+  const outcomes = readDelegationOutcomeReportedFacts(state).filter((fact) =>
+    belongsToActiveCollectionScope(fact, activeFrameKey, activeEntry),
+  );
+
+  if (outcomes.length === 0) {
+    return {
+      kind: 'delegation-collection-pending',
+      pending: false,
+      parentRunId: state.id,
+      activeFrameKey,
+      activeEntry,
+      outcomes: [],
+    };
+  }
+
+  return {
+    kind: 'delegation-collection-pending',
+    pending: true,
+    parentRunId: state.id,
+    activeFrameKey,
+    activeEntry,
+    outcomes,
+    message: DELEGATION_COLLECTION_PENDING_MESSAGE,
+  };
+}

--- a/packages/core/src/runbook/delegation-lifecycle-read-model.ts
+++ b/packages/core/src/runbook/delegation-lifecycle-read-model.ts
@@ -93,7 +93,7 @@ export function readDelegationOutcomeReportedFacts(
       completionKey,
       parentRunId: state.id,
       targetStep: completion.targetStep,
-      targetSubstep: completion.targetSubstep as string,
+      targetSubstep: completion.targetSubstep!,
       ...(completion.targetIteration !== undefined
         ? { targetIteration: completion.targetIteration }
         : {}),

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -196,6 +196,13 @@ export {
   readConsumedDelegationClosureForCwd,
 } from './delegation-service.js';
 export {
+  DELEGATION_COLLECTION_PENDING_MESSAGE,
+  readDelegationCollectionPending,
+  readDelegationOutcomeReportedFacts,
+  type DelegationCollectionPendingReadModel,
+  type DelegationOutcomeReportedFact,
+} from './delegation-lifecycle-read-model.js';
+export {
   DELEGATION_CLAIM_MARKER,
   DELEGATION_TOKEN_PATTERN,
   DELEGATION_TOKEN_HASH_PATTERN,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -89,6 +89,7 @@ export { readActiveRunScope, type ActiveRunScope } from './session-reader.js';
 export { ExecutionLifecycleService } from './execution-lifecycle-service.js';
 export {
   RunbookCompletionService,
+  lifecycleToDelegationOutcome,
   lifecycleToResult,
   type AppliedResolvedCompletion,
   type CompletionTargetMismatch,

--- a/packages/core/src/runbook/types.ts
+++ b/packages/core/src/runbook/types.ts
@@ -165,6 +165,15 @@ export type JsonObject = { readonly [key: string]: JsonValue };
  */
 export type JsonArray = readonly JsonValue[];
 
+/**
+ * Outcome projected from a delegated run terminal state into its delegating run.
+ *
+ * The literals intentionally match step results (`pass` / `fail`), but this
+ * alias marks the delegation lifecycle boundary so new APIs do not use generic
+ * "result" language when they mean a reported delegation outcome.
+ */
+export type DelegationOutcome = 'pass' | 'fail';
+
 // Unexported — only createJsonArrayStream in this module can set this property.
 // JSON.parse/stringify silently drops Symbol keys, so user-supplied --var-json
 // objects can never carry this brand regardless of their shape.


### PR DESCRIPTION
## Summary

Foundational read-model layer for the delegation collection lifecycle. Introduces a pure, derived view over existing `resolvedCompletions` rows so the orchestrator can detect delegated outcomes awaiting collection — without adding any persisted schema field.

## Changes

- **`DelegationOutcome` type** (`types.ts`) — `'pass' | 'fail'` alias marking the delegation lifecycle boundary, so new APIs avoid generic "result" language when they mean a reported delegation outcome.
- **`lifecycleToDelegationOutcome`** (`completion-service.ts`) — canonical mapping from a delegated run's terminal lifecycle (`completed`→`pass`, `stopped`→`fail`, otherwise `undefined`); `lifecycleToResult` retained as an existing-API wrapper.
- **`delegation-lifecycle-read-model.ts`** (new) — pure read model:
  - `readDelegationOutcomeReportedFacts` projects `delegation`-agent completion rows into typed outcome facts.
  - `readDelegationCollectionPending` derives a discriminated `pending: true | false` view scoped to the active frame/entry (sentinel-aware).
  - No persisted schema field introduced — derived entirely from existing state.
- **`DELEGATION_COLLECTION_PENDING` error code** (`zod-schemas.ts`) — registered for the future collection-pending guard.
- **Exports** wired through `runbook/index.ts`.

## Notes

- The active-scope rule in `belongsToActiveCollectionScope` is an explicitly-marked provisional ("Plan 1") placeholder pending the command-policy plan; it is not the final enforcement semantics.
- Adheres to the no-migration principle: this is a read model over current state, with no schema version bump.

## Testing

- New unit tests for the read model (outcome-fact projection, active/sentinel/exact-entry scoping, variant narrowing).
- Lifecycle→outcome mapping table test in `completion-service.test.ts`.
- Error-code registry test for `DELEGATION_COLLECTION_PENDING`.
- CodeRabbit review on the branch diff: **0 findings**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delegation collection pending status tracking and reporting capability.
  * Added new `DELEGATION_COLLECTION_PENDING` error code.

* **Tests**
  * Added comprehensive test coverage for delegation outcomes, lifecycle mapping, and collection pending state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->