### PR TITLE
ci: mutation-gate follow-ups (advisory comment no-op fix + assert-mutation-score tests)

### DIFF
--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -216,6 +216,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download advisory summaries
+        id: download
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: mutation-summary-*
@@ -223,7 +224,16 @@ jobs:
           merge-multiple: true
         continue-on-error: true
 
+      # Distinguish a failed download from a genuine no-op. The download step is
+      # continue-on-error, so a failure leaves zero summaries on disk — which the
+      # assembly would otherwise read as "no mutated changed files", masking the
+      # failure. DOWNLOAD_OUTCOME is the step's pre-continue-on-error outcome
+      # (success/failure/cancelled), passed via env (never interpolated into the
+      # script) so a step result cannot inject shell. When it is not 'success'
+      # we post a distinct advisory note instead of the clean no-op message.
       - name: Assemble comment body
+        env:
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
         run: |
           set -euo pipefail
           {
@@ -237,6 +247,8 @@ jobs:
                 echo
                 echo
               done
+            elif [ "${DOWNLOAD_OUTCOME}" != "success" ]; then
+              echo "_⚠️ Could not download advisory summaries (download step: ${DOWNLOAD_OUTCOME}). The mutation results may be incomplete — see the workflow logs. This check is advisory and does not block merge._"
             else
               echo "_No mutated changed files in this PR._"
             fi

--- a/scripts/__tests__/assert-mutation-score.test.mjs
+++ b/scripts/__tests__/assert-mutation-score.test.mjs
@@ -1,9 +1,15 @@
 import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 import {
   assertMutationScore,
+  changedFilesFromGit,
   fileMutationScore,
+  main,
   normalizeReportFileKeys,
+  parseArgs,
   renderMarkdown,
 } from '../assert-mutation-score.mjs';
 
@@ -346,4 +352,178 @@ test('renderMarkdown reports an empty state when nothing was scored', () => {
   );
   assert.match(md, /parser/);
   assert.match(md, /No mutated changed files/i);
+});
+
+/**
+ * Run `fn` with console.log/console.error suppressed so main()'s human-readable
+ * summary does not pollute the test reporter output. Restores both on return.
+ *
+ * @param {() => T} fn - the callback to run with console silenced.
+ * @returns {T} whatever `fn` returns.
+ * @template T
+ */
+function withSilencedConsole(fn) {
+  const { log, error } = console;
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.log = log;
+    console.error = error;
+  }
+}
+
+/**
+ * Write a minimal valid Stryker JSON report to a fresh temp dir.
+ *
+ * @returns {{ dir: string, reportPath: string }} the temp dir and report path.
+ */
+function writeTempReport() {
+  const dir = mkdtempSync(join(tmpdir(), 'assert-mutation-score-'));
+  const reportPath = join(dir, 'mutation-report.json');
+  const report = {
+    schemaVersion: '1.0',
+    projectRoot: '/repo/packages/core',
+    files: {
+      'src/a.ts': { language: 'typescript', source: '', mutants: [{ id: '0', status: 'Killed' }] },
+    },
+  };
+  writeFileSync(reportPath, JSON.stringify(report));
+  return { dir, reportPath };
+}
+
+test('parseArgs: captures --markdown and --package-name', () => {
+  const opts = parseArgs([
+    '--report',
+    'r.json',
+    '--package-dir',
+    'packages/core',
+    '--changed-file',
+    'packages/core/src/a.ts',
+    '--markdown',
+    'out.md',
+    '--package-name',
+    'core',
+  ]);
+  assert.equal(opts.markdown, 'out.md');
+  assert.equal(opts.packageName, 'core');
+});
+
+test('parseArgs: leaves packageName and markdown undefined when their flags are omitted', () => {
+  const opts = parseArgs([
+    '--report',
+    'r.json',
+    '--package-dir',
+    'packages/core',
+    '--base',
+    'origin/main',
+  ]);
+  assert.equal(opts.packageName, undefined);
+  assert.equal(opts.markdown, undefined);
+});
+
+test('parseArgs: --markdown without a value throws', () => {
+  assert.throws(
+    () =>
+      parseArgs([
+        '--report',
+        'r.json',
+        '--package-dir',
+        'packages/core',
+        '--base',
+        'm',
+        '--markdown',
+      ]),
+    /missing value for --markdown/,
+  );
+});
+
+test('main: writes the markdown summary using the --package-name label', () => {
+  const { dir, reportPath } = writeTempReport();
+  try {
+    const mdPath = join(dir, 'summary.md');
+    // A changed file outside the package yields an empty (but valid) result; the
+    // rendered header still carries the package label, which is what we pin here.
+    const code = withSilencedConsole(() =>
+      main([
+        '--report',
+        reportPath,
+        '--package-dir',
+        'packages/core',
+        '--changed-file',
+        'packages/other/src/x.ts',
+        '--markdown',
+        mdPath,
+        '--package-name',
+        'core',
+      ]),
+    );
+    assert.equal(code, 0);
+    const md = readFileSync(mdPath, 'utf8');
+    assert.match(md, /<code>core<\/code>/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('main: markdown label falls back to --package-dir when --package-name is omitted', () => {
+  const { dir, reportPath } = writeTempReport();
+  try {
+    const mdPath = join(dir, 'summary.md');
+    const code = withSilencedConsole(() =>
+      main([
+        '--report',
+        reportPath,
+        '--package-dir',
+        'packages/core',
+        '--changed-file',
+        'packages/other/src/x.ts',
+        '--markdown',
+        mdPath,
+      ]),
+    );
+    assert.equal(code, 0);
+    const md = readFileSync(mdPath, 'utf8');
+    // No --package-name: the header label is the package dir (HTML-escaped `/`).
+    assert.match(md, /<code>packages\/core<\/code>/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('main: returns 2 when the markdown summary cannot be written', () => {
+  const { dir, reportPath } = writeTempReport();
+  try {
+    // Target a path under a directory that does not exist: writeFileSync throws
+    // ENOENT and main() must surface that as a usage/IO error (exit 2).
+    const mdPath = join(dir, 'does-not-exist', 'summary.md');
+    const code = withSilencedConsole(() =>
+      main([
+        '--report',
+        reportPath,
+        '--package-dir',
+        'packages/core',
+        '--changed-file',
+        'packages/other/src/x.ts',
+        '--markdown',
+        mdPath,
+        '--package-name',
+        'core',
+      ]),
+    );
+    assert.equal(code, 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('changedFilesFromGit: fails closed (throws) on an unresolvable base ref', () => {
+  // The tests run inside the repo (a git working tree), so git is reachable but
+  // the bogus ref cannot resolve — git exits non-zero and the fail-closed branch
+  // rethrows a wrapped diagnostic rather than returning an empty changed set.
+  assert.throws(
+    () => changedFilesFromGit('rundown-no-such-base-ref-zzz'),
+    /failed to diff rundown-no-such-base-ref-zzz\.\.\.HEAD/,
+  );
 });

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -64,6 +64,37 @@ test('mutation-pr.yml posts a single sticky advisory comment', async () => {
   assert.match(yml, /pull-requests:\s*write/, 'comment job needs pull-requests: write');
 });
 
+test('mutation-pr.yml distinguishes a failed summary download from a genuine no-op', async () => {
+  const yml = await read('.github/workflows/mutation-pr.yml');
+  // The download step must be addressable (id) and stay non-fatal so the comment
+  // job still runs when the artifact download fails.
+  assert.match(
+    yml,
+    /- name: Download advisory summaries\n\s*id: download\b/,
+    'download step must have an id so its outcome can be inspected',
+  );
+  assert.match(
+    yml,
+    /- name: Download advisory summaries[\s\S]*?continue-on-error:\s*true/,
+    'download step must stay non-fatal (continue-on-error) so the comment still posts',
+  );
+  // The assemble step reads the download outcome via env (never interpolated
+  // into the run: script) and branches on it so a download failure surfaces a
+  // distinct message rather than the clean "no mutated changed files" no-op.
+  assert.match(
+    yml,
+    /- name: Assemble comment body\n\s*env:\n\s*DOWNLOAD_OUTCOME:\s*\$\{\{\s*steps\.download\.outcome\s*\}\}/,
+    'assemble step must read steps.download.outcome via env (no run: interpolation)',
+  );
+  assert.match(
+    yml,
+    /elif \[ "\$\{DOWNLOAD_OUTCOME\}" != "success" \]; then/,
+    'assemble step must branch on a non-success download outcome',
+  );
+  // The advisory no-op message stays for the genuine zero-summary case.
+  assert.match(yml, /No mutated changed files in this PR\./);
+});
+
 test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to dashboard)', async () => {
   const yml = await read('.github/workflows/mutation.yml');
   assert.doesNotMatch(

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -91,6 +91,11 @@ test('mutation-pr.yml distinguishes a failed summary download from a genuine no-
     /elif \[ "\$\{DOWNLOAD_OUTCOME\}" != "success" \]; then/,
     'assemble step must branch on a non-success download outcome',
   );
+  assert.match(
+    yml,
+    /Could not download advisory summaries \(download step: \$\{DOWNLOAD_OUTCOME\}\)/,
+    'failure branch must emit the advisory download-warning message',
+  );
   // The advisory no-op message stays for the genuine zero-summary case.
   assert.match(yml, /No mutated changed files in this PR\./);
 });

--- a/scripts/assert-mutation-score.mjs
+++ b/scripts/assert-mutation-score.mjs
@@ -258,7 +258,7 @@ export function renderMarkdown(result, packageName) {
  * @throws {Error} when the base ref is unresolvable, the merge-base is
  *   unreachable, or git invocation otherwise fails.
  */
-function changedFilesFromGit(base) {
+export function changedFilesFromGit(base) {
   try {
     return execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], { encoding: 'utf8' })
       .split('\n')
@@ -280,7 +280,7 @@ function changedFilesFromGit(base) {
  * @returns {{ report: string, packageDir: string, base?: string, changedFiles: string[], floor: number }}
  * @throws {Error} when a required option is missing or a flag lacks a value.
  */
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const opts = { changedFiles: [], floor: DEFAULT_FLOOR };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -319,7 +319,7 @@ function parseArgs(argv) {
  * @returns {number} process exit code (0 = pass, 1 = a changed file is below
  *   the floor, 2 = usage/IO error).
  */
-function main(argv) {
+export function main(argv) {
   let opts;
   try {
     opts = parseArgs(argv);


### PR DESCRIPTION
## Summary

Two follow-up hardening fixes to the **mutation-gate CI workstream** (siblings of
#484 enforceable gate and #491 advisory per-PR gate). Split out of the
delegate-lifecycle-command-seam branch (#506), where they had been swept in by a
rebase but don't belong — they touch zero delegate code.

- **`fix(ci)`** — `mutation-pr.yml` now distinguishes a *failed* summary
  download from a genuine no-op when posting the advisory PR comment, so a
  broken upload no longer reads as "no mutations." Pinned by
  `mutation-workflows.test.mjs`.
- **`test(scripts)`** — pins `assert-mutation-score` arg-parsing, markdown
  summary rendering, and git-error (fail-closed) paths.

## Verification
- `node --test scripts/__tests__/{assert-mutation-score,mutation-workflows}.test.mjs` — 34/34 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved advisory PR comment messaging by clearly separating “failed to download advisory summaries” from true “no mutated changed files” cases.
  * Enhanced CLI behavior for markdown generation and error handling, including clearer failures when output can’t be written and correct markdown labeling based on provided inputs.
* **Tests**
  * Expanded coverage for CLI argument parsing, markdown output generation, exit codes, and workflow comment assembly, including failure-path scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->