### PR TITLE
feat(core): own delegation collection operation (Plan 4)

### DIFF
--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -351,14 +351,15 @@ describe('collect command', () => {
     /**
      * Issue 4 coverage: prove the aggregation code path actually runs.
      *
-     * With `FAIL ANY STOP` aggregation and mixed pass/fail results, the
-     * emitted `STEP_TRANSITIONED` event must carry `aggregated: true`. The
-     * compiler tags all actions produced by the parent-exit aggregation
-     * state with this flag (see `packages/core/src/runbook/compiler.ts`,
-     * lines ~808–852), so its presence is a direct proof that the
-     * aggregation path fired — not just a per-substep DEFER.
+     * With `FAIL ANY STOP` aggregation and mixed pass/fail results, the run must
+     * reach a terminal `stopped` lifecycle — a per-substep DEFER would leave it
+     * `running`. After collection moved into core (Plan 4), `rd collect` renders
+     * a typed outcome rather than streaming per-transition `STEP_TRANSITIONED`
+     * events, so aggregation is proven via the `status: 'applied'` envelope's
+     * `lifecycle: 'stopped'` (and the non-zero exit) instead of an
+     * `aggregated: true` event flag.
      */
-    it('emits aggregated=true on the transition event when aggregation fires', async () => {
+    it('drives the run to a stopped lifecycle when FAIL ANY aggregation fires', async () => {
       await setupReadyToCollect(['pass', 'fail']);
 
       const result = await runCliInProcess(['collect'], workspace);
@@ -366,31 +367,73 @@ describe('collect command', () => {
       // FAIL ANY STOP aggregation on a mixed result stops the runbook.
       expect(result.exitCode).not.toBe(0);
 
-      // Find the STEP_TRANSITIONED event in the JSON stream. The event's
-      // `aggregated` field is only set to true by the aggregation code path.
-      const lines = result.stdout.trim().split('\n').filter(Boolean);
-      const events = lines
-        .map((line) => {
-          try {
-            return JSON.parse(line) as Record<string, unknown>;
-          } catch {
-            return null;
-          }
-        })
-        .filter((e): e is Record<string, unknown> => e !== null);
+      const parsed = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+      expect(parsed).toMatchObject({
+        kind: 'collect',
+        action: 'collect',
+        status: 'applied',
+        lifecycle: 'stopped',
+      });
+      expect(CollectResponseSchema.safeParse(parsed).success).toBe(true);
+    });
+  });
 
-      // Find the aggregated step_transitioned — there may be earlier
-      // non-aggregated step_transitioned events for the deferred substeps.
-      const aggregatedEvent = events.find(
-        (e) => e.type === 'step_transitioned' && e.aggregated === true,
-      );
-      expect(aggregatedEvent).toBeDefined();
-      expect(aggregatedEvent!.action).toBe('STOP');
-      expect(aggregatedEvent!.result).toBe('FAIL');
+  describe('applied JSON contract', () => {
+    /**
+     * Pin the explicit `status: 'applied'` success envelope emitted by a bare
+     * `rd collect` (JSON default mode). With `PASS ALL CONTINUE` and two passing
+     * substeps the aggregation fires CONTINUE and the run stays `running` on the
+     * advanced step — observed values: applied 2, unresolved 0, lifecycle
+     * 'running', reportedTerminalOutcome false, exit 0.
+     */
+    it('emits an applied JSON envelope for a successful bare collect', async () => {
+      await setupReadyToCollect(['pass', 'pass']);
+
+      const result = await runCliInProcess(['collect'], workspace);
+      expect(result.exitCode).toBe(0);
+
+      const parsed = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+      expect(parsed).toMatchObject({
+        kind: 'collect',
+        action: 'collect',
+        status: 'applied',
+        applied: 2,
+        unresolved: 0,
+        lifecycle: 'running',
+        reportedTerminalOutcome: false,
+      });
+      expect(parsed.parentRunId).toMatch(/^rd_[a-f0-9]{32}$/);
+      expect(CollectResponseSchema.safeParse(parsed).success).toBe(true);
     });
   });
 
   describe('already-aggregated behavior', () => {
+    /**
+     * Additive contract: the second bare `collect` (JSON mode) reports the
+     * idempotent no-op as `status: 'already-aggregated'` AND carries the new
+     * `code: 'COLLECT_ALREADY_APPLIED'` annotation. Exit 0; schema accepts it.
+     */
+    it('emits already-aggregated JSON with COLLECT_ALREADY_APPLIED code on the second invocation', async () => {
+      await setupReadyToCollect(['pass', 'pass']);
+
+      const first = await runCliInProcess(['collect'], workspace);
+      expect(first.exitCode).toBe(0);
+      expect((await getActiveState(workspace))?.step).toBe('2');
+
+      const second = await runCliInProcess(['collect'], workspace);
+      expect(second.exitCode).toBe(0);
+
+      const json = parseConcatenatedJson(second.stdout).at(-1) as Record<string, unknown>;
+      expect(json).toMatchObject({
+        kind: 'collect',
+        action: 'collect',
+        status: 'already-aggregated',
+        code: 'COLLECT_ALREADY_APPLIED',
+      });
+      expect(typeof json.parentRunId).toBe('string');
+      expect(CollectResponseSchema.safeParse(json).success).toBe(true);
+    });
+
     /**
      * Running `rd collect` twice must surface a visible, non-error outcome.
      * After the first collect succeeds (parent advances to step 2), the
@@ -837,6 +880,47 @@ describe('collect command', () => {
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stdout + result.stderr).toMatch(/not all substeps/i);
+    });
+
+    it('emits a SUBSTEPS_NOT_RESOLVED error envelope (JSON) when substeps are not all resolved', async () => {
+      // Set up DELEGATE runbook, but only mark ONE substep resolved (the other
+      // stays pending), then collect in JSON default mode.
+      const childContent = createRunbook({
+        title: 'Child',
+        steps: [{ title: 'Do work', pass: 'COMPLETE', command: 'rd echo --result pass' }],
+      });
+      await writeFile(join(workspace.cwd, 'runbooks', 'child.runbook.md'), childContent);
+      await writeFile(join(workspace.runbooksDir(), 'child.runbook.md'), childContent);
+
+      await writeFile(
+        join(workspace.cwd, 'runbooks', 'parent.runbook.md'),
+        buildParentDelegateMarkdown(),
+      );
+
+      const startResult = await runCliInProcess(
+        'run --prompted runbooks/parent.runbook.md --text',
+        workspace,
+      );
+      expect(startResult.exitCode).toBe(0);
+
+      const runbookId = (await getActiveState(workspace))!.id;
+      const statePath = join(workspace.statePath(), `${runbookId}.json`);
+      const raw = JSON.parse(await readFile(statePath, 'utf-8')) as MutableRunbookState;
+      const frameKey = (raw.activeFrameKey ?? `${raw.step}|`) as string;
+      raw.substepStates = [
+        { id: '1', frameKey, status: 'done', result: 'pass' },
+        { id: '2', frameKey, status: 'pending' },
+      ];
+      await writeFile(statePath, JSON.stringify(raw, null, 2));
+
+      const result = await runCliInProcess(['collect'], workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
+      expect(json).toMatchObject({ kind: 'error', code: 'SUBSTEPS_NOT_RESOLVED' });
+      const details = json.details as Record<string, unknown> | undefined;
+      expect(Array.isArray(details?.missingSubsteps)).toBe(true);
+      expect((details?.missingSubsteps as unknown[]).length).toBeGreaterThan(0);
     });
 
     it('errors when no active runbook', async () => {

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -906,7 +906,7 @@ describe('collect command', () => {
       const runbookId = (await getActiveState(workspace))!.id;
       const statePath = join(workspace.statePath(), `${runbookId}.json`);
       const raw = JSON.parse(await readFile(statePath, 'utf-8')) as MutableRunbookState;
-      const frameKey = (raw.activeFrameKey ?? `${raw.step}|`) as string;
+      const frameKey = raw.activeFrameKey ?? `${raw.step}|`;
       raw.substepStates = [
         { id: '1', frameKey, status: 'done', result: 'pass' },
         { id: '2', frameKey, status: 'pending' },

--- a/packages/cli/__tests__/commands/schema-validation.test.ts
+++ b/packages/cli/__tests__/commands/schema-validation.test.ts
@@ -159,6 +159,14 @@ describe('CLI JSON Output Schema Validation', () => {
         step: '1',
         parentRunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       };
+      const alreadyAggregatedWithCode = {
+        kind: 'collect',
+        action: 'collect',
+        status: 'already-aggregated',
+        step: '1',
+        parentRunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        code: 'COLLECT_ALREADY_APPLIED',
+      };
       const notActive = {
         kind: 'collect',
         action: 'collect',
@@ -169,9 +177,21 @@ describe('CLI JSON Output Schema Validation', () => {
         activeFrameKey: '1|',
         unresolved: 1,
       };
+      const applied = {
+        kind: 'collect',
+        action: 'collect',
+        status: 'applied',
+        parentRunId: 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        applied: 2,
+        unresolved: 0,
+        lifecycle: 'running',
+        reportedTerminalOutcome: false,
+      };
 
       expect(validateCollectOutput(alreadyAggregated)).toEqual({ valid: true, errors: [] });
+      expect(validateCollectOutput(alreadyAggregatedWithCode)).toEqual({ valid: true, errors: [] });
       expect(validateCollectOutput(notActive)).toEqual({ valid: true, errors: [] });
+      expect(validateCollectOutput(applied)).toEqual({ valid: true, errors: [] });
     });
   });
 

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -693,18 +693,25 @@ describe('handleParentCompletion', () => {
     expect(result).toBe('stopped');
   });
 
-  it('cascades to grandparent when parent completes', async () => {
+  it('reports a terminal parent upward exactly one level (no recursion into grandparent)', async () => {
+    // child → parent (terminal) → grandparent. Draining drives the parent to a
+    // terminal `done`; the helper records ONE outcome upward onto the
+    // grandparent via `reportTerminalParentUpward` but does NOT drain or run
+    // the execution loop for the grandparent (single-level propagation, Plan 4).
     const delegation = makeDelegationLinkage();
     const childState = makeState(CHILD_RUN_ID, { parentLinkage: delegation });
     const grandparentDelegation = makeDelegationLinkage({
       parentRunId: GRANDPARENT_RUN_ID,
       parentStepId: '2',
     });
+    // The parent itself has a parentLinkage (the grandparent), so reaching a
+    // terminal state triggers the single upward report.
     const parentState = makeState(PARENT_RUN_ID, {
       substepStates: [{ id: '1', frameKey: brandFrameKeyForTest('1'), status: 'pending' }],
       parentLinkage: grandparentDelegation,
     });
     const grandparentState = makeState(GRANDPARENT_RUN_ID, {
+      step: '2',
       substepStates: [{ id: '2', frameKey: brandFrameKeyForTest('1'), status: 'pending' }],
     });
 
@@ -717,7 +724,7 @@ describe('handleParentCompletion', () => {
     const lifecycleService = makeLifecycleService();
     const output = makeOutput();
 
-    wireMocks(manager, lifecycleService);
+    const recordChildCompletion = wireMocks(manager, lifecycleService);
 
     jest.mocked(drainResolvedCompletions).mockResolvedValue({
       unresolved: 0,
@@ -725,24 +732,36 @@ describe('handleParentCompletion', () => {
       applied: 1,
     });
 
-    await handleParentCompletion(childState, 'pass', '/test', output);
-
-    // Should cascade through the core completion service for parent and grandparent.
-    expect(core.RunbookCompletionService).toHaveBeenCalledTimes(2);
-  });
-
-  it('respects maximum recursion depth', async () => {
-    const delegation = makeDelegationLinkage();
-    const childState = makeState(CHILD_RUN_ID, { parentLinkage: delegation });
-    const output = makeOutput();
-
-    // Call with depth already at limit
-    const result = await handleParentCompletion(childState, 'pass', '/test', output, 32);
+    const result = await handleParentCompletion(childState, 'pass', '/test', output);
 
     expect(result).toBe('handled');
-    // Should not even acquire lock
-    const MockLock = core.DelegationLock as jest.MockedClass<typeof core.DelegationLock>;
-    expect(MockLock).not.toHaveBeenCalled();
+
+    // The shared core completion service is constructed once; the helper calls
+    // recordChildCompletion twice through it: once for child → parent, and once
+    // for the single upward report parent → grandparent.
+    expect(core.RunbookCompletionService).toHaveBeenCalledTimes(1);
+    expect(recordChildCompletion).toHaveBeenCalledTimes(2);
+    // First call: the child's completion onto the parent.
+    expect(recordChildCompletion).toHaveBeenNthCalledWith(1, {
+      childState,
+      result: 'pass',
+    });
+    // Second call: the terminal parent reported ONE level upward to the
+    // grandparent. `childState` is the freshly reloaded parent and the result
+    // matches the parent's terminal outcome (`done` → 'pass').
+    expect(recordChildCompletion).toHaveBeenNthCalledWith(2, {
+      childState: parentState,
+      result: 'pass',
+    });
+
+    // Single-level invariant: the grandparent is NOT drained or looped — the
+    // drain ran exactly once (for the immediate parent) and the execution loop
+    // was never invoked for a second level.
+    expect(drainResolvedCompletions).toHaveBeenCalledTimes(1);
+    expect(drainResolvedCompletions).toHaveBeenCalledWith(
+      expect.objectContaining({ runbookId: PARENT_RUN_ID }),
+    );
+    expect(runExecutionLoop).not.toHaveBeenCalled();
   });
 
   it('passes delegation-specific releaseRunbook:false policy to drain', async () => {

--- a/packages/cli/__tests__/services/schema-coverage.test.ts
+++ b/packages/cli/__tests__/services/schema-coverage.test.ts
@@ -78,6 +78,14 @@ describe('Schema Coverage', () => {
       step: '1',
       parentRunId: 'run-123',
     };
+    const alreadyAggregatedWithCode = {
+      kind: 'collect',
+      action: 'collect',
+      status: 'already-aggregated',
+      step: '1',
+      parentRunId: 'run-123',
+      code: 'COLLECT_ALREADY_APPLIED',
+    };
     const notActive = {
       kind: 'collect',
       action: 'collect',
@@ -88,12 +96,26 @@ describe('Schema Coverage', () => {
       activeFrameKey: '1|',
       unresolved: 1,
     };
+    const applied = {
+      kind: 'collect',
+      action: 'collect',
+      status: 'applied',
+      parentRunId: 'run-123',
+      applied: 2,
+      unresolved: 0,
+      lifecycle: 'running',
+      reportedTerminalOutcome: false,
+    };
 
     expect(JSON_OUTPUT_COMMANDS).toContain('collect');
     expect(CollectResponseSchema.safeParse(alreadyAggregated).success).toBe(true);
+    expect(CollectResponseSchema.safeParse(alreadyAggregatedWithCode).success).toBe(true);
     expect(CollectResponseSchema.safeParse(notActive).success).toBe(true);
+    expect(CollectResponseSchema.safeParse(applied).success).toBe(true);
     expect(COMMAND_SCHEMAS.collect.safeParse(alreadyAggregated).success).toBe(true);
+    expect(COMMAND_SCHEMAS.collect.safeParse(alreadyAggregatedWithCode).success).toBe(true);
     expect(COMMAND_SCHEMAS.collect.safeParse(notActive).success).toBe(true);
+    expect(COMMAND_SCHEMAS.collect.safeParse(applied).success).toBe(true);
   });
 
   it('keeps action commands accepting normal action responses', () => {

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -4,28 +4,22 @@ import type { Command } from 'commander';
 import {
   activeFrame,
   buildFrameKey,
+  claimControllerContext,
   deriveActiveFrame,
-  findSubstepState,
   inactiveFrame,
-  isPostDelegateAggregationCursor,
-  resolveCommandIntent,
+  RunbookCollectionService,
+  RunbookCompletionService,
   trustedRunControllerContext,
-  type CommandTargetSelector,
+  type ActorContext,
+  type DelegationPolicyOutcome,
   type Frame,
   type FrameKey,
 } from '@rundown-org/core';
-import { parseStepIdFromString, resolvedStepHasSubsteps } from '@rundown-org/parser';
+import { parseStepIdFromString } from '@rundown-org/parser';
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
-import {
-  buildTransitionContext,
-  createPassTransitionConfig,
-  type TransitionContext,
-} from '../helpers/transitions.js';
-import { handleParentCompletion, extractParentLinkage } from '../helpers/delegation-completion.js';
-import { createBridgedEmitter } from '../helpers/execution-emitter.js';
-import { drainResolvedCompletions, runExecutionLoop } from '../services/execution.js';
+import { buildTransitionContext, type TransitionContext } from '../helpers/transitions.js';
 import { resolveIndexOption, IndexOptionError } from '../helpers/index-option.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
 
@@ -86,14 +80,10 @@ export function registerCollectCommand(program: Command): void {
             }
             const ctx = contextResult.ctx;
 
-            const shouldExitWithError = await runCollect(ctx, cwd, {
+            const shouldExitWithError = await runCollect(ctx, {
               step: options.step,
               index: options.index,
               text: options.text,
-              targetSelector:
-                claimTarget.claimId !== undefined
-                  ? { kind: 'claim', claimId: claimTarget.claimId }
-                  : { kind: 'default' },
             });
 
             if (shouldExitWithError) {
@@ -114,8 +104,6 @@ interface CollectOptions {
   index?: string;
   /** True when `--text` is set (human-readable); false/undefined for JSON. */
   text?: boolean;
-  /** Resolved target selector: claim-id when supplied, otherwise default. */
-  targetSelector: CommandTargetSelector;
 }
 
 /**
@@ -197,35 +185,108 @@ function resolveCollectScope(
 }
 
 /**
- * Execute the collect workflow against a resolved transition context.
+ * Render a core {@link DelegationPolicyOutcome} onto the CLI's collect output
+ * contract. JSON is the agent-facing contract (CLAUDE.md § CLI Output
+ * Standards); `--text` emits the equivalent human message for the non-error
+ * statuses (`output.error` already honors text mode for the error arms).
  *
- * @param ctx - Transition context for the active runbook
- * @param cwd - Current working directory
- * @param options - Targeting flags forwarded from the CLI, including the resolved
- *   target selector used for the command-policy orchestrator gate
- * @returns True if the command should set a non-zero exit code
+ * @param output - Output emitter (constructed with the caller's `--text` flag)
+ * @param outcome - Core collection outcome to render
+ * @param text - True when `--text` was supplied (human-readable mode)
+ * @returns True when the command should set a non-zero exit code
  */
-async function runCollect(
-  ctx: TransitionContext,
-  cwd: string,
-  options: CollectOptions,
-): Promise<boolean> {
-  const { output, manager, actorService, sessionService, lifecycleService, state, steps } = ctx;
-
-  const policy = resolveCommandIntent({
-    actorContext: trustedRunControllerContext(state.id, 'direct-cli'),
-    intent: { kind: 'delegation-collection' },
-    targetSelector: options.targetSelector,
-    targetState: state,
-  });
-  switch (policy.kind) {
+function renderCollectOutcome(
+  output: OutputEmitter,
+  outcome: DelegationPolicyOutcome,
+  text: boolean | undefined,
+): boolean {
+  switch (outcome.kind) {
     case 'allowed':
-      break;
+      // Unreachable: collectDelegationOutcomes never returns the raw `allowed`
+      // policy member — it proceeds to apply and returns a collection outcome.
+      throw new Error('Unexpected raw allowed outcome from collection');
+    case 'collection_applied':
+      if (!text) {
+        output.json({
+          kind: 'collect',
+          action: 'collect',
+          status: 'applied',
+          parentRunId: outcome.targetRunId,
+          applied: outcome.applied,
+          unresolved: outcome.unresolved,
+          lifecycle: outcome.lifecycle,
+          reportedTerminalOutcome: outcome.reportedTerminalOutcome,
+        });
+      } else {
+        output.message(
+          `Collected ${String(outcome.applied)} delegation outcome(s) on step ${outcome.step} ` +
+            `(${String(outcome.unresolved)} unresolved; lifecycle ${outcome.lifecycle}).`,
+          'success',
+        );
+      }
+      output.flush();
+      // A FAIL-aggregation that drove the run to a terminal STOP exits non-zero,
+      // preserving the merged collect exit-code contract; COMPLETE/running exit 0.
+      return outcome.lifecycle === 'stopped';
+    case 'already_collected':
+      // Non-breaking: keep the merged `already-aggregated` status string; add
+      // the new COLLECT_ALREADY_APPLIED code as an extra field only.
+      if (!text) {
+        output.json({
+          kind: 'collect',
+          action: 'collect',
+          status: 'already-aggregated',
+          parentRunId: outcome.targetRunId,
+          step: outcome.step,
+          code: 'COLLECT_ALREADY_APPLIED',
+        });
+      } else {
+        output.message(
+          `Already aggregated: step ${outcome.step} has no unapplied delegation outcomes.`,
+          'info',
+        );
+      }
+      output.flush();
+      return false;
+    case 'collection_frame_not_active':
+      // Distinct from `already_collected`: render the existing `not-active`
+      // payload faithfully (status string + frameKey/activeFrameKey/unresolved).
+      // This is a non-error, exit-0 observation.
+      if (!text) {
+        output.json({
+          kind: 'collect',
+          action: 'collect',
+          status: 'not-active',
+          parentRunId: outcome.targetRunId,
+          step: outcome.step,
+          frameKey: outcome.frameKey,
+          activeFrameKey: outcome.activeFrameKey,
+          unresolved: outcome.unresolved,
+        });
+      } else {
+        output.message(
+          `Frame not active: step ${outcome.step} requested frame ${outcome.frameKey} ` +
+            `but cursor is on ${outcome.activeFrameKey}.`,
+          'info',
+        );
+      }
+      output.flush();
+      return false;
+    case 'missing_outcomes':
+      // Map to the existing user-facing code (collect.test.ts asserts it).
+      output.error(
+        `Cannot collect: not all substeps are resolved. Pending: ${outcome.missingSubsteps.join(', ')}.`,
+        'SUBSTEPS_NOT_RESOLVED',
+        { parentRunId: outcome.targetRunId, missingSubsteps: outcome.missingSubsteps },
+      );
+      output.flush();
+      return true;
     case 'actor_context_required':
+      // The merged `actor_context_required` member carries `{ kind; intent }`
+      // and has NO `targetRunId` field — do not read one off `outcome`.
       output.error(
         'Actor context is required to collect delegation outcomes.',
         'ACTOR_CONTEXT_REQUIRED',
-        { targetRunId: state.id },
       );
       output.flush();
       return true;
@@ -233,230 +294,76 @@ async function runCollect(
       output.error(
         'rd collect requires an actor that controls the target delegating run.',
         'COLLECT_REQUIRES_ORCHESTRATOR',
-        { targetRunId: policy.targetRunId },
+        { targetRunId: outcome.targetRunId },
       );
+      output.flush();
+      return true;
+    case 'collection_failed':
+      // Flat passthrough: core attached the user-facing `code` on the outcome
+      // (no CLI reason→code ternary — keeps "no CLI lifecycle decisions" and
+      // type-driven dispatch intact). `outcome.code` is already one of
+      // `NOT_DELEGATE_STEP` / `STEP_NOT_FOUND` / `COLLECT_OPERATION_FAILED`.
+      output.error(outcome.message, outcome.code, { parentRunId: outcome.targetRunId });
       output.flush();
       return true;
     case 'delegation_collection_pending':
     case 'open_claims':
-      throw new Error(`Unexpected collect policy outcome: ${policy.kind}`);
+      throw new Error(`Unexpected collect policy outcome: ${outcome.kind}`);
     default: {
-      const _exhaustive: never = policy;
+      const _exhaustive: never = outcome;
       return _exhaustive;
     }
   }
+}
+
+/**
+ * Execute the collect workflow against a resolved transition context.
+ *
+ * The CLI is a thin adapter: it parses flags, constructs the actor context, and
+ * delegates the collection operation to core's {@link RunbookCollectionService}.
+ * All collection logic (policy gating, drain, aggregation, single-level terminal
+ * reporting) lives in core; this command only renders the returned outcome.
+ *
+ * @param ctx - Transition context for the active runbook
+ * @param options - Targeting flags forwarded from the CLI
+ * @returns True if the command should set a non-zero exit code
+ */
+async function runCollect(ctx: TransitionContext, options: CollectOptions): Promise<boolean> {
+  const { output, manager, actorService, lifecycleService, state, steps } = ctx;
 
   const scope = resolveCollectScope(state, options, output);
   if (!scope) return true;
 
-  const currentStep = steps.find((s) => s.name === scope.stepName);
-  if (!currentStep) {
-    // A missing step is stale/corrupted state — never a valid idempotent
-    // no-op. Fail fast (mirrors `rd pop`) instead of collapsing into the
-    // `already-aggregated` success branch below, which would mask the invalid
-    // state. See CLAUDE.md § State Persistence: detect invalid state, never
-    // silently adapt it.
-    output.error(
-      `Step ${scope.stepName} not found in the loaded runbook; state may be stale or corrupted.`,
-      'STEP_NOT_FOUND',
-      { parentRunId: state.id },
-    );
-    output.flush();
-    return true;
-  }
-  const delegateSubsteps = resolvedStepHasSubsteps(currentStep)
-    ? currentStep.substeps.filter((sub) => sub.delegate)
-    : [];
+  // On the claim-targeted path `ctx.state` is the claimed child run, so
+  // `controlledRunId === state.id`; otherwise the trusted direct-CLI mapping
+  // makes the run controller the orchestrator for its own run.
+  const actorContext: ActorContext = ctx.claim
+    ? claimControllerContext({
+        claimId: ctx.claim.claimId,
+        tokenHash: ctx.claim.tokenHash,
+        controlledRunId: state.id,
+      })
+    : trustedRunControllerContext(state.id, 'direct-cli');
 
-  if (delegateSubsteps.length === 0) {
-    // Bare `rd collect` infers the cursor. If aggregation already fired
-    // automatically (e.g. delegated children completed and advanced the
-    // cursor past the DELEGATE step), the postcondition holds — report an
-    // idempotent no-op instead of erroring. An explicit `--step` that names a
-    // non-DELEGATE step is a genuine misuse and still errors.
-    //
-    // The idempotent status is gated on a core-derived structural signal:
-    // the cursor's document-order predecessor is an aggregated DELEGATE step.
-    // This is narrower than "any delegation exists somewhere in the run" — it
-    // distinguishes a genuine post-aggregation successor from an ordinary,
-    // unrelated non-DELEGATE step the cursor later advanced onto, where a bare
-    // collect is misuse and must still error. The signal is runbook logic and
-    // lives in core (see isPostDelegateAggregationCursor).
-    if (!options.step && isPostDelegateAggregationCursor(state, steps)) {
-      if (!options.text) {
-        output.json({
-          kind: 'collect',
-          action: 'collect',
-          status: 'already-aggregated',
-          step: scope.stepName,
-          parentRunId: state.id,
-        });
-      } else {
-        output.message(
-          `Already aggregated: step ${scope.stepName} is not an active DELEGATE step.`,
-          'info',
-        );
-      }
-      output.flush();
-      return false;
-    }
-    output.error(
-      `Step ${scope.stepName} is not a DELEGATE step. rd collect requires a step with - DELEGATE substeps.`,
-      'NOT_DELEGATE_STEP',
-    );
-    output.flush();
-    return true;
-  }
-
-  // Verify all DELEGATE substeps are resolved (status === 'done') in the target frame.
-  const frameKey: FrameKey = scope.frameKey;
-  const substepStates = state.substepStates ?? [];
-  const pending = delegateSubsteps.filter((sub) => {
-    const ss = findSubstepState(substepStates, sub.id, frameKey);
-    return ss?.status !== 'done';
-  });
-
-  if (pending.length > 0) {
-    const ids = pending.map((sub) => `${scope.stepName}.${sub.id}`).join(', ');
-    output.error(
-      `Cannot collect: not all substeps are resolved. Pending: ${ids}.`,
-      'SUBSTEPS_NOT_RESOLVED',
-    );
-    output.flush();
-    return true;
-  }
-
-  // Transition config is a per-substep envelope, not an aggregation decision:
-  // drainResolvedCompletions fires a PASS or FAIL event for each substep based
-  // on that substep's OWN persisted `result` (see applyDrainedCompletion in
-  // services/execution.ts). The config's `policy` and `computeActionResult`
-  // fields are identical between pass/fail (`computeActionResult` is only used
-  // to derive step-level output action results, which for DELEGATE aggregation
-  // is dominated by the XState machine's aggregated transition). We therefore
-  // use the PASS envelope unconditionally — mixed pass/fail substeps are driven
-  // correctly by each substep's persisted result.
-  const transitionConfig = createPassTransitionConfig();
-
-  // Drain completions — the XState machine's aggregation rule evaluates all
-  // substep results and selects the appropriate parent transition.
-  //
-  // When `--step` targets a non-active frame (e.g., a different FOR iteration),
-  // pass `frameOverride` so the lookup scans the requested frame's resolved
-  // completions rather than the cursor's active frame.
-  const emitter = createBridgedEmitter(state, output);
-  const activeFrameKey: FrameKey = state.activeFrameKey ?? deriveActiveFrame(state).frameKey;
-  const drained = await drainResolvedCompletions({
-    actorService,
+  const collectionService = new RunbookCollectionService({
     manager,
-    sessionService,
+    actorService,
     lifecycleService,
-    emitter,
-    runbookId: state.id,
-    steps,
-    currentState: state,
-    transitionPolicy: transitionConfig.policy,
-    computeActionResult: transitionConfig.computeActionResult,
-    ...(options.step ? { frameOverride: scope.frame } : {}),
+    completionService: new RunbookCompletionService(manager, lifecycleService, actorService),
   });
 
-  // Mirror the post-runExecutionLoop branch: when the drain itself terminates the
-  // run (either aggregation fired a STOP/COMPLETE on the first apply, or all
-  // subsequent transitions were already captured), we must still propagate the
-  // terminal outcome to a parent runbook. Prior to this, the early returns
-  // swallowed that propagation and left orphaned DELEGATE steps in the parent.
-  if (drained.status === 'stopped') {
-    output.flush();
-    const freshState = await manager.load(state.id);
-    if (freshState && extractParentLinkage(freshState)) {
-      await handleParentCompletion(freshState, 'fail', cwd, output);
-    }
-    return true;
-  }
-  if (drained.status === 'done') {
-    output.flush();
-    const freshState = await manager.load(state.id);
-    if (freshState && extractParentLinkage(freshState)) {
-      const propagation = await handleParentCompletion(freshState, 'pass', cwd, output);
-      if (propagation === 'stopped') return true;
-    }
-    return false;
-  }
-  if (drained.status === 'failed') {
-    throw new Error(drained.message);
-  }
-  if (drained.status === 'not_active') {
-    if (!options.text) {
-      output.json({
-        kind: 'collect',
-        action: 'collect',
-        status: 'not-active',
-        step: scope.stepName,
-        parentRunId: state.id,
-        frameKey: scope.frameKey,
-        activeFrameKey,
-        unresolved: drained.unresolved,
-      });
-    } else {
-      output.message(
-        `Frame not active: step ${scope.stepName} requested frame ${scope.frameKey} but cursor is on ${activeFrameKey}.`,
-        'info',
-      );
-    }
-    output.flush();
-    return false;
-  }
+  const outcome = await collectionService.collectDelegationOutcomes({
+    targetState: state,
+    steps,
+    actorContext,
+    // Pass an explicit step name ONLY for `--step`. For a bare collect, leaving
+    // it unset lets core default to the cursor AND enables its post-aggregation
+    // `already_collected` no-op (which is gated on `!stepName`); passing the
+    // cursor step explicitly would instead misclassify an advanced cursor as a
+    // NOT_DELEGATE_STEP misuse.
+    ...(options.step ? { stepName: scope.stepName } : {}),
+    frame: scope.frame,
+  });
 
-  // Drain applied transitions — advance past the aggregated step via the exec loop.
-  if (drained.applied > 0) {
-    const loopResult = await runExecutionLoop(
-      manager,
-      state.id,
-      steps,
-      cwd,
-      !!drained.state.prompted,
-      emitter,
-      { terminalReleaseMode: ctx.terminalReleaseMode, output },
-    );
-    output.flush();
-
-    if (loopResult === 'stopped') {
-      // Propagate to parent if this child has parent linkage.
-      const freshState = await manager.load(state.id);
-      if (freshState && extractParentLinkage(freshState)) {
-        await handleParentCompletion(freshState, 'fail', cwd, output);
-      }
-      return true;
-    }
-
-    if (loopResult === 'done') {
-      const freshState = await manager.load(state.id);
-      if (freshState && extractParentLinkage(freshState)) {
-        const propagation = await handleParentCompletion(freshState, 'pass', cwd, output);
-        if (propagation === 'stopped') return true;
-      }
-    }
-    return false;
-  }
-
-  // applied === 0: nothing to aggregate. Either the cursor is already past the
-  // last substep (aggregation already fired) or there are no completions to
-  // consume. Surface this as a visible, non-error outcome so a second
-  // `rd collect` invocation doesn't exit silently — mirrors the
-  // `already_cancelled` status emitted by `rd abort`.
-  if (!options.text) {
-    output.json({
-      kind: 'collect',
-      action: 'collect',
-      status: 'already-aggregated',
-      step: scope.stepName,
-      parentRunId: state.id,
-    });
-  } else {
-    output.message(
-      `Already aggregated: step ${scope.stepName} has no unapplied delegation completions.`,
-      'info',
-    );
-  }
-  output.flush();
-  return false;
+  return renderCollectOutcome(output, outcome, options.text);
 }

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -194,6 +194,9 @@ function resolveCollectScope(
  * @param outcome - Core collection outcome to render
  * @param text - True when `--text` was supplied (human-readable mode)
  * @returns True when the command should set a non-zero exit code
+ * @throws {Error} If the outcome is a policy member unreachable for a
+ *   delegation-collection intent (`allowed`, `delegation_collection_pending`,
+ *   `open_claims`) — an invariant violation, not an expected refusal.
  */
 function renderCollectOutcome(
   output: OutputEmitter,
@@ -220,7 +223,7 @@ function renderCollectOutcome(
       } else {
         output.message(
           `Collected ${String(outcome.applied)} delegation outcome(s) on step ${outcome.step} ` +
-            `(${String(outcome.unresolved)} unresolved; lifecycle ${outcome.lifecycle}).`,
+            `(${String(outcome.unresolved)} unresolved; lifecycle ${String(outcome.lifecycle)}).`,
           'success',
         );
       }

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -152,6 +152,11 @@ export function registerDelegateCommand(program: Command): void {
               case 'actor_context_required':
               case 'collect_requires_orchestrator':
               case 'open_claims':
+              case 'missing_outcomes':
+              case 'already_collected':
+              case 'collection_frame_not_active':
+              case 'collection_applied':
+              case 'collection_failed':
                 throw new Error(`Unexpected delegate policy outcome: ${policy.kind}`);
               default: {
                 const _exhaustive: never = policy;

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -28,9 +28,6 @@ import { createBridgedEmitter } from './execution-emitter.js';
 import { createPassTransitionConfig, createFailTransitionConfig } from './transitions.js';
 import type { TransitionOrchestrationPolicy } from './transition-orchestrator.js';
 
-/** Maximum recursion depth for cascading propagation. */
-const MAX_PROPAGATION_DEPTH = 32;
-
 /**
  * Extract parent linkage from a child state.
  *
@@ -45,46 +42,68 @@ export function extractParentLinkage(state: RunbookState): ParentLinkageBase | u
 }
 
 /**
- * Propagate a child run's terminal result to its parent substep.
+ * Report a terminal parent's outcome to its own delegating run — single level.
+ *
+ * This is the de-recursion boundary (Plan 4): when a parent reaches a terminal
+ * state and itself has a `parentLinkage`, we record ONE delegation outcome onto
+ * the grandparent and stop. We do NOT collect/drain the grandparent — that
+ * requires the grandparent's own orchestrator to run a collection. Recording is
+ * frame-aware and idempotent (a duplicate row is a no-op).
+ *
+ * @param completionService - Core completion service bound to the shared manager
+ * @param terminalParent - The parent run that just reached a terminal lifecycle
+ * @param result - The parent's terminal result to report upward
+ */
+async function reportTerminalParentUpward(
+  completionService: RunbookCompletionService,
+  terminalParent: RunbookState,
+  result: 'pass' | 'fail',
+): Promise<void> {
+  if (!extractParentLinkage(terminalParent)) return;
+  await completionService.recordChildCompletion({ childState: terminalParent, result });
+}
+
+/**
+ * Propagate a child run's terminal result to its immediate delegating run.
  *
  * Works for both delegation children (`rd delegate`/`rd claim`) and inline
  * children (`rd run --step`). Follows the completion propagation protocol:
  * 1. Read parent linkage from the child state
- * 2. Acquire delegation lock on the parent
- * 3. Record a resolved completion on the parent substep
- * 4. Drain resolved completions on the parent
- * 5. If the parent itself reaches terminal state and has parent linkage, recurse
+ * 2. Record a resolved completion on the parent substep (core-owned)
+ * 3. Drain the parent's resolved completions through the state machine (this is
+ *    INCREMENTAL — each available outcome advances the cursor, and FAIL-ANY can
+ *    terminate the parent on the first failure without waiting for siblings)
+ * 4. Advance the parent past the aggregated step via the execution loop
+ *
+ * This is **single-level** (Plan 4): when the parent itself reaches a terminal
+ * state and has its own `parentLinkage`, we record ONE outcome upward to the
+ * grandparent (see {@link reportTerminalParentUpward}) but DO NOT recurse into
+ * it. A deep chain therefore advances one delegating level per terminal child.
+ *
+ * Note: this auto-propagation path deliberately does NOT use the gated
+ * `collectDelegationOutcomes` core operation — that operation enforces the
+ * explicit-`rd collect` precondition (every delegate substep already resolved),
+ * which would block incremental per-substep propagation and FAIL-ANY early
+ * termination. It drains directly (core's `drainResolvedCompletions`) instead.
  *
  * @param childState - The child run's state (must have delegation or inline linkage)
  * @param result - Terminal result of the child ('pass' or 'fail')
  * @param cwd - Current working directory
  * @param output - Output emitter for CLI output
- * @param depth - Current recursion depth (default 0)
  * @returns 'handled' if propagation succeeded, 'stopped' if parent stopped,
  *          'not-applicable' if no parent linkage exists
  * @throws {Error} If delegation lock acquisition fails, parent state I/O errors,
- *         drain execution fails, or recursive propagation throws
+ *         or drain execution fails.
  */
 export async function handleParentCompletion(
   childState: RunbookState,
   result: 'pass' | 'fail',
   cwd: string,
   output: OutputEmitter,
-  depth = 0,
 ): Promise<'handled' | 'stopped' | 'not-applicable'> {
-  // Guard: no parent linkage
   const linkage = extractParentLinkage(childState);
   if (!linkage) {
     return 'not-applicable';
-  }
-
-  // Guard: recursion limit — likely a cycle or bug
-  if (depth >= MAX_PROPAGATION_DEPTH) {
-    output.warning(
-      `Propagation depth limit reached (${String(MAX_PROPAGATION_DEPTH)}). ` +
-        `Possible cycle in parent chain starting from run ${childState.id}.`,
-    );
-    return 'handled';
   }
 
   const { parentRunId, parentFrameKey } = linkage;
@@ -106,21 +125,19 @@ export async function handleParentCompletion(
   const transitionConfig =
     result === 'pass' ? createPassTransitionConfig() : createFailTransitionConfig();
 
-  // Parent completion: never release during drain.
-  // Session is managed explicitly below and by runExecutionLoop.
+  // Parent completion: never release during drain. Session release is managed
+  // explicitly on the terminal branches below and by runExecutionLoop.
   const delegationPolicy: TransitionOrchestrationPolicy = {
     onComplete: { releaseRunbook: false },
     onStopped: { releaseRunbook: false },
   };
 
-  // Re-load parent state outside lock for drain
   const parentState = await manager.load(parentRunId);
   if (!parentState) {
     return 'not-applicable';
   }
 
-  const readonlySteps = getRunbookFromState(parentState, cwd);
-  const parentSteps = [...readonlySteps];
+  const parentSteps = [...getRunbookFromState(parentState, cwd)];
 
   const emitter = createBridgedEmitter(parentState, output);
   const drained = await drainResolvedCompletions({
@@ -137,12 +154,13 @@ export async function handleParentCompletion(
     frameOverride: exactFrame(parentFrameKey, linkage.parentEntry),
   });
 
-  // 8. Check if parent reached terminal state — cascade if it also has parent linkage
+  // Terminal parent: release it from session targeting and report ONE outcome
+  // upward (single-level — no recursion into the grandparent).
   if (drained.status === 'stopped') {
     await sessionService.releaseRunbook(parentRunId);
     const freshParent = await manager.load(parentRunId);
-    if (freshParent && extractParentLinkage(freshParent)) {
-      await handleParentCompletion(freshParent, 'fail', cwd, output, depth + 1);
+    if (freshParent) {
+      await reportTerminalParentUpward(completionService, freshParent, 'fail');
     }
     output.flush();
     return 'stopped';
@@ -151,8 +169,8 @@ export async function handleParentCompletion(
   if (drained.status === 'done') {
     await sessionService.releaseRunbook(parentRunId);
     const freshParent = await manager.load(parentRunId);
-    if (freshParent && extractParentLinkage(freshParent)) {
-      return handleParentCompletion(freshParent, 'pass', cwd, output, depth + 1);
+    if (freshParent) {
+      await reportTerminalParentUpward(completionService, freshParent, 'pass');
     }
     output.flush();
     return 'handled';
@@ -165,7 +183,8 @@ export async function handleParentCompletion(
     return 'handled';
   }
 
-  // 9. If completions were applied, run execution loop to advance past resolved step
+  // Completions were applied but the parent is still active: advance past the
+  // resolved step via the execution loop, then handle any terminal it reaches.
   if (drained.applied > 0) {
     const freshParent = await manager.load(parentRunId);
     const loopState = freshParent ?? drained.state;
@@ -182,22 +201,22 @@ export async function handleParentCompletion(
     output.flush();
 
     if (loopResult === 'stopped') {
-      const freshParent = await manager.load(parentRunId);
-      if (freshParent && extractParentLinkage(freshParent)) {
-        await handleParentCompletion(freshParent, 'fail', cwd, output, depth + 1);
+      const terminalParent = await manager.load(parentRunId);
+      if (terminalParent) {
+        await reportTerminalParentUpward(completionService, terminalParent, 'fail');
       }
       return 'stopped';
     }
     if (loopResult === 'done') {
-      const freshParent = await manager.load(parentRunId);
-      if (freshParent && extractParentLinkage(freshParent)) {
-        return handleParentCompletion(freshParent, 'pass', cwd, output, depth + 1);
+      const terminalParent = await manager.load(parentRunId);
+      if (terminalParent) {
+        await reportTerminalParentUpward(completionService, terminalParent, 'pass');
       }
     }
     return 'handled';
   }
 
-  // applied === 0: waiting for other substeps
+  // applied === 0: waiting for other substeps to resolve.
   output.flush();
   return 'handled';
 }

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -18,6 +18,7 @@ import {
   resolveCommandTarget,
   resolveTransitionTarget,
   type ActionType,
+  type ClaimRecord,
   type CommandTargetResolution,
   buildFrameKey,
   deriveExecutionAt,
@@ -161,6 +162,13 @@ export interface TransitionContext {
    * (which advance a child) and for collect.
    */
   guardOpenChildren: boolean;
+  /**
+   * Resolved claim record when the target was selected via `--claim-id`;
+   * undefined for the default-stack target. Carries `claimId` and `tokenHash`
+   * needed to build a claim-controller actor context for core policy. Surfaced
+   * on the base (collect) path only — see {@link buildTransitionContext}.
+   */
+  claim?: ClaimRecord;
 }
 
 /** Result of resolving the runbook target and building transition execution context. */
@@ -268,6 +276,10 @@ export async function buildTransitionContext(
 
   let resolvedKind: 'claim' | 'default';
   let state: RunbookState;
+  // Resolved claim record, surfaced on the base (collect) path only so the
+  // collect command can build a claim-controller actor context. The pass/fail
+  // path leaves this undefined (out of scope until Plan 5/6).
+  let claim: ClaimRecord | undefined;
 
   if (options.command !== undefined) {
     // Pass/fail path: core-owned targeting. The open-children refusal applies to
@@ -329,6 +341,10 @@ export async function buildTransitionContext(
     const active = await resolveCommandTarget(sessionService, { claimId: options.claimId });
     switch (active.kind) {
       case 'claim':
+        resolvedKind = active.kind;
+        state = active.state;
+        claim = active.claim;
+        break;
       case 'default':
         resolvedKind = active.kind;
         state = active.state;
@@ -368,6 +384,7 @@ export async function buildTransitionContext(
       cwd,
       terminalReleaseMode,
       guardOpenChildren,
+      ...(claim ? { claim } : {}),
     },
   };
 }

--- a/packages/cli/src/schemas/output-schemas.ts
+++ b/packages/cli/src/schemas/output-schemas.ts
@@ -122,6 +122,31 @@ const CollectAlreadyAggregatedResponseSchema = z.object({
   step: z.string().describe('DELEGATE step scope'),
   /** Parent runbook state identifier */
   parentRunId: z.string().describe('Parent runbook state identifier'),
+  /** Optional non-error code annotating the idempotent no-op */
+  code: z.literal('COLLECT_ALREADY_APPLIED').optional().describe('Idempotent no-op code'),
+});
+
+const CollectAppliedResponseSchema = z.object({
+  /** Response type discriminant */
+  kind: z.literal('collect').describe('Response type discriminant'),
+  /** Command action that was performed */
+  action: z.literal('collect').describe('Command action that was performed'),
+  /** Collection status */
+  status: z.literal('applied').describe('Collection status'),
+  /** Target delegating run identifier */
+  parentRunId: z.string().describe('Target delegating run identifier'),
+  /** Number of delegation outcomes consumed */
+  applied: z.number().int().nonnegative().describe('Number of delegation outcomes consumed'),
+  /** Number of outcomes still unresolved after this collection */
+  unresolved: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe('Number of unresolved outcomes after collection'),
+  /** Lifecycle of the target run after collection */
+  lifecycle: z.string().describe('Target run lifecycle after collection'),
+  /** True when collection reported this run's terminal outcome upward */
+  reportedTerminalOutcome: z.boolean().describe('Whether a terminal outcome was reported upward'),
 });
 
 const CollectNotActiveResponseSchema = z.object({
@@ -153,6 +178,7 @@ export const CollectResponseSchema = z
   .discriminatedUnion('status', [
     CollectAlreadyAggregatedResponseSchema,
     CollectNotActiveResponseSchema,
+    CollectAppliedResponseSchema,
   ])
   .describe('Response from the collect command');
 

--- a/packages/core/__tests__/output/schema.test.ts
+++ b/packages/core/__tests__/output/schema.test.ts
@@ -306,6 +306,13 @@ describe('ErrorCodeSchema code registry', () => {
     ).toBe(true);
     expect(CLIErrorCodes[code]).toBe(code);
   });
+
+  it('accepts collection-operation output codes', () => {
+    for (const code of ['COLLECT_ALREADY_APPLIED', 'COLLECT_OPERATION_FAILED'] as const) {
+      expect(ErrorCodeSchema.safeParse(code).success).toBe(true);
+      expect(CLIErrorCodes[code]).toBe(code);
+    }
+  });
 });
 
 describe('WarningResponseSchema code semantics', () => {

--- a/packages/core/__tests__/runbook/collection-service.properties.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.properties.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import fc from 'fast-check';
+import type { ResolvedStep } from '@rundown-org/parser';
+import {
+  ExecutionLifecycleService,
+  RunbookActorService,
+  RunbookCollectionService,
+  RunbookCompletionService,
+  RunbookStateManager,
+  activeFrame,
+  assertRunId,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+  trustedRunControllerContext,
+  type RunbookState,
+} from '../../src/runbook/index.js';
+import { brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
+
+// The missing-outcome gate reads only from the passed `targetState` (no disk,
+// no drain), so these properties are pure: the service is wired with a real
+// manager for construction, but the gate path never touches it.
+
+const runId = assertRunId('rd_11111111111111111111111111111111');
+
+function tx(pass: 'CONTINUE' | 'STOP', fail: 'CONTINUE' | 'STOP') {
+  return {
+    pass: { kind: 'pass', retry: 0, action: { type: pass } },
+    fail: { kind: 'fail', retry: 0, action: { type: fail } },
+  } as const;
+}
+
+const allSubstepIds = ['1', '2', '3'] as const;
+
+const steps: ResolvedStep[] = [
+  {
+    kind: 'substeps',
+    name: '1',
+    description: 'Delegate work',
+    aggregation: { strategy: 'ALL' },
+    substeps: allSubstepIds.map((id) => ({
+      id,
+      description: id,
+      delegate: true as const,
+      transitions: tx('CONTINUE', 'STOP'),
+    })),
+    transitions: tx('CONTINUE', 'STOP'),
+  },
+];
+
+function state(overrides: Partial<RunbookState> = {}): RunbookState {
+  const frameKey = buildFrameKey('1');
+  return {
+    id: runId,
+    runbook: { source: 'project', path: 'p.md' },
+    runbookPath: 'p.md',
+    step: '1',
+    substep: '1',
+    stepName: 'Delegate work',
+    retryCount: 0,
+    variables: brandStoredOutputsForTest({}),
+    steps: [],
+    lifecycle: 'running',
+    startedAt: '2026-06-17T00:00:00.000Z',
+    updatedAt: '2026-06-17T00:00:00.000Z',
+    activeFrameKey: frameKey,
+    activeEntry: 1,
+    frameEntryCounts: { [frameKey]: 1 },
+    substepStates: allSubstepIds.map((id) => ({ id, frameKey, status: 'done' as const })),
+    resolvedCompletions: {},
+    schemaVersion: 1,
+    frontmatterOutputs: [],
+    ...overrides,
+  };
+}
+
+/** Build resolved-completion entries for `ids` in the given frame iteration. */
+function completionsFor(ids: readonly string[], iteration?: number) {
+  const frameKey = buildFrameKey('1', iteration);
+  const frame = activeFrame(frameKey, iteration ?? 1);
+  const entries: Record<string, ReturnType<typeof buildResolvedCompletion>> = {};
+  for (const id of ids) {
+    entries[buildCompletionKey(frame, id)] = buildResolvedCompletion({
+      agentId: `delegated-${id}`,
+      result: 'pass',
+      targetStep: '1',
+      targetSubstep: id,
+      targetFrame: frame,
+      completedAt: '2026-06-17T00:00:00.000Z',
+    });
+  }
+  return entries;
+}
+
+describe('RunbookCollectionService properties', () => {
+  let tmp: string;
+  let collectionService: RunbookCollectionService;
+
+  beforeAll(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'collection-props-'));
+    const manager = new RunbookStateManager(tmp);
+    const actorService = new RunbookActorService(manager);
+    const lifecycleService = new ExecutionLifecycleService(manager);
+    const completionService = new RunbookCompletionService(manager, lifecycleService, actorService);
+    collectionService = new RunbookCollectionService({
+      manager,
+      actorService,
+      lifecycleService,
+      completionService,
+    });
+  });
+
+  afterAll(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  const subsetArb = fc.subarray([...allSubstepIds]);
+
+  it('missing_outcomes lists exactly the delegate substeps without a frame-matching outcome', async () => {
+    await fc.assert(
+      fc.asyncProperty(subsetArb, async (resolvedInFrame) => {
+        // Restrict to a proper subset so at least one substep is missing — the
+        // full set would pass the gate and reach the (machine-backed) drain.
+        fc.pre(resolvedInFrame.length < allSubstepIds.length);
+
+        const outcome = await collectionService.collectDelegationOutcomes({
+          targetState: state({ resolvedCompletions: completionsFor(resolvedInFrame) }),
+          steps,
+          actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+          frame: activeFrame(buildFrameKey('1'), 1),
+        });
+
+        const expectedMissing = allSubstepIds
+          .filter((id) => !resolvedInFrame.includes(id))
+          .map((id) => `1.${id}`);
+
+        expect(outcome).toEqual({
+          kind: 'missing_outcomes',
+          targetRunId: runId,
+          step: '1',
+          missingSubsteps: expectedMissing,
+        });
+      }),
+      { numRuns: 40 },
+    );
+  });
+
+  it('completions in a different FOR iteration never reduce the missing set (frame-aware)', async () => {
+    await fc.assert(
+      fc.asyncProperty(subsetArb, async (resolvedInOtherFrame) => {
+        // All outcomes live in iteration 2; collection targets iteration 1, so
+        // none of them count — every delegate substep stays missing.
+        const outcome = await collectionService.collectDelegationOutcomes({
+          targetState: state({ resolvedCompletions: completionsFor(resolvedInOtherFrame, 2) }),
+          steps,
+          actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+          frame: activeFrame(buildFrameKey('1'), 1),
+        });
+
+        expect(outcome).toEqual({
+          kind: 'missing_outcomes',
+          targetRunId: runId,
+          step: '1',
+          missingSubsteps: ['1.1', '1.2', '1.3'],
+        });
+      }),
+      { numRuns: 40 },
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/collection-service.properties.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.properties.test.ts
@@ -12,17 +12,17 @@ import {
   RunbookStateManager,
   activeFrame,
   assertRunId,
-  buildCompletionKey,
   buildFrameKey,
-  buildResolvedCompletion,
   trustedRunControllerContext,
   type RunbookState,
 } from '../../src/runbook/index.js';
 import { brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
+import type { SubstepState } from '../../src/runbook/types.js';
 
 // The missing-outcome gate reads only from the passed `targetState` (no disk,
 // no drain), so these properties are pure: the service is wired with a real
-// manager for construction, but the gate path never touches it.
+// manager for construction, but the gate path never touches it. The gate is the
+// per-frame `status === 'done'` contract (frame-aware via `findSubstepState`).
 
 const runId = assertRunId('rd_11111111111111111111111111111111');
 
@@ -77,22 +77,10 @@ function state(overrides: Partial<RunbookState> = {}): RunbookState {
   };
 }
 
-/** Build resolved-completion entries for `ids` in the given frame iteration. */
-function completionsFor(ids: readonly string[], iteration?: number) {
+/** Build `done` substep-state entries for `ids` in the given frame iteration. */
+function doneSubstepStates(ids: readonly string[], iteration?: number): SubstepState[] {
   const frameKey = buildFrameKey('1', iteration);
-  const frame = activeFrame(frameKey, iteration ?? 1);
-  const entries: Record<string, ReturnType<typeof buildResolvedCompletion>> = {};
-  for (const id of ids) {
-    entries[buildCompletionKey(frame, id)] = buildResolvedCompletion({
-      agentId: `delegated-${id}`,
-      result: 'pass',
-      targetStep: '1',
-      targetSubstep: id,
-      targetFrame: frame,
-      completedAt: '2026-06-17T00:00:00.000Z',
-    });
-  }
-  return entries;
+  return ids.map((id) => ({ id, frameKey, status: 'done' as const }));
 }
 
 describe('RunbookCollectionService properties', () => {
@@ -119,22 +107,22 @@ describe('RunbookCollectionService properties', () => {
 
   const subsetArb = fc.subarray([...allSubstepIds]);
 
-  it('missing_outcomes lists exactly the delegate substeps without a frame-matching outcome', async () => {
+  it('missing_outcomes lists exactly the delegate substeps not done in the frame', async () => {
     await fc.assert(
-      fc.asyncProperty(subsetArb, async (resolvedInFrame) => {
+      fc.asyncProperty(subsetArb, async (doneInFrame) => {
         // Restrict to a proper subset so at least one substep is missing — the
         // full set would pass the gate and reach the (machine-backed) drain.
-        fc.pre(resolvedInFrame.length < allSubstepIds.length);
+        fc.pre(doneInFrame.length < allSubstepIds.length);
 
         const outcome = await collectionService.collectDelegationOutcomes({
-          targetState: state({ resolvedCompletions: completionsFor(resolvedInFrame) }),
+          targetState: state({ substepStates: doneSubstepStates(doneInFrame) }),
           steps,
           actorContext: trustedRunControllerContext(runId, 'direct-cli'),
           frame: activeFrame(buildFrameKey('1'), 1),
         });
 
         const expectedMissing = allSubstepIds
-          .filter((id) => !resolvedInFrame.includes(id))
+          .filter((id) => !doneInFrame.includes(id))
           .map((id) => `1.${id}`);
 
         expect(outcome).toEqual({
@@ -148,13 +136,14 @@ describe('RunbookCollectionService properties', () => {
     );
   });
 
-  it('completions in a different FOR iteration never reduce the missing set (frame-aware)', async () => {
+  it('substeps done in a different FOR iteration never reduce the missing set (frame-aware)', async () => {
     await fc.assert(
-      fc.asyncProperty(subsetArb, async (resolvedInOtherFrame) => {
-        // All outcomes live in iteration 2; collection targets iteration 1, so
-        // none of them count — every delegate substep stays missing.
+      fc.asyncProperty(subsetArb, async (doneInOtherFrame) => {
+        // All `done` markers live in iteration 2; collection targets iteration 1,
+        // so the per-frame lookup credits none of them — every substep stays
+        // missing. This pins that `findSubstepState` is keyed by `(id, frameKey)`.
         const outcome = await collectionService.collectDelegationOutcomes({
-          targetState: state({ resolvedCompletions: completionsFor(resolvedInOtherFrame, 2) }),
+          targetState: state({ substepStates: doneSubstepStates(doneInOtherFrame, 2) }),
           steps,
           actorContext: trustedRunControllerContext(runId, 'direct-cli'),
           frame: activeFrame(buildFrameKey('1'), 1),

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -23,7 +23,7 @@ import {
   buildResolvedCompletion,
   exactFrame,
 } from '../../src/runbook/targeting.js';
-import { brandRunIdForTest, brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
+import { brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
 
 // NOTE: there is no `createTempRunbookStateManager` helper in this repo. Core
 // runbook tests build the manager inline with `mkdtemp` + `new
@@ -183,6 +183,116 @@ describe('RunbookCollectionService', () => {
       kind: 'already_collected',
       targetRunId: runId,
       step: '2',
+    });
+  });
+
+  it('applies reported delegation outcomes through the state machine', async () => {
+    // The real machine cannot be reconstructed from a hand-built fixture at a
+    // DELEGATE cursor (entering the substep auto-spawns a delegation issue actor
+    // that needs a persisted xstate snapshot — see compiler.ts spawnChild input).
+    // Genuine spawn→issue→drain→aggregate e2e is pinned at the CLI layer
+    // (collect.test.ts). Here we spy the lowest actor seam (sendAndSync — the
+    // established core idiom, completion-service.test.ts) so the REAL
+    // drainResolvedCompletions orchestration and the REAL collection mapping run;
+    // only the XState dispatch is faked. The drain itself is pinned independently
+    // in completion-service.test.ts, so this asserts the outcome mapping, not
+    // persisted-completion deletion.
+    const frameKey = buildFrameKey('1');
+    const target = state({
+      resolvedCompletions: {
+        [buildCompletionKey(activeFrame(frameKey, 1), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-a',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:01:00.000Z',
+        }),
+        [buildCompletionKey(activeFrame(frameKey, 1), '2')]: buildResolvedCompletion({
+          agentId: 'delegated-b',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '2',
+          targetFrame: activeFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:02:00.000Z',
+        }),
+      },
+    });
+    await manager.save(target);
+
+    // Apply substep 1 (cursor → substep 2), then substep 2 (cursor → step 2),
+    // both keeping the run `running`; drain then exits at the non-substep step.
+    jest
+      .spyOn(actorService, 'sendAndSync')
+      .mockResolvedValueOnce({
+        state: state({ substep: '2', resolvedCompletions: target.resolvedCompletions }),
+        snapshot: {},
+        effects: [],
+      })
+      .mockResolvedValueOnce({
+        state: state({ step: '2', substep: undefined, lifecycle: 'running' }),
+        snapshot: {},
+        effects: [],
+      });
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: target,
+      steps,
+      actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      frame: activeFrame(frameKey, 1),
+    });
+
+    expect(outcome).toMatchObject({
+      kind: 'collection_applied',
+      targetRunId: runId,
+      step: '1',
+      applied: 2,
+      unresolved: 0,
+      lifecycle: 'running',
+      reportedTerminalOutcome: false,
+    });
+  });
+
+  it('returns already_collected when the scope has no unapplied outcomes to drain', async () => {
+    // Idempotent no-op: every delegate substep is done and carries a reported
+    // outcome (gate passes), but the cursor has advanced off the substeps
+    // (`substep` undefined), so the real drain applies nothing and reports
+    // status:'continue' with applied:0 — collection maps that to already_collected.
+    const frameKey = buildFrameKey('1');
+    const target = state({
+      substep: undefined,
+      resolvedCompletions: {
+        [buildCompletionKey(activeFrame(frameKey, 1), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-a',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:01:00.000Z',
+        }),
+        [buildCompletionKey(activeFrame(frameKey, 1), '2')]: buildResolvedCompletion({
+          agentId: 'delegated-b',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '2',
+          targetFrame: activeFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:02:00.000Z',
+        }),
+      },
+    });
+    await manager.save(target);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: target,
+        steps,
+        actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+        frame: activeFrame(frameKey, 1),
+      }),
+    ).resolves.toMatchObject({
+      kind: 'already_collected',
+      targetRunId: runId,
+      step: '1',
     });
   });
 });

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -8,6 +8,7 @@ import {
   RunbookCollectionService,
   RunbookCompletionService,
   RunbookStateManager,
+  assertClaimId,
   assertDelegationTokenHash,
   assertRunId,
   claimControllerContext,
@@ -50,7 +51,7 @@ describe('RunbookCollectionService', () => {
   const runId = assertRunId('rd_11111111111111111111111111111111');
   const controlledRunId = assertRunId('rd_22222222222222222222222222222222');
   const ancestorRunId = assertRunId('rd_33333333333333333333333333333333');
-  const claimId = 'claim-collection-middle';
+  const claimId = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
   const tokenHash = assertDelegationTokenHash(
     'sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
   );
@@ -293,6 +294,366 @@ describe('RunbookCollectionService', () => {
       kind: 'already_collected',
       targetRunId: runId,
       step: '1',
+    });
+  });
+
+  it('allows a claim controller to collect outcomes for delegations issued by its controlled run', async () => {
+    const controlled = state({ id: controlledRunId });
+    await manager.save(controlled);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: controlled,
+        steps,
+        actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      }),
+    ).resolves.toMatchObject({
+      kind: 'missing_outcomes',
+      targetRunId: controlledRunId,
+      step: '1',
+      missingSubsteps: ['1.1', '1.2'],
+    });
+  });
+
+  it('rejects a claim controller collecting into its delegating ancestor', async () => {
+    const ancestor = state({ id: ancestorRunId });
+    await manager.save(ancestor);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: ancestor,
+        steps,
+        actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      }),
+    ).resolves.toEqual({
+      kind: 'collect_requires_orchestrator',
+      targetRunId: ancestorRunId,
+    });
+  });
+
+  it('fails with STEP_NOT_FOUND when the selected step is absent from the loaded runbook', async () => {
+    const target = state();
+    await manager.save(target);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: target,
+        steps,
+        actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+        stepName: 'does-not-exist',
+      }),
+    ).resolves.toEqual({
+      kind: 'collection_failed',
+      targetRunId: runId,
+      reason: 'step_not_found',
+      code: 'STEP_NOT_FOUND',
+      message: expect.stringContaining('does-not-exist'),
+    });
+  });
+
+  it('fails with NOT_DELEGATE_STEP for a non-DELEGATE step that is not a post-aggregation cursor', async () => {
+    // Cursor on step 2 (a plain step) with no prior aggregation evidence — a bare
+    // collect here is misuse, surfaced as NOT_DELEGATE_STEP.
+    const target = state({
+      step: '2',
+      substep: undefined,
+      activeFrameKey: buildFrameKey('2'),
+      substepStates: [],
+      resolvedCompletions: {},
+    });
+    await manager.save(target);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: target,
+        steps,
+        actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      }),
+    ).resolves.toMatchObject({
+      kind: 'collection_failed',
+      targetRunId: runId,
+      reason: 'not_delegate_step',
+      code: 'NOT_DELEGATE_STEP',
+    });
+  });
+
+  it('reports missing_outcomes for a partial collection (only one of two delegate substeps resolved)', async () => {
+    // Substep 1 has a frame-matching outcome; substep 2 does not. The missing
+    // gate fires before any drain, listing exactly the unresolved substep.
+    const frameKey = buildFrameKey('1');
+    const target = state({
+      resolvedCompletions: {
+        [buildCompletionKey(activeFrame(frameKey, 1), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-a',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:07:00.000Z',
+        }),
+      },
+    });
+    await manager.save(target);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: target,
+        steps,
+        actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+        frame: activeFrame(frameKey, 1),
+      }),
+    ).resolves.toEqual({
+      kind: 'missing_outcomes',
+      targetRunId: runId,
+      step: '1',
+      missingSubsteps: ['1.2'],
+    });
+  });
+
+  // A single-DELEGATE-substep runbook used by the terminal-reporting tests.
+  const oneSubstepSteps: ResolvedStep[] = [
+    {
+      kind: 'substeps',
+      name: '1',
+      description: 'Delegate work',
+      aggregation: { strategy: 'ALL' },
+      substeps: [
+        { id: '1', description: 'A', delegate: true, transitions: tx('COMPLETE', 'STOP') },
+      ],
+      transitions: tx('COMPLETE', 'STOP'),
+    },
+  ];
+
+  const delegationLinkage = {
+    kind: 'delegation' as const,
+    parentRunId: ancestorRunId,
+    parentStepId: '1.1',
+    parentStep: '1',
+    parentFrameKey: buildFrameKey('1'),
+    parentEntry: 1,
+    tokenHash,
+  };
+
+  /** Seed a terminal controlled run with one resolved DELEGATE substep + ancestor. */
+  async function seedTerminalControlled(
+    lifecycle: 'completed' | 'stopped',
+    result: 'pass' | 'fail',
+    overrides: Partial<RunbookState> = {},
+  ): Promise<{ controlled: RunbookState }> {
+    const frameKey = buildFrameKey('1');
+    const controlled = state({
+      id: controlledRunId,
+      lifecycle,
+      substepStates: [{ id: '1', frameKey, status: 'done' }],
+      resolvedCompletions: {
+        [buildCompletionKey(activeFrame(frameKey, 1), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-grandchild',
+          result,
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:03:00.000Z',
+        }),
+      },
+      ...overrides,
+    });
+    await manager.save(controlled);
+    // sendAndSync is spied so the real machine is never reconstructed; it returns
+    // the terminal state the drain observes (status derived from lifecycle).
+    jest.spyOn(actorService, 'sendAndSync').mockResolvedValue({
+      state: state({ id: controlledRunId, step: '1', substep: undefined, lifecycle, ...overrides }),
+      snapshot: {},
+      effects: [],
+    });
+    return { controlled };
+  }
+
+  it('reports a terminal collected run upward without collecting the ancestor', async () => {
+    const ancestor = state({ id: ancestorRunId, resolvedCompletions: {} });
+    await manager.save(ancestor);
+    const { controlled } = await seedTerminalControlled('completed', 'pass', {
+      parentLinkage: delegationLinkage,
+    });
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: controlled,
+      steps: oneSubstepSteps,
+      actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      frame: activeFrame(buildFrameKey('1'), 1),
+    });
+
+    expect(outcome).toEqual({
+      kind: 'collection_applied',
+      targetRunId: controlledRunId,
+      step: '1',
+      applied: 1,
+      unresolved: 0,
+      lifecycle: 'completed',
+      reportedTerminalOutcome: true,
+    });
+    // Single-level: one outcome recorded upward; the ancestor is NOT collected.
+    const freshAncestor = await manager.load(ancestorRunId);
+    expect(Object.keys(freshAncestor?.resolvedCompletions ?? {})).toHaveLength(1);
+    expect(freshAncestor?.step).toBe('1');
+  });
+
+  it('renders a stopped terminal collection with lifecycle stopped (fail polarity)', async () => {
+    const ancestor = state({ id: ancestorRunId, resolvedCompletions: {} });
+    await manager.save(ancestor);
+    const { controlled } = await seedTerminalControlled('stopped', 'fail', {
+      parentLinkage: delegationLinkage,
+    });
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: controlled,
+      steps: oneSubstepSteps,
+      actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      frame: activeFrame(buildFrameKey('1'), 1),
+    });
+
+    expect(outcome).toEqual({
+      kind: 'collection_applied',
+      targetRunId: controlledRunId,
+      step: '1',
+      applied: 1,
+      unresolved: 0,
+      lifecycle: 'stopped',
+      reportedTerminalOutcome: true,
+    });
+  });
+
+  it('reports reportedTerminalOutcome:false for a terminal ROOT run (no parentLinkage)', async () => {
+    const { controlled } = await seedTerminalControlled('completed', 'pass');
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: controlled,
+      steps: oneSubstepSteps,
+      actorContext: trustedRunControllerContext(controlledRunId, 'direct-cli'),
+      frame: activeFrame(buildFrameKey('1'), 1),
+    });
+
+    expect(outcome).toEqual({
+      kind: 'collection_applied',
+      targetRunId: controlledRunId,
+      step: '1',
+      applied: 1,
+      unresolved: 0,
+      lifecycle: 'completed',
+      reportedTerminalOutcome: false, // root run has no delegating ancestor
+    });
+  });
+
+  it('returns collection_frame_not_active when the requested frame is not the cursor frame', async () => {
+    // Cursor sits on iteration 1 (frame `1`); the caller targets iteration 2,
+    // whose substeps are done+resolved (so the gate passes), but the real drain
+    // observes the cursor is elsewhere and short-circuits to not_active.
+    const inactiveKey = buildFrameKey('1', 2);
+    const target = state({
+      step: '1',
+      substep: '1',
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      substepStates: [
+        { id: '1', frameKey: inactiveKey, status: 'done' },
+        { id: '2', frameKey: inactiveKey, status: 'done' },
+      ],
+      resolvedCompletions: {
+        [buildCompletionKey(exactFrame(inactiveKey, 2), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-a',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(inactiveKey, 2),
+          completedAt: '2026-06-17T00:08:00.000Z',
+        }),
+        [buildCompletionKey(exactFrame(inactiveKey, 2), '2')]: buildResolvedCompletion({
+          agentId: 'delegated-b',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '2',
+          targetFrame: exactFrame(inactiveKey, 2),
+          completedAt: '2026-06-17T00:09:00.000Z',
+        }),
+      },
+    });
+    await manager.save(target);
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: target,
+      steps,
+      actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      frame: exactFrame(inactiveKey, 2),
+    });
+
+    expect(outcome).toMatchObject({
+      kind: 'collection_frame_not_active',
+      targetRunId: runId,
+      step: '1',
+      frameKey: inactiveKey,
+      activeFrameKey: buildFrameKey('1'),
+    });
+    expect(outcome).toHaveProperty('unresolved');
+  });
+
+  it('returns collection_failed with code COLLECT_OPERATION_FAILED on a drain target_mismatch', async () => {
+    // The frame-aware missing-outcome gate (which mirrors the conditions that
+    // would otherwise surface a mismatch) makes a real drain `target_mismatch`
+    // unreachable through collectDelegationOutcomes — the only failure drain can
+    // return. So this pins collection's mapping of that drain failure by spying
+    // the drain seam directly (drain itself owns producing the failure; its
+    // production is pinned in completion-service.test.ts).
+    const frameKey = buildFrameKey('1');
+    const target = state({
+      resolvedCompletions: {
+        [buildCompletionKey(activeFrame(frameKey, 1), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-a',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:06:00.000Z',
+        }),
+        [buildCompletionKey(activeFrame(frameKey, 1), '2')]: buildResolvedCompletion({
+          agentId: 'delegated-b',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '2',
+          targetFrame: activeFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:06:30.000Z',
+        }),
+      },
+    });
+    await manager.save(target);
+
+    jest.spyOn(completionService, 'drainResolvedCompletions').mockResolvedValue({
+      status: 'failed',
+      reason: 'target_mismatch',
+      message: 'Resolved completion does not match the current cursor.',
+      completion: buildResolvedCompletion({
+        agentId: 'delegated-a',
+        result: 'pass',
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrame: activeFrame(frameKey, 1),
+        completedAt: '2026-06-17T00:06:00.000Z',
+      }),
+      unresolved: 1,
+      applied: [],
+    });
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: target,
+        steps,
+        actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+        frame: activeFrame(frameKey, 1),
+      }),
+    ).resolves.toEqual({
+      kind: 'collection_failed',
+      targetRunId: runId,
+      reason: 'target_mismatch',
+      code: 'COLLECT_OPERATION_FAILED',
+      message: expect.any(String),
     });
   });
 });

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -140,8 +140,10 @@ describe('RunbookCollectionService', () => {
     });
   });
 
-  it('reports missing outcomes for delegate substeps without recorded outcomes', async () => {
-    const target = state();
+  it('reports missing outcomes for delegate substeps not yet resolved in the frame', async () => {
+    // Neither delegate substep is `done` in the target frame, so both are
+    // pending (the gate is per-frame `status === 'done'`, matching collect.ts).
+    const target = state({ substepStates: [] });
     await manager.save(target);
 
     await expect(
@@ -298,7 +300,9 @@ describe('RunbookCollectionService', () => {
   });
 
   it('allows a claim controller to collect outcomes for delegations issued by its controlled run', async () => {
-    const controlled = state({ id: controlledRunId });
+    // substepStates empty → both substeps pending → reaches the missing-outcome
+    // gate (proving the claim controller passed the orchestrator role check).
+    const controlled = state({ id: controlledRunId, substepStates: [] });
     await manager.save(controlled);
 
     await expect(
@@ -378,20 +382,11 @@ describe('RunbookCollectionService', () => {
   });
 
   it('reports missing_outcomes for a partial collection (only one of two delegate substeps resolved)', async () => {
-    // Substep 1 has a frame-matching outcome; substep 2 does not. The missing
+    // Substep 1 is done in the frame; substep 2 is not. The per-frame status
     // gate fires before any drain, listing exactly the unresolved substep.
     const frameKey = buildFrameKey('1');
     const target = state({
-      resolvedCompletions: {
-        [buildCompletionKey(activeFrame(frameKey, 1), '1')]: buildResolvedCompletion({
-          agentId: 'delegated-a',
-          result: 'pass',
-          targetStep: '1',
-          targetSubstep: '1',
-          targetFrame: activeFrame(frameKey, 1),
-          completedAt: '2026-06-17T00:07:00.000Z',
-        }),
-      },
+      substepStates: [{ id: '1', frameKey, status: 'done' }],
     });
     await manager.save(target);
 

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { ResolvedStep } from '@rundown-org/parser';
+import {
+  RunbookActorService,
+  RunbookCollectionService,
+  RunbookCompletionService,
+  RunbookStateManager,
+  assertDelegationTokenHash,
+  assertRunId,
+  claimControllerContext,
+  trustedRunControllerContext,
+  UNKNOWN_ACTOR_CONTEXT,
+  type RunbookState,
+} from '../../src/runbook/index.js';
+import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
+import {
+  activeFrame,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+  exactFrame,
+} from '../../src/runbook/targeting.js';
+import { brandRunIdForTest, brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
+
+// NOTE: there is no `createTempRunbookStateManager` helper in this repo. Core
+// runbook tests build the manager inline with `mkdtemp` + `new
+// RunbookStateManager(tmp)` (see completion-service.test.ts). Fixtures mirror the
+// proven `ResolvedStep` / `RunbookState` shapes from that suite, with
+// `delegate: true` substeps for the collection scenarios.
+
+/** Build a pass/fail transition pair for a substep or step. */
+function tx(pass: 'CONTINUE' | 'COMPLETE' | 'STOP', fail: 'CONTINUE' | 'COMPLETE' | 'STOP') {
+  return {
+    pass: { kind: 'pass', retry: 0, action: { type: pass } },
+    fail: { kind: 'fail', retry: 0, action: { type: fail } },
+  } as const;
+}
+
+describe('RunbookCollectionService', () => {
+  let tmp: string;
+  let manager: RunbookStateManager;
+  let actorService: RunbookActorService;
+  let lifecycleService: ExecutionLifecycleService;
+  let completionService: RunbookCompletionService;
+  let collectionService: RunbookCollectionService;
+
+  const runId = assertRunId('rd_11111111111111111111111111111111');
+  const controlledRunId = assertRunId('rd_22222222222222222222222222222222');
+  const ancestorRunId = assertRunId('rd_33333333333333333333333333333333');
+  const claimId = 'claim-collection-middle';
+  const tokenHash = assertDelegationTokenHash(
+    'sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+  );
+
+  // Default runbook: step 1 delegates two substeps (PASS CONTINUE so a full
+  // drain advances the run to step 2 while staying `running`); step 2 is a
+  // plain post-aggregation step.
+  const steps: ResolvedStep[] = [
+    {
+      kind: 'substeps',
+      name: '1',
+      description: 'Delegate work',
+      aggregation: { strategy: 'ALL' },
+      substeps: [
+        { id: '1', description: 'A', delegate: true, transitions: tx('CONTINUE', 'STOP') },
+        { id: '2', description: 'B', delegate: true, transitions: tx('CONTINUE', 'STOP') },
+      ],
+      transitions: tx('CONTINUE', 'STOP'),
+    },
+    {
+      kind: 'base',
+      name: '2',
+      description: 'After collection',
+      transitions: tx('CONTINUE', 'STOP'),
+    },
+  ];
+
+  function state(overrides: Partial<RunbookState> = {}): RunbookState {
+    return {
+      id: runId,
+      runbook: { source: 'project', path: 'collection-test.md' },
+      runbookPath: 'collection-test.md',
+      step: '1',
+      substep: '1',
+      stepName: 'Delegate work',
+      retryCount: 0,
+      variables: brandStoredOutputsForTest({}),
+      steps: [],
+      lifecycle: 'running',
+      startedAt: '2026-06-17T00:00:00.000Z',
+      updatedAt: '2026-06-17T00:00:00.000Z',
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      frameEntryCounts: { [buildFrameKey('1')]: 1 },
+      substepStates: [
+        { id: '1', frameKey: buildFrameKey('1'), status: 'done' },
+        { id: '2', frameKey: buildFrameKey('1'), status: 'done' },
+      ],
+      resolvedCompletions: {},
+      schemaVersion: 1,
+      frontmatterOutputs: [],
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'collection-service-'));
+    manager = new RunbookStateManager(tmp);
+    actorService = new RunbookActorService(manager);
+    lifecycleService = new ExecutionLifecycleService(manager);
+    completionService = new RunbookCompletionService(manager, lifecycleService, actorService);
+    collectionService = new RunbookCollectionService({
+      manager,
+      actorService,
+      lifecycleService,
+      completionService,
+    });
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('rejects unknown actor context before inspecting outcomes', async () => {
+    await manager.save(state());
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: state(),
+        steps,
+        actorContext: UNKNOWN_ACTOR_CONTEXT,
+      }),
+    ).resolves.toEqual({
+      kind: 'actor_context_required',
+      intent: 'delegation-collection',
+    });
+  });
+
+  it('reports missing outcomes for delegate substeps without recorded outcomes', async () => {
+    const target = state();
+    await manager.save(target);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: target,
+        steps,
+        actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      }),
+    ).resolves.toEqual({
+      kind: 'missing_outcomes',
+      targetRunId: runId,
+      step: '1',
+      missingSubsteps: ['1.1', '1.2'],
+    });
+  });
+
+  it('returns already_collected when no unapplied outcomes remain on a post-delegate cursor', async () => {
+    const target = state({
+      step: '2',
+      substep: undefined,
+      activeFrameKey: buildFrameKey('2'),
+      activeEntry: 1,
+      // Both delegate substeps of step 1 are done in their frame — the
+      // post-aggregation cursor evidence isPostDelegateAggregationCursor needs.
+      substepStates: [
+        { id: '1', frameKey: buildFrameKey('1'), status: 'done' },
+        { id: '2', frameKey: buildFrameKey('1'), status: 'done' },
+      ],
+      resolvedCompletions: {},
+    });
+    await manager.save(target);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: target,
+        steps,
+        actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      }),
+    ).resolves.toMatchObject({
+      kind: 'already_collected',
+      targetRunId: runId,
+      step: '2',
+    });
+  });
+});

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -45,6 +45,8 @@ const CLISymbolicErrorCodeValues = [
   'DELEGATION_COLLECTION_PENDING',
   'ACTOR_CONTEXT_REQUIRED',
   'COLLECT_REQUIRES_ORCHESTRATOR',
+  'COLLECT_ALREADY_APPLIED',
+  'COLLECT_OPERATION_FAILED',
   'CHILD_RUN_MISSING',
   'CHILD_LINKAGE_MISMATCH',
   'INVALID_TOKEN',
@@ -106,6 +108,10 @@ export const CLIErrorCodes = {
   ACTOR_CONTEXT_REQUIRED: 'ACTOR_CONTEXT_REQUIRED',
   /** Collection requires an actor that controls the target delegating run */
   COLLECT_REQUIRES_ORCHESTRATOR: 'COLLECT_REQUIRES_ORCHESTRATOR',
+  /** Collection found no unapplied delegation outcomes and is an idempotent no-op. */
+  COLLECT_ALREADY_APPLIED: 'COLLECT_ALREADY_APPLIED',
+  /** Core collection failed while applying delegation outcomes. */
+  COLLECT_OPERATION_FAILED: 'COLLECT_OPERATION_FAILED',
   /** Child run state file is missing on disk (transient — pruning may help) */
   CHILD_RUN_MISSING: 'CHILD_RUN_MISSING',
   /** Child runbook's persisted parentLinkage diverges from the freshly token-validated linkage (state corruption — operator intervention required) */

--- a/packages/core/src/runbook/collection-service.ts
+++ b/packages/core/src/runbook/collection-service.ts
@@ -102,6 +102,16 @@ function missingDelegationOutcomeIds(args: {
   readonly frameKey: FrameKey;
 }): readonly string[] {
   const frameKey = args.frameKey;
+  // Per-frame `status === 'done'` is the merged collect.ts contract (collect.ts
+  // lines 311-317): a delegate substep counts as resolved iff its persisted
+  // substep state IN THE TARGET FRAME is `done`. The `findSubstepState` lookup
+  // is keyed by `(id, frameKey)`, so it is already frame-aware — a substep
+  // marked done in a DIFFERENT FOR iteration is not credited to this frame.
+  // The "done but no recorded outcome to drain" case is NOT a missing-outcome
+  // refusal: it is the idempotent no-op the drain reports as already-collected,
+  // so the gate must NOT additionally require a persisted completion here (doing
+  // so would turn `already-aggregated`/`not-active` into spurious
+  // SUBSTEPS_NOT_RESOLVED errors).
   return args.delegateSubsteps
     .filter((substepId) => {
       const substepState = findSubstepState(
@@ -109,21 +119,7 @@ function missingDelegationOutcomeIds(args: {
         substepId,
         frameKey,
       );
-      // Per-frame `status === 'done'` is the merged collect.ts contract: it
-      // checks only the substep status in the target frame. The completion match
-      // below MUST be frame-aware: filter to completions whose `targetFrameKey`
-      // equals the collection frame so a resolved completion in a DIFFERENT FOR
-      // iteration is not credited to this frame (cross-iteration mis-report).
-      // The persisted `ResolvedCompletion` carries the flat field
-      // `targetFrameKey` (types.ts; NOT a nested `targetFrame` object).
-      if (substepState?.status !== 'done') return true;
-      const hasOutcome = Object.values(args.targetState.resolvedCompletions ?? {}).some(
-        (completion) =>
-          completion.targetStep === args.stepName &&
-          completion.targetSubstep === substepId &&
-          completion.targetFrameKey === frameKey,
-      );
-      return !hasOutcome;
+      return substepState?.status !== 'done';
     })
     .map((substepId) => `${args.stepName}.${substepId}`);
 }

--- a/packages/core/src/runbook/collection-service.ts
+++ b/packages/core/src/runbook/collection-service.ts
@@ -1,0 +1,315 @@
+import { resolvedStepHasSubsteps } from '@rundown-org/parser';
+import type { ActorContext } from './actor-context.js';
+import type { RunbookActorService } from './actor-service.js';
+import type { DelegationPolicyOutcome } from './command-policy.js';
+import { resolveCommandIntent } from './command-policy.js';
+import { lifecycleToDelegationOutcome } from './completion-service.js';
+import type { RunbookCompletionService } from './completion-service.js';
+import { isPostDelegateAggregationCursor } from './delegation-inference.js';
+import type { ExecutionLifecycleService } from './execution-lifecycle-service.js';
+import type { RunbookStateManager } from './state.js';
+import type { Frame, FrameKey } from './targeting.js';
+import { activeFrame, deriveActiveFrame, findSubstepState } from './targeting.js';
+import type { ResolvedStep, RunbookState } from './types.js';
+
+/** Dependencies used by the core collection operation. */
+export interface RunbookCollectionServiceDependencies {
+  /** State manager used to reload and persist target runs. */
+  readonly manager: RunbookStateManager;
+  /** Actor service used to apply collected delegation outcomes through the state machine. */
+  readonly actorService: RunbookActorService;
+  /** Lifecycle service used to consume persisted delegation outcomes. */
+  readonly lifecycleService: ExecutionLifecycleService;
+  /** Completion service used to drain resolved delegation outcomes. */
+  readonly completionService: RunbookCompletionService;
+}
+
+/** Explicit collection target resolved by a frontend adapter or another core service. */
+export interface CollectDelegationOutcomesInput {
+  /** Persisted target run receiving collected delegation outcomes. */
+  readonly targetState: RunbookState;
+  /** Parsed runbook steps for the target run. */
+  readonly steps: readonly ResolvedStep[];
+  /** Caller evidence for target-relative role derivation. */
+  readonly actorContext: ActorContext;
+  /** Optional explicit step name. Defaults to the target run cursor. */
+  readonly stepName?: string;
+  /** Optional frame override for targeted FOR collection. */
+  readonly frame?: Frame;
+}
+
+/** Core-owned service for applying reported delegation outcomes to a target run. */
+export class RunbookCollectionService {
+  readonly #deps: RunbookCollectionServiceDependencies;
+
+  /**
+   * @param deps - Core services needed to apply collection through the state machine.
+   */
+  constructor(deps: RunbookCollectionServiceDependencies) {
+    this.#deps = deps;
+  }
+
+  /**
+   * Collect reported delegation outcomes into one target delegating run scope.
+   *
+   * @param input - Target run, runbook steps, actor context, and optional scope.
+   * @returns Core-owned typed policy outcome for frontend adapters.
+   */
+  async collectDelegationOutcomes(
+    input: CollectDelegationOutcomesInput,
+  ): Promise<DelegationPolicyOutcome> {
+    return collectDelegationOutcomes({ ...input, ...this.#deps });
+  }
+}
+
+/** Dependencies accepted by the functional collection entrypoint. */
+export type CollectDelegationOutcomesOperationInput = CollectDelegationOutcomesInput &
+  RunbookCollectionServiceDependencies;
+
+function findCollectionStep(
+  steps: readonly ResolvedStep[],
+  stepName: string,
+): ResolvedStep | undefined {
+  return steps.find((step) => step.name === stepName);
+}
+
+function delegateSubstepIds(step: ResolvedStep | undefined): readonly string[] {
+  // `resolvedStepHasSubsteps` (from `@rundown-org/parser`, already used across
+  // core — see actor-service.ts, delegation-service.ts) is the canonical guard;
+  // it narrows `step.substeps` so the filter below is type-safe. Prefer it over
+  // a hand-rolled `'substeps' in step && step.substeps` check.
+  if (!step || !resolvedStepHasSubsteps(step)) return [];
+  return step.substeps.filter((substep) => substep.delegate).map((substep) => substep.id);
+}
+
+function defaultCollectionFrame(state: RunbookState): Frame {
+  return activeFrame(activeFrameKeyOf(state), state.activeEntry ?? 1);
+}
+
+/**
+ * Single fallback for the target run's active frame key. Factored out of the
+ * two prior call sites (`defaultCollectionFrame` and the missing-outcome scan),
+ * which both inlined `state.activeFrameKey ?? deriveActiveFrame(state).frameKey`.
+ */
+function activeFrameKeyOf(state: RunbookState): FrameKey {
+  return state.activeFrameKey ?? deriveActiveFrame(state).frameKey;
+}
+
+function missingDelegationOutcomeIds(args: {
+  readonly targetState: RunbookState;
+  readonly stepName: string;
+  readonly delegateSubsteps: readonly string[];
+  readonly frameKey: FrameKey;
+}): readonly string[] {
+  const frameKey = args.frameKey;
+  return args.delegateSubsteps
+    .filter((substepId) => {
+      const substepState = findSubstepState(
+        args.targetState.substepStates ?? [],
+        substepId,
+        frameKey,
+      );
+      // Per-frame `status === 'done'` is the merged collect.ts contract: it
+      // checks only the substep status in the target frame. The completion match
+      // below MUST be frame-aware: filter to completions whose `targetFrameKey`
+      // equals the collection frame so a resolved completion in a DIFFERENT FOR
+      // iteration is not credited to this frame (cross-iteration mis-report).
+      // The persisted `ResolvedCompletion` carries the flat field
+      // `targetFrameKey` (types.ts; NOT a nested `targetFrame` object).
+      if (substepState?.status !== 'done') return true;
+      const hasOutcome = Object.values(args.targetState.resolvedCompletions ?? {}).some(
+        (completion) =>
+          completion.targetStep === args.stepName &&
+          completion.targetSubstep === substepId &&
+          completion.targetFrameKey === frameKey,
+      );
+      return !hasOutcome;
+    })
+    .map((substepId) => `${args.stepName}.${substepId}`);
+}
+
+/**
+ * Collect reported delegation outcomes into one target delegating run scope.
+ *
+ * @param input - Target run, services, actor context, and optional scope.
+ * @returns Core-owned typed policy outcome.
+ */
+export async function collectDelegationOutcomes(
+  input: CollectDelegationOutcomesOperationInput,
+): Promise<DelegationPolicyOutcome> {
+  // NOTE: the merged `resolveCommandIntent` input field is `targetSelector`
+  // (not `target`), and its selector kinds are `default` | `claim` |
+  // `explicit-step` — there is NO `run` selector kind. The resolved target run
+  // is passed separately as `targetState`. For collection the frontend has
+  // already resolved `--claim-id` (or the default stack) to a concrete run, so
+  // the selector is `default` and role derivation keys off `targetState`.
+  const policy = resolveCommandIntent({
+    intent: { kind: 'delegation-collection' },
+    targetSelector: { kind: 'default' },
+    targetState: input.targetState,
+    actorContext: input.actorContext,
+  });
+  if (policy.kind !== 'allowed') return policy;
+
+  const stepName = input.stepName ?? input.targetState.step;
+  const step = findCollectionStep(input.steps, stepName);
+
+  // Stale/corrupted state: the selected step is not in the loaded runbook. This
+  // is never a valid idempotent no-op (mirrors the merged CLI's STEP_NOT_FOUND
+  // fast-fail). Surface a typed failure the CLI renders as STEP_NOT_FOUND.
+  if (!step) {
+    return {
+      kind: 'collection_failed',
+      targetRunId: input.targetState.id,
+      reason: 'step_not_found',
+      code: 'STEP_NOT_FOUND',
+      message: `Step ${stepName} not found in the loaded runbook; state may be stale or corrupted.`,
+    };
+  }
+
+  const delegateSubsteps = delegateSubstepIds(step);
+  const frame = input.frame ?? defaultCollectionFrame(input.targetState);
+  const frameKey = frame.frameKey; // every Frame variant carries frameKey
+
+  if (delegateSubsteps.length === 0) {
+    if (!input.stepName && isPostDelegateAggregationCursor(input.targetState, input.steps)) {
+      return {
+        kind: 'already_collected',
+        targetRunId: input.targetState.id,
+        step: stepName,
+      };
+    }
+    // Per spec/Plan 3: `target_not_delegating_scope` is intentionally NOT a
+    // policy variant (an upward-delegating run is still a valid collect
+    // target; the orchestrator gate is the only role check). A non-DELEGATE
+    // step that is also not a post-aggregation cursor is genuine misuse —
+    // surface it as a `collection_failed` with reason `not_delegate_step` so the
+    // CLI renders the existing `NOT_DELEGATE_STEP` error (no new variant, no
+    // contract change). Do NOT return `target_not_delegating_scope`.
+    return {
+      kind: 'collection_failed',
+      targetRunId: input.targetState.id,
+      reason: 'not_delegate_step',
+      code: 'NOT_DELEGATE_STEP',
+      message: `Step ${stepName} is not a DELEGATE step. rd collect requires a step with - DELEGATE substeps.`,
+    };
+  }
+
+  const missingSubsteps = missingDelegationOutcomeIds({
+    targetState: input.targetState,
+    stepName,
+    delegateSubsteps,
+    frameKey,
+  });
+  if (missingSubsteps.length > 0) {
+    return {
+      kind: 'missing_outcomes',
+      targetRunId: input.targetState.id,
+      step: stepName,
+      missingSubsteps,
+    };
+  }
+
+  return applyCollection(input, { stepName, frame, frameKey });
+}
+
+async function applyCollection(
+  input: CollectDelegationOutcomesOperationInput,
+  scope: { readonly stepName: string; readonly frame: Frame; readonly frameKey?: FrameKey },
+): Promise<DelegationPolicyOutcome> {
+  const drained = await input.completionService.drainResolvedCompletions({
+    runbookId: input.targetState.id,
+    steps: [...input.steps],
+    currentState: input.targetState,
+    frameOverride: scope.frame,
+  });
+
+  if (drained.status === 'failed') {
+    // `drained.reason` is `'target_mismatch'` — drain's ONLY failure reason
+    // (CompletionTargetMismatch). Core attaches the user-facing code so the CLI
+    // renders a flat passthrough.
+    return {
+      kind: 'collection_failed',
+      targetRunId: input.targetState.id,
+      reason: drained.reason,
+      code: 'COLLECT_OPERATION_FAILED',
+      message: drained.message,
+    };
+  }
+
+  // Frame requested by the caller is not the cursor's active frame: drain is
+  // observation-only and applied nothing. This is a DISTINCT outcome from the
+  // idempotent no-op: the CLI must render the existing `not-active` payload
+  // (status `not-active`, carrying `frameKey`/`activeFrameKey`/`unresolved`), so
+  // do NOT fold it into `already_collected`. Pass drain's observed frame keys
+  // through unchanged.
+  if (drained.status === 'not_active') {
+    return {
+      kind: 'collection_frame_not_active',
+      targetRunId: input.targetState.id,
+      step: scope.stepName,
+      frameKey: drained.frameKey,
+      activeFrameKey: drained.activeFrameKey,
+      unresolved: drained.unresolved,
+    };
+  }
+
+  const applied = drained.applied.length;
+
+  // Terminal: the drained outcomes advanced the target run to a terminal
+  // lifecycle. Reload the persisted terminal state so single-level reporting
+  // observes the committed lifecycle, then (single-level) report one outcome
+  // upward — never collect the ancestor.
+  if (drained.status === 'done' || drained.status === 'stopped') {
+    const fresh =
+      (await input.manager.load(input.targetState.id)) ??
+      drained.applied.at(-1)?.stateAfter ??
+      input.targetState;
+    return {
+      kind: 'collection_applied',
+      targetRunId: input.targetState.id,
+      step: scope.stepName,
+      applied,
+      unresolved: drained.unresolved,
+      lifecycle: drained.status === 'done' ? 'completed' : 'stopped',
+      reportedTerminalOutcome: await reportTerminalOutcomeToDelegatingRun(input, fresh),
+    };
+  }
+
+  // status === 'continue': nothing applied means no unapplied outcomes for the
+  // scope (idempotent no-op); otherwise outcomes were consumed but the run is
+  // still active.
+  if (applied === 0) {
+    return {
+      kind: 'already_collected',
+      targetRunId: input.targetState.id,
+      step: scope.stepName,
+    };
+  }
+  return {
+    kind: 'collection_applied',
+    targetRunId: input.targetState.id,
+    step: scope.stepName,
+    applied,
+    unresolved: drained.unresolved,
+    lifecycle: (drained.applied.at(-1)?.stateAfter ?? input.targetState).lifecycle,
+    reportedTerminalOutcome: false,
+  };
+}
+
+async function reportTerminalOutcomeToDelegatingRun(
+  input: CollectDelegationOutcomesOperationInput,
+  terminalState: RunbookState,
+): Promise<boolean> {
+  if (!terminalState.parentLinkage) return false;
+  // Reuse the canonical lifecycle→outcome mapping instead of hand-rolling
+  // `lifecycle === 'completed' ? 'pass' : 'fail'`. It returns `undefined` for
+  // non-terminal lifecycles, which also serves as the terminal guard.
+  const result = lifecycleToDelegationOutcome(terminalState.lifecycle);
+  if (!result) return false;
+  const recorded = await input.completionService.recordChildCompletion({
+    childState: terminalState,
+    result,
+  });
+  return recorded === 'recorded';
+}

--- a/packages/core/src/runbook/collection-service.ts
+++ b/packages/core/src/runbook/collection-service.ts
@@ -43,6 +43,8 @@ export class RunbookCollectionService {
   readonly #deps: RunbookCollectionServiceDependencies;
 
   /**
+   * Construct a collection service bound to a set of core dependencies.
+   *
    * @param deps - Core services needed to apply collection through the state machine.
    */
   constructor(deps: RunbookCollectionServiceDependencies) {
@@ -90,6 +92,9 @@ function defaultCollectionFrame(state: RunbookState): Frame {
  * Single fallback for the target run's active frame key. Factored out of the
  * two prior call sites (`defaultCollectionFrame` and the missing-outcome scan),
  * which both inlined `state.activeFrameKey ?? deriveActiveFrame(state).frameKey`.
+ *
+ * @param state - Target run state to read the active frame key from.
+ * @returns The persisted active frame key, or the one derived from the cursor.
  */
 function activeFrameKeyOf(state: RunbookState): FrameKey {
   return state.activeFrameKey ?? deriveActiveFrame(state).frameKey;
@@ -300,7 +305,7 @@ async function reportTerminalOutcomeToDelegatingRun(
   if (!terminalState.parentLinkage) return false;
   // Reuse the canonical lifecycle→outcome mapping instead of hand-rolling
   // `lifecycle === 'completed' ? 'pass' : 'fail'`. It returns `undefined` for
-  // non-terminal lifecycles, which also serves as the terminal guard.
+  // any non-terminal lifecycle, which also serves as the terminal guard.
   const result = lifecycleToDelegationOutcome(terminalState.lifecycle);
   if (!result) return false;
   const recorded = await input.completionService.recordChildCompletion({

--- a/packages/core/src/runbook/command-policy.ts
+++ b/packages/core/src/runbook/command-policy.ts
@@ -5,6 +5,7 @@ import {
   readDelegationCollectionPendingForPolicy,
 } from './delegation-lifecycle-read-model.js';
 import type { RunId } from './run-id.js';
+import type { FrameKey } from './targeting.js';
 import type { RunbookState } from './types.js';
 
 /** Command intent categories owned by core command policy. */
@@ -71,14 +72,14 @@ export interface ResolveCommandIntentInput {
  * Core-owned policy decision consumed by CLI, MCP, and plugin adapters.
  *
  * This is a deliberate SUBSET of the spec's 12-member `DelegationPolicyOutcome`
- * union (spec lines 366-380). This slice implements only the members reachable
- * from the policy decisions it gates: `allowed`, `actor_context_required`,
- * `collect_requires_orchestrator`, `delegation_collection_pending`, and
- * `open_claims`. The collection-operation members (`missing_outcomes`,
- * `already_collected`) are deferred to Plan 4 (Core Collection Operation); the
- * claim/terminal members (`stale_claim`, `terminal_claim_confirmed`,
- * `terminal_claim_conflict`) and `not_delegatable` are deferred to the
- * collection/claim plans (Plan 4 / Plan 5). `target_not_delegating_scope` from
+ * union (spec lines 366-380). The implemented members are: `allowed`,
+ * `actor_context_required`, `collect_requires_orchestrator`,
+ * `delegation_collection_pending`, `open_claims`, plus the collection-operation
+ * members added by Plan 4 (Core Collection Operation): `missing_outcomes`,
+ * `already_collected`, `collection_frame_not_active`, `collection_applied`, and
+ * `collection_failed`. The claim/terminal members (`stale_claim`,
+ * `terminal_claim_confirmed`, `terminal_claim_conflict`) and `not_delegatable`
+ * are deferred to the claim plans (Plan 5). `target_not_delegating_scope` from
  * the spec is intentionally NOT implemented here: under the target-relative
  * model a run delegating upward is still a valid collection target, so the
  * orchestrator check is the only gate this slice needs.
@@ -121,6 +122,89 @@ export type DelegationPolicyOutcome =
       readonly parentRunId: RunId;
       /** Open claim records blocking the command. */
       readonly claims: readonly ClaimRecord[];
+    }
+  | {
+      /** Collection target has delegation substeps without reported outcomes. */
+      readonly kind: 'missing_outcomes';
+      /** Target run that was inspected. */
+      readonly targetRunId: RunId;
+      /** Step selected for collection. */
+      readonly step: string;
+      /** Delegated substep ids still lacking delegation outcomes. */
+      readonly missingSubsteps: readonly string[];
+    }
+  | {
+      /** Collection found no unapplied outcomes for the selected scope. */
+      readonly kind: 'already_collected';
+      /** Target run that was inspected. */
+      readonly targetRunId: RunId;
+      /** Step selected for collection. */
+      readonly step: string;
+    }
+  | {
+      /**
+       * Requested frame is not the cursor's active frame. Drain was
+       * observation-only and applied nothing. This is a DISTINCT variant from
+       * `already_collected` because the CLI must render the existing
+       * `not-active` JSON payload faithfully (status string `not-active`,
+       * carrying `frameKey` / `activeFrameKey` / `unresolved`) — folding it into
+       * `already_collected` (rendered `already-aggregated`) would break the
+       * asserted `not-active` contract. The carried fields mirror drain's
+       * `not_active` result.
+       */
+      readonly kind: 'collection_frame_not_active';
+      /** Target run that was inspected. */
+      readonly targetRunId: RunId;
+      /** Step selected for collection. */
+      readonly step: string;
+      /** Frame key requested via the scope/frame override. */
+      readonly frameKey: FrameKey;
+      /** Frame key the target run cursor is actually positioned on. */
+      readonly activeFrameKey: FrameKey;
+      /** Count of substeps still without a persisted delegation outcome. */
+      readonly unresolved: number;
+    }
+  | {
+      /** Collection applied one or more delegation outcomes. */
+      readonly kind: 'collection_applied';
+      /** Target run that received the collected outcomes. */
+      readonly targetRunId: RunId;
+      /** Step selected for collection. */
+      readonly step: string;
+      /** Number of delegation outcomes consumed. */
+      readonly applied: number;
+      /** Number of outcomes still unresolved after this collection. */
+      readonly unresolved: number;
+      /** Lifecycle of the target run after collection. */
+      readonly lifecycle: RunbookState['lifecycle'];
+      /** True when collection reported this run's terminal delegation outcome upward. */
+      readonly reportedTerminalOutcome: boolean;
+    }
+  | {
+      /** Collection failed after core rejected a persisted delegation outcome. */
+      readonly kind: 'collection_failed';
+      /** Target run that was being collected. */
+      readonly targetRunId: RunId;
+      /**
+       * Machine/core reason. Every member has a real producer (no dead arms):
+       * - `not_delegate_step` — `collectDelegationOutcomes` non-DELEGATE-step guard
+       * - `step_not_found` — `collectDelegationOutcomes` stale-state guard
+       * - `target_mismatch` — `drainResolvedCompletions` `status: 'failed'`
+       *   (CompletionTargetMismatch.reason is the only drain failure reason).
+       *   There is NO `state_error` reason; drain never produces one.
+       */
+      readonly reason: 'target_mismatch' | 'not_delegate_step' | 'step_not_found';
+      /**
+       * User-facing error code, attached by core so the CLI renders a flat
+       * passthrough (no CLI reason→code ternary — keeps "no CLI lifecycle
+       * decisions" and type-driven dispatch intact):
+       * - `not_delegate_step` → `NOT_DELEGATE_STEP`
+       * - `step_not_found` → `STEP_NOT_FOUND`
+       * - `target_mismatch` → `COLLECT_OPERATION_FAILED`
+       */
+      readonly code: 'NOT_DELEGATE_STEP' | 'STEP_NOT_FOUND' | 'COLLECT_OPERATION_FAILED';
+      /** Operator-facing failure message. */
+      readonly message: string;
     };
 
 /**

--- a/packages/core/src/runbook/command-target-resolver.ts
+++ b/packages/core/src/runbook/command-target-resolver.ts
@@ -351,9 +351,16 @@ export async function resolveTransitionTarget(
       case 'actor_context_required':
         return { kind: 'actor_context_required', targetRunId: active.id };
       case 'collect_requires_orchestrator':
+      case 'missing_outcomes':
+      case 'already_collected':
+      case 'collection_frame_not_active':
+      case 'collection_applied':
+      case 'collection_failed':
         // Unreachable for a delegating-run-advance intent: the orchestrator gate
-        // belongs to the collection path only. A real occurrence is an invariant
-        // violation, not an expected refusal, so it stays a throw.
+        // and the collection-operation outcomes belong to the collection path
+        // only (emitted by collectDelegationOutcomes, never resolveCommandIntent).
+        // A real occurrence is an invariant violation, not an expected refusal,
+        // so it stays a throw.
         throw new Error(`Unexpected transition policy outcome: ${policy.kind}`);
       default: {
         const _exhaustive: never = policy;

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -116,6 +116,13 @@ export {
   type RecordCompletionResult,
   type RecordManualCompletionArgs,
 } from './completion-service.js';
+export {
+  RunbookCollectionService,
+  collectDelegationOutcomes,
+  type CollectDelegationOutcomesInput,
+  type CollectDelegationOutcomesOperationInput,
+  type RunbookCollectionServiceDependencies,
+} from './collection-service.js';
 export { compileRunbookToMachine, runbookSetup, MAX_FILE_ITERATIONS } from './compiler.js';
 export type { RunbookMachine } from './compiler.js';
 export { runRetryHook } from './retry-hook.js';


### PR DESCRIPTION
## Summary

Plan 4: moves delegation **collection** orchestration into `@rundown-org/core` behind a typed `collectDelegationOutcomes(target, actorContext)` operation, and converts the CLI `collect` command into a thin adapter. Core owns target resolution, the orchestrator policy gate, draining reported delegation outcomes, aggregation, and single-level terminal reporting; the CLI parses flags, builds actor context, and renders the typed `DelegationPolicyOutcome`.

Depends on merged Plan 1 (delegation lifecycle) and Plan 3 (core command policy).

## What changed

- **core**: new `RunbookCollectionService` / `collectDelegationOutcomes()`; `DelegationPolicyOutcome` extended with `missing_outcomes`, `already_collected`, `collection_frame_not_active`, `collection_applied`, `collection_failed`; new output codes `COLLECT_ALREADY_APPLIED`, `COLLECT_OPERATION_FAILED`.
- **cli `collect.ts`**: thin adapter over the core op + `renderCollectOutcome`; new `status: 'applied'` JSON envelope; preserves `already-aggregated` / `not-active` / error-code contracts. Post-collect `runExecutionLoop` auto-advance dropped (collection ≠ execution).
- **cli `handleParentCompletion`**: de-recursed to **single-level** — records one outcome upward on a terminal parent instead of cascading into the grandparent. `depth` / `MAX_PROPAGATION_DEPTH` removed.
- **cli `transitions.ts`**: surfaces the resolved `ClaimRecord` on `TransitionContext` (collect path) so `--claim-id` builds a claim-controller actor context.
- Schema: `CollectResponseSchema` gains the `applied` arm + optional `code` field.

## Collection is single-level

Collecting a run to terminal reports **one** outcome to its delegating ancestor but does not collect that ancestor. Deep chains require one `rd collect` (or one child completion) per delegating level. This is an intended, observable change (replaces the old fully-recursive `handleParentCompletion`).

## Deviations from the plan (each forced by a defect proven via tests)

1. **Gate is status-only** (matches merged `collect.ts`); the plan's extra completion-presence check broke the preserved `already-aggregated`/`not-active` contracts.
2. **`handleParentCompletion` keeps its incremental drain + execution loop** (de-recurse only); routing it through the *gated* core op broke incremental multi-substep propagation and FAIL-ANY early-stop. Only `rd collect` (whose precondition is "all substeps resolved") uses the gated op.
3. Auto-advance dropped in `collect.ts` only; kept in `handleParentCompletion` (consequence of #2).
4. Core apply/terminal tests use a `sendAndSync` spy (established core idiom) — a delegate-substep machine can't be reconstructed from a hand-built fixture without a persisted xstate snapshot; genuine spawn→drain→aggregate e2e lives at the CLI layer.
5. The old `aggregated=true` transition-event assertion reconciled to assert the typed `status:'applied'` / `lifecycle:'stopped'` outcome.

## Testing

- Core: 68 collection + schema tests (incl. 2 fast-check properties); CLI: 202 focused-suite tests.
- **Full integration suite: 33 suites / 570 tests / 0 failures** (after build).
- Both packages typecheck; lint clean (2 warnings are pre-existing config).
- Independent read-only audit: zero genuine regressions; all test-behavior changes judged sound.

## Notes for reviewers / CI

- **Integration tests spawn the built `dist/cli.js`** — CI must `pnpm run build` before `test:integration` (stale `dist` produces spurious failures).
- Not run (recommended pre-merge): scoped Stryker mutation testing on `collection-service.ts` and `collect.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `rd collect` with centralized outcome rendering, richer structured JSON output (including `applied`) and additional machine-readable error codes for collect operations.
* **Bug Fixes**
  * Improved collection outcome reporting for missing substeps and inactive frames.
  * Fixed delegated-run terminal outcome propagation to report only a single-level parent result.
* **Tests**
  * Expanded schema validation and schema-coverage fixtures for new `collect` response variants.
  * Added/extended core and CLI test suites covering delegation collection outcomes, error envelopes, and upward completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->