### PR TITLE
ci(#483): make Stryker mutation testing an enforceable gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,8 +423,10 @@ jobs:
 
   # Per-PR Stryker dry run: validates the mutation-testing wiring (plugin
   # resolution, packageManager, jest runner) under pnpm's isolated layout
-  # without paying for a full mutation run. The scheduled mutation.yml still
-  # runs the real mutants weekly.
+  # without paying for a full mutation run. The per-PR changed-file gate
+  # (.github/workflows/mutation-pr.yml) runs the real mutants for affected
+  # packages and enforces the per-file floor; the scheduled mutation.yml still
+  # runs the full suite weekly with the package-level `break` threshold.
   stryker-dry:
     runs-on: ubuntu-latest
     needs: setup-build-node24

--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -45,9 +45,19 @@ jobs:
           # assert-mutation-score.mjs diffs `${base}...HEAD`.
           fetch-depth: 0
 
-      # Resolve the PR base ref to a local SHA and compute whether this package
-      # has any changed source files. Skipping unaffected packages keeps the gate
-      # cheap on small PRs without spawning the (expensive) mutation run.
+      # Resolve the PR base ref and compute whether this package has any changed
+      # source files. Skipping unaffected packages keeps the gate cheap on small
+      # PRs without spawning the (expensive) mutation run.
+      #
+      # This step must fail CLOSED: a git error (unresolvable base, missing
+      # merge-base) must fail the job, never silently skip the gate. Two defects
+      # this layout avoids: (1) `fetch-depth: 0` already provides full history and
+      # `origin/<base>`, so re-fetching with `--depth=1` would re-shallow the
+      # clone and break the `${base}...HEAD` merge-base — so we do not fetch; and
+      # (2) running `git diff` as an `if` condition suppresses `set -e`, so a git
+      # failure would route to the `else` (changed=false) and skip the gate — so
+      # the diff is captured outside any condition, after an explicit base
+      # preflight, letting `set -e` fail the job on any git error. See issue #483.
       - name: Detect changes for ${{ matrix.package }}
         id: changes
         run: |
@@ -56,8 +66,14 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             base="origin/${{ github.event.repository.default_branch }}"
           fi
-          git fetch --no-tags --depth=1 origin "${base#origin/}" || true
-          if git diff --name-only "${base}...HEAD" -- '${{ matrix.dir }}/src' | grep -q .; then
+          # Fail closed if the base ref or its merge-base with HEAD is unreachable
+          # rather than letting a later diff error masquerade as "no changes".
+          git rev-parse --verify --quiet "${base}^{commit}" >/dev/null \
+            || { echo "::error::base ref '${base}' is unreachable; cannot gate." >&2; exit 1; }
+          git merge-base "${base}" HEAD >/dev/null \
+            || { echo "::error::no merge-base between '${base}' and HEAD; cannot gate." >&2; exit 1; }
+          changed_files="$(git diff --name-only "${base}...HEAD" -- '${{ matrix.dir }}/src')"
+          if [ -n "${changed_files}" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -1,0 +1,111 @@
+name: Mutation Gate (PR)
+
+# Per-PR changed-file mutation gate (issue #483).
+#
+# Stryker's `thresholds.break` gates only the project-wide aggregate, so a single
+# file can collapse (e.g. ~99% -> ~87%) while the project total stays green. This
+# workflow runs each affected package's mutation suite incrementally and then
+# post-processes the emitted JSON report (scripts/assert-mutation-score.mjs) to
+# fail when a file changed in the PR scores below the floor. It is the merge gate
+# the weekly mutation.yml report could never be.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: mutation-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation-gate:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: parser
+            dir: packages/parser
+          - package: core
+            dir: packages/core
+          - package: cli
+            dir: packages/cli
+          - package: plugin
+            dir: packages/claude-code-plugin
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so the merge-base with the PR base ref is reachable;
+          # assert-mutation-score.mjs diffs `${base}...HEAD`.
+          fetch-depth: 0
+
+      # Resolve the PR base ref to a local SHA and compute whether this package
+      # has any changed source files. Skipping unaffected packages keeps the gate
+      # cheap on small PRs without spawning the (expensive) mutation run.
+      - name: Detect changes for ${{ matrix.package }}
+        id: changes
+        run: |
+          set -euo pipefail
+          base="origin/${{ github.base_ref }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            base="origin/${{ github.event.repository.default_branch }}"
+          fi
+          git fetch --no-tags --depth=1 origin "${base#origin/}" || true
+          if git diff --name-only "${base}...HEAD" -- '${{ matrix.dir }}/src' | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No source changes under ${{ matrix.dir }}/src; skipping mutation gate."
+          fi
+          echo "base=${base}" >> "$GITHUB_OUTPUT"
+
+      - uses: ./.github/actions/setup-node-deps
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        with:
+          node-version: 24
+
+      - name: Build
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        run: pnpm run build
+
+      - name: Restore Stryker incremental cache
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: ${{ matrix.dir }}/reports/stryker-incremental.json
+          key: stryker-${{ matrix.package }}-${{ github.sha }}
+          restore-keys: stryker-${{ matrix.package }}-
+
+      # Run the real mutants for the affected package. Incremental mode (set in
+      # each stryker.config.mjs) re-tests only mutated changed code, so this is
+      # bounded even on a cold cache because Stryker still only mutates `src`.
+      - name: Run mutation tests (${{ matrix.package }})
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        run: pnpm exec stryker run
+        working-directory: ${{ matrix.dir }}
+
+      # The merge gate: fail when any file changed in this PR scores below the
+      # floor. Reads the report Stryker just emitted; no second mutation run.
+      - name: Assert per-file mutation score
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        run: |
+          pnpm run assert:mutation-score -- \
+            --report "${{ matrix.dir }}/reports/mutation/mutation-report.json" \
+            --package-dir "${{ matrix.dir }}" \
+            --base "${{ steps.changes.outputs.base }}" \
+            --floor 70
+
+      - name: Upload mutation report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        # always() so the report uploads even when the gate fails, aiding triage.
+        if: ${{ always() && steps.changes.outputs.changed == 'true' }}
+        with:
+          name: mutation-report-${{ matrix.package }}
+          path: ${{ matrix.dir }}/reports/mutation/
+          retention-days: 30

--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -18,6 +18,9 @@ concurrency:
   group: mutation-pr-${{ github.ref }}
   cancel-in-progress: true
 
+# No workflow-level permissions by default; jobs must opt in explicitly.
+permissions: {}
+
 jobs:
   mutation-gate:
     strategy:
@@ -60,11 +63,16 @@ jobs:
       # preflight, letting `set -e` fail the job on any git error. See issue #483.
       - name: Detect changes for ${{ matrix.package }}
         id: changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          PKG_DIR: ${{ matrix.dir }}
         run: |
           set -euo pipefail
-          base="origin/${{ github.base_ref }}"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            base="origin/${{ github.event.repository.default_branch }}"
+          base="origin/${BASE_REF}"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            base="origin/${DEFAULT_BRANCH}"
           fi
           # Fail closed if the base ref or its merge-base with HEAD is unreachable
           # rather than letting a later diff error masquerade as "no changes".
@@ -72,12 +80,12 @@ jobs:
             || { echo "::error::base ref '${base}' is unreachable; cannot gate." >&2; exit 1; }
           git merge-base "${base}" HEAD >/dev/null \
             || { echo "::error::no merge-base between '${base}' and HEAD; cannot gate." >&2; exit 1; }
-          changed_files="$(git diff --name-only "${base}...HEAD" -- '${{ matrix.dir }}/src')"
+          changed_files="$(git diff --name-only "${base}...HEAD" -- "${PKG_DIR}/src")"
           if [ -n "${changed_files}" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No source changes under ${{ matrix.dir }}/src; skipping mutation gate."
+            echo "No source changes under ${PKG_DIR}/src; skipping mutation gate."
           fi
           echo "base=${base}" >> "$GITHUB_OUTPUT"
 
@@ -110,11 +118,14 @@ jobs:
       # floor. Reads the report Stryker just emitted; no second mutation run.
       - name: Assert per-file mutation score
         if: ${{ steps.changes.outputs.changed == 'true' }}
+        env:
+          PKG_DIR: ${{ matrix.dir }}
+          BASE: ${{ steps.changes.outputs.base }}
         run: |
           pnpm run assert:mutation-score -- \
-            --report "${{ matrix.dir }}/reports/mutation/mutation-report.json" \
-            --package-dir "${{ matrix.dir }}" \
-            --base "${{ steps.changes.outputs.base }}" \
+            --report "${PKG_DIR}/reports/mutation/mutation-report.json" \
+            --package-dir "${PKG_DIR}" \
+            --base "${BASE}" \
             --floor 70
 
       - name: Upload mutation report

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -109,6 +109,7 @@ jmespath
 jsdoc
 jsonata
 jsonl
+judgeable
 killable
 killall
 landlock

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:unit:plugin": "pnpm --filter @rundown-org/claude-code-plugin test:unit",
     "test:unit:mcp": "pnpm --filter @rundown-org/mcp test:unit",
     "test:unit:scripts": "node --test scripts/__tests__/*.test.mjs",
+    "assert:mutation-score": "node scripts/assert-mutation-score.mjs",
     "test:integration": "run-p test:integration:*",
     "test:integration:cli": "pnpm --filter @rundown-org/cli test:integration",
     "test:integration:plugin": "pnpm --filter @rundown-org/claude-code-plugin test:integration",

--- a/packages/claude-code-plugin/stryker.config.mjs
+++ b/packages/claude-code-plugin/stryker.config.mjs
@@ -21,10 +21,12 @@ const config = {
   coverageAnalysis: 'perTest',
   incremental: true,
   incrementalFile: 'reports/stryker-incremental.json',
-  // break: 70 is a catastrophic-drop floor, not a quality target. Current
-  // package scores sit well above it; it exists so a weekly run fails loudly
-  // instead of silently uploading a red report. The per-PR changed-file gate
-  // (scripts/assert-mutation-score.mjs) is the real merge guard. See issue #483.
+  // break: 70 is a catastrophic-drop floor on the project-wide aggregate, not
+  // a quality target. It applies to every `stryker run` (the weekly full run
+  // and the per-PR run), failing loudly instead of silently uploading a red
+  // report. The aggregate cannot catch a single-file regression it absorbs --
+  // the per-PR changed-file gate (scripts/assert-mutation-score.mjs) is that
+  // guard. See issue #483.
   thresholds: { high: 80, low: 60, break: 70 },
   reporters: ['progress', 'clear-text', 'html', 'json'],
   htmlReporter: { fileName: 'reports/mutation/index.html' },

--- a/packages/claude-code-plugin/stryker.config.mjs
+++ b/packages/claude-code-plugin/stryker.config.mjs
@@ -21,7 +21,11 @@ const config = {
   coverageAnalysis: 'perTest',
   incremental: true,
   incrementalFile: 'reports/stryker-incremental.json',
-  thresholds: { high: 80, low: 60, break: null },
+  // break: 70 is a catastrophic-drop floor, not a quality target. Current
+  // package scores sit well above it; it exists so a weekly run fails loudly
+  // instead of silently uploading a red report. The per-PR changed-file gate
+  // (scripts/assert-mutation-score.mjs) is the real merge guard. See issue #483.
+  thresholds: { high: 80, low: 60, break: 70 },
   reporters: ['progress', 'clear-text', 'html', 'json'],
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },

--- a/packages/cli/stryker.config.mjs
+++ b/packages/cli/stryker.config.mjs
@@ -21,10 +21,12 @@ const config = {
   coverageAnalysis: 'perTest',
   incremental: true,
   incrementalFile: 'reports/stryker-incremental.json',
-  // break: 70 is a catastrophic-drop floor, not a quality target. Current
-  // package scores sit well above it; it exists so a weekly run fails loudly
-  // instead of silently uploading a red report. The per-PR changed-file gate
-  // (scripts/assert-mutation-score.mjs) is the real merge guard. See issue #483.
+  // break: 70 is a catastrophic-drop floor on the project-wide aggregate, not
+  // a quality target. It applies to every `stryker run` (the weekly full run
+  // and the per-PR run), failing loudly instead of silently uploading a red
+  // report. The aggregate cannot catch a single-file regression it absorbs --
+  // the per-PR changed-file gate (scripts/assert-mutation-score.mjs) is that
+  // guard. See issue #483.
   thresholds: { high: 80, low: 60, break: 70 },
   reporters: ['progress', 'clear-text', 'html', 'json'],
   htmlReporter: { fileName: 'reports/mutation/index.html' },

--- a/packages/cli/stryker.config.mjs
+++ b/packages/cli/stryker.config.mjs
@@ -21,7 +21,11 @@ const config = {
   coverageAnalysis: 'perTest',
   incremental: true,
   incrementalFile: 'reports/stryker-incremental.json',
-  thresholds: { high: 80, low: 60, break: null },
+  // break: 70 is a catastrophic-drop floor, not a quality target. Current
+  // package scores sit well above it; it exists so a weekly run fails loudly
+  // instead of silently uploading a red report. The per-PR changed-file gate
+  // (scripts/assert-mutation-score.mjs) is the real merge guard. See issue #483.
+  thresholds: { high: 80, low: 60, break: 70 },
   reporters: ['progress', 'clear-text', 'html', 'json'],
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },

--- a/packages/core/stryker.config.mjs
+++ b/packages/core/stryker.config.mjs
@@ -21,10 +21,12 @@ const config = {
   coverageAnalysis: 'perTest',
   incremental: true,
   incrementalFile: 'reports/stryker-incremental.json',
-  // break: 70 is a catastrophic-drop floor, not a quality target. Current
-  // package scores sit well above it; it exists so a weekly run fails loudly
-  // instead of silently uploading a red report. The per-PR changed-file gate
-  // (scripts/assert-mutation-score.mjs) is the real merge guard. See issue #483.
+  // break: 70 is a catastrophic-drop floor on the project-wide aggregate, not
+  // a quality target. It applies to every `stryker run` (the weekly full run
+  // and the per-PR run), failing loudly instead of silently uploading a red
+  // report. The aggregate cannot catch a single-file regression it absorbs --
+  // the per-PR changed-file gate (scripts/assert-mutation-score.mjs) is that
+  // guard. See issue #483.
   thresholds: { high: 80, low: 60, break: 70 },
   reporters: ['progress', 'clear-text', 'html', 'json'],
   htmlReporter: { fileName: 'reports/mutation/index.html' },

--- a/packages/core/stryker.config.mjs
+++ b/packages/core/stryker.config.mjs
@@ -21,12 +21,25 @@ const config = {
   coverageAnalysis: 'perTest',
   incremental: true,
   incrementalFile: 'reports/stryker-incremental.json',
-  thresholds: { high: 80, low: 60, break: null },
+  // break: 70 is a catastrophic-drop floor, not a quality target. Current
+  // package scores sit well above it; it exists so a weekly run fails loudly
+  // instead of silently uploading a red report. The per-PR changed-file gate
+  // (scripts/assert-mutation-score.mjs) is the real merge guard. See issue #483.
+  thresholds: { high: 80, low: 60, break: 70 },
   reporters: ['progress', 'clear-text', 'html', 'json'],
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
   concurrency,
-  timeoutMS: 30000,
-  timeoutFactor: 2.5,
+  // Core hosts the heaviest actors (XState machine, file locks with jittered
+  // backoff bounded to 5s, fromPromise actors that touch the filesystem). The
+  // previous 30000ms / 2.5x budget produced ~17 spurious Timeout results that
+  // mutation-testing-metrics counts as undetected mutants, depressing the score
+  // below its true value. A Timeout-as-survivor is a false negative that makes
+  // the gate fire on flake rather than on a real coverage regression, so the
+  // budget is widened to the CLI's 60000ms baseline with a 3x factor (vs 2.5x)
+  // to absorb the slowest-but-legitimate actor runs under CI contention. See
+  // issue #483.
+  timeoutMS: 60000,
+  timeoutFactor: 3,
 };
 export default config;

--- a/packages/parser/stryker.config.mjs
+++ b/packages/parser/stryker.config.mjs
@@ -21,10 +21,12 @@ const config = {
   coverageAnalysis: 'perTest',
   incremental: true,
   incrementalFile: 'reports/stryker-incremental.json',
-  // break: 70 is a catastrophic-drop floor, not a quality target. Current
-  // package scores sit well above it; it exists so a weekly run fails loudly
-  // instead of silently uploading a red report. The per-PR changed-file gate
-  // (scripts/assert-mutation-score.mjs) is the real merge guard. See issue #483.
+  // break: 70 is a catastrophic-drop floor on the project-wide aggregate, not
+  // a quality target. It applies to every `stryker run` (the weekly full run
+  // and the per-PR run), failing loudly instead of silently uploading a red
+  // report. The aggregate cannot catch a single-file regression it absorbs --
+  // the per-PR changed-file gate (scripts/assert-mutation-score.mjs) is that
+  // guard. See issue #483.
   thresholds: { high: 80, low: 60, break: 70 },
   reporters: ['progress', 'clear-text', 'html', 'json'],
   htmlReporter: { fileName: 'reports/mutation/index.html' },

--- a/packages/parser/stryker.config.mjs
+++ b/packages/parser/stryker.config.mjs
@@ -21,7 +21,11 @@ const config = {
   coverageAnalysis: 'perTest',
   incremental: true,
   incrementalFile: 'reports/stryker-incremental.json',
-  thresholds: { high: 80, low: 60, break: null },
+  // break: 70 is a catastrophic-drop floor, not a quality target. Current
+  // package scores sit well above it; it exists so a weekly run fails loudly
+  // instead of silently uploading a red report. The per-PR changed-file gate
+  // (scripts/assert-mutation-score.mjs) is the real merge guard. See issue #483.
+  thresholds: { high: 80, low: 60, break: 70 },
   reporters: ['progress', 'clear-text', 'html', 'json'],
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },

--- a/scripts/__tests__/assert-mutation-score.test.mjs
+++ b/scripts/__tests__/assert-mutation-score.test.mjs
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  assertMutationScore,
+  fileMutationScore,
+  normalizeReportFileKeys,
+} from '../assert-mutation-score.mjs';
+
+/**
+ * Build a minimal Stryker JSON report shaped like the v1 mutation report schema.
+ *
+ * @param {Record<string, string[]>} fileStatuses - map of file key -> array of
+ *   mutant status strings (e.g. 'Killed', 'Survived', 'Timeout', 'NoCoverage').
+ * @param {string} [projectRoot] - absolute project root recorded in the report.
+ * @returns {object} a report object consumable by the assertion functions.
+ */
+function makeReport(fileStatuses, projectRoot = '/repo/packages/core') {
+  const files = {};
+  let id = 0;
+  for (const [key, statuses] of Object.entries(fileStatuses)) {
+    files[key] = {
+      language: 'typescript',
+      source: '',
+      mutants: statuses.map((status) => ({ id: String(id++), status })),
+    };
+  }
+  return { schemaVersion: '1.0', projectRoot, files };
+}
+
+test('fileMutationScore: matches Stryker (killed+timeout)/(valid)', () => {
+  // 138 killed, 1 survived => 99.28%, matching the core report in issue #483.
+  const statuses = [...Array(138).fill('Killed'), 'Survived'];
+  assert.equal(fileMutationScore(statuses).toFixed(2), '99.28');
+});
+
+test('fileMutationScore: Timeout counts as detected, NoCoverage as undetected', () => {
+  // killed=2, timeout=1 (detected=3); survived=1, noCoverage=1 (undetected=2)
+  // valid=5 => 60%
+  assert.equal(fileMutationScore(['Killed', 'Killed', 'Timeout', 'Survived', 'NoCoverage']), 60);
+});
+
+test('fileMutationScore: Ignored/CompileError/RuntimeError are excluded from valid', () => {
+  // Only 1 killed mutant is valid; the rest are invalid/ignored => 100%.
+  assert.equal(fileMutationScore(['Killed', 'Ignored', 'CompileError', 'RuntimeError']), 100);
+});
+
+test('fileMutationScore: no valid mutants returns null (cannot judge)', () => {
+  assert.equal(fileMutationScore(['Ignored', 'CompileError']), null);
+  assert.equal(fileMutationScore([]), null);
+});
+
+test('assertMutationScore: changed file below floor fails', () => {
+  const report = makeReport({
+    'src/runbook/collection-service.ts': [
+      ...Array(80).fill('Killed'),
+      ...Array(20).fill('Survived'),
+    ],
+  });
+  const result = assertMutationScore({
+    report,
+    changedFiles: ['packages/core/src/runbook/collection-service.ts'],
+    packageDir: 'packages/core',
+    floor: 90,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures.length, 1);
+  assert.equal(result.failures[0].file, 'src/runbook/collection-service.ts');
+  assert.equal(result.failures[0].score, 80);
+});
+
+test('assertMutationScore: changed file above floor passes', () => {
+  const report = makeReport({
+    'src/runbook/collection-service.ts': [
+      ...Array(95).fill('Killed'),
+      ...Array(5).fill('Survived'),
+    ],
+  });
+  const result = assertMutationScore({
+    report,
+    changedFiles: ['packages/core/src/runbook/collection-service.ts'],
+    packageDir: 'packages/core',
+    floor: 90,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.failures.length, 0);
+  assert.equal(result.checked.length, 1);
+  assert.equal(result.checked[0].score, 95);
+});
+
+test('assertMutationScore: changed file exactly at floor passes (floor is inclusive)', () => {
+  const report = makeReport({
+    'src/a.ts': [...Array(90).fill('Killed'), ...Array(10).fill('Survived')],
+  });
+  const result = assertMutationScore({
+    report,
+    changedFiles: ['packages/core/src/a.ts'],
+    packageDir: 'packages/core',
+    floor: 90,
+  });
+  assert.equal(result.ok, true);
+});
+
+test('assertMutationScore: unchanged file below floor is ignored', () => {
+  const report = makeReport({
+    'src/unchanged.ts': [...Array(10).fill('Killed'), ...Array(90).fill('Survived')],
+    'src/changed.ts': [...Array(95).fill('Killed'), ...Array(5).fill('Survived')],
+  });
+  const result = assertMutationScore({
+    report,
+    changedFiles: ['packages/core/src/changed.ts'],
+    packageDir: 'packages/core',
+    floor: 90,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.checked.length, 1);
+  assert.equal(result.checked[0].file, 'src/changed.ts');
+});
+
+test('assertMutationScore: changed file not in report is skipped (not mutated)', () => {
+  // A changed file that Stryker did not mutate (e.g. excluded by `mutate`, or a
+  // markdown/test file) must not fail the gate.
+  const report = makeReport({
+    'src/a.ts': [...Array(95).fill('Killed'), ...Array(5).fill('Survived')],
+  });
+  const result = assertMutationScore({
+    report,
+    changedFiles: ['packages/core/README.md', 'packages/core/src/index.ts'],
+    packageDir: 'packages/core',
+    floor: 90,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.checked.length, 0);
+  assert.equal(result.skipped.length, 2);
+});
+
+test('assertMutationScore: changed file outside the package is ignored', () => {
+  const report = makeReport({
+    'src/a.ts': [...Array(95).fill('Killed'), ...Array(5).fill('Survived')],
+  });
+  const result = assertMutationScore({
+    report,
+    changedFiles: ['packages/cli/src/other.ts'],
+    packageDir: 'packages/core',
+    floor: 90,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.checked.length, 0);
+});
+
+test('assertMutationScore: changed file with only ignored mutants does not fail', () => {
+  const report = makeReport({
+    'src/a.ts': ['Ignored', 'CompileError'],
+  });
+  const result = assertMutationScore({
+    report,
+    changedFiles: ['packages/core/src/a.ts'],
+    packageDir: 'packages/core',
+    floor: 90,
+  });
+  assert.equal(result.ok, true);
+  // score is null -> recorded as skipped (no judgeable mutants), not a failure.
+  assert.equal(result.failures.length, 0);
+  assert.equal(result.skipped.length, 1);
+});
+
+test('assertMutationScore: throws on a missing/null report', () => {
+  assert.throws(
+    () =>
+      assertMutationScore({
+        report: null,
+        changedFiles: ['packages/core/src/a.ts'],
+        packageDir: 'packages/core',
+        floor: 90,
+      }),
+    /report/i,
+  );
+});
+
+test('assertMutationScore: throws on a structurally invalid report', () => {
+  assert.throws(
+    () =>
+      assertMutationScore({
+        report: { schemaVersion: '1.0' }, // missing files
+        changedFiles: ['packages/core/src/a.ts'],
+        packageDir: 'packages/core',
+        floor: 90,
+      }),
+    /files/i,
+  );
+});
+
+test('normalizeReportFileKeys: tolerates absolute keys via projectRoot', () => {
+  // Some Stryker versions emit absolute file keys; normalization strips the
+  // projectRoot so keys compare against package-relative changed paths.
+  const report = makeReport({ '/repo/packages/core/src/a.ts': ['Killed'] }, '/repo/packages/core');
+  const keys = normalizeReportFileKeys(report);
+  assert.ok(keys.has('src/a.ts'));
+});
+
+test('assertMutationScore: floor of 0 with no valid mutants still passes', () => {
+  const report = makeReport({ 'src/a.ts': ['Ignored'] });
+  const result = assertMutationScore({
+    report,
+    changedFiles: ['packages/core/src/a.ts'],
+    packageDir: 'packages/core',
+    floor: 0,
+  });
+  assert.equal(result.ok, true);
+});

--- a/scripts/__tests__/assert-mutation-score.test.mjs
+++ b/scripts/__tests__/assert-mutation-score.test.mjs
@@ -227,6 +227,44 @@ test('assertMutationScore: throws on an in-report entry whose `mutants` is not a
   );
 });
 
+test('assertMutationScore: throws on an in-report entry that is null', () => {
+  // A key present in the report but mapped to null is malformed; reading
+  // `.mutants` on it must not throw an opaque TypeError before the guard runs.
+  const report = {
+    schemaVersion: '1.0',
+    projectRoot: '/repo/packages/core',
+    files: { 'src/a.ts': null },
+  };
+  assert.throws(
+    () =>
+      assertMutationScore({
+        report,
+        changedFiles: ['packages/core/src/a.ts'],
+        packageDir: 'packages/core',
+        floor: 90,
+      }),
+    /mutants|malformed/i,
+  );
+});
+
+test('assertMutationScore: throws on an in-report entry that is a non-object primitive', () => {
+  const report = {
+    schemaVersion: '1.0',
+    projectRoot: '/repo/packages/core',
+    files: { 'src/a.ts': 42 },
+  };
+  assert.throws(
+    () =>
+      assertMutationScore({
+        report,
+        changedFiles: ['packages/core/src/a.ts'],
+        packageDir: 'packages/core',
+        floor: 90,
+      }),
+    /mutants|malformed/i,
+  );
+});
+
 test('normalizeReportFileKeys: tolerates absolute keys via projectRoot', () => {
   // Some Stryker versions emit absolute file keys; normalization strips the
   // projectRoot so keys compare against package-relative changed paths.

--- a/scripts/__tests__/assert-mutation-score.test.mjs
+++ b/scripts/__tests__/assert-mutation-score.test.mjs
@@ -189,6 +189,44 @@ test('assertMutationScore: throws on a structurally invalid report', () => {
   );
 });
 
+test('assertMutationScore: throws on an in-report entry missing its `mutants` array', () => {
+  // A file present in the report but missing `mutants` is malformed; the gate
+  // must fail loudly rather than throw an opaque TypeError on `.map`.
+  const report = {
+    schemaVersion: '1.0',
+    projectRoot: '/repo/packages/core',
+    files: { 'src/a.ts': { language: 'typescript', source: '' } }, // no mutants
+  };
+  assert.throws(
+    () =>
+      assertMutationScore({
+        report,
+        changedFiles: ['packages/core/src/a.ts'],
+        packageDir: 'packages/core',
+        floor: 90,
+      }),
+    /mutants|malformed/i,
+  );
+});
+
+test('assertMutationScore: throws on an in-report entry whose `mutants` is not an array', () => {
+  const report = {
+    schemaVersion: '1.0',
+    projectRoot: '/repo/packages/core',
+    files: { 'src/a.ts': { language: 'typescript', source: '', mutants: {} } },
+  };
+  assert.throws(
+    () =>
+      assertMutationScore({
+        report,
+        changedFiles: ['packages/core/src/a.ts'],
+        packageDir: 'packages/core',
+        floor: 90,
+      }),
+    /mutants|malformed/i,
+  );
+});
+
 test('normalizeReportFileKeys: tolerates absolute keys via projectRoot', () => {
   // Some Stryker versions emit absolute file keys; normalization strips the
   // projectRoot so keys compare against package-relative changed paths.

--- a/scripts/__tests__/stryker-config.test.mjs
+++ b/scripts/__tests__/stryker-config.test.mjs
@@ -40,6 +40,21 @@ for (const configPath of configs) {
     assert.equal((await loadConfig(configPath, undefined)).concurrency, 2);
   });
 
+  test(`${configPath} sets a non-null break threshold (issue #483)`, async () => {
+    const config = await loadConfig(configPath, undefined);
+    // break: null lets Stryker exit 0 regardless of score, so a catastrophic
+    // drop can never fail CI. A real floor makes the weekly run fail loudly.
+    assert.equal(
+      typeof config.thresholds?.break,
+      'number',
+      `${configPath}: thresholds.break must be a number, not null`,
+    );
+    assert.ok(
+      config.thresholds.break >= 70,
+      `${configPath}: thresholds.break should be at least 70`,
+    );
+  });
+
   test(`${configPath} pins pnpm + the explicit jest-runner plugin`, async () => {
     const config = await loadConfig(configPath, undefined);
     // pnpm's isolated layout breaks Stryker's default '@stryker-mutator/*'
@@ -52,6 +67,21 @@ for (const configPath of configs) {
     );
   });
 }
+
+test('packages/core widens the mutation timeout budget (issue #483)', async () => {
+  const config = await loadConfig('packages/core/stryker.config.mjs', undefined);
+  // Core hosts the heaviest actors; the previous 30000ms / 2.5x budget produced
+  // spurious Timeout results counted as undetected mutants, depressing the score
+  // and making the gate fire on flake. The widened budget must persist.
+  assert.ok(
+    config.timeoutMS >= 60000,
+    `core timeoutMS must be at least 60000 (was ${config.timeoutMS})`,
+  );
+  assert.ok(
+    config.timeoutFactor >= 3,
+    `core timeoutFactor must be at least 3 (was ${config.timeoutFactor})`,
+  );
+});
 
 for (const pkg of packages) {
   test(`packages/${pkg} declares the Stryker devDependencies`, async () => {

--- a/scripts/assert-mutation-score.mjs
+++ b/scripts/assert-mutation-score.mjs
@@ -177,7 +177,7 @@ export function assertMutationScore({ report, changedFiles, packageDir, floor = 
       continue;
     }
     const entry = report.files[reportKey];
-    if (!Array.isArray(entry.mutants)) {
+    if (!entry || !Array.isArray(entry.mutants)) {
       throw new Error(
         `mutation report entry for ${reportKey} has no \`mutants\` array (malformed report)`,
       );

--- a/scripts/assert-mutation-score.mjs
+++ b/scripts/assert-mutation-score.mjs
@@ -33,6 +33,7 @@
  */
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
 /**
  * Default per-file mutation-score floor (percent). A changed, mutated file must
@@ -153,7 +154,9 @@ function assertValidReport(report) {
  *   belongs to (e.g. `packages/core`).
  * @param {number} [args.floor] - minimum acceptable score (inclusive).
  * @returns {GateResult} structured outcome of the evaluation.
- * @throws {Error} when the report is missing or structurally invalid.
+ * @throws {Error} when the report is missing or structurally invalid, or when a
+ *   per-file entry present in the report lacks a `mutants` array (malformed
+ *   report).
  */
 export function assertMutationScore({ report, changedFiles, packageDir, floor = DEFAULT_FLOOR }) {
   assertValidReport(report);
@@ -173,7 +176,13 @@ export function assertMutationScore({ report, changedFiles, packageDir, floor = 
       skipped.push({ file: relative, reason: 'not mutated' });
       continue;
     }
-    const statuses = report.files[reportKey].mutants.map((m) => m.status);
+    const entry = report.files[reportKey];
+    if (!Array.isArray(entry.mutants)) {
+      throw new Error(
+        `mutation report entry for ${reportKey} has no \`mutants\` array (malformed report)`,
+      );
+    }
+    const statuses = entry.mutants.map((m) => m.status);
     const score = fileMutationScore(statuses);
     if (score === null) {
       skipped.push({ file: relative, reason: 'no valid mutants' });
@@ -335,6 +344,6 @@ function main(argv) {
 }
 
 // Only run main() when invoked directly, not when imported by tests.
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   process.exit(main(process.argv.slice(2)));
 }

--- a/scripts/assert-mutation-score.mjs
+++ b/scripts/assert-mutation-score.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+/**
+ * Per-PR changed-file mutation-score gate.
+ *
+ * Stryker has no native per-file `break` threshold — its `thresholds.break`
+ * gates only the project-wide aggregate, so a single file can collapse from
+ * ~99% to ~0% while the project total (and therefore CI) stays green. This
+ * script closes that gap by post-processing the JSON report Stryker already
+ * emits (`reports/mutation/mutation-report.json`): it computes the mutation
+ * score of every file that changed in the PR and fails (non-zero exit) when any
+ * changed, mutated file scores below a floor.
+ *
+ * The score formula mirrors mutation-testing-metrics exactly so the number this
+ * gate reports equals the number Stryker prints:
+ *   score = (Killed + Timeout) / (Killed + Timeout + Survived + NoCoverage)
+ * Ignored / CompileError / RuntimeError / Pending mutants are excluded from the
+ * denominator (they are not "valid" mutants). A file with no valid mutants has
+ * no judgeable score and is skipped rather than failed.
+ *
+ * Usage (CLI):
+ *   node scripts/assert-mutation-score.mjs \
+ *     --report packages/core/reports/mutation/mutation-report.json \
+ *     --package-dir packages/core \
+ *     --base origin/main \
+ *     [--floor 70]
+ *
+ * `--changed-file <path>` (repeatable) may be supplied instead of `--base` to
+ * pass an explicit changed-file list (used by the tests and by callers that
+ * already have the diff). Changed-file paths are repo-relative POSIX paths, the
+ * same form `git diff --name-only` produces.
+ *
+ * @see issue #483
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Default per-file mutation-score floor (percent). A changed, mutated file must
+ * score at or above this to pass. Kept equal to the package-level `break`
+ * threshold so the per-file gate and the weekly aggregate gate agree.
+ */
+export const DEFAULT_FLOOR = 70;
+
+/**
+ * Compute the mutation score for a list of mutant status strings.
+ *
+ * Mirrors mutation-testing-metrics' `countFileMetrics`:
+ * detected = Killed + Timeout; valid = detected + Survived + NoCoverage.
+ *
+ * @param {string[]} statuses - mutant status strings for a single file.
+ * @returns {number | null} the score as a percentage (0–100), or `null` when
+ *   the file has no valid mutants and therefore no judgeable score.
+ */
+export function fileMutationScore(statuses) {
+  let killed = 0;
+  let timeout = 0;
+  let survived = 0;
+  let noCoverage = 0;
+  for (const status of statuses) {
+    if (status === 'Killed') killed += 1;
+    else if (status === 'Timeout') timeout += 1;
+    else if (status === 'Survived') survived += 1;
+    else if (status === 'NoCoverage') noCoverage += 1;
+    // Ignored / CompileError / RuntimeError / Pending are not valid mutants.
+  }
+  const detected = killed + timeout;
+  const valid = detected + survived + noCoverage;
+  if (valid === 0) return null;
+  return (detected / valid) * 100;
+}
+
+/**
+ * Normalize a report's file keys to package-relative POSIX paths.
+ *
+ * Stryker normally emits keys relative to `projectRoot` (the package dir), but
+ * some versions/configs emit absolute keys. This strips the `projectRoot`
+ * prefix when present so keys compare cleanly against package-relative changed
+ * paths.
+ *
+ * @param {{ files: Record<string, unknown>, projectRoot?: string }} report - a
+ *   parsed Stryker JSON report.
+ * @returns {Map<string, string>} map of normalized key -> original report key.
+ */
+export function normalizeReportFileKeys(report) {
+  const out = new Map();
+  const root = report.projectRoot ? toPosix(report.projectRoot).replace(/\/+$/, '') : '';
+  for (const key of Object.keys(report.files)) {
+    let normalized = toPosix(key);
+    if (root && normalized.startsWith(`${root}/`)) {
+      normalized = normalized.slice(root.length + 1);
+    }
+    out.set(normalized, key);
+  }
+  return out;
+}
+
+/**
+ * Convert a path to POSIX separators for cross-platform key comparison.
+ *
+ * @param {string} p - a filesystem path.
+ * @returns {string} the path with `\` replaced by `/`.
+ */
+function toPosix(p) {
+  return p.replace(/\\/g, '/');
+}
+
+/**
+ * Validate that an object is a structurally usable Stryker JSON report.
+ *
+ * Per the no-migration principle, we reject malformed input rather than
+ * shimming it. The gate must fail loudly on a missing or shapeless report so a
+ * broken mutation run cannot silently pass the PR.
+ *
+ * @param {unknown} report - the value to validate.
+ * @returns {asserts report is { files: Record<string, { mutants: { status: string }[] }>, projectRoot?: string }}
+ * @throws {Error} when the report is null/undefined or lacks a `files` object.
+ */
+function assertValidReport(report) {
+  if (report == null || typeof report !== 'object') {
+    throw new Error('mutation report is missing or not an object');
+  }
+  if (typeof report.files !== 'object' || report.files === null) {
+    throw new Error('mutation report has no `files` object (malformed report)');
+  }
+}
+
+/**
+ * Result of evaluating the per-file gate.
+ *
+ * @typedef {object} GateResult
+ * @property {boolean} ok - true when no changed file scored below the floor.
+ * @property {{ file: string, score: number }[]} failures - changed files below
+ *   the floor.
+ * @property {{ file: string, score: number }[]} checked - changed files that had
+ *   a judgeable score and met the floor.
+ * @property {{ file: string, reason: string }[]} skipped - changed files that
+ *   could not be judged (not mutated, or no valid mutants).
+ * @property {number} floor - the floor that was applied.
+ */
+
+/**
+ * Evaluate the per-file mutation-score gate against a report and changed files.
+ *
+ * Only files that (a) live under `packageDir`, and (b) appear in the report with
+ * at least one valid mutant are judged. Changed files outside the package, files
+ * Stryker did not mutate, and files with no valid mutants never fail the gate.
+ *
+ * @param {object} args
+ * @param {unknown} args.report - parsed Stryker JSON report (validated here).
+ * @param {string[]} args.changedFiles - repo-relative POSIX paths changed in the
+ *   PR.
+ * @param {string} args.packageDir - repo-relative package directory the report
+ *   belongs to (e.g. `packages/core`).
+ * @param {number} [args.floor] - minimum acceptable score (inclusive).
+ * @returns {GateResult} structured outcome of the evaluation.
+ * @throws {Error} when the report is missing or structurally invalid.
+ */
+export function assertMutationScore({ report, changedFiles, packageDir, floor = DEFAULT_FLOOR }) {
+  assertValidReport(report);
+  const reportKeys = normalizeReportFileKeys(report);
+  const pkgPrefix = `${toPosix(packageDir).replace(/\/+$/, '')}/`;
+
+  const failures = [];
+  const checked = [];
+  const skipped = [];
+
+  for (const raw of changedFiles) {
+    const changed = toPosix(raw);
+    if (!changed.startsWith(pkgPrefix)) continue; // outside this package.
+    const relative = changed.slice(pkgPrefix.length);
+    const reportKey = reportKeys.get(relative);
+    if (reportKey === undefined) {
+      skipped.push({ file: relative, reason: 'not mutated' });
+      continue;
+    }
+    const statuses = report.files[reportKey].mutants.map((m) => m.status);
+    const score = fileMutationScore(statuses);
+    if (score === null) {
+      skipped.push({ file: relative, reason: 'no valid mutants' });
+      continue;
+    }
+    if (score < floor) {
+      failures.push({ file: relative, score });
+    } else {
+      checked.push({ file: relative, score });
+    }
+  }
+
+  return { ok: failures.length === 0, failures, checked, skipped, floor };
+}
+
+/**
+ * Determine the files changed between a base ref and the working tree via git.
+ *
+ * Uses the merge-base (`base...HEAD`) so only commits unique to the PR branch
+ * count — a stale base that moved on after branching does not inflate the
+ * changed set. Falls back to a two-dot diff when the merge-base is unavailable.
+ *
+ * @param {string} base - a git ref to diff against (e.g. `origin/main`).
+ * @returns {string[]} repo-relative POSIX paths of changed files.
+ * @throws {Error} when git invocation fails entirely.
+ */
+function changedFilesFromGit(base) {
+  const run = (args) =>
+    execFileSync('git', args, { encoding: 'utf8' })
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  try {
+    return run(['diff', '--name-only', `${base}...HEAD`]);
+  } catch {
+    // No common ancestor (e.g. shallow clone without the base): fall back to a
+    // two-dot diff so the gate still runs rather than crashing.
+    return run(['diff', '--name-only', base]);
+  }
+}
+
+/**
+ * Parse argv into options for the CLI entrypoint.
+ *
+ * @param {string[]} argv - process arguments (excluding node + script).
+ * @returns {{ report: string, packageDir: string, base?: string, changedFiles: string[], floor: number }}
+ * @throws {Error} when a required option is missing or a flag lacks a value.
+ */
+function parseArgs(argv) {
+  const opts = { changedFiles: [], floor: DEFAULT_FLOOR };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      i += 1;
+      const v = argv[i];
+      if (v === undefined) throw new Error(`missing value for ${arg}`);
+      return v;
+    };
+    if (arg === '--') continue; // pnpm forwards a bare `--`; ignore it.
+    if (arg === '--report') opts.report = next();
+    else if (arg === '--package-dir') opts.packageDir = next();
+    else if (arg === '--base') opts.base = next();
+    else if (arg === '--changed-file') opts.changedFiles.push(next());
+    else if (arg === '--floor') opts.floor = Number.parseInt(next(), 10);
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!opts.report) throw new Error('--report <path> is required');
+  if (!opts.packageDir) throw new Error('--package-dir <dir> is required');
+  if (!opts.base && opts.changedFiles.length === 0) {
+    throw new Error('one of --base <ref> or --changed-file <path> is required');
+  }
+  if (!Number.isInteger(opts.floor) || opts.floor < 0 || opts.floor > 100) {
+    throw new Error('--floor must be an integer between 0 and 100');
+  }
+  return opts;
+}
+
+/**
+ * CLI entrypoint: load the report, resolve changed files, evaluate the gate, and
+ * print a human-readable summary.
+ *
+ * @param {string[]} argv - process arguments (excluding node + script).
+ * @returns {number} process exit code (0 = pass, 1 = a changed file is below
+ *   the floor, 2 = usage/IO error).
+ */
+function main(argv) {
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (err) {
+    console.error(`error: ${err.message}`);
+    return 2;
+  }
+
+  let report;
+  try {
+    report = JSON.parse(readFileSync(opts.report, 'utf8'));
+  } catch (err) {
+    console.error(`error: failed to read mutation report ${opts.report}: ${err.message}`);
+    return 2;
+  }
+
+  const changedFiles =
+    opts.changedFiles.length > 0 ? opts.changedFiles : changedFilesFromGit(opts.base);
+
+  let result;
+  try {
+    result = assertMutationScore({
+      report,
+      changedFiles,
+      packageDir: opts.packageDir,
+      floor: opts.floor,
+    });
+  } catch (err) {
+    console.error(`error: ${err.message}`);
+    return 2;
+  }
+
+  const fmt = (score) => `${score.toFixed(2)}%`;
+  for (const c of result.checked) {
+    console.log(`ok    ${c.file} — ${fmt(c.score)} (floor ${result.floor}%)`);
+  }
+  for (const s of result.skipped) {
+    console.log(`skip  ${s.file} — ${s.reason}`);
+  }
+  for (const f of result.failures) {
+    console.error(`FAIL  ${f.file} — ${fmt(f.score)} is below floor ${result.floor}%`);
+  }
+
+  if (!result.ok) {
+    console.error(
+      `\nmutation gate: ${result.failures.length} changed file(s) below the ${result.floor}% floor. ` +
+        'Add tests that kill the surviving mutants, or justify a floor change in review.',
+    );
+    return 1;
+  }
+
+  if (result.checked.length === 0) {
+    console.log(`mutation gate: no mutated changed files in ${opts.packageDir} to check.`);
+  } else {
+    console.log(`\nmutation gate: ${result.checked.length} changed file(s) passed.`);
+  }
+  return 0;
+}
+
+// Only run main() when invoked directly, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/assert-mutation-score.mjs
+++ b/scripts/assert-mutation-score.mjs
@@ -190,28 +190,36 @@ export function assertMutationScore({ report, changedFiles, packageDir, floor = 
 }
 
 /**
- * Determine the files changed between a base ref and the working tree via git.
+ * Determine the files changed between a base ref and HEAD via git.
  *
  * Uses the merge-base (`base...HEAD`) so only commits unique to the PR branch
  * count — a stale base that moved on after branching does not inflate the
- * changed set. Falls back to a two-dot diff when the merge-base is unavailable.
+ * changed set.
+ *
+ * This fails closed: an unresolvable base or an unreachable merge-base (e.g. a
+ * shallow clone that does not contain the common ancestor) throws rather than
+ * falling back to a semantically different two-dot diff. A silent fallback could
+ * compare HEAD against a truncated base tip and yield a wrong or oversized
+ * changed-file set — masking the very regression this gate exists to catch. The
+ * caller (and CI) must surface the error and refuse to gate on a bad diff.
  *
  * @param {string} base - a git ref to diff against (e.g. `origin/main`).
  * @returns {string[]} repo-relative POSIX paths of changed files.
- * @throws {Error} when git invocation fails entirely.
+ * @throws {Error} when the base ref is unresolvable, the merge-base is
+ *   unreachable, or git invocation otherwise fails.
  */
 function changedFilesFromGit(base) {
-  const run = (args) =>
-    execFileSync('git', args, { encoding: 'utf8' })
+  try {
+    return execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], { encoding: 'utf8' })
       .split('\n')
       .map((l) => l.trim())
       .filter(Boolean);
-  try {
-    return run(['diff', '--name-only', `${base}...HEAD`]);
-  } catch {
-    // No common ancestor (e.g. shallow clone without the base): fall back to a
-    // two-dot diff so the gate still runs rather than crashing.
-    return run(['diff', '--name-only', base]);
+  } catch (err) {
+    throw new Error(
+      `failed to diff ${base}...HEAD: ${err.message.trim()}. ` +
+        'Ensure the base ref and its merge-base with HEAD are fetched ' +
+        '(checkout with full history, e.g. fetch-depth: 0, and do not re-shallow).',
+    );
   }
 }
 
@@ -276,8 +284,15 @@ function main(argv) {
     return 2;
   }
 
-  const changedFiles =
-    opts.changedFiles.length > 0 ? opts.changedFiles : changedFilesFromGit(opts.base);
+  let changedFiles;
+  try {
+    changedFiles =
+      opts.changedFiles.length > 0 ? opts.changedFiles : changedFilesFromGit(opts.base);
+  } catch (err) {
+    // Fail closed: a bad diff must not be treated as "no changed files".
+    console.error(`error: ${err.message}`);
+    return 2;
+  }
 
   let result;
   try {


### PR DESCRIPTION
Closes #483.

## Problem

Mutation testing was **100% advisory**. `thresholds.break` was `null` in all four package configs and `mutation.yml` only ran weekly, so a file could regress from ~99% to near-0% with CI staying green — exactly what happened to `collection-service.ts` (~99.28% → 86.72%) with no signal.

## Changes

**#1 — Trustworthy core timeouts** (`packages/core/stryker.config.mjs`)
- `timeoutMS 30000 → 60000`, `timeoutFactor 2.5 → 3`. Core's heavy actors (XState machine, file locks with up-to-5s jittered backoff, FS-touching `fromPromise` actors) produced ~17 spurious `Timeout` results that `mutation-testing-metrics` counts as undetected mutants, artificially depressing the score. Tuned so the score is honest before anything gates on it.

**#2 — Per-PR changed-file gate** (the only change that would have caught the `collection-service.ts` regression before merge)
- `scripts/assert-mutation-score.mjs`: post-processes Stryker's emitted `mutation-report.json` and fails (exit 1) when a PR-changed, mutated file scores below a floor. Stryker has no native per-file `break` threshold, so this is a post-processing assertion. Score formula mirrors `mutation-testing-metrics` exactly: `(Killed+Timeout)/(Killed+Timeout+Survived+NoCoverage)`. Pure-logic core is exported and unit-tested (15 tests); a thin CLI wrapper resolves changed files via merge-base `git diff <base>...HEAD`.
- `.github/workflows/mutation-pr.yml`: `pull_request` matrix over parser/core/cli/plugin. Each job skips packages with no `src` changes, restores the incremental cache, runs the mutation suite, then asserts at `--floor 70`. Actions SHA-pinned per repo convention.

**#3 — Break floor** (all four `stryker.config.mjs`)
- `thresholds.break: null → 70` as a catastrophic-drop floor for the weekly run.

## Verification

- `scripts/assert-mutation-score.test.mjs` — 15/15 pass (below-floor fail, at/above-floor pass, unchanged-file-below-floor ignored, not-mutated/outside-package/ignored-only skipped, missing/malformed report throws).
- CLI validated against the real core `mutation-report.json`: floor 90 → PASS at 99.28% (matches the issue's reported score), floor 100 → FAIL, unmutated file → skip, missing report → exit 2.
- Pre-commit hooks (biome format + lint) clean.

### Not verified locally
- End-to-end Stryker run in the new workflow (too expensive locally) — the post-processing script was validated against a real saved report instead.

## Follow-ups
- Make `mutation-pr.yml` a **required** status check in branch protection (repo setting, outside this diff).
- Pre-existing, unrelated to this PR: `check:md` fails on `main`, and the `delegation-inference.properties` property test is seed-flaky.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PR-only mutation-testing gate that runs Stryker per package only when that package’s source files changed, enforcing a 70% per-file mutation-score floor.
* **Bug Fixes**
  * Improved mutation-score evaluation to skip files with no valid judgeable mutants instead of failing.
* **Tests**
  * Added unit tests for mutation-score computation, PR gate behavior, report validation, and Stryker config invariants (including timeout budget).
* **Chores**
  * Updated mutation-testing CI/workflow comments and expanded the spell-check dictionary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->