### PR TITLE
fix(core): probe Seatbelt availability with /usr/bin/true, not /bin/true

### DIFF
--- a/packages/core/__tests__/sandbox/macos.test.ts
+++ b/packages/core/__tests__/sandbox/macos.test.ts
@@ -81,9 +81,12 @@ describe('SeatbeltSandbox', () => {
       expect(availability.supportsReadRestrictions).toBe(true);
       expect(availability.supportsWriteRestrictions).toBe(true);
       expect(availability.supportsDenyPaths).toBe(true);
+      // The probe must exec /usr/bin/true: macOS ships no /bin/true, so a
+      // /bin/true probe fails with ENOENT and falsely reports the sandbox
+      // unavailable (#544).
       expect(spawnSync).toHaveBeenCalledWith(
         '/usr/bin/sandbox-exec',
-        ['-f', expect.stringContaining('.sb'), '/bin/true'],
+        ['-f', expect.stringContaining('.sb'), '/usr/bin/true'],
         expect.objectContaining({
           stdio: 'ignore',
           timeout: 5000,
@@ -131,7 +134,7 @@ describe('SeatbeltSandbox', () => {
 
       expect(spawnSync).toHaveBeenCalledWith(
         '/usr/bin/sandbox-exec',
-        ['-f', expect.stringContaining('.sb'), '/bin/true'],
+        ['-f', expect.stringContaining('.sb'), '/usr/bin/true'],
         expect.objectContaining({
           stdio: 'ignore',
           timeout: 5000,

--- a/packages/core/src/sandbox/macos.ts
+++ b/packages/core/src/sandbox/macos.ts
@@ -311,7 +311,10 @@ export class SeatbeltSandbox implements SandboxImplementation {
     const profilePath = join(tmpdir(), `rundown-sandbox-probe-${randomUUID()}.sb`);
     try {
       writeFileSync(profilePath, '(version 1)\n(allow default)\n', { mode: 0o600 });
-      const probe = spawnSync('/usr/bin/sandbox-exec', ['-f', profilePath, '/bin/true'], {
+      // Probe with /usr/bin/true: macOS ships no /bin/true, and an ENOENT exec
+      // would falsely report the sandbox unavailable (#544) — which under the
+      // fail-closed strict default denies every command step.
+      const probe = spawnSync('/usr/bin/sandbox-exec', ['-f', profilePath, '/usr/bin/true'], {
         stdio: 'ignore',
         timeout: 5000,
         killSignal: 'SIGKILL',


### PR DESCRIPTION
## Summary

Fixes #544.

`SeatbeltSandbox.getAvailability()` probed sandbox-exec by running `/bin/true` — a path that does not exist on macOS (`true` lives at `/usr/bin/true`). The probe failed with ENOENT (exit 71), the sandbox was falsely reported unavailable, and under the fail-closed strict default (#423) **every runbook command step on macOS was policy-denied**.

Observed live 2026-07-03: the denial terminally stopped a delegated `write-plan` child mid-pipeline (see #545/#547 for the downstream failure modes it exposed).

## Change

- One-line probe fix: `/bin/true` → `/usr/bin/true` (`packages/core/src/sandbox/macos.ts`), with a comment pinning why.
- Regression assertions updated in `packages/core/__tests__/sandbox/macos.test.ts` (both probe-argv expectations now pin `/usr/bin/true`), written first and confirmed red against the old source.

## Verification

- `pnpm --filter @rundown-org/core test -- __tests__/sandbox/macos.test.ts` — 16/16 green.
- `pnpm run verify` — full suite green (2175 tests).
- Live on macOS 26.4.1: `checkSandboxAvailability()` now returns `{available: true, mechanism: seatbelt, …}`; before the fix it returned `available: false` ("sandbox-exec could not run in this environment").

## Context

Shipped as a standalone hotfix ahead of the R0 pipeline-reliability cluster (roadmap 2026-07-03 §2 R0) because the false-negative probe blocks the planning pipeline's command steps (schema validation, verify gates) on macOS entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS sandbox availability checks so they no longer report the sandbox as unavailable on systems where a common system binary isn’t present.
  * This helps sandbox-related features behave more reliably during startup and environment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->