### PR TITLE
docs: ARTIFACTS-canonical collation + claimed-child-stop guidance

### DIFF
--- a/docs/guides/composing-runbooks.md
+++ b/docs/guides/composing-runbooks.md
@@ -30,10 +30,7 @@ and `execute-plan` (both delegate internally).
 
 ## Pattern 3 — Fan-out + collate
 
-A composed stage delegates N sibling analysis runbooks, then delegates a
-collation runbook that gathers them with a wildcard artifact or `rdpath find`,
-deduplicates, and validates against the shared schema. `review-plan` delegates
-four reviewers then `review-plan-collate`. Never collate from the parent.
+A composed stage delegates N sibling analysis runbooks, then delegates a collation runbook that gathers them with a cross-run wildcard artifact selector (`Reviews "*/...json"`, resolved read-only from the shared-context manifest), deduplicates, and validates against the shared schema. `review-plan` delegates four reviewers then `review-plan-collate`. Never collate from the parent, and never discover the siblings with `rdpath find` — ARTIFACTS is the canonical mechanism.
 
 ## Pattern 4 — Gate loop (iterate-until-clean)
 

--- a/docs/guides/composing-runbooks.md
+++ b/docs/guides/composing-runbooks.md
@@ -32,11 +32,11 @@ and `execute-plan` (both delegate internally).
 
 A composed stage delegates N sibling analysis runbooks, then delegates a
 collation runbook that gathers them with a cross-run wildcard artifact selector
-(`Reviews "*/...json"`, resolved read-only from the shared-context manifest),
-deduplicates, and validates against the shared schema. `review-plan` delegates
-four reviewers then `review-plan-collate`. Never collate from the parent, and
-never discover the siblings with `rdpath find` — ARTIFACTS is the canonical
-mechanism.
+(`Reviews "*/review-plan-*.json"`, resolved read-only from the shared-context
+manifest), deduplicates, and validates against the shared schema. `review-plan`
+delegates four reviewers then `review-plan-collate`. Never collate from the
+parent, and never discover the siblings with `rdpath find` — ARTIFACTS is the
+canonical mechanism.
 
 ## Pattern 4 — Gate loop (iterate-until-clean)
 

--- a/docs/guides/composing-runbooks.md
+++ b/docs/guides/composing-runbooks.md
@@ -30,7 +30,13 @@ and `execute-plan` (both delegate internally).
 
 ## Pattern 3 — Fan-out + collate
 
-A composed stage delegates N sibling analysis runbooks, then delegates a collation runbook that gathers them with a cross-run wildcard artifact selector (`Reviews "*/...json"`, resolved read-only from the shared-context manifest), deduplicates, and validates against the shared schema. `review-plan` delegates four reviewers then `review-plan-collate`. Never collate from the parent, and never discover the siblings with `rdpath find` — ARTIFACTS is the canonical mechanism.
+A composed stage delegates N sibling analysis runbooks, then delegates a
+collation runbook that gathers them with a cross-run wildcard artifact selector
+(`Reviews "*/...json"`, resolved read-only from the shared-context manifest),
+deduplicates, and validates against the shared schema. `review-plan` delegates
+four reviewers then `review-plan-collate`. Never collate from the parent, and
+never discover the siblings with `rdpath find` — ARTIFACTS is the canonical
+mechanism.
 
 ## Pattern 4 — Gate loop (iterate-until-clean)
 

--- a/packages/claude-code-plugin/runbooks/planning/review/review-plan-collate.runbook.md
+++ b/packages/claude-code-plugin/runbooks/planning/review/review-plan-collate.runbook.md
@@ -13,15 +13,18 @@ OUTPUTS:
 Collate multiple plan reviews into a single canonical review document.
 
 ## 1. Find reviews
+- ARTIFACTS
+  - Reviews "*/review-plan-*-*.json"
 - PASS CONTINUE
 - FAIL STOP
 
-`rdpath find` exits non-zero when no files match.
-If there are no review files, there is nothing to collate.
-
-```bash
-rdpath find "*-review-plan-*-*.json"
-```
+The `Reviews` artifact set resolves every per-reviewer review file produced in
+this context. The cross-run selector `"*/review-plan-*-*.json"` desugars to
+`rd://artifacts/{{ContextId}}/*/review-plan-*-*.json` and queries the shared
+context manifest read-only — each reviewer runbook *produced* its row via its
+own `ARTIFACTS` directive, so no filesystem globbing is required. The resolved
+records are surfaced on `STEP_ENTERED.artifacts`. An empty set means there is
+nothing to collate.
 
 
 ## 2. Read the output schema
@@ -37,7 +40,7 @@ rdpath find "*-review-plan-*-*.json"
 - PASS CONTINUE
 - FAIL STOP
 
-Read all review plan review files.
+Read every review file in the `Reviews` artifact set resolved in step 1.
 Merge findings from all reviews into a single canonical review document.
 
 Deduplicate equivalent findings — when multiple reviews identify the same issue, merge their descriptions, evidence, and rationale rather than discarding duplicates.

--- a/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
@@ -124,9 +124,9 @@ rd fail --claim-id <claim_id>     # Report failure
 
 ### 4. Result propagates
 
-When the child calls `rd pass --claim-id <claim_id>` or `rd fail --claim-id <claim_id>`, the result flows back to the parent's substep. The parent step's aggregation rules determine the overall outcome.
+When the child calls `rd pass --claim-id <claim_id>` or `rd fail --claim-id <claim_id>`, the result flows back to the parent's substep. The parent step's aggregation rules determine the overall outcome. **The child's job ends there** — once its claim is reported, it must stop and return control to the orchestrator. The orchestrator (you, the parent side) drives every subsequent step, including any stage the parent auto-advances into.
 
-Always target the child with `--claim-id`. Core Rundown refuses a bare `rd pass`/`rd fail` against the parent while a claimed child is open; if you see `OPEN_DELEGATED_CHILDREN`, rerun the command with the child `--claim-id`.
+Always target the child with `--claim-id`. Core Rundown refuses a bare `rd pass`/`rd fail` against the parent while a claimed child is open; if you see `OPEN_DELEGATED_CHILDREN`, rerun the command with the child `--claim-id`. Note the guard only protects against bare commands *while a claim is open* — after a child closes its claim, bare commands fall through to the parent's default-active runbook with no guard, so a child that keeps running can silently drive the parent pipeline. A claimed child must therefore stop the moment it reports its result.
 
 ## FOR Loop Delegation
 

--- a/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
@@ -110,8 +110,9 @@ When another agent delegates work to you, the plugin injects claim instructions 
 
 1. You receive instructions containing a claim token
 2. Run `rd claim <token>` to accept the work
-3. Follow the runbook steps (same as above — follow output, pass/fail)
+3. Follow the runbook steps (same as above — follow output, pass/fail), passing `--claim-id <claim_id>` on **every** command
 4. Use `rd pass --claim-id <claim_id>` or `rd fail --claim-id <claim_id>` to report your result back to the parent
+5. **Stop.** Once you have reported your claim's final result, your job is done — end your turn and return control to the orchestrator that delegated you.
 
 Variables can be passed during claiming:
 
@@ -122,6 +123,14 @@ rd claim <token> --input-file <path>
 ```
 
 Plain `rd pass` and `rd fail` target the default active runbook, not claimed delegated children.
+
+<important>
+**A claimed child stays inside its claim and stops when the claim ends.** You were dispatched to execute exactly one delegated runbook. When it completes (or fails), the parent pipeline may auto-advance into *its* next step — but those steps belong to the **orchestrator**, not to you. Do not keep going.
+
+- Pass `--claim-id <claim_id>` on **every** `rd` command for your claimed work. **Never** issue a bare `rd pass` / `rd fail` / `rd delegate` / `rd status` as a claimed child — bare commands target the shared default-active runbook (the *parent's* pipeline), so a bare command silently drives work that is not yours.
+- The "Complete ALL steps — do not abandon a runbook" rule applies to **your claimed runbook only**, not to the parent that auto-advanced behind it.
+- After `rd pass --claim-id` / `rd fail --claim-id`, **end your turn.** Report your result in prose to whoever dispatched you; do not run further `rd` commands.
+</important>
 
 For orchestrating delegation from the parent side, see [delegating-runbooks](../delegating-runbooks/SKILL.md).
 
@@ -163,6 +172,7 @@ the JSON instead.
 | Skipping steps | Follow every step — runbook controls flow |
 | Bare `rd pass` with substeps active | Use `rd pass --step 2.1` |
 | Bare `rd pass`/`rd fail` in a claimed child | Use `rd pass --claim-id <claim_id>` to report to the parent |
+| Claimed child keeps going after reporting | Stop after `rd pass --claim-id`; the parent's next steps belong to the orchestrator, not you |
 | Abandoning without `rd stop` | Complete all steps or explicitly stop |
 
 ## Reference

--- a/packages/claude-code-plugin/skills/writing-runbooks/house-style.md
+++ b/packages/claude-code-plugin/skills/writing-runbooks/house-style.md
@@ -147,7 +147,7 @@ Add bare `- DELEGATE` to push the children to subagents instead of running inlin
 - review-plan-collate.runbook.md
 ```
 
-The collation runbook gathers siblings with a **cross-run wildcard artifact selector** (`Reviews "*/...json"`), merges, deduplicates equivalent findings, and validates against the shared schema. The selector desugars to `rd://artifacts/{{ContextId}}/*/...` and resolves the sibling runs' *produced* artifact rows read-only from the shared-context manifest — no filesystem globbing. ARTIFACTS is the canonical discovery mechanism; do **not** reach for `rdpath find` to discover sibling artifacts.
+The collation runbook gathers siblings with a **cross-run wildcard artifact selector** (`Reviews "*/review-plan-*.json"`), merges, deduplicates equivalent findings, and validates against the shared schema. The selector desugars to `rd://artifacts/{{ContextId}}/*/review-plan-*.json` and resolves the sibling runs' *produced* artifact rows read-only from the shared-context manifest — no filesystem globbing. ARTIFACTS is the canonical discovery mechanism; do **not** reach for `rdpath find` to discover sibling artifacts.
 
 ### Validation & discovery helpers
 

--- a/packages/claude-code-plugin/skills/writing-runbooks/house-style.md
+++ b/packages/claude-code-plugin/skills/writing-runbooks/house-style.md
@@ -147,7 +147,7 @@ Add bare `- DELEGATE` to push the children to subagents instead of running inlin
 - review-plan-collate.runbook.md
 ```
 
-The collation runbook gathers siblings with a wildcard artifact (`ReviewPaths "*/...json"`) or `rdpath find`, merges, deduplicates equivalent findings, and validates against the shared schema.
+The collation runbook gathers siblings with a **cross-run wildcard artifact selector** (`Reviews "*/...json"`), merges, deduplicates equivalent findings, and validates against the shared schema. The selector desugars to `rd://artifacts/{{ContextId}}/*/...` and resolves the sibling runs' *produced* artifact rows read-only from the shared-context manifest — no filesystem globbing. ARTIFACTS is the canonical discovery mechanism; do **not** reach for `rdpath find` to discover sibling artifacts.
 
 ### Validation & discovery helpers
 
@@ -155,7 +155,7 @@ The collation runbook gathers siblings with a wildcard artifact (`ReviewPaths "*
 |--------|----------------|
 | `{{ validateSchema Alias }}` | Complete `rdx --validate <path>` command (schema from the artifact's `"$schema"`) |
 | `rdx {{ path Alias }} --validate --schema <name>` | Explicit-schema validation |
-| `rdpath find "<glob>"` | Lists matching files; **exits non-zero when none match** — use as a guard ("nothing to collate") |
+| `Alias "*/<glob>"` (cross-run ARTIFACTS selector) | Resolves matching sibling-run artifacts from the shared-context manifest read-only — the canonical discovery mechanism. An empty set means "nothing to collate"; no filesystem globbing or `rdpath` |
 
 ### Skills as steps
 


### PR DESCRIPTION
## What

Two documentation changes rescued from an in-progress worktree and rebased onto current `main`.

### 1. ARTIFACTS is the canonical sibling-discovery mechanism for collation
Drops `rdpath find` in favour of a cross-run wildcard artifact selector (`Reviews "*/...json"` → `rd://artifacts/{{ContextId}}/*/...`) for discovering sibling review artifacts. The selector resolves produced rows read-only from the shared-context manifest — no filesystem globbing; an empty set means "nothing to collate".

- `docs/guides/composing-runbooks.md` — Pattern 3 no longer offers `rdpath find`
- `review-plan-collate.runbook.md` — step 1 uses the `ARTIFACTS Reviews` selector
- `house-style.md` — ARTIFACTS canonical; alias renamed to `Reviews`

Completes the doc migration for the cross-run selector shipped in #334.

### 2. A claimed child must stop after reporting its result
Documents that `OPEN_DELEGATED_CHILDREN` only guards while a claim is open; once the child closes its claim, bare `rd pass`/`rd fail` fall through to the parent's default-active runbook with no guard, so a runaway claimed child can silently drive the parent pipeline. A claimed child must pass `--claim-id` on every command and stop the moment it reports.

- `skills/delegating-runbooks/SKILL.md`
- `skills/running-runbooks/SKILL.md`

Refs #460.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how “Pattern 3 — Fan-out + collate” discovers and collates sibling review artifacts across runs using cross-run `Alias "*/<glob>"`, including behavior when no matches are found.
  * Updated the “review-plan-collate” runbook to resolve “Find reviews” from a previously resolved `Reviews` artifact set (rather than path-glob searching), and to collate only from that set.
  * Strengthened delegated-runbook instructions: claimed children must use `--claim-id` for every step and must stop immediately after `rd pass`/`rd fail`.
  * Improved house-style discovery guidance by replacing prior `rdpath find` references with the canonical shared artifact approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->