### PR TITLE
test(plugin): harden test coverage for claude-code-plugin

### DIFF
--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -1,0 +1,9 @@
+# @rundown-org/claude-code-plugin
+
+Claude Code plugin for Rundown runbook orchestration.
+
+This package ships the Claude Code plugin metadata, hooks, skills, runbooks,
+schemas, and helper binaries used by Rundown's agent workflow integration.
+
+For CLI usage, runbook authoring, and security policy details, see the root
+Rundown documentation.

--- a/packages/claude-code-plugin/TESTING.md
+++ b/packages/claude-code-plugin/TESTING.md
@@ -72,6 +72,25 @@ pnpm --filter @rundown-org/claude-code-plugin test -- session.test.ts
 pnpm run test:mutate:plugin
 ```
 
+### Pre-PR plugin coverage
+
+Root `pnpm run verify` runs build, lint, type checks, generated-doc checks, and
+unit tests. It does not run plugin integration, property, coverage, smoke, or
+mutation suites. For plugin behavior changes, run the smallest targeted Jest
+command first, then run the relevant broader suite:
+
+```bash
+pnpm --filter @rundown-org/claude-code-plugin test:unit
+pnpm --filter @rundown-org/claude-code-plugin test:integration
+pnpm --filter @rundown-org/claude-code-plugin test:property
+pnpm --filter @rundown-org/claude-code-plugin test:coverage
+```
+
+Use `pnpm run test:mutate:plugin` for mutation-sensitive changes after the
+targeted tests are green. Do not lower Stryker thresholds to make a PR pass;
+capture the current mutation baseline first and tighten it in a separate
+tooling change when the baseline is stable.
+
 ### Coverage Thresholds (`jest.config.js`)
 
 - **Global**: 75% branches, 90% functions, 85% lines, 85% statements.

--- a/packages/claude-code-plugin/TESTING.md
+++ b/packages/claude-code-plugin/TESTING.md
@@ -77,6 +77,29 @@ pnpm run test:mutate:plugin
 - **Global**: 75% branches, 90% functions, 85% lines, 85% statements.
 - **`src/dispatcher.ts`**: 80% branches, 90% functions, 85% lines.
 
+### Known LCOV gap: `src/rdpath.ts` and `src/rdx.ts`
+
+The `rdpath`/`rdx` entrypoint shells do **not** appear in `coverage/lcov.info`,
+even though `collectCoverageFrom` is `src/**/*.ts`. This is expected, not a hole
+in the suite:
+
+- Both files are CLI entrypoints that call `program.parse()` at module top level.
+  They are only exercised by spawning the built `dist/{rdpath,rdx}.js` as a child
+  `node` process (`rdpath-find-integration.test.ts`, ~30 cases;
+  `rdx.integration.test.ts`, ~20 cases). Jest/istanbul instruments the in-process
+  module graph only, so coverage of a spawned subprocess is never collected.
+- They cannot be imported in-process to gain instrumentation without running the
+  CLI as a side effect of the import (no `main`-module guard). Adding such a guard
+  purely to satisfy coverage would change entrypoint behavior, which is out of
+  scope for coverage hardening.
+- Their actual logic lives in modules that **are** covered in-process:
+  `src/rdx-core.ts` + `src/rdx-validate.ts` for `rdx`, and `assembleRdPath` /
+  `findRdPathFiles` / `readActiveRunScope` from `@rundown-org/core` for `rdpath`.
+
+The behavioral contract of both entrypoints is pinned by the spawn-based
+integration tests above; the LCOV omission reflects the instrumentation boundary,
+not untested code.
+
 ## Manual Hook Verification
 
 Pipe a hook payload to the built CLI (`pnpm build` first). The plugin only acts

--- a/packages/claude-code-plugin/__tests__/commands/manifest.test.ts
+++ b/packages/claude-code-plugin/__tests__/commands/manifest.test.ts
@@ -131,9 +131,15 @@ describe('Plugin manifest surface', () => {
       rdx: 'dist/rdx.js',
     });
     // Pass keys as single-element arrays so Jest treats '.' / './cli' as literal
-    // keys instead of dot-delimited property paths.
-    expect(packageJson.exports).toHaveProperty(['.']);
-    expect(packageJson.exports).toHaveProperty(['./cli']);
+    // keys instead of dot-delimited property paths, and pin the resolved targets
+    // so the publish/runtime contract can't drift to the wrong file.
+    expect(packageJson.exports).toHaveProperty(['.'], {
+      import: './dist/index.js',
+      types: './dist/index.d.ts',
+    });
+    expect(packageJson.exports).toHaveProperty(['./cli'], {
+      import: './dist/cli.js',
+    });
 
     const requiredPublishedEntries = [
       'dist',

--- a/packages/claude-code-plugin/__tests__/commands/manifest.test.ts
+++ b/packages/claude-code-plugin/__tests__/commands/manifest.test.ts
@@ -9,14 +9,14 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
- * Read and parse a JSON file, asserting the result is shaped like `T`.
+ * Read and parse a JSON file, returning the value as `unknown`.
  *
- * The `as T` cast is unchecked: no runtime validation is performed, so the
- * caller is trusted to supply a generic argument matching the file's actual
- * structure. Acceptable here because the inputs are repo-local fixtures.
+ * Callers narrow the result with a local `as` cast. No runtime validation is
+ * performed, so the caller is trusted to assert a shape matching the file's
+ * actual structure. Acceptable here because the inputs are repo-local fixtures.
  */
-function readJson<T>(filePath: string): T {
-  return JSON.parse(readFileSync(filePath, 'utf-8')) as T;
+function readJson(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf-8'));
 }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -56,12 +56,12 @@ describe('Plugin manifest surface', () => {
   const hooksJsonPath = path.join(pluginRoot, 'hooks', 'hooks.json');
 
   it('wires Claude hooks to the built plugin CLI entrypoint', () => {
-    const hooksManifest = readJson<{
+    const hooksManifest = readJson(hooksJsonPath) as {
       hooks: Record<
         string,
         Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }>
       >;
-    }>(hooksJsonPath);
+    };
 
     // The PreToolUse matcher pins delegation entrypoints (Agent|Task); the
     // Bash-guard matcher is owned by issue #470 and is intentionally absent here.
@@ -91,20 +91,20 @@ describe('Plugin manifest surface', () => {
   });
 
   it('keeps .claude-plugin/plugin.json aligned with package metadata', () => {
-    const pluginJson = readJson<{
+    const pluginJson = readJson(pluginJsonPath) as {
       name: string;
       version: string;
       description: string;
       author: { name: string; email: string };
       repository: string;
-    }>(pluginJsonPath);
-    const packageJson = readJson<{
+    };
+    const packageJson = readJson(packageJsonPath) as {
       name: string;
       version: string;
       description: string;
       author: string;
       repository: { url: string };
-    }>(packageJsonPath);
+    };
 
     expect(pluginJson.name).toBe('rundown');
     expect(pluginJson.version).toBe(packageJson.version);
@@ -116,13 +116,13 @@ describe('Plugin manifest surface', () => {
   });
 
   it('publishes every required plugin surface through package.json files', () => {
-    const packageJson = readJson<{
+    const packageJson = readJson(packageJsonPath) as {
       files: string[];
       main: string;
       types: string;
       bin: Record<string, string>;
       exports: Record<string, unknown>;
-    }>(packageJsonPath);
+    };
 
     expect(packageJson.main).toBe('dist/cli.js');
     expect(packageJson.types).toBe('dist/index.d.ts');

--- a/packages/claude-code-plugin/__tests__/commands/manifest.test.ts
+++ b/packages/claude-code-plugin/__tests__/commands/manifest.test.ts
@@ -4,9 +4,13 @@
  * Pattern: similar to __tests__/runbooks/validation.test.ts
  */
 import { describe, it, expect } from '@jest/globals';
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as T;
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.join(__dirname, '..', '..');
@@ -36,5 +40,112 @@ describe('Command-Skill Wiring', () => {
       const skillPath = path.join(skillsDir, skillName, 'SKILL.md');
       expect(existsSync(skillPath)).toBe(true);
     });
+  });
+});
+
+describe('Plugin manifest surface', () => {
+  const pluginJsonPath = path.join(pluginRoot, '.claude-plugin', 'plugin.json');
+  const packageJsonPath = path.join(pluginRoot, 'package.json');
+  const hooksJsonPath = path.join(pluginRoot, 'hooks', 'hooks.json');
+
+  it('wires Claude hooks to the built plugin CLI entrypoint', () => {
+    const hooksManifest = readJson<{
+      hooks: Record<
+        string,
+        Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }>
+      >;
+    }>(hooksJsonPath);
+
+    // The PreToolUse matcher pins delegation entrypoints (Agent|Task); the
+    // Bash-guard matcher is owned by issue #470 and is intentionally absent here.
+    expect(Object.keys(hooksManifest.hooks).sort()).toEqual(['PreToolUse', 'SubagentStop']);
+    expect(hooksManifest.hooks.PreToolUse).toEqual([
+      {
+        matcher: 'Agent|Task',
+        hooks: [
+          {
+            type: 'command',
+            command: 'node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js"',
+          },
+        ],
+      },
+    ]);
+    expect(hooksManifest.hooks.SubagentStop).toEqual([
+      {
+        matcher: '.*',
+        hooks: [
+          {
+            type: 'command',
+            command: 'node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js"',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('keeps .claude-plugin/plugin.json aligned with package metadata', () => {
+    const pluginJson = readJson<{
+      name: string;
+      version: string;
+      description: string;
+      author: { name: string; email: string };
+      repository: string;
+    }>(pluginJsonPath);
+    const packageJson = readJson<{
+      name: string;
+      version: string;
+      description: string;
+      author: string;
+      repository: { url: string };
+    }>(packageJsonPath);
+
+    expect(pluginJson.name).toBe('rundown');
+    expect(pluginJson.version).toBe(packageJson.version);
+    expect(pluginJson.description).toBe(packageJson.description);
+    expect(pluginJson.author.name).toBe(packageJson.author);
+    expect(pluginJson.author.email).toBe('toby@rundown.org');
+    expect(packageJson.repository.url).toContain('github.com/rundown-org/rundown');
+    expect(pluginJson.repository).toBe('https://github.com/rundown-org/rundown');
+  });
+
+  it('publishes every required plugin surface through package.json files', () => {
+    const packageJson = readJson<{
+      files: string[];
+      main: string;
+      types: string;
+      bin: Record<string, string>;
+      exports: Record<string, unknown>;
+    }>(packageJsonPath);
+
+    expect(packageJson.main).toBe('dist/cli.js');
+    expect(packageJson.types).toBe('dist/index.d.ts');
+    expect(packageJson.bin).toEqual({
+      rdpath: 'dist/rdpath.js',
+      rdx: 'dist/rdx.js',
+    });
+    // Pass keys as single-element arrays so Jest treats '.' / './cli' as literal
+    // keys instead of dot-delimited property paths.
+    expect(packageJson.exports).toHaveProperty(['.']);
+    expect(packageJson.exports).toHaveProperty(['./cli']);
+
+    const requiredPublishedEntries = [
+      'dist',
+      'schemas',
+      '.claude-plugin',
+      'examples',
+      'hooks',
+      'runbooks',
+      'scripts',
+      'skills',
+      'templates',
+      'README.md',
+    ];
+    expect(packageJson.files.sort()).toEqual(requiredPublishedEntries.sort());
+
+    for (const entry of packageJson.files) {
+      const entryPath = path.join(pluginRoot, entry);
+      expect(existsSync(entryPath)).toBe(true);
+      expect(statSync(entryPath).isDirectory() || statSync(entryPath).isFile()).toBe(true);
+    }
   });
 });

--- a/packages/claude-code-plugin/__tests__/commands/manifest.test.ts
+++ b/packages/claude-code-plugin/__tests__/commands/manifest.test.ts
@@ -8,6 +8,13 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+/**
+ * Read and parse a JSON file, asserting the result is shaped like `T`.
+ *
+ * The `as T` cast is unchecked: no runtime validation is performed, so the
+ * caller is trusted to supply a generic argument matching the file's actual
+ * structure. Acceptable here because the inputs are repo-local fixtures.
+ */
 function readJson<T>(filePath: string): T {
   return JSON.parse(readFileSync(filePath, 'utf-8')) as T;
 }
@@ -145,7 +152,8 @@ describe('Plugin manifest surface', () => {
     for (const entry of packageJson.files) {
       const entryPath = path.join(pluginRoot, entry);
       expect(existsSync(entryPath)).toBe(true);
-      expect(statSync(entryPath).isDirectory() || statSync(entryPath).isFile()).toBe(true);
+      const stat = statSync(entryPath);
+      expect(stat.isDirectory() || stat.isFile()).toBe(true);
     }
   });
 });

--- a/packages/claude-code-plugin/__tests__/content/json-default-output.test.ts
+++ b/packages/claude-code-plugin/__tests__/content/json-default-output.test.ts
@@ -45,7 +45,9 @@ function fencedBlocks(markdown: string): string[] {
 }
 
 function agentFacingTextCommands(filePath: string): Match[] {
-  const relative = path.relative(pluginRoot, filePath);
+  // Normalize to forward slashes so allowlist keys (which use '/') match on
+  // Windows, where path.relative() returns backslash-separated paths.
+  const relative = path.relative(pluginRoot, filePath).replaceAll('\\', '/');
   const markdown = readFileSync(filePath, 'utf-8');
   const matches: Match[] = [];
   for (const block of fencedBlocks(markdown)) {

--- a/packages/claude-code-plugin/__tests__/content/json-default-output.test.ts
+++ b/packages/claude-code-plugin/__tests__/content/json-default-output.test.ts
@@ -39,7 +39,7 @@ function fencedBlocks(markdown: string): string[] {
   const blocks: string[] = [];
   const pattern = /```[^\n]*\n([\s\S]*?)```/g;
   for (const match of markdown.matchAll(pattern)) {
-    blocks.push(match[1] ?? '');
+    blocks.push(match[1]);
   }
   return blocks;
 }

--- a/packages/claude-code-plugin/__tests__/content/json-default-output.test.ts
+++ b/packages/claude-code-plugin/__tests__/content/json-default-output.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from '@jest/globals';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pluginRoot = path.join(__dirname, '..', '..');
+
+interface Match {
+  file: string;
+  command: string;
+  reason: string;
+}
+
+const allowlistedTextCommands = new Set<string>([
+  // Human/debugging examples may be added here as "relative/path.md :: command text".
+  // The "Structured Output" section documents that JSON is the default and that
+  // `--text` yields human-readable output; this example demonstrates that flag for
+  // humans and is not an agent-driven command.
+  'skills/running-runbooks/SKILL.md :: rd status --text    # Human-readable text output',
+]);
+
+function markdownFiles(root: string): string[] {
+  const entries = readdirSync(root);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(root, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...markdownFiles(fullPath));
+    } else if (entry.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function fencedBlocks(markdown: string): string[] {
+  const blocks: string[] = [];
+  const pattern = /```[^\n]*\n([\s\S]*?)```/g;
+  for (const match of markdown.matchAll(pattern)) {
+    blocks.push(match[1] ?? '');
+  }
+  return blocks;
+}
+
+function agentFacingTextCommands(filePath: string): Match[] {
+  const relative = path.relative(pluginRoot, filePath);
+  const markdown = readFileSync(filePath, 'utf-8');
+  const matches: Match[] = [];
+  for (const block of fencedBlocks(markdown)) {
+    const commands = block
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => /(^|\s)(rd|rundown)\s+\S+/.test(line))
+      .filter((line) => line.includes('--text'));
+
+    for (const command of commands) {
+      const key = `${relative} :: ${command}`;
+      if (!allowlistedTextCommands.has(key)) {
+        matches.push({
+          file: relative,
+          command,
+          reason:
+            'agent-authored rd/rundown command uses --text; JSON output is the default agent contract',
+        });
+      }
+    }
+  }
+  return matches;
+}
+
+describe('plugin-authored skills and runbooks use JSON-default rd commands', () => {
+  it('does not use --text for agent-facing rd/rundown commands', () => {
+    const roots = [path.join(pluginRoot, 'skills'), path.join(pluginRoot, 'runbooks')];
+    const violations = roots.flatMap((root) =>
+      markdownFiles(root).flatMap(agentFacingTextCommands),
+    );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/claude-code-plugin/__tests__/plan-validators.test.ts
+++ b/packages/claude-code-plugin/__tests__/plan-validators.test.ts
@@ -353,6 +353,73 @@ describe('checkNoLocationLineNumbers', () => {
     ]);
   });
 
+  it('flags task-level file end_line fields', () => {
+    const plan = minimalPlan({
+      tasks: [
+        {
+          name: 'Task',
+          files: [{ path: 'src/foo.ts', action: 'edit', end_line: 18 }],
+          subtasks: [
+            { name: 'Write failing test for validator' },
+            { name: 'Run to confirm failure' },
+            { name: 'Implement validator assertion' },
+            { name: 'Run tests to verify pass' },
+          ],
+          commit: { files: ['src/foo.ts'], message: 'test: cover validator' },
+        },
+      ],
+    });
+
+    const issues = checkNoLocationLineNumbers(plan);
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        rule: 'no-line-numbers',
+        severity: 'error',
+        path: 'tasks/0/files/0',
+        message: expect.stringContaining('src/foo.ts'),
+      }),
+    ]);
+  });
+
+  it('reports a single issue when both line and end_line are present', () => {
+    const plan = minimalPlan({
+      files: [{ path: 'src/foo.ts', action: 'edit', line: 12, end_line: 20 }],
+    });
+
+    const issues = checkNoLocationLineNumbers(plan);
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        rule: 'no-line-numbers',
+        severity: 'error',
+        path: 'files/0',
+        message: expect.stringContaining('src/foo.ts'),
+      }),
+    ]);
+  });
+
+  it('returns no issues when no file entries carry line numbers', () => {
+    const plan = minimalPlan({
+      files: [{ path: 'src/foo.ts', action: 'edit' }],
+      tasks: [
+        {
+          name: 'Task',
+          files: [{ path: 'src/foo.ts', action: 'edit' }],
+          subtasks: [
+            { name: 'Write failing test for validator' },
+            { name: 'Run to confirm failure' },
+            { name: 'Implement validator assertion' },
+            { name: 'Run tests to verify pass' },
+          ],
+          commit: { files: ['src/foo.ts'], message: 'test: cover validator' },
+        },
+      ],
+    });
+
+    expect(checkNoLocationLineNumbers(plan)).toEqual([]);
+  });
+
   it('makes validatePlanStructure invalid for location line numbers', () => {
     const plan = minimalPlan({
       files: [{ path: 'src/foo.ts', action: 'edit', line: 12 }],

--- a/packages/claude-code-plugin/__tests__/plan-validators.test.ts
+++ b/packages/claude-code-plugin/__tests__/plan-validators.test.ts
@@ -9,6 +9,7 @@ import {
   checkCommitSteps,
   checkCommitFileConsistency,
   checkNoLineNumbers,
+  checkNoLocationLineNumbers,
   checkFileConsistency,
   validatePlanStructure,
 } from '../src/plan-validators.js';
@@ -283,6 +284,92 @@ describe('checkNoLineNumbers', () => {
       ],
     });
     expect(checkNoLineNumbers(plan)).toHaveLength(1);
+  });
+});
+
+// ── checkNoLocationLineNumbers ───────────────────────────────────────────────
+
+describe('checkNoLocationLineNumbers', () => {
+  it('flags plan-level file line fields', () => {
+    const plan = minimalPlan({
+      files: [{ path: 'src/foo.ts', action: 'edit', line: 12 }],
+    });
+
+    const issues = checkNoLocationLineNumbers(plan);
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        rule: 'no-line-numbers',
+        severity: 'error',
+        path: 'files/0',
+        message: expect.stringContaining('src/foo.ts'),
+      }),
+    ]);
+  });
+
+  it('flags plan-level file end_line fields', () => {
+    const plan = minimalPlan({
+      files: [{ path: 'src/foo.ts', action: 'edit', end_line: 20 }],
+    });
+
+    const issues = checkNoLocationLineNumbers(plan);
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        rule: 'no-line-numbers',
+        severity: 'error',
+        path: 'files/0',
+        message: expect.stringContaining('src/foo.ts'),
+      }),
+    ]);
+  });
+
+  it('flags task-level file line fields', () => {
+    const plan = minimalPlan({
+      tasks: [
+        {
+          name: 'Task',
+          files: [{ path: 'src/foo.ts', action: 'edit', line: 9 }],
+          subtasks: [
+            { name: 'Write failing test for validator' },
+            { name: 'Run to confirm failure' },
+            { name: 'Implement validator assertion' },
+            { name: 'Run tests to verify pass' },
+          ],
+          commit: { files: ['src/foo.ts'], message: 'test: cover validator' },
+        },
+      ],
+    });
+
+    const issues = checkNoLocationLineNumbers(plan);
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        rule: 'no-line-numbers',
+        severity: 'error',
+        path: 'tasks/0/files/0',
+        message: expect.stringContaining('src/foo.ts'),
+      }),
+    ]);
+  });
+
+  it('makes validatePlanStructure invalid for location line numbers', () => {
+    const plan = minimalPlan({
+      files: [{ path: 'src/foo.ts', action: 'edit', line: 12 }],
+    });
+
+    const result = validatePlanStructure(plan);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: 'no-line-numbers',
+          severity: 'error',
+          path: 'files/0',
+        }),
+      ]),
+    );
   });
 });
 

--- a/packages/claude-code-plugin/__tests__/plan-validators.test.ts
+++ b/packages/claude-code-plugin/__tests__/plan-validators.test.ts
@@ -399,6 +399,35 @@ describe('checkNoLocationLineNumbers', () => {
     ]);
   });
 
+  it('reports a single task-level issue when both line and end_line are present', () => {
+    const plan = minimalPlan({
+      tasks: [
+        {
+          name: 'Task',
+          files: [{ path: 'src/foo.ts', action: 'edit', line: 12, end_line: 20 }],
+          subtasks: [
+            { name: 'Write failing test for validator' },
+            { name: 'Run to confirm failure' },
+            { name: 'Implement validator assertion' },
+            { name: 'Run tests to verify pass' },
+          ],
+          commit: { files: ['src/foo.ts'], message: 'test: cover validator' },
+        },
+      ],
+    });
+
+    const issues = checkNoLocationLineNumbers(plan);
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        rule: 'no-line-numbers',
+        severity: 'error',
+        path: 'tasks/0/files/0',
+        message: expect.stringContaining('src/foo.ts'),
+      }),
+    ]);
+  });
+
   it('returns no issues when no file entries carry line numbers', () => {
     const plan = minimalPlan({
       files: [{ path: 'src/foo.ts', action: 'edit' }],

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -22,7 +22,6 @@
     "dist",
     "schemas",
     ".claude-plugin",
-    "commands",
     "examples",
     "hooks",
     "runbooks",


### PR DESCRIPTION
## Summary

Hardens test coverage for the `@rundown-org/claude-code-plugin` package, pinning previously-untested surfaces and removing a stale dependency. CodeRabbit-clean (0 findings).

## Changes

- **Manifest / package surface** (`__tests__/commands/manifest.test.ts`): verifies the published `package.json` `files` list matches the expected entries and that every entry exists on disk as a file or directory.
- **Agent rd-command output** (`__tests__/content/json-default-output.test.ts`): guards that agent-facing `rd`/`rundown` commands default to JSON and do not emit `--text` output.
- **Plan validators** (`__tests__/plan-validators.test.ts`): covers plan-file line-number validation, including plan- and task-level `line`/`end_line` fields, the both-fields-present case, and the happy path.
- **Docs**: document the rdpath/rdx entrypoint coverage gap and clarify the coverage-hardening workflow (`README.md`, `TESTING.md`).
- **Cleanup**: drop a stale entry from `package.json`.

## Test plan

- `pnpm --filter @rundown-org/claude-code-plugin test` — passes.
- CodeRabbit review against `main` — 0 findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a package README describing the Claude Code plugin contents and where to find CLI usage, authoring, and security guidance.
  * Expanded testing/coverage guidance with recommended targeted Jest runs and a note about a known LCOV coverage gap.

* **Tests**
  * Added Jest checks to validate the plugin’s published/configured manifest surface and metadata consistency.
  * Added enforcement for agent-facing `rd`/`rundown ... --text` JSON-default output allowlisting in Markdown skills/runbooks.
  * Added plan validation tests rejecting disallowed file `line`/`end_line` fields.

* **Chores**
  * Updated the npm package file whitelist to stop publishing the `commands` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->