### PR TITLE
feat(cli): actor-context ingress via resolveActorContext + --actor-source

### DIFF
--- a/docs/reference/cli-help.md
+++ b/docs/reference/cli-help.md
@@ -54,6 +54,8 @@ Options:
   -V, --version                 output the version number
   --no-color                    Disable colored output
   --schema                      Output JSON schema for the command's JSON output
+  --actor-source <source>       Actor-context provenance for role-specific
+                                mutations (direct-cli | plugin | mcp)
   -h, --help                    display help for command
 
 Policy options:

--- a/docs/superpowers/plans/2026-06-26-cli-actor-context-ingress.md
+++ b/docs/superpowers/plans/2026-06-26-cli-actor-context-ingress.md
@@ -1,0 +1,2418 @@
+# CLI Actor-Context Ingress Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize CLI construction of core `ActorContext` behind one
+`resolveActorContext(ingress, state)` helper plus an `--actor-source` /
+`RD_ACTOR_SOURCE` ingress, so every role-specific-mutation command tags its
+caller provenance accurately (replacing `delegate.ts`'s hardcoded `'direct-cli'`
+source), and the collection-pending guard still refuses bare
+`pass`/`fail`/`delegate` for every source.
+
+**Architecture:** This is a **frontend adapter** change in `@rundown-org/cli`.
+The CLI is allowed to *construct* `ActorContext` (an explicit adapter decision —
+the current delegation lifecycle brief requires the CLI compatibility lane, and
+the live code identifies the actual construction sites). The authority for this
+plan is the live code in this worktree plus the dated delegation lifecycle
+spec/planned-work docs under `docs/superpowers/`; do not rely on
+`docs/internal/*` for this work. Core keeps owning *role derivation*
+(`deriveEffectiveRole`) and *policy* (`resolveCommandIntent`,
+`resolveTransitionTarget`). The new `resolveActorContext` helper is a pure
+function that maps a typed `ActorIngress` (source tag + claim evidence) plus a
+resolved `RunbookState` to the `ActorContext` union, implementing the frozen
+trust-mapping table. A program-level `--actor-source` flag (capture-only, no
+validation in the Commander hook) and `RD_ACTOR_SOURCE` env var feed the
+`source` tag (flag wins over env). Each actor-context-constructing command reads
+and validates the source inside its own `withErrorHandling` / `OutputEmitter`
+block, so an invalid value renders the standard `INVALID_ACTOR_SOURCE` JSON
+error envelope (never a silent default, and never a raw Commander stderr line).
+Plan 6 (plugin) consumes this by setting `RD_ACTOR_SOURCE=plugin` only on
+plugin-helper-spawned `rd` calls; Plan 7 (MCP) emits `--actor-source mcp` as a
+program-level token before the subcommand
+(it cannot use the env bridge — `docs/reference/mcp.md §4` requires the CLI to
+inherit the server env unmodified). Neither adds policy logic.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), Commander 15,
+Jest (`@jest/globals`), `fast-check` (property-based tests; already a CLI dev
+dependency), `@rundown-org/core` (re-exports all actor-context symbols), the
+in-process CLI test harness (`runCliInProcess`).
+
+## Global Constraints
+
+These apply to **every** task below. Copied verbatim from the frozen framing
+brief and CLAUDE.md.
+
+- **Worktree only.** All work happens from the active repository root (`$PWD`).
+  Do not use hard-coded worktree paths in commands.
+- **Frontend adapter boundary.** Actor-context *construction* in the CLI is
+  allowed; role *derivation* stays in core (`deriveEffectiveRole`). The CLI MUST
+  NOT re-implement, replicate, or work around `resolveCommandIntent` /
+  `resolveTransitionTarget` policy. (CLAUDE.md "The CLI is a thin wrapper.")
+- **No persisted-state migration.** `ActorContext` is runtime-only and is never
+  serialized into snapshots or run state. No task may add a persisted field, a
+  schema-version bump, or a migration/fallback path.
+- **Type-driven dispatch, no silent mapping.** An invalid `--actor-source` /
+  `RD_ACTOR_SOURCE` value is a **hard error** (exit non-zero, rendered as the
+  `INVALID_ACTOR_SOURCE` JSON envelope via the command's `OutputEmitter`), never
+  a silent default. The resolver narrows on a discriminated union, never on raw
+  string `if` ladders outside the `parseActorSource` validation choke point.
+  Validation happens inside the constructing command's `withErrorHandling`
+  block — NOT in a Commander `preAction`/`preSubcommand` hook, because a thrown
+  hook error is caught by `cli.ts`'s `parseAsync().catch` and printed to stderr
+  via `console.error(error.message)`, which would bypass the JSON envelope
+  contract. **Scope of the hard-error guarantee:** it applies to any
+  command/path that actually *constructs* actor context (collect, delegate's
+  bare-issue path, pass/fail) — those read+validate the source at their
+  construction site. Read-only and non-constructing paths (e.g. `status`, and
+  the `delegate --retry` sub-path, which returns before the validation point)
+  capture the flag without validating it, so an invalid value is silently
+  ignored there rather than refused. This is by design: validation is
+  per-construction-path, and the guarantee is not weakened on any path where it
+  does apply.
+- **The INVARIANT (must be test-pinned).** The collection-pending guard
+  (`rejectBareMutationIfCollectionPending`, surfaced as
+  `delegation_collection_pending`) still refuses bare `pass`/`fail`/`delegate`
+  for **every** source, including the trusted `plugin` / `mcp` tags. Source
+  never buys past the guard.
+- **`unknown` is reachable by type, not by default.** `resolveActorContext` MUST
+  be able to return the `{ kind: 'unknown' }` context (the reserved inspect-only
+  fallback), even though no current local frontend path triggers it by default.
+- **JSON output contract unchanged.** JSON is the agent-facing default; `--text`
+  is human-only. No task changes any existing JSON envelope shape, error code,
+  or `--schema` output.
+- **TSDoc on every new exported symbol** (description, `@param`, `@returns`,
+  `@throws` where applicable). (CLAUDE.md "TSDoc Standards".)
+- **Error helpers.** Never call `Error.isError()` directly; use `isError()` from
+  `@rundown-org/core` if error-shape checks are needed.
+- **All actor-context symbols import from `@rundown-org/core`** (the barrel
+  re-exports them via `packages/core/src/runbook/index.ts`). Verified-present
+  exports the new code uses: `type ActorContext`, `type ActorContextSource`,
+  `type RunId`, `type ClaimId`, `type DelegationTokenHash`, `type RunbookState`,
+  `trustedRunControllerContext`, `claimControllerContext`,
+  `UNKNOWN_ACTOR_CONTEXT`.
+- **Verify gate.** Before declaring the plan done, `pnpm run verify` must pass.
+
+---
+
+## File Structure
+
+| File | Responsibility | Status |
+| --- | --- | --- |
+| `packages/cli/src/helpers/resolve-actor-context.ts` | NEW. Pure module. Exports `ActorIngress`, `ActorSource` validation (`parseActorSource`, `ACTOR_SOURCE_VALUES`, `InvalidActorSourceError`), and `resolveActorContext(ingress, state)`. Implements the frozen trust-mapping table. No I/O, no Commander, no core-service references. | Create |
+| `packages/cli/__tests__/helpers/resolve-actor-context.test.ts` | NEW. Table-driven unit tests across every row of the frozen table, plus `parseActorSource` precedence/validation, plus the `unknown` reachability row. | Create |
+| `packages/cli/src/cli.ts` | Register program-level **capture-only** `--actor-source <direct-cli\|plugin\|mcp>` option (mirrors the existing global `--no-color` / `--schema`). NO validation/throw in any hook. | Modify |
+| `packages/core/src/output/zod-schemas.ts` | Add the CLI-only symbolic `INVALID_ACTOR_SOURCE` code to `CLISymbolicErrorCodeValues` and `CLIErrorCodes`, so the new `OutputEmitter.error(..., 'INVALID_ACTOR_SOURCE')` envelope is schema-recognized. | Modify |
+| `packages/cli/__tests__/commands/actor-source-ingress.test.ts` | NEW. End-to-end ingress tests: pre-subcommand flag parse, `--help` advertises it at program level, env, flag-over-env precedence, invalid value renders `INVALID_ACTOR_SOURCE` JSON envelope, plus the cross-source collection-pending INVARIANT and the source-propagation driving test. | Create |
+| `packages/cli/src/helpers/actor-source-option.ts` | NEW. Tiny helper `readActorSourceIngress(command, env?)` that reads `--actor-source` (via the ACTION command's `optsWithGlobals()`) and `RD_ACTOR_SOURCE`, applies flag-over-env precedence, and returns a validated `ActorContextSource` or `undefined` (throws `InvalidActorSourceError`, which the calling command catches and renders via `OutputEmitter`). | Create |
+| `packages/cli/__tests__/helpers/actor-source-option.test.ts` | NEW. Unit tests for `readActorSourceIngress` precedence/validation against a stub `command`. | Create |
+| `packages/cli/src/commands/collect.ts` | Replace inline `ctx.claim ? claimControllerContext(...) : trustedRunControllerContext(...)` with `resolveActorContext`; read+validate the source via `readActorSourceIngress` inside the existing `withErrorHandling` block. | Modify |
+| `packages/cli/src/commands/delegate.ts` | Replace inline hardcoded `trustedRunControllerContext(state.id, 'direct-cli')` with `resolveActorContext` so the bare delegation issue carries the correct provenance source. (delegate has NO `--claim-id` option, so no claim-controller path applies — source-tag correction only.) | Modify |
+| `packages/cli/src/helpers/transitions.ts` | Thread an `actorSource: ActorContextSource` through `buildTransitionContext` into `resolveTransitionTarget` so the trusted-controller tag reflects the ingress source instead of a hardcoded `'direct-cli'`. | Modify |
+| `packages/cli/src/helpers/transition-command.ts` | Read+validate the ingress source (via `readActorSourceIngress`) inside `withErrorHandling`, pass it into `buildTransitionContext`. | Modify |
+| `packages/core/src/runbook/command-target-resolver.ts` | Add a narrow `actorContextSource?: ActorContextSource` option that refines the existing `directCliCompatibility` tag (provenance only; no policy change). Extract an exported `buildTransitionActorContext` helper. | Modify |
+| `packages/cli/__tests__/helpers/resolve-actor-context.properties.test.ts` | NEW. First CLI-package `fast-check` property suite: totality, claim-iff-evidence, no-source-on-claim, default-source/`state.id`, `controlledRunId` default, and `parseActorSource` round-trip/reject properties (Task 1). | Create |
+| `packages/cli/__tests__/commands/delegate-actor-source.test.ts` | NEW. Pure-helper source-propagation driver for `buildDelegateActorIngress` plus a coarse end-to-end `--actor-source` accept pin (Task 4). | Create |
+| `packages/cli/__tests__/commands/collect-actor-source.test.ts` | NEW. Pure-helper source + claim-evidence propagation driver for `buildCollectActorIngress` (Task 5). | Create |
+| `packages/core/__tests__/runbook/command-target-resolver.test.ts` | Add the `buildTransitionActorContext` source-propagation driver + outcome-neutrality and cross-source collection-pending pins (Task 6). | Modify |
+| `packages/cli/__tests__/commands/delegate.test.ts` | Add the cross-source / env-bridge collection-pending INVARIANT rows + `INVALID_ACTOR_SOURCE` envelope rows, reusing `setupAutoIssuedDelegation` (Task 4). | Modify |
+| `packages/cli/__tests__/commands/collect.test.ts` | Add behavior-neutral flag + `RD_ACTOR_SOURCE` env rows and the `INVALID_ACTOR_SOURCE` envelope row (Task 5). | Modify |
+| `packages/cli/__tests__/commands/pass.test.ts` / `fail.test.ts` | Add symmetric cross-source / env-bridge guard rows + `INVALID_ACTOR_SOURCE` envelope rows (Task 6). | Modify |
+| `packages/cli/src/commands/{complete,stop,claim}.ts` | One-line rationale comment recording construction-free status (Task 7). | Modify |
+
+> This table lists the **primary** files; each task's own **Files** list is
+> authoritative for the exact per-task surface (including any incidental import
+> additions noted inline in a task's steps).
+
+### Design note: how each command reaches the resolver
+
+- **collect / delegate** already resolve a target `RunbookState` and already
+  build an `ActorContext` inline. They call `resolveActorContext(ingress, state)`
+  directly, reading `ingress.source` from `readActorSourceIngress(command)`
+  inside their existing `withErrorHandling` block (so an invalid source renders
+  the `INVALID_ACTOR_SOURCE` JSON envelope, not a hook stderr line).
+  - **collect** also threads claim evidence: `claimId` / `tokenHash` come from
+    the already-resolved claim record `ctx.claim`, and `controlledRunId` defaults
+    to `state.id` (the resolved claimed child).
+  - **delegate** has NO `--claim-id` option (it registers only
+    `--step/--index/--retry/--input*/--text`), so there is no claim-targeting
+    path and no claim-controller context to build. Its defect is purely the
+    hardcoded `'direct-cli'` source at `delegate.ts:133` (the `actorContext:`
+    line inside the `resolveCommandIntent` call); the migration replaces
+    it with `resolveActorContext({ source }, state)` so the bare delegation issue
+    carries the correct provenance. No claim evidence is threaded.
+- **pass / fail** do NOT pre-resolve state in the CLI — core's
+  `resolveTransitionTarget` resolves the target *and* (today) synthesizes the
+  actor context from `directCliCompatibility: true`, hardcoding source
+  `'direct-cli'`. Rather than duplicate target resolution in the CLI (which
+  would be a shadow implementation — forbidden), we thread the ingress `source`
+  into core's existing compatibility branch so the trusted-controller tag is
+  accurate. The construction still happens at the one core choke point; the CLI
+  only supplies the provenance tag. This preserves behavior for `direct-cli`
+  exactly while making `plugin`/`mcp` tags accurate, and the collection-pending
+  guard fires identically for every source (it is source-independent in core).
+- **complete / stop** are workflow-level force-terminal overrides
+  (`forceTerminalWorkflow`) and the `--claim-id` narrow path
+  (`resolveCommandTarget` + `FORCE_COMPLETE` / `FORCE_STOP`). They do **not**
+  invoke `resolveCommandIntent` / `resolveTransitionTarget` and construct no
+  `ActorContext` today. They have no actor-context-gated mutation to migrate.
+  This plan does **not** invent one for them (that would be new policy surface,
+  out of scope and a correctness risk). They are explicitly out of scope for
+  context construction; a one-line code comment records why. (If a future plan
+  adds actor-gated policy to force-terminal, it consumes the same
+  `resolveActorContext` / `readActorSourceIngress` produced here.)
+- **claim** launches a *new* child run (`claimAndLaunch`); it is not a
+  target-relative mutation against an existing run and constructs no
+  `ActorContext` today. Like complete/stop, there is no context to migrate; a
+  one-line comment records why, and the helpers produced here are available to a
+  future plan that needs them.
+
+> Rationale for the narrowed command set: the frozen brief lists `pass`, `fail`,
+> `complete`, `stop`, `claim` as "role-specific-mutation commands that lack
+> [context]." Audit of the worktree (verified by grep) shows only `pass`/`fail`
+> actually flow an actor context into core policy (via `directCliCompatibility`);
+> `complete`/`stop`/`claim` invoke no actor-context-gated core API at all. Wiring
+> a constructed-but-unused context into them would be dead code and a silent
+> policy-surface expansion — both forbidden by CLAUDE.md ("Correctness over
+> pragmatism", "thin wrapper"). This plan therefore migrates the real
+> construction sites (collect, delegate, pass/fail) and records, in code, why
+> complete/stop/claim are construction-free. The produced helpers remain the
+> single ingress for any future need.
+
+---
+
+## Task 1: `resolveActorContext` pure resolver + unit tests
+
+**Files:**
+- Create: `packages/cli/src/helpers/resolve-actor-context.ts`
+- Test: `packages/cli/__tests__/helpers/resolve-actor-context.test.ts`
+- Test: `packages/cli/__tests__/helpers/resolve-actor-context.properties.test.ts`
+  (NEW; the FIRST property test in the CLI package — `fast-check` invariants over
+  arbitrary ingress)
+
+**Interfaces:**
+- Consumes (from `@rundown-org/core`): `type ActorContext`,
+  `type ActorContextSource`, `type RunId`, `type ClaimId`,
+  `type DelegationTokenHash`, `type RunbookState`,
+  `trustedRunControllerContext`, `claimControllerContext`,
+  `UNKNOWN_ACTOR_CONTEXT`.
+- Produces (consumed by Tasks 3-6 and by Plans 6/7's prerequisite contract):
+  - `interface ActorIngress { source?: ActorContextSource; claimId?: ClaimId; tokenHash?: DelegationTokenHash; controlledRunId?: RunId; }`
+  - `function resolveActorContext(ingress: ActorIngress, state: RunbookState): ActorContext`
+  - `const ACTOR_SOURCE_VALUES: readonly ActorContextSource[]`
+  - `class InvalidActorSourceError extends Error { readonly code: 'INVALID_ACTOR_SOURCE'; readonly value: string; }`
+  - `function parseActorSource(raw: string): ActorContextSource` (throws `InvalidActorSourceError`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/__tests__/helpers/resolve-actor-context.test.ts`:
+
+```typescript
+import { describe, it, expect } from '@jest/globals';
+import type {
+  ActorContext,
+  ClaimId,
+  DelegationTokenHash,
+  RunId,
+  RunbookState,
+} from '@rundown-org/core';
+import {
+  ACTOR_SOURCE_VALUES,
+  InvalidActorSourceError,
+  parseActorSource,
+  resolveActorContext,
+  type ActorIngress,
+} from '../../src/helpers/resolve-actor-context.js';
+
+// Minimal RunbookState stub: resolveActorContext only reads `.id`.
+function stubState(id: string): RunbookState {
+  return { id: id as RunId } as unknown as RunbookState;
+}
+
+const TARGET = stubState('run_target');
+const CLAIM_ID = 'rdclm_target' as ClaimId;
+const TOKEN_HASH = 'tokenhash_target' as DelegationTokenHash;
+const CONTROLLED = 'run_controlled' as RunId;
+
+describe('parseActorSource', () => {
+  it('exposes exactly the three frozen source values', () => {
+    expect([...ACTOR_SOURCE_VALUES]).toEqual(['direct-cli', 'plugin', 'mcp']);
+  });
+
+  it.each(['direct-cli', 'plugin', 'mcp'] as const)('accepts %s', (value) => {
+    expect(parseActorSource(value)).toBe(value);
+  });
+
+  it('rejects an unknown value with a typed hard error (no silent default)', () => {
+    expect.assertions(3);
+    try {
+      parseActorSource('remote');
+      throw new Error('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidActorSourceError);
+      expect((error as InvalidActorSourceError).code).toBe('INVALID_ACTOR_SOURCE');
+      expect((error as InvalidActorSourceError).value).toBe('remote');
+    }
+  });
+
+  it('rejects the empty string', () => {
+    expect(() => parseActorSource('')).toThrow(InvalidActorSourceError);
+  });
+
+  // Matching is exact: no implicit case folding and no whitespace trimming.
+  // These pin a future `.toLowerCase()` / `.trim()` normalization mutant.
+  it.each(['Plugin', 'MCP', 'Direct-CLI'])('rejects case variants (%s)', (value) => {
+    expect(() => parseActorSource(value)).toThrow(InvalidActorSourceError);
+  });
+
+  it.each([' plugin ', 'plugin\n', '\tmcp'])('rejects untrimmed whitespace (%j)', (value) => {
+    expect(() => parseActorSource(value)).toThrow(InvalidActorSourceError);
+  });
+});
+
+describe('resolveActorContext — frozen trust-mapping table', () => {
+  it('row 1: source unset, no claim => trusted_run_controller(direct-cli)', () => {
+    const ingress: ActorIngress = {};
+    expect(resolveActorContext(ingress, TARGET)).toEqual<ActorContext>({
+      kind: 'trusted_run_controller',
+      runId: TARGET.id,
+      source: 'direct-cli',
+    });
+  });
+
+  it('row 1b: source direct-cli, no claim => trusted_run_controller(direct-cli)', () => {
+    expect(resolveActorContext({ source: 'direct-cli' }, TARGET)).toEqual<ActorContext>({
+      kind: 'trusted_run_controller',
+      runId: TARGET.id,
+      source: 'direct-cli',
+    });
+  });
+
+  it('row 2: source plugin, no claim => trusted_run_controller(plugin)', () => {
+    expect(resolveActorContext({ source: 'plugin' }, TARGET)).toEqual<ActorContext>({
+      kind: 'trusted_run_controller',
+      runId: TARGET.id,
+      source: 'plugin',
+    });
+  });
+
+  it('row 3: source mcp, no claim => trusted_run_controller(mcp)', () => {
+    expect(resolveActorContext({ source: 'mcp' }, TARGET)).toEqual<ActorContext>({
+      kind: 'trusted_run_controller',
+      runId: TARGET.id,
+      source: 'mcp',
+    });
+  });
+
+  it('row 4: any source + full claim evidence => claim_controller (source ignored)', () => {
+    const expected: ActorContext = {
+      kind: 'claim_controller',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: CONTROLLED,
+    };
+    for (const source of ACTOR_SOURCE_VALUES) {
+      expect(
+        resolveActorContext(
+          { source, claimId: CLAIM_ID, tokenHash: TOKEN_HASH, controlledRunId: CONTROLLED },
+          TARGET,
+        ),
+      ).toEqual<ActorContext>(expected);
+    }
+  });
+
+  // Resolver invariant: if valid claim evidence is present, claim_controller
+  // wins over any source tag. This does not imply the plugin plan emits
+  // source=plugin for agent-run Bash lifecycle commands; it only pins the
+  // resolver table for callers that already have claim evidence.
+  it('row 4: source=plugin + valid claim => claim_controller (claim wins)', () => {
+    const result = resolveActorContext(
+      { source: 'plugin', claimId: CLAIM_ID, tokenHash: TOKEN_HASH, controlledRunId: CONTROLLED },
+      TARGET,
+    );
+    expect(result).toEqual<ActorContext>({
+      kind: 'claim_controller',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: CONTROLLED,
+    });
+    // Belt-and-braces: it is NOT downgraded to a trusted run controller and
+    // carries no `source` field (claim_controller has no source).
+    expect(result.kind).toBe('claim_controller');
+    expect((result as { source?: unknown }).source).toBeUndefined();
+  });
+
+  it('row 4 (MCP pin): source=mcp + valid claim => claim_controller (claim wins)', () => {
+    const result = resolveActorContext(
+      { source: 'mcp', claimId: CLAIM_ID, tokenHash: TOKEN_HASH, controlledRunId: CONTROLLED },
+      TARGET,
+    );
+    expect(result).toEqual<ActorContext>({
+      kind: 'claim_controller',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: CONTROLLED,
+    });
+    expect(result.kind).toBe('claim_controller');
+    expect((result as { source?: unknown }).source).toBeUndefined();
+  });
+
+  it('claim evidence defaults controlledRunId to the resolved target id when omitted', () => {
+    // The collect path resolves the claimed child as `state`, so a caller may
+    // omit controlledRunId and rely on `state.id`.
+    expect(
+      resolveActorContext({ claimId: CLAIM_ID, tokenHash: TOKEN_HASH }, TARGET),
+    ).toEqual<ActorContext>({
+      kind: 'claim_controller',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: TARGET.id,
+    });
+  });
+
+  it('row 5: partial claim evidence (claimId without tokenHash) => unknown', () => {
+    // No resolvable controlled run AND no *complete* claim evidence: the
+    // reserved inspect-only fallback. Type-reachable even though no default
+    // local frontend path produces it.
+    expect(resolveActorContext({ source: 'plugin', claimId: CLAIM_ID }, TARGET)).toEqual<ActorContext>(
+      { kind: 'unknown' },
+    );
+  });
+
+  it('row 5b: tokenHash without claimId => unknown', () => {
+    expect(resolveActorContext({ source: 'mcp', tokenHash: TOKEN_HASH }, TARGET)).toEqual<ActorContext>(
+      { kind: 'unknown' },
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/helpers/resolve-actor-context.test.ts`
+Expected: FAIL — `Cannot find module '../../src/helpers/resolve-actor-context.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/cli/src/helpers/resolve-actor-context.ts`:
+
+```typescript
+// packages/cli/src/helpers/resolve-actor-context.ts
+
+import {
+  type ActorContext,
+  type ActorContextSource,
+  type ClaimId,
+  type DelegationTokenHash,
+  type RunId,
+  type RunbookState,
+  UNKNOWN_ACTOR_CONTEXT,
+  claimControllerContext,
+  trustedRunControllerContext,
+} from '@rundown-org/core';
+
+// Exhaustiveness anchor: a `Record<ActorContextSource, true>` forces this object
+// to enumerate EVERY variant of the union — adding a variant to
+// `ActorContextSource` fails to type-check here until the new key is added. This
+// Record is the single source of truth; ACTOR_SOURCE_VALUES is DERIVED from its
+// keys below, so a new variant flows into the runtime array automatically rather
+// than relying on a hand-maintained array (a too-short `readonly
+// ActorContextSource[]` literal would still compile — only the Record guard is
+// load-bearing).
+const ACTOR_SOURCE_PRESENCE: Record<ActorContextSource, true> = {
+  'direct-cli': true,
+  plugin: true,
+  mcp: true,
+};
+
+/**
+ * The valid actor-context source tags, in declaration order.
+ *
+ * This is the single source of truth for `--actor-source` / `RD_ACTOR_SOURCE`
+ * validation, derived from {@link ACTOR_SOURCE_PRESENCE} so it stays exhaustive
+ * against {@link ActorContextSource} by construction (`Object.keys` preserves the
+ * literal insertion order, so the order pinned by the runtime test is stable).
+ */
+export const ACTOR_SOURCE_VALUES = Object.keys(
+  ACTOR_SOURCE_PRESENCE,
+) as readonly ActorContextSource[];
+
+/**
+ * Hard error raised when an `--actor-source` / `RD_ACTOR_SOURCE` value is not a
+ * recognised {@link ActorContextSource}.
+ *
+ * Type-driven dispatch forbids a silent default: an unknown source must fail
+ * loudly so a mis-tagged frontend is caught at ingress, not silently downgraded.
+ */
+export class InvalidActorSourceError extends Error {
+  /** Stable machine-readable error code for the CLI error envelope. */
+  readonly code = 'INVALID_ACTOR_SOURCE' as const;
+  /** The rejected raw value, echoed back for diagnostics. */
+  readonly value: string;
+
+  /**
+   * @param value - The rejected raw source string
+   */
+  constructor(value: string) {
+    super(
+      `Invalid --actor-source value "${value}". Expected one of: ${ACTOR_SOURCE_VALUES.join(', ')}.`,
+    );
+    this.name = 'InvalidActorSourceError';
+    this.value = value;
+  }
+}
+
+/**
+ * Validate a raw source string against the frozen source set.
+ *
+ * @param raw - Raw value from `--actor-source` or `RD_ACTOR_SOURCE`
+ * @returns The validated {@link ActorContextSource}
+ * @throws {InvalidActorSourceError} when `raw` is not a recognised source
+ */
+export function parseActorSource(raw: string): ActorContextSource {
+  if ((ACTOR_SOURCE_VALUES as readonly string[]).includes(raw)) {
+    return raw as ActorContextSource;
+  }
+  throw new InvalidActorSourceError(raw);
+}
+
+/**
+ * Caller evidence assembled by a CLI command before constructing actor context.
+ *
+ * All fields are optional: a bare workspace invocation supplies none and is
+ * mapped to a trusted `direct-cli` run controller (the compatibility lane).
+ */
+export interface ActorIngress {
+  /** Provenance tag from `--actor-source` / `RD_ACTOR_SOURCE`; defaults to `direct-cli`. */
+  readonly source?: ActorContextSource;
+  /** Claim id from `--claim-id`, when targeting a claimed delegated run. */
+  readonly claimId?: ClaimId;
+  /** Token hash bound to the claim, from existing claim-evidence plumbing. */
+  readonly tokenHash?: DelegationTokenHash;
+  /** Resolved claimed run id; defaults to the resolved target `state.id`. */
+  readonly controlledRunId?: RunId;
+}
+
+/**
+ * Map caller ingress + a resolved target run to a core {@link ActorContext}.
+ *
+ * Implements the frozen trust-mapping table:
+ * - complete claim evidence (`claimId` AND `tokenHash`) => `claim_controller`,
+ *   with `controlledRunId` defaulting to `state.id` (the resolved claimed run).
+ *   `source` is provenance only and does not change the claim mapping.
+ * - otherwise, a source tag (or the unset compatibility default) => a trusted
+ *   run controller for `state.id`, tagged with the resolved source.
+ * - partial/contradictory claim evidence with no resolvable controlled run =>
+ *   `unknown` (reserved inspect-only fallback; type-reachable, never a default
+ *   local path).
+ *
+ * Role derivation against a target stays in core (`deriveEffectiveRole`); this
+ * adapter only records evidence.
+ *
+ * @param ingress - Caller evidence (source tag and optional claim evidence)
+ * @param state - Resolved target run the caller is acting on
+ * @returns The constructed actor context
+ */
+export function resolveActorContext(ingress: ActorIngress, state: RunbookState): ActorContext {
+  const hasClaimId = ingress.claimId !== undefined;
+  const hasTokenHash = ingress.tokenHash !== undefined;
+
+  if (hasClaimId && hasTokenHash) {
+    return claimControllerContext({
+      claimId: ingress.claimId,
+      tokenHash: ingress.tokenHash,
+      controlledRunId: ingress.controlledRunId ?? state.id,
+    });
+  }
+
+  // Exactly one of claimId/tokenHash present is contradictory evidence with no
+  // resolvable controlled run: fall to the reserved inspect-only context.
+  if (hasClaimId || hasTokenHash) {
+    return UNKNOWN_ACTOR_CONTEXT;
+  }
+
+  return trustedRunControllerContext(state.id, ingress.source ?? 'direct-cli');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/helpers/resolve-actor-context.test.ts`
+Expected: PASS (all `parseActorSource` and `resolveActorContext` cases green).
+
+- [ ] **Step 5: Add the property-based test layer**
+
+The table-driven tests above pin specific rows; a property layer pins the
+resolver's *invariants* over arbitrary ingress, killing whole classes of mutant
+(dropped defaults, swapped branches, a leaked `source` on `claim_controller`).
+This is the FIRST property test in the CLI package — it follows the same
+`fc.assert(fc.property(...))` idiom as the core property suites under
+`packages/core/__tests__/runbook/*.properties.test.ts` (`import fc from
+'fast-check'`). `fast-check` is already a CLI dev dependency.
+
+Create `packages/cli/__tests__/helpers/resolve-actor-context.properties.test.ts`:
+
+```typescript
+import { describe, it, expect } from '@jest/globals';
+import fc from 'fast-check';
+import type {
+  ClaimId,
+  DelegationTokenHash,
+  RunId,
+  RunbookState,
+} from '@rundown-org/core';
+import {
+  ACTOR_SOURCE_VALUES,
+  InvalidActorSourceError,
+  parseActorSource,
+  resolveActorContext,
+  type ActorIngress,
+} from '../../src/helpers/resolve-actor-context.js';
+
+// resolveActorContext only reads `.id`, so a minimal cast stub suffices.
+function stubState(id: string): RunbookState {
+  return { id: id as RunId } as unknown as RunbookState;
+}
+const STATE = stubState('run_target');
+
+// Arbitraries for each optional ingress field. `source` ranges over the valid
+// set plus undefined (the helper is only ever fed an already-validated source).
+const sourceArb = fc.option(fc.constantFrom(...ACTOR_SOURCE_VALUES), { nil: undefined });
+const claimIdArb = fc.option(
+  fc.string({ minLength: 1 }).map((s) => s as ClaimId),
+  { nil: undefined },
+);
+const tokenHashArb = fc.option(
+  fc.string({ minLength: 1 }).map((s) => s as DelegationTokenHash),
+  { nil: undefined },
+);
+const controlledRunIdArb = fc.option(
+  fc.string({ minLength: 1 }).map((s) => s as RunId),
+  { nil: undefined },
+);
+
+const ingressArb: fc.Arbitrary<ActorIngress> = fc.record({
+  source: sourceArb,
+  claimId: claimIdArb,
+  tokenHash: tokenHashArb,
+  controlledRunId: controlledRunIdArb,
+});
+
+describe('resolveActorContext — properties', () => {
+  it('property 1: total and kind-closed (never throws; kind is a known variant)', () => {
+    fc.assert(
+      fc.property(ingressArb, (ingress) => {
+        const result = resolveActorContext(ingress, STATE);
+        expect(['trusted_run_controller', 'claim_controller', 'unknown']).toContain(result.kind);
+      }),
+    );
+  });
+
+  it('property 2: claim_controller iff both claimId and tokenHash are present', () => {
+    fc.assert(
+      fc.property(ingressArb, (ingress) => {
+        const isClaim = ingress.claimId !== undefined && ingress.tokenHash !== undefined;
+        expect(resolveActorContext(ingress, STATE).kind === 'claim_controller').toBe(isClaim);
+      }),
+    );
+  });
+
+  it('property 3: source never appears on a claim_controller', () => {
+    fc.assert(
+      fc.property(ingressArb, (ingress) => {
+        const result = resolveActorContext(ingress, STATE);
+        if (result.kind === 'claim_controller') {
+          expect((result as { source?: unknown }).source).toBeUndefined();
+        }
+      }),
+    );
+  });
+
+  it('property 4: no-claim path defaults source to direct-cli and targets state.id', () => {
+    // Restrict to the no-claim path (neither claim field present) so the result
+    // is always a trusted run controller.
+    const noClaimArb = fc.record({ source: sourceArb });
+    fc.assert(
+      fc.property(noClaimArb, (ingress) => {
+        const result = resolveActorContext(ingress, STATE);
+        expect(result.kind).toBe('trusted_run_controller');
+        if (result.kind === 'trusted_run_controller') {
+          expect(result.source).toBe(ingress.source ?? 'direct-cli');
+          expect(result.runId).toBe(STATE.id);
+        }
+      }),
+    );
+  });
+
+  it('property 5: complete-claim path defaults controlledRunId to state.id', () => {
+    // Force complete claim evidence so the claim_controller branch always fires.
+    const claimArb = fc.record({
+      source: sourceArb,
+      claimId: fc.string({ minLength: 1 }).map((s) => s as ClaimId),
+      tokenHash: fc.string({ minLength: 1 }).map((s) => s as DelegationTokenHash),
+      controlledRunId: controlledRunIdArb,
+    });
+    fc.assert(
+      fc.property(claimArb, (ingress) => {
+        const result = resolveActorContext(ingress, STATE);
+        expect(result.kind).toBe('claim_controller');
+        if (result.kind === 'claim_controller') {
+          expect(result.controlledRunId).toBe(ingress.controlledRunId ?? STATE.id);
+        }
+      }),
+    );
+  });
+});
+
+describe('parseActorSource — properties', () => {
+  it('property 6a: round-trips every valid value', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...ACTOR_SOURCE_VALUES), (value) => {
+        expect(parseActorSource(value)).toBe(value);
+      }),
+    );
+  });
+
+  it('property 6b: throws InvalidActorSourceError(value) for any non-valid string', () => {
+    const invalidArb = fc
+      .string()
+      .filter((s) => !(ACTOR_SOURCE_VALUES as readonly string[]).includes(s));
+    fc.assert(
+      fc.property(invalidArb, (value) => {
+        try {
+          parseActorSource(value);
+          throw new Error('should have thrown');
+        } catch (error) {
+          expect(error).toBeInstanceOf(InvalidActorSourceError);
+          expect((error as InvalidActorSourceError).value).toBe(value);
+        }
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 6: Run the property test to verify it passes**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/helpers/resolve-actor-context.properties.test.ts`
+Expected: PASS (all six properties hold across the generated ingress space).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/helpers/resolve-actor-context.ts \
+        packages/cli/__tests__/helpers/resolve-actor-context.test.ts \
+        packages/cli/__tests__/helpers/resolve-actor-context.properties.test.ts
+git commit -m "feat(cli): add resolveActorContext frozen trust-mapping resolver"
+```
+
+---
+
+## Task 2: `readActorSourceIngress` option helper + unit tests
+
+**Files:**
+- Create: `packages/cli/src/helpers/actor-source-option.ts`
+- Test: `packages/cli/__tests__/helpers/actor-source-option.test.ts`
+
+**Interfaces:**
+- Consumes: `parseActorSource`, `InvalidActorSourceError` (Task 1);
+  `type ActorContextSource` (`@rundown-org/core`); a Commander `Command`'s
+  `optsWithGlobals()` (returns `{ actorSource?: string }`).
+- Produces:
+  - `interface ActorSourceReader { optsWithGlobals(): { actorSource?: string } }`
+  - `function readActorSourceIngress(command: ActorSourceReader, env?: NodeJS.ProcessEnv): ActorContextSource | undefined`
+    — flag (`--actor-source`) wins over env (`RD_ACTOR_SOURCE`); returns
+    `undefined` when neither is set (so the resolver applies its `direct-cli`
+    default); throws `InvalidActorSourceError` on an invalid value from either
+    source.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/__tests__/helpers/actor-source-option.test.ts`:
+
+```typescript
+import { describe, it, expect } from '@jest/globals';
+import { InvalidActorSourceError } from '../../src/helpers/resolve-actor-context.js';
+import {
+  readActorSourceIngress,
+  type ActorSourceReader,
+} from '../../src/helpers/actor-source-option.js';
+
+function reader(actorSource?: string): ActorSourceReader {
+  return { optsWithGlobals: () => ({ actorSource }) };
+}
+
+describe('readActorSourceIngress', () => {
+  it('returns undefined when neither flag nor env is set', () => {
+    expect(readActorSourceIngress(reader(undefined), {})).toBeUndefined();
+  });
+
+  it('reads the validated value from the --actor-source flag', () => {
+    expect(readActorSourceIngress(reader('plugin'), {})).toBe('plugin');
+  });
+
+  it('reads the validated value from RD_ACTOR_SOURCE when the flag is unset', () => {
+    expect(readActorSourceIngress(reader(undefined), { RD_ACTOR_SOURCE: 'mcp' })).toBe('mcp');
+  });
+
+  it('lets the flag take precedence over the env var', () => {
+    expect(readActorSourceIngress(reader('plugin'), { RD_ACTOR_SOURCE: 'mcp' })).toBe('plugin');
+  });
+
+  it('throws InvalidActorSourceError on an invalid flag value (no silent default)', () => {
+    expect(() => readActorSourceIngress(reader('remote'), {})).toThrow(InvalidActorSourceError);
+  });
+
+  it('throws InvalidActorSourceError on an invalid env value', () => {
+    expect(() => readActorSourceIngress(reader(undefined), { RD_ACTOR_SOURCE: 'remote' })).toThrow(
+      InvalidActorSourceError,
+    );
+  });
+
+  it('ignores an empty-string env var (treated as unset)', () => {
+    expect(readActorSourceIngress(reader(undefined), { RD_ACTOR_SOURCE: '' })).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/helpers/actor-source-option.test.ts`
+Expected: FAIL — `Cannot find module '../../src/helpers/actor-source-option.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/cli/src/helpers/actor-source-option.ts`:
+
+```typescript
+// packages/cli/src/helpers/actor-source-option.ts
+
+import type { ActorContextSource } from '@rundown-org/core';
+import { parseActorSource } from './resolve-actor-context.js';
+
+/**
+ * Minimal structural view of the Commander command needed to read the
+ * program-level `--actor-source` option (kept narrow so tests need no real
+ * Commander instance).
+ */
+export interface ActorSourceReader {
+  /**
+   * Return this command's options merged with inherited program-level options.
+   *
+   * @returns Options object exposing the optional `actorSource` string
+   */
+  optsWithGlobals(): { actorSource?: string };
+}
+
+/**
+ * Resolve the actor-context source tag from CLI ingress.
+ *
+ * Precedence: the `--actor-source` flag wins over the `RD_ACTOR_SOURCE` env var.
+ * An empty-string env value is treated as unset. When neither is supplied this
+ * returns `undefined`, deferring the `direct-cli` compatibility default to
+ * {@link resolveActorContext}.
+ *
+ * @param command - Command exposing program-level options via `optsWithGlobals`
+ * @param env - Environment to read `RD_ACTOR_SOURCE` from (defaults to `process.env`)
+ * @returns The validated source tag, or `undefined` when none was supplied
+ * @throws {InvalidActorSourceError} when a supplied flag/env value is invalid
+ */
+export function readActorSourceIngress(
+  command: ActorSourceReader,
+  env: NodeJS.ProcessEnv = process.env,
+): ActorContextSource | undefined {
+  const flagValue = command.optsWithGlobals().actorSource;
+  if (flagValue !== undefined) {
+    return parseActorSource(flagValue);
+  }
+  const envValue = env.RD_ACTOR_SOURCE;
+  if (envValue !== undefined && envValue !== '') {
+    return parseActorSource(envValue);
+  }
+  return undefined;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/helpers/actor-source-option.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/helpers/actor-source-option.ts \
+        packages/cli/__tests__/helpers/actor-source-option.test.ts
+git commit -m "feat(cli): add readActorSourceIngress flag/env source reader"
+```
+
+---
+
+## Task 3: Register the capture-only `--actor-source` program option + parse/help pins
+
+**Files:**
+- Modify: `packages/cli/src/cli.ts` (add the option near the existing display
+  options, around lines 77-79). Capture-only; NO validation in any hook.
+- Modify: `packages/core/src/output/zod-schemas.ts` (register the new
+  CLI-only symbolic error code used by migrated commands).
+- Test: `packages/cli/__tests__/commands/actor-source-ingress.test.ts` (create)
+
+**Interfaces:**
+- Consumes: nothing new at runtime (the flag is plain Commander capture).
+- Produces: a program-level Commander option `--actor-source <source>` readable
+  by any ACTION command via `command.optsWithGlobals().actorSource`.
+
+> **Why capture-only, validated per-command (findings 2+3).** Validating in a
+> Commander `preAction`/`preSubcommand` hook is wrong on two counts: (2) the
+> hook receives `(thisCommand, actionCommand)` and the program-level `thisCommand`
+> is the *program*, not the leaf command — so `optsWithGlobals()` semantics there
+> are unreliable; (3) a thrown hook error is caught by `cli.ts`'s
+> `parseAsync().catch`, which only does `console.error(error.message)` +
+> `process.exit(1)` — bypassing the `INVALID_ACTOR_SOURCE` JSON envelope
+> contract. Therefore this task ONLY registers the flag as capture-only (like the
+> existing `--no-color`). Each actor-context-constructing command reads and
+> validates it inside its own `withErrorHandling` / `OutputEmitter` block (Tasks
+> 4, 5, 6), so an invalid value renders the standard JSON error envelope. This
+> task also registers `INVALID_ACTOR_SOURCE` in the shared output schema before
+> those commands start emitting it. Tests
+> that assert the invalid-value *envelope* therefore live in those tasks, against
+> a command that actually validates — not here. Task 3 pins only what is true
+> after registration alone: the flag PARSES pre-subcommand and is advertised at
+> program level.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/__tests__/commands/actor-source-ingress.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  createTestWorkspace,
+  getActiveState,
+  runCliInProcess,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
+
+describe('--actor-source / RD_ACTOR_SOURCE ingress', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('accepts a valid --actor-source flag without disturbing a read-only command', async () => {
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+    // `status` does not construct actor context (so it neither validates nor
+    // uses the source), but the capture-only flag must parse cleanly.
+    const result = await runCliInProcess('--actor-source plugin status', workspace);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(/unknown option/i);
+  });
+
+  // CROSS-PLAN PIN (Plan 7 / MCP): the MCP server spawns
+  // `npx --no rundown --actor-source mcp <subcommand> ...` — the flag is a
+  // PROGRAM-LEVEL token BEFORE the subcommand, and MCP cannot use the
+  // RD_ACTOR_SOURCE env bridge (docs/reference/mcp.md §4: the CLI MUST inherit
+  // the server env unmodified). These tests pin that `--actor-source` is parsed
+  // pre-subcommand and advertised at program level, so a refactor cannot quietly
+  // move it onto a per-subcommand registration and break MCP.
+  it('parses --actor-source as a program-level token placed BEFORE the subcommand', async () => {
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+    // mcp source, no claim, bare pass while NOT pending: must transition
+    // normally (proving the pre-subcommand flag was consumed, not rejected as an
+    // unknown option, and not mistaken for a subcommand argument). `pass` is
+    // migrated in Task 6; until then the flag is captured-but-unused and the
+    // transition still succeeds.
+    const result = await runCliInProcess('--actor-source mcp pass --text', workspace);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(/unknown option/i);
+    const state = await getActiveState(workspace);
+    expect(state?.step).toBe('2');
+  });
+
+  it('advertises --actor-source at the program level in --help', async () => {
+    const result = await runCliInProcess('--help', workspace);
+
+    // Program-level help (not a subcommand help) must list the flag, proving it
+    // is registered on the program, not on an individual subcommand.
+    expect(result.stdout).toMatch(/--actor-source/);
+  });
+});
+```
+
+> The invalid-value *envelope* assertions deliberately are NOT here: validation
+> is per-command (Tasks 4/5/6). Asserting the envelope against an unmigrated
+> read-only command would either fail (no validation wired) or force a
+> hook-based throw that bypasses the JSON contract (finding 3). The pre-subcommand
+> `pass` test above passes after registration because the flag is captured and
+> ignored until Task 6 — it pins parse/placement, not validation.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/actor-source-ingress.test.ts`
+Expected: FAIL — the `--actor-source` flag is unknown to Commander (`error:
+unknown option '--actor-source'`) for the pre-subcommand and status cases; the
+`--help` case fails because the flag is not yet advertised.
+
+- [ ] **Step 3: Write minimal implementation (capture-only, no hook validation)**
+
+In `packages/cli/src/cli.ts`, add the option immediately after the existing
+display options (after line 79, the `--schema` option):
+
+```typescript
+  // Display options
+  program.option('--no-color', 'Disable colored output');
+  program.option('--schema', "Output JSON schema for the command's JSON output");
+
+  // Actor-context ingress (provenance tag for role-specific mutation policy).
+  // CAPTURE-ONLY: this flag is read AND validated inside each actor-context-
+  // constructing command's withErrorHandling/OutputEmitter block (see
+  // readActorSourceIngress), NOT here. Do not add validation to a Commander hook:
+  // a thrown hook error is caught by parseAsync().catch below and printed to
+  // stderr, which would bypass the INVALID_ACTOR_SOURCE JSON envelope contract.
+  program.option(
+    '--actor-source <source>',
+    'Actor-context provenance for role-specific mutations (direct-cli | plugin | mcp)',
+  );
+```
+
+Leave the existing `program.hook('preAction', ...)` UNCHANGED (it only handles
+`--no-color`). Add NO import and NO validation call to `cli.ts`.
+
+- [ ] **Step 4: Register `INVALID_ACTOR_SOURCE` as a CLI symbolic output code**
+
+In `packages/core/src/output/zod-schemas.ts`, add the new symbolic code
+immediately after `ACTOR_CONTEXT_REQUIRED` in both the values list and
+`CLIErrorCodes`:
+
+```typescript
+const CLISymbolicErrorCodeValues = [
+  // ...
+  'DELEGATION_COLLECTION_PENDING',
+  'ACTOR_CONTEXT_REQUIRED',
+  'INVALID_ACTOR_SOURCE',
+  'COLLECT_REQUIRES_ORCHESTRATOR',
+  // ...
+] as const;
+```
+
+```typescript
+export const CLIErrorCodes = {
+  // ...
+  /** Actor context is required for the requested role-specific command */
+  ACTOR_CONTEXT_REQUIRED: 'ACTOR_CONTEXT_REQUIRED',
+  /** Actor source ingress value is invalid */
+  INVALID_ACTOR_SOURCE: 'INVALID_ACTOR_SOURCE',
+  /** Collection requires an actor that controls the target delegating run */
+  COLLECT_REQUIRES_ORCHESTRATOR: 'COLLECT_REQUIRES_ORCHESTRATOR',
+  // ...
+};
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/actor-source-ingress.test.ts`
+Expected: PASS — the flag parses pre-subcommand, status is undisturbed, and
+`--help` advertises `--actor-source` at program level.
+
+- [ ] **Step 6: Verify output schema accepts the new symbolic code**
+
+Run: `pnpm --filter @rundown-org/core test -- zod-schemas`
+Expected: PASS. If there is no focused test target for this file in the current
+Jest config, run `pnpm --filter @rundown-org/core test` and confirm it passes.
+
+- [ ] **Step 7: Verify no existing CLI tests regressed**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/status.test.ts __tests__/cli.test.ts`
+Expected: PASS (the new global capture-only option does not disturb existing
+commands).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/src/cli.ts \
+        packages/core/src/output/zod-schemas.ts \
+        packages/cli/__tests__/commands/actor-source-ingress.test.ts
+git commit -m "feat(cli): register capture-only --actor-source program option"
+```
+
+---
+
+## Task 4: Migrate `delegate.ts` to `resolveActorContext` (provenance source) + INVARIANT + envelope tests
+
+**Files:**
+- Modify: `packages/cli/src/commands/delegate.ts` (the bare-delegation-issue
+  policy call at `delegate.ts:132`; export a pure `buildDelegateActorIngress`
+  helper; read+validate the ingress source inside the existing `withErrorHandling`
+  block)
+- Test: `packages/cli/__tests__/commands/delegate.test.ts` (cross-source
+  collection-pending INVARIANT + invalid-source envelope, reusing the existing
+  `setupAutoIssuedDelegation()` fixture)
+- Test: `packages/cli/__tests__/commands/delegate-actor-source.test.ts` (NEW;
+  the pure-helper source-propagation driving test)
+
+**Interfaces:**
+- Consumes: `resolveActorContext`, `ActorIngress`, `ActorContextSource` (Task 1);
+  `readActorSourceIngress` (Task 2). Replaces the inline hardcoded
+  `trustedRunControllerContext(state.id, 'direct-cli')`.
+- Produces: `delegate` builds its actor context via `resolveActorContext` (fed by
+  the exported `buildDelegateActorIngress(actorSource): ActorIngress` helper),
+  tagged with the ingress source, and validates an invalid source through the
+  JSON envelope.
+
+> **What is actually being fixed (finding 1).** `delegate.ts:133` always built
+> `trustedRunControllerContext(state.id, 'direct-cli')` with a HARDCODED source.
+> `delegate` registers only `--step/--index/--retry/--input*/--text` — there is
+> **no `--claim-id` option**, so there is no claim-targeting path and no claim
+> bug. The ONLY defect is the hardcoded provenance: a `plugin`/`mcp` caller is
+> mislabeled `direct-cli`. The migration replaces the inline construction with
+> `resolveActorContext({ source }, state)`. No claim evidence is threaded.
+
+> **Fixture (finding 4).** The existing guard test in `delegate.test.ts` uses a
+> helper `setupAutoIssuedDelegation()` (defined in that file: it writes a
+> `delegate-parent.runbook.md` whose substep 1 has `delegate: true`, runs it
+> `--prompted`, then extracts the auto-issued token from
+> `state.substepStates.find(s => s.id === '1').delegation.token`), then calls
+> `injectDelegationOutcomeForActiveRun(workspace)` to make collection pending,
+> then asserts bare `['delegate']` → exit 1 + `DELEGATION_COLLECTION_PENDING`
+> envelope (validated against `ErrorResponseSchema`). The new tests below REUSE
+> that exact fixture so they fail for the guard, not for runbook/inference
+> reasons. They live in `delegate.test.ts` (where `setupAutoIssuedDelegation` is
+> in scope), not in the ingress test file.
+
+- [ ] **Step 1: Write the failing cross-source INVARIANT + envelope + driving tests**
+
+Append to `packages/cli/__tests__/commands/delegate.test.ts`, inside the
+top-level `describe('delegate command', ...)` (so `setupAutoIssuedDelegation`,
+`injectDelegationOutcomeForActiveRun`, `ErrorResponseSchema`, and `workspace`
+are all in scope):
+
+```typescript
+  describe('actor-source ingress', () => {
+    // INVARIANT: the collection-pending guard refuses bare delegate for EVERY
+    // source. Source never buys past the guard. Reuses the same fixture as the
+    // canonical guard test so the failure is the guard, not runbook resolution.
+    it.each(['direct-cli', 'plugin', 'mcp'] as const)(
+      'still refuses bare delegate while pending (source=%s, flag)',
+      async (source) => {
+        await setupAutoIssuedDelegation();
+        await injectDelegationOutcomeForActiveRun(workspace);
+
+        const result = await runCliInProcess(`--actor-source ${source} delegate`, workspace);
+
+        expect(result.exitCode).toBe(1);
+        const raw = JSON.parse(result.stdout);
+        expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
+        expect((raw as { code?: string }).code).toBe('DELEGATION_COLLECTION_PENDING');
+      },
+    );
+
+    it('still refuses bare delegate while pending when RD_ACTOR_SOURCE=plugin', async () => {
+      await setupAutoIssuedDelegation();
+      await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess('delegate', workspace, {
+        env: { RD_ACTOR_SOURCE: 'plugin' },
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect((JSON.parse(result.stdout) as { code?: string }).code).toBe(
+        'DELEGATION_COLLECTION_PENDING',
+      );
+    });
+
+    // ENVELOPE (finding 3): an invalid source renders the INVALID_ACTOR_SOURCE
+    // JSON envelope through the command's OutputEmitter — NOT a raw stderr line.
+    it('renders the INVALID_ACTOR_SOURCE JSON envelope on an invalid --actor-source', async () => {
+      await setupAutoIssuedDelegation();
+
+      const result = await runCliInProcess('--actor-source remote delegate', workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      const raw = JSON.parse(result.stdout);
+      expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
+      expect((raw as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
+    });
+
+    it('renders the INVALID_ACTOR_SOURCE envelope on an invalid RD_ACTOR_SOURCE', async () => {
+      await setupAutoIssuedDelegation();
+
+      const result = await runCliInProcess('delegate', workspace, {
+        env: { RD_ACTOR_SOURCE: 'remote' },
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      expect((JSON.parse(result.stdout) as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
+    });
+  });
+```
+
+- [ ] **Step 2: Write the failing SOURCE-PROPAGATION driving test (finding 5)**
+
+The guard is source-INDEPENDENT, so the INVARIANT rows above pass even before
+the source is threaded — they pin the invariant but do NOT drive the migration.
+Add a test that OBSERVES the source actually flowing into the constructed ingress
+via a pure exported helper, so the migration is genuinely test-driven (a
+first-party module spy is unreliable under this package's `isolatedModules` +
+`useESM` jest config, so a direct unit test of an exported helper is used).
+
+Create `packages/cli/__tests__/commands/delegate-actor-source.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  createTestWorkspace,
+  runCliInProcess,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
+import { buildDelegateActorIngress } from '../../src/commands/delegate.js';
+
+// Robust source-propagation driver: a pure exported helper that delegate uses to
+// build its ActorIngress from the resolved source. Module-spying a first-party
+// named export is unreliable under this package's jest config (`isolatedModules:
+// true` + `useESM: true`), so the driver is a direct unit test of the helper —
+// mirroring Task 6's `buildTransitionActorContext`. This FAILS to compile/run
+// before Step 4 extracts the helper, which is what TDD-drives the migration.
+describe('buildDelegateActorIngress threads the actor source', () => {
+  it('tags ingress.source when a source is supplied', () => {
+    expect(buildDelegateActorIngress('plugin')).toEqual({ source: 'plugin' });
+    expect(buildDelegateActorIngress('mcp')).toEqual({ source: 'mcp' });
+  });
+
+  it('produces an empty ingress (no source) when the source is undefined', () => {
+    expect(buildDelegateActorIngress(undefined)).toEqual({});
+  });
+});
+
+// A coarse end-to-end pin that the flag is at least accepted on the delegate
+// path (the behavioral effect of source is invisible at the CLI because
+// deriveEffectiveRole ignores source — so the unit test above is the real
+// driver; this only guards against the flag being rejected as unknown).
+describe('delegate accepts --actor-source without error', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('does not reject a valid --actor-source plugin on a fresh delegate', async () => {
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+    const result = await runCliInProcess('--actor-source plugin delegate', workspace);
+
+    expect(result.stdout).not.toMatch(/unknown option/i);
+    expect((JSON.parse(result.stdout) as { code?: string }).code).not.toBe('INVALID_ACTOR_SOURCE');
+  });
+});
+```
+
+> The unit test of `buildDelegateActorIngress` is the genuine driver: it fails
+> to import (helper does not exist) before Step 4. The INVARIANT rows in Step 1
+> are a separate source-independence assertion that must stay green throughout.
+
+- [ ] **Step 3: Run the new tests to verify they fail correctly**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/delegate-actor-source.test.ts`
+Expected: FAIL — `buildDelegateActorIngress` is not yet exported from
+`delegate.ts`, so the import fails (the driving failure).
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/delegate.test.ts -t "actor-source ingress"`
+Expected: the INVARIANT rows PASS (guard is source-independent), the two
+`INVALID_ACTOR_SOURCE` envelope tests FAIL (delegate does not yet validate the
+source). This split is expected and intended.
+
+- [ ] **Step 4: Migrate the construction site (extract helper + read/validate inside withErrorHandling)**
+
+In `packages/cli/src/commands/delegate.ts`, add the helper imports:
+
+```typescript
+import { resolveActorContext, type ActorIngress } from '../helpers/resolve-actor-context.js';
+import { readActorSourceIngress } from '../helpers/actor-source-option.js';
+```
+
+Add the exported pure ingress helper near the top of the module (module scope,
+not inside the action), with TSDoc:
+
+```typescript
+/**
+ * Build the delegate command's actor ingress from a resolved source tag.
+ *
+ * `delegate` registers no `--claim-id` option, so it never carries claim
+ * evidence — the ingress is provenance-source-only. Exported so the
+ * source-propagation behavior is unit-testable in isolation.
+ *
+ * @param actorSource - Resolved `--actor-source` / `RD_ACTOR_SOURCE` tag, or undefined
+ * @returns An `ActorIngress` with `source` set iff a tag was supplied
+ */
+export function buildDelegateActorIngress(
+  actorSource: ActorContextSource | undefined,
+): ActorIngress {
+  return actorSource ? { source: actorSource } : {};
+}
+```
+
+Add `type ActorContextSource` and `getErrorMessage` to the `@rundown-org/core`
+import block in `delegate.ts` (`getErrorMessage` is barrel-exported via
+`errors.ts` and already used in `packages/cli/src/helpers/wrapper.ts`; see
+CLAUDE.md Testing Conventions). Remove `trustedRunControllerContext` from that
+block — it becomes unused once the inline construction moves into the resolver
+(`resolveActorContext`).
+
+Add a trailing `command: Command` parameter to the existing `.action` signature
+(`Command` is already imported in this file). AFTER the
+`if (options.retry) { ... return; }` early return (around `delegate.ts:106-117`)
+— so it sits on the bare-issue / step-targeted path, not the `--retry` path which
+has its own handler — read and validate the source, rendering an invalid value
+through the JSON envelope:
+
+```typescript
+          let actorSource;
+          try {
+            actorSource = readActorSourceIngress(command);
+          } catch (error: unknown) {
+            // InvalidActorSourceError carries code 'INVALID_ACTOR_SOURCE' and a
+            // human message; render it through the standard JSON envelope.
+            output.error(getErrorMessage(error), 'INVALID_ACTOR_SOURCE');
+            output.flush();
+            process.exitCode = 1;
+            return;
+          }
+```
+
+Then replace the inline construction in the `isBareDelegationIssue` branch
+(the `actorContext:` line, currently at `delegate.ts:133`):
+
+```typescript
+            const policy = resolveCommandIntent({
+              actorContext: resolveActorContext(buildDelegateActorIngress(actorSource), state),
+              intent: { kind: 'delegation-issuance', command: 'delegate', targeted: false },
+              targetSelector: { kind: 'default' },
+              targetState: state,
+            });
+```
+
+> `state` is the active run resolved earlier in the bare-issue branch (it is
+> already in scope at the original construction site). `buildDelegateActorIngress`
+> is the module-scope helper added above.
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/delegate-actor-source.test.ts`
+Expected: PASS — `buildDelegateActorIngress('plugin')` returns `{ source:
+'plugin' }`, `buildDelegateActorIngress(undefined)` returns `{}`, and the
+end-to-end `--actor-source plugin delegate` is not rejected.
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/delegate.test.ts`
+Expected: PASS — all pre-existing delegate tests, the INVARIANT rows, and both
+`INVALID_ACTOR_SOURCE` envelope tests.
+
+- [ ] **Step 6: Add and run the behavior-unchanged regression test**
+
+Append to the `describe('actor-source ingress', ...)` block in
+`delegate.test.ts`:
+
+```typescript
+    it('issues a bare delegation unchanged when source=direct-cli is explicit', async () => {
+      // Behavior-neutral for the default source: explicit direct-cli must match
+      // the untagged happy path. Uses the same parent fixture the happy-path
+      // tests use so a real token is issued.
+      await setupAutoIssuedDelegation();
+
+      // setupAutoIssuedDelegation leaves an auto-issued delegation on substep 1;
+      // a fresh bare delegate with no pending outcome echoes/returns a token.
+      const explicit = await runCliInProcess('--actor-source direct-cli delegate', workspace);
+
+      expect(explicit.exitCode).toBe(0);
+      const raw = JSON.parse(explicit.stdout);
+      expect(DelegateResponseSchema.safeParse(raw).success).toBe(true);
+    });
+```
+
+> `DelegateResponseSchema` is already imported in `delegate.test.ts`. If the
+> bare-delegate-after-setup path returns an error envelope instead of a delegate
+> response in this fixture (e.g. because substep 1 already has an in-flight
+> delegation), model this assertion on whichever existing happy-path test in
+> `delegate.test.ts` issues a token, and assert exit 0 + `DelegateResponseSchema`
+> against that exact scenario. The load-bearing claim is only that explicit
+> `direct-cli` is byte-identical to the untagged path.
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/delegate.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/commands/delegate.ts \
+        packages/cli/__tests__/commands/delegate.test.ts \
+        packages/cli/__tests__/commands/delegate-actor-source.test.ts
+git commit -m "feat(cli): tag delegate actor context source via resolveActorContext"
+```
+
+---
+
+## Task 5: Migrate `collect.ts` to `resolveActorContext`
+
+**Files:**
+- Modify: `packages/cli/src/commands/collect.ts` (the inline
+  `ctx.claim ? claimControllerContext(...) : trustedRunControllerContext(...)` at
+  lines 428-434; export a pure `buildCollectActorIngress` helper; read+validate
+  the ingress source inside the existing `withErrorHandling` block)
+- Test: `packages/cli/__tests__/commands/collect.test.ts` (behavior-unchanged
+  `--actor-source plugin` tag + `RD_ACTOR_SOURCE` env fallthrough + invalid-source
+  `INVALID_ACTOR_SOURCE` envelope rows; reuses the existing `setupReadyToCollect`
+  / `getActiveState` fixtures)
+- Test: `packages/cli/__tests__/commands/collect-actor-source.test.ts` (NEW; the
+  pure-helper source + claim-evidence propagation driving test)
+
+**Interfaces:**
+- Consumes: `resolveActorContext`, `ActorIngress`, `ActorContextSource` (Task 1);
+  `readActorSourceIngress` (Task 2); `ctx.claim` (the resolved `ClaimRecord`
+  already surfaced on the collect path, carrying `claimId` and `tokenHash`);
+  `type ClaimRecord`, `type RunId` (`@rundown-org/core`).
+- Produces: `collect` builds its actor context via `resolveActorContext` (fed by
+  the exported `buildCollectActorIngress(actorSource, claim, targetStateId): ActorIngress`
+  helper), threading the provenance source tag AND full claim evidence
+  (`claimId` / `tokenHash` / `controlledRunId: state.id`) when a claim is present;
+  the claim-vs-no-claim branch and the `direct-cli`/source tag now live only in
+  the resolver, and an invalid source renders the JSON envelope.
+
+> **What is actually being fixed (finding 5).** Collection is source-INDEPENDENT
+> — the collection-pending guard ignores `source` — so the inline source spread
+> the first cut of this migration threaded (`...(actorSource ? { source } : {})`)
+> had NO unit test driving it: every collect test stayed green with the entire
+> spread deleted, leaving a surviving Stryker mutant and an untested refactor
+> risk. This is the exact regression class finding 5 was written to prevent,
+> already applied to `delegate` (Task 4) and `pass`/`fail` (Task 6) but not
+> `collect`. The fix mirrors them: extract a pure exported
+> `buildCollectActorIngress` helper and unit-test that the source tag AND the
+> claim evidence actually land in the constructed `ActorIngress`. The helper
+> builds the FULL ingress — `source` when supplied PLUS
+> `claimId` / `tokenHash` / `controlledRunId: state.id` when `ctx.claim` is
+> present. The `ClaimRecord` carries `claimId` and `tokenHash` but has NO
+> `controlledRunId` field (it has `childRunId`), so `controlledRunId` defaults to
+> the resolved claimed child `state.id`, NOT a field on the claim.
+
+- [ ] **Step 1: Write the failing behavior + env + envelope tests (collect.test.ts)**
+
+Append to `packages/cli/__tests__/commands/collect.test.ts`, inside its
+top-level `describe`:
+
+```typescript
+  it('collects unchanged when an explicit --actor-source plugin tag is supplied', async () => {
+    // Behavior-neutral pin (must stay green): source is provenance only — a
+    // plugin-tagged orchestrator of the run is still the orchestrator-for-target,
+    // so collection behaves identically to the untagged direct-cli path. Reuses
+    // the canonical drain fixture `setupReadyToCollect` already defined in this
+    // file (see the 'successful aggregation' describe block).
+    await setupReadyToCollect(['pass', 'pass']);
+
+    const tagged = await runCliInProcess(['--actor-source', 'plugin', 'collect'], workspace);
+
+    // Identical to the untagged `['collect']` happy path: exit 0 and the parent
+    // advances to step 2 (PASS ALL → CONTINUE).
+    expect(tagged.exitCode).toBe(0);
+    const state = await getActiveState(workspace);
+    expect(state?.step).toBe('2');
+  });
+
+  it('collects unchanged when the source arrives via the RD_ACTOR_SOURCE env bridge', async () => {
+    // The env fallthrough is pinned only for delegate elsewhere; collect reads
+    // the source through a DISTINCT call site (readActorSourceIngress in the
+    // collect action), so prove the RD_ACTOR_SOURCE bridge resolves on the
+    // collect path too (finding 8). Behavior stays identical to the untagged
+    // drain: exit 0, parent advances to step 2.
+    await setupReadyToCollect(['pass', 'pass']);
+
+    const tagged = await runCliInProcess('collect', workspace, {
+      env: { RD_ACTOR_SOURCE: 'plugin' },
+    });
+
+    expect(tagged.exitCode).toBe(0);
+    const state = await getActiveState(workspace);
+    expect(state?.step).toBe('2');
+  });
+
+  it('renders the INVALID_ACTOR_SOURCE JSON envelope on an invalid --actor-source for collect', async () => {
+    await setupReadyToCollect(['pass', 'pass']);
+
+    const result = await runCliInProcess(['--actor-source', 'remote', 'collect'], workspace);
+
+    expect(result.exitCode).not.toBe(0);
+    // Validate the envelope SHAPE, not just the code, matching delegate's
+    // stronger assertions (finding 7): an invalid source renders the standard
+    // error envelope via the OutputEmitter, never a raw stderr line.
+    const raw = JSON.parse(result.stdout);
+    expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
+    expect((raw as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
+  });
+```
+
+> `setupReadyToCollect` and `getActiveState` are already in scope in
+> `collect.test.ts` (the file's `successful aggregation` block uses both). Add
+> `ErrorResponseSchema` to the `@rundown-org/core` import at the top of
+> `collect.test.ts` (it is barrel-exported and imported the same way in
+> `delegate.test.ts`; the file does not import it today). The load-bearing
+> checks: a `plugin`-tagged collect — whether via the flag or the
+> `RD_ACTOR_SOURCE` env bridge — is byte-identical to the untagged drain (exit 0,
+> advance to step 2), and an invalid source renders the `INVALID_ACTOR_SOURCE`
+> envelope (schema-validated SHAPE) via the OutputEmitter (finding 3) rather than
+> a stderr line.
+
+- [ ] **Step 2: Write the failing SOURCE-PROPAGATION driving test (finding 5)**
+
+The guard is source-INDEPENDENT, so the behavior rows above pass even before the
+source is threaded — they pin the invariant but do NOT drive the migration. Add a
+test that OBSERVES the source AND the claim evidence actually flowing into the
+constructed ingress via a pure exported helper, so the migration is genuinely
+test-driven (a first-party module spy is unreliable under this package's
+`isolatedModules` + `useESM` jest config, so a direct unit test of an exported
+helper is used — mirroring `delegate-actor-source.test.ts` and Task 6's
+`buildTransitionActorContext`).
+
+Create `packages/cli/__tests__/commands/collect-actor-source.test.ts`:
+
+```typescript
+import { describe, it, expect } from '@jest/globals';
+import type {
+  ClaimId,
+  ClaimRecord,
+  DelegationTokenHash,
+  RunId,
+} from '@rundown-org/core';
+import { buildCollectActorIngress } from '../../src/commands/collect.js';
+
+// Robust source + claim-evidence propagation driver: a pure exported helper that
+// collect uses to build its ActorIngress from the resolved source tag and the
+// resolved claim record. Module-spying a first-party named export is unreliable
+// under this package's jest config (`isolatedModules: true` + `useESM: true`),
+// so the driver is a direct unit test of the helper — mirroring delegate's
+// `buildDelegateActorIngress` and Task 6's `buildTransitionActorContext`. This
+// FAILS to import before Step 4 extracts the helper, which is what TDD-drives
+// the migration: collection is source-independent, so an end-to-end test cannot
+// observe the source spread, and the entire spread could otherwise be deleted
+// with every collect test still green.
+const STATE_ID = 'run_target' as RunId;
+const CLAIM_ID = 'rdclm_target' as ClaimId;
+const TOKEN_HASH = 'tokenhash_target' as DelegationTokenHash;
+// buildCollectActorIngress only reads `.claimId` and `.tokenHash`; the rest of
+// the ClaimRecord shape (notably `childRunId`, NOT `controlledRunId`) is
+// irrelevant to ingress construction, so a minimal cast stub suffices.
+const claimStub = { claimId: CLAIM_ID, tokenHash: TOKEN_HASH } as unknown as ClaimRecord;
+
+describe('buildCollectActorIngress threads the source and claim evidence', () => {
+  it('tags ingress.source only when a source is supplied and no claim is present', () => {
+    expect(buildCollectActorIngress('plugin', undefined, STATE_ID)).toEqual({ source: 'plugin' });
+  });
+
+  it('produces an empty ingress when neither a source nor a claim is supplied', () => {
+    expect(buildCollectActorIngress(undefined, undefined, STATE_ID)).toEqual({});
+  });
+
+  it('threads source AND full claim evidence, defaulting controlledRunId to the target state id', () => {
+    // controlledRunId comes from the passed targetStateId (the resolved claimed
+    // child), NOT from a field on the claim — ClaimRecord has no controlledRunId.
+    expect(buildCollectActorIngress('mcp', claimStub, STATE_ID)).toEqual({
+      source: 'mcp',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: STATE_ID,
+    });
+  });
+
+  it('threads claim evidence with no source when only a claim is supplied', () => {
+    expect(buildCollectActorIngress(undefined, claimStub, STATE_ID)).toEqual({
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: STATE_ID,
+    });
+  });
+});
+```
+
+> The unit test of `buildCollectActorIngress` is the genuine driver: it fails to
+> import (helper does not exist) before Step 4. The behavior + env rows in Step 1
+> are separate source-independence assertions that must stay green throughout; the
+> invalid-source envelope row in Step 1 is the only Step-1 row that FAILS
+> pre-migration (collect does not yet read/validate the source).
+
+- [ ] **Step 3: Run the new tests to verify they fail correctly**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/collect-actor-source.test.ts`
+Expected: FAIL — `buildCollectActorIngress` is not yet exported from
+`collect.ts`, so the import fails (the driving failure).
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/collect.test.ts -t "INVALID_ACTOR_SOURCE JSON envelope on an invalid --actor-source for collect"`
+Expected: FAIL — `collect` does not yet read/validate the source, so an invalid
+`--actor-source remote` is silently parsed-and-ignored (collect proceeds, no
+`INVALID_ACTOR_SOURCE` envelope).
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/collect.test.ts -t "collects unchanged"`
+Expected: the two behavior-neutral rows (flag + env) may already PASS — collection
+is source-independent, so a `plugin`-tagged collect already drains identically.
+They are the neutral pins (must stay green through the migration), not the driver.
+Proceed to Step 4 regardless.
+
+- [ ] **Step 4: Migrate the construction site (extract helper + read/validate inside withErrorHandling)**
+
+In `packages/cli/src/commands/collect.ts`:
+
+Add the helper imports near the existing imports:
+
+```typescript
+import { resolveActorContext, type ActorIngress } from '../helpers/resolve-actor-context.js';
+import { readActorSourceIngress } from '../helpers/actor-source-option.js';
+```
+
+Add `type ActorContextSource`, `type ClaimRecord`, `type RunId`, and
+`getErrorMessage` to the `@rundown-org/core` import block (`getErrorMessage` is
+barrel-exported via `errors.ts` and already used in
+`packages/cli/src/helpers/wrapper.ts`; see CLAUDE.md Testing Conventions). Remove
+`claimControllerContext` and `trustedRunControllerContext` from that block — they
+become unused once the construction moves into the resolver (keep
+`type ActorContext`).
+
+Add the exported pure ingress helper near the top of the module (module scope,
+not inside the action), with TSDoc mirroring `buildDelegateActorIngress`:
+
+```typescript
+/**
+ * Build the collect command's actor ingress from the resolved source tag and
+ * the optional resolved claim record.
+ *
+ * `collect` threads the FULL ingress: the provenance `source` (when supplied)
+ * PLUS claim evidence (`claimId` / `tokenHash`) when targeting a claimed child
+ * via `--claim-id`. The {@link ClaimRecord} carries `claimId` and `tokenHash`
+ * but has NO `controlledRunId` field (it has `childRunId`) — the controlled run
+ * is the resolved claimed child, so `controlledRunId` defaults to
+ * `targetStateId` (the collect path resolves `ctx.state` to that child).
+ * Exported so the source + claim propagation is unit-testable in isolation
+ * (collection is source-independent, so an end-to-end test cannot observe the
+ * tag).
+ *
+ * @param actorSource - Resolved `--actor-source` / `RD_ACTOR_SOURCE` tag, or undefined
+ * @param claim - Resolved claim record when `--claim-id` targeted a claimed child, else undefined
+ * @param targetStateId - Resolved target run id (`state.id`), used as the claim's `controlledRunId`
+ * @returns An `ActorIngress` carrying `source` iff supplied and claim evidence iff a claim is present
+ */
+export function buildCollectActorIngress(
+  actorSource: ActorContextSource | undefined,
+  claim: ClaimRecord | undefined,
+  targetStateId: RunId,
+): ActorIngress {
+  return {
+    ...(actorSource ? { source: actorSource } : {}),
+    ...(claim
+      ? { claimId: claim.claimId, tokenHash: claim.tokenHash, controlledRunId: targetStateId }
+      : {}),
+  };
+}
+```
+
+The `runCollect` function receives `ctx: TransitionContext`. The Commander
+`Command` is available where `runCollect` is invoked (the `.action` callback);
+thread the resolved source down. Change the `runCollect` signature to accept the
+source:
+
+```typescript
+async function runCollect(
+  ctx: TransitionContext,
+  options: CollectOptions,
+  actorSource: ActorContextSource | undefined,
+): Promise<boolean> {
+```
+
+Replace the inline construction (lines 428-434) with the helper + resolver:
+
+```typescript
+  // Source is provenance only; the claim-vs-no-claim trust decision lives in
+  // resolveActorContext. buildCollectActorIngress threads the source tag plus
+  // claim evidence (claimId / tokenHash / controlledRunId: state.id) when
+  // `ctx.claim` is present — on the claim path `ctx.state` IS the claimed child,
+  // so controlledRunId === state.id; otherwise the trusted run controller maps
+  // the active run's controller to the orchestrator for its own run.
+  const actorContext: ActorContext = resolveActorContext(
+    buildCollectActorIngress(actorSource, ctx.claim, state.id),
+    state,
+  );
+```
+
+In the `.action` callback that calls `runCollect`, read AND validate the source
+inside the existing `withErrorHandling` / `OutputEmitter` block, then pass it
+down. Add the trailing `command: Command` parameter to the collect `.action`
+signature (`Command` is already imported for `registerCollectCommand`), read the
+source right after `const output = new OutputEmitter(...)`, and render an invalid
+value through the JSON envelope rather than letting it throw. The existing call
+site (`const shouldExitWithError = await runCollect(ctx, { ... })`) gains the
+`actorSource` argument:
+
+```typescript
+            let actorSource;
+            try {
+              actorSource = readActorSourceIngress(command);
+            } catch (error: unknown) {
+              // InvalidActorSourceError carries code 'INVALID_ACTOR_SOURCE' and a
+              // human message; render it through the standard JSON envelope.
+              output.error(getErrorMessage(error), 'INVALID_ACTOR_SOURCE');
+              output.flush();
+              process.exitCode = 1;
+              return;
+            }
+            // ... existing claimTarget / buildTransitionContext / ctx logic unchanged ...
+            const shouldExitWithError = await runCollect(
+              ctx,
+              { step: options.step, index: options.index, text: options.text },
+              actorSource,
+            );
+```
+
+> `output` is the `OutputEmitter` already constructed at the top of the collect
+> action, and `getErrorMessage` is the barrel-exported message extractor used in
+> every per-command catch in this plan (already used by the CLI's `wrapper.ts`).
+> The read+validate runs inside `withErrorHandling` so an invalid source renders
+> the standard `INVALID_ACTOR_SOURCE` JSON envelope instead of a raw Commander
+> stderr line (finding 3). There is NO program-level hook validation (Task 3
+> registers the flag capture-only); validation is per-command by design.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/collect-actor-source.test.ts`
+Expected: PASS — `buildCollectActorIngress('plugin', undefined, id)` returns
+`{ source: 'plugin' }`, `buildCollectActorIngress(undefined, undefined, id)`
+returns `{}`, and the claim rows thread `claimId` / `tokenHash` /
+`controlledRunId: id` with and without a source.
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/collect.test.ts`
+Expected: PASS — all pre-existing collect tests, both behavior-neutral rows (flag
++ env), and the `INVALID_ACTOR_SOURCE` envelope row.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/commands/collect.ts \
+        packages/cli/__tests__/commands/collect.test.ts \
+        packages/cli/__tests__/commands/collect-actor-source.test.ts
+git commit -m "feat(cli): build collect actor context via resolveActorContext"
+```
+
+---
+
+## Task 6: Thread the source tag into `pass`/`fail` via core's compatibility lane
+
+**Files:**
+- Modify: `packages/cli/src/helpers/transitions.ts` (`buildTransitionContext`
+  overloads + body: accept an `actorSource` and pass it to
+  `resolveTransitionTarget`)
+- Modify: `packages/cli/src/helpers/transition-command.ts` (read+validate the
+  ingress source via OutputEmitter, pass it into `buildTransitionContext`)
+- Modify: `packages/core/src/runbook/command-target-resolver.ts` (add the narrow
+  `actorContextSource?` option)
+- Test: `packages/cli/__tests__/commands/pass.test.ts` AND
+  `packages/cli/__tests__/commands/fail.test.ts` (symmetric cross-source guard +
+  invalid-source envelope rows — finding 6)
+- Test: `packages/core/__tests__/runbook/command-target-resolver.test.ts`
+  (source-propagation driving test + tag-refinement + cross-source guard)
+
+**Interfaces:**
+- Consumes: `readActorSourceIngress` (Task 2); `trustedRunControllerContext` /
+  `type ActorContextSource` (core); `resolveTransitionTarget`'s new
+  `actorContextSource?` option.
+- Produces: bare `pass`/`fail` carry an accurate `source` tag into core's
+  trusted-controller construction while preserving identical behavior for
+  `direct-cli`. The collection-pending guard remains source-independent.
+
+> **Why through core, not a CLI shadow path:** pass/fail do not pre-resolve the
+> target run in the CLI; core's `resolveTransitionTarget` resolves the target
+> AND (today) synthesizes `trustedRunControllerContext(active.id, 'direct-cli')`
+> when `directCliCompatibility` is set. Re-resolving the target in the CLI just
+> to build the context would duplicate core targeting logic — a forbidden shadow
+> implementation. Instead the CLI supplies the *source tag*, and core builds the
+> trusted-controller context with that tag at its existing choke point. Core's
+> policy and the collection-pending guard are unchanged.
+
+> **The driving test lives in core (finding 5).** The CLI-level guard rows are
+> source-INDEPENDENT, so they pass before the source is threaded and do not drive
+> the change. The test that genuinely FAILS pre-migration is the core unit test
+> in Step 1b: it asserts the constructed trusted-controller context carries
+> `source: 'plugin'` when `actorContextSource: 'plugin'` is passed. Pre-migration,
+> `resolveTransitionTarget` has no `actorContextSource` option, so the test fails
+> to compile/run until the core option is added — that is what TDD-drives the
+> refinement.
+
+- [ ] **Step 1: Write the failing SYMMETRIC CLI guard + envelope rows (pass AND fail)**
+
+Extend the `describe('collection-pending guard', ...)` block in
+**`packages/cli/__tests__/commands/pass.test.ts`** with cross-source rows and an
+invalid-source envelope row:
+
+```typescript
+    it.each(['plugin', 'mcp'] as const)(
+      'still refuses bare pass while pending when source=%s (source never buys past the guard)',
+      async (source) => {
+        await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+        const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
+
+        const result = await runCliInProcess(`--actor-source ${source} pass`, workspace);
+
+        expect(result.exitCode).toBe(1);
+        const payload = JSON.parse(result.stdout) as {
+          code?: string;
+          details?: { outcomeCompletionKeys?: string[] };
+        };
+        expect(payload.code).toBe('DELEGATION_COLLECTION_PENDING');
+        expect(payload.details?.outcomeCompletionKeys).toEqual([completionKey]);
+      },
+    );
+
+    // ENV BRIDGE (finding 7): pass reads the source through a DISTINCT call site
+    // (transition-command.ts) from delegate, so the RD_ACTOR_SOURCE bridge ×
+    // collection-pending guard must be pinned on the pass path too. A
+    // plugin-tagged bare pass still refuses while pending.
+    it('still refuses bare pass while pending when RD_ACTOR_SOURCE=plugin', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess('pass', workspace, {
+        env: { RD_ACTOR_SOURCE: 'plugin' },
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect((JSON.parse(result.stdout) as { code?: string }).code).toBe(
+        'DELEGATION_COLLECTION_PENDING',
+      );
+    });
+
+    it('renders the INVALID_ACTOR_SOURCE envelope on an invalid --actor-source for pass', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+      const result = await runCliInProcess('--actor-source remote pass', workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      // Validate the envelope SHAPE, not just the code (finding 8): an invalid
+      // source renders the standard error envelope via the OutputEmitter.
+      const raw = JSON.parse(result.stdout);
+      expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
+      expect((raw as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
+    });
+```
+
+> Add `ErrorResponseSchema` to the `'../helpers/schema-validator.js'` import at
+> the top of `pass.test.ts` (the file imports `ActionResponseSchema` from there
+> today; `ErrorResponseSchema` is exported from the same module). The
+> `RD_ACTOR_SOURCE` env-bridge row reuses the already-imported
+> `injectDelegationOutcomeForActiveRun`.
+
+Add the SYMMETRIC rows to **`packages/cli/__tests__/commands/fail.test.ts`**
+inside its `describe('collection-pending guard', ...)` block (the INVARIANT is
+"pass AND fail for every source" — finding 6):
+
+```typescript
+    it.each(['plugin', 'mcp'] as const)(
+      'still refuses bare fail while pending when source=%s (source never buys past the guard)',
+      async (source) => {
+        await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+        const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
+
+        const result = await runCliInProcess(`--actor-source ${source} fail`, workspace);
+
+        expect(result.exitCode).toBe(1);
+        const payload = JSON.parse(result.stdout) as {
+          code?: string;
+          details?: { outcomeCompletionKeys?: string[] };
+        };
+        expect(payload.code).toBe('DELEGATION_COLLECTION_PENDING');
+        expect(payload.details?.outcomeCompletionKeys).toEqual([completionKey]);
+      },
+    );
+
+    // ENV BRIDGE (finding 7): symmetric with pass — fail also reads the source
+    // through transition-command.ts, so pin the RD_ACTOR_SOURCE bridge ×
+    // collection-pending guard on the fail path too.
+    it('still refuses bare fail while pending when RD_ACTOR_SOURCE=plugin', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess('fail', workspace, {
+        env: { RD_ACTOR_SOURCE: 'plugin' },
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect((JSON.parse(result.stdout) as { code?: string }).code).toBe(
+        'DELEGATION_COLLECTION_PENDING',
+      );
+    });
+
+    it('renders the INVALID_ACTOR_SOURCE envelope on an invalid --actor-source for fail', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+      const result = await runCliInProcess('--actor-source remote fail', workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      // Validate the envelope SHAPE, not just the code (finding 8).
+      const raw = JSON.parse(result.stdout);
+      expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
+      expect((raw as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
+    });
+```
+
+> Add `ErrorResponseSchema` to the `'../helpers/schema-validator.js'` import at
+> the top of `fail.test.ts` (the file imports `ActionResponseSchema` /
+> `WarningResponseSchema` from there today; `ErrorResponseSchema` is exported
+> from the same module).
+
+> `injectDelegationOutcomeForActiveRun` is already imported in both
+> `pass.test.ts` and `fail.test.ts` (see their existing `collection-pending
+> guard` blocks). The guard rows are source-independent and may already pass; the
+> invalid-source envelope rows FAIL until Step 4 wires read+validate.
+
+- [ ] **Step 1b: Write the failing core source-propagation driving test**
+
+The genuine driver is a direct unit test of the EXPORTED
+`buildTransitionActorContext` helper that Step 3 extracts from
+`command-target-resolver.ts` (a pure function — no module-spy fragility under
+`isolatedModules`). Add to
+`packages/core/__tests__/runbook/command-target-resolver.test.ts`:
+
+```typescript
+// Extend the file's EXISTING imports — do NOT add a fresh import block.
+// `resolveTransitionTarget` is already imported from command-target-resolver.js
+// and re-importing it is a duplicate binding. Add `buildTransitionActorContext`
+// to that existing block, and add `RunId` to the existing types.js type import
+// (RunId is re-exported from types.js):
+//   import {
+//     type CommandTargetReader,
+//     buildTransitionActorContext,   // ← add
+//     resolveCommandTarget,
+//     resolveTransitionTarget,
+//   } from '../../src/runbook/command-target-resolver.js';
+//   import type { Runbook, RunbookState, RunId, Step } from '../../src/runbook/types.js'; // ← add RunId
+
+  it('buildTransitionActorContext tags the trusted controller with the source', () => {
+    const id = 'run_active' as RunId;
+    expect(buildTransitionActorContext(id, { actorContextSource: 'plugin' })).toEqual({
+      kind: 'trusted_run_controller',
+      runId: id,
+      source: 'plugin',
+    });
+    expect(buildTransitionActorContext(id, { directCliCompatibility: true })).toEqual({
+      kind: 'trusted_run_controller',
+      runId: id,
+      source: 'direct-cli',
+    });
+    expect(buildTransitionActorContext(id, {})).toEqual({ kind: 'unknown' });
+  });
+```
+
+> This fails to import (`buildTransitionActorContext` does not exist) before Step
+> 3 — that is the driving failure. It proves the source PROPAGATES into the
+> constructed context (a `plugin` tag yields `source: 'plugin'`), which the
+> source-independent CLI guard rows cannot prove. The same assertion is repeated
+> as the canonical helper test in Step 3b; keep it in one place (here) and have
+> Step 3b reference it rather than duplicating.
+
+- [ ] **Step 2: Run the new tests to verify the drivers fail**
+
+Run: `pnpm --filter @rundown-org/core exec jest __tests__/runbook/command-target-resolver.test.ts -t "buildTransitionActorContext tags the trusted controller with the source"`
+Expected: FAIL (compile or runtime) — `actorContextSource` is not yet an option
+on `resolveTransitionTarget`. THIS is the driving failure.
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/pass.test.ts __tests__/commands/fail.test.ts -t "INVALID_ACTOR_SOURCE"`
+Expected: FAIL — pass/fail do not yet read/validate the source, so an invalid
+value is silently ignored (no envelope). The cross-source guard rows may already
+pass (source-independent) and must stay green.
+
+- [ ] **Step 3: Thread `actorSource` through `buildTransitionContext`**
+
+In `packages/cli/src/helpers/transitions.ts`:
+
+Add `type ActorContextSource` to the `@rundown-org/core` import block (the file
+already imports `ClaimRecord`, `RunbookState`, etc.). Do NOT import
+`trustedRunControllerContext` here: the CLI change below only forwards
+`actorContextSource` to `resolveTransitionTarget` (core builds the
+`trustedRunControllerContext` internally, once it has resolved `active.id`), so
+importing it into `transitions.ts` would be an unused binding that fails
+lint/type checks.
+
+Update the `buildTransitionContext` pass/fail overload and implementation to
+accept an optional `actorSource`:
+
+```typescript
+export function buildTransitionContext(
+  output: OutputEmitter,
+  cwd: string,
+  options: {
+    readonly command: 'pass' | 'fail';
+    readonly claimId?: ClaimId;
+    readonly step?: string;
+    readonly actorSource?: ActorContextSource;
+  },
+): Promise<BuildTransitionContextResult>;
+```
+
+(Leave the base overload — `options?: { readonly claimId?: ClaimId }` — as-is;
+the collect path does not use this function for actor tagging.)
+
+In the implementation signature, add `actorSource` to the destructured options
+type:
+
+```typescript
+  options: {
+    readonly command?: 'pass' | 'fail';
+    readonly claimId?: ClaimId;
+    readonly step?: string;
+    readonly actorSource?: ActorContextSource;
+  } = {},
+```
+
+In the `if (options.command !== undefined)` branch, replace the
+`resolveTransitionTarget` call so it passes an explicit `actorContext` built
+from the source tag instead of relying solely on `directCliCompatibility`:
+
+```typescript
+    const active = await resolveTransitionTarget(sessionService, {
+      command: options.command,
+      claimId: options.claimId,
+      targeted: options.step !== undefined,
+      // Supply the source-tagged trusted-controller context only for the
+      // default (non-claim) target; core resolves the active run id and the
+      // bare advance is the only path that evaluates actor context. When an
+      // explicit source is absent, fall back to the direct-cli compatibility
+      // lane so behavior is byte-identical to before.
+      ...(options.actorSource && options.claimId === undefined
+        ? { actorContextSource: options.actorSource }
+        : { directCliCompatibility: true }),
+    });
+```
+
+> **Core touch point.** `resolveTransitionTarget` currently accepts
+> `actorContext?: ActorContext` and `directCliCompatibility?: boolean`, building
+> `trustedRunControllerContext(active.id, 'direct-cli')` for the latter. Passing
+> a fully-formed `actorContext` from the CLI is impossible here because the CLI
+> does not know `active.id` until core resolves it. Therefore add one narrow
+> option to core's `ResolveTransitionTargetOptions`:
+> `readonly actorContextSource?: ActorContextSource;` and extract the
+> context-construction (currently the inline expression at
+> `command-target-resolver.ts:327-331`) into a small EXPORTED helper so it is
+> unit-testable in isolation (this is what Step 1b's preferred driving test
+> targets):
+>
+> ```typescript
+> /**
+>  * Build the actor context a default-target transition presents to policy.
+>  *
+>  * Provenance-only refinement of the direct-CLI compatibility lane: an explicit
+>  * `actorContextSource` tags the trusted run controller; otherwise
+>  * `directCliCompatibility` yields the `direct-cli` tag; neither yields unknown.
+>  *
+>  * @param activeId - Resolved default-target run id
+>  * @param options - Source tag / compatibility / explicit-context flags
+>  * @returns The actor context for the bare-advance policy check
+>  */
+> export function buildTransitionActorContext(
+>   activeId: RunId,
+>   options: {
+>     readonly actorContext?: ActorContext;
+>     readonly actorContextSource?: ActorContextSource;
+>     readonly directCliCompatibility?: boolean;
+>   },
+> ): ActorContext {
+>   if (options.actorContext) return options.actorContext;
+>   if (options.actorContextSource) {
+>     return trustedRunControllerContext(activeId, options.actorContextSource);
+>   }
+>   if (options.directCliCompatibility) {
+>     return trustedRunControllerContext(activeId, 'direct-cli');
+>   }
+>   return UNKNOWN_ACTOR_CONTEXT;
+> }
+> ```
+>
+> Then replace the inline `const actorContext = ...` at lines 327-331 with
+> `const actorContext = buildTransitionActorContext(active.id, options);`. This
+> is a tag-only refinement of the *existing* compatibility mapping, not new
+> policy: role derivation and the collection-pending guard are untouched, so the
+> INVARIANT is preserved by construction. `command-target-resolver.ts` already
+> imports `UNKNOWN_ACTOR_CONTEXT`, `trustedRunControllerContext`, and `RunId`
+> (lines 1-9); the only new import this edit adds is `type ActorContextSource`
+> (add it to the existing import block from `./actor-context.js`, alongside
+> `ActorContext`).
+
+- [ ] **Step 3b: Pin the resolver outcome is source-independent (core unit tests)**
+
+Add to `packages/core/__tests__/runbook/command-target-resolver.test.ts` the
+outcome-level pins (separate from Step 1b's source-propagation driver): the
+source tag must not change the *outcome*, and the collection-pending refusal must
+fire for any source. Use the file's existing `fakeReader({ ... })` factory (it
+returns a `CommandTargetReader`); the pending-collection fixture mirrors the
+`pendingParent` construction in the existing `'refuses a bare transition when a
+delegated outcome is waiting for collection'` test.
+
+```typescript
+  it('tags the trusted controller with actorContextSource without changing the outcome', async () => {
+    const resolved = await resolveTransitionTarget(
+      fakeReader({ active: parent, openClaims: [] }),
+      { command: 'pass', actorContextSource: 'plugin' },
+    );
+    // `parent` has no pending delegated outcome, so the resolution is the
+    // default active-run target — the source tag must not alter that.
+    expect(resolved.kind).toBe('default');
+  });
+
+  it('keeps the collection-pending refusal for any source', async () => {
+    // Stage a pending delegated outcome exactly as the existing
+    // collection-pending test does, then assert the refusal regardless of source.
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const pendingParent = {
+      ...parent,
+      step: '1',
+      substep: '1',
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      frameEntryCounts: { [buildFrameKey('1')]: 1 },
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    } as RunbookState;
+    const resolved = await resolveTransitionTarget(
+      fakeReader({ active: pendingParent, openClaims: [] }),
+      { command: 'pass', actorContextSource: 'mcp' },
+    );
+    expect(resolved.kind).toBe('delegation_collection_pending');
+  });
+```
+
+The direct `buildTransitionActorContext` helper unit test (the source-propagation
+DRIVER) is already written in Step 1b — do not duplicate it here. These two
+outcome-level pins are additive: together with the Step 1b helper test they cover
+construction (source tag present), outcome-neutrality (source does not change the
+resolution), and the cross-source guard.
+
+> Both pins reuse the file's existing `fakeReader({ ... })` factory (which
+> returns a `CommandTargetReader` backed by `getActive`,
+> `getActiveForClaimId`, `listOpenClaimsForParent`); there are no
+> `makeReaderWith*` helpers in that file. The pending-collection fixture is a
+> verbatim copy of the `pendingParent` setup in the existing `'refuses a bare
+> transition when a delegated outcome is waiting for collection'` test, so the
+> `buildCompletionKey` / `activeFrame` / `buildFrameKey` / `buildResolvedCompletion`
+> imports it relies on are already present in the test file.
+
+- [ ] **Step 4: Read the source in `transition-command.ts` and forward it**
+
+In `packages/cli/src/helpers/transition-command.ts`:
+
+Add the import:
+
+```typescript
+import { readActorSourceIngress } from './actor-source-option.js';
+```
+
+Commander passes the `Command` as the final action argument. Update the action
+signature to capture it and read the source, then forward it to
+`buildTransitionContext`:
+
+Commander invokes the action callback with `(options, command)` for pass/fail
+(no positional args). Capture `command`, then read+validate the source inside
+`withErrorHandling`, rendering an invalid value through the `OutputEmitter` JSON
+envelope (finding 3 — there is NO hook validation; each command validates):
+
+```typescript
+    .action(
+      async (
+        options: { step?: string; index?: string; claimId?: string; text?: boolean },
+        command: Command,
+      ) => {
+        await withErrorHandling(
+          async () => {
+            const output = new OutputEmitter({ text: options.text, command: def.name });
+
+            let actorSource;
+            try {
+              actorSource = readActorSourceIngress(command);
+            } catch (error: unknown) {
+              output.error(getErrorMessage(error), 'INVALID_ACTOR_SOURCE');
+              output.flush();
+              process.exitCode = 1;
+              return;
+            }
+            // ... existing depError / cwd / claimTarget logic unchanged ...
+            const contextResult = await buildTransitionContext(output, cwd, {
+              command: def.name,
+              claimId: claimTarget.claimId,
+              step: options.step,
+              ...(actorSource ? { actorSource } : {}),
+            });
+```
+
+> `Command` is already imported in `transition-command.ts` (`import type {
+> Command } from 'commander'`). `transition-command.ts` imports NOTHING from
+> `@rundown-org/core` today (only commander and local `.js` modules), so add a
+> NEW import line — `import { getErrorMessage } from '@rundown-org/core';`
+> (barrel-exported; already used by `wrapper.ts`) — rather than extending a
+> non-existent core import block. The read+validate runs
+> inside `withErrorHandling` so an invalid source renders the standard
+> `INVALID_ACTOR_SOURCE` JSON envelope instead of a raw Commander stderr line.
+> There is NO program-level hook validation (Task 3 registers the flag
+> capture-only); validation is per-command by design.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/pass.test.ts __tests__/commands/fail.test.ts`
+Expected: PASS — pre-existing pass/fail tests, the symmetric cross-source guard
+rows, and both `INVALID_ACTOR_SOURCE` envelope rows; `direct-cli` behavior
+unchanged.
+
+Run: `pnpm --filter @rundown-org/core exec jest __tests__/runbook/command-target-resolver.test.ts`
+Expected: PASS — the `buildTransitionActorContext` driver, the outcome-level
+tag-refinement, and the cross-source guard tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/helpers/transitions.ts \
+        packages/cli/src/helpers/transition-command.ts \
+        packages/core/src/runbook/command-target-resolver.ts \
+        packages/core/__tests__/runbook/command-target-resolver.test.ts \
+        packages/cli/__tests__/commands/pass.test.ts \
+        packages/cli/__tests__/commands/fail.test.ts
+git commit -m "feat(cli): tag pass/fail actor source via core compatibility lane"
+```
+
+---
+
+## Task 7: Record construction-free status for `complete` / `stop` / `claim`
+
+**Files:**
+- Modify: `packages/cli/src/commands/complete.ts` (one-line rationale comment)
+- Modify: `packages/cli/src/commands/stop.ts` (one-line rationale comment)
+- Modify: `packages/cli/src/commands/claim.ts` (one-line rationale comment)
+
+**Interfaces:**
+- Consumes: nothing new at runtime.
+- Produces: in-code documentation that these commands intentionally construct no
+  `ActorContext` (they invoke no actor-context-gated core policy), so a future
+  reader does not "complete" the migration by adding dead context.
+
+> No behavior change and no new policy. This task exists so the frozen brief's
+> command list (`complete`, `stop`, `claim`) is explicitly addressed: each is
+> recorded as construction-free with a pointer to the shared helpers for any
+> future actor-gated need. No test is added because there is no behavior to pin;
+> the existing command tests continue to pass unchanged.
+
+- [ ] **Step 1: Add the rationale comment to `complete.ts`**
+
+In `packages/cli/src/commands/complete.ts`, immediately inside the `.action`
+body (after `const output = ...`), add:
+
+```typescript
+          // Actor-context ingress (Plan: cli-actor-context-ingress): `complete`
+          // is a workflow-level force-terminal override and the narrow
+          // --claim-id force path; it invokes no actor-context-gated core policy
+          // (no resolveCommandIntent / resolveTransitionTarget), so it
+          // constructs no ActorContext. A future actor-gated force-terminal
+          // policy would consume readActorSourceIngress + resolveActorContext.
+```
+
+- [ ] **Step 2: Add the rationale comment to `stop.ts`**
+
+In `packages/cli/src/commands/stop.ts`, immediately inside the `.action` body
+(after `const output = ...`), add the same rationale comment, replacing
+`complete` with `stop`:
+
+```typescript
+          // Actor-context ingress (Plan: cli-actor-context-ingress): `stop` is a
+          // workflow-level force-terminal override and the narrow --claim-id
+          // force path; it invokes no actor-context-gated core policy, so it
+          // constructs no ActorContext. A future actor-gated force-terminal
+          // policy would consume readActorSourceIngress + resolveActorContext.
+```
+
+- [ ] **Step 3: Add the rationale comment to `claim.ts`**
+
+In `packages/cli/src/commands/claim.ts`, immediately inside the `.action` body
+(after `const output = ...`), add:
+
+```typescript
+            // Actor-context ingress (Plan: cli-actor-context-ingress): `claim`
+            // launches a NEW child run (claimAndLaunch); it is not a
+            // target-relative mutation against an existing run and invokes no
+            // actor-context-gated core policy, so it constructs no ActorContext.
+            // A future need would consume readActorSourceIngress +
+            // resolveActorContext.
+```
+
+- [ ] **Step 4: Verify the three commands still pass their tests**
+
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/complete.test.ts __tests__/commands/stop.test.ts __tests__/commands/claim.test.ts`
+Expected: PASS (comment-only change; no behavior difference).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/commands/complete.ts \
+        packages/cli/src/commands/stop.ts \
+        packages/cli/src/commands/claim.ts
+git commit -m "docs(cli): record complete/stop/claim as actor-context construction-free"
+```
+
+---
+
+## Task 8: Full-suite verification gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Lint and type-check the changed packages**
+
+Run:
+```bash
+pnpm run check:lint:typed
+```
+Expected: PASS (no `any`, no unused imports left from removed inline
+constructors, TSDoc present on new exports).
+
+- [ ] **Step 2: Run the CLI and core unit suites**
+
+Run:
+```bash
+pnpm --filter @rundown-org/cli test
+pnpm --filter @rundown-org/core test
+```
+Expected: PASS.
+
+- [ ] **Step 3: Run the full pre-PR verify gate**
+
+Run:
+```bash
+pnpm run verify
+```
+Expected: PASS (format, spell, lint, test). Fix any spell-check additions for
+new identifiers (e.g. add `RD_ACTOR_SOURCE` to the dictionary if the spell check
+flags it) before declaring done.
+
+- [ ] **Step 4: Commit any verify-driven fixes**
+
+```bash
+git add -A
+git commit -m "chore(cli): verify gate fixes for actor-context ingress"
+```
+
+---
+
+## Produces — interface block for Plans 6 & 7
+
+Plans 6 (plugin) and 7 (MCP) **consume** exactly these, from this precursor.
+List this precursor as a prerequisite.
+
+```typescript
+// packages/cli/src/helpers/resolve-actor-context.ts
+export interface ActorIngress {
+  readonly source?: ActorContextSource;        // from --actor-source / RD_ACTOR_SOURCE; defaults to 'direct-cli'
+  readonly claimId?: ClaimId;                  // from --claim-id (existing plumbing)
+  readonly tokenHash?: DelegationTokenHash;    // from existing claim-evidence plumbing
+  readonly controlledRunId?: RunId;            // resolved claimed run id; defaults to state.id
+}
+
+export function resolveActorContext(ingress: ActorIngress, state: RunbookState): ActorContext;
+
+export const ACTOR_SOURCE_VALUES: readonly ActorContextSource[];           // ['direct-cli','plugin','mcp']
+export function parseActorSource(raw: string): ActorContextSource;         // throws InvalidActorSourceError
+export class InvalidActorSourceError extends Error {
+  readonly code: 'INVALID_ACTOR_SOURCE';
+  readonly value: string;
+}
+
+// packages/cli/src/helpers/actor-source-option.ts
+export interface ActorSourceReader { optsWithGlobals(): { actorSource?: string } }
+export function readActorSourceIngress(
+  command: ActorSourceReader,
+  env?: NodeJS.ProcessEnv,
+): ActorContextSource | undefined;             // flag wins over env; undefined when neither set
+```
+
+CLI surface produced (Plans 6/7 set these on the `rd` invocations they drive):
+
+- Program-level flag: `--actor-source <direct-cli|plugin|mcp>`
+- Env bridge: `RD_ACTOR_SOURCE=<direct-cli|plugin|mcp>` (flag wins; invalid value
+  is a hard error with code `INVALID_ACTOR_SOURCE`, never a silent default)
+
+**Plan 6 (plugin)** sets `RD_ACTOR_SOURCE=plugin` only in the environment of
+plugin-helper-spawned `rd` calls through the plugin `rundown()` helper. Agent-run
+Bash lifecycle commands are not routed through that helper and do not become
+`source=plugin` by this plan. No policy logic lives in the plugin.
+
+**Plan 7 (MCP)** prepends `--actor-source mcp` to the spawned CLI argv in
+`buildRundownCommand`; it does not mutate the MCP server environment. MCP
+threads `--claim-id` only for tools whose CLI command supports claim targeting
+and otherwise relies on this precursor's trusted-controller provenance. No
+policy logic lives in MCP. One-line note in that plan: the trusted-controller
+mapping assumes stdio-local; revisit if a remote transport is ever wired.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (frozen brief "Precursor PRODUCES" + scope bullets + the
+7 external-review findings):
+
+| Brief / finding requirement | Task |
+| --- | --- |
+| `resolve-actor-context.ts` exporting `ActorIngress` + `resolveActorContext` implementing the frozen table | Task 1 |
+| `--actor-source` program option (capture-only) + `RD_ACTOR_SOURCE` env bridge; flag precedence; invalid = hard error rendered as JSON envelope | Tasks 2 (reader), 3 (capture-only registration), 4/5/6 (per-command validation) |
+| Centralize `collect.ts` | Task 5 |
+| Centralize `delegate.ts` — provenance source only (NO claim path; delegate has no `--claim-id`) [finding 1] | Task 4 |
+| Wire source into `pass` AND `fail` symmetrically [finding 6] | Task 6 |
+| Address `complete`/`stop`/`claim` (construction-free, recorded; WHY = no actor-context-gated core path) | Task 7 |
+| INVARIANT: collection-pending guard refuses bare pass/fail/delegate for EVERY source | Task 4 (delegate rows, `setupAutoIssuedDelegation` fixture [finding 4]), Task 6 (pass AND fail rows + core unit) |
+| Source-PROPAGATION driving test that fails before source is threaded [finding 5] | Task 4 (`buildDelegateActorIngress` unit test), Task 5 (`buildCollectActorIngress` unit test — source + claim evidence), Task 6 (`buildTransitionActorContext` unit test) — all pure exported helpers, no fragile module spy under `isolatedModules` |
+| Invalid source renders `INVALID_ACTOR_SOURCE` JSON envelope via OutputEmitter, NOT a hook throw / stderr [findings 2+3] | Tasks 4, 5, 6 (per-command try/catch → `output.error`); Task 3 registers capture-only, no hook validation |
+| Resolver can produce `unknown` (type-complete, no default path) | Task 1 (rows 5/5b) |
+| Resolver precedence pin: claim WINS over a non-`direct-cli` source when claim evidence is present | Task 1 (row 4 plugin + MCP source rows) |
+| Property layer: `resolve-actor-context.properties.test.ts` (6 properties) pins `resolveActorContext` / `parseActorSource` invariants — totality / valid-kind closure, `claim_controller` iff `claimId && tokenHash`, source-never-on-claim, `?? 'direct-cli'` + `?? state.id` defaults, `parseActorSource` round-trip / rejection | Task 1 |
+| CROSS-PLAN PIN (Plan 7): `--actor-source` parsed PRE-subcommand + advertised at program level | Task 3 (program-level token + `--help` pins) |
+| No verification claims against superseded spec / absent docs [finding 7] | Architecture note states authority = live code + frozen brief; absent docs named as non-existent |
+| TSDoc on new exports | Tasks 1, 2, 6 (`buildTransitionActorContext`) |
+| JSON output contract unchanged | Only ADDS the `INVALID_ACTOR_SOURCE` error code via the standard `output.error` envelope; no existing envelope edited |
+| No persisted-state migration | No persisted field touched in any task |
+
+**2. Placeholder scan:** No "TBD"/"implement later"/"add error handling"/"write
+tests for the above"/"similar to Task N" remain. Every code step shows complete
+code, including the per-command validation try/catch (Tasks 4/5/6), the extracted
+`buildTransitionActorContext` helper with full TSDoc (Task 6 Step 3), and the
+spy/helper driving tests (Tasks 4/5/6). The Task 4 Step-1 verification grep was
+removed; the delegate surface is now stated as fact (no `--claim-id`, source-tag
+fix only — finding 1). The remaining "if X, model on Y" notes (Task 4 Step 6,
+Task 6 Step 1b fallback) point at named existing fixtures, not hand-waving.
+
+**3. Type consistency:** Names are stable across tasks: `ActorIngress`,
+`resolveActorContext`, `ACTOR_SOURCE_VALUES`, `parseActorSource`,
+`InvalidActorSourceError` (Task 1) are imported under those exact names in Tasks
+4, 5, 6. `readActorSourceIngress` / `ActorSourceReader` (Task 2) are imported
+under those names in Tasks 4, 5, 6. The core option is `actorContextSource` in
+the CLI call (Task 6 Step 3) and the core resolver edit (Task 6 Step 3 + 3b), and
+the extracted helper is `buildTransitionActorContext` in both its definition
+(Step 3) and its unit test (Step 3b). `getErrorMessage` (barrel-exported from
+core via `errors.ts`, already used in `wrapper.ts`) is the error-message
+extractor in every per-command catch. `ingress.controlledRunId ?? state.id`
+(Task 1 impl) matches the "defaults to state.id" claim in the Produces block and
+the collect call site (Task 5). The resolver's claim branch keys on `claimId &&
+tokenHash` (Task 1) and is fed `ctx.claim.claimId` / `ctx.claim.tokenHash`
+(Task 5) — consistent with the `ClaimRecord` fields surfaced on the collect path
+(`transitions.ts:171`). delegate threads NO claim evidence (it has no
+`--claim-id`), so its `ActorIngress` is `{ source? }` only — consistent between
+the File Structure note, the design note, and Task 4 Step 4.

--- a/docs/superpowers/specs/2026-06-27-core-hosted-actor-context-resolver.md
+++ b/docs/superpowers/specs/2026-06-27-core-hosted-actor-context-resolver.md
@@ -1,0 +1,577 @@
+# Core-Hosted Actor-Context Resolver
+
+- **Date:** 2026-06-27
+- **Status:** Proposed
+- **Supersedes (partially):** the two-helper split introduced by
+  `docs/superpowers/plans/2026-06-26-cli-actor-context-ingress.md` (Tasks 1, 5,
+  6). This spec is prospective and write-once; it does not edit that plan. A
+  follow-up plan consumes this spec.
+
+## Problem statement
+
+The CLI actor-context ingress plan claims to implement a "single frozen
+trust-mapping table," but the table is realised in **two** functions in **two**
+packages with **deliberately divergent defaults**: a CLI
+`resolveActorContext(ingress, state)` (claim path + `direct-cli` default;
+consumed by `collect`/`delegate`, which pre-resolve their target in the CLI) and
+a core `buildTransitionActorContext(activeId, options)` (no claim path,
+`unknown` default; consumed by `pass`/`fail`, whose target is resolved inside
+core's `resolveTransitionTarget`). Neither leaks policy — both only call the core
+constructors `trustedRunControllerContext` / `claimControllerContext` /
+`UNKNOWN_ACTOR_CONTEXT` — but the evidence→`ActorContext` mapping must now be
+changed in lockstep across a package boundary. Any future row added to the table
+(a new source, a new claim shape) must be edited twice and kept consistent by
+convention. This spec designs the unified, **core-hosted** mapping: one function
+in `@rundown-org/core` that both the pre-resolved-target callers
+(`collect`/`delegate`) and the core-resolves-target callers (`pass`/`fail`)
+funnel through.
+
+This is consistent with CLAUDE.md's architectural principles. The
+evidence→`ActorContext` mapping is part of the runbook program's authorization
+model (it produces the typed evidence that core's `resolveCommandIntent` /
+`deriveEffectiveRole` consume), so it belongs in core. The CLI's job — reading a
+flag and an env var and rendering an error envelope — is Category A (genuinely
+external/CLI: env-var reads, flag reads, stdout rendering) and stays in the CLI.
+
+---
+
+## 1. Current state (as the plan stands)
+
+### 1.1 The shared domain types (core, already exist)
+
+`packages/core/src/runbook/actor-context.ts` is the single source of truth for
+the union and constructors. Verified shapes:
+
+```typescript
+// actor-context.ts:6
+export type ActorContextSource = 'direct-cli' | 'plugin' | 'mcp';
+
+// actor-context.ts:9-31
+export type ActorContext =
+  | { readonly kind: 'trusted_run_controller'; readonly runId: RunId; readonly source: ActorContextSource }
+  | { readonly kind: 'claim_controller'; readonly claimId: ClaimId; readonly tokenHash: DelegationTokenHash; readonly controlledRunId: RunId }
+  | { readonly kind: 'unknown' };
+
+// actor-context.ts:48
+export const UNKNOWN_ACTOR_CONTEXT: ActorContext = { kind: 'unknown' };
+
+// actor-context.ts:57-62
+export function trustedRunControllerContext(runId: RunId, source: ActorContextSource): ActorContext;
+
+// actor-context.ts:73-84
+export function claimControllerContext(input: {
+  readonly claimId: ClaimId;
+  readonly tokenHash: DelegationTokenHash;
+  readonly controlledRunId: RunId;
+}): ActorContext;
+```
+
+Note `claim_controller` has **no `source` field** — a claim controller is
+identified by `claimId`/`tokenHash`/`controlledRunId`, never by a provenance
+tag. The evidence a CLI claim caller holds is the `ClaimRecord`
+(`packages/core/src/runbook/claim-id.ts:19-27`): `claimId`, `childRunId`,
+`tokenHash` — **not** `controlledRunId` (the resolver derives that from the
+resolved target id).
+
+### 1.2 Helper A — CLI `resolveActorContext` (planned)
+
+`docs/.../2026-06-26-cli-actor-context-ingress.md` Task 1 creates
+`packages/cli/src/helpers/resolve-actor-context.ts` exporting
+`resolveActorContext(ingress: ActorIngress, state: RunbookState): ActorContext`.
+Its table (plan lines 476-495):
+
+- `claimId && tokenHash` present → `claimControllerContext({ claimId, tokenHash, controlledRunId: ingress.controlledRunId ?? state.id })`.
+- exactly one of `claimId`/`tokenHash` → `UNKNOWN_ACTOR_CONTEXT`.
+- otherwise → `trustedRunControllerContext(state.id, ingress.source ?? 'direct-cli')`.
+
+The **default is `direct-cli`.** It is consumed by `collect`
+(`packages/cli/src/commands/collect.ts:428-434`, currently inline
+`ctx.claim ? claimControllerContext(...) : trustedRunControllerContext(state.id, 'direct-cli')`)
+and by `delegate` (`packages/cli/src/commands/delegate.ts:132-133`, currently
+inline `trustedRunControllerContext(state.id, 'direct-cli')`). Both commands
+**pre-resolve their `RunbookState`** in the CLI, so they hold a target and can
+call a `(ingress, state)` mapping directly.
+
+### 1.3 Helper B — core `buildTransitionActorContext` (planned)
+
+Task 6 extracts a helper from the inline expression already present at
+`packages/core/src/runbook/command-target-resolver.ts:327-331`:
+
+```typescript
+const actorContext =
+  options.actorContext ??
+  (options.directCliCompatibility
+    ? trustedRunControllerContext(active.id, 'direct-cli')
+    : UNKNOWN_ACTOR_CONTEXT);
+```
+
+into an exported `buildTransitionActorContext(activeId, { actorContext?, actorContextSource?, directCliCompatibility? })`.
+Its table:
+
+- explicit `actorContext` → passthrough.
+- `actorContextSource` → `trustedRunControllerContext(activeId, source)`.
+- `directCliCompatibility` → `trustedRunControllerContext(activeId, 'direct-cli')`.
+- otherwise → `UNKNOWN_ACTOR_CONTEXT`.
+
+There is **no claim path** (pass/fail's claim targeting is handled earlier in
+`resolveTransitionTarget`, lines 281-316, before the bare-advance branch that
+needs an actor context). The **default is `unknown`.** It is reached only from
+inside `resolveTransitionTarget` (`command-target-resolver.ts`,
+`ResolveTransitionTargetOptions`, lines 117-141), because `pass`/`fail` do
+**not** pre-resolve their target in the CLI — core resolves `active.id` at one
+choke point and constructs the context there. The CLI only supplies the `source`
+tag, threaded down via the new `actorContextSource?` option.
+
+### 1.4 The drift
+
+The two helpers encode the **same evidence→context table** with two
+intentional differences:
+
+| Axis | CLI `resolveActorContext` | core `buildTransitionActorContext` |
+| --- | --- | --- |
+| Claim path | yes (`claimId && tokenHash`) | no |
+| Trusted-controller source | `ingress.source ?? 'direct-cli'` | `actorContextSource` / `'direct-cli'` via `directCliCompatibility` |
+| No-evidence default | `direct-cli` (trusted) | `unknown` (strict) |
+| Target known at call time | yes (pre-resolved `state`) | no (core resolves `active.id`) |
+
+A change to the source→trust mapping — e.g. "a fourth source `remote` must map
+to `unknown` unless a claim is present" — would have to be made in both files,
+kept consistent across a package boundary, and re-tested in two suites. That is
+exactly the duplication this spec removes.
+
+---
+
+## 2. Proposed design
+
+### 2.1 One table, in core
+
+Host the evidence→`ActorContext` mapping as a single public function in core,
+co-located with the union and constructors it produces. The two caller classes
+funnel through it; nobody else implements the table.
+
+**New, in `packages/core/src/runbook/actor-context.ts`** (re-exported from
+`packages/core/src/runbook/index.ts`, the barrel that already exports
+`trustedRunControllerContext` / `claimControllerContext` /
+`UNKNOWN_ACTOR_CONTEXT` / `ActorContextSource`):
+
+```typescript
+/**
+ * Caller evidence assembled before core maps it to an {@link ActorContext}.
+ *
+ * All fields optional. Evidence only — no provenance policy, no defaults:
+ * an absent `source` maps to `unknown`, never to a trusted controller. The
+ * "a bare local CLI call is direct-cli" default is a front-end concern and is
+ * applied by the CLI ingress reader, not by this type (see § 2.3).
+ */
+export interface ActorIngress {
+  /** Provenance tag (`--actor-source` / `RD_ACTOR_SOURCE` / integration argv). */
+  readonly source?: ActorContextSource;
+  /** Claim id when acting on a claimed delegated run. */
+  readonly claimId?: ClaimId;
+  /** Token hash bound to the claim (from the resolved `ClaimRecord`). */
+  readonly tokenHash?: DelegationTokenHash;
+  /** Controlled run id; defaults to the resolved target id when omitted. */
+  readonly controlledRunId?: RunId;
+}
+
+/**
+ * Map caller ingress + a resolved target run id to an {@link ActorContext}.
+ *
+ * The single source of truth for the evidence→context table:
+ * - `claimId` AND `tokenHash` present  → `claim_controller` (source ignored;
+ *   `controlledRunId` defaults to `targetRunId`).
+ * - exactly one of `claimId`/`tokenHash` → `unknown` (contradictory evidence).
+ * - a `source` present, no claim         → `trusted_run_controller(targetRunId, source)`.
+ * - no source, no claim                  → `unknown` (strict default).
+ *
+ * Role derivation against the target stays in `deriveEffectiveRole`; this
+ * function only records typed evidence.
+ *
+ * @param ingress - Caller evidence
+ * @param targetRunId - Resolved run the caller is acting on
+ * @returns The constructed actor context
+ */
+export function resolveActorContext(ingress: ActorIngress, targetRunId: RunId): ActorContext;
+```
+
+Two deliberate refinements over the plan's CLI version:
+
+1. **Second argument is `RunId`, not `RunbookState`.** The mapping reads only
+   `.id`; the plan's CLI version takes the whole `RunbookState` and stubs it in
+   tests as `{ id } as unknown as RunbookState`. Narrowing the input removes the
+   stub and matches the call shape on both sides (`collect`/`delegate` pass
+   `state.id`; `resolveTransitionTarget` passes `active.id`).
+2. **No-evidence default is `unknown`,** matching the strict-core semantics that
+   `pass`/`fail` already depend on. The `direct-cli` compatibility default is
+   relocated to the CLI ingress boundary (§ 2.3), where it actually belongs.
+
+This makes the `unknown` context **reachable by type but never a CLI default**
+(the Global Constraint "`unknown` is reachable by type, not by default" from the
+source plan): `resolveActorContext({}, id)` returns `unknown`, but no CLI path
+produces an empty ingress (§ 2.3).
+
+### 2.2 `resolveTransitionTarget` calls the shared function
+
+`buildTransitionActorContext` is **deleted from the plan.** Instead,
+`command-target-resolver.ts` calls the shared core function at its existing
+choke point. The inline expression at lines 327-331 becomes:
+
+```typescript
+const actorContext = resolveActorContext(
+  { source: options.actorContextSource },
+  active.id,
+);
+```
+
+`ResolveTransitionTargetOptions` (lines 117-141) gains:
+
+```typescript
+/** Provenance source for the resolved default target; absent → unknown (strict). */
+readonly actorContextSource?: ActorContextSource;
+```
+
+and **drops `directCliCompatibility`** (see § 2.4 — it is redundant once a
+source tag is the only axis). The `actorContext?: ActorContext` passthrough may
+remain for strict adapters that already hold a fully-formed context, but the
+default construction now routes through `resolveActorContext`.
+
+### 2.3 The CLI keeps only ingress reading (Category A)
+
+The CLI no longer constructs `ActorContext` and no longer owns any part of the
+table. It retains, in `packages/cli/src/helpers/`:
+
+- **`ACTOR_SOURCE_VALUES` / `parseActorSource` / `InvalidActorSourceError`** —
+  validation of an `--actor-source` / `RD_ACTOR_SOURCE` **string token** against
+  the source vocabulary. This is Category A ingress validation: it answers "is
+  this flag/env string a syntactically valid source?", not "what trust does it
+  confer?". It produces a typed `ActorContextSource` or throws; it never builds
+  an `ActorContext`. (The valid-value tuple is kept exhaustive against core's
+  `ActorContextSource` by the plan's existing compile-time
+  `Record<ActorContextSource, true>` guard — see § 8 for the one residual
+  coupling.)
+- **`readActorSourceIngress(command, env?)`** — reads `--actor-source` (via
+  `optsWithGlobals()`) and `RD_ACTOR_SOURCE`, applies flag-over-env precedence,
+  and **applies the front-end default**: every `rd` invocation is a direct local
+  CLI front end unless tagged otherwise, so this returns a **concrete
+  `ActorContextSource`, defaulting to `'direct-cli'`**:
+
+  ```typescript
+  export function readActorSourceIngress(
+    command: ActorSourceReader,
+    env: NodeJS.ProcessEnv = process.env,
+  ): ActorContextSource; // never undefined; '' env treated as unset → 'direct-cli'
+  ```
+
+  This is the **one** site that owns the `direct-cli` default. It replaces the
+  plan's `... | undefined` reader (which deferred the default into the CLI
+  table). Strict domain callers (MCP-strict adapters, core tests) never call
+  `readActorSourceIngress`; they pass no `source` to `resolveActorContext` and
+  get `unknown`.
+- Catching `InvalidActorSourceError` and rendering the `INVALID_ACTOR_SOURCE`
+  JSON envelope via `OutputEmitter` inside each command's `withErrorHandling`
+  block (unchanged from the plan; still per-command, never a Commander hook).
+
+### 2.4 Default ownership — the resolved trade-off
+
+The two defaults (`direct-cli` vs `unknown`) are **unified in mechanism but kept
+distinct in ownership**, and they must stay distinct:
+
+- **`unknown` is owned by the core table.** It is the strict-core meaning of "no
+  trusted evidence." `resolveActorContext` returns it intrinsically when ingress
+  carries neither a source nor a complete claim.
+- **`direct-cli` is owned by the CLI ingress reader.** It is the front-end
+  meaning of "a bare local `rd` call is a trusted direct-CLI controller." It is
+  applied once, in `readActorSourceIngress`.
+
+They are the **same axis** — "what `source`, if any, is in the ingress" — so the
+two helpers collapse into one table. But they are **not collapsible into a
+single default value**, because:
+
+- If the **table** defaulted to `direct-cli`, every strict caller of
+  `resolveTransitionTarget` (core adapters, a future MCP-strict mode) that
+  passes no source would be silently promoted to a trusted controller —
+  destroying the strict-core `unknown` guarantee that the existing
+  `actor_context_required` refusal (`command-target-resolver.ts:351-352`)
+  depends on.
+- If the **reader** returned `undefined` and the table defaulted to `unknown`, a
+  bare local `rd collect` / `rd pass` would resolve to `unknown` and be refused
+  — a behaviour regression from today's `direct-cli` compatibility lane.
+
+So the separation is load-bearing, not stylistic. Locating each default at its
+correct owner is what lets a single table serve both a trusting front end and a
+strict core.
+
+A direct consequence: **`directCliCompatibility: boolean` is retired.**
+`directCliCompatibility: true` is exactly `actorContextSource: 'direct-cli'`;
+once the source tag is the only axis, the boolean is a second way to say the
+same thing and is removed from `ResolveTransitionTargetOptions`. Reducing the
+option surface is a concrete win the unification unlocks.
+
+### 2.5 Flow per caller class (the single funnel)
+
+**`collect`** (pre-resolved target; `packages/cli/src/commands/collect.ts`):
+
+1. Inside `withErrorHandling`: `source = readActorSourceIngress(command)` →
+   concrete `ActorContextSource` (renders `INVALID_ACTOR_SOURCE` on a bad token).
+2. Build ingress from the already-resolved `ctx.claim` (a `ClaimRecord`) and
+   `state`:
+   `{ source, ...(ctx.claim ? { claimId: ctx.claim.claimId, tokenHash: ctx.claim.tokenHash } : {}) }`.
+3. `const actorContext = resolveActorContext(ingress, state.id);` (core).
+4. `collectionService.collectDelegationOutcomes({ actorContext, ... })`.
+
+**`delegate`** (pre-resolved target; no `--claim-id` option, so no claim
+evidence; `packages/cli/src/commands/delegate.ts`):
+
+1. `source = readActorSourceIngress(command)`.
+2. `const actorContext = resolveActorContext({ source }, state.id);`.
+3. `resolveCommandIntent({ actorContext, ... })` (unchanged downstream).
+
+**`pass` / `fail`** (core-resolved target;
+`packages/cli/src/helpers/transition-command.ts` → `transitions.ts` → core):
+
+1. CLI `transition-command.ts`: `source = readActorSourceIngress(command)`.
+2. CLI `transitions.ts#buildTransitionContext` forwards it as
+   `resolveTransitionTarget(sessionService, { command, claimId, targeted, actorContextSource: source })`.
+   The CLI never constructs an `ActorContext` (it still does not know
+   `active.id`).
+3. Core `resolveTransitionTarget` resolves `active.id`, then calls the **same**
+   `resolveActorContext({ source: options.actorContextSource }, active.id)` at
+   its existing choke point. For a bare local CLI pass, `source` is `'direct-cli'`
+   (defaulted by the reader), so behaviour is byte-identical to today.
+
+All three classes now call exactly one function for the table:
+`resolveActorContext`. The `collect`/`delegate` class calls it **directly**
+(they hold the target); the `pass`/`fail` class calls it **transitively through
+`resolveTransitionTarget`** (core holds the target). No shadow target resolution
+is introduced in the CLI — that would violate "the CLI is a thin wrapper."
+
+In the actor-input-wiring vocabulary
+(`docs/internal/architecture.md § Actor input wiring`), the `source` tag is an
+**event-time-bound** value (it varies per invocation and is read at call time
+from the CLI ingress), threaded as an explicit argument rather than persisted —
+consistent with "persisted context contains only data; runtime references flow
+through invoke-input closures." `ActorContext` itself is runtime-only and is
+never serialised into snapshots (the no-persisted-state constraint holds
+unchanged).
+
+---
+
+## 3. What the CLI retains vs. surrenders
+
+| Concern | Category | Owner after this spec |
+| --- | --- | --- |
+| Read `--actor-source` flag | A (flag read) | CLI `readActorSourceIngress` |
+| Read `RD_ACTOR_SOURCE` env | A (env read) | CLI `readActorSourceIngress` |
+| Flag-over-env precedence | A | CLI `readActorSourceIngress` |
+| `direct-cli` front-end default | A (front-end policy) | CLI `readActorSourceIngress` |
+| Validate the string token | A (ingress validation) | CLI `parseActorSource` |
+| Render `INVALID_ACTOR_SOURCE` envelope | A (stdout render) | CLI command `withErrorHandling` |
+| Source vocabulary (`ActorContextSource`) | domain | core (exists) |
+| Evidence→`ActorContext` table | domain | **core `resolveActorContext` (new)** |
+| `direct-cli` vs `unknown` no-evidence default | domain (`unknown`) / front-end (`direct-cli`) | core / CLI (split, § 2.4) |
+| Claim-vs-trusted decision | domain | **core `resolveActorContext` (new)** |
+| Target resolution + choke-point construction | domain | core `resolveTransitionTarget` (exists) |
+
+The CLI explicitly **constructs no `ActorContext`** after this spec. It reads,
+validates, defaults, and renders — all Category A — and hands a typed
+`ActorContextSource` (plus, for `collect`, the already-in-hand `ClaimRecord`
+fields) to core. This removes the "frontend adapter is allowed to construct
+`ActorContext`" carve-out the source plan introduced (plan lines 12-17, 46-49):
+construction returns to core, and the CLI is a pure ingress reader again — a
+tighter fit to "the CLI is a thin wrapper."
+
+---
+
+## 4. Migration delta from the current plan
+
+The follow-up plan that implements this spec changes the source plan as follows.
+
+| Plan task | Change |
+| --- | --- |
+| **Task 1** (CLI `resolve-actor-context.ts`) | Split. `resolveActorContext` + `ActorIngress` **move to core** `actor-context.ts` (second arg becomes `RunId`; no-evidence default becomes `unknown`). `ACTOR_SOURCE_VALUES` / `parseActorSource` / `InvalidActorSourceError` **stay in the CLI** `actor-source-option.ts` (string-token validation only). The CLI table test is deleted; the table test moves to core (§ 7). |
+| **Task 2** (`readActorSourceIngress`) | Return type changes from `ActorContextSource \| undefined` to **`ActorContextSource`** (defaults to `'direct-cli'`). This single site now owns the front-end default. Tests update: "neither flag nor env set → `'direct-cli'`" (was `undefined`). |
+| **Task 3** (register flag + `INVALID_ACTOR_SOURCE` code) | Unchanged. Still capture-only flag; still per-command validation. |
+| **Task 4** (`delegate`) | Imports `resolveActorContext` + `ActorIngress` **from `@rundown-org/core`** instead of a CLI helper. Calls `resolveActorContext({ source }, state.id)`. `buildDelegateActorIngress` becomes a trivial one-liner or is dropped (the source-propagation driver moves to the core table test). |
+| **Task 5** (`collect`) | Imports `resolveActorContext` **from core**; calls it with `state.id`. Drops `claimControllerContext` / `trustedRunControllerContext` imports from `collect.ts` (the table no longer lives there). |
+| **Task 6** (`pass`/`fail`) | `buildTransitionActorContext` is **not** created. `command-target-resolver.ts` calls `resolveActorContext({ source: options.actorContextSource }, active.id)` at lines 327-331. `ResolveTransitionTargetOptions` gains `actorContextSource?` and **drops `directCliCompatibility`**. CLI `transitions.ts` forwards `actorContextSource` (never `directCliCompatibility`). |
+| **Task 7** (`complete`/`stop`/`claim` comments) | Unchanged. |
+| **Produces block / Plans 6 & 7** | The consumed symbols change package: Plans 6/7 import `resolveActorContext` / `ActorIngress` from `@rundown-org/core`, not from `packages/cli/src/helpers/`. The CLI-surface contract (`--actor-source` / `RD_ACTOR_SOURCE`, hard error on invalid) is unchanged. |
+
+Constraints that **still hold** unchanged: no persisted-state migration
+(`ActorContext` stays runtime-only); type-driven dispatch (the table narrows on a
+discriminated union, never raw string `if` ladders outside `parseActorSource`);
+no silent mapping (an invalid source is still a hard `INVALID_ACTOR_SOURCE`
+error); the INVARIANT (the collection-pending guard refuses bare
+`pass`/`fail`/`delegate` for every source — it is source-independent in core and
+untouched here); JSON output contract unchanged.
+
+---
+
+## 5. Trade-offs & alternatives
+
+### Alternative (a) — keep the CLI table, do nothing
+
+Rejected. It is the status quo the review flagged: a future table change must be
+made twice across a package boundary and kept consistent by convention. It also
+keeps the "CLI may construct `ActorContext`" carve-out, which is the only place
+the CLI owns authorization-evidence construction.
+
+### Alternative (b) — keep the split, add a cross-helper consistency test
+
+**Considered; deferred, not adopted.** The review's option (b) keeps both
+helpers and adds a test that drives the same evidence vectors through CLI
+`resolveActorContext` and core `buildTransitionActorContext` and asserts equal
+output. This is cheaper (no code moves) and pins the drift. But:
+
+- It pins **consistency**, not **single-sourcing.** Two implementations remain;
+  the test only fails *after* they diverge. A new row still has to be written
+  twice, and the test must be remembered and extended for it.
+- The two helpers have genuinely different shapes (claim path vs none;
+  `direct-cli` vs `unknown` default), so the consistency test must special-case
+  those differences — encoding the very divergence it is meant to police, and
+  becoming load-bearing documentation of "these are allowed to differ here but
+  not there."
+- It does not remove the CLI's construction carve-out.
+
+It is a reasonable **stopgap** if the core-hosting move cannot be scheduled
+immediately (e.g. to ship the source plan first, then refactor). That is why it
+is *deferred* rather than *rejected*: a follow-up plan may land (b) as an interim
+guard and this spec's design as the durable fix.
+
+### Where core-hosting is arguably *worse* (intellectual honesty)
+
+Two honest costs:
+
+1. **The bare-CLI end-to-end assertion splits across two layers.** Today the CLI
+   `resolveActorContext` lets one unit test assert "bare ingress →
+   `trusted_run_controller(direct-cli)`." After this spec, that single
+   assertion decomposes: the **core** table test asserts "no source →
+   `unknown`," and the **CLI** reader test asserts "no flag/env → `'direct-cli'`."
+   The composed truth ("bare `rd collect` → trusted direct-cli") is now verified
+   by two tests in two packages rather than one. This is a real diffusion. It is
+   acceptable because each layer's test is *simpler* and tests *one* thing
+   (table vs default-ownership), and an integration test per command still pins
+   the composed behaviour — but it is more moving parts than the monolithic CLI
+   helper.
+
+2. **`pass`/`fail` gain nothing from the move.** Their construction was already
+   in core; for them, core-hosting only swaps one core helper
+   (`buildTransitionActorContext`) for another (`resolveActorContext`). The
+   payoff is entirely on the `collect`/`delegate` side (and in deleting the
+   duplicate table). If `collect`/`delegate` did not exist, this refactor would
+   be net-neutral churn. They do exist, so the move pays — but the benefit is
+   asymmetric, and a reviewer should weigh it as "is removing one duplicated
+   table worth touching four files and a public core export?" The answer here is
+   yes (a duplicated authorization table is exactly the kind of shadow logic
+   CLAUDE.md forbids), but it is not free.
+
+Neither cost is disqualifying; both are recorded so the follow-up plan does not
+discover them mid-implementation.
+
+---
+
+## 6. Sequence summary
+
+```
+collect / delegate (target already resolved in CLI)
+  readActorSourceIngress(command)  ->  ActorContextSource (default 'direct-cli')   [CLI, Cat A]
+  resolveActorContext({ source, ...claimFields }, state.id)  ->  ActorContext      [CORE table]
+  resolveCommandIntent / collectDelegationOutcomes({ actorContext })               [CORE policy]
+
+pass / fail (target resolved inside core)
+  readActorSourceIngress(command)  ->  ActorContextSource (default 'direct-cli')   [CLI, Cat A]
+  buildTransitionContext(..., { actorSource })                                     [CLI thin forward]
+  resolveTransitionTarget(reader, { command, actorContextSource })                 [CORE]
+    -> resolves active.id
+    -> resolveActorContext({ source: actorContextSource }, active.id) -> ActorContext  [CORE table]
+    -> resolveCommandIntent({ actorContext })                                       [CORE policy]
+```
+
+One table (`resolveActorContext`), two entry paths (direct for pre-resolved
+targets, transitive for core-resolved targets).
+
+---
+
+## 7. Test strategy
+
+The point of the move is **exactly one place to test the table.**
+
+**Core unit table** (`packages/core/__tests__/runbook/actor-context.test.ts` or
+a sibling `actor-context-resolver.test.ts`) — the *only* table test:
+
+| Ingress | `targetRunId` | Expected |
+| --- | --- | --- |
+| `{}` | `r` | `{ kind: 'unknown' }` |
+| `{ source: 'direct-cli' }` | `r` | `trusted_run_controller(r, 'direct-cli')` |
+| `{ source: 'plugin' }` | `r` | `trusted_run_controller(r, 'plugin')` |
+| `{ source: 'mcp' }` | `r` | `trusted_run_controller(r, 'mcp')` |
+| `{ claimId, tokenHash }` | `r` | `claim_controller(claimId, tokenHash, controlledRunId=r)` |
+| `{ claimId, tokenHash, controlledRunId: c }` | `r` | `claim_controller(..., controlledRunId=c)` |
+| `{ source: 'plugin', claimId, tokenHash }` | `r` | `claim_controller(...)` (claim wins; **no `source`**) |
+| `{ claimId }` (no tokenHash) | `r` | `{ kind: 'unknown' }` |
+| `{ tokenHash }` (no claimId) | `r` | `{ kind: 'unknown' }` |
+
+**Core property tests** (fast-check), the invariants the review recommended,
+pinned in one place:
+
+1. **Total / well-typed:** for any `ActorIngress` and `RunId`,
+   `resolveActorContext(i, r).kind ∈ { 'trusted_run_controller', 'claim_controller', 'unknown' }`.
+2. **Claim iff complete claim evidence:** `result.kind === 'claim_controller'`
+   ⟺ `i.claimId !== undefined && i.tokenHash !== undefined`.
+3. **Source never on a claim controller:** `result.kind === 'claim_controller'`
+   ⟹ `!('source' in result)` (claim wins over any source tag, and carries none).
+4. **Default behaviour:** when no claim evidence,
+   `result.kind === (i.source !== undefined ? 'trusted_run_controller' : 'unknown')`,
+   and on the trusted branch `result.source === i.source` and `result.runId === r`.
+5. **`controlledRunId` default:** on the claim branch,
+   `result.controlledRunId === (i.controlledRunId ?? r)`.
+
+**Core resolver pins** (`command-target-resolver.test.ts`): unchanged in intent
+— `actorContextSource: 'plugin'` yields `source: 'plugin'` in the constructed
+context without changing the resolution `kind`; the collection-pending refusal
+fires for any source. These now assert *through* `resolveActorContext` (no
+`buildTransitionActorContext`), and additionally pin that
+`actorContextSource` absent → `unknown` (the strict default that replaced
+`directCliCompatibility`).
+
+**CLI tests** (`actor-source-option.test.ts`, command tests) — **no table
+test:** only `readActorSourceIngress` precedence/validation (flag wins over env;
+empty env treated as unset; **neither set → `'direct-cli'`**; invalid →
+`InvalidActorSourceError`), and per-command `INVALID_ACTOR_SOURCE` envelope
+rendering + the cross-source collection-pending INVARIANT (unchanged from the
+plan). The CLI never re-tests the evidence→context mapping.
+
+---
+
+## 8. Open questions / risks
+
+1. **Residual vocabulary coupling.** `ACTOR_SOURCE_VALUES` (the runtime tuple
+   the CLI validates against) stays in the CLI while `ActorContextSource` (the
+   type) stays in core. This is a *narrow* coupling — a list of three strings,
+   guarded exhaustive against the union by a compile-time
+   `Record<ActorContextSource, true>` check — and it is genuinely CLI ingress
+   validation (Category A). **Option:** host `ACTOR_SOURCE_VALUES` +
+   `parseActorSource` in core too (next to `ActorContextSource`), leaving the
+   CLI only the flag/env read and envelope render. That would make core the
+   single source of *both* the vocabulary and the table, at the cost of putting
+   a string-validation helper (arguably Category A) in core. Recommend deciding
+   this in the follow-up plan; the spec's mapping move is correct either way.
+2. **`actorContext?` passthrough on `ResolveTransitionTargetOptions`.** Once
+   construction routes through `resolveActorContext`, is the explicit
+   `actorContext?` passthrough still needed, or do all strict callers now supply
+   a `source` instead? If no caller passes a pre-built `actorContext`, drop it
+   for a smaller surface; if MCP-strict or a core adapter still needs to inject a
+   `claim_controller` directly, keep it. Resolve by auditing callers in the
+   follow-up plan.
+3. **Public core export surface.** `resolveActorContext` + `ActorIngress` become
+   public core exports consumed by the CLI, MCP, and plugin. This widens core's
+   committed API. Acceptable (it is the intended single seam), but the follow-up
+   plan should add the TSDoc and treat it as a stable export, not an internal
+   helper.
+4. **Source-propagation driving test relocation.** The plan's TDD drivers
+   (`buildDelegateActorIngress`, `buildTransitionActorContext` unit tests) were
+   designed to fail before the source was threaded. With the table in core, the
+   genuine driver becomes the core table test (rows asserting `source: 'plugin'`
+   propagates). The follow-up plan must ensure a test still *fails before* the
+   `actorContextSource` option exists on `resolveTransitionTarget`, so the
+   pass/fail wiring stays test-driven rather than asserted after the fact.

--- a/docs/superpowers/specs/2026-06-27-core-hosted-actor-context-resolver.md
+++ b/docs/superpowers/specs/2026-06-27-core-hosted-actor-context-resolver.md
@@ -472,7 +472,7 @@ discover them mid-implementation.
 
 ## 6. Sequence summary
 
-```
+```text
 collect / delegate (target already resolved in CLI)
   readActorSourceIngress(command)  ->  ActorContextSource (default 'direct-cli')   [CLI, Cat A]
   resolveActorContext({ source, ...claimFields }, state.id)  ->  ActorContext      [CORE table]

--- a/packages/claude-code-plugin/TESTING.md
+++ b/packages/claude-code-plugin/TESTING.md
@@ -92,8 +92,8 @@ pnpm --filter @rundown-org/claude-code-plugin test:coverage
 
 Use `pnpm run test:mutate:plugin` for mutation-sensitive changes after the
 targeted tests are green. Do not lower Stryker thresholds to make a PR pass;
-capture the current mutation baseline first and tighten it in a separate
-tooling change when the baseline is stable.
+capture the current mutation baseline first and tighten it in a separate tooling
+change when the baseline is stable.
 
 ### Coverage Thresholds (`jest.config.js`)
 
@@ -106,22 +106,24 @@ The `rdpath`/`rdx` entrypoint shells do **not** appear in `coverage/lcov.info`,
 even though `collectCoverageFrom` is `src/**/*.ts`. This is expected, not a hole
 in the suite:
 
-- Both files are CLI entrypoints that call `program.parse()` at module top level.
-  They are only exercised by spawning the built `dist/{rdpath,rdx}.js` as a child
-  `node` process (`rdpath-find-integration.test.ts`, ~30 cases;
-  `rdx.integration.test.ts`, ~20 cases). Jest/istanbul instruments the in-process
-  module graph only, so coverage of a spawned subprocess is never collected.
+- Both files are CLI entrypoints that call `program.parse()` at module top
+  level. They are only exercised by spawning the built `dist/{rdpath,rdx}.js` as
+  a child `node` process (`rdpath-find-integration.test.ts`, ~30 cases;
+  `rdx.integration.test.ts`, ~20 cases). Jest/istanbul instruments the
+  in-process module graph only, so coverage of a spawned subprocess is never
+  collected.
 - They cannot be imported in-process to gain instrumentation without running the
-  CLI as a side effect of the import (no `main`-module guard). Adding such a guard
-  purely to satisfy coverage would change entrypoint behavior, which is out of
-  scope for coverage hardening.
+  CLI as a side effect of the import (no `main`-module guard). Adding such a
+  guard purely to satisfy coverage would change entrypoint behavior, which is
+  out of scope for coverage hardening.
 - Their actual logic lives in modules that **are** covered in-process:
   `src/rdx-core.ts` + `src/rdx-validate.ts` for `rdx`, and `assembleRdPath` /
-  `findRdPathFiles` / `readActiveRunScope` from `@rundown-org/core` for `rdpath`.
+  `findRdPathFiles` / `readActiveRunScope` from `@rundown-org/core` for
+  `rdpath`.
 
 The behavioral contract of both entrypoints is pinned by the spawn-based
-integration tests above; the LCOV omission reflects the instrumentation boundary,
-not untested code.
+integration tests above; the LCOV omission reflects the instrumentation
+boundary, not untested code.
 
 ## Manual Hook Verification
 

--- a/packages/cli/__tests__/commands/actor-source-ingress.test.ts
+++ b/packages/cli/__tests__/commands/actor-source-ingress.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  createTestWorkspace,
+  getActiveState,
+  runCliInProcess,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
+
+describe('--actor-source / RD_ACTOR_SOURCE ingress', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('accepts a valid --actor-source flag without disturbing a read-only command', async () => {
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+    // `status` does not construct actor context (so it neither validates nor
+    // uses the source), but the capture-only flag must parse cleanly.
+    const result = await runCliInProcess('--actor-source plugin status', workspace);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(/unknown option/i);
+  });
+
+  // CROSS-PLAN PIN (Plan 7 / MCP): the MCP server spawns
+  // `npx --no rundown --actor-source mcp <subcommand> ...` — the flag is a
+  // PROGRAM-LEVEL token BEFORE the subcommand, and MCP cannot use the
+  // RD_ACTOR_SOURCE env bridge (docs/reference/mcp.md §4: the CLI MUST inherit
+  // the server env unmodified). These tests pin that `--actor-source` is parsed
+  // pre-subcommand and advertised at program level, so a refactor cannot quietly
+  // move it onto a per-subcommand registration and break MCP.
+  it('parses --actor-source as a program-level token placed BEFORE the subcommand', async () => {
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+    // mcp source, no claim, bare pass while NOT pending: must transition
+    // normally (proving the pre-subcommand flag was consumed, not rejected as an
+    // unknown option, and not mistaken for a subcommand argument). `pass` is
+    // migrated in Task 6; until then the flag is captured-but-unused and the
+    // transition still succeeds.
+    const result = await runCliInProcess('--actor-source mcp pass --text', workspace);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(/unknown option/i);
+    const state = await getActiveState(workspace);
+    expect(state?.step).toBe('2');
+  });
+
+  it('advertises --actor-source at the program level in --help', async () => {
+    const result = await runCliInProcess('--help', workspace);
+
+    // Program-level help (not a subcommand help) must list the flag, proving it
+    // is registered on the program, not on an individual subcommand.
+    expect(result.stdout).toMatch(/--actor-source/);
+  });
+});

--- a/packages/cli/__tests__/commands/collect-actor-source.test.ts
+++ b/packages/cli/__tests__/commands/collect-actor-source.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from '@jest/globals';
+import type { ClaimId, ClaimRecord, DelegationTokenHash, RunId } from '@rundown-org/core';
+import { buildCollectActorIngress } from '../../src/commands/collect.js';
+
+// Robust source + claim-evidence propagation driver: a pure exported helper that
+// collect uses to build its ActorIngress from the resolved source tag and the
+// resolved claim record. Module-spying a first-party named export is unreliable
+// under this package's jest config (`isolatedModules: true` + `useESM: true`),
+// so the driver is a direct unit test of the helper — mirroring delegate's
+// `buildDelegateActorIngress` and Task 6's `buildTransitionActorContext`. This
+// FAILS to import before Step 4 extracts the helper, which is what TDD-drives
+// the migration: collection is source-independent, so an end-to-end test cannot
+// observe the source spread, and the entire spread could otherwise be deleted
+// with every collect test still green.
+const STATE_ID = 'run_target' as RunId;
+const CLAIM_ID = 'rdclm_target' as ClaimId;
+const TOKEN_HASH = 'tokenhash_target' as DelegationTokenHash;
+// buildCollectActorIngress only reads `.claimId` and `.tokenHash`; the rest of
+// the ClaimRecord shape (notably `childRunId`, NOT `controlledRunId`) is
+// irrelevant to ingress construction, so a minimal cast stub suffices.
+const claimStub = { claimId: CLAIM_ID, tokenHash: TOKEN_HASH } as unknown as ClaimRecord;
+
+describe('buildCollectActorIngress threads the source and claim evidence', () => {
+  it('tags ingress.source only when a source is supplied and no claim is present', () => {
+    expect(buildCollectActorIngress('plugin', undefined, STATE_ID)).toEqual({ source: 'plugin' });
+  });
+
+  it('produces an empty ingress when neither a source nor a claim is supplied', () => {
+    expect(buildCollectActorIngress(undefined, undefined, STATE_ID)).toEqual({});
+  });
+
+  it('threads source AND full claim evidence, defaulting controlledRunId to the target state id', () => {
+    // controlledRunId comes from the passed targetStateId (the resolved claimed
+    // child), NOT from a field on the claim — ClaimRecord has no controlledRunId.
+    expect(buildCollectActorIngress('mcp', claimStub, STATE_ID)).toEqual({
+      source: 'mcp',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: STATE_ID,
+    });
+  });
+
+  it('threads claim evidence with no source when only a claim is supplied', () => {
+    expect(buildCollectActorIngress(undefined, claimStub, STATE_ID)).toEqual({
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: STATE_ID,
+    });
+  });
+});

--- a/packages/cli/__tests__/commands/collect-actor-source.test.ts
+++ b/packages/cli/__tests__/commands/collect-actor-source.test.ts
@@ -14,7 +14,7 @@ import { buildCollectActorIngress } from '../../src/commands/collect.js';
 // with every collect test still green.
 const STATE_ID = 'run_target' as RunId;
 const CLAIM_ID = 'rdclm_target' as ClaimId;
-const TOKEN_HASH = 'tokenhash_target' as DelegationTokenHash;
+const TOKEN_HASH = 'tokenHash_target' as DelegationTokenHash;
 // buildCollectActorIngress only reads `.claimId` and `.tokenHash`; the rest of
 // the ClaimRecord shape (notably `childRunId`, NOT `controlledRunId`) is
 // irrelevant to ingress construction, so a minimal cast stub suffices.

--- a/packages/cli/__tests__/commands/collect-actor-source.test.ts
+++ b/packages/cli/__tests__/commands/collect-actor-source.test.ts
@@ -47,4 +47,22 @@ describe('buildCollectActorIngress threads the source and claim evidence', () =>
       controlledRunId: STATE_ID,
     });
   });
+
+  it('preserves the direct-cli source with no claim present', () => {
+    // The other source cases pin 'plugin' and 'mcp'; pin 'direct-cli' too so a
+    // regression that drops the default source tag on the collect path is caught
+    // rather than masked by the off-path 'plugin'/'mcp' assertions.
+    expect(buildCollectActorIngress('direct-cli', undefined, STATE_ID)).toEqual({
+      source: 'direct-cli',
+    });
+  });
+
+  it('preserves the direct-cli source alongside full claim evidence', () => {
+    expect(buildCollectActorIngress('direct-cli', claimStub, STATE_ID)).toEqual({
+      source: 'direct-cli',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: STATE_ID,
+    });
+  });
 });

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { activeFrame, buildFrameKey, buildCompletionKey, type FrameKey } from '@rundown-org/core';
+import {
+  activeFrame,
+  buildFrameKey,
+  buildCompletionKey,
+  ErrorResponseSchema,
+  type FrameKey,
+} from '@rundown-org/core';
 import {
   createTestWorkspace,
   createRunbook,
@@ -324,6 +330,54 @@ describe('collect command', () => {
       expect(payload.code).not.toBe('COLLECT_REQUIRES_ORCHESTRATOR');
       expect(payload.code).not.toBe('ACTOR_CONTEXT_REQUIRED');
     }, 30_000);
+  });
+
+  it('collects unchanged when an explicit --actor-source plugin tag is supplied', async () => {
+    // Behavior-neutral pin (must stay green): source is provenance only — a
+    // plugin-tagged orchestrator of the run is still the orchestrator-for-target,
+    // so collection behaves identically to the untagged direct-cli path. Reuses
+    // the canonical drain fixture `setupReadyToCollect` already defined in this
+    // file (see the 'successful aggregation' describe block).
+    await setupReadyToCollect(['pass', 'pass']);
+
+    const tagged = await runCliInProcess(['--actor-source', 'plugin', 'collect'], workspace);
+
+    // Identical to the untagged `['collect']` happy path: exit 0 and the parent
+    // advances to step 2 (PASS ALL → CONTINUE).
+    expect(tagged.exitCode).toBe(0);
+    const state = await getActiveState(workspace);
+    expect(state?.step).toBe('2');
+  });
+
+  it('collects unchanged when the source arrives via the RD_ACTOR_SOURCE env bridge', async () => {
+    // The env fallthrough is pinned only for delegate elsewhere; collect reads
+    // the source through a DISTINCT call site (readActorSourceIngress in the
+    // collect action), so prove the RD_ACTOR_SOURCE bridge resolves on the
+    // collect path too (finding 8). Behavior stays identical to the untagged
+    // drain: exit 0, parent advances to step 2.
+    await setupReadyToCollect(['pass', 'pass']);
+
+    const tagged = await runCliInProcess('collect', workspace, {
+      env: { RD_ACTOR_SOURCE: 'plugin' },
+    });
+
+    expect(tagged.exitCode).toBe(0);
+    const state = await getActiveState(workspace);
+    expect(state?.step).toBe('2');
+  });
+
+  it('renders the INVALID_ACTOR_SOURCE JSON envelope on an invalid --actor-source for collect', async () => {
+    await setupReadyToCollect(['pass', 'pass']);
+
+    const result = await runCliInProcess(['--actor-source', 'remote', 'collect'], workspace);
+
+    expect(result.exitCode).not.toBe(0);
+    // Validate the envelope SHAPE, not just the code, matching delegate's
+    // stronger assertions (finding 7): an invalid source renders the standard
+    // error envelope via the OutputEmitter, never a raw stderr line.
+    const raw = JSON.parse(result.stdout);
+    expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
+    expect((raw as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
   });
 
   describe('successful aggregation', () => {

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -369,6 +369,11 @@ describe('collect command', () => {
   it('renders the INVALID_ACTOR_SOURCE JSON envelope on an invalid --actor-source for collect', async () => {
     await setupReadyToCollect(['pass', 'pass']);
 
+    // Source validation must reject BEFORE any transition fires, so the parent
+    // sits at step 1 (ready to collect) on entry.
+    const before = await getActiveState(workspace);
+    expect(before?.step).toBe('1');
+
     const result = await runCliInProcess(['--actor-source', 'remote', 'collect'], workspace);
 
     expect(result.exitCode).not.toBe(0);
@@ -378,6 +383,13 @@ describe('collect command', () => {
     const raw = JSON.parse(result.stdout);
     expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
     expect((raw as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
+
+    // The rejection must be inert: no collect transition runs, so the persisted
+    // parent state is unchanged (still step 1, never advanced to step 2). This
+    // pins the failure path end-to-end — envelope AND no state mutation.
+    const after = await getActiveState(workspace);
+    expect(after?.step).toBe('1');
+    expect(after).toEqual(before);
   });
 
   describe('successful aggregation', () => {

--- a/packages/cli/__tests__/commands/delegate-actor-source.test.ts
+++ b/packages/cli/__tests__/commands/delegate-actor-source.test.ts
@@ -34,12 +34,18 @@ describe('delegate accepts --actor-source without error', () => {
     await workspace.cleanup();
   });
 
-  it('does not reject a valid --actor-source plugin on a fresh delegate', async () => {
+  it('accepts --actor-source plugin and proceeds to delegation resolution', async () => {
     await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
 
     const result = await runCliInProcess('--actor-source plugin delegate', workspace);
 
+    // `simple.runbook.md` has no delegatable substep, so a bare delegate cannot
+    // succeed. Pin the EXACT downstream outcome rather than just "not
+    // INVALID_ACTOR_SOURCE": reaching RD-813 proves `--actor-source plugin`
+    // passed option parsing AND actor-source ingress validation and entered the
+    // delegation-resolution path. A weaker check would also pass on an
+    // INVALID_ACTOR_SOURCE / unknown-option envelope.
     expect(result.stdout).not.toMatch(/unknown option/i);
-    expect((JSON.parse(result.stdout) as { code?: string }).code).not.toBe('INVALID_ACTOR_SOURCE');
+    expect((JSON.parse(result.stdout) as { code?: string }).code).toBe('RD-813');
   });
 });

--- a/packages/cli/__tests__/commands/delegate-actor-source.test.ts
+++ b/packages/cli/__tests__/commands/delegate-actor-source.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { createTestWorkspace, runCliInProcess, type TestWorkspace } from '../helpers/test-utils.js';
+import { buildDelegateActorIngress } from '../../src/commands/delegate.js';
+
+// Robust source-propagation driver: a pure exported helper that delegate uses to
+// build its ActorIngress from the resolved source. Module-spying a first-party
+// named export is unreliable under this package's jest config (`isolatedModules:
+// true` + `useESM: true`), so the driver is a direct unit test of the helper —
+// mirroring Task 6's `buildTransitionActorContext`. This FAILS to compile/run
+// before Step 4 extracts the helper, which is what TDD-drives the migration.
+describe('buildDelegateActorIngress threads the actor source', () => {
+  it('tags ingress.source when a source is supplied', () => {
+    expect(buildDelegateActorIngress('plugin')).toEqual({ source: 'plugin' });
+    expect(buildDelegateActorIngress('mcp')).toEqual({ source: 'mcp' });
+  });
+
+  it('produces an empty ingress (no source) when the source is undefined', () => {
+    expect(buildDelegateActorIngress(undefined)).toEqual({});
+  });
+});
+
+// A coarse end-to-end pin that the flag is at least accepted on the delegate
+// path (the behavioral effect of source is invisible at the CLI because
+// deriveEffectiveRole ignores source — so the unit test above is the real
+// driver; this only guards against the flag being rejected as unknown).
+describe('delegate accepts --actor-source without error', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('does not reject a valid --actor-source plugin on a fresh delegate', async () => {
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+    const result = await runCliInProcess('--actor-source plugin delegate', workspace);
+
+    expect(result.stdout).not.toMatch(/unknown option/i);
+    expect((JSON.parse(result.stdout) as { code?: string }).code).not.toBe('INVALID_ACTOR_SOURCE');
+  });
+});

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -216,6 +216,80 @@ describe('delegate command', () => {
     });
   });
 
+  describe('actor-source ingress', () => {
+    // INVARIANT: the collection-pending guard refuses bare delegate for EVERY
+    // source. Source never buys past the guard. Reuses the same fixture as the
+    // canonical guard test so the failure is the guard, not runbook resolution.
+    it.each([
+      'direct-cli',
+      'plugin',
+      'mcp',
+    ] as const)('still refuses bare delegate while pending (source=%s, flag)', async (source) => {
+      await setupAutoIssuedDelegation();
+      await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess(`--actor-source ${source} delegate`, workspace);
+
+      expect(result.exitCode).toBe(1);
+      const raw = JSON.parse(result.stdout);
+      expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
+      expect((raw as { code?: string }).code).toBe('DELEGATION_COLLECTION_PENDING');
+    });
+
+    it('still refuses bare delegate while pending when RD_ACTOR_SOURCE=plugin', async () => {
+      await setupAutoIssuedDelegation();
+      await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess('delegate', workspace, {
+        env: { RD_ACTOR_SOURCE: 'plugin' },
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect((JSON.parse(result.stdout) as { code?: string }).code).toBe(
+        'DELEGATION_COLLECTION_PENDING',
+      );
+    });
+
+    // ENVELOPE (finding 3): an invalid source renders the INVALID_ACTOR_SOURCE
+    // JSON envelope through the command's OutputEmitter — NOT a raw stderr line.
+    it('renders the INVALID_ACTOR_SOURCE JSON envelope on an invalid --actor-source', async () => {
+      await setupAutoIssuedDelegation();
+
+      const result = await runCliInProcess('--actor-source remote delegate', workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      const raw = JSON.parse(result.stdout);
+      expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
+      expect((raw as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
+    });
+
+    it('renders the INVALID_ACTOR_SOURCE envelope on an invalid RD_ACTOR_SOURCE', async () => {
+      await setupAutoIssuedDelegation();
+
+      const result = await runCliInProcess('delegate', workspace, {
+        env: { RD_ACTOR_SOURCE: 'remote' },
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      expect((JSON.parse(result.stdout) as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
+    });
+
+    it('issues a bare delegation unchanged when source=direct-cli is explicit', async () => {
+      // Behavior-neutral for the default source: explicit direct-cli must match
+      // the untagged happy path. Uses the same parent fixture the happy-path
+      // tests use so a real token is issued.
+      await setupAutoIssuedDelegation();
+
+      // setupAutoIssuedDelegation leaves an auto-issued delegation on substep 1;
+      // a fresh bare delegate with no pending outcome echoes/returns a token.
+      const explicit = await runCliInProcess('--actor-source direct-cli delegate', workspace);
+
+      expect(explicit.exitCode).toBe(0);
+      const raw = JSON.parse(explicit.stdout);
+      expect(DelegateResponseSchema.safeParse(raw).success).toBe(true);
+    });
+  });
+
   describe('idempotent bare delegate', () => {
     it('echoes the auto-issued frontier token instead of RD-813 (JSON)', async () => {
       const autoToken = await setupAutoIssuedDelegation();

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -12,7 +12,11 @@ import {
   parseConcatenatedJson,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
-import { ActionResponseSchema, WarningResponseSchema } from '../helpers/schema-validator.js';
+import {
+  ActionResponseSchema,
+  ErrorResponseSchema,
+  WarningResponseSchema,
+} from '../helpers/schema-validator.js';
 
 describe('fail command', () => {
   let workspace: TestWorkspace;
@@ -55,6 +59,53 @@ describe('fail command', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('step_transitioned');
       expect(result.stdout).not.toContain('DELEGATION_COLLECTION_PENDING');
+    });
+
+    it.each([
+      'plugin',
+      'mcp',
+    ] as const)('still refuses bare fail while pending when source=%s (source never buys past the guard)', async (source) => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess(`--actor-source ${source} fail`, workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as {
+        code?: string;
+        details?: { outcomeCompletionKeys?: string[] };
+      };
+      expect(payload.code).toBe('DELEGATION_COLLECTION_PENDING');
+      expect(payload.details?.outcomeCompletionKeys).toEqual([completionKey]);
+    });
+
+    // ENV BRIDGE (finding 7): symmetric with pass — fail also reads the source
+    // through transition-command.ts, so pin the RD_ACTOR_SOURCE bridge ×
+    // collection-pending guard on the fail path too.
+    it('still refuses bare fail while pending when RD_ACTOR_SOURCE=plugin', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess('fail', workspace, {
+        env: { RD_ACTOR_SOURCE: 'plugin' },
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect((JSON.parse(result.stdout) as { code?: string }).code).toBe(
+        'DELEGATION_COLLECTION_PENDING',
+      );
+    });
+
+    it('renders the INVALID_ACTOR_SOURCE envelope on an invalid --actor-source for fail', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+      const result = await runCliInProcess('--actor-source remote fail', workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      // Validate the envelope SHAPE, not just the code (finding 8).
+      const raw = JSON.parse(result.stdout);
+      expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
+      expect((raw as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
     });
   });
 

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -13,7 +13,7 @@ import {
   parseConcatenatedJson,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
-import { ActionResponseSchema } from '../helpers/schema-validator.js';
+import { ActionResponseSchema, ErrorResponseSchema } from '../helpers/schema-validator.js';
 
 describe('pass command', () => {
   let workspace: TestWorkspace;
@@ -56,6 +56,55 @@ describe('pass command', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('step_transitioned');
       expect(result.stdout).not.toContain('DELEGATION_COLLECTION_PENDING');
+    });
+
+    it.each([
+      'plugin',
+      'mcp',
+    ] as const)('still refuses bare pass while pending when source=%s (source never buys past the guard)', async (source) => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess(`--actor-source ${source} pass`, workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as {
+        code?: string;
+        details?: { outcomeCompletionKeys?: string[] };
+      };
+      expect(payload.code).toBe('DELEGATION_COLLECTION_PENDING');
+      expect(payload.details?.outcomeCompletionKeys).toEqual([completionKey]);
+    });
+
+    // ENV BRIDGE (finding 7): pass reads the source through a DISTINCT call site
+    // (transition-command.ts) from delegate, so the RD_ACTOR_SOURCE bridge ×
+    // collection-pending guard must be pinned on the pass path too. A
+    // plugin-tagged bare pass still refuses while pending.
+    it('still refuses bare pass while pending when RD_ACTOR_SOURCE=plugin', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      await injectDelegationOutcomeForActiveRun(workspace);
+
+      const result = await runCliInProcess('pass', workspace, {
+        env: { RD_ACTOR_SOURCE: 'plugin' },
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect((JSON.parse(result.stdout) as { code?: string }).code).toBe(
+        'DELEGATION_COLLECTION_PENDING',
+      );
+    });
+
+    it('renders the INVALID_ACTOR_SOURCE envelope on an invalid --actor-source for pass', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+      const result = await runCliInProcess('--actor-source remote pass', workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      // Validate the envelope SHAPE, not just the code (finding 8): an invalid
+      // source renders the standard error envelope via the OutputEmitter.
+      const raw = JSON.parse(result.stdout);
+      expect(ErrorResponseSchema.safeParse(raw).success).toBe(true);
+      expect((raw as { code?: string }).code).toBe('INVALID_ACTOR_SOURCE');
     });
   });
 

--- a/packages/cli/__tests__/helpers/actor-source-option.test.ts
+++ b/packages/cli/__tests__/helpers/actor-source-option.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from '@jest/globals';
+import { InvalidActorSourceError } from '../../src/helpers/resolve-actor-context.js';
+import {
+  readActorSourceIngress,
+  type ActorSourceReader,
+} from '../../src/helpers/actor-source-option.js';
+
+function reader(actorSource?: string): ActorSourceReader {
+  return { optsWithGlobals: () => ({ actorSource }) };
+}
+
+describe('readActorSourceIngress', () => {
+  it('returns undefined when neither flag nor env is set', () => {
+    expect(readActorSourceIngress(reader(undefined), {})).toBeUndefined();
+  });
+
+  it('reads the validated value from the --actor-source flag', () => {
+    expect(readActorSourceIngress(reader('plugin'), {})).toBe('plugin');
+  });
+
+  it('reads the validated value from RD_ACTOR_SOURCE when the flag is unset', () => {
+    expect(readActorSourceIngress(reader(undefined), { RD_ACTOR_SOURCE: 'mcp' })).toBe('mcp');
+  });
+
+  it('lets the flag take precedence over the env var', () => {
+    expect(readActorSourceIngress(reader('plugin'), { RD_ACTOR_SOURCE: 'mcp' })).toBe('plugin');
+  });
+
+  it('throws InvalidActorSourceError on an invalid flag value (no silent default)', () => {
+    expect(() => readActorSourceIngress(reader('remote'), {})).toThrow(InvalidActorSourceError);
+  });
+
+  it('throws InvalidActorSourceError on an invalid env value', () => {
+    expect(() => readActorSourceIngress(reader(undefined), { RD_ACTOR_SOURCE: 'remote' })).toThrow(
+      InvalidActorSourceError,
+    );
+  });
+
+  it('ignores an empty-string env var (treated as unset)', () => {
+    expect(readActorSourceIngress(reader(undefined), { RD_ACTOR_SOURCE: '' })).toBeUndefined();
+  });
+});

--- a/packages/cli/__tests__/helpers/resolve-actor-context.properties.test.ts
+++ b/packages/cli/__tests__/helpers/resolve-actor-context.properties.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from '@jest/globals';
+import fc from 'fast-check';
+import type { ClaimId, DelegationTokenHash, RunId, RunbookState } from '@rundown-org/core';
+import {
+  ACTOR_SOURCE_VALUES,
+  InvalidActorSourceError,
+  parseActorSource,
+  resolveActorContext,
+  type ActorIngress,
+} from '../../src/helpers/resolve-actor-context.js';
+
+// resolveActorContext only reads `.id`, so a minimal cast stub suffices.
+function stubState(id: string): RunbookState {
+  return { id: id as RunId } as unknown as RunbookState;
+}
+const STATE = stubState('run_target');
+
+// Arbitraries for each optional ingress field. `source` ranges over the valid
+// set plus undefined (the helper is only ever fed an already-validated source).
+const sourceArb = fc.option(fc.constantFrom(...ACTOR_SOURCE_VALUES), { nil: undefined });
+const claimIdArb = fc.option(
+  fc.string({ minLength: 1 }).map((s) => s as ClaimId),
+  { nil: undefined },
+);
+const tokenHashArb = fc.option(
+  fc.string({ minLength: 1 }).map((s) => s as DelegationTokenHash),
+  { nil: undefined },
+);
+const controlledRunIdArb = fc.option(
+  fc.string({ minLength: 1 }).map((s) => s as RunId),
+  { nil: undefined },
+);
+
+const ingressArb: fc.Arbitrary<ActorIngress> = fc.record({
+  source: sourceArb,
+  claimId: claimIdArb,
+  tokenHash: tokenHashArb,
+  controlledRunId: controlledRunIdArb,
+});
+
+describe('resolveActorContext — properties', () => {
+  it('property 1: total and kind-closed (never throws; kind is a known variant)', () => {
+    fc.assert(
+      fc.property(ingressArb, (ingress) => {
+        const result = resolveActorContext(ingress, STATE);
+        expect(['trusted_run_controller', 'claim_controller', 'unknown']).toContain(result.kind);
+      }),
+    );
+  });
+
+  it('property 2: claim_controller iff both claimId and tokenHash are present', () => {
+    fc.assert(
+      fc.property(ingressArb, (ingress) => {
+        const isClaim = ingress.claimId !== undefined && ingress.tokenHash !== undefined;
+        expect(resolveActorContext(ingress, STATE).kind === 'claim_controller').toBe(isClaim);
+      }),
+    );
+  });
+
+  it('property 3: source never appears on a claim_controller', () => {
+    fc.assert(
+      fc.property(ingressArb, (ingress) => {
+        const result = resolveActorContext(ingress, STATE);
+        if (result.kind === 'claim_controller') {
+          expect((result as { source?: unknown }).source).toBeUndefined();
+        }
+      }),
+    );
+  });
+
+  it('property 4: no-claim path defaults source to direct-cli and targets state.id', () => {
+    // Restrict to the no-claim path (neither claim field present) so the result
+    // is always a trusted run controller.
+    const noClaimArb = fc.record({ source: sourceArb });
+    fc.assert(
+      fc.property(noClaimArb, (ingress) => {
+        const result = resolveActorContext(ingress, STATE);
+        expect(result.kind).toBe('trusted_run_controller');
+        if (result.kind === 'trusted_run_controller') {
+          expect(result.source).toBe(ingress.source ?? 'direct-cli');
+          expect(result.runId).toBe(STATE.id);
+        }
+      }),
+    );
+  });
+
+  it('property 5: complete-claim path defaults controlledRunId to state.id', () => {
+    // Force complete claim evidence so the claim_controller branch always fires.
+    const claimArb = fc.record({
+      source: sourceArb,
+      claimId: fc.string({ minLength: 1 }).map((s) => s as ClaimId),
+      tokenHash: fc.string({ minLength: 1 }).map((s) => s as DelegationTokenHash),
+      controlledRunId: controlledRunIdArb,
+    });
+    fc.assert(
+      fc.property(claimArb, (ingress) => {
+        const result = resolveActorContext(ingress, STATE);
+        expect(result.kind).toBe('claim_controller');
+        if (result.kind === 'claim_controller') {
+          expect(result.controlledRunId).toBe(ingress.controlledRunId ?? STATE.id);
+        }
+      }),
+    );
+  });
+});
+
+describe('parseActorSource — properties', () => {
+  it('property 6a: round-trips every valid value', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...ACTOR_SOURCE_VALUES), (value) => {
+        expect(parseActorSource(value)).toBe(value);
+      }),
+    );
+  });
+
+  it('property 6b: throws InvalidActorSourceError(value) for any non-valid string', () => {
+    const invalidArb = fc
+      .string()
+      .filter((s) => !(ACTOR_SOURCE_VALUES as readonly string[]).includes(s));
+    fc.assert(
+      fc.property(invalidArb, (value) => {
+        try {
+          parseActorSource(value);
+          throw new Error('should have thrown');
+        } catch (error) {
+          expect(error).toBeInstanceOf(InvalidActorSourceError);
+          expect((error as InvalidActorSourceError).value).toBe(value);
+        }
+      }),
+    );
+  });
+});

--- a/packages/cli/__tests__/helpers/resolve-actor-context.test.ts
+++ b/packages/cli/__tests__/helpers/resolve-actor-context.test.ts
@@ -21,7 +21,7 @@ function stubState(id: string): RunbookState {
 
 const TARGET = stubState('run_target');
 const CLAIM_ID = 'rdclm_target' as ClaimId;
-const TOKEN_HASH = 'tokenhash_target' as DelegationTokenHash;
+const TOKEN_HASH = 'tokenHash_target' as DelegationTokenHash;
 const CONTROLLED = 'run_controlled' as RunId;
 
 describe('parseActorSource', () => {
@@ -55,7 +55,7 @@ describe('parseActorSource', () => {
     expect(() => parseActorSource(value)).toThrow(InvalidActorSourceError);
   });
 
-  it.each([' plugin ', 'plugin\n', '\tmcp'])('rejects untrimmed whitespace (%j)', (value) => {
+  it.each([' plugin ', 'plugin\n', 'mcp\t'])('rejects untrimmed whitespace (%j)', (value) => {
     expect(() => parseActorSource(value)).toThrow(InvalidActorSourceError);
   });
 });
@@ -63,7 +63,7 @@ describe('parseActorSource', () => {
 describe('resolveActorContext — frozen trust-mapping table', () => {
   it('row 1: source unset, no claim => trusted_run_controller(direct-cli)', () => {
     const ingress: ActorIngress = {};
-    expect(resolveActorContext(ingress, TARGET)).toEqual<ActorContext>({
+    expect(resolveActorContext(ingress, TARGET)).toEqual({
       kind: 'trusted_run_controller',
       runId: TARGET.id,
       source: 'direct-cli',
@@ -71,7 +71,7 @@ describe('resolveActorContext — frozen trust-mapping table', () => {
   });
 
   it('row 1b: source direct-cli, no claim => trusted_run_controller(direct-cli)', () => {
-    expect(resolveActorContext({ source: 'direct-cli' }, TARGET)).toEqual<ActorContext>({
+    expect(resolveActorContext({ source: 'direct-cli' }, TARGET)).toEqual({
       kind: 'trusted_run_controller',
       runId: TARGET.id,
       source: 'direct-cli',
@@ -79,7 +79,7 @@ describe('resolveActorContext — frozen trust-mapping table', () => {
   });
 
   it('row 2: source plugin, no claim => trusted_run_controller(plugin)', () => {
-    expect(resolveActorContext({ source: 'plugin' }, TARGET)).toEqual<ActorContext>({
+    expect(resolveActorContext({ source: 'plugin' }, TARGET)).toEqual({
       kind: 'trusted_run_controller',
       runId: TARGET.id,
       source: 'plugin',
@@ -87,7 +87,7 @@ describe('resolveActorContext — frozen trust-mapping table', () => {
   });
 
   it('row 3: source mcp, no claim => trusted_run_controller(mcp)', () => {
-    expect(resolveActorContext({ source: 'mcp' }, TARGET)).toEqual<ActorContext>({
+    expect(resolveActorContext({ source: 'mcp' }, TARGET)).toEqual({
       kind: 'trusted_run_controller',
       runId: TARGET.id,
       source: 'mcp',
@@ -107,7 +107,7 @@ describe('resolveActorContext — frozen trust-mapping table', () => {
           { source, claimId: CLAIM_ID, tokenHash: TOKEN_HASH, controlledRunId: CONTROLLED },
           TARGET,
         ),
-      ).toEqual<ActorContext>(expected);
+      ).toEqual(expected);
     }
   });
 
@@ -120,7 +120,7 @@ describe('resolveActorContext — frozen trust-mapping table', () => {
       { source: 'plugin', claimId: CLAIM_ID, tokenHash: TOKEN_HASH, controlledRunId: CONTROLLED },
       TARGET,
     );
-    expect(result).toEqual<ActorContext>({
+    expect(result).toEqual({
       kind: 'claim_controller',
       claimId: CLAIM_ID,
       tokenHash: TOKEN_HASH,
@@ -137,7 +137,7 @@ describe('resolveActorContext — frozen trust-mapping table', () => {
       { source: 'mcp', claimId: CLAIM_ID, tokenHash: TOKEN_HASH, controlledRunId: CONTROLLED },
       TARGET,
     );
-    expect(result).toEqual<ActorContext>({
+    expect(result).toEqual({
       kind: 'claim_controller',
       claimId: CLAIM_ID,
       tokenHash: TOKEN_HASH,
@@ -150,9 +150,7 @@ describe('resolveActorContext — frozen trust-mapping table', () => {
   it('claim evidence defaults controlledRunId to the resolved target id when omitted', () => {
     // The collect path resolves the claimed child as `state`, so a caller may
     // omit controlledRunId and rely on `state.id`.
-    expect(
-      resolveActorContext({ claimId: CLAIM_ID, tokenHash: TOKEN_HASH }, TARGET),
-    ).toEqual<ActorContext>({
+    expect(resolveActorContext({ claimId: CLAIM_ID, tokenHash: TOKEN_HASH }, TARGET)).toEqual({
       kind: 'claim_controller',
       claimId: CLAIM_ID,
       tokenHash: TOKEN_HASH,
@@ -164,14 +162,14 @@ describe('resolveActorContext — frozen trust-mapping table', () => {
     // No resolvable controlled run AND no *complete* claim evidence: the
     // reserved inspect-only fallback. Type-reachable even though no default
     // local frontend path produces it.
-    expect(
-      resolveActorContext({ source: 'plugin', claimId: CLAIM_ID }, TARGET),
-    ).toEqual<ActorContext>({ kind: 'unknown' });
+    expect(resolveActorContext({ source: 'plugin', claimId: CLAIM_ID }, TARGET)).toEqual({
+      kind: 'unknown',
+    });
   });
 
   it('row 5b: tokenHash without claimId => unknown', () => {
-    expect(
-      resolveActorContext({ source: 'mcp', tokenHash: TOKEN_HASH }, TARGET),
-    ).toEqual<ActorContext>({ kind: 'unknown' });
+    expect(resolveActorContext({ source: 'mcp', tokenHash: TOKEN_HASH }, TARGET)).toEqual({
+      kind: 'unknown',
+    });
   });
 });

--- a/packages/cli/__tests__/helpers/resolve-actor-context.test.ts
+++ b/packages/cli/__tests__/helpers/resolve-actor-context.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from '@jest/globals';
+import type {
+  ActorContext,
+  ClaimId,
+  DelegationTokenHash,
+  RunId,
+  RunbookState,
+} from '@rundown-org/core';
+import {
+  ACTOR_SOURCE_VALUES,
+  InvalidActorSourceError,
+  parseActorSource,
+  resolveActorContext,
+  type ActorIngress,
+} from '../../src/helpers/resolve-actor-context.js';
+
+// Minimal RunbookState stub: resolveActorContext only reads `.id`.
+function stubState(id: string): RunbookState {
+  return { id: id as RunId } as unknown as RunbookState;
+}
+
+const TARGET = stubState('run_target');
+const CLAIM_ID = 'rdclm_target' as ClaimId;
+const TOKEN_HASH = 'tokenhash_target' as DelegationTokenHash;
+const CONTROLLED = 'run_controlled' as RunId;
+
+describe('parseActorSource', () => {
+  it('exposes exactly the three frozen source values', () => {
+    expect([...ACTOR_SOURCE_VALUES]).toEqual(['direct-cli', 'plugin', 'mcp']);
+  });
+
+  it.each(['direct-cli', 'plugin', 'mcp'] as const)('accepts %s', (value) => {
+    expect(parseActorSource(value)).toBe(value);
+  });
+
+  it('rejects an unknown value with a typed hard error (no silent default)', () => {
+    expect.assertions(3);
+    try {
+      parseActorSource('remote');
+      throw new Error('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidActorSourceError);
+      expect((error as InvalidActorSourceError).code).toBe('INVALID_ACTOR_SOURCE');
+      expect((error as InvalidActorSourceError).value).toBe('remote');
+    }
+  });
+
+  it('rejects the empty string', () => {
+    expect(() => parseActorSource('')).toThrow(InvalidActorSourceError);
+  });
+
+  // Matching is exact: no implicit case folding and no whitespace trimming.
+  // These pin a future `.toLowerCase()` / `.trim()` normalization mutant.
+  it.each(['Plugin', 'MCP', 'Direct-CLI'])('rejects case variants (%s)', (value) => {
+    expect(() => parseActorSource(value)).toThrow(InvalidActorSourceError);
+  });
+
+  it.each([' plugin ', 'plugin\n', '\tmcp'])('rejects untrimmed whitespace (%j)', (value) => {
+    expect(() => parseActorSource(value)).toThrow(InvalidActorSourceError);
+  });
+});
+
+describe('resolveActorContext — frozen trust-mapping table', () => {
+  it('row 1: source unset, no claim => trusted_run_controller(direct-cli)', () => {
+    const ingress: ActorIngress = {};
+    expect(resolveActorContext(ingress, TARGET)).toEqual<ActorContext>({
+      kind: 'trusted_run_controller',
+      runId: TARGET.id,
+      source: 'direct-cli',
+    });
+  });
+
+  it('row 1b: source direct-cli, no claim => trusted_run_controller(direct-cli)', () => {
+    expect(resolveActorContext({ source: 'direct-cli' }, TARGET)).toEqual<ActorContext>({
+      kind: 'trusted_run_controller',
+      runId: TARGET.id,
+      source: 'direct-cli',
+    });
+  });
+
+  it('row 2: source plugin, no claim => trusted_run_controller(plugin)', () => {
+    expect(resolveActorContext({ source: 'plugin' }, TARGET)).toEqual<ActorContext>({
+      kind: 'trusted_run_controller',
+      runId: TARGET.id,
+      source: 'plugin',
+    });
+  });
+
+  it('row 3: source mcp, no claim => trusted_run_controller(mcp)', () => {
+    expect(resolveActorContext({ source: 'mcp' }, TARGET)).toEqual<ActorContext>({
+      kind: 'trusted_run_controller',
+      runId: TARGET.id,
+      source: 'mcp',
+    });
+  });
+
+  it('row 4: any source + full claim evidence => claim_controller (source ignored)', () => {
+    const expected: ActorContext = {
+      kind: 'claim_controller',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: CONTROLLED,
+    };
+    for (const source of ACTOR_SOURCE_VALUES) {
+      expect(
+        resolveActorContext(
+          { source, claimId: CLAIM_ID, tokenHash: TOKEN_HASH, controlledRunId: CONTROLLED },
+          TARGET,
+        ),
+      ).toEqual<ActorContext>(expected);
+    }
+  });
+
+  // Resolver invariant: if valid claim evidence is present, claim_controller
+  // wins over any source tag. This does not imply the plugin plan emits
+  // source=plugin for agent-run Bash lifecycle commands; it only pins the
+  // resolver table for callers that already have claim evidence.
+  it('row 4: source=plugin + valid claim => claim_controller (claim wins)', () => {
+    const result = resolveActorContext(
+      { source: 'plugin', claimId: CLAIM_ID, tokenHash: TOKEN_HASH, controlledRunId: CONTROLLED },
+      TARGET,
+    );
+    expect(result).toEqual<ActorContext>({
+      kind: 'claim_controller',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: CONTROLLED,
+    });
+    // Belt-and-braces: it is NOT downgraded to a trusted run controller and
+    // carries no `source` field (claim_controller has no source).
+    expect(result.kind).toBe('claim_controller');
+    expect((result as { source?: unknown }).source).toBeUndefined();
+  });
+
+  it('row 4 (MCP pin): source=mcp + valid claim => claim_controller (claim wins)', () => {
+    const result = resolveActorContext(
+      { source: 'mcp', claimId: CLAIM_ID, tokenHash: TOKEN_HASH, controlledRunId: CONTROLLED },
+      TARGET,
+    );
+    expect(result).toEqual<ActorContext>({
+      kind: 'claim_controller',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: CONTROLLED,
+    });
+    expect(result.kind).toBe('claim_controller');
+    expect((result as { source?: unknown }).source).toBeUndefined();
+  });
+
+  it('claim evidence defaults controlledRunId to the resolved target id when omitted', () => {
+    // The collect path resolves the claimed child as `state`, so a caller may
+    // omit controlledRunId and rely on `state.id`.
+    expect(
+      resolveActorContext({ claimId: CLAIM_ID, tokenHash: TOKEN_HASH }, TARGET),
+    ).toEqual<ActorContext>({
+      kind: 'claim_controller',
+      claimId: CLAIM_ID,
+      tokenHash: TOKEN_HASH,
+      controlledRunId: TARGET.id,
+    });
+  });
+
+  it('row 5: partial claim evidence (claimId without tokenHash) => unknown', () => {
+    // No resolvable controlled run AND no *complete* claim evidence: the
+    // reserved inspect-only fallback. Type-reachable even though no default
+    // local frontend path produces it.
+    expect(
+      resolveActorContext({ source: 'plugin', claimId: CLAIM_ID }, TARGET),
+    ).toEqual<ActorContext>({ kind: 'unknown' });
+  });
+
+  it('row 5b: tokenHash without claimId => unknown', () => {
+    expect(
+      resolveActorContext({ source: 'mcp', tokenHash: TOKEN_HASH }, TARGET),
+    ).toEqual<ActorContext>({ kind: 'unknown' });
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -78,6 +78,17 @@ export function createProgram(): Command {
   program.option('--no-color', 'Disable colored output');
   program.option('--schema', "Output JSON schema for the command's JSON output");
 
+  // Actor-context ingress (provenance tag for role-specific mutation policy).
+  // CAPTURE-ONLY: this flag is read AND validated inside each actor-context-
+  // constructing command's withErrorHandling/OutputEmitter block (see
+  // readActorSourceIngress), NOT here. Do not add validation to a Commander hook:
+  // a thrown hook error is caught by parseAsync().catch below and printed to
+  // stderr, which would bypass the INVALID_ACTOR_SOURCE JSON envelope contract.
+  program.option(
+    '--actor-source <source>',
+    'Actor-context provenance for role-specific mutations (direct-cli | plugin | mcp)',
+  );
+
   // Policy options
   program
     .addOption(

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -162,6 +162,12 @@ export function registerClaimCommand(program: Command): void {
         await withErrorHandling(
           async () => {
             const output = new OutputEmitter({ text: options.text, command: 'claim' });
+            // Actor-context ingress (Plan: cli-actor-context-ingress): `claim`
+            // launches a NEW child run (claimAndLaunch); it is not a
+            // target-relative mutation against an existing run and invokes no
+            // actor-context-gated core policy, so it constructs no ActorContext.
+            // A future need would consume readActorSourceIngress +
+            // resolveActorContext.
             const cwd = getCwd();
             const manager = new RunbookStateManager(cwd);
             const actorService = createCliRunbookActorService(manager);

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -469,6 +469,7 @@ function renderCollectOutcome(
  *
  * @param ctx - Transition context for the active runbook
  * @param options - Targeting flags forwarded from the CLI
+ * @param actorSource - Resolved `--actor-source` / `RD_ACTOR_SOURCE` provenance tag, or undefined
  * @returns True if the command should set a non-zero exit code
  */
 async function runCollect(

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -4,26 +4,62 @@ import type { Command } from 'commander';
 import {
   activeFrame,
   buildFrameKey,
-  claimControllerContext,
   deriveActiveFrame,
   ExecutionEventEmitter,
+  getErrorMessage,
   inactiveFrame,
   RunbookCollectionService,
   RunbookCompletionService,
-  trustedRunControllerContext,
   type ActorContext,
+  type ActorContextSource,
+  type ClaimRecord,
   type DelegationPolicyOutcome,
   type Frame,
   type FrameKey,
+  type RunId,
 } from '@rundown-org/core';
 import { parseStepIdFromString } from '@rundown-org/parser';
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { buildTransitionContext, type TransitionContext } from '../helpers/transitions.js';
+import { resolveActorContext, type ActorIngress } from '../helpers/resolve-actor-context.js';
+import { readActorSourceIngress } from '../helpers/actor-source-option.js';
 import { resolveIndexOption, IndexOptionError } from '../helpers/index-option.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
 import { extractParentLinkage, propagateChildTerminal } from '../helpers/delegation-completion.js';
+
+/**
+ * Build the collect command's actor ingress from the resolved source tag and
+ * the optional resolved claim record.
+ *
+ * `collect` threads the FULL ingress: the provenance `source` (when supplied)
+ * PLUS claim evidence (`claimId` / `tokenHash`) when targeting a claimed child
+ * via `--claim-id`. The {@link ClaimRecord} carries `claimId` and `tokenHash`
+ * but has NO `controlledRunId` field (it has `childRunId`) — the controlled run
+ * is the resolved claimed child, so `controlledRunId` defaults to
+ * `targetStateId` (the collect path resolves `ctx.state` to that child).
+ * Exported so the source + claim propagation is unit-testable in isolation
+ * (collection is source-independent, so an end-to-end test cannot observe the
+ * tag).
+ *
+ * @param actorSource - Resolved `--actor-source` / `RD_ACTOR_SOURCE` tag, or undefined
+ * @param claim - Resolved claim record when `--claim-id` targeted a claimed child, else undefined
+ * @param targetStateId - Resolved target run id (`state.id`), used as the claim's `controlledRunId`
+ * @returns An `ActorIngress` carrying `source` iff supplied and claim evidence iff a claim is present
+ */
+export function buildCollectActorIngress(
+  actorSource: ActorContextSource | undefined,
+  claim: ClaimRecord | undefined,
+  targetStateId: RunId,
+): ActorIngress {
+  return {
+    ...(actorSource ? { source: actorSource } : {}),
+    ...(claim
+      ? { claimId: claim.claimId, tokenHash: claim.tokenHash, controlledRunId: targetStateId }
+      : {}),
+  };
+}
 
 /**
  * Registers the 'collect' command — triggers aggregation after DELEGATE fan-out.
@@ -51,11 +87,26 @@ export function registerCollectCommand(program: Command): void {
     .option('--claim-id <claimId>', 'Target a claimed delegated child runbook')
     .option('--text', 'Output as human-readable text')
     .action(
-      async (options: { step?: string; index?: string; claimId?: string; text?: boolean }) => {
+      async (
+        options: { step?: string; index?: string; claimId?: string; text?: boolean },
+        command: Command,
+      ) => {
         await withErrorHandling(
           async () => {
             const output = new OutputEmitter({ text: options.text, command: 'collect' });
             const cwd = getCwd();
+
+            let actorSource: ActorContextSource | undefined;
+            try {
+              actorSource = readActorSourceIngress(command);
+            } catch (error: unknown) {
+              // InvalidActorSourceError carries code 'INVALID_ACTOR_SOURCE' and a
+              // human message; render it through the standard JSON envelope.
+              output.error(getErrorMessage(error), 'INVALID_ACTOR_SOURCE');
+              output.flush();
+              process.exitCode = 1;
+              return;
+            }
 
             const claimTarget = parseClaimIdOption(options.claimId, output);
             if (!claimTarget.ok) return;
@@ -82,11 +133,15 @@ export function registerCollectCommand(program: Command): void {
             }
             const ctx = contextResult.ctx;
 
-            const shouldExitWithError = await runCollect(ctx, {
-              step: options.step,
-              index: options.index,
-              text: options.text,
-            });
+            const shouldExitWithError = await runCollect(
+              ctx,
+              {
+                step: options.step,
+                index: options.index,
+                text: options.text,
+              },
+              actorSource,
+            );
 
             if (shouldExitWithError) {
               process.exitCode = 1;
@@ -416,22 +471,26 @@ function renderCollectOutcome(
  * @param options - Targeting flags forwarded from the CLI
  * @returns True if the command should set a non-zero exit code
  */
-async function runCollect(ctx: TransitionContext, options: CollectOptions): Promise<boolean> {
+async function runCollect(
+  ctx: TransitionContext,
+  options: CollectOptions,
+  actorSource: ActorContextSource | undefined,
+): Promise<boolean> {
   const { output, manager, actorService, lifecycleService, state, steps, cwd } = ctx;
 
   const scope = resolveCollectScope(state, options, output);
   if (!scope) return true;
 
-  // On the claim-targeted path `ctx.state` is the claimed child run, so
-  // `controlledRunId === state.id`; otherwise the trusted direct-CLI mapping
-  // makes the run controller the orchestrator for its own run.
-  const actorContext: ActorContext = ctx.claim
-    ? claimControllerContext({
-        claimId: ctx.claim.claimId,
-        tokenHash: ctx.claim.tokenHash,
-        controlledRunId: state.id,
-      })
-    : trustedRunControllerContext(state.id, 'direct-cli');
+  // Source is provenance only; the claim-vs-no-claim trust decision lives in
+  // resolveActorContext. buildCollectActorIngress threads the source tag plus
+  // claim evidence (claimId / tokenHash / controlledRunId: state.id) when
+  // `ctx.claim` is present — on the claim path `ctx.state` IS the claimed child,
+  // so controlledRunId === state.id; otherwise the trusted run controller maps
+  // the active run's controller to the orchestrator for its own run.
+  const actorContext: ActorContext = resolveActorContext(
+    buildCollectActorIngress(actorSource, ctx.claim, state.id),
+    state,
+  );
 
   const collectionService = new RunbookCollectionService({
     manager,

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -47,6 +47,12 @@ export function registerCompleteCommand(program: Command): void {
       await withErrorHandling(
         async () => {
           const output = new OutputEmitter({ text: options.text, command: 'complete' });
+          // Actor-context ingress (Plan: cli-actor-context-ingress): `complete`
+          // is a workflow-level force-terminal override and the narrow
+          // --claim-id force path; it invokes no actor-context-gated core policy
+          // (no resolveCommandIntent / resolveTransitionTarget), so it
+          // constructs no ActorContext. A future actor-gated force-terminal
+          // policy would consume readActorSourceIngress + resolveActorContext.
           const cwd = getCwd();
           const manager = new RunbookStateManager(cwd);
           const sessionService = new SessionService(manager);

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -11,11 +11,14 @@ import {
   deriveDelegateFrontier,
   buildFrameKey,
   resolveCommandIntent,
-  trustedRunControllerContext,
+  getErrorMessage,
+  type ActorContextSource,
 } from '@rundown-org/core';
 import { parseStepIdFromString } from '@rundown-org/parser';
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
+import { resolveActorContext, type ActorIngress } from '../helpers/resolve-actor-context.js';
+import { readActorSourceIngress } from '../helpers/actor-source-option.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { buildRunbookRef, resolveRunbookFile } from '../helpers/resolve-runbook.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
@@ -48,6 +51,22 @@ interface DelegateActionOptions {
   inputJson?: string[];
   inputFile?: string[];
   text?: boolean;
+}
+
+/**
+ * Build the delegate command's actor ingress from a resolved source tag.
+ *
+ * `delegate` registers no `--claim-id` option, so it never carries claim
+ * evidence — the ingress is provenance-source-only. Exported so the
+ * source-propagation behavior is unit-testable in isolation.
+ *
+ * @param actorSource - Resolved `--actor-source` / `RD_ACTOR_SOURCE` tag, or undefined
+ * @returns An `ActorIngress` with `source` set iff a tag was supplied
+ */
+export function buildDelegateActorIngress(
+  actorSource: ActorContextSource | undefined,
+): ActorIngress {
+  return actorSource ? { source: actorSource } : {};
 }
 
 /**
@@ -87,295 +106,311 @@ export function registerDelegateCommand(program: Command): void {
         .helpGroup('Input options:'),
     )
     .option('--text', 'Output as human-readable text')
-    .action(async (runbookArg: string | undefined, options: DelegateActionOptions) => {
-      await withErrorHandling(
-        async () => {
-          const output = new OutputEmitter({ text: options.text, command: 'delegate' });
+    .action(
+      async (runbookArg: string | undefined, options: DelegateActionOptions, command: Command) => {
+        await withErrorHandling(
+          async () => {
+            const output = new OutputEmitter({ text: options.text, command: 'delegate' });
 
-          const depError = validateIndexRequiresStep(options.index, options.step);
-          if (depError) {
-            failRetry(output, depError, 'INVALID_SYNTAX');
-          }
-
-          const cwd = getCwd();
-
-          const manager = new RunbookStateManager(cwd);
-          const sessionService = new SessionService(manager);
-
-          // --retry has its own resolution flow; handle it up front.
-          if (options.retry) {
-            await handleRetry({
-              runbookArg,
-              options,
-              manager,
-              sessionService,
-              cwd,
-              output,
-            });
-            output.flush();
-            return;
-          }
-
-          const state = await sessionService.getActive();
-
-          if (!state) {
-            output.noActiveRunbook('delegate');
-            output.flush();
-            return;
-          }
-
-          // `--retry` is handled by the `if (options.retry)` early return above,
-          // so options.retry is always false here; bareness is just the absence
-          // of an explicit --step target.
-          const isBareDelegationIssue = options.step === undefined;
-          if (isBareDelegationIssue) {
-            const policy = resolveCommandIntent({
-              actorContext: trustedRunControllerContext(state.id, 'direct-cli'),
-              intent: { kind: 'delegation-issuance', command: 'delegate', targeted: false },
-              targetSelector: { kind: 'default' },
-              targetState: state,
-            });
-            switch (policy.kind) {
-              case 'allowed':
-                break;
-              case 'delegation_collection_pending':
-                emitDelegationCollectionPendingError(
-                  output,
-                  'delegate',
-                  policy.parentRunId,
-                  policy.outcomeCompletionKeys,
-                  policy.message,
-                );
-                output.flush();
-                process.exitCode = 1;
-                return;
-              case 'actor_context_required':
-              case 'collect_requires_orchestrator':
-              case 'open_claims':
-              case 'missing_outcomes':
-              case 'already_collected':
-              case 'collection_frame_not_active':
-              case 'collection_applied':
-              case 'collection_failed':
-                throw new Error(`Unexpected delegate policy outcome: ${policy.kind}`);
-              default: {
-                const _exhaustive: never = policy;
-                throw new Error(
-                  `Unexpected delegate policy outcome: ${JSON.stringify(_exhaustive)}`,
-                );
-              }
+            const depError = validateIndexRequiresStep(options.index, options.step);
+            if (depError) {
+              failRetry(output, depError, 'INVALID_SYNTAX');
             }
-          }
 
-          // Load parent steps from state (needed for inference and createDelegation)
-          const steps = getRunbookFromState(state, cwd);
+            const cwd = getCwd();
 
-          // Resolve runbook and step — infer whichever is missing
-          let resolvedRunbook: string;
-          let resolvedStepId: string;
-          let requestedRunbook: string | undefined;
+            const manager = new RunbookStateManager(cwd);
+            const sessionService = new SessionService(manager);
 
-          if (runbookArg && options.step) {
-            // Explicit runbook is a confirmation, not an override. The parent
-            // runbook's authored DELEGATE target remains authoritative.
-            resolvedRunbook = inferRunbookFromStep(state, steps, options.step);
-            resolvedStepId = options.step;
-            requestedRunbook = runbookArg;
-          } else if (!runbookArg && options.step) {
-            // Step given, infer runbook from substep's runbooks field
-            resolvedRunbook = inferRunbookFromStep(state, steps, options.step);
-            resolvedStepId = options.step;
-          } else if (!runbookArg && !options.step) {
-            // Nothing given, infer both. The substeps may already carry an
-            // auto-issued delegation (issued on DELEGATE-step entry); in that
-            // case echo the existing token rather than re-issuing or throwing
-            // RD-813. The delegate frontier is not surfaced as a top-level
-            // RunbookState field, so derive it from the typed per-substep
-            // delegation records (each pending delegation carries its plaintext
-            // `token`, qualified id, and child runbook ref). Derivation is
-            // runbook logic owned by core (frame-aware); the CLI consumes it.
-            const frontier = deriveDelegateFrontier(state);
-            const resolution = resolveDelegateTarget(state, steps, frontier);
-            if (resolution.kind === 'already-issued') {
-              if (!options.text) {
-                output.json({
-                  kind: 'delegate',
-                  action: 'already-delegated',
-                  step: resolution.stepId,
-                  runbook: resolution.runbookRef,
-                  token: resolution.token,
-                  parent_run_id: state.id,
-                });
-              } else {
-                output.message(`ALREADY    step ${resolution.stepId} -> ${resolution.runbookRef}`);
-                output.message(`Token:     ${resolution.token}`);
-                output.message('');
-                output.message(`RD_CLAIM_TOKEN=${resolution.token}`);
-              }
+            // --retry has its own resolution flow; handle it up front.
+            if (options.retry) {
+              await handleRetry({
+                runbookArg,
+                options,
+                manager,
+                sessionService,
+                cwd,
+                output,
+              });
               output.flush();
               return;
             }
-            if (resolution.kind === 'none') {
-              throw Errors.delegationNoDelegatableSubstep(state.step);
+
+            let actorSource: ActorContextSource | undefined;
+            try {
+              actorSource = readActorSourceIngress(command);
+            } catch (error: unknown) {
+              // InvalidActorSourceError carries code 'INVALID_ACTOR_SOURCE' and a
+              // human message; render it through the standard JSON envelope.
+              output.error(getErrorMessage(error), 'INVALID_ACTOR_SOURCE');
+              output.flush();
+              process.exitCode = 1;
+              return;
             }
-            resolvedRunbook = resolution.target.runbookRef;
-            resolvedStepId = resolution.target.stepId;
-          } else {
-            // Runbook given, no step — infer step from first pending substep
-            const inferred = inferDelegationTarget(state, steps);
-            resolvedRunbook = runbookArg!;
-            resolvedStepId = inferred.stepId;
-          }
 
-          // Resolve child runbook path
-          const childResolved = await resolveRunbookFile(cwd, resolvedRunbook);
-          if (!childResolved) {
-            throw Errors.delegationRunbookNotFound(resolvedRunbook);
-          }
-          const childPath = childResolved.path;
-          const childRunbookRef = await buildRunbookRef(childResolved);
+            const state = await sessionService.getActive();
 
-          // Parse extra vars through the standard normalization pipeline
-          const rawVars = await collectCliFlags(
-            { inputFile: options.inputFile, input: options.input, inputJson: options.inputJson },
-            cwd,
-          );
-
-          let extraVars: Record<string, TemplateVarValue> | undefined;
-          if (Object.keys(rawVars).length > 0) {
-            const routed = await routeExtraVars(rawVars, cwd);
-            for (const w of routed.warnings) {
-              output.warning(w);
+            if (!state) {
+              output.noActiveRunbook('delegate');
+              output.flush();
+              return;
             }
-            extraVars = Object.keys(routed.vars).length > 0 ? routed.vars : undefined;
-          }
 
-          // Compute frame key — use explicit iteration from --index or three-level step ID
-          const parsedTarget = parseStepIdFromString(resolvedStepId);
-          let explicitIteration: number | undefined;
-          try {
-            explicitIteration = resolveIndexOption(options.index, parsedTarget?.at);
-          } catch (error) {
-            if (error instanceof IndexOptionError) {
-              failRetry(output, error.message, error.code);
+            // `--retry` is handled by the `if (options.retry)` early return above,
+            // so options.retry is always false here; bareness is just the absence
+            // of an explicit --step target.
+            const isBareDelegationIssue = options.step === undefined;
+            if (isBareDelegationIssue) {
+              const policy = resolveCommandIntent({
+                actorContext: resolveActorContext(buildDelegateActorIngress(actorSource), state),
+                intent: { kind: 'delegation-issuance', command: 'delegate', targeted: false },
+                targetSelector: { kind: 'default' },
+                targetState: state,
+              });
+              switch (policy.kind) {
+                case 'allowed':
+                  break;
+                case 'delegation_collection_pending':
+                  emitDelegationCollectionPendingError(
+                    output,
+                    'delegate',
+                    policy.parentRunId,
+                    policy.outcomeCompletionKeys,
+                    policy.message,
+                  );
+                  output.flush();
+                  process.exitCode = 1;
+                  return;
+                case 'actor_context_required':
+                case 'collect_requires_orchestrator':
+                case 'open_claims':
+                case 'missing_outcomes':
+                case 'already_collected':
+                case 'collection_frame_not_active':
+                case 'collection_applied':
+                case 'collection_failed':
+                  throw new Error(`Unexpected delegate policy outcome: ${policy.kind}`);
+                default: {
+                  const _exhaustive: never = policy;
+                  throw new Error(
+                    `Unexpected delegate policy outcome: ${JSON.stringify(_exhaustive)}`,
+                  );
+                }
+              }
             }
-            throw error;
-          }
 
-          // Validate --index requires a FOR step (three-level syntax validated in createDelegation)
-          if (explicitIteration !== undefined) {
-            const targetStepName = parsedTarget?.step ?? state.step;
-            const targetStep = steps.find((s) => s.name === targetStepName);
-            if (targetStep && targetStep.kind !== 'for' && targetStep.kind !== 'prompted-for') {
-              failRetry(
-                output,
-                `--index requires step "${targetStepName}" to be a FOR step, but it is "${targetStep.kind}"`,
-                'INVALID_INDEX',
-              );
+            // Load parent steps from state (needed for inference and createDelegation)
+            const steps = getRunbookFromState(state, cwd);
+
+            // Resolve runbook and step — infer whichever is missing
+            let resolvedRunbook: string;
+            let resolvedStepId: string;
+            let requestedRunbook: string | undefined;
+
+            if (runbookArg && options.step) {
+              // Explicit runbook is a confirmation, not an override. The parent
+              // runbook's authored DELEGATE target remains authoritative.
+              resolvedRunbook = inferRunbookFromStep(state, steps, options.step);
+              resolvedStepId = options.step;
+              requestedRunbook = runbookArg;
+            } else if (!runbookArg && options.step) {
+              // Step given, infer runbook from substep's runbooks field
+              resolvedRunbook = inferRunbookFromStep(state, steps, options.step);
+              resolvedStepId = options.step;
+            } else if (!runbookArg && !options.step) {
+              // Nothing given, infer both. The substeps may already carry an
+              // auto-issued delegation (issued on DELEGATE-step entry); in that
+              // case echo the existing token rather than re-issuing or throwing
+              // RD-813. The delegate frontier is not surfaced as a top-level
+              // RunbookState field, so derive it from the typed per-substep
+              // delegation records (each pending delegation carries its plaintext
+              // `token`, qualified id, and child runbook ref). Derivation is
+              // runbook logic owned by core (frame-aware); the CLI consumes it.
+              const frontier = deriveDelegateFrontier(state);
+              const resolution = resolveDelegateTarget(state, steps, frontier);
+              if (resolution.kind === 'already-issued') {
+                if (!options.text) {
+                  output.json({
+                    kind: 'delegate',
+                    action: 'already-delegated',
+                    step: resolution.stepId,
+                    runbook: resolution.runbookRef,
+                    token: resolution.token,
+                    parent_run_id: state.id,
+                  });
+                } else {
+                  output.message(
+                    `ALREADY    step ${resolution.stepId} -> ${resolution.runbookRef}`,
+                  );
+                  output.message(`Token:     ${resolution.token}`);
+                  output.message('');
+                  output.message(`RD_CLAIM_TOKEN=${resolution.token}`);
+                }
+                output.flush();
+                return;
+              }
+              if (resolution.kind === 'none') {
+                throw Errors.delegationNoDelegatableSubstep(state.step);
+              }
+              resolvedRunbook = resolution.target.runbookRef;
+              resolvedStepId = resolution.target.stepId;
+            } else {
+              // Runbook given, no step — infer step from first pending substep
+              const inferred = inferDelegationTarget(state, steps);
+              resolvedRunbook = runbookArg!;
+              resolvedStepId = inferred.stepId;
             }
-          }
 
-          const activeFrameKey =
-            explicitIteration !== undefined
-              ? buildFrameKey(state.step, explicitIteration)
-              : (state.activeFrameKey ?? deriveActiveFrame(state).frameKey);
+            // Resolve child runbook path
+            const childResolved = await resolveRunbookFile(cwd, resolvedRunbook);
+            if (!childResolved) {
+              throw Errors.delegationRunbookNotFound(resolvedRunbook);
+            }
+            const childPath = childResolved.path;
+            const childRunbookRef = await buildRunbookRef(childResolved);
 
-          if (requestedRunbook) {
-            const existingDelegation = findPendingDelegationForTarget(
-              state,
-              resolvedStepId,
-              activeFrameKey,
+            // Parse extra vars through the standard normalization pipeline
+            const rawVars = await collectCliFlags(
+              { inputFile: options.inputFile, input: options.input, inputJson: options.inputJson },
+              cwd,
             );
-            if (existingDelegation) {
-              const existingRunbook = existingDelegation.childRunbookRef.path;
-              const isDifferentRunbook = requestedRunbook !== existingRunbook;
-              throw Errors.delegationAlreadyExists(
+
+            let extraVars: Record<string, TemplateVarValue> | undefined;
+            if (Object.keys(rawVars).length > 0) {
+              const routed = await routeExtraVars(rawVars, cwd);
+              for (const w of routed.warnings) {
+                output.warning(w);
+              }
+              extraVars = Object.keys(routed.vars).length > 0 ? routed.vars : undefined;
+            }
+
+            // Compute frame key — use explicit iteration from --index or three-level step ID
+            const parsedTarget = parseStepIdFromString(resolvedStepId);
+            let explicitIteration: number | undefined;
+            try {
+              explicitIteration = resolveIndexOption(options.index, parsedTarget?.at);
+            } catch (error) {
+              if (error instanceof IndexOptionError) {
+                failRetry(output, error.message, error.code);
+              }
+              throw error;
+            }
+
+            // Validate --index requires a FOR step (three-level syntax validated in createDelegation)
+            if (explicitIteration !== undefined) {
+              const targetStepName = parsedTarget?.step ?? state.step;
+              const targetStep = steps.find((s) => s.name === targetStepName);
+              if (targetStep && targetStep.kind !== 'for' && targetStep.kind !== 'prompted-for') {
+                failRetry(
+                  output,
+                  `--index requires step "${targetStepName}" to be a FOR step, but it is "${targetStep.kind}"`,
+                  'INVALID_INDEX',
+                );
+              }
+            }
+
+            const activeFrameKey =
+              explicitIteration !== undefined
+                ? buildFrameKey(state.step, explicitIteration)
+                : (state.activeFrameKey ?? deriveActiveFrame(state).frameKey);
+
+            if (requestedRunbook) {
+              const existingDelegation = findPendingDelegationForTarget(
+                state,
                 resolvedStepId,
-                isDifferentRunbook
-                  ? `in-flight delegation for a different runbook: requested ${requestedRunbook}, existing ${existingRunbook}, token hash ${existingDelegation.tokenHash}`
-                  : `in-flight delegation already exists for ${existingRunbook}, token hash ${existingDelegation.tokenHash}`,
+                activeFrameKey,
               );
+              if (existingDelegation) {
+                const existingRunbook = existingDelegation.childRunbookRef.path;
+                const isDifferentRunbook = requestedRunbook !== existingRunbook;
+                throw Errors.delegationAlreadyExists(
+                  resolvedStepId,
+                  isDifferentRunbook
+                    ? `in-flight delegation for a different runbook: requested ${requestedRunbook}, existing ${existingRunbook}, token hash ${existingDelegation.tokenHash}`
+                    : `in-flight delegation already exists for ${existingRunbook}, token hash ${existingDelegation.tokenHash}`,
+                );
+              }
+
+              const requestedResolved = await resolveRunbookFile(cwd, requestedRunbook);
+              if (!requestedResolved) {
+                throw Errors.delegationRunbookMismatch(
+                  resolvedStepId,
+                  requestedRunbook,
+                  resolvedRunbook,
+                );
+              }
+              const requestedRef = await buildRunbookRef(requestedResolved);
+              if (!sameRunbookRef(requestedRef, childRunbookRef)) {
+                throw Errors.delegationRunbookMismatch(
+                  resolvedStepId,
+                  requestedRunbook,
+                  resolvedRunbook,
+                );
+              }
             }
 
-            const requestedResolved = await resolveRunbookFile(cwd, requestedRunbook);
-            if (!requestedResolved) {
-              throw Errors.delegationRunbookMismatch(
-                resolvedStepId,
-                requestedRunbook,
-                resolvedRunbook,
-              );
+            // Create delegation (pure function — returns discriminated union)
+            const result = createDelegation(
+              {
+                state,
+                stepId: resolvedStepId,
+                childRunbookPath: childPath,
+                childRunbookRef,
+                extraVars,
+                ancestors: [],
+                frameKey: activeFrameKey,
+              },
+              steps,
+            );
+
+            switch (result.status) {
+              case 'step_not_found':
+              case 'step_not_current':
+              case 'substep_required':
+              case 'substep_not_found':
+              case 'not_delegatable':
+              case 'delegation_exists':
+              case 'parent_is_delegated':
+                // Rethrow so withErrorHandling's toRundownError -> stderr envelope
+                // fires with the same code and message as the pre-refactor throw.
+                throw result.error;
+              case 'created':
+                break;
+              default: {
+                const _exhaustive: never = result;
+                return _exhaustive;
+              }
             }
-            const requestedRef = await buildRunbookRef(requestedResolved);
-            if (!sameRunbookRef(requestedRef, childRunbookRef)) {
-              throw Errors.delegationRunbookMismatch(
-                resolvedStepId,
-                requestedRunbook,
-                resolvedRunbook,
-              );
-            }
-          }
 
-          // Create delegation (pure function — returns discriminated union)
-          const result = createDelegation(
-            {
-              state,
-              stepId: resolvedStepId,
-              childRunbookPath: childPath,
-              childRunbookRef,
-              extraVars,
-              ancestors: [],
-              frameKey: activeFrameKey,
-            },
-            steps,
-          );
-
-          switch (result.status) {
-            case 'step_not_found':
-            case 'step_not_current':
-            case 'substep_required':
-            case 'substep_not_found':
-            case 'not_delegatable':
-            case 'delegation_exists':
-            case 'parent_is_delegated':
-              // Rethrow so withErrorHandling's toRundownError -> stderr envelope
-              // fires with the same code and message as the pre-refactor throw.
-              throw result.error;
-            case 'created':
-              break;
-            default: {
-              const _exhaustive: never = result;
-              return _exhaustive;
-            }
-          }
-
-          // Persist updated substep states
-          await manager.update(state.id, {
-            substepStates: result.updatedSubstepStates,
-          });
-
-          // Output
-          if (!options.text) {
-            output.json({
-              kind: 'delegate',
-              action: 'delegated',
-              step: resolvedStepId,
-              runbook: resolvedRunbook,
-              token: result.token,
-              token_hash: result.tokenHash,
-              parent_run_id: state.id,
+            // Persist updated substep states
+            await manager.update(state.id, {
+              substepStates: result.updatedSubstepStates,
             });
-          } else {
-            output.message(`DELEGATED  step ${resolvedStepId} -> ${resolvedRunbook}`);
-            output.message(`Token:     ${result.token}`);
-            output.message('');
-            output.message(`RD_CLAIM_TOKEN=${result.token}`);
-          }
 
-          output.flush();
-        },
-        { text: options.text },
-      );
-    });
+            // Output
+            if (!options.text) {
+              output.json({
+                kind: 'delegate',
+                action: 'delegated',
+                step: resolvedStepId,
+                runbook: resolvedRunbook,
+                token: result.token,
+                token_hash: result.tokenHash,
+                parent_run_id: state.id,
+              });
+            } else {
+              output.message(`DELEGATED  step ${resolvedStepId} -> ${resolvedRunbook}`);
+              output.message(`Token:     ${result.token}`);
+              output.message('');
+              output.message(`RD_CLAIM_TOKEN=${result.token}`);
+            }
+
+            output.flush();
+          },
+          { text: options.text },
+        );
+      },
+    );
 }
 
 function sameRunbookRef(

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -122,7 +122,24 @@ export function registerDelegateCommand(program: Command): void {
             const manager = new RunbookStateManager(cwd);
             const sessionService = new SessionService(manager);
 
-            // --retry has its own resolution flow; handle it up front.
+            // Validate shared actor-source ingress before any branch so an invalid
+            // `--actor-source` always fails loudly at ingress — even on the
+            // `--retry` path, which does not consume the value but must not
+            // silently accept a mis-tagged frontend.
+            let actorSource: ActorContextSource | undefined;
+            try {
+              actorSource = readActorSourceIngress(command);
+            } catch (error: unknown) {
+              // InvalidActorSourceError carries code 'INVALID_ACTOR_SOURCE' and a
+              // human message; render it through the standard JSON envelope.
+              output.error(getErrorMessage(error), 'INVALID_ACTOR_SOURCE');
+              output.flush();
+              process.exitCode = 1;
+              return;
+            }
+
+            // --retry has its own resolution flow; handle it up front after
+            // actor-source ingress is validated.
             if (options.retry) {
               await handleRetry({
                 runbookArg,
@@ -133,18 +150,6 @@ export function registerDelegateCommand(program: Command): void {
                 output,
               });
               output.flush();
-              return;
-            }
-
-            let actorSource: ActorContextSource | undefined;
-            try {
-              actorSource = readActorSourceIngress(command);
-            } catch (error: unknown) {
-              // InvalidActorSourceError carries code 'INVALID_ACTOR_SOURCE' and a
-              // human message; render it through the standard JSON envelope.
-              output.error(getErrorMessage(error), 'INVALID_ACTOR_SOURCE');
-              output.flush();
-              process.exitCode = 1;
               return;
             }
 

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -40,6 +40,11 @@ export function registerStopCommand(program: Command): void {
         async () => {
           const cwd = getCwd();
           const output = new OutputEmitter({ text: options.text, command: 'stop' });
+          // Actor-context ingress (Plan: cli-actor-context-ingress): `stop` is a
+          // workflow-level force-terminal override and the narrow --claim-id
+          // force path; it invokes no actor-context-gated core policy, so it
+          // constructs no ActorContext. A future actor-gated force-terminal
+          // policy would consume readActorSourceIngress + resolveActorContext.
           const manager = new RunbookStateManager(cwd);
           const sessionService = new SessionService(manager);
 

--- a/packages/cli/src/helpers/actor-source-option.ts
+++ b/packages/cli/src/helpers/actor-source-option.ts
@@ -1,0 +1,46 @@
+// packages/cli/src/helpers/actor-source-option.ts
+
+import type { ActorContextSource } from '@rundown-org/core';
+import { parseActorSource } from './resolve-actor-context.js';
+
+/**
+ * Minimal structural view of the Commander command needed to read the
+ * program-level `--actor-source` option (kept narrow so tests need no real
+ * Commander instance).
+ */
+export interface ActorSourceReader {
+  /**
+   * Return this command's options merged with inherited program-level options.
+   *
+   * @returns Options object exposing the optional `actorSource` string
+   */
+  optsWithGlobals(): { actorSource?: string };
+}
+
+/**
+ * Resolve the actor-context source tag from CLI ingress.
+ *
+ * Precedence: the `--actor-source` flag wins over the `RD_ACTOR_SOURCE` env var.
+ * An empty-string env value is treated as unset. When neither is supplied this
+ * returns `undefined`, deferring the `direct-cli` compatibility default to
+ * {@link resolveActorContext}.
+ *
+ * @param command - Command exposing program-level options via `optsWithGlobals`
+ * @param env - Environment to read `RD_ACTOR_SOURCE` from (defaults to `process.env`)
+ * @returns The validated source tag, or `undefined` when none was supplied
+ * @throws {InvalidActorSourceError} when a supplied flag/env value is invalid
+ */
+export function readActorSourceIngress(
+  command: ActorSourceReader,
+  env: NodeJS.ProcessEnv = process.env,
+): ActorContextSource | undefined {
+  const flagValue = command.optsWithGlobals().actorSource;
+  if (flagValue !== undefined) {
+    return parseActorSource(flagValue);
+  }
+  const envValue = env.RD_ACTOR_SOURCE;
+  if (envValue !== undefined && envValue !== '') {
+    return parseActorSource(envValue);
+  }
+  return undefined;
+}

--- a/packages/cli/src/helpers/resolve-actor-context.ts
+++ b/packages/cli/src/helpers/resolve-actor-context.ts
@@ -40,7 +40,7 @@ export const ACTOR_SOURCE_VALUES = Object.keys(
 
 /**
  * Hard error raised when an `--actor-source` / `RD_ACTOR_SOURCE` value is not a
- * recognised {@link ActorContextSource}.
+ * recognized {@link ActorContextSource}.
  *
  * Type-driven dispatch forbids a silent default: an unknown source must fail
  * loudly so a mis-tagged frontend is caught at ingress, not silently downgraded.
@@ -52,6 +52,8 @@ export class InvalidActorSourceError extends Error {
   readonly value: string;
 
   /**
+   * Construct the error with the rejected raw value.
+   *
    * @param value - The rejected raw source string
    */
   constructor(value: string) {
@@ -68,7 +70,7 @@ export class InvalidActorSourceError extends Error {
  *
  * @param raw - Raw value from `--actor-source` or `RD_ACTOR_SOURCE`
  * @returns The validated {@link ActorContextSource}
- * @throws {InvalidActorSourceError} when `raw` is not a recognised source
+ * @throws {InvalidActorSourceError} when `raw` is not a recognized source
  */
 export function parseActorSource(raw: string): ActorContextSource {
   if ((ACTOR_SOURCE_VALUES as readonly string[]).includes(raw)) {

--- a/packages/cli/src/helpers/resolve-actor-context.ts
+++ b/packages/cli/src/helpers/resolve-actor-context.ts
@@ -1,0 +1,136 @@
+// packages/cli/src/helpers/resolve-actor-context.ts
+
+import {
+  type ActorContext,
+  type ActorContextSource,
+  type ClaimId,
+  type DelegationTokenHash,
+  type RunId,
+  type RunbookState,
+  UNKNOWN_ACTOR_CONTEXT,
+  claimControllerContext,
+  trustedRunControllerContext,
+} from '@rundown-org/core';
+
+// Exhaustiveness anchor: a `Record<ActorContextSource, true>` forces this object
+// to enumerate EVERY variant of the union — adding a variant to
+// `ActorContextSource` fails to type-check here until the new key is added. This
+// Record is the single source of truth; ACTOR_SOURCE_VALUES is DERIVED from its
+// keys below, so a new variant flows into the runtime array automatically rather
+// than relying on a hand-maintained array (a too-short `readonly
+// ActorContextSource[]` literal would still compile — only the Record guard is
+// load-bearing).
+const ACTOR_SOURCE_PRESENCE: Record<ActorContextSource, true> = {
+  'direct-cli': true,
+  plugin: true,
+  mcp: true,
+};
+
+/**
+ * The valid actor-context source tags, in declaration order.
+ *
+ * This is the single source of truth for `--actor-source` / `RD_ACTOR_SOURCE`
+ * validation, derived from {@link ACTOR_SOURCE_PRESENCE} so it stays exhaustive
+ * against {@link ActorContextSource} by construction (`Object.keys` preserves the
+ * literal insertion order, so the order pinned by the runtime test is stable).
+ */
+export const ACTOR_SOURCE_VALUES = Object.keys(
+  ACTOR_SOURCE_PRESENCE,
+) as readonly ActorContextSource[];
+
+/**
+ * Hard error raised when an `--actor-source` / `RD_ACTOR_SOURCE` value is not a
+ * recognised {@link ActorContextSource}.
+ *
+ * Type-driven dispatch forbids a silent default: an unknown source must fail
+ * loudly so a mis-tagged frontend is caught at ingress, not silently downgraded.
+ */
+export class InvalidActorSourceError extends Error {
+  /** Stable machine-readable error code for the CLI error envelope. */
+  readonly code = 'INVALID_ACTOR_SOURCE' as const;
+  /** The rejected raw value, echoed back for diagnostics. */
+  readonly value: string;
+
+  /**
+   * @param value - The rejected raw source string
+   */
+  constructor(value: string) {
+    super(
+      `Invalid --actor-source value "${value}". Expected one of: ${ACTOR_SOURCE_VALUES.join(', ')}.`,
+    );
+    this.name = 'InvalidActorSourceError';
+    this.value = value;
+  }
+}
+
+/**
+ * Validate a raw source string against the frozen source set.
+ *
+ * @param raw - Raw value from `--actor-source` or `RD_ACTOR_SOURCE`
+ * @returns The validated {@link ActorContextSource}
+ * @throws {InvalidActorSourceError} when `raw` is not a recognised source
+ */
+export function parseActorSource(raw: string): ActorContextSource {
+  if ((ACTOR_SOURCE_VALUES as readonly string[]).includes(raw)) {
+    return raw as ActorContextSource;
+  }
+  throw new InvalidActorSourceError(raw);
+}
+
+/**
+ * Caller evidence assembled by a CLI command before constructing actor context.
+ *
+ * All fields are optional: a bare workspace invocation supplies none and is
+ * mapped to a trusted `direct-cli` run controller (the compatibility lane).
+ */
+export interface ActorIngress {
+  /** Provenance tag from `--actor-source` / `RD_ACTOR_SOURCE`; defaults to `direct-cli`. */
+  readonly source?: ActorContextSource;
+  /** Claim id from `--claim-id`, when targeting a claimed delegated run. */
+  readonly claimId?: ClaimId;
+  /** Token hash bound to the claim, from existing claim-evidence plumbing. */
+  readonly tokenHash?: DelegationTokenHash;
+  /** Resolved claimed run id; defaults to the resolved target `state.id`. */
+  readonly controlledRunId?: RunId;
+}
+
+/**
+ * Map caller ingress + a resolved target run to a core {@link ActorContext}.
+ *
+ * Implements the frozen trust-mapping table:
+ * - complete claim evidence (`claimId` AND `tokenHash`) => `claim_controller`,
+ *   with `controlledRunId` defaulting to `state.id` (the resolved claimed run).
+ *   `source` is provenance only and does not change the claim mapping.
+ * - otherwise, a source tag (or the unset compatibility default) => a trusted
+ *   run controller for `state.id`, tagged with the resolved source.
+ * - partial/contradictory claim evidence with no resolvable controlled run =>
+ *   `unknown` (reserved inspect-only fallback; type-reachable, never a default
+ *   local path).
+ *
+ * Role derivation against a target stays in core (`deriveEffectiveRole`); this
+ * adapter only records evidence.
+ *
+ * @param ingress - Caller evidence (source tag and optional claim evidence)
+ * @param state - Resolved target run the caller is acting on
+ * @returns The constructed actor context
+ */
+export function resolveActorContext(ingress: ActorIngress, state: RunbookState): ActorContext {
+  const hasClaimId = ingress.claimId !== undefined;
+  const hasTokenHash = ingress.tokenHash !== undefined;
+
+  if (hasClaimId && hasTokenHash) {
+    return claimControllerContext({
+      claimId: ingress.claimId,
+      tokenHash: ingress.tokenHash,
+      controlledRunId: ingress.controlledRunId ?? state.id,
+    });
+  }
+
+  // Exactly one of claimId/tokenHash present is contradictory evidence with no
+  // resolvable controlled run: fall to the reserved inspect-only context.
+  if (hasClaimId || hasTokenHash) {
+    return UNKNOWN_ACTOR_CONTEXT;
+  }
+
+  return trustedRunControllerContext(state.id, ingress.source ?? 'direct-cli');
+}

--- a/packages/cli/src/helpers/resolve-actor-context.ts
+++ b/packages/cli/src/helpers/resolve-actor-context.ts
@@ -33,9 +33,13 @@ const ACTOR_SOURCE_PRESENCE: Record<ActorContextSource, true> = {
  * validation, derived from {@link ACTOR_SOURCE_PRESENCE} so it stays exhaustive
  * against {@link ActorContextSource} by construction (`Object.keys` preserves the
  * literal insertion order, so the order pinned by the runtime test is stable).
+ *
+ * Frozen so the `readonly` type contract is enforced at runtime too: the exported
+ * array backs `parseActorSource` validation, and an unfrozen array could be
+ * mutated by a consumer and silently widen or narrow the accepted source set.
  */
-export const ACTOR_SOURCE_VALUES = Object.keys(
-  ACTOR_SOURCE_PRESENCE,
+export const ACTOR_SOURCE_VALUES = Object.freeze(
+  Object.keys(ACTOR_SOURCE_PRESENCE),
 ) as readonly ActorContextSource[];
 
 /**

--- a/packages/cli/src/helpers/transition-command.ts
+++ b/packages/cli/src/helpers/transition-command.ts
@@ -1,8 +1,10 @@
 // packages/cli/src/helpers/transition-command.ts
 
 import type { Command } from 'commander';
+import { getErrorMessage, type ActorContextSource } from '@rundown-org/core';
 import { getCwd } from './context.js';
 import { withErrorHandling } from './wrapper.js';
+import { readActorSourceIngress } from './actor-source-option.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import {
   buildTransitionContext,
@@ -61,10 +63,23 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
     .option('--claim-id <claimId>', 'Target a claimed delegated child runbook')
     .option('--text', 'Output as human-readable text')
     .action(
-      async (options: { step?: string; index?: string; claimId?: string; text?: boolean }) => {
+      async (
+        options: { step?: string; index?: string; claimId?: string; text?: boolean },
+        command: Command,
+      ) => {
         await withErrorHandling(
           async () => {
             const output = new OutputEmitter({ text: options.text, command: def.name });
+
+            let actorSource: ActorContextSource | undefined;
+            try {
+              actorSource = readActorSourceIngress(command);
+            } catch (error: unknown) {
+              output.error(getErrorMessage(error), 'INVALID_ACTOR_SOURCE');
+              output.flush();
+              process.exitCode = 1;
+              return;
+            }
 
             const depError = validateIndexRequiresStep(options.index, options.step);
             if (depError) {
@@ -83,6 +98,7 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
               // A `--step` target makes the transition deliberate, exempting it
               // from the bare-only open-delegated-children guard.
               step: options.step,
+              ...(actorSource ? { actorSource } : {}),
             });
             switch (contextResult.kind) {
               case 'ready':

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -18,6 +18,7 @@ import {
   resolveCommandTarget,
   resolveTransitionTarget,
   type ActionType,
+  type ActorContextSource,
   type ClaimRecord,
   type CommandTargetResolution,
   buildFrameKey,
@@ -253,6 +254,7 @@ export function buildTransitionContext(
     readonly command: 'pass' | 'fail';
     readonly claimId?: ClaimId;
     readonly step?: string;
+    readonly actorSource?: ActorContextSource;
   },
 ): Promise<BuildTransitionContextResult>;
 export function buildTransitionContext(
@@ -267,6 +269,7 @@ export async function buildTransitionContext(
     readonly command?: 'pass' | 'fail';
     readonly claimId?: ClaimId;
     readonly step?: string;
+    readonly actorSource?: ActorContextSource;
   } = {},
 ): Promise<BuildTransitionContextResult> {
   const manager = new RunbookStateManager(cwd);
@@ -288,7 +291,14 @@ export async function buildTransitionContext(
       command: options.command,
       claimId: options.claimId,
       targeted: options.step !== undefined,
-      directCliCompatibility: true,
+      // Supply the source-tagged trusted-controller context only for the
+      // default (non-claim) target; core resolves the active run id and the
+      // bare advance is the only path that evaluates actor context. When an
+      // explicit source is absent, fall back to the direct-cli compatibility
+      // lane so behavior is byte-identical to before.
+      ...(options.actorSource && options.claimId === undefined
+        ? { actorContextSource: options.actorSource }
+        : { directCliCompatibility: true }),
     });
     switch (active.kind) {
       case 'claim':

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -243,6 +243,9 @@ export type BaseBuildTransitionContextResult =
  * @param options.step - Explicit `--step` target. When present, the transition
  *   is deliberate and exempt from the bare-only open-delegated-children refusal
  *   (both the resolver pre-check and the decisive-write re-check are skipped).
+ * @param options.actorSource - Provenance tag (`--actor-source` /
+ *   `RD_ACTOR_SOURCE`) threaded into core's trusted-controller construction for
+ *   the default (non-claim) target; absent falls back to the `direct-cli` lane.
  * @returns `{ kind: 'ready', ctx }` when a target is resolved, or a typed
  *   refusal/confirm/conflict outcome otherwise.
  * @throws {Error} if state is missing runbookSrc (corrupted state)

--- a/packages/core/__tests__/runbook/command-target-resolver.test.ts
+++ b/packages/core/__tests__/runbook/command-target-resolver.test.ts
@@ -255,6 +255,18 @@ describe('resolveTransitionTarget', () => {
       runId: id,
       source: 'direct-cli',
     });
+    // Precedence contract: an explicit source wins over the legacy direct-cli
+    // compatibility fallback when both are present.
+    expect(
+      buildTransitionActorContext(id, {
+        actorContextSource: 'plugin',
+        directCliCompatibility: true,
+      }),
+    ).toEqual({
+      kind: 'trusted_run_controller',
+      runId: id,
+      source: 'plugin',
+    });
     expect(buildTransitionActorContext(id, {})).toEqual({ kind: 'unknown' });
   });
 

--- a/packages/core/__tests__/runbook/command-target-resolver.test.ts
+++ b/packages/core/__tests__/runbook/command-target-resolver.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   type CommandTargetReader,
+  buildTransitionActorContext,
   resolveCommandTarget,
   resolveTransitionTarget,
 } from '../../src/runbook/command-target-resolver.js';
@@ -24,7 +25,7 @@ import {
 } from '../../src/runbook/targeting.js';
 import { trustedRunControllerContext } from '../../src/runbook/actor-context.js';
 import { makeBaseStep } from '../helpers/step-factories.js';
-import type { Runbook, RunbookState, Step } from '../../src/runbook/types.js';
+import type { Runbook, RunbookState, RunId, Step } from '../../src/runbook/types.js';
 import { assertClaimed, linkageFor } from './claim-test-helpers.js';
 
 const parent = { id: 'parent', lifecycle: 'running' } as RunbookState;
@@ -240,6 +241,60 @@ describe('resolveTransitionTarget', () => {
       message:
         'A delegated claim has reported an outcome that must be collected by the orchestrator.',
     });
+  });
+
+  it('buildTransitionActorContext tags the trusted controller with the source', () => {
+    const id = 'run_active' as RunId;
+    expect(buildTransitionActorContext(id, { actorContextSource: 'plugin' })).toEqual({
+      kind: 'trusted_run_controller',
+      runId: id,
+      source: 'plugin',
+    });
+    expect(buildTransitionActorContext(id, { directCliCompatibility: true })).toEqual({
+      kind: 'trusted_run_controller',
+      runId: id,
+      source: 'direct-cli',
+    });
+    expect(buildTransitionActorContext(id, {})).toEqual({ kind: 'unknown' });
+  });
+
+  it('tags the trusted controller with actorContextSource without changing the outcome', async () => {
+    const resolved = await resolveTransitionTarget(fakeReader({ active: parent, openClaims: [] }), {
+      command: 'pass',
+      actorContextSource: 'plugin',
+    });
+    // `parent` has no pending delegated outcome, so the resolution is the
+    // default active-run target — the source tag must not alter that.
+    expect(resolved.kind).toBe('default');
+  });
+
+  it('keeps the collection-pending refusal for any source', async () => {
+    // Stage a pending delegated outcome exactly as the existing
+    // collection-pending test does, then assert the refusal regardless of source.
+    const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+    const pendingParent = {
+      ...parent,
+      step: '1',
+      substep: '1',
+      activeFrameKey: buildFrameKey('1'),
+      activeEntry: 1,
+      frameEntryCounts: { [buildFrameKey('1')]: 1 },
+      resolvedCompletions: {
+        [key]: buildResolvedCompletion({
+          agentId: 'delegation',
+          result: 'pass',
+          targetStep: '1',
+          targetSubstep: '1',
+          targetFrame: activeFrame(buildFrameKey('1'), 1),
+          completedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      },
+    } as RunbookState;
+    const resolved = await resolveTransitionTarget(
+      fakeReader({ active: pendingParent, openClaims: [] }),
+      { command: 'pass', actorContextSource: 'mcp' },
+    );
+    expect(resolved.kind).toBe('delegation_collection_pending');
   });
 
   it('returns kind none when there is no active runbook and no claim id', async () => {

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -44,6 +44,7 @@ const CLISymbolicErrorCodeValues = [
   'OPEN_DELEGATED_CHILDREN',
   'DELEGATION_COLLECTION_PENDING',
   'ACTOR_CONTEXT_REQUIRED',
+  'INVALID_ACTOR_SOURCE',
   'COLLECT_REQUIRES_ORCHESTRATOR',
   'COLLECT_ALREADY_APPLIED',
   'COLLECT_OPERATION_FAILED',
@@ -106,6 +107,8 @@ export const CLIErrorCodes = {
   DELEGATION_COLLECTION_PENDING: 'DELEGATION_COLLECTION_PENDING',
   /** Actor context is required for the requested role-specific command */
   ACTOR_CONTEXT_REQUIRED: 'ACTOR_CONTEXT_REQUIRED',
+  /** Actor source ingress value is invalid */
+  INVALID_ACTOR_SOURCE: 'INVALID_ACTOR_SOURCE',
   /** Collection requires an actor that controls the target delegating run */
   COLLECT_REQUIRES_ORCHESTRATOR: 'COLLECT_REQUIRES_ORCHESTRATOR',
   /** Collection found no unapplied delegation outcomes and is an idempotent no-op. */

--- a/packages/core/src/runbook/command-target-resolver.ts
+++ b/packages/core/src/runbook/command-target-resolver.ts
@@ -280,6 +280,9 @@ export async function resolveCommandTarget(
  *
  * @param activeId - Resolved default-target run id
  * @param options - Source tag / compatibility / explicit-context flags
+ * @param options.actorContext - Explicit actor context that wins outright when supplied
+ * @param options.actorContextSource - Provenance tag refining the trusted-controller source
+ * @param options.directCliCompatibility - Direct-CLI compatibility fallback yielding the `direct-cli` tag
  * @returns The actor context for the bare-advance policy check
  */
 export function buildTransitionActorContext(

--- a/packages/core/src/runbook/command-target-resolver.ts
+++ b/packages/core/src/runbook/command-target-resolver.ts
@@ -2,6 +2,7 @@ import {
   UNKNOWN_ACTOR_CONTEXT,
   trustedRunControllerContext,
   type ActorContext,
+  type ActorContextSource,
 } from './actor-context.js';
 import type { ClaimId, ClaimIdResolution, ClaimRecord } from './claim-id.js';
 import { resolveCommandIntent } from './command-policy.js';
@@ -129,6 +130,15 @@ export interface ResolveTransitionTargetOptions {
   readonly targeted?: boolean;
   /** Actor context supplied by the frontend adapter; strict core default is unknown. */
   readonly actorContext?: ActorContext;
+  /**
+   * Provenance source tag refining the direct-CLI compatibility lane.
+   *
+   * When supplied (and no explicit `actorContext` is given), the resolver tags
+   * the constructed `trusted_run_controller` with this source instead of the
+   * hardcoded `direct-cli`. Provenance only — it does not change role derivation
+   * or the collection-pending guard.
+   */
+  readonly actorContextSource?: ActorContextSource;
   /**
    * Compatibility adapter for direct local CLI calls.
    *
@@ -262,6 +272,35 @@ export async function resolveCommandTarget(
 }
 
 /**
+ * Build the actor context a default-target transition presents to policy.
+ *
+ * Provenance-only refinement of the direct-CLI compatibility lane: an explicit
+ * `actorContextSource` tags the trusted run controller; otherwise
+ * `directCliCompatibility` yields the `direct-cli` tag; neither yields unknown.
+ *
+ * @param activeId - Resolved default-target run id
+ * @param options - Source tag / compatibility / explicit-context flags
+ * @returns The actor context for the bare-advance policy check
+ */
+export function buildTransitionActorContext(
+  activeId: RunId,
+  options: {
+    readonly actorContext?: ActorContext;
+    readonly actorContextSource?: ActorContextSource;
+    readonly directCliCompatibility?: boolean;
+  },
+): ActorContext {
+  if (options.actorContext) return options.actorContext;
+  if (options.actorContextSource) {
+    return trustedRunControllerContext(activeId, options.actorContextSource);
+  }
+  if (options.directCliCompatibility) {
+    return trustedRunControllerContext(activeId, 'direct-cli');
+  }
+  return UNKNOWN_ACTOR_CONTEXT;
+}
+
+/**
  * Resolve the runbook that may receive a manual pass/fail transition.
  *
  * The authoritative targeting boundary for manual transitions. Shares claim-id
@@ -324,11 +363,7 @@ export async function resolveTransitionTarget(
   // bare-only open-delegated-children refusal.
   if (!options.targeted) {
     const openClaims = await targetReader.listOpenClaimsForParent(active.id);
-    const actorContext =
-      options.actorContext ??
-      (options.directCliCompatibility
-        ? trustedRunControllerContext(active.id, 'direct-cli')
-        : UNKNOWN_ACTOR_CONTEXT);
+    const actorContext = buildTransitionActorContext(active.id, options);
     const policy = resolveCommandIntent({
       actorContext,
       intent: { kind: 'delegating-run-advance', command: options.command, targeted: false },


### PR DESCRIPTION
## Summary

Centralizes CLI construction of core `ActorContext` behind one
`resolveActorContext(ingress, state)` helper plus an `--actor-source` /
`RD_ACTOR_SOURCE` ingress, so every role-specific-mutation command tags its
caller provenance accurately — replacing `delegate.ts`'s hardcoded
`'direct-cli'` source — while the collection-pending guard still refuses bare
`pass`/`fail`/`delegate` for **every** source.

This is a **frontend adapter** change in `@rundown-org/cli`. Role *derivation*
(`deriveEffectiveRole`) and *policy* (`resolveCommandIntent`,
`resolveTransitionTarget`) stay in core. The new resolver is a pure function
mapping a typed `ActorIngress` (source tag + claim evidence) plus a resolved
`RunbookState` to the `ActorContext` union (the frozen trust-mapping table).

## What changed

- **New `resolveActorContext` resolver** (`packages/cli/src/helpers/resolve-actor-context.ts`)
  — `ActorIngress`, `parseActorSource`, `ACTOR_SOURCE_VALUES`,
  `InvalidActorSourceError`. Table-driven unit tests + the package's first
  `fast-check` property suite (totality, claim-iff-evidence, no-source-on-claim,
  default fallbacks, parse round-trip/reject).
- **`readActorSourceIngress` reader** (`actor-source-option.ts`) — flag wins over
  `RD_ACTOR_SOURCE` env; empty env treated as unset; invalid value throws.
- **Program-level capture-only `--actor-source <direct-cli|plugin|mcp>`** flag
  (no hook validation — each constructing command validates inside its own
  `withErrorHandling`/`OutputEmitter` block so an invalid value renders the
  `INVALID_ACTOR_SOURCE` JSON envelope, never a raw stderr line). New
  `INVALID_ACTOR_SOURCE` symbolic code registered in core output schema.
- **`delegate`** — replaces the hardcoded `'direct-cli'` source with
  `resolveActorContext(buildDelegateActorIngress(source), state)`. Source is
  validated up front (before the `--retry` branch) so a mis-tagged frontend
  always fails loudly.
- **`collect`** — builds actor context via `resolveActorContext`
  (`buildCollectActorIngress` threads source + full claim evidence).
- **`pass`/`fail`** — thread the source tag into core's existing compatibility
  lane via a new narrow `actorContextSource?` option on `resolveTransitionTarget`
  and an extracted, unit-tested `buildTransitionActorContext` helper. No
  duplicate target resolution in the CLI.
- **`complete`/`stop`/`claim`** — one-line rationale comments recording they
  invoke no actor-context-gated core policy (construction-free).

## Invariants pinned by tests

- The collection-pending guard refuses bare `pass`/`fail`/`delegate` for **every**
  source (`direct-cli`/`plugin`/`mcp`, flag and `RD_ACTOR_SOURCE` env) — source
  never buys past the guard.
- Invalid `--actor-source` / `RD_ACTOR_SOURCE` renders the `INVALID_ACTOR_SOURCE`
  JSON envelope (schema-validated shape) on the constructing paths.
- `--actor-source` parses pre-subcommand and is advertised at program level
  (cross-plan pin for the MCP front end).
- Source-propagation driver tests (pure exported `build*ActorIngress` /
  `buildTransitionActorContext` helpers) fail before the source is threaded.
- `direct-cli` behavior is byte-identical to before; no persisted-state
  migration, no existing JSON envelope changed.

## Verification

`pnpm run verify` passes end-to-end (format, spell, lint:fast, lint:typed, build,
types, docs, full test suite). CLI suite 2673 green, core suite 3533 green.

Also fixes a pre-existing prettier formatting issue in
`packages/claude-code-plugin/TESTING.md` (separate commit) so the verify gate is
fully green.

This precursor produces the `--actor-source` / `RD_ACTOR_SOURCE` surface and the
`resolveActorContext` / `readActorSourceIngress` helpers consumed by the
follow-up plugin (Plan 6) and MCP (Plan 7) plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a program-level `--actor-source <source>` option (with `RD_ACTOR_SOURCE` fallback) supporting `direct-cli`, `plugin`, and `mcp`.
  * Ensured actor-source provenance is consistently applied across collect, delegate, pass, fail, and transition workflows.

* **Bug Fixes**
  * Invalid `--actor-source` / `RD_ACTOR_SOURCE` values now reliably return a standardized JSON error (`INVALID_ACTOR_SOURCE`).
  * Kept existing “collection pending”/guard behavior consistent across actor sources.

* **Documentation**
  * Updated CLI help/reference to list `--actor-source` at the top level.

* **Tests**
  * Added/expanded CLI and core tests covering parsing, precedence, and end-to-end behavior across collect/delegate/pass/fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->