### PR TITLE
ci(mcp): add blocking FTA complexity gate for packages/mcp

### DIFF
--- a/.github/workflows/complexity-mcp.yml
+++ b/.github/workflows/complexity-mcp.yml
@@ -27,6 +27,14 @@ on:
       - 'packages/mcp/package.json'
       - '.github/workflows/complexity-mcp.yml'
 
+# Cancel superseded runs on the same ref (matches ci.yml).
+concurrency:
+  group: complexity-mcp-${{ github.ref }}
+  cancel-in-progress: true
+
+# Restrictive default token scope; the single job grants only what it needs.
+permissions: {}
+
 jobs:
   complexity:
     runs-on: ubuntu-latest

--- a/.github/workflows/complexity-mcp.yml
+++ b/.github/workflows/complexity-mcp.yml
@@ -1,0 +1,46 @@
+name: Complexity (mcp)
+
+# Blocking FTA (Fast TypeScript Analyzer) complexity gate for packages/mcp.
+#
+# `fta src --score-cap 63` exits non-zero when any file in packages/mcp/src scores
+# above the cap, failing the check. This is a tightly scoped pilot — a per-package
+# template other packages can copy — NOT a repo-wide gate.
+#
+# Bumping the cap: a legitimate refactor may push the worst score above 63. To raise
+# it, re-measure (`pnpm --filter @rundown-org/mcp run analyze:complexity`) and edit the
+# --score-cap number in packages/mcp/package.json's analyze:complexity script.
+#
+# Required-check caveat: if this is later marked a required status check, a PR that does
+# not touch packages/mcp/** is skipped by the paths filter below and can sit "pending".
+# Fix by adding an always-pass shim job or dropping the paths filter before requiring it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/mcp/src/**'
+      - 'packages/mcp/package.json'
+      - '.github/workflows/complexity-mcp.yml'
+  pull_request:
+    paths:
+      - 'packages/mcp/src/**'
+      - 'packages/mcp/package.json'
+      - '.github/workflows/complexity-mcp.yml'
+
+jobs:
+  complexity:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: 24
+
+      - name: FTA complexity gate
+        run: pnpm run analyze:complexity
+        working-directory: packages/mcp

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -12,7 +12,8 @@
     "check:types": "tsc --noEmit -p tsconfig.test.json",
     "test": "jest",
     "test:unit": "jest --maxWorkers=2",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "analyze:complexity": "fta src --score-cap 63"
   },
   "engines": {
     "node": ">=24.0.0"
@@ -39,6 +40,7 @@
     "@jest/globals": "^30.4.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^26.0.1",
+    "fta-cli": "3.0.0",
     "jest": "^30.4.2",
     "jest-mock": "^30.4.1",
     "ts-jest": "^29.4.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,9 @@ importers:
       '@types/node':
         specifier: ^26.0.1
         version: 26.0.1
+      fta-cli:
+        specifier: 3.0.0
+        version: 3.0.0
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@26.0.1)
@@ -3510,6 +3513,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fta-cli@3.0.0:
+    resolution: {integrity: sha512-SBmoqIwbN7PLDmwmrPgjr6Z6/S9jPhNz5TCPmEVFkIaeloc/T2WXLeeXqhG1+C0UQxpOfGrC7CUb4friqbc2kQ==}
+    hasBin: true
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -9074,6 +9081,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  fta-cli@3.0.0: {}
 
   function-bind@1.1.2: {}
 


### PR DESCRIPTION
Closes #511

## Summary

Adds a **blocking** [FTA](https://github.com/sgb-io/fta) (Fast TypeScript Analyzer) complexity gate, scoped to **`packages/mcp`** as a per-package pilot other packages can copy later. FTA emits a per-file score (cyclomatic + Halstead; lower = better) and exits non-zero when any file exceeds `--score-cap <N>`.

Deliberately **not** repo-wide: the hot packages (core ~139, cli ~101, parser ~91) would make a whole-repo gate red on day one.

## Decisions

- **Target:** `packages/mcp/src` — smallest, lowest-max, low-churn front end (3 files; worst `tools.ts` = 61.3).
- **Cap:** `--score-cap 63` (worst 61.3 + ~1.7 buffer): passes today, blocks regressions, tolerates trivial noise.
- **Tool:** `fta-cli@3.0.0` pinned exactly as a devDependency (no `npx`/`dlx` at CI time). Only a `prepublishOnly` script → no pnpm `allowBuilds` entry needed.

## Changes

- `packages/mcp/package.json` — exact-pinned `fta-cli` devDep + `"analyze:complexity": "fta src --score-cap 63"`.
- `pnpm-lock.yaml` — `fta-cli@3.0.0` added (integrity-pinned, zero deps, no build scripts).
- `.github/workflows/complexity-mcp.yml` (new) — `push(main)` + `pull_request`, `paths:`-filtered to `packages/mcp/src/**`, the manifest, and the workflow file; shared `setup-node-deps` composite; no build/DB/creds; final step runs `pnpm run analyze:complexity`.

## Verification

- Frozen install (`pnpm install --frozen-lockfile`) consistent (exit 0).
- Pass case (cap 63): exit **0** — worst `tools.ts` 61.26 < 63.
- Fail case (`fta src --score-cap 61`): exit **1**.
- `scripts/__tests__/pnpm-ci-invariants.test.mjs`: 5/5 pass (pnpm SHA pin, no `npm ci`, no `package-lock.json`).
- Workflow YAML parses; `pnpm run check:spell` clean.

## Follow-ups

- **Bumping the cap** for a legitimate refactor: re-measure (`pnpm --filter @rundown-org/mcp run analyze:complexity`) and edit `--score-cap` in `packages/mcp/package.json` (documented in the workflow header).
- **Required-check caveat:** if later marked a *required* status check, a PR not touching `packages/mcp/**` is `paths:`-skipped and can sit "pending" — add an always-pass shim job or drop the paths filter before requiring it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new coverage command for the MCP package.
  * Added an automated complexity check to help catch overly complex changes during CI.
* **Chores**
  * Introduced a new CI workflow that runs on relevant pushes and pull requests, with safer default permissions and canceling outdated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->