### PR TITLE
ci(mutation): shard producer + fix core/cli OOM death-spiral (#485)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -97,7 +97,11 @@ jobs:
         working-directory: ${{ matrix.dir }}
         # The dashboard key is deliberately absent here: shards never upload.
         # ignoreStatic is left unset so static mutants are scored at full fidelity.
-        run: pnpm exec stryker run --mutate "${{ matrix.mutate }}" --allowEmpty
+        # matrix.mutate is passed via env (not templated into the shell) so a
+        # file path with shell metacharacters can't inject into the command.
+        env:
+          MUTATE: ${{ matrix.mutate }}
+        run: pnpm exec stryker run --mutate "$MUTATE" --allowEmpty
       - name: Upload shard report
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -49,6 +49,12 @@ jobs:
             github.event.inputs.package == 'all' ||
             github.event.inputs.package == matrix.package }}
       STRYKER_DASHBOARD_VERSION: main
+      # GitHub's linux runner is 4 vCPU / 16 GB. Stryker's config default is 2
+      # (a conservative local default); CI has the cores to spare, so run 4
+      # test-runner processes in parallel. Safe now that enableFindRelatedTests
+      # keeps each in-band child's footprint small and maxTestRunnerReuse
+      # recycles it. Roughly halves wall-clock vs the default 2. See issue #485.
+      STRYKER_CONCURRENCY: '4'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         if: ${{ env.RUN_PACKAGE == 'true' }}
@@ -149,11 +155,13 @@ jobs:
 
       - name: Run mutation tests
         if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
-        # The weekly full run is the only one allowed to run long; a differential
-        # push or a single-package dispatch that hasn't finished in 50 min is
-        # hung or mis-scoped, not legitimately slow — fail it fast rather than
-        # burn the full job ceiling.
-        timeout-minutes: ${{ github.event_name == 'schedule' && 350 || 50 }}
+        # Non-schedule runs are bounded to the 60-min hard cap: a differential
+        # push is change-sized, and a workflow_dispatch is used to calibrate
+        # full-package throughput at this concurrency (a cold full core/cli will
+        # hit the cap, and the partial "N/total tested" progress in the log is
+        # the throughput sample used to size the producer shards). The weekly
+        # keeps the longer budget until that sharding lands.
+        timeout-minutes: ${{ github.event_name == 'schedule' && 350 || 60 }}
         env:
           # Which automated main-branch runs may upload to the canonical
           # dashboard baseline:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -18,191 +18,132 @@ on:
   schedule:
     - cron: '0 6 * * 1' # Weekly Monday 06:00 UTC
 
+permissions:
+  contents: read
+
 jobs:
-  mutate:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - package: parser
-            dir: packages/parser
-          - package: core
-            dir: packages/core
-          - package: cli
-            dir: packages/cli
-          - package: plugin
-            dir: packages/claude-code-plugin
+  # A full core/cli campaign cannot finish in a single 60-min CI job, so the
+  # producer fans out across shards. This job decides the shard matrix for the
+  # event: schedule/dispatch shard the full mutate scope; push shards only the
+  # changed source (differential). Each shard mutates a DISJOINT file set, which
+  # is what lets the merge job stitch the partial reports back into one
+  # full-fidelity per-module report.
+  plan:
     runs-on: ubuntu-latest
-    # Job ceiling sized for the weekly full-fidelity run (the heavy producer).
-    # The per-trigger budget is enforced on the run step below — push/dispatch
-    # runs are differential or single-package and must finish quickly, so they
-    # get a tight step timeout while the weekly gets the room.
-    timeout-minutes: 360
-    # On schedule and push-to-main, run every package. On workflow_dispatch, run
-    # the selected package (or 'all'). This filter lives at the step level via
-    # env.RUN_PACKAGE because the `matrix` context is not available in a
-    # job-level `if:`.
-    env:
-      RUN_PACKAGE: >-
-        ${{ github.event_name == 'schedule' ||
-            github.event_name == 'push' ||
-            github.event.inputs.package == 'all' ||
-            github.event.inputs.package == matrix.package }}
-      STRYKER_DASHBOARD_VERSION: main
-      # GitHub's linux runner is 4 vCPU / 16 GB. Stryker's config default is 2
-      # (a conservative local default); CI has the cores to spare, so run 4
-      # test-runner processes in parallel. Safe now that enableFindRelatedTests
-      # keeps each in-band child's footprint small and maxTestRunnerReuse
-      # recycles it. Roughly halves wall-clock vs the default 2. See issue #485.
-      STRYKER_CONCURRENCY: '4'
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      empty: ${{ steps.plan.outputs.empty }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        if: ${{ env.RUN_PACKAGE == 'true' }}
         with:
           persist-credentials: false
-          # Full history so `github.event.before` (the pre-push SHA) is reachable
-          # for the push-path diff below. The weekly schedule and dispatch ignore
-          # it, but a shallow clone would make the push diff impossible.
+          # Full history so the push differential can diff github.event.before.
           fetch-depth: 0
-
-      # Push-to-main is scoped to the files this push changed so the run tracks
-      # change size and actually finishes — a cold full run of core/cli cannot
-      # complete in the job budget (issue #485). The weekly `schedule` is the
-      # full-fidelity producer and `workflow_dispatch` is an explicit full run,
-      # so both leave `scope` empty and fall through to the unscoped command.
-      # Runs on the runner's preinstalled node (before setup-node); the config
-      # import only reads process.env, mirroring mutation-pr.yml's detect step.
-      - name: Detect changed files (push)
-        id: changes
-        if: ${{ env.RUN_PACKAGE == 'true' && github.event_name == 'push' }}
-        env:
-          BEFORE: ${{ github.event.before }}
-          PKG_DIR: ${{ matrix.dir }}
-        run: |
-          set -euo pipefail
-          base="${BEFORE}"
-          # A zero/unreachable base (branch creation, force-push, or a pruned
-          # parent) degrades to HEAD~1; a root commit with no parent degrades to
-          # a full run rather than failing the producer.
-          if [ -z "${base}" ] || [ "${base}" = "0000000000000000000000000000000000000000" ] \
-             || ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
-            if git rev-parse --verify --quiet 'HEAD~1^{commit}' >/dev/null; then
-              base="$(git rev-parse HEAD~1)"
-            else
-              echo "scope=full" >> "$GITHUB_OUTPUT"
-              echo "::notice::no usable diff base; running ${PKG_DIR} in full."
-              exit 0
-            fi
-          fi
-          changed_files="$(git diff --name-only --diff-filter=d "${base}" HEAD -- "${PKG_DIR}/src")"
-          if [ -z "${changed_files}" ]; then
-            echo "scope=none" >> "$GITHUB_OUTPUT"
-            echo "No source changes under ${PKG_DIR}/src for this push; skipping."
-            exit 0
-          fi
-          # Combine the changed files with the package's own `!` mutate
-          # exclusions (read from the config) so an excluded file that changed is
-          # still not mutated — same merge mutation-pr.yml performs.
-          pkg_rel="$(printf '%s\n' "${changed_files}" | sed "s#^${PKG_DIR}/##")"
-          excludes="$(cd "${PKG_DIR}" && node --input-type=module -e 'import("./stryker.config.mjs").then((m) => { const c = m.default ?? m.config ?? {}; process.stdout.write((c.mutate ?? []).filter((p) => p.startsWith("!")).join("\n")); });')" \
-            || { echo "::error::failed to read mutate exclusions from ${PKG_DIR}/stryker.config.mjs" >&2; exit 1; }
-          mutate="$(printf '%s\n%s\n' "${pkg_rel}" "${excludes}" | sed '/^[[:space:]]*$/d' | paste -sd, -)"
-          echo "scope=changed" >> "$GITHUB_OUTPUT"
-          echo "mutate=${mutate}" >> "$GITHUB_OUTPUT"
-
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
-        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
-
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
-        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
         with:
           node-version-file: .nvmrc
           cache: 'pnpm'
-
-      - name: Install dependencies
-        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
-        run: pnpm run build
-
-      - name: Download previous baseline from dashboard
-        id: baseline
-        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
+      - run: pnpm install --frozen-lockfile
+      - name: Plan shard matrix
+        id: plan
         env:
-          MODULE: ${{ matrix.package }}
-          PKG_DIR: ${{ matrix.dir }}
-        run: |
-          set -uo pipefail
-          mkdir -p "${PKG_DIR}/reports"
-          baseline="${PKG_DIR}/reports/stryker-incremental.json"
-          url="https://dashboard.stryker-mutator.io/api/reports/github.com/tobyhede/rundown/${STRYKER_DASHBOARD_VERSION}?module=${MODULE}"
-          # Keep the baseline only if curl succeeds AND the body is non-empty
-          # valid JSON. A 200 with an empty/truncated body would otherwise feed a
-          # corrupt baseline into incremental mode and pollute the uploaded report.
-          if curl --fail --silent --show-error --max-time 60 \
-               --output "${baseline}" "${url}" \
-               && [ -s "${baseline}" ] \
-               && node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' "${baseline}"; then
-            echo "Previous baseline downloaded for module ${MODULE}."
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::no previous baseline for module ${MODULE}; producing a cold one."
-            rm -f "${baseline}"
-            echo "present=false" >> "$GITHUB_OUTPUT"
-          fi
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PACKAGE: ${{ github.event.inputs.package }}
+          PUSH_BASE: ${{ github.event.before }}
+          # Source-line budget per shard (a mutant-count proxy). Sized so every
+          # shard lands well under the 60-min hard cap at concurrency 4. Lower it
+          # to add shards if a shard ever times out.
+          MAX_SHARD_LINES: '6000'
+        run: node scripts/mutation-shard-plan.mjs
 
-      - name: Run mutation tests
-        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
-        # Non-schedule runs are bounded to the 60-min hard cap: a differential
-        # push is change-sized, and a workflow_dispatch is used to calibrate
-        # full-package throughput at this concurrency (a cold full core/cli will
-        # hit the cap, and the partial "N/total tested" progress in the log is
-        # the throughput sample used to size the producer shards). The weekly
-        # keeps the longer budget until that sharding lands.
-        timeout-minutes: ${{ github.event_name == 'schedule' && 350 || 60 }}
-        env:
-          # Which automated main-branch runs may upload to the canonical
-          # dashboard baseline:
-          #   - schedule: always. The weekly `--force` run re-tests every mutant,
-          #     so it (re)produces a complete, full-fidelity baseline.
-          #   - push: ONLY when a full baseline was downloaded. A push is scoped
-          #     to changed files, so it can only safely upload by MERGING its
-          #     results into an existing complete baseline. Uploading a scoped
-          #     report with no base would overwrite the dashboard with a thin,
-          #     changed-files-only report — the corruption the PR workflow avoids
-          #     by never uploading. With no baseline, the push still runs (scoped)
-          #     but does not upload; the next weekly re-seeds the baseline.
-          # workflow_dispatch is ad-hoc (possibly a feature branch / single
-          # package) and never uploads. The dashboard reporter is enabled only
-          # when STRYKER_DASHBOARD_API_KEY is present. See issue #485.
-          STRYKER_DASHBOARD_API_KEY: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || (github.event_name == 'push' && steps.baseline.outputs.present == 'true'))) && secrets.STRYKER_DASHBOARD_API_KEY || '' }}
-          PUSH_SCOPE: ${{ steps.changes.outputs.scope }}
-          PUSH_MUTATE: ${{ steps.changes.outputs.mutate }}
-        # Weekly cron forces a complete re-run (drift-proof full fidelity);
-        # push-to-main mutates only the files the push changed, merging
-        # incrementally against the downloaded baseline so it actually finishes;
-        # dispatch runs the selected package in full. Static mutants are scored
-        # in every case (ignoreStatic left unset). See issue #485.
-        run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm exec stryker run --incremental --force
-          elif [ "${{ github.event_name }}" = "push" ] && [ "${PUSH_SCOPE}" = "changed" ]; then
-            pnpm exec stryker run --incremental --mutate "${PUSH_MUTATE}" --allowEmpty
-          else
-            pnpm exec stryker run --incremental
-          fi
-        working-directory: ${{ matrix.dir }}
-
-      - name: Upload mutation report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        # always() so the report uploads even when the mutation run fails, but
-        # only for packages this dispatch actually ran — a push that skipped this
-        # package (no changed source) produces no report to upload.
-        if: ${{ always() && env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
+  # One job per shard. Hard-capped at 60 min; a shard that exceeds it is
+  # mis-sized (shrink MAX_SHARD_LINES), not legitimately slow. Shards never hold
+  # the dashboard key, so they cannot upload a partial, scoped report that would
+  # corrupt the baseline — only the merge job uploads.
+  mutate:
+    needs: plan
+    if: ${{ needs.plan.outputs.empty != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    env:
+      # GitHub's linux runner is 4 vCPU / 16 GB; the config default is a
+      # conservative 2. Safe now that enableFindRelatedTests keeps each in-band
+      # child small and maxTestRunnerReuse recycles it. See issue #485.
+      STRYKER_CONCURRENCY: '4'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          name: mutation-report-${{ matrix.package }}
-          path: |
-            ${{ matrix.dir }}/reports/mutation/
-          retention-days: 30
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - name: Run mutation shard
+        # A low score makes Stryker exit non-zero on thresholds.break; that floor
+        # belongs on the merged aggregate, not a single shard, so a shard must
+        # not fail the job on score alone. A genuine crash produces no report and
+        # is caught by the merge job's per-module completeness check. The report
+        # uploads regardless via always() below.
+        continue-on-error: true
+        timeout-minutes: 60
+        working-directory: ${{ matrix.dir }}
+        # The dashboard key is deliberately absent here: shards never upload.
+        # ignoreStatic is left unset so static mutants are scored at full fidelity.
+        run: pnpm exec stryker run --mutate "${{ matrix.mutate }}" --allowEmpty
+      - name: Upload shard report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: mutation-report-${{ matrix.module }}-shard${{ matrix.shard }}
+          path: ${{ matrix.dir }}/reports/mutation/mutation-report.json
+          retention-days: 7
+          if-no-files-found: warn
+
+  # Stitch every shard's partial report into one full per-module report, apply
+  # the aggregate break floor, and (only on the weekly schedule, on main) upload
+  # the complete baseline to the dashboard. A push is differential, so its merge
+  # is partial by construction and never uploads; a dispatch may run off a
+  # feature branch and never uploads.
+  merge:
+    needs: [plan, mutate]
+    if: ${{ always() && needs.plan.outputs.empty != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Download shard reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: shard-reports
+          pattern: mutation-report-*
+      - name: Merge reports, enforce floor, upload baseline
+        env:
+          DOWNLOAD_DIR: shard-reports
+          MATRIX: ${{ needs.plan.outputs.matrix }}
+          VERSION: main
+          # Upload ONLY on the weekly schedule on main: that is the only run that
+          # shards the FULL scope, so its merge is a complete report safe to
+          # (re)seed the baseline. Gating the key (not just a flag) means a
+          # dispatch/push physically cannot push to the dashboard.
+          UPLOAD: ${{ (github.ref == 'refs/heads/main' && github.event_name == 'schedule') && 'true' || 'false' }}
+          DASHBOARD_API_KEY: ${{ (github.ref == 'refs/heads/main' && github.event_name == 'schedule') && secrets.STRYKER_DASHBOARD_API_KEY || '' }}
+          # Enforce the aggregate break floor on the producer run; advisory on
+          # dispatch/push (report the score without failing).
+          APPLY_BREAK: ${{ github.event_name == 'schedule' && 'true' || 'false' }}
+        run: node scripts/mutation-merge-reports.mjs

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -33,7 +33,11 @@ jobs:
           - package: plugin
             dir: packages/claude-code-plugin
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Job ceiling sized for the weekly full-fidelity run (the heavy producer).
+    # The per-trigger budget is enforced on the run step below — push/dispatch
+    # runs are differential or single-package and must finish quickly, so they
+    # get a tight step timeout while the weekly gets the room.
+    timeout-minutes: 360
     # On schedule and push-to-main, run every package. On workflow_dispatch, run
     # the selected package (or 'all'). This filter lives at the step level via
     # env.RUN_PACKAGE because the `matrix` context is not available in a
@@ -50,26 +54,76 @@ jobs:
         if: ${{ env.RUN_PACKAGE == 'true' }}
         with:
           persist-credentials: false
+          # Full history so `github.event.before` (the pre-push SHA) is reachable
+          # for the push-path diff below. The weekly schedule and dispatch ignore
+          # it, but a shallow clone would make the push diff impossible.
+          fetch-depth: 0
+
+      # Push-to-main is scoped to the files this push changed so the run tracks
+      # change size and actually finishes — a cold full run of core/cli cannot
+      # complete in the job budget (issue #485). The weekly `schedule` is the
+      # full-fidelity producer and `workflow_dispatch` is an explicit full run,
+      # so both leave `scope` empty and fall through to the unscoped command.
+      # Runs on the runner's preinstalled node (before setup-node); the config
+      # import only reads process.env, mirroring mutation-pr.yml's detect step.
+      - name: Detect changed files (push)
+        id: changes
+        if: ${{ env.RUN_PACKAGE == 'true' && github.event_name == 'push' }}
+        env:
+          BEFORE: ${{ github.event.before }}
+          PKG_DIR: ${{ matrix.dir }}
+        run: |
+          set -euo pipefail
+          base="${BEFORE}"
+          # A zero/unreachable base (branch creation, force-push, or a pruned
+          # parent) degrades to HEAD~1; a root commit with no parent degrades to
+          # a full run rather than failing the producer.
+          if [ -z "${base}" ] || [ "${base}" = "0000000000000000000000000000000000000000" ] \
+             || ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+            if git rev-parse --verify --quiet 'HEAD~1^{commit}' >/dev/null; then
+              base="$(git rev-parse HEAD~1)"
+            else
+              echo "scope=full" >> "$GITHUB_OUTPUT"
+              echo "::notice::no usable diff base; running ${PKG_DIR} in full."
+              exit 0
+            fi
+          fi
+          changed_files="$(git diff --name-only --diff-filter=d "${base}" HEAD -- "${PKG_DIR}/src")"
+          if [ -z "${changed_files}" ]; then
+            echo "scope=none" >> "$GITHUB_OUTPUT"
+            echo "No source changes under ${PKG_DIR}/src for this push; skipping."
+            exit 0
+          fi
+          # Combine the changed files with the package's own `!` mutate
+          # exclusions (read from the config) so an excluded file that changed is
+          # still not mutated — same merge mutation-pr.yml performs.
+          pkg_rel="$(printf '%s\n' "${changed_files}" | sed "s#^${PKG_DIR}/##")"
+          excludes="$(cd "${PKG_DIR}" && node --input-type=module -e 'import("./stryker.config.mjs").then((m) => { const c = m.default ?? m.config ?? {}; process.stdout.write((c.mutate ?? []).filter((p) => p.startsWith("!")).join("\n")); });')" \
+            || { echo "::error::failed to read mutate exclusions from ${PKG_DIR}/stryker.config.mjs" >&2; exit 1; }
+          mutate="$(printf '%s\n%s\n' "${pkg_rel}" "${excludes}" | sed '/^[[:space:]]*$/d' | paste -sd, -)"
+          echo "scope=changed" >> "$GITHUB_OUTPUT"
+          echo "mutate=${mutate}" >> "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
-        if: ${{ env.RUN_PACKAGE == 'true' }}
+        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
-        if: ${{ env.RUN_PACKAGE == 'true' }}
+        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
         with:
           node-version-file: .nvmrc
           cache: 'pnpm'
 
       - name: Install dependencies
-        if: ${{ env.RUN_PACKAGE == 'true' }}
+        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        if: ${{ env.RUN_PACKAGE == 'true' }}
+        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
         run: pnpm run build
 
       - name: Download previous baseline from dashboard
-        if: ${{ env.RUN_PACKAGE == 'true' }}
+        id: baseline
+        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
         env:
           MODULE: ${{ matrix.package }}
           PKG_DIR: ${{ matrix.dir }}
@@ -86,27 +140,48 @@ jobs:
                && [ -s "${baseline}" ] \
                && node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' "${baseline}"; then
             echo "Previous baseline downloaded for module ${MODULE}."
+            echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "::notice::no previous baseline for module ${MODULE}; producing a cold one."
             rm -f "${baseline}"
+            echo "present=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run mutation tests
-        if: ${{ env.RUN_PACKAGE == 'true' }}
+        if: ${{ env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
+        # The weekly full run is the only one allowed to run long; a differential
+        # push or a single-package dispatch that hasn't finished in 50 min is
+        # hung or mis-scoped, not legitimately slow — fail it fast rather than
+        # burn the full job ceiling.
+        timeout-minutes: ${{ github.event_name == 'schedule' && 350 || 50 }}
         env:
-          # Only automated main-branch runs (schedule/push) may upload to the
-          # canonical dashboard baseline. workflow_dispatch is ad-hoc (and may run
-          # off a feature branch or a single package), so it runs WITHOUT the key
-          # and therefore cannot overwrite the main baseline — the dashboard
-          # reporter is enabled only when STRYKER_DASHBOARD_API_KEY is present.
-          STRYKER_DASHBOARD_API_KEY: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'push')) && secrets.STRYKER_DASHBOARD_API_KEY || '' }}
+          # Which automated main-branch runs may upload to the canonical
+          # dashboard baseline:
+          #   - schedule: always. The weekly `--force` run re-tests every mutant,
+          #     so it (re)produces a complete, full-fidelity baseline.
+          #   - push: ONLY when a full baseline was downloaded. A push is scoped
+          #     to changed files, so it can only safely upload by MERGING its
+          #     results into an existing complete baseline. Uploading a scoped
+          #     report with no base would overwrite the dashboard with a thin,
+          #     changed-files-only report — the corruption the PR workflow avoids
+          #     by never uploading. With no baseline, the push still runs (scoped)
+          #     but does not upload; the next weekly re-seeds the baseline.
+          # workflow_dispatch is ad-hoc (possibly a feature branch / single
+          # package) and never uploads. The dashboard reporter is enabled only
+          # when STRYKER_DASHBOARD_API_KEY is present. See issue #485.
+          STRYKER_DASHBOARD_API_KEY: ${{ (github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || (github.event_name == 'push' && steps.baseline.outputs.present == 'true'))) && secrets.STRYKER_DASHBOARD_API_KEY || '' }}
+          PUSH_SCOPE: ${{ steps.changes.outputs.scope }}
+          PUSH_MUTATE: ${{ steps.changes.outputs.mutate }}
         # Weekly cron forces a complete re-run (drift-proof full fidelity);
-        # push-to-main refreshes incrementally against the downloaded baseline.
-        # Both upload to the dashboard (key present) and score static mutants
-        # (the ignoreStatic env is left unset here). See issue #485.
+        # push-to-main mutates only the files the push changed, merging
+        # incrementally against the downloaded baseline so it actually finishes;
+        # dispatch runs the selected package in full. Static mutants are scored
+        # in every case (ignoreStatic left unset). See issue #485.
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
             pnpm exec stryker run --incremental --force
+          elif [ "${{ github.event_name }}" = "push" ] && [ "${PUSH_SCOPE}" = "changed" ]; then
+            pnpm exec stryker run --incremental --mutate "${PUSH_MUTATE}" --allowEmpty
           else
             pnpm exec stryker run --incremental
           fi
@@ -115,8 +190,9 @@ jobs:
       - name: Upload mutation report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         # always() so the report uploads even when the mutation run fails, but
-        # only for packages this dispatch actually ran.
-        if: ${{ always() && env.RUN_PACKAGE == 'true' }}
+        # only for packages this dispatch actually ran — a push that skipped this
+        # package (no changed source) produces no report to upload.
+        if: ${{ always() && env.RUN_PACKAGE == 'true' && steps.changes.outputs.scope != 'none' }}
         with:
           name: mutation-report-${{ matrix.package }}
           path: |

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -106,6 +106,7 @@ initialisation
 initialise
 initialised
 initialises
+instrumenter
 jmespath
 jsdoc
 jsonata
@@ -185,6 +186,7 @@ rehydrated
 renderable
 rebranded
 rebrands
+respawns
 resumability
 runbook
 runbookref

--- a/docs/internal/mutation-testing-ci.md
+++ b/docs/internal/mutation-testing-ci.md
@@ -20,36 +20,43 @@ gates proved structurally too slow regardless of tuning.
 
 ## Full-fidelity producer (`.github/workflows/mutation.yml`)
 
-Since the `enableFindRelatedTests` fix (see Config below) a full `core` (~17k
-mutants) or `cli` (~9k) campaign **does** complete — a full `policy/**` scope
-(1921 mutants) finishes in ~25 min at zero OOM where it previously never
-finished. The producer still splits its triggers by scope so that push-to-main
-stays fast and only the weekly pays for full fidelity:
+Even with the `enableFindRelatedTests` fix (see Config below), a full `core`
+(~17k mutants) or `cli` (~9k) campaign does not fit a single **60-min** CI job,
+so the producer fans out across shards. It runs as a three-job pipeline — **plan
+→ mutate → merge** — so that every individual job stays under the 60-min hard
+cap:
 
-- **Weekly cron** — the full-fidelity producer.
-  `stryker run --incremental --force` re-tests every mutant for every package
-  and uploads the complete report, (re)seeding the dashboard baseline. This is
-  the only trigger that runs a package in full, so it gets the long per-step
-  budget (350 min within a 360-min job ceiling).
-- **Push to `main`** — differential. A "Detect changed files (push)" step diffs
-  `github.event.before...HEAD` under each package's `src` (mirroring the PR
-  workflow's merge, including the config's `!` mutate exclusions) and passes the
-  result to `--mutate ... --allowEmpty`. A package with no changed source is
-  skipped entirely; the run is bounded to change size and gets a tight 50-min
-  step budget. Full git history (`fetch-depth: 0`) is required for the diff.
-- **`workflow_dispatch`** — runs the selected package in full (`--incremental`),
-  ad-hoc, and never uploads. It shares the **50-min** non-schedule step budget,
-  so it suits a quick package check; a cold full `core`/`cli` campaign needs the
-  weekly's 350-min budget (or a temporary budget bump) to finish on-demand.
+- **`plan`** (`scripts/mutation-shard-plan.mjs`) globs each package's
+  mutate-eligible files (the config `mutate` array, `!` negations included) and
+  greedily partitions them into shards balanced by source line count — a mutant
+  proxy — sized by `MAX_SHARD_LINES` (6000) so each shard lands well under 60
+  min at concurrency 4. It emits a GitHub Actions matrix. On **push** it instead
+  shards only the source changed since `github.event.before` (differential); a
+  package with no changed source contributes no shards. Shards mutate **disjoint
+  file sets**, which is what lets the merge reassemble a complete report.
+- **`mutate`** runs one job per shard from that matrix —
+  `stryker run --mutate <shard files> --allowEmpty` at `STRYKER_CONCURRENCY=4`,
+  hard-capped at 60 min. A shard **never holds the dashboard key**, so it cannot
+  upload a partial, scoped report. Each shard uploads its `mutation-report.json`
+  as an artifact. The run step is `continue-on-error` because a sub-floor score
+  makes Stryker exit non-zero on `thresholds.break`, and that floor belongs on
+  the merged aggregate, not a single shard.
+- **`merge`** (`scripts/mutation-merge-reports.mjs`) downloads every shard
+  artifact, unions the disjoint `files` maps into one complete per-module
+  report, recomputes the aggregate score, and writes a job summary. It verifies
+  that every shard the plan emitted produced a report — a crashed shard
+  (swallowed by `continue-on-error`) leaves a gap that fails the merge. On the
+  **weekly schedule on `main`** — the only run that shards the FULL scope — it
+  PUTs each complete report to the Stryker dashboard (gating both the upload
+  flag and the `STRYKER_DASHBOARD_API_KEY` on `refs/heads/main && schedule`) and
+  enforces the aggregate `break` floor. A push (differential, partial) and a
+  dispatch (may be a feature branch) never upload and are advisory only.
 - `ignoreStatic` is OFF (env unset) so static mutants are scored.
-- **Upload safety.** The dashboard upload (`STRYKER_DASHBOARD_API_KEY`) is
-  enabled for the weekly run always, but for a push **only when a full baseline
-  was downloaded** (`steps.baseline.outputs.present == 'true'`). A push is
-  scoped to changed files, so it can only upload safely by merging into an
-  existing complete baseline — uploading a changed-files-only report with no
-  base would overwrite the dashboard with a thin report (the same corruption the
-  PR check avoids by never uploading). With no baseline a push still runs
-  scoped, but does not upload; the next weekly re-seeds.
+- **Upload safety.** Only the weekly schedule produces a complete report, so it
+  is the only run that may (re)seed the dashboard baseline. A push merge is
+  partial by construction (changed files only) and a dispatch may run off a
+  feature branch, so neither uploads — exactly the thin-report corruption the PR
+  check also avoids.
 
 ## Config (`packages/*/stryker.config.mjs`)
 

--- a/docs/internal/mutation-testing-ci.md
+++ b/docs/internal/mutation-testing-ci.md
@@ -20,15 +20,68 @@ gates proved structurally too slow regardless of tuning.
 
 ## Full-fidelity producer (`.github/workflows/mutation.yml`)
 
-- Runs on **push to `main`** (incremental refresh) and **weekly cron**
-  (`--force` complete refresh), every package.
+Since the `enableFindRelatedTests` fix (see Config below) a full `core` (~17k
+mutants) or `cli` (~9k) campaign **does** complete — a full `policy/**` scope
+(1921 mutants) finishes in ~25 min at zero OOM where it previously never
+finished. The producer still splits its triggers by scope so that push-to-main
+stays fast and only the weekly pays for full fidelity:
+
+- **Weekly cron** — the full-fidelity producer.
+  `stryker run --incremental --force` re-tests every mutant for every package
+  and uploads the complete report, (re)seeding the dashboard baseline. This is
+  the only trigger that runs a package in full, so it gets the long per-step
+  budget (350 min within a 360-min job ceiling).
+- **Push to `main`** — differential. A "Detect changed files (push)" step diffs
+  `github.event.before...HEAD` under each package's `src` (mirroring the PR
+  workflow's merge, including the config's `!` mutate exclusions) and passes the
+  result to `--mutate ... --allowEmpty`. A package with no changed source is
+  skipped entirely; the run is bounded to change size and gets a tight 50-min
+  step budget. Full git history (`fetch-depth: 0`) is required for the diff.
+- **`workflow_dispatch`** — runs the selected package in full (`--incremental`),
+  ad-hoc, and never uploads. It shares the **50-min** non-schedule step budget,
+  so it suits a quick package check; a cold full `core`/`cli` campaign needs the
+  weekly's 350-min budget (or a temporary budget bump) to finish on-demand.
 - `ignoreStatic` is OFF (env unset) so static mutants are scored.
-- Uploads the full report per module to the Stryker Dashboard
-  (`STRYKER_DASHBOARD_API_KEY`), which is both the trend/score surface and the
-  baseline the PR check downloads.
+- **Upload safety.** The dashboard upload (`STRYKER_DASHBOARD_API_KEY`) is
+  enabled for the weekly run always, but for a push **only when a full baseline
+  was downloaded** (`steps.baseline.outputs.present == 'true'`). A push is
+  scoped to changed files, so it can only upload safely by merging into an
+  existing complete baseline — uploading a changed-files-only report with no
+  base would overwrite the dashboard with a thin report (the same corruption the
+  PR check avoids by never uploading). With no baseline a push still runs
+  scoped, but does not upload; the next weekly re-seeds.
 
 ## Config (`packages/*/stryker.config.mjs`)
 
+- **Targeted `mutate` scope.** Mutation is focused on correctness-critical code.
+  `core` excludes the JSON-output format contract (`src/output/**` — declarative
+  Zod plus derived types), terminal rendering (`src/cli/**`), and logging
+  (`src/logger.ts`); `cli` excludes doc codegen (`src/scripts/**`) and the
+  output renderers (`src/services/renderers/**`). These layers produce many
+  equivalent/noise mutants for little signal. The exclusions are pinned by
+  `scripts/__tests__/stryker-config.test.mjs` so the scope cannot silently
+  re-widen.
+- **Campaign completion (`enableFindRelatedTests` + `maxTestRunnerReuse`).** The
+  `@stryker-mutator/jest-runner` runs Jest in-band (`runInBand: true`) inside
+  one long-lived child process. `core`/`cli` had overridden
+  `jest.enableFindRelatedTests` to `false` (the schema default is `true`), which
+  made **every mutant reload the entire test suite** — measured at ~1.3
+  mutants/min, and the in-band child's heap crept until it OOM'd. Stryker then
+  restarted and retried the same mutant, which re-leaked to the same wall: a
+  death spiral that floored throughput to ~0, which is why a cold `core`/`cli`
+  campaign never finished (`parser`/`plugin`, which left the default in place,
+  always completed). Restoring `enableFindRelatedTests: true` scopes each mutant
+  to only the test files that _transitively import_ the mutated source (~72
+  mutants/min on `policy/**`, ~55×). `maxTestRunnerReuse` (default `25`,
+  override with `STRYKER_MAX_TEST_RUNNER_REUSE`) then recycles the child every
+  _n_ runs to cap the small residual per-run leak, so a full campaign holds at
+  zero OOM. The tradeoff of `findRelatedTests`: a mutant whose only killing test
+  reaches the code with **no static import path** (a subprocess that spawns the
+  CLI, a dynamic `import()`, source read as a string) is no longer exercised and
+  reports as a false survivor. The inverse graph is transitive, so ordinary
+  integration tests still count; only runtime-only coverage is lost — acceptable
+  because the alternative does not complete. Both pins live in
+  `scripts/__tests__/stryker-config.test.mjs`.
 - `ignoreStatic` is `false` by default; only `STRYKER_IGNORE_STATIC=true`
   enables it (the PR workflow sets it).
 - The `dashboard` reporter is added to `reporters` only when

--- a/packages/cli/stryker.config.mjs
+++ b/packages/cli/stryker.config.mjs
@@ -6,6 +6,19 @@ const parsePositiveInteger = (value, fallback) => {
 
 const concurrency = parsePositiveInteger(process.env.STRYKER_CONCURRENCY, 2);
 
+// Recycle each test-runner child process after this many mutant runs. The
+// @stryker-mutator/jest-runner executes Jest in-band (`runInBand: true`) inside
+// one long-lived child process, and repeated in-band `jest.runCLI` leaks a few
+// MB of heap per run (module registry + ts-jest + instrumenter context that
+// jest never fully releases between in-band runs). Left unbounded the child
+// OOMs mid-campaign; Stryker's RetryRejectedDecorator then restarts it and
+// retries the same mutant, which re-leaks to the same wall — a death spiral
+// that floored throughput to ~0. Recycling caps the leak by construction:
+// `recover()` disposes and respawns the child (re-running only its cheap config
+// load, NOT the dry run). This is the supported lever for "a memory leak you
+// cannot resolve" per the Stryker schema. See issue #485.
+const maxTestRunnerReuse = parsePositiveInteger(process.env.STRYKER_MAX_TEST_RUNNER_REUSE, 25);
+
 /**
  * Parse a boolean-ish env value. Only 'true'/'1' enable the flag; unset or any
  * other value is the fallback. Keeps local `stryker run` conservative.
@@ -42,10 +55,41 @@ const config = {
   // Naming the plugin makes Stryker resolve it from this package's node_modules.
   plugins: ['@stryker-mutator/jest-runner'],
   testRunner: 'jest',
-  jest: { configFile: 'jest.stryker.config.js', enableFindRelatedTests: false },
+  // enableFindRelatedTests scopes each mutant run to only the test files that
+  // *transitively import* the mutated source (jest's inverse module graph),
+  // instead of reloading the entire suite for every mutant. With it `false`,
+  // each mutant reloaded the whole CLI test suite (filtered only by test-name
+  // pattern), which OOM'd the in-band runner and floored throughput; with it
+  // `true` the per-mutant cost and per-run heap drop enough for a full campaign
+  // to finish. This is the single change that lets a full core/cli campaign
+  // finish.
+  //
+  // Tradeoff: a mutant whose ONLY killing test reaches the code with no static
+  // import path — a subprocess that spawns the CLI, a dynamic `import()`, or a
+  // test that reads source as a string — is no longer exercised and reports as a
+  // false survivor. The inverse graph is transitive, so ordinary integration
+  // tests still count; only runtime-only coverage is lost. That residue is
+  // acceptable because the alternative (`false`) does not complete. See #485.
+  jest: { configFile: 'jest.stryker.config.js', enableFindRelatedTests: true },
   testRunnerNodeArgs: ['--experimental-vm-modules'],
   checkers: [],
-  mutate: ['src/**/*.ts', '!src/**/*.d.ts', '!src/index.ts', '!src/cli.ts', '!src/schemas/**'],
+  // The CLI is a thin wrapper, so its mutation value is fairly uniform across
+  // the orchestration helpers/services — there is no large low-value core to
+  // carve out the way there is in `core`. The only clear noise is presentation
+  // and codegen, excluded below; the real lever for keeping CLI runs bounded is
+  // the changed-file (`--mutate`) scoping the workflows apply. See issue #485.
+  mutate: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/index.ts',
+    '!src/cli.ts',
+    '!src/schemas/**',
+    // Doc codegen (`gen-cli-help.ts`): not shipped runtime logic and untested,
+    // so every mutant would survive as pure noise.
+    '!src/scripts/**',
+    // JSON/text output renderers — presentation, low correctness stakes.
+    '!src/services/renderers/**',
+  ],
   coverageAnalysis: 'perTest',
   incremental: true,
   incrementalFile: 'reports/stryker-incremental.json',
@@ -68,6 +112,7 @@ const config = {
     reportType: 'full',
   },
   concurrency,
+  maxTestRunnerReuse,
   ignoreStatic,
   timeoutMS: 60000,
   timeoutFactor: 2.5,

--- a/packages/core/stryker.config.mjs
+++ b/packages/core/stryker.config.mjs
@@ -6,6 +6,20 @@ const parsePositiveInteger = (value, fallback) => {
 
 const concurrency = parsePositiveInteger(process.env.STRYKER_CONCURRENCY, 2);
 
+// Recycle each test-runner child process after this many mutant runs. The
+// @stryker-mutator/jest-runner executes Jest in-band (`runInBand: true`) inside
+// one long-lived child process, and repeated in-band `jest.runCLI` leaks a few
+// MB of heap per run (module registry + ts-jest + instrumenter context that
+// jest never fully releases between in-band runs). Left unbounded the child
+// OOMs mid-campaign; Stryker's RetryRejectedDecorator then restarts it and
+// retries the same mutant, which re-leaks to the same wall — a death spiral
+// that floored throughput to ~0 and is why a cold core campaign never finished.
+// Recycling caps the leak by construction: `recover()` disposes and respawns
+// the child (re-running only its cheap config load, NOT the dry run). This is
+// the supported lever for "a memory leak you cannot resolve" per the Stryker
+// schema. See issue #485.
+const maxTestRunnerReuse = parsePositiveInteger(process.env.STRYKER_MAX_TEST_RUNNER_REUSE, 25);
+
 /**
  * Parse a boolean-ish env value. Only 'true'/'1' enable the flag; unset or any
  * other value is the fallback. Keeps local `stryker run` conservative.
@@ -42,10 +56,52 @@ const config = {
   // Naming the plugin makes Stryker resolve it from this package's node_modules.
   plugins: ['@stryker-mutator/jest-runner'],
   testRunner: 'jest',
-  jest: { configFile: 'jest.stryker.config.js', enableFindRelatedTests: false },
+  // enableFindRelatedTests scopes each mutant run to only the test files that
+  // *transitively import* the mutated source (jest's inverse module graph),
+  // instead of reloading the entire suite for every mutant. With it `false`,
+  // each mutant ran all 302 test files / 3682 tests (filtered only by test-name
+  // pattern), which measured ~1.3 mutants/min and OOM'd the in-band runner; with
+  // it `true` the same policy/** scope measured ~72 mutants/min (~55x) with the
+  // per-run heap small enough that the residual leak stays recoverable. This is
+  // the single change that lets a full core/cli campaign finish.
+  //
+  // Tradeoff: a mutant whose ONLY killing test reaches the code with no static
+  // import path — a subprocess that spawns the CLI, a dynamic `import()`, or a
+  // test that reads source as a string — is no longer exercised and reports as a
+  // false survivor. The inverse graph is transitive, so ordinary integration
+  // tests (e.g. a runbook test importing executor.ts -> policy/evaluator.ts)
+  // still count; only runtime-only coverage is lost. That residue is acceptable
+  // because the alternative (`false`) does not complete at all. See issue #485.
+  jest: { configFile: 'jest.stryker.config.js', enableFindRelatedTests: true },
   testRunnerNodeArgs: ['--experimental-vm-modules'],
   checkers: [],
-  mutate: ['src/**/*.ts', '!src/**/*.d.ts', '!src/index.ts', '!src/types.ts', '!src/schemas.ts'],
+  // Mutation is scoped to the correctness-critical heart of core — the state
+  // machine and everything it drives (runbook/**, policy/**, sandbox/**,
+  // events/**). The exclusions below drop presentation and declarative layers
+  // where mutation testing spends a large fraction of the mutant budget for
+  // almost no signal: their mutants are overwhelmingly equivalent or trivial.
+  // Trimming them focuses the full-fidelity run on logic that can actually
+  // harbour a costly bug. See issue #485.
+  mutate: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/index.ts',
+    '!src/types.ts',
+    '!src/schemas.ts',
+    // JSON-output format contract: 62 KB of declarative Zod schemas plus the
+    // z.infer<> type re-exports and trivial type guards built on them. This is
+    // the machine-readable output *spec*, not runbook logic — mutating it yields
+    // equivalent/noise mutants, and the giant zod-schemas.ts alone dominates the
+    // count.
+    '!src/output/**',
+    // Terminal rendering: ANSI color codes, output writers, and the
+    // intentionally branch-free "format-only" display models. Presentation is a
+    // Category A (CLI) concern with low correctness stakes; string-literal
+    // mutations here are pure noise.
+    '!src/cli/**',
+    // Logging plumbing — no runbook behaviour.
+    '!src/logger.ts',
+  ],
   coverageAnalysis: 'perTest',
   incremental: true,
   incrementalFile: 'reports/stryker-incremental.json',
@@ -68,6 +124,7 @@ const config = {
     reportType: 'full',
   },
   concurrency,
+  maxTestRunnerReuse,
   ignoreStatic,
   // Core hosts the heaviest actors (XState machine, file locks with jittered
   // backoff bounded to 5s, fromPromise actors that touch the filesystem). The

--- a/scripts/__tests__/mutation-sharding.test.mjs
+++ b/scripts/__tests__/mutation-sharding.test.mjs
@@ -43,7 +43,14 @@ function plan(env) {
 }
 
 test('plan: a dispatch for core emits only balanced, disjoint core shards', () => {
-  const { include } = plan({ EVENT_NAME: 'workflow_dispatch', INPUT_PACKAGE: 'core' });
+  // Pin MAX_SHARD_LINES so the split is driven by an explicit budget rather than
+  // the current size of packages/core (which would make the >=2 assertion drift
+  // as the package grows or shrinks).
+  const { include } = plan({
+    EVENT_NAME: 'workflow_dispatch',
+    INPUT_PACKAGE: 'core',
+    MAX_SHARD_LINES: '1000',
+  });
   assert.ok(include.length >= 2, 'core must split into multiple shards');
   assert.ok(
     include.every((e) => e.module === 'core'),
@@ -120,6 +127,32 @@ function runMerge(downloadDir, env) {
   }
 }
 
+/**
+ * Run the merge script and return both its exit code and captured stderr, so a
+ * test can assert on what the merger did (e.g. that no upload was attempted).
+ *
+ * @param {string} downloadDir - artifact directory.
+ * @param {Record<string,string>} env - extra environment.
+ * @returns {{status: number, stderr: string}} exit code and stderr text.
+ */
+function runMergeCapture(downloadDir, env) {
+  try {
+    execFileSync('node', [mergeScript], {
+      cwd: repoRoot,
+      env: hermeticEnv({
+        DOWNLOAD_DIR: downloadDir,
+        OUT_DIR: join(downloadDir, 'merged'),
+        ...env,
+      }),
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    return { status: 0, stderr: '' };
+  } catch (err) {
+    return { status: err.status ?? 1, stderr: err.stderr ?? '' };
+  }
+}
+
 test('merge: passes when shards are complete and above the floor', () => {
   const dir = mkdtempSync(join(tmpdir(), 'merge-ok-'));
   try {
@@ -165,6 +198,36 @@ test('merge: enforces the aggregate break floor', () => {
       0,
       'advisory run must not fail on score',
     );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('merge: never uploads a module with a missing shard, and still fails', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'merge-upload-gap-'));
+  try {
+    // core plans 2 shards but shard2 crashed (no artifact) → incomplete module.
+    writeReport(join(dir, 'mutation-report-core-shard1'), { Killed: 8 });
+    const matrix = JSON.stringify({
+      include: [
+        { module: 'core', shard: 1 },
+        { module: 'core', shard: 2 },
+      ],
+    });
+    // DASHBOARD_BASE points at an unroutable host: if the completeness gate ever
+    // regresses and an upload IS attempted, it fails loudly (recorded as an
+    // `upload core:` failure below) instead of touching the real dashboard.
+    const { status, stderr } = runMergeCapture(dir, {
+      MATRIX: matrix,
+      UPLOAD: 'true',
+      DASHBOARD_API_KEY: 'dummy-key',
+      DASHBOARD_BASE: 'http://127.0.0.1:1/api/reports',
+      APPLY_BREAK: 'false',
+    });
+    assert.equal(status, 1, 'an incomplete merge must fail');
+    assert.doesNotMatch(stderr, /uploaded /, 'must not report a successful upload');
+    assert.doesNotMatch(stderr, /upload core:/, 'must not attempt to upload the incomplete module');
+    assert.match(stderr, /a shard crashed/, 'must report the missing shard');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/__tests__/mutation-sharding.test.mjs
+++ b/scripts/__tests__/mutation-sharding.test.mjs
@@ -214,8 +214,8 @@ test('merge: never uploads a module with a missing shard, and still fails', () =
         { module: 'core', shard: 2 },
       ],
     });
-    // DASHBOARD_BASE points at an unroutable host: if the completeness gate ever
-    // regresses and an upload IS attempted, it fails loudly (recorded as an
+    // DASHBOARD_BASE points at a closed local port: if the completeness gate
+    // ever regresses and an upload IS attempted, it fails loudly (recorded as an
     // `upload core:` failure below) instead of touching the real dashboard.
     const { status, stderr } = runMergeCapture(dir, {
       MATRIX: matrix,

--- a/scripts/__tests__/mutation-sharding.test.mjs
+++ b/scripts/__tests__/mutation-sharding.test.mjs
@@ -10,6 +10,23 @@ const planScript = 'scripts/mutation-shard-plan.mjs';
 const mergeScript = 'scripts/mutation-merge-reports.mjs';
 
 /**
+ * Build a child environment that is hermetic w.r.t. GitHub Actions output
+ * channels. CI always sets `GITHUB_OUTPUT` / `GITHUB_STEP_SUMMARY`; if inherited
+ * they redirect the scripts' emissions to those files (making the planner write
+ * no stdout, and the merger pollute the real job summary). Stripping them makes
+ * these tests behave identically in CI and locally.
+ *
+ * @param {Record<string,string>} [extra] - extra environment to layer on top.
+ * @returns {NodeJS.ProcessEnv} the sanitized child environment.
+ */
+function hermeticEnv(extra) {
+  const env = { ...process.env, ...extra };
+  delete env.GITHUB_OUTPUT;
+  delete env.GITHUB_STEP_SUMMARY;
+  return env;
+}
+
+/**
  * Run the shard planner and return its emitted matrix (stdout JSON when
  * GITHUB_OUTPUT is unset).
  *
@@ -19,7 +36,7 @@ const mergeScript = 'scripts/mutation-merge-reports.mjs';
 function plan(env) {
   const out = execFileSync('node', [planScript], {
     cwd: repoRoot,
-    env: { ...process.env, ...env },
+    env: hermeticEnv(env),
     encoding: 'utf8',
   });
   return JSON.parse(out);
@@ -89,12 +106,11 @@ function runMerge(downloadDir, env) {
   try {
     execFileSync('node', [mergeScript], {
       cwd: repoRoot,
-      env: {
-        ...process.env,
+      env: hermeticEnv({
         DOWNLOAD_DIR: downloadDir,
         OUT_DIR: join(downloadDir, 'merged'),
         ...env,
-      },
+      }),
       encoding: 'utf8',
       stdio: 'pipe',
     });

--- a/scripts/__tests__/mutation-sharding.test.mjs
+++ b/scripts/__tests__/mutation-sharding.test.mjs
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const repoRoot = new URL('../..', import.meta.url).pathname;
+const planScript = 'scripts/mutation-shard-plan.mjs';
+const mergeScript = 'scripts/mutation-merge-reports.mjs';
+
+/**
+ * Run the shard planner and return its emitted matrix (stdout JSON when
+ * GITHUB_OUTPUT is unset).
+ *
+ * @param {Record<string,string>} env - extra environment for the planner.
+ * @returns {{include: Array<object>}} the parsed matrix.
+ */
+function plan(env) {
+  const out = execFileSync('node', [planScript], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return JSON.parse(out);
+}
+
+test('plan: a dispatch for core emits only balanced, disjoint core shards', () => {
+  const { include } = plan({ EVENT_NAME: 'workflow_dispatch', INPUT_PACKAGE: 'core' });
+  assert.ok(include.length >= 2, 'core must split into multiple shards');
+  assert.ok(
+    include.every((e) => e.module === 'core'),
+    'a core dispatch must not plan other modules',
+  );
+  // Shards must be disjoint and collectively cover the eligible set exactly once.
+  const all = include.flatMap((e) => e.mutate.split(','));
+  assert.equal(new Set(all).size, all.length, 'shards must mutate disjoint files');
+});
+
+test('plan: respects the config mutate exclusions (no output/cli/index)', () => {
+  const { include } = plan({ EVENT_NAME: 'workflow_dispatch', INPUT_PACKAGE: 'core' });
+  const files = include.flatMap((e) => e.mutate.split(','));
+  assert.ok(files.length > 0, 'core must have eligible files');
+  for (const f of files) {
+    assert.doesNotMatch(f, /^output\//, `excluded output/ leaked: ${f}`);
+    assert.doesNotMatch(f, /^cli\//, `excluded cli/ leaked: ${f}`);
+    assert.doesNotMatch(f, /\.d\.ts$/, `declaration file leaked: ${f}`);
+    assert.notEqual(f, 'index.ts', 'src/index.ts must be excluded');
+  }
+});
+
+test('plan: a dispatch for a single package excludes the others', () => {
+  const { include } = plan({ EVENT_NAME: 'workflow_dispatch', INPUT_PACKAGE: 'parser' });
+  assert.ok(include.length >= 1);
+  assert.ok(include.every((e) => e.module === 'parser'));
+});
+
+/**
+ * Write a minimal Stryker report fixture with the given per-status counts.
+ *
+ * @param {string} dir - directory to write `mutation-report.json` into.
+ * @param {Record<string, number>} statuses - status -> mutant count.
+ */
+function writeReport(dir, statuses) {
+  mkdirSync(dir, { recursive: true });
+  let id = 0;
+  const mutants = [];
+  for (const [status, n] of Object.entries(statuses)) {
+    for (let i = 0; i < n; i++) mutants.push({ id: `${id++}`, status });
+  }
+  writeFileSync(
+    join(dir, 'mutation-report.json'),
+    JSON.stringify({
+      schemaVersion: '2',
+      thresholds: { high: 80, low: 60 },
+      files: { [`f${dir.length}.ts`]: { mutants } },
+    }),
+  );
+}
+
+/**
+ * Run the merge script and return its exit code.
+ *
+ * @param {string} downloadDir - artifact directory.
+ * @param {Record<string,string>} env - extra environment.
+ * @returns {number} the process exit code.
+ */
+function runMerge(downloadDir, env) {
+  try {
+    execFileSync('node', [mergeScript], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        DOWNLOAD_DIR: downloadDir,
+        OUT_DIR: join(downloadDir, 'merged'),
+        ...env,
+      },
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    return 0;
+  } catch (err) {
+    return err.status ?? 1;
+  }
+}
+
+test('merge: passes when shards are complete and above the floor', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'merge-ok-'));
+  try {
+    writeReport(join(dir, 'mutation-report-core-shard1'), { Killed: 8 });
+    writeReport(join(dir, 'mutation-report-core-shard2'), { Killed: 2, Survived: 0 });
+    const matrix = JSON.stringify({
+      include: [
+        { module: 'core', shard: 1 },
+        { module: 'core', shard: 2 },
+      ],
+    });
+    assert.equal(runMerge(dir, { MATRIX: matrix, APPLY_BREAK: 'true' }), 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('merge: fails when a shard is missing (crash) even with continue-on-error', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'merge-gap-'));
+  try {
+    writeReport(join(dir, 'mutation-report-core-shard1'), { Killed: 8 });
+    // shard2 absent → crashed
+    const matrix = JSON.stringify({
+      include: [
+        { module: 'core', shard: 1 },
+        { module: 'core', shard: 2 },
+      ],
+    });
+    assert.equal(runMerge(dir, { MATRIX: matrix, APPLY_BREAK: 'false' }), 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('merge: enforces the aggregate break floor', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'merge-low-'));
+  try {
+    writeReport(join(dir, 'mutation-report-core-shard1'), { Killed: 5, Survived: 5 }); // 50%
+    const matrix = JSON.stringify({ include: [{ module: 'core', shard: 1 }] });
+    assert.equal(runMerge(dir, { MATRIX: matrix, APPLY_BREAK: 'true', BREAK: '70' }), 1);
+    assert.equal(
+      runMerge(dir, { MATRIX: matrix, APPLY_BREAK: 'false' }),
+      0,
+      'advisory run must not fail on score',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/__tests__/mutation-workflows.test.mjs
+++ b/scripts/__tests__/mutation-workflows.test.mjs
@@ -100,33 +100,64 @@ test('mutation-pr.yml distinguishes a failed summary download from a genuine no-
   assert.match(yml, /No mutated changed files in this PR\./);
 });
 
-test('mutation.yml is the full-fidelity producer (no ignoreStatic, uploads to dashboard)', async () => {
+test('mutation.yml is the full-fidelity producer (no ignoreStatic, shards score static)', async () => {
   const yml = await read('.github/workflows/mutation.yml');
   assert.doesNotMatch(
     yml,
     /STRYKER_IGNORE_STATIC:/,
     'producer must score static mutants (no ignoreStatic env assignment)',
   );
+  assert.match(yml, /push:\s*\n\s*branches:\s*\[main\]/, 'producer must run on push to main');
+});
+
+test('mutation.yml shards the campaign across a plan/mutate/merge pipeline', async () => {
+  const yml = await read('.github/workflows/mutation.yml');
+  // The shard matrix is computed by the plan job and consumed by the mutate job.
+  assert.match(yml, /\bplan:\s*\n/, 'must define a plan job');
+  assert.match(yml, /\bmutate:\s*\n/, 'must define a mutate job');
+  assert.match(yml, /\bmerge:\s*\n/, 'must define a merge job');
   assert.match(
     yml,
-    /STRYKER_DASHBOARD_API_KEY/,
-    'producer must pass the dashboard API key for upload',
+    /matrix:\s*\$\{\{\s*fromJson\(needs\.plan\.outputs\.matrix\)\s*\}\}/,
+    'mutate must run the plan job matrix',
   );
-  // The upload key must be gated on automated main-branch runs so an ad-hoc
-  // workflow_dispatch (possibly off a feature branch) cannot overwrite the
-  // canonical baseline. Match the exact boolean grouping — the ref AND the
-  // parenthesized (schedule || push) event group — so the test also fails on a
-  // mis-grouping (e.g. && between the events, which is always false) rather than
-  // only on a dropped token.
+  assert.match(yml, /node scripts\/mutation-shard-plan\.mjs/, 'plan must run the shard planner');
   assert.match(
     yml,
-    /STRYKER_DASHBOARD_API_KEY:\s*\$\{\{\s*\(github\.ref == 'refs\/heads\/main' && \(github\.event_name == 'schedule' \|\| github\.event_name == 'push'\)\) && secrets\.STRYKER_DASHBOARD_API_KEY/,
-    'producer must gate the upload key on refs/heads/main AND (schedule || push)',
+    /node scripts\/mutation-merge-reports\.mjs/,
+    'merge must run the report merger',
   );
+  assert.match(yml, /STRYKER_CONCURRENCY:\s*'4'/, 'shards run at concurrency 4');
+});
+
+test('mutation.yml caps every shard at the 60-min hard limit', async () => {
+  const yml = await read('.github/workflows/mutation.yml');
+  // The mutate job and its run step are both bounded so a mis-sized shard fails
+  // fast rather than burning a long budget.
+  const mutateJob = yml.match(/\n {2}mutate:\n([\s\S]*?)\n {2}merge:/)?.[1];
+  assert.ok(mutateJob, 'mutate job must precede merge job');
+  assert.match(mutateJob, /timeout-minutes:\s*60/, 'mutate job must cap at 60 min');
+});
+
+test('mutation.yml shards never upload; only the schedule merge seeds the baseline', async () => {
+  const yml = await read('.github/workflows/mutation.yml');
+  // The shard (mutate) job must not carry the dashboard key — a scoped shard
+  // report would overwrite the baseline with a partial one.
+  const mutateJob = yml.match(/\n {2}mutate:\n([\s\S]*?)\n {2}merge:/)?.[1];
+  assert.ok(mutateJob, 'mutate job must precede merge job');
+  assert.doesNotMatch(
+    mutateJob,
+    /STRYKER_DASHBOARD_API_KEY|DASHBOARD_API_KEY/,
+    'shards must not reference the dashboard key (they must not upload)',
+  );
+  // Only the weekly schedule on main produces a complete report, so the merge
+  // gates both the upload flag and the key itself on refs/heads/main AND
+  // schedule. Gating the key (not just a flag) means a dispatch/push physically
+  // cannot push to the dashboard.
   assert.match(
     yml,
-    /push:\s*\n\s*branches:\s*\[main\]/,
-    'producer must run on push to main to refresh the baseline',
+    /DASHBOARD_API_KEY:\s*\$\{\{\s*\(github\.ref == 'refs\/heads\/main' && github\.event_name == 'schedule'\) && secrets\.STRYKER_DASHBOARD_API_KEY/,
+    'merge must gate the upload key on refs/heads/main AND schedule',
   );
 });
 

--- a/scripts/__tests__/stryker-config.test.mjs
+++ b/scripts/__tests__/stryker-config.test.mjs
@@ -230,6 +230,94 @@ for (const [configPath, moduleName] of Object.entries(expectedModules)) {
   });
 }
 
+// Targeting invariants (issue #485): mutation is scoped to correctness-critical
+// code. Presentation and declarative layers are excluded so the full-fidelity
+// run spends its budget where a costly bug can actually hide. These pins stop a
+// future edit from silently re-widening the scope and reinflating the run.
+const expectedMutateExclusions = {
+  'packages/core/stryker.config.mjs': ['!src/output/**', '!src/cli/**', '!src/logger.ts'],
+  'packages/cli/stryker.config.mjs': ['!src/scripts/**', '!src/services/renderers/**'],
+};
+for (const [configPath, exclusions] of Object.entries(expectedMutateExclusions)) {
+  test(`${configPath} excludes low-value presentation/declarative paths from mutation`, async () => {
+    const config = await loadConfig(configPath, undefined);
+    assert.ok(Array.isArray(config.mutate), `${configPath}: mutate must be an array`);
+    // The base glob must stay first so the negations actually subtract from it.
+    assert.equal(
+      config.mutate[0],
+      'src/**/*.ts',
+      `${configPath}: mutate[0] must be the 'src/**/*.ts' base glob`,
+    );
+    for (const exclusion of exclusions) {
+      assert.ok(
+        config.mutate.includes(exclusion),
+        `${configPath}: mutate must exclude ${exclusion} (low-value mutation target)`,
+      );
+    }
+  });
+}
+
+// core/cli explicitly carry the throughput+memory fix that lets a full campaign
+// finish. parser/plugin leave jest.enableFindRelatedTests at its schema default
+// (true) and are small enough to complete; these two had it overridden to false,
+// which made every mutant reload the whole suite -> ~1.3 mutants/min and an
+// OOM death spiral. The pins below stop a future edit from re-introducing that.
+const campaignFinishConfigs = [
+  'packages/core/stryker.config.mjs',
+  'packages/cli/stryker.config.mjs',
+];
+for (const configPath of campaignFinishConfigs) {
+  test(`${configPath} scopes each mutant to related tests (issue #485)`, async () => {
+    const config = await loadConfig(configPath, undefined);
+    // false reloads all test files per mutant (the regression that floored
+    // throughput and OOM'd the in-band runner). true restores the jest-runner
+    // default: only the tests that transitively import the mutated file run.
+    assert.equal(
+      config.jest?.enableFindRelatedTests,
+      true,
+      `${configPath}: jest.enableFindRelatedTests must be true (false stops the campaign from finishing)`,
+    );
+  });
+
+  test(`${configPath} recycles the test runner to cap the in-band leak (issue #485)`, async () => {
+    const config = await loadConfigWithEnv(configPath, {
+      STRYKER_MAX_TEST_RUNNER_REUSE: undefined,
+    });
+    // A positive maxTestRunnerReuse is what bounds the residual per-run heap leak
+    // in Stryker's long-lived in-band jest child. 0/undefined means infinite
+    // reuse, i.e. no recycling — the leak is then unbounded again.
+    assert.equal(
+      typeof config.maxTestRunnerReuse,
+      'number',
+      `${configPath}: maxTestRunnerReuse must be a number`,
+    );
+    assert.ok(
+      config.maxTestRunnerReuse > 0,
+      `${configPath}: maxTestRunnerReuse must be > 0 (0 disables recycling and re-opens the leak)`,
+    );
+  });
+
+  test(`${configPath} honors STRYKER_MAX_TEST_RUNNER_REUSE overrides`, async () => {
+    assert.equal(
+      (await loadConfigWithEnv(configPath, { STRYKER_MAX_TEST_RUNNER_REUSE: '10' }))
+        .maxTestRunnerReuse,
+      10,
+    );
+    // Non-positive / garbage falls back to the safe default rather than 0
+    // (which would silently disable recycling).
+    assert.equal(
+      (await loadConfigWithEnv(configPath, { STRYKER_MAX_TEST_RUNNER_REUSE: '0' }))
+        .maxTestRunnerReuse,
+      25,
+    );
+    assert.equal(
+      (await loadConfigWithEnv(configPath, { STRYKER_MAX_TEST_RUNNER_REUSE: 'nope' }))
+        .maxTestRunnerReuse,
+      25,
+    );
+  });
+}
+
 test('packages/core widens the mutation timeout budget (issue #483)', async () => {
   const config = await loadConfig('packages/core/stryker.config.mjs', undefined);
   // Core hosts the heaviest actors; the previous 30000ms / 2.5x budget produced

--- a/scripts/mutation-merge-reports.mjs
+++ b/scripts/mutation-merge-reports.mjs
@@ -1,0 +1,215 @@
+// Merge per-shard Stryker reports back into one full report per module, upload
+// it once to the dashboard, and apply the aggregate break threshold.
+//
+// The producer fans a module's mutation campaign across shards that each mutate
+// a DISJOINT set of files (see mutation-shard-plan.mjs). Each shard uploads its
+// partial `mutation-report.json` as a CI artifact but never writes to the
+// dashboard — a partial, scoped report would overwrite the module's baseline
+// with a thin one. This job runs after all shards: it unions their `files`
+// (disjoint keys, so no collision) into a single complete module report,
+// recomputes the aggregate score, PUTs it to the dashboard once (when the run
+// is an upload-eligible producer), and fails if a module's aggregate falls
+// under the break floor.
+//
+// Inputs (env):
+//   DOWNLOAD_DIR   - dir holding `mutation-report-<module>-shard<N>/mutation-report.json`
+//   MATRIX         - the plan job's matrix JSON; used to verify every expected
+//                    shard produced a report (a crashed shard runs under
+//                    continue-on-error, so its absence must fail the merge here)
+//   UPLOAD         - 'true' to PUT merged reports to the dashboard
+//   DASHBOARD_API_KEY - Stryker dashboard key (required when UPLOAD=true)
+//   APPLY_BREAK    - 'true' to exit non-zero when a module aggregate < BREAK
+//   BREAK          - aggregate break floor (default 70)
+//   PROJECT        - dashboard project slug (default github.com/tobyhede/rundown)
+//   VERSION        - dashboard report version (default main)
+//   OUT_DIR        - where merged reports are written (default ./merged-reports)
+
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const downloadDir = process.env.DOWNLOAD_DIR ?? 'shard-reports';
+const upload = process.env.UPLOAD === 'true';
+const apiKey = process.env.DASHBOARD_API_KEY ?? '';
+const applyBreak = process.env.APPLY_BREAK === 'true';
+const breakFloor = Number.parseInt(process.env.BREAK ?? '', 10) || 70;
+const project = process.env.PROJECT ?? 'github.com/tobyhede/rundown';
+const version = process.env.VERSION ?? 'main';
+const outDir = process.env.OUT_DIR ?? 'merged-reports';
+const dashboardBase = 'https://dashboard.stryker-mutator.io/api/reports';
+
+const DETECTED = new Set(['Killed', 'Timeout']);
+const UNDETECTED = new Set(['Survived', 'NoCoverage']);
+
+/**
+ * Recompute a report's mutation score from its merged mutants. Mirrors Stryker:
+ * score = detected / valid, where valid = detected + undetected and
+ * ignored/runtime/compile-error mutants are excluded.
+ *
+ * @param {object} report - a (merged) mutation-testing report.
+ * @returns {{score: number, detected: number, valid: number, total: number}}
+ */
+function scoreOf(report) {
+  let detected = 0;
+  let undetected = 0;
+  let total = 0;
+  for (const file of Object.values(report.files ?? {})) {
+    for (const m of file.mutants ?? []) {
+      total += 1;
+      if (DETECTED.has(m.status)) detected += 1;
+      else if (UNDETECTED.has(m.status)) undetected += 1;
+    }
+  }
+  const valid = detected + undetected;
+  return { score: valid ? (detected / valid) * 100 : 100, detected, valid, total };
+}
+
+/**
+ * Discover shard report files grouped by module. Expects artifact directories
+ * named `mutation-report-<module>-shard<N>` each containing one report JSON.
+ *
+ * @param {string} dir - the artifact download directory.
+ * @returns {Map<string, string[]>} module name -> report file paths.
+ */
+function collectShardReports(dir) {
+  const byModule = new Map();
+  if (!existsSync(dir)) return byModule;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const match = /^mutation-report-([a-z]+)-shard\d+$/.exec(entry.name);
+    if (!match) continue;
+    const module = match[1];
+    const reportPath = join(dir, entry.name, 'mutation-report.json');
+    if (!existsSync(reportPath)) continue;
+    if (!byModule.has(module)) byModule.set(module, []);
+    byModule.get(module).push(reportPath);
+  }
+  return byModule;
+}
+
+/**
+ * Combine shard reports for one module into a single complete report. `files`
+ * keys are disjoint across shards; `testFiles` may repeat (same file relates to
+ * sources in several shards) and is merged by key.
+ *
+ * @param {string[]} reportPaths - shard report file paths for the module.
+ * @returns {object} the merged report.
+ */
+function mergeModule(reportPaths) {
+  const reports = reportPaths.map((p) => JSON.parse(readFileSync(p, 'utf8')));
+  const merged = {
+    schemaVersion: reports[0].schemaVersion,
+    thresholds: reports[0].thresholds,
+    projectRoot: reports[0].projectRoot,
+    files: {},
+  };
+  if (reports[0].framework) merged.framework = reports[0].framework;
+  if (reports[0].config) merged.config = reports[0].config;
+  const testFiles = {};
+  for (const r of reports) {
+    Object.assign(merged.files, r.files ?? {});
+    Object.assign(testFiles, r.testFiles ?? {});
+  }
+  if (Object.keys(testFiles).length > 0) merged.testFiles = testFiles;
+  return merged;
+}
+
+/**
+ * PUT a merged module report to the Stryker dashboard.
+ *
+ * @param {string} module - the dashboard module name.
+ * @param {object} report - the full merged report.
+ * @returns {Promise<void>}
+ * @throws when the dashboard responds with a non-2xx status.
+ */
+async function uploadToDashboard(module, report) {
+  const url = `${dashboardBase}/${project}/${encodeURIComponent(version)}?module=${encodeURIComponent(module)}`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', 'X-Api-Key': apiKey },
+    body: JSON.stringify(report),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`dashboard PUT ${module} failed: ${res.status} ${res.statusText} ${body}`);
+  }
+  const json = await res.json().catch(() => ({}));
+  process.stderr.write(`uploaded ${module}: ${json.href ?? url}\n`);
+}
+
+/**
+ * Expected shard count per module, parsed from the plan matrix. A shard that
+ * crashed produced no artifact; comparing found-vs-expected turns that silent
+ * gap into a merge failure (low-score exits are swallowed by continue-on-error,
+ * so absence is the only crash signal left).
+ *
+ * @returns {Map<string, number>} module -> expected shard count.
+ */
+function expectedShardCounts() {
+  const counts = new Map();
+  const raw = process.env.MATRIX;
+  if (!raw) return counts;
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return counts;
+  }
+  for (const entry of parsed.include ?? []) {
+    counts.set(entry.module, (counts.get(entry.module) ?? 0) + 1);
+  }
+  return counts;
+}
+
+const byModule = collectShardReports(downloadDir);
+if (byModule.size === 0) {
+  process.stderr.write(`no shard reports found under ${downloadDir}; nothing to merge.\n`);
+  process.exit(0);
+}
+if (upload && !apiKey) throw new Error('UPLOAD=true but DASHBOARD_API_KEY is empty');
+
+const expected = expectedShardCounts();
+
+mkdirSync(outDir, { recursive: true });
+const failures = [];
+const summary = [];
+
+// Fail on any module that lost a shard (crash → no artifact), so a partial
+// merge never masquerades as a complete baseline.
+for (const [module, want] of expected) {
+  const got = byModule.get(module)?.length ?? 0;
+  if (got < want)
+    failures.push(`${module}: only ${got}/${want} shard reports present (a shard crashed)`);
+}
+
+for (const [module, paths] of byModule) {
+  const merged = mergeModule(paths);
+  const { score, detected, valid, total } = scoreOf(merged);
+  writeFileSync(join(outDir, `${module}.json`), JSON.stringify(merged));
+  summary.push(
+    `${module}: ${score.toFixed(2)}% (${detected}/${valid} detected, ${total} mutants, ${paths.length} shards)`,
+  );
+
+  if (upload) {
+    try {
+      await uploadToDashboard(module, merged);
+    } catch (err) {
+      failures.push(`upload ${module}: ${err.message}`);
+    }
+  }
+  if (applyBreak && score < breakFloor) {
+    failures.push(`${module} score ${score.toFixed(2)}% under break ${breakFloor}`);
+  }
+}
+
+process.stderr.write(`\nmerged module scores:\n${summary.join('\n')}\n`);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  writeFileSync(
+    process.env.GITHUB_STEP_SUMMARY,
+    `## Mutation (merged)\n\n${summary.map((s) => `- ${s}`).join('\n')}\n`,
+    { flag: 'a' },
+  );
+}
+if (failures.length > 0) {
+  process.stderr.write(`\nFAILURES:\n${failures.join('\n')}\n`);
+  process.exit(1);
+}

--- a/scripts/mutation-merge-reports.mjs
+++ b/scripts/mutation-merge-reports.mjs
@@ -35,7 +35,7 @@ const breakFloor = Number.parseInt(process.env.BREAK ?? '', 10) || 70;
 const project = process.env.PROJECT ?? 'github.com/tobyhede/rundown';
 const version = process.env.VERSION ?? 'main';
 const outDir = process.env.OUT_DIR ?? 'merged-reports';
-const dashboardBase = 'https://dashboard.stryker-mutator.io/api/reports';
+const dashboardBase = process.env.DASHBOARD_BASE ?? 'https://dashboard.stryker-mutator.io/api/reports';
 
 const DETECTED = new Set(['Killed', 'Timeout']);
 const UNDETECTED = new Set(['Survived', 'NoCoverage']);
@@ -174,11 +174,16 @@ const failures = [];
 const summary = [];
 
 // Fail on any module that lost a shard (crash → no artifact), so a partial
-// merge never masquerades as a complete baseline.
+// merge never masquerades as a complete baseline. An incomplete module must
+// also be barred from the dashboard upload below: seeding the baseline with a
+// partial report is exactly the corruption this check exists to prevent.
+const incomplete = new Set();
 for (const [module, want] of expected) {
   const got = byModule.get(module)?.length ?? 0;
-  if (got < want)
+  if (got < want) {
+    incomplete.add(module);
     failures.push(`${module}: only ${got}/${want} shard reports present (a shard crashed)`);
+  }
 }
 
 for (const [module, paths] of byModule) {
@@ -189,7 +194,9 @@ for (const [module, paths] of byModule) {
     `${module}: ${score.toFixed(2)}% (${detected}/${valid} detected, ${total} mutants, ${paths.length} shards)`,
   );
 
-  if (upload) {
+  // Only upload a module with full shard coverage; an incomplete merge would
+  // overwrite the dashboard baseline with a partial report.
+  if (upload && !incomplete.has(module)) {
     try {
       await uploadToDashboard(module, merged);
     } catch (err) {

--- a/scripts/mutation-merge-reports.mjs
+++ b/scripts/mutation-merge-reports.mjs
@@ -35,7 +35,8 @@ const breakFloor = Number.parseInt(process.env.BREAK ?? '', 10) || 70;
 const project = process.env.PROJECT ?? 'github.com/tobyhede/rundown';
 const version = process.env.VERSION ?? 'main';
 const outDir = process.env.OUT_DIR ?? 'merged-reports';
-const dashboardBase = process.env.DASHBOARD_BASE ?? 'https://dashboard.stryker-mutator.io/api/reports';
+const dashboardBase =
+  process.env.DASHBOARD_BASE ?? 'https://dashboard.stryker-mutator.io/api/reports';
 
 const DETECTED = new Set(['Killed', 'Timeout']);
 const UNDETECTED = new Set(['Survived', 'NoCoverage']);

--- a/scripts/mutation-shard-plan.mjs
+++ b/scripts/mutation-shard-plan.mjs
@@ -124,9 +124,15 @@ function partition(files) {
   const shardCount = Math.max(1, Math.ceil(totalLines / maxShardLines));
   const shards = Array.from({ length: shardCount }, () => ({ lines: 0, files: [] }));
   for (const f of [...files].sort((a, b) => b.lines - a.lines)) {
-    shards.sort((a, b) => a.lines - b.lines);
-    shards[0].lines += f.lines;
-    shards[0].files.push(f.file);
+    // Place each file on the currently least-loaded shard. A linear min-scan
+    // avoids re-sorting the whole shard array on every file while preserving the
+    // LPT balancing behaviour (ties resolve to the earliest shard, as before).
+    let lightest = shards[0];
+    for (let i = 1; i < shards.length; i++) {
+      if (shards[i].lines < lightest.lines) lightest = shards[i];
+    }
+    lightest.lines += f.lines;
+    lightest.files.push(f.file);
   }
   return shards.map((s) => s.files).filter((f) => f.length > 0);
 }

--- a/scripts/mutation-shard-plan.mjs
+++ b/scripts/mutation-shard-plan.mjs
@@ -1,0 +1,190 @@
+// Emit the CI shard matrix for the mutation producer (.github/workflows/mutation.yml).
+//
+// A full `core`/`cli` mutation campaign cannot fit a single 60-min CI job, so
+// the producer fans out across matrix shards. This script decides — for the
+// triggering event — WHICH files each shard mutates, balancing shards by source
+// line count (a cheap proxy for mutant count) so every shard lands well under
+// the 60-min hard cap. Shards mutate DISJOINT file sets, which is what lets the
+// merge job (mutation-merge-reports.mjs) stitch their partial reports back into
+// one full per-module report for the dashboard.
+//
+// Inputs (env):
+//   EVENT_NAME       - 'schedule' | 'push' | 'workflow_dispatch'
+//   INPUT_PACKAGE    - dispatch package filter ('all'|'parser'|'core'|'cli'|'plugin')
+//   PUSH_BASE        - github.event.before SHA (push differential diff base)
+//   MAX_SHARD_LINES  - target max source lines per shard (default 9000)
+//   GITHUB_OUTPUT    - file to append `matrix=` / `empty=` outputs (optional; else stdout)
+//
+// Output: a GitHub Actions matrix `{ include: [{ package, dir, module, shard,
+// shardCount, mutate }] }` where `mutate` is a comma-separated file list passed
+// straight to `stryker run --mutate`.
+
+import { readFileSync, appendFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { globSync } from 'glob';
+
+/** Packages that run mutation testing, in matrix order. */
+const PACKAGES = [
+  { package: 'parser', dir: 'packages/parser', module: 'parser' },
+  { package: 'core', dir: 'packages/core', module: 'core' },
+  { package: 'cli', dir: 'packages/cli', module: 'cli' },
+  { package: 'plugin', dir: 'packages/claude-code-plugin', module: 'plugin' },
+];
+
+const repoRoot = process.cwd();
+const eventName = process.env.EVENT_NAME ?? 'workflow_dispatch';
+const inputPackage = process.env.INPUT_PACKAGE ?? 'all';
+const pushBase = process.env.PUSH_BASE ?? '';
+const maxShardLines = Number.parseInt(process.env.MAX_SHARD_LINES ?? '', 10) || 9000;
+
+/**
+ * Which packages this event should run. Schedule and push cover every package;
+ * a dispatch covers the chosen one (or all).
+ *
+ * @param {{package: string}} pkg - candidate package descriptor.
+ * @returns {boolean} true when this event should mutate the package.
+ */
+function selectedForEvent(pkg) {
+  if (eventName === 'schedule' || eventName === 'push') return true;
+  return inputPackage === 'all' || inputPackage === pkg.package;
+}
+
+/**
+ * Load a package's Stryker `mutate` patterns (glob includes plus `!` negations).
+ *
+ * @param {string} dir - repo-relative package directory.
+ * @returns {Promise<string[]>} the configured mutate patterns.
+ */
+async function mutatePatterns(dir) {
+  const cfgUrl = pathToFileURL(join(repoRoot, dir, 'stryker.config.mjs'));
+  const cfg = (await import(cfgUrl.href)).default;
+  const mutate = cfg?.mutate;
+  if (!Array.isArray(mutate)) throw new Error(`${dir}: stryker.config.mjs has no mutate array`);
+  return mutate;
+}
+
+/**
+ * Resolve the diff base for a push, degrading safely: an unset/unreachable
+ * pre-push SHA falls back to HEAD~1, and a root commit yields null (→ full run).
+ *
+ * @returns {string | null} a usable base ref, or null to mutate the full scope.
+ */
+function resolveDiffBase() {
+  const reachable = (ref) => {
+    try {
+      execFileSync('git', ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {
+        stdio: 'ignore',
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const zero = '0000000000000000000000000000000000000000';
+  if (pushBase && pushBase !== zero && reachable(pushBase)) return pushBase;
+  if (reachable('HEAD~1'))
+    return execFileSync('git', ['rev-parse', 'HEAD~1'], { encoding: 'utf8' }).trim();
+  return null;
+}
+
+/**
+ * Files changed under `<dir>/src` between base and HEAD (added/modified, not
+ * deleted), repo-relative.
+ *
+ * @param {string} dir - repo-relative package directory.
+ * @param {string} base - diff base ref.
+ * @returns {Set<string>} changed source file paths.
+ */
+function changedSourceFiles(dir, base) {
+  const out = execFileSync(
+    'git',
+    ['diff', '--name-only', '--diff-filter=d', base, 'HEAD', '--', `${dir}/src`],
+    { encoding: 'utf8' },
+  );
+  return new Set(
+    out
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * Greedily partition files into shards balanced by line count (LPT heuristic):
+ * largest files first, each onto the currently-lightest shard. Shard count is
+ * sized so no shard's projected lines exceed `maxShardLines`.
+ *
+ * @param {Array<{file: string, lines: number}>} files - eligible files with sizes.
+ * @returns {string[][]} arrays of file paths, one per shard.
+ */
+function partition(files) {
+  const totalLines = files.reduce((sum, f) => sum + f.lines, 0);
+  const shardCount = Math.max(1, Math.ceil(totalLines / maxShardLines));
+  const shards = Array.from({ length: shardCount }, () => ({ lines: 0, files: [] }));
+  for (const f of [...files].sort((a, b) => b.lines - a.lines)) {
+    shards.sort((a, b) => a.lines - b.lines);
+    shards[0].lines += f.lines;
+    shards[0].files.push(f.file);
+  }
+  return shards.map((s) => s.files).filter((f) => f.length > 0);
+}
+
+const include = [];
+const base = eventName === 'push' ? resolveDiffBase() : null;
+
+for (const pkg of PACKAGES) {
+  if (!selectedForEvent(pkg)) continue;
+  const patterns = await mutatePatterns(pkg.dir);
+  // Split the Stryker mutate array into positive globs and `!` negations and
+  // feed them to glob's include + `ignore`, so the eligible set matches exactly
+  // what Stryker would mutate.
+  const positives = patterns.filter((p) => !p.startsWith('!'));
+  const ignore = patterns.filter((p) => p.startsWith('!')).map((p) => p.slice(1));
+  const eligibleRel = globSync(positives, { cwd: join(repoRoot, pkg.dir), ignore });
+  let eligible = eligibleRel.map((rel) => ({
+    file: rel, // package-relative; stryker runs with working-directory: <dir>
+    repoRel: `${pkg.dir}/${rel}`,
+  }));
+
+  if (eventName === 'push') {
+    if (base === null) {
+      // No usable base → mutate the full scope rather than skip the producer.
+    } else {
+      const changed = changedSourceFiles(pkg.dir, base);
+      eligible = eligible.filter((e) => changed.has(e.repoRel));
+      if (eligible.length === 0) continue; // package unchanged this push
+    }
+  }
+
+  const withSizes = eligible.map((e) => ({
+    file: e.file,
+    lines: readFileSync(join(repoRoot, e.repoRel), 'utf8').split('\n').length,
+  }));
+  const shards = partition(withSizes);
+  shards.forEach((files, i) => {
+    include.push({
+      package: pkg.package,
+      dir: pkg.dir,
+      module: pkg.module,
+      shard: i + 1,
+      shardCount: shards.length,
+      mutate: files.join(','),
+    });
+  });
+}
+
+const matrix = { include };
+const empty = include.length === 0;
+const summary = include
+  .map((e) => `${e.package} shard ${e.shard}/${e.shardCount} (${e.mutate.split(',').length} files)`)
+  .join('\n');
+
+const out = process.env.GITHUB_OUTPUT;
+if (out) {
+  appendFileSync(out, `matrix=${JSON.stringify(matrix)}\n`);
+  appendFileSync(out, `empty=${empty}\n`);
+}
+process.stderr.write(`mutation shard plan (${eventName}):\n${summary || '(no shards)'}\n`);
+if (!out) process.stdout.write(`${JSON.stringify(matrix, null, 2)}\n`);


### PR DESCRIPTION
## What

Makes full `core`/`cli` mutation campaigns actually complete within CI time limits, via two parts:

1. **Fix the OOM death-spiral.** Both `stryker.config.mjs` files set `jest.enableFindRelatedTests: false`, forcing every mutant to reload the full 302-file / 3682-test suite in one in-band child that OOM'd and death-spiralled (campaigns never finished). Restores `enableFindRelatedTests: true` (~55× throughput), adds `maxTestRunnerReuse` to recycle the child, removes an inert `workerIdleMemoryLimit`, and pins the `mutate` scope + differential push path.

2. **Shard the producer.** A plan → parallel-mutate → merge fan-out so a full ~17k-mutant core / ~9k cli campaign fits under a 60-min hard cap at concurrency 4:
   - `scripts/mutation-shard-plan.mjs` — emits the CI shard matrix, greedily partitioning mutate-eligible files into **disjoint** shards balanced by source line count. On `push` it shards only changed files (differential); on `schedule`/`dispatch`, the full set.
   - `scripts/mutation-merge-reports.mjs` — unions the disjoint per-shard reports into one complete per-module report, **verifies every planned shard produced a report** (catches a crashed shard hidden by `continue-on-error`), and only on the upload-eligible producer run PUTs the merged report to the dashboard and enforces the aggregate break floor. Individual shards never hold the dashboard key, so they can't upload a partial baseline.

## Commits

- `915869ed5` fix(mutation): make core/cli campaigns complete instead of OOM-spiralling
- `4ca2446e2` ci(mutation): concurrency 4 + 60-min cap to calibrate sharding
- `77a45c230` ci(mutation): shard the producer to fit a 60-min hard cap

## Relationship to prior work

Builds on the mutation-CI foundation from #491 (advisory gate) and #501 (producer jest-sandbox), both already in this branch's history. The sharding pipeline and the OOM-completion fix are new and not present in `main`.

## Tests

Invariants pinned in `scripts/__tests__/mutation-sharding.test.mjs`, `stryker-config.test.mjs`, and `mutation-workflows.test.mjs`.

Refs #485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mutation testing now runs in sharded stages, which should help large campaigns finish more reliably within time limits.
  * Shard reports are merged into a single combined result, with coverage checks to catch missing pieces.

* **Bug Fixes**
  * Improved test-runner recycling and related-test selection to reduce memory growth and instability during mutation runs.
  * Refined mutation scope exclusions to avoid noisy or less useful files.

* **Documentation**
  * Updated mutation-testing CI docs to reflect the new workflow and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->