### PR TITLE
ci(#485): cut PR mutation-gate runtime with ignoreStatic + concurrency

### DIFF
--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -36,7 +36,20 @@ jobs:
           - package: plugin
             dir: packages/claude-code-plugin
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Raised 30 -> 45 as a guardrail layered on top of ignoreStatic +
+    # STRYKER_CONCURRENCY (below), not the primary fix. Both legs previously hit
+    # the 30m cap on ~2197 (cli) / ~2157 (core) instrumented mutants at the
+    # forced concurrency of 2 (run 28277202919). The margin mainly covers cli,
+    # which has no static-mutant shortcut. See issue #485.
+    timeout-minutes: 45
+    # ubuntu-latest runners have 4 vCPUs; raise Stryker's forced concurrency from
+    # the config default of 2 to 4 to maximise throughput on the gate (~2x the
+    # mutant rate). Scoped to CI via env so local-dev stays conservative at 2.
+    # The configs' widened timeout budgets (core 60s/3x, cli 60s/2.5x) already
+    # absorb CI contention, so this is unlikely to induce spurious per-mutant
+    # timeouts. See issue #485.
+    env:
+      STRYKER_CONCURRENCY: '4'
     permissions:
       contents: read
 

--- a/packages/claude-code-plugin/stryker.config.mjs
+++ b/packages/claude-code-plugin/stryker.config.mjs
@@ -32,6 +32,14 @@ const config = {
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
   concurrency,
+  // Skip static mutants (evaluated once at load time, not per-test) so Stryker
+  // reports them Ignored instead of running them. Static mutants are
+  // disproportionately expensive (core measured them at ~49% of test time);
+  // dropping them keeps the per-PR gate well under its timeout. Trade-off:
+  // static mutants become Ignored (not scored), a small fidelity loss that also
+  // affects the weekly exhaustive mutation.yml; acceptable for a time-bounded
+  // gate. Applied for consistency across packages. See issue #485.
+  ignoreStatic: true,
   timeoutMS: 30000,
   timeoutFactor: 2.5,
 };

--- a/packages/cli/stryker.config.mjs
+++ b/packages/cli/stryker.config.mjs
@@ -32,6 +32,14 @@ const config = {
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
   concurrency,
+  // Skip static mutants (evaluated once at load time, not per-test) so Stryker
+  // reports them Ignored instead of running them. The per-PR gate timed out at
+  // 30m on ~2197 instrumented mutants for cli (run 28277202919); static mutants
+  // are disproportionately expensive (core measured them at ~49% of test time).
+  // Trade-off: static mutants become Ignored (not scored), a small fidelity loss
+  // that also affects the weekly exhaustive mutation.yml; acceptable for a
+  // time-bounded gate. See issue #485.
+  ignoreStatic: true,
   timeoutMS: 60000,
   timeoutFactor: 2.5,
 };

--- a/packages/core/stryker.config.mjs
+++ b/packages/core/stryker.config.mjs
@@ -32,6 +32,15 @@ const config = {
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
   concurrency,
+  // Skip static mutants (those evaluated once at load time, not per-test) so
+  // Stryker reports them Ignored instead of running them. The per-PR gate timed
+  // out at 30m on ~2157 instrumented mutants for core (run 28277202919), where
+  // Stryker reported "10 static mutants (0% of total) estimated to take 49% of
+  // the time running the tests" -- dropping them reclaims that ~half. Trade-off:
+  // static mutants become Ignored (not scored), a small fidelity loss that also
+  // affects the weekly exhaustive mutation.yml; acceptable for a time-bounded
+  // gate. See issue #485.
+  ignoreStatic: true,
   // Core hosts the heaviest actors (XState machine, file locks with jittered
   // backoff bounded to 5s, fromPromise actors that touch the filesystem). The
   // previous 30000ms / 2.5x budget produced ~17 spurious Timeout results that

--- a/packages/parser/stryker.config.mjs
+++ b/packages/parser/stryker.config.mjs
@@ -32,6 +32,14 @@ const config = {
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
   concurrency,
+  // Skip static mutants (evaluated once at load time, not per-test) so Stryker
+  // reports them Ignored instead of running them. Static mutants are
+  // disproportionately expensive (core measured them at ~49% of test time);
+  // dropping them keeps the per-PR gate well under its timeout. Trade-off:
+  // static mutants become Ignored (not scored), a small fidelity loss that also
+  // affects the weekly exhaustive mutation.yml; acceptable for a time-bounded
+  // gate. Applied for consistency across packages. See issue #485.
+  ignoreStatic: true,
   timeoutMS: 30000,
   timeoutFactor: 2.5,
 };


### PR DESCRIPTION
## Problem

The **Mutation Gate (PR)** workflow times out at its `timeout-minutes: 30` cap. Latest run on PR #482 (run [28277202919](https://github.com/tobyhede/rundown/actions/runs/28277202919)) shows both heavy legs blowing the budget even after PR #486 scoped each leg to the PR's changed source files via `--mutate`:

| Leg | Scoped files | Instrumented mutants | Dry run | Mutation phase |
| --- | --- | --- | --- | --- |
| `mutation-gate (cli)` | 10 | **2197** | OK ~2.4m | **timed out at 30m** |
| `mutation-gate (core)` | 8 | **2157** | OK ~2m | **timed out at 30m** |

Core additionally logged: *"Detected 10 static mutants (0% of total) that are estimated to take 49% of the time running the tests! You might want to enable ignoreStatic"*.

**Root cause:** ~2,200 mutants/leg at the config's forced `concurrency: 2` needs ~40+ min. #486's `--mutate` scoping was necessary but insufficient. This applies the standard Stryker levers tracked in issue #485.

## The fix — three levers

1. **`ignoreStatic: true`** in every package's `stryker.config.mjs` (core, cli, parser, plugin). Static mutants are evaluated once at load time and are disproportionately expensive — core measured them at **~49%** of its test time. Dropping them reclaims roughly half of core's runtime.
   - **Trade-off:** static mutants become `Ignored` (not scored), a small fidelity loss that also affects the weekly exhaustive `mutation.yml`. Acceptable for a time-bounded merge gate.
2. **`STRYKER_CONCURRENCY: '4'`** in the `mutation-gate` job `env:`. `ubuntu-latest` runners have 4 vCPUs; this lifts Stryker's forced concurrency from the config default of **2 to 4** (~2x mutant throughput). Scoped to CI via env, so local-dev stays conservative at 2. All four configs already read `STRYKER_CONCURRENCY` via the same `parsePositiveInteger(process.env.STRYKER_CONCURRENCY, 2)` helper, so **no config rewiring was needed**.
   - **Why 4 not 3:** the configs already carry widened timeout budgets (core `60s`/`3x`, cli `60s`/`2.5x`) introduced precisely to absorb CI contention, so 4 runners on 4 vCPUs is unlikely to induce spurious per-mutant timeouts. 4 maximises throughput; the `timeout-minutes` bump below is the safety net if contention does bite.
3. **`timeout-minutes: 30 -> 45`** on the `mutation-gate` job — a guardrail layered on top of levers 1 and 2, **not** the primary fix. The extra margin mainly covers cli, which has no static-mutant shortcut.

## Verification

- All four configs load with `ignoreStatic: true` and `concurrency` honouring `STRYKER_CONCURRENCY`.
- `node --test scripts/__tests__/stryker-config.test.mjs` — **17/17 pass** (config-shape, concurrency-override, break-threshold, and core timeout-budget assertions all green).
- `biome` format + `cspell` clean on all changed files.

## Scope

Changes limited to `.github/workflows/mutation-pr.yml` and the four per-package `stryker.config.mjs` files. No package src/test logic touched.

Builds on PR #486's `--mutate` scoping. Relates to PR #482 (the run that surfaced the timeout). Implements part of issue #485.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mutation-check settings to better balance runtime and reliability across the project.
  * Increased the mutation-gate timeout and adjusted parallel processing to reduce timeouts during checks.
  * Standardized handling of static mutation cases so they’re skipped in scoring and reported as ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->