### PR TITLE
fix(core): collect trust — typed caller evidence + subprocess withholding (Cluster E: #509-P1)

### DIFF
--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -438,16 +438,16 @@ as an ordinary `argv`, indistinguishable from a human invocation. They are
 therefore **not** direct-CLI-trusted callers. The shared boundary
 `bareRoleSpecificMutation`
 (`packages/core/src/runbook/subprocess-mutation-boundary.ts`) classifies a bare
-(default-target) `rundown pass` / `rundown fail` / `rundown delegate` as the
-invocations whose only available trust is `direct_cli`; the spawning front end
-withholds those (the CLI process itself cannot distinguish a plugin-spawned bare
-`rundown pass` from a human-run one, so the block happens front-end-side).
-`--claim-id` mutations are **preserved**: their `claim_controller` evidence
-(`claimId`, `tokenHash`, `controlledRunId`) is reconstructable CLI-side from the
-resolved claim record, so they do not rely on direct-CLI trust and delegated
-children can still complete. See
-[Claude Code Plugin Trust Model](./plugin-trust-model.md) for the plugin's other
-trust boundaries.
+(default-target) `rundown pass` / `rundown fail` / `rundown delegate` /
+`rundown complete` / `rundown stop` / `rundown collect` as the invocations whose
+only available trust is `direct_cli`; the spawning front end withholds those
+(the CLI process itself cannot distinguish a plugin-spawned bare `rundown pass`
+from a human-run one, so the block happens front-end-side). `--claim-id`
+mutations are **preserved**: their `claim_controller` evidence (`claimId`,
+`tokenHash`, `controlledRunId`) is reconstructable CLI-side from the resolved
+claim record, so they do not rely on direct-CLI trust and delegated children can
+still complete. See [Claude Code Plugin Trust Model](./plugin-trust-model.md)
+for the plugin's other trust boundaries.
 
 ---
 

--- a/docs/internal/plugin-trust-model.md
+++ b/docs/internal/plugin-trust-model.md
@@ -70,9 +70,10 @@ an ordinary `argv`, indistinguishable from a human invocation, and a bare
 default-target invocation would silently inherit direct-CLI
 (`trusted_run_controller`) trust over the active run. The plugin/MCP front end
 is **not** a direct-CLI-trusted caller, so it withholds bare role-specific
-lifecycle mutations — bare `rundown pass`, `rundown fail`, and
-`rundown delegate` — rather than spawning them. The classification is the
-shared, argv-only predicate `bareRoleSpecificMutation`
+lifecycle mutations — bare `rundown pass`, `rundown fail`, `rundown delegate`,
+`rundown complete`, `rundown stop`, and `rundown collect` — rather than spawning
+them. The classification is the shared, argv-only predicate
+`bareRoleSpecificMutation`
 (`packages/core/src/runbook/subprocess-mutation-boundary.ts`); no source label
 is read or trusted, and `--actor-source` / `RD_ACTOR_SOURCE` do not exist.
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -97,29 +97,30 @@ cross the process boundary: a spawned `rundown pass` / `rundown fail` /
 `rundown delegate` arrives as an ordinary `argv`, indistinguishable from a human
 at the terminal, and would silently inherit direct-CLI trust
 (`trusted_run_controller`) over the active run. The server therefore withholds
-bare `pass` / `fail` (without claim evidence) and every `delegate` call,
-refusing them in-process without invoking the CLI (see [§5.6](#pass),
-[§5.7](#fail), and [§5.11](#delegate)). Only `pass` / `fail` carrying a real
+bare `pass` / `fail` / `complete` / `stop` / `collect` (without claim evidence)
+and every `delegate` call, refusing them in-process without invoking the CLI
+(see [§5.6](#pass), [§5.7](#fail), [§5.11](#delegate), and [§5.13](#collect)).
+Only `pass` / `fail` / `complete` / `stop` / `collect` carrying a real
 `--claim-id` present independent claim evidence and pass through. Tools that
 exist purely for local session management, destructive state operations, or
 authoring helpers are CLI-only (see [§5.14](#unsupported-cli-operations)).
 
 The server MUST register exactly the following tools:
 
-| Tool                    | Required parameters | Optional parameters                                                    | CLI mapping                                                                                                                 |
-| ----------------------- | ------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| [`validate`](#validate) | `file`              | —                                                                      | `rundown check <file>`                                                                                                      |
-| [`list`](#list)         | —                   | `all`, `tags`                                                          | `rundown ls [--all] [--tags <tags>]`                                                                                        |
-| [`status`](#status)     | —                   | `claimId`                                                              | `rundown status [--claim-id <id>]`                                                                                          |
-| [`run`](#run)           | —                   | `file`, `prompted`, `step`, `index`, `input`, `inputJson`, `inputFile` | `rundown run [<file>] [--prompted] [--step <id>] [--index <n>] [--input ...] [--input-json ...] [--input-file ...]`         |
-| [`pass`](#pass)         | —                   | `step`, `index`, `claimId`                                             | `rundown pass [--step <id>] [--index <n>] [--claim-id <id>]` — bare form (no `claimId`) withheld in-process ([§5.6](#pass)) |
-| [`fail`](#fail)         | —                   | `step`, `index`, `claimId`                                             | `rundown fail [--step <id>] [--index <n>] [--claim-id <id>]` — bare form (no `claimId`) withheld in-process ([§5.7](#fail)) |
-| [`goto`](#goto)         | `step`              | `index`, `claimId`                                                     | `rundown goto <step> [--index <n>] [--claim-id <id>]`                                                                       |
-| [`complete`](#complete) | —                   | `message`, `claimId`                                                   | `rundown complete [<message>] [--claim-id <id>]`                                                                            |
-| [`stop`](#stop)         | —                   | `message`, `claimId`                                                   | `rundown stop [<message>] [--claim-id <id>]`                                                                                |
-| [`delegate`](#delegate) | —                   | `runbook`, `step`, `index`, `retry`, `input`, `inputJson`, `inputFile` | Always withheld in-process; never invokes the CLI ([§5.11](#delegate))                                                      |
-| [`claim`](#claim)       | `token`             | `input`, `inputJson`, `inputFile`                                      | `rundown claim <token> [--input ...] [--input-json ...] [--input-file ...]`                                                 |
-| [`collect`](#collect)   | —                   | `step`, `index`, `claimId`                                             | `rundown collect [--step <id>] [--index <n>] [--claim-id <id>]`                                                             |
+| Tool                    | Required parameters | Optional parameters                                                    | CLI mapping                                                                                                                        |
+| ----------------------- | ------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [`validate`](#validate) | `file`              | —                                                                      | `rundown check <file>`                                                                                                             |
+| [`list`](#list)         | —                   | `all`, `tags`                                                          | `rundown ls [--all] [--tags <tags>]`                                                                                               |
+| [`status`](#status)     | —                   | `claimId`                                                              | `rundown status [--claim-id <id>]`                                                                                                 |
+| [`run`](#run)           | —                   | `file`, `prompted`, `step`, `index`, `input`, `inputJson`, `inputFile` | `rundown run [<file>] [--prompted] [--step <id>] [--index <n>] [--input ...] [--input-json ...] [--input-file ...]`                |
+| [`pass`](#pass)         | —                   | `step`, `index`, `claimId`                                             | `rundown pass [--step <id>] [--index <n>] [--claim-id <id>]` — bare form (no `claimId`) withheld in-process ([§5.6](#pass))        |
+| [`fail`](#fail)         | —                   | `step`, `index`, `claimId`                                             | `rundown fail [--step <id>] [--index <n>] [--claim-id <id>]` — bare form (no `claimId`) withheld in-process ([§5.7](#fail))        |
+| [`goto`](#goto)         | `step`              | `index`, `claimId`                                                     | `rundown goto <step> [--index <n>] [--claim-id <id>]`                                                                              |
+| [`complete`](#complete) | —                   | `message`, `claimId`                                                   | `rundown complete [<message>] [--claim-id <id>]`                                                                                   |
+| [`stop`](#stop)         | —                   | `message`, `claimId`                                                   | `rundown stop [<message>] [--claim-id <id>]`                                                                                       |
+| [`delegate`](#delegate) | —                   | `runbook`, `step`, `index`, `retry`, `input`, `inputJson`, `inputFile` | Always withheld in-process; never invokes the CLI ([§5.11](#delegate))                                                             |
+| [`claim`](#claim)       | `token`             | `input`, `inputJson`, `inputFile`                                      | `rundown claim <token> [--input ...] [--input-json ...] [--input-file ...]`                                                        |
+| [`collect`](#collect)   | —                   | `step`, `index`, `claimId`                                             | `rundown collect [--step <id>] [--index <n>] [--claim-id <id>]` — bare form (no `claimId`) withheld in-process ([§5.13](#collect)) |
 
 Parameter types are defined per tool below. The server MUST validate tool inputs
 against the declared schema and reject inputs that fail validation without
@@ -326,6 +327,18 @@ Aggregate a delegated step and advance the parent runbook through core.
 | `index`   | integer ≥ 0 | No       | When set, forwarded as `--index <value>` for FOR-loop targeting. Requires `step`.      |
 | `claimId` | string      | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.            |
 
+Over MCP, `collect` REQUIRES claim evidence: a bare `collect` without a real
+`claimId` is classified as a subprocess lifecycle mutation and withheld
+in-process — the server MUST return a withheld-mutation `error` payload WITHOUT
+invoking the CLI. A spawned bare `rundown collect` would silently inherit
+direct-CLI (`trusted_run_controller`) trust over the delegating run and drive
+parent aggregation that is orchestrator-only. Only a `collect` carrying a real
+`claimId` presents independent claim-controller evidence — collecting
+delegations issued by the claimed run itself — and is forwarded to the CLI;
+collection into an ancestor remains refused by core policy
+(`COLLECT_REQUIRES_ORCHESTRATOR`). To aggregate a delegated step on the parent,
+run `rundown collect` directly in a trusted terminal.
+
 <a id="unsupported-cli-operations"></a>
 
 ### 5.14 Unsupported CLI Operations
@@ -451,9 +464,12 @@ withheld in-process by the subprocess mutation boundary (see
 [§5.11](#delegate)), because delegation carries no claim evidence and a
 subprocess-spawned `delegate` would silently inherit direct-CLI trust over the
 active run. To issue or retry a delegation, run `rundown delegate` directly in a
-trusted terminal. For the claim and collect tools, claim lifecycle and result
-aggregation are inherited unchanged from the CLI; the MCP server adds no policy
-or state of its own. Token abort likewise remains CLI-only (see
+trusted terminal. For the claim tool, claim lifecycle is inherited unchanged
+from the CLI; the MCP server adds no policy or state of its own. A bare
+`collect` (no `claimId`) is likewise withheld in-process by the subprocess
+mutation boundary ([§5.13](#collect)) — a claim-evidenced `collect` carrying a
+real `claimId` is unaffected, and its result aggregation is inherited unchanged
+from the CLI. Token abort likewise remains CLI-only (see
 [§5.14](#unsupported-cli-operations)). See
 [docs/reference/cli.md Delegation Commands](cli.md#delegation-commands) and
 [docs/reference/runtime.md State Persistence](runtime.md#state-persistence).

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/rundown.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/rundown.test.ts
@@ -130,6 +130,7 @@ describe('rundown', () => {
       ['pass'],
       ['fail'],
       ['delegate'],
+      ['collect'],
     ])('withholds a bare %s mutation instead of spawning the CLI', (command) => {
       const mockExec = mockExecFileSync('should not run');
       setExecSync(mockExec);
@@ -176,6 +177,7 @@ describe('rundown', () => {
     it.each([
       [['pass', '--claim-id', 'claim-1']],
       [['fail', '--claim-id=claim-1']],
+      [['collect', '--claim-id', 'claim-1']],
     ])('spawns the claim-evidence mutation %j', (args) => {
       const mockExec = mockExecFileSync('ok');
       setExecSync(mockExec);

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -4,19 +4,17 @@ import type { Command } from 'commander';
 import {
   activeFrame,
   buildFrameKey,
-  claimControllerContext,
   deriveActiveFrame,
   ExecutionEventEmitter,
   inactiveFrame,
   RunbookCollectionService,
   RunbookCompletionService,
-  trustedRunControllerContext,
-  type ActorContext,
   type DelegationPolicyOutcome,
   type Frame,
   type FrameKey,
 } from '@rundown-org/core';
 import { parseStepIdFromString } from '@rundown-org/parser';
+import { readLifecycleCallerEvidence } from '../helpers/caller-evidence.js';
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
@@ -407,8 +405,9 @@ function renderCollectOutcome(
 /**
  * Execute the collect workflow against a resolved transition context.
  *
- * The CLI is a thin adapter: it parses flags, constructs the actor context, and
- * delegates the collection operation to core's {@link RunbookCollectionService}.
+ * The CLI is a thin adapter: it parses flags, gathers typed caller evidence
+ * (core maps evidence to trust), and delegates the collection operation to
+ * core's {@link RunbookCollectionService}.
  * All collection logic (policy gating, drain, aggregation, single-level terminal
  * reporting) lives in core; this command only renders the returned outcome.
  *
@@ -422,16 +421,19 @@ async function runCollect(ctx: TransitionContext, options: CollectOptions): Prom
   const scope = resolveCollectScope(state, options, output);
   if (!scope) return true;
 
-  // On the claim-targeted path `ctx.state` is the claimed child run, so
-  // `controlledRunId === state.id`; otherwise the trusted direct-CLI mapping
-  // makes the run controller the orchestrator for its own run.
-  const actorContext: ActorContext = ctx.claim
-    ? claimControllerContext({
-        claimId: ctx.claim.claimId,
-        tokenHash: ctx.claim.tokenHash,
-        controlledRunId: state.id,
-      })
-    : trustedRunControllerContext(state.id);
+  // On the claim-targeted path the resolved claim record supplies
+  // reconstructable claim-controller evidence; a bare invocation is the
+  // direct-CLI lane. The CLI never constructs an actor context — core maps
+  // evidence to trust (actorContextFromEvidence) behind the collection seam.
+  const callerEvidence = readLifecycleCallerEvidence(
+    ctx.claim
+      ? {
+          claimId: ctx.claim.claimId,
+          tokenHash: ctx.claim.tokenHash,
+          controlledRunId: ctx.claim.childRunId,
+        }
+      : undefined,
+  );
 
   const collectionService = new RunbookCollectionService({
     manager,
@@ -443,7 +445,7 @@ async function runCollect(ctx: TransitionContext, options: CollectOptions): Prom
   const outcome = await collectionService.collectDelegationOutcomes({
     targetState: state,
     steps,
-    actorContext,
+    callerEvidence,
     // Pass an explicit step name ONLY for `--step`. For a bare collect, leaving
     // it unset lets core default to the cursor AND enables its post-aggregation
     // `already_collected` no-op (which is gated on `!stepName`); passing the

--- a/packages/core/__tests__/runbook/collection-service.properties.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.properties.test.ts
@@ -13,7 +13,6 @@ import {
   activeFrame,
   assertRunId,
   buildFrameKey,
-  trustedRunControllerContext,
   type RunbookState,
 } from '../../src/runbook/index.js';
 import { brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
@@ -117,7 +116,7 @@ describe('RunbookCollectionService properties', () => {
         const outcome = await collectionService.collectDelegationOutcomes({
           targetState: state({ substepStates: doneSubstepStates(doneInFrame) }),
           steps,
-          actorContext: trustedRunControllerContext(runId),
+          callerEvidence: { kind: 'direct_cli' },
           frame: activeFrame(buildFrameKey('1'), 1),
         });
 
@@ -145,7 +144,7 @@ describe('RunbookCollectionService properties', () => {
         const outcome = await collectionService.collectDelegationOutcomes({
           targetState: state({ substepStates: doneSubstepStates(doneInOtherFrame, 2) }),
           steps,
-          actorContext: trustedRunControllerContext(runId),
+          callerEvidence: { kind: 'direct_cli' },
           frame: activeFrame(buildFrameKey('1'), 1),
         });
 

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -12,9 +12,7 @@ import {
   assertClaimId,
   assertDelegationTokenHash,
   assertRunId,
-  claimControllerContext,
-  trustedRunControllerContext,
-  UNKNOWN_ACTOR_CONTEXT,
+  type CallerEvidence,
   type RunbookState,
 } from '../../src/runbook/index.js';
 import type { ExecutionObservationEffect } from '../../src/events/execution-observation.js';
@@ -67,6 +65,8 @@ describe('RunbookCollectionService', () => {
   const tokenHash = assertDelegationTokenHash(
     'sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
   );
+
+  const DIRECT_CLI_EVIDENCE: CallerEvidence = { kind: 'direct_cli' };
 
   // Default runbook: step 1 delegates two substeps (PASS CONTINUE so a full
   // drain advances the run to step 2 while staying `running`); step 2 is a
@@ -137,14 +137,21 @@ describe('RunbookCollectionService', () => {
     await rm(tmp, { recursive: true, force: true });
   });
 
-  it('rejects unknown actor context before inspecting outcomes', async () => {
+  it.each<[string, CallerEvidence]>([
+    ['plugin', { kind: 'plugin', agentId: 'subagent-1' }],
+    ['mcp', { kind: 'mcp', toolName: 'collect' }],
+    ['unknown', { kind: 'unknown' }],
+  ])('refuses collection with actor_context_required for %s caller evidence (no minted trust)', async (_kind, callerEvidence) => {
     await manager.save(state());
 
+    // The seam maps evidence to trust in core: plugin/mcp/unknown evidence maps
+    // to UNKNOWN_ACTOR_CONTEXT regardless of metadata, so the existing policy
+    // gate refuses before inspecting any outcome state.
     await expect(
       collectionService.collectDelegationOutcomes({
         targetState: state(),
         steps,
-        actorContext: UNKNOWN_ACTOR_CONTEXT,
+        callerEvidence,
       }),
     ).resolves.toEqual({
       kind: 'actor_context_required',
@@ -162,7 +169,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
       }),
     ).resolves.toEqual({
       kind: 'missing_outcomes',
@@ -192,7 +199,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
       }),
     ).resolves.toMatchObject({
       kind: 'already_collected',
@@ -253,7 +260,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      actorContext: trustedRunControllerContext(runId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -402,7 +409,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      actorContext: trustedRunControllerContext(runId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -494,7 +501,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      actorContext: trustedRunControllerContext(runId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -562,7 +569,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      actorContext: trustedRunControllerContext(runId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -611,7 +618,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
         frame: activeFrame(frameKey, 1),
       }),
     ).resolves.toMatchObject({
@@ -631,7 +638,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: controlled,
         steps,
-        actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+        callerEvidence: { kind: 'claim', claimId, tokenHash, controlledRunId },
       }),
     ).resolves.toMatchObject({
       kind: 'missing_outcomes',
@@ -649,7 +656,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: ancestor,
         steps,
-        actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+        callerEvidence: { kind: 'claim', claimId, tokenHash, controlledRunId },
       }),
     ).resolves.toEqual({
       kind: 'collect_requires_orchestrator',
@@ -665,7 +672,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
         stepName: 'does-not-exist',
       }),
     ).resolves.toEqual({
@@ -693,7 +700,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
       }),
     ).resolves.toMatchObject({
       kind: 'collection_failed',
@@ -719,7 +726,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
         frame: activeFrame(frameKey, 1),
       }),
     ).resolves.toEqual({
@@ -772,7 +779,7 @@ describe('RunbookCollectionService', () => {
     const result = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps: oneSubstepSteps,
-      actorContext: trustedRunControllerContext(runId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
     // Readiness must NOT refuse: the live row is the authoritative outcome signal,
@@ -845,7 +852,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: controlled,
       steps: oneSubstepSteps,
-      actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      callerEvidence: { kind: 'claim', claimId, tokenHash, controlledRunId },
       frame: activeFrame(buildFrameKey('1'), 1),
     });
 
@@ -875,7 +882,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: controlled,
       steps: oneSubstepSteps,
-      actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      callerEvidence: { kind: 'claim', claimId, tokenHash, controlledRunId },
       frame: activeFrame(buildFrameKey('1'), 1),
     });
 
@@ -897,7 +904,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: controlled,
       steps: oneSubstepSteps,
-      actorContext: trustedRunControllerContext(controlledRunId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(buildFrameKey('1'), 1),
     });
 
@@ -923,7 +930,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: controlled,
       steps: oneSubstepSteps,
-      actorContext: trustedRunControllerContext(controlledRunId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(buildFrameKey('1'), 1),
     });
 
@@ -982,7 +989,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      actorContext: trustedRunControllerContext(runId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: exactFrame(inactiveKey, 2),
     });
 
@@ -1046,7 +1053,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
         frame: activeFrame(frameKey, 1),
       }),
     ).resolves.toEqual({
@@ -1092,7 +1099,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps: mixedSteps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
         frame: activeFrame(frameKey, 1),
       }),
     ).resolves.toEqual({
@@ -1131,7 +1138,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
       }),
     ).resolves.toEqual({
       kind: 'missing_outcomes',
@@ -1157,7 +1164,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: { ...controlled, lifecycle: 'running' },
       steps: oneSubstepSteps,
-      actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      callerEvidence: { kind: 'claim', claimId, tokenHash, controlledRunId },
       frame: activeFrame(buildFrameKey('1'), 1),
     });
 
@@ -1204,7 +1211,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: controlled,
       steps: oneSubstepSteps,
-      actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      callerEvidence: { kind: 'claim', claimId, tokenHash, controlledRunId },
       frame: activeFrame(frameKey, 1),
     });
 
@@ -1233,7 +1240,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: controlled,
       steps: oneSubstepSteps,
-      actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      callerEvidence: { kind: 'claim', claimId, tokenHash, controlledRunId },
       frame: activeFrame(buildFrameKey('1'), 1),
     });
 
@@ -1299,7 +1306,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
       }),
     ).resolves.toMatchObject({
       kind: 'already_collected',
@@ -1345,7 +1352,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: controlled,
       steps: oneSubstepSteps,
-      actorContext: claimControllerContext({ claimId, tokenHash, controlledRunId }),
+      callerEvidence: { kind: 'claim', claimId, tokenHash, controlledRunId },
       frame: activeFrame(frameKey, 1),
     });
 
@@ -1377,7 +1384,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      actorContext: trustedRunControllerContext(runId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -1439,7 +1446,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        actorContext: trustedRunControllerContext(runId),
+        callerEvidence: DIRECT_CLI_EVIDENCE,
         frame: activeFrame(frameKey, 1),
       }),
     ).rejects.toThrow('Step "ghost" not found');
@@ -1472,7 +1479,7 @@ describe('RunbookCollectionService', () => {
     return collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      actorContext: trustedRunControllerContext(runId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
   }
@@ -1581,7 +1588,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      actorContext: trustedRunControllerContext(runId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -1646,7 +1653,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      actorContext: trustedRunControllerContext(runId),
+      callerEvidence: DIRECT_CLI_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
     return { outcome, observeEntrySpy, frontier, reEntryEffects };

--- a/packages/core/__tests__/runbook/subprocess-mutation-boundary.test.ts
+++ b/packages/core/__tests__/runbook/subprocess-mutation-boundary.test.ts
@@ -73,7 +73,6 @@ describe('bareRoleSpecificMutation', () => {
     [['ls', '--all']],
     [['run', 'workflow.md']],
     [['claim', 'rd_tok_abc']],
-    [['collect']],
     [['goto', '3.1']],
     [[]],
   ])('does not withhold the non-role-specific call %j', (argv) => {
@@ -95,6 +94,36 @@ describe('bareRoleSpecificMutation', () => {
     [['complete', '--claim-id', 'rdclm_x', '--text']],
   ])('does not withhold the claim-evidence terminal mutation %j', (argv) => {
     expect(bareRoleSpecificMutation(argv)).toBeUndefined();
+  });
+
+  it.each([
+    [['collect'], 'collect'],
+    [['collect', '--step', '1'], 'collect'],
+    [['collect', '--step', '1', '--index', '2'], 'collect'],
+  ])('classifies bare collect %j as a withheld %s', (argv, expected) => {
+    // A subprocess-spawned bare `rd collect` would mint orchestrator trust over
+    // the parent's aggregation with no independent evidence (#509-P1).
+    expect(bareRoleSpecificMutation(argv)).toBe(expected);
+  });
+
+  it.each([
+    [['collect', '--claim-id', 'claim-1']],
+    [['collect', '--claim-id=claim-1']],
+    [['collect', '--step', '1', '--claim-id', 'rdclm_x']],
+  ])('does not withhold the claim-evidence collect %j', (argv) => {
+    // A claimed child collecting delegations issued by its OWN controlled run
+    // carries reconstructable claim-controller evidence; ancestor collection is
+    // still refused downstream by core policy (collect_requires_orchestrator).
+    expect(bareRoleSpecificMutation(argv)).toBeUndefined();
+  });
+
+  it.each([
+    // `--claim-id=foo` is consumed as the value of `--step`, not a real flag.
+    [['collect', '--step', '--claim-id=foo'], 'collect'],
+    // After `--` every token is positional: a trailing --claim-id is content.
+    [['collect', '--', '--claim-id', 'claim-1'], 'collect'],
+  ])('withholds collect %j where --claim-id is not flag-position evidence', (argv, expected) => {
+    expect(bareRoleSpecificMutation(argv)).toBe(expected);
   });
 
   it.each([
@@ -133,8 +162,10 @@ describe('bareRoleSpecificMutation', () => {
   it('withholds every bare alias as its canonical command (property)', () => {
     // For each canonical mutation, every registered alias must normalize back to
     // it so no alias form can slip a bare mutation past the boundary.
-    const aliasPairs = (['pass', 'fail', 'delegate', 'complete', 'stop'] as const).flatMap(
-      (canonical) => mutationCommandAliases(canonical).map((alias) => [alias, canonical] as const),
+    const aliasPairs = (
+      ['pass', 'fail', 'delegate', 'complete', 'stop', 'collect'] as const
+    ).flatMap((canonical) =>
+      mutationCommandAliases(canonical).map((alias) => [alias, canonical] as const),
     );
     // complete/stop/delegate have no aliases; the > 0 guard still holds via pass/fail.
     expect(aliasPairs.length).toBeGreaterThan(0);
@@ -152,7 +183,7 @@ describe('bareRoleSpecificMutation', () => {
     );
   });
 
-  it('never withholds pass/fail/complete/stop that carries --claim-id (property)', () => {
+  it('never withholds pass/fail/complete/stop/collect that carries --claim-id (property)', () => {
     // `extra` excludes value-taking space options so the trailing `--claim-id`
     // lands in flag position (not consumed as a preceding option's value, and
     // not pushed past the `--` terminator into positional content).
@@ -160,7 +191,7 @@ describe('bareRoleSpecificMutation', () => {
       s !== '--' && s !== '--step' && s !== '--index' && s !== '--claim-id';
     fc.assert(
       fc.property(
-        fc.constantFrom('pass', 'fail', 'complete', 'stop'),
+        fc.constantFrom('pass', 'fail', 'complete', 'stop', 'collect'),
         fc.array(fc.string().filter(notBeforeClaimFlag), { maxLength: 4 }),
         fc.string(),
         (command, extra, claimId) => {
@@ -210,6 +241,7 @@ describe('bareRoleSpecificMutation: program-level (global) options before the co
     [['--deny-all', 'pass'], 'pass'],
     [['--no-color', 'fail'], 'fail'],
     [['--no-color', 'delegate'], 'delegate'],
+    [['--no-color', 'collect'], 'collect'],
     [['--sandbox', 'pass'], 'pass'],
     // Value-taking global (space form): consumes its value token, command at 2.
     [['--policy', 'x.json', 'pass'], 'pass'],
@@ -308,6 +340,8 @@ describe('mutationCommandAliases', () => {
     // positional, not an alias — pin the no-alias contract so a regression fails here.
     ['complete', []],
     ['stop', []],
+    // No aliases: `collect` has no CLI alias forms.
+    ['collect', []],
   ] as const)('exposes the canonical alias set for %s', (command, expected) => {
     // Single source of truth consumed by the CLI command registration. Changing
     // these is a deliberate surface change, so pin them here.
@@ -317,7 +351,7 @@ describe('mutationCommandAliases', () => {
 
 describe('subprocessMutationWithheldMessage', () => {
   it('names the command and never mentions a source label', () => {
-    for (const command of ['pass', 'fail', 'delegate'] as const) {
+    for (const command of ['pass', 'fail', 'delegate', 'collect'] as const) {
       const message = subprocessMutationWithheldMessage(command);
       expect(message).toContain(`rundown ${command}`);
       expect(message).toContain('--claim-id');

--- a/packages/core/__tests__/runbook/subprocess-mutation-boundary.test.ts
+++ b/packages/core/__tests__/runbook/subprocess-mutation-boundary.test.ts
@@ -13,10 +13,11 @@ import {
 } from '../../src/runbook/subprocess-mutation-boundary.js';
 
 // Subprocess trust boundary coverage. A plugin/MCP front end spawns the CLI, so
-// a bare (default-target) `rd pass` / `rd fail` / `rd delegate` would silently
-// inherit direct-CLI trust. `bareRoleSpecificMutation` is the single source of
-// truth for which spawned argv must be withheld; `--claim-id` mutations carry
-// independent claim evidence and must survive the boundary.
+// a bare (default-target) `rd pass` / `rd fail` / `rd delegate` / `rd complete`
+// / `rd stop` / `rd collect` would silently inherit direct-CLI trust.
+// `bareRoleSpecificMutation` is the single source of truth for which spawned
+// argv must be withheld; `--claim-id` mutations carry independent claim
+// evidence and must survive the boundary.
 
 describe('bareRoleSpecificMutation', () => {
   it.each([
@@ -167,7 +168,7 @@ describe('bareRoleSpecificMutation', () => {
     ).flatMap((canonical) =>
       mutationCommandAliases(canonical).map((alias) => [alias, canonical] as const),
     );
-    // complete/stop/delegate have no aliases; the > 0 guard still holds via pass/fail.
+    // complete/stop/delegate/collect have no aliases; the > 0 guard still holds via pass/fail.
     expect(aliasPairs.length).toBeGreaterThan(0);
     fc.assert(
       fc.property(

--- a/packages/core/src/runbook/collection-service.ts
+++ b/packages/core/src/runbook/collection-service.ts
@@ -1,5 +1,5 @@
 import { resolvedStepHasSubsteps } from '@rundown-org/parser';
-import type { ActorContext } from './actor-context.js';
+import { actorContextFromEvidence, type CallerEvidence } from './actor-context.js';
 import type { RunbookActorService } from './actor-service.js';
 import type { DelegationPolicyOutcome } from './command-policy.js';
 import { resolveCommandIntent } from './command-policy.js';
@@ -46,8 +46,13 @@ export interface CollectDelegationOutcomesInput {
   readonly targetState: RunbookState;
   /** Parsed runbook steps for the target run. */
   readonly steps: readonly ResolvedStep[];
-  /** Caller evidence for target-relative role derivation. */
-  readonly actorContext: ActorContext;
+  /**
+   * Typed caller evidence supplied by the frontend. Core maps it to a
+   * target-relative actor context via {@link actorContextFromEvidence};
+   * frontends never construct trust directly (mirrors the lifecycle command
+   * seam in lifecycle-command-service.ts).
+   */
+  readonly callerEvidence: CallerEvidence;
   /** Optional explicit step name. Defaults to the target run cursor. */
   readonly stepName?: string;
   /** Optional frame override for targeted FOR collection. */
@@ -70,7 +75,7 @@ export class RunbookCollectionService {
   /**
    * Collect reported delegation outcomes into one target delegating run scope.
    *
-   * @param input - Target run, runbook steps, actor context, and optional scope.
+   * @param input - Target run, runbook steps, caller evidence, and optional scope.
    * @returns Core-owned typed policy outcome for frontend adapters.
    */
   async collectDelegationOutcomes(
@@ -186,12 +191,17 @@ function missingDelegationOutcomeIds(args: {
 /**
  * Collect reported delegation outcomes into one target delegating run scope.
  *
- * @param input - Target run, services, actor context, and optional scope.
+ * @param input - Target run, services, caller evidence, and optional scope.
  * @returns Core-owned typed policy outcome.
  */
 export async function collectDelegationOutcomes(
   input: CollectDelegationOutcomesOperationInput,
 ): Promise<DelegationPolicyOutcome> {
+  // Core owns the evidence->trust mapping: direct_cli yields a trusted run
+  // controller for the resolved target; claim evidence anchors on its own
+  // controlledRunId; plugin/mcp/unknown yield UNKNOWN_ACTOR_CONTEXT and are
+  // refused by the policy gate below (actor_context_required).
+  const actorContext = actorContextFromEvidence(input.callerEvidence, input.targetState.id);
   // NOTE: the merged `resolveCommandIntent` input field is `targetSelector`
   // (not `target`), and its selector kinds are `default` | `claim` |
   // `explicit-step` — there is NO `run` selector kind. The resolved target run
@@ -208,7 +218,7 @@ export async function collectDelegationOutcomes(
     targetSelector: { kind: 'default' },
     // Stryker restore ObjectLiteral,StringLiteral
     targetState: input.targetState,
-    actorContext: input.actorContext,
+    actorContext,
   });
   if (policy.kind !== 'allowed') return policy;
 

--- a/packages/core/src/runbook/subprocess-mutation-boundary.ts
+++ b/packages/core/src/runbook/subprocess-mutation-boundary.ts
@@ -21,7 +21,13 @@
  * end cannot supply this trust as evidence, so a bare invocation of one of these
  * must be withheld rather than spawned.
  */
-export type RoleSpecificMutationCommand = 'pass' | 'fail' | 'delegate' | 'complete' | 'stop';
+export type RoleSpecificMutationCommand =
+  | 'pass'
+  | 'fail'
+  | 'delegate'
+  | 'complete'
+  | 'stop'
+  | 'collect';
 
 const ROLE_SPECIFIC_MUTATION_COMMANDS: ReadonlySet<RoleSpecificMutationCommand> = new Set([
   'pass',
@@ -29,6 +35,7 @@ const ROLE_SPECIFIC_MUTATION_COMMANDS: ReadonlySet<RoleSpecificMutationCommand> 
   'delegate',
   'complete',
   'stop',
+  'collect',
 ]);
 
 function isRoleSpecificMutationCommand(value: string): value is RoleSpecificMutationCommand {
@@ -52,6 +59,8 @@ const MUTATION_COMMAND_ALIASES: Readonly<Record<RoleSpecificMutationCommand, rea
   // No aliases (decision #5): `done` is the `[message]` positional, not an alias.
   complete: [],
   stop: [],
+  // No aliases: `collect` has no CLI alias forms.
+  collect: [],
 };
 
 /**
@@ -254,8 +263,8 @@ function locateCommandIndex(argv: readonly string[]): number {
  *
  * @param argv - CLI argument vector. The command may be preceded by program-level
  *   global options, so its position is supplied via `commandIndex`. Every
- *   non-`delegate` guarded command (`pass` / `fail` / `complete` / `stop`)
- *   reaches this function; `delegate` is claim-less and never exempted.
+ *   non-`delegate` guarded command (`pass` / `fail` / `complete` / `stop` /
+ *   `collect`) reaches this function; `delegate` is claim-less and never exempted.
  * @param commandIndex - Index of the command token in `argv` (from
  *   {@link locateCommandIndex}). Scanning starts after it; options before it are
  *   program-level globals, not the command's own flags.
@@ -287,16 +296,16 @@ function carriesClaimEvidence(argv: readonly string[], commandIndex: number): bo
 /**
  * Classify a spawned CLI argv as a bare role-specific lifecycle mutation.
  *
- * A call is bare iff its command is `pass`, `fail`, `delegate`, `complete`, or
- * `stop` and it carries no claim evidence. These are exactly the invocations
- * whose only available trust is direct-CLI, so a subprocess front end
- * (plugin / MCP) must withhold them rather than let them silently inherit
+ * A call is bare iff its command is `pass`, `fail`, `delegate`, `complete`,
+ * `stop`, or `collect` and it carries no claim evidence. These are exactly the
+ * invocations whose only available trust is direct-CLI, so a subprocess front
+ * end (plugin / MCP) must withhold them rather than let them silently inherit
  * `{ kind: 'direct_cli' }` trust.
  *
  * `delegate` is claim-less and is ALWAYS bare: no `--claim-id` token can exempt
- * it. Every other guarded command (`pass` / `fail` / `complete` / `stop`) carries
- * a legitimate `--claim-id` claim-controller form, and only a real `--claim-id`
- * flag in *flag position* exempts them — a
+ * it. Every other guarded command (`pass` / `fail` / `complete` / `stop` /
+ * `collect`) carries a legitimate `--claim-id` claim-controller form, and only a
+ * real `--claim-id` flag in *flag position* exempts them — a
  * `--claim-id` token consumed as the value of a preceding value-taking option
  * (`--step`, `--index`, `--claim-id`) is not evidence (see
  * {@link carriesClaimEvidence}). The boundary fails closed: when claim evidence
@@ -329,9 +338,9 @@ export function bareRoleSpecificMutation(
   }
   // `delegate` has no claim form, so every subprocess `delegate` is bare and
   // withheld — a stray `--claim-id` cannot make it claim-evidenced. Every other
-  // guarded command (`pass` / `fail` / `complete` / `stop`) carries a legitimate
-  // `--claim-id` claim-controller form whose evidence is reconstructable
-  // CLI-side, so those are exempted here. See
+  // guarded command (`pass` / `fail` / `complete` / `stop` / `collect`) carries
+  // a legitimate `--claim-id` claim-controller form whose evidence is
+  // reconstructable CLI-side, so those are exempted here. See
   // docs/superpowers/specs/2026-06-28-plugin-mcp-caller-evidence-ingress-design.md
   // § Blocking scope.
   if (command !== 'delegate' && carriesClaimEvidence(argv, commandIndex)) {

--- a/packages/mcp/__tests__/tools.test.ts
+++ b/packages/mcp/__tests__/tools.test.ts
@@ -352,6 +352,7 @@ describe('subprocess trust boundary', () => {
     ['pass'],
     ['fail'],
     ['delegate'],
+    ['collect'],
   ] as const)('withholds a bare %s mutation without spawning the CLI', async (tool) => {
     const runCli = jest.fn<RunCli>();
     const handlers = registerWithHandlers(runCli);
@@ -377,9 +378,23 @@ describe('subprocess trust boundary', () => {
     expect(runCli).not.toHaveBeenCalled();
   });
 
+  it('withholds a --step-targeted bare collect (still direct-CLI trust)', async () => {
+    const runCli = jest.fn<RunCli>();
+    const handlers = registerWithHandlers(runCli);
+
+    // --step scopes the aggregation but carries no evidence: a step-targeted
+    // bare collect still mints orchestrator trust and must be withheld.
+    const res = await handlers.get('collect')?.({ step: '1' });
+    expect(parseToolResponse(res)).toEqual({
+      error: expect.stringContaining('subprocess front end'),
+    });
+    expect(runCli).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['pass'],
     ['fail'],
+    ['collect'],
   ] as const)('spawns a %s --claim-id claim-evidence mutation through the boundary', async (tool) => {
     const runCli = jest.fn<RunCli>().mockResolvedValue({ success: true, data: { ok: true } });
     const handlers = registerWithHandlers(runCli);

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -44,10 +44,11 @@ export function registerRundownTools(server: RundownToolRegistrar, runCli: RunCl
         }
         // Subprocess trust boundary: the MCP server spawns the CLI, so typed
         // caller evidence cannot cross the process boundary. Bare `pass` /
-        // `fail`, and every subprocess `delegate`, would silently inherit
-        // direct-CLI trust over the active run. Withhold them here rather than
-        // spawn them; only `pass` / `fail` with `--claim-id` carry independent
-        // claim evidence and pass through. See subprocess-mutation-boundary.ts.
+        // `fail` / `complete` / `stop` / `collect`, and every subprocess
+        // `delegate`, would silently inherit direct-CLI trust over the active
+        // run. Withhold them here rather than spawn them; only invocations with
+        // `--claim-id` carry independent claim evidence and pass through. See
+        // subprocess-mutation-boundary.ts.
         const withheld = bareRoleSpecificMutation(command);
         if (withheld !== undefined) {
           return createMcpTextResponse({ error: subprocessMutationWithheldMessage(withheld) });


### PR DESCRIPTION
## Summary

Cluster E of the delegation-lifecycle roadmap (item 6). **Stacked on #537 (Cluster D) → #535 (Cluster C)** — retarget as the stack merges.

Closes the collect trust hole: a subprocess-spawned `rd collect` could mint orchestrator trust with no independent evidence, driving parent aggregation that should be orchestrator-only.

1. **Trust decided in core, not the front end** — `CollectDelegationOutcomesInput` now takes typed `callerEvidence: CallerEvidence`; core maps it via `actorContextFromEvidence(evidence, targetState.id)` before `resolveCommandIntent`. After this change no front end constructs trust contexts (grep-clean outside core). `direct_cli` maps bit-identically to the old bare arm; `--claim-id` evidence anchors on the claim's own `controlledRunId` (provably `=== state.id` — the resolver loads state by `childRunId`); plugin/mcp/unknown evidence refuses with `actor_context_required`.
2. **`collect` joins the subprocess withhold set** — completing the Cluster A precedent (complete/stop): bare or `--step`-targeted subprocess `rd collect` is withheld before spawning at both front ends (MCP + plugin, which consult `bareRoleSpecificMutation` generically — no front-end src changes, tests only); `--claim-id` collect passes through. Coverage mirrors Cluster A: flipped non-withheld pin, claim exemption, value-slot smuggling, `--` terminator, behind-globals, property tests.
3. **Docs** — architecture/plugin-trust-model withhold enumerations, mcp.md §5.1 collect row + §5.13, and the §8 correction (collect is no longer 'inherited unchanged from the CLI'). Pre-existing complete/stop doc staleness intentionally excluded → #538.

## Blast radius (risk-reviewed empirically)

None for legitimate flows: plugin hooks never intercept the orchestrating agent's own Bash `rd collect`; runbook scenario collects bypass the boundary; command-step-spawned CLI collect is #520 territory (unchanged). The only behavior change is the intended one: bare MCP/plugin subprocess collect is withheld.

## Process

Full `rundown:planning` pipeline: plan → 4-dimension review (4× PASS; one warning — a docs gap — amended into the plan pre-implementation) → collation → implementation (4 TDD commits) → code review (PASS, note-level only; comment-staleness notes fixed in a follow-up commit).

## Verification

`pnpm run verify` exit 0 (3,815 unit tests); `pnpm run test:integration` exit 0 (603 tests, incl. the untouched CLI collect integration suite — bare direct-CLI collect behavior-identical); `pnpm run test:property` green.

Addresses the P1 (trust) portion of #509 — P2/P3 landed in Cluster B (#528). With this, roadmap items 1/5/6/7/10/13/15 plus #496/#500/#508 are covered across the C/D/E stack.

## Note

The #536 mid-verify stop hit this pipeline too (third occurrence, commented on the issue); recovered via explicit-step completion, verify independently confirmed green.