### PR TITLE
ci(#483): scope PR mutation gate to changed files with --mutate

### DIFF
--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -80,9 +80,27 @@ jobs:
             || { echo "::error::base ref '${base}' is unreachable; cannot gate." >&2; exit 1; }
           git merge-base "${base}" HEAD >/dev/null \
             || { echo "::error::no merge-base between '${base}' and HEAD; cannot gate." >&2; exit 1; }
-          changed_files="$(git diff --name-only "${base}...HEAD" -- "${PKG_DIR}/src")"
+          # Exclude deletions (--diff-filter=d): a deleted file cannot be
+          # mutation-tested, and an all-negation `--mutate` (which is what a
+          # deletion-only diff would reduce to below) makes Stryker fall back to
+          # its DEFAULT glob and mutate the whole tree — the exact cold-run
+          # blow-up this gate must avoid. A deletion-only PR therefore has no
+          # mutable changed source and is skipped, same as it passes today.
+          changed_files="$(git diff --name-only --diff-filter=d "${base}...HEAD" -- "${PKG_DIR}/src")"
           if [ -n "${changed_files}" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            # Build the `--mutate` value for the run step: the changed source
+            # files made package-relative (Stryker runs with cwd=${PKG_DIR}) PLUS
+            # this package's own `mutate` exclusion patterns, read straight from
+            # stryker.config.mjs so they can never drift from the source of truth.
+            # Stryker applies the positive patterns then subtracts the negatives,
+            # yielding exactly (changed files ∩ config-mutable files) — the same
+            # set the config glob would mutate, narrowed to this PR's changes.
+            pkg_rel="$(printf '%s\n' "${changed_files}" | sed "s#^${PKG_DIR}/##")"
+            excludes="$(cd "${PKG_DIR}" && node --input-type=module -e 'import("./stryker.config.mjs").then((m) => { const c = m.default ?? m.config ?? {}; process.stdout.write((c.mutate ?? []).filter((p) => p.startsWith("!")).join("\n")); });')" \
+              || { echo "::error::failed to read mutate exclusions from ${PKG_DIR}/stryker.config.mjs" >&2; exit 1; }
+            mutate="$(printf '%s\n%s\n' "${pkg_rel}" "${excludes}" | sed '/^[[:space:]]*$/d' | paste -sd, -)"
+            echo "mutate=${mutate}" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No source changes under ${PKG_DIR}/src; skipping mutation gate."
@@ -106,12 +124,23 @@ jobs:
           key: stryker-${{ matrix.package }}-${{ github.sha }}
           restore-keys: stryker-${{ matrix.package }}-
 
-      # Run the real mutants for the affected package. Incremental mode (set in
-      # each stryker.config.mjs) re-tests only mutated changed code, so this is
-      # bounded even on a cold cache because Stryker still only mutates `src`.
+      # Run the real mutants for the affected package, scoped to ONLY the files
+      # changed in this PR (`--mutate`, built in the detect step with config
+      # exclusions preserved). The per-file gate below scores only changed files,
+      # so mutating the whole `src` tree is pure waste — and it is not merely
+      # slow, it is unbounded: incremental mode does NOT keep a COLD run cheap
+      # (incremental needs a warm baseline, which a timed-out job never saves), so
+      # a cold sweep instruments every file in the config glob (thousands of
+      # mutants for core/cli) and blows past timeout-minutes before a single score
+      # is computed — see cancelled run 28231020823. Scoping to the changed set
+      # collapses each leg from hours to minutes. `--allowEmpty` makes a PR that
+      # touches only config-excluded files (e.g. index.ts) a clean no-op pass
+      # instead of an error. See issue #483.
       - name: Run mutation tests (${{ matrix.package }})
         if: ${{ steps.changes.outputs.changed == 'true' }}
-        run: pnpm exec stryker run
+        env:
+          MUTATE: ${{ steps.changes.outputs.mutate }}
+        run: pnpm exec stryker run --mutate "${MUTATE}" --allowEmpty
         working-directory: ${{ matrix.dir }}
 
       # The merge gate: fail when any file changed in this PR scores below the


### PR DESCRIPTION
## Problem

The `Mutation Gate (PR)` workflow (`.github/workflows/mutation-pr.yml`, landed today in `0eed6ce18`) runs a **full** Stryker mutation sweep on every PR that touches a package's `src`. On a cold incremental cache Stryker instruments **every** file in the config `mutate` glob — **9,495 mutants for cli, 16,811 for core** (concurrency 2) — which runs for hours and hits the job's `timeout-minutes: 30`.

Run [28231020823](https://github.com/tobyhede/rundown/actions/runs/28231020823) shows both `mutation-gate (core)` and `mutation-gate (cli)` legs **cancelled at ~30 min, only 7–15% through**. The workflow comment claimed incremental mode keeps cold runs bounded, but incremental needs a warm baseline that a timed-out job never saves — so the claim was false and every core/cli-src PR is currently blocked, including #482.

The per-file gate (`scripts/assert-mutation-score.mjs --base`) only **scores files changed since the PR base**, so mutating the whole tree is pure waste.

## Fix (workflow-only)

Stryker 9.6.1 has **no `--since` flag**; the native lever for scoping mutation is `--mutate`. This PR:

- **`--diff-filter=d`** on the changed-file detection — a deleted file can't be mutation-tested, and a deletion-only diff would otherwise reduce to an all-negation `--mutate`, making Stryker fall back to its DEFAULT glob (the exact full-tree sweep we're killing).
- **Computes `--mutate`** from the changed source files (made package-relative for Stryker's cwd) **plus the package's own `mutate` exclusions, read directly from `stryker.config.mjs`** so they never drift from the source of truth. Stryker applies the positives then subtracts the negatives → exactly `(changed ∩ config-mutable)`.
- **`--allowEmpty`** so a PR touching only config-excluded files (e.g. `index.ts`, `schemas/**`) is a clean no-op pass instead of an error — preserving today's behaviour.

This collapses each leg from hours to minutes.

## Verification (local, Stryker 9.6.1)

- Full glob (status quo): **962 source files**, ~9,495 mutants for cli.
- Scoped `--mutate "src/commands/abort.ts,…,!src/index.ts,!src/cli.ts,!src/schemas/**"`: Stryker reports **"Found 1 of 962 file(s)"**, **"Instrumented 1 source file(s) with 208 mutant(s)"** — the appended negations correctly drop changed-but-excluded files (`cli.ts`, `schemas/**`).
- Empty-mutate edge (PR changes only an excluded file) on a **clean incremental cache**: `--allowEmpty` → **exit 0**, "mutation score of NaN ≥ break threshold 70", writes a 0-file report; the scorer skips it → gate passes.
- biome format check and cspell pass; YAML parses cleanly.

## Deliberately out of scope (tracked separately under #483)

- `ignoreStatic`, concurrency tuning, warm-cache priming, and merge-queue integration — orthogonal optimisations, not needed to unblock the timeout.
- No change to `stryker.config.mjs`, `assert-mutation-score.mjs`, or any package source — kept workflow-only to stay conflict-free with in-flight PRs (e.g. #482).

Refs #483, run 28231020823. Unblocks #482 and every PR touching core/cli `src`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Mutation checks now focus only on files changed in a pull request, reducing unnecessary runs.
  * PRs that only touch excluded files now complete successfully without failing the check.
  * Deleted-file-only changes are skipped by the mutation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->