### PR TITLE
feat(#485): advisory per-PR mutation gate + dashboard baseline producer

### DIFF
--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -116,13 +116,19 @@ jobs:
         run: |
           set -uo pipefail
           mkdir -p "${PKG_DIR}/reports"
+          baseline="${PKG_DIR}/reports/stryker-incremental.json"
           url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/main?module=${MODULE}"
+          # A 200 with an empty or truncated body must not be trusted as a
+          # baseline: require a non-empty file AND valid JSON before keeping it,
+          # otherwise fall through to a cold incremental run.
           if curl --fail --silent --show-error --max-time 60 \
-               --output "${PKG_DIR}/reports/stryker-incremental.json" "${url}"; then
+               --output "${baseline}" "${url}" \
+               && [ -s "${baseline}" ] \
+               && node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' "${baseline}"; then
             echo "Baseline downloaded for module ${MODULE}."
           else
             echo "::notice::no dashboard baseline for module ${MODULE}; running cold incremental."
-            rm -f "${PKG_DIR}/reports/stryker-incremental.json"
+            rm -f "${baseline}"
           fi
 
       # Advisory run: scoped to changed files, incremental, never fatal.
@@ -154,6 +160,24 @@ jobs:
             --package-name "${PKG}" \
             --markdown "${RUNNER_TEMP}/mutation-summary-${PKG}.md"
 
+      # If Stryker or scoring failed, no markdown summary was written and the
+      # comment job would otherwise report a clean "no mutated changed files"
+      # result — masking the failure. Write a diagnostic summary so the sticky
+      # comment surfaces the failure. Advisory: never fails the job. Runs before
+      # the upload step so the diagnostic gets included in the artifact.
+      - name: Diagnose advisory failure (${{ matrix.package }})
+        if: ${{ steps.changes.outputs.changed == 'true' && (steps.stryker.outcome == 'failure' || steps.assert.outcome == 'failure') }}
+        env:
+          PKG: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          summary="${RUNNER_TEMP}/mutation-summary-${PKG}.md"
+          {
+            echo "#### ⚠️ \`${PKG}\` — advisory mutation scoring did not complete"
+            echo
+            echo "_The mutation run or scoring step failed. This is advisory and does not block merge. See the workflow logs for details._"
+          } > "${summary}"
+
       - name: Upload advisory summary
         if: ${{ always() && steps.changes.outputs.changed == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
@@ -174,9 +198,10 @@ jobs:
   comment:
     needs: mutation-gate
     # Only on real PRs (sticky comments need a PR number). Always runs so the
-    # comment updates even when every package was skipped. Fork PRs get no
-    # comment (read-only token) but the gate job still produced artifacts.
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    # comment updates even when every package was skipped. Fork PRs are skipped
+    # cleanly: their read-only token cannot post a comment, so the job would only
+    # fail noisily — the gate job still produced artifacts for them.
+    if: ${{ always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -28,19 +28,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `module` (the dashboard module name) always equals `package`, so it is
+        # derived from matrix.package rather than duplicated here — keeping this
+        # matrix in sync with the producer workflow (mutation.yml).
         include:
           - package: parser
             dir: packages/parser
-            module: parser
           - package: core
             dir: packages/core
-            module: core
           - package: cli
             dir: packages/cli
-            module: cli
           - package: plugin
             dir: packages/claude-code-plugin
-            module: plugin
     runs-on: ubuntu-latest
     # Advisory: this is a guardrail against a runaway run wasting minutes, not a
     # merge gate. ignoreStatic + concurrency keep a scoped run well under it.
@@ -111,7 +110,7 @@ jobs:
       - name: Download Stryker baseline from dashboard
         if: ${{ steps.changes.outputs.changed == 'true' }}
         env:
-          MODULE: ${{ matrix.module }}
+          MODULE: ${{ matrix.package }}
           PKG_DIR: ${{ matrix.dir }}
         run: |
           set -uo pipefail

--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -211,6 +211,8 @@ jobs:
     if: ${{ always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     permissions:
+      # Elevated solely so the "Post sticky comment" step can create/update the
+      # advisory PR comment. The gate job itself runs with contents: read only.
       pull-requests: write
     steps:
       - name: Download advisory summaries

--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -165,6 +165,11 @@ jobs:
       # result — masking the failure. Write a diagnostic summary so the sticky
       # comment surfaces the failure. Advisory: never fails the job. Runs before
       # the upload step so the diagnostic gets included in the artifact.
+      #
+      # A below-floor file makes the scorer exit non-zero *after* writing a valid
+      # score table, so `assert.outcome == 'failure'` does not mean "no summary".
+      # Only write the generic diagnostic when no non-empty summary exists, so we
+      # never clobber the below-floor annotation the gate exists to surface.
       - name: Diagnose advisory failure (${{ matrix.package }})
         if: ${{ steps.changes.outputs.changed == 'true' && (steps.stryker.outcome == 'failure' || steps.assert.outcome == 'failure') }}
         env:
@@ -172,6 +177,9 @@ jobs:
         run: |
           set -euo pipefail
           summary="${RUNNER_TEMP}/mutation-summary-${PKG}.md"
+          if [ -s "${summary}" ]; then
+            exit 0
+          fi
           {
             echo "#### ⚠️ \`${PKG}\` — advisory mutation scoring did not complete"
             echo

--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -1,13 +1,16 @@
 name: Mutation Gate (PR)
 
-# Per-PR changed-file mutation gate (issue #483).
+# Per-PR ADVISORY mutation report (issue #485).
 #
-# Stryker's `thresholds.break` gates only the project-wide aggregate, so a single
-# file can collapse (e.g. ~99% -> ~87%) while the project total stays green. This
-# workflow runs each affected package's mutation suite incrementally and then
-# post-processes the emitted JSON report (scripts/assert-mutation-score.mjs) to
-# fail when a file changed in the PR scores below the floor. It is the merge gate
-# the weekly mutation.yml report could never be.
+# This check is advisory: it never blocks merge. It runs each affected package's
+# mutation suite scoped to the PR's changed files (so runtime tracks change size),
+# scores each changed file, and surfaces the result as a sticky PR comment (see
+# the `comment` job). Static mutants are ignored here (STRYKER_IGNORE_STATIC) to
+# keep the advisory run fast; the exhaustive producer run (mutation.yml) scores
+# them at full fidelity. The incremental baseline is downloaded from the public
+# Stryker Dashboard report for `main` — no API key is needed to read it, and this
+# workflow deliberately never uploads (which would corrupt the baseline with a
+# partial, changed-file-scoped report).
 
 on:
   pull_request:
@@ -18,7 +21,6 @@ concurrency:
   group: mutation-pr-${{ github.ref }}
   cancel-in-progress: true
 
-# No workflow-level permissions by default; jobs must opt in explicitly.
 permissions: {}
 
 jobs:
@@ -29,27 +31,25 @@ jobs:
         include:
           - package: parser
             dir: packages/parser
+            module: parser
           - package: core
             dir: packages/core
+            module: core
           - package: cli
             dir: packages/cli
+            module: cli
           - package: plugin
             dir: packages/claude-code-plugin
+            module: plugin
     runs-on: ubuntu-latest
-    # Raised 30 -> 45 as a guardrail layered on top of ignoreStatic +
-    # STRYKER_CONCURRENCY (below), not the primary fix. Both legs previously hit
-    # the 30m cap on ~2197 (cli) / ~2157 (core) instrumented mutants at the
-    # forced concurrency of 2 (run 28277202919). The margin mainly covers cli,
-    # which has no static-mutant shortcut. See issue #485.
+    # Advisory: this is a guardrail against a runaway run wasting minutes, not a
+    # merge gate. ignoreStatic + concurrency keep a scoped run well under it.
     timeout-minutes: 45
-    # ubuntu-latest runners have 4 vCPUs; raise Stryker's forced concurrency from
-    # the config default of 2 to 4 to maximise throughput on the gate (~2x the
-    # mutant rate). Scoped to CI via env so local-dev stays conservative at 2.
-    # The configs' widened timeout budgets (core 60s/3x, cli 60s/2.5x) already
-    # absorb CI contention, so this is unlikely to induce spurious per-mutant
-    # timeouts. See issue #485.
     env:
       STRYKER_CONCURRENCY: '4'
+      # PR-only: reclaim static-mutant time on the advisory run. The producer
+      # run leaves this unset so it scores static mutants. See issue #485.
+      STRYKER_IGNORE_STATIC: 'true'
     permissions:
       contents: read
 
@@ -61,19 +61,9 @@ jobs:
           # assert-mutation-score.mjs diffs `${base}...HEAD`.
           fetch-depth: 0
 
-      # Resolve the PR base ref and compute whether this package has any changed
-      # source files. Skipping unaffected packages keeps the gate cheap on small
-      # PRs without spawning the (expensive) mutation run.
-      #
-      # This step must fail CLOSED: a git error (unresolvable base, missing
-      # merge-base) must fail the job, never silently skip the gate. Two defects
-      # this layout avoids: (1) `fetch-depth: 0` already provides full history and
-      # `origin/<base>`, so re-fetching with `--depth=1` would re-shallow the
-      # clone and break the `${base}...HEAD` merge-base — so we do not fetch; and
-      # (2) running `git diff` as an `if` condition suppresses `set -e`, so a git
-      # failure would route to the `else` (changed=false) and skip the gate — so
-      # the diff is captured outside any condition, after an explicit base
-      # preflight, letting `set -e` fail the job on any git error. See issue #483.
+      # Resolve the PR base ref and compute whether this package has changed
+      # source files. Skipping unaffected packages keeps the run cheap. Fails
+      # CLOSED on git errors (see issue #483 for the rationale on the layout).
       - name: Detect changes for ${{ matrix.package }}
         id: changes
         env:
@@ -87,28 +77,13 @@ jobs:
           if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
             base="origin/${DEFAULT_BRANCH}"
           fi
-          # Fail closed if the base ref or its merge-base with HEAD is unreachable
-          # rather than letting a later diff error masquerade as "no changes".
           git rev-parse --verify --quiet "${base}^{commit}" >/dev/null \
-            || { echo "::error::base ref '${base}' is unreachable; cannot gate." >&2; exit 1; }
+            || { echo "::error::base ref '${base}' is unreachable; cannot score." >&2; exit 1; }
           git merge-base "${base}" HEAD >/dev/null \
-            || { echo "::error::no merge-base between '${base}' and HEAD; cannot gate." >&2; exit 1; }
-          # Exclude deletions (--diff-filter=d): a deleted file cannot be
-          # mutation-tested, and an all-negation `--mutate` (which is what a
-          # deletion-only diff would reduce to below) makes Stryker fall back to
-          # its DEFAULT glob and mutate the whole tree — the exact cold-run
-          # blow-up this gate must avoid. A deletion-only PR therefore has no
-          # mutable changed source and is skipped, same as it passes today.
+            || { echo "::error::no merge-base between '${base}' and HEAD; cannot score." >&2; exit 1; }
           changed_files="$(git diff --name-only --diff-filter=d "${base}...HEAD" -- "${PKG_DIR}/src")"
           if [ -n "${changed_files}" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            # Build the `--mutate` value for the run step: the changed source
-            # files made package-relative (Stryker runs with cwd=${PKG_DIR}) PLUS
-            # this package's own `mutate` exclusion patterns, read straight from
-            # stryker.config.mjs so they can never drift from the source of truth.
-            # Stryker applies the positive patterns then subtracts the negatives,
-            # yielding exactly (changed files ∩ config-mutable files) — the same
-            # set the config glob would mutate, narrowed to this PR's changes.
             pkg_rel="$(printf '%s\n' "${changed_files}" | sed "s#^${PKG_DIR}/##")"
             excludes="$(cd "${PKG_DIR}" && node --input-type=module -e 'import("./stryker.config.mjs").then((m) => { const c = m.default ?? m.config ?? {}; process.stdout.write((c.mutate ?? []).filter((p) => p.startsWith("!")).join("\n")); });')" \
               || { echo "::error::failed to read mutate exclusions from ${PKG_DIR}/stryker.config.mjs" >&2; exit 1; }
@@ -116,7 +91,7 @@ jobs:
             echo "mutate=${mutate}" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No source changes under ${PKG_DIR}/src; skipping mutation gate."
+            echo "No source changes under ${PKG_DIR}/src; skipping advisory run."
           fi
           echo "base=${base}" >> "$GITHUB_OUTPUT"
 
@@ -129,50 +104,67 @@ jobs:
         if: ${{ steps.changes.outputs.changed == 'true' }}
         run: pnpm run build
 
-      - name: Restore Stryker incremental cache
-        if: ${{ steps.changes.outputs.changed == 'true' }}
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
-        with:
-          path: ${{ matrix.dir }}/reports/stryker-incremental.json
-          key: stryker-${{ matrix.package }}-${{ github.sha }}
-          restore-keys: stryker-${{ matrix.package }}-
-
-      # Run the real mutants for the affected package, scoped to ONLY the files
-      # changed in this PR (`--mutate`, built in the detect step with config
-      # exclusions preserved). The per-file gate below scores only changed files,
-      # so mutating the whole `src` tree is pure waste — and it is not merely
-      # slow, it is unbounded: incremental mode does NOT keep a COLD run cheap
-      # (incremental needs a warm baseline, which a timed-out job never saves), so
-      # a cold sweep instruments every file in the config glob (thousands of
-      # mutants for core/cli) and blows past timeout-minutes before a single score
-      # is computed — see cancelled run 28231020823. Scoping to the changed set
-      # collapses each leg from hours to minutes. `--allowEmpty` makes a PR that
-      # touches only config-excluded files (e.g. index.ts) a clean no-op pass
-      # instead of an error. See issue #483.
-      - name: Run mutation tests (${{ matrix.package }})
+      # Download the public `main` baseline so incremental mode can reuse
+      # unchanged results. Best-effort: a 404/empty body degrades to a cold
+      # incremental run (still bounded by --mutate scoping). No API key needed —
+      # OSS dashboard reports are public reads.
+      - name: Download Stryker baseline from dashboard
         if: ${{ steps.changes.outputs.changed == 'true' }}
         env:
+          MODULE: ${{ matrix.module }}
+          PKG_DIR: ${{ matrix.dir }}
+        run: |
+          set -uo pipefail
+          mkdir -p "${PKG_DIR}/reports"
+          url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/main?module=${MODULE}"
+          if curl --fail --silent --show-error --max-time 60 \
+               --output "${PKG_DIR}/reports/stryker-incremental.json" "${url}"; then
+            echo "Baseline downloaded for module ${MODULE}."
+          else
+            echo "::notice::no dashboard baseline for module ${MODULE}; running cold incremental."
+            rm -f "${PKG_DIR}/reports/stryker-incremental.json"
+          fi
+
+      # Advisory run: scoped to changed files, incremental, never fatal.
+      - name: Run mutation tests (${{ matrix.package }})
+        id: stryker
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        continue-on-error: true
+        env:
           MUTATE: ${{ steps.changes.outputs.mutate }}
-        run: pnpm exec stryker run --mutate "${MUTATE}" --allowEmpty
+        run: pnpm exec stryker run --incremental --mutate "${MUTATE}" --allowEmpty
         working-directory: ${{ matrix.dir }}
 
-      # The merge gate: fail when any file changed in this PR scores below the
-      # floor. Reads the report Stryker just emitted; no second mutation run.
-      - name: Assert per-file mutation score
+      # Score changed files and render the advisory markdown. Non-fatal: a
+      # below-floor file annotates the comment, it does not fail the check.
+      - name: Score changed files (advisory)
+        id: assert
         if: ${{ steps.changes.outputs.changed == 'true' }}
+        continue-on-error: true
         env:
           PKG_DIR: ${{ matrix.dir }}
           BASE: ${{ steps.changes.outputs.base }}
+          PKG: ${{ matrix.package }}
         run: |
           pnpm run assert:mutation-score -- \
             --report "${PKG_DIR}/reports/mutation/mutation-report.json" \
             --package-dir "${PKG_DIR}" \
             --base "${BASE}" \
-            --floor 70
+            --floor 70 \
+            --package-name "${PKG}" \
+            --markdown "${RUNNER_TEMP}/mutation-summary-${PKG}.md"
+
+      - name: Upload advisory summary
+        if: ${{ always() && steps.changes.outputs.changed == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: mutation-summary-${{ matrix.package }}
+          path: ${{ runner.temp }}/mutation-summary-${{ matrix.package }}.md
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload mutation report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        # always() so the report uploads even when the gate fails, aiding triage.
         if: ${{ always() && steps.changes.outputs.changed == 'true' }}
         with:
           name: mutation-report-${{ matrix.package }}

--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -170,3 +170,47 @@ jobs:
           name: mutation-report-${{ matrix.package }}
           path: ${{ matrix.dir }}/reports/mutation/
           retention-days: 30
+
+  comment:
+    needs: mutation-gate
+    # Only on real PRs (sticky comments need a PR number). Always runs so the
+    # comment updates even when every package was skipped. Fork PRs get no
+    # comment (read-only token) but the gate job still produced artifacts.
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download advisory summaries
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
+        with:
+          pattern: mutation-summary-*
+          path: summaries
+          merge-multiple: true
+        continue-on-error: true
+
+      - name: Assemble comment body
+        run: |
+          set -euo pipefail
+          {
+            echo "### 🧬 Mutation score (advisory)"
+            echo
+            echo "_Per-file mutation scores for files changed in this PR. **This check is advisory and never blocks merge.** Trend & full reports: the Stryker Dashboard. See issue #485._"
+            echo
+            if ls summaries/*.md >/dev/null 2>&1; then
+              for f in summaries/*.md; do
+                cat "$f"
+                echo
+                echo
+              done
+            else
+              echo "_No mutated changed files in this PR._"
+            fi
+          } > comment.md
+          cat comment.md
+
+      - name: Post sticky comment
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
+        with:
+          header: mutation-advisory
+          path: comment.md

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,6 +1,8 @@
 name: Mutation Testing
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       package:
@@ -32,14 +34,17 @@ jobs:
             dir: packages/claude-code-plugin
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # On schedule, run every package. On workflow_dispatch, run the selected
-    # package (or 'all'). This filter lives at the step level via env.RUN_PACKAGE
-    # because the `matrix` context is not available in a job-level `if:`.
+    # On schedule and push-to-main, run every package. On workflow_dispatch, run
+    # the selected package (or 'all'). This filter lives at the step level via
+    # env.RUN_PACKAGE because the `matrix` context is not available in a
+    # job-level `if:`.
     env:
       RUN_PACKAGE: >-
         ${{ github.event_name == 'schedule' ||
+            github.event_name == 'push' ||
             github.event.inputs.package == 'all' ||
             github.event.inputs.package == matrix.package }}
+      STRYKER_DASHBOARD_VERSION: main
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         if: ${{ env.RUN_PACKAGE == 'true' }}
@@ -63,17 +68,37 @@ jobs:
         if: ${{ env.RUN_PACKAGE == 'true' }}
         run: pnpm run build
 
-      - name: Restore Stryker incremental cache
+      - name: Download previous baseline from dashboard
         if: ${{ env.RUN_PACKAGE == 'true' }}
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
-        with:
-          path: ${{ matrix.dir }}/reports/stryker-incremental.json
-          key: stryker-${{ matrix.package }}-${{ github.sha }}
-          restore-keys: stryker-${{ matrix.package }}-
+        env:
+          MODULE: ${{ matrix.package }}
+          PKG_DIR: ${{ matrix.dir }}
+        run: |
+          set -uo pipefail
+          mkdir -p "${PKG_DIR}/reports"
+          url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/main?module=${MODULE}"
+          if curl --fail --silent --show-error --max-time 60 \
+               --output "${PKG_DIR}/reports/stryker-incremental.json" "${url}"; then
+            echo "Previous baseline downloaded for module ${MODULE}."
+          else
+            echo "::notice::no previous baseline for module ${MODULE}; producing a cold one."
+            rm -f "${PKG_DIR}/reports/stryker-incremental.json"
+          fi
 
       - name: Run mutation tests
         if: ${{ env.RUN_PACKAGE == 'true' }}
-        run: pnpm exec stryker run
+        env:
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        # Weekly cron forces a complete re-run (drift-proof full fidelity);
+        # push-to-main refreshes incrementally against the downloaded baseline.
+        # Both upload to the dashboard (key present) and score static mutants
+        # (the ignoreStatic env is left unset here). See issue #485.
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            pnpm exec stryker run --incremental --force
+          else
+            pnpm exec stryker run --incremental
+          fi
         working-directory: ${{ matrix.dir }}
 
       - name: Upload mutation report

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -94,7 +94,12 @@ jobs:
       - name: Run mutation tests
         if: ${{ env.RUN_PACKAGE == 'true' }}
         env:
-          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+          # Only automated main-branch runs (schedule/push) may upload to the
+          # canonical dashboard baseline. workflow_dispatch is ad-hoc (and may run
+          # off a feature branch or a single package), so it runs WITHOUT the key
+          # and therefore cannot overwrite the main baseline — the dashboard
+          # reporter is enabled only when STRYKER_DASHBOARD_API_KEY is present.
+          STRYKER_DASHBOARD_API_KEY: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'push')) && secrets.STRYKER_DASHBOARD_API_KEY || '' }}
         # Weekly cron forces a complete re-run (drift-proof full fidelity);
         # push-to-main refreshes incrementally against the downloaded baseline.
         # Both upload to the dashboard (key present) and score static mutants

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -76,13 +76,19 @@ jobs:
         run: |
           set -uo pipefail
           mkdir -p "${PKG_DIR}/reports"
+          baseline="${PKG_DIR}/reports/stryker-incremental.json"
           url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/${STRYKER_DASHBOARD_VERSION}?module=${MODULE}"
+          # Keep the baseline only if curl succeeds AND the body is non-empty
+          # valid JSON. A 200 with an empty/truncated body would otherwise feed a
+          # corrupt baseline into incremental mode and pollute the uploaded report.
           if curl --fail --silent --show-error --max-time 60 \
-               --output "${PKG_DIR}/reports/stryker-incremental.json" "${url}"; then
+               --output "${baseline}" "${url}" \
+               && [ -s "${baseline}" ] \
+               && node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' "${baseline}"; then
             echo "Previous baseline downloaded for module ${MODULE}."
           else
             echo "::notice::no previous baseline for module ${MODULE}; producing a cold one."
-            rm -f "${PKG_DIR}/reports/stryker-incremental.json"
+            rm -f "${baseline}"
           fi
 
       - name: Run mutation tests

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           set -uo pipefail
           mkdir -p "${PKG_DIR}/reports"
-          url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/main?module=${MODULE}"
+          url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/${STRYKER_DASHBOARD_VERSION}?module=${MODULE}"
           if curl --fail --silent --show-error --max-time 60 \
                --output "${PKG_DIR}/reports/stryker-incremental.json" "${url}"; then
             echo "Previous baseline downloaded for module ${MODULE}."

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
   <a href="https://coderabbit.ai">
     <img src="https://img.shields.io/coderabbit/prs/github/tobyhede/rundown" alt="CodeRabbit Reviews." />
   </a>
+  <a href="https://dashboard.stryker-mutator.io/reports/github.com/tobyhede/rundown/main">
+    <img src="https://img.shields.io/endpoint?style=flat&amp;url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Ftobyhede%2Frundown%2Fmain" alt="Mutation testing badge" />
+  </a>
 </p>
 
 ## Why Rundown?

--- a/docs/internal/mutation-testing-ci.md
+++ b/docs/internal/mutation-testing-ci.md
@@ -1,0 +1,55 @@
+# Mutation Testing in CI
+
+Mutation testing runs in two roles, split by issue #485 after per-PR blocking
+gates proved structurally too slow regardless of tuning.
+
+## Advisory per-PR check (`.github/workflows/mutation-pr.yml`)
+
+- **Non-blocking.** It is intentionally NOT a required status check. It posts a
+  single sticky PR comment (header `mutation-advisory`) with per-file mutation
+  scores for the files changed in the PR.
+- **Scoped + fast.** Runs Stryker with `--mutate` limited to the PR's changed
+  source files, `--incremental` against the public `main` baseline downloaded
+  from the Stryker Dashboard, and `STRYKER_IGNORE_STATIC=true` to skip static
+  mutants. The Stryker run and the per-file score step are
+  `continue-on-error: true`, so a low score annotates the comment but never
+  fails the job.
+- **No secret.** The baseline is a public dashboard read (`curl`). The PR run
+  never uploads (an upload of a changed-file-scoped report would corrupt the
+  baseline).
+
+## Full-fidelity producer (`.github/workflows/mutation.yml`)
+
+- Runs on **push to `main`** (incremental refresh) and **weekly cron**
+  (`--force` complete refresh), every package.
+- `ignoreStatic` is OFF (env unset) so static mutants are scored.
+- Uploads the full report per module to the Stryker Dashboard
+  (`STRYKER_DASHBOARD_API_KEY`), which is both the trend/score surface and the
+  baseline the PR check downloads.
+
+## Config (`packages/*/stryker.config.mjs`)
+
+- `ignoreStatic` is `false` by default; only `STRYKER_IGNORE_STATIC=true`
+  enables it (the PR workflow sets it).
+- The `dashboard` reporter is added to `reporters` only when
+  `STRYKER_DASHBOARD_API_KEY` is present, so only the producer uploads.
+- `dashboard.project` is `github.com/tobyhede/rundown`; `dashboard.module` is
+  the package name (`parser`/`core`/`cli`/`plugin`); `reportType` is `full`.
+- `thresholds.break: 70` still applies to every `stryker run`; on the advisory
+  PR run it is neutralized by `continue-on-error` and superseded by the per-file
+  score in `scripts/assert-mutation-score.mjs`.
+
+## Options considered and declined
+
+- **Per-PR blocking gate (status quo before #485).** Even scoped to changed
+  files with `ignoreStatic` and concurrency 4, big-file PRs ran 40+ minutes.
+  Blocking on it stalls merges; the empirical and Stryker-community guidance is
+  to keep mutation testing advisory and track the score as a trend.
+- **Merge queue (`merge_group:`).** A valid way to move an enforced check off
+  the per-PR critical path, but it adds a gate-aggregation job and branch-
+  protection wiring for a check we have decided should be advisory, not
+  enforced. Revisit only if an enforced signal becomes a requirement.
+- **`actions/cache` for the incremental baseline.** Workable but needs custom
+  split restore/save (the combined action only saves on success) and suffers
+  7-day/10 GB eviction cold-starts. The dashboard gives a durable, public,
+  trend-tracking baseline with no cache plumbing, so it was preferred.

--- a/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
+++ b/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
@@ -56,20 +56,20 @@ gh api repos/actions/download-artifact/git/tags/$(gh api repos/actions/download-
 ```
 Record the resulting commit SHA as `DL_ARTIFACT_SHA`.
 
-- [ ] **Step 2: Resolve `marocchino/sticky-pull-request-comment` latest v2 SHA**
+- [ ] **Step 2: Resolve `marocchino/sticky-pull-request-comment` v3.0.4 SHA**
 
 Run:
 ```bash
-gh api repos/marocchino/sticky-pull-request-comment/git/refs/tags/v2 --jq '.object.sha'
+gh api repos/marocchino/sticky-pull-request-comment/git/refs/tags/v3.0.4 --jq '.object.sha'
 ```
-Expected: a 40-char commit SHA (dereference as in Step 1 if it points at a tag object). Record as `STICKY_SHA` and note the exact tag (e.g. `v2.9.4`) for the version comment.
+Expected: a 40-char commit SHA (dereference as in Step 1 if it points at a tag object). The shipped workflow pins `0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4`. Record as `STICKY_SHA` and note the exact tag (`v3.0.4`) for the version comment.
 
 - [ ] **Step 3: Record the values**
 
 Write both SHAs and their version comments into the scratchpad (or a sticky note) so Tasks 4–5 use the exact strings, e.g.:
 ```
 DL_ARTIFACT: actions/download-artifact@<DL_ARTIFACT_SHA>  # v7
-STICKY:      marocchino/sticky-pull-request-comment@<STICKY_SHA>  # v2.9.4
+STICKY:      marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
 ```
 No commit for this task.
 
@@ -480,7 +480,7 @@ test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => 
   const yml = await read('.github/workflows/mutation-pr.yml');
   assert.match(yml, /STRYKER_IGNORE_STATIC:\s*'true'/, 'PR run must opt into ignoreStatic');
   assert.match(yml, /continue-on-error:\s*true/, 'advisory steps must be non-fatal');
-  assert.match(yml, /dashboard\.stryker-mutator\.io\/api\/reports/, 'PR run must download the dashboard baseline');
+  assert.match(yml, /https:\/\/dashboard\.stryker-mutator\.io\/api\/reports\//, 'PR run must download the dashboard baseline');
   assert.doesNotMatch(yml, /STRYKER_DASHBOARD_API_KEY/, 'PR workflow must not reference the upload secret');
 });
 
@@ -613,7 +613,7 @@ jobs:
       - name: Download Stryker baseline from dashboard
         if: ${{ steps.changes.outputs.changed == 'true' }}
         env:
-          MODULE: ${{ matrix.module }}
+          MODULE: ${{ matrix.package }}
           PKG_DIR: ${{ matrix.dir }}
         run: |
           set -uo pipefail
@@ -770,6 +770,8 @@ Append this job to `.github/workflows/mutation-pr.yml` (use the exact SHAs/versi
     if: ${{ always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     permissions:
+      # Elevated solely so the "Post sticky comment" step can create/update the
+      # advisory PR comment. The gate job itself runs with contents: read only.
       pull-requests: write
     steps:
       - name: Download advisory summaries
@@ -801,7 +803,7 @@ Append this job to `.github/workflows/mutation-pr.yml` (use the exact SHAs/versi
           cat comment.md
 
       - name: Post sticky comment
-        uses: marocchino/sticky-pull-request-comment@<STICKY_SHA>  # v2.x.x
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
         with:
           header: mutation-advisory
           path: comment.md
@@ -845,6 +847,10 @@ test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to da
   const yml = await read('.github/workflows/mutation.yml');
   assert.doesNotMatch(yml, /STRYKER_IGNORE_STATIC:/, 'producer must score static mutants (no ignoreStatic env assignment)');
   assert.match(yml, /STRYKER_DASHBOARD_API_KEY/, 'producer must pass the dashboard API key for upload');
+  // The upload key must be gated on automated main-branch runs so an ad-hoc
+  // workflow_dispatch (possibly off a feature branch) cannot overwrite the
+  // canonical baseline. The key assignment carries the event/ref condition.
+  assert.match(yml, /STRYKER_DASHBOARD_API_KEY:[^\n]*github\.event_name == 'schedule'[^\n]*secrets\.STRYKER_DASHBOARD_API_KEY/, 'producer must gate the upload key on schedule/push main runs');
   assert.match(yml, /push:\s*\n\s*branches:\s*\[main\]/, 'producer must run on push to main to refresh the baseline');
 });
 ```
@@ -926,7 +932,12 @@ on:
       - name: Run mutation tests
         if: ${{ env.RUN_PACKAGE == 'true' }}
         env:
-          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+          # Only automated main-branch runs (schedule/push) may upload to the
+          # canonical dashboard baseline. workflow_dispatch is ad-hoc (and may run
+          # off a feature branch or a single package), so it runs WITHOUT the key
+          # and therefore cannot overwrite the main baseline — the dashboard
+          # reporter is enabled only when STRYKER_DASHBOARD_API_KEY is present.
+          STRYKER_DASHBOARD_API_KEY: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'push')) && secrets.STRYKER_DASHBOARD_API_KEY || '' }}
         # Weekly cron forces a complete re-run (drift-proof full fidelity);
         # push-to-main refreshes incrementally against the downloaded baseline.
         # Both upload to the dashboard (key present) and score static mutants

--- a/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
+++ b/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
@@ -480,7 +480,9 @@ test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => 
   const yml = await read('.github/workflows/mutation-pr.yml');
   assert.match(yml, /STRYKER_IGNORE_STATIC:\s*'true'/, 'PR run must opt into ignoreStatic');
   assert.match(yml, /continue-on-error:\s*true/, 'advisory steps must be non-fatal');
-  assert.match(yml, /https:\/\/dashboard\.stryker-mutator\.io\/api\/reports\//, 'PR run must download the dashboard baseline');
+  // Substring check, not a regex: avoids CodeQL's url-anchor heuristic, which
+  // can't be satisfied for a URL that sits mid-line in the YAML.
+  assert.ok(yml.includes('https://dashboard.stryker-mutator.io/api/reports/'), 'PR run must download the dashboard baseline');
   assert.doesNotMatch(yml, /STRYKER_DASHBOARD_API_KEY/, 'PR workflow must not reference the upload secret');
 });
 

--- a/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
+++ b/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
@@ -47,30 +47,38 @@
 - [ ] **Step 1: Resolve `actions/download-artifact` v7 SHA**
 
 Run:
+
 ```bash
 gh api repos/actions/download-artifact/git/refs/tags/v7 --jq '.object.sha'
 ```
+
 Expected: a 40-char commit SHA. If the ref is a tag object (not a commit), dereference it:
+
 ```bash
 gh api repos/actions/download-artifact/git/tags/$(gh api repos/actions/download-artifact/git/refs/tags/v7 --jq '.object.sha') --jq '.object.sha'
 ```
+
 Record the resulting commit SHA as `DL_ARTIFACT_SHA`.
 
 - [ ] **Step 2: Resolve `marocchino/sticky-pull-request-comment` v3.0.4 SHA**
 
 Run:
+
 ```bash
 gh api repos/marocchino/sticky-pull-request-comment/git/refs/tags/v3.0.4 --jq '.object.sha'
 ```
+
 Expected: a 40-char commit SHA (dereference as in Step 1 if it points at a tag object). The shipped workflow pins `0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4`. Record as `STICKY_SHA` and note the exact tag (`v3.0.4`) for the version comment.
 
 - [ ] **Step 3: Record the values**
 
 Write both SHAs and their version comments into the scratchpad (or a sticky note) so Tasks 4–5 use the exact strings, e.g.:
-```
+
+```text
 DL_ARTIFACT: actions/download-artifact@<DL_ARTIFACT_SHA>  # v7
 STICKY:      marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
 ```
+
 No commit for this task.
 
 ---
@@ -376,11 +384,13 @@ Expected: FAIL — `renderMarkdown` is not exported / not defined.
 In `scripts/assert-mutation-score.mjs`:
 
 (a) Extend the fs import:
+
 ```js
 import { readFileSync, writeFileSync } from 'node:fs';
 ```
 
 (b) Add the exported function (place it after `assertMutationScore`):
+
 ```js
 /**
  * Render a GateResult as a GitHub-flavored markdown fragment for a PR comment.
@@ -420,12 +430,14 @@ export function renderMarkdown(result, packageName) {
 ```
 
 (c) In `parseArgs`, add the two flags (alongside the existing `--floor` handling):
+
 ```js
     else if (arg === '--markdown') opts.markdown = next();
     else if (arg === '--package-name') opts.packageName = next();
 ```
 
 (d) In `main`, after `result` is computed and before the existing exit logic, write the markdown when requested:
+
 ```js
   if (opts.markdown) {
     try {
@@ -1114,9 +1126,11 @@ Expected: format, spell, lint, and tests all pass.
 - [ ] **Step 2: Run the new/affected tests together**
 
 Run:
+
 ```bash
 node --test scripts/__tests__/stryker-config.test.mjs scripts/__tests__/assert-mutation-score.test.mjs scripts/__tests__/mutation-workflows.test.mjs
 ```
+
 Expected: all PASS.
 
 - [ ] **Step 3: Lint all touched workflows**
@@ -1135,5 +1149,4 @@ These are not code changes and are not committed:
 3. **Remove the required check.** In branch protection for `main`, remove any required status check from the old blocking `Mutation Gate (PR)` jobs so the advisory check cannot block merges.
 4. **Seed the baseline.** Trigger `mutation.yml` once on `main` (push or `workflow_dispatch`) so the first dashboard baseline exists for PRs to download.
 5. **Close the loop on #485.** Comment on issue #485 summarizing the resolution (advisory + dashboard, fidelity restored, merge-queue/actions-cache declined with rationale) and close it.
-```
 

--- a/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
+++ b/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
@@ -857,7 +857,7 @@ test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to da
   // The upload key must be gated on automated main-branch runs so an ad-hoc
   // workflow_dispatch (possibly off a feature branch) cannot overwrite the
   // canonical baseline. The key assignment carries the event/ref condition.
-  assert.match(yml, /STRYKER_DASHBOARD_API_KEY:[^\n]*github\.ref == 'refs\/heads\/main'[^\n]*github\.event_name == 'schedule'[^\n]*github\.event_name == 'push'[^\n]*secrets\.STRYKER_DASHBOARD_API_KEY/, 'producer must gate the upload key on refs/heads/main schedule/push runs');
+  assert.match(yml, /STRYKER_DASHBOARD_API_KEY:\s*\$\{\{\s*\(github\.ref == 'refs\/heads\/main' && \(github\.event_name == 'schedule' \|\| github\.event_name == 'push'\)\) && secrets\.STRYKER_DASHBOARD_API_KEY/, 'producer must gate the upload key on refs/heads/main AND (schedule || push)');
   assert.match(yml, /push:\s*\n\s*branches:\s*\[main\]/, 'producer must run on push to main to refresh the baseline');
 });
 ```

--- a/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
+++ b/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
@@ -532,19 +532,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `module` always equals `package`, so it is derived from matrix.package
+        # rather than duplicated (keeps this matrix in sync with mutation.yml).
         include:
           - package: parser
             dir: packages/parser
-            module: parser
           - package: core
             dir: packages/core
-            module: core
           - package: cli
             dir: packages/cli
-            module: cli
           - package: plugin
             dir: packages/claude-code-plugin
-            module: plugin
     runs-on: ubuntu-latest
     # Advisory: this is a guardrail against a runaway run wasting minutes, not a
     # merge gate. ignoreStatic + concurrency keep a scoped run well under it.
@@ -905,17 +903,22 @@ on:
         run: |
           set -uo pipefail
           mkdir -p "${PKG_DIR}/reports"
+          baseline="${PKG_DIR}/reports/stryker-incremental.json"
           url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/${STRYKER_DASHBOARD_VERSION}?module=${MODULE}"
+          # Keep the baseline only if curl succeeds AND the body is non-empty
+          # valid JSON, so a 200 with a truncated body can't corrupt the report.
           if curl --fail --silent --show-error --max-time 60 \
-               --output "${PKG_DIR}/reports/stryker-incremental.json" "${url}"; then
+               --output "${baseline}" "${url}" \
+               && [ -s "${baseline}" ] \
+               && node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' "${baseline}"; then
             echo "Previous baseline downloaded for module ${MODULE}."
           else
             echo "::notice::no previous baseline for module ${MODULE}; producing a cold one."
-            rm -f "${PKG_DIR}/reports/stryker-incremental.json"
+            rm -f "${baseline}"
           fi
 ```
 
-(Note: `matrix.package` already equals the module name — `parser`/`core`/`cli`/`plugin` — so no matrix change is needed.)
+(Note: `matrix.package` already equals the module name — `parser`/`core`/`cli`/`plugin` — so `MODULE` is derived from `matrix.package` and the redundant `module:` matrix field is dropped.)
 
 (d) Replace the "Run mutation tests" step so the dashboard key is in scope and the weekly cron forces a complete refresh while push stays incremental:
 

--- a/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
+++ b/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
@@ -1,0 +1,1071 @@
+# Mutation Gate Advisory + Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve issue #485 by making the per-PR mutation check advisory (non-blocking), restoring exhaustive-run fidelity, and adopting the Stryker Dashboard as the cross-run incremental baseline and score-trend surface.
+
+**Architecture:** Three roles, cleanly separated. (1) The **per-PR workflow** (`mutation-pr.yml`) becomes advisory: it downloads the public `main` baseline from the Stryker Dashboard, runs Stryker scoped to changed files with `ignoreStatic` on, computes per-file scores, and posts a single sticky PR comment — it never fails the job. (2) The **producer workflow** (`mutation.yml`) runs on push-to-main and weekly cron with `ignoreStatic` OFF (full fidelity), and uploads the full report to the dashboard (the baseline + trend). (3) The **Stryker configs** gate `ignoreStatic` behind an env var (default OFF) and enable the dashboard reporter only when the upload API key is present.
+
+**Tech Stack:** StrykerJS (jest-runner), GitHub Actions, Node.js 24, pnpm, `node:test`, Stryker Dashboard (dashboard.stryker-mutator.io), `marocchino/sticky-pull-request-comment`.
+
+## Global Constraints
+
+- **Dashboard project slug:** `github.com/tobyhede/rundown` (exact, verbatim in every config).
+- **Dashboard modules:** one per package — `parser`, `core`, `cli`, `plugin` (the `plugin` module maps to `packages/claude-code-plugin`).
+- **Secret:** `STRYKER_DASHBOARD_API_KEY` is a GitHub Actions secret (added by the maintainer out-of-band). It is consumed **only** by the producer workflow (`mutation.yml`) for uploads. The PR workflow must never reference it — baseline download is an unauthenticated public GET.
+- **`ignoreStatic` policy:** ON for the advisory PR run only (via `STRYKER_IGNORE_STATIC=true`); OFF everywhere else (default). The exhaustive producer run must score static mutants.
+- **GitHub Actions are SHA-pinned** with a `# vN` version comment. Never use a floating tag. Resolve new action SHAs with `gh api` (Task 0).
+- **CLI output is JSON by default**; this plan touches CI/scripts only, not CLI command output.
+- **No persisted-state migration** concerns apply here (no `.rundown/` state touched).
+- Run `pnpm run verify` before any push (format, spell, lint, test).
+
+---
+
+## File Structure
+
+| File | Role | Change |
+| --- | --- | --- |
+| `packages/{parser,core,cli,claude-code-plugin}/stryker.config.mjs` | Stryker config per package | Env-gate `ignoreStatic` (default false); add conditional `dashboard` reporter + `dashboard` config block (module per package) |
+| `scripts/__tests__/stryker-config.test.mjs` | Config invariants (node:test) | Add `ignoreStatic` default/env tests and dashboard-reporter/config tests |
+| `scripts/assert-mutation-score.mjs` | Per-file score gate | Add `renderMarkdown()` + `--markdown` / `--package-name` flags; preserve existing exit codes |
+| `scripts/__tests__/assert-mutation-score.test.mjs` | Gate unit tests (node:test) | Add `renderMarkdown()` tests |
+| `.github/workflows/mutation-pr.yml` | Per-PR advisory check | Rewrite: dashboard baseline download, scoped incremental run, `ignoreStatic=true`, non-fatal steps, write+upload per-package markdown; add aggregation job posting one sticky comment |
+| `.github/workflows/mutation.yml` | Exhaustive producer | Add `push: [main]` trigger, dashboard upload (key present), `ignoreStatic` OFF, `--force` on cron; keep weekly + dispatch |
+| `scripts/__tests__/mutation-workflows.test.mjs` | New workflow-content invariants (node:test) | Pin the fidelity split (PR sets `STRYKER_IGNORE_STATIC: 'true'`; producer never sets it) and advisory non-fatal markers |
+| `docs/internal/mutation-testing-ci.md` | New descriptive doc | Document the current strategy + the declined options (merge-queue, actions/cache) with rationale |
+
+---
+
+## Task 0: Resolve and pin new action SHAs
+
+**Files:**
+- (none yet — this task records SHAs used by Tasks 4–5)
+
+**Interfaces:**
+- Produces: two pinned `uses:` lines (download-artifact, sticky-pull-request-comment) referenced verbatim in Tasks 4 and 5.
+
+- [ ] **Step 1: Resolve `actions/download-artifact` v7 SHA**
+
+Run:
+```bash
+gh api repos/actions/download-artifact/git/refs/tags/v7 --jq '.object.sha'
+```
+Expected: a 40-char commit SHA. If the ref is a tag object (not a commit), dereference it:
+```bash
+gh api repos/actions/download-artifact/git/tags/$(gh api repos/actions/download-artifact/git/refs/tags/v7 --jq '.object.sha') --jq '.object.sha'
+```
+Record the resulting commit SHA as `DL_ARTIFACT_SHA`.
+
+- [ ] **Step 2: Resolve `marocchino/sticky-pull-request-comment` latest v2 SHA**
+
+Run:
+```bash
+gh api repos/marocchino/sticky-pull-request-comment/git/refs/tags/v2 --jq '.object.sha'
+```
+Expected: a 40-char commit SHA (dereference as in Step 1 if it points at a tag object). Record as `STICKY_SHA` and note the exact tag (e.g. `v2.9.4`) for the version comment.
+
+- [ ] **Step 3: Record the values**
+
+Write both SHAs and their version comments into the scratchpad (or a sticky note) so Tasks 4–5 use the exact strings, e.g.:
+```
+DL_ARTIFACT: actions/download-artifact@<DL_ARTIFACT_SHA>  # v7
+STICKY:      marocchino/sticky-pull-request-comment@<STICKY_SHA>  # v2.9.4
+```
+No commit for this task.
+
+---
+
+## Task 1: Env-gate `ignoreStatic` (default OFF) in all four Stryker configs
+
+**Files:**
+- Modify: `packages/core/stryker.config.mjs`, `packages/parser/stryker.config.mjs`, `packages/cli/stryker.config.mjs`, `packages/claude-code-plugin/stryker.config.mjs`
+- Test: `scripts/__tests__/stryker-config.test.mjs`
+
+**Interfaces:**
+- Consumes: `process.env.STRYKER_IGNORE_STATIC` (string `'true'`/`'1'` ⇒ true; unset/anything else ⇒ false).
+- Produces: each config exports `ignoreStatic: boolean`, defaulting to `false` when the env var is unset.
+
+- [ ] **Step 1: Add the failing tests**
+
+In `scripts/__tests__/stryker-config.test.mjs`, add a generalized env-aware loader after the existing `loadConfig` function (around line 33):
+
+```js
+/**
+ * Load a Stryker config with an arbitrary set of env vars temporarily applied.
+ * Restores prior env values (including "unset") in a finally block.
+ *
+ * @param {string} configPath - repo-relative path to a stryker.config.mjs.
+ * @param {Record<string, string | undefined>} env - env vars to apply; a value
+ *   of `undefined` deletes the var for the duration of the load.
+ * @returns {Promise<object>} the config module's default export.
+ */
+async function loadConfigWithEnv(configPath, env) {
+  const keys = Object.keys(env);
+  const previous = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  try {
+    for (const k of keys) {
+      if (env[k] === undefined) delete process.env[k];
+      else process.env[k] = env[k];
+    }
+    const configUrl = pathToFileURL(join(repoRoot, configPath));
+    configUrl.searchParams.set('case', `${JSON.stringify(env)}-${Date.now()}-${Math.random()}`);
+    return (await import(configUrl.href)).default;
+  } finally {
+    for (const k of keys) {
+      if (previous[k] === undefined) delete process.env[k];
+      else process.env[k] = previous[k];
+    }
+  }
+}
+```
+
+Then, inside the existing `for (const configPath of configs)` loop (after the `break` threshold test, ~line 56), add:
+
+```js
+  test(`${configPath} defaults ignoreStatic to false for exhaustive fidelity (issue #485)`, async () => {
+    const config = await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: undefined });
+    // The producer run (mutation.yml) sets no env, so static mutants MUST be
+    // scored there. Only the advisory PR run opts into ignoreStatic.
+    assert.equal(
+      config.ignoreStatic,
+      false,
+      `${configPath}: ignoreStatic must default to false (exhaustive run must score static mutants)`,
+    );
+  });
+
+  test(`${configPath} enables ignoreStatic only when STRYKER_IGNORE_STATIC is truthy (issue #485)`, async () => {
+    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: 'true' })).ignoreStatic, true);
+    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: '1' })).ignoreStatic, true);
+    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: 'false' })).ignoreStatic, false);
+    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: '' })).ignoreStatic, false);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test scripts/__tests__/stryker-config.test.mjs`
+Expected: FAIL — the new `ignoreStatic` tests fail because every config currently hardcodes `ignoreStatic: true`, so the default-false assertion fails.
+
+- [ ] **Step 3: Add the boolean env parser to each config**
+
+In each of the four `stryker.config.mjs` files, immediately after the existing `const concurrency = parsePositiveInteger(process.env.STRYKER_CONCURRENCY, 2);` line, add:
+
+```js
+/**
+ * Parse a boolean-ish env value. Only 'true'/'1' enable the flag; unset or any
+ * other value is the fallback. Keeps local `stryker run` conservative.
+ *
+ * @param {string | undefined} value - the raw env value.
+ * @param {boolean} fallback - value when unset/unrecognized.
+ * @returns {boolean}
+ */
+const parseBoolean = (value, fallback) => {
+  if (value === undefined) return fallback;
+  return value === 'true' || value === '1';
+};
+
+// ignoreStatic is OFF by default so the exhaustive producer run (mutation.yml)
+// scores static mutants at full fidelity. The advisory per-PR gate sets
+// STRYKER_IGNORE_STATIC=true to reclaim the static-mutant time on a run whose
+// false negatives are acceptable (it never blocks merge). See issue #485.
+const ignoreStatic = parseBoolean(process.env.STRYKER_IGNORE_STATIC, false);
+```
+
+- [ ] **Step 4: Replace the hardcoded `ignoreStatic` block in each config**
+
+In each of the four files, replace the existing `ignoreStatic` comment block and `ignoreStatic: true,` line with the single line:
+
+```js
+  ignoreStatic,
+```
+
+(The old comment — beginning `// Skip static mutants ...` and ending at `ignoreStatic: true,` — is now stale because it claims the trade-off "also affects the weekly exhaustive mutation.yml"; the explanatory comment now lives next to the `const ignoreStatic` declaration added in Step 3, so the inline block is removed.) Read each file first to capture its exact current block before replacing.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `node --test scripts/__tests__/stryker-config.test.mjs`
+Expected: PASS — all tests, including the new `ignoreStatic` default/env tests and the pre-existing concurrency/break/plugin tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/*/stryker.config.mjs packages/claude-code-plugin/stryker.config.mjs scripts/__tests__/stryker-config.test.mjs
+git commit -m "fix(#485): env-gate ignoreStatic (default off) to restore exhaustive fidelity"
+```
+
+---
+
+## Task 2: Add the conditional Stryker Dashboard reporter to all four configs
+
+**Files:**
+- Modify: `packages/core/stryker.config.mjs`, `packages/parser/stryker.config.mjs`, `packages/cli/stryker.config.mjs`, `packages/claude-code-plugin/stryker.config.mjs`
+- Test: `scripts/__tests__/stryker-config.test.mjs`
+
+**Interfaces:**
+- Consumes: `process.env.STRYKER_DASHBOARD_API_KEY` (presence ⇒ enable upload), `process.env.STRYKER_DASHBOARD_VERSION` (optional explicit version; Stryker auto-detects from CI when unset).
+- Produces: each config exports `reporters` including `'dashboard'` **iff** the API key env is set, and a `dashboard` object with `project` = `github.com/tobyhede/rundown`, `module` = the package's module name, `reportType: 'full'`.
+
+**Module-name map (use the exact value per file):**
+- `packages/parser/stryker.config.mjs` → `parser`
+- `packages/core/stryker.config.mjs` → `core`
+- `packages/cli/stryker.config.mjs` → `cli`
+- `packages/claude-code-plugin/stryker.config.mjs` → `plugin`
+
+- [ ] **Step 1: Add the failing tests**
+
+In `scripts/__tests__/stryker-config.test.mjs`, add inside the `for (const configPath of configs)` loop:
+
+```js
+  test(`${configPath} omits the dashboard reporter when no API key is set`, async () => {
+    const config = await loadConfigWithEnv(configPath, { STRYKER_DASHBOARD_API_KEY: undefined });
+    assert.ok(
+      Array.isArray(config.reporters) && !config.reporters.includes('dashboard'),
+      `${configPath}: dashboard reporter must be off without STRYKER_DASHBOARD_API_KEY`,
+    );
+  });
+
+  test(`${configPath} enables the dashboard reporter when the API key is set`, async () => {
+    const config = await loadConfigWithEnv(configPath, { STRYKER_DASHBOARD_API_KEY: 'fake-key' });
+    assert.ok(
+      config.reporters.includes('dashboard'),
+      `${configPath}: dashboard reporter must turn on when STRYKER_DASHBOARD_API_KEY is present`,
+    );
+  });
+
+  test(`${configPath} pins the dashboard project and a full report type`, async () => {
+    const config = await loadConfigWithEnv(configPath, { STRYKER_DASHBOARD_API_KEY: 'fake-key' });
+    assert.equal(config.dashboard?.project, 'github.com/tobyhede/rundown');
+    assert.equal(config.dashboard?.reportType, 'full');
+    assert.ok(
+      typeof config.dashboard?.module === 'string' && config.dashboard.module.length > 0,
+      `${configPath}: dashboard.module must be a non-empty per-package module name`,
+    );
+  });
+```
+
+Add one module-specific assertion after the loop (so each module name is pinned):
+
+```js
+const expectedModules = {
+  'packages/parser/stryker.config.mjs': 'parser',
+  'packages/core/stryker.config.mjs': 'core',
+  'packages/cli/stryker.config.mjs': 'cli',
+  'packages/claude-code-plugin/stryker.config.mjs': 'plugin',
+};
+for (const [configPath, moduleName] of Object.entries(expectedModules)) {
+  test(`${configPath} declares dashboard.module = ${moduleName}`, async () => {
+    const config = await loadConfigWithEnv(configPath, { STRYKER_DASHBOARD_API_KEY: 'fake-key' });
+    assert.equal(config.dashboard.module, moduleName);
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test scripts/__tests__/stryker-config.test.mjs`
+Expected: FAIL — configs have no `dashboard` block and `reporters` is a static array.
+
+- [ ] **Step 3: Make the reporters list conditional in each config**
+
+In each of the four files, replace the static reporters line:
+
+```js
+  reporters: ['progress', 'clear-text', 'html', 'json'],
+```
+
+with a computed list. Add this just above the `const config = {` declaration (after the `ignoreStatic` const from Task 1):
+
+```js
+// The dashboard reporter UPLOADS the report and requires an API key, so enable
+// it only when one is present. The producer workflow (mutation.yml) sets the
+// key; the advisory PR workflow does not (it only downloads the public
+// baseline), so PR runs never upload partial, changed-file-scoped reports that
+// would corrupt the dashboard baseline. See issue #485.
+const reporters = ['progress', 'clear-text', 'html', 'json'];
+if (process.env.STRYKER_DASHBOARD_API_KEY) reporters.push('dashboard');
+```
+
+and change the config property to reference it:
+
+```js
+  reporters,
+```
+
+- [ ] **Step 4: Add the `dashboard` config block in each config**
+
+In each of the four files, add a `dashboard` property to the `config` object (place it next to `htmlReporter` / `jsonReporter`). Use the correct module name per the map above — example shown for `core`:
+
+```js
+  dashboard: {
+    project: 'github.com/tobyhede/rundown',
+    module: 'core',
+    // version is auto-detected from the CI environment (branch/ref) when unset;
+    // the producer workflow may pin it via STRYKER_DASHBOARD_VERSION.
+    version: process.env.STRYKER_DASHBOARD_VERSION || undefined,
+    reportType: 'full',
+  },
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `node --test scripts/__tests__/stryker-config.test.mjs`
+Expected: PASS — all config tests including the new dashboard tests and module-name assertions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/*/stryker.config.mjs packages/claude-code-plugin/stryker.config.mjs scripts/__tests__/stryker-config.test.mjs
+git commit -m "feat(#485): enable Stryker Dashboard reporter when API key present"
+```
+
+---
+
+## Task 3: Add markdown summary output to the per-file gate script
+
+**Files:**
+- Modify: `scripts/assert-mutation-score.mjs`
+- Test: `scripts/__tests__/assert-mutation-score.test.mjs`
+
+**Interfaces:**
+- Consumes: the existing `GateResult` shape `{ ok, failures, checked, skipped, floor }` produced by `assertMutationScore`.
+- Produces: `export function renderMarkdown(result, packageName)` → markdown string; new CLI flags `--markdown <path>` and `--package-name <name>`. Exit codes are unchanged (0 pass, 1 below-floor, 2 usage/IO).
+
+- [ ] **Step 1: Add the failing tests**
+
+In `scripts/__tests__/assert-mutation-score.test.mjs`, add (adjust the import line to include `renderMarkdown` alongside the existing imports from `../assert-mutation-score.mjs`):
+
+```js
+test('renderMarkdown renders a table of checked, failed, and skipped files', () => {
+  const md = renderMarkdown(
+    {
+      ok: false,
+      failures: [{ file: 'src/a.ts', score: 42.5 }],
+      checked: [{ file: 'src/b.ts', score: 91.0 }],
+      skipped: [{ file: 'src/c.ts', reason: 'not mutated' }],
+      floor: 70,
+    },
+    'core',
+  );
+  assert.match(md, /core/);
+  assert.match(md, /floor 70%/);
+  assert.match(md, /src\/a\.ts/);
+  assert.match(md, /42\.50%/);
+  assert.match(md, /src\/b\.ts/);
+  assert.match(md, /91\.00%/);
+  assert.match(md, /src\/c\.ts/);
+  assert.match(md, /not mutated/);
+});
+
+test('renderMarkdown reports an empty state when nothing was scored', () => {
+  const md = renderMarkdown(
+    { ok: true, failures: [], checked: [], skipped: [], floor: 70 },
+    'parser',
+  );
+  assert.match(md, /parser/);
+  assert.match(md, /No mutated changed files/i);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test scripts/__tests__/assert-mutation-score.test.mjs`
+Expected: FAIL — `renderMarkdown` is not exported / not defined.
+
+- [ ] **Step 3: Implement `renderMarkdown` and wire the CLI flags**
+
+In `scripts/assert-mutation-score.mjs`:
+
+(a) Extend the fs import:
+```js
+import { readFileSync, writeFileSync } from 'node:fs';
+```
+
+(b) Add the exported function (place it after `assertMutationScore`):
+```js
+/**
+ * Render a GateResult as a GitHub-flavored markdown fragment for a PR comment.
+ *
+ * @param {import('./assert-mutation-score.mjs').GateResult} result - the gate outcome.
+ * @param {string} packageName - human label for the package/module (e.g. `core`).
+ * @returns {string} a markdown fragment (no trailing newline).
+ */
+export function renderMarkdown(result, packageName) {
+  const { checked, failures, skipped, floor, ok } = result;
+  const status = ok ? '✅' : '⚠️';
+  const lines = [`#### ${status} \`${packageName}\` — per-file mutation score (floor ${floor}%)`, ''];
+  if (checked.length === 0 && failures.length === 0 && skipped.length === 0) {
+    lines.push('_No mutated changed files to score._');
+    return lines.join('\n');
+  }
+  lines.push('| File | Score | Status |', '| --- | ---: | --- |');
+  for (const f of failures) lines.push(`| \`${f.file}\` | ${f.score.toFixed(2)}% | ❌ below floor |`);
+  for (const c of checked) lines.push(`| \`${c.file}\` | ${c.score.toFixed(2)}% | ✅ |`);
+  for (const s of skipped) lines.push(`| \`${s.file}\` | — | ⏭️ ${s.reason} |`);
+  return lines.join('\n');
+}
+```
+
+(c) In `parseArgs`, add the two flags (alongside the existing `--floor` handling):
+```js
+    else if (arg === '--markdown') opts.markdown = next();
+    else if (arg === '--package-name') opts.packageName = next();
+```
+
+(d) In `main`, after `result` is computed and before the existing exit logic, write the markdown when requested:
+```js
+  if (opts.markdown) {
+    try {
+      writeFileSync(opts.markdown, renderMarkdown(result, opts.packageName ?? opts.packageDir));
+    } catch (err) {
+      console.error(`error: failed to write markdown summary ${opts.markdown}: ${err.message}`);
+      return 2;
+    }
+  }
+```
+
+(The markdown is written for both pass and fail so the advisory comment always reflects the run.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test scripts/__tests__/assert-mutation-score.test.mjs`
+Expected: PASS — all existing gate tests plus the two new `renderMarkdown` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/assert-mutation-score.mjs scripts/__tests__/assert-mutation-score.test.mjs
+git commit -m "feat(#485): add markdown summary output to per-file mutation gate"
+```
+
+---
+
+## Task 4: Make `mutation-pr.yml` advisory with a dashboard baseline
+
+**Files:**
+- Modify: `.github/workflows/mutation-pr.yml`
+- Test: `scripts/__tests__/mutation-workflows.test.mjs` (created here)
+
+**Interfaces:**
+- Consumes: `STRYKER_IGNORE_STATIC` (Task 1), `--markdown`/`--package-name` (Task 3), the public dashboard download endpoint.
+- Produces: per-package markdown artifacts named `mutation-summary-<package>` (consumed by Task 5). The job never fails on a low score.
+
+- [ ] **Step 1: Add the failing workflow-invariant tests**
+
+Create `scripts/__tests__/mutation-workflows.test.mjs`:
+
+```js
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+const read = (p) => readFile(new URL(`../../${p}`, import.meta.url), 'utf-8');
+
+test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => {
+  const yml = await read('.github/workflows/mutation-pr.yml');
+  assert.match(yml, /STRYKER_IGNORE_STATIC:\s*'true'/, 'PR run must opt into ignoreStatic');
+  assert.match(yml, /continue-on-error:\s*true/, 'advisory steps must be non-fatal');
+  assert.match(yml, /dashboard\.stryker-mutator\.io\/api\/reports/, 'PR run must download the dashboard baseline');
+  assert.doesNotMatch(yml, /STRYKER_DASHBOARD_API_KEY/, 'PR workflow must not reference the upload secret');
+});
+
+test('mutation-pr.yml uploads per-package markdown summaries', async () => {
+  const yml = await read('.github/workflows/mutation-pr.yml');
+  assert.match(yml, /mutation-summary-/, 'PR run must upload a per-package markdown summary artifact');
+});
+
+void repoRoot;
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test scripts/__tests__/mutation-workflows.test.mjs`
+Expected: FAIL — the current `mutation-pr.yml` has no `STRYKER_IGNORE_STATIC` env, no dashboard download, no `continue-on-error`, and uploads no summary.
+
+- [ ] **Step 3: Rewrite `mutation-pr.yml`**
+
+Replace the file contents with the advisory version below. (Differences from current: new header comment; job env adds `STRYKER_IGNORE_STATIC: 'true'`; the `actions/cache` step is replaced by a public dashboard baseline download; the Stryker run and the assert step are `continue-on-error: true` and the assert writes markdown; a new `mutation-summary-<pkg>` artifact is uploaded.)
+
+```yaml
+name: Mutation Gate (PR)
+
+# Per-PR ADVISORY mutation report (issue #485).
+#
+# This check is advisory: it never blocks merge. It runs each affected package's
+# mutation suite scoped to the PR's changed files (so runtime tracks change size),
+# scores each changed file, and surfaces the result as a sticky PR comment (see
+# the `comment` job). Static mutants are ignored here (STRYKER_IGNORE_STATIC) to
+# keep the advisory run fast; the exhaustive producer run (mutation.yml) scores
+# them at full fidelity. The incremental baseline is downloaded from the public
+# Stryker Dashboard report for `main` — no API key is needed to read it, and this
+# workflow deliberately never uploads (which would corrupt the baseline with a
+# partial, changed-file-scoped report).
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: mutation-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  mutation-gate:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: parser
+            dir: packages/parser
+            module: parser
+          - package: core
+            dir: packages/core
+            module: core
+          - package: cli
+            dir: packages/cli
+            module: cli
+          - package: plugin
+            dir: packages/claude-code-plugin
+            module: plugin
+    runs-on: ubuntu-latest
+    # Advisory: this is a guardrail against a runaway run wasting minutes, not a
+    # merge gate. ignoreStatic + concurrency keep a scoped run well under it.
+    timeout-minutes: 45
+    env:
+      STRYKER_CONCURRENCY: '4'
+      # PR-only: reclaim static-mutant time on the advisory run. The producer
+      # run leaves this unset so it scores static mutants. See issue #485.
+      STRYKER_IGNORE_STATIC: 'true'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so the merge-base with the PR base ref is reachable;
+          # assert-mutation-score.mjs diffs `${base}...HEAD`.
+          fetch-depth: 0
+
+      # Resolve the PR base ref and compute whether this package has changed
+      # source files. Skipping unaffected packages keeps the run cheap. Fails
+      # CLOSED on git errors (see issue #483 for the rationale on the layout).
+      - name: Detect changes for ${{ matrix.package }}
+        id: changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          PKG_DIR: ${{ matrix.dir }}
+        run: |
+          set -euo pipefail
+          base="origin/${BASE_REF}"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            base="origin/${DEFAULT_BRANCH}"
+          fi
+          git rev-parse --verify --quiet "${base}^{commit}" >/dev/null \
+            || { echo "::error::base ref '${base}' is unreachable; cannot score." >&2; exit 1; }
+          git merge-base "${base}" HEAD >/dev/null \
+            || { echo "::error::no merge-base between '${base}' and HEAD; cannot score." >&2; exit 1; }
+          changed_files="$(git diff --name-only --diff-filter=d "${base}...HEAD" -- "${PKG_DIR}/src")"
+          if [ -n "${changed_files}" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            pkg_rel="$(printf '%s\n' "${changed_files}" | sed "s#^${PKG_DIR}/##")"
+            excludes="$(cd "${PKG_DIR}" && node --input-type=module -e 'import("./stryker.config.mjs").then((m) => { const c = m.default ?? m.config ?? {}; process.stdout.write((c.mutate ?? []).filter((p) => p.startsWith("!")).join("\n")); });')" \
+              || { echo "::error::failed to read mutate exclusions from ${PKG_DIR}/stryker.config.mjs" >&2; exit 1; }
+            mutate="$(printf '%s\n%s\n' "${pkg_rel}" "${excludes}" | sed '/^[[:space:]]*$/d' | paste -sd, -)"
+            echo "mutate=${mutate}" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No source changes under ${PKG_DIR}/src; skipping advisory run."
+          fi
+          echo "base=${base}" >> "$GITHUB_OUTPUT"
+
+      - uses: ./.github/actions/setup-node-deps
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        with:
+          node-version: 24
+
+      - name: Build
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        run: pnpm run build
+
+      # Download the public `main` baseline so incremental mode can reuse
+      # unchanged results. Best-effort: a 404/empty body degrades to a cold
+      # incremental run (still bounded by --mutate scoping). No API key needed —
+      # OSS dashboard reports are public reads.
+      - name: Download Stryker baseline from dashboard
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        env:
+          MODULE: ${{ matrix.module }}
+          PKG_DIR: ${{ matrix.dir }}
+        run: |
+          set -uo pipefail
+          mkdir -p "${PKG_DIR}/reports"
+          url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/main?module=${MODULE}"
+          if curl --fail --silent --show-error --max-time 60 \
+               --output "${PKG_DIR}/reports/stryker-incremental.json" "${url}"; then
+            echo "Baseline downloaded for module ${MODULE}."
+          else
+            echo "::notice::no dashboard baseline for module ${MODULE}; running cold incremental."
+            rm -f "${PKG_DIR}/reports/stryker-incremental.json"
+          fi
+
+      # Advisory run: scoped to changed files, incremental, never fatal.
+      - name: Run mutation tests (${{ matrix.package }})
+        id: stryker
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        continue-on-error: true
+        env:
+          MUTATE: ${{ steps.changes.outputs.mutate }}
+        run: pnpm exec stryker run --incremental --mutate "${MUTATE}" --allowEmpty
+        working-directory: ${{ matrix.dir }}
+
+      # Score changed files and render the advisory markdown. Non-fatal: a
+      # below-floor file annotates the comment, it does not fail the check.
+      - name: Score changed files (advisory)
+        id: assert
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        continue-on-error: true
+        env:
+          PKG_DIR: ${{ matrix.dir }}
+          BASE: ${{ steps.changes.outputs.base }}
+          PKG: ${{ matrix.package }}
+        run: |
+          pnpm run assert:mutation-score -- \
+            --report "${PKG_DIR}/reports/mutation/mutation-report.json" \
+            --package-dir "${PKG_DIR}" \
+            --base "${BASE}" \
+            --floor 70 \
+            --package-name "${PKG}" \
+            --markdown "${RUNNER_TEMP}/mutation-summary-${PKG}.md"
+
+      - name: Upload advisory summary
+        if: ${{ always() && steps.changes.outputs.changed == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: mutation-summary-${{ matrix.package }}
+          path: ${{ runner.temp }}/mutation-summary-${{ matrix.package }}.md
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload mutation report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        if: ${{ always() && steps.changes.outputs.changed == 'true' }}
+        with:
+          name: mutation-report-${{ matrix.package }}
+          path: ${{ matrix.dir }}/reports/mutation/
+          retention-days: 30
+```
+
+(The `comment` job is added in Task 5.)
+
+- [ ] **Step 4: Run the workflow-invariant tests to verify they pass**
+
+Run: `node --test scripts/__tests__/mutation-workflows.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Lint the workflow**
+
+Run: `actionlint .github/workflows/mutation-pr.yml`
+Expected: no output (clean). If `actionlint` is not installed, install it (`brew install actionlint`) or fall back to a YAML syntax check:
+`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/mutation-pr.yml'))"` (expected: no error).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/mutation-pr.yml scripts/__tests__/mutation-workflows.test.mjs
+git commit -m "fix(#485): make the per-PR mutation check advisory with a dashboard baseline"
+```
+
+---
+
+## Task 5: Post one sticky PR comment aggregating the package summaries
+
+**Files:**
+- Modify: `.github/workflows/mutation-pr.yml` (add a `comment` job)
+- Test: `scripts/__tests__/mutation-workflows.test.mjs`
+
+**Interfaces:**
+- Consumes: the `mutation-summary-<package>` artifacts from Task 4; the SHAs from Task 0.
+- Produces: a single sticky PR comment with header `mutation-advisory`.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `scripts/__tests__/mutation-workflows.test.mjs`:
+
+```js
+test('mutation-pr.yml posts a single sticky advisory comment', async () => {
+  const yml = await read('.github/workflows/mutation-pr.yml');
+  assert.match(yml, /sticky-pull-request-comment/, 'must use a sticky comment action');
+  assert.match(yml, /header:\s*mutation-advisory/, 'sticky comment must use a stable header');
+  assert.match(yml, /pull-requests:\s*write/, 'comment job needs pull-requests: write');
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test scripts/__tests__/mutation-workflows.test.mjs`
+Expected: FAIL — no `comment` job yet.
+
+- [ ] **Step 3: Add the `comment` job**
+
+Append this job to `.github/workflows/mutation-pr.yml` (use the exact SHAs/version comments resolved in Task 0 in place of `<DL_ARTIFACT_SHA> # v7` and `<STICKY_SHA> # v2.x.x`):
+
+```yaml
+  comment:
+    needs: mutation-gate
+    # Only on real PRs (sticky comments need a PR number). Always runs so the
+    # comment updates even when every package was skipped. Fork PRs get no
+    # comment (read-only token) but the gate job still produced artifacts.
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download advisory summaries
+        uses: actions/download-artifact@<DL_ARTIFACT_SHA>  # v7
+        with:
+          pattern: mutation-summary-*
+          path: summaries
+          merge-multiple: true
+        continue-on-error: true
+
+      - name: Assemble comment body
+        run: |
+          set -euo pipefail
+          {
+            echo "### 🧬 Mutation score (advisory)"
+            echo
+            echo "_Per-file mutation scores for files changed in this PR. **This check is advisory and never blocks merge.** Trend & full reports: the Stryker Dashboard. See issue #485._"
+            echo
+            if ls summaries/*.md >/dev/null 2>&1; then
+              for f in summaries/*.md; do
+                cat "$f"
+                echo
+                echo
+              done
+            else
+              echo "_No mutated changed files in this PR._"
+            fi
+          } > comment.md
+          cat comment.md
+
+      - name: Post sticky comment
+        uses: marocchino/sticky-pull-request-comment@<STICKY_SHA>  # v2.x.x
+        with:
+          header: mutation-advisory
+          path: comment.md
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node --test scripts/__tests__/mutation-workflows.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Lint the workflow**
+
+Run: `actionlint .github/workflows/mutation-pr.yml`
+Expected: no output. (Fall back to the `python3 -c "import yaml; ..."` check as in Task 4 Step 5 if `actionlint` is unavailable.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/mutation-pr.yml scripts/__tests__/mutation-workflows.test.mjs
+git commit -m "feat(#485): post a sticky advisory mutation comment on PRs"
+```
+
+---
+
+## Task 6: Make `mutation.yml` the dashboard baseline producer at full fidelity
+
+**Files:**
+- Modify: `.github/workflows/mutation.yml`
+- Test: `scripts/__tests__/mutation-workflows.test.mjs`
+
+**Interfaces:**
+- Consumes: `STRYKER_DASHBOARD_API_KEY` secret, the dashboard reporter (Task 2). Leaves `STRYKER_IGNORE_STATIC` unset ⇒ `ignoreStatic` OFF (Task 1).
+- Produces: a full dashboard report per module for version `main` (the baseline the PR workflow downloads) on every push to `main` and weekly.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `scripts/__tests__/mutation-workflows.test.mjs`:
+
+```js
+test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to dashboard)', async () => {
+  const yml = await read('.github/workflows/mutation.yml');
+  assert.doesNotMatch(yml, /STRYKER_IGNORE_STATIC/, 'producer must score static mutants (no ignoreStatic env)');
+  assert.match(yml, /STRYKER_DASHBOARD_API_KEY/, 'producer must pass the dashboard API key for upload');
+  assert.match(yml, /push:\s*\n\s*branches:\s*\[main\]/, 'producer must run on push to main to refresh the baseline');
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test scripts/__tests__/mutation-workflows.test.mjs`
+Expected: FAIL — `mutation.yml` has no `push` trigger, no dashboard key env.
+
+- [ ] **Step 3: Update `mutation.yml`**
+
+Apply these edits to `.github/workflows/mutation.yml`:
+
+(a) Add a `push` trigger to the `on:` block (alongside the existing `workflow_dispatch` and `schedule`):
+
+```yaml
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to test'
+        required: true
+        type: choice
+        options:
+          - all
+          - parser
+          - core
+          - cli
+          - plugin
+  schedule:
+    - cron: '0 6 * * 1' # Weekly Monday 06:00 UTC
+```
+
+(b) Update the `RUN_PACKAGE` filter so `push` runs every package (like `schedule`):
+
+```yaml
+    env:
+      RUN_PACKAGE: >-
+        ${{ github.event_name == 'schedule' ||
+            github.event_name == 'push' ||
+            github.event.inputs.package == 'all' ||
+            github.event.inputs.package == matrix.package }}
+      STRYKER_DASHBOARD_VERSION: main
+```
+
+(c) Replace the `actions/cache` "Restore Stryker incremental cache" step with a public baseline download (so each run refreshes incremental against the last published `main` baseline):
+
+```yaml
+      - name: Download previous baseline from dashboard
+        if: ${{ env.RUN_PACKAGE == 'true' }}
+        env:
+          MODULE: ${{ matrix.package }}
+          PKG_DIR: ${{ matrix.dir }}
+        run: |
+          set -uo pipefail
+          mkdir -p "${PKG_DIR}/reports"
+          url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/main?module=${MODULE}"
+          if curl --fail --silent --show-error --max-time 60 \
+               --output "${PKG_DIR}/reports/stryker-incremental.json" "${url}"; then
+            echo "Previous baseline downloaded for module ${MODULE}."
+          else
+            echo "::notice::no previous baseline for module ${MODULE}; producing a cold one."
+            rm -f "${PKG_DIR}/reports/stryker-incremental.json"
+          fi
+```
+
+(Note: `matrix.package` already equals the module name — `parser`/`core`/`cli`/`plugin` — so no matrix change is needed.)
+
+(d) Replace the "Run mutation tests" step so the dashboard key is in scope and the weekly cron forces a complete refresh while push stays incremental:
+
+```yaml
+      - name: Run mutation tests
+        if: ${{ env.RUN_PACKAGE == 'true' }}
+        env:
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        # Weekly cron forces a complete re-run (drift-proof full fidelity);
+        # push-to-main refreshes incrementally against the downloaded baseline.
+        # Both upload to the dashboard (key present) and score static mutants
+        # (STRYKER_IGNORE_STATIC unset). See issue #485.
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            pnpm exec stryker run --incremental --force
+          else
+            pnpm exec stryker run --incremental
+          fi
+        working-directory: ${{ matrix.dir }}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node --test scripts/__tests__/mutation-workflows.test.mjs`
+Expected: PASS — all workflow invariants.
+
+- [ ] **Step 5: Lint the workflow**
+
+Run: `actionlint .github/workflows/mutation.yml`
+Expected: no output. (Fall back to the `python3 -c "import yaml; ..."` check if `actionlint` is unavailable.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/mutation.yml scripts/__tests__/mutation-workflows.test.mjs
+git commit -m "feat(#485): make mutation.yml the full-fidelity dashboard baseline producer"
+```
+
+---
+
+## Task 7: Document the strategy and record the declined options
+
+**Files:**
+- Create: `docs/internal/mutation-testing-ci.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a descriptive doc of the current (post-change) mutation-testing CI design. (This is descriptive — current design — so it belongs in `docs/internal/`, not `docs/superpowers/`.)
+
+- [ ] **Step 1: Write the doc**
+
+Create `docs/internal/mutation-testing-ci.md`:
+
+```markdown
+# Mutation Testing in CI
+
+Mutation testing runs in two roles, split by issue #485 after per-PR blocking
+gates proved structurally too slow regardless of tuning.
+
+## Advisory per-PR check (`.github/workflows/mutation-pr.yml`)
+
+- **Non-blocking.** It is intentionally NOT a required status check. It posts a
+  single sticky PR comment (header `mutation-advisory`) with per-file mutation
+  scores for the files changed in the PR.
+- **Scoped + fast.** Runs Stryker with `--mutate` limited to the PR's changed
+  source files, `--incremental` against the public `main` baseline downloaded
+  from the Stryker Dashboard, and `STRYKER_IGNORE_STATIC=true` to skip
+  static mutants. The Stryker run and the per-file score step are
+  `continue-on-error: true`, so a low score annotates the comment but never
+  fails the job.
+- **No secret.** The baseline is a public dashboard read (`curl`). The PR run
+  never uploads (an upload of a changed-file-scoped report would corrupt the
+  baseline).
+
+## Full-fidelity producer (`.github/workflows/mutation.yml`)
+
+- Runs on **push to `main`** (incremental refresh) and **weekly cron**
+  (`--force` complete refresh), every package.
+- `ignoreStatic` is OFF (env unset) so static mutants are scored.
+- Uploads the full report per module to the Stryker Dashboard
+  (`STRYKER_DASHBOARD_API_KEY`), which is both the trend/score surface and the
+  baseline the PR check downloads.
+
+## Config (`packages/*/stryker.config.mjs`)
+
+- `ignoreStatic` is `false` by default; only `STRYKER_IGNORE_STATIC=true`
+  enables it (the PR workflow sets it).
+- The `dashboard` reporter is added to `reporters` only when
+  `STRYKER_DASHBOARD_API_KEY` is present, so only the producer uploads.
+- `dashboard.project` is `github.com/tobyhede/rundown`; `dashboard.module` is
+  the package name (`parser`/`core`/`cli`/`plugin`); `reportType` is `full`.
+- `thresholds.break: 70` still applies to every `stryker run`; on the advisory
+  PR run it is neutralized by `continue-on-error` and superseded by the per-file
+  score in `scripts/assert-mutation-score.mjs`.
+
+## Options considered and declined
+
+- **Per-PR blocking gate (status quo before #485).** Even scoped to changed
+  files with `ignoreStatic` and concurrency 4, big-file PRs ran 40+ minutes.
+  Blocking on it stalls merges; the empirical and Stryker-community guidance is
+  to keep mutation testing advisory and track the score as a trend.
+- **Merge queue (`merge_group:`).** A valid way to move an enforced check off
+  the per-PR critical path, but it adds a gate-aggregation job and branch-
+  protection wiring for a check we have decided should be advisory, not
+  enforced. Revisit only if an enforced signal becomes a requirement.
+- **`actions/cache` for the incremental baseline.** Workable but needs custom
+  split restore/save (the combined action only saves on success) and suffers
+  7-day/10 GB eviction cold-starts. The dashboard gives a durable, public,
+  trend-tracking baseline with no cache plumbing, so it was preferred.
+```
+
+- [ ] **Step 2: Verify the doc spell-checks**
+
+Run: `pnpm run check:spell`
+Expected: PASS (add any new legitimate terms to the project dictionary if flagged — e.g. `ignoreStatic` is camelCase in code fences; prefer wording that avoids dictionary churn).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/internal/mutation-testing-ci.md
+git commit -m "docs(#485): document advisory + dashboard mutation-testing CI strategy"
+```
+
+---
+
+## Task 8: Add the mutation-score badge to the README
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: the dashboard project (populated by Task 6's producer run).
+- Produces: a mutation-score badge in the centered badge row, matching the
+  existing `<a><img/></a>` HTML style.
+
+- [ ] **Step 1: Add the badge**
+
+In `README.md`, inside the centered badge `<p align="center">` block (lines
+9–19), add this as the last badge, immediately after the CodeRabbit `</a>`
+(line 18) and before the closing `</p>`:
+
+```html
+  <a href="https://dashboard.stryker-mutator.io/reports/github.com/tobyhede/rundown/main">
+    <img src="https://img.shields.io/endpoint?style=flat&amp;url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Ftobyhede%2Frundown%2Fmain" alt="Mutation testing badge" />
+  </a>
+```
+
+(The `&` in the shields endpoint query is written `&amp;` to match the
+HTML-fragment context; GitHub renders it back to `&`. Style matches the
+license/npm/CodeRabbit badges: an `<a>` wrapping an `<img>` with an `alt`.)
+
+- [ ] **Step 2: Verify it renders**
+
+Run: `grep -n "badge-api.stryker-mutator.io" README.md`
+Expected: one match inside the `<p align="center">` block. Optionally preview
+the README to confirm the badge sits in the row (it shows "unknown" until the
+first producer run from Task 6's Manual Step 4 publishes a baseline).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(#485): add Stryker mutation-score badge to README"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run the full pre-PR verification**
+
+Run: `pnpm run verify`
+Expected: format, spell, lint, and tests all pass.
+
+- [ ] **Step 2: Run the new/affected tests together**
+
+Run:
+```bash
+node --test scripts/__tests__/stryker-config.test.mjs scripts/__tests__/assert-mutation-score.test.mjs scripts/__tests__/mutation-workflows.test.mjs
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Lint all touched workflows**
+
+Run: `actionlint .github/workflows/mutation-pr.yml .github/workflows/mutation.yml`
+Expected: no output.
+
+---
+
+## Manual steps (maintainer — outside this plan's code)
+
+These are not code changes and are not committed:
+
+1. **Add the secret.** `STRYKER_DASHBOARD_API_KEY` → repo Actions secrets (in progress per the maintainer).
+2. **Enable the dashboard project.** Confirm `github.com/tobyhede/rundown` is enabled at dashboard.stryker-mutator.io so uploads are accepted.
+3. **Remove the required check.** In branch protection for `main`, remove any required status check from the old blocking `Mutation Gate (PR)` jobs so the advisory check cannot block merges.
+4. **Seed the baseline.** Trigger `mutation.yml` once on `main` (push or `workflow_dispatch`) so the first dashboard baseline exists for PRs to download.
+5. **Close the loop on #485.** Comment on issue #485 summarizing the resolution (advisory + dashboard, fidelity restored, merge-queue/actions-cache declined with rationale) and close it.
+```
+

--- a/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
+++ b/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
@@ -481,10 +481,13 @@ test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => 
   assert.match(yml, /STRYKER_IGNORE_STATIC:\s*'true'/, 'PR run must opt into ignoreStatic');
   assert.match(yml, /continue-on-error:\s*true/, 'advisory steps must be non-fatal');
   // Parse the URL and compare its host exactly (CodeQL flags substring/regex
-  // checks against URL-shaped literals as incomplete URL sanitization).
-  const baselineUrl = yml.match(/url="([^"]+)"/)?.[1];
+  // checks against URL-shaped literals as incomplete URL sanitization). Scope
+  // the extraction to the baseline-download step so an unrelated `url=` can't
+  // satisfy it.
+  const baselineUrl = yml.match(/name: Download Stryker baseline from dashboard[\s\S]*?url="([^"]+)"/)?.[1];
   assert.ok(baselineUrl, 'PR run must define a baseline download URL');
   assert.equal(new URL(baselineUrl).hostname, 'dashboard.stryker-mutator.io', 'PR run must download the baseline from the Stryker dashboard');
+  assert.ok(new URL(baselineUrl).pathname.startsWith('/api/reports/'), 'baseline must use the dashboard report API path');
   assert.doesNotMatch(yml, /STRYKER_DASHBOARD_API_KEY/, 'PR workflow must not reference the upload secret');
 });
 
@@ -854,7 +857,7 @@ test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to da
   // The upload key must be gated on automated main-branch runs so an ad-hoc
   // workflow_dispatch (possibly off a feature branch) cannot overwrite the
   // canonical baseline. The key assignment carries the event/ref condition.
-  assert.match(yml, /STRYKER_DASHBOARD_API_KEY:[^\n]*github\.event_name == 'schedule'[^\n]*secrets\.STRYKER_DASHBOARD_API_KEY/, 'producer must gate the upload key on schedule/push main runs');
+  assert.match(yml, /STRYKER_DASHBOARD_API_KEY:[^\n]*github\.ref == 'refs\/heads\/main'[^\n]*github\.event_name == 'schedule'[^\n]*github\.event_name == 'push'[^\n]*secrets\.STRYKER_DASHBOARD_API_KEY/, 'producer must gate the upload key on refs/heads/main schedule/push runs');
   assert.match(yml, /push:\s*\n\s*branches:\s*\[main\]/, 'producer must run on push to main to refresh the baseline');
 });
 ```

--- a/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
+++ b/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
@@ -606,13 +606,19 @@ jobs:
         run: |
           set -uo pipefail
           mkdir -p "${PKG_DIR}/reports"
+          baseline="${PKG_DIR}/reports/stryker-incremental.json"
           url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/main?module=${MODULE}"
+          # A 200 with an empty or truncated body must not be trusted as a
+          # baseline: require a non-empty file AND valid JSON before keeping it,
+          # otherwise fall through to a cold incremental run.
           if curl --fail --silent --show-error --max-time 60 \
-               --output "${PKG_DIR}/reports/stryker-incremental.json" "${url}"; then
+               --output "${baseline}" "${url}" \
+               && [ -s "${baseline}" ] \
+               && node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' "${baseline}"; then
             echo "Baseline downloaded for module ${MODULE}."
           else
             echo "::notice::no dashboard baseline for module ${MODULE}; running cold incremental."
-            rm -f "${PKG_DIR}/reports/stryker-incremental.json"
+            rm -f "${baseline}"
           fi
 
       # Advisory run: scoped to changed files, incremental, never fatal.
@@ -643,6 +649,24 @@ jobs:
             --floor 70 \
             --package-name "${PKG}" \
             --markdown "${RUNNER_TEMP}/mutation-summary-${PKG}.md"
+
+      # If Stryker or scoring failed, no markdown summary was written and the
+      # comment job would otherwise report a clean "no mutated changed files"
+      # result — masking the failure. Write a diagnostic summary so the sticky
+      # comment surfaces the failure. Advisory: never fails the job. Runs before
+      # the upload step so the diagnostic gets included in the artifact.
+      - name: Diagnose advisory failure (${{ matrix.package }})
+        if: ${{ steps.changes.outputs.changed == 'true' && (steps.stryker.outcome == 'failure' || steps.assert.outcome == 'failure') }}
+        env:
+          PKG: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          summary="${RUNNER_TEMP}/mutation-summary-${PKG}.md"
+          {
+            echo "#### ⚠️ \`${PKG}\` — advisory mutation scoring did not complete"
+            echo
+            echo "_The mutation run or scoring step failed. This is advisory and does not block merge. See the workflow logs for details._"
+          } > "${summary}"
 
       - name: Upload advisory summary
         if: ${{ always() && steps.changes.outputs.changed == 'true' }}
@@ -720,9 +744,10 @@ Append this job to `.github/workflows/mutation-pr.yml` (use the exact SHAs/versi
   comment:
     needs: mutation-gate
     # Only on real PRs (sticky comments need a PR number). Always runs so the
-    # comment updates even when every package was skipped. Fork PRs get no
-    # comment (read-only token) but the gate job still produced artifacts.
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    # comment updates even when every package was skipped. Fork PRs are skipped
+    # cleanly: their read-only token cannot post a comment, so the job would only
+    # fail noisily — the gate job still produced artifacts for them.
+    if: ${{ always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
+++ b/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
@@ -392,15 +392,29 @@ import { readFileSync, writeFileSync } from 'node:fs';
 export function renderMarkdown(result, packageName) {
   const { checked, failures, skipped, floor, ok } = result;
   const status = ok ? '✅' : '⚠️';
-  const lines = [`#### ${status} \`${packageName}\` — per-file mutation score (floor ${floor}%)`, ''];
+  // Render interpolated values as HTML-escaped text wrapped in <code>. GitHub
+  // renders the comment markdown to HTML, and backslash escapes do NOT work
+  // inside a markdown code span, so a backtick in a file path would still break
+  // a `...` span. Encoding `, |, <, >, & as HTML entities leaves nothing for the
+  // markdown/table parser to misinterpret. Newlines are collapsed to spaces.
+  const htmlEscape = (value) =>
+    String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/`/g, '&#96;')
+      .replace(/\|/g, '&#124;')
+      .replace(/\r?\n/g, ' ');
+  const codeCell = (value) => `<code>${htmlEscape(value)}</code>`;
+  const lines = [`#### ${status} ${codeCell(packageName)} — per-file mutation score (floor ${floor}%)`, ''];
   if (checked.length === 0 && failures.length === 0 && skipped.length === 0) {
     lines.push('_No mutated changed files to score._');
     return lines.join('\n');
   }
   lines.push('| File | Score | Status |', '| --- | ---: | --- |');
-  for (const f of failures) lines.push(`| \`${f.file}\` | ${f.score.toFixed(2)}% | ❌ below floor |`);
-  for (const c of checked) lines.push(`| \`${c.file}\` | ${c.score.toFixed(2)}% | ✅ |`);
-  for (const s of skipped) lines.push(`| \`${s.file}\` | — | ⏭️ ${s.reason} |`);
+  for (const f of failures) lines.push(`| ${codeCell(f.file)} | ${f.score.toFixed(2)}% | ❌ below floor |`);
+  for (const c of checked) lines.push(`| ${codeCell(c.file)} | ${c.score.toFixed(2)}% | ✅ |`);
+  for (const s of skipped) lines.push(`| ${codeCell(s.file)} | — | ⏭️ ${htmlEscape(s.reason)} |`);
   return lines.join('\n');
 }
 ```
@@ -655,6 +669,11 @@ jobs:
       # result — masking the failure. Write a diagnostic summary so the sticky
       # comment surfaces the failure. Advisory: never fails the job. Runs before
       # the upload step so the diagnostic gets included in the artifact.
+      #
+      # A below-floor file makes the scorer exit non-zero *after* writing a valid
+      # score table, so `assert.outcome == 'failure'` does not mean "no summary".
+      # Only write the generic diagnostic when no non-empty summary exists, so we
+      # never clobber the below-floor annotation the gate exists to surface.
       - name: Diagnose advisory failure (${{ matrix.package }})
         if: ${{ steps.changes.outputs.changed == 'true' && (steps.stryker.outcome == 'failure' || steps.assert.outcome == 'failure') }}
         env:
@@ -662,6 +681,9 @@ jobs:
         run: |
           set -euo pipefail
           summary="${RUNNER_TEMP}/mutation-summary-${PKG}.md"
+          if [ -s "${summary}" ]; then
+            exit 0
+          fi
           {
             echo "#### ⚠️ \`${PKG}\` — advisory mutation scoring did not complete"
             echo
@@ -823,7 +845,7 @@ Append to `scripts/__tests__/mutation-workflows.test.mjs`:
 ```js
 test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to dashboard)', async () => {
   const yml = await read('.github/workflows/mutation.yml');
-  assert.doesNotMatch(yml, /STRYKER_IGNORE_STATIC/, 'producer must score static mutants (no ignoreStatic env)');
+  assert.doesNotMatch(yml, /STRYKER_IGNORE_STATIC:/, 'producer must score static mutants (no ignoreStatic env assignment)');
   assert.match(yml, /STRYKER_DASHBOARD_API_KEY/, 'producer must pass the dashboard API key for upload');
   assert.match(yml, /push:\s*\n\s*branches:\s*\[main\]/, 'producer must run on push to main to refresh the baseline');
 });
@@ -883,7 +905,7 @@ on:
         run: |
           set -uo pipefail
           mkdir -p "${PKG_DIR}/reports"
-          url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/main?module=${MODULE}"
+          url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/${STRYKER_DASHBOARD_VERSION}?module=${MODULE}"
           if curl --fail --silent --show-error --max-time 60 \
                --output "${PKG_DIR}/reports/stryker-incremental.json" "${url}"; then
             echo "Previous baseline downloaded for module ${MODULE}."

--- a/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
+++ b/docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md
@@ -480,9 +480,11 @@ test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => 
   const yml = await read('.github/workflows/mutation-pr.yml');
   assert.match(yml, /STRYKER_IGNORE_STATIC:\s*'true'/, 'PR run must opt into ignoreStatic');
   assert.match(yml, /continue-on-error:\s*true/, 'advisory steps must be non-fatal');
-  // Substring check, not a regex: avoids CodeQL's url-anchor heuristic, which
-  // can't be satisfied for a URL that sits mid-line in the YAML.
-  assert.ok(yml.includes('https://dashboard.stryker-mutator.io/api/reports/'), 'PR run must download the dashboard baseline');
+  // Parse the URL and compare its host exactly (CodeQL flags substring/regex
+  // checks against URL-shaped literals as incomplete URL sanitization).
+  const baselineUrl = yml.match(/url="([^"]+)"/)?.[1];
+  assert.ok(baselineUrl, 'PR run must define a baseline download URL');
+  assert.equal(new URL(baselineUrl).hostname, 'dashboard.stryker-mutator.io', 'PR run must download the baseline from the Stryker dashboard');
   assert.doesNotMatch(yml, /STRYKER_DASHBOARD_API_KEY/, 'PR workflow must not reference the upload secret');
 });
 

--- a/packages/claude-code-plugin/TESTING.md
+++ b/packages/claude-code-plugin/TESTING.md
@@ -92,8 +92,8 @@ pnpm --filter @rundown-org/claude-code-plugin test:coverage
 
 Use `pnpm run test:mutate:plugin` for mutation-sensitive changes after the
 targeted tests are green. Do not lower Stryker thresholds to make a PR pass;
-capture the current mutation baseline first and tighten it in a separate
-tooling change when the baseline is stable.
+capture the current mutation baseline first and tighten it in a separate tooling
+change when the baseline is stable.
 
 ### Coverage Thresholds (`jest.config.js`)
 
@@ -106,22 +106,24 @@ The `rdpath`/`rdx` entrypoint shells do **not** appear in `coverage/lcov.info`,
 even though `collectCoverageFrom` is `src/**/*.ts`. This is expected, not a hole
 in the suite:
 
-- Both files are CLI entrypoints that call `program.parse()` at module top level.
-  They are only exercised by spawning the built `dist/{rdpath,rdx}.js` as a child
-  `node` process (`rdpath-find-integration.test.ts`, ~30 cases;
-  `rdx.integration.test.ts`, ~20 cases). Jest/istanbul instruments the in-process
-  module graph only, so coverage of a spawned subprocess is never collected.
+- Both files are CLI entrypoints that call `program.parse()` at module top
+  level. They are only exercised by spawning the built `dist/{rdpath,rdx}.js` as
+  a child `node` process (`rdpath-find-integration.test.ts`, ~30 cases;
+  `rdx.integration.test.ts`, ~20 cases). Jest/istanbul instruments the
+  in-process module graph only, so coverage of a spawned subprocess is never
+  collected.
 - They cannot be imported in-process to gain instrumentation without running the
-  CLI as a side effect of the import (no `main`-module guard). Adding such a guard
-  purely to satisfy coverage would change entrypoint behavior, which is out of
-  scope for coverage hardening.
+  CLI as a side effect of the import (no `main`-module guard). Adding such a
+  guard purely to satisfy coverage would change entrypoint behavior, which is
+  out of scope for coverage hardening.
 - Their actual logic lives in modules that **are** covered in-process:
   `src/rdx-core.ts` + `src/rdx-validate.ts` for `rdx`, and `assembleRdPath` /
-  `findRdPathFiles` / `readActiveRunScope` from `@rundown-org/core` for `rdpath`.
+  `findRdPathFiles` / `readActiveRunScope` from `@rundown-org/core` for
+  `rdpath`.
 
 The behavioral contract of both entrypoints is pinned by the spawn-based
-integration tests above; the LCOV omission reflects the instrumentation boundary,
-not untested code.
+integration tests above; the LCOV omission reflects the instrumentation
+boundary, not untested code.
 
 ## Manual Hook Verification
 

--- a/packages/claude-code-plugin/stryker.config.mjs
+++ b/packages/claude-code-plugin/stryker.config.mjs
@@ -25,6 +25,14 @@ const parseBoolean = (value, fallback) => {
 // false negatives are acceptable (it never blocks merge). See issue #485.
 const ignoreStatic = parseBoolean(process.env.STRYKER_IGNORE_STATIC, false);
 
+// The dashboard reporter UPLOADS the report and requires an API key, so enable
+// it only when one is present. The producer workflow (mutation.yml) sets the
+// key; the advisory PR workflow does not (it only downloads the public
+// baseline), so PR runs never upload partial, changed-file-scoped reports that
+// would corrupt the dashboard baseline. See issue #485.
+const reporters = ['progress', 'clear-text', 'html', 'json'];
+if (process.env.STRYKER_DASHBOARD_API_KEY) reporters.push('dashboard');
+
 const config = {
   packageManager: 'pnpm',
   // Explicit plugin list: pnpm's isolated layout breaks Stryker's default
@@ -47,9 +55,17 @@ const config = {
   // the per-PR changed-file gate (scripts/assert-mutation-score.mjs) is that
   // guard. See issue #483.
   thresholds: { high: 80, low: 60, break: 70 },
-  reporters: ['progress', 'clear-text', 'html', 'json'],
+  reporters,
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
+  dashboard: {
+    project: 'github.com/tobyhede/rundown',
+    module: 'plugin',
+    // version is auto-detected from the CI environment (branch/ref) when unset;
+    // the producer workflow may pin it via STRYKER_DASHBOARD_VERSION.
+    version: process.env.STRYKER_DASHBOARD_VERSION || undefined,
+    reportType: 'full',
+  },
   concurrency,
   ignoreStatic,
   timeoutMS: 30000,

--- a/packages/claude-code-plugin/stryker.config.mjs
+++ b/packages/claude-code-plugin/stryker.config.mjs
@@ -6,6 +6,25 @@ const parsePositiveInteger = (value, fallback) => {
 
 const concurrency = parsePositiveInteger(process.env.STRYKER_CONCURRENCY, 2);
 
+/**
+ * Parse a boolean-ish env value. Only 'true'/'1' enable the flag; unset or any
+ * other value is the fallback. Keeps local `stryker run` conservative.
+ *
+ * @param {string | undefined} value - the raw env value.
+ * @param {boolean} fallback - value when unset/unrecognized.
+ * @returns {boolean}
+ */
+const parseBoolean = (value, fallback) => {
+  if (value === undefined) return fallback;
+  return value === 'true' || value === '1';
+};
+
+// ignoreStatic is OFF by default so the exhaustive producer run (mutation.yml)
+// scores static mutants at full fidelity. The advisory per-PR gate sets
+// STRYKER_IGNORE_STATIC=true to reclaim the static-mutant time on a run whose
+// false negatives are acceptable (it never blocks merge). See issue #485.
+const ignoreStatic = parseBoolean(process.env.STRYKER_IGNORE_STATIC, false);
+
 const config = {
   packageManager: 'pnpm',
   // Explicit plugin list: pnpm's isolated layout breaks Stryker's default
@@ -32,14 +51,7 @@ const config = {
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
   concurrency,
-  // Skip static mutants (evaluated once at load time, not per-test) so Stryker
-  // reports them Ignored instead of running them. Static mutants are
-  // disproportionately expensive (core measured them at ~49% of test time);
-  // dropping them keeps the per-PR gate well under its timeout. Trade-off:
-  // static mutants become Ignored (not scored), a small fidelity loss that also
-  // affects the weekly exhaustive mutation.yml; acceptable for a time-bounded
-  // gate. Applied for consistency across packages. See issue #485.
-  ignoreStatic: true,
+  ignoreStatic,
   timeoutMS: 30000,
   timeoutFactor: 2.5,
 };

--- a/packages/cli/stryker.config.mjs
+++ b/packages/cli/stryker.config.mjs
@@ -25,6 +25,14 @@ const parseBoolean = (value, fallback) => {
 // false negatives are acceptable (it never blocks merge). See issue #485.
 const ignoreStatic = parseBoolean(process.env.STRYKER_IGNORE_STATIC, false);
 
+// The dashboard reporter UPLOADS the report and requires an API key, so enable
+// it only when one is present. The producer workflow (mutation.yml) sets the
+// key; the advisory PR workflow does not (it only downloads the public
+// baseline), so PR runs never upload partial, changed-file-scoped reports that
+// would corrupt the dashboard baseline. See issue #485.
+const reporters = ['progress', 'clear-text', 'html', 'json'];
+if (process.env.STRYKER_DASHBOARD_API_KEY) reporters.push('dashboard');
+
 const config = {
   packageManager: 'pnpm',
   // Explicit plugin list: pnpm's isolated layout breaks Stryker's default
@@ -47,9 +55,17 @@ const config = {
   // the per-PR changed-file gate (scripts/assert-mutation-score.mjs) is that
   // guard. See issue #483.
   thresholds: { high: 80, low: 60, break: 70 },
-  reporters: ['progress', 'clear-text', 'html', 'json'],
+  reporters,
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
+  dashboard: {
+    project: 'github.com/tobyhede/rundown',
+    module: 'cli',
+    // version is auto-detected from the CI environment (branch/ref) when unset;
+    // the producer workflow may pin it via STRYKER_DASHBOARD_VERSION.
+    version: process.env.STRYKER_DASHBOARD_VERSION || undefined,
+    reportType: 'full',
+  },
   concurrency,
   ignoreStatic,
   timeoutMS: 60000,

--- a/packages/cli/stryker.config.mjs
+++ b/packages/cli/stryker.config.mjs
@@ -6,6 +6,25 @@ const parsePositiveInteger = (value, fallback) => {
 
 const concurrency = parsePositiveInteger(process.env.STRYKER_CONCURRENCY, 2);
 
+/**
+ * Parse a boolean-ish env value. Only 'true'/'1' enable the flag; unset or any
+ * other value is the fallback. Keeps local `stryker run` conservative.
+ *
+ * @param {string | undefined} value - the raw env value.
+ * @param {boolean} fallback - value when unset/unrecognized.
+ * @returns {boolean}
+ */
+const parseBoolean = (value, fallback) => {
+  if (value === undefined) return fallback;
+  return value === 'true' || value === '1';
+};
+
+// ignoreStatic is OFF by default so the exhaustive producer run (mutation.yml)
+// scores static mutants at full fidelity. The advisory per-PR gate sets
+// STRYKER_IGNORE_STATIC=true to reclaim the static-mutant time on a run whose
+// false negatives are acceptable (it never blocks merge). See issue #485.
+const ignoreStatic = parseBoolean(process.env.STRYKER_IGNORE_STATIC, false);
+
 const config = {
   packageManager: 'pnpm',
   // Explicit plugin list: pnpm's isolated layout breaks Stryker's default
@@ -32,14 +51,7 @@ const config = {
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
   concurrency,
-  // Skip static mutants (evaluated once at load time, not per-test) so Stryker
-  // reports them Ignored instead of running them. The per-PR gate timed out at
-  // 30m on ~2197 instrumented mutants for cli (run 28277202919); static mutants
-  // are disproportionately expensive (core measured them at ~49% of test time).
-  // Trade-off: static mutants become Ignored (not scored), a small fidelity loss
-  // that also affects the weekly exhaustive mutation.yml; acceptable for a
-  // time-bounded gate. See issue #485.
-  ignoreStatic: true,
+  ignoreStatic,
   timeoutMS: 60000,
   timeoutFactor: 2.5,
 };

--- a/packages/core/stryker.config.mjs
+++ b/packages/core/stryker.config.mjs
@@ -25,6 +25,14 @@ const parseBoolean = (value, fallback) => {
 // false negatives are acceptable (it never blocks merge). See issue #485.
 const ignoreStatic = parseBoolean(process.env.STRYKER_IGNORE_STATIC, false);
 
+// The dashboard reporter UPLOADS the report and requires an API key, so enable
+// it only when one is present. The producer workflow (mutation.yml) sets the
+// key; the advisory PR workflow does not (it only downloads the public
+// baseline), so PR runs never upload partial, changed-file-scoped reports that
+// would corrupt the dashboard baseline. See issue #485.
+const reporters = ['progress', 'clear-text', 'html', 'json'];
+if (process.env.STRYKER_DASHBOARD_API_KEY) reporters.push('dashboard');
+
 const config = {
   packageManager: 'pnpm',
   // Explicit plugin list: pnpm's isolated layout breaks Stryker's default
@@ -47,9 +55,17 @@ const config = {
   // the per-PR changed-file gate (scripts/assert-mutation-score.mjs) is that
   // guard. See issue #483.
   thresholds: { high: 80, low: 60, break: 70 },
-  reporters: ['progress', 'clear-text', 'html', 'json'],
+  reporters,
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
+  dashboard: {
+    project: 'github.com/tobyhede/rundown',
+    module: 'core',
+    // version is auto-detected from the CI environment (branch/ref) when unset;
+    // the producer workflow may pin it via STRYKER_DASHBOARD_VERSION.
+    version: process.env.STRYKER_DASHBOARD_VERSION || undefined,
+    reportType: 'full',
+  },
   concurrency,
   ignoreStatic,
   // Core hosts the heaviest actors (XState machine, file locks with jittered

--- a/packages/core/stryker.config.mjs
+++ b/packages/core/stryker.config.mjs
@@ -6,6 +6,25 @@ const parsePositiveInteger = (value, fallback) => {
 
 const concurrency = parsePositiveInteger(process.env.STRYKER_CONCURRENCY, 2);
 
+/**
+ * Parse a boolean-ish env value. Only 'true'/'1' enable the flag; unset or any
+ * other value is the fallback. Keeps local `stryker run` conservative.
+ *
+ * @param {string | undefined} value - the raw env value.
+ * @param {boolean} fallback - value when unset/unrecognized.
+ * @returns {boolean}
+ */
+const parseBoolean = (value, fallback) => {
+  if (value === undefined) return fallback;
+  return value === 'true' || value === '1';
+};
+
+// ignoreStatic is OFF by default so the exhaustive producer run (mutation.yml)
+// scores static mutants at full fidelity. The advisory per-PR gate sets
+// STRYKER_IGNORE_STATIC=true to reclaim the static-mutant time on a run whose
+// false negatives are acceptable (it never blocks merge). See issue #485.
+const ignoreStatic = parseBoolean(process.env.STRYKER_IGNORE_STATIC, false);
+
 const config = {
   packageManager: 'pnpm',
   // Explicit plugin list: pnpm's isolated layout breaks Stryker's default
@@ -32,15 +51,7 @@ const config = {
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
   concurrency,
-  // Skip static mutants (those evaluated once at load time, not per-test) so
-  // Stryker reports them Ignored instead of running them. The per-PR gate timed
-  // out at 30m on ~2157 instrumented mutants for core (run 28277202919), where
-  // Stryker reported "10 static mutants (0% of total) estimated to take 49% of
-  // the time running the tests" -- dropping them reclaims that ~half. Trade-off:
-  // static mutants become Ignored (not scored), a small fidelity loss that also
-  // affects the weekly exhaustive mutation.yml; acceptable for a time-bounded
-  // gate. See issue #485.
-  ignoreStatic: true,
+  ignoreStatic,
   // Core hosts the heaviest actors (XState machine, file locks with jittered
   // backoff bounded to 5s, fromPromise actors that touch the filesystem). The
   // previous 30000ms / 2.5x budget produced ~17 spurious Timeout results that

--- a/packages/parser/stryker.config.mjs
+++ b/packages/parser/stryker.config.mjs
@@ -25,6 +25,14 @@ const parseBoolean = (value, fallback) => {
 // false negatives are acceptable (it never blocks merge). See issue #485.
 const ignoreStatic = parseBoolean(process.env.STRYKER_IGNORE_STATIC, false);
 
+// The dashboard reporter UPLOADS the report and requires an API key, so enable
+// it only when one is present. The producer workflow (mutation.yml) sets the
+// key; the advisory PR workflow does not (it only downloads the public
+// baseline), so PR runs never upload partial, changed-file-scoped reports that
+// would corrupt the dashboard baseline. See issue #485.
+const reporters = ['progress', 'clear-text', 'html', 'json'];
+if (process.env.STRYKER_DASHBOARD_API_KEY) reporters.push('dashboard');
+
 const config = {
   packageManager: 'pnpm',
   // Explicit plugin list: pnpm's isolated layout breaks Stryker's default
@@ -47,9 +55,17 @@ const config = {
   // the per-PR changed-file gate (scripts/assert-mutation-score.mjs) is that
   // guard. See issue #483.
   thresholds: { high: 80, low: 60, break: 70 },
-  reporters: ['progress', 'clear-text', 'html', 'json'],
+  reporters,
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
+  dashboard: {
+    project: 'github.com/tobyhede/rundown',
+    module: 'parser',
+    // version is auto-detected from the CI environment (branch/ref) when unset;
+    // the producer workflow may pin it via STRYKER_DASHBOARD_VERSION.
+    version: process.env.STRYKER_DASHBOARD_VERSION || undefined,
+    reportType: 'full',
+  },
   concurrency,
   ignoreStatic,
   timeoutMS: 30000,

--- a/packages/parser/stryker.config.mjs
+++ b/packages/parser/stryker.config.mjs
@@ -6,6 +6,25 @@ const parsePositiveInteger = (value, fallback) => {
 
 const concurrency = parsePositiveInteger(process.env.STRYKER_CONCURRENCY, 2);
 
+/**
+ * Parse a boolean-ish env value. Only 'true'/'1' enable the flag; unset or any
+ * other value is the fallback. Keeps local `stryker run` conservative.
+ *
+ * @param {string | undefined} value - the raw env value.
+ * @param {boolean} fallback - value when unset/unrecognized.
+ * @returns {boolean}
+ */
+const parseBoolean = (value, fallback) => {
+  if (value === undefined) return fallback;
+  return value === 'true' || value === '1';
+};
+
+// ignoreStatic is OFF by default so the exhaustive producer run (mutation.yml)
+// scores static mutants at full fidelity. The advisory per-PR gate sets
+// STRYKER_IGNORE_STATIC=true to reclaim the static-mutant time on a run whose
+// false negatives are acceptable (it never blocks merge). See issue #485.
+const ignoreStatic = parseBoolean(process.env.STRYKER_IGNORE_STATIC, false);
+
 const config = {
   packageManager: 'pnpm',
   // Explicit plugin list: pnpm's isolated layout breaks Stryker's default
@@ -32,14 +51,7 @@ const config = {
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation-report.json' },
   concurrency,
-  // Skip static mutants (evaluated once at load time, not per-test) so Stryker
-  // reports them Ignored instead of running them. Static mutants are
-  // disproportionately expensive (core measured them at ~49% of test time);
-  // dropping them keeps the per-PR gate well under its timeout. Trade-off:
-  // static mutants become Ignored (not scored), a small fidelity loss that also
-  // affects the weekly exhaustive mutation.yml; acceptable for a time-bounded
-  // gate. Applied for consistency across packages. See issue #485.
-  ignoreStatic: true,
+  ignoreStatic,
   timeoutMS: 30000,
   timeoutFactor: 2.5,
 };

--- a/scripts/__tests__/assert-mutation-score.test.mjs
+++ b/scripts/__tests__/assert-mutation-score.test.mjs
@@ -306,29 +306,37 @@ test('renderMarkdown renders a table of checked, failed, and skipped files', () 
   assert.match(md, /not mutated/);
 });
 
-test('renderMarkdown escapes backticks, pipes, and newlines in file paths and reasons', () => {
+test('renderMarkdown HTML-escapes backticks, pipes, angle brackets, and newlines', () => {
   const md = renderMarkdown(
     {
       ok: false,
-      failures: [{ file: 'src/a`b|c.ts', score: 42.5 }],
+      failures: [{ file: 'src/a`b|c<x>.ts', score: 42.5 }],
       checked: [],
-      skipped: [{ file: 'src/d.ts', reason: 'weird | reason\nwith newline' }],
+      skipped: [{ file: 'src/d.ts', reason: 'weird | <reason>\nwith newline' }],
       floor: 70,
     },
     'co`re|x',
   );
-  // The pipe is escaped so it cannot start a new table cell.
-  assert.match(md, /src\/a\\`b\\\|c\.ts/);
-  assert.match(md, /weird \\\| reason/);
-  // The package name in the header code span is inline-escaped (backtick
-  // escaped); the pipe is left as-is since the header is not a table cell.
-  assert.match(md, /co\\`re\|x/);
-  // No raw newline survives inside a rendered table row (only the row joiners).
+  // Backtick, pipe, and angle brackets are encoded as HTML entities so neither
+  // the markdown code-span parser nor the table parser can choke on them.
+  assert.match(md, /src\/a&#96;b&#124;c&lt;x&gt;\.ts/);
+  assert.match(md, /weird &#124; &lt;reason&gt;/);
+  // File cells are wrapped in <code>; the package name in the header too.
+  assert.match(md, /<code>src\/a&#96;b&#124;c&lt;x&gt;\.ts<\/code>/);
+  assert.match(md, /<code>co&#96;re&#124;x<\/code>/);
+  // No raw backtick or raw pipe-as-separator leaks from the escaped values.
+  assert.doesNotMatch(md, /`/);
+  // Each table data row keeps exactly the four `|` column separators (the escaped
+  // pipes inside cells became &#124; and no longer count as separators).
+  const dataRows = md.split('\n').filter((l) => l.startsWith('| ') && !l.startsWith('| ---'));
+  for (const row of dataRows) {
+    assert.equal((row.match(/\|/g) ?? []).length, 4, `row has 4 separators: ${row}`);
+  }
+  // The embedded newline in the reason collapsed to a space, not left raw.
+  assert.match(md, /weird &#124; &lt;reason&gt; with newline/);
   for (const line of md.split('\n')) {
     assert.doesNotMatch(line, /\r/);
   }
-  // The skip reason's embedded newline was collapsed to a space, not left raw.
-  assert.match(md, /weird \\\| reason with newline/);
 });
 
 test('renderMarkdown reports an empty state when nothing was scored', () => {

--- a/scripts/__tests__/assert-mutation-score.test.mjs
+++ b/scripts/__tests__/assert-mutation-score.test.mjs
@@ -306,6 +306,31 @@ test('renderMarkdown renders a table of checked, failed, and skipped files', () 
   assert.match(md, /not mutated/);
 });
 
+test('renderMarkdown escapes backticks, pipes, and newlines in file paths and reasons', () => {
+  const md = renderMarkdown(
+    {
+      ok: false,
+      failures: [{ file: 'src/a`b|c.ts', score: 42.5 }],
+      checked: [],
+      skipped: [{ file: 'src/d.ts', reason: 'weird | reason\nwith newline' }],
+      floor: 70,
+    },
+    'co`re|x',
+  );
+  // The pipe is escaped so it cannot start a new table cell.
+  assert.match(md, /src\/a\\`b\\\|c\.ts/);
+  assert.match(md, /weird \\\| reason/);
+  // The package name in the header code span is inline-escaped (backtick
+  // escaped); the pipe is left as-is since the header is not a table cell.
+  assert.match(md, /co\\`re\|x/);
+  // No raw newline survives inside a rendered table row (only the row joiners).
+  for (const line of md.split('\n')) {
+    assert.doesNotMatch(line, /\r/);
+  }
+  // The skip reason's embedded newline was collapsed to a space, not left raw.
+  assert.match(md, /weird \\\| reason with newline/);
+});
+
 test('renderMarkdown reports an empty state when nothing was scored', () => {
   const md = renderMarkdown(
     { ok: true, failures: [], checked: [], skipped: [], floor: 70 },

--- a/scripts/__tests__/assert-mutation-score.test.mjs
+++ b/scripts/__tests__/assert-mutation-score.test.mjs
@@ -4,6 +4,7 @@ import {
   assertMutationScore,
   fileMutationScore,
   normalizeReportFileKeys,
+  renderMarkdown,
 } from '../assert-mutation-score.mjs';
 
 /**
@@ -282,4 +283,34 @@ test('assertMutationScore: floor of 0 with no valid mutants still passes', () =>
     floor: 0,
   });
   assert.equal(result.ok, true);
+});
+
+test('renderMarkdown renders a table of checked, failed, and skipped files', () => {
+  const md = renderMarkdown(
+    {
+      ok: false,
+      failures: [{ file: 'src/a.ts', score: 42.5 }],
+      checked: [{ file: 'src/b.ts', score: 91.0 }],
+      skipped: [{ file: 'src/c.ts', reason: 'not mutated' }],
+      floor: 70,
+    },
+    'core',
+  );
+  assert.match(md, /core/);
+  assert.match(md, /floor 70%/);
+  assert.match(md, /src\/a\.ts/);
+  assert.match(md, /42\.50%/);
+  assert.match(md, /src\/b\.ts/);
+  assert.match(md, /91\.00%/);
+  assert.match(md, /src\/c\.ts/);
+  assert.match(md, /not mutated/);
+});
+
+test('renderMarkdown reports an empty state when nothing was scored', () => {
+  const md = renderMarkdown(
+    { ok: true, failures: [], checked: [], skipped: [], floor: 70 },
+    'parser',
+  );
+  assert.match(md, /parser/);
+  assert.match(md, /No mutated changed files/i);
 });

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -51,8 +51,8 @@ test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to da
   const yml = await read('.github/workflows/mutation.yml');
   assert.doesNotMatch(
     yml,
-    /STRYKER_IGNORE_STATIC/,
-    'producer must score static mutants (no ignoreStatic env)',
+    /STRYKER_IGNORE_STATIC:/,
+    'producer must score static mutants (no ignoreStatic env assignment)',
   );
   assert.match(
     yml,

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -19,14 +19,22 @@ test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => 
     /- name: Score changed files \(advisory\)[\s\S]*?continue-on-error:\s*true/,
     'advisory scoring must be non-fatal',
   );
-  // Plain substring containment, not a regex: the intent is "the YAML embeds
-  // this exact dashboard URL", and a string check both expresses that directly
-  // and avoids CodeQL's url-anchor heuristic (js/regex/missing-regexp-anchor),
-  // which can't be satisfied here — the URL sits mid-line, so `^`/`$` anchors
-  // are semantically wrong.
+  // Verify the baseline is fetched from the Stryker dashboard by extracting the
+  // URL and comparing its parsed host exactly. We deliberately avoid a
+  // substring/regex check against a URL-shaped literal: CodeQL flags those as
+  // incomplete URL sanitization (js/incomplete-url-substring-sanitization /
+  // js/regex/missing-regexp-anchor), and exact host comparison after `new URL()`
+  // is both the query's recommended pattern and a stronger assertion.
+  const baselineUrl = yml.match(/url="([^"]+)"/)?.[1];
+  assert.ok(baselineUrl, 'PR run must define a baseline download URL');
+  assert.equal(
+    new URL(baselineUrl).hostname,
+    'dashboard.stryker-mutator.io',
+    'PR run must download the baseline from the Stryker dashboard',
+  );
   assert.ok(
-    yml.includes('https://dashboard.stryker-mutator.io/api/reports/'),
-    'PR run must download the dashboard baseline',
+    new URL(baselineUrl).pathname.startsWith('/api/reports/'),
+    'baseline must use the dashboard report API path',
   );
   assert.doesNotMatch(
     yml,

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -10,13 +10,25 @@ test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => 
   const yml = await read('.github/workflows/mutation-pr.yml');
   assert.match(yml, /STRYKER_IGNORE_STATIC:\s*'true'/, 'PR run must opt into ignoreStatic');
   assert.match(yml, /continue-on-error:\s*true/, 'advisory steps must be non-fatal');
-  assert.match(yml, /dashboard\.stryker-mutator\.io\/api\/reports/, 'PR run must download the dashboard baseline');
-  assert.doesNotMatch(yml, /STRYKER_DASHBOARD_API_KEY/, 'PR workflow must not reference the upload secret');
+  assert.match(
+    yml,
+    /dashboard\.stryker-mutator\.io\/api\/reports/,
+    'PR run must download the dashboard baseline',
+  );
+  assert.doesNotMatch(
+    yml,
+    /STRYKER_DASHBOARD_API_KEY/,
+    'PR workflow must not reference the upload secret',
+  );
 });
 
 test('mutation-pr.yml uploads per-package markdown summaries', async () => {
   const yml = await read('.github/workflows/mutation-pr.yml');
-  assert.match(yml, /mutation-summary-/, 'PR run must upload a per-package markdown summary artifact');
+  assert.match(
+    yml,
+    /mutation-summary-/,
+    'PR run must upload a per-package markdown summary artifact',
+  );
 });
 
 test('mutation-pr.yml posts a single sticky advisory comment', async () => {
@@ -28,9 +40,21 @@ test('mutation-pr.yml posts a single sticky advisory comment', async () => {
 
 test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to dashboard)', async () => {
   const yml = await read('.github/workflows/mutation.yml');
-  assert.doesNotMatch(yml, /STRYKER_IGNORE_STATIC/, 'producer must score static mutants (no ignoreStatic env)');
-  assert.match(yml, /STRYKER_DASHBOARD_API_KEY/, 'producer must pass the dashboard API key for upload');
-  assert.match(yml, /push:\s*\n\s*branches:\s*\[main\]/, 'producer must run on push to main to refresh the baseline');
+  assert.doesNotMatch(
+    yml,
+    /STRYKER_IGNORE_STATIC/,
+    'producer must score static mutants (no ignoreStatic env)',
+  );
+  assert.match(
+    yml,
+    /STRYKER_DASHBOARD_API_KEY/,
+    'producer must pass the dashboard API key for upload',
+  );
+  assert.match(
+    yml,
+    /push:\s*\n\s*branches:\s*\[main\]/,
+    'producer must run on push to main to refresh the baseline',
+  );
 });
 
 void repoRoot;

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+const read = (p) => readFile(new URL(`../../${p}`, import.meta.url), 'utf-8');
+
+test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => {
+  const yml = await read('.github/workflows/mutation-pr.yml');
+  assert.match(yml, /STRYKER_IGNORE_STATIC:\s*'true'/, 'PR run must opt into ignoreStatic');
+  assert.match(yml, /continue-on-error:\s*true/, 'advisory steps must be non-fatal');
+  assert.match(yml, /dashboard\.stryker-mutator\.io\/api\/reports/, 'PR run must download the dashboard baseline');
+  assert.doesNotMatch(yml, /STRYKER_DASHBOARD_API_KEY/, 'PR workflow must not reference the upload secret');
+});
+
+test('mutation-pr.yml uploads per-package markdown summaries', async () => {
+  const yml = await read('.github/workflows/mutation-pr.yml');
+  assert.match(yml, /mutation-summary-/, 'PR run must upload a per-package markdown summary artifact');
+});
+
+void repoRoot;

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -19,4 +19,11 @@ test('mutation-pr.yml uploads per-package markdown summaries', async () => {
   assert.match(yml, /mutation-summary-/, 'PR run must upload a per-package markdown summary artifact');
 });
 
+test('mutation-pr.yml posts a single sticky advisory comment', async () => {
+  const yml = await read('.github/workflows/mutation-pr.yml');
+  assert.match(yml, /sticky-pull-request-comment/, 'must use a sticky comment action');
+  assert.match(yml, /header:\s*mutation-advisory/, 'sticky comment must use a stable header');
+  assert.match(yml, /pull-requests:\s*write/, 'comment job needs pull-requests: write');
+});
+
 void repoRoot;

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -21,7 +21,7 @@ test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => 
   );
   assert.match(
     yml,
-    /dashboard\.stryker-mutator\.io\/api\/reports/,
+    /https:\/\/dashboard\.stryker-mutator\.io\/api\/reports\//,
     'PR run must download the dashboard baseline',
   );
   assert.doesNotMatch(
@@ -58,6 +58,14 @@ test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to da
     yml,
     /STRYKER_DASHBOARD_API_KEY/,
     'producer must pass the dashboard API key for upload',
+  );
+  // The upload key must be gated on automated main-branch runs so an ad-hoc
+  // workflow_dispatch (possibly off a feature branch) cannot overwrite the
+  // canonical baseline. The key assignment carries the event/ref condition.
+  assert.match(
+    yml,
+    /STRYKER_DASHBOARD_API_KEY:[^\n]*github\.event_name == 'schedule'[^\n]*secrets\.STRYKER_DASHBOARD_API_KEY/,
+    'producer must gate the upload key on schedule/push main runs',
   );
   assert.match(
     yml,

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -78,13 +78,14 @@ test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to da
   );
   // The upload key must be gated on automated main-branch runs so an ad-hoc
   // workflow_dispatch (possibly off a feature branch) cannot overwrite the
-  // canonical baseline. Require all three guards together — the ref must be
-  // refs/heads/main AND the event must be schedule or push — so the test fails
-  // if any one of them is dropped.
+  // canonical baseline. Match the exact boolean grouping — the ref AND the
+  // parenthesized (schedule || push) event group — so the test also fails on a
+  // mis-grouping (e.g. && between the events, which is always false) rather than
+  // only on a dropped token.
   assert.match(
     yml,
-    /STRYKER_DASHBOARD_API_KEY:[^\n]*github\.ref == 'refs\/heads\/main'[^\n]*github\.event_name == 'schedule'[^\n]*github\.event_name == 'push'[^\n]*secrets\.STRYKER_DASHBOARD_API_KEY/,
-    'producer must gate the upload key on refs/heads/main schedule/push runs',
+    /STRYKER_DASHBOARD_API_KEY:\s*\$\{\{\s*\(github\.ref == 'refs\/heads\/main' && \(github\.event_name == 'schedule' \|\| github\.event_name == 'push'\)\) && secrets\.STRYKER_DASHBOARD_API_KEY/,
+    'producer must gate the upload key on refs/heads/main AND (schedule || push)',
   );
   assert.match(
     yml,

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -9,7 +9,16 @@ const read = (p) => readFile(new URL(`../../${p}`, import.meta.url), 'utf-8');
 test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => {
   const yml = await read('.github/workflows/mutation-pr.yml');
   assert.match(yml, /STRYKER_IGNORE_STATIC:\s*'true'/, 'PR run must opt into ignoreStatic');
-  assert.match(yml, /continue-on-error:\s*true/, 'advisory steps must be non-fatal');
+  assert.match(
+    yml,
+    /- name: Run mutation tests[\s\S]*?continue-on-error:\s*true/,
+    'Stryker advisory run must be non-fatal',
+  );
+  assert.match(
+    yml,
+    /- name: Score changed files \(advisory\)[\s\S]*?continue-on-error:\s*true/,
+    'advisory scoring must be non-fatal',
+  );
   assert.match(
     yml,
     /dashboard\.stryker-mutator\.io\/api\/reports/,

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -26,4 +26,11 @@ test('mutation-pr.yml posts a single sticky advisory comment', async () => {
   assert.match(yml, /pull-requests:\s*write/, 'comment job needs pull-requests: write');
 });
 
+test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to dashboard)', async () => {
+  const yml = await read('.github/workflows/mutation.yml');
+  assert.doesNotMatch(yml, /STRYKER_IGNORE_STATIC/, 'producer must score static mutants (no ignoreStatic env)');
+  assert.match(yml, /STRYKER_DASHBOARD_API_KEY/, 'producer must pass the dashboard API key for upload');
+  assert.match(yml, /push:\s*\n\s*branches:\s*\[main\]/, 'producer must run on push to main to refresh the baseline');
+});
+
 void repoRoot;

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -19,9 +19,13 @@ test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => 
     /- name: Score changed files \(advisory\)[\s\S]*?continue-on-error:\s*true/,
     'advisory scoring must be non-fatal',
   );
-  assert.match(
-    yml,
-    /https:\/\/dashboard\.stryker-mutator\.io\/api\/reports\//,
+  // Plain substring containment, not a regex: the intent is "the YAML embeds
+  // this exact dashboard URL", and a string check both expresses that directly
+  // and avoids CodeQL's url-anchor heuristic (js/regex/missing-regexp-anchor),
+  // which can't be satisfied here — the URL sits mid-line, so `^`/`$` anchors
+  // are semantically wrong.
+  assert.ok(
+    yml.includes('https://dashboard.stryker-mutator.io/api/reports/'),
     'PR run must download the dashboard baseline',
   );
   assert.doesNotMatch(

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -25,7 +25,12 @@ test('mutation-pr.yml runs the advisory gate with ignoreStatic on', async () => 
   // incomplete URL sanitization (js/incomplete-url-substring-sanitization /
   // js/regex/missing-regexp-anchor), and exact host comparison after `new URL()`
   // is both the query's recommended pattern and a stronger assertion.
-  const baselineUrl = yml.match(/url="([^"]+)"/)?.[1];
+  // Scope the extraction to the baseline-download step so an unrelated `url=`
+  // elsewhere in the workflow can't satisfy this assertion. The pattern carries
+  // no URL/host literal, so it stays clear of CodeQL's URL queries.
+  const baselineUrl = yml.match(
+    /name: Download Stryker baseline from dashboard[\s\S]*?url="([^"]+)"/,
+  )?.[1];
   assert.ok(baselineUrl, 'PR run must define a baseline download URL');
   assert.equal(
     new URL(baselineUrl).hostname,
@@ -73,11 +78,13 @@ test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to da
   );
   // The upload key must be gated on automated main-branch runs so an ad-hoc
   // workflow_dispatch (possibly off a feature branch) cannot overwrite the
-  // canonical baseline. The key assignment carries the event/ref condition.
+  // canonical baseline. Require all three guards together — the ref must be
+  // refs/heads/main AND the event must be schedule or push — so the test fails
+  // if any one of them is dropped.
   assert.match(
     yml,
-    /STRYKER_DASHBOARD_API_KEY:[^\n]*github\.event_name == 'schedule'[^\n]*secrets\.STRYKER_DASHBOARD_API_KEY/,
-    'producer must gate the upload key on schedule/push main runs',
+    /STRYKER_DASHBOARD_API_KEY:[^\n]*github\.ref == 'refs\/heads\/main'[^\n]*github\.event_name == 'schedule'[^\n]*github\.event_name == 'push'[^\n]*secrets\.STRYKER_DASHBOARD_API_KEY/,
+    'producer must gate the upload key on refs/heads/main schedule/push runs',
   );
   assert.match(
     yml,

--- a/scripts/__tests__/stryker-config.test.mjs
+++ b/scripts/__tests__/stryker-config.test.mjs
@@ -139,6 +139,28 @@ for (const configPath of configs) {
     );
   });
 
+  test(`${configPath} pins dashboard.version from STRYKER_DASHBOARD_VERSION`, async () => {
+    const pinned = await loadConfigWithEnv(configPath, {
+      STRYKER_DASHBOARD_API_KEY: 'fake-key',
+      STRYKER_DASHBOARD_VERSION: 'main',
+    });
+    assert.equal(
+      pinned.dashboard?.version,
+      'main',
+      `${configPath}: dashboard.version must come from STRYKER_DASHBOARD_VERSION`,
+    );
+
+    const unset = await loadConfigWithEnv(configPath, {
+      STRYKER_DASHBOARD_API_KEY: 'fake-key',
+      STRYKER_DASHBOARD_VERSION: undefined,
+    });
+    assert.equal(
+      unset.dashboard?.version,
+      undefined,
+      `${configPath}: dashboard.version must be undefined (CI auto-detect) when unset`,
+    );
+  });
+
   test(`${configPath} pins pnpm + the explicit jest-runner plugin`, async () => {
     const config = await loadConfig(configPath, undefined);
     // pnpm's isolated layout breaks Stryker's default '@stryker-mutator/*'

--- a/scripts/__tests__/stryker-config.test.mjs
+++ b/scripts/__tests__/stryker-config.test.mjs
@@ -95,10 +95,22 @@ for (const configPath of configs) {
   });
 
   test(`${configPath} enables ignoreStatic only when STRYKER_IGNORE_STATIC is truthy (issue #485)`, async () => {
-    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: 'true' })).ignoreStatic, true);
-    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: '1' })).ignoreStatic, true);
-    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: 'false' })).ignoreStatic, false);
-    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: '' })).ignoreStatic, false);
+    assert.equal(
+      (await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: 'true' })).ignoreStatic,
+      true,
+    );
+    assert.equal(
+      (await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: '1' })).ignoreStatic,
+      true,
+    );
+    assert.equal(
+      (await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: 'false' })).ignoreStatic,
+      false,
+    );
+    assert.equal(
+      (await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: '' })).ignoreStatic,
+      false,
+    );
   });
 
   test(`${configPath} omits the dashboard reporter when no API key is set`, async () => {

--- a/scripts/__tests__/stryker-config.test.mjs
+++ b/scripts/__tests__/stryker-config.test.mjs
@@ -101,6 +101,32 @@ for (const configPath of configs) {
     assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: '' })).ignoreStatic, false);
   });
 
+  test(`${configPath} omits the dashboard reporter when no API key is set`, async () => {
+    const config = await loadConfigWithEnv(configPath, { STRYKER_DASHBOARD_API_KEY: undefined });
+    assert.ok(
+      Array.isArray(config.reporters) && !config.reporters.includes('dashboard'),
+      `${configPath}: dashboard reporter must be off without STRYKER_DASHBOARD_API_KEY`,
+    );
+  });
+
+  test(`${configPath} enables the dashboard reporter when the API key is set`, async () => {
+    const config = await loadConfigWithEnv(configPath, { STRYKER_DASHBOARD_API_KEY: 'fake-key' });
+    assert.ok(
+      config.reporters.includes('dashboard'),
+      `${configPath}: dashboard reporter must turn on when STRYKER_DASHBOARD_API_KEY is present`,
+    );
+  });
+
+  test(`${configPath} pins the dashboard project and a full report type`, async () => {
+    const config = await loadConfigWithEnv(configPath, { STRYKER_DASHBOARD_API_KEY: 'fake-key' });
+    assert.equal(config.dashboard?.project, 'github.com/tobyhede/rundown');
+    assert.equal(config.dashboard?.reportType, 'full');
+    assert.ok(
+      typeof config.dashboard?.module === 'string' && config.dashboard.module.length > 0,
+      `${configPath}: dashboard.module must be a non-empty per-package module name`,
+    );
+  });
+
   test(`${configPath} pins pnpm + the explicit jest-runner plugin`, async () => {
     const config = await loadConfig(configPath, undefined);
     // pnpm's isolated layout breaks Stryker's default '@stryker-mutator/*'
@@ -111,6 +137,19 @@ for (const configPath of configs) {
       Array.isArray(config.plugins) && config.plugins.includes('@stryker-mutator/jest-runner'),
       `${configPath}: plugins must explicitly include '@stryker-mutator/jest-runner'`,
     );
+  });
+}
+
+const expectedModules = {
+  'packages/parser/stryker.config.mjs': 'parser',
+  'packages/core/stryker.config.mjs': 'core',
+  'packages/cli/stryker.config.mjs': 'cli',
+  'packages/claude-code-plugin/stryker.config.mjs': 'plugin',
+};
+for (const [configPath, moduleName] of Object.entries(expectedModules)) {
+  test(`${configPath} declares dashboard.module = ${moduleName}`, async () => {
+    const config = await loadConfigWithEnv(configPath, { STRYKER_DASHBOARD_API_KEY: 'fake-key' });
+    assert.equal(config.dashboard.module, moduleName);
   });
 }
 

--- a/scripts/__tests__/stryker-config.test.mjs
+++ b/scripts/__tests__/stryker-config.test.mjs
@@ -32,6 +32,34 @@ async function loadConfig(configPath, value) {
   }
 }
 
+/**
+ * Load a Stryker config with an arbitrary set of env vars temporarily applied.
+ * Restores prior env values (including "unset") in a finally block.
+ *
+ * @param {string} configPath - repo-relative path to a stryker.config.mjs.
+ * @param {Record<string, string | undefined>} env - env vars to apply; a value
+ *   of `undefined` deletes the var for the duration of the load.
+ * @returns {Promise<object>} the config module's default export.
+ */
+async function loadConfigWithEnv(configPath, env) {
+  const keys = Object.keys(env);
+  const previous = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  try {
+    for (const k of keys) {
+      if (env[k] === undefined) delete process.env[k];
+      else process.env[k] = env[k];
+    }
+    const configUrl = pathToFileURL(join(repoRoot, configPath));
+    configUrl.searchParams.set('case', `${JSON.stringify(env)}-${Date.now()}-${Math.random()}`);
+    return (await import(configUrl.href)).default;
+  } finally {
+    for (const k of keys) {
+      if (previous[k] === undefined) delete process.env[k];
+      else process.env[k] = previous[k];
+    }
+  }
+}
+
 for (const configPath of configs) {
   test(`${configPath} parses STRYKER_CONCURRENCY overrides`, async () => {
     assert.equal((await loadConfig(configPath, '1')).concurrency, 1);
@@ -53,6 +81,24 @@ for (const configPath of configs) {
       config.thresholds.break >= 70,
       `${configPath}: thresholds.break should be at least 70`,
     );
+  });
+
+  test(`${configPath} defaults ignoreStatic to false for exhaustive fidelity (issue #485)`, async () => {
+    const config = await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: undefined });
+    // The producer run (mutation.yml) sets no env, so static mutants MUST be
+    // scored there. Only the advisory PR run opts into ignoreStatic.
+    assert.equal(
+      config.ignoreStatic,
+      false,
+      `${configPath}: ignoreStatic must default to false (exhaustive run must score static mutants)`,
+    );
+  });
+
+  test(`${configPath} enables ignoreStatic only when STRYKER_IGNORE_STATIC is truthy (issue #485)`, async () => {
+    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: 'true' })).ignoreStatic, true);
+    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: '1' })).ignoreStatic, true);
+    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: 'false' })).ignoreStatic, false);
+    assert.equal((await loadConfigWithEnv(configPath, { STRYKER_IGNORE_STATIC: '' })).ignoreStatic, false);
   });
 
   test(`${configPath} pins pnpm + the explicit jest-runner plugin`, async () => {

--- a/scripts/assert-mutation-score.mjs
+++ b/scripts/assert-mutation-score.mjs
@@ -208,14 +208,23 @@ export function assertMutationScore({ report, changedFiles, packageDir, floor = 
 export function renderMarkdown(result, packageName) {
   const { checked, failures, skipped, floor, ok } = result;
   const status = ok ? '✅' : '⚠️';
-  // Escape values before interpolating into markdown so a backtick, pipe, or
-  // newline in a file path or skip reason cannot break the table layout or
-  // spoof the sticky comment. `escapeInline` neutralizes code-span content;
-  // `escapeTableCell` also escapes the cell separator.
-  const escapeInline = (value) => String(value).replace(/[`\\]/g, '\\$&').replace(/\r?\n/g, ' ');
-  const escapeTableCell = (value) => escapeInline(value).replace(/\|/g, '\\|');
+  // Render interpolated values as HTML-escaped text wrapped in <code>. GitHub
+  // renders the comment markdown to HTML, and backslash escapes do NOT work
+  // inside a markdown code span, so a backtick in a file path would still break
+  // a `...` span. Encoding `, |, <, >, & as HTML entities leaves nothing for the
+  // markdown/table parser to misinterpret. Newlines are collapsed to spaces so a
+  // value can't break the table row.
+  const htmlEscape = (value) =>
+    String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/`/g, '&#96;')
+      .replace(/\|/g, '&#124;')
+      .replace(/\r?\n/g, ' ');
+  const codeCell = (value) => `<code>${htmlEscape(value)}</code>`;
   const lines = [
-    `#### ${status} \`${escapeInline(packageName)}\` — per-file mutation score (floor ${floor}%)`,
+    `#### ${status} ${codeCell(packageName)} — per-file mutation score (floor ${floor}%)`,
     '',
   ];
   if (checked.length === 0 && failures.length === 0 && skipped.length === 0) {
@@ -224,11 +233,9 @@ export function renderMarkdown(result, packageName) {
   }
   lines.push('| File | Score | Status |', '| --- | ---: | --- |');
   for (const f of failures)
-    lines.push(`| \`${escapeTableCell(f.file)}\` | ${f.score.toFixed(2)}% | ❌ below floor |`);
-  for (const c of checked)
-    lines.push(`| \`${escapeTableCell(c.file)}\` | ${c.score.toFixed(2)}% | ✅ |`);
-  for (const s of skipped)
-    lines.push(`| \`${escapeTableCell(s.file)}\` | — | ⏭️ ${escapeTableCell(s.reason)} |`);
+    lines.push(`| ${codeCell(f.file)} | ${f.score.toFixed(2)}% | ❌ below floor |`);
+  for (const c of checked) lines.push(`| ${codeCell(c.file)} | ${c.score.toFixed(2)}% | ✅ |`);
+  for (const s of skipped) lines.push(`| ${codeCell(s.file)} | — | ⏭️ ${htmlEscape(s.reason)} |`);
   return lines.join('\n');
 }
 

--- a/scripts/assert-mutation-score.mjs
+++ b/scripts/assert-mutation-score.mjs
@@ -208,8 +208,14 @@ export function assertMutationScore({ report, changedFiles, packageDir, floor = 
 export function renderMarkdown(result, packageName) {
   const { checked, failures, skipped, floor, ok } = result;
   const status = ok ? '✅' : '⚠️';
+  // Escape values before interpolating into markdown so a backtick, pipe, or
+  // newline in a file path or skip reason cannot break the table layout or
+  // spoof the sticky comment. `escapeInline` neutralizes code-span content;
+  // `escapeTableCell` also escapes the cell separator.
+  const escapeInline = (value) => String(value).replace(/[`\\]/g, '\\$&').replace(/\r?\n/g, ' ');
+  const escapeTableCell = (value) => escapeInline(value).replace(/\|/g, '\\|');
   const lines = [
-    `#### ${status} \`${packageName}\` — per-file mutation score (floor ${floor}%)`,
+    `#### ${status} \`${escapeInline(packageName)}\` — per-file mutation score (floor ${floor}%)`,
     '',
   ];
   if (checked.length === 0 && failures.length === 0 && skipped.length === 0) {
@@ -218,9 +224,11 @@ export function renderMarkdown(result, packageName) {
   }
   lines.push('| File | Score | Status |', '| --- | ---: | --- |');
   for (const f of failures)
-    lines.push(`| \`${f.file}\` | ${f.score.toFixed(2)}% | ❌ below floor |`);
-  for (const c of checked) lines.push(`| \`${c.file}\` | ${c.score.toFixed(2)}% | ✅ |`);
-  for (const s of skipped) lines.push(`| \`${s.file}\` | — | ⏭️ ${s.reason} |`);
+    lines.push(`| \`${escapeTableCell(f.file)}\` | ${f.score.toFixed(2)}% | ❌ below floor |`);
+  for (const c of checked)
+    lines.push(`| \`${escapeTableCell(c.file)}\` | ${c.score.toFixed(2)}% | ✅ |`);
+  for (const s of skipped)
+    lines.push(`| \`${escapeTableCell(s.file)}\` | — | ⏭️ ${escapeTableCell(s.reason)} |`);
   return lines.join('\n');
 }
 

--- a/scripts/assert-mutation-score.mjs
+++ b/scripts/assert-mutation-score.mjs
@@ -208,13 +208,17 @@ export function assertMutationScore({ report, changedFiles, packageDir, floor = 
 export function renderMarkdown(result, packageName) {
   const { checked, failures, skipped, floor, ok } = result;
   const status = ok ? '✅' : '⚠️';
-  const lines = [`#### ${status} \`${packageName}\` — per-file mutation score (floor ${floor}%)`, ''];
+  const lines = [
+    `#### ${status} \`${packageName}\` — per-file mutation score (floor ${floor}%)`,
+    '',
+  ];
   if (checked.length === 0 && failures.length === 0 && skipped.length === 0) {
     lines.push('_No mutated changed files to score._');
     return lines.join('\n');
   }
   lines.push('| File | Score | Status |', '| --- | ---: | --- |');
-  for (const f of failures) lines.push(`| \`${f.file}\` | ${f.score.toFixed(2)}% | ❌ below floor |`);
+  for (const f of failures)
+    lines.push(`| \`${f.file}\` | ${f.score.toFixed(2)}% | ❌ below floor |`);
   for (const c of checked) lines.push(`| \`${c.file}\` | ${c.score.toFixed(2)}% | ✅ |`);
   for (const s of skipped) lines.push(`| \`${s.file}\` | — | ⏭️ ${s.reason} |`);
   return lines.join('\n');

--- a/scripts/assert-mutation-score.mjs
+++ b/scripts/assert-mutation-score.mjs
@@ -32,7 +32,7 @@
  * @see issue #483
  */
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
 /**
@@ -199,6 +199,28 @@ export function assertMutationScore({ report, changedFiles, packageDir, floor = 
 }
 
 /**
+ * Render a GateResult as a GitHub-flavored markdown fragment for a PR comment.
+ *
+ * @param {GateResult} result - the gate outcome.
+ * @param {string} packageName - human label for the package/module (e.g. `core`).
+ * @returns {string} a markdown fragment (no trailing newline).
+ */
+export function renderMarkdown(result, packageName) {
+  const { checked, failures, skipped, floor, ok } = result;
+  const status = ok ? '✅' : '⚠️';
+  const lines = [`#### ${status} \`${packageName}\` — per-file mutation score (floor ${floor}%)`, ''];
+  if (checked.length === 0 && failures.length === 0 && skipped.length === 0) {
+    lines.push('_No mutated changed files to score._');
+    return lines.join('\n');
+  }
+  lines.push('| File | Score | Status |', '| --- | ---: | --- |');
+  for (const f of failures) lines.push(`| \`${f.file}\` | ${f.score.toFixed(2)}% | ❌ below floor |`);
+  for (const c of checked) lines.push(`| \`${c.file}\` | ${c.score.toFixed(2)}% | ✅ |`);
+  for (const s of skipped) lines.push(`| \`${s.file}\` | — | ⏭️ ${s.reason} |`);
+  return lines.join('\n');
+}
+
+/**
  * Determine the files changed between a base ref and HEAD via git.
  *
  * Uses the merge-base (`base...HEAD`) so only commits unique to the PR branch
@@ -255,6 +277,8 @@ function parseArgs(argv) {
     else if (arg === '--base') opts.base = next();
     else if (arg === '--changed-file') opts.changedFiles.push(next());
     else if (arg === '--floor') opts.floor = Number.parseInt(next(), 10);
+    else if (arg === '--markdown') opts.markdown = next();
+    else if (arg === '--package-name') opts.packageName = next();
     else throw new Error(`unknown argument: ${arg}`);
   }
   if (!opts.report) throw new Error('--report <path> is required');
@@ -314,6 +338,15 @@ function main(argv) {
   } catch (err) {
     console.error(`error: ${err.message}`);
     return 2;
+  }
+
+  if (opts.markdown) {
+    try {
+      writeFileSync(opts.markdown, renderMarkdown(result, opts.packageName ?? opts.packageDir));
+    } catch (err) {
+      console.error(`error: failed to write markdown summary ${opts.markdown}: ${err.message}`);
+      return 2;
+    }
   }
 
   const fmt = (score) => `${score.toFixed(2)}%`;


### PR DESCRIPTION
## Summary

Makes the per-PR mutation check **advisory** (never blocks merge) and establishes `mutation.yml` as the full-fidelity dashboard baseline producer. Closes #485.

- **`mutation-pr.yml` (advisory):** per-PR run scoped to changed files, `ignoreStatic` for speed, incremental against the public `main` dashboard baseline, surfaced as a single sticky PR comment. Never fails the check.
- **`mutation.yml` (producer):** runs on push-to-main + weekly cron, scores static mutants at full fidelity, uploads to the Stryker Dashboard (the baseline the advisory run reads).
- **`scripts/assert-mutation-score.mjs`:** per-file scoring + GitHub-flavored markdown summary rendering.
- README mutation-score badge; strategy documented in `docs/superpowers/plans/2026-06-27-mutation-gate-advisory.md`.

## Code-review hardening

Three rounds of CodeRabbit review were applied on top of the feature commits:

- **Sticky-comment safety:** comment values rendered via HTML entities wrapped in `<code>` (backslash escapes don't work inside markdown code spans) so a backtick/pipe/newline in a file path can't break the table or spoof the comment.
- **Baseline integrity:** both workflows validate the downloaded baseline is non-empty valid JSON before use, else fall back to a cold incremental run — preventing a truncated body from corrupting the (uploaded) producer report.
- **Honest failure reporting:** a diagnostic summary is emitted when scoring genuinely fails, but it never overwrites a real score table (including the below-floor case, where the scorer writes the table *then* exits non-zero).
- **Fork PRs:** the comment job is skipped cleanly (read-only token) instead of failing noisily.
- **Cleanups:** dashboard version pinned via `STRYKER_DASHBOARD_VERSION`, redundant matrix `module` field dropped, tightened/added regression tests.

## Testing

- `node --test scripts/__tests__/` — 71 tests pass (workflow-shape, scoring, markdown-escaping, and stryker-config tests)
- `actionlint` clean on both workflows
- biome clean on changed JS

The per-PR check is **advisory** — it will not block this or future PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PRs now get a non-blocking, sticky mutation-testing advisory comment with per-package summaries.
  * Mutation testing on the main branch now runs on `push` (in addition to schedule/dispatch) to keep incremental baselines current.
  * Added a Stryker mutation-testing badge to the README.
* **Bug Fixes**
  * Improved CI messaging when PR changed files or baseline inputs can’t be determined.
  * Avoids empty or stale PR comments by generating an advisory fallback when needed.
* **Documentation**
  * Updated CI mutation-testing docs to reflect the advisory-per-PR vs full-refresh main-branch flow.
* **Tests**
  * Added workflow and rendering/config assertions for mutation score reporting and CI wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->