### PR TITLE
fix(#467): correct execute-plan standalone guidance and artifact diagnostic

### DIFF
--- a/packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts
@@ -18,12 +18,15 @@ describe('executing-plans skill', () => {
     expect(skill).toMatch(/^description:\s*\S+/m);
   });
 
-  it('declares the runbook entrypoint with its required PlanPath input', () => {
+  it('declares the runbook entrypoint with its required PlanPath artifact URI', () => {
     const skill = readSkill();
-    // execute-plan declares PlanPath REQUIRED, so the start command must supply
-    // it — a bare `rd run` would fail before a runbook becomes active.
-    expect(skill).toMatch(/`rd run rundown:execute-plan --input PlanPath=<path-to-plan>`/);
-    expect(skill).toMatch(/Resolve `PlanPath` first/);
+    // execute-plan declares PlanPath REQUIRED and consumes it as an ARTIFACT, so
+    // a standalone start must supply the plan's rd:// artifact URI — a bare
+    // filesystem path (or bare `rd run`) fails before the runbook activates.
+    expect(skill).toMatch(/rd run rundown:execute-plan --input PlanPath=<rd:\/\/[^>]*plan URI>/);
+    expect(skill).toMatch(/Resolve `PlanPath`\s+first/);
+    // Points the implementer at the inspection commands that yield the URI.
+    expect(skill).toMatch(/rd artifact uri/);
     expect(skill).toMatch(/Skill\(skill:\s*"rundown:running-runbooks"\)/);
   });
 

--- a/packages/claude-code-plugin/__tests__/skills/running-runbooks.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/running-runbooks.test.ts
@@ -7,8 +7,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const skillPath = path.join(__dirname, '..', '..', 'skills', 'running-runbooks', 'SKILL.md');
 
+function readSkill(): string {
+  return readFileSync(skillPath, 'utf-8');
+}
+
 function readDescription(): string {
-  const skill = readFileSync(skillPath, 'utf-8');
+  const skill = readSkill();
   const match = /^description:\s*(.+)$/m.exec(skill);
   expect(match).not.toBeNull();
   return match![1];
@@ -28,5 +32,20 @@ describe('running-runbooks skill description', () => {
 
   it('still covers delegation claim tokens', () => {
     expect(readDescription()).toMatch(/claim token/i);
+  });
+});
+
+describe('running-runbooks structured-output guidance', () => {
+  it('documents JSON as the agent-facing default', () => {
+    expect(readSkill()).toMatch(/JSON is the agent-facing output format/);
+  });
+
+  it('never demonstrates `--text` as an agent command example', () => {
+    // `--text` is humans/debugging only; the agent protocol is JSON. Mirrors the
+    // no-added-flags lock in planning.test.ts / end-to-end-testing.test.ts so the
+    // primary execution-protocol skill cannot drift back to teaching the flag.
+    const skill = readSkill();
+    expect(skill).not.toContain('rd status --text');
+    expect(skill).toMatch(/Do not add `--text`/);
   });
 });

--- a/packages/claude-code-plugin/__tests__/skills/running-runbooks.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/running-runbooks.test.ts
@@ -45,7 +45,10 @@ describe('running-runbooks structured-output guidance', () => {
     // no-added-flags lock in planning.test.ts / end-to-end-testing.test.ts so the
     // primary execution-protocol skill cannot drift back to teaching the flag.
     const skill = readSkill();
-    expect(skill).not.toContain('rd status --text');
+    // Catch ANY `rd <cmd> … --text` example, not just the status variant. The
+    // single-line match cannot false-positive on the prohibition prose, which
+    // mentions `--text` with no `rd` command token on the same line.
+    expect(skill).not.toMatch(/\brd\b[^\n]*--text/);
     expect(skill).toMatch(/Do not add `--text`/);
   });
 });

--- a/packages/claude-code-plugin/skills/executing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/executing-plans/SKILL.md
@@ -7,13 +7,20 @@ description: Use when implementing a written plan task-by-task — the per-task 
 
 <important>
 ## Runbook-Orchestrated Skill
-This runbook requires the path to the plan to execute. Resolve `PlanPath` first
-(ask the user if it is not already known). Load the execution protocol *before*
-starting, so you can handle delegated tasks the moment they appear:
+This runbook requires the plan's **artifact URI** as `PlanPath` — an `rd://…`
+value produced by `write-plan`, **not** a filesystem path. Resolve `PlanPath`
+first (ask the user if it is not already known). Load the execution protocol
+*before* starting, so you can handle delegated tasks the moment they appear:
 
 1. `Skill(skill: "rundown:running-runbooks")`
 2. `Skill(skill: "rundown:delegating-runbooks")` — this runbook delegates
-3. Then start it: `rd run rundown:execute-plan --input PlanPath=<path-to-plan>`
+3. Then start it:
+   - **Delegated pipeline** (`write-plan → execute-plan`): `PlanPath` is
+     inherited automatically — no `--input` needed.
+   - **Standalone**: pass the plan's artifact URI —
+     `rd run rundown:execute-plan --input PlanPath=<rd://… plan URI>`. Discover
+     the alias with `rd artifact ls`, then resolve its URI with
+     `rd artifact uri PlanPath --text`.
 </important>
 
 Implement a written plan one task at a time, holding each task to its own tests and committing as you go. This skill is the **context** an execution runbook orchestrates: how to do each task well. The [`execute-plan`](../../runbooks/planning/execute-plan.runbook.md) runbook owns the *sequence* (implement → review → verify) and the *gates*; this skill owns the *craft* of a single task.

--- a/packages/claude-code-plugin/skills/executing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/executing-plans/SKILL.md
@@ -19,8 +19,9 @@ first (ask the user if it is not already known). Load the execution protocol
      inherited automatically — no `--input` needed.
    - **Standalone**: pass the plan's artifact URI —
      `rd run rundown:execute-plan --input PlanPath=<rd://… plan URI>`. Discover
-     the alias with `rd artifact ls`, then resolve its URI with
-     `rd artifact uri PlanPath --text`.
+     the alias with `rd artifact ls`, then read the `uri` field of
+     `rd artifact uri PlanPath` (JSON is the default; agents do not add
+     `--text`).
 </important>
 
 Implement a written plan one task at a time, holding each task to its own tests and committing as you go. This skill is the **context** an execution runbook orchestrates: how to do each task well. The [`execute-plan`](../../runbooks/planning/execute-plan.runbook.md) runbook owns the *sequence* (implement → review → verify) and the *gates*; this skill owns the *craft* of a single task.

--- a/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
@@ -137,13 +137,16 @@ rd prune --all       # Remove all runbook state
 
 ## Structured Output
 
-JSON is the default output format — all commands emit machine-readable JSON unless `--text` is passed:
+JSON is the agent-facing output format — every command emits machine-readable JSON by default:
 
 ```bash
 rd status           # Current state as JSON (default)
 rd run <file>       # Execution events as JSON (default)
-rd status --text    # Human-readable text output
 ```
+
+The `--text` flag exists only for humans reading output in a terminal; it is
+not part of the agent protocol. **Do not add `--text`** to any command — parse
+the JSON instead.
 
 ## Rules
 

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -9,6 +9,37 @@ import {
   listRunbookStates,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
+import { textModeAgentAdvisory } from '../../src/commands/run.js';
+
+describe('textModeAgentAdvisory', () => {
+  it('warns when --text is captured (non-terminal stdout — the agent case)', () => {
+    const advisory = textModeAgentAdvisory({ text: true }, undefined);
+    expect(advisory).not.toBeNull();
+    // Steers toward dropping --text for JSON without implying the run failed or
+    // must be re-run (the advisory fires after the run has already started).
+    expect(advisory).toContain('--text');
+    expect(advisory).toContain('omit it');
+    expect(advisory).toContain('JSON');
+    expect(advisory).not.toMatch(/re-?run/i);
+  });
+
+  it('warns for any falsy isTTY — locks `!isTTY`, not `=== undefined`', () => {
+    // Node reports `undefined` for a pipe, but the gate is `!isTTY`: a host that
+    // ever surfaces `false` must still warn. Pins the contract so a refactor to
+    // `isTTY === undefined` can't silently stop emitting on a `false` stdout.
+    expect(textModeAgentAdvisory({ text: true }, false)).not.toBeNull();
+  });
+
+  it('stays silent for an interactive terminal (a human watching execution)', () => {
+    expect(textModeAgentAdvisory({ text: true }, true)).toBeNull();
+  });
+
+  it('stays silent in JSON mode regardless of stdout (the agent default)', () => {
+    expect(textModeAgentAdvisory({ text: false }, undefined)).toBeNull();
+    expect(textModeAgentAdvisory({}, undefined)).toBeNull();
+    expect(textModeAgentAdvisory({ text: false }, true)).toBeNull();
+  });
+});
 
 describe('start command', () => {
   let workspace: TestWorkspace;
@@ -19,6 +50,28 @@ describe('start command', () => {
 
   afterEach(async () => {
     await workspace.cleanup();
+  });
+
+  describe('--text agent advisory (wired)', () => {
+    it('writes the advisory to stderr without contaminating the --text stdout stream', async () => {
+      const result = await runCliInProcess(
+        'run --prompted runbooks/simple.runbook.md --text',
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      // Goes to stderr (the captured-output / agent case: in-process stdout is
+      // non-TTY), and never leaks into the human-readable stdout event stream.
+      expect(result.stderr).toContain('--text is human-readable output');
+      expect(result.stdout).not.toContain('--text is human-readable output');
+    });
+
+    it('stays silent in JSON mode (the agent default — no --text)', async () => {
+      const result = await runCliInProcess('run --prompted runbooks/simple.runbook.md', workspace);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toContain('--text is human-readable output');
+    });
   });
 
   describe('file mode', () => {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -93,6 +93,11 @@ export function registerRunCommand(program: Command): void {
       ) => {
         const output = new OutputEmitter({ text: options.text, command: 'run' });
 
+        const advisory = textModeAgentAdvisory(options, process.stdout.isTTY);
+        if (advisory) {
+          process.stderr.write(`${advisory}\n`);
+        }
+
         try {
           const cwd = getCwd();
           const manager = new RunbookStateManager(cwd);
@@ -314,6 +319,32 @@ export function registerRunCommand(program: Command): void {
         }
       },
     );
+}
+
+/**
+ * Build the stderr advisory shown when `run` is invoked with `--text` while
+ * stdout is not a terminal — i.e. the event stream is being captured, which is
+ * the signature of an agent driving the runbook rather than a human watching it.
+ *
+ * `--text` renders human-readable events instead of the JSON event stream agents
+ * parse to drive a runbook, so a captured `run --text` is almost always a
+ * misconfiguration. The advisory goes to stderr so it never contaminates the
+ * `--text` stdout stream, and is gated on a non-terminal stdout so an interactive
+ * human deliberately watching execution is never nagged.
+ *
+ * @param options - Parsed `run` options; only `text` is consulted
+ * @param options.text - Whether `--text` (human-readable output) was requested
+ * @param isTTY - `process.stdout.isTTY` at invocation (true only for a terminal)
+ * @returns The one-line advisory, or `null` when none applies (JSON mode, or a TTY)
+ */
+export function textModeAgentAdvisory(
+  options: { text?: boolean },
+  isTTY: boolean | undefined,
+): string | null {
+  if (!options.text || isTTY) {
+    return null;
+  }
+  return 'rd run: --text is human-readable output; omit it for the JSON events agents parse to drive runbooks.';
 }
 
 /**

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -2163,7 +2163,7 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runbook: RUNBOOK,
         scopeVars: { Plan: uri },
       }),
-    ).rejects.toThrow(/unresolvable-uri.*Plan/s);
+    ).rejects.toThrow(/unresolvable-uri.*Plan.*belongs to context.*missing-context/s);
   });
 
   it('errors `unresolvable-uri` when the URI parses but matches no manifest row', async () => {

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -2054,7 +2054,7 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runbook: RUNBOOK,
         scopeVars: { Plan: `rd://artifacts/${CONTEXT_ID}/${CHILD_RUN}/missing.json` },
       }),
-    ).rejects.toThrow(/unresolvable-uri.*Plan.*missing\.json.*matched no manifest row/s);
+    ).rejects.toThrow(/unresolvable-uri.*Plan.*missing\.json.*matched no artifact row/s);
   });
 
   it('rehydrates a naked selector URI with exactly one match into one trusted record', async () => {
@@ -2147,7 +2147,7 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runbook: RUNBOOK,
         scopeVars: { Plan: 'not-a-uri' },
       }),
-    ).rejects.toThrow(/unresolvable-uri.*Plan.*not-a-uri.*did not parse/s);
+    ).rejects.toThrow(/unresolvable-uri.*Plan.*not-a-uri.*is not an artifact URI/s);
   });
 
   it('fails clearly for naked ARTIFACTS when scope contains an unresolved URI string', async () => {
@@ -2178,7 +2178,7 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runbook: RUNBOOK,
         scopeVars: { Plan: `rd://artifacts/${CONTEXT_ID}/*/missing.json` },
       }),
-    ).rejects.toThrow(/unresolvable-uri.*Plan.*missing\.json.*matched no manifest row/s);
+    ).rejects.toThrow(/unresolvable-uri.*Plan.*missing\.json.*matched no artifact row/s);
   });
 
   it('errors `partial-resolve` when one URI in a URI[] fails to resolve', async () => {

--- a/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
+++ b/packages/core/__tests__/runbook/artifact-directive-resolver.test.ts
@@ -2196,7 +2196,7 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
         runbook: RUNBOOK,
         scopeVars: { Plans: [a.uri, `rd://artifacts/${CONTEXT_ID}/*/missing.json`] },
       }),
-    ).rejects.toThrow(/partial-resolve/);
+    ).rejects.toThrow(/partial-resolve.*Plans.*matched no artifact row.*all-or-nothing/s);
   });
 
   it('errors `partial-resolve` when one URI in a JSON string URI array fails to resolve', async () => {
@@ -2216,7 +2216,7 @@ describe('resolveArtifactDeclarations — naked assertion form', () => {
           Plans: JSON.stringify([a.uri, `rd://artifacts/${CONTEXT_ID}/*/missing.json`]),
         },
       }),
-    ).rejects.toThrow(/partial-resolve/);
+    ).rejects.toThrow(/partial-resolve.*Plans.*matched no artifact row.*all-or-nothing/s);
   });
 
   it('does not accept JSON string arrays containing non-rd URI values as URI arrays', async () => {

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -717,6 +717,35 @@ async function resolveNakedDeclaration(
   );
 }
 
+/**
+ * Build the human-readable suffix for an `unresolvable-uri` / `partial-resolve`
+ * failure, classifying *why* the value did not resolve so the message is
+ * actionable.
+ *
+ * The reason-code prefix (`unresolvable-uri:` / `partial-resolve:`) is owned by
+ * the caller and is machine-parseable; this helper only produces the trailing
+ * human guidance. Classification re-parses the value (cheap, error-path only):
+ * a value that is not an `rd://` URI at all (e.g. a bare filesystem path) is the
+ * common #467 case and gets a pointer to `rd artifact uri`; a well-formed URI is
+ * either cross-context or simply absent from this run's manifest.
+ *
+ * @param uri - The unresolved value as it appeared in scope
+ * @param options - Resolver options carrying the current context identity
+ * @returns Actionable explanation of the failure, without the reason-code prefix
+ */
+function describeUnresolvableUri(uri: string, options: ResolveArtifactDeclarationsOptions): string {
+  let ref: ArtifactRef;
+  try {
+    ref = parseArtifactUri(uri);
+  } catch {
+    return `value "${uri}" is not an artifact URI (expected rd://artifacts/…). If this is a Rundown-produced plan, pass its artifact URI — list aliases with \`rd artifact ls\` and resolve one with \`rd artifact uri <alias> --text\`.`;
+  }
+  if (ref.contextId !== options.contextId) {
+    return `URI "${uri}" belongs to context "${ref.contextId}", not this run's context "${options.contextId}".`;
+  }
+  return `URI "${uri}" matched no artifact row in this run's manifest.`;
+}
+
 function resolveUriString(
   name: string,
   uri: string,
@@ -729,7 +758,7 @@ function resolveUriString(
   // resolution is all-or-nothing, so an empty result is an error here.
   if (resolved === null || resolved.length === 0) {
     throw new Error(
-      `unresolvable-uri: ARTIFACTS naked declaration "${name}" URI "${uri}" did not parse or matched no manifest row`,
+      `unresolvable-uri: ARTIFACTS naked declaration "${name}" — ${describeUnresolvableUri(uri, options)}`,
     );
   }
   if (resolved.length === 1) {
@@ -757,7 +786,7 @@ function resolveUriStringArray(
     const matches = resolveSingleUriAgainstManifest(uri, options, records);
     if (matches === null || matches.length === 0) {
       throw new Error(
-        `partial-resolve: ARTIFACTS naked declaration "${name}" URI "${uri}" did not resolve; URI[] resolution is all-or-nothing`,
+        `partial-resolve: ARTIFACTS naked declaration "${name}" — ${describeUnresolvableUri(uri, options)} URI[] resolution is all-or-nothing.`,
       );
     }
     for (const match of matches) {

--- a/packages/core/src/runbook/artifact-directive-resolver.ts
+++ b/packages/core/src/runbook/artifact-directive-resolver.ts
@@ -718,32 +718,57 @@ async function resolveNakedDeclaration(
 }
 
 /**
+ * Outcome of resolving a single naked-form URI value against the manifest.
+ *
+ * The non-`matched` arms are the named failure reasons. They are produced by
+ * {@link resolveSingleUriAgainstManifest} — the single place that parses the
+ * value and checks the context — so the diagnostic formatter never re-derives
+ * them. Adding a new failure path is a compile error in
+ * {@link describeUnresolvableReason} (exhaustive switch), which keeps the
+ * resolver and its diagnostics from silently drifting apart.
+ */
+type UriResolution =
+  | { readonly kind: 'matched'; readonly records: readonly TrustedArtifactRecord[] }
+  /** Value did not parse as an `rd://` artifact URI (e.g. a bare filesystem path). */
+  | { readonly kind: 'not-a-uri' }
+  /** Well-formed URI naming a context other than this run's. */
+  | { readonly kind: 'cross-context'; readonly uriContextId: string }
+  /** Well-formed, same-context URI that matched no manifest row. */
+  | { readonly kind: 'no-row' };
+
+/**
  * Build the human-readable suffix for an `unresolvable-uri` / `partial-resolve`
- * failure, classifying *why* the value did not resolve so the message is
- * actionable.
+ * failure from the resolver's named reason, so the message is actionable.
  *
  * The reason-code prefix (`unresolvable-uri:` / `partial-resolve:`) is owned by
  * the caller and is machine-parseable; this helper only produces the trailing
- * human guidance. Classification re-parses the value (cheap, error-path only):
- * a value that is not an `rd://` URI at all (e.g. a bare filesystem path) is the
- * common #467 case and gets a pointer to `rd artifact uri`; a well-formed URI is
- * either cross-context or simply absent from this run's manifest.
+ * human guidance. It does not re-parse: it formats the reason
+ * {@link resolveSingleUriAgainstManifest} already determined. The `default` arm
+ * is an exhaustiveness guard — a new {@link UriResolution} failure kind fails
+ * to compile here until it is given a message.
  *
  * @param uri - The unresolved value as it appeared in scope
+ * @param reason - The named, non-`matched` resolution outcome
  * @param options - Resolver options carrying the current context identity
  * @returns Actionable explanation of the failure, without the reason-code prefix
  */
-function describeUnresolvableUri(uri: string, options: ResolveArtifactDeclarationsOptions): string {
-  let ref: ArtifactRef;
-  try {
-    ref = parseArtifactUri(uri);
-  } catch {
-    return `value "${uri}" is not an artifact URI (expected rd://artifacts/…). If this is a Rundown-produced plan, pass its artifact URI — list aliases with \`rd artifact ls\` and resolve one with \`rd artifact uri <alias> --text\`.`;
+function describeUnresolvableReason(
+  uri: string,
+  reason: Exclude<UriResolution, { kind: 'matched' }>,
+  options: ResolveArtifactDeclarationsOptions,
+): string {
+  switch (reason.kind) {
+    case 'not-a-uri':
+      return `value "${uri}" is not an artifact URI (expected rd://artifacts/…). If this is a Rundown-produced plan, pass its artifact URI — list aliases with \`rd artifact ls\` and resolve one with \`rd artifact uri <alias>\`.`;
+    case 'cross-context':
+      return `URI "${uri}" belongs to context "${reason.uriContextId}", not this run's context "${options.contextId}".`;
+    case 'no-row':
+      return `URI "${uri}" matched no artifact row in this run's manifest.`;
+    default: {
+      const _exhaustive: never = reason;
+      return _exhaustive;
+    }
   }
-  if (ref.contextId !== options.contextId) {
-    return `URI "${uri}" belongs to context "${ref.contextId}", not this run's context "${options.contextId}".`;
-  }
-  return `URI "${uri}" matched no artifact row in this run's manifest.`;
 }
 
 function resolveUriString(
@@ -753,26 +778,25 @@ function resolveUriString(
   records: readonly ArtifactManifestRecord[],
 ): TrustedArtifactValue {
   const resolved = resolveSingleUriAgainstManifest(uri, options, records);
-  // Per spec §10.1.2: `unresolvable-uri` covers both "did not parse" (null)
-  // and "parsed but matched no manifest row" (empty array). Naked-form
-  // resolution is all-or-nothing, so an empty result is an error here.
-  if (resolved === null || resolved.length === 0) {
+  // Per spec §10.1.2, naked-form resolution is all-or-nothing: any non-`matched`
+  // outcome is an `unresolvable-uri` error, classified by the resolver's reason.
+  if (resolved.kind !== 'matched') {
     throw new Error(
-      `unresolvable-uri: ARTIFACTS naked declaration "${name}" — ${describeUnresolvableUri(uri, options)}`,
+      `unresolvable-uri: ARTIFACTS naked declaration "${name}" — ${describeUnresolvableReason(uri, resolved, options)}`,
     );
   }
-  if (resolved.length === 1) {
-    // Single-element path: brandTrustedArtifactRecord is idempotent and
-    // resolved[0] is already a TrustedArtifactRecord (from
+  if (resolved.records.length === 1) {
+    // Single-element path: brandTrustedArtifactRecord is idempotent and the
+    // record is already a TrustedArtifactRecord (from
     // resolveSingleUriAgainstManifest). Re-call defensively so a future
     // refactor that changes the helper's return type still emits a branded
     // value here.
-    return brandTrustedArtifactRecord(resolved[0]);
+    return brandTrustedArtifactRecord(resolved.records[0]);
   }
   // Multi-record path: brand the freshly-spread CONTAINER. The elements
   // are already per-record branded; brandTrustedArtifactArray is idempotent
   // and only attaches the container symbol when missing.
-  return brandTrustedArtifactArray([...resolved]);
+  return brandTrustedArtifactArray([...resolved.records]);
 }
 
 function resolveUriStringArray(
@@ -784,12 +808,12 @@ function resolveUriStringArray(
   const resolved: TrustedArtifactRecord[] = [];
   for (const uri of uris) {
     const matches = resolveSingleUriAgainstManifest(uri, options, records);
-    if (matches === null || matches.length === 0) {
+    if (matches.kind !== 'matched') {
       throw new Error(
-        `partial-resolve: ARTIFACTS naked declaration "${name}" — ${describeUnresolvableUri(uri, options)} URI[] resolution is all-or-nothing.`,
+        `partial-resolve: ARTIFACTS naked declaration "${name}" — ${describeUnresolvableReason(uri, matches, options)} URI[] resolution is all-or-nothing.`,
       );
     }
-    for (const match of matches) {
+    for (const match of matches.records) {
       resolved.push(match);
     }
   }
@@ -799,15 +823,18 @@ function resolveUriStringArray(
 /**
  * Resolve a single URI string against the manifest snapshot.
  *
- * Returns `null` when the URI is malformed or names a context other than the
- * resolver's current context. Returns the matching records (possibly empty)
- * otherwise. The caller maps `null` and `[]` into the appropriate named
- * error per spec §10.1.2.
+ * This is the single classification point: it parses the value, checks the
+ * context, and matches against the manifest, returning a discriminated
+ * {@link UriResolution} that names *why* resolution succeeded or failed. The
+ * caller maps any non-`matched` outcome to the appropriate named error per spec
+ * §10.1.2 (via {@link describeUnresolvableReason}) without re-deriving the
+ * reason.
  *
  * @param uri - URI string to resolve
  * @param options - Resolver options carrying current context identity
  * @param records - Coalesced manifest snapshot for the current context
- * @returns Matching records, or `null` when the URI is malformed or cross-context
+ * @returns A {@link UriResolution}: `matched` with one or more records, or a
+ *   named failure (`not-a-uri`, `cross-context`, `no-row`)
  * @throws {Error} When `resolveSelector` returns an unbranded value — a
  *   defensive impossibility that indicates a broken sanctioned producer.
  */
@@ -815,15 +842,15 @@ function resolveSingleUriAgainstManifest(
   uri: string,
   options: ResolveArtifactDeclarationsOptions,
   records: readonly ArtifactManifestRecord[],
-): TrustedArtifactRecord[] | null {
+): UriResolution {
   let ref: ArtifactRef;
   try {
     ref = parseArtifactUri(uri);
   } catch {
-    return null;
+    return { kind: 'not-a-uri' };
   }
   if (ref.contextId !== options.contextId) {
-    return null;
+    return { kind: 'cross-context', uriContextId: ref.contextId };
   }
   if (ref.kind === 'exact') {
     // Find the record by exact identity (contextId, runId, key) and gate
@@ -836,10 +863,10 @@ function resolveSingleUriAgainstManifest(
         isExistingRegularArtifactFile(record.uri, options) &&
         record.kind === 'artifact-record'
       ) {
-        return [brandTrustedArtifactRecord(record)];
+        return { kind: 'matched', records: [brandTrustedArtifactRecord(record)] };
       }
     }
-    return [];
+    return { kind: 'no-row' };
   }
   // Selector form — dispatch through the shared selector pathway.
   const selector: SelectorArtifactRef = {
@@ -854,16 +881,20 @@ function resolveSingleUriAgainstManifest(
   // brandTrustedArtifactRecord (single match) or brandTrustedArtifactArray
   // (multi-match including zero-match). Narrow via the runtime guards so
   // the type-narrowing is anchored by an actual brand check, not a cast.
+  let matched: readonly TrustedArtifactRecord[];
   if (isTrustedArtifactArray(result)) {
-    return [...result];
+    matched = result;
+  } else if (isTrustedArtifactRecord(result)) {
+    matched = [result];
+  } else {
+    // Defensive impossibility: if resolveSelector ever returned something
+    // unbranded, the type system would catch it at the assignment above. The
+    // throw documents the invariant for runtime auditors.
+    throw new Error(
+      `resolveSelector produced an unbranded result for URI "${uri}"; this indicates a broken sanctioned producer.`,
+    );
   }
-  if (isTrustedArtifactRecord(result)) {
-    return [result];
-  }
-  // Defensive impossibility: if resolveSelector ever returned something
-  // unbranded, the type system would catch it at the assignment above. The
-  // throw documents the invariant for runtime auditors.
-  throw new Error(
-    `resolveSelector produced an unbranded result for URI "${uri}"; this indicates a broken sanctioned producer.`,
-  );
+  // A zero-match selector is a "no row" outcome, not an empty success — the
+  // naked-form caller treats it identically to a missing exact row.
+  return matched.length === 0 ? { kind: 'no-row' } : { kind: 'matched', records: matched };
 }


### PR DESCRIPTION
## What & why

The `executing-plans` skill advertised a standalone invocation that cannot work:

```
rd run rundown:execute-plan --input PlanPath=<path-to-plan>
```

Step 2 of `execute-plan` consumes `PlanPath` via the naked consumer directive
`ARTIFACTS - PlanPath`, which asserts `PlanPath` is **already** a manifest-backed
artifact. A bare filesystem path is not — so the run died with a cryptic
`unresolvable-uri` error.

The capability the skill needs already exists: passing the plan's **`rd://`
artifact URI** via `--input` rehydrates it into a `TrustedArtifactValue`
(`artifact-inputs.ts`), which the naked consumer accepts by reference
(`resolveNakedDeclaration`). So this is a **documentation + diagnostic** gap, not
a missing feature.

Forward-looking `--artifacts` boundary-channel ergonomics (frontmatter
`artifacts:` + CLI flag) are tracked separately in #480 and are **not** part of
this PR.

## Changes

- **`skills/executing-plans/SKILL.md`** — `PlanPath` is documented as the plan's
  `rd://` artifact URI (not a path). Distinguishes the delegated pipeline
  (`write-plan → execute-plan`, where `PlanPath` is inherited automatically — no
  `--input`) from a standalone run, and points at `rd artifact ls` /
  `rd artifact uri PlanPath --text` to discover the URI.
- **`artifact-directive-resolver.ts`** — new `describeUnresolvableUri()` helper
  classifies the failure at the `unresolvable-uri` / `partial-resolve` throw
  sites: *not an artifact URI* (e.g. a bare path → points at `rd artifact uri`),
  *cross-context*, or *no matching row*. The machine-parseable reason-code
  prefixes are preserved, so anything keying on them is unaffected.
- **Tests** — updated the resolver and skill assertions to the new message
  suffixes / guidance.

**Not changed:** `execute-plan.runbook.md` / `implement-plan.runbook.md`. Naked
`ARTIFACTS - PlanPath` is the correct consumer form; the originally-suggested
rewrite to `ARTIFACTS - PlanPath "{{PlanPath}}"` was deliberately rejected, and
minting manifest rows for external on-disk files is out of scope (non-core).

## Verification

- Full unit suite green across all packages (core, cli, plugin, parser, …).
- `build`, `check:types`, `check:lint:fast`, `check:lint:typed` pass.
- Manual: a bare-path `--input PlanPath=./nope.json` now yields an actionable
  "is not an artifact URI" message with the `rd artifact uri` hint.

Closes #467. Related: #480.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced artifact URI resolution error messaging with more precise, categorized explanations (e.g., not an artifact URI, cross-context, matched no artifact row) while keeping partial/array all-or-nothing behavior.
  * Updated **executing-plans**: `PlanPath` is now handled as the plan artifact URI (`rd://...`) and is resolved before execution.
  * When using `run --text` with non-TTY stdout, the CLI now emits a one-line stderr advisory to preserve machine-readable output.
* **Documentation**
  * Refreshed **running-runbooks** and **executing-plans** guidance to explicitly forbid adding `--text` to agent commands.
* **Tests**
  * Updated and expanded resolver, skill, and CLI `run` tests to match the new wording and structured-output rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->