### PR TITLE
test: make the CLI/core mutation gate measure honestly (raise 4 files over floor + linkage sweep)

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -349,3 +349,4 @@ normalises
 desync
 desyncing
 desyncs
+unhomed

--- a/packages/cli/__tests__/commands/abort.test.ts
+++ b/packages/cli/__tests__/commands/abort.test.ts
@@ -12,7 +12,35 @@ import {
 } from '../helpers/test-utils.js';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { Command } from 'commander';
 import { validateCommandOutput } from '../helpers/schema-validator.js';
+// Stryker static-import linkage (mutation testing): the behavioural tests below
+// drive the CLI through `runCliInProcess`, whose `import('../cli.js')` seam is
+// dynamic and invisible to Jest's static inverse-module graph. Stryker runs
+// `jest --findRelatedTests src/commands/abort.ts` per mutant; without a *static*
+// import of the command module here that query matches no test file, so zero
+// tests run per mutant and every mutant falsely survives (~0% score). The static
+// import + wiring test link this file into the graph so the covering tests
+// actually run against each mutant. Mirrors collect.test.ts / delegate.test.ts.
+import { registerAbortCommand } from '../../src/commands/abort.js';
+
+describe('abort command wiring', () => {
+  it('registers the abort command with its documented flags and descriptions', () => {
+    const program = new Command();
+    registerAbortCommand(program);
+
+    const abort = program.commands.find((c) => c.name() === 'abort');
+    expect(abort).toBeDefined();
+    expect(abort?.description()).toBe('Cancel a delegation token');
+
+    const byLong = new Map(abort!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(expect.arrayContaining(['--force', '--text']));
+    expect(byLong.get('--force')?.description).toBe(
+      'Force cancel even if delegation is claimed (stops child run)',
+    );
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('abort command - unit tests', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/artifact.test.ts
+++ b/packages/cli/__tests__/commands/artifact.test.ts
@@ -11,11 +11,37 @@ import {
   brandTrustedArtifactArrayForTest,
   brandTrustedArtifactRecordForTest,
 } from '../helpers/brand-helpers.js';
+import { Command } from 'commander';
 import { createTestWorkspace, runCliInProcess, type TestWorkspace } from '../helpers/test-utils.js';
 import { validateCommandOutput } from '../helpers/schema-validator.js';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/artifact.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerArtifactCommand } from '../../src/commands/artifact.js';
 
 const RUN_ID = assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
 const CONTEXT_ID = 'ctx1';
+
+describe('artifact command wiring', () => {
+  it('registers the artifact command with its subcommands and descriptions', () => {
+    const program = new Command();
+    registerArtifactCommand(program);
+
+    const artifact = program.commands.find((c) => c.name() === 'artifact');
+    expect(artifact).toBeDefined();
+    expect(artifact?.description()).toBe('Inspect Rundown artifact aliases');
+
+    const subNames = artifact!.commands.map((c) => c.name()).sort();
+    expect(subNames).toEqual(['inspect', 'ls', 'path', 'uri']);
+
+    // Every artifact subcommand exposes the shared --text human-output flag.
+    for (const sub of artifact!.commands) {
+      const text = sub.options.find((o) => o.long === '--text');
+      expect(text?.description).toBe('Output as human-readable text');
+    }
+  });
+});
 
 describe('artifact command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/claim.test.ts
+++ b/packages/cli/__tests__/commands/claim.test.ts
@@ -17,7 +17,63 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { ErrorResponseSchema } from '@rundown-org/core';
+import { Command } from 'commander';
 import { validateCommandOutput } from '../helpers/schema-validator.js';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/claim.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerClaimCommand } from '../../src/commands/claim.js';
+
+describe('claim command wiring', () => {
+  it('registers the claim command with its documented flags, descriptions, and defaults', () => {
+    const program = new Command();
+    registerClaimCommand(program);
+
+    const claim = program.commands.find((c) => c.name() === 'claim');
+    expect(claim).toBeDefined();
+    expect(claim?.description()).toBe('Claim a delegation token and launch the child runbook');
+
+    const byLong = new Map(claim!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(
+      expect.arrayContaining([
+        '--text',
+        '--input-file',
+        '--input',
+        '--input-json',
+        '--artifacts',
+        '--artifacts-json',
+      ]),
+    );
+
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+    expect(byLong.get('--input-file')?.description).toBe('Load inputs from YAML file (repeatable)');
+    expect(byLong.get('--input')?.description).toBe(
+      'Set input (repeatable, omit =value to inherit from env)',
+    );
+    expect(byLong.get('--input-json')?.description).toBe('Set input with JSON value (repeatable)');
+    expect(byLong.get('--artifacts')?.description).toBe(
+      'Supply an input artifact by rd:// URI (repeatable)',
+    );
+    expect(byLong.get('--artifacts-json')?.description).toBe(
+      'Supply input artifacts as a JSON array of rd:// URIs (repeatable)',
+    );
+
+    // The four repeatable input/artifact channels default to an empty array so
+    // their argParsers accumulate, and share the 'Input options:' help group.
+    for (const long of [
+      '--input-file',
+      '--input',
+      '--input-json',
+      '--artifacts',
+      '--artifacts-json',
+    ]) {
+      const opt = byLong.get(long) as { defaultValue?: unknown; helpGroupHeading?: string };
+      expect(opt.defaultValue).toEqual([]);
+      expect(opt.helpGroupHeading).toBe('Input options:');
+    }
+  });
+});
 
 describe('claim command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -1,18 +1,31 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { Command } from 'commander';
 import { activeFrame, buildFrameKey, buildCompletionKey, type FrameKey } from '@rundown-org/core';
+// Static import of the command module under test. The behavioural tests below
+// drive the command through `runCliInProcess`, which reaches it via a *dynamic*
+// `import('../cli.js')` — an edge Stryker's `enableFindRelatedTests` (Jest's
+// static inverse-module graph) cannot see. Without a static import here, a
+// per-mutant `jest --findRelatedTests src/commands/collect.ts` matches no test
+// file, so Stryker runs zero tests per mutant and every mutant falsely survives
+// (0.00% score). This static edge links the file into the graph so the covering
+// tests actually run against each mutant.
+import { registerCollectCommand } from '../../src/commands/collect.js';
 import {
   createTestWorkspace,
   createRunbook,
   runCliInProcess,
   getActiveState,
+  getAllStates,
+  readRunbookState,
   parseConcatenatedJson,
   findActionOutput,
   readSession,
   writeSession,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
+import type { RunbookState } from '@rundown-org/core';
 import { CollectResponseSchema } from '../../src/schemas/output-schemas.js';
 
 interface SubstepState {
@@ -130,6 +143,34 @@ async function markSubstepsResolved(
   raw.resolvedCompletions = resolvedCompletions;
   await writeFile(statePath, JSON.stringify(raw, null, 2));
 }
+
+describe('collect command wiring', () => {
+  it('registers the collect command with its documented flags and descriptions', () => {
+    const program = new Command();
+    registerCollectCommand(program);
+
+    const collect = program.commands.find((c) => c.name() === 'collect');
+    expect(collect).toBeDefined();
+    expect(collect?.description()).toBe(
+      'Collect delegation results and fire aggregation transition',
+    );
+
+    const byLong = new Map(collect!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(
+      expect.arrayContaining(['--step', '--index', '--claim-id', '--text']),
+    );
+
+    // Pin each option's help text so a mutated description string is killed.
+    expect(byLong.get('--step')?.description).toBe(
+      'Target specific DELEGATE step scope (e.g., "1" or "1.2")',
+    );
+    expect(byLong.get('--index')?.description).toBe(
+      'FOR loop iteration to target (requires --step on a FOR step)',
+    );
+    expect(byLong.get('--claim-id')?.description).toBe('Target a claimed delegated child runbook');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('collect command', () => {
   let workspace: TestWorkspace;
@@ -385,6 +426,16 @@ describe('collect command', () => {
         lifecycle: 'stopped',
       });
       expect(CollectResponseSchema.safeParse(parsed).success).toBe(true);
+
+      // `streamAppliedObservations` must forward the aggregation's terminal
+      // `RUNBOOK_STOPPED` observation onto the output stream as a
+      // `runbook_stopped` execution event. Asserting it appears pins the
+      // RUNBOOK_STOPPED case arm (a dropped/mislabelled case suppresses it).
+      const streamedTypes = parseConcatenatedJson(result.stdout)
+        .filter((v): v is Record<string, unknown> => typeof v === 'object' && v !== null)
+        .map((o) => o.type)
+        .filter((t): t is string => typeof t === 'string');
+      expect(streamedTypes).toContain('runbook_stopped');
     });
   });
 
@@ -732,6 +783,39 @@ describe('collect command', () => {
       expect(typeof parsed.unresolved).toBe('number');
       expect(CollectResponseSchema.safeParse(parsed).success).toBe(true);
     });
+
+    /**
+     * The `--text` rendering of the not-active outcome: it must report the
+     * requested vs active frame keys in the human-readable "Frame not active"
+     * message rather than the JSON payload.
+     */
+    it('reports a frame-not-active message in --text mode', async () => {
+      const runbookId = await setupReadyToCollect(['pass', 'pass']);
+
+      const statePath = join(workspace.statePath(), `${runbookId}.json`);
+      const raw = JSON.parse(await readFile(statePath, 'utf-8')) as MutableRunbookState;
+      const overrideFrame = buildFrameKey('1', 99);
+      if (raw.substepStates) {
+        raw.substepStates = raw.substepStates.map((ss) => ({ ...ss, frameKey: overrideFrame }));
+      }
+      await writeFile(statePath, JSON.stringify(raw, null, 2));
+
+      const result = await runCliInProcess(
+        ['collect', '--step', '1.1', '--index', '99', '--text'],
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const out = result.stdout + result.stderr;
+      // Pin the full not-active message so both interpolated frame keys (the
+      // requested override frame and the active cursor frame) are asserted and
+      // the "Frame not active: step S requested frame X but cursor is on Y."
+      // string literal is killed.
+      const activeFrameKey = (await getActiveState(workspace))!.activeFrameKey!;
+      expect(out).toContain(
+        `Frame not active: step 1 requested frame ${overrideFrame} but cursor is on ${activeFrameKey}.`,
+      );
+    });
   });
 
   describe('end-to-end CLI flow', () => {
@@ -931,15 +1015,35 @@ describe('collect command', () => {
       expect(result.exitCode).not.toBe(0);
       const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
       expect(json).toMatchObject({ kind: 'error', code: 'SUBSTEPS_NOT_RESOLVED' });
+      // Pin the exact human-readable message so the "Cannot collect: not all
+      // substeps are resolved. Pending: N." string literal is killed, and the
+      // pending substep (qualified id "1.2") is interpolated into it.
+      expect(String(json.error)).toBe(
+        'Cannot collect: not all substeps are resolved. Pending: 1.2.',
+      );
       const details = json.details as Record<string, unknown> | undefined;
-      expect(Array.isArray(details?.missingSubsteps)).toBe(true);
-      expect((details?.missingSubsteps as unknown[]).length).toBeGreaterThan(0);
+      expect(details?.missingSubsteps).toEqual(['1.2']);
     });
 
     it('errors when no active runbook', async () => {
-      const result = await runCliInProcess(['collect', '--text'], workspace);
+      const result = await runCliInProcess(['collect'], workspace);
 
-      expect(result.stdout + result.stderr).toMatch(/no active runbook/i);
+      // In JSON mode the no-active path renders as a warning envelope tagged with
+      // the command context ('collect') the OutputEmitter was constructed with —
+      // pinning both the emit and the 'collect' command literal.
+      const json = parseConcatenatedJson(result.stdout).find(
+        (o): o is Record<string, unknown> =>
+          typeof o === 'object' &&
+          o !== null &&
+          (o as { code?: string }).code === 'NO_ACTIVE_RUNBOOK',
+      );
+      expect(json).toBeDefined();
+      expect(json).toMatchObject({
+        kind: 'warning',
+        command: 'collect',
+        code: 'NO_ACTIVE_RUNBOOK',
+      });
+      expect(String(json!.message)).toMatch(/no active runbook/i);
     });
   });
 
@@ -989,6 +1093,361 @@ describe('collect command', () => {
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stdout + result.stderr).toMatch(/invalid --step value/i);
+    });
+
+    /**
+     * `resolveCollectScope` forwards `--index` through `resolveIndexOption`,
+     * which rejects a non-positive-integer value with an `IndexOptionError`.
+     * The scope resolver must catch that typed error, emit its `INVALID_SYNTAX`
+     * envelope, and abort with a non-zero exit — never rethrow or fall through
+     * to scope derivation.
+     */
+    it('errors with INVALID_SYNTAX on a non-integer --index value', async () => {
+      await setupReadyToCollect(['pass', 'pass']);
+
+      const result = await runCliInProcess(
+        ['collect', '--step', '1.1', '--index', 'abc'],
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
+      expect(json).toMatchObject({ kind: 'error', code: 'INVALID_SYNTAX' });
+      expect(String(json.error)).toMatch(/invalid --index value/i);
+    });
+  });
+
+  describe('applied text output', () => {
+    /**
+     * Cover the human-readable `renderAppliedOutcome` branch: a bare
+     * `rd collect --text` on a successful PASS ALL aggregation prints the
+     * "Collected N delegation outcome(s) on step S" summary (applied 2,
+     * unresolved 0, lifecycle running) instead of the JSON envelope.
+     */
+    it('prints the collected-N summary line on a successful --text collect', async () => {
+      await setupReadyToCollect(['pass', 'pass']);
+
+      const result = await runCliInProcess(['collect', '--text'], workspace);
+      expect(result.exitCode).toBe(0);
+
+      const out = result.stdout + result.stderr;
+      // Pin the full summary string so the "Collected N delegation outcome(s) on
+      // step S (M unresolved; lifecycle L)." literal and all interpolated values
+      // are killed together.
+      expect(out).toContain(
+        'Collected 2 delegation outcome(s) on step 1 (0 unresolved; lifecycle running).',
+      );
+    });
+  });
+
+  describe('collect advances into an inline stage', () => {
+    // Stage 1 is DELEGATE'd to a worker; stages 2 and 3 are INLINE-composed gate
+    // children. When `rd collect` applies the delegated stage-1 outcome it drives
+    // the parent PASS ALL -> CONTINUE into the inline stage-2 gate, which runs the
+    // execution loop (advancesIntoLoop) to launch + activate the inline child and
+    // streams its execution events through the shared emitter before the trailing
+    // collect action object.
+    const PIPELINE = [
+      '# Pipeline',
+      '',
+      '## 1. Plan',
+      '',
+      '- DELEGATE',
+      '- PASS ALL CONTINUE',
+      '- FAIL ANY STOP',
+      '',
+      '### 1.1 Write plan',
+      '',
+      '- DELEGATE',
+      '- worker.runbook.md',
+      '',
+      '## 2. Review',
+      '',
+      '- PASS ALL CONTINUE',
+      '- FAIL ANY STOP',
+      '- gate.runbook.md',
+      '',
+      '## 3. Execute',
+      '',
+      '- PASS ALL COMPLETE',
+      '- FAIL ANY STOP',
+      '- gate.runbook.md',
+      '',
+    ].join('\n');
+
+    const WORKER = [
+      '# Worker',
+      '',
+      '## 1. Do work',
+      '',
+      '- PASS COMPLETE',
+      '- FAIL STOP',
+      '',
+      'Do the delegated work.',
+      '',
+    ].join('\n');
+    const GATE = [
+      '# Gate',
+      '',
+      '## 1. Check',
+      '',
+      '- PASS COMPLETE',
+      '- FAIL STOP',
+      '',
+      'Check the gate.',
+      '',
+    ].join('\n');
+
+    function findInlineChild(
+      states: RunbookState[],
+      parentRunId: string,
+    ): RunbookState | undefined {
+      return states.find((s) => {
+        const link = s.parentLinkage;
+        return link?.kind === 'inline' && link.parentRunId === parentRunId;
+      });
+    }
+
+    async function driveToPendingCollect(): Promise<string> {
+      await writeFile(join(workspace.runbooksDir(), 'pipeline.runbook.md'), PIPELINE);
+      await writeFile(join(workspace.runbooksDir(), 'worker.runbook.md'), WORKER);
+      await writeFile(join(workspace.runbooksDir(), 'gate.runbook.md'), GATE);
+
+      const start = await runCliInProcess('run --prompted pipeline.runbook.md', workspace);
+      expect(start.exitCode).toBe(0);
+
+      const parent = await getActiveState(workspace);
+      expect(parent).not.toBeNull();
+      const parentRunId = parent!.id;
+      const token = parent!.substepStates!.find((s) => s.delegation?.token)!.delegation!.token!;
+
+      // Claim + explicitly close the delegated worker -> reports the outcome.
+      const claim = await runCliInProcess(`claim ${token}`, workspace);
+      expect(claim.exitCode).toBe(0);
+      const claimId = String(findActionOutput(claim.stdout)!.claim_id);
+      const closed = await runCliInProcess(['complete', '--claim-id', claimId], workspace);
+      expect(closed.exitCode).toBe(0);
+
+      return parentRunId;
+    }
+
+    it('runs the execution loop to launch + activate the inline child, then emits the applied object last', async () => {
+      const parentRunId = await driveToPendingCollect();
+
+      const collected = await runCliInProcess('collect', workspace);
+      expect(collected.exitCode).toBe(0);
+
+      // The parent advanced into stage 2 (the inline gate stage) and is running.
+      const parentAfter = await readRunbookState(workspace, parentRunId);
+      expect(parentAfter!.step).toBe('2');
+      expect(parentAfter!.lifecycle).toBe('running');
+
+      // The execution loop launched the inline gate child and made it active.
+      const states = await getAllStates(workspace);
+      const inlineChild = findInlineChild(states, parentRunId);
+      expect(inlineChild).toBeDefined();
+      const active = await getActiveState(workspace);
+      expect(active!.id).toBe(inlineChild!.id);
+
+      // Streamed execution events precede the trailing applied collect object.
+      const objects = parseConcatenatedJson(collected.stdout).filter(
+        (v): v is Record<string, unknown> => typeof v === 'object' && v !== null,
+      );
+      expect(objects.length).toBeGreaterThan(1);
+      const last = objects.at(-1)!;
+      expect(last).toMatchObject({ kind: 'collect', action: 'collect', status: 'applied' });
+      // The applied object is the ONLY collect object and it is strictly last.
+      const collectIndices = objects
+        .map((object, index) => ({ object, index }))
+        .filter(({ object }) => object.kind === 'collect')
+        .map(({ index }) => index);
+      expect(collectIndices).toEqual([objects.length - 1]);
+      // At least one streamed execution event (step_entered / runbook_started)
+      // landed before the applied object.
+      const eventCount = objects.filter((o) => typeof o.type === 'string').length;
+      expect(eventCount).toBeGreaterThan(0);
+
+      // The aggregation's `STEP_TRANSITIONED` observation (stage 1 -> stage 2)
+      // must be forwarded by `streamAppliedObservations` as a `step_transitioned`
+      // event — pinning that case arm against a drop/mislabel mutation.
+      const streamedTypes = objects
+        .map((o) => o.type)
+        .filter((t): t is string => typeof t === 'string');
+      expect(streamedTypes).toContain('step_transitioned');
+    }, 30_000);
+
+    // A `collect` that drives the collected run itself to a terminal lifecycle
+    // must propagate that terminal outcome to its parent. Here the inline gate
+    // child G is ITSELF a delegating runbook whose DELEGATE step is `PASS ALL
+    // COMPLETE`: collecting G's reported outcome completes G, and because G was
+    // launched as an INLINE child of the pipeline P, the terminal-propagation
+    // pass resolves P's stage-2 composite substep (inline branch) and advances P.
+    const COLLECTING_PIPELINE = [
+      '# Collecting Pipeline',
+      '',
+      '## 1. Plan',
+      '',
+      '- DELEGATE',
+      '- PASS ALL CONTINUE',
+      '- FAIL ANY STOP',
+      '',
+      '### 1.1 Write plan',
+      '',
+      '- DELEGATE',
+      '- worker.runbook.md',
+      '',
+      '## 2. Review',
+      '',
+      '- PASS ALL COMPLETE',
+      '- FAIL ANY STOP',
+      '- collecting-gate.runbook.md',
+      '',
+    ].join('\n');
+
+    const COLLECTING_GATE = [
+      '# Collecting Gate',
+      '',
+      '## 1. Delegate check',
+      '',
+      '- DELEGATE',
+      '- PASS ALL COMPLETE',
+      '- FAIL ANY STOP',
+      '',
+      '### 1.1 Check',
+      '',
+      '- DELEGATE',
+      '- worker.runbook.md',
+      '',
+    ].join('\n');
+
+    /**
+     * Claim the sole auto-issued delegation token of the active run and report
+     * its terminal result. `result: 'pass'` closes via `complete`; `'fail'` via
+     * `fail`, which lets the collecting run's FAIL ANY aggregation STOP it.
+     */
+    async function claimAndReportActiveDelegation(result: 'pass' | 'fail' = 'pass'): Promise<void> {
+      const active = await getActiveState(workspace);
+      const token = active!.substepStates!.find((s) => s.delegation?.token)!.delegation!.token!;
+      const claim = await runCliInProcess(`claim ${token}`, workspace);
+      expect(claim.exitCode).toBe(0);
+      const claimId = String(findActionOutput(claim.stdout)!.claim_id);
+      const cmd = result === 'pass' ? 'complete' : 'fail';
+      const closed = await runCliInProcess([cmd, '--claim-id', claimId], workspace);
+      // A reported pass records cleanly (exit 0); a reported fail may surface a
+      // non-zero exit when the child's own FAIL handler stops it — either way the
+      // outcome is recorded, which is what the collecting run later drains.
+      if (result === 'pass') expect(closed.exitCode).toBe(0);
+    }
+
+    it('propagates a collected inline child terminal to its parent (inline linkage)', async () => {
+      await writeFile(join(workspace.runbooksDir(), 'pipeline.runbook.md'), COLLECTING_PIPELINE);
+      await writeFile(join(workspace.runbooksDir(), 'worker.runbook.md'), WORKER);
+      await writeFile(join(workspace.runbooksDir(), 'collecting-gate.runbook.md'), COLLECTING_GATE);
+
+      const start = await runCliInProcess('run --prompted pipeline.runbook.md', workspace);
+      expect(start.exitCode).toBe(0);
+      const parentRunId = (await getActiveState(workspace))!.id;
+
+      // Stage 1: report + collect -> parent CONTINUEs into the inline gate child.
+      await claimAndReportActiveDelegation();
+      const collect1 = await runCliInProcess('collect', workspace);
+      expect(collect1.exitCode).toBe(0);
+
+      // The inline gate child G is now the active run (its own DELEGATE step).
+      const gate = await getActiveState(workspace);
+      expect(gate!.id).not.toBe(parentRunId);
+      expect(gate!.parentLinkage?.kind).toBe('inline');
+
+      // Report G's delegated worker, then collect on G. G's `PASS ALL COMPLETE`
+      // drives G terminal (completed); the collect command's terminal-propagation
+      // pass then resolves the parent's stage-2 substep and completes the parent.
+      await claimAndReportActiveDelegation();
+      const collect2 = await runCliInProcess('collect', workspace);
+      expect(collect2.exitCode).toBe(0);
+
+      const gateAfter = await readRunbookState(workspace, gate!.id);
+      expect(gateAfter!.lifecycle).toBe('completed');
+
+      // Inline propagation advanced the parent to its terminal completed state.
+      const parentAfter = await readRunbookState(workspace, parentRunId);
+      expect(parentAfter!.lifecycle).toBe('completed');
+
+      // The final JSON object is still the applied collect action object.
+      const objects = parseConcatenatedJson(collect2.stdout).filter(
+        (v): v is Record<string, unknown> => typeof v === 'object' && v !== null,
+      );
+      expect(objects.at(-1)).toMatchObject({
+        kind: 'collect',
+        action: 'collect',
+        status: 'applied',
+      });
+
+      // Completing the gate child streams a `runbook_completed` observation via
+      // `streamAppliedObservations` — pinning the RUNBOOK_COMPLETED case arm.
+      const streamedTypes = objects
+        .map((o) => o.type)
+        .filter((t): t is string => typeof t === 'string');
+      expect(streamedTypes).toContain('runbook_completed');
+    }, 40_000);
+
+    it('propagates a STOPPED inline child terminal to the parent and exits non-zero', async () => {
+      await writeFile(join(workspace.runbooksDir(), 'pipeline.runbook.md'), COLLECTING_PIPELINE);
+      await writeFile(join(workspace.runbooksDir(), 'worker.runbook.md'), WORKER);
+      await writeFile(join(workspace.runbooksDir(), 'collecting-gate.runbook.md'), COLLECTING_GATE);
+
+      const start = await runCliInProcess('run --prompted pipeline.runbook.md', workspace);
+      expect(start.exitCode).toBe(0);
+      const parentRunId = (await getActiveState(workspace))!.id;
+
+      // Stage 1 passes -> parent CONTINUEs into the inline gate child G.
+      await claimAndReportActiveDelegation('pass');
+      expect((await runCliInProcess('collect', workspace)).exitCode).toBe(0);
+      const gate = await getActiveState(workspace);
+      expect(gate!.parentLinkage?.kind).toBe('inline');
+
+      // FAIL G's delegated worker, then collect on G. G's `FAIL ANY STOP`
+      // aggregation drives G to a STOPPED terminal; the terminal-propagation pass
+      // then propagates that stop to the parent and the command exits non-zero.
+      await claimAndReportActiveDelegation('fail');
+      const collectStop = await runCliInProcess('collect', workspace);
+      expect(collectStop.exitCode).not.toBe(0);
+
+      const gateAfter = await readRunbookState(workspace, gate!.id);
+      expect(gateAfter!.lifecycle).toBe('stopped');
+      const parentAfter = await readRunbookState(workspace, parentRunId);
+      expect(parentAfter!.lifecycle).toBe('stopped');
+
+      // The applied action object is still the last JSON object on the stop path.
+      const objects = parseConcatenatedJson(collectStop.stdout).filter(
+        (v): v is Record<string, unknown> => typeof v === 'object' && v !== null,
+      );
+      expect(objects.at(-1)).toMatchObject({
+        kind: 'collect',
+        action: 'collect',
+        status: 'applied',
+        lifecycle: 'stopped',
+      });
+    }, 40_000);
+  });
+
+  describe('claim-id validation', () => {
+    /**
+     * An invalid `--claim-id` must be rejected by `parseClaimIdOption` before any
+     * transition context is built: the command emits the claim-id validation
+     * error and bails (the `if (!claimTarget.ok) return` guard).
+     */
+    it('rejects a malformed --claim-id', async () => {
+      await setupReadyToCollect(['pass', 'pass']);
+
+      const result = await runCliInProcess(['collect', '--claim-id', 'not-a-claim-id'], workspace);
+
+      const json = parseConcatenatedJson(result.stdout).find(
+        (o): o is Record<string, unknown> =>
+          typeof o === 'object' && o !== null && (o as { kind?: string }).kind === 'error',
+      );
+      expect(json).toBeDefined();
+      // The active runbook must NOT have advanced — the guard returned early.
+      expect((await getActiveState(workspace))?.step).toBe('1');
     });
   });
 });

--- a/packages/cli/__tests__/commands/command-test-mutation-linkage.test.ts
+++ b/packages/cli/__tests__/commands/command-test-mutation-linkage.test.ts
@@ -96,9 +96,20 @@ function testFiles(): string[] {
     .sort();
 }
 
+/**
+ * Registrable command modules under `src/commands` — i.e. files that export a
+ * `register<Name>Command` symbol (the Commander subcommand registrar). Shared
+ * helpers or type-only files that might live under `src/commands` are excluded
+ * so the orphaned-module check holds *commands* — not arbitrary source files —
+ * to the per-command test-home rule.
+ */
 function commandModules(): string[] {
   return readdirSync(commandsSrcDir)
     .filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
+    .filter((f) => {
+      const src = readFileSync(path.join(commandsSrcDir, f), 'utf-8');
+      return /export\s+function\s+register[A-Za-z0-9]*Command\b/.test(src);
+    })
     .map((f) => f.replace(/\.ts$/, ''))
     .sort();
 }

--- a/packages/cli/__tests__/commands/command-test-mutation-linkage.test.ts
+++ b/packages/cli/__tests__/commands/command-test-mutation-linkage.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from '@jest/globals';
+import { readdirSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Regression guard for the Stryker "static-import linkage" fix.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * CLI Stryker runs with `jest.enableFindRelatedTests: true`. Per mutant it asks
+ * Jest `--findRelatedTests src/commands/<x>.ts`, which resolves covering test
+ * files through Jest's STATIC import graph. Every command test drives the CLI
+ * through `runCliInProcess`, whose runner loads commands via a DYNAMIC
+ * `await import('../cli.js')` — an edge the static graph cannot see. Without a
+ * STATIC import of the command module in its own test file, `--findRelatedTests`
+ * matches nothing, Stryker runs ZERO tests per mutant, and the file scores ~0%:
+ * a measurement gap, not a real test-quality signal.
+ *
+ * The fix (see collect.test.ts / delegate.test.ts and the `* command wiring`
+ * blocks across the per-command test files) is a single static import of the
+ * command module in each per-command test file. This guard fails if any
+ * per-command test file loses that static edge, or if a NEW command module is
+ * added without a per-command test home wired the same way.
+ *
+ * WHY A GUARD TEST (not an eslint rule)
+ * -------------------------------------
+ * This mirrors the repo's existing structural content-guard tests (e.g.
+ * `packages/claude-code-plugin/__tests__/content/json-default-output.test.ts`).
+ * A guard test is lower friction than a bespoke eslint `no-restricted-syntax`
+ * rule, needs no rule wiring, and documents its command→module mapping and
+ * intentional exclusions inline where reviewers will see them.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const commandsTestDir = __dirname;
+const commandsSrcDir = path.join(__dirname, '..', '..', 'src', 'commands');
+
+/**
+ * Per-command test file → the command source module(s) it must statically
+ * import so Stryker's `--findRelatedTests` credits its behavioural tests.
+ *
+ * A test file may map to multiple modules when it is the shared home for
+ * sibling commands (e.g. `stash-pop.test.ts` owns both `stash` and `pop`).
+ */
+const COMMAND_TEST_MODULE_MAP: Readonly<Record<string, readonly string[]>> = {
+  'abort.test.ts': ['abort'],
+  'artifact.test.ts': ['artifact'],
+  'claim.test.ts': ['claim'],
+  'collect.test.ts': ['collect'],
+  'complete.test.ts': ['complete'],
+  'delegate.test.ts': ['delegate'],
+  'echo.test.ts': ['echo'],
+  'fail.test.ts': ['fail'],
+  'goto.test.ts': ['goto'],
+  'ls.test.ts': ['ls'],
+  'pass.test.ts': ['pass'],
+  'prune.test.ts': ['prune'],
+  'resolve.test.ts': ['resolve'],
+  'run.test.ts': ['run'],
+  'scenario-suite.test.ts': ['scenario-suite'],
+  'scenarios.test.ts': ['scenarios'],
+  'stash-pop.test.ts': ['stash', 'pop'],
+  'status.test.ts': ['status'],
+  'stop.test.ts': ['stop'],
+};
+
+/**
+ * Cross-cutting test files that are NOT per-command homes: they exercise
+ * behaviour that spans commands (JSON envelope shape, output formatting, schema
+ * validation, terminal boundaries, run flag surfaces) rather than owning a
+ * single command's mutation coverage. They are intentionally exempt from the
+ * static-import requirement.
+ */
+const CROSS_CUTTING_TEST_FILES: ReadonlySet<string> = new Set([
+  'command-test-mutation-linkage.test.ts', // this guard
+  'forced-terminal-boundary.test.ts',
+  'json-output.test.ts',
+  'output-format.test.ts',
+  'run-prompted.test.ts',
+  'run-variables.test.ts',
+  'schema-validation.test.ts',
+]);
+
+/**
+ * Command source modules that have NO dedicated per-command test home, so no
+ * static-import edge can be added for them. Tracked as a residual mutation-gate
+ * gap rather than silently ignored: when one of these gains a per-command test
+ * file, add it to COMMAND_TEST_MODULE_MAP and drop it here.
+ */
+const UNHOMED_COMMAND_MODULES: ReadonlySet<string> = new Set(['check', 'prompt']);
+
+function testFiles(): string[] {
+  return readdirSync(commandsTestDir)
+    .filter((f) => f.endsWith('.test.ts'))
+    .sort();
+}
+
+function commandModules(): string[] {
+  return readdirSync(commandsSrcDir)
+    .filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
+    .map((f) => f.replace(/\.ts$/, ''))
+    .sort();
+}
+
+function staticImportsModule(testFile: string, moduleName: string): boolean {
+  const source = readFileSync(path.join(commandsTestDir, testFile), 'utf-8');
+  // Match a top-level `import ... from '../../src/commands/<module>.js'`. Any
+  // static import of the module (register fn, helper, or type) creates the edge
+  // Stryker needs; the linkage does not depend on WHICH symbol is imported.
+  const pattern = new RegExp(String.raw`from\s+['"]\.\./\.\./src/commands/${moduleName}\.js['"]`);
+  return pattern.test(source);
+}
+
+describe('command-test mutation linkage guard', () => {
+  it('every mapped per-command test file statically imports its command module(s)', () => {
+    const failures: string[] = [];
+    for (const [testFile, modules] of Object.entries(COMMAND_TEST_MODULE_MAP)) {
+      for (const moduleName of modules) {
+        if (!staticImportsModule(testFile, moduleName)) {
+          failures.push(
+            `${testFile} must statically import '../../src/commands/${moduleName}.js' ` +
+              `(Stryker --findRelatedTests linkage). See collect.test.ts for the pattern.`,
+          );
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it('every per-command test file is either mapped or an intentional cross-cutting exclusion', () => {
+    const unclassified = testFiles().filter(
+      (f) => !(f in COMMAND_TEST_MODULE_MAP) && !CROSS_CUTTING_TEST_FILES.has(f),
+    );
+    expect(unclassified).toEqual([]);
+  });
+
+  it('every mapped command module exists in src/commands', () => {
+    const known = new Set(commandModules());
+    const missing: string[] = [];
+    for (const modules of Object.values(COMMAND_TEST_MODULE_MAP)) {
+      for (const moduleName of modules) {
+        if (!known.has(moduleName)) missing.push(moduleName);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('every command module either has a test home or is a tracked residual gap', () => {
+    const homed = new Set(Object.values(COMMAND_TEST_MODULE_MAP).flat());
+    const orphaned = commandModules().filter(
+      (m) => !homed.has(m) && !UNHOMED_COMMAND_MODULES.has(m),
+    );
+    // A new command with a dedicated test file must be wired into
+    // COMMAND_TEST_MODULE_MAP; one without a test home must be added to
+    // UNHOMED_COMMAND_MODULES (and ideally given a test home) — otherwise it
+    // silently regresses to a ~0% mutation score.
+    expect(orphaned).toEqual([]);
+  });
+
+  it('all cross-cutting exclusions and residual-gap modules still exist', () => {
+    const files = new Set(testFiles());
+    for (const f of CROSS_CUTTING_TEST_FILES) {
+      expect(files.has(f)).toBe(true);
+    }
+    const modules = new Set(commandModules());
+    for (const m of UNHOMED_COMMAND_MODULES) {
+      expect(modules.has(m)).toBe(true);
+    }
+  });
+});

--- a/packages/cli/__tests__/commands/complete.test.ts
+++ b/packages/cli/__tests__/commands/complete.test.ts
@@ -12,10 +12,34 @@ import {
   parseConcatenatedJson,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/complete.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerCompleteCommand } from '../../src/commands/complete.js';
 
 interface ClaimOutput extends Record<string, unknown> {
   claim_id: string;
 }
+
+describe('complete command wiring', () => {
+  it('registers the complete command with its documented flags and descriptions', () => {
+    const program = new Command();
+    registerCompleteCommand(program);
+
+    const complete = program.commands.find((c) => c.name() === 'complete');
+    expect(complete).toBeDefined();
+    expect(complete?.description()).toBe(
+      'Force early completion of current runbook (runbooks auto-complete on final step)',
+    );
+
+    const byLong = new Map(complete!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(expect.arrayContaining(['--claim-id', '--text']));
+    expect(byLong.get('--claim-id')?.description).toBe('Target a claimed delegated child runbook');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('complete command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { buildFrameKey, DelegateResponseSchema, ErrorResponseSchema } from '@rundown-org/core';
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { Command } from 'commander';
 import {
   createTestWorkspace,
   injectDelegationOutcomeForActiveRun,
@@ -10,7 +11,94 @@ import {
   type TestWorkspace,
   createRunbook,
   parseCliJsonObject,
+  parseConcatenatedJson,
 } from '../helpers/test-utils.js';
+
+/**
+ * Locate the `{ kind: 'error' }` envelope among the (possibly concatenated)
+ * JSON objects a command emits — the fresh-issue path can prepend execution
+ * events before the error object, so a single `JSON.parse` is not safe.
+ */
+function findErrorEnvelope(stdout: string): Record<string, unknown> | undefined {
+  return parseConcatenatedJson(stdout).find(
+    (o): o is Record<string, unknown> =>
+      typeof o === 'object' && o !== null && (o as { kind?: string }).kind === 'error',
+  );
+}
+// Static import of the command module under test. The behavioural tests below
+// drive the command through `runCliInProcess`, which reaches it via a *dynamic*
+// `import('../cli.js')` — an edge Stryker's `enableFindRelatedTests` (Jest's
+// static inverse-module graph) cannot see. Without a static import here, a
+// per-mutant `jest --findRelatedTests src/commands/delegate.ts` matches no test
+// file, so Stryker runs zero tests per mutant and every mutant falsely survives
+// (0.00% score). This static edge links the file into the graph so the covering
+// tests actually run against each mutant.
+import { registerDelegateCommand } from '../../src/commands/delegate.js';
+
+describe('delegate command wiring', () => {
+  it('registers the delegate command with its documented flags, descriptions, and defaults', () => {
+    const program = new Command();
+    registerDelegateCommand(program);
+
+    const delegate = program.commands.find((c) => c.name() === 'delegate');
+    expect(delegate).toBeDefined();
+    expect(delegate?.description()).toBe('Create a delegation token for a child runbook');
+
+    const byLong = new Map(delegate!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(
+      expect.arrayContaining([
+        '--step',
+        '--index',
+        '--retry',
+        '--input',
+        '--input-json',
+        '--input-file',
+        '--artifacts',
+        '--artifacts-json',
+        '--text',
+      ]),
+    );
+
+    // Pin each option's help text so a mutated description string is killed.
+    expect(byLong.get('--step')?.description).toBe(
+      'Step to delegate (e.g., 1.1 or 1.2.1 for step.iteration.substep)',
+    );
+    expect(byLong.get('--index')?.description).toBe(
+      'FOR loop iteration to target (requires --step)',
+    );
+    expect(byLong.get('--retry')?.description).toBe(
+      'Retry an existing delegation: cancel and re-issue with a fresh token',
+    );
+    expect(byLong.get('--input')?.description).toBe(
+      'Set input for child context (repeatable, omit =value to inherit from env)',
+    );
+    expect(byLong.get('--input-json')?.description).toBe('Set input with JSON value (repeatable)');
+    expect(byLong.get('--input-file')?.description).toBe('Load inputs from YAML file (repeatable)');
+    expect(byLong.get('--artifacts')?.description).toBe(
+      'Supply an input artifact by rd:// URI (repeatable)',
+    );
+    expect(byLong.get('--artifacts-json')?.description).toBe(
+      'Supply input artifacts as a JSON array of rd:// URIs (repeatable)',
+    );
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+
+    // The five repeatable input/artifact channels default to an empty array so
+    // the argParsers accumulate; pin the default so a mutated `.default([])` dies.
+    // They also share the 'Input options:' help group; pin that so a mutated
+    // `.helpGroup(...)` heading is killed.
+    for (const long of [
+      '--input',
+      '--input-json',
+      '--input-file',
+      '--artifacts',
+      '--artifacts-json',
+    ]) {
+      const opt = byLong.get(long) as { defaultValue?: unknown; helpGroupHeading?: string };
+      expect(opt.defaultValue).toEqual([]);
+      expect(opt.helpGroupHeading).toBe('Input options:');
+    }
+  });
+});
 
 describe('delegate command', () => {
   let workspace: TestWorkspace;
@@ -1058,6 +1146,36 @@ describe('delegate command', () => {
       expect(retryOutput.step).toBe('1.1');
     });
 
+    it('token form --text: renders the RETRIED / Token / RD_CLAIM_TOKEN lines', async () => {
+      await setupDelegation();
+
+      const first = await runCliInProcess(
+        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        workspace,
+      );
+      expect(first.exitCode).toBe(0);
+      const originalToken = (JSON.parse(first.stdout) as Record<string, unknown>).token as string;
+
+      const retry = await runCliInProcess(
+        ['delegate', '--retry', originalToken, '--text'],
+        workspace,
+      );
+
+      expect(retry.exitCode).toBe(0);
+      // Human-readable retry envelope (the else-branch of the `retried` arm).
+      expect(retry.stdout).toMatch(/RETRIED\s+step 1\.1 -> .*child\.runbook\.md/);
+      expect(retry.stdout).toMatch(/Token:\s+rdtk_/);
+      // The fresh token is echoed both as the summary Token line and as the
+      // machine-consumable RD_CLAIM_TOKEN export line, and differs from the old.
+      const claimTokenLine = retry.stdout
+        .split('\n')
+        .find((line) => line.startsWith('RD_CLAIM_TOKEN='));
+      expect(claimTokenLine).toBeDefined();
+      const mintedToken = claimTokenLine!.slice('RD_CLAIM_TOKEN='.length).trim();
+      expect(mintedToken.startsWith('rdtk_')).toBe(true);
+      expect(mintedToken).not.toBe(originalToken);
+    });
+
     it('--step form: resolves active-frame substep and retries', async () => {
       await setupDelegation();
 
@@ -1357,7 +1475,55 @@ describe('delegate command', () => {
       );
 
       expect(retry.exitCode).not.toBe(0);
-      expect(retry.stdout + retry.stderr).toMatch(/--index requires step .* to be a FOR step/);
+      // Pin the full assertForStep message via the parsed JSON error field: it
+      // names the target step ("1") and its actual kind ("substeps"), so a
+      // mutated step name / kind interpolation is caught, not only the prefix.
+      expect(findErrorEnvelope(retry.stdout || retry.stderr)).toEqual(
+        expect.objectContaining({
+          kind: 'error',
+          code: 'INVALID_INDEX',
+          error: '--index requires step "1" to be a FOR step, but it is "substeps"',
+        }),
+      );
+    });
+
+    it('rejects a non-token runbook positional on the --retry path', async () => {
+      // `--retry <runbook.md>` (a positional that is NOT a delegation token, with
+      // no --step) is a misuse: the guard `runbookArg && !tokenArg` rejects it
+      // with the "does not accept a runbook positional" INVALID_SYNTAX envelope.
+      await setupDelegation();
+
+      const retry = await runCliInProcess(
+        ['delegate', '--retry', 'runbooks/child.runbook.md'],
+        workspace,
+      );
+
+      expect(retry.exitCode).not.toBe(0);
+      const combined = retry.stdout + retry.stderr;
+      expect(combined).toContain('INVALID_SYNTAX');
+      expect(combined).toMatch(/--retry does not accept a runbook positional/);
+      expect(combined).toContain('runbooks/child.runbook.md');
+    });
+
+    it('rejects --index on a non-FOR step on the FRESH issue path too', async () => {
+      // The fresh-issue path has its own assertForStep guard (independent of
+      // --retry). substeps.runbook.md step 1 is kind 'substeps', so a fresh
+      // `delegate --step 1.1 --index 2` must be rejected with INVALID_INDEX.
+      await setupDelegation();
+
+      const result = await runCliInProcess(
+        ['delegate', '--step', '1.1', '--index', '2'],
+        workspace,
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      expect(findErrorEnvelope(result.stdout || result.stderr)).toEqual(
+        expect.objectContaining({
+          kind: 'error',
+          code: 'INVALID_INDEX',
+          error: '--index requires step "1" to be a FOR step, but it is "substeps"',
+        }),
+      );
     });
 
     it('FOR-iteration: --step with --index targets the right frame', async () => {

--- a/packages/cli/__tests__/commands/echo.test.ts
+++ b/packages/cli/__tests__/commands/echo.test.ts
@@ -1,5 +1,30 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { Command } from 'commander';
 import { createTestWorkspace, runCliInProcess, type TestWorkspace } from '../helpers/test-utils.js';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/echo.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerEchoCommand } from '../../src/commands/echo.js';
+
+describe('echo command wiring', () => {
+  it('registers the echo command with its documented flags, descriptions, and defaults', () => {
+    const program = new Command();
+    registerEchoCommand(program);
+
+    const echo = program.commands.find((c) => c.name() === 'echo');
+    expect(echo).toBeDefined();
+    expect(echo?.description()).toBe('Echo command for runbook testing');
+
+    const byLong = new Map(echo!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(expect.arrayContaining(['--result', '--text']));
+    expect(byLong.get('--result')?.description).toBe('Add result to sequence (pass|fail)');
+    expect(byLong.get('--result')?.short).toBe('-r');
+    // `--result` accumulates into an array via its collect argParser; pin the default.
+    expect((byLong.get('--result') as { defaultValue?: unknown }).defaultValue).toEqual([]);
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('echo command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -13,6 +13,35 @@ import {
   type TestWorkspace,
 } from '../helpers/test-utils.js';
 import { ActionResponseSchema, WarningResponseSchema } from '../helpers/schema-validator.js';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/fail.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerFailCommand } from '../../src/commands/fail.js';
+
+describe('fail command wiring', () => {
+  it('registers the fail command with its aliases, flags, and descriptions', () => {
+    const program = new Command();
+    registerFailCommand(program);
+
+    const fail = program.commands.find((c) => c.name() === 'fail');
+    expect(fail).toBeDefined();
+    expect(fail?.description()).toBe('Mark current step as failed (triggers FAIL transition)');
+    expect(fail?.aliases()).toEqual(['no']);
+
+    const byLong = new Map(fail!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(
+      expect.arrayContaining(['--step', '--index', '--claim-id', '--text']),
+    );
+    expect(byLong.get('--step')?.description).toBe('Target specific substep');
+    expect(byLong.get('--index')?.description).toBe(
+      'FOR loop iteration to target (requires --step)',
+    );
+    expect(byLong.get('--claim-id')?.description).toBe('Target a claimed delegated child runbook');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('fail command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/goto.test.ts
+++ b/packages/cli/__tests__/commands/goto.test.ts
@@ -5,6 +5,29 @@ import {
   getActiveState,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/goto.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerGotoCommand } from '../../src/commands/goto.js';
+
+describe('goto command wiring', () => {
+  it('registers the goto command with its documented flags and descriptions', () => {
+    const program = new Command();
+    registerGotoCommand(program);
+
+    const goto = program.commands.find((c) => c.name() === 'goto');
+    expect(goto).toBeDefined();
+    expect(goto?.description()).toBe('Jump to specific step (e.g., "3" or "3.1" for substep)');
+
+    const byLong = new Map(goto!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(expect.arrayContaining(['--index', '--claim-id', '--text']));
+    expect(byLong.get('--index')?.description).toBe('FOR loop iteration to target');
+    expect(byLong.get('--claim-id')?.description).toBe('Target a claimed delegated child runbook');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('goto command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/ls.test.ts
+++ b/packages/cli/__tests__/commands/ls.test.ts
@@ -3,7 +3,33 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { Command } from 'commander';
 import { createTestWorkspace, runCliInProcess } from '../helpers/test-utils.js';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/ls.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerLsCommand } from '../../src/commands/ls.js';
+
+describe('ls command wiring', () => {
+  it('registers the ls command with its documented flags and descriptions', () => {
+    const program = new Command();
+    registerLsCommand(program);
+
+    const ls = program.commands.find((c) => c.name() === 'ls');
+    expect(ls).toBeDefined();
+    expect(ls?.description()).toBe('List runbooks (active by default, --all for available)');
+
+    const byLong = new Map(ls!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(expect.arrayContaining(['--all', '--text', '--tags']));
+    expect(byLong.get('--all')?.description).toBe('List all available runbook files');
+    expect(byLong.get('--all')?.short).toBe('-a');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+    expect(byLong.get('--tags')?.description).toBe(
+      'Filter available runbooks by comma-separated tags',
+    );
+  });
+});
 
 describe('rd ls', () => {
   let workspace: Awaited<ReturnType<typeof createTestWorkspace>>;

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -14,6 +14,35 @@ import {
   type TestWorkspace,
 } from '../helpers/test-utils.js';
 import { ActionResponseSchema } from '../helpers/schema-validator.js';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/pass.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerPassCommand } from '../../src/commands/pass.js';
+
+describe('pass command wiring', () => {
+  it('registers the pass command with its aliases, flags, and descriptions', () => {
+    const program = new Command();
+    registerPassCommand(program);
+
+    const pass = program.commands.find((c) => c.name() === 'pass');
+    expect(pass).toBeDefined();
+    expect(pass?.description()).toBe('Mark current step as passed (triggers PASS transition)');
+    expect(pass?.aliases()).toEqual(['yes', 'ok']);
+
+    const byLong = new Map(pass!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(
+      expect.arrayContaining(['--step', '--index', '--claim-id', '--text']),
+    );
+    expect(byLong.get('--step')?.description).toBe('Target specific substep');
+    expect(byLong.get('--index')?.description).toBe(
+      'FOR loop iteration to target (requires --step)',
+    );
+    expect(byLong.get('--claim-id')?.description).toBe('Target a claimed delegated child runbook');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('pass command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/prune.test.ts
+++ b/packages/cli/__tests__/commands/prune.test.ts
@@ -12,6 +12,49 @@ import {
   parseConcatenatedJson,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/prune.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerPruneCommand } from '../../src/commands/prune.js';
+
+describe('prune command wiring', () => {
+  it('registers the prune command with its documented flags and descriptions', () => {
+    const program = new Command();
+    registerPruneCommand(program);
+
+    const prune = program.commands.find((c) => c.name() === 'prune');
+    expect(prune).toBeDefined();
+    expect(prune?.description()).toBe('Remove runbook state (does not delete runbook files)');
+
+    const byLong = new Map(prune!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(
+      expect.arrayContaining([
+        '--dry-run',
+        '--completed',
+        '--stopped',
+        '--active',
+        '--inactive',
+        '--all',
+        '--text',
+      ]),
+    );
+    expect(byLong.get('--dry-run')?.description).toBe(
+      'Show what would be removed without deleting',
+    );
+    expect(byLong.get('--completed')?.description).toBe(
+      'Prune successfully completed runbook state',
+    );
+    expect(byLong.get('--stopped')?.description).toBe(
+      'Prune stopped (aborted/failed) runbook state',
+    );
+    expect(byLong.get('--active')?.description).toBe('Prune active runbook state');
+    expect(byLong.get('--inactive')?.description).toBe('Prune inactive (orphaned) runbook state');
+    expect(byLong.get('--all')?.description).toBe('Prune all runbook state');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('prune command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/resolve.test.ts
+++ b/packages/cli/__tests__/commands/resolve.test.ts
@@ -18,6 +18,59 @@ import {
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { RUNDOWN_DIR } from '@rundown-org/core';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/resolve.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerResolveCommand } from '../../src/commands/resolve.js';
+
+describe('resolve command wiring', () => {
+  it('registers the resolve command with its documented flags, descriptions, and defaults', () => {
+    const program = new Command();
+    registerResolveCommand(program);
+
+    const resolve = program.commands.find((c) => c.name() === 'resolve');
+    expect(resolve).toBeDefined();
+    expect(resolve?.description()).toBe('Resolve and validate runbook variables and data sources');
+
+    const byLong = new Map(resolve!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(
+      expect.arrayContaining([
+        '--input-file',
+        '--input',
+        '--input-json',
+        '--artifacts',
+        '--artifacts-json',
+        '--text',
+      ]),
+    );
+    expect(byLong.get('--input-file')?.description).toBe('Load inputs from YAML file (repeatable)');
+    expect(byLong.get('--input')?.description).toBe(
+      'Set input (repeatable, omit =value to inherit from env)',
+    );
+    expect(byLong.get('--input-json')?.description).toBe('Set input with JSON value (repeatable)');
+    expect(byLong.get('--artifacts')?.description).toBe(
+      'Supply an input artifact by rd:// URI (repeatable)',
+    );
+    expect(byLong.get('--artifacts-json')?.description).toBe(
+      'Supply input artifacts as a JSON array of rd:// URIs (repeatable)',
+    );
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+
+    for (const long of [
+      '--input-file',
+      '--input',
+      '--input-json',
+      '--artifacts',
+      '--artifacts-json',
+    ]) {
+      const opt = byLong.get(long) as { defaultValue?: unknown; helpGroupHeading?: string };
+      expect(opt.defaultValue).toEqual([]);
+      expect(opt.helpGroupHeading).toBe('Input options:');
+    }
+  });
+});
 
 describe('rd resolve', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdir, writeFile, readdir, readFile } from 'node:fs/promises';
+import { mkdir, writeFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { appendArtifactManifestRecordSync, assertRunId } from '@rundown-org/core';
+import {
+  appendArtifactManifestRecordSync,
+  assertRunId,
+  type RunbookState,
+} from '@rundown-org/core';
 import {
   createTestWorkspace,
   createRunbook,
@@ -402,15 +406,16 @@ describe('run --step inline linkage (sandbox-visible coverage)', () => {
   }
 
   /** Locate the inline child state by scanning runs for a parentLinkage row. */
-  async function findChildState(parentRunId: string): Promise<Record<string, unknown> | null> {
+  async function findChildState(parentRunId: string): Promise<RunbookState | null> {
     const files = await readdir(workspace.statePath());
     for (const f of files) {
       if (!f.endsWith('.json') || f === 'session.json') continue;
-      const content = JSON.parse(await readFile(join(workspace.statePath(), f), 'utf-8')) as Record<
-        string,
-        unknown
-      >;
-      if (content.id !== parentRunId && content.parentLinkage) return content;
+      const id = f.slice(0, -'.json'.length);
+      if (id === parentRunId) continue;
+      // Validated read: a schema rename now fails at compile time on the
+      // typed field accesses below, not silently at runtime (CodeRabbit #529).
+      const state = await readRunbookState(workspace, id);
+      if (state?.parentLinkage) return state;
     }
     return null;
   }
@@ -452,7 +457,7 @@ describe('run --step inline linkage (sandbox-visible coverage)', () => {
 
       const childState = await findChildState(parentRunId);
       expect(childState).not.toBeNull();
-      const linkage = childState!.parentLinkage as Record<string, unknown>;
+      const linkage = childState!.parentLinkage!;
       expect(linkage.kind).toBe('inline');
       expect(linkage.parentRunId).toBe(parentRunId);
       expect(linkage.parentStepId).toBe('2');
@@ -487,7 +492,7 @@ describe('run --step inline linkage (sandbox-visible coverage)', () => {
 
       const childState = await findChildState(parentRunId);
       expect(childState).not.toBeNull();
-      const templateVars = childState!.templateVars as Record<string, unknown>;
+      const templateVars = childState!.templateVars!;
       expect(templateVars.Region).toBe('cli-region');
     });
   });
@@ -520,7 +525,7 @@ describe('run --step inline linkage (sandbox-visible coverage)', () => {
 
       const childState = await findChildState(parentRunId);
       expect(childState).not.toBeNull();
-      const linkage = childState!.parentLinkage as Record<string, unknown>;
+      const linkage = childState!.parentLinkage!;
       // buildFrameKey(step, iteration) → "1|2" (not the active frame "1|1").
       expect(linkage.parentFrameKey).toBe('1|2');
     });

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile, readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { appendArtifactManifestRecordSync, assertRunId } from '@rundown-org/core';
 import {
   createTestWorkspace,
+  createRunbook,
   runCliInProcess,
   readSession,
   getActiveState,
+  readRunbookState,
   listRunbookStates,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
@@ -318,5 +320,397 @@ required:
       expect(state).not.toBeNull();
       expect(state!.variables.PlanPath).toMatchObject({ kind: 'artifact-record', uri });
     });
+  });
+});
+
+// The inline-linkage (`rd run --step`) surface is the bulk of run.ts and is
+// otherwise exercised only by integration tests, which the Stryker sandbox
+// excludes (jest.config.shared.js drops `integration` from discovery). These
+// command-level tests run inside the sandbox so the `--step` code path — inline
+// linkage construction, its validation branches, the afterInit substep upsert,
+// and terminal propagation — is covered by mutation testing. They default to
+// JSON output per the CLI JSON-first testing convention.
+describe('run --step inline linkage (sandbox-visible coverage)', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  /** Write a parent runbook with a two-substep step 1 and a plain step 2. */
+  async function writeSubstepParent(vars?: Record<string, string>): Promise<void> {
+    const content = createRunbook({
+      title: 'Parent',
+      ...(vars && { vars }),
+      steps: [
+        {
+          title: 'Review',
+          pass: 'CONTINUE',
+          substeps: [
+            { title: 'Code review', content: 'Do code review.' },
+            { title: 'Security review', content: 'Do security review.' },
+          ],
+        },
+        { title: 'Done', pass: 'COMPLETE', content: 'Final step.' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'parent.runbook.md'), content);
+  }
+
+  /** Write a parent runbook whose step 1 is a FOR loop with substeps. */
+  async function writeForParent(): Promise<void> {
+    const content = createRunbook({
+      title: 'Parent',
+      steps: [
+        {
+          title: 'Process',
+          for: { variable: 'i', start: 1, end: 3 },
+          pass: 'CONTINUE',
+          substeps: [
+            { title: 'Handle item', content: 'Handle item {{i}}.' },
+            { title: 'Verify item', content: 'Verify item {{i}}.' },
+          ],
+        },
+        { title: 'Done', pass: 'COMPLETE', content: 'Final step.' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'parent.runbook.md'), content);
+  }
+
+  /** Write a single-step auto-executing child that passes and completes. */
+  async function writePassingChild(): Promise<void> {
+    const content = createRunbook({
+      title: 'Child',
+      steps: [{ title: 'Execute', pass: 'COMPLETE', command: 'rd echo --result pass' }],
+    });
+    await writeFile(join(workspace.cwd, 'child.runbook.md'), content);
+  }
+
+  /** Write a single-step auto-executing child that fails and stops. */
+  async function writeStoppingChild(): Promise<void> {
+    const content = createRunbook({
+      title: 'Child',
+      steps: [
+        { title: 'Execute', pass: 'COMPLETE', fail: 'STOP', command: 'rd echo --result fail' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'child.runbook.md'), content);
+  }
+
+  /** Locate the inline child state by scanning runs for a parentLinkage row. */
+  async function findChildState(parentRunId: string): Promise<Record<string, unknown> | null> {
+    const files = await readdir(workspace.statePath());
+    for (const f of files) {
+      if (!f.endsWith('.json') || f === 'session.json') continue;
+      const content = JSON.parse(await readFile(join(workspace.statePath(), f), 'utf-8')) as Record<
+        string,
+        unknown
+      >;
+      if (content.id !== parentRunId && content.parentLinkage) return content;
+    }
+    return null;
+  }
+
+  /** Start a substep parent in prompted mode and return its run id. */
+  async function startSubstepParent(vars?: Record<string, string>): Promise<string> {
+    await writeSubstepParent(vars);
+    const result = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+    const state = await getActiveState(workspace);
+    expect(state).not.toBeNull();
+    return state!.id;
+  }
+
+  describe('happy path', () => {
+    it('auto-completing inline child marks the parent substep done and exits 0', async () => {
+      const parentRunId = await startSubstepParent();
+      await writePassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // afterInit sets the substep 'running', then propagateChildTerminal marks
+      // it 'done' with the child's pass result — pins the full inline lifecycle.
+      const parent = await readRunbookState(workspace, parentRunId);
+      const ss = (parent!.substepStates ?? []).find((s) => s.id === '1');
+      expect(ss).toBeDefined();
+      expect(ss!.status).toBe('done');
+      expect(ss!.result).toBe('pass');
+    });
+
+    it('builds an inline parentLinkage on the child pointing at the targeted substep', async () => {
+      const parentRunId = await startSubstepParent();
+      await writePassingChild();
+
+      // Target 1.2 so parentStepId is unambiguously the substep id '2'.
+      const result = await runCliInProcess('run child.runbook.md --step 1.2', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const childState = await findChildState(parentRunId);
+      expect(childState).not.toBeNull();
+      const linkage = childState!.parentLinkage as Record<string, unknown>;
+      expect(linkage.kind).toBe('inline');
+      expect(linkage.parentRunId).toBe(parentRunId);
+      expect(linkage.parentStepId).toBe('2');
+      expect(linkage.parentStep).toBe('1');
+      expect(linkage.parentFrameKey).toBeDefined();
+    });
+
+    it('inline child auto-executes even though it inherits no prompted flag', async () => {
+      const parentRunId = await startSubstepParent();
+      await writePassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const childState = await findChildState(parentRunId);
+      expect(childState).not.toBeNull();
+      expect(childState!.lifecycle).toBe('completed');
+    });
+
+    it('inline child inherits parent template variables', async () => {
+      await writeSubstepParent({ Region: 'seed' });
+      const start = await runCliInProcess(
+        ['run', '--prompted', 'parent.runbook.md', '--input', 'Region=cli-region'],
+        workspace,
+      );
+      expect(start.exitCode).toBe(0);
+      const parentRunId = (await getActiveState(workspace))!.id;
+      await writePassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const childState = await findChildState(parentRunId);
+      expect(childState).not.toBeNull();
+      const templateVars = childState!.templateVars as Record<string, unknown>;
+      expect(templateVars.Region).toBe('cli-region');
+    });
+  });
+
+  describe('terminal propagation', () => {
+    it('inline child that fails and stops exits 1 and stops the parent', async () => {
+      const parentRunId = await startSubstepParent();
+      await writeStoppingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      // propagateChildTerminal reports 'stopped' → process.exit(1).
+      expect(result.exitCode).toBe(1);
+
+      const parent = await readRunbookState(workspace, parentRunId);
+      const ss = (parent!.substepStates ?? []).find((s) => s.id === '1');
+      expect(ss?.result).toBe('fail');
+    });
+  });
+
+  describe('FOR-loop iteration targeting (--index)', () => {
+    it('targets a non-active FOR iteration and encodes it in parentFrameKey', async () => {
+      await writeForParent();
+      const start = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(start.exitCode).toBe(0);
+      const parentRunId = (await getActiveState(workspace))!.id;
+      await writePassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1.1 --index 2', workspace);
+      expect(result.exitCode).toBe(0);
+
+      const childState = await findChildState(parentRunId);
+      expect(childState).not.toBeNull();
+      const linkage = childState!.parentLinkage as Record<string, unknown>;
+      // buildFrameKey(step, iteration) → "1|2" (not the active frame "1|1").
+      expect(linkage.parentFrameKey).toBe('1|2');
+    });
+
+    it('rejects --index against a non-FOR step with INVALID_INDEX', async () => {
+      await startSubstepParent();
+      await writePassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1.1 --index 2', workspace);
+      expect(result.exitCode).toBe(1);
+      const out = result.stdout + result.stderr;
+      expect(out).toContain('INVALID_INDEX');
+      expect(out).toContain('FOR step');
+    });
+  });
+
+  describe('validation errors', () => {
+    it('rejects a step id that does not exist (RD-801)', async () => {
+      await startSubstepParent();
+      await writePassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 9', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain('RD-801');
+    });
+
+    it('rejects targeting a step with substeps without a substep qualifier (RD-803)', async () => {
+      await startSubstepParent();
+      await writePassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain('RD-803');
+    });
+
+    it('rejects a substep id that does not exist on the step (RD-806)', async () => {
+      await startSubstepParent();
+      await writePassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1.9', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain('RD-806');
+    });
+
+    it('rejects targeting a step that has no substeps (RD-815)', async () => {
+      const content = createRunbook({
+        title: 'Parent',
+        steps: [
+          { title: 'Setup', pass: 'CONTINUE', content: 'Setup.' },
+          { title: 'Done', pass: 'COMPLETE', content: 'Final step.' },
+        ],
+      });
+      await writeFile(join(workspace.cwd, 'parent.runbook.md'), content);
+      const start = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(start.exitCode).toBe(0);
+      await writePassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1', workspace);
+      expect(result.exitCode).toBe(1);
+      const out = result.stdout + result.stderr;
+      expect(out).toContain('RD-815');
+    });
+
+    it('rejects a step that is not at the parent frontier (RD-802)', async () => {
+      // Both steps have substeps so the substep-shape checks pass; only the
+      // frontier check (parentState.step !== target) can then reject step 2.
+      const content = createRunbook({
+        title: 'Parent',
+        steps: [
+          {
+            title: 'Review',
+            pass: 'CONTINUE',
+            substeps: [{ title: 'Code review', content: 'Do code review.' }],
+          },
+          {
+            title: 'Verify',
+            pass: 'COMPLETE',
+            substeps: [{ title: 'Final check', content: 'Do final check.' }],
+          },
+        ],
+      });
+      await writeFile(join(workspace.cwd, 'parent.runbook.md'), content);
+      const start = await runCliInProcess('run --prompted parent.runbook.md', workspace);
+      expect(start.exitCode).toBe(0);
+      await writePassingChild();
+
+      // Parent frontier is step 1; target substep 2.1.
+      const result = await runCliInProcess('run child.runbook.md --step 2.1', workspace);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain('RD-802');
+    });
+
+    it('rejects a substep whose cursor has already advanced (drain path, already resolved)', async () => {
+      await startSubstepParent();
+      await writePassingChild();
+
+      // Resolve substep 1.1 directly on the parent — drain advances the cursor.
+      const pass = await runCliInProcess('pass --step 1.1', workspace);
+      expect(pass.exitCode).toBe(0);
+
+      const result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(1);
+      const out = result.stdout + result.stderr;
+      expect(out).toContain('already resolved');
+      expect(out).toContain('DELEGATION_ALREADY_RESOLVED');
+    });
+
+    it('rejects --step with no active parent runbook (NO_ACTIVE_RUNBOOK)', async () => {
+      await writePassingChild();
+      const result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      expect(result.exitCode).toBe(1);
+      const out = result.stdout + result.stderr;
+      expect(out).toContain('--step requires an active parent runbook');
+      expect(out).toContain('NO_ACTIVE_RUNBOOK');
+    });
+  });
+});
+
+describe('run error handling and warnings (sandbox-visible coverage)', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it('exits 1 when an auto-executing runbook stops', async () => {
+    await writeFile(
+      join(workspace.cwd, 'stops.runbook.md'),
+      `# Stops
+
+## 1. Fail hard
+- PASS COMPLETE
+- FAIL STOP
+
+\`\`\`bash
+rd echo --result fail
+\`\`\`
+`,
+    );
+
+    const result = await runCliInProcess('run stops.runbook.md', workspace);
+    // result.loopResult === 'stopped' → process.exit(1) on the no-linkage path.
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('warns for an undefined template variable preserved as literal text', async () => {
+    await writeFile(
+      join(workspace.cwd, 'undef.runbook.md'),
+      `# Undef
+
+## 1. Uses undefined
+- PASS COMPLETE
+
+Value is {{ missingVar }}.
+`,
+    );
+
+    const result = await runCliInProcess('run --prompted undef.runbook.md', workspace);
+    expect(result.exitCode).toBe(0);
+    const out = result.stdout + result.stderr;
+    expect(out).toContain('missingVar');
+    expect(out).toContain('preserved as literal text');
+  });
+
+  it('surfaces a syntax error as INVALID_SYNTAX for an unparseable runbook', async () => {
+    // A file with no H2 step headings has no runnable steps.
+    await writeFile(
+      join(workspace.cwd, 'broken.runbook.md'),
+      `# Broken
+
+Just prose, no steps at all.
+`,
+    );
+
+    const result = await runCliInProcess('run broken.runbook.md', workspace);
+    expect(result.exitCode).toBe(1);
+    // Either the prepare pipeline or the RunbookSyntaxError catch branch reports
+    // a non-zero failure; the run must not silently succeed.
+    expect(result.stdout + result.stderr).not.toBe('');
+  });
+
+  it('reports RUNBOOK_NOT_FOUND with a discovery hint for a missing file', async () => {
+    const result = await runCliInProcess('run does-not-exist.runbook.md', workspace);
+    expect(result.exitCode).toBe(1);
+    const out = result.stdout + result.stderr;
+    expect(out).toContain('RUNBOOK_NOT_FOUND');
+    expect(out).toContain('does-not-exist.runbook.md');
   });
 });

--- a/packages/cli/__tests__/commands/scenario-suite.test.ts
+++ b/packages/cli/__tests__/commands/scenario-suite.test.ts
@@ -3,6 +3,36 @@ import { validateCommandOutput } from '../helpers/schema-validator.js';
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/scenario-suite.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerScenarioSuiteCommand } from '../../src/commands/scenario-suite.js';
+
+describe('scenario-suite command wiring', () => {
+  it('registers the scenario-suite command with its subcommands and descriptions', () => {
+    const program = new Command();
+    registerScenarioSuiteCommand(program);
+
+    const suite = program.commands.find((c) => c.name() === 'scenario-suite');
+    expect(suite).toBeDefined();
+    expect(suite?.description()).toBe('List, show, or run cases from a scenario suite file');
+
+    const byName = new Map(suite!.commands.map((c) => [c.name(), c]));
+    expect([...byName.keys()].sort()).toEqual(['ls', 'run', 'show']);
+    expect(byName.get('ls')?.description()).toBe('List all cases in a scenario suite');
+    expect(byName.get('show')?.description()).toBe('Show details for a specific case in a suite');
+    expect(byName.get('run')?.description()).toBe(
+      'Execute a case (or all cases with --all) from a suite',
+    );
+
+    const runByLong = new Map((byName.get('run')?.options ?? []).map((o) => [o.long, o]));
+    expect(runByLong.get('--all')?.description).toBe('Run all cases in the suite');
+    expect(runByLong.get('--quiet')?.description).toBe('Suppress command output');
+    expect(runByLong.get('--quiet')?.short).toBe('-q');
+  });
+});
 
 describe('scenario-suite command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/scenarios.test.ts
+++ b/packages/cli/__tests__/commands/scenarios.test.ts
@@ -1,6 +1,33 @@
 import { createTestWorkspace, runCliInProcess, type TestWorkspace } from '../helpers/test-utils.js';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/scenarios.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerScenariosCommand } from '../../src/commands/scenarios.js';
+
+describe('scenario command wiring', () => {
+  it('registers the scenario command with its subcommands and descriptions', () => {
+    const program = new Command();
+    registerScenariosCommand(program);
+
+    const scenario = program.commands.find((c) => c.name() === 'scenario');
+    expect(scenario).toBeDefined();
+    expect(scenario?.description()).toBe('List, show, or run scenarios from a runbook');
+
+    const byName = new Map(scenario!.commands.map((c) => [c.name(), c]));
+    expect([...byName.keys()].sort()).toEqual(['ls', 'run', 'show']);
+    expect(byName.get('ls')?.description()).toBe('List all scenarios in a runbook');
+    expect(byName.get('show')?.description()).toBe('Show details for a specific scenario');
+    expect(byName.get('run')?.description()).toBe('Execute a scenario and verify the result');
+
+    const runQuiet = byName.get('run')?.options.find((o) => o.long === '--quiet');
+    expect(runQuiet?.description).toBe('Suppress command output');
+    expect(runQuiet?.short).toBe('-q');
+  });
+});
 
 describe('scenario command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/stash-pop.test.ts
+++ b/packages/cli/__tests__/commands/stash-pop.test.ts
@@ -12,6 +12,45 @@ import {
   writeSession,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests` credits the
+// behavioural tests below for BOTH command modules exercised here (which reach
+// the commands only via the dynamic `import('../cli.js')` seam in
+// runCliInProcess). This file is the per-command home for stash AND pop, so it
+// statically imports both register functions. See collect.test.ts.
+import { registerStashCommand } from '../../src/commands/stash.js';
+import { registerPopCommand } from '../../src/commands/pop.js';
+
+describe('stash/pop command wiring', () => {
+  it('registers the stash command with its documented flags and descriptions', () => {
+    const program = new Command();
+    registerStashCommand(program);
+
+    const stash = program.commands.find((c) => c.name() === 'stash');
+    expect(stash).toBeDefined();
+    expect(stash?.description()).toBe('Pause runbook enforcement, preserve state');
+
+    const byLong = new Map(stash!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(expect.arrayContaining(['--claim-id', '--text']));
+    expect(byLong.get('--claim-id')?.description).toBe('Target a claimed delegated child runbook');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+
+  it('registers the pop command with its documented flags and descriptions', () => {
+    const program = new Command();
+    registerPopCommand(program);
+
+    const pop = program.commands.find((c) => c.name() === 'pop');
+    expect(pop).toBeDefined();
+    expect(pop?.description()).toBe('Resume enforcement from stashed runbook');
+
+    const byLong = new Map(pop!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(expect.arrayContaining(['--claim-id', '--text']));
+    expect(byLong.get('--claim-id')?.description).toBe('Target a claimed delegated child runbook');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('stash command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -11,6 +11,28 @@ import {
   readRunbookState,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/status.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerStatusCommand } from '../../src/commands/status.js';
+
+describe('status command wiring', () => {
+  it('registers the status command with its documented flags and descriptions', () => {
+    const program = new Command();
+    registerStatusCommand(program);
+
+    const status = program.commands.find((c) => c.name() === 'status');
+    expect(status).toBeDefined();
+    expect(status?.description()).toBe('Show current runbook state');
+
+    const byLong = new Map(status!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(expect.arrayContaining(['--claim-id', '--text']));
+    expect(byLong.get('--claim-id')?.description).toBe('Target a claimed delegated child runbook');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('status command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -16,10 +16,32 @@ import {
   parseFinalCliJsonObject,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
+import { Command } from 'commander';
+// Stryker static-import linkage (mutation testing): links this test file into
+// Jest's static inverse-module graph so `--findRelatedTests src/commands/stop.ts`
+// credits the behavioural tests below (which reach the command only via the
+// dynamic `import('../cli.js')` seam in runCliInProcess). See collect.test.ts.
+import { registerStopCommand } from '../../src/commands/stop.js';
 
 interface ClaimOutput extends Record<string, unknown> {
   claim_id: string;
 }
+
+describe('stop command wiring', () => {
+  it('registers the stop command with its documented flags and descriptions', () => {
+    const program = new Command();
+    registerStopCommand(program);
+
+    const stop = program.commands.find((c) => c.name() === 'stop');
+    expect(stop).toBeDefined();
+    expect(stop?.description()).toBe('Abort current runbook');
+
+    const byLong = new Map(stop!.options.map((o) => [o.long, o]));
+    expect([...byLong.keys()]).toEqual(expect.arrayContaining(['--claim-id', '--text']));
+    expect(byLong.get('--claim-id')?.description).toBe('Target a claimed delegated child runbook');
+    expect(byLong.get('--text')?.description).toBe('Output as human-readable text');
+  });
+});
 
 describe('stop command', () => {
   let workspace: TestWorkspace;

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -879,7 +879,7 @@ describe('prepareRunbook', () => {
       // Pin the not-found message text and structured details (the discovery hint
       // and the echoed runbook name) so the error envelope stays stable.
       expect(result.error).toContain('Runbook not found: missing.md');
-      expect(result.error).toContain('rd ls --all');
+      expect(result.error).toContain('rundown ls --all');
       expect(result.details).toEqual({ runbook: 'missing.md' });
     }
   });

--- a/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
+++ b/packages/cli/__tests__/helpers/runbook-pipeline.test.ts
@@ -388,6 +388,8 @@ const {
   prepareResolvedRunnableRunbook,
   loadAndParseResolvedRunbook,
   startRunbook,
+  countSubsteps,
+  inferEntryFromState,
   buildContextVars,
   buildTemplateVars,
 } = await import('../../src/helpers/runbook-pipeline.js');
@@ -719,6 +721,152 @@ beforeEach(() => {
 // validateSources was removed in the unified variable model refactoring.
 // Source validation now happens during variable resolution.
 
+describe('countSubsteps', () => {
+  it('sums substep counts across steps and ignores steps without substeps', () => {
+    const steps = [
+      makeStep({ substeps: [{ id: '1' }, { id: '2' }] }), // 2 substeps
+      makeStep({ name: '2' }), // base step, contributes 0
+      makeStep({
+        name: '3',
+        forClause: { variable: 'i', start: 1, source: 'items' },
+        substeps: [{ id: '1' }, { id: '2' }, { id: '3' }],
+      }), // 3 substeps
+    ];
+    // Pins the accumulator arithmetic (a `-` mutant would go negative).
+    expect(countSubsteps(steps)).toBe(5);
+  });
+
+  it('returns 0 when no step defines substeps', () => {
+    expect(countSubsteps([makeStep(), makeStep({ name: '2' })])).toBe(0);
+  });
+});
+
+describe('inferEntryFromState', () => {
+  const FRAME_KEY = brandFrameKeyForTest('1');
+
+  const OTHER_KEY = brandFrameKeyForTest('2');
+
+  it('returns the active entry when the target frame is the active frame', () => {
+    const state = makeState(MOCK_RUN_ID, {
+      activeFrameKey: FRAME_KEY,
+      activeEntry: 7,
+    }) as unknown as RunbookState;
+    // Pins the `activeFrameKey === frameKey && activeEntry` active-frame branch.
+    expect(inferEntryFromState(state, FRAME_KEY)).toBe(7);
+  });
+
+  it('returns the recorded frame entry count when the frame is not the active frame', () => {
+    const state = makeState(MOCK_RUN_ID, {
+      activeFrameKey: OTHER_KEY,
+      activeEntry: 3,
+      frameEntryCounts: { [FRAME_KEY]: 5 },
+    }) as unknown as RunbookState;
+    // The active frame differs, so the recorded count must win, not activeEntry.
+    expect(inferEntryFromState(state, FRAME_KEY)).toBe(5);
+  });
+
+  it('defaults to 1 when there is no active match and no recorded count', () => {
+    const state = makeState(MOCK_RUN_ID, {
+      activeFrameKey: OTHER_KEY,
+      activeEntry: 3,
+    }) as unknown as RunbookState;
+    expect(inferEntryFromState(state, FRAME_KEY)).toBe(1);
+  });
+});
+
+describe('prepareRunbook — warning propagation', () => {
+  beforeEach(() => {
+    jest.mocked(resolveRunbookFile).mockResolvedValue({
+      path: '/test/good.md',
+      source: 'project',
+      sourceRoot: '/test',
+    });
+    jest.mocked(parser.parseRunbookDocument).mockReturnValue(mockParseResult());
+  });
+
+  it('surfaces collected warnings on a prepared success result', async () => {
+    jest.mocked(resolveVariables).mockResolvedValue({
+      vars: {},
+      warnings: ['heads up'],
+      providedKeys: new Set(),
+    });
+
+    const result = await prepareRunbook('good.md', {}, '/test');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.warnings).toEqual(['heads up']);
+  });
+
+  it('omits the warnings field entirely on a prepared success with no warnings', async () => {
+    // Pins the `allWarnings.length > 0 ? allWarnings : undefined` guard: a
+    // `>= 0` mutant would surface an empty array instead of undefined.
+    const result = await prepareRunbook('good.md', {}, '/test');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.warnings).toBeUndefined();
+  });
+
+  it('surfaces collected warnings on a runnable success result', async () => {
+    jest.mocked(resolveVariables).mockResolvedValue({
+      vars: {},
+      warnings: ['runnable warn'],
+      providedKeys: new Set(),
+    });
+
+    const result = await prepareRunnableRunbook('good.md', {}, '/test');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.warnings).toEqual(['runnable warn']);
+  });
+
+  it('omits the warnings field on a runnable success with no warnings', async () => {
+    const result = await prepareRunnableRunbook('good.md', {}, '/test');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.warnings).toBeUndefined();
+  });
+
+  it('surfaces collected warnings on a MISSING_REQUIRED_VARS failure', async () => {
+    jest
+      .mocked(parser.parseRunbookDocument)
+      .mockReturnValue(mockParseResult({ frontmatter: { required: ['PlanPath'] } }));
+    jest.mocked(resolveVariables).mockResolvedValue({
+      vars: {},
+      warnings: ['missing-path warn'],
+      providedKeys: new Set(),
+    });
+
+    const result = await prepareRunbook('good.md', {}, '/test');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('MISSING_REQUIRED_VARS');
+      expect(result.warnings).toEqual(['missing-path warn']);
+    }
+  });
+
+  it('surfaces collected warnings on a VALIDATION_ERROR failure', async () => {
+    jest
+      .mocked(parser.parseRunbookDocument)
+      .mockReturnValue(
+        mockParseResult({ diagnostics: [{ severity: 'error', message: 'bad clause' }] }),
+      );
+    jest.mocked(resolveVariables).mockResolvedValue({
+      vars: {},
+      warnings: ['validation warn'],
+      providedKeys: new Set(),
+    });
+
+    const result = await prepareRunbook('good.md', {}, '/test');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('VALIDATION_ERROR');
+      expect(result.warnings).toEqual(['validation warn']);
+    }
+  });
+});
+
 describe('prepareRunbook', () => {
   it('returns error when file not found', async () => {
     jest.mocked(resolveRunbookFile).mockResolvedValue(null);
@@ -728,6 +876,11 @@ describe('prepareRunbook', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe('RUNBOOK_NOT_FOUND');
+      // Pin the not-found message text and structured details (the discovery hint
+      // and the echoed runbook name) so the error envelope stays stable.
+      expect(result.error).toContain('Runbook not found: missing.md');
+      expect(result.error).toContain('rd ls --all');
+      expect(result.details).toEqual({ runbook: 'missing.md' });
     }
   });
 
@@ -912,6 +1065,28 @@ describe('prepareRunbook', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.prepared.runId).toBe('rd_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+    }
+  });
+
+  it('mints a fresh run id for a resolved runnable runbook when no options are supplied', async () => {
+    // Called with no options object at all, so `options?.runId` must short-circuit
+    // to `generateRunId()` — pins the optional-chaining access (a non-optional
+    // `options.runId` mutant would throw on the undefined options).
+    const request = {
+      resolved: {
+        path: '/test/child.runbook.md',
+        source: 'project' as const,
+        sourceRoot: '/test',
+      },
+      runbookRef: { source: 'project' as const, path: 'child.runbook.md' },
+      displayName: 'child.runbook.md',
+    };
+
+    const result = await prepareResolvedRunnableRunbook(request, {}, '/test');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.prepared.runId).toBe(MOCK_RUN_ID);
     }
   });
 
@@ -1857,6 +2032,56 @@ describe('startRunbook', () => {
       (...args: unknown[]) => unknown
     >;
     expect(createBridgedEmitterMock.mock.calls).toContainEqual([initializedState, ctx.output]);
+  });
+
+  it('returns a launch-failed result when actor initialization yields no state', async () => {
+    // initializeState resolving to a falsy state must abort the launch with a
+    // structured launch-failed envelope — pins the `if (!initializedState) throw`
+    // guard and its message, and confirms the session push never happens.
+    const runId = brandRunIdForTest(`rd_${'7'.repeat(32)}`);
+    const createdState = makeState(runId) as unknown as RunbookState;
+    const mockPushRunbook = mockFn<SessionService['pushRunbook']>().mockResolvedValue(undefined);
+    const mockDelete = mockFn<RunbookStateManager['delete']>().mockResolvedValue(undefined);
+    const ctx = makeRunPipelineContext({
+      manager: {
+        create: mockFn<RunbookStateManager['create']>().mockResolvedValue(createdState),
+        delete: mockDelete,
+      },
+      // initializeState resolves to null -> the launch must fail before push.
+      actorService: {
+        initializeState: mockFn<RunbookActorService['initializeState']>().mockResolvedValue(null),
+      },
+      sessionService: { pushRunbook: mockPushRunbook },
+    });
+
+    const prepared: RunnableRunbook = {
+      filePath: '/test/runbook.md',
+      source: 'project',
+      sourceRoot: '/test',
+      runbookRef: { source: 'project', path: 'runbook.runbook.md' },
+      runId,
+      rawContent: '# Test',
+      runbook: { steps: [makeStep() as PreparedRunbook['runbook']['steps'][number]] },
+      mergedVariables: {
+        RunId: runId,
+        RunbookRef: { source: 'project', path: 'runbook.runbook.md' },
+      },
+      runtimeVars: {},
+      stats: { steps: 1, substeps: 0 },
+      frontmatter: null,
+    };
+
+    const result = await startRunbook(ctx, prepared, { file: 'runbook.md' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('launch-failed');
+      expect(result.error).toContain('Failed to initialize runbook engine');
+    }
+    expect(mockPushRunbook).not.toHaveBeenCalled();
+    // The created run is cleaned up so no orphaned state lingers.
+    expect(mockDelete).toHaveBeenCalledWith(runId);
+    expect(runExecutionLoop).not.toHaveBeenCalled();
   });
 
   it('cleans up an activated runbook when afterStarted fails', async () => {

--- a/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-explicit-target.test.ts
@@ -282,6 +282,133 @@ describe('resolveManualCompletionCursor', () => {
     ).toThrow('conflicts with AT');
   });
 
+  it('throws when the active state is not at a substep even though the step defines substeps', () => {
+    // state.substep is undefined, but the active step DOES define substeps. The
+    // substep-mode guard is a disjunction (`!substep || !hasSubsteps || ...`),
+    // so the missing active substep alone must trigger the refusal — pinning the
+    // first `||` against a `&&` mutant that would let this fall through.
+    mockParseStepId({ step: '1', substep: '1' });
+
+    expect(() =>
+      resolveManualCompletionCursor(NO_STEPS, makeState({ substep: undefined }), target('1.1')),
+    ).toThrow('--step requires the runbook to be at a substep');
+  });
+
+  it('lists the valid substeps in the not-found error message', () => {
+    // Step defines substeps ['1', '2']; targeting '99' must enumerate the valid
+    // ids joined with ", " — pins the join separator string literal.
+    mockParseStepId({ step: '1', substep: '99' });
+
+    expect(() =>
+      resolveManualCompletionCursor(NO_STEPS, makeState({ substep: '1' }), target('1.99')),
+    ).toThrow('Valid substeps: 1, 2');
+  });
+
+  it('omits the iteration field entirely when no --index applies (non-FOR step)', () => {
+    // Default step kind is 'substeps' (not FOR) and no --index is supplied, so
+    // resolvedIndex is undefined and the cursor must NOT carry an iteration key —
+    // pins the `resolvedIndex !== undefined ? {...} : {}` spread guard.
+    mockParseStepId({ step: '1', substep: '1' });
+
+    const cursor = resolveManualCompletionCursor(
+      NO_STEPS,
+      makeState({ substep: '1' }),
+      target('1.1'),
+    );
+
+    expect(Object.hasOwn(cursor, 'iteration')).toBe(false);
+  });
+
+  it('keeps the explicit --index even when the active FOR frame reports a different iteration', () => {
+    // With an explicit --index the derived active iteration must be ignored:
+    // pins the `resolvedIndex === undefined && isForStep` default-only guard.
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, end: 9, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    mockFindStep(forStep);
+    jest.mocked(core.deriveActiveFrame).mockReturnValue({
+      step: '1',
+      iteration: 9,
+      frameKey: '1[9]' as FrameKey,
+    });
+    mockParseStepId({ step: '1', substep: '1' });
+
+    const cursor = resolveManualCompletionCursor(
+      NO_STEPS,
+      makeState({ substep: '1' }),
+      target('1.1', '2'),
+    );
+
+    expect(cursor.iteration).toBe(2);
+  });
+
+  it('accepts --index exactly equal to the FOR start bound', () => {
+    // Boundary: resolvedIndex === start must pass (the check is strict `<`).
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 3, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    mockFindStep(forStep);
+    mockParseStepId({ step: '1', substep: '1' });
+
+    const cursor = resolveManualCompletionCursor(
+      NO_STEPS,
+      makeState({ substep: '1' }),
+      target('1.1', '3'),
+    );
+
+    expect(cursor.iteration).toBe(3);
+  });
+
+  it('accepts --index exactly equal to the FOR end bound', () => {
+    // Boundary: resolvedIndex === end must pass (the check is strict `>`).
+    const forStep = {
+      name: '1',
+      kind: 'for',
+      forClause: { start: 1, end: 5, source: undefined },
+      substeps: [{ id: '1' }, { id: '2' }],
+    };
+    mockFindStep(forStep);
+    mockParseStepId({ step: '1', substep: '1' });
+
+    const cursor = resolveManualCompletionCursor(
+      NO_STEPS,
+      makeState({ substep: '1' }),
+      target('1.1', '5'),
+    );
+
+    expect(cursor.iteration).toBe(5);
+  });
+
+  it('falls back to the derived active frame key when the state has no activeFrameKey', () => {
+    // activeFrameKey is undefined, so the target frame key must resolve via the
+    // `?? active.frameKey` fallback ('1'); the target ('1') then matches the
+    // active frame and yields an active frame carrying the active entry. Pins the
+    // `??` against a `&&` mutant (which would produce `undefined`, forcing an
+    // inactive frame).
+    mockParseStepId({ step: '1', substep: '2' });
+    // Pin the derived active frame explicitly (the suite uses clearAllMocks, which
+    // does not restore mockReturnValue implementations set by earlier FOR tests).
+    jest.mocked(core.deriveActiveFrame).mockReturnValue({
+      step: '1',
+      iteration: undefined,
+      frameKey: '1' as FrameKey,
+    });
+
+    const cursor = resolveManualCompletionCursor(
+      NO_STEPS,
+      makeState({ substep: '1', activeFrameKey: undefined, activeEntry: 4 }),
+      target('1.2'),
+    );
+
+    expect(cursor.frame).toMatchObject({ kind: 'active', entry: 4 });
+  });
+
   it('throws when --step uses a template AT expression without --index', () => {
     const forStep = {
       name: '1',

--- a/packages/cli/__tests__/helpers/transitions-seam.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-seam.test.ts
@@ -256,7 +256,7 @@ describe('emitOpenDelegatedChildrenError', () => {
     emitOpenDelegatedChildrenError(output, 'pass', PARENT_RUN_ID, [TEST_CLAIM_ID], [CHILD_RUN_ID]);
     expect(output.error).toHaveBeenCalledTimes(1);
     const [message, code, details] = output.error.mock.calls[0];
-    expect(message).toContain('Cannot run bare rd pass');
+    expect(message).toContain('Cannot run bare rundown pass');
     expect(message).toContain(TEST_CLAIM_ID);
     expect(message).toContain('--claim-id');
     expect(code).toBe('OPEN_DELEGATED_CHILDREN');
@@ -281,9 +281,9 @@ describe('emitDelegationCollectionPendingError', () => {
     );
     expect(output.error).toHaveBeenCalledTimes(1);
     const [message, code, details] = output.error.mock.calls[0];
-    expect(message).toContain('Cannot run bare rd fail');
+    expect(message).toContain('Cannot run bare rundown fail');
     expect(message).toContain('Delegated outcome pending.');
-    expect(message).toContain('rd collect');
+    expect(message).toContain('rundown collect');
     expect(code).toBe('DELEGATION_COLLECTION_PENDING');
     expect(details).toEqual({
       command: 'fail',

--- a/packages/cli/__tests__/helpers/transitions-seam.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-seam.test.ts
@@ -6,6 +6,7 @@ import type {
   ClaimId,
   ClaimRecord,
   CommandTargetResolution,
+  FrameKey,
   LifecycleTransitionOutcome,
   RunId,
   RunbookState,
@@ -705,7 +706,7 @@ describe('runSeamTransition — applied render (buildActionSink / renderTransiti
     const output = makeOutput();
     mockRunTransition.mockResolvedValue(
       appliedOutcome({
-        duplicate: { at: '1.1', frameKey: '1', entry: 2 },
+        duplicate: { at: '1.1', frameKey: '1' as FrameKey, entry: 2 },
       }),
     );
 

--- a/packages/cli/__tests__/helpers/transitions-seam.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-seam.test.ts
@@ -1,0 +1,758 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { mockErrorHelpers } from './mock-error-helpers.js';
+import { mockFn } from './typed-mocks.js';
+import type {
+  ActionType,
+  ClaimId,
+  ClaimRecord,
+  CommandTargetResolution,
+  LifecycleTransitionOutcome,
+  RunId,
+  RunbookState,
+  TransitionObservationEvent,
+} from '@rundown-org/core';
+import type { ResolvedStep } from '@rundown-org/parser';
+import type { OutputEmitter } from '../../src/services/output-emitter.js';
+
+// The unit-under-test (runSeamTransition, renderRefusal, renderApplied,
+// buildActionSink, renderTransitionEvents, the config + emit helpers,
+// buildTransitionContext) is only reachable from the CLI command layer through a
+// *dynamic* `import('../cli.js')` in the in-process CLI runner. Because Stryker
+// scopes each mutant to its *static* importers, the pass/fail integration suites
+// never count toward this module's mutation score. This suite statically imports
+// transitions.ts and drives the seam through structural core doubles so those
+// branches — including the correctness-critical result→action mapping and the
+// typed-refusal render table — are pinned directly.
+
+const PARENT_RUN_ID = 'rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as RunId;
+const CHILD_RUN_ID = 'rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as RunId;
+const TEST_CLAIM_ID = 'rdclm_abcdefghijklmnopqrstu1' as ClaimId;
+
+const mockRunTransition = mockFn<(args: unknown) => Promise<LifecycleTransitionOutcome>>();
+const mockManagerLoad = mockFn<(id: RunId) => Promise<RunbookState | null>>();
+const mockResolveCommandTarget = mockFn<(...args: unknown[]) => Promise<CommandTargetResolution>>();
+const mockResolveTransitionTarget = mockFn<(...args: unknown[]) => Promise<unknown>>();
+
+jest.unstable_mockModule('@rundown-org/core', () => ({
+  RunbookStateManager: jest.fn().mockImplementation(() => ({ load: mockManagerLoad })),
+  RunbookActorService: jest.fn(),
+  RunbookCompletionService: jest.fn(),
+  RunbookLifecycleCommandService: jest
+    .fn()
+    .mockImplementation(() => ({ runTransition: mockRunTransition })),
+  SessionService: jest.fn().mockImplementation(() => ({})),
+  ExecutionLifecycleService: jest.fn().mockImplementation(() => ({})),
+  resolveCommandTarget: mockResolveCommandTarget,
+  resolveTransitionTarget: mockResolveTransitionTarget,
+  // `formatTransitionAction` is echoed into the buffered action object; the mock
+  // returns a sentinel so we can assert the sink forwards the derived label.
+  formatTransitionAction: mockFn<(action: ActionType) => string>().mockReturnValue('ACTION_LABEL'),
+  // resolveManualCompletionCursor collaborators (only the --step path uses them).
+  parseStepIdFromString: mockFn<(input: string) => unknown>().mockReturnValue({
+    step: '1',
+    substep: '1',
+  }),
+  buildFrameKey: mockFn<(step: string, iteration?: number) => string>().mockImplementation(
+    (step, iteration) => (iteration !== undefined ? `${step}[${String(iteration)}]` : step),
+  ),
+  deriveExecutionAt:
+    mockFn<(step: string, substep?: string, iteration?: number) => string>().mockReturnValue('1.1'),
+  deriveActiveFrame: mockFn<
+    (state: RunbookState) => { step: string; iteration?: number; frameKey: string }
+  >().mockReturnValue({ step: '1', iteration: undefined, frameKey: '1' }),
+  activeFrame: mockFn<
+    (frameKey: string, entry: number) => { kind: 'active'; frameKey: string; entry: number }
+  >().mockImplementation((frameKey, entry) => ({ kind: 'active', frameKey, entry })),
+  inactiveFrame: mockFn<
+    (frameKey: string) => { kind: 'inactive'; frameKey: string }
+  >().mockImplementation((frameKey) => ({ kind: 'inactive', frameKey })),
+  logger: { warn: mockFn<(...args: unknown[]) => void>() },
+  ...mockErrorHelpers,
+}));
+
+jest.unstable_mockModule('@rundown-org/parser', () => ({
+  resolvedStepHasSubsteps: mockFn<(step: ResolvedStep) => boolean>().mockReturnValue(true),
+}));
+
+jest.unstable_mockModule('../../src/helpers/actor-service-factory', () => ({
+  createCliRunbookActorService: mockFn<() => Record<string, unknown>>().mockReturnValue({}),
+}));
+
+jest.unstable_mockModule('../../src/helpers/runbook-loader', () => ({
+  getRunbookFromState: mockFn<() => readonly ResolvedStep[]>().mockReturnValue([]),
+}));
+
+jest.unstable_mockModule('../../src/helpers/caller-evidence', () => ({
+  readLifecycleCallerEvidence: mockFn<() => unknown>().mockReturnValue({ kind: 'direct_cli' }),
+}));
+
+const mockRunExecutionLoop =
+  mockFn<(...args: unknown[]) => Promise<string>>().mockResolvedValue('done');
+const mockFindStepOrThrow =
+  mockFn<(steps: readonly ResolvedStep[], name: string) => ResolvedStep>();
+jest.unstable_mockModule('../../src/services/execution', () => ({
+  findStepOrThrow: mockFindStepOrThrow,
+  runExecutionLoop: mockRunExecutionLoop,
+}));
+
+jest.unstable_mockModule('../../src/helpers/execution-emitter', () => ({
+  createBridgedEmitter: mockFn<() => Record<string, unknown>>().mockReturnValue({
+    emit: jest.fn(),
+  }),
+}));
+
+// A structural sink whose methods are jest fns so renderTransitionEvents can
+// dispatch through the manual-completion (emitter-bridged) path without throwing.
+const mockManualSink = {
+  onErrorOccurred: mockFn<(payload: unknown) => void>(),
+  onStepTransitioned: mockFn<(payload: unknown) => void>(),
+  onRunbookCompleted: mockFn<(payload: unknown) => void>(),
+  onRunbookStopped: mockFn<(payload: unknown) => void>(),
+};
+jest.unstable_mockModule('../../src/helpers/transition-orchestrator', () => ({
+  transitionSinkFromEmitter: mockFn<() => typeof mockManualSink>().mockReturnValue(mockManualSink),
+}));
+
+const { getRunbookFromState } = await import('../../src/helpers/runbook-loader.js');
+const { resolvedStepHasSubsteps } = await import('@rundown-org/parser');
+const {
+  runSeamTransition,
+  createPassTransitionConfig,
+  createFailTransitionConfig,
+  emitOpenDelegatedChildrenError,
+  emitDelegationCollectionPendingError,
+  buildTransitionContext,
+} = await import('../../src/helpers/transitions.js');
+
+interface MockOutput {
+  error: jest.Mock<(message: string, code?: string, details?: unknown) => void>;
+  noActiveRunbook: jest.Mock<(command?: string) => void>;
+  json: jest.Mock<(data: unknown) => void>;
+  message: jest.Mock<(text: string) => void>;
+  action: jest.Mock<(block: unknown) => void>;
+  complete: jest.Mock<(message?: string, position?: unknown) => void>;
+  stopped: jest.Mock<(message?: string, position?: unknown) => void>;
+  status: jest.Mock<(action: string, message?: string, data?: unknown) => void>;
+  warning: jest.Mock<(text: string) => void>;
+  isJson: jest.Mock<() => boolean>;
+  flush: jest.Mock<() => void>;
+}
+
+function makeOutput(json = true): MockOutput & OutputEmitter {
+  return {
+    error: mockFn<(message: string, code?: string, details?: unknown) => void>(),
+    noActiveRunbook: mockFn<(command?: string) => void>(),
+    json: mockFn<(data: unknown) => void>(),
+    message: mockFn<(text: string) => void>(),
+    action: mockFn<(block: unknown) => void>(),
+    complete: mockFn<(message?: string, position?: unknown) => void>(),
+    stopped: mockFn<(message?: string, position?: unknown) => void>(),
+    status: mockFn<(action: string, message?: string, data?: unknown) => void>(),
+    warning: mockFn<(text: string) => void>(),
+    isJson: mockFn<() => boolean>().mockReturnValue(json),
+    flush: mockFn<() => void>(),
+  } as unknown as MockOutput & OutputEmitter;
+}
+
+function claimRecord(): ClaimRecord {
+  return {
+    kind: 'claim-record',
+    claimId: TEST_CLAIM_ID,
+    childRunId: CHILD_RUN_ID,
+    tokenHash: `sha256:${'a'.repeat(64)}`,
+    parentRunId: PARENT_RUN_ID,
+    parentStepId: '1',
+    parentStep: '1',
+    parentFrameKey: '1',
+    parentEntry: 1,
+    claimedAt: '2026-07-02T00:00:00.000Z',
+    updatedAt: '2026-07-02T00:00:00.000Z',
+  } as unknown as ClaimRecord;
+}
+
+function makeState(overrides: Record<string, unknown> = {}): RunbookState {
+  return {
+    id: PARENT_RUN_ID,
+    step: '1',
+    substep: undefined,
+    activeEntry: 1,
+    activeFrameKey: '1',
+    ...overrides,
+  } as unknown as RunbookState;
+}
+
+function stepEvent(
+  overrides: Partial<Record<string, unknown>> = {},
+): Extract<TransitionObservationEvent, { type: 'STEP_TRANSITIONED' }> {
+  return {
+    type: 'STEP_TRANSITIONED',
+    payload: {
+      action: 'CONTINUE',
+      from: '1',
+      at: '2',
+      result: 'PASS',
+      ...overrides,
+    },
+  } as unknown as Extract<TransitionObservationEvent, { type: 'STEP_TRANSITIONED' }>;
+}
+
+function appliedOutcome(
+  overrides: Partial<Extract<LifecycleTransitionOutcome, { kind: 'applied' }>> = {},
+): LifecycleTransitionOutcome {
+  return {
+    kind: 'applied',
+    runId: PARENT_RUN_ID,
+    mutation: 'run-transition',
+    terminalReleaseMode: 'stack-pop',
+    status: 'continue',
+    events: [],
+    loop: { kind: 'none' },
+    ...overrides,
+  } as unknown as LifecycleTransitionOutcome;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockManagerLoad.mockResolvedValue(makeState());
+  jest.mocked(getRunbookFromState).mockReturnValue([]);
+  mockRunExecutionLoop.mockResolvedValue('done');
+});
+
+describe('createPassTransitionConfig', () => {
+  it('maps RETRY and STOP results to a false action-result but CONTINUE/NEXT to true', () => {
+    const config = createPassTransitionConfig();
+    expect(config.eventType).toBe('PASS');
+    expect(config.commandName).toBe('pass');
+    expect(config.lastResult).toBe('pass');
+    // Correctness-critical: pass action-result depends on the action type.
+    expect(config.computeActionResult('RETRY')).toBe(false);
+    expect(config.computeActionResult('STOP')).toBe(false);
+    expect(config.computeActionResult('CONTINUE')).toBe(true);
+    expect(config.computeActionResult('NEXT')).toBe(true);
+    expect(config.computeActionResult('COMPLETE')).toBe(true);
+    expect(config.policy.onStopped.releaseRunbook).toBe(true);
+    expect(config.policy.onComplete.releaseRunbook).toBe(true);
+  });
+});
+
+describe('createFailTransitionConfig', () => {
+  it('always maps the action-result to false regardless of action type', () => {
+    const config = createFailTransitionConfig();
+    expect(config.eventType).toBe('FAIL');
+    expect(config.commandName).toBe('fail');
+    expect(config.lastResult).toBe('fail');
+    expect(config.computeActionResult('CONTINUE')).toBe(false);
+    expect(config.computeActionResult('RETRY')).toBe(false);
+    expect(config.computeActionResult('STOP')).toBe(false);
+    expect(config.policy.onStopped.releaseRunbook).toBe(true);
+    expect(config.policy.onComplete.releaseRunbook).toBe(true);
+  });
+});
+
+describe('emitOpenDelegatedChildrenError', () => {
+  it('emits OPEN_DELEGATED_CHILDREN with structured details', () => {
+    const output = makeOutput();
+    emitOpenDelegatedChildrenError(output, 'pass', PARENT_RUN_ID, [TEST_CLAIM_ID], [CHILD_RUN_ID]);
+    expect(output.error).toHaveBeenCalledTimes(1);
+    const [message, code, details] = output.error.mock.calls[0];
+    expect(message).toContain('Cannot run bare rd pass');
+    expect(message).toContain(TEST_CLAIM_ID);
+    expect(message).toContain('--claim-id');
+    expect(code).toBe('OPEN_DELEGATED_CHILDREN');
+    expect(details).toEqual({
+      command: 'pass',
+      parentRunId: PARENT_RUN_ID,
+      claimIds: [TEST_CLAIM_ID],
+      childRunIds: [CHILD_RUN_ID],
+    });
+  });
+});
+
+describe('emitDelegationCollectionPendingError', () => {
+  it('emits DELEGATION_COLLECTION_PENDING with the core message and keys', () => {
+    const output = makeOutput();
+    emitDelegationCollectionPendingError(
+      output,
+      'fail',
+      PARENT_RUN_ID,
+      ['1|1|'],
+      'Delegated outcome pending.',
+    );
+    expect(output.error).toHaveBeenCalledTimes(1);
+    const [message, code, details] = output.error.mock.calls[0];
+    expect(message).toContain('Cannot run bare rd fail');
+    expect(message).toContain('Delegated outcome pending.');
+    expect(message).toContain('rd collect');
+    expect(code).toBe('DELEGATION_COLLECTION_PENDING');
+    expect(details).toEqual({
+      command: 'fail',
+      parentRunId: PARENT_RUN_ID,
+      outcomeCompletionKeys: ['1|1|'],
+    });
+  });
+});
+
+describe('buildTransitionContext', () => {
+  it('resolves a claim target with release-runbook terminal mode and surfaces the claim', async () => {
+    const output = makeOutput();
+    mockResolveCommandTarget.mockResolvedValue({
+      kind: 'claim',
+      state: makeState({ id: CHILD_RUN_ID }),
+      claim: claimRecord(),
+    } as unknown as CommandTargetResolution);
+
+    const result = await buildTransitionContext(output, '/cwd', { claimId: TEST_CLAIM_ID });
+
+    expect(result.kind).toBe('ready');
+    if (result.kind === 'ready') {
+      expect(result.ctx.terminalReleaseMode).toBe('release-runbook');
+      expect(result.ctx.guardOpenChildren).toBe(false);
+      expect(result.ctx.claim).toBeDefined();
+    }
+  });
+
+  it('resolves a default target with stack-pop terminal mode and no claim', async () => {
+    const output = makeOutput();
+    mockResolveCommandTarget.mockResolvedValue({
+      kind: 'default',
+      state: makeState(),
+    } as unknown as CommandTargetResolution);
+
+    const result = await buildTransitionContext(output, '/cwd');
+
+    expect(result.kind).toBe('ready');
+    if (result.kind === 'ready') {
+      expect(result.ctx.terminalReleaseMode).toBe('stack-pop');
+      expect(result.ctx.claim).toBeUndefined();
+    }
+  });
+
+  it('passes a "none" refusal straight through without building a context', async () => {
+    const output = makeOutput();
+    mockResolveCommandTarget.mockResolvedValue({
+      kind: 'none',
+    } as unknown as CommandTargetResolution);
+
+    const result = await buildTransitionContext(output, '/cwd');
+
+    expect(result.kind).toBe('none');
+  });
+
+  it('passes a stale_claim refusal straight through', async () => {
+    const output = makeOutput();
+    mockResolveCommandTarget.mockResolvedValue({
+      kind: 'stale_claim',
+      claimId: TEST_CLAIM_ID,
+      message: 'stale',
+    } as unknown as CommandTargetResolution);
+
+    const result = await buildTransitionContext(output, '/cwd', { claimId: TEST_CLAIM_ID });
+
+    expect(result.kind).toBe('stale_claim');
+  });
+
+  it('passes a terminal_claim refusal straight through', async () => {
+    const output = makeOutput();
+    mockResolveCommandTarget.mockResolvedValue({
+      kind: 'terminal_claim',
+    } as unknown as CommandTargetResolution);
+
+    const result = await buildTransitionContext(output, '/cwd', { claimId: TEST_CLAIM_ID });
+
+    expect(result.kind).toBe('terminal_claim');
+  });
+});
+
+describe('runSeamTransition — explicit --step target resolution', () => {
+  it('resolves a --step cursor and forwards it as the manualTarget with an explicit-step selector', async () => {
+    const output = makeOutput();
+    // Drive the Category-A cursor parse: resolveTransitionTarget yields a resolved
+    // default target, and the cursor collaborators are wired to a valid substep.
+    mockResolveTransitionTarget.mockResolvedValue({
+      kind: 'default',
+      state: makeState({ substep: '1' }),
+    });
+    jest
+      .mocked(getRunbookFromState)
+      .mockReturnValue([
+        { name: '1', kind: 'substeps', substeps: [{ id: '1' }] },
+      ] as unknown as readonly ResolvedStep[]);
+    mockFindStepOrThrow.mockReturnValue({
+      name: '1',
+      kind: 'substeps',
+      substeps: [{ id: '1' }],
+    } as unknown as ResolvedStep);
+    jest.mocked(resolvedStepHasSubsteps).mockReturnValue(true);
+    mockRunTransition.mockResolvedValue(appliedOutcome());
+
+    const result = await runSeamTransition(output, '/cwd', createPassTransitionConfig(), {
+      step: '1.1',
+    });
+
+    expect(mockResolveTransitionTarget).toHaveBeenCalledTimes(1);
+    const runArgs = mockRunTransition.mock.calls[0][0] as Record<string, unknown>;
+    expect(runArgs.targetSelector).toEqual({ kind: 'explicit-step', step: '1.1' });
+    expect(runArgs.manualTarget).toMatchObject({ step: '1', substep: '1' });
+    expect(result.applied).toBeDefined();
+  });
+
+  it('leaves the cursor undefined when the --step target resolution refuses, and re-renders via the seam', async () => {
+    const output = makeOutput();
+    // A refusal (kind 'none') from the target resolution must NOT attempt a cursor
+    // parse; the seam call re-resolves and renders the same typed refusal.
+    mockResolveTransitionTarget.mockResolvedValue({ kind: 'none' });
+    mockRunTransition.mockResolvedValue({ kind: 'none' });
+
+    const result = await runSeamTransition(output, '/cwd', createFailTransitionConfig(), {
+      step: '1.1',
+    });
+
+    const runArgs = mockRunTransition.mock.calls[0][0] as Record<string, unknown>;
+    expect(runArgs.targetSelector).toEqual({ kind: 'explicit-step', step: '1.1' });
+    expect(runArgs.manualTarget).toBeUndefined();
+    expect(output.noActiveRunbook).toHaveBeenCalledWith('fail');
+    expect(result.exitError).toBe(false);
+  });
+
+  it('uses a claim selector when both --step and --claim-id are supplied', async () => {
+    const output = makeOutput();
+    mockResolveTransitionTarget.mockResolvedValue({ kind: 'none' });
+    mockRunTransition.mockResolvedValue({ kind: 'none' });
+
+    await runSeamTransition(output, '/cwd', createPassTransitionConfig(), {
+      step: '1.1',
+      claimId: TEST_CLAIM_ID,
+    });
+
+    const runArgs = mockRunTransition.mock.calls[0][0] as Record<string, unknown>;
+    expect(runArgs.targetSelector).toEqual({ kind: 'claim', claimId: TEST_CLAIM_ID });
+  });
+
+  it('uses a claim selector for a bare --claim-id transition without --step', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue({ kind: 'none' });
+
+    await runSeamTransition(output, '/cwd', createPassTransitionConfig(), {
+      claimId: TEST_CLAIM_ID,
+    });
+
+    const runArgs = mockRunTransition.mock.calls[0][0] as Record<string, unknown>;
+    expect(runArgs.targetSelector).toEqual({ kind: 'claim', claimId: TEST_CLAIM_ID });
+    expect(mockResolveTransitionTarget).not.toHaveBeenCalled();
+  });
+
+  it('selects the default target when neither --step nor --claim-id is supplied', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue({ kind: 'none' });
+
+    // A bare transition must target the default stack — never fall through to a
+    // claim selector or an empty/mistyped selector (pins the else-branch default
+    // against the claim/explicit-step branches so target selection can't silently
+    // change for a bare pass/fail).
+    await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    const runArgs = mockRunTransition.mock.calls[0][0] as Record<string, unknown>;
+    expect(runArgs.targetSelector).toEqual({ kind: 'default' });
+    expect(mockResolveTransitionTarget).not.toHaveBeenCalled();
+  });
+});
+
+describe('runSeamTransition — refusal render table', () => {
+  it('renders the no-active-runbook refusal without an error exit', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue({ kind: 'none' });
+
+    const result = await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    expect(output.noActiveRunbook).toHaveBeenCalledWith('pass');
+    expect(result.applied).toBeUndefined();
+    expect(result.exitError).toBe(false);
+    expect(output.flush).toHaveBeenCalled();
+  });
+
+  it('renders a stale claim refusal with a non-zero exit', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue({
+      kind: 'stale_claim',
+      claimId: TEST_CLAIM_ID,
+      message: 'claim gone',
+    });
+
+    const result = await runSeamTransition(output, '/cwd', createFailTransitionConfig());
+
+    expect(output.error).toHaveBeenCalledWith('claim gone', 'CLAIMED_RUNBOOK_UNAVAILABLE');
+    expect(result.exitError).toBe(true);
+  });
+
+  it('renders a confirmed terminal claim as an idempotent JSON payload without error exit', async () => {
+    const output = makeOutput(true);
+    mockRunTransition.mockResolvedValue({
+      kind: 'terminal_claim_confirmed',
+      claimId: TEST_CLAIM_ID,
+      lifecycle: 'completed',
+      result: 'pass',
+    });
+
+    const result = await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    expect(output.json).toHaveBeenCalledWith({
+      kind: 'action',
+      action: 'pass',
+      status: 'already-resolved',
+      claimId: TEST_CLAIM_ID,
+      lifecycle: 'completed',
+    });
+    expect(result.exitError).toBe(false);
+  });
+
+  it('renders a confirmed terminal claim as a text message when not in JSON mode', async () => {
+    const output = makeOutput(false);
+    mockRunTransition.mockResolvedValue({
+      kind: 'terminal_claim_confirmed',
+      claimId: TEST_CLAIM_ID,
+      lifecycle: 'stopped',
+      result: 'fail',
+    });
+
+    await runSeamTransition(output, '/cwd', createFailTransitionConfig());
+
+    expect(output.json).not.toHaveBeenCalled();
+    expect(output.message).toHaveBeenCalledTimes(1);
+    expect(output.message.mock.calls[0][0]).toContain('ALREADY FAIL');
+  });
+
+  it('renders a terminal claim conflict with a non-zero exit', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue({
+      kind: 'terminal_claim_conflict',
+      claimId: TEST_CLAIM_ID,
+      lifecycle: 'completed',
+      expectedResult: 'pass',
+      requestedResult: 'fail',
+    });
+
+    const result = await runSeamTransition(output, '/cwd', createFailTransitionConfig());
+
+    expect(output.error).toHaveBeenCalledTimes(1);
+    const [message, code] = output.error.mock.calls[0];
+    expect(message).toContain('already resolved as pass');
+    expect(message).toContain('cannot fail');
+    expect(code).toBe('DELEGATION_RESULT_CONFLICT');
+    expect(result.exitError).toBe(true);
+  });
+
+  it('renders the open-delegated-children refusal derived from the outcome claims', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue({
+      kind: 'open_delegated_children',
+      parentRunId: PARENT_RUN_ID,
+      claims: [claimRecord()],
+    });
+
+    const result = await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    expect(output.error).toHaveBeenCalledTimes(1);
+    const [, code, details] = output.error.mock.calls[0];
+    expect(code).toBe('OPEN_DELEGATED_CHILDREN');
+    expect(details).toEqual({
+      command: 'pass',
+      parentRunId: PARENT_RUN_ID,
+      claimIds: [TEST_CLAIM_ID],
+      childRunIds: [CHILD_RUN_ID],
+    });
+    expect(result.exitError).toBe(true);
+  });
+
+  it('renders the delegation-collection-pending refusal', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue({
+      kind: 'delegation_collection_pending',
+      parentRunId: PARENT_RUN_ID,
+      outcomeCompletionKeys: ['1|1|'],
+      message: 'pending',
+    } as unknown as LifecycleTransitionOutcome);
+
+    const result = await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    const [, code, details] = output.error.mock.calls[0];
+    expect(code).toBe('DELEGATION_COLLECTION_PENDING');
+    expect(details).toEqual({
+      command: 'pass',
+      parentRunId: PARENT_RUN_ID,
+      outcomeCompletionKeys: ['1|1|'],
+    });
+    expect(result.exitError).toBe(true);
+  });
+
+  it('renders the actor-context-required refusal with the target run id', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue({
+      kind: 'actor_context_required',
+      targetRunId: PARENT_RUN_ID,
+    });
+
+    const result = await runSeamTransition(output, '/cwd', createFailTransitionConfig());
+
+    expect(output.error).toHaveBeenCalledWith(
+      'Actor context is required to fail this run.',
+      'ACTOR_CONTEXT_REQUIRED',
+      { targetRunId: PARENT_RUN_ID },
+    );
+    expect(result.exitError).toBe(true);
+  });
+});
+
+describe('runSeamTransition — applied render (buildActionSink / renderTransitionEvents)', () => {
+  it('renders a run-transition STEP_TRANSITIONED event as a buffered action block', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue(
+      appliedOutcome({
+        events: [stepEvent({ command: 'pass', forIndex: 2, forEnd: 5 })],
+      }),
+    );
+
+    const result = await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    expect(output.action).toHaveBeenCalledTimes(1);
+    const block = output.action.mock.calls[0][0] as Record<string, unknown>;
+    expect(block.action).toBe('ACTION_LABEL');
+    expect(block.from).toBe('1');
+    expect(block.at).toBe('2');
+    expect(block.result).toBe('PASS');
+    expect(block.forIndex).toBe(2);
+    expect(block.forEnd).toBe(5);
+    expect(block.command).toBe('pass');
+    expect(result.applied).toEqual({ status: 'continue', runId: PARENT_RUN_ID });
+    expect(result.exitError).toBe(false);
+  });
+
+  it('omits forIndex/forEnd from the action block for a non-FOR STEP_TRANSITIONED event', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue(
+      appliedOutcome({
+        // No forIndex on the event → the buffered action must not carry forIndex
+        // or forEnd (pins the `forIndex !== undefined ? {...} : {}` spread guard).
+        events: [stepEvent({ command: 'pass' })],
+      }),
+    );
+
+    await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    const block = output.action.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.hasOwn(block, 'forIndex')).toBe(false);
+    expect(Object.hasOwn(block, 'forEnd')).toBe(false);
+  });
+
+  it('renders a RUNBOOK_COMPLETED event via output.complete', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue(
+      appliedOutcome({
+        status: 'done',
+        events: [
+          {
+            type: 'RUNBOOK_COMPLETED',
+            payload: { message: 'all done', finalPosition: { at: '2' } },
+          } as unknown as TransitionObservationEvent,
+        ],
+      }),
+    );
+
+    await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    expect(output.complete).toHaveBeenCalledWith('all done', { at: '2' });
+  });
+
+  it('renders a RUNBOOK_STOPPED event via output.stopped and reports a stopped status exit', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue(
+      appliedOutcome({
+        status: 'stopped',
+        events: [
+          {
+            type: 'RUNBOOK_STOPPED',
+            payload: { message: 'halted', position: { at: '1' } },
+          } as unknown as TransitionObservationEvent,
+        ],
+      }),
+    );
+
+    const result = await runSeamTransition(output, '/cwd', createFailTransitionConfig());
+
+    expect(output.stopped).toHaveBeenCalledWith('halted', { at: '1' });
+    expect(result.applied).toEqual({ status: 'stopped', runId: PARENT_RUN_ID });
+    expect(result.exitError).toBe(true);
+  });
+
+  it('renders an ERROR_OCCURRED event via output.error', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue(
+      appliedOutcome({
+        events: [
+          {
+            type: 'ERROR_OCCURRED',
+            payload: { message: 'boom', code: 'RD-999' },
+          } as unknown as TransitionObservationEvent,
+        ],
+      }),
+    );
+
+    await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    expect(output.error).toHaveBeenCalledWith('boom', 'RD-999');
+  });
+
+  it('emits an already-resolved status for a duplicate re-record', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue(
+      appliedOutcome({
+        duplicate: { at: '1.1', frameKey: '1', entry: 2 },
+      }),
+    );
+
+    await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    expect(output.status).toHaveBeenCalledWith('pass', 'Completion already recorded for 1.1', {
+      status: 'already-resolved',
+      at: '1.1',
+      frameKey: '1',
+      entry: 2,
+    });
+  });
+
+  it('drives the execution loop for a run directive and propagates a stopped loop result', async () => {
+    const output = makeOutput();
+    mockRunExecutionLoop.mockResolvedValue('stopped');
+    mockRunTransition.mockResolvedValue(
+      appliedOutcome({
+        loop: { kind: 'run', prompted: false },
+        terminalReleaseMode: 'release-runbook',
+      }),
+    );
+
+    const result = await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    expect(mockRunExecutionLoop).toHaveBeenCalledTimes(1);
+    const loopArgs = mockRunExecutionLoop.mock.calls[0];
+    // The seam directive's terminalReleaseMode + output are forwarded verbatim.
+    expect(loopArgs[6]).toEqual({ terminalReleaseMode: 'release-runbook', output });
+    expect(result.applied).toEqual({ status: 'stopped', runId: PARENT_RUN_ID });
+    expect(result.exitError).toBe(true);
+  });
+
+  it('routes a manual-completion drain through the emitter-bridged sink, not the action sink', async () => {
+    const output = makeOutput();
+    mockRunTransition.mockResolvedValue(
+      appliedOutcome({
+        mutation: 'manual-completion',
+        events: [stepEvent()],
+      }),
+    );
+
+    await runSeamTransition(output, '/cwd', createPassTransitionConfig());
+
+    // manual-completion renders through the bridged emitter sink...
+    expect(mockManualSink.onStepTransitioned).toHaveBeenCalledTimes(1);
+    // ...and NOT through the buffered top-level action sink.
+    expect(output.action).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/__tests__/errors/factory.test.ts
+++ b/packages/core/__tests__/errors/factory.test.ts
@@ -1,202 +1,471 @@
 import { describe, it, expect } from '@jest/globals';
-import { Errors, RundownError } from '../../src/errors.js';
+// Import Errors directly from the factory module (not the `../../src/errors.js`
+// barrel). Stryker's `enableFindRelatedTests` uses jest's `--findRelatedTests`,
+// whose reverse-dependency graph does not traverse the `export *` re-export
+// chain (errors.ts → errors/index.ts → errors/factory.ts). Importing the module
+// under test directly is what links this test file to factory.ts so its mutants
+// are actually exercised. RundownError is imported from its own module for the
+// same reason.
+import { Errors } from '../../src/errors/factory.js';
+import { RundownError } from '../../src/errors/rundown-error.js';
 
 /**
- * Extended tests for Errors factory functions.
- * Complements the tests in rundown-error.test.ts with additional factory coverage.
+ * Exhaustive tests for the {@link Errors} factory.
+ *
+ * Every factory function is exercised and each assertion pins a distinct
+ * observable: the RundownError class, the mapped error code, every context
+ * field the factory writes (including join separators and `String(...)`
+ * coercions), any message template authored inside the factory, and the
+ * `cause` linkage where applicable. This kills the ArrowFunction (`=> undefined`),
+ * string-literal (error-code key), and object-literal (`{ … }` → `{}`) mutants
+ * that survive when a factory is either untested or only asserted on `.code`.
  */
-describe('Errors factory - extended coverage', () => {
+describe('Errors factory - exhaustive coverage', () => {
   describe('File/IO errors', () => {
-    it('fileNotReadable creates correct error', () => {
-      const error = Errors.fileNotReadable('config.yaml');
+    it('fileNotFound maps file → RD-101', () => {
+      const error = Errors.fileNotFound('runbook.md');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-101');
+      expect(error.context.file).toBe('runbook.md');
+      expect(error.message).toBe('Runbook file not found: runbook.md');
+    });
 
+    it('fileNotReadable maps file → RD-102', () => {
+      const error = Errors.fileNotReadable('config.yaml');
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-102');
       expect(error.context.file).toBe('config.yaml');
       expect(error.message).toContain('config.yaml');
     });
 
-    it('stateDirNotAccessible creates correct error', () => {
+    it('stateDirNotAccessible maps path → context.file → RD-103', () => {
       const error = Errors.stateDirNotAccessible('/path/to/.rundown');
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-103');
       expect(error.context.file).toBe('/path/to/.rundown');
+      expect(error.message).toContain('/path/to/.rundown');
     });
   });
 
   describe('Parse/Syntax errors', () => {
-    it('emptyRunbook creates correct error', () => {
+    it('emptyRunbook maps file → RD-201', () => {
       const error = Errors.emptyRunbook('empty.runbook.md');
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-201');
       expect(error.context.file).toBe('empty.runbook.md');
     });
 
-    it('noStepsFound creates correct error', () => {
+    it('noStepsFound maps file → RD-202', () => {
       const error = Errors.noStepsFound('no-steps.runbook.md');
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-202');
       expect(error.context.file).toBe('no-steps.runbook.md');
     });
 
-    it('invalidFrontmatter creates error with file only', () => {
+    it('invalidFrontmatter maps file only → RD-203', () => {
       const error = Errors.invalidFrontmatter('test.runbook.md');
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-203');
       expect(error.context.file).toBe('test.runbook.md');
+      expect(error.context.message).toBeUndefined();
     });
 
-    it('invalidFrontmatter creates error with message', () => {
+    it('invalidFrontmatter maps file + message → RD-203', () => {
       const error = Errors.invalidFrontmatter('test.runbook.md', 'Invalid YAML: missing colon');
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-203');
       expect(error.context.file).toBe('test.runbook.md');
       expect(error.context.message).toBe('Invalid YAML: missing colon');
       expect(error.message).toContain('Invalid YAML: missing colon');
     });
+
+    it('syntaxError maps message + file + line → RD-204', () => {
+      const error = Errors.syntaxError('Unexpected token at position 5', 'test.md', 10);
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-204');
+      expect(error.context.file).toBe('test.md');
+      expect(error.context.message).toBe('Unexpected token at position 5');
+      expect(error.context.line).toBe(10);
+      expect(error.message).toBe(
+        'Runbook syntax error: test.md - Unexpected token at position 5 (line 10)',
+      );
+    });
+
+    it('syntaxError maps message alone (no file/line) → RD-204', () => {
+      const error = Errors.syntaxError('Invalid YAML');
+      expect(error.code).toBe('RD-204');
+      expect(error.context.message).toBe('Invalid YAML');
+      expect(error.context.file).toBeUndefined();
+      expect(error.context.line).toBeUndefined();
+      expect(error.message).toBe('Runbook syntax error - Invalid YAML');
+    });
   });
 
   describe('State errors', () => {
-    it('stateParseError creates error with file only', () => {
-      const error = Errors.stateParseError('state.json');
+    it('noActiveRunbook has empty context → RD-301', () => {
+      const error = Errors.noActiveRunbook();
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-301');
+      expect(error.message).toBe('No active runbook');
+    });
 
+    it('stateParseError maps file only → RD-302', () => {
+      const error = Errors.stateParseError('state.json');
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-302');
       expect(error.context.file).toBe('state.json');
+      expect(error.context.message).toBeUndefined();
     });
 
-    it('stateParseError creates error with message', () => {
+    it('stateParseError maps file + message → RD-302', () => {
       const error = Errors.stateParseError('state.json', 'Unexpected token at position 42');
-
-      expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-302');
+      expect(error.context.file).toBe('state.json');
       expect(error.context.message).toBe('Unexpected token at position 42');
     });
 
-    it('runbookCompleted creates error without file', () => {
+    it('runbookCompleted without file → RD-303', () => {
       const error = Errors.runbookCompleted();
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-303');
+      expect(error.context.file).toBeUndefined();
     });
 
-    it('runbookCompleted creates error with file', () => {
+    it('runbookCompleted with file → RD-303', () => {
       const error = Errors.runbookCompleted('deploy.runbook.md');
-
-      expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-303');
       expect(error.context.file).toBe('deploy.runbook.md');
     });
 
-    it('runbookStopped creates error without file', () => {
+    it('runbookStopped without file → RD-304', () => {
       const error = Errors.runbookStopped();
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-304');
+      expect(error.context.file).toBeUndefined();
     });
 
-    it('runbookStopped creates error with file', () => {
+    it('runbookStopped with file → RD-304', () => {
       const error = Errors.runbookStopped('deploy.runbook.md');
-
-      expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-304');
       expect(error.context.file).toBe('deploy.runbook.md');
     });
   });
 
   describe('Validation errors', () => {
-    it('gotoTargetNotFound creates error with step only', () => {
+    it('gotoTargetNotFound maps step only → RD-401', () => {
       const error = Errors.gotoTargetNotFound('10');
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-401');
       expect(error.context.step).toBe('10');
       expect(error.context.substep).toBeUndefined();
     });
+
+    it('gotoTargetNotFound maps step + substep → RD-401', () => {
+      const error = Errors.gotoTargetNotFound('5', '2');
+      expect(error.code).toBe('RD-401');
+      expect(error.context.step).toBe('5');
+      expect(error.context.substep).toBe('2');
+      expect(error.message).toContain('at step 5.2');
+    });
+
+    it('invalidStepSequence coerces expected/found to strings + maps line → RD-402', () => {
+      const error = Errors.invalidStepSequence(3, 5, 42);
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-402');
+      // String(expected) / String(found) coercion — assert the string form.
+      expect(error.context.expected).toBe('3');
+      expect(error.context.found).toBe('5');
+      expect(error.context.line).toBe(42);
+      expect(error.message).toContain('(expected 3, found 5)');
+      expect(error.message).toContain('(line 42)');
+    });
+
+    it('invalidStepSequence omits line when not provided', () => {
+      const error = Errors.invalidStepSequence(1, 2);
+      expect(error.code).toBe('RD-402');
+      expect(error.context.expected).toBe('1');
+      expect(error.context.found).toBe('2');
+      expect(error.context.line).toBeUndefined();
+    });
   });
 
   describe('Execution errors', () => {
-    it('engineInitFailed creates error without cause', () => {
+    it('engineInitFailed without cause → RD-501', () => {
       const error = Errors.engineInitFailed();
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-501');
       expect(error.cause).toBeUndefined();
     });
 
-    it('engineInitFailed creates error with cause', () => {
+    it('engineInitFailed with cause → RD-501', () => {
       const cause = new Error('XState initialization failed');
       const error = Errors.engineInitFailed(cause);
-
-      expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-501');
       expect(error.cause).toBe(cause);
     });
 
-    it('runbookHasNoSteps creates error without file', () => {
+    it('runbookHasNoSteps without file → RD-502', () => {
       const error = Errors.runbookHasNoSteps();
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-502');
+      expect(error.context.file).toBeUndefined();
     });
 
-    it('runbookHasNoSteps creates error with file', () => {
+    it('runbookHasNoSteps with file → RD-502', () => {
       const error = Errors.runbookHasNoSteps('empty.runbook.md');
-
-      expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-502');
       expect(error.context.file).toBe('empty.runbook.md');
     });
 
-    it('childRunbookActive creates error without childId', () => {
+    it('childRunbookActive without childId → RD-503', () => {
       const error = Errors.childRunbookActive();
-
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-503');
+      expect(error.context.childId).toBeUndefined();
     });
 
-    it('childRunbookActive creates error with childId', () => {
+    it('childRunbookActive with childId → RD-503', () => {
       const error = Errors.childRunbookActive('abc-123');
-
-      expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-503');
       expect(error.context.childId).toBe('abc-123');
     });
   });
 
   describe('Command errors', () => {
-    it('missingRequiredArg creates correct error', () => {
-      const error = Errors.missingRequiredArg('file');
+    it('invalidStepFormat maps value → RD-601', () => {
+      const error = Errors.invalidStepFormat('abc');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-601');
+      expect(error.context.value).toBe('abc');
+      expect(error.message).toBe('Invalid step ID format: "abc"');
+    });
 
+    it('missingRequiredArg maps argName → RD-602', () => {
+      const error = Errors.missingRequiredArg('file');
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-602');
       expect(error.context.argName).toBe('file');
       expect(error.message).toContain('file');
     });
+
+    it('scenarioNotFound maps scenario + file → RD-603', () => {
+      const error = Errors.scenarioNotFound('happy-path', 'test.md');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-603');
+      expect(error.context.scenario).toBe('happy-path');
+      expect(error.context.file).toBe('test.md');
+      expect(error.message).toBe('Scenario not found: happy-path in test.md');
+    });
+
+    it('scenarioNotFound maps scenario only → RD-603', () => {
+      const error = Errors.scenarioNotFound('happy-path');
+      expect(error.code).toBe('RD-603');
+      expect(error.context.scenario).toBe('happy-path');
+      expect(error.context.file).toBeUndefined();
+      expect(error.message).toBe('Scenario not found: happy-path');
+    });
   });
 
-  describe('Generic errors', () => {
-    it('delegationInvariantViolated creates correct error', () => {
-      const error = Errors.delegationInvariantViolated('retryDelegation abort result');
+  describe('Delegation / substep-targeting errors', () => {
+    it('delegationStepNotFound maps step → RD-801', () => {
+      const error = Errors.delegationStepNotFound('2');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-801');
+      expect(error.context.step).toBe('2');
+    });
 
+    it('delegationStepNotCurrent maps step + current → RD-802', () => {
+      const error = Errors.delegationStepNotCurrent('2', '1');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-802');
+      expect(error.context.step).toBe('2');
+      expect(error.context.current).toBe('1');
+    });
+
+    it('delegationSubstepRequired joins substeps with ", " → RD-803', () => {
+      const error = Errors.delegationSubstepRequired('2', ['2.1', '2.2', '2.3']);
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-803');
+      expect(error.context.step).toBe('2');
+      // Pins the join separator; a mutated separator would not equal this.
+      expect(error.context.substeps).toBe('2.1, 2.2, 2.3');
+    });
+
+    it('delegationAlreadyExists maps step (+ optional message) → RD-804', () => {
+      const withMessage = Errors.delegationAlreadyExists('2', 'already delegated');
+      expect(withMessage).toBeInstanceOf(RundownError);
+      expect(withMessage.code).toBe('RD-804');
+      expect(withMessage.context.step).toBe('2');
+      expect(withMessage.context.message).toBe('already delegated');
+
+      const withoutMessage = Errors.delegationAlreadyExists('3');
+      expect(withoutMessage.code).toBe('RD-804');
+      expect(withoutMessage.context.step).toBe('3');
+      expect(withoutMessage.context.message).toBeUndefined();
+    });
+
+    it('delegationRunbookNotFound maps runbook → RD-805', () => {
+      const error = Errors.delegationRunbookNotFound('child.runbook.md');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-805');
+      expect(error.context.runbook).toBe('child.runbook.md');
+    });
+
+    it('delegationRunbookMismatch maps step/requested/authored + message → RD-822', () => {
+      const error = Errors.delegationRunbookMismatch('2', 'req.md', 'auth.md');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-822');
+      expect(error.context.step).toBe('2');
+      expect(error.context.requested).toBe('req.md');
+      expect(error.context.authored).toBe('auth.md');
+      // Interpolated message template authored inside the factory.
+      expect(error.context.message).toBe('requested req.md, authored auth.md');
+      expect(error.message).toContain('requested req.md, authored auth.md');
+    });
+
+    it('delegationSubstepNotFound joins available with ", " → RD-806', () => {
+      const error = Errors.delegationSubstepNotFound('2.9', '2', ['2.1', '2.2']);
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-806');
+      expect(error.context.substep).toBe('2.9');
+      expect(error.context.step).toBe('2');
+      expect(error.context.available).toBe('2.1, 2.2');
+    });
+
+    it('invalidToken maps token → RD-807', () => {
+      const error = Errors.invalidToken('bad_token');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-807');
+      expect(error.context.token).toBe('bad_token');
+    });
+
+    it('tokenNotFound maps token → RD-808', () => {
+      const error = Errors.tokenNotFound('rdtk_missing');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-808');
+      expect(error.context.token).toBe('rdtk_missing');
+    });
+
+    it('tokenCancelled maps token → RD-809', () => {
+      const error = Errors.tokenCancelled('rdtk_cancelled');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-809');
+      expect(error.context.token).toBe('rdtk_cancelled');
+    });
+
+    it('delegationLockTimeout maps parentRunId → RD-810', () => {
+      const error = Errors.delegationLockTimeout('run-123');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-810');
+      expect(error.context.parentRunId).toBe('run-123');
+    });
+
+    it('delegationAlreadyClaimed maps step + childRunId → RD-811', () => {
+      const error = Errors.delegationAlreadyClaimed('2', 'child-9');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-811');
+      expect(error.context.step).toBe('2');
+      expect(error.context.childRunId).toBe('child-9');
+    });
+
+    it('delegationInFlight maps step/childRunId + interpolated message → RD-823', () => {
+      const error = Errors.delegationInFlight('2', 'child-9');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-823');
+      expect(error.context.step).toBe('2');
+      expect(error.context.childRunId).toBe('child-9');
+      expect(error.context.message).toBe(
+        'child run child-9 is still linked; run "rd abort <token> --force" before retrying',
+      );
+      expect(error.message).toContain('child run child-9 is still linked');
+    });
+
+    it('delegationAlreadyResolved maps step → RD-812', () => {
+      const error = Errors.delegationAlreadyResolved('2');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-812');
+      expect(error.context.step).toBe('2');
+    });
+
+    it('delegationNoDelegatableSubstep maps step → RD-813', () => {
+      const error = Errors.delegationNoDelegatableSubstep('2');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-813');
+      expect(error.context.step).toBe('2');
+    });
+
+    it('delegationSubstepNoRunbook maps substep + step → RD-814', () => {
+      const error = Errors.delegationSubstepNoRunbook('2.1', '2');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-814');
+      expect(error.context.substep).toBe('2.1');
+      expect(error.context.step).toBe('2');
+    });
+
+    it('delegationStepNoSubsteps maps step → RD-815', () => {
+      const error = Errors.delegationStepNoSubsteps('2');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-815');
+      expect(error.context.step).toBe('2');
+    });
+
+    it('delegationSnapshotStale maps substepId + step → RD-817', () => {
+      const error = Errors.delegationSnapshotStale('2.1', '2');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-817');
+      expect(error.context.substepId).toBe('2.1');
+      expect(error.context.step).toBe('2');
+    });
+
+    it('delegationOwnerLostSubsteps maps substepId + step → RD-818', () => {
+      const error = Errors.delegationOwnerLostSubsteps('2.1', '2');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-818');
+      expect(error.context.substepId).toBe('2.1');
+      expect(error.context.step).toBe('2');
+    });
+
+    it('delegationNestedForbidden maps runId → RD-819', () => {
+      const error = Errors.delegationNestedForbidden('run-77');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-819');
+      expect(error.context.runId).toBe('run-77');
+    });
+
+    it('delegationInvariantViolated maps reason → RD-821', () => {
+      const error = Errors.delegationInvariantViolated('retryDelegation abort result');
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-821');
       expect(error.context.reason).toBe('retryDelegation abort result');
     });
+  });
 
-    it('unknown preserves cause', () => {
-      const cause = new Error('Original error');
-      const error = Errors.unknown('Unexpected failure', cause);
+  describe('Retry-hook errors', () => {
+    it('retryHookStaleSubstep maps substepId + parentStep → RD-905', () => {
+      const error = Errors.retryHookStaleSubstep('2.1', '2');
+      expect(error).toBeInstanceOf(RundownError);
+      expect(error.code).toBe('RD-905');
+      expect(error.context.substepId).toBe('2.1');
+      expect(error.context.parentStep).toBe('2');
+    });
+  });
 
+  describe('Generic errors', () => {
+    it('unknown maps message and omits cause when not given → RD-999', () => {
+      const error = Errors.unknown('Something went wrong');
       expect(error).toBeInstanceOf(RundownError);
       expect(error.code).toBe('RD-999');
-      expect(error.cause).toBe(cause);
+      expect(error.context.message).toBe('Something went wrong');
+      expect(error.cause).toBeUndefined();
+      expect(error.message).toContain('- Something went wrong');
+    });
+
+    it('unknown preserves cause → RD-999', () => {
+      const cause = new Error('Original error');
+      const error = Errors.unknown('Unexpected failure', cause);
+      expect(error.code).toBe('RD-999');
       expect(error.context.message).toBe('Unexpected failure');
+      expect(error.cause).toBe(cause);
     });
   });
 });

--- a/packages/core/__tests__/errors/factory.test.ts
+++ b/packages/core/__tests__/errors/factory.test.ts
@@ -375,7 +375,7 @@ describe('Errors factory - exhaustive coverage', () => {
       expect(error.context.step).toBe('2');
       expect(error.context.childRunId).toBe('child-9');
       expect(error.context.message).toBe(
-        'child run child-9 is still linked; run "rd abort <token> --force" before retrying',
+        'child run child-9 is still linked; run "rundown abort <token> --force" before retrying',
       );
       expect(error.message).toContain('child run child-9 is still linked');
     });


### PR DESCRIPTION
## Why

The advisory per-file mutation gate (issue #485) flagged several files below the 70% floor — but for most of them the low score was a **measurement artifact, not untested code**. Stryker runs `enableFindRelatedTests: true`, which selects covering tests via Jest's **static** import graph. Three things defeat that graph, so real tests weren't being counted:

- **Dynamic `import('../cli.js')`** in `in-process-cli-runner.ts` — every CLI command test drives the CLI through this seam, so no command module's tests were linked (`status.ts` made Stryker exit with *"No tests were executed"*).
- **Barrel `export *` re-exports** — core error tests imported through `src/errors.js`, which Jest's reverse-dependency graph doesn't traverse.
- **Integration tests excluded** from the mutation sandbox (`jest.config.shared.js`).

The fix is sandbox-visible tests that **statically import** the target, plus real assertions. This is **test-only** — no production changes.

## What

**Per-file mutation scores (scoped, advisory floor 70%):**

| File | Before | After |
|------|--------|-------|
| `core/src/errors/factory.ts` | 5.81% | **100%** |
| `cli/src/helpers/transitions.ts` | 30.55% | **87.78%** |
| `cli/src/helpers/runbook-pipeline.ts` | 66.07% | **71.07%** |
| `cli/src/commands/delegate.ts` | 0.00% | **70.37%** |
| `cli/src/commands/run.ts` | 22.33% | improved* |
| `cli/src/commands/collect.ts` | 0.00% | 67.32%* |

\* `run.ts` full-suite ≥70% not confirmed (huge full-suite run); `collect.ts` residual is unreachable defensive arms + equivalent mutants. Both left as advisory.

**Systemic fix — the durable win:** a static-import "wiring" edge added to **all 16 per-command test suites** so the gate measures them honestly (e.g. `status.ts` 0/crash → 68.29%, `fail.ts` → 83.33%), plus a structural **regression guard** (`command-test-mutation-linkage.test.ts`) that fails if a new command test omits the edge or a new command module has no test home.

## Verification

Test-only. Verified locally on this branch (post-#523 base): core `factory.test.ts` 54 pass; full `__tests__/commands` 633 pass (26 suites); transitions helper suites 57 pass. biome + eslint clean.

## Follow-ups (not in this PR)

- `run.ts` / `collect.ts` remain below floor (advisory).
- `rundown-error.ts` likely has the same barrel-import linkage bug.
- `refusal-renderers.ts` / `lifecycle-seam-factory.ts` (#523 code) have no dedicated per-file coverage.
- `check.ts` / `prompt.ts` have no per-command test home (tracked in the guard's residual-gap list).
- Architectural: `run.ts`'s `buildInlineLinkage()` duplicates core `delegation-service` validation and should move to core (thin-wrapper principle).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded CLI coverage with static “command wiring” checks for many commands, validating registered descriptions, subcommands, option flags, help text, and pinned defaults (including repeatable options).
  * Strengthened CLI behavior assertions for output rendering, structured error/warning envelopes, and streamed stop/transition propagation.
  * Added/expanded runbook execution, transitions (“seam”) unit coverage, cursor/target edge cases, and helper pipeline behavior (including failure modes).
  * Reworked exhaustive error-factory assertions and updated spell-check dictionary vocabulary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->