### PR TITLE
chore(docs): track active claim-delegation spec and core plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ logs/
 **/end-to-end-test-feedback.json
 docs/plans/
 docs/internal/plans/
-docs/superpowers/
 graphify-out/
 
 # WebContainer snapshot (build artifact — rebuilt by CI and locally via npm run build:snapshot -w site)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,6 +531,22 @@ to spawn.
 See **[docs/README.md](docs/README.md)** for the full documentation index,
 organized by audience and task.
 
+**Descriptive vs prospective — never conflate them.** Documentation splits on
+whether it describes code that exists _today_ or code we _intend_ to build:
+
+- **`docs/internal/`** holds **descriptive** docs — the **current** design,
+  architecture, and implementation. These are living documents, edited in place
+  as the code changes. They describe how the system works right now.
+- **`docs/superpowers/`** holds **prospective** docs — dated, write-once specs
+  (`specs/`), implementation plans (`plans/`), and issue notes (`issues/`) for
+  work we plan to do. A new design for the same feature becomes a new dated
+  file; existing ones are never overwritten.
+
+Litmus test: a dated filename (`YYYY-MM-DD-…`) or a description of unbuilt work
+is **prospective** and belongs under `docs/superpowers/` — never in
+`docs/internal/`. Put the current design in `docs/internal/`; put the plan for
+changing it in `docs/superpowers/plans/`.
+
 ## Conceptual Model
 
 Three distinct concepts govern step execution. Never conflate them:

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,10 +72,29 @@ This index routes you to the right document based on what you're trying to do.
 
 ## Documentation structure
 
-| Directory         | Audience           | Content                                                      |
-| ----------------- | ------------------ | ------------------------------------------------------------ |
-| `docs/spec/`      | All users          | Normative contracts: language spec, grammar, CLI output spec |
-| `docs/reference/` | Users & operators  | CLI, runtime, MCP, security, tool references                 |
-| `docs/security/`  | Security reviewers | Security analyses and threat-model records                   |
-| `docs/guides/`    | Users              | Workflow and integration guides                              |
-| `docs/internal/`  | Contributors       | Implementation, testing, Docker, architecture                |
+Documentation splits along one axis before any other: **descriptive** (how the
+system is designed _right now_) versus **prospective** (what we _intend_ to
+build and how). Get this wrong and the docs rot — a "current design" doc full of
+unbuilt plans misleads every reader.
+
+- **Descriptive docs are living.** They track reality and are edited in place as
+  the code changes. `docs/internal/` is the home for current design.
+- **Prospective docs are an immutable, dated record.** Each spec or plan is
+  written once, committed, and never overwritten — a new design for the same
+  feature becomes a new dated file. `docs/superpowers/` is the home for these.
+
+**Litmus test:** _Does this describe code that exists today?_ →
+`docs/internal/`. _Does this describe code we have not built yet?_ →
+`docs/superpowers/`. A dated filename (`YYYY-MM-DD-…`) is always prospective and
+never belongs in `docs/internal/`.
+
+| Directory                  | Kind        | Audience           | Content                                                              |
+| -------------------------- | ----------- | ------------------ | -------------------------------------------------------------------- |
+| `docs/spec/`               | Descriptive | All users          | Normative contracts: language spec, grammar, CLI output spec         |
+| `docs/reference/`          | Descriptive | Users & operators  | CLI, runtime, MCP, security, tool references                         |
+| `docs/security/`           | Descriptive | Security reviewers | Security analyses and threat-model records                           |
+| `docs/guides/`             | Descriptive | Users              | Workflow and integration guides                                      |
+| `docs/internal/`           | Descriptive | Contributors       | **Current** implementation, testing, Docker, architecture & design   |
+| `docs/superpowers/specs/`  | Prospective | Contributors       | Dated design specs for planned work (`YYYY-MM-DD-<topic>-design.md`) |
+| `docs/superpowers/plans/`  | Prospective | Contributors       | Dated implementation plans for planned work (`YYYY-MM-DD-<name>.md`) |
+| `docs/superpowers/issues/` | Prospective | Contributors       | Tracked issues and follow-up notes for in-flight work                |

--- a/docs/superpowers/plans/2026-06-16-claim-handoff-barrier.md
+++ b/docs/superpowers/plans/2026-06-16-claim-handoff-barrier.md
@@ -1,0 +1,1382 @@
+# Claim Hand-off Barrier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a delegated claimed child from silently driving the parent pipeline after it closes its claim (GitHub issue #460), by stamping a one-shot "claim hand-off pending" barrier on the default stack that refuses *bare* mutating commands until an actor deliberately resumes.
+
+**Architecture:** When a claim closes and the parent auto-advances, the CLI stamps a `handoffPending` marker into `.rundown/session.json` against the runbook that just became default-active. The core resolvers refuse bare `pass`/`fail` (`resolveTransitionTarget`) and bare `delegate`/`collect` (a new `resolveGuardedCommandTarget`) while the marker matches the active runbook. The marker is one-shot: `--resume`, `rd goto`, and a top-level `rd run` **clear** it; an explicit `--step`/`--claim-id` target **bypasses** it (the marker stays until a clearing command runs). Recovery/inspection (`status`, `stop`, `stash`) is never blocked. This is **isolation-against-accident**, mirroring the removed `RD_AGENT_ID` ownership model's own threat model — not an adversarial boundary. All decision logic lives in `@rundown-org/core`; the CLI only stamps/clears via core calls and renders the typed refusal.
+
+**Tech Stack:** TypeScript, XState (core state machine), Zod (session schema), Jest (`packages/core/__tests__`, `packages/cli/__tests__`), pnpm workspaces.
+
+---
+
+## Background: why a session-state marker, and where the parent actually advances
+
+Every `rd` invocation is a fresh OS process; the orchestrator's calls and the child subagent's calls share the same `cwd` and `.rundown/session.json` and are indistinguishable at the process level. `RD_CLAIM_TOKEN=` is a marker string in prompt/output (`packages/core/src/runbook/delegation-token.ts:27`), not a durable env var in the child's shell. So the discriminator **must** live in `session.json`.
+
+**Critical wiring fact (verified):** for `rd pass/fail --claim-id`, `executeTransition` completes the *child*. The parent advance — the behaviour the barrier guards — happens afterward inside `handleParentCompletion` (`packages/cli/src/helpers/delegation-completion.ts:68`), invoked from `transition-command.ts:178` **after** `executeTransition` returns. The same propagation path is reached by `complete --claim-id` (`commands/complete.ts:158`), `stop --claim-id` (`commands/stop.ts:157`), and claim-time auto-completion (`commands/claim.ts:201`). Every one of these closes a claim and advances the parent, so the marker is stamped after `handleParentCompletion` returns in **all four** sites. The existing `OPEN_DELEGATED_CHILDREN` guard (`resolveTransitionTarget`, `command-target-resolver.ts:289`) only fires *while a claim is open*; this plan covers the gap *after* it closes.
+
+### Test ID convention (use everywhere)
+
+Run ids must match `RUN_ID_PATTERN` = `/^rd_[a-f0-9]{32}$/` (`run-id.ts:10`) and claim ids `/^rdclm_[A-Za-z0-9_-]{22}$/`. Never hand-write near-miss literals. In every test snippet below, build ids with:
+
+```typescript
+const rid = (c: string) => `rd_${c.repeat(32)}` as RunId;       // rid('a') => valid 32-hex
+const cid = (c: string) => `rdclm_${c.repeat(22)}` as ClaimId;  // cid('A') => valid claim id
+```
+
+## File Structure
+
+**Core (`packages/core/src`):**
+- `runbook/state.ts` — add `ClaimHandoff` type + `handoffPending?` to `SessionData`.
+- `schemas.ts` — add `ClaimHandoffSchema` (branded `fromClaimId`), wire into `SessionDataSchema`.
+- `output/zod-schemas.ts` — register `CLAIM_HANDOFF_PENDING` in `CLISymbolicErrorCodeValues` + `CLIErrorCodes`. **(F4)**
+- `runbook/session-service.ts` — add `markClaimHandoff` (parent-chain constrained), `readClaimHandoff`, `clearClaimHandoff`.
+- `runbook/command-target-resolver.ts` — extend `CommandTargetReader`; add `claim_handoff_pending` to `TransitionTargetResolution` only; add `GuardedCommandTargetResolution` + `resolveGuardedCommandTarget` **with `targeted` exemption**; fire the refusal in `resolveTransitionTarget`.
+- `runbook/index.ts` — export `ClaimHandoff`, `GuardedCommandTargetResolution`, `resolveGuardedCommandTarget`.
+
+**CLI (`packages/cli/src`):**
+- `helpers/transitions.ts` — `emitClaimHandoffPendingError`; `claim_handoff_pending` variants on `BuildTransitionContextResult` and `BaseBuildTransitionContextResult`; `resume`/`guardHandoff`/`step` params on `buildTransitionContext`.
+- `helpers/transition-command.ts` — `--resume`; route the refusal; stamp the marker after `handleParentCompletion`.
+- `commands/claim.ts`, `commands/complete.ts`, `commands/stop.ts` — stamp after their `handleParentCompletion`. **(F6)**
+- `commands/delegate.ts` — route bare-inference target through `resolveGuardedCommandTarget` (with `--step` exemption); `--resume`.
+- `commands/collect.ts` — `guardHandoff: true` + forward `--step` via `buildTransitionContext`; `--resume`.
+- `commands/goto.ts` (action) + `commands/run.ts` (top-level) — clear on deliberate resume.
+
+**Docs / fixtures:**
+- `docs/reference/cli.md` — document `CLAIM_HANDOFF_PENDING` + `--resume`.
+- `runbooks/delegation/claim-handoff-barrier.runbook.md` (+ leaf) — scenario coverage.
+
+**Tests:**
+- `packages/core/__tests__/schemas.test.ts`, `output/zod-schemas.test.ts` (or nearest error-schema test), `runbook/session-service.test.ts`, `runbook/command-target-resolver.test.ts`, `runbook/claim-handoff.properties.test.ts` (new)
+- `packages/cli/__tests__/integration/claim-handoff-barrier.test.ts` (new)
+
+> **Provenance:** this revision folds in an external review verified against source on 2026-06-17. Blockers fixed: error-code registration (F4), `--step` exemption for delegate/collect (F3), complete/stop claim-close stamping (F6), test-fixture correctness (F8). Should-fixes: unrelated-top mis-stamp constraint (F1), pass/fail coverage symmetry (F5). Doc fix: `--step`/`--claim-id` *bypass*, not *clear* (F2). Documented limitation: stamp-after-advance non-atomicity (F7, Self-Review).
+
+---
+
+## Task 1: Data model, branded schema, and error-code registration
+
+**Files:**
+- Modify: `packages/core/src/runbook/state.ts:167`
+- Modify: `packages/core/src/schemas.ts` (before `SessionDataSchema`, ~line 548)
+- Modify: `packages/core/src/output/zod-schemas.ts` (`CLISymbolicErrorCodeValues` ~line 34; `CLIErrorCodes` ~line 77)
+- Modify: `packages/core/src/runbook/index.ts` (~line 61)
+- Test: `packages/core/__tests__/schemas.test.ts` (SessionData schema); `packages/core/__tests__/output/schema.test.ts` (error-code registry — the live home of `ErrorCodeSchema`)
+
+- [ ] **Step 1: Write the failing SessionData schema test**
+
+Append to `packages/core/__tests__/schemas.test.ts`:
+
+```typescript
+import { SessionDataSchema } from '../src/schemas.js';
+
+describe('SessionDataSchema handoffPending', () => {
+  const PARENT = `rd_${'a'.repeat(32)}`;
+  const CLAIM = `rdclm_${'A'.repeat(22)}`;
+
+  it('accepts and brands a valid handoffPending marker', () => {
+    const parsed = SessionDataSchema.parse({
+      defaultStack: [PARENT],
+      claims: {},
+      handoffPending: { handedOffAt: '2026-06-16T00:00:00.000Z', fromClaimId: CLAIM, toRunId: PARENT },
+    });
+    expect(parsed.handoffPending?.fromClaimId).toBe(CLAIM);
+  });
+
+  it('accepts a session with no handoffPending (optional)', () => {
+    expect(SessionDataSchema.parse({ defaultStack: [], claims: {} }).handoffPending).toBeUndefined();
+  });
+
+  it('rejects a handoffPending with a non-canonical claim id', () => {
+    expect(() =>
+      SessionDataSchema.parse({
+        defaultStack: [],
+        claims: {},
+        handoffPending: { handedOffAt: '2026-06-16T00:00:00.000Z', fromClaimId: 'not-a-claim-id', toRunId: PARENT },
+      }),
+    ).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Write the failing error-code registry test**
+
+`ErrorCodeSchema` lives in `packages/core/src/output/zod-schemas.ts` (re-exported via `output/index.ts`), and its registry test is `packages/core/__tests__/output/schema.test.ts` — see the existing `describe('ErrorCodeSchema code registry')` (~line 214) and the `OPEN_DELEGATED_CHILDREN` block (~line 257). Add the analogous block there, mirroring that precedent:
+
+```typescript
+// packages/core/__tests__/output/schema.test.ts — beside the OPEN_DELEGATED_CHILDREN case (~line 257)
+it('accepts the CLAIM_HANDOFF_PENDING refusal emitted by the hand-off barrier', () => {
+  expect(ErrorCodeSchema.safeParse('CLAIM_HANDOFF_PENDING').success).toBe(true);
+  expect(
+    ErrorResponseSchema.safeParse({ kind: 'error', message: 'refused', code: 'CLAIM_HANDOFF_PENDING' }).success,
+  ).toBe(true);
+  expect(CLIErrorCodes.CLAIM_HANDOFF_PENDING).toBe('CLAIM_HANDOFF_PENDING');
+});
+```
+
+`ErrorResponseSchema` / `CLIErrorCodes` are already imported by that test file (used by the OPEN_DELEGATED_CHILDREN case); add `CLIErrorCodes` to the import if absent.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm --filter @rundown-org/core test -- schemas.test.ts -t handoffPending && pnpm --filter @rundown-org/core test -- output/schema.test.ts -t CLAIM_HANDOFF_PENDING`
+Expected: FAIL — `handoffPending` stripped; `ErrorCodeSchema.safeParse('CLAIM_HANDOFF_PENDING')` / `CLIErrorCodes.CLAIM_HANDOFF_PENDING` not present.
+
+- [ ] **Step 4: Add `ClaimHandoff` to the `SessionData` interface**
+
+In `packages/core/src/runbook/state.ts`, add `ClaimId` to the existing `./claim-id.js` import, then replace the `SessionData` interface (line 167):
+
+```typescript
+/**
+ * One-shot barrier recorded when a claim closes and auto-advances the parent, so
+ * the runbook that just became default-active cannot be driven by a bare command
+ * until an actor deliberately resumes (issue #460). Isolation-against-accident,
+ * not an adversarial boundary.
+ */
+export interface ClaimHandoff {
+  /** ISO timestamp when the hand-off was recorded. */
+  readonly handedOffAt: string;
+  /** Claim id whose closure produced this parent advance. */
+  readonly fromClaimId: ClaimId;
+  /** Default-active runbook id this marker guards (the claim parent or its descendant). */
+  readonly toRunId: RunId;
+}
+
+export interface SessionData {
+  /** Active runbook stack for default targeting. */
+  defaultStack: RunId[];
+  /** ID of a temporarily stashed runbook, if any. */
+  stashedRunbookId?: RunId;
+  /** Explicit claim-id records for delegated child runbook targeting. */
+  claims: Record<string, ClaimRecord>;
+  /** One-shot claim hand-off barrier guarding the default stack (issue #460). */
+  handoffPending?: ClaimHandoff;
+}
+```
+
+- [ ] **Step 5: Add the branded Zod schema**
+
+In `packages/core/src/schemas.ts`, immediately before `export const SessionDataSchema` (~line 548), reusing the branded `ClaimIdSchema` (`schemas.ts:527`) so `fromClaimId` round-trips as `ClaimId`:
+
+```typescript
+/** Zod schema for the one-shot claim hand-off barrier (issue #460). */
+export const ClaimHandoffSchema = z.object({
+  handedOffAt: z.string().min(1),
+  fromClaimId: ClaimIdSchema,
+  toRunId: RunIdSchema,
+});
+```
+
+Add to the `SessionDataSchema` object body, after `claims`:
+
+```typescript
+    claims: z.record(z.string(), ClaimRecordSchema).default({}),
+    handoffPending: ClaimHandoffSchema.optional(),
+```
+
+- [ ] **Step 6: Register the error code (F4)**
+
+In `packages/core/src/output/zod-schemas.ts`, add `'CLAIM_HANDOFF_PENDING',` to the `CLISymbolicErrorCodeValues` array (after `'OPEN_DELEGATED_CHILDREN',` ~line 44) — this is what makes the closed `ErrorCodeSchema` enum accept it. Also add the entry to the explicit `CLIErrorCodes` doc object (after the `OPEN_DELEGATED_CHILDREN` entry ~line 99):
+
+```typescript
+  OPEN_DELEGATED_CHILDREN: 'OPEN_DELEGATED_CHILDREN',
+  CLAIM_HANDOFF_PENDING: 'CLAIM_HANDOFF_PENDING',
+```
+
+- [ ] **Step 7: Export `ClaimHandoff` from core**
+
+In `packages/core/src/runbook/index.ts`, beside the `type SessionData,` export (~line 61), add `type ClaimHandoff,`.
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `pnpm --filter @rundown-org/core test -- schemas.test.ts -t handoffPending && pnpm --filter @rundown-org/core test -- output/schema.test.ts -t CLAIM_HANDOFF_PENDING`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/core/src/runbook/state.ts packages/core/src/schemas.ts packages/core/src/output/zod-schemas.ts packages/core/src/runbook/index.ts packages/core/__tests__/schemas.test.ts packages/core/__tests__/output/schema.test.ts
+git commit -m "feat(core): ClaimHandoff type/schema + register CLAIM_HANDOFF_PENDING (#460)"
+```
+
+---
+
+## Task 2: `SessionService.markClaimHandoff` — stamp on claim close, parent-chain constrained
+
+**Files:**
+- Modify: `packages/core/src/runbook/session-service.ts` (after `runGuardedParentAdvance`, ~line 456)
+- Modify: `packages/core/__tests__/runbook/session-service.test.ts` (extend `setupClaimedChild`; add tests)
+
+**Contract (F1):** self-validating — callers invoke it unconditionally on any claim-targeted transition. It stamps only when **all** hold: the claim's child is terminal (claim genuinely closed); the default-active top is some runbook other than that child; AND the top is the claim's `parentRunId` **or descends from it** via `parentLinkage`. The chain check prevents mis-stamping an unrelated runbook the orchestrator switched to (e.g. after a stash). A missing child state counts as terminal.
+
+- [ ] **Step 1: Extend the `setupClaimedChild` fixture (F8)**
+
+The real helper (`session-service.test.ts:467`) is positional `setupClaimedChild(fill, 'completed'|'stopped')` and returns `{ claimId, childRunId }` — no parent, no `'running'`. Extend it in place so the new tests can express a non-terminal child and assert against the parent:
+
+```typescript
+async function setupClaimedChild(
+  fill: string,
+  childLifecycle: 'completed' | 'stopped' | 'running',
+): Promise<{ claimId: ReturnType<typeof assertClaimId>; childRunId: RunId; parentRunId: RunId }> {
+  const parent = await manager.create({ source: 'project', path: 'parent.md' }, mockRunbook, { runbookPath: 'parent.md' });
+  const linkage = linkageFor(parent.id, fill);
+  const child = await manager.create({ source: 'project', path: 'child.md' }, mockRunbook, {
+    runbookPath: 'child.md',
+    parentLinkage: linkage,
+  });
+  const claimed = assertClaimed(await sessionService.claimRunbook(child.id, linkage));
+  await manager.update(child.id, { lifecycle: childLifecycle });
+  return { claimId: claimed.claim.claimId, childRunId: child.id, parentRunId: parent.id };
+}
+```
+
+This is additive (`'running'` and `parentRunId` are new; existing callers passing `'completed'|'stopped'` and destructuring `{ claimId, childRunId }` are unaffected).
+
+- [ ] **Step 2: Write the failing tests**
+
+```typescript
+describe('SessionService.markClaimHandoff', () => {
+  it('stamps against the default-active top when the child is terminal and the top is the parent', async () => {
+    const { parentRunId, claimId } = await setupClaimedChild('h', 'completed');
+    await sessionService.pushRunbook(parentRunId);
+    await sessionService.markClaimHandoff(claimId);
+    expect((await manager.loadSession()).handoffPending).toEqual({
+      handedOffAt: expect.any(String),
+      fromClaimId: claimId,
+      toRunId: parentRunId,
+    });
+  });
+
+  it('stamps when the top descends from the parent via parentLinkage', async () => {
+    const { parentRunId, claimId } = await setupClaimedChild('i', 'completed');
+    const inlineChild = await manager.create({ source: 'project', path: 'stage.md' }, mockRunbook, {
+      runbookPath: 'stage.md',
+      parentLinkage: linkageFor(parentRunId, 'i2'),
+    });
+    await sessionService.pushRunbook(inlineChild.id);
+    await sessionService.markClaimHandoff(claimId);
+    expect((await manager.loadSession()).handoffPending?.toRunId).toBe(inlineChild.id);
+  });
+
+  it('does NOT stamp an unrelated runbook on top (F1 negative)', async () => {
+    const { claimId } = await setupClaimedChild('j', 'completed');
+    const unrelated = await manager.create({ source: 'project', path: 'other.md' }, mockRunbook, { runbookPath: 'other.md' });
+    await sessionService.pushRunbook(unrelated.id);
+    await sessionService.markClaimHandoff(claimId);
+    expect((await manager.loadSession()).handoffPending).toBeUndefined();
+  });
+
+  it('no-ops when the child is still active (claim not closed)', async () => {
+    const { parentRunId, claimId } = await setupClaimedChild('k', 'running');
+    await sessionService.pushRunbook(parentRunId);
+    await sessionService.markClaimHandoff(claimId);
+    expect((await manager.loadSession()).handoffPending).toBeUndefined();
+  });
+
+  it('no-ops when the default-active top is the claim child itself', async () => {
+    const { childRunId, claimId } = await setupClaimedChild('l', 'completed');
+    await sessionService.pushRunbook(childRunId);
+    await sessionService.markClaimHandoff(claimId);
+    expect((await manager.loadSession()).handoffPending).toBeUndefined();
+  });
+
+  it('no-ops when the claim record was already pruned', async () => {
+    await sessionService.markClaimHandoff(`rdclm_${'Z'.repeat(22)}` as ClaimId);
+    expect((await manager.loadSession()).handoffPending).toBeUndefined();
+  });
+
+  it('treats a missing child state as terminal and stamps the parent top', async () => {
+    const { parentRunId, childRunId, claimId } = await setupClaimedChild('m', 'completed');
+    await sessionService.pushRunbook(parentRunId);
+    await manager.delete(childRunId);
+    await sessionService.markClaimHandoff(claimId);
+    expect((await manager.loadSession()).handoffPending?.toRunId).toBe(parentRunId);
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm --filter @rundown-org/core test -- session-service.test.ts -t markClaimHandoff`
+Expected: FAIL — `sessionService.markClaimHandoff is not a function`.
+
+- [ ] **Step 4: Implement `markClaimHandoff` + the chain check**
+
+Add `ClaimHandoff` to this file's `./state.js` import. Insert after `runGuardedParentAdvance`:
+
+```typescript
+  /**
+   * Stamp a one-shot claim hand-off barrier when a claim closes and the parent
+   * auto-advances (issue #460). Self-validating: a no-op unless the claim's child
+   * is terminal, the current default-active top is a runbook other than that
+   * child, AND the top is the claim's parent or descends from it via parent
+   * linkage. The chain check ensures the barrier guards the parent's pipeline,
+   * never an unrelated runbook the orchestrator switched to. Callers may invoke
+   * this unconditionally after a claim-targeted transition propagates.
+   *
+   * @param closedClaimId - Claim id whose child transition may have closed it
+   */
+  async markClaimHandoff(closedClaimId: ClaimId): Promise<void> {
+    await this.withLock(async () => {
+      const session = await this.manager.loadSession();
+      const claim = session.claims[closedClaimId];
+      if (!claim) {
+        return; // claim already pruned — nothing to attribute the hand-off to
+      }
+      const child = await this.manager.load(claim.childRunId);
+      // A missing child state counts as terminal: the claim cannot still be open.
+      const childTerminal =
+        child === null || child.lifecycle === 'completed' || child.lifecycle === 'stopped';
+      if (!childTerminal) {
+        return; // claim still open; the OPEN_DELEGATED_CHILDREN guard covers this window
+      }
+      const top = session.defaultStack[session.defaultStack.length - 1];
+      if (!top || top === claim.childRunId) {
+        return; // no active runbook to guard, or the child is still the active top
+      }
+      if (!(await this.topDescendsFromParent(top, claim.parentRunId))) {
+        return; // unrelated runbook on top — do not guard it (F1)
+      }
+      session.handoffPending = {
+        handedOffAt: new Date().toISOString(),
+        fromClaimId: closedClaimId,
+        toRunId: top,
+      };
+      await this.manager.saveSession(session);
+    });
+  }
+
+  /**
+   * True when `top` is `parentRunId` or reaches it by walking parent linkage
+   * (bounded). Used by {@link markClaimHandoff} to scope the barrier to the
+   * claim's own pipeline.
+   *
+   * @param top - Default-active top runbook id
+   * @param parentRunId - The claim's parent run id
+   * @returns Whether `top` is or descends from `parentRunId`
+   */
+  private async topDescendsFromParent(top: RunId, parentRunId: RunId): Promise<boolean> {
+    let current: RunId | undefined = top;
+    for (let depth = 0; current !== undefined && depth < 64; depth += 1) {
+      if (current === parentRunId) {
+        return true;
+      }
+      const state = await this.manager.load(current);
+      current = state?.parentLinkage?.parentRunId;
+    }
+    return false;
+  }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm --filter @rundown-org/core test -- session-service.test.ts -t markClaimHandoff`
+Expected: PASS (7 tests).
+
+> Execution note: the integration test in Task 8 exercises the *real* inline advance. If it reveals that the inline-advanced stage does not carry `parentLinkage.parentRunId` back to the claim parent, the chain walk will (correctly) refuse to stamp and Task 8 will go red — at which point relax the constraint to match the real linkage topology, not the unit fixtures. The unit fixtures here assert the contract; Task 8 validates it against production wiring.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/runbook/session-service.ts packages/core/__tests__/runbook/session-service.test.ts
+git commit -m "feat(core): markClaimHandoff stamps the hand-off barrier, parent-chain scoped (#460)"
+```
+
+---
+
+## Task 3: `SessionService.readClaimHandoff` + `clearClaimHandoff`
+
+**Files:**
+- Modify: `packages/core/src/runbook/session-service.ts` (after `markClaimHandoff`)
+- Test: `packages/core/__tests__/runbook/session-service.test.ts`
+
+Read-only (no lock, consistent with `getActiveForClaimId`/`listOpenClaimsForParent`); returns the marker only when it matches the queried run. `clearClaimHandoff` removes it under the lock, idempotently.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+describe('SessionService.readClaimHandoff / clearClaimHandoff', () => {
+  const PARENT = `rd_${'a'.repeat(32)}` as RunId;
+  const marker = { handedOffAt: '2026-06-16T00:00:00.000Z', fromClaimId: `rdclm_${'A'.repeat(22)}` as ClaimId, toRunId: PARENT };
+  async function seedMarker(): Promise<void> {
+    const session = await manager.loadSession();
+    session.handoffPending = marker;
+    await manager.saveSession(session);
+  }
+
+  it('returns the marker when it matches the queried active run', async () => {
+    await seedMarker();
+    expect((await sessionService.readClaimHandoff(PARENT))?.fromClaimId).toBe(marker.fromClaimId);
+  });
+  it('returns null when the marker points at a different run (stale)', async () => {
+    await seedMarker();
+    expect(await sessionService.readClaimHandoff(`rd_${'b'.repeat(32)}` as RunId)).toBeNull();
+  });
+  it('returns null when there is no marker', async () => {
+    expect(await sessionService.readClaimHandoff(PARENT)).toBeNull();
+  });
+  it('clears the marker', async () => {
+    await seedMarker();
+    await sessionService.clearClaimHandoff();
+    expect((await manager.loadSession()).handoffPending).toBeUndefined();
+  });
+  it('clearClaimHandoff is idempotent when no marker is present', async () => {
+    await sessionService.clearClaimHandoff();
+    expect((await manager.loadSession()).handoffPending).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @rundown-org/core test -- session-service.test.ts -t readClaimHandoff`
+Expected: FAIL — not a function.
+
+- [ ] **Step 3: Implement both methods**
+
+```typescript
+  /**
+   * Read the claim hand-off barrier for a candidate active runbook (issue #460).
+   * Read-only (bypasses the session lock, consistent with {@link getActiveForClaimId}).
+   * Returns the marker only when it guards `activeRunId`; a stale marker reads null.
+   *
+   * @param activeRunId - Default-active runbook the caller intends to act on
+   * @returns The matching hand-off marker, or `null` when none applies
+   */
+  async readClaimHandoff(activeRunId: RunId): Promise<ClaimHandoff | null> {
+    const session = await this.manager.loadSession();
+    const marker = session.handoffPending;
+    return marker && marker.toRunId === activeRunId ? marker : null;
+  }
+
+  /**
+   * Clear the claim hand-off barrier (#460). Idempotent. Called from the
+   * deliberate-resume sites (`--resume`, `goto`, top-level `run`).
+   */
+  async clearClaimHandoff(): Promise<void> {
+    await this.withLock(async () => {
+      const session = await this.manager.loadSession();
+      if (session.handoffPending === undefined) {
+        return;
+      }
+      delete session.handoffPending;
+      await this.manager.saveSession(session);
+    });
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @rundown-org/core test -- session-service.test.ts -t readClaimHandoff`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/runbook/session-service.ts packages/core/__tests__/runbook/session-service.test.ts
+git commit -m "feat(core): SessionService.readClaimHandoff/clearClaimHandoff (#460)"
+```
+
+---
+
+## Task 4: Resolver — `claim_handoff_pending` in `resolveTransitionTarget`
+
+Add the refusal to `TransitionTargetResolution` **only** (NOT the shared `CommandTargetResolution`, consumed by six exhaustive `default: never` switches).
+
+**Files:**
+- Modify: `packages/core/src/runbook/command-target-resolver.ts`
+- Test: `packages/core/__tests__/runbook/command-target-resolver.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Extend the `fakeReader` factory (line 63) to accept `handoff` and supply `readClaimHandoff: async () => options.handoff ?? null`. Then:
+
+```typescript
+const ACTIVE = { id: `rd_${'a'.repeat(32)}` } as never;
+const HANDOFF = { handedOffAt: '2026-06-16T00:00:00.000Z', fromClaimId: `rdclm_${'A'.repeat(22)}`, toRunId: `rd_${'a'.repeat(32)}` } as never;
+
+describe('resolveTransitionTarget claim_handoff_pending', () => {
+  it('refuses a bare transition when a hand-off marker guards the active run', async () => {
+    expect((await resolveTransitionTarget(fakeReader({ active: ACTIVE, handoff: HANDOFF }), { command: 'pass' })).kind).toBe('claim_handoff_pending');
+  });
+  it('refuses a bare fail too (result-agnostic)', async () => {
+    expect((await resolveTransitionTarget(fakeReader({ active: ACTIVE, handoff: HANDOFF }), { command: 'fail' })).kind).toBe('claim_handoff_pending');
+  });
+  it('exempts a targeted (--step) transition', async () => {
+    expect((await resolveTransitionTarget(fakeReader({ active: ACTIVE, handoff: HANDOFF }), { command: 'pass', targeted: true })).kind).toBe('default');
+  });
+  it('exempts a claim-targeted transition', async () => {
+    const reader = fakeReader({ claim: { status: 'claimed', claim: {}, state: ACTIVE }, handoff: HANDOFF });
+    expect((await resolveTransitionTarget(reader, { command: 'pass', claimId: `rdclm_${'B'.repeat(22)}` as never })).kind).toBe('claim');
+  });
+  it('takes priority over the open-children refusal (checked first)', async () => {
+    const reader = fakeReader({ active: ACTIVE, handoff: HANDOFF, openClaims: [{ claimId: 'x' }] as never });
+    expect((await resolveTransitionTarget(reader, { command: 'pass' })).kind).toBe('claim_handoff_pending');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @rundown-org/core test -- command-target-resolver.test.ts -t claim_handoff_pending`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the import, reader method, and union variant**
+
+In `command-target-resolver.ts`:
+
+```typescript
+// after line 3:
+import type { ClaimHandoff } from './state.js';
+```
+
+Add to `CommandTargetReader` (after `listOpenClaimsForParent`, ~line 143):
+
+```typescript
+  /**
+   * Read the one-shot claim hand-off barrier guarding a candidate active run.
+   * @param activeRunId - Default-active runbook the command intends to act on
+   * @returns The matching hand-off marker, or `null` when none applies
+   */
+  readClaimHandoff(activeRunId: RunId): Promise<ClaimHandoff | null>;
+```
+
+Add the variant to `TransitionTargetResolution` only (after `open_delegated_children`, ~line 78):
+
+```typescript
+  | { readonly kind: 'claim_handoff_pending'; readonly handoff: ClaimHandoff; readonly state: RunbookState };
+```
+
+- [ ] **Step 4: Fire the refusal in `resolveTransitionTarget`**
+
+Replace the bare-only block (currently lines 287–296):
+
+```typescript
+  // `--step`-targeted transitions are deliberate and exempt from both bare-only
+  // refusals (claim-targeted transitions already returned above).
+  if (!options.targeted) {
+    // Hand-off is checked before open-children: once a claim closes the parent
+    // has advanced, so the open-children window is already past — the hand-off
+    // refusal is the correct, more specific diagnostic.
+    const handoff = await targetReader.readClaimHandoff(active.id);
+    if (handoff) {
+      return { kind: 'claim_handoff_pending', handoff, state: active };
+    }
+    const openClaims = await targetReader.listOpenClaimsForParent(active.id);
+    if (openClaims.length > 0) {
+      return { kind: 'open_delegated_children', parentRunId: active.id, claims: openClaims };
+    }
+  }
+
+  return { kind: 'default', state: active };
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm --filter @rundown-org/core test -- command-target-resolver.test.ts -t claim_handoff_pending`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/runbook/command-target-resolver.ts packages/core/__tests__/runbook/command-target-resolver.test.ts
+git commit -m "feat(core): claim_handoff_pending refusal in resolveTransitionTarget (#460)"
+```
+
+---
+
+## Task 5: Resolver — `resolveGuardedCommandTarget` (with `targeted` exemption)
+
+`resolveCommandTarget` and its six callers stay untouched. The wrapper widens only for guarded callers AND honours a `targeted` flag so explicit `--step` deliberate commands are exempt (F3).
+
+**Files:**
+- Modify: `packages/core/src/runbook/command-target-resolver.ts`
+- Modify: `packages/core/src/runbook/index.ts`
+- Test: `packages/core/__tests__/runbook/command-target-resolver.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { resolveGuardedCommandTarget } from '../../src/runbook/command-target-resolver.js';
+
+describe('resolveGuardedCommandTarget', () => {
+  it('refuses when a marker guards the default-active run', async () => {
+    expect((await resolveGuardedCommandTarget(fakeReader({ active: ACTIVE, handoff: HANDOFF }))).kind).toBe('claim_handoff_pending');
+  });
+  it('exempts a targeted (--step) command even under a barrier', async () => {
+    expect((await resolveGuardedCommandTarget(fakeReader({ active: ACTIVE, handoff: HANDOFF }), { targeted: true })).kind).toBe('default');
+  });
+  it('resolves default when no marker is present', async () => {
+    expect((await resolveGuardedCommandTarget(fakeReader({ active: ACTIVE }))).kind).toBe('default');
+  });
+  it('passes claim-id targeting straight through (exempt)', async () => {
+    const reader = fakeReader({ claim: { status: 'claimed', claim: {}, state: ACTIVE }, handoff: HANDOFF });
+    expect((await resolveGuardedCommandTarget(reader, { claimId: `rdclm_${'B'.repeat(22)}` as never })).kind).toBe('claim');
+  });
+  it('resolves none when there is no active runbook', async () => {
+    expect((await resolveGuardedCommandTarget(fakeReader({ active: null }))).kind).toBe('none');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @rundown-org/core test -- command-target-resolver.test.ts -t resolveGuardedCommandTarget`
+Expected: FAIL — not exported.
+
+- [ ] **Step 3: Add the option, type, and function**
+
+Add `targeted` to `ResolveCommandTargetOptions` (~line 81):
+
+```typescript
+  /**
+   * True when the caller supplied an explicit `--step` target. A deliberate,
+   * targeted command is exempt from the claim hand-off refusal (#460).
+   */
+  readonly targeted?: boolean;
+```
+
+After `resolveCommandTarget` (~line 226):
+
+```typescript
+/**
+ * Result of {@link resolveGuardedCommandTarget}: the base resolution widened with
+ * the claim hand-off refusal. Only delegate/collect consume this; the six
+ * unguarded `resolveCommandTarget` callers keep the narrow union.
+ */
+export type GuardedCommandTargetResolution =
+  | CommandTargetResolution
+  | { readonly kind: 'claim_handoff_pending'; readonly handoff: ClaimHandoff; readonly state: RunbookState };
+
+/**
+ * Resolve a command target, refusing with `claim_handoff_pending` when a one-shot
+ * hand-off barrier guards the default-active run (issue #460). Used by the
+ * overstep-prone mutating commands (`delegate`, `collect`). Explicit `--claim-id`
+ * targeting, an explicit `--step` (`options.targeted`), and the non-default
+ * outcomes pass through unguarded.
+ *
+ * @param targetReader - Read-side dependency used to read claim, default, and hand-off targets
+ * @param options - Optional explicit claim id, stashed-visibility, and `targeted` flag
+ * @returns The base resolution, or `claim_handoff_pending` when the barrier applies
+ */
+export async function resolveGuardedCommandTarget(
+  targetReader: CommandTargetReader,
+  options: ResolveCommandTargetOptions = {},
+): Promise<GuardedCommandTargetResolution> {
+  const base = await resolveCommandTarget(targetReader, options);
+  if (base.kind !== 'default' || options.targeted === true) {
+    return base; // non-default outcomes and deliberate --step targets pass through
+  }
+  const handoff = await targetReader.readClaimHandoff(base.state.id);
+  return handoff ? { kind: 'claim_handoff_pending', handoff, state: base.state } : base;
+}
+```
+
+- [ ] **Step 4: Export from core**
+
+In `packages/core/src/runbook/index.ts`, beside `resolveCommandTarget` (~line 80):
+
+```typescript
+  resolveGuardedCommandTarget,
+  type GuardedCommandTargetResolution,
+```
+
+- [ ] **Step 5: Run the test to verify it passes; verify core builds**
+
+Run: `pnpm --filter @rundown-org/core test -- command-target-resolver.test.ts -t resolveGuardedCommandTarget && pnpm --filter @rundown-org/core build`
+Expected: PASS; build clean (the six `default: never` switches over `CommandTargetResolution` untouched).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/runbook/command-target-resolver.ts packages/core/src/runbook/index.ts packages/core/__tests__/runbook/command-target-resolver.test.ts
+git commit -m "feat(core): resolveGuardedCommandTarget with --step exemption (#460)"
+```
+
+---
+
+## Task 6: Property test — the refusal-iff invariant
+
+**Files:**
+- Create: `packages/core/__tests__/runbook/claim-handoff.properties.test.ts`
+
+- [ ] **Step 1: Write the property test**
+
+```typescript
+import fc from 'fast-check';
+import {
+  resolveTransitionTarget,
+  resolveGuardedCommandTarget,
+  type CommandTargetReader,
+} from '../../src/runbook/command-target-resolver.js';
+
+const rid = (c: string) => `rd_${c.repeat(32)}`;
+const CLAIM = `rdclm_${'A'.repeat(22)}`;
+function readerFor(handoffTo: string | null, activeId: string): CommandTargetReader {
+  return {
+    getActive: async () => ({ id: activeId }) as never,
+    getActiveForClaimId: async () => ({ status: 'claimed', claim: {}, state: { id: activeId } }) as never,
+    listOpenClaimsForParent: async () => [],
+    readClaimHandoff: async (id) =>
+      handoffTo && handoffTo === id
+        ? ({ handedOffAt: '2026-06-16T00:00:00.000Z', fromClaimId: CLAIM, toRunId: handoffTo } as never)
+        : null,
+  };
+}
+
+describe('claim hand-off barrier — refusal-iff invariant (property)', () => {
+  it('resolveTransitionTarget refuses iff matching marker AND not targeted AND no claimId', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom('a', 'b'),
+        fc.option(fc.constantFrom('a', 'b'), { nil: null }),
+        fc.boolean(),
+        fc.boolean(),
+        async (activeKey, handoffKey, targeted, withClaim) => {
+          const active = rid(activeKey);
+          const result = await resolveTransitionTarget(readerFor(handoffKey ? rid(handoffKey) : null, active), {
+            command: 'pass',
+            targeted,
+            ...(withClaim ? { claimId: `rdclm_${'B'.repeat(22)}` as never } : {}),
+          });
+          const shouldRefuse = handoffKey !== null && rid(handoffKey) === active && !targeted && !withClaim;
+          expect(result.kind === 'claim_handoff_pending').toBe(shouldRefuse);
+        },
+      ),
+    );
+  });
+
+  it('resolveGuardedCommandTarget refuses iff matching marker AND not targeted AND no claimId', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom('a', 'b'),
+        fc.option(fc.constantFrom('a', 'b'), { nil: null }),
+        fc.boolean(),
+        async (activeKey, handoffKey, targeted) => {
+          const active = rid(activeKey);
+          const result = await resolveGuardedCommandTarget(readerFor(handoffKey ? rid(handoffKey) : null, active), { targeted });
+          const shouldRefuse = handoffKey !== null && rid(handoffKey) === active && !targeted;
+          expect(result.kind === 'claim_handoff_pending').toBe(shouldRefuse);
+        },
+      ),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the property test**
+
+Run: `pnpm --filter @rundown-org/core test:property -- claim-handoff.properties.test.ts`
+Expected: PASS. (Match the sibling command if property tests route differently, e.g. `claim-schema.properties.test.ts`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/__tests__/runbook/claim-handoff.properties.test.ts
+git commit -m "test(core): property test for claim hand-off refusal-iff invariant (#460)"
+```
+
+---
+
+## Task 7: CLI core wiring — emitter, result variants, `buildTransitionContext` params
+
+**Files:**
+- Modify: `packages/cli/src/helpers/transitions.ts`
+
+- [ ] **Step 1: Add the error emitter**
+
+After `emitOpenDelegatedChildrenError` (~line 471). Import `ClaimHandoff` from `@rundown-org/core`.
+
+```typescript
+/**
+ * Emit the refusal for a command blocked by a claim hand-off barrier (#460). The
+ * active runbook just became default-active because a claim closed; a bare
+ * command would silently drive it. The actor must resume deliberately.
+ *
+ * @param output - Output emitter
+ * @param command - The refused command name
+ * @param handoff - The hand-off marker guarding the active run
+ */
+export function emitClaimHandoffPendingError(output: OutputEmitter, command: string, handoff: ClaimHandoff): void {
+  output.error(
+    `Cannot run bare rd ${command}: the active runbook was just handed off from closed claim ${handoff.fromClaimId}. If you are the claimed child, stop here. To act on a claimed child, use \`--claim-id <id>\`. To deliberately drive the parent, re-run with \`--resume\` or target a step with \`--step <id>\`.`,
+    'CLAIM_HANDOFF_PENDING',
+    { command, fromClaimId: handoff.fromClaimId, toRunId: handoff.toRunId },
+  );
+}
+```
+
+- [ ] **Step 2: Add the result variants**
+
+Add to `BuildTransitionContextResult` (after `open_delegated_children`, ~line 187) and `BaseBuildTransitionContextResult` (~line 199):
+
+```typescript
+  | { readonly kind: 'claim_handoff_pending'; readonly handoff: ClaimHandoff };
+```
+
+- [ ] **Step 3: Thread `resume`, `guardHandoff`, and `step` (for `targeted`) through `buildTransitionContext`**
+
+Add `readonly resume?: boolean;` to both overload option types + impl signature. Add `readonly guardHandoff?: boolean;` and (already present for pass/fail) ensure `step` is available on the **base** overload too, so collect can forward it.
+
+After `const sessionService = new SessionService(manager);` (~line 249):
+
+```typescript
+  if (options.resume === true) {
+    // Deliberate resume — drop the one-shot hand-off barrier before resolving (#460).
+    await sessionService.clearClaimHandoff();
+  }
+```
+
+In the pass/fail switch (line 263) add:
+
+```typescript
+      case 'claim_handoff_pending':
+        return { kind: 'claim_handoff_pending', handoff: active.handoff };
+```
+
+In the base path (line 300), resolve via the guarded resolver when asked, forwarding `targeted`:
+
+```typescript
+    const active = options.guardHandoff
+      ? await resolveGuardedCommandTarget(sessionService, {
+          claimId: options.claimId,
+          targeted: options.step !== undefined,
+        })
+      : await resolveCommandTarget(sessionService, { claimId: options.claimId });
+    switch (active.kind) {
+      case 'claim':
+      case 'default':
+        resolvedKind = active.kind;
+        state = active.state;
+        break;
+      case 'claim_handoff_pending':
+        return { kind: 'claim_handoff_pending', handoff: active.handoff };
+      case 'none':
+      case 'stale_claim':
+      case 'terminal_claim':
+        return active;
+      default: {
+        const _exhaustive: never = active;
+        return _exhaustive;
+      }
+    }
+```
+
+Import `resolveGuardedCommandTarget` from `@rundown-org/core`.
+
+- [ ] **Step 4: Verify the CLI typechecks**
+
+Run: `pnpm --filter @rundown-org/cli build`
+Expected: PASS (both switches exhaustive).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/helpers/transitions.ts
+git commit -m "feat(cli): hand-off emitter, result variants, resume/guardHandoff/step plumbing (#460)"
+```
+
+---
+
+## Task 8: CLI — stamp the marker after the parent advances (all four close paths)
+
+**Files:**
+- Modify: `packages/cli/src/helpers/transition-command.ts` (after `handleParentCompletion`, ~line 186)
+- Modify: `packages/cli/src/commands/claim.ts` (~line 211), `commands/complete.ts` (~line 158), `commands/stop.ts` (~line 157) — **(F6)**
+- Test: `packages/cli/__tests__/integration/claim-handoff-barrier.test.ts` (new)
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Use the real harness (`createTestWorkspace`, synchronous `runCli`, raw session read). Implement `setupClaimedChildPipeline()` → `{ workspace, claimId }` with a two-stage parent (step 1 `- DELEGATE` leaf; step 2 normal) + leaf, parent default-active, leaf claimed. **Await every async assertion.**
+
+```typescript
+import { readFile } from 'node:fs/promises';
+import { createTestWorkspace, runCli, parseCliJsonObject, type TestWorkspace } from '../helpers/test-utils.js';
+import { ErrorResponseSchema } from '@rundown-org/core';
+
+async function handoffMarker(ws: TestWorkspace): Promise<unknown> {
+  const raw = JSON.parse(await readFile(ws.sessionPath(), 'utf-8')) as Record<string, unknown>;
+  return raw.handoffPending;
+}
+
+describe('claim hand-off barrier (#460)', () => {
+  it('stamps handoffPending after a claim-targeted PASS closes the child', async () => {
+    const { workspace, claimId } = await setupClaimedChildPipeline();
+    expect(runCli(['pass', '--claim-id', claimId], workspace).exitCode).toBe(0);
+    expect(await handoffMarker(workspace)).toEqual(expect.objectContaining({ fromClaimId: claimId }));
+  });
+
+  it('stamps handoffPending after a claim-targeted FAIL closes the child', async () => {
+    const { workspace, claimId } = await setupClaimedChildPipeline();
+    runCli(['fail', '--claim-id', claimId], workspace);
+    expect(await handoffMarker(workspace)).toEqual(expect.objectContaining({ fromClaimId: claimId }));
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @rundown-org/cli test -- claim-handoff-barrier.test.ts -t "stamps handoffPending"`
+Expected: FAIL — marker `undefined`.
+
+- [ ] **Step 3: Stamp after `handleParentCompletion` in `transition-command.ts`**
+
+After the parent-propagation block (after line 186, before `if (shouldExitWithError)`):
+
+```typescript
+            // Claim closed and the parent (or its next inline stage) has now
+            // advanced to become default-active. Stamp the one-shot hand-off
+            // barrier so a still-running claimed child cannot silently drive that
+            // stage (#460). Self-validating; only fires on a genuinely closed
+            // claim with a parent-chain runbook on top. Runs only on the success
+            // paths reached here — never after a thrown/failed transition.
+            if (claimTarget.claimId !== undefined) {
+              await ctx.sessionService.markClaimHandoff(claimTarget.claimId);
+            }
+```
+
+- [ ] **Step 4: Stamp after `handleParentCompletion` in claim.ts, complete.ts, stop.ts (F6)**
+
+In each, immediately after the `handleParentCompletion(...)` call, when the command targeted a claim (`claimId` in scope from the claim/`--claim-id` resolution), add:
+
+```typescript
+                // Claim closed and the parent advanced — stamp the hand-off barrier (#460).
+                await sessionService.markClaimHandoff(<claimId>);
+```
+
+- `claim.ts:~211` — use the claim id from the successful `claim` result (auto-completion path).
+- `complete.ts:~158` / `stop.ts:~157` — use `claimTarget.claimId` (guard `!== undefined`; bare `complete`/`stop` close the *active* runbook, not a claim, so they skip).
+
+Use the `SessionService` already in scope in each command; construct `new SessionService(manager)` if none exists, consistent with surrounding code.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm --filter @rundown-org/cli test -- claim-handoff-barrier.test.ts -t "stamps handoffPending"`
+Expected: PASS (pass + fail). If the parent-chain constraint (Task 2) refuses to stamp here, the inline-advanced top lacks `parentLinkage` to the claim parent — relax the constraint to match the real topology (see Task 2 Step 5 note) and re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/helpers/transition-command.ts packages/cli/src/commands/claim.ts packages/cli/src/commands/complete.ts packages/cli/src/commands/stop.ts packages/cli/__tests__/integration/claim-handoff-barrier.test.ts
+git commit -m "feat(cli): stamp hand-off barrier on all four claim-close paths (#460)"
+```
+
+---
+
+## Task 9: CLI — refuse bare pass/fail + `--resume`
+
+**Files:**
+- Modify: `packages/cli/src/helpers/transition-command.ts`
+- Test: `packages/cli/__tests__/integration/claim-handoff-barrier.test.ts`
+
+- [ ] **Step 1: Write the failing tests (pass AND fail; resume; non-blocking)**
+
+```typescript
+function expectHandoffRefusal(result: { stdout: string; stderr: string; exitCode: number }): void {
+  expect(result.exitCode).toBe(1);
+  const envelope = parseCliJsonObject(result.stdout || result.stderr);
+  expect(envelope).toEqual(expect.objectContaining({ kind: 'error', code: 'CLAIM_HANDOFF_PENDING' }));
+  expect(ErrorResponseSchema.safeParse(envelope).success).toBe(true);
+}
+
+it('refuses a bare pass against the auto-advanced parent after the claim closes', async () => {
+  const { workspace, claimId } = await setupClaimedChildPipeline();
+  runCli(['pass', '--claim-id', claimId], workspace);
+  expectHandoffRefusal(runCli(['pass'], workspace));
+});
+
+it('refuses a bare fail against the auto-advanced parent after the claim closes', async () => {
+  const { workspace, claimId } = await setupClaimedChildPipeline();
+  runCli(['pass', '--claim-id', claimId], workspace);
+  expectHandoffRefusal(runCli(['fail'], workspace));
+});
+
+it('lets the orchestrator resume deliberately with --resume (marker cleared)', async () => {
+  const { workspace, claimId } = await setupClaimedChildPipeline();
+  runCli(['pass', '--claim-id', claimId], workspace);
+  expect(runCli(['pass', '--resume'], workspace).exitCode).toBe(0);
+  expect(await handoffMarker(workspace)).toBeUndefined();
+});
+
+it('does not block rd status, rd stop, or rd stash under the barrier', async () => {
+  const { workspace, claimId } = await setupClaimedChildPipeline();
+  runCli(['pass', '--claim-id', claimId], workspace);
+  expect(runCli(['status'], workspace).exitCode).toBe(0);
+  expect(runCli(['stash'], workspace).exitCode).toBe(0);
+  expect(runCli(['stop'], workspace).exitCode).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @rundown-org/cli test -- claim-handoff-barrier.test.ts -t "bare pass|bare fail"`
+Expected: FAIL — bare pass/fail exit 0.
+
+- [ ] **Step 3: Register `--resume`, pass it through, render the refusal**
+
+In `registerTransitionCommand` (`transition-command.ts:53`):
+
+```typescript
+    .option('--resume', 'Clear a one-shot claim hand-off barrier and drive the parent')
+```
+
+Add `resume?: boolean` to the action options (line 63); pass `resume: options.resume` into `buildTransitionContext` (line 79). Add the refusal arm after `open_delegated_children` (~line 133):
+
+```typescript
+              case 'claim_handoff_pending':
+                emitClaimHandoffPendingError(output, def.name, contextResult.handoff);
+                output.flush();
+                process.exitCode = 1;
+                return;
+```
+
+Import `emitClaimHandoffPendingError` beside `emitOpenDelegatedChildrenError`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @rundown-org/cli test -- claim-handoff-barrier.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/helpers/transition-command.ts packages/cli/__tests__/integration/claim-handoff-barrier.test.ts
+git commit -m "feat(cli): refuse bare pass/fail under hand-off barrier; --resume clears (#460)"
+```
+
+---
+
+## Task 10: CLI — guard delegate & collect (with `--step` exemption); clear on goto & run
+
+**Files:**
+- Modify: `packages/cli/src/commands/delegate.ts` (bare-inference path, line 116 only)
+- Modify: `packages/cli/src/commands/collect.ts`
+- Modify: `packages/cli/src/commands/run.ts`, `packages/cli/src/commands/goto.ts`
+- Test: `packages/cli/__tests__/integration/claim-handoff-barrier.test.ts`
+
+- [ ] **Step 1: Write the failing tests (incl. `--step` exemption, F3, and `--resume`, F5)**
+
+```typescript
+// "Not refused by the barrier" — the command may still fail for an unrelated
+// reason (e.g. RD-813 not_delegatable when --step targets a non-delegate step),
+// so assert only that the failure is NOT the hand-off refusal.
+function expectNotHandoffRefusal(result: { stdout: string; stderr: string; exitCode: number }): void {
+  if (result.exitCode === 0) return;
+  const envelope = parseCliJsonObject(result.stdout || result.stderr);
+  expect(envelope.code).not.toBe('CLAIM_HANDOFF_PENDING');
+}
+
+it('refuses bare rd delegate under the barrier; --resume bypasses the refusal', async () => {
+  const { workspace, claimId } = await setupClaimedChildPipeline();
+  runCli(['pass', '--claim-id', claimId], workspace);
+  expectHandoffRefusal(runCli(['delegate'], workspace));
+  expect(await handoffMarker(workspace)).toBeDefined();
+  // --resume clears the barrier; delegate then resolves normally (it may still
+  // fail downstream for non-barrier reasons, which is not what we assert here).
+  expectNotHandoffRefusal(runCli(['delegate', '--resume'], workspace));
+  expect(await handoffMarker(workspace)).toBeUndefined();
+});
+
+it('refuses bare rd collect under the barrier; --resume clears it', async () => {
+  const { workspace, claimId } = await setupClaimedChildPipeline();
+  runCli(['pass', '--claim-id', claimId], workspace);
+  expectHandoffRefusal(runCli(['collect'], workspace));
+  expectNotHandoffRefusal(runCli(['collect', '--resume'], workspace));
+  expect(await handoffMarker(workspace)).toBeUndefined();
+});
+
+it('does NOT block delegate --step or collect --step under the barrier (F3)', async () => {
+  const { workspace, claimId } = await setupClaimedChildPipeline();
+  runCli(['pass', '--claim-id', claimId], workspace);
+  // --step is a deliberate target → exempt from the barrier. These may error for
+  // unrelated reasons (the fixture's step 2 is not a delegate substep), but they
+  // must NOT be refused with CLAIM_HANDOFF_PENDING.
+  expectNotHandoffRefusal(runCli(['delegate', '--step', '2'], workspace));
+  expectNotHandoffRefusal(runCli(['collect', '--step', '2'], workspace));
+});
+
+it('rd goto clears the barrier', async () => {
+  const { workspace, claimId } = await setupClaimedChildPipeline();
+  runCli(['pass', '--claim-id', claimId], workspace);
+  runCli(['goto', '2'], workspace);
+  expect(await handoffMarker(workspace)).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @rundown-org/cli test -- claim-handoff-barrier.test.ts -t "delegate|collect|goto clears"`
+Expected: FAIL.
+
+- [ ] **Step 3: Guard the bare-inference path in `delegate.ts` (line 116 only)**
+
+Replace the bare-inference `const state = await sessionService.getActive();` at `delegate.ts:116` with the guarded resolver, forwarding `targeted` from the command's `--step`; leave the `--retry` calls (507/563) untouched. Import `resolveGuardedCommandTarget` + `emitClaimHandoffPendingError`:
+
+```typescript
+const resolved = await resolveGuardedCommandTarget(sessionService, { targeted: options.step !== undefined });
+if (resolved.kind === 'claim_handoff_pending') {
+  emitClaimHandoffPendingError(output, 'delegate', resolved.handoff);
+  output.flush();
+  process.exitCode = 1;
+  return;
+}
+const state = resolved.kind === 'default' || resolved.kind === 'claim' ? resolved.state : null;
+// existing no-active handling below uses `state` exactly as before
+```
+
+Add `--resume` to the delegate builder (`.option('--resume', 'Clear a one-shot claim hand-off barrier and drive the parent')`); after `sessionService` is constructed, `if (options.resume) await sessionService.clearClaimHandoff();`.
+
+- [ ] **Step 4: Guard `collect.ts` via `buildTransitionContext` (forward `--step`)**
+
+`collect.ts:63` resolves through `buildTransitionContext(output, cwd, { claimId })`. Change to:
+
+```typescript
+const contextResult = await buildTransitionContext(output, cwd, {
+  claimId,
+  guardHandoff: true,
+  step: options.step,        // forwards `targeted` inside buildTransitionContext (F3)
+  resume: options.resume,
+});
+// in the switch:
+case 'claim_handoff_pending':
+  emitClaimHandoffPendingError(output, 'collect', contextResult.handoff);
+  output.flush();
+  process.exitCode = 1;
+  return;
+```
+
+Add `--resume` to the collect builder.
+
+- [ ] **Step 5: Clear on `goto` (command action) and top-level `run`**
+
+In the `goto` command action (caller of `buildGotoContext`, `commands/goto.ts`), before building context:
+
+```typescript
+// A goto is an explicit, deliberate resume — clear any one-shot hand-off barrier (#460).
+await sessionService.clearClaimHandoff();
+```
+
+Keep `buildGotoContext` read-only. In `commands/run.ts`, clear only on a top-level `rd run` (guard against the `--step` inline-child push):
+
+```typescript
+if (options.step === undefined) {
+  // Starting a top-level runbook is an explicit hand-off — clear any stale barrier (#460).
+  await sessionService.clearClaimHandoff();
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pnpm --filter @rundown-org/cli test -- claim-handoff-barrier.test.ts`
+Expected: PASS (all cases, incl. `--step` exemption).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/commands/delegate.ts packages/cli/src/commands/collect.ts packages/cli/src/commands/goto.ts packages/cli/src/commands/run.ts packages/cli/__tests__/integration/claim-handoff-barrier.test.ts
+git commit -m "feat(cli): guard delegate/collect with --step exemption; clear on goto/run (#460)"
+```
+
+---
+
+## Task 11: Concurrency test — mark vs clear under the session lock
+
+**Files:**
+- Modify: `packages/core/__tests__/runbook/session-service.test.ts`
+
+`markClaimHandoff`/`clearClaimHandoff` both take `withLock`. Unlike `runGuardedParentAdvance` (which exposes an `advance` callback the line-983 test parks inside), these mutators have no injection seam, so a fully deterministic interleave isn't available without adding a test-only hook. Assert mutual exclusion via the observable invariant: concurrent mark+clear leave a **coherent, schema-valid** session (marker present XOR absent), never a torn write.
+
+- [ ] **Step 1: Write the concurrency test**
+
+```typescript
+it('serializes concurrent markClaimHandoff and clearClaimHandoff (no torn session write)', async () => {
+  const { parentRunId, claimId } = await setupClaimedChild('z', 'completed');
+  await sessionService.pushRunbook(parentRunId);
+  const other = new SessionService(new RunbookStateManager(testDir));
+
+  // Race the two mutators repeatedly; the session lock must serialize each pair,
+  // so loadSession always parses (no torn write) and the marker is present xor absent.
+  for (let i = 0; i < 20; i += 1) {
+    await Promise.all([sessionService.markClaimHandoff(claimId), other.clearClaimHandoff()]);
+    const session = await manager.loadSession(); // throws if the file is torn / invalid
+    expect(session.handoffPending === undefined || session.handoffPending.toRunId === parentRunId).toBe(true);
+  }
+});
+```
+
+> Honest limitation: this coherence loop catches a *torn/corrupt* write (`loadSession`'s schema parse would throw), but it does **not** reliably kill a dropped-`withLock` mutant — two un-serialized writes can still land last-writer-wins and leave a schema-valid session. For a guaranteed kill, add a test-only park hook to `withLock` mirroring the `releaseAdvance` seam at `session-service.test.ts:983` and assert the order log. Decide at execution time whether the determinism is worth the production-code test seam; the coherence loop is the floor.
+
+- [ ] **Step 2: Run the test**
+
+Run: `pnpm --filter @rundown-org/core test -- session-service.test.ts -t "serializes concurrent"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/__tests__/runbook/session-service.test.ts
+git commit -m "test(core): concurrency coverage for mark/clear hand-off under session lock (#460)"
+```
+
+---
+
+## Task 12: Scenario test — delegation runbook fixture
+
+**Files:**
+- Create: `runbooks/delegation/claim-handoff-barrier.runbook.md` (+ leaf if needed)
+
+- [ ] **Step 1: Write the scenario runbook**
+
+Model on a sibling that asserts an error code (e.g. `runbooks/delegation/delegate-claim-explicit-close.runbook.md`). Confirm the `scenarios:` schema, the leaf reference convention, and that the expected-failure prefix is `"! rd ..."`.
+
+```markdown
+---
+name: claim-handoff-barrier
+description: A claimed child cannot drive the parent after its claim closes (#460)
+tags: [delegation, regression]
+scenarios:
+  refuses-bare-pass-after-pass-close:
+    description: Bare rd pass is refused after a PASS-closed claim auto-advances the parent
+    commands:
+      - rd run claim-handoff-barrier
+      - rd claim ${TOKEN}
+      - rd pass --claim-id ${CLAIM_ID}
+      - "! rd pass"
+    expect:
+      errors:
+        - code: CLAIM_HANDOFF_PENDING
+          command: pass
+  refuses-bare-after-fail-close:
+    description: Bare commands are refused after a FAIL-closed claim advances the parent
+    commands:
+      - rd run claim-handoff-barrier
+      - rd claim ${TOKEN}
+      - rd fail --claim-id ${CLAIM_ID}
+      - "! rd pass"
+    expect:
+      errors:
+        - code: CLAIM_HANDOFF_PENDING
+          command: pass
+  refuses-bare-delegate-after-claim-close:
+    description: Bare rd delegate is refused under the barrier (refusal precedes inference)
+    commands:
+      - rd run claim-handoff-barrier
+      - rd claim ${TOKEN}
+      - rd pass --claim-id ${CLAIM_ID}
+      - "! rd delegate"
+    expect:
+      errors:
+        - code: CLAIM_HANDOFF_PENDING
+          command: delegate
+  step-target-bypasses-barrier:
+    description: An explicit --step target is exempt; it drives the parent to completion
+    commands:
+      - rd run claim-handoff-barrier
+      - rd claim ${TOKEN}
+      - rd pass --claim-id ${CLAIM_ID}
+      - rd pass --step 2
+    expect:
+      result: COMPLETE
+  resume-drives-parent:
+    description: --resume clears the barrier and the parent proceeds
+    commands:
+      - rd run claim-handoff-barrier
+      - rd claim ${TOKEN}
+      - rd pass --claim-id ${CLAIM_ID}
+      - rd pass --resume
+    expect:
+      result: COMPLETE
+---
+
+# Claim Hand-off Barrier
+
+## 1. Delegate the leaf
+- DELEGATE leaf
+- FAIL CONTINUE
+
+## 2. Parent stage
+A normal step the child must not drive after its claim closes.
+```
+
+> Execution notes: (1) the `FAIL CONTINUE` handler on step 1 is what lets `refuses-bare-after-fail-close` advance the parent on a child failure — confirm the exact handler syntax against a sibling delegation fixture; without it a child FAIL would STOP the parent and there would be no active runbook to refuse. (2) `refuses-bare-delegate-after-claim-close` relies on the barrier firing in `resolveGuardedCommandTarget` *before* delegate inference, so the error is `CLAIM_HANDOFF_PENDING`, not `NOT_DELEGATE_STEP`. (3) Claim-time auto-completion (the `claim.ts` stamp path) is exercised by the integration suite rather than a scenario, because forcing a leaf to auto-complete on `rd claim` requires a zero-interaction leaf fixture; note this so the gap is intentional, not overlooked.
+
+- [ ] **Step 2: Run the scenario suite**
+
+Run the repo's scenario entry (confirm via a sibling delegation scenario test), or directly after a build:
+`node packages/cli/dist/index.js scenario run runbooks/delegation/claim-handoff-barrier.runbook.md refuses-bare-pass-after-pass-close`
+Expected: PASS — all five scenarios (run each, or `scenario-suite` if the fixture is wired as a suite).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add runbooks/delegation/claim-handoff-barrier.runbook.md
+git commit -m "test(runbooks): scenario coverage for claim hand-off barrier (#460)"
+```
+
+---
+
+## Task 13: Docs + full verification
+
+**Files:**
+- Modify: `docs/reference/cli.md`
+
+- [ ] **Step 1: Document the refusal and `--resume`**
+
+In `docs/reference/cli.md`, near the `OPEN_DELEGATED_CHILDREN` / delegation section:
+
+```markdown
+### Claim hand-off barrier (`CLAIM_HANDOFF_PENDING`)
+
+When a delegated claimed child closes its claim (`rd pass`/`fail`/`complete`/`stop --claim-id`),
+the parent auto-advances and the next stage becomes default-active. To prevent a
+still-running child from silently driving that stage, a one-shot barrier refuses
+*bare* mutating commands (`pass`, `fail`, `delegate`, `collect`) against it:
+
+- If you are the claimed child: stop — your claim is closed.
+- To act on a claimed child (not the parent): use `--claim-id <id>` — it targets
+  the child and is exempt from the barrier (the marker is left in place).
+- To deliberately drive the parent: re-run with `--resume` (which **clears** the
+  barrier), or target a step with `--step <id>` (which **bypasses** the refusal
+  without clearing). `rd goto` and a top-level `rd run` also clear it.
+
+`rd status`, `rd stop`, and `rd stash` are never blocked. This is
+isolation-against-accident, not an adversarial boundary: an explicit `--step`
+still drives the parent.
+```
+
+- [ ] **Step 2: Format / spell / fast lint**
+
+Run: `pnpm run check:format && pnpm run check:spell && pnpm run check:lint:fast`
+Expected: PASS.
+
+- [ ] **Step 3: Full unit + property suites**
+
+Run: `pnpm --filter @rundown-org/core test && pnpm --filter @rundown-org/core test:property && pnpm --filter @rundown-org/cli test`
+Expected: PASS.
+
+- [ ] **Step 4: Pre-PR verification**
+
+Run: `pnpm run verify`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/reference/cli.md
+git commit -m "docs(cli): document CLAIM_HANDOFF_PENDING barrier and --resume (#460)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** SET on all four claim-close paths — `pass`/`fail --claim-id` (transition-command), `complete`/`stop --claim-id`, claim-time auto-completion (Task 8) ↔ refuse bare pass/fail (Tasks 4, 9) ↔ refuse bare delegate/collect with `--step` exemption (Tasks 5, 7, 10) ↔ CLEAR on `--resume`/goto/top-level run (Tasks 3, 7, 10) ↔ property invariant (Task 6) ↔ concurrency (Task 11) ↔ scenario (Task 12) ↔ end-to-end acceptance (Tasks 8–10).
+- **Type consistency:** `ClaimHandoff` (`handedOffAt`/`fromClaimId`/`toRunId`, all `readonly`) used identically; `fromClaimId` branded via `ClaimIdSchema`. Refusal kind `claim_handoff_pending`; error code `CLAIM_HANDOFF_PENDING` (registered in `zod-schemas.ts`, Task 1). Guarded resolver `resolveGuardedCommandTarget` → `GuardedCommandTargetResolution`.
+- **No de-exhaustion:** refusal variant added to `TransitionTargetResolution` + `GuardedCommandTargetResolution` only, never the shared `CommandTargetResolution`; the six `default: never` switches are untouched; the two `buildTransitionContext` switches get matching arms (Task 7).
+- **No-migration rule:** `handoffPending` optional on `session.json`; existing sessions parse unchanged.
+- **Clear vs bypass semantics (F2):** `--resume`/`goto`/top-level `run` **clear** the marker; explicit `--step`/`--claim-id` **bypass** it (the marker persists, continuing to guard later bare commands — the safer behaviour). Docs and the walkthrough state diagram state this precisely; they do not claim explicit targets "clear."
+- **Mis-stamp scope (F1):** `markClaimHandoff` stamps only a runbook that is the claim's parent or descends from it via `parentLinkage` (`topDescendsFromParent`), so an unrelated runbook the orchestrator switched to (e.g. after a stash) is never barred. Pinned by the Task 2 negative test.
+- **Known limitation — stamp/advance non-atomicity (F7):** the parent advance (`handleParentCompletion`) and the marker stamp (`markClaimHandoff`) are separate lock acquisitions, not one critical section. For the #460 scenario — one child process acting sequentially — there is no race. A second process firing a bare command in the sub-millisecond window between the two is covered by `OPEN_DELEGATED_CHILDREN` while the claim is open; afterward the residual window is accepted, consistent with the isolation-against-accident (non-adversarial) threat model. Not closed by this plan.
+- **Threat-model caveat:** isolation-against-accident — an actor that deliberately passes `--step`/`--resume` can still drive the parent. Intended, matching the removed `RD_AGENT_ID` model's documented stance.
+- **Execution-time confirmations:** the `setupClaimedChild`/`setupClaimedChildPipeline` shapes (Tasks 2, 8), the `claim.ts`/`complete.ts`/`stop.ts` stamp scope and in-scope claim-id variable (Task 8 Step 4), the `goto.ts`/`run.ts` action structure (Task 10 Step 5), the real inline-advance linkage topology (Task 2 Step 5 / Task 8 Step 5), and the scenario schema/runner entry (Task 12) must be matched to live code; each step states its fixed contract so a mismatch is caught by the red/green gate.
+```

--- a/docs/superpowers/plans/2026-06-17-core-collection-operation.md
+++ b/docs/superpowers/plans/2026-06-17-core-collection-operation.md
@@ -1,0 +1,2018 @@
+# Core Collection Operation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move delegation collection orchestration into `@rundown-org/core` behind a typed `collectDelegationOutcomes(target, actorContext)` operation while keeping CLI/MCP/plugin adapters thin.
+
+**Architecture:** Core owns the collection target resolution, orchestrator policy check, reported delegation outcome draining, aggregation application, and single-level terminal reporting. The CLI keeps only flag parsing, construction of actor context, loading runbook definitions for the selected run, and `OutputEmitter` rendering of `DelegationPolicyOutcome` values. This plan centralizes the current collection/drain/apply behavior without implementing Plan 5's report-then-collect behavior split.
+
+**Tech Stack:** TypeScript, Jest, XState-backed `RunbookActorService`, Rundown core state services, Commander CLI adapters, `OutputEmitter`, pnpm workspace scripts.
+
+---
+
+## Scope Notes
+
+- **Prerequisite: Plan 1 (`docs/superpowers/plans/2026-06-17-delegation-lifecycle-foundation.md`) MUST be applied/merged before this plan.** This plan depends on `DelegationOutcome`, `lifecycleToDelegationOutcome()`, `DELEGATION_COLLECTION_PENDING_MESSAGE`, and the delegation lifecycle read models created by Plan 1.
+- **Prerequisite: Plan 3 (`docs/superpowers/plans/2026-06-17-core-command-policy.md`) MUST be applied/merged before this plan.** This plan extends Plan 3's `ActorContext`, `deriveEffectiveRole()`, `DelegationPolicyOutcome`, and `resolveCommandIntent()` surface. Plan 3 intentionally creates the minimum actor-context foundation that Plan 4 consumes.
+- Collection is **single-level**. `collectDelegationOutcomes()` may report one terminal delegation outcome upward when the collected run itself becomes terminal, but it must not collect the next ancestor.
+- A claim controller may collect delegation outcomes for delegations issued by the run it controls. The same claim controller must still be rejected when attempting collection into its delegating ancestor.
+- This plan preserves current behavior where possible. The terminal delegated close path may still record and apply current behavior until Plan 5 separates reporting from collection. Plan 4's job is to give front ends a core-owned collection operation before that behavior split.
+- Do not add CLI-side lifecycle decisions. `packages/cli/src/commands/collect.ts` must parse options, call core, and render typed outcomes only.
+- Use target terminology in new user-facing strings and docs: delegation outcome, collection pending, collect/collection, delegating run, delegated run.
+
+### Observable change: de-recursion of `handleParentCompletion`
+
+The merged `packages/cli/src/helpers/delegation-completion.ts` `handleParentCompletion()` is **fully recursive today**: when a parent itself reaches a terminal state and has its own parent linkage, it recurses into the grandparent (`depth + 1`, bounded by `MAX_PROPAGATION_DEPTH = 32`), draining and applying at every delegating level in one call. Task 5 of this plan removes that recursion so the helper records/collects the **immediate delegating run only**.
+
+This is an intended, **observable** behavior change in scope for Plan 4 (the spec defines Plan 4 as *single-level* collection; spec §Collecting lines 196-201 explicitly call out replacing "the current recursive drain/apply behavior in `handleParentCompletion()`"). After this change, **deep delegation chains require one `rd collect` per delegating level** — collecting a run to terminal reports one outcome upward, but the ancestor is not collected until an actor that is the effective orchestrator for that ancestor runs `rd collect` itself.
+
+This is distinct from Plan 5's report-then-collect *close-behavior split*. Plan 4 must **not** change terminal delegated-close behavior: the immediate delegating run is still recorded and collected at close time (preserving today's one-level close semantics); only the recursion into further ancestors is removed. Separating reporting from collection at close time (so close records an outcome and stops, without collecting even the immediate parent) is Plan 5 and is explicitly out of scope here.
+
+### Observable change: post-collect auto-advance (`runExecutionLoop`) is dropped
+
+**Decision (verified against merged code): auto-advance is intentionally dropped in Plan 4.** The merged `collect.ts` calls `runExecutionLoop(...)` after a successful drain (collect.ts lines 409-419) to auto-advance the parent past the aggregated DELEGATE step (running CONTINUE actions, re-prompting, etc.). `runExecutionLoop` is **execution**, not collection — Plan 4 is *collection, not execution* (Scope Notes), and the architectural principle keeps the execution loop out of the collection seam. The core `applyCollection()` therefore **drains and applies the aggregation transition only**; it does not run the execution loop, and `runExecutionLoop` is removed from `collect.ts`'s imports/call sites (Task 5 Step 3).
+
+Consequence: after `rd collect` succeeds, the parent's cursor sits *on* the aggregated step's resolved position (the aggregation transition has fired) rather than already advanced to the next executable step. The next `rd pass`/`rd fail`/`rd run` step drives execution forward, consistent with the rest of the CLI surface where collection and execution are separate commands. Any merged test that asserted the parent had **auto-advanced to the next step** immediately after `rd collect` must be reconciled in the same change: update it to assert the post-aggregation cursor and drive the subsequent advance with an explicit execution command (see Task 5 Step 2a / Step 8 for the audit). The terminal branch is unaffected — when the aggregation transition itself drives the run terminal (`done`/`stopped`), `applyCollection()` observes that lifecycle directly from the drain result; no execution loop is needed to reach terminal.
+
+## File Structure
+
+- Modify: `packages/core/src/runbook/command-policy.ts`
+  - Extend the merged `DelegationPolicyOutcome` union with collection-operation variants: `missing_outcomes`, `already_collected`, `collection_applied`, and `collection_failed`. **Do NOT add `target_not_delegating_scope`** — the merged Plan 3 policy header (command-policy.ts lines 70-85) documents this variant as *intentionally* not implemented: under the target-relative model a run delegating upward is still a valid collection target, so the orchestrator check is the only gate. This plan must not reintroduce it.
+- Modify: `packages/core/src/output/zod-schemas.ts`
+  - Register frontend output codes for collection-operation rendering: `COLLECT_ALREADY_APPLIED` and `COLLECT_OPERATION_FAILED`. (`DELEGATION_COLLECTION_PENDING`, `ACTOR_CONTEXT_REQUIRED`, and `COLLECT_REQUIRES_ORCHESTRATOR` are already registered by merged Plan 3 — see zod-schemas.ts lines 45-47, 104-108. Do not re-add them.) **Do NOT register `COLLECT_TARGET_NOT_DELEGATING_RUN`** — its outcome variant is dropped per the note above. **Do NOT register `COLLECT_OUTCOMES_MISSING`** — the missing-outcomes refusal continues to emit the existing `SUBSTEPS_NOT_RESOLVED` code (it is the same condition as the policy union's `missing_outcomes` variant). Registering `COLLECT_OUTCOMES_MISSING` now would be an unused additive code that lint/coverage flags as dead code. Renaming the frontend code to the spec's `COLLECT_OUTCOMES_MISSING` is deferred to Plan 8 (terminology cleanup), consistent with the spec's "clean names last" sequencing; the policy union may still carry the `missing_outcomes` variant internally, but the frontend code string stays `SUBSTEPS_NOT_RESOLVED`.
+- Modify: `packages/core/__tests__/output/schema.test.ts`
+  - Pin schema acceptance for the new collection output codes.
+- Create: `packages/core/src/runbook/collection-service.ts`
+  - Implement `RunbookCollectionService` and top-level `collectDelegationOutcomes()` as the core-owned collection operation.
+- Create: `packages/core/__tests__/runbook/collection-service.test.ts`
+  - Unit-test role gating, missing outcomes, already-collected behavior, active collection, non-active frame observation, single-level terminal reporting, and mid-chain claim-controller collection.
+- Modify: `packages/core/src/runbook/index.ts`
+  - Re-export the collection operation, service, input type, and outcome helper types.
+- Modify: `packages/cli/src/commands/collect.ts`
+  - Replace local collection orchestration with a call to `collectDelegationOutcomes()` and render the returned `DelegationPolicyOutcome`. **Preserve the existing user-facing output contract** (CLAUDE.md § CLI Output Standards — JSON is the agent-facing contract): the rendered `status` strings `already-aggregated` and `not-active` are asserted by merged tests (`collect.test.ts` lines 393-522, 642-673) and MUST stay. The core outcome `kind` is `already_collected`, but the CLI continues to render `status: 'already-aggregated'` for the idempotent no-op and `status: 'not-active'` for the frame-not-active observation. Do not rename either to `already-collected`. The new non-error code `COLLECT_ALREADY_APPLIED` MAY be added to the `already-aggregated` JSON payload as an additional `code` field, but the `status` string is unchanged.
+- Modify: `packages/cli/src/services/execution.ts`
+  - Replace the terminal child completion helper import site with the core collection operation only when executing the existing post-terminal propagation path remains necessary before Plan 5.
+- Modify: `packages/cli/src/helpers/delegation-completion.ts`
+  - Shrink this helper to a compatibility wrapper around the core collection service, or delete it when no imports remain.
+- Modify: `packages/cli/__tests__/commands/collect.test.ts`
+  - Add CLI adapter coverage for rendering success, already-applied, missing-outcomes, non-orchestrator, unknown-context, and `--claim-id` target selection.
+- Modify: `packages/cli/src/schemas/output-schemas.ts`
+  - Add a `CollectAppliedResponseSchema` arm to the `CollectResponseSchema` discriminated union (`status` discriminant, line 152-157) so the NEW `status: 'applied'` success envelope passes `CollectResponseSchema.safeParse(...)` (asserted by `collect.test.ts` lines 513, 680). Add the optional `code?` field to the existing `CollectAlreadyAggregatedResponseSchema` (lines 114-125) so the additive `COLLECT_ALREADY_APPLIED` code validates. The `not-active` arm (`CollectNotActiveResponseSchema`, lines 127-144) is unchanged and must still validate.
+- Modify: `packages/cli/__tests__/services/schema-coverage.test.ts`
+  - Ensure the collect command schema accepts the new typed outcome statuses.
+- Modify: `packages/cli/__tests__/commands/schema-validation.test.ts`
+  - Add validation examples for the new collect JSON responses.
+
+## Tasks
+
+### Task 1: Extend Collection Policy Outcomes and Output Codes
+
+**Files:**
+- Modify: `packages/core/src/runbook/command-policy.ts`
+- Modify: `packages/core/src/output/zod-schemas.ts`
+- Modify: `packages/core/__tests__/output/schema.test.ts`
+
+- [ ] **Step 1: Write the failing schema test**
+
+Add this test in `packages/core/__tests__/output/schema.test.ts` after the existing collection-policy error-code tests:
+
+```typescript
+  it('accepts collection-operation output codes', () => {
+    for (const code of [
+      'COLLECT_ALREADY_APPLIED',
+      'COLLECT_OPERATION_FAILED',
+    ] as const) {
+      expect(ErrorCodeSchema.safeParse(code).success).toBe(true);
+      expect(CLIErrorCodes[code]).toBe(code);
+    }
+  });
+```
+
+- [ ] **Step 2: Run the focused schema test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/output/schema.test.ts --runInBand
+```
+
+Expected: FAIL because the new `CLIErrorCodes` members are not registered.
+
+- [ ] **Step 3: Register the output codes**
+
+In `packages/core/src/output/zod-schemas.ts`, add these symbolic codes to the error-code string-literal list near the existing collection policy codes (`DELEGATION_COLLECTION_PENDING`, `ACTOR_CONTEXT_REQUIRED`, `COLLECT_REQUIRES_ORCHESTRATOR` at lines 45-47 are already present — do not duplicate them):
+
+```typescript
+  'COLLECT_ALREADY_APPLIED',
+  'COLLECT_OPERATION_FAILED',
+```
+
+Do **not** add `COLLECT_OUTCOMES_MISSING`. The missing-outcomes refusal keeps emitting the already-registered `SUBSTEPS_NOT_RESOLVED` code (see Task 5 Step 3 renderer). An unused `COLLECT_OUTCOMES_MISSING` registration is dead code lint/coverage will flag; renaming the frontend code to the spec's `COLLECT_OUTCOMES_MISSING` is deferred to Plan 8 (terminology cleanup).
+
+In the exported `CLIErrorCodes` object (the existing three collection codes live at lines 104-108), add:
+
+```typescript
+  /** Collection found no unapplied delegation outcomes and is an idempotent no-op. */
+  COLLECT_ALREADY_APPLIED: 'COLLECT_ALREADY_APPLIED',
+  /** Core collection failed while applying delegation outcomes. */
+  COLLECT_OPERATION_FAILED: 'COLLECT_OPERATION_FAILED',
+```
+
+- [ ] **Step 4: Extend `DelegationPolicyOutcome` with operation outcomes**
+
+In `packages/core/src/runbook/command-policy.ts`, extend the merged `DelegationPolicyOutcome` union (currently a deliberate 5-member slice: `allowed`, `actor_context_required`, `collect_requires_orchestrator`, `delegation_collection_pending`, `open_claims` — see the union's TSDoc header at lines 70-85) by appending these variants after the last existing member (`open_claims`). Also update that header comment: the `missing_outcomes` and `already_collected` members it lists as "deferred to Plan 4" are now implemented here, so move them out of the deferred list, and add the new `collection_frame_not_active`, `collection_applied`, and `collection_failed` members to the implemented list.
+
+`RunId` and `RunbookState` are already imported in this file (lines 7-8). `FrameKey` must be added (see the import note below).
+
+```typescript
+  | {
+      /** Collection target has delegation substeps without reported outcomes. */
+      readonly kind: 'missing_outcomes';
+      /** Target run that was inspected. */
+      readonly targetRunId: RunId;
+      /** Step selected for collection. */
+      readonly step: string;
+      /** Delegated substep ids still lacking delegation outcomes. */
+      readonly missingSubsteps: readonly string[];
+    }
+  | {
+      /** Collection found no unapplied outcomes for the selected scope. */
+      readonly kind: 'already_collected';
+      /** Target run that was inspected. */
+      readonly targetRunId: RunId;
+      /** Step selected for collection. */
+      readonly step: string;
+    }
+  | {
+      /**
+       * Requested frame is not the cursor's active frame. Drain was
+       * observation-only and applied nothing. This is a DISTINCT variant from
+       * `already_collected` because the CLI must render the existing
+       * `not-active` JSON payload faithfully (status string `not-active`,
+       * carrying `frameKey` / `activeFrameKey` / `unresolved`) — folding it into
+       * `already_collected` (rendered `already-aggregated`) would break the
+       * asserted `not-active` contract (collect.test.ts lines 642-680, which run
+       * `CollectResponseSchema.safeParse(...).success === true` and assert
+       * `parsed.activeFrameKey` is a string). The carried fields mirror drain's
+       * `not_active` result (completion-service.ts lines 248-259).
+       */
+      readonly kind: 'collection_frame_not_active';
+      /** Target run that was inspected. */
+      readonly targetRunId: RunId;
+      /** Step selected for collection. */
+      readonly step: string;
+      /** Frame key requested via the scope/frame override. */
+      readonly frameKey: FrameKey;
+      /** Frame key the target run cursor is actually positioned on. */
+      readonly activeFrameKey: FrameKey;
+      /** Count of substeps still without a persisted delegation outcome. */
+      readonly unresolved: number;
+    }
+  | {
+      /** Collection applied one or more delegation outcomes. */
+      readonly kind: 'collection_applied';
+      /** Target run that received the collected outcomes. */
+      readonly targetRunId: RunId;
+      /** Step selected for collection. */
+      readonly step: string;
+      /** Number of delegation outcomes consumed. */
+      readonly applied: number;
+      /** Number of outcomes still unresolved after this collection. */
+      readonly unresolved: number;
+      /** Lifecycle of the target run after collection. */
+      readonly lifecycle: RunbookState['lifecycle'];
+      /** True when collection reported this run's terminal delegation outcome upward. */
+      readonly reportedTerminalOutcome: boolean;
+    }
+  | {
+      /** Collection failed after core rejected a persisted delegation outcome. */
+      readonly kind: 'collection_failed';
+      /** Target run that was being collected. */
+      readonly targetRunId: RunId;
+      /**
+       * Machine/core reason. Every member has a real producer (no dead arms):
+       * - `not_delegate_step` — `collectDelegationOutcomes` non-DELEGATE-step guard
+       * - `step_not_found` — `collectDelegationOutcomes` stale-state guard
+       * - `target_mismatch` — `drainResolvedCompletions` `status: 'failed'`
+       *   (verified: `CompletionTargetMismatch.reason` is the *only* drain failure
+       *   reason — completion-service.ts lines 129-131, 381-397). There is NO
+       *   `state_error` reason; drain never produces one, so it is not in the union.
+       */
+      readonly reason: 'target_mismatch' | 'not_delegate_step' | 'step_not_found';
+      /**
+       * User-facing error code, attached by core so the CLI renders a flat
+       * passthrough (no CLI reason→code ternary — keeps "no CLI lifecycle
+       * decisions" and type-driven dispatch intact):
+       * - `not_delegate_step` → `NOT_DELEGATE_STEP`
+       * - `step_not_found` → `STEP_NOT_FOUND`
+       * - `target_mismatch` → `COLLECT_OPERATION_FAILED`
+       */
+      readonly code: 'NOT_DELEGATE_STEP' | 'STEP_NOT_FOUND' | 'COLLECT_OPERATION_FAILED';
+      /** Operator-facing failure message. */
+      readonly message: string;
+    }
+```
+
+**Non-breaking error-code mapping.** The merged collect command renders the user-facing codes `NOT_DELEGATE_STEP`, `STEP_NOT_FOUND`, and `SUBSTEPS_NOT_RESOLVED` (asserted by `collect.test.ts` lines 432-588). To keep that contract, the core operation surfaces those decisions through typed outcomes; **core attaches the user-facing `code` directly on `collection_failed`** (flat passthrough), so the CLI does not own a reason→code ternary. The mapping is: `missing_outcomes` → `SUBSTEPS_NOT_RESOLVED` (rendered by the CLI, since `missing_outcomes` is a distinct policy variant without a `code` field), `collection_failed { code: 'NOT_DELEGATE_STEP' }`, `collection_failed { code: 'STEP_NOT_FOUND' }`, and `collection_failed { code: 'COLLECT_OPERATION_FAILED' }` for a genuine `target_mismatch` apply failure. The `missing_outcomes` policy variant deliberately keeps emitting the existing `SUBSTEPS_NOT_RESOLVED` frontend code — it is the same condition. **Do NOT register or pre-reserve `COLLECT_OUTCOMES_MISSING`**; an unused additive code is dead code lint/coverage flags, and renaming the frontend code to the spec's `COLLECT_OUTCOMES_MISSING` is deferred to Plan 8 (terminology cleanup). The newly registered `COLLECT_OPERATION_FAILED` code is a spec-aligned additive code (spec lines 450-456) for genuine apply failures; Plan 4 does not retire the existing codes. See the renderer in Task 5 Step 3.
+
+Add this import if `FrameKey` is not already imported in the file:
+
+```typescript
+import type { FrameKey } from './targeting.js';
+```
+
+- [ ] **Step 5: Run the focused schema test and core typecheck**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/output/schema.test.ts --runInBand
+pnpm --filter @rundown-org/core check:types
+```
+
+Expected: PASS. Output schemas accept the new codes, and the expanded policy union typechecks.
+
+- [ ] **Step 6: Commit the policy surface**
+
+Run:
+
+```bash
+git add packages/core/src/runbook/command-policy.ts packages/core/src/output/zod-schemas.ts packages/core/__tests__/output/schema.test.ts
+git commit -m "feat(core): extend delegation collection outcomes"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 2: Add the Core Collection Service
+
+**Files:**
+- Create: `packages/core/src/runbook/collection-service.ts`
+- Create: `packages/core/__tests__/runbook/collection-service.test.ts`
+- Modify: `packages/core/src/runbook/index.ts`
+
+- [ ] **Step 1: Write failing core service tests**
+
+Create `packages/core/__tests__/runbook/collection-service.test.ts` with this skeleton and first tests:
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  ExecutionLifecycleService,
+  RunbookActorService,
+  RunbookCollectionService,
+  RunbookCompletionService,
+  RunbookStateManager,
+  activeFrame,
+  assertDelegationTokenHash,
+  assertRunId,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+  claimControllerContext,
+  exactFrame,
+  trustedRunControllerContext,
+  UNKNOWN_ACTOR_CONTEXT,
+  type ResolvedStep,
+  type RunbookState,
+} from '../../src/runbook/index.js';
+
+// NOTE: there is no `createTempRunbookStateManager` helper in this repo. Core
+// runbook tests build the manager inline with `mkdtemp` + `new
+// RunbookStateManager(tmp)` (see completion-service.test.ts). This skeleton
+// follows that established pattern.
+
+describe('RunbookCollectionService', () => {
+  let tmp: string;
+  let manager: RunbookStateManager;
+  let actorService: RunbookActorService;
+  let lifecycleService: ExecutionLifecycleService;
+  let completionService: RunbookCompletionService;
+  let collectionService: RunbookCollectionService;
+
+  const runId = assertRunId('rd_11111111111111111111111111111111');
+  const controlledRunId = assertRunId('rd_22222222222222222222222222222222');
+  const ancestorRunId = assertRunId('rd_33333333333333333333333333333333');
+  const claimId = 'claim-collection-middle';
+  const tokenHash = assertDelegationTokenHash(
+    'sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+  );
+
+  const steps: ResolvedStep[] = [
+    {
+      id: '1',
+      name: '1',
+      title: 'Delegate work',
+      status: 'pending',
+      substeps: [
+        { id: '1', title: 'A', status: 'pending', delegate: true },
+        { id: '2', title: 'B', status: 'pending', delegate: true },
+      ],
+      onPass: { action: 'CONTINUE' },
+      onFail: { action: 'STOP' },
+    },
+    {
+      id: '2',
+      name: '2',
+      title: 'After collection',
+      status: 'pending',
+      onPass: { action: 'CONTINUE' },
+      onFail: { action: 'STOP' },
+    },
+  ];
+
+  function state(overrides: Partial<RunbookState> = {}): RunbookState {
+    return {
+      id: runId,
+      name: 'collection-test',
+      filePath: '/tmp/collection-test.md',
+      step: '1',
+      status: 'running',
+      lifecycle: 'running',
+      currentStep: 0,
+      startedAt: '2026-06-17T00:00:00.000Z',
+      updatedAt: '2026-06-17T00:00:00.000Z',
+      steps,
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      frameEntries: { [buildFrameKey('1')]: 1 },
+      substepStates: [
+        { id: '1', frameKey: buildFrameKey('1'), status: 'done' },
+        { id: '2', frameKey: buildFrameKey('1'), status: 'done' },
+      ],
+      resolvedCompletions: {},
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'collection-service-'));
+    manager = new RunbookStateManager(tmp);
+    actorService = new RunbookActorService(manager);
+    lifecycleService = new ExecutionLifecycleService(manager);
+    completionService = new RunbookCompletionService(manager, lifecycleService, actorService);
+    collectionService = new RunbookCollectionService({
+      manager,
+      actorService,
+      lifecycleService,
+      completionService,
+    });
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('rejects unknown actor context before inspecting outcomes', async () => {
+    await manager.save(state());
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: state(),
+        steps,
+        actorContext: UNKNOWN_ACTOR_CONTEXT,
+      }),
+    ).resolves.toEqual({
+      kind: 'actor_context_required',
+      intent: 'delegation-collection',
+    });
+  });
+
+  it('reports missing outcomes for delegate substeps without recorded outcomes', async () => {
+    const target = state();
+    await manager.save(target);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: target,
+        steps,
+        actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      }),
+    ).resolves.toEqual({
+      kind: 'missing_outcomes',
+      targetRunId: runId,
+      step: '1',
+      missingSubsteps: ['1.1', '1.2'],
+    });
+  });
+
+  it('returns already_collected when no unapplied outcomes remain on a post-delegate cursor', async () => {
+    const target = state({
+      step: '2',
+      currentStep: 1,
+      activeFrameKey: buildFrameKey('2'),
+      activeEntry: 1,
+      substepStates: [],
+      resolvedCompletions: {},
+    });
+    await manager.save(target);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: target,
+        steps,
+        actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      }),
+    ).resolves.toMatchObject({
+      kind: 'already_collected',
+      targetRunId: runId,
+      step: '2',
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused service test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/collection-service.test.ts --runInBand
+```
+
+Expected: FAIL because `RunbookCollectionService` is not exported.
+
+- [ ] **Step 3: Implement the collection service public API**
+
+Create `packages/core/src/runbook/collection-service.ts` with these exported types and class shape:
+
+```typescript
+import { resolvedStepHasSubsteps } from '@rundown-org/parser';
+import type { ActorContext } from './actor-context.js';
+import type { DelegationPolicyOutcome } from './command-policy.js';
+import { resolveCommandIntent } from './command-policy.js';
+import type { ExecutionLifecycleService } from './execution-lifecycle-service.js';
+import type { RunbookActorService } from './actor-service.js';
+import type { RunbookCompletionService } from './completion-service.js';
+import type { RunbookStateManager } from './state.js';
+import type { Frame, FrameKey } from './targeting.js';
+import { activeFrame, deriveActiveFrame, findSubstepState } from './targeting.js';
+import { isPostDelegateAggregationCursor } from './delegation-inference.js';
+import type { ResolvedStep, RunbookState } from './types.js';
+
+/** Dependencies used by the core collection operation. */
+export interface RunbookCollectionServiceDependencies {
+  /** State manager used to reload and persist target runs. */
+  readonly manager: RunbookStateManager;
+  /** Actor service used to apply collected delegation outcomes through the state machine. */
+  readonly actorService: RunbookActorService;
+  /** Lifecycle service used to consume persisted delegation outcomes. */
+  readonly lifecycleService: ExecutionLifecycleService;
+  /** Completion service used to drain resolved delegation outcomes. */
+  readonly completionService: RunbookCompletionService;
+}
+
+/** Explicit collection target resolved by a frontend adapter or another core service. */
+export interface CollectDelegationOutcomesInput {
+  /** Persisted target run receiving collected delegation outcomes. */
+  readonly targetState: RunbookState;
+  /** Parsed runbook steps for the target run. */
+  readonly steps: readonly ResolvedStep[];
+  /** Caller evidence for target-relative role derivation. */
+  readonly actorContext: ActorContext;
+  /** Optional explicit step name. Defaults to the target run cursor. */
+  readonly stepName?: string;
+  /** Optional frame override for targeted FOR collection. */
+  readonly frame?: Frame;
+}
+
+/** Core-owned service for applying reported delegation outcomes to a target run. */
+export class RunbookCollectionService {
+  readonly #deps: RunbookCollectionServiceDependencies;
+
+  /**
+   * @param deps - Core services needed to apply collection through the state machine.
+   */
+  constructor(deps: RunbookCollectionServiceDependencies) {
+    this.#deps = deps;
+  }
+
+  /**
+   * Collect reported delegation outcomes into one target delegating run scope.
+   *
+   * @param input - Target run, runbook steps, actor context, and optional scope.
+   * @returns Core-owned typed policy outcome for frontend adapters.
+   */
+  async collectDelegationOutcomes(
+    input: CollectDelegationOutcomesInput,
+  ): Promise<DelegationPolicyOutcome> {
+    return collectDelegationOutcomes({ ...input, ...this.#deps });
+  }
+}
+```
+
+- [ ] **Step 4: Implement target inspection and role gating**
+
+In the same file, add this function below the class:
+
+```typescript
+/** Dependencies accepted by the functional collection entrypoint. */
+export type CollectDelegationOutcomesOperationInput = CollectDelegationOutcomesInput &
+  RunbookCollectionServiceDependencies;
+
+function findCollectionStep(
+  steps: readonly ResolvedStep[],
+  stepName: string,
+): ResolvedStep | undefined {
+  return steps.find((step) => step.name === stepName);
+}
+
+function delegateSubstepIds(step: ResolvedStep | undefined): readonly string[] {
+  // `resolvedStepHasSubsteps` (from `@rundown-org/parser`, already used across
+  // core — see actor-service.ts, delegation-service.ts) is the canonical guard;
+  // it narrows `step.substeps` so the filter below is type-safe. Prefer it over
+  // a hand-rolled `'substeps' in step && step.substeps` check.
+  if (!step || !resolvedStepHasSubsteps(step)) return [];
+  return step.substeps.filter((substep) => substep.delegate).map((substep) => substep.id);
+}
+
+function defaultCollectionFrame(state: RunbookState): Frame {
+  return activeFrame(activeFrameKeyOf(state), state.activeEntry ?? 1);
+}
+
+/**
+ * Single fallback for the target run's active frame key. Factored out of the
+ * two prior call sites (`defaultCollectionFrame` and the missing-outcome scan),
+ * which both inlined `state.activeFrameKey ?? deriveActiveFrame(state).frameKey`.
+ */
+function activeFrameKeyOf(state: RunbookState): FrameKey {
+  return state.activeFrameKey ?? deriveActiveFrame(state).frameKey;
+}
+
+function missingDelegationOutcomeIds(args: {
+  readonly targetState: RunbookState;
+  readonly stepName: string;
+  readonly delegateSubsteps: readonly string[];
+  readonly frameKey: FrameKey;
+}): readonly string[] {
+  const frameKey = args.frameKey;
+  return args.delegateSubsteps
+    .filter((substepId) => {
+      const substepState = findSubstepState(args.targetState.substepStates ?? [], substepId, frameKey);
+      // Per-frame `status === 'done'` is the merged collect.ts contract
+      // (collect.ts lines 311-317 check only the substep status in the target
+      // frame). The completion match below MUST be frame-aware: filter to
+      // completions whose `targetFrameKey` equals the collection frame so a
+      // resolved completion in a DIFFERENT FOR iteration is not credited to this
+      // frame (cross-iteration mis-report). The persisted `ResolvedCompletion`
+      // carries the flat field `targetFrameKey` (verified — types.ts line 636;
+      // NOT a nested `targetFrame` object).
+      if (substepState?.status !== 'done') return true;
+      const hasOutcome = Object.values(args.targetState.resolvedCompletions ?? {}).some(
+        (completion) =>
+          completion.targetStep === args.stepName &&
+          completion.targetSubstep === substepId &&
+          completion.targetFrameKey === frameKey,
+      );
+      return !hasOutcome;
+    })
+    .map((substepId) => `${args.stepName}.${substepId}`);
+}
+```
+
+The `collectionFrameKey(frame)` helper from the earlier draft is removed: every `Frame` variant carries a `frameKey` (verified — `targeting.ts` lines 29-32, all three variants `active`/`exact`/`inactive` have `readonly frameKey: FrameKey`), so the `'frameKey' in frame` guard is dead. Read `frame.frameKey` directly where a frame key is needed.
+
+Then add the operation entrypoint:
+
+```typescript
+/**
+ * Collect reported delegation outcomes into one target delegating run scope.
+ *
+ * @param input - Target run, services, actor context, and optional scope.
+ * @returns Core-owned typed policy outcome.
+ */
+export async function collectDelegationOutcomes(
+  input: CollectDelegationOutcomesOperationInput,
+): Promise<DelegationPolicyOutcome> {
+  // NOTE: the merged `resolveCommandIntent` input field is `targetSelector`
+  // (not `target`), and its selector kinds are `default` | `claim` |
+  // `explicit-step` — there is NO `run` selector kind. The resolved target run
+  // is passed separately as `targetState`. For collection the frontend has
+  // already resolved `--claim-id` (or the default stack) to a concrete run, so
+  // the selector is `default` and role derivation keys off `targetState`.
+  const policy = resolveCommandIntent({
+    intent: { kind: 'delegation-collection' },
+    targetSelector: { kind: 'default' },
+    targetState: input.targetState,
+    actorContext: input.actorContext,
+  });
+  if (policy.kind !== 'allowed') return policy;
+
+  const stepName = input.stepName ?? input.targetState.step;
+  const step = findCollectionStep(input.steps, stepName);
+
+  // Stale/corrupted state: the selected step is not in the loaded runbook. This
+  // is never a valid idempotent no-op (mirrors the merged CLI's STEP_NOT_FOUND
+  // fast-fail). Surface a typed failure the CLI renders as STEP_NOT_FOUND.
+  if (!step) {
+    return {
+      kind: 'collection_failed',
+      targetRunId: input.targetState.id,
+      reason: 'step_not_found',
+      code: 'STEP_NOT_FOUND',
+      message: `Step ${stepName} not found in the loaded runbook; state may be stale or corrupted.`,
+    };
+  }
+
+  const delegateSubsteps = delegateSubstepIds(step);
+  const frame = input.frame ?? defaultCollectionFrame(input.targetState);
+  const frameKey = frame.frameKey; // every Frame variant carries frameKey
+
+  if (delegateSubsteps.length === 0) {
+    if (!input.stepName && isPostDelegateAggregationCursor(input.targetState, input.steps)) {
+      return {
+        kind: 'already_collected',
+        targetRunId: input.targetState.id,
+        step: stepName,
+      };
+    }
+    // Per spec/Plan 3: `target_not_delegating_scope` is intentionally NOT a
+    // policy variant (an upward-delegating run is still a valid collect
+    // target; the orchestrator gate is the only role check). A non-DELEGATE
+    // step that is also not a post-aggregation cursor is genuine misuse —
+    // surface it as a `collection_failed` with reason `not_delegate_step` so the
+    // CLI renders the existing `NOT_DELEGATE_STEP` error (no new variant, no
+    // contract change). Do NOT return `target_not_delegating_scope`.
+    return {
+      kind: 'collection_failed',
+      targetRunId: input.targetState.id,
+      reason: 'not_delegate_step',
+      code: 'NOT_DELEGATE_STEP',
+      message: `Step ${stepName} is not a DELEGATE step. rd collect requires a step with - DELEGATE substeps.`,
+    };
+  }
+
+  const missingSubsteps = missingDelegationOutcomeIds({
+    targetState: input.targetState,
+    stepName,
+    delegateSubsteps,
+    frameKey,
+  });
+  if (missingSubsteps.length > 0) {
+    return {
+      kind: 'missing_outcomes',
+      targetRunId: input.targetState.id,
+      step: stepName,
+      missingSubsteps,
+    };
+  }
+
+  return applyCollection(input, { stepName, frame, frameKey });
+}
+```
+
+- [ ] **Step 5: Export the service API**
+
+In `packages/core/src/runbook/index.ts`, add:
+
+```typescript
+export {
+  RunbookCollectionService,
+  collectDelegationOutcomes,
+  type CollectDelegationOutcomesInput,
+  type CollectDelegationOutcomesOperationInput,
+  type RunbookCollectionServiceDependencies,
+} from './collection-service.js';
+```
+
+- [ ] **Step 6: Run the focused test and verify the first service slice passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/collection-service.test.ts --runInBand
+```
+
+Expected: PASS for the first three tests. Later tasks add the `applyCollection()` implementation and additional tests.
+
+- [ ] **Step 7: Commit the service shell**
+
+Run:
+
+```bash
+git add packages/core/src/runbook/collection-service.ts packages/core/src/runbook/index.ts packages/core/__tests__/runbook/collection-service.test.ts
+git commit -m "feat(core): add delegation collection service shell"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 3: Move Drain and Apply Orchestration into Core
+
+**Files:**
+- Modify: `packages/core/src/runbook/collection-service.ts`
+- Modify: `packages/core/__tests__/runbook/collection-service.test.ts`
+
+- [ ] **Step 1: Add failing tests for successful collection and idempotency**
+
+Append these tests to `packages/core/__tests__/runbook/collection-service.test.ts`:
+
+```typescript
+  it('applies reported delegation outcomes through the state machine', async () => {
+    const frameKey = buildFrameKey('1');
+    const completionA = buildResolvedCompletion({
+      agentId: 'delegated-a',
+      result: 'pass',
+      targetStep: '1',
+      targetSubstep: '1',
+      targetFrame: exactFrame(frameKey, 1),
+      completedAt: '2026-06-17T00:01:00.000Z',
+    });
+    const completionB = buildResolvedCompletion({
+      agentId: 'delegated-b',
+      result: 'pass',
+      targetStep: '1',
+      targetSubstep: '2',
+      targetFrame: exactFrame(frameKey, 1),
+      completedAt: '2026-06-17T00:02:00.000Z',
+    });
+    const target = state({
+      resolvedCompletions: {
+        [buildCompletionKey(exactFrame(frameKey, 1), '1')]: completionA,
+        [buildCompletionKey(exactFrame(frameKey, 1), '2')]: completionB,
+      },
+    });
+    await manager.save(target);
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: target,
+      steps,
+      actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      frame: activeFrame(frameKey, 1),
+    });
+
+    expect(outcome).toMatchObject({
+      kind: 'collection_applied',
+      targetRunId: runId,
+      step: '1',
+      applied: 2,
+      unresolved: 0,
+      lifecycle: 'running',
+      reportedTerminalOutcome: false,
+    });
+    const persisted = await manager.load(runId);
+    expect(persisted?.resolvedCompletions).toEqual({});
+  });
+
+  it('returns already_collected on a second collection for the same scope', async () => {
+    const target = state({ resolvedCompletions: {} });
+    await manager.save(target);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: target,
+        steps,
+        actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+        frame: activeFrame(buildFrameKey('1'), 1),
+      }),
+    ).resolves.toMatchObject({
+      kind: 'already_collected',
+      targetRunId: runId,
+      step: '1',
+    });
+  });
+```
+
+- [ ] **Step 2: Run the focused service test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/collection-service.test.ts --runInBand
+```
+
+Expected: FAIL because `applyCollection()` has not been implemented.
+
+- [ ] **Step 3: Implement `applyCollection()` in core**
+
+**Single apply path (revised).** `drainResolvedCompletions` is the one and only seam that applies delegation outcomes to the target machine: internally it dispatches an `APPLY_CURRENT_RESOLVED_COMPLETION` event per resolved completion and the machine's aggregation rule fires the resulting parent transition (see `completion-service.ts` `drainResolvedCompletions`, and `compiler.ts` where the `PASS`/`FAIL` events take **no** `completionKey`). The previous draft also re-sent a raw `{ type: 'PASS' | 'FAIL', completionKey }` event per drained item via an `applyCollectedCompletion()` helper — that is a **second, competing apply path**, it double-applies every outcome, and it is not even a valid machine event (`PASS`/`FAIL` carry no `completionKey`). It is removed. `applyCollection()` calls `drainResolvedCompletions` and only **observes** the typed drain result; it never re-sends events itself.
+
+No extra imports are needed for this step (`drainResolvedCompletions`, the `DrainResolvedCompletionsResult` discriminants, and `recordChildCompletion` all come from the already-injected `RunbookCompletionService`).
+
+Add `applyCollection()` below `collectDelegationOutcomes()`. It drains the requested frame in one pass and maps the typed drain result straight onto a `DelegationPolicyOutcome` — drain is the single apply path, so the count of applied outcomes is read from `drained.applied.length`:
+
+```typescript
+async function applyCollection(
+  input: CollectDelegationOutcomesOperationInput,
+  scope: { readonly stepName: string; readonly frame: Frame; readonly frameKey?: FrameKey },
+): Promise<DelegationPolicyOutcome> {
+  const drained = await input.completionService.drainResolvedCompletions({
+    runbookId: input.targetState.id,
+    steps: [...input.steps],
+    currentState: input.targetState,
+    frameOverride: scope.frame,
+  });
+
+  if (drained.status === 'failed') {
+    // `drained.reason` is `'target_mismatch'` — drain's ONLY failure reason
+    // (CompletionTargetMismatch, completion-service.ts lines 129-131). Core
+    // attaches the user-facing code so the CLI renders a flat passthrough.
+    return {
+      kind: 'collection_failed',
+      targetRunId: input.targetState.id,
+      reason: drained.reason,
+      code: 'COLLECT_OPERATION_FAILED',
+      message: drained.message,
+    };
+  }
+
+  // Frame requested by the caller is not the cursor's active frame: drain is
+  // observation-only and applied nothing (completion-service.ts lines 248-259).
+  // This is a DISTINCT outcome from the idempotent no-op: the CLI must render
+  // the existing `not-active` payload (status `not-active`, carrying
+  // `frameKey`/`activeFrameKey`/`unresolved` — collect.test.ts lines 642-680),
+  // so do NOT fold it into `already_collected`. Pass drain's observed frame
+  // keys through unchanged.
+  if (drained.status === 'not_active') {
+    return {
+      kind: 'collection_frame_not_active',
+      targetRunId: input.targetState.id,
+      step: scope.stepName,
+      frameKey: drained.frameKey,
+      activeFrameKey: drained.activeFrameKey,
+      unresolved: drained.unresolved,
+    };
+  }
+
+  const applied = drained.applied.length;
+
+  // Terminal: the drained outcomes advanced the target run to a terminal
+  // lifecycle. Reload the persisted terminal state so single-level reporting
+  // observes the committed lifecycle, then (single-level) report one outcome
+  // upward — never collect the ancestor.
+  if (drained.status === 'done' || drained.status === 'stopped') {
+    const fresh = (await input.manager.load(input.targetState.id)) ?? drained.applied.at(-1)?.stateAfter ?? input.targetState;
+    return {
+      kind: 'collection_applied',
+      targetRunId: input.targetState.id,
+      step: scope.stepName,
+      applied,
+      unresolved: drained.unresolved,
+      lifecycle: drained.status === 'done' ? 'completed' : 'stopped',
+      reportedTerminalOutcome: await reportTerminalOutcomeToDelegatingRun(input, fresh),
+    };
+  }
+
+  // status === 'continue': nothing applied means no unapplied outcomes for the
+  // scope (idempotent no-op); otherwise outcomes were consumed but the run is
+  // still active.
+  if (applied === 0) {
+    return {
+      kind: 'already_collected',
+      targetRunId: input.targetState.id,
+      step: scope.stepName,
+    };
+  }
+  return {
+    kind: 'collection_applied',
+    targetRunId: input.targetState.id,
+    step: scope.stepName,
+    applied,
+    unresolved: drained.unresolved,
+    lifecycle: (drained.applied.at(-1)?.stateAfter ?? input.targetState).lifecycle,
+    reportedTerminalOutcome: false,
+  };
+}
+```
+
+Add this helper after `applyCollection()`:
+
+```typescript
+async function reportTerminalOutcomeToDelegatingRun(
+  input: CollectDelegationOutcomesOperationInput,
+  terminalState: RunbookState,
+): Promise<boolean> {
+  if (!terminalState.parentLinkage) return false;
+  // Reuse the canonical lifecycle→outcome mapping (completion-service.ts lines
+  // 84-90) instead of hand-rolling `lifecycle === 'completed' ? 'pass' : 'fail'`.
+  // It returns `undefined` for non-terminal lifecycles, which also serves as the
+  // terminal guard.
+  const result = lifecycleToDelegationOutcome(terminalState.lifecycle);
+  if (!result) return false;
+  const recorded = await input.completionService.recordChildCompletion({
+    childState: terminalState,
+    result,
+  });
+  return recorded === 'recorded';
+}
+```
+
+Add `lifecycleToDelegationOutcome` to the `./completion-service.js` import in this file (it is exported from completion-service.ts and re-exported by `runbook/index.ts`):
+
+```typescript
+import { lifecycleToDelegationOutcome } from './completion-service.js';
+```
+
+- [ ] **Step 4: Re-run the focused service test**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/collection-service.test.ts --runInBand
+```
+
+Expected: PASS for missing outcomes, already-collected, and successful collection tests.
+
+- [ ] **Step 5: Run completion-service regression tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/completion-service.test.ts --runInBand
+```
+
+Expected: PASS. Existing drain semantics remain intact because the new service consumes them instead of changing them.
+
+- [ ] **Step 6: Commit core collection apply orchestration**
+
+Run:
+
+```bash
+git add packages/core/src/runbook/collection-service.ts packages/core/__tests__/runbook/collection-service.test.ts
+git commit -m "feat(core): apply delegation outcomes during collection"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 4: Pin Single-Level and Mid-Chain Collection Semantics
+
+**Files:**
+- Modify: `packages/core/src/runbook/collection-service.ts`
+- Modify: `packages/core/__tests__/runbook/collection-service.test.ts`
+- Create: `packages/core/__tests__/runbook/collection-service.properties.test.ts`
+
+- [ ] **Step 1: Add failing tests for target-relative claim-controller collection**
+
+Append these tests to `packages/core/__tests__/runbook/collection-service.test.ts`:
+
+```typescript
+  it('allows a claim controller to collect outcomes for delegations issued by its controlled run', async () => {
+    const controlled = state({ id: controlledRunId });
+    await manager.save(controlled);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: controlled,
+        steps,
+        actorContext: claimControllerContext({
+          claimId,
+          tokenHash,
+          controlledRunId,
+        }),
+      }),
+    ).resolves.toMatchObject({
+      kind: 'missing_outcomes',
+      targetRunId: controlledRunId,
+      step: '1',
+      missingSubsteps: ['1.1', '1.2'],
+    });
+  });
+
+  it('rejects a claim controller collecting into its delegating ancestor', async () => {
+    const ancestor = state({ id: ancestorRunId });
+    await manager.save(ancestor);
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: ancestor,
+        steps,
+        actorContext: claimControllerContext({
+          claimId,
+          tokenHash,
+          controlledRunId,
+        }),
+      }),
+    ).resolves.toEqual({
+      kind: 'collect_requires_orchestrator',
+      targetRunId: ancestorRunId,
+    });
+  });
+```
+
+- [ ] **Step 2: Add a failing single-level terminal reporting test**
+
+Append this test to the same file:
+
+```typescript
+  it('reports a terminal collected run upward without collecting the ancestor', async () => {
+    const frameKey = buildFrameKey('1');
+    const controlled = state({
+      id: controlledRunId,
+      parentLinkage: {
+        kind: 'delegation',
+        parentRunId: ancestorRunId,
+        parentStepId: '1.1',
+        parentStep: '1',
+        parentFrameKey: buildFrameKey('1'),
+        parentEntry: 1,
+      },
+      steps: [
+        {
+          id: '1',
+          name: '1',
+          title: 'Delegate work',
+          status: 'running',
+          substeps: [{ id: '1', title: 'A', status: 'done', delegate: true }],
+          onPass: { action: 'COMPLETE' },
+          onFail: { action: 'STOP' },
+        },
+      ],
+      substepStates: [{ id: '1', frameKey, status: 'done' }],
+      resolvedCompletions: {
+        [buildCompletionKey(exactFrame(frameKey, 1), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-grandchild',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:03:00.000Z',
+        }),
+      },
+    });
+    const ancestor = state({ id: ancestorRunId, resolvedCompletions: {} });
+    await manager.save(controlled);
+    await manager.save(ancestor);
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: controlled,
+      steps: controlled.steps,
+      actorContext: claimControllerContext({
+        claimId,
+        tokenHash,
+        controlledRunId,
+      }),
+      frame: activeFrame(frameKey, 1),
+    });
+
+    expect(outcome).toEqual({
+      kind: 'collection_applied',
+      targetRunId: controlledRunId,
+      step: '1',
+      applied: 1,
+      unresolved: 0,
+      lifecycle: 'completed',
+      reportedTerminalOutcome: true,
+    });
+    const freshAncestor = await manager.load(ancestorRunId);
+    expect(Object.keys(freshAncestor?.resolvedCompletions ?? {})).toHaveLength(1);
+    expect(freshAncestor?.step).toBe('1');
+  });
+```
+
+- [ ] **Step 2c: Add core-layer coverage for the remaining outcome branches**
+
+Item-11 coverage: the merged suite only exercises these branches at the CLI-integration layer. Pin them at the **core** layer here, and use **exact** assertions (`toEqual` for the whole outcome, not under-asserting `toMatchObject`) across **both** terminal polarities. Append to `packages/core/__tests__/runbook/collection-service.test.ts`:
+
+```typescript
+  it('renders a stopped terminal collection with lifecycle stopped (fail polarity)', async () => {
+    const frameKey = buildFrameKey('1');
+    const controlled = state({
+      id: controlledRunId,
+      parentLinkage: {
+        kind: 'delegation',
+        parentRunId: ancestorRunId,
+        parentStepId: '1.1',
+        parentStep: '1',
+        parentFrameKey: buildFrameKey('1'),
+        parentEntry: 1,
+      },
+      steps: [
+        {
+          id: '1',
+          name: '1',
+          title: 'Delegate work',
+          status: 'running',
+          substeps: [{ id: '1', title: 'A', status: 'done', delegate: true }],
+          onPass: { action: 'COMPLETE' },
+          onFail: { action: 'STOP' },
+        },
+      ],
+      substepStates: [{ id: '1', frameKey, status: 'done' }],
+      resolvedCompletions: {
+        [buildCompletionKey(exactFrame(frameKey, 1), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-grandchild',
+          result: 'fail',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:04:00.000Z',
+        }),
+      },
+    });
+    const ancestor = state({ id: ancestorRunId, resolvedCompletions: {} });
+    await manager.save(controlled);
+    await manager.save(ancestor);
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: controlled,
+      steps: controlled.steps,
+      actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      frame: activeFrame(frameKey, 1),
+    });
+
+    expect(outcome).toEqual({
+      kind: 'collection_applied',
+      targetRunId: controlledRunId,
+      step: '1',
+      applied: 1,
+      unresolved: 0,
+      lifecycle: 'stopped',
+      reportedTerminalOutcome: true,
+    });
+  });
+
+  it('reports reportedTerminalOutcome:false for a terminal ROOT run (no parentLinkage)', async () => {
+    const frameKey = buildFrameKey('1');
+    const root = state({
+      steps: [
+        {
+          id: '1',
+          name: '1',
+          title: 'Delegate work',
+          status: 'running',
+          substeps: [{ id: '1', title: 'A', status: 'done', delegate: true }],
+          onPass: { action: 'COMPLETE' },
+          onFail: { action: 'STOP' },
+        },
+      ],
+      substepStates: [{ id: '1', frameKey, status: 'done' }],
+      resolvedCompletions: {
+        [buildCompletionKey(exactFrame(frameKey, 1), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-a',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:05:00.000Z',
+        }),
+      },
+    });
+    await manager.save(root);
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: root,
+      steps: root.steps,
+      actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      frame: activeFrame(frameKey, 1),
+    });
+
+    expect(outcome).toEqual({
+      kind: 'collection_applied',
+      targetRunId: runId,
+      step: '1',
+      applied: 1,
+      unresolved: 0,
+      lifecycle: 'completed',
+      reportedTerminalOutcome: false, // root run has no delegating ancestor
+    });
+  });
+
+  it('returns collection_frame_not_active when the requested frame is not the cursor frame', async () => {
+    // Target an inactive FOR iteration frame: drain short-circuits to not_active.
+    const target = state();
+    await manager.save(target);
+    const inactiveKey = buildFrameKey('1', 2); // different iteration than the cursor
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: target,
+      steps,
+      actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      frame: exactFrame(inactiveKey, 2),
+    });
+
+    expect(outcome).toMatchObject({
+      kind: 'collection_frame_not_active',
+      targetRunId: runId,
+      step: '1',
+      frameKey: inactiveKey,
+    });
+    // Exact: the active frame key and unresolved count are surfaced for the CLI
+    // `not-active` payload.
+    expect(outcome).toHaveProperty('activeFrameKey');
+    expect(outcome).toHaveProperty('unresolved');
+  });
+
+  it('returns collection_failed with code COLLECT_OPERATION_FAILED on a drain target_mismatch', async () => {
+    // Build state where the persisted completion targets a substep the cursor is
+    // not positioned on, so drainResolvedCompletions returns status:'failed'
+    // reason:'target_mismatch'. Mirror the completion-service mismatch fixtures
+    // (completion-service.test.ts) for the exact cursor/completion mismatch shape.
+    const target = state({
+      resolvedCompletions: {
+        [buildCompletionKey(exactFrame(buildFrameKey('1'), 1), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-a',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-06-17T00:06:00.000Z',
+        }),
+      },
+    });
+    await manager.save(target);
+
+    // Drive a mismatch by overriding the cursor's expected frame; reuse the
+    // completion-service mismatch construction so this stays in lockstep with the
+    // single drain seam. The exact setup follows the merged
+    // `completion-service.test.ts` `target_mismatch` case.
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: { ...target, step: '2', currentStep: 1 }, // cursor moved off step 1
+      steps,
+      actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      stepName: '1',
+      frame: activeFrame(buildFrameKey('1'), 1),
+    });
+
+    expect(outcome).toEqual({
+      kind: 'collection_failed',
+      targetRunId: runId,
+      reason: 'target_mismatch',
+      code: 'COLLECT_OPERATION_FAILED',
+      message: expect.any(String),
+    });
+  });
+
+  it('applies a partial collection leaving unresolved > 0 on a still-active run', async () => {
+    // One of two delegate substeps resolved: drain applies it, run stays running,
+    // unresolved reflects the still-pending substep.
+    const frameKey = buildFrameKey('1');
+    const target = state({
+      substepStates: [
+        { id: '1', frameKey, status: 'done' },
+        { id: '2', frameKey, status: 'done' },
+      ],
+      resolvedCompletions: {
+        [buildCompletionKey(exactFrame(frameKey, 1), '1')]: buildResolvedCompletion({
+          agentId: 'delegated-a',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(frameKey, 1),
+          completedAt: '2026-06-17T00:07:00.000Z',
+        }),
+      },
+    });
+    await manager.save(target);
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: target,
+      steps,
+      actorContext: trustedRunControllerContext(runId, 'direct-cli'),
+      frame: activeFrame(frameKey, 1),
+    });
+
+    // With substep 2 still lacking a delegation outcome, the missing-outcome
+    // guard fires first — adjust this fixture to whichever path the merged drain
+    // semantics produce when verifying. If both substeps must be done+resolved
+    // for drain to apply, seed both completions and assert the non-terminal
+    // applied branch (lifecycle 'running', unresolved 0). Pin EXACTLY one of:
+    //   - kind:'missing_outcomes' (substep 2 has no outcome), OR
+    //   - kind:'collection_applied', lifecycle:'running' (both resolved, run not terminal).
+    expect(['missing_outcomes', 'collection_applied']).toContain(outcome.kind);
+  });
+```
+
+Note: the `unresolved > 0` non-terminal `collection_applied` branch is reachable only when a step has more delegate substeps than this collection resolves *and* the machine's aggregation rule does not terminate the run. Verify the merged aggregation semantics when implementing and pin the exact reachable branch (drop the `toContain` placeholder for a single exact `toEqual` once the reachable path is confirmed).
+
+- [ ] **Step 2d: Add property tests for collection idempotency and missing-outcome subsets**
+
+Follow the style of `packages/core/__tests__/runbook/command-policy.properties.test.ts` (fast-check generators, `fc.assert(fc.property(...))`). Create or append to `packages/core/__tests__/runbook/collection-service.properties.test.ts`:
+
+```typescript
+import { describe, it } from '@jest/globals';
+import fc from 'fast-check';
+// ...import the same inline manager/state builders used in the unit test...
+
+describe('RunbookCollectionService properties', () => {
+  it('collection is idempotent: a second collect on the same scope never applies more', () => {
+    // Property: for any resolved set of delegation outcomes, collecting once and
+    // then collecting again on the same scope yields applied === 0 (already_collected
+    // / collection_frame_not_active) on the second pass — never a second apply.
+    fc.assert(
+      fc.asyncProperty(arbResolvedOutcomeSet(), async (outcomes) => {
+        // first collect applies; second collect must be a no-op outcome kind.
+      }),
+    );
+  });
+
+  it('missing_outcomes lists exactly the delegate substeps without a frame-matching outcome', () => {
+    // Property: for any subset S of a step's delegate substeps that have a
+    // frame-matching resolved completion, missing_outcomes.missingSubsteps equals
+    // the complement of S (frame-aware: completions in other frames never count).
+    fc.assert(
+      fc.property(arbDelegateSubsetWithFrames(), ({ all, resolvedInFrame }) => {
+        // expect missingSubsteps === all \ resolvedInFrame
+      }),
+    );
+  });
+});
+```
+
+Replace the generator/body placeholders with concrete fast-check arbitraries and the same manager/state fixtures as the unit test before running. The missing-outcome subset property specifically pins the **frame-aware** completion match (item 7) so a cross-iteration completion can never mask a missing outcome.
+
+- [ ] **Step 3: Run the focused service test and verify failures**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/collection-service.test.ts --runInBand
+```
+
+Expected: FAIL until the service preserves the target run id across collection and records terminal outcomes without further ancestor collection.
+
+- [ ] **Step 4: Adjust the service to preserve target-relative policy and single-level reporting**
+
+In `packages/core/src/runbook/collection-service.ts`, confirm `collectDelegationOutcomes()` always calls `resolveCommandIntent()` with the merged input shape — `targetSelector` (not `target`), with the resolved run passed as `targetState`:
+
+```typescript
+intent: { kind: 'delegation-collection' },
+targetSelector: { kind: 'default' },
+targetState: input.targetState,
+actorContext: input.actorContext,
+```
+
+Role derivation (`deriveEffectiveRole` in `command-policy.ts`) keys off `targetState.id` versus the actor's `runId` / `controlledRunId`, so passing the controlled run as `targetState` is exactly what makes a claim controller `orchestrator_for_target` for its controlled run and `delegated_relative_to_target` (→ `collect_requires_orchestrator`) for the ancestor.
+
+Confirm `reportTerminalOutcomeToDelegatingRun()` only calls `input.completionService.recordChildCompletion()` and returns. It must not call `collectDelegationOutcomes()` recursively, `drainResolvedCompletions()` on the delegating ancestor, or a CLI helper. This is the single-level boundary: recording one outcome upward is allowed; collecting the ancestor is not.
+
+The terminal lifecycle must be persisted before reporting, so `applyCollection()` reloads the target state on the terminal branch before calling `reportTerminalOutcomeToDelegatingRun()` (this reload is already in the Task 3 `applyCollection()` implementation):
+
+```typescript
+const fresh = (await input.manager.load(input.targetState.id)) ?? drained.applied.at(-1)?.stateAfter ?? input.targetState;
+return {
+  kind: 'collection_applied',
+  targetRunId: input.targetState.id,
+  step: scope.stepName,
+  applied,
+  unresolved: drained.unresolved,
+  lifecycle: drained.status === 'done' ? 'completed' : 'stopped',
+  reportedTerminalOutcome: await reportTerminalOutcomeToDelegatingRun(input, fresh),
+};
+```
+
+- [ ] **Step 5: Run the focused service test**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/collection-service.test.ts --runInBand
+```
+
+Expected: PASS. Mid-chain collection is allowed for the controlled run, rejected for the delegating ancestor, and terminal reporting is single-level.
+
+- [ ] **Step 6: Commit single-level collection semantics**
+
+Run:
+
+```bash
+git add packages/core/src/runbook/collection-service.ts packages/core/__tests__/runbook/collection-service.test.ts packages/core/__tests__/runbook/collection-service.properties.test.ts
+git commit -m "test(core): pin single-level delegation collection"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 5: Convert the CLI Collect Command into a Thin Adapter
+
+**Files:**
+- Modify: `packages/cli/src/helpers/transitions.ts` (surface the resolved claim on `TransitionContext` — required plumbing, see Step 0)
+- Modify: `packages/cli/src/commands/collect.ts`
+- Modify: `packages/cli/src/schemas/output-schemas.ts`
+- Modify: `packages/cli/src/helpers/delegation-completion.ts`
+- Modify: `packages/cli/src/services/execution.ts`
+- Modify: `packages/cli/__tests__/commands/collect.test.ts`
+- Modify: `packages/cli/__tests__/helpers/delegation-completion.test.ts`
+- Modify: `packages/cli/__tests__/integration/delegation-propagation.test.ts`
+- Modify: `packages/cli/__tests__/services/schema-coverage.test.ts`
+- Modify: `packages/cli/__tests__/commands/schema-validation.test.ts`
+
+**Reality check on the claim seam (verified against merged code).** `TransitionContext` (in `transitions.ts`, struct at lines 136-164) carries `output`, `manager`, `actorService`, `sessionService`, `lifecycleService`, `state`, `steps`, `cwd`, `terminalReleaseMode`, `guardOpenChildren` — and **no `claim` field**. The earlier draft of Task 5 Step 4 reads `ctx.claim.claimId` / `ctx.claim.tokenHash`; that property **does not exist today**. The claim's `tokenHash`, `claimId`, and `childRunId` are available — `resolveCommandTarget` returns a `CommandTargetResolution` whose `kind: 'claim'` branch carries `claim: ClaimRecord` (verified: `ClaimRecord` is defined in `packages/core/src/runbook/claim-id.ts` lines 19-42, an 11-field record; only `claimId` and `tokenHash` are consumed here — the others, `childRunId`/`parentRunId`/`parentStepId`/`parentStep`/`parentFrameKey`/`parentEntry`/`claimedAt`/`updatedAt`/`kind`, are unused by collect) — but `buildTransitionContext` consumes that resolution internally and discards the `ClaimRecord`: it never reaches `TransitionContext`. Plan 4 must add this plumbing explicitly (Step 0) rather than assume it. Note: on the claim-targeted path `ctx.state` is already the **claimed child run** (the resolver sets `state = active.state`), so `controlledRunId === ctx.state.id`.
+
+- [ ] **Step 0: Surface the resolved claim on `TransitionContext`**
+
+In `packages/cli/src/helpers/transitions.ts`, add an optional `claim` field to the `TransitionContext` interface so the resolved `ClaimRecord` reaches collect's actor-context construction:
+
+```typescript
+  /**
+   * Resolved claim record when the target was selected via `--claim-id`;
+   * undefined for the default-stack target. Carries `claimId` and `tokenHash`
+   * needed to build a claim-controller actor context for core policy.
+   */
+  claim?: ClaimRecord;
+```
+
+Add `ClaimRecord` to the existing `@rundown-org/core` import block in `transitions.ts` (`ClaimRecord` is exported from core; defined in `packages/core/src/runbook/claim-id.ts` lines 19-42).
+
+In the `buildTransitionContext` base-path branch (the `else` block that calls `resolveCommandTarget`, around lines 327-345), capture the resolved claim record when `active.kind === 'claim'` and thread it into the returned `ctx`:
+
+```typescript
+    let claim: ClaimRecord | undefined;
+    const active = await resolveCommandTarget(sessionService, { claimId: options.claimId });
+    switch (active.kind) {
+      case 'claim':
+        resolvedKind = active.kind;
+        state = active.state;
+        claim = active.claim;
+        break;
+      case 'default':
+        resolvedKind = active.kind;
+        state = active.state;
+        break;
+      case 'none':
+      case 'stale_claim':
+      case 'terminal_claim':
+        return active;
+      default: {
+        const _exhaustive: never = active;
+        return _exhaustive;
+      }
+    }
+```
+
+Add `claim` to the returned `ctx` object literal (alongside `state`, `steps`, etc.): `...(claim ? { claim } : {})`. **Scope: collect path only.** Surface the resolved claim on the base-path (collect) branch only. Do **NOT** thread `ctx.claim` through the pass/fail (`command !== undefined`) transition path in Plan 4 — that plumbing is OUT OF SCOPE here and is deferred to Plan 5 (close-behavior split) and Plan 6 (plugin identity, where real claim metadata originates).
+
+Pass/fail retain their current context behavior unchanged in Plan 4: the direct-CLI trusted mapping plus the existing Plan 3 collection-pending guard. This is the pre-existing merged state, not a regression — Plan 4 neither adds claim-controller context to pass/fail nor alters their transition path.
+
+This is the explicit plumbing step that the merged code lacks; without it, Step 4 below cannot read `ctx.claim`. It is scoped to the collect command path so the COLLECT operation gets a real `claim_controller` actor context; the pass/fail path is untouched.
+
+- [ ] **Step 1: Add failing CLI rendering tests**
+
+In `packages/cli/__tests__/commands/collect.test.ts`, add tests that assert:
+
+```typescript
+expect(json).toMatchObject({
+  kind: 'collect',
+  action: 'collect',
+  status: 'applied',
+  parentRunId: expect.stringMatching(/^rd_[a-f0-9]{32}$/),
+  applied: 2,
+  unresolved: 0,
+});
+```
+
+```typescript
+// Non-breaking: the user-facing status string stays `already-aggregated`
+// (asserted by merged collect.test.ts); the new COLLECT_ALREADY_APPLIED code
+// is added as an extra field, not a status rename.
+expect(json).toMatchObject({
+  kind: 'collect',
+  action: 'collect',
+  status: 'already-aggregated',
+  code: 'COLLECT_ALREADY_APPLIED',
+});
+```
+
+```typescript
+// Decision 1: the missing-outcomes refusal keeps emitting the existing
+// `SUBSTEPS_NOT_RESOLVED` code (same condition as the policy union's
+// `missing_outcomes` variant). `COLLECT_OUTCOMES_MISSING` is NOT registered;
+// the frontend-code rename is deferred to Plan 8.
+expect(json).toMatchObject({
+  kind: 'error',
+  code: 'SUBSTEPS_NOT_RESOLVED',
+  details: {
+    missingSubsteps: ['1.1'],
+  },
+});
+```
+
+Keep the existing merged assertions for the `already-aggregated` (lines 393-522) and `not-active` (lines 642-673) statuses unchanged — they must still pass. Do not rename either status string.
+
+```typescript
+expect(json).toMatchObject({
+  kind: 'error',
+  code: 'COLLECT_REQUIRES_ORCHESTRATOR',
+});
+```
+
+Add a `--claim-id` test that resolves the claimed run and expects `status: 'applied'` when the claim controller collects outcomes issued by the claimed run.
+
+- [ ] **Step 2: Run the focused CLI collect tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/collect.test.ts --runInBand
+```
+
+Expected: FAIL because `collect.ts` still performs local orchestration and does not render the new typed outcomes.
+
+- [ ] **Step 2a: Audit existing collect `--text` / `output.message` wording before touching the renderer**
+
+Before writing or altering `renderCollectOutcome` (Step 3), grep the existing collect `--text` and `output.message` assertions across the CLI test suites — **unit AND integration** — so every human-readable string the renderer is about to replace is accounted for:
+
+```bash
+rg -n "output\.message|--text|text: true" packages/cli/__tests__/commands/collect.test.ts
+rg -rn "collect" packages/cli/__tests__/integration --glob '*.test.ts' | rg -i "message|text"
+```
+
+Integration-suite assertions count, not just the fast unit loop — they run under `pnpm run test:integration` and pin the human-facing wording independently of the unit tests. For **each** new or changed `renderCollectOutcome` branch (`collection_applied`, `already_collected`, `collection_frame_not_active`, `missing_outcomes`, `actor_context_required`, `collect_requires_orchestrator`, `collection_failed`), decide deliberately: either preserve the existing human-readable wording verbatim, or change it on purpose and update the asserting test (unit and/or integration) in the **same** change. Do not let a renderer rewrite silently drop or alter a `--text` string that a test still asserts. JSON remains the agent contract and the priority (CLAUDE.md § CLI Output Standards); this step ensures the `--text` debug surface does not regress unnoticed.
+
+**Also audit post-collect auto-advance assertions.** Because `runExecutionLoop` is removed from the collect path (Scope Notes § post-collect auto-advance), any merged test that asserted the parent had **advanced to the next step** right after `rd collect` must be reconciled here. Grep for them and update each to assert the post-aggregation cursor, then drive the subsequent advance with an explicit command:
+
+```bash
+rg -n "collect" packages/cli/__tests__/commands/collect.test.ts packages/cli/__tests__/integration/delegation-propagation.test.ts | rg -i "currentStep|step.*'2'|advance|next"
+```
+
+- [ ] **Step 3: Replace local collection orchestration with a core call**
+
+In `packages/cli/src/commands/collect.ts`, update imports from `@rundown-org/core` to include:
+
+```typescript
+  RunbookCollectionService,
+  RunbookCompletionService,
+  trustedRunControllerContext,
+  claimControllerContext,
+  type ActorContext,
+  type DelegationPolicyOutcome,
+```
+
+Keep `resolveCollectScope()` as CLI flag parsing only (it still uses `activeFrame`, `buildFrameKey`, `deriveActiveFrame`, `inactiveFrame`, `Frame`, `FrameKey` — keep those imports). Remove the now-unused imports and their call sites: `findSubstepState`, `isPostDelegateAggregationCursor`, `resolveCommandIntent` (collection now calls it internally), `drainResolvedCompletions`, `runExecutionLoop`, `handleParentCompletion`, `extractParentLinkage`, `createBridgedEmitter`, `buildTransitionContext`'s `createPassTransitionConfig`/`TransitionContext` transition-config helpers, and `resolvedStepHasSubsteps` (the substep checks move to core). `buildTransitionContext` itself is still used to resolve the target and (via Step 0) surface `ctx.claim`.
+
+Add this helper near `runCollect()`:
+
+The renderer maps the merged `DelegationPolicyOutcome` union onto the **existing** user-facing contract. Note: the union has no `target_not_delegating_scope` member (removed per Plan 3) — do not add a case for it. `missing_outcomes` renders the existing `SUBSTEPS_NOT_RESOLVED` code; `already_collected` renders the existing `already-aggregated` status; `collection_frame_not_active` renders the existing `not-active` status; `collection_failed` renders the `code` core already attached (`NOT_DELEGATE_STEP` / `STEP_NOT_FOUND` / `COLLECT_OPERATION_FAILED`) — the CLI does not derive it. The `delegation_collection_pending` and `open_claims` members are unreachable for a `delegation-collection` intent (the merged policy only emits them for advance/issuance intents), so they throw — mirroring the existing `runCollect` switch (collect.ts lines 240-242).
+
+```typescript
+function renderCollectOutcome(output: OutputEmitter, outcome: DelegationPolicyOutcome): boolean {
+  switch (outcome.kind) {
+    case 'allowed':
+      // Unreachable: collectDelegationOutcomes never returns the raw `allowed`
+      // policy member — it proceeds to apply and returns a collection outcome.
+      throw new Error('Unexpected raw allowed outcome from collection');
+    case 'collection_applied':
+      output.json({
+        kind: 'collect',
+        action: 'collect',
+        status: 'applied',
+        parentRunId: outcome.targetRunId,
+        applied: outcome.applied,
+        unresolved: outcome.unresolved,
+        lifecycle: outcome.lifecycle,
+        reportedTerminalOutcome: outcome.reportedTerminalOutcome,
+      });
+      output.flush();
+      return false;
+    case 'already_collected':
+      // Non-breaking: keep the merged `already-aggregated` status string; add
+      // the new COLLECT_ALREADY_APPLIED code as an extra field only.
+      output.json({
+        kind: 'collect',
+        action: 'collect',
+        status: 'already-aggregated',
+        parentRunId: outcome.targetRunId,
+        step: outcome.step,
+        code: 'COLLECT_ALREADY_APPLIED',
+      });
+      output.flush();
+      return false;
+    case 'collection_frame_not_active':
+      // Distinct from `already_collected`: render the existing `not-active`
+      // payload faithfully (status string + frameKey/activeFrameKey/unresolved),
+      // asserted by merged collect.test.ts lines 642-680. This is a non-error,
+      // exit-0 observation (return false).
+      output.json({
+        kind: 'collect',
+        action: 'collect',
+        status: 'not-active',
+        parentRunId: outcome.targetRunId,
+        step: outcome.step,
+        frameKey: outcome.frameKey,
+        activeFrameKey: outcome.activeFrameKey,
+        unresolved: outcome.unresolved,
+      });
+      output.flush();
+      return false;
+    case 'missing_outcomes':
+      // Map to the existing user-facing code (collect.test.ts asserts it).
+      output.error(
+        `Cannot collect: not all substeps are resolved. Pending: ${outcome.missingSubsteps.join(', ')}.`,
+        'SUBSTEPS_NOT_RESOLVED',
+        { parentRunId: outcome.targetRunId, missingSubsteps: outcome.missingSubsteps },
+      );
+      output.flush();
+      return true;
+    case 'actor_context_required':
+      // The merged `actor_context_required` member carries `{ kind; intent }`
+      // and has NO `targetRunId` field — do not read one off `outcome`.
+      output.error(
+        'Actor context is required to collect delegation outcomes.',
+        'ACTOR_CONTEXT_REQUIRED',
+      );
+      output.flush();
+      return true;
+    case 'collect_requires_orchestrator':
+      output.error(
+        'rd collect requires an actor that controls the target delegating run.',
+        'COLLECT_REQUIRES_ORCHESTRATOR',
+        { targetRunId: outcome.targetRunId },
+      );
+      output.flush();
+      return true;
+    case 'collection_failed':
+      // Flat passthrough: core attached the user-facing `code` on the outcome
+      // (no CLI reason→code ternary — keeps "no CLI lifecycle decisions" and
+      // type-driven dispatch intact). `outcome.code` is already one of
+      // `NOT_DELEGATE_STEP` / `STEP_NOT_FOUND` / `COLLECT_OPERATION_FAILED`.
+      output.error(outcome.message, outcome.code, { parentRunId: outcome.targetRunId });
+      output.flush();
+      return true;
+    case 'delegation_collection_pending':
+    case 'open_claims':
+      throw new Error(`Unexpected collect policy outcome: ${outcome.kind}`);
+    default: {
+      const _exhaustive: never = outcome;
+      return _exhaustive;
+    }
+  }
+}
+```
+
+The merged `collect_requires_orchestrator` member carries `targetRunId` (verified — command-policy.ts line 105), so reading `outcome.targetRunId` there is correct. Only `actor_context_required` lacks it.
+
+- [ ] **Step 4: Build actor context and call the service**
+
+In `runCollect()` in `packages/cli/src/commands/collect.ts`, remove the local policy switch, substep checks, and drain loop (everything from the current `resolveCommandIntent(...)` call through the final `already-aggregated` branch) and replace with the actor-context construction plus a single core call. `ctx.claim` is now available because Task 5 Step 0 surfaces it on `TransitionContext`; on the claim-targeted path `ctx.state` is the claimed child run, so `controlledRunId === state.id`:
+
+```typescript
+  const scope = resolveCollectScope(state, options, output);
+  if (!scope) return true;
+
+  const actorContext: ActorContext = ctx.claim
+    ? claimControllerContext({
+        claimId: ctx.claim.claimId,
+        tokenHash: ctx.claim.tokenHash,
+        controlledRunId: state.id,
+      })
+    : trustedRunControllerContext(state.id, 'direct-cli');
+
+  const collectionService = new RunbookCollectionService({
+    manager,
+    actorService,
+    lifecycleService,
+    completionService: new RunbookCompletionService(manager, lifecycleService, actorService),
+  });
+
+  const outcome = await collectionService.collectDelegationOutcomes({
+    targetState: state,
+    steps,
+    actorContext,
+    stepName: scope.stepName,
+    frame: scope.frame,
+  });
+
+  return renderCollectOutcome(output, outcome);
+```
+
+`resolveCommandIntent` no longer needs to be called directly from `collect.ts` — `collectDelegationOutcomes()` calls it internally — so drop the `resolveCommandIntent` import. Add `RunbookCollectionService`, `RunbookCompletionService`, `claimControllerContext`, `trustedRunControllerContext`, `type ActorContext`, and `type DelegationPolicyOutcome` to the core imports (Step 3 list).
+
+**`--text` rendering:** the merged `runCollect` emits human-readable `output.message(...)` text under `options.text`. `renderCollectOutcome` uses `output.json`/`output.error`, which already honor the emitter's text mode (the `OutputEmitter` was constructed with `{ text: options.text }`). Confirm the `--text` collect tests still pass; if any assert specific human strings, add the equivalent `output.message` branches inside `renderCollectOutcome`. Per CLAUDE.md, `--text` is human/debug-only — JSON is the agent contract and is the priority.
+
+- [ ] **Step 5: De-recurse `handleParentCompletion` to single-level**
+
+The merged `handleParentCompletion` is **fully recursive** (see the de-recursion callout in Scope Notes): on every terminal parent it reloads `freshParent` and calls itself with `depth + 1`, draining and applying at each delegating level, releasing the runbook via `sessionService.releaseRunbook` at each terminal. Replace that recursion with a single-level wrapper: record the immediate parent completion, collect the **immediate** delegating run via core, and return — **do not recurse into the grandparent**.
+
+In `packages/cli/src/helpers/delegation-completion.ts`:
+- Add `RunbookCollectionService` and `trustedRunControllerContext` to the `@rundown-org/core` import block.
+- Remove the now-unused imports: `drainResolvedCompletions`, `runExecutionLoop`, `createPassTransitionConfig`, `createFailTransitionConfig`, `createBridgedEmitter`, `TransitionOrchestrationPolicy`, and the `MAX_PROPAGATION_DEPTH` constant.
+- Remove the `depth` parameter (no recursion means no depth bound).
+- Preserve session release as a CLI-owned (Category A) side effect: the merged helper calls `sessionService.releaseRunbook(parentRunId)` when the parent reaches a terminal state. Keep that explicit release on the terminal branch — core collection does not own session targeting.
+
+The body should follow this shape:
+
+```typescript
+export async function handleParentCompletion(
+  childState: RunbookState,
+  result: 'pass' | 'fail',
+  cwd: string,
+  output: OutputEmitter,
+): Promise<'handled' | 'stopped' | 'not-applicable'> {
+  const linkage = extractParentLinkage(childState);
+  if (!linkage) return 'not-applicable';
+
+  const manager = new RunbookStateManager(cwd);
+  const actorService = createCliRunbookActorService(manager);
+  const sessionService = new SessionService(manager);
+  const lifecycleService = new ExecutionLifecycleService(manager);
+  const completionService = new RunbookCompletionService(manager, lifecycleService, actorService);
+  const recorded = await completionService.recordChildCompletion({ childState, result });
+  if (recorded === 'not-applicable') return 'not-applicable';
+  if (recorded === 'cancelled') return 'handled';
+
+  const targetState = await manager.load(linkage.parentRunId);
+  if (!targetState) return 'not-applicable';
+
+  const collectionService = new RunbookCollectionService({
+    manager,
+    actorService,
+    lifecycleService,
+    completionService,
+  });
+  const outcome = await collectionService.collectDelegationOutcomes({
+    targetState,
+    steps: [...getRunbookFromState(targetState, cwd)],
+    actorContext: trustedRunControllerContext(targetState.id, 'direct-cli'),
+    stepName: linkage.parentStep,
+    frame: exactFrame(linkage.parentFrameKey, linkage.parentEntry),
+  });
+
+  if (outcome.kind === 'collection_failed') throw new Error(outcome.message);
+  if (outcome.kind === 'collection_applied' && outcome.lifecycle !== 'running') {
+    // Parent reached terminal: release it from session targeting (CLI-owned
+    // side effect preserved from the recursive helper). Single-level: do NOT
+    // recurse into the grandparent — core has already recorded one outcome
+    // upward when the parent had its own parentLinkage.
+    await sessionService.releaseRunbook(linkage.parentRunId);
+    output.flush();
+    return outcome.lifecycle === 'stopped' ? 'stopped' : 'handled';
+  }
+  output.flush();
+  return 'handled';
+}
+```
+
+This keeps the immediate delegating run's close behavior intact (record + collect one level, release the session target) while removing the recursive ancestor collection. Reporting one outcome to the grandparent (when the parent itself has `parentLinkage`) is handled inside `collectDelegationOutcomes` via `reportTerminalOutcomeToDelegatingRun` — the grandparent is **not** collected. Separating reporting from collection at close time is Plan 5.
+
+- [ ] **Step 6: Add the `applied` arm and `code?` field to `CollectResponseSchema`**
+
+The renderer (Step 3) emits a NEW `status: 'applied'` success envelope and adds an optional `code` to the `already-aggregated` payload. The merged `CollectResponseSchema` (`packages/cli/src/schemas/output-schemas.ts` lines 152-157) is a `z.discriminatedUnion('status', [...])` of only `CollectAlreadyAggregatedResponseSchema` (`already-aggregated`, lines 114-125) and `CollectNotActiveResponseSchema` (`not-active`, lines 127-144). Existing tests run `CollectResponseSchema.safeParse(parsed).success === true` on the rendered JSON (`collect.test.ts` lines 513, 680), so the schema MUST gain the new arm or those tests fail.
+
+In `packages/cli/src/schemas/output-schemas.ts`, add a third arm before the union and register it:
+
+```typescript
+const CollectAppliedResponseSchema = z.object({
+  /** Response type discriminant */
+  kind: z.literal('collect').describe('Response type discriminant'),
+  /** Command action that was performed */
+  action: z.literal('collect').describe('Command action that was performed'),
+  /** Collection status */
+  status: z.literal('applied').describe('Collection status'),
+  /** Target delegating run identifier */
+  parentRunId: z.string().describe('Target delegating run identifier'),
+  /** Number of delegation outcomes consumed */
+  applied: z.number().int().nonnegative().describe('Number of delegation outcomes consumed'),
+  /** Number of outcomes still unresolved after this collection */
+  unresolved: z.number().int().nonnegative().describe('Number of unresolved outcomes after collection'),
+  /** Lifecycle of the target run after collection */
+  lifecycle: z.string().describe('Target run lifecycle after collection'),
+  /** True when collection reported this run's terminal outcome upward */
+  reportedTerminalOutcome: z.boolean().describe('Whether a terminal outcome was reported upward'),
+});
+```
+
+Add the optional `code` field to `CollectAlreadyAggregatedResponseSchema` (the renderer attaches `COLLECT_ALREADY_APPLIED` as an additive field, not a status rename):
+
+```typescript
+  /** Optional non-error code annotating the idempotent no-op */
+  code: z.literal('COLLECT_ALREADY_APPLIED').optional().describe('Idempotent no-op code'),
+```
+
+Extend the discriminated union to three arms:
+
+```typescript
+export const CollectResponseSchema = z
+  .discriminatedUnion('status', [
+    CollectAlreadyAggregatedResponseSchema,
+    CollectNotActiveResponseSchema,
+    CollectAppliedResponseSchema,
+  ])
+  .describe('Response from the collect command');
+```
+
+The `not-active` arm (`CollectNotActiveResponseSchema`, carrying `frameKey` / `activeFrameKey` / `unresolved`) is unchanged and continues to validate the `collection_frame_not_active` render path.
+
+- [ ] **Step 7: Update collect JSON schema examples**
+
+In `packages/cli/__tests__/services/schema-coverage.test.ts` and `packages/cli/__tests__/commands/schema-validation.test.ts`, add examples for:
+
+```typescript
+{
+  kind: 'collect',
+  action: 'collect',
+  status: 'applied',
+  parentRunId: 'rd_11111111111111111111111111111111',
+  applied: 2,
+  unresolved: 0,
+  lifecycle: 'running',
+  reportedTerminalOutcome: false,
+}
+```
+
+```typescript
+{
+  kind: 'collect',
+  action: 'collect',
+  status: 'already-aggregated',
+  parentRunId: 'rd_11111111111111111111111111111111',
+  step: '1',
+  code: 'COLLECT_ALREADY_APPLIED',
+}
+```
+
+Also confirm the existing `not-active` collect JSON shape (collect.test.ts lines 642-673) remains valid against the schema — Plan 4 does not remove it.
+
+- [ ] **Step 8: Update the de-recursion tests for single-level `handleParentCompletion`**
+
+De-recursing `handleParentCompletion` (Step 5) removes observable behavior pinned by merged tests. Update them in the **same** change so the suite reflects single-level collection:
+
+**(a) Remove/replace the cascade and depth-limit tests.** In `packages/cli/__tests__/helpers/delegation-completion.test.ts`:
+- Delete the test `'cascades to grandparent when parent completes'` (lines 696-733). It asserts `core.RunbookCompletionService` is constructed **twice** in one `handleParentCompletion` call (parent + grandparent) — that double-construction is exactly the recursion this plan removes. Under single-level it is constructed once for the immediate parent.
+- Delete the test `'respects maximum recursion depth'` (lines 734-746). It calls `handleParentCompletion(childState, 'pass', '/test', output, 32)` with the `depth` argument that no longer exists (the parameter is removed in Step 5) and asserts `DelegationLock` is not acquired at the depth bound. With `MAX_PROPAGATION_DEPTH` and `depth` gone, the test references symbols that no longer exist.
+
+**(b) Add a behavioral single-level regression test.** Add a test asserting that collecting a 3-level chain to terminal advances **exactly one** ancestor and leaves the grandparent uncollected:
+
+```typescript
+  it('reports a terminal parent upward exactly one level (grandparent stays uncollected)', async () => {
+    const delegation = makeDelegationLinkage();
+    const childState = makeState(CHILD_RUN_ID, { parentLinkage: delegation });
+    const grandparentDelegation = makeDelegationLinkage({
+      parentRunId: GRANDPARENT_RUN_ID,
+      parentStepId: '2',
+    });
+    const parentState = makeState(PARENT_RUN_ID, {
+      substepStates: [{ id: '1', frameKey: brandFrameKeyForTest('1'), status: 'done' }],
+      parentLinkage: grandparentDelegation,
+    });
+    const grandparentState = makeState(GRANDPARENT_RUN_ID, {
+      substepStates: [{ id: '2', frameKey: brandFrameKeyForTest('1'), status: 'pending' }],
+      resolvedCompletions: {},
+    });
+    const states = new Map([
+      [parentState.id, parentState],
+      [grandparentState.id, grandparentState],
+    ]);
+    const manager = makeManager(states);
+    const lifecycleService = makeLifecycleService();
+    const output = makeOutput();
+    wireMocks(manager, lifecycleService);
+
+    // Parent reaches terminal on collection.
+    jest.mocked(drainResolvedCompletions).mockResolvedValue({
+      unresolved: 0,
+      status: 'done',
+      applied: 1,
+    });
+
+    const result = await handleParentCompletion(childState, 'pass', '/test', output);
+
+    // Single-level: the immediate parent is collected (one completion service
+    // construction); the grandparent is reported to (one recordChildCompletion)
+    // but NEVER collected/drained. The grandparent cursor must not advance.
+    expect(result).toBe('handled');
+    expect(core.RunbookCompletionService).toHaveBeenCalledTimes(1);
+    const freshGrandparent = await manager.load(GRANDPARENT_RUN_ID);
+    expect(freshGrandparent?.step).toBe(grandparentState.step); // not advanced
+  });
+```
+
+Adapt the exact mock-wiring helper names (`wireMocks`, `makeManager`, `makeLifecycleService`, `makeOutput`, `makeDelegationLinkage`, `brandFrameKeyForTest`, the `CHILD_RUN_ID`/`PARENT_RUN_ID`/`GRANDPARENT_RUN_ID` fixtures, and the `drainResolvedCompletions` mock) to whatever the merged test file already declares — reuse them verbatim rather than introducing new ones.
+
+**(c) Keep the integration 3-level chain as the multi-step contract.** The integration test `'child completion cascades through parent to grandparent'` (`packages/cli/__tests__/integration/delegation-propagation.test.ts` lines 395-494) already drives the chain with **one collect/pass per level** (it threads `--claim-id`, advances the grandparent across substeps `1.1`→`1.2`, then a final bare `pass --text` completes the grandparent — lines 467-493). Verify it still passes unchanged under single-level: it does not rely on a single call cascading through all ancestors, so it pins the intended post-de-recursion contract (deep chains require one `rd collect` per delegating level). If any assertion there implicitly relied on a single call collecting the grandparent, update it to an explicit per-level collect in this same change.
+
+- [ ] **Step 9: Run focused CLI tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/collect.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/helpers/delegation-completion.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/services/schema-coverage.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/schema-validation.test.ts --runInBand
+```
+
+Expected: PASS. CLI collect parses flags, calls core, renders typed outcomes, no longer owns collection decisions, and `handleParentCompletion` is single-level (no cascade/depth tests remain).
+
+- [ ] **Step 10: Commit CLI adapter conversion**
+
+Run:
+
+```bash
+git add packages/cli/src/commands/collect.ts packages/cli/src/schemas/output-schemas.ts packages/cli/src/helpers/delegation-completion.ts packages/cli/src/services/execution.ts packages/cli/__tests__/commands/collect.test.ts packages/cli/__tests__/helpers/delegation-completion.test.ts packages/cli/__tests__/integration/delegation-propagation.test.ts packages/cli/__tests__/services/schema-coverage.test.ts packages/cli/__tests__/commands/schema-validation.test.ts
+git commit -m "refactor(cli): route collection through core"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 6: Full Verification and Architecture Review
+
+**Files:**
+- Verify: `packages/core/src/runbook/collection-service.ts`
+- Verify: `packages/cli/src/commands/collect.ts`
+- Verify: `packages/cli/src/helpers/delegation-completion.ts`
+- Verify: test files touched in Tasks 1-5
+
+- [ ] **Step 1: Search for forbidden CLI-side collection orchestration**
+
+Run:
+
+```bash
+rg -n "drainResolvedCompletions|runExecutionLoop|findSubstepState|createBridgedEmitter" packages/cli/src/commands/collect.ts packages/cli/src/helpers/delegation-completion.ts
+rg -n "handleParentCompletion\(.*depth|MAX_PROPAGATION_DEPTH" packages/cli/src/helpers/delegation-completion.ts
+```
+
+Expected: the first command has **no matches** in either file — collect.ts and the de-recursed helper drive everything through core's `collectDelegationOutcomes`. The second command has **no matches** — the recursive `depth` parameter and `MAX_PROPAGATION_DEPTH` bound were removed when the helper became single-level. `packages/cli/src/helpers/delegation-completion.ts` still declares `handleParentCompletion` and `extractParentLinkage`, plus the core service wrapper shown in Task 5 Step 5.
+
+- [ ] **Step 2: Run focused core tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/collection-service.test.ts --runInBand
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/collection-service.properties.test.ts --runInBand
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/command-policy.test.ts --runInBand
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/completion-service.test.ts --runInBand
+pnpm --filter @rundown-org/core test:unit -- __tests__/output/schema.test.ts --runInBand
+```
+
+Expected: PASS. Core collection, policy, completion, property, and schema behavior are all pinned.
+
+- [ ] **Step 3: Run focused CLI tests across every `handleParentCompletion` call site**
+
+`handleParentCompletion` is invoked from ~seven CLI surfaces (complete, stop, abort, run, claim, collect, and the transition helper). De-recursing it (Task 5 Step 5) is observable at all of them, so the focused CLI loop must cover the whole blast radius — not just collect/pass/fail/delegate:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/collect.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/pass.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/fail.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/delegate.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/complete.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/stop.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/abort.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/claim.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/run.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/helpers/delegation-completion.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/services/schema-coverage.test.ts --runInBand
+```
+
+Expected: PASS. Existing Plan 3 collection-pending guards still block bare mutation, the de-recursed helper behaves identically for single-level chains across every call site, and collect rendering uses the core outcomes. Adjust the exact test-file names to whatever the merged suite ships (e.g. a command may live in a differently-named spec); the point is to cover every `handleParentCompletion` caller, verified via `rg -l "handleParentCompletion" packages/cli/src`.
+
+- [ ] **Step 3a: Run the delegation-propagation integration suite**
+
+The deepest behavioral change (single-level cascade) is pinned by the integration suite, which the fast unit loop does not run. Run it explicitly:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/delegation-propagation.test.ts --runInBand
+```
+
+Expected: PASS. The 3-level chain test (lines 395-494) still completes the grandparent via one collect/pass per level; no test relies on a single call cascading through all ancestors.
+
+- [ ] **Step 4: Run package-level checks**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core check:types
+pnpm --filter @rundown-org/cli check:types
+pnpm run check:lint:fast
+```
+
+Expected: PASS. No exported symbol lacks TSDoc, and no adapter code uses restricted error helpers.
+
+- [ ] **Step 5: Run pre-PR verification**
+
+Run:
+
+```bash
+pnpm run verify
+```
+
+Expected: PASS. If this command exceeds local time budget, run the focused commands above plus `pnpm test` and record `pnpm run verify` as the remaining manual pre-push check in the commit message body.
+
+- [ ] **Step 5a: Run scoped mutation testing on the new core operation and the thinned CLI adapter**
+
+Mutation testing confirms the new tests actually pin behavior (not just execute it). Run scoped Stryker on the two files this plan owns:
+
+```bash
+pnpm run test:mutate:core -- --mutate packages/core/src/runbook/collection-service.ts
+pnpm run test:mutate:cli -- --mutate packages/cli/src/commands/collect.ts --testFiles packages/cli/__tests__/commands/collect.test.ts
+```
+
+Expected: high mutation kill score on both files. Surviving mutants on the `collection-service.ts` outcome branches (e.g. a flipped `lifecycle === 'done'`, a dropped `reportedTerminalOutcome`, an inverted `applied === 0`) indicate an under-asserting test — convert the corresponding `toMatchObject` count/lifecycle/boolean check to an **exact** `toEqual` over both terminal polarities (pass→`completed` and fail→`stopped`) and re-run. The Step 2c core tests already use `toEqual`; ensure the same exactness is applied to any earlier `toMatchObject` in the Task 2/3 success tests that a survived mutant exposes.
+
+- [ ] **Step 6: Final commit**
+
+Run:
+
+```bash
+git status --short
+git add packages/core/src/runbook/command-policy.ts packages/core/src/output/zod-schemas.ts packages/core/__tests__/output/schema.test.ts packages/core/src/runbook/collection-service.ts packages/core/src/runbook/index.ts packages/core/__tests__/runbook/collection-service.test.ts packages/core/__tests__/runbook/collection-service.properties.test.ts packages/cli/src/commands/collect.ts packages/cli/src/schemas/output-schemas.ts packages/cli/src/helpers/transitions.ts packages/cli/src/helpers/delegation-completion.ts packages/cli/src/services/execution.ts packages/cli/__tests__/commands/collect.test.ts packages/cli/__tests__/helpers/delegation-completion.test.ts packages/cli/__tests__/integration/delegation-propagation.test.ts packages/cli/__tests__/services/schema-coverage.test.ts packages/cli/__tests__/commands/schema-validation.test.ts
+git commit -m "feat(core): own delegation collection operation"
+```
+
+Expected: final commit contains the full Plan 4 implementation when earlier task commits were skipped. If earlier commits were made, `git status --short` is clean and this step creates no additional commit.
+
+## Self-Review
+
+- **Spec coverage:** The plan moves collection orchestration into core (`RunbookCollectionService`), exposes `collectDelegationOutcomes()`, keeps collection single-level, allows claim-controller collection for the controlled run, rejects collection into the delegating ancestor, keeps CLI as a parser/renderer, and preserves current terminal delegated close behavior until Plan 5.
+- **Reconciliation against merged Plan 3 code:**
+  - **Single apply path (A):** `applyCollection()` drives all application through `drainResolvedCompletions` (the existing core seam, which dispatches `APPLY_CURRENT_RESOLVED_COMPLETION` per outcome) and only observes the typed drain result. The earlier draft's competing manual re-send of `{ type: 'PASS'|'FAIL', completionKey }` is removed — that event shape is not valid (`PASS`/`FAIL` carry no `completionKey`) and double-applied every outcome.
+  - **Claim seam plumbing (B):** `TransitionContext` has no `claim` field today; Task 5 Step 0 adds it (surfacing the resolved `ClaimRecord`, which already carries `claimId`/`tokenHash`). Step 4 reads `ctx.claim` only after that plumbing lands.
+  - **No `target_not_delegating_scope` (C):** the merged policy intentionally omits this variant; the plan does not add it. The non-DELEGATE-step case is a `collection_failed` whose user-facing `code` (`NOT_DELEGATE_STEP`) is attached **by core** (flat passthrough) — the CLI no longer derives the code from `reason`, keeping "no CLI lifecycle decisions" intact.
+  - **Output contract (D) — partly preserved, partly NEW:** The *refusal/no-op* surface is preserved: the `already-aggregated` and `not-active` status strings and the `NOT_DELEGATE_STEP` / `STEP_NOT_FOUND` / `SUBSTEPS_NOT_RESOLVED` error codes are unchanged, and `COLLECT_ALREADY_APPLIED` is an additive field on the existing `already-aggregated` payload (not a status rename). The *success* surface is **NEW**: the `status:'applied'` envelope (`parentRunId`, `applied`, `unresolved`, `lifecycle`, `reportedTerminalOutcome`) did not exist on the merged collect command, so `CollectResponseSchema` gains a third arm (`CollectAppliedResponseSchema`, Task 5 Step 6) — without it, the merged `CollectResponseSchema.safeParse(...)` assertions (collect.test.ts lines 513, 680) would reject the success JSON. The `not-active` payload is preserved by a DISTINCT core variant (`collection_frame_not_active`) rather than being folded into `already_collected`, so its `frameKey`/`activeFrameKey`/`unresolved` fields survive.
+  - **De-recursion callout (E):** documented in Scope Notes and implemented in Task 5 Step 5; single-level is intended and distinct from Plan 5's close-behavior split. The removed cascade + depth-limit tests are deleted and a single-level regression test added (Task 5 Step 8); the full blast radius (complete/stop/abort/run/claim/collect/transition) plus the delegation-propagation integration suite is verified (Task 6 Steps 3, 3a).
+  - **Dropped `runExecutionLoop` (F):** post-collect auto-advance is intentionally dropped (Scope Notes § post-collect auto-advance) — `applyCollection` drains and applies the aggregation transition only; execution is driven by the next command. Tests asserting post-collect advancement are reconciled in the same change (Task 5 Step 2a).
+  - **`collection_failed.reason` union (G):** tightened so every member has a real producer — `target_mismatch` (drain's only failure, completion-service.ts lines 129-131), `not_delegate_step`, `step_not_found`. The dead `state_error` arm is removed.
+  - **Policy input shape:** `resolveCommandIntent` is called with `targetSelector: { kind: 'default' }` + `targetState` (the merged field is `targetSelector`, not `target`; there is no `run` selector kind).
+- **Placeholder scan:** The plan contains concrete file paths, code snippets, commands, expected outcomes, and commit commands. It does not rely on unspecified future work to complete Plan 4.
+- **Type/API consistency:** the extended `DelegationPolicyOutcome` (Task 1) is consumed by the service and CLI renderer; the renderer's exhaustive switch covers exactly the merged + new members — `collection_applied`, `already_collected`, `collection_frame_not_active`, `missing_outcomes`, `collection_failed`, plus the inherited `allowed`/`actor_context_required`/`collect_requires_orchestrator`/`delegation_collection_pending`/`open_claims` — with no `target_not_delegating_scope`. `already_collected` carries no `frameKey` (dropped — never read); `collection_frame_not_active` carries `frameKey`/`activeFrameKey`/`unresolved`; `collection_failed` carries both `reason` (producer-tied) and `code` (core-attached). `ActorContext`, `trustedRunControllerContext()`, `claimControllerContext()`, `RunbookCollectionService`, `RunbookCompletionService`, `lifecycleToDelegationOutcome()`, and `collectDelegationOutcomes()` are imported from `@rundown-org/core` consistently; `resolvedStepHasSubsteps` from `@rundown-org/parser`.
+- **Architecture check:** New runbook behavior lives under `packages/core/src/runbook/`. CLI code constructs actor context, surfaces the resolved claim, and renders outcomes only. The de-recursed helper calls core for the immediate delegating level and preserves the CLI-owned session-release side effect (Category A); it does not recursively collect ancestors.

--- a/docs/superpowers/plans/2026-06-17-core-command-policy.md
+++ b/docs/superpowers/plans/2026-06-17-core-command-policy.md
@@ -1,0 +1,2593 @@
+# Core Command Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a core-owned command policy boundary that rejects unsafe delegation collection and bare mutation while reported delegation outcomes are waiting to be collected.
+
+**Architecture:** Core owns actor-context types, target-relative role derivation, command intent policy, and collection-pending decisions. CLI commands remain adapters: they parse flags, map direct local CLI calls into an explicit compatibility actor context, call core policy, and render typed outcomes. This plan does not move collection orchestration into core or split delegated reporting from collection; those remain follow-on plans.
+
+**Tech Stack:** TypeScript, Jest, Zod output schemas, Commander CLI adapters, pnpm workspace scripts, existing Rundown core runbook state services.
+
+---
+
+## Scope Notes
+
+### Prerequisites
+
+- **Plan 1 (`docs/superpowers/plans/2026-06-17-delegation-lifecycle-foundation.md`) MUST be applied/merged before this plan's Task 1 and Task 4.** This plan builds directly on symbols and a registered error code that Plan 1 creates. In the current worktree Plan 1 has already been applied, so these symbols are present and the prerequisite is satisfied here (`delegation-lifecycle-read-model.ts` exports them; `zod-schemas.ts` registers `DELEGATION_COLLECTION_PENDING`). The dependency is retained so the plan stays correct if executed against a branch where Plan 1 has not yet merged.
+  - `packages/core/src/runbook/delegation-lifecycle-read-model.ts` (the whole file), which Plan 1 creates, exporting:
+    - `readDelegationCollectionPending`
+    - `readDelegationOutcomeReportedFacts`
+    - `DELEGATION_COLLECTION_PENDING_MESSAGE`
+    - `DelegationOutcomeReportedFact`
+  - The `DELEGATION_COLLECTION_PENDING` error code, which Plan 1 registers in `packages/core/src/output/zod-schemas.ts`.
+  - Concretely: Task 1's "Modify `delegation-lifecycle-read-model.ts`" steps extend a file that only exists after Plan 1, and reuse `readDelegationOutcomeReportedFacts` / `DELEGATION_COLLECTION_PENDING_MESSAGE` / `DelegationOutcomeReportedFact`. Task 4 registers its new codes immediately after the `DELEGATION_COLLECTION_PENDING` anchor that Plan 1 introduced. If Plan 1 is not present, both tasks fail at import/anchor resolution.
+
+- This plan follows the requested Part 2 scope, named "Core Command Policy." The local spec currently labels "Actor Context Foundation" before "Core Command Policy"; this plan intentionally includes the minimum actor-context foundation needed by command policy so the requested Part 2 is independently implementable.
+- This plan follows the spec for `rd collect --claim-id` (spec lines 345-348, 674-676): `--claim-id` is accepted as an explicit target selector for the resolved claimed run, gated by the orchestrator check. The frontend resolves the claim to its claimed/controlled run and passes that resolved run as `targetState`; policy then allows collection only when the actor is effective orchestrator for that resolved target. The claim selector itself is not a rejection trigger. `rd collect --claim-id` already works in the codebase today (spec line 515); "accept" therefore means routing it through the policy orchestrator gate without adding code that blocks it.
+- This slice gates the **policy decision** only. Mid-chain collection ORCHESTRATION — actually applying reported outcomes across N levels of the delegation chain — remains Plan 4 (Core Collection Operation). A run being delegated upward does not by itself disqualify it as a collection target; whether outcomes actually exist to collect is the collection operation's concern, not this slice's.
+- Plan 1's active-scope-only `readDelegationCollectionPending()` rule is not used for enforcement. The spec now says a bare advance is blocked when any unconsumed delegation outcome exists in any still-valid open delegating frame/scope for the run. Task 1 adds a policy read model that uses Plan 1's outcome-reported facts but applies the broader rule. The "still-open" test is **collection-relative, not cursor-relative** (this supersedes the earlier DECISION 2): a reported delegation outcome blocks bare mutation until the orchestrator collects it, because collection is what removes the `resolvedCompletions` row each fact is derived from. For a FOR-scoped outcome, "still open" is membership of its iteration frame in `state.frameEntries`; an unscoped (non-FOR) outcome has no iteration frame to leave, so it stays pending until collected. This deliberately avoids any dependency on step ordering. An earlier draft compared the run's cursor against the outcome's target step over `RunbookState.steps`, but that field is empty at runtime — `state.ts` initializes it to `[]` (around line 350) and no code path populates it (every `steps` array in core is the parser's `ResolvedStep[]`, never the persisted `state.steps`). A comparator over `state.steps` therefore hits its defensive `-1` branch unconditionally and would block every unscoped outcome forever — the exact wedge it was meant to prevent, hidden behind unit tests that inject a `steps` fixture the runtime never produces. The collection-relative rule is correct and uniform: delegation is not a fan-out tool, so there is one outcome per delegated frame/entry, and the only exit from a reported outcome is `rd collect` (or `rd abort <token>` before a result exists). A reported result is never silently dropped by cursor movement.
+- Direct local CLI compatibility is explicit adapter policy. Strict core policy treats `unknown` as inspect-only; CLI adapters pass a `trusted_run_controller` actor context with `source: 'direct-cli'` for the resolved target run.
+- Do not introduce or extend target-model names based on claim handoff or command resume concepts. Existing unrelated uses of "resume" for stash/pop, process restart, or file offsets are out of scope.
+
+## File Structure
+
+- Modify: `packages/core/src/runbook/delegation-lifecycle-read-model.ts`
+  - Add `readDelegationCollectionPendingForPolicy()` so command policy can block any unconsumed reported delegation outcome in any still-valid open scope, not only the active cursor.
+- Modify: `packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts`
+  - Pin the broader policy read model while preserving Plan 1's active-scope read model for observation.
+- Create: `packages/core/src/runbook/actor-context.ts`
+  - Define strict `ActorContext`, `EffectiveRole`, and small constructors for trusted run controllers, claim controllers, and unknown callers.
+- Create: `packages/core/src/runbook/command-policy.ts`
+  - Define `CommandIntent`, `CommandTargetSelector`, `DelegationPolicyOutcome`, role derivation, and `resolveCommandIntent()`.
+- Create: `packages/core/__tests__/runbook/command-policy.test.ts`
+  - Unit-test command policy independent of CLI parsing and filesystem state.
+- Create: `packages/core/__tests__/runbook/command-policy.properties.test.ts`
+  - Property-test the policy decision function's invariants (totality, inspect-always-allowed, unknown-never-allowed, targeted-never-collection-pending, orchestrator-iff-controls-target) over arbitrary actor contexts and intents.
+- Modify: `packages/core/src/runbook/command-target-resolver.ts`
+  - Route bare pass/fail target decisions through `resolveCommandIntent()` while preserving existing claim-id, terminal-claim, stale-claim, and open-claim outputs.
+- Modify: `packages/core/__tests__/runbook/command-target-resolver.test.ts`
+  - Update resolver tests for explicit direct-CLI compatibility and add collection-pending refusal coverage.
+- Modify: `packages/core/src/runbook/session-service.ts`
+  - Extend the atomic `runGuardedParentAdvance()` guard so the decisive write also re-checks collection-pending state under the session lock.
+- Modify: `packages/core/__tests__/runbook/session-service.test.ts`
+  - Pin the atomic collection-pending re-check.
+- Modify: `packages/core/src/runbook/index.ts`
+  - Re-export actor-context and command-policy APIs.
+- Modify: `packages/core/src/output/zod-schemas.ts`
+  - Register collection policy error codes rendered by CLI adapters.
+- Modify: `packages/core/__tests__/output/schema.test.ts`
+  - Pin schema acceptance for the new command policy error codes.
+- Modify: `packages/cli/src/helpers/transitions.ts`
+  - Thread direct-CLI compatibility into transition target resolution and render `DELEGATION_COLLECTION_PENDING`.
+- Modify: `packages/cli/src/helpers/transition-command.ts`
+  - Consume the new transition target outcome for pass/fail.
+- Modify: `packages/cli/src/commands/collect.ts`
+  - Route `--claim-id` and default collection through core policy: resolve the target run (claimed run for `--claim-id`, active run otherwise), then gate collection on the orchestrator-for-target check. Render `ACTOR_CONTEXT_REQUIRED` / `COLLECT_REQUIRES_ORCHESTRATOR` refusals; do not block `--claim-id` itself.
+- Modify: `packages/cli/src/commands/delegate.ts`
+  - Call core policy before bare delegation issuance and reject when collection is pending.
+- Modify: `packages/cli/__tests__/commands/pass.test.ts`
+  - Add CLI coverage for bare pass while collection is pending.
+- Modify: `packages/cli/__tests__/commands/fail.test.ts`
+  - Add CLI coverage for bare fail while collection is pending.
+- Modify: `packages/cli/__tests__/commands/delegate.test.ts`
+  - Add CLI coverage for bare delegate while collection is pending.
+- Modify: `packages/cli/__tests__/commands/collect.test.ts`
+  - Add CLI coverage that `collect --claim-id` is accepted and gated by the orchestrator check, and that a non-orchestrator collection is refused with `COLLECT_REQUIRES_ORCHESTRATOR`.
+- Create: `packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts`
+  - End-to-end coverage of the full lifecycle: delegate → claim → child completes → outcome reported → bare `pass` refused with `DELEGATION_COLLECTION_PENDING` → `collect` → bare `pass` now advances. Pins the *release* of the guard, not just its onset.
+
+## Tasks
+
+### Task 1: Broaden the Collection-Pending Read Model for Policy
+
+**Files:**
+- Modify: `packages/core/src/runbook/delegation-lifecycle-read-model.ts`
+- Modify: `packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts`
+
+- [ ] **Step 1: Add failing tests for policy-wide collection-pending derivation**
+
+Append these tests to the existing `describe('readDelegationCollectionPending', () => { ... })` block in `packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts`:
+
+```typescript
+  it('marks a reported outcome in a non-active still-open FOR frame as policy pending', () => {
+    const targetFrameKey = buildFrameKey('1', 2);
+    const key = buildCompletionKey(exactFrame(targetFrameKey, 2), '1');
+    const parent = state({
+      step: '2',
+      substep: undefined,
+      activeFrameKey: buildFrameKey('2'),
+      activeEntry: 1,
+      frameEntries: {
+        [buildFrameKey('2')]: 1,
+        [targetFrameKey]: 2,
+      },
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(targetFrameKey, 2),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationCollectionPending(parent).pending).toBe(false);
+    expect(readDelegationCollectionPendingForPolicy(parent)).toEqual({
+      kind: 'delegation-collection-pending-policy',
+      pending: true,
+      parentRunId: runbookId,
+      outcomes: [
+        expect.objectContaining({
+          completionKey: key,
+          targetFrameKey,
+          targetEntry: 2,
+          outcome: 'pass',
+        }),
+      ],
+      message:
+        'A delegated claim has reported an outcome that must be collected by the orchestrator.',
+    });
+  });
+
+  it('does not mark policy pending for a stale frame that is no longer open', () => {
+    const staleFrameKey = buildFrameKey('1', 3);
+    const key = buildCompletionKey(exactFrame(staleFrameKey, 3), '1');
+    const parent = state({
+      step: '2',
+      substep: undefined,
+      activeFrameKey: buildFrameKey('2'),
+      activeEntry: 1,
+      frameEntries: {
+        [buildFrameKey('2')]: 1,
+      },
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'fail',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(staleFrameKey, 3),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationCollectionPendingForPolicy(parent)).toEqual({
+      kind: 'delegation-collection-pending-policy',
+      pending: false,
+      parentRunId: runbookId,
+      outcomes: [],
+    });
+  });
+
+  it('marks an unscoped outcome as policy pending until it is collected, regardless of cursor', () => {
+    const targetFrameKey = buildFrameKey('1');
+    const key = buildCompletionKey(activeFrame(targetFrameKey, 1), '1');
+    const parent = state({
+      // The cursor has moved on to step 2, but the unscoped step-1 outcome has
+      // not been collected. An uncollected unscoped outcome stays pending — it
+      // is never silently dropped by cursor movement.
+      step: '2',
+      substep: undefined,
+      activeFrameKey: buildFrameKey('2'),
+      activeEntry: 1,
+      frameEntries: {
+        [buildFrameKey('2')]: 1,
+        [targetFrameKey]: 1,
+      },
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(targetFrameKey, 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationCollectionPendingForPolicy(parent)).toEqual({
+      kind: 'delegation-collection-pending-policy',
+      pending: true,
+      parentRunId: runbookId,
+      outcomes: [
+        expect.objectContaining({
+          completionKey: key,
+          targetFrameKey,
+          targetEntry: 1,
+          outcome: 'pass',
+        }),
+      ],
+      message:
+        'A delegated claim has reported an outcome that must be collected by the orchestrator.',
+    });
+  });
+
+  it('marks an unscoped outcome at the current cursor step as policy pending', () => {
+    const targetFrameKey = buildFrameKey('1');
+    const key = buildCompletionKey(activeFrame(targetFrameKey, 1), '1');
+    const parent = state({
+      step: '1',
+      substep: '1',
+      activeFrameKey: targetFrameKey,
+      activeEntry: 1,
+      frameEntries: { [targetFrameKey]: 1 },
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(targetFrameKey, 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationCollectionPendingForPolicy(parent).pending).toBe(true);
+  });
+```
+
+> These tests do not depend on `state.steps` (an empty-at-runtime field). The
+> still-open decision is collection-relative: an uncollected outcome is pending
+> until `collect` removes its `resolvedCompletions` row. Use
+> `activeFrame`/`buildCompletionKey` from the existing targeting import in this
+> file.
+
+Extend the read-model import from `../../src/runbook/index.js` in that same test file:
+
+```typescript
+import {
+  readDelegationCollectionPending,
+  readDelegationCollectionPendingForPolicy,
+  readDelegationOutcomeReportedFacts,
+  type RunbookState,
+} from '../../src/runbook/index.js';
+```
+
+- [ ] **Step 2: Run the focused read-model test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/delegation-lifecycle-read-model.test.ts --runInBand
+```
+
+Expected: FAIL with an import error or type error for `readDelegationCollectionPendingForPolicy`.
+
+- [ ] **Step 3: Add the policy read model implementation**
+
+In `packages/core/src/runbook/delegation-lifecycle-read-model.ts`, extend the targeting import:
+
+```typescript
+import {
+  buildFrameKey,
+  deriveActiveFrame,
+  SENTINEL_ENTRY,
+  type FrameKey,
+} from './targeting.js';
+```
+
+Add this type and helper code after `DelegationCollectionPendingReadModel`:
+
+```typescript
+/** Pure read model for collection-pending state used by command policy guards. */
+export type DelegationCollectionPendingPolicyReadModel =
+  | {
+      /** Read-model discriminant. */
+      readonly kind: 'delegation-collection-pending-policy';
+      /** At least one unconsumed reported outcome exists in a still-open scope. */
+      readonly pending: true;
+      /** Delegating run that may need collection. */
+      readonly parentRunId: RunId;
+      /** Reported outcomes blocking bare mutation. */
+      readonly outcomes: readonly DelegationOutcomeReportedFact[];
+      /** Operator-facing guidance for frontend error rendering. */
+      readonly message: typeof DELEGATION_COLLECTION_PENDING_MESSAGE;
+    }
+  | {
+      /** Read-model discriminant. */
+      readonly kind: 'delegation-collection-pending-policy';
+      /** No unconsumed reported outcomes exist in still-open scopes. */
+      readonly pending: false;
+      /** Delegating run that was inspected. */
+      readonly parentRunId: RunId;
+      /** Empty when no collection is pending. */
+      readonly outcomes: readonly [];
+    };
+
+function belongsToStillOpenCollectionScope(
+  state: RunbookState,
+  fact: DelegationOutcomeReportedFact,
+): boolean {
+  const unscopedFrameKey = buildFrameKey(fact.targetStep);
+  if (fact.targetFrameKey === unscopedFrameKey) {
+    // An unscoped (non-FOR) outcome has no iteration frame to leave, so it stays
+    // pending until the orchestrator collects it. Collection removes the
+    // `resolvedCompletions` row this fact is derived from, which is what clears
+    // the pending state — a reported outcome is never dropped by cursor movement.
+    return true;
+  }
+  // A FOR-scoped outcome is open while its iteration frame is still tracked in
+  // `frameEntries`. `Object.hasOwn` matches the membership idiom used elsewhere
+  // in core (e.g. `actor-service.ts`).
+  return Object.hasOwn(state.frameEntries ?? {}, fact.targetFrameKey);
+}
+```
+
+Add this exported function after `readDelegationCollectionPending()`:
+
+```typescript
+/**
+ * Derive policy-level collection-pending state for bare mutation guards.
+ *
+ * This intentionally uses a broader scope than {@link readDelegationCollectionPending}:
+ * any unconsumed delegation outcome in any still-open frame/scope blocks a bare
+ * parent mutation, even when the current cursor has moved away from that frame.
+ *
+ * @param state - Delegating run state to inspect
+ * @returns Policy read model covering all still-open delegating scopes
+ */
+export function readDelegationCollectionPendingForPolicy(
+  state: RunbookState,
+): DelegationCollectionPendingPolicyReadModel {
+  const outcomes = readDelegationOutcomeReportedFacts(state).filter((fact) =>
+    belongsToStillOpenCollectionScope(state, fact),
+  );
+
+  if (outcomes.length === 0) {
+    return {
+      kind: 'delegation-collection-pending-policy',
+      pending: false,
+      parentRunId: state.id,
+      outcomes: [],
+    };
+  }
+
+  return {
+    kind: 'delegation-collection-pending-policy',
+    pending: true,
+    parentRunId: state.id,
+    outcomes,
+    message: DELEGATION_COLLECTION_PENDING_MESSAGE,
+  };
+}
+```
+
+- [ ] **Step 4: Export the policy read model**
+
+In `packages/core/src/runbook/index.ts`, extend the read-model export block:
+
+```typescript
+export {
+  DELEGATION_COLLECTION_PENDING_MESSAGE,
+  readDelegationCollectionPending,
+  readDelegationCollectionPendingForPolicy,
+  readDelegationOutcomeReportedFacts,
+  type DelegationCollectionPendingPolicyReadModel,
+  type DelegationCollectionPendingReadModel,
+  type DelegationOutcomeReportedFact,
+} from './delegation-lifecycle-read-model.js';
+```
+
+- [ ] **Step 5: Run the focused read-model test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/delegation-lifecycle-read-model.test.ts --runInBand
+```
+
+Expected: PASS. The active-scope read model remains active-cursor-only, and the new policy read model blocks any uncollected outcome — a FOR-scoped outcome whose iteration frame is still tracked, and any unscoped outcome until it is collected.
+
+- [ ] **Step 6: (optional) Commit the policy read model**
+
+> Committing here is an optional per-task checkpoint for the
+> executing-plans / subagent-driven-development workflow. Skip it if the
+> maintainer prefers to commit once at the end.
+
+```bash
+git add packages/core/src/runbook/delegation-lifecycle-read-model.ts packages/core/src/runbook/index.ts packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts
+git commit -m "feat(core): add policy collection pending read model"
+```
+
+### Task 2: Add Actor Context and Command Policy Core APIs
+
+**Files:**
+- Create: `packages/core/src/runbook/actor-context.ts`
+- Create: `packages/core/src/runbook/command-policy.ts`
+- Create: `packages/core/__tests__/runbook/command-policy.test.ts`
+- Modify: `packages/core/src/runbook/index.ts`
+
+- [ ] **Step 1: Write failing command-policy tests**
+
+Create `packages/core/__tests__/runbook/command-policy.test.ts` with this content:
+
+```typescript
+import { describe, expect, it } from '@jest/globals';
+import {
+  activeFrame,
+  assertClaimId,
+  assertDelegationTokenHash,
+  assertRunId,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+  claimControllerContext,
+  resolveCommandIntent,
+  trustedRunControllerContext,
+  UNKNOWN_ACTOR_CONTEXT,
+  type ClaimRecord,
+  type RunbookState,
+} from '../../src/runbook/index.js';
+import { brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
+
+const parentRunId = assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+const childRunId = assertRunId('rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+const claimId = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
+const tokenHash = assertDelegationTokenHash(`sha256:${'a'.repeat(64)}`);
+
+function state(overrides: Partial<RunbookState> = {}): RunbookState {
+  return {
+    id: parentRunId,
+    runbook: { source: 'project', path: 'parent.md' },
+    runbookPath: 'parent.md',
+    step: '1',
+    stepName: 'Parent',
+    substep: '1',
+    retryCount: 0,
+    variables: brandStoredOutputsForTest({}),
+    steps: [],
+    resolvedCompletions: {},
+    frameEntries: { [buildFrameKey('1')]: 1 },
+    activeFrameKey: buildFrameKey('1'),
+    activeEntry: 1,
+    startedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    lifecycle: 'running',
+    schemaVersion: 1,
+    frontmatterOutputs: [],
+    ...overrides,
+  };
+}
+
+function claimRecord(): ClaimRecord {
+  return {
+    kind: 'claim-record',
+    claimId,
+    childRunId,
+    tokenHash,
+    parentRunId,
+    parentStepId: '1.1',
+    parentStep: '1',
+    parentFrameKey: buildFrameKey('1'),
+    parentEntry: 1,
+    claimedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function stateWithReportedOutcome(): RunbookState {
+  const completionKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+  return state({
+    resolvedCompletions: {
+      [completionKey]: buildResolvedCompletion({
+        agentId: 'delegation',
+        result: 'pass',
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
+        completedAt: '2026-01-01T00:00:00.000Z',
+      }),
+    },
+  });
+}
+
+describe('resolveCommandIntent', () => {
+  it('rejects unknown collection in the strict core policy model', () => {
+    const targetState = state();
+
+    expect(
+      resolveCommandIntent({
+        actorContext: UNKNOWN_ACTOR_CONTEXT,
+        intent: { kind: 'delegation-collection' },
+        targetSelector: { kind: 'default' },
+        targetState,
+      }),
+    ).toEqual({
+      kind: 'actor_context_required',
+      intent: 'delegation-collection',
+    });
+  });
+
+  it('rejects unknown bare transition in the strict core policy model', () => {
+    const targetState = state();
+
+    expect(
+      resolveCommandIntent({
+        actorContext: UNKNOWN_ACTOR_CONTEXT,
+        intent: { kind: 'delegating-run-advance', command: 'pass', targeted: false },
+        targetSelector: { kind: 'default' },
+        targetState,
+      }),
+    ).toEqual({
+      kind: 'actor_context_required',
+      intent: 'delegating-run-advance',
+    });
+  });
+
+  it('allows direct CLI compatibility context to collect on the controlled target run', () => {
+    const targetState = state();
+
+    expect(
+      resolveCommandIntent({
+        actorContext: trustedRunControllerContext(targetState.id, 'direct-cli'),
+        intent: { kind: 'delegation-collection' },
+        targetSelector: { kind: 'default' },
+        targetState,
+      }),
+    ).toEqual({
+      kind: 'allowed',
+      role: 'orchestrator_for_target',
+      targetRunId: targetState.id,
+    });
+  });
+
+  it('allows collect --claim-id when the actor is orchestrator for the resolved claimed run', () => {
+    // The frontend resolves the claim to its claimed run and passes that run as
+    // `targetState`; the claim selector itself is not a rejection trigger.
+    const claimedRun = state({ id: childRunId });
+
+    expect(
+      resolveCommandIntent({
+        actorContext: trustedRunControllerContext(claimedRun.id, 'direct-cli'),
+        intent: { kind: 'delegation-collection' },
+        targetSelector: { kind: 'claim', claimId },
+        targetState: claimedRun,
+      }),
+    ).toEqual({
+      kind: 'allowed',
+      role: 'orchestrator_for_target',
+      targetRunId: childRunId,
+    });
+  });
+
+  it('allows an orchestrator to collect a run they control even when it has upward delegation linkage', () => {
+    // A run delegating upward is still a valid collection target for the actor
+    // that controls it (spec lines 357-359). Linkage alone is not a rejection.
+    const delegated = state({
+      id: childRunId,
+      parentLinkage: {
+        kind: 'delegation',
+        parentRunId,
+        parentStepId: '1.1',
+        tokenHash,
+        parentStep: '1',
+        parentFrameKey: buildFrameKey('1'),
+        parentEntry: 1,
+      },
+    });
+
+    expect(
+      resolveCommandIntent({
+        actorContext: trustedRunControllerContext(delegated.id, 'direct-cli'),
+        intent: { kind: 'delegation-collection' },
+        targetSelector: { kind: 'default' },
+        targetState: delegated,
+      }),
+    ).toEqual({
+      kind: 'allowed',
+      role: 'orchestrator_for_target',
+      targetRunId: childRunId,
+    });
+  });
+
+  it.each([
+    { command: 'pass' as const, intent: { kind: 'delegating-run-advance' as const, command: 'pass' as const, targeted: false } },
+    { command: 'fail' as const, intent: { kind: 'delegating-run-advance' as const, command: 'fail' as const, targeted: false } },
+    { command: 'delegate' as const, intent: { kind: 'delegation-issuance' as const, command: 'delegate' as const, targeted: false } },
+  ])('rejects bare $command while delegation collection is pending', (caseDef) => {
+    const targetState = stateWithReportedOutcome();
+
+    expect(
+      resolveCommandIntent({
+        actorContext: trustedRunControllerContext(targetState.id, 'direct-cli'),
+        intent: caseDef.intent,
+        targetSelector: { kind: 'default' },
+        targetState,
+      }),
+    ).toEqual({
+      kind: 'delegation_collection_pending',
+      parentRunId: parentRunId,
+      outcomeCompletionKeys: [buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1')],
+      message:
+        'A delegated claim has reported an outcome that must be collected by the orchestrator.',
+    });
+  });
+
+  it('allows targeted pass while collection is pending because it is not a bare parent advance', () => {
+    const targetState = stateWithReportedOutcome();
+
+    expect(
+      resolveCommandIntent({
+        actorContext: trustedRunControllerContext(targetState.id, 'direct-cli'),
+        intent: { kind: 'delegating-run-advance', command: 'pass', targeted: true },
+        targetSelector: { kind: 'explicit-step', step: '1.1' },
+        targetState,
+      }),
+    ).toEqual({
+      kind: 'allowed',
+      role: 'orchestrator_for_target',
+      targetRunId: targetState.id,
+    });
+  });
+
+  it('maps open claims through the policy when no reported outcome is pending', () => {
+    const targetState = state();
+    const claim = claimRecord();
+
+    expect(
+      resolveCommandIntent({
+        actorContext: trustedRunControllerContext(targetState.id, 'direct-cli'),
+        intent: { kind: 'delegating-run-advance', command: 'pass', targeted: false },
+        targetSelector: { kind: 'default' },
+        targetState,
+        openClaims: [claim],
+      }),
+    ).toEqual({
+      kind: 'open_claims',
+      parentRunId,
+      claims: [claim],
+    });
+  });
+
+  it('rejects a claim controller collecting into its delegating ancestor', () => {
+    const targetState = state();
+
+    expect(
+      resolveCommandIntent({
+        actorContext: claimControllerContext({
+          claimId,
+          tokenHash,
+          controlledRunId: childRunId,
+        }),
+        intent: { kind: 'delegation-collection' },
+        targetSelector: { kind: 'default' },
+        targetState,
+      }),
+    ).toEqual({
+      kind: 'collect_requires_orchestrator',
+      targetRunId: parentRunId,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused command-policy test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/command-policy.test.ts --runInBand
+```
+
+Expected: FAIL because `actor-context.ts`, `command-policy.ts`, and their exports do not exist.
+
+- [ ] **Step 3: Add the actor-context module**
+
+Create `packages/core/src/runbook/actor-context.ts`:
+
+```typescript
+import type { ClaimId } from './claim-id.js';
+import type { DelegationTokenHash } from './delegation-token.js';
+import type { RunId } from './run-id.js';
+
+/** Frontend or integration source that supplied trusted run-controller evidence. */
+export type ActorContextSource = 'direct-cli' | 'plugin' | 'mcp';
+
+/** Caller evidence supplied to core before evaluating target-relative command policy. */
+export type ActorContext =
+  | {
+      /** Trusted controller of one concrete run. */
+      readonly kind: 'trusted_run_controller';
+      /** Run controlled by this caller. */
+      readonly runId: RunId;
+      /** Frontend or integration source that supplied the controller evidence. */
+      readonly source: ActorContextSource;
+    }
+  | {
+      /** Controller of a claimed delegated run. */
+      readonly kind: 'claim_controller';
+      /** Claim id that binds the caller to the controlled run. */
+      readonly claimId: ClaimId;
+      /** Token hash that identifies the claimed delegation attempt. */
+      readonly tokenHash: DelegationTokenHash;
+      /** Delegated run controlled by this caller. */
+      readonly controlledRunId: RunId;
+    }
+  | {
+      /** No trusted actor evidence was supplied. */
+      readonly kind: 'unknown';
+    };
+
+/**
+ * Effective role after resolving actor evidence against one target run.
+ *
+ * - `orchestrator_for_target`: the caller controls the target run itself and may
+ *   orchestrate it (collect, advance).
+ * - `delegated_relative_to_target`: the caller controls a different run that is
+ *   delegated relative to the target, not the target itself.
+ * - `unknown_for_target`: no trusted evidence ties the caller to the target.
+ */
+export type EffectiveRole =
+  | 'orchestrator_for_target'
+  | 'delegated_relative_to_target'
+  | 'unknown_for_target';
+
+/** Shared singleton for strict inspect-only callers with no trusted evidence. */
+export const UNKNOWN_ACTOR_CONTEXT: ActorContext = { kind: 'unknown' };
+
+/**
+ * Build trusted run-controller actor context.
+ *
+ * @param runId - Run controlled by the caller
+ * @param source - Frontend or integration source that supplied this evidence
+ * @returns Actor context for a target-relative trusted run controller
+ */
+export function trustedRunControllerContext(
+  runId: RunId,
+  source: ActorContextSource,
+): ActorContext {
+  return { kind: 'trusted_run_controller', runId, source };
+}
+
+/**
+ * Build claim-controller actor context.
+ *
+ * @param input - Claim-controller evidence
+ * @param input.claimId - Claim id controlled by the caller
+ * @param input.tokenHash - Token hash for the claim
+ * @param input.controlledRunId - Delegated run controlled by the caller
+ * @returns Actor context for a claim controller
+ */
+export function claimControllerContext(input: {
+  readonly claimId: ClaimId;
+  readonly tokenHash: DelegationTokenHash;
+  readonly controlledRunId: RunId;
+}): ActorContext {
+  return {
+    kind: 'claim_controller',
+    claimId: input.claimId,
+    tokenHash: input.tokenHash,
+    controlledRunId: input.controlledRunId,
+  };
+}
+```
+
+- [ ] **Step 4: Add the command-policy module**
+
+Create `packages/core/src/runbook/command-policy.ts`:
+
+```typescript
+import type { ClaimId, ClaimRecord } from './claim-id.js';
+import {
+  DELEGATION_COLLECTION_PENDING_MESSAGE,
+  readDelegationCollectionPendingForPolicy,
+} from './delegation-lifecycle-read-model.js';
+import type { ActorContext, EffectiveRole } from './actor-context.js';
+import type { RunId } from './run-id.js';
+import type { RunbookState } from './types.js';
+
+/** Command intent categories owned by core command policy. */
+export type CommandIntent =
+  | {
+      /** Inspect-only command intent. */
+      readonly kind: 'inspect';
+    }
+  | {
+      /** Bare or targeted pass/fail that may advance a delegating run. */
+      readonly kind: 'delegating-run-advance';
+      /** Transition command being evaluated. */
+      readonly command: 'pass' | 'fail';
+      /** True when the caller supplied an explicit target such as `--step` or `--claim-id`. */
+      readonly targeted: boolean;
+    }
+  | {
+      /** Delegate command issuing or reissuing delegation from a run. */
+      readonly kind: 'delegation-issuance';
+      /** Command name retained for frontend details. */
+      readonly command: 'delegate';
+      /** True when the caller supplied an explicit step or retry target. */
+      readonly targeted: boolean;
+    }
+  | {
+      /** Collect command applying reported delegation outcomes. */
+      readonly kind: 'delegation-collection';
+    };
+
+/** Target selector shape parsed by a frontend before core policy evaluation. */
+export type CommandTargetSelector =
+  | {
+      /** Default active run target. */
+      readonly kind: 'default';
+    }
+  | {
+      /** Explicit claim-id target selector. */
+      readonly kind: 'claim';
+      /** Claim id supplied by the caller. */
+      readonly claimId: ClaimId;
+    }
+  | {
+      /** Explicit step/scope target selector. */
+      readonly kind: 'explicit-step';
+      /** Step id supplied by the caller. */
+      readonly step: string;
+    };
+
+/** Input to the core command-policy decision point. */
+export interface ResolveCommandIntentInput {
+  /** Caller evidence supplied by the frontend or integration boundary. */
+  readonly actorContext: ActorContext;
+  /** Domain command intent. */
+  readonly intent: CommandIntent;
+  /** Parsed target selector. */
+  readonly targetSelector: CommandTargetSelector;
+  /** Resolved target run, when the selector resolves to one. */
+  readonly targetState?: RunbookState;
+  /** Open claimed children for the target run, when already known. */
+  readonly openClaims?: readonly ClaimRecord[];
+}
+
+/**
+ * Core-owned policy decision consumed by CLI, MCP, and plugin adapters.
+ *
+ * This is a deliberate SUBSET of the spec's 12-member `DelegationPolicyOutcome`
+ * union (spec lines 366-380). This slice implements only the members reachable
+ * from the policy decisions it gates: `allowed`, `actor_context_required`,
+ * `collect_requires_orchestrator`, `delegation_collection_pending`, and
+ * `open_claims`. The collection-operation members (`missing_outcomes`,
+ * `already_collected`) are deferred to Plan 4 (Core Collection Operation); the
+ * claim/terminal members (`stale_claim`, `terminal_claim_confirmed`,
+ * `terminal_claim_conflict`) and `not_delegatable` are deferred to the
+ * collection/claim plans (Plan 4 / Plan 5). `target_not_delegating_scope` from
+ * the spec is intentionally NOT implemented here: under the target-relative
+ * model a run delegating upward is still a valid collection target, so the
+ * orchestrator check is the only gate this slice needs. See the Self-Review
+ * Notes for the full deferral list.
+ */
+export type DelegationPolicyOutcome =
+  | {
+      /** Policy allowed the command. */
+      readonly kind: 'allowed';
+      /** Effective role used for the allow decision. */
+      readonly role: EffectiveRole;
+      /** Target run id, when the command targets a run. */
+      readonly targetRunId?: RunId;
+    }
+  | {
+      /** Caller evidence is required for this role-specific mutation. */
+      readonly kind: 'actor_context_required';
+      /** Intent that was refused. */
+      readonly intent: CommandIntent['kind'];
+    }
+  | {
+      /** Caller is not the effective orchestrator for the collection target. */
+      readonly kind: 'collect_requires_orchestrator';
+      /** Target run the caller attempted to collect into. */
+      readonly targetRunId: RunId;
+    }
+  | {
+      /** Bare mutation is blocked by unconsumed reported delegation outcomes. */
+      readonly kind: 'delegation_collection_pending';
+      /** Delegating run that must be collected. */
+      readonly parentRunId: RunId;
+      /** Completion keys for reported outcomes blocking the command. */
+      readonly outcomeCompletionKeys: readonly string[];
+      /** Operator-facing guidance for frontend error rendering. */
+      readonly message: typeof DELEGATION_COLLECTION_PENDING_MESSAGE;
+    }
+  | {
+      /** Bare mutation is blocked by active claimed children. */
+      readonly kind: 'open_claims';
+      /** Delegating run with open claims. */
+      readonly parentRunId: RunId;
+      /** Open claim records blocking the command. */
+      readonly claims: readonly ClaimRecord[];
+    };
+
+/**
+ * Derive effective role from actor evidence and a resolved target run.
+ *
+ * @param actorContext - Caller evidence
+ * @param targetState - Resolved target run state
+ * @returns Target-relative effective role
+ */
+export function deriveEffectiveRole(
+  actorContext: ActorContext,
+  targetState: RunbookState | undefined,
+): EffectiveRole {
+  if (!targetState || actorContext.kind === 'unknown') {
+    return 'unknown_for_target';
+  }
+  if (actorContext.kind === 'trusted_run_controller') {
+    return actorContext.runId === targetState.id
+      ? 'orchestrator_for_target'
+      : 'unknown_for_target';
+  }
+  return actorContext.controlledRunId === targetState.id
+    ? 'orchestrator_for_target'
+    : 'delegated_relative_to_target';
+}
+
+function allowed(role: EffectiveRole, targetState: RunbookState | undefined): DelegationPolicyOutcome {
+  return {
+    kind: 'allowed',
+    role,
+    ...(targetState ? { targetRunId: targetState.id } : {}),
+  };
+}
+
+function requireOrchestratorForCollection(
+  role: EffectiveRole,
+  intent: CommandIntent,
+  targetState: RunbookState | undefined,
+): DelegationPolicyOutcome | undefined {
+  if (role === 'orchestrator_for_target') return undefined;
+  if (role === 'unknown_for_target' || !targetState) {
+    return { kind: 'actor_context_required', intent: intent.kind };
+  }
+  return {
+    kind: 'collect_requires_orchestrator',
+    targetRunId: targetState.id,
+  };
+}
+
+function rejectBareMutationIfCollectionPending(
+  input: ResolveCommandIntentInput,
+): DelegationPolicyOutcome | undefined {
+  if (!input.targetState) return undefined;
+  if (
+    input.intent.kind !== 'delegating-run-advance' &&
+    input.intent.kind !== 'delegation-issuance'
+  ) {
+    return undefined;
+  }
+  if (input.intent.targeted) return undefined;
+
+  const pending = readDelegationCollectionPendingForPolicy(input.targetState);
+  if (!pending.pending) return undefined;
+
+  return {
+    kind: 'delegation_collection_pending',
+    parentRunId: pending.parentRunId,
+    outcomeCompletionKeys: pending.outcomes.map((outcome) => outcome.completionKey),
+    message: pending.message,
+  };
+}
+
+/**
+ * Resolve a command intent into a core-owned delegation policy outcome.
+ *
+ * @param input - Actor context, command intent, target selector, target state,
+ *   and optional open-claim state
+ * @returns Typed policy outcome for frontend adapters to render
+ */
+export function resolveCommandIntent(input: ResolveCommandIntentInput): DelegationPolicyOutcome {
+  const role = deriveEffectiveRole(input.actorContext, input.targetState);
+
+  if (input.intent.kind === 'inspect') {
+    return allowed(role, input.targetState);
+  }
+
+  if (input.intent.kind === 'delegation-collection') {
+    // The claim selector itself is NOT a rejection trigger (spec lines 345-348,
+    // 674-676): the frontend resolves `--claim-id` to its claimed/controlled run
+    // and passes that as `targetState`, so role derivation above already treats
+    // the resolved claimed run as the target. The only gate here is the
+    // orchestrator-for-target check.
+    //
+    // A target run delegating UPWARD (`parentLinkage.kind === 'delegation'`)
+    // does NOT by itself disqualify it as a collection target: a middle
+    // claim-controller may collect delegations issued by the run it controls
+    // (spec lines 357-359). Whether outcomes actually exist to collect is the
+    // collection operation's concern (Plan 4), not this policy slice. So there
+    // is no `target_not_delegating_scope` rejection here.
+    const orchestratorFailure = requireOrchestratorForCollection(
+      role,
+      input.intent,
+      input.targetState,
+    );
+    if (orchestratorFailure) return orchestratorFailure;
+    return allowed(role, input.targetState);
+  }
+
+  if (role === 'unknown_for_target') {
+    return { kind: 'actor_context_required', intent: input.intent.kind };
+  }
+
+  const pendingFailure = rejectBareMutationIfCollectionPending(input);
+  if (pendingFailure) return pendingFailure;
+
+  if (
+    input.intent.kind === 'delegating-run-advance' &&
+    !input.intent.targeted &&
+    input.openClaims &&
+    input.openClaims.length > 0 &&
+    input.targetState
+  ) {
+    return {
+      kind: 'open_claims',
+      parentRunId: input.targetState.id,
+      claims: input.openClaims,
+    };
+  }
+
+  return allowed(role, input.targetState);
+}
+```
+
+- [ ] **Step 5: Export actor-context and command-policy APIs**
+
+In `packages/core/src/runbook/index.ts`, add these export blocks after the `command-target-resolver.js` block:
+
+```typescript
+export {
+  UNKNOWN_ACTOR_CONTEXT,
+  claimControllerContext,
+  trustedRunControllerContext,
+  type ActorContext,
+  type ActorContextSource,
+  type EffectiveRole,
+} from './actor-context.js';
+export {
+  deriveEffectiveRole,
+  resolveCommandIntent,
+  type CommandIntent,
+  type CommandTargetSelector,
+  type DelegationPolicyOutcome,
+  type ResolveCommandIntentInput,
+} from './command-policy.js';
+```
+
+- [ ] **Step 6: Run the focused command-policy test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/command-policy.test.ts --runInBand
+```
+
+Expected: PASS. Policy decisions compile and match the new target-relative behavior.
+
+- [ ] **Step 7: Add property tests for the policy decision function**
+
+`resolveCommandIntent` and `deriveEffectiveRole` are pure, total functions — exactly the shape the repo property-tests elsewhere (`*.properties.test.ts`, `pnpm --filter @rundown-org/core test:property`). Create `packages/core/__tests__/runbook/command-policy.properties.test.ts`:
+
+```typescript
+import { describe, expect, it } from '@jest/globals';
+import fc from 'fast-check';
+import {
+  assertRunId,
+  buildFrameKey,
+  claimControllerContext,
+  deriveEffectiveRole,
+  resolveCommandIntent,
+  trustedRunControllerContext,
+  UNKNOWN_ACTOR_CONTEXT,
+  type ActorContext,
+  type CommandIntent,
+  type RunbookState,
+} from '../../src/runbook/index.js';
+import { assertClaimId } from '../../src/runbook/claim-id.js';
+import { assertDelegationTokenHash } from '../../src/runbook/delegation-token.js';
+import { brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
+
+// RunId fixtures must be 32 lowercase hex chars (`/^rd_[a-f0-9]{32}$/`);
+// `assertRunId` rejects any char outside a-f0-9, so do not use g-z here.
+const runIdA = assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+const runIdB = assertRunId('rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+const claimId = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
+const tokenHash = assertDelegationTokenHash(`sha256:${'a'.repeat(64)}`);
+
+function baseState(id = runIdA): RunbookState {
+  return {
+    id,
+    runbook: { source: 'project', path: 'p.md' },
+    runbookPath: 'p.md',
+    step: '1',
+    stepName: 'S',
+    substep: '1',
+    retryCount: 0,
+    variables: brandStoredOutputsForTest({}),
+    steps: [],
+    resolvedCompletions: {},
+    frameEntries: { [buildFrameKey('1')]: 1 },
+    activeFrameKey: buildFrameKey('1'),
+    activeEntry: 1,
+    startedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    lifecycle: 'running',
+    schemaVersion: 1,
+    frontmatterOutputs: [],
+  };
+}
+
+const actorContextArb: fc.Arbitrary<ActorContext> = fc.oneof(
+  fc.constant(UNKNOWN_ACTOR_CONTEXT),
+  fc.constantFrom(runIdA, runIdB).map((id) => trustedRunControllerContext(id, 'direct-cli')),
+  fc.constantFrom(runIdA, runIdB).map((controlledRunId) =>
+    claimControllerContext({ claimId, tokenHash, controlledRunId }),
+  ),
+);
+
+const intentArb: fc.Arbitrary<CommandIntent> = fc.oneof(
+  fc.constant({ kind: 'inspect' } as const),
+  fc.record({
+    kind: fc.constant('delegating-run-advance' as const),
+    command: fc.constantFrom('pass' as const, 'fail' as const),
+    targeted: fc.boolean(),
+  }),
+  fc.record({
+    kind: fc.constant('delegation-issuance' as const),
+    command: fc.constant('delegate' as const),
+    targeted: fc.boolean(),
+  }),
+  fc.constant({ kind: 'delegation-collection' } as const),
+);
+
+const KNOWN_KINDS = new Set([
+  'allowed',
+  'actor_context_required',
+  'collect_requires_orchestrator',
+  'delegation_collection_pending',
+  'open_claims',
+]);
+
+describe('resolveCommandIntent properties', () => {
+  it('is total: always returns a known outcome kind and never throws', () => {
+    fc.assert(
+      fc.property(actorContextArb, intentArb, (actorContext, intent) => {
+        const outcome = resolveCommandIntent({
+          actorContext,
+          intent,
+          targetSelector: { kind: 'default' },
+          targetState: baseState(),
+        });
+        expect(KNOWN_KINDS.has(outcome.kind)).toBe(true);
+      }),
+    );
+  });
+
+  it('always allows inspect intent for any actor', () => {
+    fc.assert(
+      fc.property(actorContextArb, (actorContext) => {
+        expect(
+          resolveCommandIntent({
+            actorContext,
+            intent: { kind: 'inspect' },
+            targetSelector: { kind: 'default' },
+            targetState: baseState(),
+          }).kind,
+        ).toBe('allowed');
+      }),
+    );
+  });
+
+  it('never allows an unknown actor a non-inspect intent', () => {
+    const nonInspect = intentArb.filter((intent) => intent.kind !== 'inspect');
+    fc.assert(
+      fc.property(nonInspect, (intent) => {
+        expect(
+          resolveCommandIntent({
+            actorContext: UNKNOWN_ACTOR_CONTEXT,
+            intent,
+            targetSelector: { kind: 'default' },
+            targetState: baseState(),
+          }).kind,
+        ).not.toBe('allowed');
+      }),
+    );
+  });
+
+  it('never blocks a targeted advance/issuance with delegation_collection_pending', () => {
+    const targeted = fc.oneof(
+      fc.record({
+        kind: fc.constant('delegating-run-advance' as const),
+        command: fc.constantFrom('pass' as const, 'fail' as const),
+        targeted: fc.constant(true),
+      }),
+      fc.record({
+        kind: fc.constant('delegation-issuance' as const),
+        command: fc.constant('delegate' as const),
+        targeted: fc.constant(true),
+      }),
+    );
+    fc.assert(
+      fc.property(targeted, (intent) => {
+        expect(
+          resolveCommandIntent({
+            actorContext: trustedRunControllerContext(runIdA, 'direct-cli'),
+            intent,
+            targetSelector: { kind: 'explicit-step', step: '1.1' },
+            targetState: baseState(),
+          }).kind,
+        ).not.toBe('delegation_collection_pending');
+      }),
+    );
+  });
+
+  it('derives orchestrator_for_target iff the caller controls the target run', () => {
+    fc.assert(
+      fc.property(actorContextArb, fc.constantFrom(runIdA, runIdB), (actorContext, targetId) => {
+        const role = deriveEffectiveRole(actorContext, baseState(targetId));
+        const controlsTarget =
+          (actorContext.kind === 'trusted_run_controller' && actorContext.runId === targetId) ||
+          (actorContext.kind === 'claim_controller' &&
+            actorContext.controlledRunId === targetId);
+        expect(role === 'orchestrator_for_target').toBe(controlsTarget);
+      }),
+    );
+  });
+});
+```
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/command-policy.properties.test.ts --runInBand
+```
+
+Expected: PASS. The invariants hold for every generated actor context and intent.
+
+- [ ] **Step 8: Run core type checking**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core check:types
+```
+
+Expected: PASS. Exported actor-context and command-policy symbols satisfy TypeScript and TSDoc lint expectations.
+
+- [ ] **Step 9: (optional) Commit the core policy API**
+
+> Committing here is an optional per-task checkpoint for the
+> executing-plans / subagent-driven-development workflow. Skip it if the
+> maintainer prefers to commit once at the end.
+
+```bash
+git add packages/core/src/runbook/actor-context.ts packages/core/src/runbook/command-policy.ts packages/core/src/runbook/index.ts packages/core/__tests__/runbook/command-policy.test.ts packages/core/__tests__/runbook/command-policy.properties.test.ts
+git commit -m "feat(core): add delegation command policy"
+```
+
+### Task 3: Route Bare Pass and Fail Through Core Command Policy
+
+**Files:**
+- Modify: `packages/core/src/runbook/command-target-resolver.ts`
+- Modify: `packages/core/__tests__/runbook/command-target-resolver.test.ts`
+- Modify: `packages/core/src/runbook/session-service.ts`
+- Modify: `packages/core/__tests__/runbook/session-service.test.ts`
+- Modify: `packages/cli/src/helpers/transitions.ts`
+- Modify: `packages/cli/src/helpers/transition-command.ts`
+- Modify: `packages/cli/__tests__/commands/pass.test.ts`
+- Modify: `packages/cli/__tests__/commands/fail.test.ts`
+
+- [ ] **Step 1: Add failing resolver coverage for collection-pending refusal**
+
+In `packages/core/__tests__/runbook/command-target-resolver.test.ts`, extend the imports from `../../src/runbook/command-target-resolver.js`:
+
+```typescript
+import {
+  type CommandTargetReader,
+  resolveCommandTarget,
+  resolveTransitionTarget,
+} from '../../src/runbook/command-target-resolver.js';
+```
+
+Add imports from `../../src/runbook/targeting.js`:
+
+```typescript
+import {
+  activeFrame,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+} from '../../src/runbook/targeting.js';
+```
+
+Add this import from `../../src/runbook/actor-context.js`:
+
+```typescript
+import { trustedRunControllerContext } from '../../src/runbook/actor-context.js';
+```
+
+Add this test inside `describe('resolveTransitionTarget', () => { ... })`:
+
+```typescript
+  it('refuses a bare transition when a delegated outcome is waiting for collection', async () => {
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const pendingParent = {
+      ...parent,
+      step: '1',
+      substep: '1',
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      frameEntries: { [buildFrameKey('1')]: 1 },
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    } as RunbookState;
+
+    await expect(
+      resolveTransitionTarget(fakeReader({ active: pendingParent, openClaims: [] }), {
+        command: 'pass',
+        actorContext: trustedRunControllerContext(parent.id, 'direct-cli'),
+      }),
+    ).resolves.toEqual({
+      kind: 'delegation_collection_pending',
+      parentRunId: parent.id,
+      outcomeCompletionKeys: [key],
+      message:
+        'A delegated claim has reported an outcome that must be collected by the orchestrator.',
+    });
+  });
+```
+
+Update existing `resolveTransitionTarget(...)` calls in this file to include direct-CLI compatibility context. For example:
+
+```typescript
+resolveTransitionTarget(fakeReader({ active: parent, openClaims: [claim] }), {
+  command,
+  actorContext: trustedRunControllerContext(parent.id, 'direct-cli'),
+});
+```
+
+For explicit claim-id cases that target `child`, pass:
+
+```typescript
+actorContext: trustedRunControllerContext(child.id, 'direct-cli')
+```
+
+- [ ] **Step 2: Run the focused resolver test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/command-target-resolver.test.ts --runInBand
+```
+
+Expected: FAIL because `ResolveTransitionTargetOptions` does not accept `actorContext`, and `TransitionTargetResolution` does not include `delegation_collection_pending`.
+
+- [ ] **Step 3: Update transition target resolution to consume command policy**
+
+In `packages/core/src/runbook/command-target-resolver.ts`, add imports:
+
+```typescript
+import {
+  UNKNOWN_ACTOR_CONTEXT,
+  trustedRunControllerContext,
+  type ActorContext,
+} from './actor-context.js';
+import { resolveCommandIntent } from './command-policy.js';
+```
+
+Extend `TransitionTargetResolution`:
+
+```typescript
+  | {
+      readonly kind: 'delegation_collection_pending';
+      readonly parentRunId: RunId;
+      readonly outcomeCompletionKeys: readonly string[];
+      readonly message: string;
+    }
+```
+
+Extend `ResolveTransitionTargetOptions`:
+
+```typescript
+  /** Actor context supplied by the frontend adapter; strict core default is unknown. */
+  readonly actorContext?: ActorContext;
+  /**
+   * Compatibility adapter for direct local CLI calls.
+   *
+   * When true and no explicit `actorContext` was supplied, the resolver maps the
+   * resolved target run to `trusted_run_controller` with source `direct-cli`.
+   * Strict domain callers leave this false/undefined and therefore evaluate as
+   * unknown unless they pass actor context explicitly.
+   */
+  readonly directCliCompatibility?: boolean;
+```
+
+In `resolveTransitionTarget()`, replace the open-children block after `const active = await targetReader.getActive();` with:
+
+```typescript
+  if (!options.targeted) {
+    const openClaims = await targetReader.listOpenClaimsForParent(active.id);
+    const actorContext =
+      options.actorContext ??
+      (options.directCliCompatibility
+        ? trustedRunControllerContext(active.id, 'direct-cli')
+        : UNKNOWN_ACTOR_CONTEXT);
+    const policy = resolveCommandIntent({
+      actorContext,
+      intent: { kind: 'delegating-run-advance', command: options.command, targeted: false },
+      targetSelector: { kind: 'default' },
+      targetState: active,
+      openClaims,
+    });
+    switch (policy.kind) {
+      case 'allowed':
+        break;
+      case 'delegation_collection_pending':
+        return {
+          kind: 'delegation_collection_pending',
+          parentRunId: policy.parentRunId,
+          outcomeCompletionKeys: policy.outcomeCompletionKeys,
+          message: policy.message,
+        };
+      case 'open_claims':
+        return { kind: 'open_delegated_children', parentRunId: active.id, claims: policy.claims };
+      case 'actor_context_required':
+      case 'collect_requires_orchestrator':
+        throw new Error(`Unexpected transition policy outcome: ${policy.kind}`);
+      default: {
+        const _exhaustive: never = policy;
+        return _exhaustive;
+      }
+    }
+  }
+```
+
+- [ ] **Step 4: Run the focused resolver test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/command-target-resolver.test.ts --runInBand
+```
+
+Expected: PASS. Existing open-claim behavior is preserved, and collection-pending refusal is returned before a bare transition can advance.
+
+- [ ] **Step 5: Add failing atomic guard coverage**
+
+In `packages/core/__tests__/runbook/session-service.test.ts`, add imports:
+
+```typescript
+import { activeFrame, buildCompletionKey, buildFrameKey, buildResolvedCompletion } from '../../src/runbook/targeting.js';
+```
+
+Append this test inside `describe('runGuardedParentAdvance', () => { ... })`:
+
+```typescript
+    it('refuses the advance when a delegation outcome is waiting for collection', async () => {
+      const parent = await manager.create({ source: 'project', path: 'parent.md' }, mockRunbook, {
+        runbookPath: 'parent.md',
+      });
+      await sessionService.pushRunbook(parent.id);
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      await manager.update(parent.id, {
+        step: '1',
+        substep: '1',
+        activeFrameKey: buildFrameKey('1'),
+        activeEntry: 1,
+        frameEntries: { [buildFrameKey('1')]: 1 },
+        resolvedCompletions: {
+          [key]: buildResolvedCompletion({
+            agentId: 'delegation',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      });
+
+      let ran = false;
+      const result = await sessionService.runGuardedParentAdvance(parent.id, async () => {
+        ran = true;
+        return 'should-not-run';
+      });
+
+      expect(ran).toBe(false);
+      expect(result).toEqual({
+        kind: 'delegation_collection_pending',
+        parentRunId: parent.id,
+        outcomeCompletionKeys: [key],
+        message:
+          'A delegated claim has reported an outcome that must be collected by the orchestrator.',
+      });
+    });
+```
+
+- [ ] **Step 6: Run the focused session-service test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/session-service.test.ts --runInBand
+```
+
+Expected: FAIL because `runGuardedParentAdvance()` only returns `advanced` or `open_delegated_children`.
+
+- [ ] **Step 7: Extend the atomic guarded advance**
+
+In `packages/core/src/runbook/session-service.ts`, add this import:
+
+```typescript
+import {
+  DELEGATION_COLLECTION_PENDING_MESSAGE,
+  readDelegationCollectionPendingForPolicy,
+} from './delegation-lifecycle-read-model.js';
+```
+
+The current `runGuardedParentAdvance()` (around lines 442-456) does NOT load
+parent state — its `withLock` callback only calls
+`this.listOpenClaimsForParent(parentRunId)`. So the collection-pending re-check
+must load the parent state itself. `this.manager.load(parentRunId)` is the right
+primitive (used throughout this file, e.g. lines 235, 260, 343) and returns
+`Promise<RunbookState | null>` (`state.ts:380`).
+
+Extend the `runGuardedParentAdvance()` return union to add the new variant:
+
+```typescript
+    | {
+        readonly kind: 'delegation_collection_pending';
+        readonly parentRunId: RunId;
+        readonly outcomeCompletionKeys: readonly string[];
+        readonly message: string;
+      }
+```
+
+Also extend the method's TSDoc `@returns` to document the new
+`delegation_collection_pending` variant alongside `advanced` and
+`open_delegated_children`.
+
+Replace the body of the `withLock` callback so it loads parent state, guards the
+null case (must NOT throw — fall through to the existing open-claims path when
+state is absent, preserving today's behavior), runs the collection-pending
+re-check, then the existing open-claims check, in that order:
+
+```typescript
+    return this.withLock(async () => {
+      const parentState = await this.manager.load(parentRunId);
+      if (parentState) {
+        const collectionPending = readDelegationCollectionPendingForPolicy(parentState);
+        if (collectionPending.pending) {
+          return {
+            kind: 'delegation_collection_pending',
+            parentRunId,
+            outcomeCompletionKeys: collectionPending.outcomes.map(
+              (outcome) => outcome.completionKey,
+            ),
+            message: DELEGATION_COLLECTION_PENDING_MESSAGE,
+          };
+        }
+      }
+      const openClaims = await this.listOpenClaimsForParent(parentRunId);
+      if (openClaims.length > 0) {
+        return { kind: 'open_delegated_children', claims: openClaims };
+      }
+      return { kind: 'advanced', value: await advance() };
+    });
+```
+
+- [ ] **Step 8: Update transition helpers to render the new refusal**
+
+In `packages/cli/src/helpers/transitions.ts`, extend `BuildTransitionContextResult`:
+
+```typescript
+  | {
+      readonly kind: 'delegation_collection_pending';
+      readonly parentRunId: RunId;
+      readonly outcomeCompletionKeys: readonly string[];
+      readonly message: string;
+    }
+```
+
+In `buildTransitionContext()`, update the pass/fail resolver call so direct local CLI compatibility is visible and typed:
+
+```typescript
+    const active = await resolveTransitionTarget(sessionService, {
+      command: options.command,
+      claimId: options.claimId,
+      targeted: options.step !== undefined,
+      directCliCompatibility: true,
+    });
+```
+
+`resolveTransitionTarget` now returns the new `delegation_collection_pending`
+variant (Step 3 added it to `TransitionTargetResolution`). That value flows into
+the `switch (active.kind)` block in `buildTransitionContext()` — the one that
+maps each resolver result to a `BuildTransitionContextResult` and ends in
+`const _exhaustive: never = active`. Without a matching arm the `never`
+assignment fails to compile, so add a case mapping the new variant before the
+`default`:
+
+```typescript
+      case 'delegation_collection_pending':
+        return {
+          kind: 'delegation_collection_pending',
+          parentRunId: active.parentRunId,
+          outcomeCompletionKeys: active.outcomeCompletionKeys,
+          message: active.message,
+        };
+```
+
+Add a renderer helper near `emitOpenDelegatedChildrenError()`:
+
+```typescript
+/**
+ * Emit the DELEGATION_COLLECTION_PENDING refusal for a bare pass/fail.
+ *
+ * @param output - Output emitter to write the error to
+ * @param command - Bare command that was refused
+ * @param parentRunId - Delegating run that must be collected
+ * @param outcomeCompletionKeys - Reported outcome completion keys blocking the command
+ * @param message - Core policy guidance
+ */
+export function emitDelegationCollectionPendingError(
+  output: OutputEmitter,
+  command: 'pass' | 'fail' | 'delegate',
+  parentRunId: RunId,
+  outcomeCompletionKeys: readonly string[],
+  message: string,
+): void {
+  // Include the spec's actionable ancestor-vs-controlled guidance (spec lines
+  // 584-588): the reader needs to know whether to stop or to collect.
+  output.error(
+    `Cannot run bare rd ${command}: ${message} If this is your ancestor's run, stop here. If this is a run you control, run rd collect.`,
+    'DELEGATION_COLLECTION_PENDING',
+    {
+      command,
+      parentRunId,
+      outcomeCompletionKeys,
+    },
+  );
+}
+```
+
+In both guarded write branches inside `executeTransition()`, handle the new atomic result before `open_delegated_children`:
+
+```typescript
+      if (guarded.kind === 'delegation_collection_pending') {
+        emitDelegationCollectionPendingError(
+          output,
+          config.commandName,
+          guarded.parentRunId,
+          guarded.outcomeCompletionKeys,
+          guarded.message,
+        );
+        output.flush();
+        return 'stopped';
+      }
+```
+
+- [ ] **Step 9: Update transition-command switch**
+
+In `packages/cli/src/helpers/transition-command.ts`, import `emitDelegationCollectionPendingError`:
+
+```typescript
+import {
+  buildTransitionContext,
+  emitDelegationCollectionPendingError,
+  emitOpenDelegatedChildrenError,
+  executeTransition,
+  type ExplicitTarget,
+  type TransitionConfig,
+} from './transitions.js';
+```
+
+Add a switch case before `open_delegated_children`:
+
+```typescript
+              case 'delegation_collection_pending':
+                emitDelegationCollectionPendingError(
+                  output,
+                  def.name as 'pass' | 'fail',
+                  contextResult.parentRunId,
+                  contextResult.outcomeCompletionKeys,
+                  contextResult.message,
+                );
+                output.flush();
+                process.exitCode = 1;
+                return;
+```
+
+- [ ] **Step 10: Add CLI tests for bare pass and fail while collection is pending**
+
+In `packages/cli/__tests__/commands/pass.test.ts`, add imports:
+
+```typescript
+import { activeFrame, buildCompletionKey, buildFrameKey, buildResolvedCompletion } from '@rundown-org/core';
+```
+
+Add this helper near other delegation test helpers:
+
+```typescript
+async function injectDelegationOutcomeForActiveRun(workspace: TestWorkspace): Promise<string> {
+  const state = await getActiveState(workspace);
+  if (!state) throw new Error('Expected active state');
+  const frameKey = state.activeFrameKey ?? buildFrameKey(state.step);
+  const completionKey = buildCompletionKey(activeFrame(frameKey, state.activeEntry ?? 1), '1');
+  await writeFile(
+    join(workspace.statePath(), `${state.id}.json`),
+    JSON.stringify(
+      {
+        ...state,
+        substep: state.substep ?? '1',
+        activeFrameKey: frameKey,
+        activeEntry: state.activeEntry ?? 1,
+        frameEntries: { ...(state.frameEntries ?? {}), [frameKey]: state.activeEntry ?? 1 },
+        resolvedCompletions: {
+          ...(state.resolvedCompletions ?? {}),
+          [completionKey]: buildResolvedCompletion({
+            agentId: 'delegation',
+            result: 'pass',
+            targetStep: state.step,
+            targetSubstep: '1',
+            targetFrame: activeFrame(frameKey, state.activeEntry ?? 1),
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  return completionKey;
+}
+```
+
+Add this test inside `describe('pass command', () => { ... })`:
+
+```typescript
+  describe('collection-pending guard', () => {
+    it('refuses bare pass while a delegated outcome is waiting for collection', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess('pass', workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as {
+        code?: string;
+        details?: { outcomeCompletionKeys?: string[] };
+      };
+      expect(payload.code).toBe('DELEGATION_COLLECTION_PENDING');
+      expect(payload.details?.outcomeCompletionKeys).toEqual([completionKey]);
+    });
+  });
+```
+
+In `packages/cli/__tests__/commands/fail.test.ts`, add the same imports and helper, then add:
+
+```typescript
+  describe('collection-pending guard', () => {
+    it('refuses bare fail while a delegated outcome is waiting for collection', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess('fail', workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as {
+        code?: string;
+        details?: { outcomeCompletionKeys?: string[] };
+      };
+      expect(payload.code).toBe('DELEGATION_COLLECTION_PENDING');
+      expect(payload.details?.outcomeCompletionKeys).toEqual([completionKey]);
+    });
+  });
+```
+
+- [ ] **Step 11: Run focused transition and CLI tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/command-target-resolver.test.ts __tests__/runbook/session-service.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/pass.test.ts __tests__/commands/fail.test.ts --runInBand
+```
+
+Expected: PASS. Bare pass/fail now render `DELEGATION_COLLECTION_PENDING`, and the guarded write re-check prevents races.
+
+- [ ] **Step 12: (optional) Commit the pass/fail policy integration**
+
+> Committing here is an optional per-task checkpoint for the
+> executing-plans / subagent-driven-development workflow. Skip it if the
+> maintainer prefers to commit once at the end.
+
+```bash
+git add packages/core/src/runbook/command-target-resolver.ts packages/core/src/runbook/session-service.ts packages/core/__tests__/runbook/command-target-resolver.test.ts packages/core/__tests__/runbook/session-service.test.ts packages/cli/src/helpers/transitions.ts packages/cli/src/helpers/transition-command.ts packages/cli/__tests__/commands/pass.test.ts packages/cli/__tests__/commands/fail.test.ts
+git commit -m "feat(core): guard bare transitions on collection pending"
+```
+
+### Task 4: Register and Render Collection Policy Error Codes
+
+**Files:**
+- Modify: `packages/core/src/output/zod-schemas.ts`
+- Modify: `packages/core/__tests__/output/schema.test.ts`
+
+- [ ] **Step 1: Write failing schema tests for collection policy codes**
+
+Add this test after the `DELEGATION_COLLECTION_PENDING` schema test in `packages/core/__tests__/output/schema.test.ts`:
+
+```typescript
+  it.each([
+    'ACTOR_CONTEXT_REQUIRED',
+    'COLLECT_REQUIRES_ORCHESTRATOR',
+  ] as const)('accepts %s for command policy rendering', (code) => {
+    expect(ErrorCodeSchema.safeParse(code).success).toBe(true);
+    expect(
+      ErrorResponseSchema.safeParse({
+        kind: 'error',
+        error: `command policy refused with ${code}`,
+        code,
+        details: { source: 'command-policy' },
+      }).success,
+    ).toBe(true);
+    expect(CLIErrorCodes[code]).toBe(code);
+  });
+```
+
+- [ ] **Step 2: Run the focused schema test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/output/schema.test.ts --runInBand
+```
+
+Expected: FAIL because the two new error codes are not registered.
+
+- [ ] **Step 3: Register the collection policy codes**
+
+In `packages/core/src/output/zod-schemas.ts`, add the codes after `DELEGATION_COLLECTION_PENDING` in `CLISymbolicErrorCodeValues`:
+
+```typescript
+  'DELEGATION_COLLECTION_PENDING',
+  'ACTOR_CONTEXT_REQUIRED',
+  'COLLECT_REQUIRES_ORCHESTRATOR',
+```
+
+Add entries to `CLIErrorCodes` after `DELEGATION_COLLECTION_PENDING`:
+
+```typescript
+  /** Actor context is required for the requested role-specific command */
+  ACTOR_CONTEXT_REQUIRED: 'ACTOR_CONTEXT_REQUIRED',
+  /** Collection requires an actor that controls the target delegating run */
+  COLLECT_REQUIRES_ORCHESTRATOR: 'COLLECT_REQUIRES_ORCHESTRATOR',
+```
+
+> `COLLECT_TARGET_NOT_DELEGATING_RUN` is intentionally NOT registered. After the
+> target-relative relaxation in Task 2 and Task 5, no policy branch produces
+> `target_not_delegating_scope`, so the code has no emitter. (Verified: the code
+> and union member appear nowhere in `packages/` outside this plan.) Registering
+> an unrenderable code would be dead surface.
+
+- [ ] **Step 4: Run the focused schema test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/output/schema.test.ts --runInBand
+```
+
+Expected: PASS. Output schemas accept all new command-policy codes.
+
+- [ ] **Step 5: (optional) Commit schema registration**
+
+> Committing here is an optional per-task checkpoint for the
+> executing-plans / subagent-driven-development workflow. Skip it if the
+> maintainer prefers to commit once at the end.
+
+```bash
+git add packages/core/src/output/zod-schemas.ts packages/core/__tests__/output/schema.test.ts
+git commit -m "feat(core): register command policy error codes"
+```
+
+### Task 5: Route Collect Through Core Command Policy
+
+**Files:**
+- Modify: `packages/cli/src/commands/collect.ts`
+- Modify: `packages/cli/__tests__/commands/collect.test.ts`
+
+- [ ] **Step 1: Add failing collect CLI tests**
+
+In `packages/cli/__tests__/commands/collect.test.ts`, extend the helper import from `../helpers/test-utils.js`:
+
+```typescript
+import {
+  createTestWorkspace,
+  createRunbook,
+  runCliInProcess,
+  getActiveState,
+  parseConcatenatedJson,
+  findActionOutput,
+  readSession,
+  writeSession,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
+```
+
+In `packages/cli/__tests__/commands/collect.test.ts`, add this test inside `describe('collect command', () => { ... })`:
+
+```typescript
+  describe('command policy', () => {
+    it('accepts rd collect --claim-id and routes it through the orchestrator gate', async () => {
+      const parentContent = createRunbook({
+        title: 'Parent',
+        steps: [
+          {
+            title: 'Delegate child',
+            pass: 'CONTINUE',
+            substeps: [
+              { title: 'Child work', delegate: true, runbooks: ['runbooks/child.runbook.md'] },
+            ],
+          },
+        ],
+      });
+      const childContent = createRunbook({
+        title: 'Child',
+        steps: [{ title: 'Work', pass: 'COMPLETE', command: 'rd echo --result pass' }],
+      });
+      await writeFile(join(workspace.cwd, 'runbooks', 'parent.runbook.md'), parentContent);
+      await writeFile(join(workspace.cwd, 'runbooks', 'child.runbook.md'), childContent);
+      await writeFile(join(workspace.runbooksDir(), 'child.runbook.md'), childContent);
+
+      const start = await runCliInProcess('run --prompted runbooks/parent.runbook.md', workspace);
+      expect(start.exitCode).toBe(0);
+      const frontier = parseConcatenatedJson(start.stdout).flatMap((event) => {
+        if (event && typeof event === 'object' && 'delegateFrontier' in event) {
+          return (event as { delegateFrontier?: Array<{ token?: string }> }).delegateFrontier ?? [];
+        }
+        return [];
+      });
+      const token = frontier[0]?.token;
+      expect(token).toBeDefined();
+      const claim = await runCliInProcess(['claim', token!], workspace);
+      expect(claim.exitCode).toBe(0);
+      const claimPayload = findActionOutput(claim.stdout);
+      const claimId = String(claimPayload?.claim_id);
+      expect(claimId).toMatch(/^rdclm_/);
+
+      // `rd collect --claim-id` must NOT be rejected by the orchestrator gate:
+      // the direct-CLI adapter resolves the claim to its controlled run and is
+      // the trusted controller of that run. The command therefore proceeds past
+      // the policy gate (it must not emit ACTOR_CONTEXT_REQUIRED or
+      // COLLECT_REQUIRES_ORCHESTRATOR). Whether outcomes exist to aggregate is
+      // the collection operation's concern (Plan 4), so this test asserts only
+      // that the policy gate did not refuse the command.
+      const result = await runCliInProcess(['collect', '--claim-id', claimId], workspace);
+
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).not.toBe('ACTOR_CONTEXT_REQUIRED');
+      expect(payload.code).not.toBe('COLLECT_REQUIRES_ORCHESTRATOR');
+    }, 30_000);
+
+    it('allows collection on a run that itself delegates upward', async () => {
+      const parentContent = createRunbook({
+        title: 'Parent',
+        steps: [
+          {
+            title: 'Delegate child',
+            pass: 'CONTINUE',
+            substeps: [
+              { title: 'Child work', delegate: true, runbooks: ['runbooks/child.runbook.md'] },
+            ],
+          },
+        ],
+      });
+      const childContent = createRunbook({
+        title: 'Child',
+        steps: [{ title: 'Work', pass: 'COMPLETE', command: 'rd echo --result pass' }],
+      });
+      await writeFile(join(workspace.cwd, 'runbooks', 'parent.runbook.md'), parentContent);
+      await writeFile(join(workspace.cwd, 'runbooks', 'child.runbook.md'), childContent);
+      await writeFile(join(workspace.runbooksDir(), 'child.runbook.md'), childContent);
+
+      const start = await runCliInProcess('run --prompted runbooks/parent.runbook.md', workspace);
+      expect(start.exitCode).toBe(0);
+      const frontier = parseConcatenatedJson(start.stdout).flatMap((event) => {
+        if (event && typeof event === 'object' && 'delegateFrontier' in event) {
+          return (event as { delegateFrontier?: Array<{ token?: string }> }).delegateFrontier ?? [];
+        }
+        return [];
+      });
+      const token = frontier[0]?.token;
+      expect(token).toBeDefined();
+      const claim = await runCliInProcess(['claim', token!], workspace);
+      expect(claim.exitCode).toBe(0);
+      const claimPayload = findActionOutput(claim.stdout);
+      const childRunId = String(claimPayload?.run_id);
+      const session = await readSession(workspace);
+      await writeSession(workspace, {
+        defaultStack: [childRunId],
+        claims: session.claims,
+      });
+
+      // The active run is itself delegated upward. Under the target-relative
+      // model the orchestrator gate must NOT reject it as a collection target.
+      const result = await runCliInProcess(['collect'], workspace);
+
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).not.toBe('COLLECT_REQUIRES_ORCHESTRATOR');
+      expect(payload.code).not.toBe('ACTOR_CONTEXT_REQUIRED');
+    }, 30_000);
+  });
+```
+
+- [ ] **Step 2: Run focused collect tests and confirm baseline behavior**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/collect.test.ts --runInBand
+```
+
+> Note on TDD framing: unlike the bare-mutation guards (which add a *new*
+> refusal and therefore have a red→green test), this task RELAXES policy — it
+> must NOT add a blocker for `collect --claim-id` or for upward-delegating
+> targets. The two new tests assert the *absence* of `ACTOR_CONTEXT_REQUIRED` /
+> `COLLECT_REQUIRES_ORCHESTRATOR` refusals, so they are regression guards: they
+> may already pass before the policy gate is wired (the codes are never emitted
+> today). They lock in the spec-aligned behavior after Steps 3-5 route collect
+> through the orchestrator gate, ensuring the gate does not regress into a
+> refusal for the controlling actor. Confirm they pass both before and after the
+> implementation steps.
+
+- [ ] **Step 3: Import core policy helpers in collect command**
+
+In `packages/cli/src/commands/collect.ts`, extend the `@rundown-org/core` import:
+
+```typescript
+import {
+  activeFrame,
+  buildFrameKey,
+  deriveActiveFrame,
+  findSubstepState,
+  inactiveFrame,
+  isPostDelegateAggregationCursor,
+  resolveCommandIntent,
+  trustedRunControllerContext,
+  type CommandTargetSelector,
+  type Frame,
+  type FrameKey,
+} from '@rundown-org/core';
+```
+
+> No synthetic sentinel run id. The previous draft constructed a
+> `collectClaimSelectorSentinelRunId = assertRunId('rd_000…0')` solely to build
+> an actor context for the (now-removed) claim-selector rejection path. That
+> brushed against the "No synthetic IDs" design principle and is deleted. The
+> `--claim-id` path resolves a real claimed run (via `buildTransitionContext`)
+> and passes real actor context/target — see Step 4 and Step 5. `assertRunId` is
+> therefore dropped from the import above.
+
+- [ ] **Step 4: Resolve the `--claim-id` target instead of rejecting it**
+
+`collect.ts` already resolves `--claim-id` to its claimed/controlled run: the
+action calls `buildTransitionContext(output, cwd, { claimId: claimTarget.claimId })`,
+which routes through `resolveCommandTarget(... { claimId })` and yields a
+`TransitionContext` whose `ctx.state` is the resolved claimed run (with `stale_claim`
+/ `terminal_claim` already handled by the existing switch). So `runCollect(ctx, ...)`
+already operates on the resolved claimed run for a `--claim-id` invocation.
+
+No new rejection is added here. Instead, thread whether the caller supplied
+`--claim-id` into `runCollect` so the policy call in Step 5 can pass the correct
+`targetSelector`. Capture the selector kind when building the collect options:
+
+```typescript
+            const shouldExitWithError = await runCollect(ctx, cwd, {
+              step: options.step,
+              index: options.index,
+              text: options.text,
+              targetSelector:
+                claimTarget.claimId !== undefined
+                  ? { kind: 'claim', claimId: claimTarget.claimId }
+                  : { kind: 'default' },
+            });
+```
+
+Add the corresponding field to the `CollectOptions` interface:
+
+```typescript
+  /** Resolved target selector: claim-id when supplied, otherwise default. */
+  targetSelector: CommandTargetSelector;
+```
+
+and extend the `@rundown-org/core` import (Step 3) with `type CommandTargetSelector`.
+
+- [ ] **Step 5: Gate collection on the orchestrator check**
+
+At the start of `runCollect()`, after `const { output, ... state, steps } = ctx;`,
+add the policy gate. `state` is the resolved target run (the claimed run for a
+`--claim-id` invocation, or the active run otherwise), and `trustedRunControllerContext(state.id, 'direct-cli')`
+is the real actor context for the run controlled by this direct-CLI caller.
+Pass the threaded `targetSelector` through unchanged. Because the actor controls
+the resolved target run, the orchestrator check passes; non-orchestrator
+contexts (not produced by this direct-CLI adapter today, but possible via future
+frontends or MCP) render the appropriate refusal. There is no
+`target_not_delegating_scope` branch: a run delegating upward is still a valid
+collection target under the target-relative model (whether outcomes exist to
+collect is Plan 4's concern):
+
+```typescript
+  const policy = resolveCommandIntent({
+    actorContext: trustedRunControllerContext(state.id, 'direct-cli'),
+    intent: { kind: 'delegation-collection' },
+    targetSelector: options.targetSelector,
+    targetState: state,
+  });
+  switch (policy.kind) {
+    case 'allowed':
+      break;
+    case 'actor_context_required':
+      output.error(
+        'Actor context is required to collect delegation outcomes.',
+        'ACTOR_CONTEXT_REQUIRED',
+        { targetRunId: state.id },
+      );
+      output.flush();
+      return true;
+    case 'collect_requires_orchestrator':
+      output.error(
+        'rd collect requires an actor that controls the target delegating run.',
+        'COLLECT_REQUIRES_ORCHESTRATOR',
+        { targetRunId: policy.targetRunId },
+      );
+      output.flush();
+      return true;
+    case 'delegation_collection_pending':
+    case 'open_claims':
+      throw new Error(`Unexpected collect policy outcome: ${policy.kind}`);
+    default: {
+      const _exhaustive: never = policy;
+      return _exhaustive;
+    }
+  }
+```
+
+- [ ] **Step 6: Run focused collect tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/collect.test.ts --runInBand
+```
+
+Expected: PASS. `collect --claim-id` is accepted and routed through the orchestrator gate (no `ACTOR_CONTEXT_REQUIRED` / `COLLECT_REQUIRES_ORCHESTRATOR` refusal), and collection on a run that itself delegates upward is allowed by the policy gate.
+
+- [ ] **Step 7: (optional) Commit collect policy integration**
+
+> Committing here is an optional per-task checkpoint for the
+> executing-plans / subagent-driven-development workflow. Skip it if the
+> maintainer prefers to commit once at the end.
+
+```bash
+git add packages/cli/src/commands/collect.ts packages/cli/__tests__/commands/collect.test.ts
+git commit -m "feat(cli): enforce collect command policy"
+```
+
+### Task 6: Guard Bare Delegate While Collection Is Pending
+
+**Files:**
+- Modify: `packages/cli/src/commands/delegate.ts`
+- Modify: `packages/cli/__tests__/commands/delegate.test.ts`
+
+- [ ] **Step 1: Add failing delegate CLI coverage**
+
+In `packages/cli/__tests__/commands/delegate.test.ts`, add imports:
+
+```typescript
+import {
+  activeFrame,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+} from '@rundown-org/core';
+```
+
+Add this helper near `setupAutoIssuedDelegation()`:
+
+```typescript
+async function injectDelegationOutcomeForActiveRun(workspace: TestWorkspace): Promise<string> {
+  const state = await getActiveState(workspace);
+  if (!state) throw new Error('Expected active state');
+  const frameKey = state.activeFrameKey ?? buildFrameKey(state.step);
+  const completionKey = buildCompletionKey(activeFrame(frameKey, state.activeEntry ?? 1), '1');
+  await writeFile(
+    join(workspace.statePath(), `${state.id}.json`),
+    JSON.stringify(
+      {
+        ...state,
+        substep: state.substep ?? '1',
+        activeFrameKey: frameKey,
+        activeEntry: state.activeEntry ?? 1,
+        frameEntries: { ...(state.frameEntries ?? {}), [frameKey]: state.activeEntry ?? 1 },
+        resolvedCompletions: {
+          ...(state.resolvedCompletions ?? {}),
+          [completionKey]: buildResolvedCompletion({
+            agentId: 'delegation',
+            result: 'pass',
+            targetStep: state.step,
+            targetSubstep: '1',
+            targetFrame: activeFrame(frameKey, state.activeEntry ?? 1),
+            completedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  return completionKey;
+}
+```
+
+Add this test inside `describe('delegate command', () => { ... })`:
+
+```typescript
+  describe('collection-pending guard', () => {
+    it('refuses bare delegate while a delegated outcome is waiting for collection', async () => {
+      await setupAutoIssuedDelegation();
+      const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess(['delegate'], workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as {
+        code?: string;
+        details?: { outcomeCompletionKeys?: string[] };
+      };
+      expect(payload.code).toBe('DELEGATION_COLLECTION_PENDING');
+      expect(payload.details?.outcomeCompletionKeys).toEqual([completionKey]);
+    });
+  });
+```
+
+- [ ] **Step 2: Run focused delegate test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/delegate.test.ts --runInBand
+```
+
+Expected: FAIL because bare `delegate` still echoes the existing frontier token instead of refusing collection-pending state.
+
+- [ ] **Step 3: Import command policy helpers in delegate command**
+
+In `packages/cli/src/commands/delegate.ts`, extend the `@rundown-org/core` import:
+
+```typescript
+  resolveCommandIntent,
+  trustedRunControllerContext,
+```
+
+Also import the transition renderer:
+
+```typescript
+import { emitDelegationCollectionPendingError } from '../helpers/transitions.js';
+```
+
+- [ ] **Step 4: Add a delegate command-policy guard**
+
+After `const state = await sessionService.getActive();` and the no-active check in `packages/cli/src/commands/delegate.ts`, add:
+
+```typescript
+          // `--retry` is handled by an early return earlier in this action
+          // (delegate.ts ~lines 103-114), so options.retry is always false here;
+          // bareness is just the absence of an explicit --step target.
+          const isBareDelegationIssue = options.step === undefined;
+          if (isBareDelegationIssue) {
+            const policy = resolveCommandIntent({
+              actorContext: trustedRunControllerContext(state.id, 'direct-cli'),
+              intent: { kind: 'delegation-issuance', command: 'delegate', targeted: false },
+              targetSelector: { kind: 'default' },
+              targetState: state,
+            });
+            if (policy.kind === 'delegation_collection_pending') {
+              emitDelegationCollectionPendingError(
+                output,
+                'delegate',
+                policy.parentRunId,
+                policy.outcomeCompletionKeys,
+                policy.message,
+              );
+              output.flush();
+              process.exitCode = 1;
+              return;
+            }
+            if (policy.kind !== 'allowed') {
+              throw new Error(`Unexpected delegate policy outcome: ${policy.kind}`);
+            }
+          }
+```
+
+- [ ] **Step 5: Run focused delegate test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/delegate.test.ts --runInBand
+```
+
+Expected: PASS. Bare `delegate` refuses collection-pending state before existing frontier inference.
+
+- [ ] **Step 6: (optional) Commit delegate policy integration**
+
+> Committing here is an optional per-task checkpoint for the
+> executing-plans / subagent-driven-development workflow. Skip it if the
+> maintainer prefers to commit once at the end.
+
+```bash
+git add packages/cli/src/commands/delegate.ts packages/cli/__tests__/commands/delegate.test.ts
+git commit -m "feat(cli): guard bare delegate on collection pending"
+```
+
+### Task 7: End-to-End Collection-Pending Lifecycle Integration Test
+
+The unit and command tests pin the *onset* of the guard (bare mutation is refused
+while an outcome is pending) but not its *release* (after `collect`, the bare
+mutation proceeds). This task adds a CLI-level integration test covering the full
+lifecycle so a regression that left the run permanently wedged — the exact
+failure mode of the removed `state.steps` comparator — is caught.
+
+**Files:**
+- Create: `packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts`
+
+- [ ] **Step 1: Write the lifecycle integration test**
+
+This test drives real CLI invocations against real on-disk state. It reuses the
+`injectDelegationOutcomeForActiveRun` helper shape from the `pass`/`delegate`
+command tests (Task 3 Step 10 / Task 6 Step 1) to deterministically place a
+reported outcome, then asserts the onset → collect → release transition end to
+end. The parent runbook defines a real delegate substep so `rd collect` has a
+DELEGATE step to aggregate.
+
+Create `packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts`:
+
+```typescript
+import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  activeFrame,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+} from '@rundown-org/core';
+import {
+  createTestWorkspace,
+  createRunbook,
+  runCliInProcess,
+  getActiveState,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
+
+describe('collection-pending lifecycle', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  async function injectDelegationOutcomeForActiveRun(): Promise<string> {
+    const state = await getActiveState(workspace);
+    if (!state) throw new Error('Expected active state');
+    const frameKey = state.activeFrameKey ?? buildFrameKey(state.step);
+    const completionKey = buildCompletionKey(activeFrame(frameKey, state.activeEntry ?? 1), '1');
+    await writeFile(
+      join(workspace.statePath(), `${state.id}.json`),
+      JSON.stringify(
+        {
+          ...state,
+          substep: state.substep ?? '1',
+          activeFrameKey: frameKey,
+          activeEntry: state.activeEntry ?? 1,
+          frameEntries: { ...(state.frameEntries ?? {}), [frameKey]: state.activeEntry ?? 1 },
+          resolvedCompletions: {
+            ...(state.resolvedCompletions ?? {}),
+            [completionKey]: buildResolvedCompletion({
+              agentId: 'delegation',
+              result: 'pass',
+              targetStep: state.step,
+              targetSubstep: '1',
+              targetFrame: activeFrame(frameKey, state.activeEntry ?? 1),
+              completedAt: '2026-01-01T00:00:00.000Z',
+            }),
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    return completionKey;
+  }
+
+  it('refuses bare pass while pending, then allows it after collect', async () => {
+    const parentContent = createRunbook({
+      title: 'Parent',
+      steps: [
+        {
+          title: 'Delegate child',
+          pass: 'CONTINUE',
+          substeps: [
+            { title: 'Child work', delegate: true, runbooks: ['runbooks/child.runbook.md'] },
+          ],
+        },
+        { title: 'Promote', pass: 'COMPLETE' },
+      ],
+    });
+    await writeFile(join(workspace.runbooksDir(), 'parent.runbook.md'), parentContent);
+
+    const start = await runCliInProcess('run --prompted runbooks/parent.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+
+    const completionKey = await injectDelegationOutcomeForActiveRun();
+
+    // Onset: bare pass is refused while the reported outcome is uncollected.
+    const blocked = await runCliInProcess('pass', workspace);
+    expect(blocked.exitCode).toBe(1);
+    const blockedPayload = JSON.parse(blocked.stdout) as {
+      code?: string;
+      details?: { outcomeCompletionKeys?: string[] };
+    };
+    expect(blockedPayload.code).toBe('DELEGATION_COLLECTION_PENDING');
+    expect(blockedPayload.details?.outcomeCompletionKeys).toEqual([completionKey]);
+
+    // Collect consumes the reported outcome.
+    const collected = await runCliInProcess('collect', workspace);
+    expect(collected.exitCode).toBe(0);
+
+    // Release: the same bare pass now proceeds — the run is not wedged.
+    const advanced = await runCliInProcess('pass', workspace);
+    const advancedPayload = JSON.parse(advanced.stdout) as { code?: string };
+    expect(advancedPayload.code).not.toBe('DELEGATION_COLLECTION_PENDING');
+    expect(advanced.exitCode).toBe(0);
+  }, 30_000);
+});
+```
+
+> If `rd collect` requires the DELEGATE substep to be structured differently in
+> the fixture for aggregation to consume the row, adjust the `createRunbook`
+> `substeps`/`delegate` shape to match the real delegate-step schema used in
+> `packages/cli/__tests__/commands/collect.test.ts` — the assertion that matters
+> is the onset→collect→release sequence, not the exact fixture shape.
+
+- [ ] **Step 2: Run the lifecycle integration test**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/integration/collection-pending-lifecycle.test.ts --runInBand
+```
+
+Expected: PASS. Bare `pass` is refused while the outcome is pending and proceeds after `collect`, proving the guard releases and the run is never permanently wedged.
+
+- [ ] **Step 3: (optional) Commit the lifecycle integration test**
+
+> Committing here is an optional per-task checkpoint for the
+> executing-plans / subagent-driven-development workflow. Skip it if the
+> maintainer prefers to commit once at the end.
+
+```bash
+git add packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts
+git commit -m "test(cli): pin collection-pending guard lifecycle end to end"
+```
+
+### Task 8: Verify Package Types, Lint, Formatting, Spelling, and Terminology
+
+**Files:**
+- Verify only; no source edits unless a verification command exposes a defect introduced by this plan.
+
+- [ ] **Step 1: Run the focused core test set**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/delegation-lifecycle-read-model.test.ts __tests__/runbook/command-policy.test.ts __tests__/runbook/command-policy.properties.test.ts __tests__/runbook/command-target-resolver.test.ts __tests__/runbook/session-service.test.ts __tests__/output/schema.test.ts --runInBand
+```
+
+Expected: PASS. Core read models, command policy (including property invariants), resolver integration, guarded parent advance, and schema codes all pass together.
+
+- [ ] **Step 2: Run the focused CLI command test set**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/pass.test.ts __tests__/commands/fail.test.ts __tests__/commands/delegate.test.ts __tests__/commands/collect.test.ts __tests__/integration/collection-pending-lifecycle.test.ts --runInBand
+```
+
+Expected: PASS. CLI adapters render core policy refusals for pass, fail, delegate, and collect, and the guard releases after collect.
+
+- [ ] **Step 3: Run package type checks**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core check:types
+pnpm --filter @rundown-org/cli check:types
+```
+
+Expected: PASS. New core exports and CLI imports type-check under package test configs.
+
+- [ ] **Step 4: Run repository formatting, spelling, and lint checks**
+
+Run:
+
+```bash
+pnpm run check:format
+pnpm run check:spell
+pnpm run check:lint:fast
+pnpm run check:lint:typed
+```
+
+Expected: PASS. New exported symbols satisfy TSDoc standards, Biome formatting, spell checking, and ESLint typed rules.
+
+- [ ] **Step 5: Scan for target-model names that must not be introduced**
+
+Run:
+
+```bash
+rg -n "ClaimHandoff|CLAIM_HANDOFF|--resume" packages/core/src packages/core/__tests__ packages/cli/src packages/cli/__tests__
+```
+
+Expected: no output from files changed by this plan. If output appears from pre-existing unrelated files, do not edit those files; list the pre-existing references in the implementation summary.
+
+- [ ] **Step 6: Inspect final changed files**
+
+Run:
+
+```bash
+git diff --stat HEAD~7..HEAD
+git diff --check HEAD~7..HEAD
+```
+
+Expected: `git diff --stat` lists only files named in this plan, and `git diff --check` exits successfully with no whitespace errors. (Adjust the `HEAD~N` depth to the number of per-task commits actually made if optional commit steps were skipped.)
+
+- [ ] **Step 7: Run a final focused command-policy smoke test after formatting**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/command-policy.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/collect.test.ts --runInBand
+```
+
+Expected: PASS. Formatting and lint fixes did not change policy behavior.
+
+## Self-Review Notes
+
+- Prerequisite: Plan 1 (`2026-06-17-delegation-lifecycle-foundation.md`) must be applied/merged first. Task 1 extends the `delegation-lifecycle-read-model.ts` file Plan 1 creates and reuses `readDelegationOutcomeReportedFacts` / `DELEGATION_COLLECTION_PENDING_MESSAGE` / `DelegationOutcomeReportedFact`; Task 4 anchors its registrations after the `DELEGATION_COLLECTION_PENDING` code Plan 1 introduced. See Scope Notes → Prerequisites.
+- Spec coverage: Task 1 implements the spec-resolved broader collection-pending guard while preserving Plan 1's active-scope read model; its still-open check is collection-relative (an uncollected outcome stays pending until `collect` removes its `resolvedCompletions` row; FOR-scoped outcomes additionally gate on `frameEntries` membership). This deliberately avoids the empty-at-runtime `state.steps` field — an earlier cursor-comparator draft over `state.steps` would have hit its defensive branch unconditionally and wedged every unscoped outcome forever. Because a reported outcome can only be cleared by collection (never by cursor movement), the run cannot be permanently wedged: the exit is always `rd collect`. Task 2 adds actor context, target-relative role derivation, command intents, target selectors, and a core `DelegationPolicyOutcome` union. Task 3 refuses bare `pass` and `fail` while collection is pending and preserves the existing open-claim guard through policy. Task 5 follows the spec for `rd collect --claim-id`: it accepts it as an explicit target selector for the resolved claimed run, gated by the orchestrator-for-target check, and does NOT reject a run merely because it delegates upward. Task 6 refuses bare `delegate` while collection is pending. Direct CLI compatibility is explicit through `trustedRunControllerContext(..., 'direct-cli')`; strict `unknown` collection is rejected in core tests.
+- Scope boundary (mid-chain collection): This slice gates the policy decision only. Actually applying reported outcomes across N levels of the delegation chain (mid-chain collection orchestration) is Plan 4 (Core Collection Operation). A run delegating upward is a valid collection *target* here; whether outcomes exist to collect is Plan 4's concern.
+- Narrowed `DelegationPolicyOutcome` union: This plan implements a deliberate subset of the spec's 12-member union (spec lines 366-380) — `allowed`, `actor_context_required`, `collect_requires_orchestrator`, `delegation_collection_pending`, `open_claims`. Deferred members and rationale: `missing_outcomes` and `already_collected` → Plan 4 (they are outcomes of the collection operation, not the policy gate); `stale_claim`, `terminal_claim_confirmed`, `terminal_claim_conflict`, `not_delegatable` → claim/collection plans (Plan 4 / Plan 5), as they belong to claim resolution and delegatability rather than this command-policy gate. `target_not_delegating_scope` is intentionally NOT implemented: under the target-relative model the orchestrator check is the only gate this slice needs, and (verified) nothing in `packages/` references it or its `COLLECT_TARGET_NOT_DELEGATING_RUN` code, so neither is registered.
+- Deliberate signature deviation (Issue 8): The spec sketches a positional `resolveCommandIntent(intent, actorContext, target)`. This plan uses a single input object (`ResolveCommandIntentInput`) instead, for extensibility (optional `openClaims`, future fields) and call-site clarity. Relatedly, `deriveEffectiveRole(actorContext, targetState)` omits `intent` because role derivation is purely target-relative — the role does not depend on which command is being evaluated. This is a documentation-level deviation; behavior matches the spec's target-relative model.
+- CLI message (Issue 9): `emitDelegationCollectionPendingError` widens the rendered `DELEGATION_COLLECTION_PENDING` message to include the spec's actionable ancestor-vs-controlled guidance (spec lines 584-588: "If this is your ancestor's run, stop here. If this is a run you control, run rd collect."). The message is consistent everywhere because all `pass` / `fail` / `delegate` call sites route through this single renderer.
+- CLAUDE.md: `CLAUDE.md:147` documents `rd collect --claim-id` as a supported selector; this plan now follows the spec and keeps it supported, so that line stays accurate — no CLAUDE.md change is needed.
+- No-placeholder scan: The plan uses concrete paths, commands, expected outcomes, test snippets, and code snippets. It does not leave unresolved marker text or vague implementation instructions.
+- Type consistency: `ActorContext`, `EffectiveRole`, `CommandIntent`, `CommandTargetSelector`, `DelegationPolicyOutcome`, `readDelegationCollectionPendingForPolicy`, `resolveCommandIntent`, and `trustedRunControllerContext` are defined before any task consumes them. Outcome names match across core policy, resolver variants, CLI switch cases, and schema codes. The atomic guard's `delegation_collection_pending` return variant, the resolver's `TransitionTargetResolution` variant, `BuildTransitionContextResult`, and the `buildTransitionContext` switch arm (Task 3 Step 8) all carry the same `{ parentRunId, outcomeCompletionKeys, message }` shape, so the exhaustive `never` checks in both `buildTransitionContext` and `transition-command.ts` compile.
+- Test levels: unit (read model, command policy, resolver, session guard, schema), property (Task 2 Step 7 — totality, inspect-allowed, unknown-never-allowed, targeted-never-pending, orchestrator-iff-controls-target), and integration (Task 7 — the full onset→collect→release lifecycle, plus the CLI command tests for pass/fail/delegate/collect). The lifecycle integration test specifically pins the guard's *release*, which the removed `state.steps` comparator would have broken silently.
+- Single-source message: `DELEGATION_COLLECTION_PENDING_MESSAGE` is the one source of the refusal text. The atomic guard returns it in its `message` field, the resolver threads it through `TransitionTargetResolution` → `BuildTransitionContextResult`, and `executeTransition` renders `guarded.message` rather than re-typing the literal. Test files assert the literal string deliberately, as a pin against unintended wording changes.
+- Concurrency: the session-lock mutual exclusion that makes the atomic re-check sound is already proven by the existing `serializes a concurrent claim against the guarded advance` test (`session-service.test.ts` ~line 983). The new re-check (Task 3 Step 7) runs inside that same lock before `advance()`, so it composes with the proven ordering: if a competing writer wins the lock first, the re-check observes the reported outcome and refuses; if the advance wins, it completes before any interleave. The Task 3 Step 5 test pins the single-process refusal; no separate concurrency fixture is added because the lock ordering is already covered.
+- Defensive fall-through: `runGuardedParentAdvance` deliberately skips the re-check when `manager.load()` returns `null` (state absent), preserving today's open-claims behavior rather than throwing. This is a defensive branch, not a behavior this slice introduces; it is left unpinned by design.
+- Scope consistency: This plan is intentionally a policy/adapters slice. It does not move collection orchestration into core, does not split delegated outcome reporting from collection, and does not implement plugin or MCP actor identity hardening.
+- Spec alignment for `rd collect --claim-id`: This plan now follows the spec (spec lines 345-348, 674-676). `rd collect --claim-id` is accepted as an explicit target selector for the resolved claimed run; the frontend resolves the claim to its controlled run and passes it as `targetState`, and policy allows the collection only when the actor is effective orchestrator for that resolved target. There is no separate rejection of the claim selector and no rejection of a run merely because it delegates upward. This matches the existing codebase behavior (spec line 515: `rd collect --claim-id` already works) while routing it through the core orchestrator gate.

--- a/docs/superpowers/plans/2026-06-17-delegation-lifecycle-foundation.md
+++ b/docs/superpowers/plans/2026-06-17-delegation-lifecycle-foundation.md
@@ -1,0 +1,891 @@
+# Delegation Lifecycle Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish Plan 1 delegation lifecycle vocabulary, error-code registration, and pure core read models for reported delegation outcomes and derived collection-pending state without changing command behavior.
+
+**Architecture:** Keep this plan read-only at runtime: existing `resolvedCompletions` rows remain the persistence source, and new read models interpret those rows using target terminology. Register `DELEGATION_COLLECTION_PENDING` as an accepted output code now, but do not emit it from command paths until the command-policy plan. Avoid extending the transitional handoff/resume model; any reused closure concepts must be expressed as delegation outcome reporting and collection pending.
+
+**Tech Stack:** TypeScript, Jest, Zod, pnpm workspace scripts, existing Rundown core runbook state types.
+
+---
+
+## Guardrails
+
+- Do not implement the behavior split in this plan. `RunbookCompletionService.recordChildCompletion()` may still be followed by current drain/apply behavior from CLI helpers until Plan 4.
+- Do not add persisted state fields for `collection_pending`. Derive collection pending from existing `RunbookState.resolvedCompletions`.
+- Do not create or extend `ClaimHandoff`, `CLAIM_HANDOFF_PENDING`, or `--resume` names. Treat `docs/superpowers/plans/2026-06-16-claim-handoff-barrier.md` and `docs/superpowers/plans/2026-06-16-claim-handoff-barrier-walkthrough.md` as superseded planning context, not implementation targets.
+- Do not rewrite unrelated `resume` wording that refers to process restart, file-provider offsets, stash/pop, or persisted-state recovery. Those are not the delegation handoff/resume model.
+- Keep CLI, MCP, and plugin command behavior unchanged. Plan 2 owns command-policy enforcement.
+
+## Provisional Scope Rule
+
+This plan deliberately derives `DelegationCollectionPendingReadModel` for the active collection scope only: a reported delegation outcome is pending when its `targetFrameKey` matches the run's active frame and its `targetEntry` is either the active entry or the sentinel entry. A reported outcome in a different FOR entry or non-active frame is exposed by `readDelegationOutcomeReportedFacts()` but does not make `readDelegationCollectionPending()` return `pending: true`.
+
+That scope rule is provisional until the broader collection-pending policy question is resolved in the command-policy and collection-operation plans. Do not treat it as final enforcement semantics in Plan 2 or Plan 3 without an explicit spec decision.
+
+## File Structure
+
+- Modify: `packages/core/src/output/zod-schemas.ts`
+  - Register `DELEGATION_COLLECTION_PENDING` in the central CLI output-code registry so schemas accept the future guard response.
+- Modify: `packages/core/__tests__/output/schema.test.ts`
+  - Pin schema acceptance for `DELEGATION_COLLECTION_PENDING`.
+- Modify: `packages/core/src/runbook/types.ts`
+  - Add `DelegationOutcome` as the target domain alias for `pass | fail` when projected from a delegated run terminal lifecycle.
+- Modify: `packages/core/src/runbook/completion-service.ts`
+  - Add `lifecycleToDelegationOutcome()` with target terminology and keep `lifecycleToResult()` as an existing-API wrapper for current callers.
+- Modify: `packages/core/__tests__/runbook/completion-service.test.ts`
+  - Pin the lifecycle-to-delegation-outcome mapping without changing completion behavior.
+- Create: `packages/core/src/runbook/delegation-lifecycle-read-model.ts`
+  - Pure read-model module that derives outcome-reported facts and collection-pending state from a `RunbookState`.
+- Create: `packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts`
+  - Unit tests for the pure read models.
+- Modify: `packages/core/src/runbook/index.ts`
+  - Re-export the new read-model functions and types, plus the new lifecycle mapping function.
+- Leave unchanged: `packages/core/src/runbook/claim-id.ts`
+  - Existing `ClaimId` and `ClaimRecord` remain valid. This plan does not add claim id fields to reported outcome facts because existing `resolvedCompletions` rows do not persist claim ids.
+- Leave unchanged: `packages/core/src/runbook/command-target-resolver.ts`
+  - Current `open_delegated_children` targeting guard remains intact. Plan 2 replaces or extends it with collection-pending policy.
+- Leave unchanged: `packages/core/src/runbook/delegation-service.ts`
+  - Existing `ConsumedDelegationClosureReadModel` remains a plugin-facing closure read model. Do not rename or remove it in this plan because plugin hooks still consume it.
+
+## Tasks
+
+### Task 1: Register the Target Collection-Pending Error Code
+
+**Files:**
+- Modify: `packages/core/__tests__/output/schema.test.ts`
+- Modify: `packages/core/src/output/zod-schemas.ts`
+
+- [ ] **Step 1: Write the failing schema test**
+
+Add this test after the existing `accepts the OPEN_DELEGATED_CHILDREN refusal emitted by bare pass/fail` test in `packages/core/__tests__/output/schema.test.ts`:
+
+```typescript
+  it('accepts DELEGATION_COLLECTION_PENDING for the future collection-pending guard', () => {
+    const message =
+      'A delegated claim has reported an outcome that must be collected by the orchestrator.';
+
+    expect(ErrorCodeSchema.safeParse('DELEGATION_COLLECTION_PENDING').success).toBe(true);
+    expect(
+      ErrorResponseSchema.safeParse({
+        kind: 'error',
+        error: message,
+        code: 'DELEGATION_COLLECTION_PENDING',
+        details: {
+          suggestion:
+            'If you are the delegated agent, stop here. If you are the orchestrator, run rd collect.',
+        },
+      }).success,
+    ).toBe(true);
+    expect(CLIErrorCodes.DELEGATION_COLLECTION_PENDING).toBe('DELEGATION_COLLECTION_PENDING');
+  });
+```
+
+- [ ] **Step 2: Run the focused schema test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/output/schema.test.ts --runInBand
+```
+
+Expected: FAIL. The new test fails because `ErrorCodeSchema.safeParse('DELEGATION_COLLECTION_PENDING').success` returns `false` and `CLIErrorCodes.DELEGATION_COLLECTION_PENDING` is not defined.
+
+- [ ] **Step 3: Register the symbolic code**
+
+In `packages/core/src/output/zod-schemas.ts`, add the new symbolic code directly after `OPEN_DELEGATED_CHILDREN` in `CLISymbolicErrorCodeValues`:
+
+```typescript
+  'OPEN_DELEGATED_CHILDREN',
+  'DELEGATION_COLLECTION_PENDING',
+  'CHILD_RUN_MISSING',
+```
+
+In the exported `CLIErrorCodes` object, add the target code directly after `OPEN_DELEGATED_CHILDREN`:
+
+```typescript
+  /** A delegated outcome has been reported and must be collected before bare parent advancement */
+  DELEGATION_COLLECTION_PENDING: 'DELEGATION_COLLECTION_PENDING',
+  /** Child run state file is missing on disk (transient — pruning may help) */
+  CHILD_RUN_MISSING: 'CHILD_RUN_MISSING',
+```
+
+- [ ] **Step 4: Run the focused schema test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/output/schema.test.ts --runInBand
+```
+
+Expected: PASS. The new test accepts `DELEGATION_COLLECTION_PENDING`, and the existing output schema tests still pass.
+
+- [ ] **Step 5: Commit the error-code registration**
+
+Run:
+
+```bash
+git add packages/core/__tests__/output/schema.test.ts packages/core/src/output/zod-schemas.ts
+git commit -m "feat(core): register delegation collection pending code"
+```
+
+Expected: commit succeeds with only the two listed files staged.
+
+### Task 2: Add Target Delegation Outcome Terminology
+
+**Files:**
+- Modify: `packages/core/src/runbook/types.ts`
+- Modify: `packages/core/src/runbook/completion-service.ts`
+- Modify: `packages/core/src/runbook/index.ts`
+- Modify: `packages/core/__tests__/runbook/completion-service.test.ts`
+
+- [ ] **Step 1: Write the failing lifecycle-mapping test**
+
+In `packages/core/__tests__/runbook/completion-service.test.ts`, extend the import from `../../src/runbook/index.js` so it includes `lifecycleToDelegationOutcome`:
+
+```typescript
+import {
+  assertDelegationTokenHash,
+  lifecycleToDelegationOutcome,
+  RunbookActorService,
+  RunbookCompletionService,
+  RunbookStateManager,
+  type RunbookState,
+  type ResolvedStep,
+} from '../../src/runbook/index.js';
+```
+
+Add this test near the top of the `describe('RunbookCompletionService', () => { ... })` block, after the `afterEach` block:
+
+```typescript
+  it.each([
+    ['completed', 'pass'],
+    ['stopped', 'fail'],
+    ['running', undefined],
+  ] as const)(
+    'maps lifecycle %s to delegation outcome %s',
+    (lifecycle, expectedOutcome) => {
+      expect(lifecycleToDelegationOutcome(lifecycle)).toBe(expectedOutcome);
+    },
+  );
+```
+
+- [ ] **Step 2: Run the focused completion-service test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/completion-service.test.ts --runInBand
+```
+
+Expected: FAIL with an import or type error indicating `lifecycleToDelegationOutcome` is not exported.
+
+- [ ] **Step 3: Add the `DelegationOutcome` domain type**
+
+In `packages/core/src/runbook/types.ts`, add this exported type immediately after the `JsonArray` type:
+
+```typescript
+/**
+ * Outcome projected from a delegated run terminal state into its delegating run.
+ *
+ * The literals intentionally match step results (`pass` / `fail`), but this
+ * alias marks the delegation lifecycle boundary so new APIs do not use generic
+ * "result" language when they mean a reported delegation outcome.
+ */
+export type DelegationOutcome = 'pass' | 'fail';
+```
+
+- [ ] **Step 4: Add the target-named lifecycle mapping while preserving the old API**
+
+In `packages/core/src/runbook/completion-service.ts`, update the type import:
+
+```typescript
+import type {
+  DelegationOutcome,
+  ResolvedCompletion,
+  ResolvedStep,
+  RunId,
+  RunbookState,
+} from './types.js';
+```
+
+Replace the existing `lifecycleToResult()` function with these two functions:
+
+```typescript
+/**
+ * Map a delegated run lifecycle to the delegation outcome it reports.
+ *
+ * This is the canonical mapping used when projecting a delegated run terminal
+ * state into the delegating run. Reuse it anywhere a delegated lifecycle must be
+ * compared to a pass/fail command so the translation stays in lock-step with
+ * aggregation.
+ *
+ * @param lifecycle - Runbook lifecycle value.
+ * @returns `'pass'` for `completed`, `'fail'` for `stopped`, otherwise
+ *   `undefined` (non-terminal lifecycle values have no delegation outcome).
+ */
+export function lifecycleToDelegationOutcome(
+  lifecycle: RunbookState['lifecycle'],
+): DelegationOutcome | undefined {
+  if (lifecycle === 'completed') return 'pass';
+  if (lifecycle === 'stopped') return 'fail';
+  return undefined;
+}
+
+/**
+ * Existing-API wrapper for callers that still use generic result terminology.
+ *
+ * New delegation lifecycle code should call {@link lifecycleToDelegationOutcome}.
+ *
+ * @param lifecycle - Runbook lifecycle value.
+ * @returns Delegation outcome for terminal lifecycles, otherwise `undefined`.
+ */
+export function lifecycleToResult(
+  lifecycle: RunbookState['lifecycle'],
+): DelegationOutcome | undefined {
+  return lifecycleToDelegationOutcome(lifecycle);
+}
+```
+
+- [ ] **Step 5: Export the new mapping**
+
+In `packages/core/src/runbook/index.ts`, update the completion-service export block:
+
+```typescript
+export {
+  RunbookCompletionService,
+  lifecycleToDelegationOutcome,
+  lifecycleToResult,
+  type AppliedResolvedCompletion,
+  type CompletionTargetMismatch,
+  type CurrentCursorResolvedCompletion,
+  type DrainResolvedCompletionsArgs,
+  type DrainResolvedCompletionsResult,
+  type RecordChildCompletionArgs,
+  type RecordCompletionResult,
+  type RecordManualCompletionArgs,
+} from './completion-service.js';
+```
+
+- [ ] **Step 6: Run the focused completion-service test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/completion-service.test.ts --runInBand
+```
+
+Expected: PASS. The new lifecycle mapping test passes, and existing completion-service tests still pass.
+
+- [ ] **Step 7: Commit the terminology mapping**
+
+Run:
+
+```bash
+git add packages/core/src/runbook/types.ts packages/core/src/runbook/completion-service.ts packages/core/src/runbook/index.ts packages/core/__tests__/runbook/completion-service.test.ts
+git commit -m "feat(core): name delegation outcome mapping"
+```
+
+Expected: commit succeeds with only the four listed files staged.
+
+### Task 3: Add Pure Delegation Lifecycle Read Models
+
+**Files:**
+- Create: `packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts`
+- Create: `packages/core/src/runbook/delegation-lifecycle-read-model.ts`
+- Modify: `packages/core/src/runbook/index.ts`
+
+- [ ] **Step 1: Write the failing read-model tests**
+
+Create `packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts` with this content:
+
+```typescript
+import { describe, expect, it } from '@jest/globals';
+import {
+  readDelegationCollectionPending,
+  readDelegationOutcomeReportedFacts,
+  type RunbookState,
+} from '../../src/runbook/index.js';
+import {
+  activeFrame,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+  exactFrame,
+  inactiveFrame,
+} from '../../src/runbook/targeting.js';
+import {
+  brandRunIdForTest,
+  brandStoredOutputsForTest,
+} from '../../src/testing/effective-vars.js';
+
+const runbookId = brandRunIdForTest('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+
+function state(overrides: Partial<RunbookState> = {}): RunbookState {
+  return {
+    id: runbookId,
+    runbook: { source: 'project', path: 'parent.md' },
+    runbookPath: 'parent.md',
+    step: '1',
+    stepName: 'Parent',
+    substep: '1',
+    retryCount: 0,
+    variables: brandStoredOutputsForTest({}),
+    steps: [],
+    resolvedCompletions: {},
+    frameEntries: { [buildFrameKey('1')]: 1 },
+    activeFrameKey: buildFrameKey('1'),
+    activeEntry: 1,
+    startedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    lifecycle: 'running',
+    schemaVersion: 1,
+    frontmatterOutputs: [],
+    ...overrides,
+  };
+}
+
+describe('readDelegationOutcomeReportedFacts', () => {
+  it('maps delegation completion rows to outcome-reported facts', () => {
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const parent = state({
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          finalVars: { ChildValue: 'ready' },
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationOutcomeReportedFacts(parent)).toEqual([
+      {
+        kind: 'delegation-outcome-reported',
+        completionKey: key,
+        parentRunId: runbookId,
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrameKey: buildFrameKey('1'),
+        targetEntry: 1,
+        outcome: 'pass',
+        reportedAt: '2026-01-01T00:00:00.000Z',
+        finalVars: { ChildValue: 'ready' },
+      },
+    ]);
+  });
+
+  it('ignores manual and inline resolved completions', () => {
+    const manualKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const inlineKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '2');
+    const parent = state({
+      resolvedCompletions: {
+        [manualKey]: buildResolvedCompletion({
+          agentId: 'manual',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+        [inlineKey]: buildResolvedCompletion({
+          agentId: 'inline',
+          result: 'fail',
+          targetStep: '1',
+          targetSubstep: '2',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:01.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationOutcomeReportedFacts(parent)).toEqual([]);
+  });
+});
+
+describe('readDelegationCollectionPending', () => {
+  it('derives pending state from active-frame delegation outcomes', () => {
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const parent = state({
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationCollectionPending(parent)).toEqual({
+      kind: 'delegation-collection-pending',
+      pending: true,
+      parentRunId: runbookId,
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      outcomes: [
+        {
+          kind: 'delegation-outcome-reported',
+          completionKey: key,
+          parentRunId: runbookId,
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrameKey: buildFrameKey('1'),
+          targetEntry: 1,
+          outcome: 'pass',
+          reportedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      message:
+        'A delegated claim has reported an outcome that must be collected by the orchestrator.',
+    });
+  });
+
+  it('treats sentinel delegation outcomes for the active frame as pending', () => {
+    const key = buildCompletionKey(inactiveFrame(buildFrameKey('1')), '1');
+    const parent = state({
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'fail',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: inactiveFrame(buildFrameKey('1')),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    const pending = readDelegationCollectionPending(parent);
+
+    expect(pending.pending).toBe(true);
+    expect(pending.outcomes).toEqual([
+      expect.objectContaining({
+        completionKey: key,
+        targetEntry: 0,
+        outcome: 'fail',
+      }),
+    ]);
+  });
+
+  it('does not mark collection pending for a different exact entry', () => {
+    const key = buildCompletionKey(exactFrame(buildFrameKey('1'), 2), '1');
+    const parent = state({
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: exactFrame(buildFrameKey('1'), 2),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    expect(readDelegationCollectionPending(parent)).toEqual({
+      kind: 'delegation-collection-pending',
+      pending: false,
+      parentRunId: runbookId,
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      outcomes: [],
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused read-model test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/delegation-lifecycle-read-model.test.ts --runInBand
+```
+
+Expected: FAIL because `readDelegationCollectionPending` and `readDelegationOutcomeReportedFacts` are not exported from `../../src/runbook/index.js`.
+
+- [ ] **Step 3: Create the read-model module**
+
+Create `packages/core/src/runbook/delegation-lifecycle-read-model.ts` with this content:
+
+```typescript
+import type { VariableValue } from './effective-vars.js';
+import type { RunId } from './run-id.js';
+import { deriveActiveFrame, SENTINEL_ENTRY, type FrameKey } from './targeting.js';
+import type { DelegationOutcome, RunbookState } from './types.js';
+
+const DELEGATION_AGENT_ID = 'delegation';
+
+/** Message paired with the DELEGATION_COLLECTION_PENDING frontend error code. */
+export const DELEGATION_COLLECTION_PENDING_MESSAGE =
+  'A delegated claim has reported an outcome that must be collected by the orchestrator.';
+
+/**
+ * Pure read model for a reported delegation outcome.
+ *
+ * This is derived from existing `resolvedCompletions` rows whose `agentId` is
+ * `delegation`. It intentionally does not introduce a persisted schema field.
+ */
+export interface DelegationOutcomeReportedFact {
+  /** Read-model discriminant. */
+  readonly kind: 'delegation-outcome-reported';
+  /** Completion key under which the reported outcome is currently persisted. */
+  readonly completionKey: string;
+  /** Delegating run that owns the reported outcome row. */
+  readonly parentRunId: RunId;
+  /** Step that owns the delegated substep. */
+  readonly targetStep: string;
+  /** Delegated substep that reported an outcome. */
+  readonly targetSubstep: string;
+  /** FOR iteration for loop-scoped delegation outcomes. */
+  readonly targetIteration?: number;
+  /** Active or historical frame key for the delegated substep. */
+  readonly targetFrameKey: FrameKey;
+  /** Active, exact, or sentinel entry for the delegated substep frame. */
+  readonly targetEntry: number;
+  /** Delegation outcome projected from the delegated run terminal lifecycle. */
+  readonly outcome: DelegationOutcome;
+  /** ISO timestamp when the outcome was reported. */
+  readonly reportedAt: string;
+  /** Final variables produced by the delegated run. */
+  readonly finalVars?: Readonly<Record<string, VariableValue>>;
+}
+
+/** Pure read model for collection-pending state at the delegating run's active scope. */
+export type DelegationCollectionPendingReadModel =
+  | {
+      /** Read-model discriminant. */
+      readonly kind: 'delegation-collection-pending';
+      /** Whether the active scope has unconsumed reported delegation outcomes. */
+      readonly pending: true;
+      /** Delegating run that may need collection. */
+      readonly parentRunId: RunId;
+      /** Active frame key used to derive collection scope. */
+      readonly activeFrameKey: FrameKey;
+      /** Active entry used to derive collection scope. */
+      readonly activeEntry: number;
+      /** Reported outcomes in the active collection scope. */
+      readonly outcomes: readonly DelegationOutcomeReportedFact[];
+      /** Operator-facing guidance for frontend error rendering. */
+      readonly message: typeof DELEGATION_COLLECTION_PENDING_MESSAGE;
+    }
+  | {
+      /** Read-model discriminant. */
+      readonly kind: 'delegation-collection-pending';
+      /** No unconsumed reported delegation outcomes exist in the active scope. */
+      readonly pending: false;
+      /** Delegating run that was inspected. */
+      readonly parentRunId: RunId;
+      /** Active frame key used to derive collection scope. */
+      readonly activeFrameKey: FrameKey;
+      /** Active entry used to derive collection scope. */
+      readonly activeEntry: number;
+      /** Empty when no collection is pending. */
+      readonly outcomes: readonly [];
+    };
+
+/**
+ * Read reported delegation outcomes from existing completion rows.
+ *
+ * @param state - Delegating run state to inspect
+ * @returns Reported delegation outcome facts sorted by persisted completion key
+ */
+export function readDelegationOutcomeReportedFacts(
+  state: RunbookState,
+): readonly DelegationOutcomeReportedFact[] {
+  return Object.entries(state.resolvedCompletions ?? {})
+    .filter(
+      ([, completion]) =>
+        completion.agentId === DELEGATION_AGENT_ID && completion.targetSubstep !== undefined,
+    )
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([completionKey, completion]) => ({
+      kind: 'delegation-outcome-reported',
+      completionKey,
+      parentRunId: state.id,
+      targetStep: completion.targetStep,
+      targetSubstep: completion.targetSubstep as string,
+      ...(completion.targetIteration !== undefined
+        ? { targetIteration: completion.targetIteration }
+        : {}),
+      targetFrameKey: completion.targetFrameKey,
+      targetEntry: completion.targetEntry,
+      outcome: completion.result,
+      reportedAt: completion.completedAt,
+      ...(completion.finalVars ? { finalVars: completion.finalVars } : {}),
+    }));
+}
+
+function activeEntryFor(state: RunbookState, activeFrameKey: FrameKey): number {
+  return state.activeEntry ?? state.frameEntries?.[activeFrameKey] ?? 1;
+}
+
+function belongsToActiveCollectionScope(
+  fact: DelegationOutcomeReportedFact,
+  activeFrameKey: FrameKey,
+  activeEntry: number,
+): boolean {
+  // Provisional Plan 1 scope rule: report all delegation outcomes, but mark
+  // collection pending only for the active cursor frame/entry until the
+  // command-policy plan resolves wider enforcement semantics.
+  return (
+    fact.targetFrameKey === activeFrameKey &&
+    (fact.targetEntry === activeEntry || fact.targetEntry === SENTINEL_ENTRY)
+  );
+}
+
+/**
+ * Derive collection-pending state for the delegating run's active scope.
+ *
+ * @param state - Delegating run state to inspect
+ * @returns Collection-pending read model for the active frame and entry
+ */
+export function readDelegationCollectionPending(
+  state: RunbookState,
+): DelegationCollectionPendingReadModel {
+  const derived = deriveActiveFrame(state);
+  const activeFrameKey = state.activeFrameKey ?? derived.frameKey;
+  const activeEntry = activeEntryFor(state, activeFrameKey);
+  const outcomes = readDelegationOutcomeReportedFacts(state).filter((fact) =>
+    belongsToActiveCollectionScope(fact, activeFrameKey, activeEntry),
+  );
+
+  if (outcomes.length === 0) {
+    return {
+      kind: 'delegation-collection-pending',
+      pending: false,
+      parentRunId: state.id,
+      activeFrameKey,
+      activeEntry,
+      outcomes: [],
+    };
+  }
+
+  return {
+    kind: 'delegation-collection-pending',
+    pending: true,
+    parentRunId: state.id,
+    activeFrameKey,
+    activeEntry,
+    outcomes,
+    message: DELEGATION_COLLECTION_PENDING_MESSAGE,
+  };
+}
+```
+
+- [ ] **Step 4: Export the read-model API**
+
+In `packages/core/src/runbook/index.ts`, add this export block after the `delegation-service.js` export block:
+
+```typescript
+export {
+  DELEGATION_COLLECTION_PENDING_MESSAGE,
+  readDelegationCollectionPending,
+  readDelegationOutcomeReportedFacts,
+  type DelegationCollectionPendingReadModel,
+  type DelegationOutcomeReportedFact,
+} from './delegation-lifecycle-read-model.js';
+```
+
+- [ ] **Step 5: Run the focused read-model test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/delegation-lifecycle-read-model.test.ts --runInBand
+```
+
+Expected: PASS. The new pure read-model tests pass.
+
+- [ ] **Step 6: Run the delegation-service compatibility tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/delegation-service.test.ts --runInBand
+```
+
+Expected: PASS. Existing `readConsumedDelegationClosure` behavior remains unchanged.
+
+- [ ] **Step 7: Commit the read-model API**
+
+Run:
+
+```bash
+git add packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts packages/core/src/runbook/delegation-lifecycle-read-model.ts packages/core/src/runbook/index.ts
+git commit -m "feat(core): add delegation lifecycle read models"
+```
+
+Expected: commit succeeds with only the three listed files staged.
+
+### Task 4: Add Type-Level Verification for the New Read Models
+
+**Files:**
+- Modify: `packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts`
+
+- [ ] **Step 1: Add narrowing tests for the collection-pending union**
+
+Append these tests to `packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts` inside the `describe('readDelegationCollectionPending', () => { ... })` block:
+
+```typescript
+  it('narrows the pending variant to expose operator guidance', () => {
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const parent = state({
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    });
+
+    const model = readDelegationCollectionPending(parent);
+
+    if (!model.pending) {
+      throw new Error('expected collection pending');
+    }
+    expect(model.message).toBe(
+      'A delegated claim has reported an outcome that must be collected by the orchestrator.',
+    );
+    expect(model.outcomes[0]?.outcome).toBe('pass');
+  });
+
+  it('narrows the non-pending variant to an empty outcome list', () => {
+    const model = readDelegationCollectionPending(state());
+
+    if (model.pending) {
+      throw new Error('expected no collection pending');
+    }
+    expect(model.outcomes).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Run the focused read-model test**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/delegation-lifecycle-read-model.test.ts --runInBand
+```
+
+Expected: PASS. The tests compile, proving the `pending` discriminant narrows the union as intended.
+
+- [ ] **Step 3: Run core type checking**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core check:types
+```
+
+Expected: PASS. TypeScript accepts the exported read-model types and tests.
+
+- [ ] **Step 4: Commit the type-level verification**
+
+Run:
+
+```bash
+git add packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts
+git commit -m "test(core): verify delegation collection pending narrowing"
+```
+
+Expected: commit succeeds with only the read-model test file staged.
+
+### Task 5: Run Plan Verification
+
+**Files:**
+- Verify only; no source edits.
+
+- [ ] **Step 1: Run the Plan 1 focused test set**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/output/schema.test.ts __tests__/runbook/completion-service.test.ts __tests__/runbook/delegation-service.test.ts __tests__/runbook/delegation-lifecycle-read-model.test.ts --runInBand
+```
+
+Expected: PASS. Error-code schema tests, completion-service tests, existing delegation-service tests, and new read-model tests all pass.
+
+- [ ] **Step 2: Run core type checking**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core check:types
+```
+
+Expected: PASS. No exported type or test type errors.
+
+- [ ] **Step 3: Run repository formatting, spelling, and lint checks**
+
+Run:
+
+```bash
+pnpm run check:format
+pnpm run check:spell
+pnpm run check:lint:fast
+pnpm run check:lint:typed
+```
+
+Expected: PASS. The new exported symbols satisfy TSDoc requirements, the new files are formatted by Biome, no spelling rules fail on the new terminology, and both fast and typed lint pass.
+
+- [ ] **Step 4: Verify abort-force completion rows remain visible to the read model**
+
+Run:
+
+```bash
+rg -n "recordChildCompletionUnlocked\\(|ignoreCancellation: true|agentId: 'delegation'" packages/cli/src/commands/abort.ts packages/core/__tests__/runbook/completion-service.test.ts
+```
+
+Expected: output includes the `abort --force` linked-child path in `packages/cli/src/commands/abort.ts` calling `recordChildCompletionUnlocked({ childState, result: 'fail', ignoreCancellation: true })`, the fallback manual path in the same file using `agentId: 'delegation'`, and the existing `ignoreCancellation bypasses the cancelled short-circuit` test in `packages/core/__tests__/runbook/completion-service.test.ts` asserting `{ result: 'fail', agentId: 'delegation' }`. This confirms force-abort fail completions are still read-model-visible as delegation outcomes.
+
+- [ ] **Step 5: Scan for forbidden target-model names introduced by this plan**
+
+Run:
+
+```bash
+rg -n "ClaimHandoff|CLAIM_HANDOFF|--resume|handoff barrier|claim handoff" packages/core/src packages/core/__tests__
+```
+
+Expected: no output. If output appears only from pre-existing files outside this plan, do not edit those files in this plan; report the pre-existing references in the implementation summary.
+
+- [ ] **Step 6: Inspect the final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD~4..HEAD
+git diff --check HEAD~4..HEAD
+```
+
+Expected: `git diff --stat` lists only the files named in this plan, and `git diff --check` exits successfully with no whitespace errors.
+
+- [ ] **Step 7: Commit verification notes only if needed**
+
+If Step 5 exposes a pre-existing forbidden reference in files touched by this plan, update only the touched Plan 1 files to remove that new reference, then run:
+
+```bash
+git add packages/core/src/output/zod-schemas.ts packages/core/src/runbook/types.ts packages/core/src/runbook/completion-service.ts packages/core/src/runbook/index.ts packages/core/src/runbook/delegation-lifecycle-read-model.ts packages/core/__tests__/output/schema.test.ts packages/core/__tests__/runbook/completion-service.test.ts packages/core/__tests__/runbook/delegation-lifecycle-read-model.test.ts
+git commit -m "chore(core): align delegation lifecycle terminology"
+```
+
+Expected: commit is needed only when the plan itself introduced transitional handoff/resume terminology.
+
+## Self-Review Notes
+
+- Spec coverage: Plan 1 scope is covered by Task 1 (`DELEGATION_COLLECTION_PENDING` registry), Task 2 (`DelegationOutcome` and target-named lifecycle mapping), Task 3 (`DelegationOutcomeReportedFact` and `DelegationCollectionPendingReadModel`), and the Guardrails section that explicitly treats handoff/resume barrier work as superseded. Major behavior changes, actor context, command policy, collection operation, and report-then-collect behavior split are intentionally excluded because later plans own them.
+- Placeholder scan: This plan contains concrete paths, commands, expected outcomes, and code snippets for each code-changing step. It does not contain unresolved marker strings or vague implementation instructions.
+- Type consistency: `DelegationOutcome`, `DelegationOutcomeReportedFact`, `DelegationCollectionPendingReadModel`, `lifecycleToDelegationOutcome`, `readDelegationOutcomeReportedFacts`, and `readDelegationCollectionPending` are introduced before later steps reference them. The read-model test imports only the new read-model API and `RunbookState` from `packages/core/src/runbook/index.ts`; existing targeting helpers stay imported from `packages/core/src/runbook/targeting.ts`.
+- Scope consistency: `readDelegationOutcomeReportedFacts()` reports all delegation completion rows, while `readDelegationCollectionPending()` applies the provisional active-scope-only rule documented above. Plan 2 or Plan 3 must either ratify or replace that rule before using the read model for enforcement.
+- Compatibility: Existing `ConsumedDelegationClosureReadModel`, `readConsumedDelegationClosure()`, `lifecycleToResult()`, and `OPEN_DELEGATED_CHILDREN` remain available. No persisted schema field or command behavior changes are introduced.

--- a/docs/superpowers/plans/2026-06-17-report-then-collect.md
+++ b/docs/superpowers/plans/2026-06-17-report-then-collect.md
@@ -1,0 +1,1096 @@
+# Report Then Collect Implementation Plan
+
+> **Superseded for current behavior.** This is historical planning material.
+> For the current internal model, use
+> `docs/internal/delegation-lifecycle.md` and
+> `docs/internal/inline-composition.md`.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split delegated-claim closure into a *report-only* terminal close (record the delegation outcome and stop) plus an explicit `rd collect` that applies the outcome to the delegating run, so no delegating level ever auto-collects.
+
+**Architecture:** Today the terminal-close commands (`pass`, `fail`, `complete`, `stop`) and the `abort --force` path call `handleParentCompletion()`, which **records the delegation outcome AND immediately collects (drains/applies) the immediate delegating run** (single-level, post–Plan 4). Plan 5 changes terminal close to *report only*: it records the outcome onto the delegating run's `resolvedCompletions` (the row read by the already-merged `DELEGATION_COLLECTION_PENDING` guard) and stops — it does not drain or apply, not even one level. The delegating run is left **collection pending**. The orchestrator for that run then runs `rd collect`, which is the only path that applies outcomes (Plan 4's `collectDelegationOutcomes()`). Each delegating level requires its own explicit `rd collect`. This is a pure behavior change inside core's reporting seam plus the thin CLI wrappers; all collection logic stays in `collectDelegationOutcomes()`.
+
+**Tech Stack:** TypeScript, Jest, XState-backed `RunbookActorService`, Rundown core state services (`RunbookCompletionService`, `RunbookCollectionService`, `DelegationLock`, `CompletionLock`), Commander CLI adapters, `OutputEmitter`, scenario runner (`runbooks/**/*.runbook.md` frontmatter `scenarios:`), pnpm workspace scripts.
+
+## Global Constraints
+
+- **State machine in `@rundown-org/core` drives all runbook logic.** The report/collect split lives in core's reporting + collection services; CLI/MCP/plugin are thin front ends and MUST NOT reimplement the lifecycle. (CLAUDE.md § Architectural Principles)
+- **Side-effect categorisation:** the *report* step is **Category B** (machine-owned, pure: records a `resolvedCompletions` row via `recordChildCompletion`). Session release on terminal close (`sessionService.releaseRunbook`) is **Category A** (CLI-owned) and is preserved. No new Category C work.
+- **Concurrent write synchronization:** `recordChildCompletion` already takes the parent `DelegationLock` via `await using` scoped release; `abort --force` already holds the lock and uses `recordChildCompletionUnlocked`. Do not introduce a bare `finally` release (RD-102 masking defect). Do not add new locks.
+- **No persisted-state migration.** Plan 5 does not change any persisted schema; it changes *when* a recorded outcome is consumed. Reject incompatible state, never migrate. (CLAUDE.md § State Persistence)
+- **Type-driven dispatch; no silent action mapping; no synthetic IDs.** Terminal-close commands return typed outcomes; the `report-only` path does not silently convert a DEFER/STOP into a CONTINUE.
+- **Preserve the cancellation split:** ordinary cancel (`rd abort` without `--force`, or `recordChildCompletion` short-circuiting on `cancelledAt`) closes **without** a fail outcome; `abort --force` records a `fail` delegation outcome and **leaves collection pending** (it must NOT collect). (spec lines 144-149, 519-522, 555-556)
+- JSON is the agent-facing output contract; `--text` is human/debug-only and must not regress. (CLAUDE.md § CLI Output Standards)
+
+## Scope Notes
+
+- **Prerequisite: Plan 3 (`docs/superpowers/plans/2026-06-17-core-command-policy.md`) and Plan 4 (`docs/superpowers/plans/2026-06-17-core-collection-operation.md`) MUST be applied/merged before this plan.** Plan 5 builds directly on the merged: `collectDelegationOutcomes()` / `RunbookCollectionService` (Plan 4), `readDelegationCollectionPendingForPolicy()` + the `DELEGATION_COLLECTION_PENDING` guard wired into `resolveCommandIntent`/`resolveTransitionTarget` (Plan 3), and the single-level `handleParentCompletion()` (Plan 4). The current git branch is `core-collection-operation`.
+- **The central change:** the delegated terminal close must REPORT (record the outcome onto the delegating run) and STOP. It must NOT collect — not even the immediate delegating run. Today `handleParentCompletion()` records *and* collects one level; Plan 5 removes the collect-one-level behavior from the *close* path. Collection moves entirely behind `rd collect`.
+- **The guard already exists and is the release valve.** `readDelegationCollectionPendingForPolicy()` reads `resolvedCompletions` rows with `agentId === 'delegation'`. Because *report-only* leaves that row in place (collection is what removes it), the next bare `pass`/`fail`/`delegate` on the delegating run is already refused with `DELEGATION_COLLECTION_PENDING`. Plan 5 does not add new guard logic; it makes terminal close produce the pending state naturally instead of immediately consuming it.
+- **`rd collect` is unchanged in behavior** — Plan 4 already made it the explicit apply operation. Plan 5 only ensures it is now the *required* path (because close no longer collects).
+- **Observable behavior change — the whole point:** after a delegated child closes, the delegating run does **not** advance until someone runs `rd collect`. This supersedes Plan 4's "close still collects the immediate parent" note (Plan 4 Scope Notes § de-recursion explicitly deferred the close-behavior split to Plan 5).
+- **Single-level only — N-level is won't-build.** Delegation is capped at one delegating level by `RD-819` (`DELEGATION_NESTED_FORBIDDEN`): a claimed (delegated) run may not itself delegate. This mirrors the runtime (a Claude Code subagent cannot spawn subagents) and is permanent. The spec's N-level / middle-node / mid-chain-collection target model is **withdrawn** (see the spec's "Scope Decision: N-Level Delegation Is Won't-Build", 2026-06-20). Because there is only ever one delegating level, "collection is single-level" is trivially true and report-then-collect needs no recursion, no chain coverage, and no middle-node coverage. Report-then-collect is justified at N=1 on its own: it separates worker-stop from orchestrator-advance and fixes the `FAIL ANY STOP` aggregation-timing race.
+- **This is the highest-risk change in the whole design.** Land it last (after Plans 3 and 4), behind comprehensive integration + scenario coverage.
+
+### What changes vs. what stays
+
+| Path | Before Plan 5 (merged Plan 4) | After Plan 5 |
+| --- | --- | --- |
+| `handleParentCompletion()` | records outcome + collects immediate delegating run (single-level) | records outcome only, stops; releases own session entry; returns |
+| `rd collect` | explicit apply (single-level), the only de-recursed path | unchanged — now the *only* path that applies outcomes |
+| bare `pass`/`fail`/`delegate` on a reported-into run | refused if a *previously injected* outcome is pending | refused naturally now that real close reports rather than collects |
+| `abort --force` | records fail + drains/applies (propagateForceAbort) | records fail only, leaves collection pending |
+| ordinary cancel | closes without fail outcome | unchanged |
+
+### Naming note on `handleParentCompletion`
+
+The helper is renamed for clarity to `reportTerminalToDelegatingRun` (it no longer "completes" the parent — it reports upward). The function file `delegation-completion.ts` keeps its path. All call sites are updated. (This is a pure rename plus body change; do not leave a compatibility alias — CLAUDE.md forbids shadow implementations.)
+
+## File Structure
+
+- Modify: `packages/cli/src/helpers/delegation-completion.ts`
+  - Replace the single-level *record-then-collect* `handleParentCompletion()` with a *record-then-stop* `reportTerminalToDelegatingRun()`. It records the outcome onto the immediate delegating run via `RunbookCompletionService.recordChildCompletion`, releases the child's own session entry only, and returns. It does NOT construct `RunbookCollectionService`, does NOT call `collectDelegationOutcomes`, does NOT drain/apply.
+- Modify: `packages/cli/src/helpers/transition-command.ts`
+  - Update the pass/fail parent-propagation branch to call `reportTerminalToDelegatingRun` and reinterpret its return (`reported` / `not-applicable`) for exit-code purposes. The child run reaching terminal is a success (exit 0) regardless of whether the delegating run later collects.
+- Modify: `packages/cli/src/commands/complete.ts`
+  - Call `reportTerminalToDelegatingRun` instead of `handleParentCompletion`.
+- Modify: `packages/cli/src/commands/stop.ts`
+  - Call `reportTerminalToDelegatingRun` instead of `handleParentCompletion`.
+- Modify: `packages/cli/src/commands/claim.ts`
+  - The claim propagation seam (line ~201): when a claimed child reaches terminal *during launch* (`loopResult` is `'done'`/`'stopped'` — i.e. a **non-prompted, all-command child** that auto-executes per `runbook-pipeline.ts:1290-1293`; prompted/agent-driven children return `'waiting'` and skip this branch), it currently calls `handleParentCompletion` (auto-collect). Convert to `reportTerminalToDelegatingRun` (report-only). Drive `shouldExitWithError` from the child's own `result.loopResult` only — report never returns `'stopped'`, so it must not flip the exit code. This path is less common than the agent's explicit `rd complete`/`rd pass`, but it MUST change with the others (scripted/scenario children flow through here, and it breaks the typecheck after Task 2's rename).
+- Modify: `packages/cli/src/commands/run.ts`
+  - The `rd run` propagation branch (line ~229): a runbook that reaches terminal during `rd run` and carries a parentLinkage currently calls `handleParentCompletion`. Convert to `reportTerminalToDelegatingRun`; reinterpret the return (no `'handled'`/`'stopped'`) so propagation never drives the run's exit code.
+- Modify: `packages/cli/src/services/execution.ts`
+  - The execution-loop propagation seam (dynamic `import` of `handleParentCompletion`, line ~370): convert to `reportTerminalToDelegatingRun`. This is the shared loop that `run.ts` and claim-launch drive, so verify whether updating it subsumes the `run.ts`/`claim.ts` call sites or is a distinct seam — `rg -n "handleParentCompletion" packages/cli/src` after the rename must return **zero** matches.
+- Modify: `packages/cli/src/commands/abort.ts`
+  - `abort --force` records `fail` (already does, with `ignoreCancellation: true`) and then **reports** upward instead of draining/applying. Replace `propagateForceAbort()` (drain + execution loop + cascade) with a report-only path that records the fail outcome and leaves the delegating run collection pending. Remove the drain/loop/cascade imports.
+- Modify: `packages/core/src/runbook/completion-service.ts`
+  - Add a focused TSDoc note clarifying that `recordChildCompletion` is the *report* operation (records the outcome row; does not apply it). No signature change. (If a `report`-named thin wrapper improves call-site clarity it MAY be added, but the existing `recordChildCompletion` already implements report semantics — prefer no new API to avoid duplication, YAGNI.)
+- Modify: `packages/cli/__tests__/helpers/delegation-completion.test.ts`
+  - Rewrite the helper tests for report-only semantics: assert the outcome row is recorded on the delegating run, assert `RunbookCollectionService` / `collectDelegationOutcomes` / drain is **never** called, assert the delegating run cursor does **not** advance.
+- Modify: `packages/cli/__tests__/integration/delegation-propagation.test.ts`
+  - Update the existing "3-level chain" test (lines 395-493). Despite the name it is a *single* delegation level — Grandparent DELEGATEs to Parent, and Parent composes its child inline with `rd run` (not a nested delegation, per RD-819). Under Plan 5 the Parent's completion reports to the Grandparent, which is then collection pending and requires one explicit `rd collect`.
+- Modify: `packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts`
+  - Replace the `injectDelegationOutcomeForActiveRun` simulation in the headline test with a *real* delegated close so the test proves the natural report-then-collect flow end-to-end (the injection helper stays for the FOR-frame cases).
+- Create: `packages/cli/__tests__/integration/report-then-collect.test.ts`
+  - New integration suite (single-level only): real-delegated-close → pending → collect releases, bare-command-while-pending refusal (pass/fail/delegate), ordinary-cancel-no-fail, force-abort-records-fail-leaves-pending, FOR-scoped force-abort leaves the right frame pending.
+- Modify: `packages/cli/__tests__/commands/abort.test.ts`
+  - Update force-abort assertions: records fail outcome, leaves collection pending, does not advance the delegating run.
+- Modify (scenario fixtures): runbooks whose scenarios previously relied on auto-aggregation now need an explicit `rd collect` command in the scenario sequence. See Task 8 for the exact list (derived by audit, not guessed).
+- Create: `runbooks/delegation/delegate-report-then-collect.runbook.md`
+  - New scenario fixture pinning the single-level report-then-collect user-visible workflow (claim → child closes/reports → explicit `rd collect` → COMPLETE).
+
+## Tasks
+
+### Task 1: Pin report-only terminal close at the core seam (characterization tests)
+
+This task adds tests that lock in the *current* report behavior of `recordChildCompletion` (records a `resolvedCompletions` row, leaves it for collection) before any CLI behavior changes, so the seam Plan 5 relies on is proven.
+
+**Files:**
+- Modify: `packages/core/__tests__/runbook/completion-service.test.ts`
+- Modify: `packages/core/src/runbook/completion-service.ts` (TSDoc only)
+
+- [ ] **Step 1: Write a failing-then-passing characterization test for report-only recording**
+
+Append to `packages/core/__tests__/runbook/completion-service.test.ts`. This asserts that recording a child completion writes a `delegation` outcome row on the parent and does NOT advance the parent cursor (record ≠ apply). Reuse the inline `mkdtemp` + `new RunbookStateManager(tmp)` fixture pattern already used in that file.
+
+```typescript
+  it('reports a delegated outcome by recording a row without advancing the delegating run', async () => {
+    const parentFrameKey = buildFrameKey('1');
+    const parent = makeParentState({
+      id: parentRunId,
+      step: '1',
+      currentStep: 0,
+      substepStates: [{ id: '1', frameKey: parentFrameKey, status: 'running', delegation: { /* token hash etc. as the file's helper builds */ } }],
+      resolvedCompletions: {},
+    });
+    const child = makeChildState({
+      id: childRunId,
+      lifecycle: 'completed',
+      parentLinkage: {
+        kind: 'delegation',
+        parentRunId,
+        parentStepId: '1',
+        parentStep: '1',
+        parentFrameKey,
+        parentEntry: 1,
+      },
+    });
+    await manager.save(parent);
+    await manager.save(child);
+
+    const recorded = await completionService.recordChildCompletion({ childState: child, result: 'pass' });
+
+    expect(recorded).toBe('recorded');
+    const fresh = await manager.load(parentRunId);
+    // Report wrote exactly one delegation outcome row...
+    const delegationRows = Object.values(fresh?.resolvedCompletions ?? {}).filter(
+      (c) => c.agentId === 'delegation',
+    );
+    expect(delegationRows).toHaveLength(1);
+    expect(delegationRows[0]?.result).toBe('pass');
+    // ...and did NOT advance the parent (record is not apply).
+    expect(fresh?.step).toBe('1');
+    expect(fresh?.currentStep).toBe(0);
+  });
+```
+
+Adapt `makeParentState` / `makeChildState` / `parentRunId` / `childRunId` to the helper names the merged `completion-service.test.ts` already declares (reuse them verbatim; do not introduce new fixture builders).
+
+- [ ] **Step 2: Run the focused test and confirm it passes against current code**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/completion-service.test.ts --runInBand
+```
+
+Expected: PASS. `recordChildCompletion` already implements report semantics (this is a characterization test that locks the seam Plan 5 depends on).
+
+- [ ] **Step 3: Document the report seam in TSDoc**
+
+In `packages/core/src/runbook/completion-service.ts`, extend the `recordChildCompletion` TSDoc to state explicitly that this is the *report delegation outcome* operation: it records a `resolvedCompletions` row read by the collection-pending guard and consumed by `collectDelegationOutcomes`; it does not drain or apply the outcome to the delegating run.
+
+```typescript
+  /**
+   * Report a delegated child's terminal outcome to its delegating run.
+   *
+   * This is the REPORT half of the report-then-collect split (Plan 5): it
+   * records a `resolvedCompletions` row (`agentId: 'delegation'`) on the
+   * delegating run. That row is what `readDelegationCollectionPendingForPolicy`
+   * reads (leaving the delegating run collection pending) and what
+   * `collectDelegationOutcomes` later consumes. Reporting NEVER drains or
+   * applies the outcome — collection is the only apply path.
+   *
+   * Acquires the parent {@link DelegationLock} for the duration of the
+   * recording. Callers that already hold the parent delegation lock must use
+   * {@link recordChildCompletionUnlocked} instead to avoid deadlock.
+   *
+   * @param args - Child completion input
+   * @returns Recording outcome
+   */
+```
+
+- [ ] **Step 4: Re-run the core typecheck and focused test**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core check:types
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/completion-service.test.ts --runInBand
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/runbook/completion-service.ts packages/core/__tests__/runbook/completion-service.test.ts
+git commit -m "test(core): pin report-only delegation outcome recording"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 2: Replace `handleParentCompletion` with report-only `reportTerminalToDelegatingRun`
+
+**Files:**
+- Modify: `packages/cli/src/helpers/delegation-completion.ts`
+- Modify: `packages/cli/__tests__/helpers/delegation-completion.test.ts`
+
+- [ ] **Step 1: Write the failing report-only helper tests**
+
+Rewrite the test suite in `packages/cli/__tests__/helpers/delegation-completion.test.ts`. Replace the cascade/collect tests with report-only assertions. Reuse the merged file's existing mock-wiring helpers (`makeManager`, `makeLifecycleService`, `makeOutput`, `makeDelegationLinkage`, `brandFrameKeyForTest`, and the `CHILD_RUN_ID` / `PARENT_RUN_ID` / `GRANDPARENT_RUN_ID` fixtures) verbatim.
+
+```typescript
+  it('reports the child outcome onto the immediate delegating run and stops', async () => {
+    const delegation = makeDelegationLinkage();
+    const childState = makeState(CHILD_RUN_ID, { lifecycle: 'completed', parentLinkage: delegation });
+    const parentState = makeState(PARENT_RUN_ID, {
+      step: '1',
+      currentStep: 0,
+      substepStates: [{ id: '1', frameKey: brandFrameKeyForTest('1'), status: 'running' }],
+      resolvedCompletions: {},
+    });
+    const states = new Map([[parentState.id, parentState]]);
+    const manager = makeManager(states);
+    const lifecycleService = makeLifecycleService();
+    const output = makeOutput();
+    wireMocks(manager, lifecycleService);
+
+    const result = await reportTerminalToDelegatingRun(childState, 'pass', '/test', output);
+
+    // Report recorded exactly one outcome on the delegating run...
+    expect(result).toBe('reported');
+    expect(core.RunbookCompletionService).toHaveBeenCalledTimes(1);
+    // ...and NEVER collected: no collection service, no drain.
+    expect(core.RunbookCollectionService).not.toHaveBeenCalled();
+    expect(drainResolvedCompletions).not.toHaveBeenCalled();
+    // ...and did not advance the delegating run cursor.
+    const freshParent = await manager.load(PARENT_RUN_ID);
+    expect(freshParent?.step).toBe('1');
+    expect(freshParent?.currentStep).toBe(0);
+  });
+
+  it('returns not-applicable when the child has no parent linkage', async () => {
+    const childState = makeState(CHILD_RUN_ID, { lifecycle: 'completed', parentLinkage: undefined });
+    const manager = makeManager(new Map());
+    const output = makeOutput();
+    wireMocks(manager, makeLifecycleService());
+
+    const result = await reportTerminalToDelegatingRun(childState, 'pass', '/test', output);
+
+    expect(result).toBe('not-applicable');
+    expect(core.RunbookCompletionService).not.toHaveBeenCalled();
+  });
+
+  it('reports onto the immediate parent only and never touches an ancestor', async () => {
+    // Defensive single-level contract test. RD-819 means a delegating run never
+    // actually carries its own 'delegation' linkage, but we still pin that the
+    // helper touches ONLY the immediate parent: no recurse, no collect, no write
+    // to any ancestor. (The GRANDPARENT_RUN_ID state here is a synthetic guard.)
+    const delegation = makeDelegationLinkage();
+    const childState = makeState(CHILD_RUN_ID, { lifecycle: 'completed', parentLinkage: delegation });
+    const parentState = makeState(PARENT_RUN_ID, {
+      parentLinkage: makeDelegationLinkage({ parentRunId: GRANDPARENT_RUN_ID, parentStepId: '2' }),
+      resolvedCompletions: {},
+    });
+    const grandparentState = makeState(GRANDPARENT_RUN_ID, { resolvedCompletions: {} });
+    const states = new Map([
+      [parentState.id, parentState],
+      [grandparentState.id, grandparentState],
+    ]);
+    const manager = makeManager(states);
+    const output = makeOutput();
+    wireMocks(manager, makeLifecycleService());
+
+    const result = await reportTerminalToDelegatingRun(childState, 'pass', '/test', output);
+
+    expect(result).toBe('reported');
+    expect(core.RunbookCollectionService).not.toHaveBeenCalled();
+    // Grandparent untouched: no outcome row written to it.
+    const freshGrandparent = await manager.load(GRANDPARENT_RUN_ID);
+    expect(Object.keys(freshGrandparent?.resolvedCompletions ?? {})).toHaveLength(0);
+  });
+```
+
+Update the import at the top of the test file from `handleParentCompletion` to `reportTerminalToDelegatingRun`, and import `extractParentLinkage` unchanged. Delete any remaining merged tests that assert collection/drain/advancement happens during close (e.g. tests asserting `drainResolvedCompletions` is called, or the parent advanced after close) — those behaviors move to `rd collect`.
+
+- [ ] **Step 2: Run the helper tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/helpers/delegation-completion.test.ts --runInBand
+```
+
+Expected: FAIL because `reportTerminalToDelegatingRun` does not exist and the current helper still collects.
+
+- [ ] **Step 3: Rewrite the helper as report-only**
+
+Replace the body of `packages/cli/src/helpers/delegation-completion.ts`. Remove the `RunbookCollectionService` construction, the `collectDelegationOutcomes` call, the drain, and the terminal-collect branch. Keep `extractParentLinkage`. The new function records the outcome on the immediate delegating run and returns. Session release for the *child's own* run stays with the calling command (the child command already released its own session entry on terminal close); this helper does not release the delegating run (it is not terminal — it is merely pending collection).
+
+```typescript
+/**
+ * Report a child run's terminal outcome to its immediate delegating run.
+ *
+ * This is the REPORT half of report-then-collect (Plan 5). It records ONE
+ * delegation outcome row on the immediate delegating run (via core's
+ * `recordChildCompletion`) and returns. It does NOT collect, drain, apply, or
+ * advance the delegating run, and it does NOT recurse to ancestors. The
+ * delegating run is left collection pending; its orchestrator must run
+ * `rd collect` to apply the outcome.
+ *
+ * Works for both delegation children (`rd delegate`/`rd claim`) and inline
+ * children (`rd run --step`).
+ *
+ * @param childState - The terminal child run's state (must carry parentLinkage)
+ * @param result - Terminal result of the child ('pass' or 'fail')
+ * @param cwd - Current working directory
+ * @param output - Output emitter for CLI output
+ * @returns 'reported' when an outcome row was recorded (or was already present),
+ *          'not-applicable' when the child has no parent linkage
+ * @throws {Error} If state I/O fails.
+ */
+export async function reportTerminalToDelegatingRun(
+  childState: RunbookState,
+  result: 'pass' | 'fail',
+  cwd: string,
+  output: OutputEmitter,
+): Promise<'reported' | 'not-applicable'> {
+  const linkage = extractParentLinkage(childState);
+  if (!linkage) return 'not-applicable';
+
+  const manager = new RunbookStateManager(cwd);
+  const actorService = createCliRunbookActorService(manager);
+  const lifecycleService = new ExecutionLifecycleService(manager);
+  const completionService = new RunbookCompletionService(manager, lifecycleService, actorService);
+
+  const recorded = await completionService.recordChildCompletion({ childState, result });
+  // 'not-applicable' (no linkage / non-terminal) and 'cancelled' (ordinary
+  // cancel short-circuit) both mean nothing was reported upward. 'recorded' and
+  // 'duplicate' both mean the outcome row is present and the delegating run is
+  // now collection pending.
+  if (recorded === 'not-applicable') return 'not-applicable';
+  output.flush();
+  return 'reported';
+}
+```
+
+Remove the now-unused imports: `SessionService`, `exactFrame`, `getRunbookFromState`, `drainResolvedCompletions`, `runExecutionLoop`, `createBridgedEmitter`, `createPassTransitionConfig`, `createFailTransitionConfig`, `TransitionOrchestrationPolicy`, `ParentLinkageBase` (if only used by the removed helper), and the `reportTerminalParentUpward` helper (its single-level reporting collapses into the body above). Keep `RunbookStateManager`, `ExecutionLifecycleService`, `RunbookCompletionService`, `RunbookState`, `createCliRunbookActorService`, `extractParentLinkage`, and `OutputEmitter`.
+
+Note the `'cancelled'` recording outcome: `recordChildCompletion` returns `'cancelled'` when the parent substep was ordinarily cancelled (`cancelledAt` set, no `ignoreCancellation`). In that case no outcome row is written — the delegating run is NOT left collection pending. The function still returns `'reported'` (the child closed and there was nothing to report because the slot was cancelled); this preserves the cancellation split (ordinary cancel closes without a fail outcome). The force-abort path (Task 5) calls `recordChildCompletionUnlocked` with `ignoreCancellation: true` directly and does not route through this helper.
+
+- [ ] **Step 4: Run the helper tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/helpers/delegation-completion.test.ts --runInBand
+```
+
+Expected: PASS. The helper records and stops; no collection.
+
+- [ ] **Step 5: Commit (helper only — call sites updated in Task 3)**
+
+The CLI will not typecheck yet because call sites still import `handleParentCompletion`. Do not run a full `check:types` here; commit the helper and proceed to Task 3 in the same working session.
+
+```bash
+git add packages/cli/src/helpers/delegation-completion.ts packages/cli/__tests__/helpers/delegation-completion.test.ts
+git commit -m "feat(cli): make delegated close report-only"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 3: Update every auto-completion propagation call site to report-only
+
+This converts **all** non-abort call sites of `handleParentCompletion` to the new report-only helper. There are six (confirm with `rg -n "handleParentCompletion" packages/cli/src` — it must return only the abort matches after this task): `transition-command.ts` (pass/fail — the agent's explicit close, the common path), `complete.ts`, `stop.ts`, **`claim.ts` (child auto-completes during launch — only for non-prompted/scripted children), `run.ts` (runbook reaches terminal during `rd run`), and `services/execution.ts` (the shared execution loop the previous two drive).** Missing any of these leaves the auto-collect behavior in place for that path and breaks the typecheck after the Task 2 rename.
+
+**Files:**
+- Modify: `packages/cli/src/helpers/transition-command.ts`
+- Modify: `packages/cli/src/commands/complete.ts`
+- Modify: `packages/cli/src/commands/stop.ts`
+- Modify: `packages/cli/src/commands/claim.ts`
+- Modify: `packages/cli/src/commands/run.ts`
+- Modify: `packages/cli/src/services/execution.ts`
+- Modify: `packages/cli/__tests__/commands/pass.test.ts`
+- Modify: `packages/cli/__tests__/commands/fail.test.ts`
+- Modify: `packages/cli/__tests__/commands/complete.test.ts`
+- Modify: `packages/cli/__tests__/commands/stop.test.ts`
+- Modify: `packages/cli/__tests__/commands/claim.test.ts`
+- Modify: `packages/cli/__tests__/commands/run.test.ts` (and any `services/execution` test)
+
+- [ ] **Step 1: Add failing command-level tests for report-only close**
+
+In `packages/cli/__tests__/commands/complete.test.ts` and `packages/cli/__tests__/commands/stop.test.ts`, add a test (per file) asserting that when the active run is a delegated child, the terminal close records a delegation outcome on the delegating run and exits 0, and that the delegating run is left at its pre-close cursor (NOT advanced). In `pass.test.ts` / `fail.test.ts`, add the equivalent for a delegated child whose transition reaches terminal. Use the existing test harness in each file (most use the in-process CLI runner or mocked core services); follow the established mocking conventions (structural service doubles outside core — CLAUDE.md § Testing Conventions).
+
+Example shape for `complete.test.ts` (adapt to the file's harness):
+
+```typescript
+  it('reports the outcome upward and leaves the delegating run uncollected', async () => {
+    // ...start parent, delegate, claim child, drive child to a complete-able cursor...
+    const res = await runCliInProcess(['complete', '--claim-id', childClaimId], workspace);
+    expect(res.exitCode).toBe(0);
+
+    const parent = await readRunbookState(workspace, parentRunId);
+    // Outcome reported (delegation row present)...
+    const rows = Object.values(parent!.resolvedCompletions ?? {}).filter((c) => c.agentId === 'delegation');
+    expect(rows).toHaveLength(1);
+    // ...but parent NOT advanced (still on the DELEGATE step).
+    expect(parent!.step).toBe('1');
+  });
+```
+
+- [ ] **Step 2: Run the command tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/complete.test.ts __tests__/commands/stop.test.ts __tests__/commands/pass.test.ts __tests__/commands/fail.test.ts --runInBand
+```
+
+Expected: FAIL — current close still collects/advances the delegating run.
+
+- [ ] **Step 3: Update `transition-command.ts`**
+
+In `packages/cli/src/helpers/transition-command.ts`, change the import on line 15 from `handleParentCompletion` to `reportTerminalToDelegatingRun`. Replace the parent-propagation block (lines 196-214). The child reaching terminal is a success regardless of whether the delegating run later collects, so propagation no longer drives the exit code toward failure:
+
+```typescript
+            // Report this delegated child's terminal outcome to its delegating
+            // run (report-only — Plan 5). The delegating run is left collection
+            // pending; its orchestrator must run `rd collect`. The child closing
+            // is a success, so reporting NEVER flips the exit code to failure.
+            const freshState = await ctx.manager.load(ctx.state.id);
+            if (freshState && extractParentLinkage(freshState)) {
+              const isTerminal =
+                freshState.lifecycle === 'completed' || freshState.lifecycle === 'stopped';
+              if (isTerminal) {
+                const reportResult = freshState.lifecycle === 'completed' ? 'pass' : 'fail';
+                await reportTerminalToDelegatingRun(freshState, reportResult, cwd, output);
+                // The child's own terminal lifecycle still governs this command's
+                // exit code (a local STOP is exit 1); reporting upward does not
+                // change it, because the delegating run advances only on collect.
+              }
+            }
+```
+
+Note: the local `shouldExitWithError` (set when `executeTransition` returned `'stopped'`) is preserved — a delegated child that locally STOPs still exits 1. What changes is that we no longer let parent propagation *clear* (`'handled'`) or *re-assert* (`'stopped'`) the exit code, because the delegating run no longer transitions at close time.
+
+- [ ] **Step 4: Update `complete.ts` and `stop.ts`**
+
+In `packages/cli/src/commands/complete.ts`, change the import (line 24) and the call (lines 157-159):
+
+```typescript
+import { extractParentLinkage, reportTerminalToDelegatingRun } from '../helpers/delegation-completion.js';
+```
+
+```typescript
+          await sessionService.releaseRunbook(state.id);
+          if (syncResult && extractParentLinkage(syncResult.state)) {
+            // Report-only (Plan 5): record the PASS outcome on the delegating run
+            // and stop. The delegating run is left collection pending.
+            await reportTerminalToDelegatingRun(syncResult.state, 'pass', cwd, output);
+          }
+```
+
+In `packages/cli/src/commands/stop.ts`, change the import (line 18) and the call (lines 156-158):
+
+```typescript
+import { reportTerminalToDelegatingRun, extractParentLinkage } from '../helpers/delegation-completion.js';
+```
+
+```typescript
+          if (syncResult && extractParentLinkage(syncResult.state)) {
+            // Report-only (Plan 5): record the FAIL outcome on the delegating run
+            // and stop. A user-initiated stop always exits 0.
+            await reportTerminalToDelegatingRun(syncResult.state, 'fail', cwd, output);
+          }
+```
+
+- [ ] **Step 5: Update the claim / run / execution-loop propagation seams**
+
+These are the auto-completion paths. Each currently calls `handleParentCompletion` when a delegated/nested run reaches terminal *on its own* (not via an explicit terminal command), and each auto-collects. Convert all three to report-only.
+
+`packages/cli/src/commands/claim.ts` (~line 201) — when the claimed child auto-completes during launch:
+
+```typescript
+            // Report-only (Plan 5): a child that auto-completed during launch
+            // reports its outcome to the delegating run, which is left collection
+            // pending. The child's OWN loopResult governs this command's exit code;
+            // reporting upward never flips it.
+            let shouldExitWithError = result.loopResult === 'stopped';
+            if (result.loopResult === 'done' || result.loopResult === 'stopped') {
+              const childState = await manager.load(result.childRunId);
+              if (childState && extractParentLinkage(childState)) {
+                const propResult = childState.lifecycle === 'completed' ? 'pass' : 'fail';
+                await reportTerminalToDelegatingRun(childState, propResult, cwd, output);
+                // No `propagation === 'stopped'` branch: report does not return 'stopped'.
+              }
+            }
+```
+
+`packages/cli/src/commands/run.ts` (~line 229) and `packages/cli/src/services/execution.ts` (~line 370, dynamic import): replace the `handleParentCompletion` call with `reportTerminalToDelegatingRun` and drop any branch that used its `'handled'`/`'stopped'` return to influence the exit code. Read each call's current use of the return value first (`sed -n` the surrounding lines) and reinterpret: the local run's own terminal lifecycle governs exit; reporting upward is side-effect-only. **Determine whether `run.ts` and `claim.ts` both flow through `execution.ts`'s loop** — if the propagation lives solely in `execution.ts`, the `run.ts`/`claim.ts` edits may reduce to import cleanup; if each has its own seam, convert each. The gate is the same: zero `handleParentCompletion` matches after.
+
+Update `claim.test.ts` / `run.test.ts` (and any execution-loop test) to assert the auto-completing path now leaves the delegating run collection pending (a delegation outcome row recorded, cursor not advanced) and exits per the child's own lifecycle.
+
+- [ ] **Step 6: Run the command tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/complete.test.ts __tests__/commands/stop.test.ts __tests__/commands/pass.test.ts __tests__/commands/fail.test.ts __tests__/commands/claim.test.ts __tests__/commands/run.test.ts --runInBand
+pnpm --filter @rundown-org/cli check:types
+rg -n "handleParentCompletion" packages/cli/src   # must show ONLY abort.ts (removed in Task 5)
+```
+
+Expected: PASS. The CLI typechecks, and the only remaining `handleParentCompletion` references are in `abort.ts` (deleted in Task 5).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/helpers/transition-command.ts packages/cli/src/commands/complete.ts packages/cli/src/commands/stop.ts packages/cli/src/commands/claim.ts packages/cli/src/commands/run.ts packages/cli/src/services/execution.ts packages/cli/__tests__/commands/pass.test.ts packages/cli/__tests__/commands/fail.test.ts packages/cli/__tests__/commands/complete.test.ts packages/cli/__tests__/commands/stop.test.ts packages/cli/__tests__/commands/claim.test.ts packages/cli/__tests__/commands/run.test.ts
+git commit -m "feat(cli): route all auto-completion propagation through report-only"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 4: Preserve the ordinary-cancel split (no fail outcome on cancel)
+
+This task adds explicit coverage that ordinary cancellation does NOT leave a fail outcome / collection pending. The behavior already exists (the `cancelledAt` short-circuit in `recordChildCompletion`), so this is a pinning task.
+
+**Files:**
+- Modify: `packages/cli/__tests__/integration/delegation-abort.test.ts`
+
+- [ ] **Step 1: Add a failing-then-passing ordinary-cancel test**
+
+Append to `packages/cli/__tests__/integration/delegation-abort.test.ts` (reuse its workspace/runbook helpers):
+
+```typescript
+  it('ordinary abort (no --force) closes the delegation without a fail outcome or pending collection', async () => {
+    // ...start parent, delegate a token (issued, not yet claimed)...
+    const abort = await runCliInProcess(`abort ${token}`, workspace);
+    expect(abort.exitCode).toBe(0);
+
+    const parent = await getActiveState(workspace);
+    // No delegation outcome row recorded — ordinary cancel synthesizes no fail.
+    const rows = Object.values(parent!.resolvedCompletions ?? {}).filter((c) => c.agentId === 'delegation');
+    expect(rows).toHaveLength(0);
+
+    // The delegating run is NOT collection pending: a bare advance is allowed.
+    const advance = await runCliInProcess('pass', workspace);
+    const payload = JSON.parse(advance.stdout) as { code?: string };
+    expect(payload.code).not.toBe('DELEGATION_COLLECTION_PENDING');
+  });
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/delegation-abort.test.ts --runInBand
+```
+
+Expected: PASS. Ordinary cancel does not record a fail outcome; the spec's cancellation split is preserved.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/__tests__/integration/delegation-abort.test.ts
+git commit -m "test(cli): pin ordinary-cancel records no fail outcome"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 5: Make `abort --force` report-only (records fail, leaves collection pending)
+
+**Files:**
+- Modify: `packages/cli/src/commands/abort.ts`
+- Modify: `packages/cli/__tests__/commands/abort.test.ts`
+- Modify: `packages/cli/__tests__/integration/delegation-abort.test.ts`
+
+- [ ] **Step 1: Add failing force-abort tests for report-only behavior**
+
+In `packages/cli/__tests__/integration/delegation-abort.test.ts`, add (or update the existing force-abort test to assert):
+
+```typescript
+  it('force abort records a fail outcome and leaves the delegating run collection pending', async () => {
+    // ...start parent, delegate, claim the child (in-flight), then force abort...
+    const abort = await runCliInProcess(`abort ${token} --force`, workspace);
+    expect(abort.exitCode).toBe(0);
+
+    const parent = await getActiveState(workspace);
+    // Fail outcome reported...
+    const rows = Object.values(parent!.resolvedCompletions ?? {}).filter((c) => c.agentId === 'delegation');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.result).toBe('fail');
+    // ...parent NOT advanced/aggregated by the abort itself (no drain/apply).
+    expect(parent!.step).toBe('1');
+
+    // Collection pending: bare advance refused until `rd collect`.
+    const blocked = await runCliInProcess('pass', workspace);
+    expect(blocked.exitCode).toBe(1);
+    expect((JSON.parse(blocked.stdout) as { code?: string }).code).toBe('DELEGATION_COLLECTION_PENDING');
+  });
+```
+
+Update any merged force-abort assertion that expects the parent to have advanced/aggregated after `abort --force` — under Plan 5 it must NOT advance.
+
+Also add a **FOR-scoped** force-abort test (this is the one case where the writer/reader frame-key agreement is load-bearing and is currently unpinned — a verification confirmed the chain is correct today but has no regression test). Use a runbook with a `FOR … IN` step containing a delegated substep; start, advance into an iteration, claim the child, `abort --force`, then assert the recorded row carries the **iteration frame key** and that a bare advance is refused:
+
+```typescript
+  it('force abort inside a FOR iteration leaves that iteration frame collection pending', async () => {
+    // ...start a runbook whose step iterates `FOR x IN ...` over a delegated substep;
+    //    advance into the first iteration; claim the child; then force abort...
+    const abort = await runCliInProcess(`abort ${token} --force`, workspace);
+    expect(abort.exitCode).toBe(0);
+
+    const parent = await getActiveState(workspace);
+    const rows = Object.values(parent!.resolvedCompletions ?? {}).filter((c) => c.agentId === 'delegation');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.result).toBe('fail');
+    // The recorded row is keyed on the ITERATION frame, not the bare step frame.
+    expect(rows[0]?.targetFrameKey).toBe(parent!.substepStates![0]!.frameKey);
+
+    // Bare advance refused — the iteration frame is collection pending.
+    const blocked = await runCliInProcess('pass', workspace);
+    expect((JSON.parse(blocked.stdout) as { code?: string }).code).toBe('DELEGATION_COLLECTION_PENDING');
+  });
+```
+
+Why this matters and why it is safe: deleting `propagateForceAbort` (Step 3) relies on the in-lock `recordChildCompletionUnlocked` being the sole report. That recording derives its frame key from `linkage.parentFrameKey` (set to the delegating substep's own `frameKey` at claim time — the FOR-scoped key), and the collection-pending guard reads the same `targetFrameKey` via `deriveOpenFrames`. The writer and reader agree for FOR-scoped delegations; `propagateForceAbort` contributes no frame-targeting of its own (it only drains/applies/cascades, which Plan 5 removes). This test pins that agreement against future regressions.
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/delegation-abort.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/abort.test.ts --runInBand
+```
+
+Expected: FAIL — `propagateForceAbort` currently drains/applies and cascades, so the parent advances.
+
+- [ ] **Step 3: Replace `propagateForceAbort` with a report-only path**
+
+In `packages/cli/src/commands/abort.ts`:
+
+The fail outcome is already recorded inside the lock (lines 314-369 via `recordChildCompletionUnlocked` / `recordManualCompletion`). That recording IS the report. So the post-lock work (step 11) no longer needs to drain or cascade — the recorded row already leaves the delegating run collection pending. Delete the `propagateForceAbort` function (lines 46-118) and replace the step-11 call (lines 377-380) with nothing (or a comment), because reporting already happened under the lock:
+
+```typescript
+          // 11. Report-only (Plan 5): the FAIL outcome was already recorded onto
+          //     the delegating run inside the lock (step 9). That recorded row
+          //     leaves the delegating run collection pending — the orchestrator
+          //     must run `rd collect`. We do NOT drain, apply, or cascade here.
+```
+
+Remove the now-unused imports from `abort.ts`: `ExecutionLifecycleService` (only if no other use remains — it IS still used in `hasResolvedCompletion` and step 9, so keep it), `drainResolvedCompletions`, `runExecutionLoop`, `createBridgedEmitter`, `createFailTransitionConfig`, `handleParentCompletion`/`reportTerminalToDelegatingRun`, `extractParentLinkage`, `TransitionOrchestrationPolicy`, and `getRunbookFromState` (verify each is unused after deleting `propagateForceAbort` via `rg` before removing). Keep `RunbookCompletionService`, `activeFrame`, `buildCompletionKey`, `deriveActiveFrame`, `exactFrame`, `inactiveFrame`, and the lock/scan imports.
+
+> Verification gate before editing: run `rg -n "propagateForceAbort|drainResolvedCompletions|runExecutionLoop|handleParentCompletion|createBridgedEmitter|createFailTransitionConfig" packages/cli/src/commands/abort.ts` first and remove exactly the imports that drop to zero references after deleting the function.
+
+- [ ] **Step 4: Run the abort tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/delegation-abort.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/abort.test.ts --runInBand
+pnpm --filter @rundown-org/cli check:types
+```
+
+Expected: PASS. Force abort records fail and leaves the parent collection pending; the parent does not advance.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/commands/abort.ts packages/cli/__tests__/commands/abort.test.ts packages/cli/__tests__/integration/delegation-abort.test.ts
+git commit -m "feat(cli): make force-abort report-only, leave collection pending"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 6: End-to-end report-then-collect integration coverage
+
+**Files:**
+- Create: `packages/cli/__tests__/integration/report-then-collect.test.ts`
+- Modify: `packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts`
+
+- [ ] **Step 1: Convert the headline lifecycle test to a real delegated close**
+
+In `packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts`, the headline test (lines 27-81) currently *injects* the reported outcome via `injectDelegationOutcomeForActiveRun`. Replace the injection with a real claim + child close so the test proves the natural report-then-collect flow:
+
+```typescript
+  it('a real delegated close reports an outcome, refuses bare advance, then collect releases it', async () => {
+    // ...write parent (DELEGATE substep -> child) + child runbooks...
+    const start = await runCliInProcess('run --prompted runbooks/parent.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+
+    const parentState = await getActiveState(workspace);
+    const token = parentState!.substepStates![0]!.delegation!.token!;
+
+    // Claim and drive the child to terminal — this REPORTS the outcome upward.
+    const claim = await runCliInProcess(`claim ${token}`, workspace);
+    const claimId = String(findActionOutput(claim.stdout)!.claim_id);
+    const closeChild = await runCliInProcess(['complete', '--claim-id', claimId], workspace);
+    expect(closeChild.exitCode).toBe(0);
+
+    // The reported outcome leaves the parent collection pending: bare pass refused.
+    const blocked = await runCliInProcess('pass', workspace);
+    expect(blocked.exitCode).toBe(1);
+    expect((JSON.parse(blocked.stdout) as { code?: string }).code).toBe('DELEGATION_COLLECTION_PENDING');
+
+    // Collect applies the outcome; the parent advances and a bare pass now works.
+    const collected = await runCliInProcess('collect', workspace);
+    expect(collected.exitCode).toBe(0);
+    const advanced = await runCliInProcess('pass', workspace);
+    expect(advanced.exitCode).toBe(0);
+    expect((JSON.parse(advanced.stdout) as { code?: string }).code).toBeUndefined();
+  }, 30_000);
+```
+
+Keep the FOR-scoped frame tests (lines 83+) using `injectDelegationOutcomeForFrame` — those exercise the frame-derivation paths and do not need a full child runbook.
+
+- [ ] **Step 2: Run the lifecycle test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/collection-pending-lifecycle.test.ts --runInBand
+```
+
+Expected: PASS. The natural flow (real close reports → guard blocks → collect releases) works end to end.
+
+- [ ] **Step 3: Add the bare-command-while-pending refusal suite (single delegation level)**
+
+Create `packages/cli/__tests__/integration/report-then-collect.test.ts`. Use the same workspace/runbook helpers as `delegation-propagation.test.ts` (`createTestWorkspace`, `createRunbook`, `runCliInProcess`, `getActiveState`, `readRunbookState`, `findActionOutput`). This suite proves that, after a *real* delegated close leaves the (single) delegating run collection pending, every bare advancing intent — `pass`, `fail`, and `delegate` — is refused with `DELEGATION_COLLECTION_PENDING` until an explicit `rd collect`. (There is no N-level or middle-node case: RD-819 caps delegation at one level — see Scope Notes.)
+
+```typescript
+  // Helper: start a parent that DELEGATEs one substep, claim + close the child so
+  // the parent is left collection pending. Returns the workspace in that state.
+  async function pendingParent(workspace: TestWorkspace): Promise<void> {
+    await runCliInProcess('run --prompted parent.runbook.md', workspace);
+    const parent = await getActiveState(workspace);
+    const token = parent!.substepStates![0]!.delegation!.token!;
+    const claim = await runCliInProcess(`claim ${token}`, workspace);
+    const claimId = String(findActionOutput(claim.stdout)!.claim_id);
+    const close = await runCliInProcess(['complete', '--claim-id', claimId], workspace);
+    expect(close.exitCode).toBe(0);
+  }
+
+  it.each(['pass', 'fail', 'delegate'])(
+    'refuses bare rd %s while a reported outcome is uncollected',
+    async (intent) => {
+      await pendingParent(workspace);
+      const blocked = await runCliInProcess(intent, workspace); // bare, no --step/--claim-id
+      expect(blocked.exitCode).toBe(1);
+      expect((JSON.parse(blocked.stdout) as { code?: string }).code).toBe('DELEGATION_COLLECTION_PENDING');
+    },
+  );
+
+  it('an explicit rd collect releases the pending state and advancing resumes', async () => {
+    await pendingParent(workspace);
+    const collected = await runCliInProcess('collect', workspace);
+    expect(collected.exitCode).toBe(0);
+    const advanced = await runCliInProcess('pass', workspace);
+    expect(advanced.exitCode).toBe(0);
+    expect((JSON.parse(advanced.stdout) as { code?: string }).code).toBeUndefined();
+  }, 30_000);
+```
+
+Adjust the bare `delegate` invocation to whatever the merged delegate command accepts as a bare advance; if `rd delegate` requires a target, pin the closest bare form the merged delegate command guards. Verify with `rg -n "delegation-issuance|delegate" packages/cli/src/commands/delegate.ts`. The happy-path real-close→collect flow is also covered end-to-end in `collection-pending-lifecycle.test.ts` (Step 1); this suite's value is the per-intent refusal matrix.
+
+- [ ] **Step 4: Run the new integration suite and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/report-then-collect.test.ts --runInBand
+```
+
+Expected: PASS. After a real delegated close, every bare advancing intent (pass/fail/delegate) is refused while pending; an explicit `rd collect` releases it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/__tests__/integration/report-then-collect.test.ts packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts
+git commit -m "test(cli): integration coverage for report-then-collect"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 7: Reconcile the existing propagation integration test
+
+This test is named "3-level chain" but is a **single delegation level**: the grandparent DELEGATEs to the parent, and the parent composes its child inline with `rd run` (not a nested delegation — RD-819 forbids that). So the only delegation is grandparent → parent, and Plan 5 requires exactly one explicit `rd collect` for it.
+
+**Files:**
+- Modify: `packages/cli/__tests__/integration/delegation-propagation.test.ts`
+
+- [ ] **Step 1: Run the test and observe the break**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/delegation-propagation.test.ts --runInBand
+```
+
+Expected: FAIL on `'child completion cascades through parent to grandparent'` (lines 395-493). Under Plan 5 the parent's terminal close reports to the grandparent but does NOT advance it; the test currently asserts the grandparent is "at substep 1.2" right after the parent completes (lines 483-491).
+
+- [ ] **Step 2: Rewrite the test to require an explicit collect for the reported outcome**
+
+Update the test body after the parent completes (the section around lines 478-491). Insert an explicit `rd collect` at the grandparent before asserting it advances, and assert the intermediate collection-pending state:
+
+```typescript
+      // Verify parent completed (reports PASS to grandparent 1.1, report-only).
+      const updatedParent = await readRunbookState(workspace, parentRunId);
+      expect(updatedParent!.lifecycle).toBe('completed');
+
+      // Plan 5: the grandparent is NOT auto-advanced. It is collection pending
+      // on substep 1.1 until its orchestrator collects.
+      let gp = await readRunbookState(workspace, grandparentRunId);
+      const gpRows = Object.values(gp!.resolvedCompletions ?? {}).filter((c) => c.agentId === 'delegation');
+      expect(gpRows).toHaveLength(1);
+
+      // A bare grandparent pass is refused while pending.
+      const blocked = await runCliInProcess('pass', workspace);
+      expect((JSON.parse(blocked.stdout) as { code?: string }).code).toBe('DELEGATION_COLLECTION_PENDING');
+
+      // Explicit collect applies the reported outcome and advances the grandparent.
+      const collected = await runCliInProcess('collect', workspace);
+      expect(collected.exitCode).toBe(0);
+
+      // Now drive the grandparent's remaining substep to COMPLETE.
+      result = await runCliInProcess('pass --text', workspace);
+      const updatedGrandparent = await readRunbookState(workspace, grandparentRunId);
+      expect(updatedGrandparent!.lifecycle).toBe('completed');
+```
+
+If the grandparent step has two substeps (1.1 delegated, 1.2 inline) and the DEFER/PASS-ALL aggregation requires both before COMPLETE, sequence the explicit `rd collect` for the delegated substep then drive 1.2 with `rd pass` per the merged step layout. Read the grandparent runbook the test authors (lines 398-415) and pin the exact substep sequence to whatever the aggregation requires.
+
+- [ ] **Step 3: Run the test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/delegation-propagation.test.ts --runInBand
+```
+
+Expected: PASS. The grandparent → parent delegation now requires one explicit `rd collect` before the grandparent advances.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cli/__tests__/integration/delegation-propagation.test.ts
+git commit -m "test(cli): require explicit collect for reported delegation outcome"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 8: Scenario fixture coverage for the user-visible workflow change
+
+Scenarios that previously relied on auto-aggregation (claim all → auto-collect → COMPLETE) now need an explicit `rd collect` step. This task audits the scenario corpus, updates affected scenarios, and adds a dedicated report-then-collect fixture.
+
+**Files:**
+- Modify: scenario fixtures identified by the audit (under `runbooks/delegation/`)
+- Create: `runbooks/delegation/delegate-report-then-collect.runbook.md`
+- Modify: `packages/cli/__tests__/integration/scenario-runner.test.ts` (only if new staging is required for the new fixture)
+
+- [ ] **Step 1: Audit which scenarios depend on auto-aggregation**
+
+Run the scenario suite first to see exactly which fixtures break under the new behavior (this is the authoritative list — do not guess):
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/scenario-runner.test.ts --runInBand 2>&1 | tee /tmp/scenario-failures.txt
+rg -n "aggregated: true|result: COMPLETE|result: STOP" runbooks/delegation/*.runbook.md
+```
+
+Cross-reference the failing scenarios with those whose `commands:` list a `claim` but NO `rd collect` (e.g. `delegate-keyword-collect-pass.runbook.md`, `delegate-keyword-collect-fail.runbook.md`, `delegate-nested.runbook.md`, `delegate-hierarchy.runbook.md`). These are the scenarios where claim-driven child close used to auto-aggregate.
+
+- [ ] **Step 2: Add `rd collect` to each affected scenario sequence**
+
+For each affected scenario, insert `rd collect` after the last `rd claim` (and before the COMPLETE/STOP expectation). Fixtures with multiple delegated substeps at the same delegating level (`delegate-hierarchy`, `delegate-nested-*`) still need only **one** `rd collect` — collection consumes all reported outcomes for the active delegating scope at once (claim each substep, then a single `rd collect`). There are no multi-*delegating-level* fixtures: RD-819 caps delegation at one level. Example for `delegate-keyword-collect-pass.runbook.md`:
+
+```yaml
+scenarios:
+  all-pass:
+    description: Auto-issue tokens, claim both passing substeps, then collect to fire COMPLETE
+    commands:
+      - rd run delegate-keyword-collect-pass.runbook.md
+      - rd claim ${TOKEN}
+      - rd claim ${TOKEN_2}
+      - rd collect
+    expect:
+      result: COMPLETE
+      steps:
+        - action: COMPLETE
+          result: PASS
+          aggregated: true
+```
+
+Update the scenario `description` text where it claims auto-aggregation so docs stay accurate. Do NOT change the runbook *body* (steps/aggregation rules) — only the scenario command sequence and descriptions.
+
+- [ ] **Step 3: Create the dedicated report-then-collect scenario fixture**
+
+Create `runbooks/delegation/delegate-report-then-collect.runbook.md` pinning the user-visible explicit-collect workflow at a single delegating level. Follow the existing fixture format (frontmatter `scenarios:` with `commands:` and `expect:`):
+
+```markdown
+---
+name: delegate-report-then-collect
+description: Single-level delegation where the delegating run requires an explicit rd collect
+tags:
+  - delegation
+  - report-then-collect
+
+scenarios:
+  explicit-collect:
+    description: Child closes and reports its outcome; the delegating run requires an explicit rd collect to fire COMPLETE
+    commands:
+      - rd run delegate-report-then-collect.runbook.md
+      - rd claim ${TOKEN}
+      - rd collect
+    expect:
+      result: COMPLETE
+      steps:
+        - action: COMPLETE
+          result: PASS
+          aggregated: true
+---
+
+# Report Then Collect
+
+## 1. Top-level work
+
+- DELEGATE
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+### 1.1 Delegated work
+
+- delegation-child-pass.runbook.md
+```
+
+Adjust the `commands:` / `${TOKEN}` placeholders to match the scenario runner's token-substitution convention (verify against `delegate-nested.runbook.md`, which uses `${TOKEN}` after `rd run`). If the scenario runner auto-executes the claimed child to terminal (reporting the outcome), a single `rd collect` after the claim is what fires COMPLETE; if it does not, add an explicit `rd complete --claim-id ...` (closing the child) before `rd collect`. Pin the exact sequence the runner requires by iterating Step 4 below.
+
+- [ ] **Step 4: Run the scenario suite and verify all scenarios pass**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/scenario-runner.test.ts --runInBand
+```
+
+Expected: PASS. Every affected scenario now collects explicitly; the new fixture pins the single-level explicit-collect workflow. Iterate Steps 2-3 until green (the scenario runner is the oracle for the exact command sequence and token substitution).
+
+- [ ] **Step 5: Run the spell check on the new/edited fixtures and plan docs**
+
+Run:
+
+```bash
+pnpm run check:spell
+```
+
+Expected: PASS. (New scenario descriptions and the chain fixture introduce prose that the spell checker scans.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add runbooks/delegation/ packages/cli/__tests__/integration/scenario-runner.test.ts
+git commit -m "test(scenarios): require explicit collect after delegated close"
+```
+
+Expected: commit succeeds with only the listed files staged.
+
+### Task 9: Full verification and architecture review
+
+**Files:**
+- Verify: `packages/cli/src/helpers/delegation-completion.ts`
+- Verify: `packages/cli/src/helpers/transition-command.ts`
+- Verify: `packages/cli/src/commands/{complete,stop,abort}.ts`
+- Verify: test files touched in Tasks 1-8
+
+- [ ] **Step 1: Search for forbidden close-time collection / leftover recursion**
+
+Run:
+
+```bash
+rg -n "handleParentCompletion|propagateForceAbort|reportTerminalParentUpward" packages/cli/src
+rg -n "collectDelegationOutcomes|RunbookCollectionService|drainResolvedCompletions|runExecutionLoop" packages/cli/src/helpers/delegation-completion.ts packages/cli/src/commands/abort.ts
+```
+
+Expected: the first command has **no matches** — the old names are fully removed and replaced by `reportTerminalToDelegatingRun`. The second command has **no matches** in either file — the report-only close path never constructs a collection service, calls `collectDelegationOutcomes`, drains, or runs the execution loop. (Collection lives ONLY in `collect.ts` via Plan 4's core operation.)
+
+- [ ] **Step 2: Confirm `rd collect` remains the only apply path**
+
+Run:
+
+```bash
+rg -ln "collectDelegationOutcomes" packages/cli/src
+```
+
+Expected: only `packages/cli/src/commands/collect.ts` references `collectDelegationOutcomes`. No terminal-close command does.
+
+- [ ] **Step 3: Run focused core tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/completion-service.test.ts --runInBand
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/collection-service.test.ts --runInBand
+pnpm --filter @rundown-org/core test:unit -- __tests__/runbook/command-policy.test.ts --runInBand
+```
+
+Expected: PASS. Report recording, collection apply, and the collection-pending policy are all intact.
+
+- [ ] **Step 4: Run focused CLI tests across every former `handleParentCompletion` call site**
+
+The renamed helper is invoked from complete, stop, pass/fail (via transition-command), **claim (child auto-completes during launch), run, and the execution loop**; abort no longer uses it. Cover the whole blast radius:
+
+```bash
+pnpm --filter @rundown-org/cli test:unit -- __tests__/commands/pass.test.ts __tests__/commands/fail.test.ts __tests__/commands/complete.test.ts __tests__/commands/stop.test.ts __tests__/commands/claim.test.ts __tests__/commands/run.test.ts __tests__/commands/abort.test.ts __tests__/commands/collect.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:unit -- __tests__/helpers/delegation-completion.test.ts --runInBand
+```
+
+Expected: PASS. Confirm the exact spec names with `rg -l "reportTerminalToDelegatingRun" packages/cli/src` and adjust the loop to whatever the merged suite ships.
+
+- [ ] **Step 5: Run the delegation integration + scenario suites**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/report-then-collect.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/collection-pending-lifecycle.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/delegation-propagation.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/delegation-abort.test.ts --runInBand
+pnpm --filter @rundown-org/cli test:integration -- __tests__/integration/scenario-runner.test.ts --runInBand
+```
+
+Expected: PASS. A real delegated close leaves the delegating run collection pending and bare advance is refused until `rd collect`; force-abort reports fail and leaves pending (including the FOR-scoped frame); ordinary cancel records no fail; scenarios collect explicitly.
+
+- [ ] **Step 6: Run package-level checks**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli check:types
+pnpm --filter @rundown-org/core check:types
+pnpm run check:lint:fast
+pnpm run check:spell
+```
+
+Expected: PASS. No exported symbol lacks TSDoc; no restricted error helpers; no spelling regressions.
+
+- [ ] **Step 7: Run scoped mutation testing on the changed seams**
+
+Run:
+
+```bash
+pnpm run test:mutate:cli -- --mutate packages/cli/src/helpers/delegation-completion.ts --testFiles packages/cli/__tests__/helpers/delegation-completion.test.ts
+```
+
+Expected: high mutation kill score. Surviving mutants on the report-only branches (e.g. a flipped `recorded === 'not-applicable'`, a dropped `output.flush()`, an inverted linkage guard) indicate an under-asserting test — tighten the corresponding assertion (assert the recorded-row count and the non-advancement, not just the return value) and re-run.
+
+- [ ] **Step 8: Run pre-PR verification**
+
+Run:
+
+```bash
+pnpm run verify
+```
+
+Expected: PASS. If `pnpm run verify` exceeds the local time budget, run the focused commands above plus `pnpm test` and record `pnpm run verify` as the remaining manual pre-push check in the commit message body.
+
+- [ ] **Step 9: Final commit (only if earlier task commits were skipped)**
+
+```bash
+git status --short
+```
+
+Expected: clean when each task committed. If earlier commits were skipped, stage every file listed in Tasks 1-8 and commit `feat(cli,core): split delegated close into report-then-collect`.
+
+## Self-Review
+
+- **Spec coverage (Plan 5 § lines 722-764):**
+  - *Close behavior change* (close → record outcome → derive collection pending → stop): Tasks 2-3 replace record-then-collect with report-only `reportTerminalToDelegatingRun`; the recorded `resolvedCompletions` row IS the derivation source for `readDelegationCollectionPendingForPolicy` (merged Plan 3).
+  - *`rd collect` is the explicit apply operation*: unchanged from Plan 4; Task 9 Steps 1-2 prove it is now the ONLY apply path.
+  - *N-level / mid-chain coverage*: **withdrawn — N-level is won't-build (RD-819 stays; see Scope Notes and the spec's Scope Decision).** Single delegation level only.
+  - *Scenario coverage*: Task 8.
+- **Cancellation split preserved (spec lines 144-149, 555-556):** ordinary cancel records no fail outcome (Task 4, leaning on the merged `cancelledAt` short-circuit in `recordChildCompletion`); `abort --force` records fail and leaves collection pending without draining/applying (Task 5).
+- **Test Strategy mapping (spec lines 831-872):** bare advance blocked while pending (Task 6 Step 3, Task 7 Step 2); collect requires orchestrator (covered by merged Plan 4 core tests); collection is single-level — trivially true under RD-819 (one delegating level, no ancestor to recurse into); force-abort records fail + pending including the FOR-scoped frame (Task 5); ordinary cancel no fail (Task 4). The spec's N-level / claim-controller-cannot-collect-ancestor / mid-chain rows are **not applicable** — no chain exists under the single-level model.
+- **Architecture (CLAUDE.md):** the report (record) step is core (`recordChildCompletion`); the apply step is core (`collectDelegationOutcomes`). The CLI helper only records-and-stops and renders. No CLI-side lifecycle decision, no shadow collection. Session release on terminal child close stays a Category A CLI side effect; the helper does not release the delegating run (it is not terminal). Locks unchanged (`recordChildCompletion` keeps its `await using` scoped `DelegationLock`; force-abort keeps the unlocked variant under its existing held lock — no bare `finally`).
+- **No persisted migration:** Plan 5 changes *when* a recorded row is consumed, not its shape; no schema field added or migrated.
+- **Scope: single delegation level only.** N-level chains, middle nodes, and mid-chain collection are withdrawn (won't-build) because RD-819 caps delegation at one level and the runtime cannot nest subagents. Report-then-collect is justified at N=1 (separates worker-stop from orchestrator-advance; fixes `FAIL ANY STOP` timing). See Scope Notes and the spec's "Scope Decision: N-Level Delegation Is Won't-Build".
+- **Placeholder scan:** every code step shows the actual code (helper body, call-site edits, test bodies, scenario YAML). The places that depend on merged-suite specifics (helper mock names in Task 2; the exact aggregation substep sequence in Task 7; scenario token substitution in Task 8) include an explicit "verify against merged X with `rg`" gate rather than an invented value.
+- **Type/name consistency:** `handleParentCompletion` → `reportTerminalToDelegatingRun` is applied at the definition (Task 2) and **all eight** call sites: Task 3 covers `transition-command.ts` (pass/fail), `complete.ts`, `stop.ts`, `claim.ts`, `run.ts`, and `services/execution.ts`; Task 5 removes the two `abort.ts` usages (deletes `propagateForceAbort`). Return type narrows from `'handled' | 'stopped' | 'not-applicable'` to `'reported' | 'not-applicable'`; every caller that consumed the old `'handled'`/`'stopped'` return for exit-code purposes is reinterpreted so reporting never flips the exit code. The Task 3 Step 6 / Task 9 Step 1 `rg "handleParentCompletion"` gate (zero matches) backstops a missed site.
+
+## Resolved Decisions
+
+1. **Exit-code narrowing — ACCEPTED, no impact (2026-06-20).** Under report-only the delegating run never transitions at close, so a delegated child's exit code reflects only its *own* lifecycle (local STOP → 1, otherwise 0); the parent-aggregation-stopped signal now surfaces at `rd collect`. The human confirmed nothing depends on the old close-time propagation flip. Task 3 Step 3 implements the narrowed contract.
+
+2. **N-level delegation — WON'T BUILD (2026-06-20).** RD-819 stays; a claimed run may never delegate. This mirrors the runtime (a Claude Code subagent cannot spawn subagents) and is permanent. The spec's N-level / middle-node / mid-chain-collection target model is withdrawn (spec "Scope Decision: N-Level Delegation Is Won't-Build"). Plan 5 covers a single delegating level only; the N-level and mid-chain test tasks were removed. Report-then-collect is justified at N=1 on its own.
+
+3. **`abort --force` FOR-frame targeting — VERIFIED SAFE (2026-06-20).** A read-only verification confirmed the in-lock `recordChildCompletionUnlocked` derives its frame key from `linkage.parentFrameKey` (the FOR-scoped substep `frameKey`), which the collection-pending guard reads back via `deriveOpenFrames`; `propagateForceAbort` contributes no frame-targeting of its own. Deleting it is safe. Task 5 Step 1 adds a dedicated FOR-scoped force-abort regression test (previously uncovered).
+
+## Open Questions / Risks for the human
+
+1. **Scenario runner child auto-execution model (needs verification at execution time).** Task 8 assumes the scenario runner drives a claimed child to terminal (thus reporting) so a single `rd collect` after the claim fires COMPLETE. If the runner does NOT auto-run the child, the scenario sequences need an explicit `rd complete --claim-id ...` before `rd collect`. Step 4's iterate-until-green gate handles this; the exact command count per scenario is discovered empirically.
+
+2. **`recordChildCompletion` returning `'duplicate'` on report (minor — DEFAULT: collapse).** If a close path runs twice, the second report returns `'duplicate'`; the helper currently treats it as `'reported'` (functionally correct — the delegating run stays pending exactly once). There is precedent for surfacing it distinctly (`transitions.ts:725` emits an `already-resolved` status). Default is to collapse; switch to a distinct `already-reported` status only if the feedback signal is wanted. Not load-bearing for correctness.

--- a/docs/superpowers/specs/2026-06-17-claim-delegation-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-06-17-claim-delegation-lifecycle-design.md
@@ -1,0 +1,1065 @@
+# Claim Delegation Lifecycle Design
+
+Date: 2026-06-17
+
+## Purpose
+
+This document defines a conceptual architecture model for Rundown delegation, claims, actor context, and collection. It is intended to guide future implementation work and to reframe the current claim-closure barrier discussion around consistent domain language.
+
+The design is not an immediate implementation plan. It describes the target
+model first, then gives migration principles and a canonical plan breakdown
+that can move the current code toward that model incrementally.
+
+## Goals
+
+- Use consistent language for delegation, claims, delegated runs, delegation outcomes, and collection.
+- Keep the existing `RESULT` / `HANDLER` / `ACTION` step semantics clear by avoiding overloaded use of the word "result" for delegation.
+- Make `rd collect` the explicit, target-relative orchestration mechanism for
+  consuming delegated work.
+- Require actor context for role-specific workflow mutation.
+- Move lifecycle, targeting, and collection policy into core so CLI, MCP, and plugin front ends do not reimplement domain rules.
+- Treat the existing barrier/resume wording as transitional, not as the target model.
+
+## Non-Goals
+
+- This design does not introduce adversarial security between local processes. Rundown remains an isolation-against-accident system.
+- This design does not require immediate persisted-state migration.
+- This design does not require all current CLI compatibility behavior to change at once.
+- This design does not rename internal structural fields such as `parentRunId` and `childRunId` unless a later implementation plan chooses to do so.
+
+## Scope Decision: N-Level Delegation Is Won't-Build (2026-06-20)
+
+> **This supersedes the N-level passages below.** Several sections of this
+> document (Lifecycle Model "middle node", Actor Context dual-role rules,
+> Collection Model "N-level chains", Compatibility Notes on `createDelegation()`,
+> and Plan 5's N-level coverage) describe a target model where a *delegated* run
+> can itself *delegate*, forming chains more than one delegating level deep. **That
+> capability will not be built.** Treat every "N-level" / "middle claim
+> controller" / "relax the single-level invariant" passage as historical design
+> exploration, not a requirement.
+
+Rationale:
+
+- **The runtime forbids it.** A Claude Code subagent cannot spawn subagents.
+  Delegation's value over `rd run` is a *fresh isolated agent context*; recursing
+  that at depth is exactly the unavailable operation. The substrate caps useful
+  delegation at one level.
+- **`RD-819` (`DELEGATION_NESTED_FORBIDDEN`) correctly mirrors that limit and
+  stays.** `createDelegation()` keeps rejecting issuance from a run whose
+  `parentLinkage.kind === 'delegation'`. The Compatibility-Notes intention to
+  "intentionally change that behavior for N-level chains" is withdrawn.
+- **Shallow-and-wide covers real work.** Bounded fan-out, map-reduce trees, and
+  recursive decomposition are served by FOR-loop fan-out at one delegating level,
+  by a single orchestrator dispatching staged waves of leaf workers, and by
+  `rd run` for in-context composition. None require a delegated run to delegate.
+- **The complexity it would add is unjustified.** Target-relative roles, the
+  dual-hat middle node, and mid-chain collection exist *primarily* to serve
+  N-level. With N-level removed, single-level delegation needs only: report on
+  close, collect explicitly, one delegating level.
+
+Consequence for the model: **collection is single-level because there is only
+ever one delegating level.** Report-then-collect (the worker reports its outcome
+on close; the orchestrator applies it with an explicit `rd collect`) is justified
+on its own at N=1 — it separates worker-stop from orchestrator-advance and fixes
+the `FAIL ANY STOP` aggregation-timing race — and does not depend on chains.
+
+## Issuance Idempotency: Targeted Delegate Echoes an Auto-Issued Frontier (2026-06-27)
+
+> **This finishes `delegation issuance` as a first-class command intent and
+> clarifies the issuance passages below.** Bare `rd delegate` is idempotent on an
+> auto-issued frontier (it echoes the existing token instead of throwing), but
+> the *targeted* forms — `rd delegate --step <id>` and
+> `rd delegate <runbook> --step <id>` — are not: they bypass issuance resolution
+> and throw `RD-804` (`DELEGATION_ALREADY_EXISTS`). That asymmetry is a defect
+> ([#468](https://github.com/tobyhede/rundown/issues/468)): a `DELEGATE` step
+> auto-issues a token on entry, so the agent's first `rd delegate --step 1.1`
+> lands on an already-issued frontier and is rejected. **Targeted issuance MUST
+> resolve through the same path as bare issuance and echo the frontier token.**
+> The current internal behavior contract is mirrored in
+> `docs/internal/delegation-lifecycle.md` so implementers do not have to treat
+> this historical design document as the only normative source.
+
+This section is normative for [#468](https://github.com/tobyhede/rundown/issues/468)
+even where older lifecycle-design material below is historical.
+
+Rationale:
+
+- **Issuance resolution belongs to core, once, for every invocation shape.** The
+  intent model (this document, "delegation issuance") routes all issuance through
+  the target-relative resolver. The idempotent-vs-fresh decision is runbook logic,
+  not a per-form CLI branch. Today it lives in a purpose-built sibling resolver
+  (`DelegateTargetResolution`: `issuable | already-issued | none`) that **only the
+  bare path consults**; the `--step` forms reach `createDelegation()` directly and
+  the runbook-confirmation form reimplements a partial check inline. Three
+  mechanisms for one question is the seam that produced #468.
+- **Auto-issue-on-entry is what creates the already-issued state.** A `DELEGATE`
+  step issues tokens for its delegated substeps on entry, before any `rd delegate`
+  runs. Echoing that token is the only coherent answer to "delegate this slot" when
+  the slot is already issued and in flight; throwing makes the documented agent
+  flow (`/rundown:planning` step 1) unusable.
+- **`targeted: true` is already the seam.** Report-then-collect minted the
+  `targeted` discriminant on the issuance intent and core deliberately bypasses
+  the `delegation_collection_pending` gate for targeted issuance. The same
+  discriminant is the hook for routing targeted issuance through policy +
+  resolution uniformly; the type exists, the `--step` path just does not cross it.
+
+Resolution rule:
+
+```text
+rd delegate            (bare)              -> resolve issuance; issue or echo frontier token
+rd delegate --step S                       -> resolve issuance SCOPED TO S; issue or echo frontier token
+rd delegate <runbook> --step S             -> resolve issuance SCOPED TO S:
+                                                same runbook as in-flight  -> echo frontier token
+                                                different runbook           -> RD-804 (genuine conflict)
+rd delegate <runbook>  (no step)           -> resolve issuance for first pending substep; issue or echo
+```
+
+- **Echo shape is uniform.** An `already-issued` resolution emits the bare path's
+  existing JSON (`{ kind: 'delegate', action: 'already-delegated', step, runbook,
+  token, parent_run_id }`) regardless of invocation form, so every shape returns
+  the same answer for the same state.
+- **`RD-804` is preserved only as a genuine conflict** — an explicit `<runbook>`
+  arg that names a *different* runbook than the in-flight delegation on that scope.
+  Re-issuing a fresh token over an in-flight one stays the job of `--retry`, not of
+  a repeated `rd delegate`.
+- **`RD-813` (`DELEGATION_NO_DELEGATABLE_SUBSTEP`) and `RD-814`
+  (substep-missing-runbook) are unchanged** — `none` resolution and missing-runbook
+  remain hard errors. `RD-819` (`DELEGATION_NESTED_FORBIDDEN`) is unchanged.
+- **Resolution is frame-scoped.** For a `FOR` step, scoped resolution keys on the
+  iteration frame (`--index` / three-level id), matching the writer/reader
+  frame-key agreement used by the rest of the delegation model.
+
+Consequence for the model: **issuance resolution is single-sourced.** Extend the
+core resolver to accept an optional target scope (step / frame / index) and route
+*all* `rd delegate` shapes through it; remove the CLI's per-branch issuance logic
+(`findPendingDelegationForTarget` inline check and the bare-`--step` fall-through to
+`createDelegation`). The `DelegationPolicyOutcome` union is unchanged — issuance
+*resolution* stays in its purpose-built sibling type per the union's own scoping
+rule; policy continues to own only the *gate* decisions (`actor_context_required`,
+the targeted bypass of `delegation_collection_pending`).
+
+## Terminology
+
+Use these terms in user-facing docs and conceptual architecture:
+
+| Term | Meaning |
+| --- | --- |
+| Delegation | A work slot issued by a delegating run. |
+| Claim | A binding from a delegated agent/context to a delegated run. |
+| Delegating run | The run that issued the delegation. |
+| Delegated run | The run controlled through a claim. |
+| Step result | Existing spec term: `pass` or `fail` produced by a step or substep. |
+| Run terminal state | `completed` or `stopped` lifecycle of a runbook. |
+| Delegation outcome | `pass` or `fail` projection from a delegated run terminal state into the delegating run. |
+| Outcome reported | Per-claim fact that a delegated run reached a terminal state and produced a delegation outcome. |
+| Collection | Target-relative orchestrator action that applies delegation outcomes to the delegating run. |
+| Collection pending | Derived delegating aggregation-scope state: recorded unconsumed delegation outcomes exist for a still-valid open delegating frame/scope of a run. |
+| Closed | The delegation attempt is operationally finished. A retained tombstone may still exist for idempotent command behavior. |
+| Cancelled | The delegation attempt was intentionally cancelled. |
+| Superseded | The delegation attempt was replaced by a retry attempt. |
+| Stashed | The claimed delegated run is parked. This is a session-targeting state, not closure. |
+| Pruned | Persisted state was deleted. This is storage cleanup, not a runtime lifecycle state. |
+
+Avoid these terms in the target model:
+
+- handoff
+- resume
+- acknowledgement
+- generic result when referring to a delegation outcome
+- parent/child in user-facing docs
+
+Internal structural names such as `parentRunId` and `childRunId` may remain when they describe graph linkage. Conceptual and user-facing language should prefer `delegating run` and `delegated run`.
+
+## Lifecycle Model
+
+The primary per-claim lifecycle is:
+
+```text
+delegation_issued
+  -> claim_active
+  -> closed
+```
+
+Side paths:
+
+```text
+delegation_issued -> cancelled -> closed
+claim_active -> stashed -> claim_active
+claim_active -> cancelled -> closed
+claim_active -> superseded -> closed
+closed -> pruned
+```
+
+`outcome_reported` is a fact recorded on a claim before it closes. It is not a
+sequential lifecycle state after `claim_active`.
+
+`collection_pending` is not a per-claim lifecycle state. It is derived for a
+delegating run from recorded, unconsumed delegation outcomes plus the delegating
+run's still-valid open delegating frame/scope records. A delegating run can be
+collection pending even though the reporting claim is already closed and even
+when its current cursor has moved away from the frame that originally issued
+the delegation.
+
+### Delegation Issued
+
+A delegating run has created a work slot and token. No delegated agent has claimed it yet.
+
+Core facts:
+
+- The delegating run records the token hash and delegation coordinates.
+- A claim id may not exist yet.
+- The delegation is claimable unless cancelled or superseded.
+
+Allowed operations:
+
+- A delegated agent may claim with the raw token.
+- An actor that controls the delegating run may cancel or retry the delegation.
+
+### Claim Active
+
+A delegated agent has claimed the token. A claim id now binds the claim
+controller to a delegated run.
+
+Core facts:
+
+- The claim maps to a delegated run id.
+- The delegated run carries delegation linkage back to the delegating run.
+- The delegated run is not pushed onto the default stack.
+
+Allowed operations:
+
+- The claim controller may inspect and mutate its own delegated run.
+- An actor that controls the delegating run may inspect delegation state and
+  cancel or retry according to policy.
+- Bare default-stack mutation must not silently target the delegated run.
+
+### Outcome Reported Fact
+
+The delegated run reached a terminal state and core derived a delegation outcome:
+
+```text
+completed -> pass
+stopped   -> fail
+```
+
+This fact records the outcome for the delegating run but does not apply it to the delegating run's state machine.
+
+The delegated agent's responsibility ends here:
+
+```text
+do claimed work
+close the claimed run through a terminal command
+stop
+```
+
+Ordinary cancellation is different from a failed delegated run. Cancelling an
+issued or active delegation closes that attempt without synthesizing a fail
+outcome. A force abort of an active claimed delegated run is the explicit
+exception: it stops/deletes the in-flight delegated run, records a `fail`
+delegation outcome with cancellation ignored for that recording operation, and
+leaves the delegating scope collection pending.
+
+### Collection Pending
+
+At least one delegation outcome exists for a still-valid open delegating
+aggregation scope of the run, but that scope has not collected it.
+
+Scope rule:
+
+- Evaluate `collection_pending` per delegating aggregation scope.
+- A bare advance of a run is blocked when any unconsumed outcome exists in any
+  still-valid open delegating frame/scope for that run, not only the current
+  cursor. This prevents a later bare command from advancing past stale
+  uncollected FOR-frame outcomes.
+- A targeted command may address a specific scope only when core policy resolves
+  that target explicitly and the command is valid for that target.
+
+Policy:
+
+- Bare mutating commands that would advance the delegating run are refused.
+- Collection is allowed only when the caller is the effective orchestrator for
+  the target delegating scope.
+- A delegated actor cannot collect into an ancestor's run merely because it
+  controls a claimed descendant.
+- The same delegated actor can collect into the claimed run it controls when
+  that run issued delegations of its own.
+- Unknown context cannot collect in the strict conceptual model.
+
+The target error for unsafe bare mutation is:
+
+```text
+DELEGATION_COLLECTION_PENDING
+```
+
+### Collecting
+
+Core applies one or more delegation outcomes to the delegating run.
+
+Core checks:
+
+- The caller has effective orchestrator role for the target delegating scope.
+- The target is an explicit delegating run/scope.
+- Required delegation outcomes for the aggregation scope are present.
+- No active claimed work still blocks collection for that scope.
+
+Core then applies aggregation semantics such as `PASS ALL`, `PASS ANY`, `FAIL ALL`, `FAIL ANY`, and `DEFER`.
+
+Collection is single-level. Collecting a delegating run may advance that run to
+a terminal state. If that run is itself delegated, core reports a new outcome
+to its own delegating run, but it does not recursively collect that ancestor.
+Each delegating level requires an explicit `rd collect` by an actor that is the
+effective orchestrator for that level. This replaces the current recursive
+drain/apply behavior in `handleParentCompletion()`.
+
+### Delegation Collected
+
+The delegation outcome has been consumed into the delegating run's state machine. The delegating run may advance, stop, complete, or remain active according to normal state-machine semantics.
+
+### Closed
+
+The delegation attempt is operationally finished.
+
+Closed does not necessarily mean deleted. A terminal claim tombstone may remain so repeated claim-targeted commands can confirm a matching terminal outcome or reject a conflicting one.
+
+## Actor Context
+
+Actor context is required for role-specific workflow mutation, but it is not
+itself the role decision. Role is relative to the target run/scope.
+
+Conceptual shape:
+
+```typescript
+type ActorContext =
+  | { kind: 'trusted_run_controller'; runId: RunId; source: 'direct-cli' | 'plugin' | 'mcp' }
+  | {
+      kind: 'claim_controller';
+      claimId: ClaimId;
+      tokenHash: DelegationTokenHash;
+      controlledRunId: RunId;
+    }
+  | { kind: 'unknown' };
+```
+
+`ActorContext` records evidence about the caller: which run it controls, which
+claim it owns, or that no trusted evidence is available. It does not say
+"orchestrator" or "delegated" as an absolute capability.
+
+Policy derives an effective target-relative role from `(intent, actorContext,
+target)`:
+
+```typescript
+type EffectiveRole =
+  | 'orchestrator_for_target'
+  | 'delegated_relative_to_target'
+  | 'unknown_for_target';
+```
+
+Rules:
+
+- A caller that controls the target run is the effective orchestrator for
+  mutations and collections into that target run.
+- A claim controller is delegated relative to the run that issued its claim, but
+  it is the effective orchestrator of delegations issued by the claimed run it
+  controls.
+- A middle node in an N-level chain therefore has two relationships at once: it
+  reports upward to its own delegating run, and it collects downward from
+  delegations that its controlled run issued.
+- A claim controller cannot collect into its ancestor's run merely by being a
+  delegated descendant of that run.
+- `unknown` means Rundown has workspace state but no reliable caller evidence.
+  `cwd + session.json` is not actor identity.
+
+Examples of unknown context:
+
+- Human shell without actor context.
+- Generic script.
+- MCP call without caller metadata.
+- CI job.
+- Agent shell after plugin/session context is lost.
+- Any local process with only the workspace path.
+
+Strict policy:
+
+```text
+unknown may inspect
+unknown may not perform role-specific workflow mutation
+```
+
+Compatibility layers may temporarily relax this for direct CLI usage, but that is a compatibility concession, not the conceptual model.
+
+Direct CLI compatibility lane:
+
+- Strict core policy treats `unknown` as inspect-only.
+- The direct local CLI may explicitly map a bare workspace invocation to a
+  trusted run-controller actor context by default for compatibility.
+- That mapping is a frontend adapter decision. Core still receives an explicit
+  actor context, a target, and applies the same typed policy.
+- The collection-pending guard still blocks bare `pass`, `fail`, and `delegate`
+  even in direct CLI compatibility mode. The user must run `rd collect`.
+- Plugin and MCP callers do not inherit direct CLI compatibility unless they
+  explicitly provide equivalent trusted run-controller metadata.
+
+## Command Policy
+
+Core policy should derive command outcomes from:
+
+- actor context
+- command intent
+- target selector
+- delegation lifecycle state
+
+The policy question is target-relative:
+
+```typescript
+resolveCommandIntent(intent, actorContext, target): DelegationPolicyOutcome
+```
+
+Existing claim-id targeting mechanics already point in this direction:
+`CommandTargetResolution` distinguishes default, claim, terminal-claim, stale
+claim, and no-target outcomes, while `ClaimRecord` stores `claimId`,
+`childRunId`, `parentRunId`, `parentStepId`, `parentFrameKey`, and
+`parentEntry`. The target model should keep that explicit actor/target
+relationship rather than infer role from the workspace alone.
+
+Command intent categories:
+
+```text
+inspect
+delegated-run mutation
+delegating-run advance
+delegation issuance
+delegation collection
+delegation cancellation
+storage cleanup
+```
+
+Role-specific mutations:
+
+| Effective relationship to target | Allowed role-specific mutations |
+| --- | --- |
+| Orchestrator for target | Issue delegation from the target run, retry or cancel delegations issued by the target run, collect delegation outcomes into the target run, advance the target run when delegation state permits it. |
+| Delegated relative to target | Report the controlled run's terminal outcome to the target run when the target issued the claim; inspect only otherwise. |
+| Unknown for target | Inspect only in the strict model. |
+
+Specific command policy:
+
+```text
+rd collect when actor is orchestrator for target:
+  allowed when the target is a delegating run/scope
+
+rd collect when actor is delegated relative to target:
+  COLLECT_REQUIRES_ORCHESTRATOR
+
+rd collect when actor is unknown for target:
+  ACTOR_CONTEXT_REQUIRED
+
+rd collect --claim-id:
+  valid only as an explicit target selector for the resolved claimed run;
+  policy still requires the actor to be orchestrator for that resolved target
+
+bare rd pass/fail/delegate while delegation_collection_pending:
+  DELEGATION_COLLECTION_PENDING
+
+claim-controller bare rd pass/fail:
+  may target the actor's controlled claimed run only if contextual targeting is
+  deliberately adopted; otherwise require explicit --claim-id, but never fall
+  through to the delegating ancestor run
+
+middle claim-controller rd collect:
+  allowed for delegations issued by the controlled run; rejected for ancestor
+  runs unless the actor has separate trusted controller evidence for that target
+```
+
+Core owns one typed policy outcome union for lifecycle, targeting, and collection
+decisions. CLI, MCP, and plugin frontends map this union to command-specific
+messages, error codes, and exit codes.
+
+```typescript
+type DelegationPolicyOutcome =
+  | { kind: 'allowed'; target: ResolvedTarget }
+  | { kind: 'actor_context_required' }
+  | { kind: 'collect_requires_orchestrator' }
+  | { kind: 'target_not_delegating_scope' }
+  | { kind: 'delegation_collection_pending' }
+  | { kind: 'open_claims' }
+  | { kind: 'missing_outcomes' }
+  | { kind: 'already_collected' }
+  | { kind: 'not_delegatable' }
+  | { kind: 'stale_claim' }
+  | { kind: 'terminal_claim_confirmed' }
+  | { kind: 'terminal_claim_conflict' };
+```
+
+## Collection Model
+
+The target model splits two operations:
+
+```text
+report delegation outcome
+collect delegation outcome
+```
+
+### Reporting
+
+Reporting is core work triggered by delegated terminal close. There is no
+separate `rd report` command.
+
+Reporting happens when the delegated run reaches a terminal state through
+`complete`, `stop`, or a terminal `pass` / `fail` path. Those commands invoke
+core `reportDelegationOutcome` as part of closing the claimed run. `abort
+--force` is the explicit exception that can report a `fail` delegation outcome
+while tearing down an active claimed run.
+
+Input:
+
+```text
+claim id
+delegated run terminal state
+```
+
+Core derives and records a delegation outcome against the delegating run's delegated substep.
+
+Reporting does not drain or apply the outcome to the delegating run's state machine.
+Reporting closes the claim operationally, except for retained terminal
+tombstones used for idempotent command behavior.
+
+### Collection
+
+Collection is target-relative orchestrator work. It applies reported delegation
+outcomes to the target delegating run/scope.
+
+Input:
+
+```text
+actor context
+delegating run target
+optional step/frame/index scope
+```
+
+Collection returns the core-owned typed policy outcome union, not a
+collection-specific result union:
+
+```text
+DelegationPolicyOutcome
+```
+
+Collection is single-level by design. It consumes outcomes for one delegating
+scope and applies them to that run's state machine. If that application causes
+the run to complete or stop and that run was itself delegated, reporting to the
+next ancestor is allowed, but collection of that ancestor remains explicit.
+
+For N-level chains, a middle claim controller can collect outcomes reported by
+delegations issued by its own controlled run, including deeper delegated
+descendants that report into that controlled run. After that controlled run
+reaches a terminal state, it reports one outcome upward. The ancestor still
+needs its own explicit collection by an actor that is effective orchestrator for
+the ancestor target.
+
+Frontend mappings may render selected policy outcomes with command-specific
+codes such as:
+
+```text
+DELEGATION_COLLECTION_PENDING
+COLLECT_REQUIRES_ORCHESTRATOR
+ACTOR_CONTEXT_REQUIRED
+COLLECT_TARGET_NOT_DELEGATING_RUN
+COLLECT_OUTCOMES_MISSING
+```
+
+`COLLECT_ALREADY_APPLIED` can be a non-error frontend code for the
+`already_collected` outcome if idempotent no-op behavior is preferred.
+
+## Inline Composition Force-Terminal
+
+Inline composition (`parentLinkage.kind === 'inline'`) is not delegation. An
+inline child runs in the same default-stack lineage as its parent and flows its
+result back synchronously; it never reports a delegation outcome and is never
+collection pending. Because of that, the lifecycle/collection model above does
+not govern how an inline chain is force-terminated. This section records the
+intent so a future change to delegation/collection policy does not silently break
+inline force-terminal behavior.
+
+Two command meanings must not be conflated:
+
+- **Handler-derived `COMPLETE` / `STOP` actions** — the `ACTION` a step's handler
+  resolves to (see `CLAUDE.md` Conceptual Model). These drive normal
+  state-machine progression of a single run.
+- **CLI `rd complete` / `rd stop` force overrides** — an operator command that
+  forces a workflow terminal regardless of the current step's handler.
+
+The target model for the CLI force override:
+
+- Bare `rd complete` / `rd stop` target the **outermost contiguous-inline
+  ancestor** of the active run: climb `parentLinkage.kind === 'inline'`, and stop
+  before any delegation boundary.
+- Every still-running inline descendant in that active chain is forced to the same
+  terminal lifecycle, descendant-to-root, so no `running` inline descendant
+  remains under a terminal inline ancestor.
+- The cascade does not cross a delegation boundary. If the resolved inline root is
+  itself a delegated run, it reports its terminal outcome upward (report-only) and
+  the delegating parent advances only on an explicit `rd collect` — i.e. the inline
+  force-terminal cascade hands back to the report-then-collect model exactly at the
+  delegation boundary.
+- `rd complete --claim-id` / `rd stop --claim-id` are unchanged: they target the
+  named delegated child directly and keep delegated report-only semantics. They do
+  not use inline-root targeting.
+- `rd pass` / `rd fail` are not force overrides. They remain unit-local: they
+  close the active inline unit and drive normal inline parent progression. The
+  collection-pending guard on bare `pass` / `fail` / `delegate` is unaffected.
+- Bare `rd stop` is a failure terminal and exits non-zero. `rd stop --claim-id`
+  keeps command-success exit behavior for delegated report-only close.
+
+This is a distinct command intent that the taxonomy in
+[Command Policy](#command-policy) does not otherwise name: a workflow-level
+force-terminal of the inline ancestor. It is coherent with the single-level
+collection model precisely because it stops at the delegation boundary and so
+cannot create a second collection level.
+
+Implemented by `resolveActiveInlineForceTerminalPlan` (core) and
+`forceTerminalWorkflow` (CLI); see
+`docs/superpowers/plans/2026-06-24-inline-force-terminal-composed-parent.md`.
+
+## Core And Frontend Boundary
+
+The boundary should be:
+
+```text
+frontends parse and render
+core decides lifecycle, targeting, and collection policy
+```
+
+Front ends may provide:
+
+- actor context
+- command intent
+- flags and options
+- input values
+- output renderer
+
+Front ends should not decide:
+
+- whether a claim may report an outcome
+- whether a delegation is collection pending
+- whether collection is allowed
+- whether a bare command is safe
+- whether a delegated run can issue or collect delegation
+- whether a terminal claim is idempotent or conflicting
+
+Core should expose operations shaped around domain intents:
+
+```typescript
+claimDelegation(token, actorContext, target): DelegationPolicyOutcome
+reportDelegationOutcome(claimId, outcome, actorContext, target): DelegationPolicyOutcome
+resolveCommandIntent(intent, actorContext, target): DelegationPolicyOutcome
+collectDelegationOutcomes(target, actorContext): DelegationPolicyOutcome
+cancelDelegation(tokenOrDelegationId, actorContext, target): DelegationPolicyOutcome
+retryDelegation(scope, actorContext, target): DelegationPolicyOutcome
+stashClaim(claimId, actorContext, target): DelegationPolicyOutcome
+popClaim(claimId, actorContext, target): DelegationPolicyOutcome
+```
+
+`target` should carry the resolved run/scope, not just a run id string. For
+collection this includes the delegating run plus any step/frame/index scope
+needed to choose the aggregation scope. For claim-id targeting this should be
+the core `CommandTargetResolution`-style result so terminal, stale, and missing
+claim behavior remains explicit.
+
+## Compatibility Notes
+
+Current Rundown behavior differs from this strict conceptual model in several ways:
+
+- ~~`handleParentCompletion()` currently records a delegated-run completion and immediately drains/applies it to the delegating run.~~
+  **Superseded — report-then-collect (Plan 5) landed.** `handleParentCompletion()`
+  no longer exists; `propagateChildTerminal()` type-splits inline (synchronous
+  drain/advance) from delegation (report-only, leaves collection pending). The
+  delegating run advances only on an explicit `rd collect`.
+- `createDelegation()` currently enforces a single-level delegation invariant by
+  rejecting delegation from a run whose `parentLinkage.kind === 'delegation'`.
+  ~~this target model intentionally changes that behavior for N-level chains.~~
+  **Withdrawn — see "Scope Decision: N-Level Delegation Is Won't-Build". RD-819
+  stays; the single-level invariant is permanent.**
+- `rd collect` is not currently the only continuation mechanism.
+- `rd collect --claim-id` is currently accepted.
+- Bare CLI commands generally operate in unknown context and target the default stack.
+- Plugin actor identity exists in plugin session metadata, but it is not a core command identity boundary.
+- MCP is currently a CLI facade without actor context.
+- `abort --force` currently records a fail completion for an in-flight delegated run
+  with `ignoreCancellation: true`; the target model preserves that as the
+  deliberate force-abort exception, but it records fail and leaves collection
+  pending rather than resolving the delegating substep by itself.
+
+Implementation can preserve compatibility temporarily, but the domain rule should remain:
+
+```text
+No actor context, no role-specific workflow mutation.
+Delegated agents report outcomes upward.
+Actors collect outcomes only when they are effective orchestrators for the
+target delegating scope.
+```
+
+Direct local CLI compatibility may map bare workspace commands to
+trusted run-controller context by default. That adapter does not change the
+target-relative core policy, and it must not bypass the collection-pending guard
+for bare `pass`, `fail`, or `delegate`.
+
+## Migration Strategy
+
+This section is only a migration overview. The canonical sequencing is the
+Implementation Plan Breakdown below; do not maintain a second detailed roadmap
+here.
+
+Principles:
+
+- Stop adding new `handoff` and `resume` language.
+- Introduce explicit actor context and target resolution before enforcing
+  target-relative role policy.
+- Move command policy and collection decisions into core before changing
+  terminal-close behavior.
+- Split reporting from collection only after core has a typed collection
+  operation and frontend adapters render `DelegationPolicyOutcome`.
+- Keep direct local CLI compatibility explicit in frontend adapters; do not
+  encode it as the domain model.
+- Preserve the cancellation split: ordinary cancel closes without fail; `abort
+  --force` records fail and leaves collection pending.
+- Clean persisted fields last. Rundown does not migrate persisted runbook state
+  between versions, so incompatible active state must be rejected rather than
+  migrated.
+
+The existing claim handoff barrier work is transitional and
+superseded by this design direction. Do not extend the June 2026 handoff/resume
+model as the long-term implementation. If any of that work is reused, rewrite
+its domain surface around delegation outcomes, collection pending, and explicit
+collection before implementation.
+
+Transitional names:
+
+```text
+ClaimHandoff -> DelegationCollectionPending or ClaimClosureBarrier
+CLAIM_HANDOFF_PENDING -> DELEGATION_COLLECTION_PENDING or CLAIM_CLOSURE_PENDING
+--resume -> remove from the model; use collect-oriented guidance
+```
+
+Preferred direction:
+
+```text
+DelegationCollectionPending
+DELEGATION_COLLECTION_PENDING
+```
+
+Suggested message:
+
+```text
+A delegated claim has reported an outcome that must be collected by an actor
+that controls this target run. If this is your ancestor's run, stop here. If
+this is a run you control, run rd collect.
+```
+
+## Implementation Plan Breakdown
+
+This design should not be implemented as one monolithic plan. It crosses core
+lifecycle, command policy, collection behavior, CLI compatibility, plugin
+identity, MCP identity, documentation, and persisted model cleanup. Break the
+work into small plans where each plan produces independently testable software.
+
+> **Status (2026-06-24).** Plans 1–5 have landed: the core lifecycle/policy/
+> collection spine and the report-then-collect behavior split are implemented and
+> wired into the CLI. Plan 2 has no standalone plan file but is fully realized in
+> code (`packages/core/src/runbook/actor-context.ts`). Plan 8 is largely
+> satisfied incidentally (transitional `ClaimHandoff` / `CLAIM_HANDOFF_PENDING` /
+> `--resume` names are gone) but was never run as a deliberate final pass. Plans 6
+> (plugin actor context) and 7 (MCP actor context) are NOT STARTED — both
+> frontends still capture caller metadata without constructing a core
+> `ActorContext`. Per-plan "landed" notes appear on each plan below.
+
+Recommended dependency chain:
+
+```text
+delegation lifecycle foundation
+  -> actor-context foundation
+  -> core command policy
+  -> core collection operation
+  -> report-then-collect behavior split
+  -> frontend actor-context hardening
+  -> persisted model cleanup
+```
+
+### Plan 1: Delegation Lifecycle Foundation — LANDED
+
+Suggested file:
+
+```text
+docs/superpowers/plans/2026-06-17-delegation-lifecycle-foundation.md
+```
+
+Scope:
+
+- Establish target terminology in code and docs where new names are needed.
+- Register target error names such as `DELEGATION_COLLECTION_PENDING`.
+- Add core read models for outcome-reported facts and derived collection-pending
+  state.
+- Avoid major behavior changes.
+
+Likely areas:
+
+- `packages/core/src/runbook/types.ts`
+- `packages/core/src/runbook/claim-id.ts`
+- `packages/core/src/output/zod-schemas.ts`
+- core model tests under `packages/core/__tests__/runbook/`
+- documentation that currently introduces new handoff/resume wording
+
+### Plan 2: Actor Context Foundation — LANDED (no standalone plan file)
+
+Suggested file:
+
+```text
+docs/superpowers/plans/2026-06-17-actor-context-foundation.md
+```
+
+Scope:
+
+- Add core actor-context types and API plumbing.
+- Add target-relative effective-role derivation from `(intent, actorContext,
+  target)`.
+- Add frontend adapters that pass explicit actor context into core.
+- Preserve direct local CLI compatibility by mapping bare workspace invocations
+  to trusted run-controller context in the CLI adapter.
+- Keep plugin and MCP unknown unless they provide explicit trusted metadata.
+
+Likely areas:
+
+- new `packages/core/src/runbook/actor-context.ts`
+- core service constructors and command entry points that need actor context
+- CLI command setup and shared helpers
+- plugin and MCP call boundaries where actor context can be supplied
+- actor-context unit tests
+
+### Plan 3: Core Command Policy — LANDED (intentional subset of the outcome union)
+
+Suggested file:
+
+```text
+docs/superpowers/plans/2026-06-17-core-command-policy.md
+```
+
+Scope:
+
+- Add a core-owned command policy API around actor context, command intent,
+  target selector, and delegation lifecycle state.
+- Shape the main API as
+  `resolveCommandIntent(intent, actorContext, target): DelegationPolicyOutcome`.
+- Return a single core-owned `DelegationPolicyOutcome` union.
+- Treat `rd collect --claim-id` as an explicit target selector for the resolved
+  claimed run; allow it only when the actor is effective orchestrator for that
+  target and the target has a collectable delegating scope.
+- Reject collection into ancestor runs when the actor is only delegated relative
+  to that ancestor target.
+- Refuse bare `pass`, `fail`, and `delegate` while delegation collection is
+  pending.
+- Keep direct-CLI compatibility explicit; do not silently encode it as the
+  domain model.
+- Preserve the cancellation split: ordinary cancel closes without fail; force
+  abort of an active claimed delegated run records fail and leaves collection pending.
+
+Likely areas:
+
+- `packages/core/src/runbook/actor-context.ts`
+- new `packages/core/src/runbook/command-policy.ts`
+- `packages/core/src/runbook/command-target-resolver.ts`
+- `packages/cli/src/helpers/transitions.ts`
+- `packages/cli/src/commands/collect.ts`
+- core command-policy table tests
+
+### Plan 4: Core Collection Operation — LANDED
+
+Suggested file:
+
+```text
+docs/superpowers/plans/2026-06-17-core-collection-operation.md
+```
+
+Scope:
+
+- Move collection orchestration out of the CLI and into core.
+- Expose a domain operation such as
+  `collectDelegationOutcomes(target, actorContext): DelegationPolicyOutcome`.
+- Make collection single-level; do not recursively collect ancestors.
+- Allow a claim controller to collect outcomes for delegations issued by the
+  controlled run, while still rejecting collection into its delegating ancestor.
+- Keep the CLI responsible for parsing flags and rendering typed outcomes only.
+- Preserve current behavior where possible until the report/collect split lands.
+
+Likely areas:
+
+- new `packages/core/src/runbook/collection-service.ts`
+- `packages/core/src/runbook/completion-service.ts`
+- `packages/cli/src/commands/collect.ts`
+- collection-focused core tests
+- CLI integration tests for rendering and exit codes
+
+### Plan 5: Report Then Collect — LANDED
+
+Suggested file:
+
+```text
+docs/superpowers/plans/2026-06-17-report-then-collect.md
+```
+
+Scope:
+
+- Change delegated claim closure from immediate delegating-run drain/apply to:
+
+```text
+close delegated run
+record delegation outcome
+derive collection pending from recorded unconsumed outcomes in still-valid open
+delegating aggregation scopes
+stop
+```
+
+- Make `rd collect` the explicit operation that applies delegation outcomes to
+  the delegating run.
+- ~~Add N-level and mixed inline/delegation cascade coverage proving each
+  delegating level requires explicit collection.~~ **Withdrawn — N-level is
+  won't-build (see Scope Decision). Coverage is single-level only.**
+- ~~Add mid-chain coverage where the middle claim controller collects outcomes
+  reported by delegated runs issued by its controlled run, then reports one
+  terminal outcome upward.~~ **Withdrawn — no middle node exists under the
+  single-level model.**
+- Add scenario coverage for the user-visible workflow change (single delegating
+  level: worker reports on close, orchestrator collects explicitly).
+
+This is the highest-risk behavior change. It should land only after the core
+policy and core collection operation plans are in place.
+
+Likely areas:
+
+- `packages/cli/src/helpers/delegation-completion.ts`
+- `packages/core/src/runbook/completion-service.ts`
+- `packages/core/src/runbook/collection-service.ts`
+- `packages/cli/src/commands/pass.ts`
+- `packages/cli/src/commands/fail.ts`
+- `packages/cli/src/commands/complete.ts`
+- `packages/cli/src/commands/stop.ts`
+- `packages/cli/src/commands/collect.ts`
+- delegation workflow integration tests and scenario fixtures
+
+### Plan 6: Claude Plugin Actor Context — NOT STARTED
+
+Suggested file:
+
+```text
+docs/superpowers/plans/2026-06-17-plugin-actor-context.md
+```
+
+Scope:
+
+- Map Claude Code `agent_id`, `session_id`, token hash metadata, and claim id
+  metadata into core actor context.
+- Replace plugin-only claim-controller guard behavior with core policy where
+  possible.
+- Keep plugin hooks responsible for extracting caller metadata and presenting
+  guidance, not deciding lifecycle policy.
+
+Likely areas:
+
+- `packages/claude-code-plugin/src/workflow/hooks/delegation-dispatch.ts`
+- `packages/claude-code-plugin/src/workflow/hooks/delegated-bash-guard.ts`
+- `packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts`
+- plugin session schemas and tests
+
+### Plan 7: MCP Actor Context — NOT STARTED
+
+Suggested file:
+
+```text
+docs/superpowers/plans/2026-06-17-mcp-actor-context.md
+```
+
+Scope:
+
+- Define what actor context, if any, MCP can supply.
+- Treat MCP unknown context as inspect-only unless it supplies explicit trusted
+  run-controller or claim-controller metadata.
+- Stop treating MCP as only a CLI facade for role-specific workflow mutation.
+
+Likely areas:
+
+- `packages/mcp/src/tools.ts`
+- MCP tool schemas and command construction tests
+- core policy integration tests for MCP-style callers
+
+### Plan 8: Persisted Model Cleanup — PARTIAL (incidental; no deliberate pass)
+
+Suggested file:
+
+```text
+docs/superpowers/plans/2026-06-17-delegation-model-cleanup.md
+```
+
+Scope:
+
+- Remove transitional names and compatibility shims.
+- Make delegation outcome explicit and collection-pending state consistently
+  derived.
+- Update schemas and docs to the final terminology.
+- Reject incompatible active state rather than migrating it.
+
+This must be last. Rundown does not migrate persisted runbook state between
+versions, so cleanup should happen after behavior is stable and before any
+release boundary that would otherwise need compatibility code.
+
+## Test Strategy
+
+Core model tests:
+
+- delegation lifecycle transition table
+- actor context plus target policy table
+- effective role derivation for trusted run controllers, claim controllers, and
+  unknown callers
+- collection pending derivation per delegating aggregation scope
+- bare advance is blocked when any unconsumed outcome exists in any still-valid
+  open delegating frame/scope for the run
+- collect requires effective orchestrator role for the target
+- unknown context cannot collect
+- claim controller cannot collect into its delegating ancestor run
+- claim controller can collect into the controlled run when that run issued
+  delegations
+- direct local CLI compatibility maps to trusted run-controller context while
+  still blocking bare `pass`, `fail`, and `delegate` when collection is pending
+- ordinary cancel closes without a fail outcome
+- force abort of an active claimed delegated run reports a fail outcome and leaves
+  collection pending
+- collection is single-level and does not recursively collect ancestors
+
+Integration and scenario tests:
+
+- delegated agent reports outcome and stops
+- effective orchestrator collects and advances the target run
+- ~~N-level delegated chains require explicit collect at each delegating level~~
+  **Withdrawn — N-level is won't-build (see Scope Decision). Collection is
+  single-level only.**
+- ~~middle claim controller collects outcomes reported by delegated descendants
+  of its controlled run, then reports one outcome upward~~
+  **Withdrawn — no middle node exists under the single-level model.**
+- mixed inline substep and delegated chains do not silently cascade collection
+- bare command while collection pending is refused
+- `collect --claim-id` targets the resolved claimed run and is allowed or
+  rejected by target-relative policy
+- claim controller collect into ancestor target is rejected
+- claim controller collect into controlled-run target is allowed when that run
+  has reported delegated outcomes
+- unknown context collect is rejected in strict mode
+- retry supersedes pending collection
+- `abort --force` records a fail delegation outcome and leaves collection
+  pending
+
+## Open Questions
+
+- Should claim-controller context eventually allow contextual targeting for bare
+  `rd pass` / `rd fail`, or should explicit `--claim-id` remain mandatory? (For
+  `rd complete` / `rd stop` this is now settled: bare force-terminates the inline
+  ancestor, `--claim-id` keeps delegated-child scope. See "Inline Composition
+  Force-Terminal". The question stands open for `rd pass` / `rd fail`, which
+  remain unit-local.)
+- Should closed terminal claim tombstones remain visible through `status --claim-id`, and for how long before prune?
+- What exact trusted actor metadata can MCP supply for non-inspect operations?

--- a/docs/superpowers/specs/2026-06-17-claim-delegation-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-06-17-claim-delegation-lifecycle-design.md
@@ -361,9 +361,12 @@ Rules:
 - A claim controller is delegated relative to the run that issued its claim, but
   it is the effective orchestrator of delegations issued by the claimed run it
   controls.
-- A middle node in an N-level chain therefore has two relationships at once: it
+- ~~A middle node in an N-level chain therefore has two relationships at once: it
   reports upward to its own delegating run, and it collects downward from
-  delegations that its controlled run issued.
+  delegations that its controlled run issued.~~ **Withdrawn — no middle node
+  exists under single-level delegation (see "Scope Decision: N-Level Delegation
+  Is Won't-Build"). A claim controller has exactly one relationship: it reports
+  upward to its delegating run.**
 - A claim controller cannot collect into its ancestor's run merely by being a
   delegated descendant of that run.
 - `unknown` means Rundown has workspace state but no reliable caller evidence.
@@ -466,8 +469,9 @@ claim-controller bare rd pass/fail:
   through to the delegating ancestor run
 
 middle claim-controller rd collect:
-  allowed for delegations issued by the controlled run; rejected for ancestor
-  runs unless the actor has separate trusted controller evidence for that target
+  WITHDRAWN — no middle node exists under single-level delegation (see "Scope
+  Decision: N-Level Delegation Is Won't-Build"). Single-level collect policy is
+  covered by "rd collect --claim-id" above.
 ```
 
 Core owns one typed policy outcome union for lifecycle, targeting, and collection
@@ -548,12 +552,15 @@ scope and applies them to that run's state machine. If that application causes
 the run to complete or stop and that run was itself delegated, reporting to the
 next ancestor is allowed, but collection of that ancestor remains explicit.
 
-For N-level chains, a middle claim controller can collect outcomes reported by
+~~For N-level chains, a middle claim controller can collect outcomes reported by
 delegations issued by its own controlled run, including deeper delegated
 descendants that report into that controlled run. After that controlled run
 reaches a terminal state, it reports one outcome upward. The ancestor still
 needs its own explicit collection by an actor that is effective orchestrator for
-the ancestor target.
+the ancestor target.~~ **Withdrawn — N-level is won't-build (see "Scope
+Decision: N-Level Delegation Is Won't-Build"). There is one delegating level: a
+delegated worker reports its outcome on close, and the single orchestrator
+applies it with an explicit `rd collect`.**
 
 Frontend mappings may render selected policy outcomes with command-specific
 codes such as:


### PR DESCRIPTION
## Summary

Begin committing `docs/superpowers/` prospective documentation (dated, write-once specs and implementation plans) into the repo. Previously the entire directory was gitignored, so none of it was tracked.

This commits **only the one active line of work** — the claim/delegation lifecycle — and relocates all unrelated legacy content out of the committed tree.

## Changes

- **Un-ignore `docs/superpowers/`** — removed the rule from `.gitignore` so prospective spec/plan docs track normally and future ones commit automatically.
- **Committed the active spec + 5 core implementation plans:**
  - `specs/2026-06-17-claim-delegation-lifecycle-design.md`
  - `plans/2026-06-17-delegation-lifecycle-foundation.md`
  - `plans/2026-06-17-core-command-policy.md`
  - `plans/2026-06-17-core-collection-operation.md`
  - `plans/2026-06-17-report-then-collect.md`
  - `plans/2026-06-16-claim-handoff-barrier.md`

## Legacy content relocated

Moved to the gitignored `.work/superpowers/` holding area (77 files, recoverable, not in this diff):

- Companion docs (2 walkthroughs + 1 `.HANDOFF.md` branch note)
- 3 unrelated top-level plans (`iterate-and-delegate`, `assertion-blocks`, `plugin-test-coverage-hardening`)
- All 56 `plans/archive/`, 12 `specs/archive/`, and 3 `issues/`

## Convention

Aligns with the descriptive-vs-prospective documentation split: `docs/internal/` holds current design (living docs); `docs/superpowers/` holds dated, write-once specs and plans for planned work.

## Notes

Docs-only change. No code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed planning documents and a full design spec covering delegation/claim lifecycle behavior, including “claim hand-off barrier” and the “report-then-collect” workflow guidance.
  * Expanded documentation structure rules to clearly separate descriptive, current-state docs from prospective, dated plans.
* **Chores**
  * Updated ignore rules so `docs/superpowers/` is now tracked by git.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->