### PR TITLE
fix(#468): make targeted rd delegate --step idempotent

### DIFF
--- a/docs/superpowers/plans/2026-06-27-targeted-delegation-idempotency.md
+++ b/docs/superpowers/plans/2026-06-27-targeted-delegation-idempotency.md
@@ -1,0 +1,614 @@
+# Plan: Targeted delegation idempotency (issue #468)
+
+**Date:** 2026-06-27
+**Issue:** https://github.com/tobyhede/rundown/issues/468
+**Branch/worktree:** `worktree-fix-468-targeted-delegation-idempotency`
+
+## Problem
+
+`rd delegate --step <id>` throws `RD-804` (`delegationAlreadyExists`) when the
+targeted substep already carries an auto-issued (in-flight, unclaimed)
+delegation token. Bare `rd delegate` already handles the same state idempotently
+by echoing the existing token with `action: "already-delegated"`.
+
+This breaks `/rundown:planning`, where a DELEGATE step auto-issues a token on
+entry and the workflow instructs the agent to run `rd delegate --step 1.1`.
+
+## Desired behavior
+
+- `rd delegate --step S`
+  - If S has an in-flight delegation for its authored runbook → **echo** the
+    existing token (`action: "already-delegated"`).
+- `rd delegate <runbook> --step S`
+  - If `<runbook>` matches the in-flight runbook for S → **echo**.
+  - If `<runbook>` conflicts with the in-flight runbook → preserve **RD-804**.
+- Never re-issue a fresh token except via `--retry`.
+- Echo JSON shape must match bare already-issued delegation:
+  `{ kind: "delegate", action: "already-delegated", step, runbook, token, parent_run_id }`.
+
+## Current behavior (verified)
+
+`packages/cli/src/commands/delegate.ts`, targeted issuance path:
+
+1. Runbook/step resolution (lines ~178–228):
+   - `runbookArg && step` → `resolvedRunbook = inferRunbookFromStep(...)`
+     (authored target is authoritative), `requestedRunbook = runbookArg`.
+   - `!runbookArg && step` → `resolvedRunbook = inferRunbookFromStep(...)`, no
+     `requestedRunbook`.
+2. Child runbook resolution + vars (lines ~230–251).
+3. Frame key computation (lines ~253–281).
+4. `if (requestedRunbook)` block (lines ~283–316):
+   - **First** checks `findPendingDelegationForTarget` (a CLI-local ad hoc scan,
+     `delegate.ts:388–402`). If a pending delegation exists → throws **RD-804**
+     *regardless* of whether the requested runbook matches (the
+     `isDifferentRunbook` flag only selects the error message wording).
+   - **Then** (no existing delegation) validates requested-vs-authored:
+     unresolvable or non-matching requested runbook → `delegationRunbookMismatch`
+     (**RD-822**).
+5. `createDelegation(...)` (lines ~318–349). For the `--step`-only path with an
+   existing delegation, this returns `delegation_exists` → throws **RD-804**.
+
+So two code paths currently produce RD-804 for an already-delegated substep:
+the `requestedRunbook` pre-check (explicit-runbook form) and the
+`createDelegation` `delegation_exists` result (`--step`-only form).
+
+RD-819 (nested delegation forbidden) is enforced inside `createDelegation`
+(step 0: `state.parentLinkage?.kind === 'delegation'` → `parent_is_delegated`,
+matched at the `case 'parent_is_delegated':` label `delegate.ts:339` and
+rethrown by the shared `throw result.error` at `delegate.ts:342`).
+
+## Design
+
+### Where logic lives (architecture)
+
+> **Revised after review:** the echo-vs-conflict *decision* moves into core,
+> mirroring how the bare path lets core own the decision via
+> `resolveDelegateTarget` (discriminated `issuable | already-issued | none`) and
+> the CLI merely renders it. The earlier plan left that decision in the CLI; the
+> review correctly flagged this as a second site deciding "requested == existing
+> runbook" (the first is `createDelegation`, `delegation-service.ts:581–586`),
+> drifting from CLAUDE.md's "delegation resolution lives in core" and producing a
+> message-format inconsistency (CLI used `.path`; core uses `formatRunbookRef` =
+> `source:path`).
+
+- **Core owns the targeted resolution decision.** Add a pure
+  `resolveTargetedDelegation(...)` to
+  `packages/core/src/runbook/delegation-inference.ts` returning a discriminated
+  union `{ kind: 'issuable' } | { kind: 'echo'; … } | { kind: 'conflict'; error }`.
+  It is the single source of truth for the echo-vs-conflict (RD-804) decision and
+  the conflict message. It is built on the pure `findPendingDelegation` scan
+  (promoted from the CLI-local `findPendingDelegationForTarget`).
+- **CLI is a thin adapter.** It performs front-end runbook discovery
+  (`resolveRunbookFile` → `buildRunbookRef`) to turn the *requested* positional
+  arg into a serializable `RunbookRef`, hands that to core as data (exactly the
+  pattern already used to pass `childRunbookRef` into `createDelegation`,
+  `delegate.ts:322–330`), then renders the returned discriminant. No comparison
+  or policy logic in the CLI.
+- **Why the decision can live in core despite the I/O:** `RunbookRef` is plain
+  `{ source, path }` data (no function refs, no process-runtime handles), so the
+  CLI does the I/O and passes the *result* to a pure function. The I/O boundary
+  justified keeping the *resolution* in the CLI only under the old design; with a
+  `RunbookRef` parameter it does not.
+- **RD-822 (requested-vs-authored mismatch) stays a CLI post-issuable check** —
+  see the CLI section. It is deliberately *not* folded into
+  `resolveTargetedDelegation`, because it needs the resolved *authored*
+  `childRunbookRef`, and resolving the authored runbook before the echo decision
+  would make the echo path depend on authored-runbook resolvability (breaking the
+  file-removed idempotency guarantee). RD-822 only fires on the issuable path,
+  where resolving the authored runbook is required anyway.
+- No persisted-state changes, no schema changes. The `DelegateResponseSchema`
+  already includes the `already-delegated` action
+  (`packages/core/src/output/zod-schemas.ts:1353`). No migrations / shims.
+
+### Core change: `findPendingDelegation` + `resolveTargetedDelegation`
+
+Add both to `packages/core/src/runbook/delegation-inference.ts`.
+
+`findPendingDelegation` — pure scan, cast-free via a type-guard `.find`
+predicate (idiom precedent: `isRetryDelegationInFlightLike` at
+`delegate.ts:421`):
+
+```ts
+/**
+ * Find the in-flight (pending, unclaimed, non-cancelled) delegation on a target
+ * substep within a frame, with a recoverable plaintext token. Returns undefined
+ * when the step id has no substep segment, when no matching substep state
+ * exists, or when the delegation is cancelled/claimed/tokenless. Pure; no I/O.
+ */
+export function findPendingDelegation(
+  state: DelegationInferenceState,
+  stepId: string,
+  frameKey: FrameKey,
+): (StepDelegation & { token: string }) | undefined {
+  const parsed = parseStepIdFromString(stepId);
+  if (!parsed?.substep) return undefined;
+  const match = (state.substepStates ?? []).find(
+    (ss): ss is SubstepState & { delegation: StepDelegation & { token: string } } =>
+      ss.id === parsed.substep &&
+      ss.frameKey === frameKey &&
+      ss.delegation?.cancelledAt === null &&
+      ss.delegation.childRunId === null &&
+      ss.delegation.token != null,
+  );
+  return match?.delegation;
+}
+```
+
+`resolveTargetedDelegation` — owns the echo-vs-conflict decision and message:
+
+```ts
+/** How the CLI's requested positional arg resolved (front-end discovery). */
+export type RequestedRunbookArg =
+  | { readonly kind: 'none' } // bare `--step S`
+  | { readonly kind: 'resolved'; readonly ref: RunbookRef; readonly raw: string }
+  | { readonly kind: 'unresolvable'; readonly raw: string };
+
+export type TargetedDelegateResolution =
+  | { readonly kind: 'issuable' }
+  | {
+      readonly kind: 'echo';
+      readonly stepId: string;
+      readonly token: string;
+      readonly runbookRef: string;
+    }
+  | { readonly kind: 'conflict'; readonly error: RundownError };
+
+/**
+ * Resolve a targeted `rd delegate [<runbook>] --step S` against any in-flight
+ * delegation on the substep. Single source of truth for the RD-804
+ * echo-vs-conflict decision (the bare path's `resolveDelegateTarget` analogue).
+ * Pure; no I/O — the CLI resolves the requested arg to a `RunbookRef` first.
+ */
+export function resolveTargetedDelegation(
+  state: DelegationInferenceState,
+  stepId: string,
+  frameKey: FrameKey,
+  requested: RequestedRunbookArg,
+): TargetedDelegateResolution {
+  const existing = findPendingDelegation(state, stepId, frameKey);
+  if (!existing) return { kind: 'issuable' };
+
+  const matches =
+    requested.kind === 'none' ||
+    (requested.kind === 'resolved' && sameRunbookRef(requested.ref, existing.childRunbookRef));
+
+  if (!matches) {
+    const requestedLabel = requested.kind === 'none' ? '' : requested.raw;
+    return {
+      kind: 'conflict',
+      error: Errors.delegationAlreadyExists(
+        stepId,
+        `in-flight delegation for a different runbook: requested ${requestedLabel}, ` +
+          `existing ${existing.childRunbookRef.path}, token hash ${existing.tokenHash}`,
+      ),
+    };
+  }
+
+  return {
+    kind: 'echo',
+    stepId,
+    token: existing.token, // narrowed to `string` by findPendingDelegation
+    runbookRef: existing.childRunbookRef.path,
+  };
+}
+```
+
+- **Cast-free narrowing (review fix):** the type-guard `.find` predicate makes
+  `match` carry `delegation: StepDelegation & { token: string }`, so
+  `match?.delegation` is `(StepDelegation & { token: string }) | undefined` with
+  **no `as` cast**. The earlier plan's "mirrors `deriveDelegateFrontier`"
+  rationale was wrong: `deriveDelegateFrontier` is cast-free only because it
+  pushes a *fresh `DelegateFrontierEntry` literal* after in-loop control-flow
+  narrowing (`delegation-inference.ts:260–266`); it never returns a narrowed
+  existing record, so it could not have justified a cast here.
+- **`token != null`** (not `!delegation.token`) — behaviorally identical (tokens
+  are never `''`) but `!= null` reads as an explicit presence check. The filter
+  is deliberate: a pending unclaimed delegation always retains its plaintext
+  token (removed only on claim/abort, `types.ts:648–651`), so a (corrupt-only)
+  tokenless record is treated as "no pending delegation" and falls through to
+  `createDelegation`'s token-agnostic `delegation_exists` guard — no dead
+  defensive branch anywhere.
+- **Message single-sourced + consistency (review fix):** the conflict message now
+  comes *only* from `resolveTargetedDelegation`. It keeps the CLI's historical
+  wording (raw requested arg + existing `.path`) so the kept regression test
+  `delegate.test.ts:664–691` (`toContain('runbooks/child-b.runbook.md')`) still
+  passes. `createDelegation`'s own `delegation_exists` message
+  (`formatRunbookRef`, source-qualified, `delegation-service.ts:584–586`) is no
+  longer reachable on the targeted CLI path (the decision resolves before
+  `createDelegation`), so the two-format divergence the review flagged is gone
+  from this surface; that branch remains a defensive internal guard.
+- **`findSubstepState` reuse (NIT, declined with reason):** `findSubstepState`
+  (`targeting.ts:372`) centralizes id+frameKey matching, but it returns
+  `SubstepState | undefined` and cannot express the `delegation.token` narrowing.
+  Reusing it would reintroduce a cast or a second narrowing step, defeating the
+  cast-free goal above. The type-guard predicate must check the delegation fields
+  anyway, so the inline `.find` is the cleaner choice here.
+- Import/type notes: `parseStepIdFromString`, `SubstepState` (`./types.js`:15),
+  `RunbookRef` (`./runbook-ref.js`:16), and `Errors` are **already imported** in
+  `delegation-inference.ts`. The only genuinely new imports are `StepDelegation`
+  (add to the existing `./types.js` type import) and `sameRunbookRef`.
+  **`sameRunbookRef`:** core has **no** ref-equality export today (verified —
+  `runbook-ref.ts` exports only schema/types). Add a tiny pure
+  `sameRunbookRef(a, b) => a.source === b.source && a.path === b.path` — best
+  placed in `runbook-ref.ts` (its natural home, typed on `RunbookRef`) and
+  exported via the barrel. The CLI's local `sameRunbookRef` (`delegate.ts:381`)
+  types its params as `Awaited<ReturnType<typeof buildRunbookRef>>` rather than
+  `RunbookRef`, but `buildRunbookRef` yields a `RunbookRef`, so the promotion to
+  a `RunbookRef`-typed core function is type-compatible. Remove the CLI copy and
+  import the core one — single source of truth.
+- **Export from the core barrel.** `packages/core/src/runbook/index.ts` uses an
+  explicit named export list for `delegation-inference.js` (lines ~158–169) — add
+  `findPendingDelegation`, `resolveTargetedDelegation`, and the two new types.
+  The CLI helper re-exports `from '@rundown-org/core'`, so without the barrel
+  entries the imports will not resolve and the build fails.
+- Re-export `resolveTargetedDelegation` (+ types) and `findPendingDelegation`
+  from `packages/cli/src/helpers/delegate-inference.ts` alongside the existing
+  re-exports.
+
+### CLI change: `delegate.ts`
+
+1. **Reorder** so the targeted idempotency echo runs *before* authored child
+   runbook resolution, making the echo path independent of re-resolving the
+   authored runbook (idempotent even if the authored file later changes — see the
+   optional test in §Tests). The frame-key block (`delegate.ts:253–281`) depends
+   only on `resolvedStepId`, `steps` (loaded at line 171), `options.index`, and
+   `state` — none of `childResolved`/`childRunbookRef`/`extraVars` — so moving it
+   up breaks nothing. **Pin this exact order** (the only order that both compiles
+   and delivers the idempotency guarantee):
+
+   1. Runbook/step resolution (current `delegate.ts:174–228`).
+   2. Frame-key block, moved up: `parsedTarget`, `explicitIteration`,
+      `--index` FOR validation, `activeFrameKey` (current `253–281`).
+   3. Resolve the *requested* arg to a `RequestedRunbookArg` (CLI I/O), call
+      `resolveTargetedDelegation`, switch on the result: `echo` →
+      `emitAlreadyDelegated` + `return`; `conflict` → `throw resolution.error`;
+      `issuable` → fall through.
+   4. Authored child resolution: `resolveRunbookFile` → `childPath`,
+      `childRunbookRef` (current `230–236`).
+   5. No-existing RD-822 mismatch check (needs `childRunbookRef`; reuses the
+      already-resolved requested arg).
+   6. `extraVars` (current `238–251`).
+   7. `createDelegation` + persist + emit (current `318–374`).
+
+2. **Replace** the current `if (requestedRunbook)` block with the core-driven
+   resolution (CLI does I/O + render only — no comparison/policy):
+
+```ts
+// Resolve the requested positional arg to serializable data for core. Only the
+// requested arg is resolved here — never the authored target — so the echo path
+// stays independent of authored-runbook resolvability.
+let requested: RequestedRunbookArg;
+if (!requestedRunbook) {
+  requested = { kind: 'none' };
+} else {
+  const r = await resolveRunbookFile(cwd, requestedRunbook);
+  requested = r
+    ? { kind: 'resolved', ref: await buildRunbookRef(r), raw: requestedRunbook }
+    : { kind: 'unresolvable', raw: requestedRunbook };
+}
+
+const resolution = resolveTargetedDelegation(state, resolvedStepId, activeFrameKey, requested);
+switch (resolution.kind) {
+  case 'echo':
+    emitAlreadyDelegated(output, {
+      stepId: resolution.stepId,
+      runbookRef: resolution.runbookRef,
+      token: resolution.token,
+      parentRunId: state.id,
+      text: options.text,
+    });
+    output.flush();
+    return;
+  case 'conflict':
+    throw resolution.error;
+  case 'issuable':
+    break;
+  default: {
+    const _exhaustive: never = resolution;
+    return _exhaustive;
+  }
+}
+
+// Issuable only: authored child resolution (step 4), then preserve the
+// requested-vs-authored mismatch validation (RD-822), reusing `requested`.
+const childResolved = await resolveRunbookFile(cwd, resolvedRunbook);
+if (!childResolved) throw Errors.delegationRunbookNotFound(resolvedRunbook);
+const childPath = childResolved.path;
+const childRunbookRef = await buildRunbookRef(childResolved);
+
+if (requested.kind === 'unresolvable') {
+  throw Errors.delegationRunbookMismatch(resolvedStepId, requested.raw, resolvedRunbook);
+}
+if (requested.kind === 'resolved' && !sameRunbookRef(requested.ref, childRunbookRef)) {
+  throw Errors.delegationRunbookMismatch(resolvedStepId, requested.raw, resolvedRunbook);
+}
+```
+
+   Notes:
+   - The echo/conflict decision and the RD-804 message now live entirely in
+     core `resolveTargetedDelegation`; the CLI only resolves I/O and renders.
+   - The unresolvable-requested case splits cleanly: **with** an in-flight
+     delegation, core returns `conflict` (RD-804); **without** one (issuable),
+     the CLI's RD-822 mismatch fires. Both are now covered by tests (see §Tests).
+   - Authored child resolution (step 4) runs only on the issuable path, after the
+     echo `return`, so the echo never calls `resolveRunbookFile` for the authored
+     target and cannot throw `delegationRunbookNotFound`.
+
+3. **Extract** the echo into a shared helper used by both the bare path
+   (currently inline at `delegate.ts:199–216`) and the new targeted path, so the
+   JSON/text shapes cannot drift:
+
+```ts
+function emitAlreadyDelegated(
+  output: OutputEmitter,
+  opts: { stepId: string; runbookRef: string; token: string; parentRunId: string; text?: boolean },
+): void {
+  if (!opts.text) {
+    output.json({
+      kind: 'delegate',
+      action: 'already-delegated',
+      step: opts.stepId,
+      runbook: opts.runbookRef,
+      token: opts.token,
+      parent_run_id: opts.parentRunId,
+    });
+  } else {
+    output.message(`ALREADY    step ${opts.stepId} -> ${opts.runbookRef}`);
+    output.message(`Token:     ${opts.token}`);
+    output.message('');
+    output.message(`RD_CLAIM_TOKEN=${opts.token}`);
+  }
+}
+```
+
+   Update the bare path to call `emitAlreadyDelegated` too.
+
+4. **Remove** the now-unused CLI-local `findPendingDelegationForTarget`
+   (`delegate.ts:388–402`). Import `resolveTargetedDelegation` and the
+   `RequestedRunbookArg` type from `../helpers/delegate-inference.js`
+   (`findPendingDelegation` need not be imported by the CLI — it is an internal
+   dependency of `resolveTargetedDelegation`). Keep the `parseStepIdFromString`
+   import (still used for `parsedTarget`).
+
+5. **Drop the now-unused `StepDelegation` type import** from `delegate.ts:35`.
+   Its only use is the return type of the removed `findPendingDelegationForTarget`
+   (line 392), so leaving it triggers an ESLint unused-import failure. Keep
+   `RunbookState`, `TemplateVarValue`, and `FrameKey` on that import line — all
+   still used (e.g. by the retry `ResolvedTarget`/`RetryHandlerOptions` types).
+
+6. **`sameRunbookRef`:** the echo-vs-conflict comparison now lives in core
+   (`resolveTargetedDelegation`). The CLI still needs `sameRunbookRef` for the
+   RD-822 mismatch check (step 5 of the pinned order), so promote the helper to
+   core (`runbook-ref.ts`, exported via barrel) and have the CLI **import it**,
+   deleting the local copy at `delegate.ts:381` — one source of truth, no
+   duplicate definition.
+
+### Invariants preserved
+
+- **RD-819 (nested delegation):** preserved by fall-through, *for all
+  system-produced states*. A delegated child (`parentLinkage.kind ===
+  'delegation'`) can never accumulate a pending delegation record: auto issuance
+  throws RD-819 at `delegation-inference.ts:421` (`inferAllDelegateSubsteps`)
+  before creating any record, and manual `createDelegation` returns
+  `parent_is_delegated` at `delegation-service.ts:472–478` before its
+  existing-delegation check. So in a nested child `findPendingDelegation` returns
+  undefined and control falls through to `createDelegation`, which enforces
+  RD-819 (rethrown at `delegate.ts:342`). No CLI-side replication of the
+  state-machine guard. **Already pinned:** the existing CLI test
+  `delegate.test.ts:809–857` ("refuses nested delegation when active runbook is
+  itself a claimed child") injects `parentLinkage.kind === 'delegation'` and,
+  because `setupDelegation()` aborts the auto-token (no pending delegation), drives
+  exactly the fall-through path — it must continue to error RD-819. Core RD-819
+  coverage also exists (`create-delegation.test.ts:1209`,
+  `delegation-inference.test.ts:192`), so a *new* dedicated fall-through test is
+  redundant; we keep `delegate.test.ts:809` as the load-bearing regression guard.
+  **Caveat (acknowledged, not guarded):** because the echo now precedes
+  `createDelegation`, an *injected/corrupt* state holding both a delegation
+  linkage and a tokened pending delegation would echo and bypass RD-819. This is
+  unreachable in normal operation and consistent with the project's
+  no-corrupt-state stance; we deliberately do not add a CLI-side `parentLinkage`
+  short-circuit (that would duplicate state-machine logic).
+- **Collection-pending guard (RD `DELEGATION_COLLECTION_PENDING`):** the targeted
+  path never calls `resolveCommandIntent` (only the bare path does, gated by
+  `isBareDelegationIssue`). Targeted issuance is therefore inherently exempt; the
+  echo runs without consulting the guard. Req #5 is satisfied structurally.
+- **RD-822 (runbook mismatch):** preserved for the no-existing-delegation,
+  requested-runbook path.
+- **No re-issue except `--retry`:** `--retry` keeps its own early-return flow
+  (`handleRetry`), untouched.
+
+## Tests
+
+### Core — `packages/core/__tests__/runbook/delegation-inference.test.ts`
+
+**`describe('findPendingDelegation')`** (reuse `makeState`, `makeActiveDelegation`,
+`buildFrameKey`). **Each negative case must differ from the positive case in
+exactly ONE field** — otherwise an AND→OR conjunction mutant on the predicate
+survives (the suite would still pass with `||` because two fields are wrong at
+once). Start from a single canonical "pending, tokened, matching" fixture and
+flip one dimension per case:
+
+1. returns the delegation when a pending, unclaimed, non-cancelled, **tokened**
+   delegation exists on the target substep in the active frame (positive).
+2. returns `undefined` when the step id has no substep segment (e.g. `"1"`).
+3. returns `undefined` when only the substep **id** differs (no id match).
+4. returns `undefined` when only the **frame key** differs (frame-scoped).
+5. returns `undefined` when only `cancelledAt` is set (`!== null`).
+6. returns `undefined` when only `childRunId` is set (`!== null`, claimed).
+7. returns `undefined` when only the `token` is absent (token-filter).
+8. returns `undefined` when the matching substep has `delegation === undefined`
+   (id+frame match, no delegation record) — exercises the `?.` short-circuit.
+
+> **Helper note:** `makeActiveDelegation()` (`delegation-inference.test.ts:61–71`)
+> does **not** set a `token` field. The `token != null` predicate filter means
+> the positive cases must build delegations *with* a token (extend the helper to
+> accept/default `token: 'rdtk_aaa'`); case 7 uses a tokenless one. Without this,
+> case 1 fails against the filter.
+
+**`describe('resolveTargetedDelegation')`** (the new decision function):
+
+1. `requested.kind === 'none'` + in-flight delegation → `{ kind: 'echo', token, runbookRef, stepId }` with the existing token.
+2. `requested.kind === 'resolved'` matching the existing ref → `echo`.
+3. `requested.kind === 'resolved'` with a *different* ref → `{ kind: 'conflict' }`, `error.code === 'RD-804'`, message contains `requested`/`existing`/token hash, **no `rdtk_`**.
+4. `requested.kind === 'unresolvable'` + in-flight delegation → `{ kind: 'conflict' }` (RD-804) — pins the branch the CLI cannot reach via `sameRunbookRef` (mutation gap the review flagged).
+5. no in-flight delegation (any `requested`) → `{ kind: 'issuable' }`.
+
+**Property test — `packages/core/__tests__/runbook/delegation-inference.properties.test.ts`**
+(fast-check; reuse `DelegationSpec`/`substepFromSpec`/`makeFrontierState`/`frameArb`
+from the existing file, extending `DelegationSpec`/`specArb` with a `childRunId`
+dimension). Invariants for `findPendingDelegation` over a random
+`SubstepState[]`:
+- **defined IFF** some substep matches `parsed.substep` AND `frameKey` AND
+  `cancelledAt === null` AND `childRunId === null` AND `token != null`;
+- when defined, the returned record is one of the matching substeps' delegations
+  and `result.token` is a non-empty string;
+- **determinism:** result is invariant under array reordering of the input
+  (mirrors the existing `deriveDelegateFrontier` order-independence property).
+  This directly underwrites the mutation-survivability claim for the predicate.
+
+### CLI — `packages/cli/__tests__/commands/delegate.test.ts`
+
+New / updated tests (use existing `setupAutoIssuedDelegation`, `setupDelegation`,
+`injectDelegationOutcomeForActiveRun`, `parseCliJsonObject`):
+
+- **NEW (req #1):** after `setupAutoIssuedDelegation()`,
+  `rd delegate --step 1.1` → exit 0, `action: "already-delegated"`, `step: "1.1"`,
+  `token` equals the auto-issued token, token starts with `rdtk_`.
+- **NEW (req #2):** after `setupAutoIssuedDelegation()`,
+  `rd delegate runbooks/child.runbook.md --step 1.1` → exit 0,
+  `already-delegated`, same token.
+- **NEW (req #3):** after `setupAutoIssuedDelegation()` plus a `child-b.runbook.md`
+  on disk, `rd delegate runbooks/child-b.runbook.md --step 1.1` → exit ≠ 0,
+  `code: "RD-804"`, message contains `in-flight delegation for a different
+  runbook`, requested + existing paths, `sha256:`, and no `rdtk_`.
+- **UPDATE `collection-pending guard` (req #5, currently lines 170–186):**
+  `exempts a targeted delegate --step from the collection-pending guard` — after
+  `setupAutoIssuedDelegation()` + `injectDelegationOutcomeForActiveRun()`,
+  `rd delegate --step 1.1` now → exit 0, `action: "already-delegated"`, and
+  assert `code !== "DELEGATION_COLLECTION_PENDING"` (proves the guard was
+  bypassed and the targeted path reached delegation logic and echoed instead of
+  erroring). Rewrite the explanatory comment accordingly.
+- **UPDATE `inference` (currently lines 535–550):**
+  `rd delegate --step 2.1 reports the existing auto-issued delegation as an
+  error` → rename/repurpose to assert idempotent echo: exit 0,
+  `already-delegated`, `step: "2.1"`, token equals the pre-issued frontier token,
+  persisted token unchanged.
+- **UPDATE `error cases` (currently lines 639–662):**
+  `errors for an existing pending delegation on the same substep...` — the second
+  identical `delegate runbooks/child.runbook.md --step 1.1` now echoes: exit 0,
+  `already-delegated`, same token. Rename to reflect idempotency.
+- **🔴 DELETE/UPDATE the duplicate at `inference` lines 563–587** (review BLOCKER):
+  `explicit rd delegate child.runbook.md --step 1.1 reports the existing
+  delegation as an error` asserts RD-804 on a *second identical* matching-runbook
+  call — functionally the same scenario as lines 639–662 (only array-vs-string
+  args differ). Under the new design it now echoes. **Delete it as a duplicate**
+  of the (updated) 639–662 test. The original plan omitted this test entirely; a
+  TDD executor would otherwise hit an unexplained red. (If kept instead of
+  deleted, flip its expectation to echo — but deletion is preferred since it adds
+  no coverage over 639–662.)
+- **NEW (unresolvable requested + in-flight — review mutation gap):** after
+  `setupAutoIssuedDelegation()`, `rd delegate runbooks/made-up-child.runbook.md
+  --step 1.1` (a runbook that does **not** resolve) → exit ≠ 0, `code: "RD-804"`,
+  no `rdtk_`. This is distinct from the existing `:714` test, which uses
+  `setupDelegation()` (auto-token aborted → no in-flight delegation → RD-822).
+  Here the in-flight delegation is present, so core returns `conflict` (RD-804).
+  Without this case the `requested.kind === 'unresolvable'` → conflict branch is
+  uncovered (and is the branch that prevents `sameRunbookRef(undefined, …)`).
+- **KEEP unchanged (regression guards):**
+  - `errors when an in-flight delegation targets a different runbook...`
+    (lines 664–691) — still RD-804 (existing + different runbook).
+  - `rejects explicit child runbook delegation when the requested runbook differs
+    from the authored target` (lines 693–712) — still RD-822 (no existing +
+    different).
+  - `rejects explicit child runbook delegation when the requested runbook is not
+    authored` (lines 714–728) — still RD-822.
+  - `idempotent bare delegate` block (lines 219–243) — still passes (req #4).
+  - The existing nested-delegation **RD-819** test (`delegate.test.ts` ~809–857,
+    via `setupDelegation()` whose aborted token leaves no pending delegation) —
+    must still error RD-819, pinning the fall-through reasoning above.
+- **OPTIONAL (strong-idempotency guarantee):** after `setupAutoIssuedDelegation()`,
+  delete the authored child runbook file on disk, then `rd delegate --step 1.1`
+  → still exit 0, `already-delegated`, same token. Proves the echo path does not
+  re-resolve the authored target (justifies the pinned reorder). Omit only if the
+  reorder's stronger guarantee is dropped.
+
+### CLI integration — `packages/cli/__tests__/integration/delegation-h3-runbook-substep.test.ts`
+
+- **UPDATE** `does not issue a duplicate manual delegation after frontier
+  creation` (lines 295–315): the `rd delegate --step 1.1` call after the bare
+  idempotent echo should now also be idempotent — exit 0, output matches
+  `already-delegated` and `rdtk_` (the existing token), not RD-804. Update the
+  comment that says `--step` "still errors." **Also chain `rd claim <echoedToken>`**
+  to prove the echoed token is live (the same delegation a child can claim), not a
+  stale string — closes the loop end-to-end.
+
+### Scenario suite — `runbooks/scenario-suite.yaml`
+
+- **ADD a scenario** covering the `/rundown:planning` flow that motivated #468:
+  `rd run` a DELEGATE runbook (auto-issues on entry) → `rd delegate --step 1.1`
+  (now echoes) → `rd claim ${TOKEN}` → assert `result: COMPLETE`. No scenario
+  currently runs `rd delegate --step` at all (verified). `${TOKEN}` is captured
+  from the `rd run` entry frontier, so it remains valid after the echo.
+  **Documented limitation:** the scenario harness captures delegate tokens only
+  from `action === 'delegated'` (not `already-delegated`) and has no per-command
+  stdout assertion, so the scenario proves the *workflow stays unbroken*
+  (echo → claim → complete) but **cannot** assert the `already-delegated` echo
+  JSON shape — that assertion stays at the command-test layer (the NEW req #1/#2
+  tests above). Add the scenario for end-to-end coverage; do not rely on it for
+  the echo-shape contract.
+
+### Docs
+
+- `packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md` — scan for any
+  statement that `--step` re-issues or errors on an already-delegated substep.
+  Current quick-reference lines (29–34, 65–86) only document the happy path and
+  do not contradict idempotency; add a one-line note that `rd delegate --step S`
+  is idempotent (echoes the in-flight token) if it improves clarity. Low priority.
+
+## Execution order (TDD)
+
+1. Core: write `findPendingDelegation` + `resolveTargetedDelegation` unit tests
+   (red) → implement both in `delegation-inference.ts` (green). Add the property
+   test for `findPendingDelegation`.
+2. Core barrel + CLI helper: export/re-export `resolveTargetedDelegation`,
+   `findPendingDelegation`, and the new types.
+3. CLI: write/upgrade `delegate.test.ts` cases (red) — including the BLOCKER
+   delete/update at 563–587 and the unresolvable-requested case — → implement the
+   `delegate.ts` reorder + core-driven resolution switch + `emitAlreadyDelegated`,
+   remove the local scan, drop the unused `StepDelegation` import, resolve the
+   `sameRunbookRef` single-source decision (green).
+4. Update the integration test (+ claim-chaining).
+5. Add the scenario-suite case.
+6. Docs scan/touch-up.
+
+## Verification
+
+```bash
+pnpm --filter @rundown-org/core test -- delegation-inference.test.ts
+pnpm --filter @rundown-org/core test -- delegation-inference.properties.test.ts
+pnpm --filter @rundown-org/cli test -- delegate.test.ts
+pnpm --filter @rundown-org/cli test -- delegation-h3-runbook-substep.test.ts
+pnpm --filter @rundown-org/cli test -- scenario   # scenario-suite runner (new case)
+```
+
+Then broaden:
+
+```bash
+pnpm --filter @rundown-org/core test
+pnpm --filter @rundown-org/cli test
+pnpm run verify   # before PR (format, spell, lint, test)
+```
+
+Consider scoped mutation runs on the changed surfaces if time allows:
+
+```bash
+pnpm run test:mutate:core -- --mutate packages/core/src/runbook/delegation-inference.ts
+pnpm run test:mutate:cli -- --mutate packages/cli/src/commands/delegate.ts --testFiles packages/cli/__tests__/commands/delegate.test.ts
+```
+
+## Out of scope
+
+- Actor-source / actor-context ingress plans (the unrelated dated plans under
+  `docs/superpowers/plans/`).
+- Any change to `--retry` resolution.
+- Any persisted-state schema or migration work.

--- a/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
@@ -81,6 +81,12 @@ rd delegate --step 2.1 --input-json config='{"debug":true}'
 
 The `delegate` command issues a token (`rdtk_...`) and queues the substep for external execution.
 
+`rd delegate --step S` is **idempotent**: when the substep already carries an
+in-flight (auto-issued, unclaimed) delegation, it echoes the existing token
+(`action: "already-delegated"`) instead of erroring. Re-issuing a fresh token
+requires `--retry`. Naming a different runbook than the in-flight one is a
+conflict (RD-804).
+
 **Constraints:**
 - `--step` must target the active step frontier
 - When the active step has substeps, bare step IDs (e.g., `2`) are rejected — use qualified IDs (e.g., `2.1`)

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { DelegateResponseSchema, ErrorResponseSchema } from '@rundown-org/core';
+import { buildFrameKey, DelegateResponseSchema, ErrorResponseSchema } from '@rundown-org/core';
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
@@ -624,8 +624,14 @@ describe('delegate command', () => {
       await setupDelegationWithPendingDelegateRunbookRef();
 
       const before = await getActiveState(workspace);
-      const issuedToken = before?.substepStates?.find((substep) => substep.id === '1')?.delegation
-        ?.token;
+      // Substep ids collide across steps (every step has a `1`). Scope the
+      // lookup to step 2's active frame so a cross-step id collision cannot
+      // satisfy the assertion. The setup `goto 2`s, so the cursor sits in
+      // step 2's base frame (`2|`).
+      const beforeFrame = before?.activeFrameKey ?? buildFrameKey('2');
+      const issuedToken = before?.substepStates?.find(
+        (substep) => substep.id === '1' && substep.frameKey === beforeFrame,
+      )?.delegation?.token;
       expect(issuedToken).toBeDefined();
 
       const result = await runCliInProcess(['delegate', '--step', '2.1'], workspace);
@@ -639,8 +645,10 @@ describe('delegate command', () => {
 
       // No re-issue: the persisted delegation token is unchanged.
       const after = await getActiveState(workspace);
-      const afterToken = after?.substepStates?.find((substep) => substep.id === '1')?.delegation
-        ?.token;
+      const afterFrame = after?.activeFrameKey ?? buildFrameKey('2');
+      const afterToken = after?.substepStates?.find(
+        (substep) => substep.id === '1' && substep.frameKey === afterFrame,
+      )?.delegation?.token;
       expect(afterToken).toBe(issuedToken);
     });
 

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { DelegateResponseSchema, ErrorResponseSchema } from '@rundown-org/core';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   createTestWorkspace,
@@ -172,17 +172,19 @@ describe('delegate command', () => {
       // so it bypasses the collection-pending guard (which gates bare issuance
       // only) and reaches real delegation logic. In this same pending state bare
       // `delegate` returns DELEGATION_COLLECTION_PENDING (see the test above);
-      // the targeted form instead surfaces RD-804 for the substep's already
-      // in-flight auto-issued delegation. The contrast in error codes is the
-      // proof that the guard was skipped, not that delegation itself succeeded.
+      // the targeted form instead reaches the delegation logic and idempotently
+      // echoes the substep's already in-flight auto-issued delegation. The
+      // success (exit 0, `already-delegated`) — never DELEGATION_COLLECTION_PENDING
+      // — is the proof that the guard was skipped.
       await setupAutoIssuedDelegation();
       await injectDelegationOutcomeForActiveRun(workspace);
 
       const result = await runCliInProcess(['delegate', '--step', '1.1'], workspace);
 
-      const raw = JSON.parse(result.stdout) as { code?: string };
-      expect(raw.code).not.toBe('DELEGATION_COLLECTION_PENDING');
-      expect(raw.code).toBe('RD-804');
+      expect(result.exitCode).toBe(0);
+      const json = parseCliJsonObject(result.stdout);
+      expect(json).toMatchObject({ kind: 'delegate', action: 'already-delegated', step: '1.1' });
+      expect(json.code).not.toBe('DELEGATION_COLLECTION_PENDING');
     });
 
     it('exempts a targeted delegate --retry from the collection-pending guard', async () => {
@@ -239,6 +241,92 @@ describe('delegate command', () => {
       expect(result.stdout).toContain('ALREADY');
       expect(result.stdout).toContain('rdtk_');
       expect(result.stdout).toContain('RD_CLAIM_TOKEN=');
+    });
+  });
+
+  describe('idempotent targeted delegate', () => {
+    it('rd delegate --step 1.1 echoes the in-flight auto-issued token (req #1)', async () => {
+      const autoToken = await setupAutoIssuedDelegation();
+
+      const result = await runCliInProcess(['delegate', '--step', '1.1'], workspace);
+
+      expect(result.exitCode).toBe(0);
+      const json = parseCliJsonObject(result.stdout);
+      expect(json).toMatchObject({ kind: 'delegate', action: 'already-delegated', step: '1.1' });
+      expect(json.token).toBe(autoToken);
+      expect((json.token as string).startsWith('rdtk_')).toBe(true);
+    });
+
+    it('rd delegate <matching-runbook> --step 1.1 echoes the in-flight token (req #2)', async () => {
+      const autoToken = await setupAutoIssuedDelegation();
+
+      const result = await runCliInProcess(
+        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = parseCliJsonObject(result.stdout);
+      expect(json).toMatchObject({ kind: 'delegate', action: 'already-delegated', step: '1.1' });
+      expect(json.token).toBe(autoToken);
+    });
+
+    it('rd delegate <different-runbook> --step 1.1 conflicts with RD-804 (req #3)', async () => {
+      await setupAutoIssuedDelegation();
+
+      const childBContent = createRunbook({
+        steps: [{ title: 'Child B step', pass: 'COMPLETE', command: 'rd echo --result pass' }],
+      });
+      await writeFile(join(workspace.cwd, 'runbooks', 'child-b.runbook.md'), childBContent);
+
+      const result = await runCliInProcess(
+        ['delegate', 'runbooks/child-b.runbook.md', '--step', '1.1'],
+        workspace,
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      const envelope = parseCliJsonObject(result.stdout || result.stderr);
+      expect(envelope).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-804' }));
+      expect(JSON.stringify(envelope)).toContain('in-flight delegation for a different runbook');
+      expect(JSON.stringify(envelope)).toContain('runbooks/child-b.runbook.md');
+      expect(JSON.stringify(envelope)).toContain('child.runbook.md');
+      expect(JSON.stringify(envelope)).toContain('sha256:');
+      expect(JSON.stringify(envelope)).not.toMatch(/rdtk_/);
+    });
+
+    it('rd delegate <unresolvable-runbook> --step 1.1 conflicts with RD-804 when in-flight', async () => {
+      // An unresolvable requested runbook on a substep that already carries an
+      // in-flight delegation surfaces the RD-804 conflict (core returns
+      // `conflict`), distinct from the RD-822 mismatch raised when no delegation
+      // is in flight (see the `setupDelegation()`-based test below).
+      await setupAutoIssuedDelegation();
+
+      const result = await runCliInProcess(
+        ['delegate', 'runbooks/made-up-child.runbook.md', '--step', '1.1'],
+        workspace,
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      const envelope = parseCliJsonObject(result.stdout || result.stderr);
+      expect(envelope).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-804' }));
+      expect(JSON.stringify(envelope)).not.toMatch(/rdtk_/);
+    });
+
+    it('echoes even after the authored child runbook file is removed (strong idempotency)', async () => {
+      // The echo path must not re-resolve the authored target, so deleting the
+      // child runbook on disk cannot break idempotency. Pins the reorder that
+      // runs the echo decision before authored-runbook resolution.
+      const autoToken = await setupAutoIssuedDelegation();
+
+      await rm(join(workspace.cwd, 'runbooks', 'child.runbook.md'));
+      await rm(join(workspace.runbooksDir(), 'child.runbook.md'));
+
+      const result = await runCliInProcess(['delegate', '--step', '1.1'], workspace);
+
+      expect(result.exitCode).toBe(0);
+      const json = parseCliJsonObject(result.stdout);
+      expect(json).toMatchObject({ kind: 'delegate', action: 'already-delegated', step: '1.1' });
+      expect(json.token).toBe(autoToken);
     });
   });
 
@@ -532,21 +620,28 @@ describe('delegate command', () => {
       expect(`${result.stdout}\n${result.stderr}`).toContain('RD-813');
     });
 
-    it('rd delegate --step 2.1 reports the existing auto-issued delegation as an error', async () => {
+    it('rd delegate --step 2.1 idempotently echoes the existing auto-issued delegation', async () => {
       await setupDelegationWithPendingDelegateRunbookRef();
+
+      const before = await getActiveState(workspace);
+      const issuedToken = before?.substepStates?.find((substep) => substep.id === '1')?.delegation
+        ?.token;
+      expect(issuedToken).toBeDefined();
 
       const result = await runCliInProcess(['delegate', '--step', '2.1'], workspace);
 
-      expect(result.exitCode).not.toBe(0);
-      const envelope = parseCliJsonObject(result.stdout || result.stderr);
+      expect(result.exitCode).toBe(0);
+      const envelope = parseCliJsonObject(result.stdout);
       expect(envelope).toEqual(
-        expect.objectContaining({
-          kind: 'error',
-          code: 'RD-804',
-        }),
+        expect.objectContaining({ kind: 'delegate', action: 'already-delegated', step: '2.1' }),
       );
-      expect(JSON.stringify(envelope)).toContain('sha256:');
-      expect(JSON.stringify(envelope)).not.toMatch(/rdtk_/);
+      expect(envelope.token).toBe(issuedToken);
+
+      // No re-issue: the persisted delegation token is unchanged.
+      const after = await getActiveState(workspace);
+      const afterToken = after?.substepStates?.find((substep) => substep.id === '1')?.delegation
+        ?.token;
+      expect(afterToken).toBe(issuedToken);
     });
 
     it('backward compat: explicit rd delegate child.runbook.md --step 1.1 still works', async () => {
@@ -558,32 +653,6 @@ describe('delegate command', () => {
       );
 
       expect(result.exitCode).toBe(0);
-    });
-
-    it('explicit rd delegate child.runbook.md --step 1.1 reports the existing delegation as an error', async () => {
-      await setupDelegation();
-
-      const first = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
-        workspace,
-      );
-      expect(first.exitCode).toBe(0);
-
-      const result = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
-        workspace,
-      );
-
-      expect(result.exitCode).not.toBe(0);
-      const envelope = parseCliJsonObject(result.stdout || result.stderr);
-      expect(envelope).toEqual(
-        expect.objectContaining({
-          kind: 'error',
-          code: 'RD-804',
-        }),
-      );
-      expect(JSON.stringify(envelope)).toContain('sha256:');
-      expect(JSON.stringify(envelope)).not.toMatch(/rdtk_/);
     });
   });
 
@@ -636,7 +705,7 @@ describe('delegate command', () => {
       expect(JSON.stringify(envelope)).not.toMatch(/rdtk_/);
     });
 
-    it('errors for an existing pending delegation on the same substep without showing the token again', async () => {
+    it('idempotently echoes a repeated matching delegation on the same substep', async () => {
       await setupDelegation();
 
       const first = await runCliInProcess(
@@ -644,21 +713,20 @@ describe('delegate command', () => {
         workspace,
       );
       expect(first.exitCode).toBe(0);
+      const firstJson = parseCliJsonObject(first.stdout);
+      const firstToken = firstJson.token;
+      expect(typeof firstToken).toBe('string');
 
       const second = await runCliInProcess(
         'delegate runbooks/child.runbook.md --step 1.1',
         workspace,
       );
-      expect(second.exitCode).not.toBe(0);
-      const envelope = parseCliJsonObject(second.stdout || second.stderr);
+      expect(second.exitCode).toBe(0);
+      const envelope = parseCliJsonObject(second.stdout);
       expect(envelope).toEqual(
-        expect.objectContaining({
-          kind: 'error',
-          code: 'RD-804',
-        }),
+        expect.objectContaining({ kind: 'delegate', action: 'already-delegated', step: '1.1' }),
       );
-      expect(JSON.stringify(envelope)).toContain('sha256:');
-      expect(JSON.stringify(envelope)).not.toMatch(/rdtk_/);
+      expect(envelope.token).toBe(firstToken);
     });
 
     it('errors when an in-flight delegation targets a different runbook without exposing the raw token', async () => {

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -662,6 +662,29 @@ describe('delegate command', () => {
 
       expect(result.exitCode).toBe(0);
     });
+
+    it('rejects a no-step positional runbook that differs from the authored target (RD-822)', async () => {
+      await setupDelegation();
+      const childBContent = createRunbook({
+        steps: [{ title: 'Child B step', pass: 'COMPLETE', command: 'rd echo --result pass' }],
+      });
+      await writeFile(join(workspace.cwd, 'runbooks', 'child-b.runbook.md'), childBContent);
+
+      const result = await runCliInProcess(['delegate', 'runbooks/child-b.runbook.md'], workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      const envelope = parseCliJsonObject(result.stdout || result.stderr);
+      expect(envelope).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-822' }));
+      expect(JSON.stringify(envelope)).not.toMatch(/rdtk_/);
+    });
+
+    it('accepts a no-step positional runbook that matches the authored target', async () => {
+      await setupDelegation();
+      const result = await runCliInProcess(['delegate', 'runbooks/child.runbook.md'], workspace);
+      expect(result.exitCode).toBe(0);
+      const json = parseCliJsonObject(result.stdout);
+      expect(json).toMatchObject({ kind: 'delegate', action: 'delegated', step: '1.1' });
+    });
   });
 
   describe('error cases', () => {

--- a/packages/cli/__tests__/integration/delegate-workflow.test.ts
+++ b/packages/cli/__tests__/integration/delegate-workflow.test.ts
@@ -503,10 +503,12 @@ describe('DELEGATE manual issuance requires authored DELEGATE annotation', () =>
     }
   });
 
-  it('after auto-delegation, rd delegate --step on a remaining substep is rejected with already-delegated error', async () => {
+  it('after auto-delegation, rd delegate --step on a delegated substep idempotently echoes the token', async () => {
     // This variant DOES include `- DELEGATE` so auto-delegation fires on
     // step entry, producing delegation records for both substeps. A
-    // subsequent manual `rd delegate --step 1.1` should then be rejected.
+    // subsequent manual `rd delegate --step 1.1` naming the same authored
+    // runbook is idempotent: it echoes the in-flight auto-issued token
+    // (issue #468) rather than erroring.
     const childContent = createRunbook({
       title: 'Child',
       steps: [{ title: 'Do work', pass: 'COMPLETE', command: 'rd echo --result pass' }],
@@ -547,11 +549,18 @@ describe('DELEGATE manual issuance requires authored DELEGATE annotation', () =>
     const start = await runCliInProcess('run --prompted runbooks/parent.runbook.md', workspace);
     expect(start.exitCode).toBe(0);
 
-    // Auto-delegation already consumed substep 1.1; manual delegation must be rejected.
+    // Substep 1.1 already carries an auto-issued delegation for the same
+    // authored runbook; the targeted manual delegate echoes it idempotently.
+    const before = await getActiveState(workspace);
+    const issuedToken = before?.substepStates?.find((substep) => substep.id === '1')?.delegation
+      ?.token;
+    expect(issuedToken).toBeDefined();
+
     const manual = await runCliInProcess('delegate child.runbook.md --step 1.1', workspace);
-    expect(manual.exitCode).not.toBe(0);
-    expect(manual.stdout + manual.stderr).toMatch(/RD-804|active delegation exists|already/i);
-    expect(manual.stdout + manual.stderr).not.toMatch(/rdtk_/);
+    expect(manual.exitCode).toBe(0);
+    const json = parseCliJsonObject(manual.stdout);
+    expect(json).toMatchObject({ kind: 'delegate', action: 'already-delegated', step: '1.1' });
+    expect(json.token).toBe(issuedToken);
   });
 });
 

--- a/packages/cli/__tests__/integration/delegation-h3-runbook-substep.test.ts
+++ b/packages/cli/__tests__/integration/delegation-h3-runbook-substep.test.ts
@@ -299,12 +299,19 @@ Done.
     let result = runCli('run --prompted parent.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
 
+    // The auto-issued frontier token created on entry. Every idempotent echo
+    // below must reproduce *this exact* token — a different token would mean a
+    // duplicate delegation was issued.
+    const [originalToken] = extractTokens(result.stdout);
+    expect(originalToken).toBeDefined();
+    expect(originalToken).toMatch(/^rdtk_/);
+
     // Bare `rd delegate` is idempotent on an auto-issued frontier: it echoes
     // the existing token rather than re-issuing or throwing RD-813.
     result = runCli('delegate', workspace);
     expect(result.exitCode).toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).toMatch(/already-delegated/);
-    expect(`${result.stdout}\n${result.stderr}`).toMatch(/rdtk_/);
+    expect(/rdtk_[A-Za-z0-9_]+/.exec(result.stdout)?.[0]).toBe(originalToken);
 
     // Explicit `--step` on an already-delegated substep is idempotent: it echoes
     // the existing in-flight token rather than re-issuing a duplicate delegation
@@ -313,7 +320,8 @@ Done.
     expect(result.exitCode).toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).toMatch(/already-delegated/);
     const echoedToken = /rdtk_[A-Za-z0-9_]+/.exec(result.stdout)?.[0];
-    expect(echoedToken).toBeDefined();
+    // Same token as the original frontier — proves no duplicate was created.
+    expect(echoedToken).toBe(originalToken);
 
     // The echoed token is live, not a stale string: a child can claim the very
     // same delegation it names — closing the loop end-to-end.

--- a/packages/cli/__tests__/integration/delegation-h3-runbook-substep.test.ts
+++ b/packages/cli/__tests__/integration/delegation-h3-runbook-substep.test.ts
@@ -306,12 +306,19 @@ Done.
     expect(`${result.stdout}\n${result.stderr}`).toMatch(/already-delegated/);
     expect(`${result.stdout}\n${result.stderr}`).toMatch(/rdtk_/);
 
-    // Explicit `--step` on an already-delegated substep still errors (it must
-    // not silently re-issue a duplicate in-flight delegation).
+    // Explicit `--step` on an already-delegated substep is idempotent: it echoes
+    // the existing in-flight token rather than re-issuing a duplicate delegation
+    // or erroring RD-804.
     result = runCli('delegate --step 1.1', workspace);
-    expect(result.exitCode).not.toBe(0);
-    expect(result.stdout + result.stderr).toMatch(/RD-804|active delegation exists|already/i);
-    expect(result.stdout + result.stderr).not.toMatch(/rdtk_/);
+    expect(result.exitCode).toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(/already-delegated/);
+    const echoedToken = /rdtk_[A-Za-z0-9_]+/.exec(result.stdout)?.[0];
+    expect(echoedToken).toBeDefined();
+
+    // The echoed token is live, not a stale string: a child can claim the very
+    // same delegation it names — closing the loop end-to-end.
+    const claim = runCli(`claim ${echoedToken!}`, workspace);
+    expect(claim.exitCode).toBe(0);
   });
 
   it('completes parent after frontier token claim for single H3 runbook-list substep', async () => {

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -11,6 +11,7 @@ import {
   deriveDelegateFrontier,
   buildFrameKey,
   resolveCommandIntent,
+  sameRunbookRef,
   trustedRunControllerContext,
 } from '@rundown-org/core';
 import { parseStepIdFromString } from '@rundown-org/parser';
@@ -23,6 +24,8 @@ import {
   inferDelegationTarget,
   inferRunbookFromStep,
   resolveDelegateTarget,
+  resolveTargetedDelegation,
+  type RequestedRunbookArg,
 } from '../helpers/delegate-inference.js';
 import {
   resolveIndexOption,
@@ -32,7 +35,7 @@ import {
 import { collectCliFlags, routeExtraVars } from '../services/variable-discovery.js';
 import { parseInputOption, parseInputJsonOption, collect } from '../helpers/option-utils.js';
 import { emitDelegationCollectionPendingError } from '../helpers/transitions.js';
-import type { RunbookState, StepDelegation, TemplateVarValue, FrameKey } from '@rundown-org/core';
+import type { RunbookState, TemplateVarValue, FrameKey } from '@rundown-org/core';
 
 /**
  * Options accepted by `rd delegate` (covers both fresh-issue and --retry flows).
@@ -197,21 +200,13 @@ export function registerDelegateCommand(program: Command): void {
             const frontier = deriveDelegateFrontier(state);
             const resolution = resolveDelegateTarget(state, steps, frontier);
             if (resolution.kind === 'already-issued') {
-              if (!options.text) {
-                output.json({
-                  kind: 'delegate',
-                  action: 'already-delegated',
-                  step: resolution.stepId,
-                  runbook: resolution.runbookRef,
-                  token: resolution.token,
-                  parent_run_id: state.id,
-                });
-              } else {
-                output.message(`ALREADY    step ${resolution.stepId} -> ${resolution.runbookRef}`);
-                output.message(`Token:     ${resolution.token}`);
-                output.message('');
-                output.message(`RD_CLAIM_TOKEN=${resolution.token}`);
-              }
+              emitAlreadyDelegated(output, {
+                stepId: resolution.stepId,
+                runbookRef: resolution.runbookRef,
+                token: resolution.token,
+                parentRunId: state.id,
+                text: options.text,
+              });
               output.flush();
               return;
             }
@@ -227,30 +222,11 @@ export function registerDelegateCommand(program: Command): void {
             resolvedStepId = inferred.stepId;
           }
 
-          // Resolve child runbook path
-          const childResolved = await resolveRunbookFile(cwd, resolvedRunbook);
-          if (!childResolved) {
-            throw Errors.delegationRunbookNotFound(resolvedRunbook);
-          }
-          const childPath = childResolved.path;
-          const childRunbookRef = await buildRunbookRef(childResolved);
-
-          // Parse extra vars through the standard normalization pipeline
-          const rawVars = await collectCliFlags(
-            { inputFile: options.inputFile, input: options.input, inputJson: options.inputJson },
-            cwd,
-          );
-
-          let extraVars: Record<string, TemplateVarValue> | undefined;
-          if (Object.keys(rawVars).length > 0) {
-            const routed = await routeExtraVars(rawVars, cwd);
-            for (const w of routed.warnings) {
-              output.warning(w);
-            }
-            extraVars = Object.keys(routed.vars).length > 0 ? routed.vars : undefined;
-          }
-
-          // Compute frame key — use explicit iteration from --index or three-level step ID
+          // Compute frame key — use explicit iteration from --index or three-level
+          // step ID. Computed before the idempotency check (it depends only on the
+          // resolved step, --index, and state) and before authored-runbook
+          // resolution, so the echo path never re-resolves the authored target
+          // (idempotent even if the authored child file later changes).
           const parsedTarget = parseStepIdFromString(resolvedStepId);
           let explicitIteration: number | undefined;
           try {
@@ -280,39 +256,84 @@ export function registerDelegateCommand(program: Command): void {
               ? buildFrameKey(state.step, explicitIteration)
               : (state.activeFrameKey ?? deriveActiveFrame(state).frameKey);
 
-          if (requestedRunbook) {
-            const existingDelegation = findPendingDelegationForTarget(
-              state,
-              resolvedStepId,
-              activeFrameKey,
-            );
-            if (existingDelegation) {
-              const existingRunbook = existingDelegation.childRunbookRef.path;
-              const isDifferentRunbook = requestedRunbook !== existingRunbook;
-              throw Errors.delegationAlreadyExists(
-                resolvedStepId,
-                isDifferentRunbook
-                  ? `in-flight delegation for a different runbook: requested ${requestedRunbook}, existing ${existingRunbook}, token hash ${existingDelegation.tokenHash}`
-                  : `in-flight delegation already exists for ${existingRunbook}, token hash ${existingDelegation.tokenHash}`,
-              );
-            }
-
+          // Resolve the requested positional arg to serializable data for core.
+          // Only the requested arg is resolved here — never the authored target —
+          // so the echo path stays independent of authored-runbook resolvability.
+          let requested: RequestedRunbookArg;
+          if (!requestedRunbook) {
+            requested = { kind: 'none' };
+          } else {
             const requestedResolved = await resolveRunbookFile(cwd, requestedRunbook);
-            if (!requestedResolved) {
-              throw Errors.delegationRunbookMismatch(
-                resolvedStepId,
-                requestedRunbook,
-                resolvedRunbook,
-              );
+            requested = requestedResolved
+              ? {
+                  kind: 'resolved',
+                  ref: await buildRunbookRef(requestedResolved),
+                  raw: requestedRunbook,
+                }
+              : { kind: 'unresolvable', raw: requestedRunbook };
+          }
+
+          // Core owns the echo-vs-conflict (RD-804) decision; the CLI renders it.
+          const targeted = resolveTargetedDelegation(
+            state,
+            resolvedStepId,
+            activeFrameKey,
+            requested,
+          );
+          switch (targeted.kind) {
+            case 'echo':
+              emitAlreadyDelegated(output, {
+                stepId: targeted.stepId,
+                runbookRef: targeted.runbookRef,
+                token: targeted.token,
+                parentRunId: state.id,
+                text: options.text,
+              });
+              output.flush();
+              return;
+            case 'conflict':
+              throw targeted.error;
+            case 'issuable':
+              break;
+            default: {
+              const _exhaustive: never = targeted;
+              return _exhaustive;
             }
-            const requestedRef = await buildRunbookRef(requestedResolved);
-            if (!sameRunbookRef(requestedRef, childRunbookRef)) {
-              throw Errors.delegationRunbookMismatch(
-                resolvedStepId,
-                requestedRunbook,
-                resolvedRunbook,
-              );
+          }
+
+          // Issuable only: resolve the authored child runbook. This runs after the
+          // echo `return`, so the echo path never calls resolveRunbookFile for the
+          // authored target and cannot throw delegationRunbookNotFound.
+          const childResolved = await resolveRunbookFile(cwd, resolvedRunbook);
+          if (!childResolved) {
+            throw Errors.delegationRunbookNotFound(resolvedRunbook);
+          }
+          const childPath = childResolved.path;
+          const childRunbookRef = await buildRunbookRef(childResolved);
+
+          // Preserve the requested-vs-authored mismatch validation (RD-822),
+          // reusing the already-resolved requested arg. Only fires on the
+          // issuable path, where the authored child is resolved anyway.
+          if (requested.kind === 'unresolvable') {
+            throw Errors.delegationRunbookMismatch(resolvedStepId, requested.raw, resolvedRunbook);
+          }
+          if (requested.kind === 'resolved' && !sameRunbookRef(requested.ref, childRunbookRef)) {
+            throw Errors.delegationRunbookMismatch(resolvedStepId, requested.raw, resolvedRunbook);
+          }
+
+          // Parse extra vars through the standard normalization pipeline
+          const rawVars = await collectCliFlags(
+            { inputFile: options.inputFile, input: options.input, inputJson: options.inputJson },
+            cwd,
+          );
+
+          let extraVars: Record<string, TemplateVarValue> | undefined;
+          if (Object.keys(rawVars).length > 0) {
+            const routed = await routeExtraVars(rawVars, cwd);
+            for (const w of routed.warnings) {
+              output.warning(w);
             }
+            extraVars = Object.keys(routed.vars).length > 0 ? routed.vars : undefined;
           }
 
           // Create delegation (pure function — returns discriminated union)
@@ -378,27 +399,45 @@ export function registerDelegateCommand(program: Command): void {
     });
 }
 
-function sameRunbookRef(
-  left: Awaited<ReturnType<typeof buildRunbookRef>>,
-  right: Awaited<ReturnType<typeof buildRunbookRef>>,
-): boolean {
-  return left.source === right.source && left.path === right.path;
-}
-
-function findPendingDelegationForTarget(
-  state: RunbookState,
-  stepId: string,
-  frameKey: FrameKey,
-): StepDelegation | undefined {
-  const parsed = parseStepIdFromString(stepId);
-  if (!parsed?.substep) return undefined;
-  return state.substepStates?.find(
-    (substep) =>
-      substep.id === parsed.substep &&
-      substep.frameKey === frameKey &&
-      substep.delegation?.cancelledAt === null &&
-      substep.delegation.childRunId === null,
-  )?.delegation;
+/**
+ * Emit the `already-delegated` echo (idempotent delegate) in JSON or text form.
+ *
+ * Shared by the bare `rd delegate` path and the targeted `--step` path so the
+ * JSON/text shapes cannot drift between them.
+ *
+ * @param output - OutputEmitter to render through.
+ * @param opts - Echo fields.
+ * @param opts.stepId - Qualified step id of the already-delegated substep.
+ * @param opts.runbookRef - Child runbook reference for the in-flight delegation.
+ * @param opts.token - Recoverable plaintext delegation token to echo.
+ * @param opts.parentRunId - Parent run id that owns the delegation.
+ * @param opts.text - When true, render human-readable text instead of JSON.
+ */
+function emitAlreadyDelegated(
+  output: OutputEmitter,
+  opts: {
+    stepId: string;
+    runbookRef: string;
+    token: string;
+    parentRunId: string;
+    text?: boolean;
+  },
+): void {
+  if (!opts.text) {
+    output.json({
+      kind: 'delegate',
+      action: 'already-delegated',
+      step: opts.stepId,
+      runbook: opts.runbookRef,
+      token: opts.token,
+      parent_run_id: opts.parentRunId,
+    });
+  } else {
+    output.message(`ALREADY    step ${opts.stepId} -> ${opts.runbookRef}`);
+    output.message(`Token:     ${opts.token}`);
+    output.message('');
+    output.message(`RD_CLAIM_TOKEN=${opts.token}`);
+  }
 }
 
 /**

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -216,10 +216,15 @@ export function registerDelegateCommand(program: Command): void {
             resolvedRunbook = resolution.target.runbookRef;
             resolvedStepId = resolution.target.stepId;
           } else {
-            // Runbook given, no step — infer step from first pending substep
+            // Runbook given, no step — infer the target substep from the first
+            // pending delegate substep. The positional is a confirmation of the
+            // authored target, not an override: use the authored runbook as the
+            // child and validate the positional against it (RD-822 on mismatch),
+            // mirroring the `--step` form.
             const inferred = inferDelegationTarget(state, steps);
-            resolvedRunbook = runbookArg!;
+            resolvedRunbook = inferred.runbookRef;
             resolvedStepId = inferred.stepId;
+            requestedRunbook = runbookArg;
           }
 
           // Compute frame key — use explicit iteration from --index or three-level

--- a/packages/cli/src/helpers/delegate-inference.ts
+++ b/packages/cli/src/helpers/delegate-inference.ts
@@ -1,11 +1,15 @@
 export {
+  findPendingDelegation,
   inferAllDelegateSubsteps,
   inferDelegationTarget,
   inferRunbookFromStep,
   resolveDelegateTarget,
+  resolveTargetedDelegation,
   type DelegateTargetResolution,
   type DelegationInferenceState,
   type InferredDelegation,
+  type RequestedRunbookArg,
   type ResolvedDelegationRunbook,
   type ResolveDelegationRunbook,
+  type TargetedDelegateResolution,
 } from '@rundown-org/core';

--- a/packages/core/__tests__/runbook/delegation-inference.properties.test.ts
+++ b/packages/core/__tests__/runbook/delegation-inference.properties.test.ts
@@ -11,6 +11,7 @@ import {
   buildFrameKey,
   deriveActiveFrame,
   deriveDelegateFrontier,
+  findPendingDelegation,
   inferDelegationTarget,
   isPostDelegateAggregationCursor,
   type DelegationInferenceState,
@@ -136,6 +137,8 @@ interface DelegationSpec {
   readonly frameKey: FrameKey;
   readonly token: string | undefined;
   readonly cancelled: boolean;
+  /** When true, the delegation is claimed (`childRunId` set, not pending). */
+  readonly claimed: boolean;
 }
 
 /**
@@ -155,7 +158,7 @@ function substepFromSpec(spec: DelegationSpec): SubstepState {
       childRunbookPath: 'child.runbook.md',
       childRunbookRef: { source: 'project', path: 'child.runbook.md' },
       contextSnapshot: { vars: brandEffectiveVarsForTest({}), ancestors: [] },
-      childRunId: null,
+      childRunId: spec.claimed ? brandRunIdForTest(`rd_${'2'.repeat(32)}`) : null,
       createdAt: '2026-01-01T00:00:00.000Z',
       cancelledAt: spec.cancelled ? '2026-01-02T00:00:00.000Z' : null,
     },
@@ -212,6 +215,7 @@ describe('deriveDelegateFrontier invariants', () => {
     frameKey: frameArb,
     token: fc.option(fc.string({ minLength: 1, maxLength: 16 }), { nil: undefined }),
     cancelled: fc.boolean(),
+    claimed: fc.boolean(),
   });
 
   const specsArb: fc.Arbitrary<readonly DelegationSpec[]> = fc.array(specArb, {
@@ -392,6 +396,94 @@ describe('isPostDelegateAggregationCursor invariants', () => {
         // DELEGATE successor regardless of stale done records.
         expect(isPostDelegateAggregationCursor(state, STEPS)).toBe(false);
       }),
+    );
+  });
+});
+
+describe('findPendingDelegation invariants', () => {
+  const STEP = '1';
+  const frameArb: fc.Arbitrary<FrameKey> = fc.oneof(
+    fc.constant(buildFrameKey(STEP)),
+    fc.constant(buildFrameKey(STEP, 1)),
+    fc.constant(buildFrameKey(STEP, 2)),
+  );
+  const idArb = fc.constantFrom('1', '2', '3');
+  const specArb: fc.Arbitrary<DelegationSpec> = fc.record({
+    id: idArb,
+    frameKey: frameArb,
+    token: fc.option(fc.string({ minLength: 1, maxLength: 16 }), { nil: undefined }),
+    cancelled: fc.boolean(),
+    claimed: fc.boolean(),
+  });
+  const specsArb = fc.array(specArb, { minLength: 0, maxLength: 8 });
+
+  // Production guarantees one substep state per (id, frameKey); dedupe the
+  // generated specs to mirror that invariant so the single-result lookup is
+  // fully order-deterministic.
+  function uniqueStates(specs: readonly DelegationSpec[]): SubstepState[] {
+    const byKey = new Map<string, SubstepState>();
+    for (const spec of specs) {
+      byKey.set(`${spec.id}|${spec.frameKey}`, substepFromSpec(spec));
+    }
+    return [...byKey.values()];
+  }
+
+  it('is defined iff some substep matches id, frame, non-cancelled, unclaimed, tokened', () => {
+    fc.assert(
+      fc.property(specsArb, idArb, frameArb, (specs, targetId, targetFrame) => {
+        const substepStates = uniqueStates(specs);
+        const state = makeFrontierState(STEP, targetFrame, substepStates);
+        const result = findPendingDelegation(state, `${STEP}.${targetId}`, targetFrame);
+
+        const expectMatch = substepStates.some(
+          (ss) =>
+            ss.id === targetId &&
+            ss.frameKey === targetFrame &&
+            ss.delegation?.cancelledAt === null &&
+            ss.delegation.childRunId === null &&
+            ss.delegation.token != null,
+        );
+        expect(result !== undefined).toBe(expectMatch);
+
+        if (result) {
+          expect(typeof result.token).toBe('string');
+          expect(result.token.length).toBeGreaterThan(0);
+          const isMatchingSubstepDelegation = substepStates.some((ss) => ss.delegation === result);
+          expect(isMatchingSubstepDelegation).toBe(true);
+        }
+      }),
+    );
+  });
+
+  it('is invariant under input reordering (determinism)', () => {
+    fc.assert(
+      fc.property(
+        specsArb,
+        idArb,
+        frameArb,
+        fc.array(fc.integer(), { maxLength: 8 }),
+        (specs, targetId, targetFrame, shuffleSeed) => {
+          const original = uniqueStates(specs);
+          const shuffled = original
+            .map((ss, i) => ({ ss, key: shuffleSeed[i] ?? i }))
+            .sort((a, b) => a.key - b.key)
+            .map((entry) => entry.ss);
+
+          const stepId = `${STEP}.${targetId}`;
+          const base = findPendingDelegation(
+            makeFrontierState(STEP, targetFrame, original),
+            stepId,
+            targetFrame,
+          );
+          const reordered = findPendingDelegation(
+            makeFrontierState(STEP, targetFrame, shuffled),
+            stepId,
+            targetFrame,
+          );
+
+          expect(reordered?.token).toBe(base?.token);
+        },
+      ),
     );
   });
 });

--- a/packages/core/__tests__/runbook/delegation-inference.properties.test.ts
+++ b/packages/core/__tests__/runbook/delegation-inference.properties.test.ts
@@ -448,7 +448,18 @@ describe('findPendingDelegation invariants', () => {
         if (result) {
           expect(typeof result.token).toBe('string');
           expect(result.token.length).toBeGreaterThan(0);
-          const isMatchingSubstepDelegation = substepStates.some((ss) => ss.delegation === result);
+          // The returned delegation must belong to a substep matching the
+          // *targeted* id and frame (not merely exist somewhere), so a lookup
+          // that ignored id or frameKey would be caught here too.
+          const isMatchingSubstepDelegation = substepStates.some(
+            (ss) =>
+              ss.id === targetId &&
+              ss.frameKey === targetFrame &&
+              ss.delegation === result &&
+              ss.delegation.cancelledAt === null &&
+              ss.delegation.childRunId === null &&
+              ss.delegation.token != null,
+          );
           expect(isMatchingSubstepDelegation).toBe(true);
         }
       }),

--- a/packages/core/__tests__/runbook/delegation-inference.test.ts
+++ b/packages/core/__tests__/runbook/delegation-inference.test.ts
@@ -716,6 +716,20 @@ describe('findPendingDelegation', () => {
     const state = makeState({ step: '1', activeFrameKey: frameKey, substepStates });
     expect(findPendingDelegation(state, '1.1', frameKey)).toBeUndefined();
   });
+
+  it('returns undefined when the frame key does not belong to the parsed step', () => {
+    // Substep ids collide across steps (every step has a `1`). A request for
+    // step 2's substep (`2.1`) must not match step 1's substep `1.1` just
+    // because they share substep id `1` and the caller passed step 1's frame
+    // (the CLI derives the frame from the *current* step). Without this guard,
+    // `rd delegate --step 2.1` while positioned on step 1 would echo step 1.1's
+    // token mislabeled as 2.1.
+    const substepStates: SubstepState[] = [
+      { id: '1', frameKey, status: 'pending', delegation: makeActiveDelegation() },
+    ];
+    const state = makeState({ step: '1', activeFrameKey: frameKey, substepStates });
+    expect(findPendingDelegation(state, '2.1', frameKey)).toBeUndefined();
+  });
 });
 
 describe('resolveTargetedDelegation', () => {

--- a/packages/core/__tests__/runbook/delegation-inference.test.ts
+++ b/packages/core/__tests__/runbook/delegation-inference.test.ts
@@ -9,13 +9,16 @@ import type {
 import {
   buildFrameKey,
   deriveDelegateFrontier,
+  findPendingDelegation,
   inferAllDelegateSubsteps,
   inferDelegationTarget,
   inferRunbookFromStep,
   isPostDelegateAggregationCursor,
   resolveDelegateTarget,
+  resolveTargetedDelegation,
   type DelegationInferenceState,
   type FrameKey,
+  type RequestedRunbookArg,
   type RunbookState,
   type StepDelegation,
   type SubstepState,
@@ -58,8 +61,9 @@ function makeState(overrides: Partial<DelegationInferenceState> = {}): Delegatio
   };
 }
 
-function makeActiveDelegation(): StepDelegation {
+function makeActiveDelegation(overrides: Partial<StepDelegation> = {}): StepDelegation {
   return {
+    token: 'rdtk_aaa',
     tokenHash: assertDelegationTokenHash(`sha256:${'a'.repeat(64)}`),
     childRunbookPath: 'child.runbook.md',
     childRunbookRef: { source: 'project', path: 'child.runbook.md' },
@@ -67,6 +71,7 @@ function makeActiveDelegation(): StepDelegation {
     childRunId: null,
     createdAt: '2026-01-01T00:00:00.000Z',
     cancelledAt: null,
+    ...overrides,
   };
 }
 
@@ -646,5 +651,143 @@ describe('isPostDelegateAggregationCursor', () => {
       ],
     });
     expect(isPostDelegateAggregationCursor(state, buildSteps())).toBe(true);
+  });
+});
+
+describe('findPendingDelegation', () => {
+  const frameKey = buildFrameKey('1');
+
+  // Canonical "pending, tokened, matching" fixture; each negative case below
+  // flips exactly ONE dimension so an AND->OR predicate mutant cannot survive.
+  function stateWithDelegation(overrides: Partial<StepDelegation> = {}): DelegationInferenceState {
+    const substepStates: SubstepState[] = [
+      { id: '1', frameKey, status: 'pending', delegation: makeActiveDelegation(overrides) },
+    ];
+    return makeState({ step: '1', activeFrameKey: frameKey, substepStates });
+  }
+
+  it('returns the delegation for a pending, unclaimed, non-cancelled, tokened substep', () => {
+    const result = findPendingDelegation(stateWithDelegation(), '1.1', frameKey);
+    expect(result?.token).toBe('rdtk_aaa');
+  });
+
+  it('returns undefined when the step id has no substep segment', () => {
+    expect(findPendingDelegation(stateWithDelegation(), '1', frameKey)).toBeUndefined();
+  });
+
+  it('returns undefined when only the substep id differs', () => {
+    expect(findPendingDelegation(stateWithDelegation(), '1.2', frameKey)).toBeUndefined();
+  });
+
+  it('returns undefined when only the frame key differs', () => {
+    expect(
+      findPendingDelegation(stateWithDelegation(), '1.1', buildFrameKey('1', 2)),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when only cancelledAt is set', () => {
+    expect(
+      findPendingDelegation(
+        stateWithDelegation({ cancelledAt: '2026-01-02T00:00:00.000Z' }),
+        '1.1',
+        frameKey,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when only childRunId is set (claimed)', () => {
+    expect(
+      findPendingDelegation(
+        stateWithDelegation({ childRunId: brandRunIdForTest(`rd_${'2'.repeat(32)}`) }),
+        '1.1',
+        frameKey,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when only the token is absent', () => {
+    expect(
+      findPendingDelegation(stateWithDelegation({ token: undefined }), '1.1', frameKey),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the matching substep has no delegation record', () => {
+    const substepStates: SubstepState[] = [{ id: '1', frameKey, status: 'pending' }];
+    const state = makeState({ step: '1', activeFrameKey: frameKey, substepStates });
+    expect(findPendingDelegation(state, '1.1', frameKey)).toBeUndefined();
+  });
+});
+
+describe('resolveTargetedDelegation', () => {
+  const frameKey = buildFrameKey('1');
+
+  function stateWithDelegation(overrides: Partial<StepDelegation> = {}): DelegationInferenceState {
+    const substepStates: SubstepState[] = [
+      { id: '1', frameKey, status: 'pending', delegation: makeActiveDelegation(overrides) },
+    ];
+    return makeState({ step: '1', activeFrameKey: frameKey, substepStates });
+  }
+
+  const noneRequested: RequestedRunbookArg = { kind: 'none' };
+
+  it('echoes the existing token for a bare targeted request with an in-flight delegation', () => {
+    const result = resolveTargetedDelegation(stateWithDelegation(), '1.1', frameKey, noneRequested);
+    expect(result).toEqual({
+      kind: 'echo',
+      stepId: '1.1',
+      token: 'rdtk_aaa',
+      runbookRef: 'child.runbook.md',
+    });
+  });
+
+  it('echoes when the requested runbook matches the in-flight runbook', () => {
+    const requested: RequestedRunbookArg = {
+      kind: 'resolved',
+      ref: { source: 'project', path: 'child.runbook.md' },
+      raw: 'child.runbook.md',
+    };
+    const result = resolveTargetedDelegation(stateWithDelegation(), '1.1', frameKey, requested);
+    expect(result).toMatchObject({ kind: 'echo', token: 'rdtk_aaa' });
+  });
+
+  it('conflicts (RD-804) when the requested runbook differs from the in-flight runbook', () => {
+    const requested: RequestedRunbookArg = {
+      kind: 'resolved',
+      ref: { source: 'project', path: 'child-b.runbook.md' },
+      raw: 'child-b.runbook.md',
+    };
+    const result = resolveTargetedDelegation(stateWithDelegation(), '1.1', frameKey, requested);
+    expect(result.kind).toBe('conflict');
+    if (result.kind !== 'conflict') throw new Error('expected conflict');
+    expect(result.error.code).toBe('RD-804');
+    const message = result.error.message;
+    expect(message).toContain('child-b.runbook.md');
+    expect(message).toContain('child.runbook.md');
+    expect(message).toContain('sha256:');
+    expect(message).not.toContain('rdtk_');
+  });
+
+  it('conflicts (RD-804) when the requested runbook is unresolvable but a delegation is in flight', () => {
+    const requested: RequestedRunbookArg = { kind: 'unresolvable', raw: 'made-up.runbook.md' };
+    const result = resolveTargetedDelegation(stateWithDelegation(), '1.1', frameKey, requested);
+    expect(result.kind).toBe('conflict');
+    if (result.kind !== 'conflict') throw new Error('expected conflict');
+    expect(result.error.code).toBe('RD-804');
+    expect(result.error.message).not.toContain('rdtk_');
+  });
+
+  it('is issuable when no in-flight delegation exists, regardless of requested arg', () => {
+    const empty = makeState({ step: '1', activeFrameKey: frameKey, substepStates: [] });
+    expect(resolveTargetedDelegation(empty, '1.1', frameKey, noneRequested)).toEqual({
+      kind: 'issuable',
+    });
+    const requested: RequestedRunbookArg = {
+      kind: 'resolved',
+      ref: { source: 'project', path: 'child.runbook.md' },
+      raw: 'child.runbook.md',
+    };
+    expect(resolveTargetedDelegation(empty, '1.1', frameKey, requested)).toEqual({
+      kind: 'issuable',
+    });
   });
 });

--- a/packages/core/__tests__/runbook/delegation-inference.test.ts
+++ b/packages/core/__tests__/runbook/delegation-inference.test.ts
@@ -792,6 +792,23 @@ describe('resolveTargetedDelegation', () => {
     expect(message).not.toContain('rdtk_');
   });
 
+  it('conflicts (RD-804) when the requested runbook shares the path but differs in source', () => {
+    // sameRunbookRef compares BOTH source and path. The in-flight delegation
+    // targets { source: 'project', path: 'child.runbook.md' }; a request for the
+    // same path under a different source resolves the SAME runbook name to a
+    // DIFFERENT file, so it must conflict rather than echo.
+    const requested: RequestedRunbookArg = {
+      kind: 'resolved',
+      ref: { source: 'plugin', path: 'child.runbook.md' },
+      raw: 'child.runbook.md',
+    };
+    const result = resolveTargetedDelegation(stateWithDelegation(), '1.1', frameKey, requested);
+    expect(result.kind).toBe('conflict');
+    if (result.kind !== 'conflict') throw new Error('expected conflict');
+    expect(result.error.code).toBe('RD-804');
+    expect(result.error.message).not.toContain('rdtk_');
+  });
+
   it('conflicts (RD-804) when the requested runbook is unresolvable but a delegation is in flight', () => {
     const requested: RequestedRunbookArg = { kind: 'unresolvable', raw: 'made-up.runbook.md' };
     const result = resolveTargetedDelegation(stateWithDelegation(), '1.1', frameKey, requested);

--- a/packages/core/__tests__/runbook/delegation-inference.test.ts
+++ b/packages/core/__tests__/runbook/delegation-inference.test.ts
@@ -717,6 +717,17 @@ describe('findPendingDelegation', () => {
     expect(findPendingDelegation(state, '1.1', frameKey)).toBeUndefined();
   });
 
+  it('returns undefined when the substep is already done', () => {
+    // Mirrors resolveDelegateTarget's isSubstepDone guard: a completed substep
+    // must not be treated as carrying an in-flight delegation, even if a
+    // (stale) pending delegation record lingers on it.
+    const substepStates: SubstepState[] = [
+      { id: '1', frameKey, status: 'done', result: 'pass', delegation: makeActiveDelegation() },
+    ];
+    const state = makeState({ step: '1', activeFrameKey: frameKey, substepStates });
+    expect(findPendingDelegation(state, '1.1', frameKey)).toBeUndefined();
+  });
+
   it('returns undefined when the frame key does not belong to the parsed step', () => {
     // Substep ids collide across steps (every step has a `1`). A request for
     // step 2's substep (`2.1`) must not match step 1's substep `1.1` just

--- a/packages/core/__tests__/runbook/delegation-inference.test.ts
+++ b/packages/core/__tests__/runbook/delegation-inference.test.ts
@@ -807,6 +807,11 @@ describe('resolveTargetedDelegation', () => {
     if (result.kind !== 'conflict') throw new Error('expected conflict');
     expect(result.error.code).toBe('RD-804');
     expect(result.error.message).not.toContain('rdtk_');
+    // The detail must be source-qualified so an operator can distinguish the
+    // two same-filename refs — a path-only message would render both as
+    // "child.runbook.md" and look like a false positive.
+    expect(result.error.message).toContain('plugin:child.runbook.md');
+    expect(result.error.message).toContain('project:child.runbook.md');
   });
 
   it('conflicts (RD-804) when the requested runbook is unresolvable but a delegation is in flight', () => {

--- a/packages/core/src/runbook/delegation-inference.ts
+++ b/packages/core/src/runbook/delegation-inference.ts
@@ -286,7 +286,12 @@ export function findPendingDelegation(
   frameKey: FrameKey,
 ): (StepDelegation & { token: string }) | undefined {
   const parsed = parseStepIdFromString(stepId);
-  if (!parsed?.substep) return undefined;
+  // Require a substep segment AND that the frame belongs to the parsed step.
+  // Substep ids collide across steps, and the frame key is the authority on
+  // which step a substep instance belongs to; without the frame-step check a
+  // request for `<other>.<id>` could match the current step's substep `<id>`
+  // (the CLI derives the frame from the current step, not the parsed step).
+  if (!parsed?.substep || !isFrameForStep(frameKey, parsed.step)) return undefined;
   const match = (state.substepStates ?? []).find(
     (ss): ss is SubstepState & { delegation: StepDelegation & { token: string } } =>
       ss.id === parsed.substep &&

--- a/packages/core/src/runbook/delegation-inference.ts
+++ b/packages/core/src/runbook/delegation-inference.ts
@@ -14,7 +14,7 @@ import { Errors } from '../errors/index.js';
 import type { RundownError } from '../errors/index.js';
 import type { DelegateFrontierEntry } from '../events/types.js';
 import type { ParentLinkage, RunId, RunbookState, StepDelegation, SubstepState } from './types.js';
-import { sameRunbookRef, type RunbookRef } from './runbook-ref.js';
+import { formatRunbookRef, sameRunbookRef, type RunbookRef } from './runbook-ref.js';
 import { buildFrameKey, deriveActiveFrame, findSubstepState, type FrameKey } from './targeting.js';
 
 /**
@@ -367,12 +367,16 @@ export function resolveTargetedDelegation(
 
   if (!matches) {
     // `requested.kind === 'none'` always matches, so here it is resolved/unresolvable.
-    const requestedLabel = requested.raw;
+    // Source-qualify both refs so a same-filename / different-source mismatch is
+    // legible rather than rendering both sides as the bare filename. The
+    // unresolvable form has no canonical ref, so fall back to the raw arg.
+    const requestedLabel =
+      requested.kind === 'resolved' ? formatRunbookRef(requested.ref) : requested.raw;
     return {
       kind: 'conflict',
       error: Errors.delegationAlreadyExists(
         stepId,
-        `in-flight delegation for a different runbook: requested ${requestedLabel}, existing ${existing.childRunbookRef.path}, token hash ${existing.tokenHash}`,
+        `in-flight delegation for a different runbook: requested ${requestedLabel}, existing ${formatRunbookRef(existing.childRunbookRef)}, token hash ${existing.tokenHash}`,
       ),
     };
   }

--- a/packages/core/src/runbook/delegation-inference.ts
+++ b/packages/core/src/runbook/delegation-inference.ts
@@ -11,9 +11,10 @@ import { hasRunbooks, parseStepIdFromString, resolvedStepHasSubsteps } from '@ru
 import type { ResolvedStep, Substep } from '@rundown-org/parser';
 
 import { Errors } from '../errors/index.js';
+import type { RundownError } from '../errors/index.js';
 import type { DelegateFrontierEntry } from '../events/types.js';
-import type { ParentLinkage, RunId, RunbookState, SubstepState } from './types.js';
-import type { RunbookRef } from './runbook-ref.js';
+import type { ParentLinkage, RunId, RunbookState, StepDelegation, SubstepState } from './types.js';
+import { sameRunbookRef, type RunbookRef } from './runbook-ref.js';
 import { buildFrameKey, deriveActiveFrame, findSubstepState, type FrameKey } from './targeting.js';
 
 /**
@@ -266,6 +267,114 @@ export function deriveDelegateFrontier(state: RunbookState): DelegateFrontierEnt
     });
   }
   return frontier;
+}
+
+/**
+ * Find the in-flight (pending, unclaimed, non-cancelled) delegation on a target
+ * substep within a frame, with a recoverable plaintext token. Returns undefined
+ * when the step id has no substep segment, when no matching substep state
+ * exists, or when the delegation is cancelled/claimed/token-less. Pure; no I/O.
+ *
+ * @param state - Current runbook state data (per-frame substep states).
+ * @param stepId - Qualified step id, for example `1.1`.
+ * @param frameKey - Frame key scoping the lookup.
+ * @returns The matching delegation (narrowed to carry a `token`), or undefined.
+ */
+export function findPendingDelegation(
+  state: DelegationInferenceState,
+  stepId: string,
+  frameKey: FrameKey,
+): (StepDelegation & { token: string }) | undefined {
+  const parsed = parseStepIdFromString(stepId);
+  if (!parsed?.substep) return undefined;
+  const match = (state.substepStates ?? []).find(
+    (ss): ss is SubstepState & { delegation: StepDelegation & { token: string } } =>
+      ss.id === parsed.substep &&
+      ss.frameKey === frameKey &&
+      ss.delegation?.cancelledAt === null &&
+      ss.delegation.childRunId === null &&
+      ss.delegation.token != null,
+  );
+  return match?.delegation;
+}
+
+/**
+ * How the CLI's requested positional arg resolved (front-end discovery).
+ *
+ * - `none` — bare `rd delegate --step S` (no positional runbook).
+ * - `resolved` — the positional arg resolved to a canonical `RunbookRef`.
+ * - `unresolvable` — the positional arg did not resolve to a runbook on disk.
+ */
+export type RequestedRunbookArg =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'resolved'; readonly ref: RunbookRef; readonly raw: string }
+  | { readonly kind: 'unresolvable'; readonly raw: string };
+
+/**
+ * Resolution of a targeted `rd delegate [<runbook>] --step S` against any
+ * in-flight delegation on the substep.
+ *
+ * - `issuable` — no in-flight delegation; the caller proceeds to issue one.
+ * - `echo` — an in-flight delegation exists and matches the request; the caller
+ *   echoes the existing token (`action: "already-delegated"`).
+ * - `conflict` — an in-flight delegation exists for a different runbook; the
+ *   caller throws the carried RD-804 error.
+ */
+export type TargetedDelegateResolution =
+  | { readonly kind: 'issuable' }
+  | {
+      readonly kind: 'echo';
+      readonly stepId: string;
+      readonly token: string;
+      readonly runbookRef: string;
+    }
+  | { readonly kind: 'conflict'; readonly error: RundownError };
+
+/**
+ * Resolve a targeted `rd delegate [<runbook>] --step S` against any in-flight
+ * delegation on the substep. Single source of truth for the RD-804
+ * echo-vs-conflict decision (the bare path's {@link resolveDelegateTarget}
+ * analogue). Pure; no I/O — the CLI resolves the requested arg to a
+ * `RunbookRef` first and passes it as data.
+ *
+ * @param state - Current runbook state data.
+ * @param stepId - Qualified step id, for example `1.1`.
+ * @param frameKey - Frame key scoping the lookup.
+ * @param requested - The CLI-resolved requested positional arg.
+ * @returns Discriminated `issuable | echo | conflict` resolution.
+ */
+export function resolveTargetedDelegation(
+  state: DelegationInferenceState,
+  stepId: string,
+  frameKey: FrameKey,
+  requested: RequestedRunbookArg,
+): TargetedDelegateResolution {
+  const existing = findPendingDelegation(state, stepId, frameKey);
+  if (!existing) return { kind: 'issuable' };
+
+  const matches =
+    requested.kind === 'none' ||
+    (requested.kind === 'resolved' && sameRunbookRef(requested.ref, existing.childRunbookRef));
+
+  if (!matches) {
+    // `requested.kind === 'none'` always matches, so here it is resolved/unresolvable.
+    const requestedLabel = requested.raw;
+    return {
+      kind: 'conflict',
+      error: Errors.delegationAlreadyExists(
+        stepId,
+        `in-flight delegation for a different runbook: requested ${requestedLabel}, ` +
+          `existing ${existing.childRunbookRef.path}, token hash ${existing.tokenHash}`,
+      ),
+    };
+  }
+
+  return {
+    kind: 'echo',
+    stepId,
+    token: existing.token,
+    runbookRef: existing.childRunbookRef.path,
+  };
 }
 
 /**

--- a/packages/core/src/runbook/delegation-inference.ts
+++ b/packages/core/src/runbook/delegation-inference.ts
@@ -296,6 +296,10 @@ export function findPendingDelegation(
     (ss): ss is SubstepState & { delegation: StepDelegation & { token: string } } =>
       ss.id === parsed.substep &&
       ss.frameKey === frameKey &&
+      // Exclude completed substeps, mirroring resolveDelegateTarget's
+      // isSubstepDone guard so the targeted path cannot classify a done
+      // substep's lingering delegation record as in-flight.
+      ss.status !== 'done' &&
       ss.delegation?.cancelledAt === null &&
       ss.delegation.childRunId === null &&
       ss.delegation.token != null,
@@ -368,8 +372,7 @@ export function resolveTargetedDelegation(
       kind: 'conflict',
       error: Errors.delegationAlreadyExists(
         stepId,
-        `in-flight delegation for a different runbook: requested ${requestedLabel}, ` +
-          `existing ${existing.childRunbookRef.path}, token hash ${existing.tokenHash}`,
+        `in-flight delegation for a different runbook: requested ${requestedLabel}, existing ${existing.childRunbookRef.path}, token hash ${existing.tokenHash}`,
       ),
     };
   }

--- a/packages/core/src/runbook/delegation-service.ts
+++ b/packages/core/src/runbook/delegation-service.ts
@@ -16,7 +16,7 @@ import type {
   SubstepState,
   TemplateVarValue,
 } from './types.js';
-import type { RunbookRef } from './runbook-ref.js';
+import { formatRunbookRef, type RunbookRef } from './runbook-ref.js';
 
 /**
  * Pure read model describing whether a consumed delegation token has been closed.
@@ -431,10 +431,6 @@ export type CreateDelegationResult =
   | CreateDelegationNotDelegatableResult
   | CreateDelegationExistsResult
   | CreateDelegationParentDelegatedResult;
-
-function formatRunbookRef(ref: RunbookRef): string {
-  return `${ref.source}:${ref.path}`;
-}
 
 /**
  * Create a delegation for an authored DELEGATE substep of the current runbook.

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -305,6 +305,7 @@ export {
   RUNBOOK_REF_ERROR_TEXT,
   RunbookRefSchema,
   RunbookSourceSchema,
+  formatRunbookRef,
   sameRunbookRef,
   type RunbookRef,
   type RunbookSource,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -156,16 +156,20 @@ export type { FileProvider } from './file-provider.js';
 export { resolveForValue, ForResolutionError, type ResolvedIteration } from './source-resolver.js';
 export {
   deriveDelegateFrontier,
+  findPendingDelegation,
   inferAllDelegateSubsteps,
   inferDelegationTarget,
   inferRunbookFromStep,
   isPostDelegateAggregationCursor,
   resolveDelegateTarget,
+  resolveTargetedDelegation,
   type DelegateTargetResolution,
   type DelegationInferenceState,
   type InferredDelegation,
+  type RequestedRunbookArg,
   type ResolvedDelegationRunbook,
   type ResolveDelegationRunbook,
+  type TargetedDelegateResolution,
 } from './delegation-inference.js';
 export {
   forIterateActor,
@@ -301,6 +305,7 @@ export {
   RUNBOOK_REF_ERROR_TEXT,
   RunbookRefSchema,
   RunbookSourceSchema,
+  sameRunbookRef,
   type RunbookRef,
   type RunbookSource,
 } from './runbook-ref.js';

--- a/packages/core/src/runbook/runbook-ref.ts
+++ b/packages/core/src/runbook/runbook-ref.ts
@@ -115,3 +115,17 @@ export const RunbookRefSchema = z
  * Canonical local-disk runbook reference shared by run state, events, and artifacts.
  */
 export type RunbookRef = z.infer<typeof RunbookRefSchema>;
+
+/**
+ * Structural equality for two canonical runbook references.
+ *
+ * Two references identify the same runbook when both their source root and
+ * source-root-relative (or normalized absolute, for `external`) path match.
+ *
+ * @param left - First runbook reference.
+ * @param right - Second runbook reference.
+ * @returns True when both `source` and `path` are equal.
+ */
+export function sameRunbookRef(left: RunbookRef, right: RunbookRef): boolean {
+  return left.source === right.source && left.path === right.path;
+}

--- a/packages/core/src/runbook/runbook-ref.ts
+++ b/packages/core/src/runbook/runbook-ref.ts
@@ -129,3 +129,18 @@ export type RunbookRef = z.infer<typeof RunbookRefSchema>;
 export function sameRunbookRef(left: RunbookRef, right: RunbookRef): boolean {
   return left.source === right.source && left.path === right.path;
 }
+
+/**
+ * Render a canonical runbook reference as a source-qualified `source:path`
+ * string for diagnostics.
+ *
+ * Source-qualifying is what keeps two same-filename references under different
+ * source roots (e.g. `project:child.runbook.md` vs `plugin:child.runbook.md`)
+ * distinguishable in operator-facing messages.
+ *
+ * @param ref - Runbook reference to render.
+ * @returns The `source:path` string.
+ */
+export function formatRunbookRef(ref: RunbookRef): string {
+  return `${ref.source}:${ref.path}`;
+}

--- a/runbooks/scenario-suite.yaml
+++ b/runbooks/scenario-suite.yaml
@@ -158,6 +158,20 @@ cases:
       - rd claim ${TOKEN}
     result: COMPLETE
 
+  delegate-targeted-idempotent-echo-completed:
+    description: >-
+      Targeted `rd delegate --step` echoes the auto-issued token instead of
+      erroring (issue #468 — the /rundown:planning flow), then claim completes.
+      ${TOKEN} is captured from the `rd run` entry frontier, so it stays valid
+      after the idempotent echo.
+    file: delegation/delegate-basic.runbook.md
+    commands:
+      - "true # delegation-child-pass.runbook.md"
+      - rd run delegate-basic.runbook.md
+      - rd delegate --step 1.1
+      - rd claim ${TOKEN}
+    result: COMPLETE
+
   delegate-failure-child-fails:
     description: Child fails, failure propagates STOP to parent
     file: delegation/delegate-failure-child-fails.runbook.md


### PR DESCRIPTION
## Summary

Fixes #468. `rd delegate --step <id>` now **echoes** an in-flight (auto-issued, unclaimed) delegation token with `action: "already-delegated"` instead of throwing `RD-804`, mirroring how bare `rd delegate` already behaves. This unblocks `/rundown:planning`, where a DELEGATE step auto-issues a token on entry and the workflow then runs `rd delegate --step 1.1`.

### Behaviour

- `rd delegate --step S` — in-flight delegation for the authored runbook → **echo** the existing token.
- `rd delegate <runbook> --step S` — runbook matches the in-flight one → **echo**; conflicts → preserve **RD-804**.
- Requested-vs-authored mismatch (no in-flight delegation) still errors **RD-822**.
- Re-issuing a fresh token still requires `--retry`.
- **RD-819** (nested delegation) preserved via fall-through to `createDelegation`.

## Design

Core owns the echo-vs-conflict decision via a new pure `resolveTargetedDelegation` (built on `findPendingDelegation`), returning a discriminated `issuable | echo | conflict`. The CLI resolves the requested positional arg to a `RunbookRef`, hands it to core as data, and renders the result — no comparison/policy logic in the CLI (consistent with CLAUDE.md's "delegation resolution lives in core").

The echo decision runs **before** authored-runbook resolution, so it stays idempotent even if the authored child file later changes (strong idempotency). `sameRunbookRef` promoted to core (`runbook-ref.ts`); the CLI-local `findPendingDelegationForTarget`/`sameRunbookRef` removed. The shared `emitAlreadyDelegated` helper keeps the bare and targeted echo shapes from drifting.

No persisted-state or schema changes; no migrations.

## Tests

- **Core** — unit tests for `findPendingDelegation` (one-field-flip cases incl. cross-step + done guards) and `resolveTargetedDelegation`; property tests (defined-IFF + reorder-determinism) extended with a `childRunId`/`claimed` dimension.
- **CLI** — command tests (echo for `--step`, matching/different/unresolvable runbook, collection-pending exemption, idempotent repeat, strong-idempotency after file removal); integration test asserts the echoed token equals the original (no duplicate) and chains a live `rd claim`; a `/rundown:planning`-flow scenario in `scenario-suite.yaml`.
- Docs: idempotency note in the delegating-runbooks SKILL.

## Review

Two CodeRabbit rounds. Fixed all actionable findings — including two genuine correctness bugs the plan missed: `findPendingDelegation` could match a substep across steps (frame derived from the current step) and could match a `done` substep's lingering record. Remaining findings skipped with documented reasons (echo+`--input` mirrors pre-existing bare-path semantics; the no-`--step` path is upstream-guarded by `inferDelegationTarget`; scenario per-command assertion is a harness limitation covered at the command-test layer).

## Verification

`pnpm --filter @rundown-org/core test` (3547) and `pnpm --filter @rundown-org/cli test` (2613) green; lint + spell clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Targeted `rd delegate --step S` is now idempotent: when an in-flight substep delegation already exists for the same runbook, it echoes the existing token (`action: "already-delegated"`).
  * The echoed token can be used immediately with `rd claim`.
* **Bug Fixes**
  * Re-delegating no longer errors on matching in-flight targeted steps; conflicting/unresolvable requests still return the same conflict outcome (RD-804) without leaking raw tokens.
* **Documentation**
  * Updated `delegate` command docs to clarify `--step` idempotency and when `--retry` is needed.
* **Tests**
  * Expanded unit, command, integration, and scenario-suite coverage for echo, conflict, and end-to-end claim behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->