### PR TITLE
fix(core): fail closed on token-retry snapshot missing `at`

### DIFF
--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -694,6 +694,86 @@ describe('RunbookLifecycleCommandService', () => {
       expect(retried.kind).toBe('retried');
     });
 
+    it('rejects a token retry whose snapshot is missing `at` (fail closed, no legacy reconstruction)', async () => {
+      // A persisted context snapshot ALWAYS records `at` (buildContextSnapshot
+      // derives it unconditionally via deriveExecutionAt). A snapshot missing
+      // `at` is an incompatible/older persisted shape; per the no-migration rule
+      // the retry must fail closed (RD-817) rather than reconstruct a `1.x`
+      // label from `substep`/`stepId`.
+      const { seam: localSeam, deps } = await startSeamOnDelegateStep();
+      const first = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'direct_cli' },
+      });
+      if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+      // Resolve the real scan, then strip `at` to emulate an incompatible
+      // snapshot. `findDelegationByToken` is a readonly dep, so swap it by
+      // constructing a fresh seam over the same deps rather than mutating.
+      const realScan = await new DelegationScanService(manager).findByToken(first.token);
+      if (!realScan) throw new Error('expected scan');
+      const { at: _at, ...snapshotWithoutAt } = realScan.delegation.contextSnapshot;
+      const localSeamStale = new RunbookLifecycleCommandService({
+        ...deps,
+        findDelegationByToken: async () => ({
+          ...realScan,
+          delegation: { ...realScan.delegation, contextSnapshot: snapshotWithoutAt },
+        }),
+      });
+
+      const outcome = await localSeamStale.issueDelegation({
+        mode: 'retry',
+        callerEvidence: { kind: 'direct_cli' },
+        locator: { kind: 'token', token: first.token },
+      });
+
+      expect(outcome.kind).toBe('error');
+      if (outcome.kind !== 'error') throw new Error('expected error');
+      expect(outcome.error.code).toBe('RD-817');
+    });
+
+    it('surfaces the canonical snapshot `at` as the token-retry label (FOR iteration)', async () => {
+      // A token retry whose snapshot records `at` = "1.2.1" (a FOR iteration)
+      // must surface that canonical label, not the bare step.
+      const steps: readonly ResolvedStep[] = [
+        delegateForStep('1', [delegateSubstep('1', 'child.md')]),
+      ];
+      const activeFrameKey = buildFrameKey('1', 1);
+      const state = baseState({
+        activeFrameKey,
+        frameEntryCounts: { [activeFrameKey]: 1 },
+        forStack: [
+          {
+            stepId: '1',
+            iteration: 1,
+            start: 1,
+            end: 2,
+            implicit: false,
+            source: { kind: 'range' },
+          },
+        ],
+      });
+      await activate(state);
+      const { seam: localSeam } = buildIssuanceSeam(state, steps);
+
+      const first = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'direct_cli' },
+        explicitStep: '1.1',
+        explicitIteration: 2,
+      });
+      if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+      const retried = await localSeam.issueDelegation({
+        mode: 'retry',
+        callerEvidence: { kind: 'direct_cli' },
+        locator: { kind: 'token', token: first.token },
+      });
+      expect(retried.kind).toBe('retried');
+      if (retried.kind !== 'retried') throw new Error('expected retried');
+      expect(retried.stepLabel).toBe('1.2.1');
+    });
+
     it('returns token-not-found for an unknown token', async () => {
       const { seam: localSeam } = await startSeamOnDelegateStep();
       const outcome = await localSeam.issueDelegation({

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -676,11 +676,20 @@ export class RunbookLifecycleCommandService {
       targetState = scan.parentState;
       substepId = scan.substepId ?? scan.stepId;
       frameKey = scan.frameKey;
-      // Prefer the canonical contextSnapshot.at so FOR-iteration retries surface
-      // as e.g. "1.2.1"; fall back for snapshots predating the `at` field.
+      // The canonical contextSnapshot.at surfaces FOR-iteration retries as e.g.
+      // "1.2.1". `buildContextSnapshot` derives `at` unconditionally, so a
+      // persisted snapshot always carries it; its absence means the snapshot is
+      // from an incompatible/older persisted shape. Fail closed per the
+      // no-migration rule (reject; never reconstruct the label from legacy
+      // `substep`/`stepId` fields) — mirroring the downstream staleness gate.
       const snapshot = scan.delegation.contextSnapshot;
-      stepLabel =
-        snapshot.at ?? (snapshot.substep ? `${scan.stepId}.${snapshot.substep}` : scan.stepId);
+      if (snapshot.at === undefined) {
+        return {
+          kind: 'error',
+          error: Errors.delegationSnapshotStale(substepId, scan.stepId),
+        };
+      }
+      stepLabel = snapshot.at;
     } else if (locator.kind === 'step') {
       const active = await this.#deps.sessionService.getActive();
       if (!active) return { kind: 'no-active-runbook' };


### PR DESCRIPTION
## What

The token-locator retry branch in `#issueRetry` (`lifecycle-command-service.ts`) still reconstructs the step label from legacy `snapshot.substep`/`stepId` fields when `contextSnapshot.at` is absent:

```ts
stepLabel =
  snapshot.at ?? (snapshot.substep ? `${scan.stepId}.${snapshot.substep}` : scan.stepId);
```

This is a compatibility shim for snapshots predating the `at` field, which violates the **no-migration / reject-invalid-persisted-state** rule in CLAUDE.md.

## Why

`buildContextSnapshot` derives `at` unconditionally (`delegation-context.ts`), so any snapshot persisted by current code always carries it. A missing `at` can only come from an incompatible/older shape. Per the no-migration rule we must **fail closed** — reject via the existing `Errors.delegationSnapshotStale` (RD-817), the same error the downstream `retryDelegation` staleness gate raises — instead of reconstructing a label from legacy fields.

## Changes

- Reject `at`-absent snapshots in the token-retry branch with RD-817.
- RED regression test: token retry with `at`-stripped snapshot → RD-817.
- Happy-path test: a snapshot with `at` still surfaces the canonical FOR-iteration label (e.g. `1.2.1`).

## Provenance

Rescued from the abandoned `delegate-lifecycle-command-seam` branch (commit `c34f7ed62`, authored the day after PR #506 merged). Cherry-picked cleanly onto current `main`.

## Verification

`packages/core` `lifecycle-command-service` suite: **47 passed, 47 total** (incl. the 2 new tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token-based retry now uses the stored canonical step label for FOR-iteration runs, preventing incorrect retry labels.
  * Stale delegation snapshots now fail closed instead of falling back to legacy label reconstruction, improving retry reliability.
* **Tests**
  * Added coverage for retry behavior when snapshot data is incomplete and when canonical step labels are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->