### PR TITLE
feat(core): derive delegation supersession on retry (Cluster B / item 13)

### DIFF
--- a/packages/cli/__tests__/integration/delegate-workflow.test.ts
+++ b/packages/cli/__tests__/integration/delegate-workflow.test.ts
@@ -1599,8 +1599,9 @@ describe('DELEGATE re-entry and retry', () => {
     // stale FAIL resolvedCompletion row is consumed and the substep reset.
     const retry = await runCliInProcess(['delegate', '--retry', token2], workspace);
     expect(retry.exitCode).toBe(0);
-    const retryOutput = JSON.parse(retry.stdout) as Record<string, unknown>;
-    const token2b = retryOutput.token as string;
+    const retryOutput = findActionOutput<{ token: string }>(retry.stdout);
+    expect(retryOutput).not.toBeNull();
+    const token2b = retryOutput!.token;
     expect(token2b.startsWith('rdtk_')).toBe(true);
     expect(token2b).not.toBe(token2);
 
@@ -1608,6 +1609,10 @@ describe('DELEGATE re-entry and retry', () => {
     // reported, so readiness (which reads live outcome rows) refuses. Nothing is
     // applied and no aggregation transition fires from the superseded FAIL.
     const collectStale = await runCliInProcess(['collect'], workspace);
+    // Readiness refuses (missing_outcomes → SUBSTEPS_NOT_RESOLVED → exit 1). Assert
+    // the exit code before parsing so a crashed collect (empty stdout, no parsed
+    // events) cannot pass the negative event assertions below vacuously.
+    expect(collectStale.exitCode).toBe(1);
     const staleEvents = flattenEventObjects(parseConcatenatedJson(collectStale.stdout));
     expect(staleEvents.some((e) => e.status === 'applied')).toBe(false);
     expect(

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -775,8 +775,11 @@ describe('RunbookCollectionService', () => {
       actorContext: trustedRunControllerContext(runId),
       frame: activeFrame(frameKey, 1),
     });
-    // Readiness must NOT refuse: the live row is the authoritative outcome signal.
-    expect(result.kind).not.toBe('missing_outcomes');
+    // Readiness must NOT refuse: the live row is the authoritative outcome signal,
+    // so collection proceeds and drains the row (asserting the exact success kind
+    // rather than merely `not missing_outcomes`, which unrelated refusals like
+    // `collection_failed` would also satisfy).
+    expect(result.kind).toBe('collection_applied');
   });
 
   const delegationLinkage = {


### PR DESCRIPTION
## Summary

Implements **Cluster B / roadmap item 13 — "retry supersedes pending collection"** (spec line 1059 of `docs/superpowers/specs/2026-06-17-claim-delegation-lifecycle-design.md`).

The governing decision (`docs/superpowers/notes/2026-07-01-superseded-lifecycle-strike-decision.md`) is to **strike the persisted `superseded` lifecycle state** — a stored per-claim status would violate *derive-from-state / no synthetic IDs* and force a persisted-state schema change the no-migration rule forbids. Supersession is instead realized **behaviorally**: when a delegation is re-issued (retry, or re-delegate after cancel), any outcome the prior attempt already reported is consumed so a later `rd collect` cannot drain the stale row.

## How supersession is realized

1. **Force-cancel + fresh token** — `retryDelegation` aborts the prior delegation (`abortDelegation` → `cancelledAt`) and mints a fresh attempt.
2. **Reset the re-issued substep** — `createDelegation` resets the entry to `{ status: 'pending', result: undefined }`, mirroring the machine RETRY hook so manual and machine paths converge.
3. **Consume the pending outcome** — the lifecycle seam's `#supersedePendingOutcome` drains the prior attempt's reported `resolvedCompletions` row before persisting the reset, on both the retry and re-delegate-after-cancel paths.
4. **Readiness from live rows** — `rd collect` readiness reads live outcome rows (not cached substep status), so a superseded substep is uncollectable until the fresh attempt reports.

## Changes

- `fix(core): reset re-issued substep status/result in createDelegation`
- `fix(core): base rd collect readiness on live outcome rows, not cached status`
- `fix(core): consume pending delegation outcome row on manual retry`
- `test(cli): pin abort --force -> delegate --retry -> collect supersession`
- `docs(spec): strike persisted superseded lifecycle state; document derived supersession`

## Test plan

- Core: `collection-service`, `lifecycle-command-service`, `retry-delegation` — 104 passed
- CLI: `delegate` + `delegate-workflow` integration — 104 passed
- End-to-end scenario pinned: *abort --force → delegate --retry supersedes the stale FAIL; `collect` drains only the fresh outcome* (`delegate-workflow.test.ts`)

## Scope boundary

Consuming the row before persisting the reset **narrows** the window against a concurrent `rd collect` — it does not fully close it. A retry is not atomic against a concurrent collect; full lock-span atomicity is tracked separately (**Cluster D**) and is out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retried delegations now fully reset the target substep back to a fresh pending state, clearing any previous result.
  * When re-issuing a delegation, any stale delegation outcome is automatically superseded/consumed.
* **Bug Fixes**
  * Collection readiness now depends on the latest live delegation outcome data, avoiding outdated outcomes being applied.
  * Abort-then-retry flows no longer allow collect to drain stale results; only the fresh outcome becomes collectable.
* **Documentation**
  * Added a dated note clarifying the superseded delegation lifecycle behavior.
* **Tests**
  * Added unit and integration coverage for retry/supersession and collect readiness after abort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->