### PR TITLE
ci(mutation): drop core from advisory PR mutation gate

### DIFF
--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -29,13 +29,21 @@ jobs:
       fail-fast: false
       matrix:
         # `module` (the dashboard module name) always equals `package`, so it is
-        # derived from matrix.package rather than duplicated here — keeping this
-        # matrix in sync with the producer workflow (mutation.yml).
+        # derived from matrix.package rather than duplicated here.
+        #
+        # `core` is deliberately OMITTED from this advisory PR matrix. A
+        # changed-file core mutation run legitimately approaches the 60-min cap
+        # (the producer has to SHARD core to fit — see mutation.yml), so on a PR
+        # it almost always finishes after merge and gates nothing (this whole
+        # workflow is advisory: continue-on-error throughout, no required-check
+        # ruleset). The producer already differential-scores core on every push
+        # to main and full-fidelity weekly, which is the run that feeds the
+        # dashboard trend. Keeping core here only burned ~1h of CI per PR for a
+        # comment that arrived too late to act on. Do not re-add it without a
+        # sharding strategy that keeps a PR run under a few minutes.
         include:
           - package: parser
             dir: packages/parser
-          - package: core
-            dir: packages/core
           - package: cli
             dir: packages/cli
           - package: plugin
@@ -43,9 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     # Advisory: this is a guardrail against a runaway run wasting minutes, not a
     # merge gate. ignoreStatic + concurrency keep a scoped run well under it.
-    # Matches the producer run (mutation.yml): a PR that rewrites a whole
-    # subsystem invalidates the incremental baseline for every mutant its
-    # changed tests cover, and that full re-run legitimately needs ~50m.
+    # With core excluded from this matrix, a changed-file run for the remaining
+    # packages lands in minutes; the cap only backstops a pathological run.
     timeout-minutes: 60
     env:
       STRYKER_CONCURRENCY: '4'


### PR DESCRIPTION
## Summary

The per-PR mutation gate (`mutation-pr.yml`) is **advisory** — every step is `continue-on-error` and the `main` ruleset has no required status checks, so it gates nothing. Its only output is the sticky per-file "🧬 Mutation score (advisory)" comment.

A changed-file **core** mutation run legitimately approaches the 60-min cap (the producer, `mutation.yml`, has to *shard* core to fit). On a PR it therefore almost always finishes **after** merge — burning ~1h of CI for a comment that arrives too late to act on. Observed on #554: parser/cli/plugin finished in seconds, while `mutation-gate (core)` was still crawling toward the cap.

The producer already **differential-scores core on every push to `main`** and full-fidelity weekly, uploading the dashboard baseline — that's the run that feeds the trend. The per-PR core run duplicated it with worse latency.

## Change

- Remove `core` from the advisory PR matrix; keep `parser` / `cli` / `plugin` (all finish in minutes) for fast changed-file feedback.
- Document *why* core is omitted, with a guard against re-adding it without a sharding strategy that keeps a PR run under a few minutes.
- Trim the now-stale ~50m timeout rationale (the cap is now just a runaway backstop).

## Scope / safety

- No behaviour change to the producer (`mutation.yml`); core mutation coverage and the dashboard baseline are unaffected.
- No required-check impact — the gate was never required.
- Workflow-only change.