### PR TITLE
R1 explicit targeting: remove ambient CLI trust — everyone names their authority (#460)

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -392,3 +392,6 @@ subsec
 noexec
 ppid
 chokepoints
+ungated
+remediations
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -456,6 +456,20 @@ to `UNKNOWN_ACTOR_CONTEXT` (the structural fix for #460). `plugin` and `mcp`
 evidence — and any agent id, session id, or tool name they carry — always map to
 `UNKNOWN_ACTOR_CONTEXT`.
 
+### Run-targeted terminals carry derived authority over contiguous inline chains
+
+A terminal command (`complete` / `stop`) targeted with `--run <rd_…>` at a
+member of a **contiguous inline composition chain** carries derived
+run-controller authority over the root the chain walk reaches. Rationale: a
+contiguous-inline chain is one orchestrator's composition — every member was
+launched, in-session, by whoever launched the root — so naming any member names
+the same authority. Two independent walls keep this from widening into #460: a
+claimed child's run is never a `defaultStack` member (so `--run` cannot resolve
+it), and the chain walk climbs only `parentLinkage.kind === 'inline'`, so a
+**delegation boundary always severs the chain**. Pinned by the seam tests in
+`transitions-seam.test.ts`; names-are-not-capabilities remains the tier-1
+posture (#540 tracks the capability upgrade).
+
 ### Guards do no cross-run IO or policy
 
 Cross-run IO and policy stay in the seam and `resolveTransitionTarget`, never in

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -352,6 +352,30 @@ it.
    `ActorContext` by core via `actorContextFromEvidence`
    (`packages/core/src/runbook/actor-context.ts`). Front ends never construct a
    final `ActorContext`; they describe who is calling and what they can prove.
+   The mapping is evaluated against an `EvidenceTarget` — the resolved run's id
+   plus its **delegation exposure**, classified at decision time by
+   `classifyDelegationExposure`
+   (`packages/core/src/runbook/delegation-exposure.ts`). A run is `delegating`
+   iff any of six clauses holds: (a) its document authors a DELEGATE substep
+   (static — protection starts before any issuance); (b) it has open claimed
+   children; (c) it has reported-but-uncollected delegation outcomes; (d) any
+   substep state carries a delegation record (sticky history — exposure never
+   decays after claims close); (e) it carries parent linkage (inline or
+   delegation); (f) it composes children inline — statically, any substep
+   carries runbook-list entries, or at runtime any substep state carries an
+   inline launch record (sticky, like d). Only a `standalone` run (all six
+   clauses fail) keeps the bare `direct_cli` convenience lane; on any
+   delegation-exposed target the only trust-granting evidence is
+   `run_controller` (`--run <rd_…>`) or `claim` (`--claim-id`) — "everyone names
+   their authority". Two consistency caveats are deliberate: (i) the
+   document-derived clauses (a and f's static signal) are re-parsed at decision
+   time, so a mid-run edit of the runbook document can flip a not-yet-issued
+   run's static exposure — the state-derived clauses are monotone and never
+   decay; (ii) exposure classification and target resolution are two lock-free
+   reads, and the design stays fail-closed because trust is bound to the
+   classified run's id: `deriveEffectiveRole` refuses an id mismatch with the
+   resolved target, so an interleave (e.g. an inline child popping between the
+   reads) can never transfer one run's trust onto another.
 2. **Target resolution + policy.** `resolveTransitionTarget` resolves the target
    run and runs strict target-relative policy, returning typed refusals (`none`,
    `stale_claim`, `terminal_claim_confirmed` / `terminal_claim_conflict`,
@@ -399,8 +423,15 @@ work:
 
 - **gathers native caller evidence** — `readLifecycleCallerEvidence`
   (`packages/cli/src/helpers/caller-evidence.ts`) returns
-  `{ kind: 'direct_cli' }` for a bare invocation, or reconstructed `claim`
-  evidence for `--claim-id`;
+  `{ kind: 'direct_cli' }` for a bare invocation, `run_controller` evidence for
+  a validated `--run <rd_…>`, or reconstructed `claim` evidence for
+  `--claim-id`. It no longer decides whether a bare invocation grants anything —
+  core does, from the target's delegation exposure;
+- **parses `--run`** — `parseRunOption`
+  (`packages/cli/src/helpers/run-option.ts`) validates the id format via core's
+  `isRunId` and enforces mutual exclusion with `--claim-id` (Category-A flag
+  parsing only; a `--run` id is resolved and policy-checked in core against the
+  session `defaultStack`);
 - **parses `--step` / `--index`** into a pre-resolved `ManualCompletionCursor`
   via `resolveManualCompletionCursor`
   (`packages/cli/src/helpers/transitions.ts`) — raw-argument input handling on
@@ -418,9 +449,11 @@ The CLI constructs **no** `ActorContext`.
 `ActorContext` has no `source` field. Source tagging is not a trust mechanism:
 there is no `--actor-source` flag and no `RD_ACTOR_SOURCE` env var, and they
 must not be reintroduced. The only trust-granting `CallerEvidence` variants are
-`direct_cli` (the local direct-CLI compatibility lane) and `claim`
-(reconstructable claim-controller evidence). `plugin` and `mcp` evidence — and
-any agent id, session id, or tool name they carry — always map to
+`run_controller` (caller-named run authority from an explicit `--run <rd_…>`),
+`claim` (reconstructable claim-controller evidence), and `direct_cli` — the
+**standalone-run convenience lane only**: on a delegation-exposed target it maps
+to `UNKNOWN_ACTOR_CONTEXT` (the structural fix for #460). `plugin` and `mcp`
+evidence — and any agent id, session id, or tool name they carry — always map to
 `UNKNOWN_ACTOR_CONTEXT`.
 
 ### Guards do no cross-run IO or policy
@@ -435,19 +468,54 @@ the seam is what lets the state machine remain a pure per-run program.
 The plugin and MCP server reach the CLI by spawning a subprocess, so typed
 `CallerEvidence` cannot cross that boundary — a spawned `rundown pass` arrives
 as an ordinary `argv`, indistinguishable from a human invocation. They are
-therefore **not** direct-CLI-trusted callers. The shared boundary
-`bareRoleSpecificMutation`
+therefore **not** direct-CLI-trusted callers.
+
+**Core is the primary gate.** Since R1, core itself refuses ambient direct-CLI
+trust on every delegation-exposed run (the exposure-conditional `direct_cli`
+mapping above), so the subprocess withhold set is **defense-in-depth**, no
+longer the primary protection. Its remaining job is to stop a spawned bare
+mutation from silently consuming the standalone-run convenience lane and to keep
+refusals front-end-rendered (a clear typed withhold instead of a downstream
+policy error). The shared boundary `bareRoleSpecificMutation`
 (`packages/core/src/runbook/subprocess-mutation-boundary.ts`) classifies a bare
 (default-target) `rundown pass` / `rundown fail` / `rundown delegate` /
 `rundown complete` / `rundown stop` / `rundown collect` as the invocations whose
-only available trust is `direct_cli`; the spawning front end withholds those
-(the CLI process itself cannot distinguish a plugin-spawned bare `rundown pass`
-from a human-run one, so the block happens front-end-side). `--claim-id`
-mutations are **preserved**: their `claim_controller` evidence (`claimId`,
-`tokenHash`, `controlledRunId`) is reconstructable CLI-side from the resolved
-claim record, so they do not rely on direct-CLI trust and delegated children can
-still complete. See [Claude Code Plugin Trust Model](./plugin-trust-model.md)
-for the plugin's other trust boundaries.
+only available trust is `direct_cli`; the spawning front end withholds those.
+
+**Two explicit lanes pass through.** `--claim-id` mutations are preserved: their
+`claim_controller` evidence (`claimId`, `tokenHash`, `controlledRunId`) is
+reconstructable CLI-side from the resolved claim record. `--run <rd_…>`
+mutations are preserved on all six commands — including `delegate`, previously
+withheld-always — because explicit run targeting is named evidence, not silent
+trust inheritance (`carriesExplicitRunTarget` mirrors `carriesClaimEvidence`'s
+fail-closed value-slot handling). The MCP mutating tools expose this as an
+optional `runId` parameter mapped to `--run` argv. See
+[Claude Code Plugin Trust Model](./plugin-trust-model.md) for the plugin's other
+trust boundaries.
+
+### Refusal messages never echo the target run id
+
+The `ACTOR_CONTEXT_REQUIRED` refusal (and the `COLLECT_REQUIRES_ORCHESTRATOR`
+remediation) tells the caller to pass `--run <rd_…>` "using the run id from your
+orchestration context" and deliberately does **not** echo the target run id in
+the message or the JSON details. Echoing it would convert the accident barrier
+into a copy-paste bypass for exactly the lingering-child agent it exists to
+stop. This is UX-shaped accident-proofing, never a security property: run ids
+are natively present in claim output (`parent_run_id`), on every event
+(`runbookId` — an inline child's id also rides the `inlineLaunch` **payload** on
+the launch event; there is no event type named `inlineLaunch`), and via
+`rundown status`. Names are not capabilities — the real authorization boundary
+is tier-2 capability work (#540 / R4).
+
+### Residual ambient session-management lane (R1 scope decision)
+
+`stash`, `pop`, `prune` (including `--all`), `abort`, `claim`, and `status`
+remain ungated by delegation exposure. A bare `stash` can pause a delegating
+pipeline, a bare `pop` can reorder the stack, and `prune --all` can destroy live
+run state — ambient session-management disruption/DoS, but **not** run-driving
+takeover: none of these can advance, complete, or delegate on behalf of the
+orchestrator, which is the defect class R1 closes. Gating session management
+behind exposure is follow-up work tracked outside this document.
 
 ### Lifecycle write diagnostics
 

--- a/docs/reference/cli-help.md
+++ b/docs/reference/cli-help.md
@@ -154,6 +154,8 @@ Options:
   --step <stepId>       Target specific substep
   --index <number>      FOR loop iteration to target (requires --step)
   --claim-id <claimId>  Target a claimed delegated child runbook
+  --run <runId>         Name the run you control (explicit orchestrator
+                        targeting)
   --text                Output as human-readable text
   -h, --help            display help for command
 ```
@@ -169,6 +171,8 @@ Options:
   --step <stepId>       Target specific substep
   --index <number>      FOR loop iteration to target (requires --step)
   --claim-id <claimId>  Target a claimed delegated child runbook
+  --run <runId>         Name the run you control (explicit orchestrator
+                        targeting)
   --text                Output as human-readable text
   -h, --help            display help for command
 ```
@@ -185,6 +189,8 @@ Arguments:
 
 Options:
   --claim-id <claimId>  Target a claimed delegated child runbook
+  --run <runId>         Name the run you control (explicit orchestrator
+                        targeting)
   --text                Output as human-readable text
   -h, --help            display help for command
 ```
@@ -199,6 +205,8 @@ Jump to specific step (e.g., "3" or "3.1" for substep)
 Options:
   --index <number>      FOR loop iteration to target
   --claim-id <claimId>  Target a claimed delegated child runbook
+  --run <runId>         Name the run you control (explicit orchestrator
+                        targeting)
   --text                Output as human-readable text
   -h, --help            display help for command
 ```
@@ -228,6 +236,8 @@ Arguments:
 
 Options:
   --claim-id <claimId>  Target a claimed delegated child runbook
+  --run <runId>         Name the run you control (explicit orchestrator
+                        targeting)
   --text                Output as human-readable text
   -h, --help            display help for command
 ```
@@ -475,6 +485,8 @@ Options:
   --index <number>             FOR loop iteration to target (requires --step)
   --retry                      Retry an existing delegation: cancel and re-issue
                                with a fresh token
+  --run <runId>                Name the run you control (explicit orchestrator
+                               targeting)
   --text                       Output as human-readable text
   -h, --help                   display help for command
 
@@ -540,6 +552,8 @@ Options:
   --index <number>      FOR loop iteration to target (requires --step on a FOR
                         step)
   --claim-id <claimId>  Target a claimed delegated child runbook
+  --run <runId>         Name the run you control (explicit orchestrator
+                        targeting)
   --text                Output as human-readable text
   -h, --help            display help for command
 ```

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "check:md": "prettier --check \"**/*.md\"",
     "check:spell": "cspell --no-progress --no-must-find-files .",
     "check:lint:fast": "biome lint .",
-    "check:lint:typed": "eslint .",
+    "check:lint:typed": "node --max-old-space-size=8192 node_modules/eslint/bin/eslint.js .",
     "check:types": "run-p check:types:core check:types:parser check:types:plugin check:types:cli check:types:mcp",
     "check:types:core": "pnpm --filter @rundown-org/core check:types",
     "check:types:parser": "pnpm --filter @rundown-org/parser check:types",

--- a/packages/claude-code-plugin/__tests__/helpers/test-utils.ts
+++ b/packages/claude-code-plugin/__tests__/helpers/test-utils.ts
@@ -262,3 +262,26 @@ export function assertDefined<T>(
     throw new Error(message);
   }
 }
+
+/**
+ * Extract the active run id from a `rundown status` invocation result.
+ *
+ * Post-R1 named-authority helper shared by the runbook integration suites:
+ * mutating commands need `--run <rd_…>`, and the id is resolved from the
+ * status payload's `state` path.
+ *
+ * @param result - Exit code and stdout of a `rundown status` invocation
+ * @returns The active run id (`rd_` + 32 hex)
+ * @throws {Error} When the status payload carries no run id
+ */
+export function activeRunIdFromStatus(result: { exitCode: number | null; stdout: string }): string {
+  if (result.exitCode !== 0) {
+    throw new Error(`status exited ${String(result.exitCode)}: ${result.stdout}`);
+  }
+  const parsed = JSON.parse(result.stdout) as { state?: string };
+  const match = /rd_[a-f0-9]{32}/.exec(parsed.state ?? '');
+  if (!match) {
+    throw new Error(`No active run id in status: ${result.stdout}`);
+  }
+  return match[0];
+}

--- a/packages/claude-code-plugin/__tests__/runbooks/end-to-end-test-runtime.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/end-to-end-test-runtime.integration.test.ts
@@ -112,10 +112,20 @@ describe('end-to-end-test runtime delegation + artifact handoff', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  /** Advance the active runbook with a bare `rundown pass` and collect its events. */
+  /** Advance the active runbook with a run-targeted `rundown pass` and collect its events. */
   function pass(): JsonEvent[] {
-    const result = runCli(['pass'], tempDir);
+    const result = runCli(['pass', '--run', activeRunId()], tempDir);
     return parseJsonEvents(result.stdout);
+  }
+
+  /** Resolve the active run id from `rundown status` (post-R1 named authority). */
+  function activeRunId(): string {
+    const result = runCli(['status'], tempDir);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout) as { state?: string };
+    const match = /rd_[a-f0-9]{32}/.exec(parsed.state ?? '');
+    if (!match) throw new Error(`No active run id in status: ${result.stdout}`);
+    return match[0];
   }
 
   function status(): StatusResponse {
@@ -237,7 +247,7 @@ describe('end-to-end-test runtime delegation + artifact handoff', () => {
     expect(beforeCollect.position?.current).toBe('1');
 
     // Explicit collect aggregates the reported outcome: PASS ALL → CONTINUE → step 2.
-    const collected = runCli(['collect'], tempDir);
+    const collected = runCli(['collect', '--run', activeRunId()], tempDir);
     expect(collected.exitCode).toBe(0);
     const collectEvents = parseJsonEvents(collected.stdout);
     expect(

--- a/packages/claude-code-plugin/__tests__/runbooks/end-to-end-test-runtime.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/end-to-end-test-runtime.integration.test.ts
@@ -26,7 +26,7 @@ import { mkdtempSync } from 'node:fs';
 import * as path from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { runCli } from '../helpers/test-utils.js';
+import { runCli, activeRunIdFromStatus } from '../helpers/test-utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -118,14 +118,8 @@ describe('end-to-end-test runtime delegation + artifact handoff', () => {
     return parseJsonEvents(result.stdout);
   }
 
-  /** Resolve the active run id from `rundown status` (post-R1 named authority). */
   function activeRunId(): string {
-    const result = runCli(['status'], tempDir);
-    expect(result.exitCode).toBe(0);
-    const parsed = JSON.parse(result.stdout) as { state?: string };
-    const match = /rd_[a-f0-9]{32}/.exec(parsed.state ?? '');
-    if (!match) throw new Error(`No active run id in status: ${result.stdout}`);
-    return match[0];
+    return activeRunIdFromStatus(runCli(['status'], tempDir));
   }
 
   function status(): StatusResponse {

--- a/packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts
@@ -126,6 +126,16 @@ describe('execute-plan runtime delegation + artifact handoff', () => {
     return JSON.parse(result.stdout) as StatusResponse;
   }
 
+  /** Resolve the active run id from `rundown status` (post-R1 named authority). */
+  function activeRunId(): string {
+    const result = runCli(['status'], tempDir);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout) as { state?: string };
+    const match = /rd_[a-f0-9]{32}/.exec(parsed.state ?? '');
+    if (!match) throw new Error(`No active run id in status: ${result.stdout}`);
+    return match[0];
+  }
+
   function driveToImplementDelegate(): { token: string } {
     const start = runCli(['run', '--prompted', '--allow-all', 'exec-plan-harness'], tempDir);
     expect(start.exitCode).toBe(0);
@@ -141,7 +151,7 @@ describe('execute-plan runtime delegation + artifact handoff', () => {
       ) {
         return { token: pending.token };
       }
-      runCli(['pass'], tempDir);
+      runCli(['pass', '--run', activeRunId()], tempDir);
     }
     throw new Error('Did not reach execute-plan implement DELEGATE step');
   }

--- a/packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/execute-plan-runtime.integration.test.ts
@@ -16,7 +16,7 @@ import { mkdtempSync } from 'node:fs';
 import * as path from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { runCli } from '../helpers/test-utils.js';
+import { runCli, activeRunIdFromStatus } from '../helpers/test-utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -126,14 +126,8 @@ describe('execute-plan runtime delegation + artifact handoff', () => {
     return JSON.parse(result.stdout) as StatusResponse;
   }
 
-  /** Resolve the active run id from `rundown status` (post-R1 named authority). */
   function activeRunId(): string {
-    const result = runCli(['status'], tempDir);
-    expect(result.exitCode).toBe(0);
-    const parsed = JSON.parse(result.stdout) as { state?: string };
-    const match = /rd_[a-f0-9]{32}/.exec(parsed.state ?? '');
-    if (!match) throw new Error(`No active run id in status: ${result.stdout}`);
-    return match[0];
+    return activeRunIdFromStatus(runCli(['status'], tempDir));
   }
 
   function driveToImplementDelegate(): { token: string } {

--- a/packages/claude-code-plugin/__tests__/runbooks/workflow.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/workflow.integration.test.ts
@@ -146,6 +146,16 @@ describe('Built-in Runbook Workflow Integration', () => {
   });
 
   describe('prompted mode step navigation', () => {
+    /** Resolve the active run id from `rundown status` (post-R1 named authority). */
+    function activeRunId(): string {
+      const statusResult = runCli(['status'], tempDir);
+      expect(statusResult.exitCode).toBe(0);
+      const parsed = JSON.parse(statusResult.stdout) as { state?: string };
+      const match = /rd_[a-f0-9]{32}/.exec(parsed.state ?? '');
+      if (!match) throw new Error(`No active run id in status: ${statusResult.stdout}`);
+      return match[0];
+    }
+
     function runPromptedUntilStep(
       runbookPath: string,
       stepId: string,
@@ -157,7 +167,7 @@ describe('Built-in Runbook Workflow Integration', () => {
 
       let entered = findEnteredStep(events, stepId);
       for (let index = 0; index < 30 && !entered; index += 1) {
-        result = runCli(['pass'], tempDir);
+        result = runCli(['pass', '--run', activeRunId()], tempDir);
         expect(result.exitCode).toBe(0);
         events.push(...parseJsonEvents(result.stdout));
         entered = findEnteredStep(events, stepId);
@@ -276,7 +286,7 @@ describe('Built-in Runbook Workflow Integration', () => {
         );
 
         for (let index = 0; index < 40 && !reviewEntered; index += 1) {
-          result = runCli(['pass'], tempDir);
+          result = runCli(['pass', '--run', activeRunId()], tempDir);
           expect(result.exitCode).toBe(0);
           combinedOutput += result.stdout + result.stderr;
           events.push(...parseJsonEvents(result.stdout));

--- a/packages/claude-code-plugin/__tests__/runbooks/workflow.integration.test.ts
+++ b/packages/claude-code-plugin/__tests__/runbooks/workflow.integration.test.ts
@@ -8,7 +8,7 @@ import { mkdtempSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { runCli } from '../helpers/test-utils.js';
+import { runCli, activeRunIdFromStatus } from '../helpers/test-utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -146,14 +146,8 @@ describe('Built-in Runbook Workflow Integration', () => {
   });
 
   describe('prompted mode step navigation', () => {
-    /** Resolve the active run id from `rundown status` (post-R1 named authority). */
     function activeRunId(): string {
-      const statusResult = runCli(['status'], tempDir);
-      expect(statusResult.exitCode).toBe(0);
-      const parsed = JSON.parse(statusResult.stdout) as { state?: string };
-      const match = /rd_[a-f0-9]{32}/.exec(parsed.state ?? '');
-      if (!match) throw new Error(`No active run id in status: ${statusResult.stdout}`);
-      return match[0];
+      return activeRunIdFromStatus(runCli(['status'], tempDir));
     }
 
     function runPromptedUntilStep(

--- a/packages/claude-code-plugin/src/workflow/hooks/rundown.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/rundown.ts
@@ -58,12 +58,14 @@ export function rundown(args: string[], cwd: string, execOptions: RundownExecOpt
     throw new Error(delegateValidation.message);
   }
 
-  // Subprocess trust boundary: this helper is the single choke point for every
-  // plugin->CLI spawn. A bare (no `--claim-id`) `pass` / `fail` / `delegate`
-  // would arrive at the CLI as an ordinary argv and silently inherit direct-CLI
-  // trust over the active run. Fail closed by withholding it here; `--claim-id`
-  // mutations carry independent claim evidence and read-only commands pass
-  // through. See subprocess-mutation-boundary.ts.
+  // Subprocess trust boundary (defense-in-depth): this helper is the single
+  // choke point for every plugin->CLI spawn. Core itself is the primary gate —
+  // it refuses ambient direct-CLI trust on every delegation-exposed run — so
+  // this withhold only stops a bare mutation from silently consuming the
+  // standalone-run convenience lane, and keeps the refusal front-end-rendered.
+  // Explicitly-targeted mutations — `--claim-id` (claim evidence) or `--run`
+  // (named run authority) — and read-only commands pass through. See
+  // subprocess-mutation-boundary.ts.
   const withheld = bareRoleSpecificMutation(args);
   if (withheld !== undefined) {
     throw new Error(subprocessMutationWithheldMessage(withheld));

--- a/packages/cli/__tests__/commands/abort.test.ts
+++ b/packages/cli/__tests__/commands/abort.test.ts
@@ -9,6 +9,7 @@ import {
   parseCliJsonObject,
   parseConcatenatedJson,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -515,7 +516,9 @@ describe('abort command - unit tests', () => {
       expect(rows).toHaveLength(1);
       expect(rows[0]?.result).toBe('fail');
 
-      const blocked = await runCliInProcess('pass', workspace);
+      // Post-R1 the guard needs named authority: the run-targeted bare-shaped
+      // advance still refuses with the collection-pending guard.
+      const blocked = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
       expect(blocked.exitCode).toBe(1);
       expect(`${blocked.stdout}${blocked.stderr}`).toContain('DELEGATION_COLLECTION_PENDING');
     });

--- a/packages/cli/__tests__/commands/claim.test.ts
+++ b/packages/cli/__tests__/commands/claim.test.ts
@@ -12,6 +12,7 @@ import {
   parseCliJsonObject,
   parseFinalCliJsonObject,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
@@ -715,9 +716,13 @@ rd echo --result fail
       await runCliInProcess('run --prompted parent.runbook.md --text', workspace);
       const token = await getAutoIssuedToken();
 
-      // Cancel the delegation (via stop command on parent). Bare stop is a
-      // failure terminal and exits non-zero.
-      let result = await runCliInProcess('stop --text', workspace);
+      // Cancel the delegation (via run-targeted stop on the delegating parent
+      // — named authority post-R1). A stop is a failure terminal and exits
+      // non-zero.
+      let result = await runCliInProcess(
+        await withRunTarget(['stop', '--text'], workspace),
+        workspace,
+      );
       expect(result.exitCode).toBe(1);
 
       // Attempt to claim — parent is stopped, delegation cannot be claimed

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -375,8 +375,12 @@ describe('collect command', () => {
       const result = await runCliInProcess(['collect', '--run', childRunId], workspace);
 
       const payload = JSON.parse(result.stdout) as { code?: string };
-      expect(payload.code).not.toBe('COLLECT_REQUIRES_ORCHESTRATOR');
-      expect(payload.code).not.toBe('ACTOR_CONTEXT_REQUIRED');
+      // Pin the full outcome, not just the absence of the two gate refusals:
+      // the named child has no delegations of its own to collect, so the only
+      // acceptable result is the benign no-delegate-step error — any authority
+      // refusal or unexpected failure must fail this test.
+      expect(result.exitCode).not.toBe(0);
+      expect(payload.code).toBe('NOT_DELEGATE_STEP');
     }, 30_000);
   });
 

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -23,6 +23,7 @@ import {
   createRunbook,
   runCliInProcess,
   getActiveState,
+  withRunTarget,
   getAllStates,
   readRunbookState,
   parseConcatenatedJson,
@@ -364,8 +365,14 @@ describe('collect command', () => {
       });
 
       // The active run is itself delegated upward. Under the target-relative
-      // model the orchestrator gate must NOT reject it as a collection target.
-      const result = await runCliInProcess(['collect'], workspace);
+      // model the orchestrator gate must NOT reject it as a collection target —
+      // but post-R1 the orchestrator must NAME the run it collects: the child
+      // is delegation-linked (clause e), so a bare collect is refused.
+      const bare = await runCliInProcess(['collect'], workspace);
+      const bareEnvelope = JSON.parse(bare.stdout) as { code?: string };
+      expect(bareEnvelope.code).toBe('ACTOR_CONTEXT_REQUIRED');
+
+      const result = await runCliInProcess(['collect', '--run', childRunId], workspace);
 
       const payload = JSON.parse(result.stdout) as { code?: string };
       expect(payload.code).not.toBe('COLLECT_REQUIRES_ORCHESTRATOR');
@@ -411,7 +418,7 @@ describe('collect command', () => {
     it('fires CONTINUE and advances to next step when PASS ALL passes', async () => {
       await setupReadyToCollect(['pass', 'pass']);
 
-      const result = await runCliInProcess(['collect'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
 
       expect(result.exitCode).toBe(0);
 
@@ -423,7 +430,7 @@ describe('collect command', () => {
     it('fires STOP and halts when FAIL ANY and a substep failed', async () => {
       await setupReadyToCollect(['pass', 'fail']);
 
-      const result = await runCliInProcess(['collect'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
 
       // Parent should have stopped (non-zero exit).
       expect(result.exitCode).not.toBe(0);
@@ -453,7 +460,7 @@ describe('collect command', () => {
     it('drives the run to a stopped lifecycle when FAIL ANY aggregation fires', async () => {
       await setupReadyToCollect(['pass', 'fail']);
 
-      const result = await runCliInProcess(['collect'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
 
       // FAIL ANY STOP aggregation on a mixed result stops the runbook.
       expect(result.exitCode).not.toBe(0);
@@ -490,7 +497,7 @@ describe('collect command', () => {
     it('emits an applied JSON envelope for a successful bare collect', async () => {
       await setupReadyToCollect(['pass', 'pass']);
 
-      const result = await runCliInProcess(['collect'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(result.exitCode).toBe(0);
 
       const parsed = findCollectOutput(result.stdout, 'applied');
@@ -517,11 +524,11 @@ describe('collect command', () => {
     it('emits already-aggregated JSON with COLLECT_ALREADY_APPLIED code on the second invocation', async () => {
       await setupReadyToCollect(['pass', 'pass']);
 
-      const first = await runCliInProcess(['collect'], workspace);
+      const first = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(first.exitCode).toBe(0);
       expect((await getActiveState(workspace))?.step).toBe('2');
 
-      const second = await runCliInProcess(['collect'], workspace);
+      const second = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(second.exitCode).toBe(0);
 
       const json = parseConcatenatedJson(second.stdout).at(-1) as Record<string, unknown>;
@@ -545,7 +552,7 @@ describe('collect command', () => {
       await setupReadyToCollect(['pass', 'pass']);
 
       // First collect: fires aggregation, advances to step 2.
-      const first = await runCliInProcess(['collect'], workspace);
+      const first = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(first.exitCode).toBe(0);
 
       const after = await getActiveState(workspace);
@@ -555,18 +562,21 @@ describe('collect command', () => {
       // DELEGATE step, so aggregation already fired. Bare collect infers the
       // cursor and reports an idempotent already-aggregated no-op (exit 0)
       // rather than the NOT_DELEGATE_STEP error.
-      const second = await runCliInProcess(['collect', '--text'], workspace);
+      const second = await runCliInProcess(
+        await withRunTarget(['collect', '--text'], workspace),
+        workspace,
+      );
       expect(second.exitCode).toBe(0);
       expect(second.stdout).toMatch(/already aggregated/i);
     });
 
     it('bare rd collect after auto-aggregation returns already-aggregated, not NOT_DELEGATE_STEP', async () => {
       await setupReadyToCollect(['pass', 'pass']);
-      const first = await runCliInProcess(['collect'], workspace);
+      const first = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(first.exitCode).toBe(0);
       expect((await getActiveState(workspace))?.step).toBe('2');
 
-      const result = await runCliInProcess(['collect'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
 
       expect(result.exitCode).toBe(0);
       const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
@@ -575,11 +585,14 @@ describe('collect command', () => {
 
     it('rd collect --step <non-delegate> still errors NOT_DELEGATE_STEP', async () => {
       await setupReadyToCollect(['pass', 'pass']);
-      const first = await runCliInProcess(['collect'], workspace);
+      const first = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(first.exitCode).toBe(0);
       expect((await getActiveState(workspace))?.step).toBe('2');
 
-      const result = await runCliInProcess(['collect', '--step', '2'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['collect', '--step', '2'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).toBe(1);
       const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
@@ -605,7 +618,7 @@ describe('collect command', () => {
       );
       expect(start.exitCode).toBe(0);
 
-      const result = await runCliInProcess(['collect'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
 
       expect(result.exitCode).toBe(1);
       const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
@@ -629,7 +642,10 @@ describe('collect command', () => {
       raw.resolvedCompletions = {};
       await writeFile(statePath, JSON.stringify(raw, null, 2));
 
-      const result = await runCliInProcess(['collect', '--text'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['collect', '--text'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toMatch(/already aggregated/i);
@@ -646,7 +662,7 @@ describe('collect command', () => {
       raw.resolvedCompletions = {};
       await writeFile(statePath, JSON.stringify(raw, null, 2));
 
-      const result = await runCliInProcess(['collect'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
 
       expect(result.exitCode).toBe(0);
       // JSON output is pretty-printed; parse the whole payload.
@@ -716,17 +732,20 @@ describe('collect command', () => {
 
       // Mark the single DELEGATE substep resolved and aggregate to step 2.
       await markSubstepsResolved(workspace, runbookId, ['pass']);
-      const collect1 = await runCliInProcess(['collect'], workspace);
+      const collect1 = await runCliInProcess(
+        await withRunTarget(['collect'], workspace),
+        workspace,
+      );
       expect(collect1.exitCode).toBe(0);
       expect((await getActiveState(workspace))?.step).toBe('2');
 
       // Advance the cursor off the aggregation successor to an unrelated step.
-      const pass2 = await runCliInProcess(['pass'], workspace);
+      const pass2 = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
       expect(pass2.exitCode).toBe(0);
       expect((await getActiveState(workspace))?.step).toBe('3');
 
       // Bare collect on step 3 — NOT the aggregation successor. Must error.
-      const result = await runCliInProcess(['collect'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(result.exitCode).toBe(1);
       const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
       expect(json).toMatchObject({ kind: 'error', code: 'NOT_DELEGATE_STEP' });
@@ -749,7 +768,7 @@ describe('collect command', () => {
       raw.step = '99'; // not present in the parent runbook (steps are '1' / '2')
       await writeFile(statePath, JSON.stringify(raw, null, 2));
 
-      const result = await runCliInProcess(['collect'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
 
       expect(result.exitCode).toBe(1);
       const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
@@ -764,7 +783,10 @@ describe('collect command', () => {
       raw.step = '99';
       await writeFile(statePath, JSON.stringify(raw, null, 2));
 
-      const result = await runCliInProcess(['collect', '--text'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['collect', '--text'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).toBe(1);
       const out = result.stdout + result.stderr;
@@ -775,7 +797,10 @@ describe('collect command', () => {
     it('rd collect --step <missing> reports STEP_NOT_FOUND, not NOT_DELEGATE_STEP', async () => {
       await setupReadyToCollect(['pass', 'pass']);
 
-      const result = await runCliInProcess(['collect', '--step', '99'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['collect', '--step', '99'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).toBe(1);
       const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
@@ -806,7 +831,7 @@ describe('collect command', () => {
       await writeFile(statePath, JSON.stringify(raw, null, 2));
 
       const result = await runCliInProcess(
-        ['collect', '--step', '1.1', '--index', '99'],
+        await withRunTarget(['collect', '--step', '1.1', '--index', '99'], workspace),
         workspace,
       );
 
@@ -841,7 +866,7 @@ describe('collect command', () => {
       await writeFile(statePath, JSON.stringify(raw, null, 2));
 
       const result = await runCliInProcess(
-        ['collect', '--step', '1.1', '--index', '99', '--text'],
+        await withRunTarget(['collect', '--step', '1.1', '--index', '99', '--text'], workspace),
         workspace,
       );
 
@@ -956,7 +981,10 @@ describe('collect command', () => {
 
       // `rd collect` is the only apply path: it drains the reported outcomes and
       // advances the parent past the DELEGATE step (PASS ALL → CONTINUE → step 2).
-      const collectResult = await runCliInProcess(['collect', '--text'], workspace);
+      const collectResult = await runCliInProcess(
+        await withRunTarget(['collect', '--text'], workspace),
+        workspace,
+      );
       expect(collectResult.exitCode).toBe(0);
 
       const collectedParent = JSON.parse(
@@ -974,7 +1002,10 @@ describe('collect command', () => {
       // Explicit `--step` naming a non-DELEGATE step is a genuine misuse and
       // still errors NOT_DELEGATE_STEP (unlike bare collect, which infers the
       // cursor and reports an idempotent already-aggregated no-op).
-      const result = await runCliInProcess(['collect', '--step', '1', '--text'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['collect', '--step', '1', '--text'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stdout + result.stderr).toMatch(/not a DELEGATE step/i);
@@ -1013,7 +1044,10 @@ describe('collect command', () => {
       ];
       await writeFile(statePath, JSON.stringify(raw, null, 2));
 
-      const result = await runCliInProcess(['collect', '--text'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['collect', '--text'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stdout + result.stderr).toMatch(/not all substeps/i);
@@ -1050,7 +1084,7 @@ describe('collect command', () => {
       ];
       await writeFile(statePath, JSON.stringify(raw, null, 2));
 
-      const result = await runCliInProcess(['collect'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
 
       expect(result.exitCode).not.toBe(0);
       const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
@@ -1097,7 +1131,10 @@ describe('collect command', () => {
     it('scopes collect to the requested step when --step is provided', async () => {
       await setupReadyToCollect(['pass', 'pass']);
 
-      const result = await runCliInProcess(['collect', '--step', '1.1'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['collect', '--step', '1.1'], workspace),
+        workspace,
+      );
       expect(result.exitCode).toBe(0);
 
       // After collect, the parent must have advanced to step 2 — identical
@@ -1113,7 +1150,10 @@ describe('collect command', () => {
     it('errors when --step targets a non-DELEGATE step', async () => {
       await setupReadyToCollect(['pass', 'pass']);
 
-      const result = await runCliInProcess(['collect', '--step', '2', '--text'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['collect', '--step', '2', '--text'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stdout + result.stderr).toMatch(/step 2 is not a DELEGATE step/i);
@@ -1167,7 +1207,10 @@ describe('collect command', () => {
     it('prints the collected-N summary line on a successful --text collect', async () => {
       await setupReadyToCollect(['pass', 'pass']);
 
-      const result = await runCliInProcess(['collect', '--text'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['collect', '--text'], workspace),
+        workspace,
+      );
       expect(result.exitCode).toBe(0);
 
       const out = result.stdout + result.stderr;
@@ -1274,7 +1317,10 @@ describe('collect command', () => {
     it('runs the execution loop to launch + activate the inline child, then emits the applied object last', async () => {
       const parentRunId = await driveToPendingCollect();
 
-      const collected = await runCliInProcess('collect', workspace);
+      const collected = await runCliInProcess(
+        await withRunTarget(['collect'], workspace),
+        workspace,
+      );
       expect(collected.exitCode).toBe(0);
 
       // The parent advanced into stage 2 (the inline gate stage) and is running.
@@ -1390,7 +1436,10 @@ describe('collect command', () => {
 
       // Stage 1: report + collect -> parent CONTINUEs into the inline gate child.
       await claimAndReportActiveDelegation();
-      const collect1 = await runCliInProcess('collect', workspace);
+      const collect1 = await runCliInProcess(
+        await withRunTarget(['collect'], workspace),
+        workspace,
+      );
       expect(collect1.exitCode).toBe(0);
 
       // The inline gate child G is now the active run (its own DELEGATE step).
@@ -1402,7 +1451,10 @@ describe('collect command', () => {
       // drives G terminal (completed); the collect command's terminal-propagation
       // pass then resolves the parent's stage-2 substep and completes the parent.
       await claimAndReportActiveDelegation();
-      const collect2 = await runCliInProcess('collect', workspace);
+      const collect2 = await runCliInProcess(
+        await withRunTarget(['collect'], workspace),
+        workspace,
+      );
       expect(collect2.exitCode).toBe(0);
 
       const gateAfter = await readRunbookState(workspace, gate!.id);
@@ -1441,7 +1493,9 @@ describe('collect command', () => {
 
       // Stage 1 passes -> parent CONTINUEs into the inline gate child G.
       await claimAndReportActiveDelegation('pass');
-      expect((await runCliInProcess('collect', workspace)).exitCode).toBe(0);
+      expect(
+        (await runCliInProcess(await withRunTarget(['collect'], workspace), workspace)).exitCode,
+      ).toBe(0);
       const gate = await getActiveState(workspace);
       expect(gate!.parentLinkage?.kind).toBe('inline');
 
@@ -1449,7 +1503,10 @@ describe('collect command', () => {
       // aggregation drives G to a STOPPED terminal; the terminal-propagation pass
       // then propagates that stop to the parent and the command exits non-zero.
       await claimAndReportActiveDelegation('fail');
-      const collectStop = await runCliInProcess('collect', workspace);
+      const collectStop = await runCliInProcess(
+        await withRunTarget(['collect'], workspace),
+        workspace,
+      );
       expect(collectStop.exitCode).not.toBe(0);
 
       const gateAfter = await readRunbookState(workspace, gate!.id);

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { Command } from 'commander';
-import { activeFrame, buildFrameKey, buildCompletionKey, type FrameKey } from '@rundown-org/core';
+import {
+  activeFrame,
+  buildFrameKey,
+  buildCompletionKey,
+  COLLECT_REQUIRES_ORCHESTRATOR_MESSAGE,
+  type FrameKey,
+} from '@rundown-org/core';
 // Static import of the command module under test. The behavioural tests below
 // drive the command through `runCliInProcess`, which reaches it via a *dynamic*
 // `import('../cli.js')` — an edge Stryker's `enableFindRelatedTests` (Jest's
@@ -365,6 +371,40 @@ describe('collect command', () => {
       expect(payload.code).not.toBe('COLLECT_REQUIRES_ORCHESTRATOR');
       expect(payload.code).not.toBe('ACTOR_CONTEXT_REQUIRED');
     }, 30_000);
+  });
+
+  describe('--run explicit targeting', () => {
+    it('collects the named delegating parent via collect --run <parentId>', async () => {
+      const runbookId = await setupReadyToCollect(['pass', 'pass']);
+
+      const result = await runCliInProcess(['collect', '--run', runbookId], workspace);
+
+      expect(result.exitCode).toBe(0);
+      const state = await getActiveState(workspace);
+      expect(state?.step).toBe('2');
+    });
+
+    it('refuses a well-formed but unknown --run id with RUN_TARGET_UNAVAILABLE', async () => {
+      await setupReadyToCollect(['pass', 'pass']);
+      const bogus = `rd_${'f'.repeat(32)}`;
+
+      const result = await runCliInProcess(['collect', '--run', bogus], workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('RUN_TARGET_UNAVAILABLE');
+      // The refusal collected nothing.
+      const state = await getActiveState(workspace);
+      expect(state?.step).toBe('1');
+    });
+
+    it('names the --run remediation in the orchestrator-gate refusal message', () => {
+      // The COLLECT_REQUIRES_ORCHESTRATOR envelope must point at BOTH explicit
+      // authority lanes and never echo a run id (decision 4).
+      expect(COLLECT_REQUIRES_ORCHESTRATOR_MESSAGE).toContain('--run');
+      expect(COLLECT_REQUIRES_ORCHESTRATOR_MESSAGE).toContain('--claim-id');
+      expect(COLLECT_REQUIRES_ORCHESTRATOR_MESSAGE).not.toMatch(/rd_[a-f0-9]{32}/);
+    });
   });
 
   describe('successful aggregation', () => {

--- a/packages/cli/__tests__/commands/complete.test.ts
+++ b/packages/cli/__tests__/commands/complete.test.ts
@@ -57,7 +57,7 @@ describe('complete command', () => {
     it('forces the named stack-member run terminal via complete --run <id>', async () => {
       await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
       const active = await getActiveState(workspace);
-      expect(active).toBeDefined();
+      expect(active).not.toBeNull();
 
       const result = await runCliInProcess(`complete --run ${active!.id}`, workspace);
 

--- a/packages/cli/__tests__/commands/complete.test.ts
+++ b/packages/cli/__tests__/commands/complete.test.ts
@@ -53,6 +53,34 @@ describe('complete command', () => {
     await workspace.cleanup();
   });
 
+  describe('--run explicit targeting', () => {
+    it('forces the named stack-member run terminal via complete --run <id>', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const active = await getActiveState(workspace);
+      expect(active).toBeDefined();
+
+      const result = await runCliInProcess(`complete --run ${active!.id}`, workspace);
+
+      expect(result.exitCode).toBe(0);
+      const state = await readRunbookState(workspace, active!.id);
+      expect(state?.lifecycle).toBe('completed');
+    });
+
+    it('refuses a well-formed but unknown --run id with RUN_TARGET_UNAVAILABLE', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const bogus = `rd_${'f'.repeat(32)}`;
+
+      const result = await runCliInProcess(`complete --run ${bogus}`, workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('RUN_TARGET_UNAVAILABLE');
+      // The active run was not forced terminal by the refusal.
+      const state = await getActiveState(workspace);
+      expect(state?.lifecycle).toBe('running');
+    });
+  });
+
   it('completes through the machine and persists frontmatter finalVars', async () => {
     const runbook = `---
 outputs:

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { Command } from 'commander';
 import {
   createTestWorkspace,
+  extractToken,
   injectDelegationOutcomeForActiveRun,
   runCliInProcess,
   getActiveState,
@@ -343,6 +344,40 @@ describe('delegate command', () => {
       // later `rd collect` cannot drain the prior attempt's result.
       const after = await getActiveState(workspace);
       expect(Object.keys(after?.resolvedCompletions ?? {})).not.toContain(completionKey);
+    });
+  });
+
+  describe('delegate --run', () => {
+    it('issues delegation against the named run', async () => {
+      await setupDelegation();
+      const parent = await getActiveState(workspace);
+      if (!parent) throw new Error('Expected active parent run');
+
+      const result = await runCliInProcess(['delegate', '--run', parent.id], workspace);
+
+      expect(result.exitCode).toBe(0);
+      expect(extractToken(result.stdout)).toBeDefined();
+    });
+
+    it('refuses a well-formed foreign run id with RUN_TARGET_UNAVAILABLE', async () => {
+      await setupDelegation();
+      const foreign = `rd_${'f'.repeat(32)}`;
+
+      const result = await runCliInProcess(['delegate', '--run', foreign], workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('RUN_TARGET_UNAVAILABLE');
+    });
+
+    it('rejects a malformed --run id with INVALID_RUN_ID', async () => {
+      await setupDelegation();
+
+      const result = await runCliInProcess(['delegate', '--run', 'not-a-run-id'], workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('INVALID_RUN_ID');
     });
   });
 

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -13,6 +13,7 @@ import {
   createRunbook,
   parseCliJsonObject,
   parseConcatenatedJson,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 
 /**
@@ -256,7 +257,7 @@ describe('delegate command', () => {
       await setupAutoIssuedDelegation();
       const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
 
-      const result = await runCliInProcess(['delegate'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['delegate'], workspace), workspace);
 
       expect(result.exitCode).toBe(1);
       const raw = JSON.parse(result.stdout);
@@ -280,7 +281,10 @@ describe('delegate command', () => {
       await setupAutoIssuedDelegation();
       const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
 
-      const result = await runCliInProcess(['delegate', 'runbooks/child.runbook.md'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).toBe(1);
       const raw = JSON.parse(result.stdout);
@@ -305,7 +309,10 @@ describe('delegate command', () => {
       await setupAutoIssuedDelegation();
       await injectDelegationOutcomeForActiveRun(workspace);
 
-      const result = await runCliInProcess(['delegate', '--step', '1.1'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', '--step', '1.1'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).toBe(0);
       const json = parseCliJsonObject(result.stdout);
@@ -327,7 +334,10 @@ describe('delegate command', () => {
       const autoToken = await setupAutoIssuedDelegation();
       const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
 
-      const retry = await runCliInProcess(['delegate', '--retry', autoToken], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', autoToken], workspace),
+        workspace,
+      );
 
       expect(retry.exitCode).toBe(0);
       const retryOutput = JSON.parse(retry.stdout) as {
@@ -385,7 +395,7 @@ describe('delegate command', () => {
     it('echoes the auto-issued frontier token instead of RD-813 (JSON)', async () => {
       const autoToken = await setupAutoIssuedDelegation();
 
-      const result = await runCliInProcess(['delegate'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['delegate'], workspace), workspace);
 
       expect(result.exitCode).toBe(0);
       const json = parseCliJsonObject(result.stdout);
@@ -398,7 +408,10 @@ describe('delegate command', () => {
     it('echoes the auto-issued frontier token in text mode', async () => {
       await setupAutoIssuedDelegation();
 
-      const result = await runCliInProcess(['delegate', '--text'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', '--text'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('ALREADY');
@@ -411,13 +424,13 @@ describe('delegate command', () => {
     it('rd delegate <matching-runbook> (no --step) echoes the auto-issued token — parity with bare', async () => {
       const autoToken = await setupAutoIssuedDelegation();
 
-      const bare = await runCliInProcess(['delegate'], workspace);
+      const bare = await runCliInProcess(await withRunTarget(['delegate'], workspace), workspace);
       expect(bare.exitCode).toBe(0);
       const bareJson = parseCliJsonObject(bare.stdout);
       expect(bareJson).toMatchObject({ kind: 'delegate', action: 'already-delegated' });
 
       const positional = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md'], workspace),
         workspace,
       );
 
@@ -436,7 +449,10 @@ describe('delegate command', () => {
       });
       await writeFile(join(workspace.cwd, 'runbooks', 'child-b.runbook.md'), childBContent);
 
-      const result = await runCliInProcess(['delegate', 'runbooks/child-b.runbook.md'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', 'runbooks/child-b.runbook.md'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).not.toBe(0);
       const envelope = parseCliJsonObject(result.stdout || result.stderr);
@@ -495,7 +511,10 @@ describe('delegate command', () => {
       }
 
       const issued = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--index', '2'],
+        await withRunTarget(
+          ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--index', '2'],
+          workspace,
+        ),
         workspace,
       );
       expect(issued.exitCode).toBe(0);
@@ -504,7 +523,10 @@ describe('delegate command', () => {
 
       // Repeating the same frame-scoped target echoes the in-flight token.
       const repeat = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--index', '2'],
+        await withRunTarget(
+          ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--index', '2'],
+          workspace,
+        ),
         workspace,
       );
       expect(repeat.exitCode).toBe(0);
@@ -514,7 +536,10 @@ describe('delegate command', () => {
 
       // A different iteration is a different frame: no echo, fresh mint.
       const other = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--index', '3'],
+        await withRunTarget(
+          ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--index', '3'],
+          workspace,
+        ),
         workspace,
       );
       expect(other.exitCode).toBe(0);
@@ -538,7 +563,10 @@ describe('delegate command', () => {
       const delegationBefore = stateBefore?.substepStates?.find((ss) => ss.id === '1')?.delegation;
       expect(delegationBefore?.childRunId).not.toBeNull();
 
-      const result = await runCliInProcess(['delegate', '--step', '1.1'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', '--step', '1.1'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).not.toBe(0);
       const envelope = parseCliJsonObject(result.stdout || result.stderr);
@@ -556,7 +584,10 @@ describe('delegate command', () => {
     it('rd delegate --step 1.1 echoes the in-flight auto-issued token (req #1)', async () => {
       const autoToken = await setupAutoIssuedDelegation();
 
-      const result = await runCliInProcess(['delegate', '--step', '1.1'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', '--step', '1.1'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).toBe(0);
       const json = parseCliJsonObject(result.stdout);
@@ -569,7 +600,7 @@ describe('delegate command', () => {
       const autoToken = await setupAutoIssuedDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
 
@@ -588,7 +619,10 @@ describe('delegate command', () => {
       await writeFile(join(workspace.cwd, 'runbooks', 'child-b.runbook.md'), childBContent);
 
       const result = await runCliInProcess(
-        ['delegate', 'runbooks/child-b.runbook.md', '--step', '1.1'],
+        await withRunTarget(
+          ['delegate', 'runbooks/child-b.runbook.md', '--step', '1.1'],
+          workspace,
+        ),
         workspace,
       );
 
@@ -610,7 +644,10 @@ describe('delegate command', () => {
       await setupAutoIssuedDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', 'runbooks/made-up-child.runbook.md', '--step', '1.1'],
+        await withRunTarget(
+          ['delegate', 'runbooks/made-up-child.runbook.md', '--step', '1.1'],
+          workspace,
+        ),
         workspace,
       );
 
@@ -629,7 +666,10 @@ describe('delegate command', () => {
       await rm(join(workspace.cwd, 'runbooks', 'child.runbook.md'));
       await rm(join(workspace.runbooksDir(), 'child.runbook.md'));
 
-      const result = await runCliInProcess(['delegate', '--step', '1.1'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', '--step', '1.1'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).toBe(0);
       const json = parseCliJsonObject(result.stdout);
@@ -643,7 +683,10 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1.1 --text',
+        await withRunTarget(
+          ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--text'],
+          workspace,
+        ),
         workspace,
       );
 
@@ -658,7 +701,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
 
@@ -673,7 +716,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1.1',
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(result.exitCode).toBe(0);
@@ -697,7 +740,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const delegated = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1.1',
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(delegated.exitCode).toBe(0);
@@ -720,7 +763,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const delegated = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1.1',
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(delegated.exitCode).toBe(0);
@@ -758,7 +801,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const delegated = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1.1',
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(delegated.exitCode).toBe(0);
@@ -786,7 +829,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
 
@@ -855,7 +898,10 @@ describe('delegate command', () => {
       );
       expect(startResult.exitCode).toBe(0);
 
-      const gotoResult = await runCliInProcess(['goto', '2'], workspace);
+      const gotoResult = await runCliInProcess(
+        await withRunTarget(['goto', '2'], workspace),
+        workspace,
+      );
       expect(gotoResult.exitCode).toBe(0);
     }
 
@@ -902,7 +948,7 @@ describe('delegate command', () => {
         ?.token;
       expect(issuedToken).toBeDefined();
 
-      const result = await runCliInProcess(['delegate'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['delegate'], workspace), workspace);
 
       // Idempotent: echoes the pre-issued token rather than throwing RD-813.
       expect(result.exitCode).toBe(0);
@@ -922,7 +968,10 @@ describe('delegate command', () => {
     it('rd delegate --step 1.1 does not infer after inline child launch takes scope', async () => {
       await setupActiveInlineRunbookRef();
 
-      const result = await runCliInProcess(['delegate', '--step', '1.1'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', '--step', '1.1'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).not.toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).toContain('RD-813');
@@ -942,7 +991,10 @@ describe('delegate command', () => {
       )?.delegation?.token;
       expect(issuedToken).toBeDefined();
 
-      const result = await runCliInProcess(['delegate', '--step', '2.1'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', '--step', '2.1'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).toBe(0);
       const envelope = parseCliJsonObject(result.stdout);
@@ -964,7 +1016,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
 
@@ -978,7 +1030,10 @@ describe('delegate command', () => {
       });
       await writeFile(join(workspace.cwd, 'runbooks', 'child-b.runbook.md'), childBContent);
 
-      const result = await runCliInProcess(['delegate', 'runbooks/child-b.runbook.md'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', 'runbooks/child-b.runbook.md'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).not.toBe(0);
       const envelope = parseCliJsonObject(result.stdout || result.stderr);
@@ -988,7 +1043,10 @@ describe('delegate command', () => {
 
     it('accepts a no-step positional runbook that matches the authored target', async () => {
       await setupDelegation();
-      const result = await runCliInProcess(['delegate', 'runbooks/child.runbook.md'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md'], workspace),
+        workspace,
+      );
       expect(result.exitCode).toBe(0);
       const json = parseCliJsonObject(result.stdout);
       expect(json).toMatchObject({ kind: 'delegate', action: 'delegated', step: '1.1' });
@@ -1000,7 +1058,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 99.1',
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '99.1'], workspace),
         workspace,
       );
 
@@ -1016,7 +1074,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', '--step', '{N}', '--index', '2'],
+        await withRunTarget(['delegate', '--step', '{N}', '--index', '2'], workspace),
         workspace,
       );
 
@@ -1037,7 +1095,10 @@ describe('delegate command', () => {
       await rm(join(workspace.cwd, 'runbooks', 'child.runbook.md'));
       await rm(join(workspace.runbooksDir(), 'child.runbook.md'));
 
-      const result = await runCliInProcess(['delegate', '--step', '1.1'], workspace);
+      const result = await runCliInProcess(
+        await withRunTarget(['delegate', '--step', '1.1'], workspace),
+        workspace,
+      );
 
       expect(result.exitCode).not.toBe(0);
       const envelope = parseCliJsonObject(result.stdout || result.stderr);
@@ -1072,7 +1133,7 @@ describe('delegate command', () => {
       expect(start.exitCode).toBe(0);
 
       const result = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
 
@@ -1086,7 +1147,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const first = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1.1',
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
@@ -1095,7 +1156,7 @@ describe('delegate command', () => {
       expect(typeof firstToken).toBe('string');
 
       const second = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1.1',
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(second.exitCode).toBe(0);
@@ -1115,13 +1176,16 @@ describe('delegate command', () => {
       await writeFile(join(workspace.cwd, 'runbooks', 'child-b.runbook.md'), childBContent);
 
       const first = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1.1',
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
 
       const second = await runCliInProcess(
-        'delegate runbooks/child-b.runbook.md --step 1.1',
+        await withRunTarget(
+          ['delegate', 'runbooks/child-b.runbook.md', '--step', '1.1'],
+          workspace,
+        ),
         workspace,
       );
 
@@ -1144,7 +1208,10 @@ describe('delegate command', () => {
       await writeFile(join(workspace.cwd, 'runbooks', 'child-b.runbook.md'), childBContent);
 
       const result = await runCliInProcess(
-        'delegate runbooks/child-b.runbook.md --step 1.1',
+        await withRunTarget(
+          ['delegate', 'runbooks/child-b.runbook.md', '--step', '1.1'],
+          workspace,
+        ),
         workspace,
       );
 
@@ -1160,7 +1227,10 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        'delegate runbooks/made-up-child.runbook.md --step 1.1',
+        await withRunTarget(
+          ['delegate', 'runbooks/made-up-child.runbook.md', '--step', '1.1'],
+          workspace,
+        ),
         workspace,
       );
 
@@ -1194,7 +1264,7 @@ describe('delegate command', () => {
       expect(start.exitCode).toBe(0);
 
       const result = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1',
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1'], workspace),
         workspace,
       );
 
@@ -1212,7 +1282,7 @@ describe('delegate command', () => {
       await writeFile(join(workspace.cwd, 'runbooks', 'child.runbook.md'), childContent);
 
       const result = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1.1',
+        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
         workspace,
       );
 
@@ -1283,7 +1353,7 @@ describe('delegate command', () => {
       );
 
       const result = await runCliInProcess(
-        'delegate runbooks/child.runbook.md --step 1.1',
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
 
@@ -1307,7 +1377,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const first = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
@@ -1315,7 +1385,10 @@ describe('delegate command', () => {
       const originalToken = firstOutput.token as string;
       const originalHash = firstOutput.token_hash as string;
 
-      const retry = await runCliInProcess(['delegate', '--retry', originalToken], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', originalToken], workspace),
+        workspace,
+      );
 
       expect(retry.exitCode).toBe(0);
       const retryOutput = JSON.parse(retry.stdout) as Record<string, unknown>;
@@ -1330,14 +1403,14 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const first = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
       const originalToken = (JSON.parse(first.stdout) as Record<string, unknown>).token as string;
 
       const retry = await runCliInProcess(
-        ['delegate', '--retry', originalToken, '--text'],
+        await withRunTarget(['delegate', '--retry', originalToken, '--text'], workspace),
         workspace,
       );
 
@@ -1360,14 +1433,17 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const first = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
       const firstOutput = JSON.parse(first.stdout) as Record<string, unknown>;
       const originalToken = firstOutput.token as string;
 
-      const retry = await runCliInProcess(['delegate', '--retry', '--step', '1.1'], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', '--step', '1.1'], workspace),
+        workspace,
+      );
 
       expect(retry.exitCode).toBe(0);
       const retryOutput = JSON.parse(retry.stdout) as Record<string, unknown>;
@@ -1380,14 +1456,17 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const first = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
       const firstOutput = JSON.parse(first.stdout) as Record<string, unknown>;
       const originalToken = firstOutput.token as string;
 
-      const retry = await runCliInProcess(['delegate', '--retry'], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry'], workspace),
+        workspace,
+      );
 
       expect(retry.exitCode).toBe(0);
       const retryOutput = JSON.parse(retry.stdout) as Record<string, unknown>;
@@ -1399,7 +1478,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const first = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
@@ -1409,7 +1488,10 @@ describe('delegate command', () => {
       const claim = await runCliInProcess(['claim', token], workspace);
       expect(claim.exitCode).toBe(0);
 
-      const retry = await runCliInProcess(['delegate', '--retry', token], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', token], workspace),
+        workspace,
+      );
 
       expect(retry.exitCode).not.toBe(0);
       const envelope = parseCliJsonObject(retry.stdout || retry.stderr);
@@ -1430,7 +1512,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const first = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
@@ -1438,7 +1520,7 @@ describe('delegate command', () => {
       const originalToken = firstOutput.token as string;
 
       const retry = await runCliInProcess(
-        ['delegate', '--retry', originalToken, '--step', '1.1'],
+        await withRunTarget(['delegate', '--retry', originalToken, '--step', '1.1'], workspace),
         workspace,
       );
 
@@ -1449,7 +1531,10 @@ describe('delegate command', () => {
     it('errors when --step has no delegation', async () => {
       await runCliInProcess('run --prompted runbooks/substeps.runbook.md --text', workspace);
 
-      const retry = await runCliInProcess(['delegate', '--retry', '--step', '1.1'], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', '--step', '1.1'], workspace),
+        workspace,
+      );
 
       expect(retry.exitCode).not.toBe(0);
       // Retry CLI now propagates the inner RundownError verbatim through
@@ -1484,7 +1569,10 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const retry = await runCliInProcess(
-        ['delegate', '--retry', 'rdtk_unknown00000000000000000000000000'],
+        await withRunTarget(
+          ['delegate', '--retry', 'rdtk_unknown00000000000000000000000000'],
+          workspace,
+        ),
         workspace,
       );
 
@@ -1500,13 +1588,16 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const retry = await runCliInProcess(
-        [
-          'delegate',
-          '--retry',
-          'rdtk_unknown00000000000000000000000000',
-          '--input-file',
-          'does-not-exist.yaml',
-        ],
+        await withRunTarget(
+          [
+            'delegate',
+            '--retry',
+            'rdtk_unknown00000000000000000000000000',
+            '--input-file',
+            'does-not-exist.yaml',
+          ],
+          workspace,
+        ),
         workspace,
       );
 
@@ -1558,16 +1649,19 @@ describe('delegate command', () => {
       // the cursor past step 1 so a retry --step 1.1 sees a non-current step.
       await setupDelegation();
       const first = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
 
       // Move cursor off step 1 by goto'ing step 2.
-      const goto = await runCliInProcess(['goto', '2'], workspace);
+      const goto = await runCliInProcess(await withRunTarget(['goto', '2'], workspace), workspace);
       expect(goto.exitCode).toBe(0);
 
-      const retry = await runCliInProcess(['delegate', '--retry', '--step', '1.1'], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', '--step', '1.1'], workspace),
+        workspace,
+      );
 
       expect(retry.exitCode).not.toBe(0);
       // Retry CLI now propagates the inner RundownError verbatim through
@@ -1581,12 +1675,18 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const firstRetry = await runCliInProcess(
-        ['delegate', '--retry', '--step', '1.1', '--input', 'environment=staging'],
+        await withRunTarget(
+          ['delegate', '--retry', '--step', '1.1', '--input', 'environment=staging'],
+          workspace,
+        ),
         workspace,
       );
       expect(firstRetry.exitCode).toBe(0);
 
-      const retry = await runCliInProcess(['delegate', '--retry', '--step', '1.1'], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', '--step', '1.1'], workspace),
+        workspace,
+      );
       expect(retry.exitCode).toBe(0);
 
       const state = await getActiveState(workspace);
@@ -1601,20 +1701,26 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const first = await runCliInProcess(
-        [
-          'delegate',
-          'runbooks/child.runbook.md',
-          '--step',
-          '1.1',
-          '--input',
-          'environment=staging',
-        ],
+        await withRunTarget(
+          [
+            'delegate',
+            'runbooks/child.runbook.md',
+            '--step',
+            '1.1',
+            '--input',
+            'environment=staging',
+          ],
+          workspace,
+        ),
         workspace,
       );
       expect(first.exitCode).toBe(0);
 
       const retry = await runCliInProcess(
-        ['delegate', '--retry', '--step', '1.1', '--input', 'environment=production'],
+        await withRunTarget(
+          ['delegate', '--retry', '--step', '1.1', '--input', 'environment=production'],
+          workspace,
+        ),
         workspace,
       );
       expect(retry.exitCode).toBe(0);
@@ -1632,13 +1738,16 @@ describe('delegate command', () => {
 
       // Create a delegation; default substepState status is 'pending' (not failed).
       const first = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
 
       // Retry succeeds regardless of substep result.
-      const retry = await runCliInProcess(['delegate', '--retry', '--step', '1.1'], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', '--step', '1.1'], workspace),
+        workspace,
+      );
       expect(retry.exitCode).toBe(0);
       const retryOutput = JSON.parse(retry.stdout) as Record<string, unknown>;
       expect(retryOutput.action).toBe('retried');
@@ -1650,7 +1759,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const retry = await runCliInProcess(
-        ['delegate', '--retry', '--step', '1.1', '--index', '3'],
+        await withRunTarget(['delegate', '--retry', '--step', '1.1', '--index', '3'], workspace),
         workspace,
       );
 
@@ -1674,7 +1783,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const retry = await runCliInProcess(
-        ['delegate', '--retry', 'runbooks/child.runbook.md'],
+        await withRunTarget(['delegate', '--retry', 'runbooks/child.runbook.md'], workspace),
         workspace,
       );
 
@@ -1692,7 +1801,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', '--step', '1.1', '--index', '2'],
+        await withRunTarget(['delegate', '--step', '1.1', '--index', '2'], workspace),
         workspace,
       );
 
@@ -1754,7 +1863,10 @@ describe('delegate command', () => {
 
       // Seed delegations in both FOR iteration frames (buildFrameKey('1', 1) and ('1', 2))
       const del1 = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--index', '1'],
+        await withRunTarget(
+          ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--index', '1'],
+          workspace,
+        ),
         workspace,
       );
       expect(del1.exitCode).toBe(0);
@@ -1763,7 +1875,10 @@ describe('delegate command', () => {
       const iter1Hash = del1Output.token_hash as string;
 
       const del2 = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--index', '2'],
+        await withRunTarget(
+          ['delegate', 'runbooks/child.runbook.md', '--step', '1.1', '--index', '2'],
+          workspace,
+        ),
         workspace,
       );
       expect(del2.exitCode).toBe(0);
@@ -1773,7 +1888,7 @@ describe('delegate command', () => {
 
       // Retry only iteration 2
       const retry = await runCliInProcess(
-        ['delegate', '--retry', '--step', '1.1', '--index', '2'],
+        await withRunTarget(['delegate', '--retry', '--step', '1.1', '--index', '2'], workspace),
         workspace,
       );
       expect(retry.exitCode).toBe(0);
@@ -1819,14 +1934,17 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        [
-          'delegate',
-          'runbooks/child.runbook.md',
-          '--step',
-          '1.1',
-          '--artifacts',
-          'Plan=rd://artifacts/ctx-a/Plan',
-        ],
+        await withRunTarget(
+          [
+            'delegate',
+            'runbooks/child.runbook.md',
+            '--step',
+            '1.1',
+            '--artifacts',
+            'Plan=rd://artifacts/ctx-a/Plan',
+          ],
+          workspace,
+        ),
         workspace,
       );
 
@@ -1844,14 +1962,17 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        [
-          'delegate',
-          'runbooks/child.runbook.md',
-          '--step',
-          '1.1',
-          '--artifacts-json',
-          'Plan=["rd://artifacts/ctx-a/Plan"]',
-        ],
+        await withRunTarget(
+          [
+            'delegate',
+            'runbooks/child.runbook.md',
+            '--step',
+            '1.1',
+            '--artifacts-json',
+            'Plan=["rd://artifacts/ctx-a/Plan"]',
+          ],
+          workspace,
+        ),
         workspace,
       );
 
@@ -1884,7 +2005,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
 
@@ -1909,7 +2030,10 @@ describe('delegate command', () => {
       const autoToken = await setupAutoIssuedDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', '--step', '1.1', '--input-file', 'does-not-exist.yaml'],
+        await withRunTarget(
+          ['delegate', '--step', '1.1', '--input-file', 'does-not-exist.yaml'],
+          workspace,
+        ),
         workspace,
       );
 
@@ -1923,14 +2047,17 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        [
-          'delegate',
-          'runbooks/child.runbook.md',
-          '--step',
-          '1.1',
-          '--input-file',
-          'does-not-exist.yaml',
-        ],
+        await withRunTarget(
+          [
+            'delegate',
+            'runbooks/child.runbook.md',
+            '--step',
+            '1.1',
+            '--input-file',
+            'does-not-exist.yaml',
+          ],
+          workspace,
+        ),
         workspace,
       );
 
@@ -1950,7 +2077,7 @@ describe('delegate command', () => {
       await setupAutoIssuedDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', '--step', '1.1', '--input', 'RunId=foo'],
+        await withRunTarget(['delegate', '--step', '1.1', '--input', 'RunId=foo'], workspace),
         workspace,
       );
 
@@ -1981,7 +2108,7 @@ describe('delegate command', () => {
       await setupDelegation();
 
       const result = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
 
@@ -1992,7 +2119,7 @@ describe('delegate command', () => {
     it('already-delegated envelope conforms to DelegateResponseSchema', async () => {
       await setupAutoIssuedDelegation();
 
-      const result = await runCliInProcess(['delegate'], workspace);
+      const result = await runCliInProcess(await withRunTarget(['delegate'], workspace), workspace);
 
       expect(result.exitCode).toBe(0);
       assertConformsToSchema(parseCliJsonObject(result.stdout));
@@ -2001,13 +2128,16 @@ describe('delegate command', () => {
     it('retried envelope conforms to DelegateResponseSchema', async () => {
       await setupDelegation();
       const first = await runCliInProcess(
-        ['delegate', 'runbooks/child.runbook.md', '--step', '1.1'],
+        await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
         workspace,
       );
       expect(first.exitCode).toBe(0);
       const firstToken = parseCliJsonObject(first.stdout).token as string;
 
-      const retry = await runCliInProcess(['delegate', '--retry', firstToken], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', firstToken], workspace),
+        workspace,
+      );
 
       expect(retry.exitCode).toBe(0);
       assertConformsToSchema(parseCliJsonObject(retry.stdout));

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -389,6 +389,30 @@ describe('delegate command', () => {
       const payload = JSON.parse(result.stdout) as { code?: string };
       expect(payload.code).toBe('INVALID_RUN_ID');
     });
+
+    it('refuses a --retry token whose --run names a run that does not own it (RUN_TARGET_MISMATCH)', async () => {
+      // Fail-closed: named authority is never silently discarded. A token owned
+      // by the active parent combined with a foreign --run id must refuse — and
+      // the refusal must not echo the actual owning run id (accident barrier).
+      const autoToken = await setupAutoIssuedDelegation();
+      const parent = await getActiveState(workspace);
+      if (!parent) throw new Error('Expected active parent run');
+      const foreign = `rd_${'f'.repeat(32)}`;
+
+      const result = await runCliInProcess(
+        ['delegate', '--retry', autoToken, '--run', foreign],
+        workspace,
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      const payload = JSON.parse(result.stdout) as { code?: string; message?: string };
+      expect(payload.code).toBe('RUN_TARGET_MISMATCH');
+      expect(payload.message ?? '').not.toContain(parent.id);
+      // No re-mint happened: the persisted delegation still answers to the
+      // original token (a bare retry of the same token still resolves it).
+      const after = await getActiveState(workspace);
+      expect(after?.substepStates?.some((s) => s.delegation !== undefined)).toBe(true);
+    });
   });
 
   describe('idempotent bare delegate', () => {

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -11,6 +11,7 @@ import {
   readRunbookState,
   parseConcatenatedJson,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 import { ActionResponseSchema, WarningResponseSchema } from '../helpers/schema-validator.js';
 import { Command } from 'commander';
@@ -59,7 +60,9 @@ describe('fail command', () => {
       await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
       const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
 
-      const result = await runCliInProcess('fail', workspace);
+      // Post-R1 the guard needs named authority: a run-targeted bare-shaped
+      // advance still refuses with the collection-pending guard.
+      const result = await runCliInProcess(await withRunTarget(['fail'], workspace), workspace);
 
       expect(result.exitCode).toBe(1);
       const payload = JSON.parse(result.stdout) as {
@@ -77,7 +80,11 @@ describe('fail command', () => {
       await runCliInProcess('run --prompted runbooks/substeps.runbook.md --text', workspace);
       await injectDelegationOutcomeForActiveRun(workspace);
 
-      const result = await runCliInProcess('fail --step 1.2', workspace);
+      // Post-R1 the sanctioned targeted recovery is run+step.
+      const result = await runCliInProcess(
+        await withRunTarget(['fail', '--step', '1.2'], workspace),
+        workspace,
+      );
 
       // The targeted transition runs to completion: exit 0, a real transition is
       // emitted, and the bare-only collection-pending guard never fires.
@@ -369,10 +376,16 @@ Do work.
       const claim = await runCliInProcess(`claim ${token!}`, workspace);
       const childId = String(findActionOutput(claim.stdout)?.run_id);
 
-      // Plain fail is refused while a claimed delegated child is open: it must
-      // not stop the default-stack parent, and must not touch the claimed child
-      // (callers resolve the child via `--claim-id`). Open-delegated-children guard.
-      const failResult = await runCliInProcess('fail', workspace);
+      // Plain fail is refused outright post-R1 (no ambient trust on a
+      // delegating parent); the run-targeted bare-shaped fail is then held by
+      // the open-delegated-children guard. Neither may stop the parent or touch
+      // the claimed child (callers resolve the child via `--claim-id`).
+      const bareFail = await runCliInProcess('fail', workspace);
+      expect(bareFail.exitCode).toBe(1);
+      expect((JSON.parse(bareFail.stdout) as { code?: string }).code).toBe(
+        'ACTOR_CONTEXT_REQUIRED',
+      );
+      const failResult = await runCliInProcess(await withRunTarget(['fail'], workspace), workspace);
       expect(failResult.exitCode).toBe(1);
       const failPayload = JSON.parse(failResult.stdout) as { code?: string };
       expect(failPayload.code).toBe('OPEN_DELEGATED_CHILDREN');

--- a/packages/cli/__tests__/commands/fail.test.ts
+++ b/packages/cli/__tests__/commands/fail.test.ts
@@ -87,6 +87,36 @@ describe('fail command', () => {
     });
   });
 
+  describe('--run explicit targeting', () => {
+    it('applies fail --run <id> to the named running run', async () => {
+      await runCliInProcess('run --prompted runbooks/retry.runbook.md --text', workspace);
+      const active = await getActiveState(workspace);
+      expect(active).toBeDefined();
+
+      const result = await runCliInProcess(`fail --run ${active!.id}`, workspace);
+
+      expect(result.exitCode).toBe(0);
+      const state = await getActiveState(workspace);
+      expect(state?.retryCount).toBe(1);
+      expect(state?.step).toBe('1');
+    });
+
+    it('refuses a well-formed but unknown --run id with RUN_TARGET_UNAVAILABLE', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const bogus = `rd_${'e'.repeat(32)}`;
+
+      const result = await runCliInProcess(`fail --run ${bogus}`, workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('RUN_TARGET_UNAVAILABLE');
+      // The refusal did not mutate the active run.
+      const state = await getActiveState(workspace);
+      expect(state?.step).toBe('1');
+      expect(state?.lifecycle).toBe('running');
+    });
+  });
+
   describe('FAIL: RETRY N', () => {
     beforeEach(async () => {
       await runCliInProcess('run --prompted runbooks/retry.runbook.md --text', workspace);

--- a/packages/cli/__tests__/commands/goto.test.ts
+++ b/packages/cli/__tests__/commands/goto.test.ts
@@ -86,6 +86,44 @@ describe('goto command', () => {
     });
   });
 
+  describe('--run explicit targeting', () => {
+    beforeEach(async () => {
+      await runCliInProcess('run --prompted runbooks/goto.runbook.md --text', workspace);
+    });
+
+    it('navigates the named run via goto <step> --run <id>', async () => {
+      const active = await getActiveState(workspace);
+      expect(active).toBeDefined();
+
+      const result = await runCliInProcess(`goto 3 --run ${active!.id}`, workspace);
+
+      expect(result.exitCode).toBe(0);
+      const state = await getActiveState(workspace);
+      expect(state?.step).toBe('3');
+    });
+
+    it('refuses a well-formed but unknown --run id with RUN_TARGET_UNAVAILABLE', async () => {
+      const bogus = `rd_${'f'.repeat(32)}`;
+
+      const result = await runCliInProcess(`goto 3 --run ${bogus}`, workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('RUN_TARGET_UNAVAILABLE');
+      // The refusal navigated nothing.
+      const state = await getActiveState(workspace);
+      expect(state?.step).toBe('1');
+    });
+
+    it('rejects a malformed --run id with INVALID_RUN_ID', async () => {
+      const result = await runCliInProcess('goto 3 --run not-a-run-id', workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('INVALID_RUN_ID');
+    });
+  });
+
   describe('error handling', () => {
     it('shows no active runbook when none started', async () => {
       const result = await runCliInProcess(['goto', '1', '--text'], workspace);

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -12,6 +12,7 @@ import {
   getAllStates,
   parseConcatenatedJson,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 import {
   ActionResponseSchema,
@@ -64,7 +65,10 @@ describe('pass command', () => {
       await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
       const completionKey = await injectDelegationOutcomeForActiveRun(workspace);
 
-      const result = await runCliInProcess('pass', workspace);
+      // Post-R1 the guard needs named authority: a run-targeted bare-shaped
+      // advance still refuses with the collection-pending guard (naming
+      // authority does not skip collection discipline).
+      const result = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
 
       expect(result.exitCode).toBe(1);
       const payload = JSON.parse(result.stdout) as {
@@ -82,7 +86,12 @@ describe('pass command', () => {
       await runCliInProcess('run --prompted runbooks/substeps.runbook.md --text', workspace);
       await injectDelegationOutcomeForActiveRun(workspace);
 
-      const result = await runCliInProcess('pass --step 1.1', workspace);
+      // Post-R1 a step name is a completion target, not authority: the
+      // sanctioned targeted recovery is run+step (keeps the guard exemption).
+      const result = await runCliInProcess(
+        await withRunTarget(['pass', '--step', '1.1'], workspace),
+        workspace,
+      );
 
       // The targeted transition runs to completion: exit 0, a real transition is
       // emitted, and the bare-only collection-pending guard never fires.
@@ -517,11 +526,17 @@ Do child work.
       expect(claim.exitCode).toBe(0);
       const childId = String(findActionOutput(claim.stdout)?.run_id);
 
-      // Anonymous pass is refused while a claimed delegated child is open: it
-      // must not advance the default-stack parent past the DELEGATE step, and it
-      // must not touch the agent-owned child (callers resolve the child via
-      // `--claim-id`). This is the open-delegated-children guard.
-      const passResult = await runCliInProcess('pass', workspace);
+      // Anonymous pass is refused outright post-R1 (no ambient trust on a
+      // delegating parent), and even the run-targeted bare-shaped advance is
+      // held by the open-delegated-children guard: neither may advance the
+      // parent past the DELEGATE step or touch the agent-owned child (callers
+      // resolve the child via `--claim-id`).
+      const barePass = await runCliInProcess('pass', workspace);
+      expect(barePass.exitCode).toBe(1);
+      expect((JSON.parse(barePass.stdout) as { code?: string }).code).toBe(
+        'ACTOR_CONTEXT_REQUIRED',
+      );
+      const passResult = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
       expect(passResult.exitCode).toBe(1);
       const passPayload = JSON.parse(passResult.stdout) as { code?: string };
       expect(passPayload.code).toBe('OPEN_DELEGATED_CHILDREN');

--- a/packages/cli/__tests__/commands/pass.test.ts
+++ b/packages/cli/__tests__/commands/pass.test.ts
@@ -13,7 +13,11 @@ import {
   parseConcatenatedJson,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
-import { ActionResponseSchema } from '../helpers/schema-validator.js';
+import {
+  ActionResponseSchema,
+  ErrorResponseSchema,
+  validateSchema,
+} from '../helpers/schema-validator.js';
 import { Command } from 'commander';
 // Stryker static-import linkage (mutation testing): links this test file into
 // Jest's static inverse-module graph so `--findRelatedTests src/commands/pass.ts`
@@ -85,6 +89,73 @@ describe('pass command', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('step_transitioned');
       expect(result.stdout).not.toContain('DELEGATION_COLLECTION_PENDING');
+    });
+  });
+
+  describe('--run explicit targeting', () => {
+    it('applies pass --run <id> to the named running run', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const active = await getActiveState(workspace);
+      expect(active).toBeDefined();
+
+      const result = await runCliInProcess(`pass --run ${active!.id}`, workspace);
+
+      expect(result.exitCode).toBe(0);
+      const state = await getActiveState(workspace);
+      expect(state?.step).toBe('2');
+    });
+
+    it('refuses a well-formed but unknown --run id with a schema-valid RUN_TARGET_UNAVAILABLE envelope', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const bogus = `rd_${'f'.repeat(32)}`;
+
+      const result = await runCliInProcess(`pass --run ${bogus}`, workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('RUN_TARGET_UNAVAILABLE');
+      // Envelope-validation gate for the new code: the refusal must satisfy the
+      // closed ErrorResponseSchema (RUN_TARGET_UNAVAILABLE is enum-registered).
+      const validation = validateSchema(ErrorResponseSchema, payload);
+      expect(validation.valid).toBe(true);
+      // The run was not mutated by the refusal.
+      const state = await getActiveState(workspace);
+      expect(state?.step).toBe('1');
+    });
+
+    it('rejects a malformed --run id with INVALID_RUN_ID', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+      const result = await runCliInProcess('pass --run not-a-run-id', workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('INVALID_RUN_ID');
+    });
+
+    it('rejects --run combined with --claim-id as INVALID_SYNTAX', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const active = await getActiveState(workspace);
+
+      const result = await runCliInProcess(
+        `pass --run ${active!.id} --claim-id rdclm_abcdefghijklmnopqrstu1`,
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('INVALID_SYNTAX');
+    });
+
+    it('drives the named run substep via pass --run <id> --step <n>', async () => {
+      await runCliInProcess('run --prompted runbooks/substeps.runbook.md --text', workspace);
+      const active = await getActiveState(workspace);
+      expect(active).toBeDefined();
+
+      const result = await runCliInProcess(`pass --run ${active!.id} --step 1.1`, workspace);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('step_transitioned');
     });
   });
 

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -56,6 +56,35 @@ describe('stop command', () => {
     await workspace.cleanup();
   });
 
+  describe('--run explicit targeting', () => {
+    it('forces the named stack-member run terminal via stop --run <id>', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const active = await getActiveState(workspace);
+      expect(active).toBeDefined();
+
+      const result = await runCliInProcess(`stop --run ${active!.id}`, workspace);
+
+      // A run-targeted stop is still a workflow failure terminal (exit 1).
+      expect(result.exitCode).toBe(1);
+      const state = await readRunbookState(workspace, active!.id);
+      expect(state?.lifecycle).toBe('stopped');
+    });
+
+    it('refuses a well-formed but unknown --run id with RUN_TARGET_UNAVAILABLE', async () => {
+      await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+      const bogus = `rd_${'f'.repeat(32)}`;
+
+      const result = await runCliInProcess(`stop --run ${bogus}`, workspace);
+
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('RUN_TARGET_UNAVAILABLE');
+      // The active run was not stopped by the refusal.
+      const state = await getActiveState(workspace);
+      expect(state?.lifecycle).toBe('running');
+    });
+  });
+
   describe('basic stop', () => {
     beforeEach(async () => {
       await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);

--- a/packages/cli/__tests__/commands/stop.test.ts
+++ b/packages/cli/__tests__/commands/stop.test.ts
@@ -859,24 +859,32 @@ Run the child task.
       const parentState = await getActiveState(workspace);
       const parentRunId = parentState!.id;
 
-      const token = parentState?.substepStates?.[0]?.delegation?.token;
-      expect(token).toEqual(expect.stringMatching(/^rdtk_/));
-      if (typeof token !== 'string') throw new Error('Expected delegation token');
+      const token1 = parentState?.substepStates?.[0]?.delegation?.token;
+      const token2 = parentState?.substepStates?.[1]?.delegation?.token;
+      if (typeof token1 !== 'string' || typeof token2 !== 'string') {
+        throw new Error('Expected delegation tokens');
+      }
 
-      result = await runCliInProcess(`claim ${token} --text`, workspace);
+      // Stop the first child through its claim — the delegated child's fail is
+      // reported (uncollected) to parent substep 1.1; the claim-path stop is a
+      // report-only close and exits 0.
+      result = await runCliInProcess(`claim ${token1}`, workspace);
+      expect(result.exitCode).toBe(0);
+      const claimId1 = String(findActionOutput(result.stdout)?.claim_id);
+      result = await runCliInProcess(['stop', '--claim-id', claimId1], workspace);
       expect(result.exitCode).toBe(0);
 
-      // Stop the child — propagates fail to parent substep 1.1
-      // Parent DEFER model: 1.1 fails, advance to 1.2.
-      // The claimed child is a delegated child (delegation linkage), so it is its
-      // own force-terminal root; bare stop exits non-zero.
-      result = await runCliInProcess('stop --text', workspace);
+      // Resolve the sibling substep the same way so collection can aggregate.
+      result = await runCliInProcess(`claim ${token2}`, workspace);
+      expect(result.exitCode).toBe(0);
+      const claimId2 = String(findActionOutput(result.stdout)?.claim_id);
+      result = await runCliInProcess(['stop', '--claim-id', claimId2], workspace);
+      expect(result.exitCode).toBe(0);
+
+      // The orchestrator collects with named authority: FAIL ANY fires STOP.
+      result = await runCliInProcess(['collect', '--run', parentRunId], workspace);
       expect(result.exitCode).toBe(1);
 
-      // Parent is now active at substep 1.2 — complete it to trigger aggregation
-      result = await runCliInProcess('pass --text', workspace);
-
-      // Aggregation: FAIL ANY (1.1 failed) triggers STOP
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
       expect(updatedParent!.lifecycle).toBe('stopped');
@@ -1010,29 +1018,37 @@ Approve the deployment.
       const grandparentRunId = grandparentState!.id;
 
       const token1 = grandparentState?.substepStates?.[0]?.delegation?.token;
-      expect(token1).toEqual(expect.stringMatching(/^rdtk_/));
-      if (typeof token1 !== 'string') throw new Error('Expected delegation token');
+      const token2 = grandparentState?.substepStates?.[1]?.delegation?.token;
+      if (typeof token1 !== 'string' || typeof token2 !== 'string') {
+        throw new Error('Expected delegation tokens');
+      }
+
+      // Stop the claimed parent through its claim — a report-only close (exit
+      // 0) that reports fail (uncollected) to grandparent substep 1.1.
       result = await runCliInProcess(`claim ${token1}`, workspace);
       expect(result.exitCode).toBe(0);
-
-      const parentState = await getActiveState(workspace);
-      const parentRunId = parentState!.id;
-
-      // Stop the claimed parent — propagates fail to grandparent substep 1.1.
-      // Grandparent DEFER: 1.1 fail, advance to 1.2. The claimed parent is a
-      // delegated child (delegation linkage), so it is its own force-terminal
-      // root; bare stop exits non-zero.
-      result = await runCliInProcess('stop --text', workspace);
-      expect(result.exitCode).toBe(1);
+      const claimAction1 = findActionOutput(result.stdout);
+      const parentClaimId = String(claimAction1?.claim_id);
+      const parentRunId = String(claimAction1?.run_id);
+      result = await runCliInProcess(['stop', '--claim-id', parentClaimId], workspace);
+      expect(result.exitCode).toBe(0);
 
       // Verify parent is stopped
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
       expect(updatedParent!.lifecycle).toBe('stopped');
 
-      // Grandparent is now active at substep 1.2 — complete it
-      // Aggregation: FAIL ANY triggers STOP
-      result = await runCliInProcess('pass --text', workspace);
+      // Resolve the sibling substep the same way so collection can aggregate.
+      result = await runCliInProcess(`claim ${token2}`, workspace);
+      expect(result.exitCode).toBe(0);
+      const claimId2 = String(findActionOutput(result.stdout)?.claim_id);
+      result = await runCliInProcess(['stop', '--claim-id', claimId2], workspace);
+      expect(result.exitCode).toBe(0);
+
+      // The orchestrator collects the grandparent with named authority:
+      // FAIL ANY aggregation fires STOP.
+      result = await runCliInProcess(['collect', '--run', grandparentRunId], workspace);
+      expect(result.exitCode).toBe(1);
 
       // Verify grandparent is stopped
       const updatedGrandparent = await readRunbookState(workspace, grandparentRunId);

--- a/packages/cli/__tests__/helpers/caller-evidence.test.ts
+++ b/packages/cli/__tests__/helpers/caller-evidence.test.ts
@@ -13,7 +13,26 @@ describe('readLifecycleCallerEvidence', () => {
       controlledRunId: assertRunId('rd_11111111111111111111111111111111'),
     };
 
-    expect(readLifecycleCallerEvidence(claim)).toEqual({ kind: 'claim', ...claim });
+    expect(readLifecycleCallerEvidence({ claim })).toEqual({ kind: 'claim', ...claim });
+  });
+
+  it('maps a validated --run id to run_controller evidence naming that run', () => {
+    const runId = assertRunId('rd_22222222222222222222222222222222');
+
+    expect(readLifecycleCallerEvidence({ runId })).toEqual({ kind: 'run_controller', runId });
+  });
+
+  it('gives claim evidence precedence when both inputs are somehow present', () => {
+    // Exclusivity is enforced upstream by parseRunOption; the evidence reader
+    // still has a deterministic precedence rather than an undefined state.
+    const claim = {
+      claimId: assertClaimId('rdclm_abcdefghijklmnopqrstu1'),
+      tokenHash: assertDelegationTokenHash(`sha256:${'a'.repeat(64)}`),
+      controlledRunId: assertRunId('rd_11111111111111111111111111111111'),
+    };
+    const runId = assertRunId('rd_22222222222222222222222222222222');
+
+    expect(readLifecycleCallerEvidence({ claim, runId })).toEqual({ kind: 'claim', ...claim });
   });
 
   it('never emits a source label', () => {

--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -21,6 +21,8 @@ import {
   formatArtifactAssertionDescription,
   executeCommandSequence,
   createInProcessCommandExecutor,
+  substituteRunIds,
+  captureRunIdFromJsonObject,
 } from '../../src/helpers/command-sequence.js';
 import type { InProcessCliRunner } from '../../src/helpers/command-sequence.js';
 import type { ArtifactAssertion, StepAssertion } from '../../src/schemas/scenarios.js';
@@ -983,6 +985,47 @@ describe('substituteClaimIds', () => {
     expect(() => substituteClaimIds('rd pass --claim-id ${CLAIM_ID_2}', ['rdclm_first'])).toThrow(
       /Missing captured claim id/,
     );
+  });
+});
+
+describe('substituteRunIds', () => {
+  const runA = `rd_${'a'.repeat(32)}`;
+  const runB = `rd_${'b'.repeat(32)}`;
+
+  it('${RUN_ID} maps to first captured run id', () => {
+    expect(substituteRunIds('rd collect --run ${RUN_ID}', [runA])).toBe(`rd collect --run ${runA}`);
+  });
+
+  it('${RUN_ID_2} maps to second captured run id', () => {
+    expect(substituteRunIds('rd pass --run ${RUN_ID_2}', [runA, runB])).toBe(
+      `rd pass --run ${runB}`,
+    );
+  });
+
+  it('throws for uncaptured run id references (fail closed)', () => {
+    expect(() => substituteRunIds('rd collect --run ${RUN_ID}', [])).toThrow(
+      /Missing captured run id/,
+    );
+    expect(() => substituteRunIds('rd pass --run ${RUN_ID_2}', [runA])).toThrow(
+      /Missing captured run id/,
+    );
+  });
+
+  it('leaves commands without placeholders untouched', () => {
+    expect(substituteRunIds('rd pass --claim-id ${CLAIM_ID}', [])).toBe(
+      'rd pass --claim-id ${CLAIM_ID}',
+    );
+  });
+});
+
+describe('captureRunIdFromJsonObject', () => {
+  it('captures runbookId from runbook_started events in emission order', () => {
+    const captured: string[] = [];
+    captureRunIdFromJsonObject({ type: 'runbook_started', runbookId: 'rd_1' }, captured);
+    captureRunIdFromJsonObject({ type: 'step_entered', runbookId: 'rd_x' }, captured);
+    captureRunIdFromJsonObject({ type: 'runbook_started', runbookId: 'rd_2' }, captured);
+    captureRunIdFromJsonObject({ type: 'runbook_started' }, captured);
+    expect(captured).toEqual(['rd_1', 'rd_2']);
   });
 });
 

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -41,9 +41,12 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   // through the factory rather than leaking the real module.
   assertClaimId: jest.fn((s: string) => s),
   runbooksDir: jest.fn((cwd: string) => `${cwd}/.rundown/runbooks`),
-  // Used only by buildGotoContext (not exercised by these unit tests); the mock
-  // exists to satisfy the ESM named-import link check for goto-workflow.ts.
+  // Used only by buildGotoContext (not exercised by these unit tests); the mocks
+  // exist to satisfy the ESM named-import link check for goto-workflow.ts.
   resolveCommandTarget: jest.fn(),
+  resolveCommandIntent: jest.fn(),
+  actorContextFromEvidence: jest.fn(),
+  classifyDelegationExposure: jest.fn(),
   ...mockErrorHelpers,
 }));
 

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -41,13 +41,14 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   // through the factory rather than leaking the real module.
   assertClaimId: jest.fn((s: string) => s),
   runbooksDir: jest.fn((cwd: string) => `${cwd}/.rundown/runbooks`),
-  // Used only by buildGotoContext (not exercised by these unit tests); the mocks
-  // exist to satisfy the ESM named-import link check for goto-workflow.ts.
-  resolveCommandTarget: jest.fn(),
-  resolveCommandIntent: jest.fn(),
-  actorContextFromEvidence: jest.fn(),
-  classifyDelegationExposure: jest.fn(),
   ...mockErrorHelpers,
+}));
+
+// Mock the lifecycle seam factory: buildGotoContext dispatches into the core
+// navigation seam through it (not exercised by these unit tests); mocking the
+// factory keeps this suite off the seam's core-service import graph.
+jest.unstable_mockModule('../../src/helpers/lifecycle-seam-factory', () => ({
+  buildNonDelegatingLifecycleSeam: jest.fn(),
 }));
 
 // Mock execution service
@@ -413,7 +414,6 @@ describe('executeGoto', () => {
       steps: [makeStep()],
       cwd: '/test',
       terminalReleaseMode: 'stack-pop' as const,
-      exposure: 'standalone' as const,
     };
 
     const result = await executeGoto(ctx, { step: '2' });
@@ -449,7 +449,6 @@ describe('executeGoto', () => {
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
       terminalReleaseMode: 'stack-pop' as const,
-      exposure: 'standalone' as const,
     };
 
     const target: StepId = { step: '2' };
@@ -495,7 +494,6 @@ describe('executeGoto', () => {
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
       terminalReleaseMode: 'stack-pop' as const,
-      exposure: 'standalone' as const,
     };
 
     const result = await executeGoto(ctx, { step: '2' });
@@ -533,7 +531,6 @@ describe('executeGoto', () => {
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
       terminalReleaseMode: 'stack-pop' as const,
-      exposure: 'standalone' as const,
     };
 
     const result = await executeGoto(ctx, { step: '2' });

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -413,6 +413,7 @@ describe('executeGoto', () => {
       steps: [makeStep()],
       cwd: '/test',
       terminalReleaseMode: 'stack-pop' as const,
+      exposure: 'standalone' as const,
     };
 
     const result = await executeGoto(ctx, { step: '2' });
@@ -448,6 +449,7 @@ describe('executeGoto', () => {
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
       terminalReleaseMode: 'stack-pop' as const,
+      exposure: 'standalone' as const,
     };
 
     const target: StepId = { step: '2' };
@@ -493,6 +495,7 @@ describe('executeGoto', () => {
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
       terminalReleaseMode: 'stack-pop' as const,
+      exposure: 'standalone' as const,
     };
 
     const result = await executeGoto(ctx, { step: '2' });
@@ -530,6 +533,7 @@ describe('executeGoto', () => {
       steps: [makeStep({ name: '1' }), makeStep({ name: '2' })],
       cwd: '/test',
       terminalReleaseMode: 'stack-pop' as const,
+      exposure: 'standalone' as const,
     };
 
     const result = await executeGoto(ctx, { step: '2' });

--- a/packages/cli/__tests__/helpers/lifecycle-seam-factory.test.ts
+++ b/packages/cli/__tests__/helpers/lifecycle-seam-factory.test.ts
@@ -112,7 +112,9 @@ describe('buildNonDelegatingLifecycleSeam', () => {
       await expect(
         seam.issueDelegation({
           mode: 'fresh',
-          callerEvidence: { kind: 'direct_cli' },
+          // Named orchestrator authority (post-R1, direct_cli is refused on a
+          // delegating run before the resolver stub is ever reached).
+          callerEvidence: { kind: 'run_controller', runId: state!.id },
           explicitStep: '1.1',
         }),
       ).rejects.toThrow(REFUSAL);

--- a/packages/cli/__tests__/helpers/run-option.test.ts
+++ b/packages/cli/__tests__/helpers/run-option.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
 import { assertClaimId } from '@rundown-org/core';
+import { Command } from 'commander';
 import { parseRunOption } from '../../src/helpers/run-option.js';
 import { OutputEmitter } from '../../src/services/output-emitter.js';
+import { registerPassCommand } from '../../src/commands/pass.js';
+import { registerFailCommand } from '../../src/commands/fail.js';
+import { registerCompleteCommand } from '../../src/commands/complete.js';
+import { registerStopCommand } from '../../src/commands/stop.js';
+import { registerCollectCommand } from '../../src/commands/collect.js';
+import { registerDelegateCommand } from '../../src/commands/delegate.js';
 
 const claimId = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
 
@@ -47,5 +54,33 @@ describe('parseRunOption', () => {
     const result = parseRunOption(`rd_${'a'.repeat(32)}`, claimId, output);
     expect(result.ok).toBe(false);
     expect(errorSpy).toHaveBeenCalledWith(expect.any(String), 'INVALID_SYNTAX');
+  });
+});
+
+describe('--run registration drift guard', () => {
+  // pass/fail derive --run from the single-source PASS_FAIL_VALUE_TAKING_OPTION_NAMES
+  // mechanism; the other mutating commands register it manually. This guard
+  // pins every mutating command in the subprocess withhold set to a --run
+  // Commander option so a future command cannot silently miss the flag.
+  // (goto joins this list when its --run flag lands.)
+  const registrations: ReadonlyArray<{
+    readonly name: string;
+    readonly register: (program: Command) => void;
+  }> = [
+    { name: 'pass', register: registerPassCommand },
+    { name: 'fail', register: registerFailCommand },
+    { name: 'complete', register: registerCompleteCommand },
+    { name: 'stop', register: registerStopCommand },
+    { name: 'collect', register: registerCollectCommand },
+    { name: 'delegate', register: registerDelegateCommand },
+  ];
+
+  it.each(registrations)('registers --run on $name', ({ name, register }) => {
+    const program = new Command();
+    register(program);
+    const command = program.commands.find((c) => c.name() === name);
+    expect(command).toBeDefined();
+    const runOption = command!.options.find((o) => o.long === '--run');
+    expect(runOption).toBeDefined();
   });
 });

--- a/packages/cli/__tests__/helpers/run-option.test.ts
+++ b/packages/cli/__tests__/helpers/run-option.test.ts
@@ -9,6 +9,7 @@ import { registerCompleteCommand } from '../../src/commands/complete.js';
 import { registerStopCommand } from '../../src/commands/stop.js';
 import { registerCollectCommand } from '../../src/commands/collect.js';
 import { registerDelegateCommand } from '../../src/commands/delegate.js';
+import { registerGotoCommand } from '../../src/commands/goto.js';
 
 const claimId = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
 
@@ -60,9 +61,8 @@ describe('parseRunOption', () => {
 describe('--run registration drift guard', () => {
   // pass/fail derive --run from the single-source PASS_FAIL_VALUE_TAKING_OPTION_NAMES
   // mechanism; the other mutating commands register it manually. This guard
-  // pins every mutating command in the subprocess withhold set to a --run
-  // Commander option so a future command cannot silently miss the flag.
-  // (goto joins this list when its --run flag lands.)
+  // pins every mutating command in the subprocess withhold set (plus goto) to a
+  // --run Commander option so a future command cannot silently miss the flag.
   const registrations: ReadonlyArray<{
     readonly name: string;
     readonly register: (program: Command) => void;
@@ -73,6 +73,7 @@ describe('--run registration drift guard', () => {
     { name: 'stop', register: registerStopCommand },
     { name: 'collect', register: registerCollectCommand },
     { name: 'delegate', register: registerDelegateCommand },
+    { name: 'goto', register: registerGotoCommand },
   ];
 
   it.each(registrations)('registers --run on $name', ({ name, register }) => {

--- a/packages/cli/__tests__/helpers/run-option.test.ts
+++ b/packages/cli/__tests__/helpers/run-option.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+import { assertClaimId } from '@rundown-org/core';
+import { parseRunOption } from '../../src/helpers/run-option.js';
+import { OutputEmitter } from '../../src/services/output-emitter.js';
+
+const claimId = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
+
+function makeOutput(): {
+  output: OutputEmitter;
+  errorSpy: jest.SpiedFunction<OutputEmitter['error']>;
+} {
+  const output = new OutputEmitter({ command: 'pass' });
+  const errorSpy = jest.spyOn(output, 'error');
+  jest.spyOn(output, 'flush').mockImplementation(() => {});
+  return { output, errorSpy };
+}
+
+describe('parseRunOption', () => {
+  const previousExitCode = process.exitCode;
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
+    jest.restoreAllMocks();
+  });
+
+  it('returns ok with no runId when --run is absent', () => {
+    const { output } = makeOutput();
+    expect(parseRunOption(undefined, undefined, output)).toEqual({ ok: true });
+  });
+
+  it('accepts a well-formed run id', () => {
+    const { output } = makeOutput();
+    const result = parseRunOption(`rd_${'a'.repeat(32)}`, undefined, output);
+    expect(result).toEqual({ ok: true, runId: `rd_${'a'.repeat(32)}` });
+  });
+
+  it('rejects a malformed run id with INVALID_RUN_ID', () => {
+    const { output, errorSpy } = makeOutput();
+    const result = parseRunOption('not-a-run-id', undefined, output);
+    expect(result.ok).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(expect.any(String), 'INVALID_RUN_ID');
+  });
+
+  it('rejects --run combined with --claim-id as INVALID_SYNTAX (mutually exclusive)', () => {
+    // An orchestrator names its own run; a child names its claim — never both.
+    const { output, errorSpy } = makeOutput();
+    const result = parseRunOption(`rd_${'a'.repeat(32)}`, claimId, output);
+    expect(result.ok).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(expect.any(String), 'INVALID_SYNTAX');
+  });
+});

--- a/packages/cli/__tests__/helpers/terminal-command.test.ts
+++ b/packages/cli/__tests__/helpers/terminal-command.test.ts
@@ -101,12 +101,18 @@ describe('renderTerminalOutcome', () => {
   it('renders actor_context_required as ACTOR_CONTEXT_REQUIRED and exits non-zero', async () => {
     const { exitError, calls } = await render({
       kind: 'actor_context_required',
-      targetRunId: RUN_ID,
     });
     expect(exitError).toBe(true);
     expect(codeOf(calls, 'error')).toBe('ACTOR_CONTEXT_REQUIRED');
     const errorCall = calls.find((c) => c.method === 'error');
-    expect(errorCall?.args[2]).toEqual({ targetRunId: RUN_ID });
+    // The remediation names both explicit-authority lanes...
+    expect(errorCall?.args[0]).toContain('--run');
+    expect(errorCall?.args[0]).toContain('--claim-id');
+    // ...and the envelope carries NO details object and never echoes the
+    // target run id — that would hand the refused caller a copy-paste bypass
+    // of the accident barrier (decision 4).
+    expect(errorCall?.args[2]).toBeUndefined();
+    expect(JSON.stringify(errorCall?.args)).not.toContain(RUN_ID);
   });
 
   it('renders delegation_collection_pending via DELEGATION_COLLECTION_PENDING and exits non-zero', async () => {

--- a/packages/cli/__tests__/helpers/test-utils.ts
+++ b/packages/cli/__tests__/helpers/test-utils.ts
@@ -376,6 +376,26 @@ export async function getActiveState(workspace: TestWorkspace): Promise<RunbookS
 }
 
 /**
+ * Append explicit --run targeting for the workspace's active run.
+ *
+ * Post-R1, bare mutations on delegating runs are refused; orchestrator-side
+ * tests name their authority the way a real orchestrator does.
+ *
+ * @param args - CLI argv to extend (e.g. `['pass']`)
+ * @param workspace - Test workspace whose active run supplies the id
+ * @returns The argv with `--run <activeRunId>` appended
+ * @throws {Error} When no active run exists to target
+ */
+export async function withRunTarget(
+  args: readonly string[],
+  workspace: TestWorkspace,
+): Promise<string[]> {
+  const state = await getActiveState(workspace);
+  if (!state) throw new Error('withRunTarget: no active run to target');
+  return [...args, '--run', state.id];
+}
+
+/**
  * Get agent stack active state.
  * Returns the runbook state for the top of the given agent's stack.
  */

--- a/packages/cli/__tests__/helpers/transitions-seam.test.ts
+++ b/packages/cli/__tests__/helpers/transitions-seam.test.ts
@@ -597,20 +597,24 @@ describe('runSeamTransition — refusal render table', () => {
     expect(result.exitError).toBe(true);
   });
 
-  it('renders the actor-context-required refusal with the target run id', async () => {
+  it('renders the actor-context-required refusal without echoing the target run id', async () => {
     const output = makeOutput();
     mockRunTransition.mockResolvedValue({
       kind: 'actor_context_required',
-      targetRunId: PARENT_RUN_ID,
     });
 
     const result = await runSeamTransition(output, '/cwd', createFailTransitionConfig());
 
-    expect(output.error).toHaveBeenCalledWith(
-      'Actor context is required to fail this run.',
-      'ACTOR_CONTEXT_REQUIRED',
-      { targetRunId: PARENT_RUN_ID },
-    );
+    const [message, code, details] = output.error.mock.calls[0];
+    expect(code).toBe('ACTOR_CONTEXT_REQUIRED');
+    // The remediation names both explicit-authority lanes...
+    expect(message).toContain('--run');
+    expect(message).toContain('--claim-id');
+    expect(message).toContain('rundown fail');
+    // ...and never hands the id back: no details object, no run id anywhere
+    // in the envelope (accident barrier, decision 4).
+    expect(details).toBeUndefined();
+    expect(JSON.stringify(output.error.mock.calls[0])).not.toContain(PARENT_RUN_ID);
     expect(result.exitError).toBe(true);
   });
 });

--- a/packages/cli/__tests__/integration/artifact-cross-run-latest.test.ts
+++ b/packages/cli/__tests__/integration/artifact-cross-run-latest.test.ts
@@ -6,6 +6,7 @@ import {
   runCliInProcess,
   parseConcatenatedJson,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 
 /**
@@ -167,7 +168,7 @@ rd echo --result pass
     // Aggregation fires when the second child resolves, advancing the parent to
     // step 2. collect is idempotent and guarantees the step-2 entry is emitted.
     const collect = await runCliInProcess(
-      ['collect', '--allow-all', '--non-interactive'],
+      await withRunTarget(['collect', '--allow-all', '--non-interactive'], workspace),
       workspace,
     );
     expect(collect.exitCode).toBe(0);

--- a/packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts
+++ b/packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts
@@ -34,7 +34,7 @@ describe('collection-pending lifecycle', () => {
     await workspace.cleanup();
   });
 
-  it('a real delegated close reports an outcome, refuses bare advance, then collect releases it', async () => {
+  it('a real delegated close reports an outcome, refuses a premature advance, then collect releases it', async () => {
     const parentContent = createRunbook({
       title: 'Parent',
       steps: [
@@ -75,7 +75,7 @@ describe('collection-pending lifecycle', () => {
     const closeChild = await runCliInProcess(['complete', '--claim-id', claimId], workspace);
     expect(closeChild.exitCode).toBe(0);
 
-    // Onset: the reported outcome leaves the parent collection pending — bare
+    // Onset: the reported outcome leaves the parent collection pending — a run-targeted
     // pass is refused.
     const blocked = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
     expect(blocked.exitCode).toBe(1);
@@ -85,7 +85,7 @@ describe('collection-pending lifecycle', () => {
     const collected = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(collected.exitCode).toBe(0);
 
-    // Release: the same bare pass now proceeds — the run is not wedged.
+    // Release: the same run-targeted pass now proceeds — the run is not wedged.
     const advanced = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
     // A successful advance carries no error code on ANY emitted event — assert
     // their collective absence rather than merely that the pending code is gone,
@@ -132,14 +132,14 @@ describe('collection-pending lifecycle', () => {
     expect(closeChild.exitCode).toBe(0);
   }
 
-  it('bare rd complete against a collection-pending run refuses with DELEGATION_COLLECTION_PENDING (item 8 e2e)', async () => {
+  it('run-targeted rd complete against a collection-pending run refuses with DELEGATION_COLLECTION_PENDING (item 8 e2e)', async () => {
     await reportChildOutcomeLeavingParentPending();
     const result = await runCliInProcess(await withRunTarget(['complete'], workspace), workspace);
     expect(result.exitCode).toBe(1);
     expect(emittedCodes(result.stdout)).toContain('DELEGATION_COLLECTION_PENDING');
   }, 30_000);
 
-  it('bare rd stop against a collection-pending run refuses with DELEGATION_COLLECTION_PENDING (item 8 e2e)', async () => {
+  it('run-targeted rd stop against a collection-pending run refuses with DELEGATION_COLLECTION_PENDING (item 8 e2e)', async () => {
     await reportChildOutcomeLeavingParentPending();
     const result = await runCliInProcess(await withRunTarget(['stop'], workspace), workspace);
     expect(result.exitCode).toBe(1);

--- a/packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts
+++ b/packages/cli/__tests__/integration/collection-pending-lifecycle.test.ts
@@ -11,6 +11,7 @@ import {
   parseConcatenatedJson,
   runCliInProcess,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 import { bareRoleSpecificMutation, buildFrameKey } from '@rundown-org/core';
 
@@ -76,16 +77,16 @@ describe('collection-pending lifecycle', () => {
 
     // Onset: the reported outcome leaves the parent collection pending — bare
     // pass is refused.
-    const blocked = await runCliInProcess('pass', workspace);
+    const blocked = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
     expect(blocked.exitCode).toBe(1);
     expect(emittedCodes(blocked.stdout)).toContain('DELEGATION_COLLECTION_PENDING');
 
     // Collect applies the reported outcome; the parent advances.
-    const collected = await runCliInProcess('collect', workspace);
+    const collected = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(collected.exitCode).toBe(0);
 
     // Release: the same bare pass now proceeds — the run is not wedged.
-    const advanced = await runCliInProcess('pass', workspace);
+    const advanced = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
     // A successful advance carries no error code on ANY emitted event — assert
     // their collective absence rather than merely that the pending code is gone,
     // which also catches any other failure code that might wedge the run.
@@ -133,14 +134,14 @@ describe('collection-pending lifecycle', () => {
 
   it('bare rd complete against a collection-pending run refuses with DELEGATION_COLLECTION_PENDING (item 8 e2e)', async () => {
     await reportChildOutcomeLeavingParentPending();
-    const result = await runCliInProcess('complete', workspace);
+    const result = await runCliInProcess(await withRunTarget(['complete'], workspace), workspace);
     expect(result.exitCode).toBe(1);
     expect(emittedCodes(result.stdout)).toContain('DELEGATION_COLLECTION_PENDING');
   }, 30_000);
 
   it('bare rd stop against a collection-pending run refuses with DELEGATION_COLLECTION_PENDING (item 8 e2e)', async () => {
     await reportChildOutcomeLeavingParentPending();
-    const result = await runCliInProcess('stop', workspace);
+    const result = await runCliInProcess(await withRunTarget(['stop'], workspace), workspace);
     expect(result.exitCode).toBe(1);
     expect(emittedCodes(result.stdout)).toContain('DELEGATION_COLLECTION_PENDING');
   }, 30_000);
@@ -204,7 +205,7 @@ describe('collection-pending lifecycle', () => {
         markDelegateSubstepDone: true,
       });
 
-      const blocked = await runCliInProcess('pass', workspace);
+      const blocked = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
       expect(blocked.exitCode).toBe(1);
       const blockedPayloads = parseConcatenatedJson(blocked.stdout) as Array<{
         code?: string;
@@ -216,11 +217,14 @@ describe('collection-pending lifecycle', () => {
       expect(pending).toBeDefined();
       expect(pending?.details?.outcomeCompletionKeys).toEqual([completionKey]);
 
-      const collected = await runCliInProcess('collect', workspace);
+      const collected = await runCliInProcess(
+        await withRunTarget(['collect'], workspace),
+        workspace,
+      );
       expect(collected.exitCode).toBe(0);
 
       // The bare pass now releases — the FOR-scoped outcome no longer wedges it.
-      const advanced = await runCliInProcess('pass', workspace);
+      const advanced = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
       expect(advanced.exitCode).toBe(0);
       expect(emittedCodes(advanced.stdout)).not.toContain('DELEGATION_COLLECTION_PENDING');
     }, 30_000);
@@ -236,7 +240,10 @@ describe('collection-pending lifecycle', () => {
         forStack: [rangeFrame(1)],
         activeFrameKey: buildFrameKey('1', 1),
       });
-      const blockedWhileLive = await runCliInProcess('pass', workspace);
+      const blockedWhileLive = await runCliInProcess(
+        await withRunTarget(['pass'], workspace),
+        workspace,
+      );
       expect(blockedWhileLive.exitCode).toBe(1);
       expect(emittedCodes(blockedWhileLive.stdout)).toContain('DELEGATION_COLLECTION_PENDING');
 
@@ -250,7 +257,10 @@ describe('collection-pending lifecycle', () => {
         activeFrameKey: buildFrameKey('1', 2),
         activeEntry: 2,
       });
-      const afterAdvance = await runCliInProcess('pass', workspace);
+      const afterAdvance = await runCliInProcess(
+        await withRunTarget(['pass'], workspace),
+        workspace,
+      );
       expect(afterAdvance.exitCode).toBe(0);
       expect(emittedCodes(afterAdvance.stdout)).not.toContain('DELEGATION_COLLECTION_PENDING');
     }, 30_000);

--- a/packages/cli/__tests__/integration/delegate-workflow.test.ts
+++ b/packages/cli/__tests__/integration/delegate-workflow.test.ts
@@ -11,6 +11,7 @@ import {
   parseConcatenatedJson,
   findActionOutput,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 
 /**
@@ -254,7 +255,10 @@ describe('DELEGATE full workflow — rd run → auto-delegation → rd claim →
     expect(afterParent!.step).toBe('1');
 
     // Explicit collect aggregates both reported outcomes: PASS ALL → CONTINUE → step 2.
-    const collectResult = await runCliInProcess(['collect', '--text'], workspace);
+    const collectResult = await runCliInProcess(
+      await withRunTarget(['collect', '--text'], workspace),
+      workspace,
+    );
     expect(collectResult.exitCode).toBe(0);
 
     const advancedParent = await readRunbookState(workspace, parentRunId);
@@ -276,7 +280,7 @@ describe('DELEGATE full workflow — rd run → auto-delegation → rd claim →
 
     // Bare collect must reject the stale state with STEP_NOT_FOUND rather than
     // collapsing it into an `already-aggregated` success.
-    const result = await runCliInProcess(['collect'], workspace);
+    const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(result.exitCode).toBe(1);
     const json = parseConcatenatedJson(result.stdout).at(-1) as Record<string, unknown>;
     expect(json).toMatchObject({ kind: 'error', code: 'STEP_NOT_FOUND' });
@@ -316,7 +320,10 @@ describe('DELEGATE full workflow — rd run → auto-delegation → rd claim →
     expect(afterParent!.lifecycle).not.toBe('stopped');
 
     // Explicit collect aggregates the reported outcomes: FAIL ANY → STOP.
-    const collectResult = await runCliInProcess(['collect', '--text'], workspace);
+    const collectResult = await runCliInProcess(
+      await withRunTarget(['collect', '--text'], workspace),
+      workspace,
+    );
     expect(collectResult.exitCode).toBe(1);
 
     afterParent = await readRunbookState(workspace, parentRunId);
@@ -346,7 +353,10 @@ describe('DELEGATE full workflow — rd run → auto-delegation → rd claim →
     const finalPass = await runCliInProcess(['pass', '--claim-id', claimId2], workspace);
     expect(finalPass.exitCode).toBe(0);
 
-    const collectResult = await runCliInProcess(['collect'], workspace);
+    const collectResult = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(collectResult.exitCode).toBe(0);
     const events = flattenEventObjects(parseConcatenatedJson(collectResult.stdout));
     const transition = events.find(
@@ -437,7 +447,10 @@ describe('DELEGATE manual issuance requires authored DELEGATE annotation', () =>
     );
     expect(start.exitCode).toBe(0);
 
-    const manual = await runCliInProcess(['delegate', '--step', '1.1'], workspace);
+    const manual = await runCliInProcess(
+      await withRunTarget(['delegate', '--step', '1.1'], workspace),
+      workspace,
+    );
     expect(manual.exitCode).not.toBe(0);
     expect(manual.stdout + manual.stderr).toMatch(/RD-813|no delegatable substep/i);
 
@@ -556,7 +569,10 @@ describe('DELEGATE manual issuance requires authored DELEGATE annotation', () =>
       ?.token;
     expect(issuedToken).toBeDefined();
 
-    const manual = await runCliInProcess('delegate child.runbook.md --step 1.1', workspace);
+    const manual = await runCliInProcess(
+      await withRunTarget(['delegate', 'child.runbook.md', '--step', '1.1'], workspace),
+      workspace,
+    );
     expect(manual.exitCode).toBe(0);
     const json = parseCliJsonObject(manual.stdout);
     expect(json).toMatchObject({ kind: 'delegate', action: 'already-delegated', step: '1.1' });
@@ -675,7 +691,10 @@ describe('DELEGATE re-entry and retry', () => {
     // re-entering the DELEGATE step and re-issuing fresh tokens for BOTH
     // substeps under uniform re-delegation. RETRY is non-terminal, so collect
     // exits 0 and reports the re-opened substeps as unresolved again.
-    const collectResult = await runCliInProcess(['collect'], workspace);
+    const collectResult = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(collectResult.exitCode).toBe(0);
     const parsedCollect = parseConcatenatedJson(collectResult.stdout);
     const collectEvents = flattenEventObjects(parsedCollect);
@@ -731,7 +750,10 @@ describe('DELEGATE re-entry and retry', () => {
 
     // `rd collect` drives FAIL ANY → RETRY, re-issuing fresh tokens for BOTH
     // substeps and streaming the re-entry frontier.
-    const collectResult = await runCliInProcess(['collect'], workspace);
+    const collectResult = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(collectResult.exitCode).toBe(0);
     const tokenFrontier = findAllFrontiersInEvents(parseConcatenatedJson(collectResult.stdout)).at(
       -1,
@@ -857,7 +879,10 @@ describe('DELEGATE re-entry and retry', () => {
 
     // `rd collect` drives the pass-branch RETRY, re-issuing fresh tokens for
     // BOTH substeps symmetrically (re-entry frontier lives in state).
-    const collectResult = await runCliInProcess(['collect'], workspace);
+    const collectResult = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(collectResult.exitCode).toBe(0);
     const reentered = await readRunbookState(workspace, parentRunId);
     const entry1Token = reentered?.substepStates?.find((x) => x.id === '1')?.delegation?.token;
@@ -968,7 +993,10 @@ describe('DELEGATE re-entry and retry', () => {
     // of active session top (parent is looked up via scan).
     {
       const { parentRunId, token2, priorDelegation } = await setupPendingSecond();
-      const retry = await runCliInProcess(['delegate', '--retry', token2], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', token2], workspace),
+        workspace,
+      );
       expect(retry.exitCode).toBe(0);
       const out = JSON.parse(retry.stdout) as Record<string, unknown>;
       expect(out.action).toBe('retried');
@@ -995,7 +1023,10 @@ describe('DELEGATE re-entry and retry', () => {
     // manipulation is needed.
     {
       const { parentRunId, priorDelegation } = await setupPendingSecond();
-      const retry = await runCliInProcess(['delegate', '--retry', '--step', '1.2'], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', '--step', '1.2'], workspace),
+        workspace,
+      );
       expect(retry.exitCode).toBe(0);
       const out = JSON.parse(retry.stdout) as Record<string, unknown>;
       expect(out.action).toBe('retried');
@@ -1027,7 +1058,10 @@ describe('DELEGATE re-entry and retry', () => {
       const preSs1 = preSubsteps?.find((s) => s.id === '1');
       const priorDelegation = preSs1?.delegation as Record<string, unknown>;
 
-      const retry = await runCliInProcess(['delegate', '--retry'], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry'], workspace),
+        workspace,
+      );
       expect(retry.exitCode).toBe(0);
       const out = JSON.parse(retry.stdout) as Record<string, unknown>;
       expect(out.action).toBe('retried');
@@ -1088,7 +1122,10 @@ describe('DELEGATE re-entry and retry', () => {
     // `rd collect` applies both reported outcomes and drives FAIL ANY → RETRY 1,
     // re-entering the DELEGATE step with fresh tokens for BOTH substeps under
     // uniform re-delegation. RETRY is non-terminal → collect exits 0.
-    const firstCollect = await runCliInProcess(['collect'], workspace);
+    const firstCollect = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(firstCollect.exitCode).toBe(0);
     const firstSummary = flattenEventObjects(parseConcatenatedJson(firstCollect.stdout)).find(
       (e) => e.kind === 'collect',
@@ -1133,7 +1170,10 @@ describe('DELEGATE re-entry and retry', () => {
 
     // `rd collect` drains the second round: retry budget exhausted → the
     // exhaustion action (STOP) fires. STOP is terminal → collect exits 1.
-    const secondCollect = await runCliInProcess(['collect'], workspace);
+    const secondCollect = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(secondCollect.exitCode).toBe(1);
 
     // Core invariant: the second cycle does NOT mint a new frontier (retry
@@ -1231,7 +1271,10 @@ describe('DELEGATE re-entry and retry', () => {
     // applies ss1's reported fail and advances the substep cursor to 1.2 (the
     // command substep). The step rule has NOT aggregated yet — 1.2 is still
     // unresolved (collect reports unresolved > 0, lifecycle running).
-    const collectResult = await runCliInProcess(['collect'], workspace);
+    const collectResult = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(collectResult.exitCode).toBe(0);
     const collect = flattenEventObjects(parseConcatenatedJson(collectResult.stdout)).find(
       (e) => e.kind === 'collect',
@@ -1248,7 +1291,7 @@ describe('DELEGATE re-entry and retry', () => {
     // delegation report), RETRY fires inline here and `rd fail` exits 0
     // (non-terminal re-entry). 1.1 gets a fresh delegation; 1.2 (no delegation)
     // is untouched by the hook.
-    const fail12 = await runCliInProcess(['fail'], workspace);
+    const fail12 = await runCliInProcess(await withRunTarget(['fail'], workspace), workspace);
     expect(fail12.exitCode).toBe(0);
 
     // STEP_TRANSITIONED with action=RETRY is the canonical retry signal.
@@ -1360,7 +1403,10 @@ describe('DELEGATE re-entry and retry', () => {
     // `rd collect` applies the reported outcome and drives the iteration-level
     // FAIL ANY RETRY → re-issues a fresh delegation token in the SAME iteration
     // frame. RETRY is non-terminal → collect exits 0.
-    const collectResult = await runCliInProcess(['collect'], workspace);
+    const collectResult = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(collectResult.exitCode).toBe(0);
     const collect = flattenEventObjects(parseConcatenatedJson(collectResult.stdout)).find(
       (e) => e.kind === 'collect',
@@ -1415,7 +1461,10 @@ describe('DELEGATE re-entry and retry', () => {
       expect(preDel.childRunId).toBeNull();
       expect(preSs?.result).toBeUndefined();
 
-      const retry = await runCliInProcess(['delegate', '--retry', token2], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', token2], workspace),
+        workspace,
+      );
       expect(retry.exitCode).toBe(0);
       const out = JSON.parse(retry.stdout) as Record<string, unknown>;
       expect(out.action).toBe('retried');
@@ -1451,7 +1500,10 @@ describe('DELEGATE re-entry and retry', () => {
       const priorHash = preDel.tokenHash;
       const childRunId = preDel.childRunId;
 
-      const retry = await runCliInProcess(['delegate', '--retry', token2], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', token2], workspace),
+        workspace,
+      );
       expect(retry.exitCode).not.toBe(0);
       const out = parseCliJsonObject(retry.stdout || retry.stderr);
       expect(out).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-823' }));
@@ -1494,7 +1546,10 @@ describe('DELEGATE re-entry and retry', () => {
       const childRunId = preDel.childRunId;
       expect(childRunId).not.toBeNull();
 
-      const retry = await runCliInProcess(['delegate', '--retry', token1], workspace);
+      const retry = await runCliInProcess(
+        await withRunTarget(['delegate', '--retry', token1], workspace),
+        workspace,
+      );
       expect(retry.exitCode).not.toBe(0);
       const out = parseCliJsonObject(retry.stdout || retry.stderr);
       expect(out).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-823' }));
@@ -1560,7 +1615,10 @@ describe('DELEGATE re-entry and retry', () => {
     // — already-cancelled is a no-op (no double-cancel error) — then
     // `createDelegation` replaces the record. The command exits 0 and
     // emits a fresh token.
-    const retry = await runCliInProcess(['delegate', '--retry', tokenA2], workspace);
+    const retry = await runCliInProcess(
+      await withRunTarget(['delegate', '--retry', tokenA2], workspace),
+      workspace,
+    );
     expect(retry.exitCode).toBe(0);
     const retryOutput = JSON.parse(retry.stdout) as Record<string, unknown>;
     expect(retryOutput.action).toBe('retried');
@@ -1597,7 +1655,10 @@ describe('DELEGATE re-entry and retry', () => {
 
     // Retry mints a fresh token for 1.2 and supersedes the aborted attempt: its
     // stale FAIL resolvedCompletion row is consumed and the substep reset.
-    const retry = await runCliInProcess(['delegate', '--retry', token2], workspace);
+    const retry = await runCliInProcess(
+      await withRunTarget(['delegate', '--retry', token2], workspace),
+      workspace,
+    );
     expect(retry.exitCode).toBe(0);
     const retryOutput = findActionOutput<{ token: string }>(retry.stdout);
     expect(retryOutput).not.toBeNull();
@@ -1608,7 +1669,10 @@ describe('DELEGATE re-entry and retry', () => {
     // Collect must NOT drain the stale attempt-1 FAIL: 1.2's fresh attempt has not
     // reported, so readiness (which reads live outcome rows) refuses. Nothing is
     // applied and no aggregation transition fires from the superseded FAIL.
-    const collectStale = await runCliInProcess(['collect'], workspace);
+    const collectStale = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     // Readiness refuses (missing_outcomes → SUBSTEPS_NOT_RESOLVED → exit 1). Assert
     // the exit code before parsing so a crashed collect (empty stdout, no parsed
     // events) cannot pass the negative event assertions below vacuously.
@@ -1633,7 +1697,10 @@ describe('DELEGATE re-entry and retry', () => {
     r = await runCliInProcess(['pass', '--claim-id', claimId2b], workspace);
     expect(r.exitCode).toBe(0);
 
-    const collectFresh = await runCliInProcess(['collect'], workspace);
+    const collectFresh = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(collectFresh.exitCode).toBe(0);
     const freshEvents = flattenEventObjects(parseConcatenatedJson(collectFresh.stdout));
     const collect = freshEvents.find((e) => e.kind === 'collect');
@@ -1809,7 +1876,10 @@ describe('DELEGATE with custom substep transitions', () => {
 
     // Explicit collect applies outcomes; per-substep `- FAIL STOP` on 1.2 fires
     // STOP even though the step rule (PASS ANY CONTINUE) would otherwise pass.
-    const collectResult = await runCliInProcess(['collect'], workspace);
+    const collectResult = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(collectResult.exitCode).toBe(1);
 
     parentState = await readRunbookState(workspace, parentRunId);
@@ -1893,7 +1963,10 @@ describe('DELEGATE with custom substep transitions', () => {
     expect(afterParent?.step).toBe('1');
 
     // Explicit collect aggregates: PASS ANY (1.1 passed) → CONTINUE → step 2.
-    const collectResult = await runCliInProcess(['collect'], workspace);
+    const collectResult = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(collectResult.exitCode).toBe(0);
 
     afterParent = await readRunbookState(workspace, parentRunId);

--- a/packages/cli/__tests__/integration/delegate-workflow.test.ts
+++ b/packages/cli/__tests__/integration/delegate-workflow.test.ts
@@ -266,7 +266,7 @@ describe('DELEGATE full workflow — rd run → auto-delegation → rd claim →
     expect(advancedParent!.step).toBe('2');
   }, 20_000);
 
-  it('bare rd collect fails fast when persisted state.step no longer resolves to a runbook step', async () => {
+  it('run-targeted rd collect fails fast when persisted state.step no longer resolves to a runbook step', async () => {
     const { parentRunId } = await setupParentWithChildren();
 
     // Corrupt the persisted cursor so it names a step absent from the loaded
@@ -278,7 +278,7 @@ describe('DELEGATE full workflow — rd run → auto-delegation → rd claim →
     raw.step = '99';
     await writeFile(statePath, JSON.stringify(raw, null, 2));
 
-    // Bare collect must reject the stale state with STEP_NOT_FOUND rather than
+    // The run-targeted collect must reject the stale state with STEP_NOT_FOUND rather than
     // collapsing it into an `already-aggregated` success.
     const result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(result.exitCode).toBe(1);

--- a/packages/cli/__tests__/integration/delegation-abort.test.ts
+++ b/packages/cli/__tests__/integration/delegation-abort.test.ts
@@ -181,8 +181,9 @@ describe('Delegation abort integration', () => {
     expect(rows[0]?.result).toBe('fail');
     expect(parent!.step).toBe('1');
 
-    // Collection pending: a bare advance is refused until `rd collect`.
-    const blocked = runCli('pass', workspace);
+    // Collection pending: a run-targeted bare-shaped advance is refused until
+    // `rd collect` (named authority does not skip collection discipline).
+    const blocked = runCli(`pass --run ${parent!.id}`, workspace);
     expect(blocked.exitCode).toBe(1);
     expect(`${blocked.stdout}${blocked.stderr}`).toContain('DELEGATION_COLLECTION_PENDING');
   });
@@ -243,8 +244,9 @@ describe('Delegation abort integration', () => {
     const recordedFrameSubstep = parent?.substepStates?.find((ss) => ss.id === '1');
     expect(rows[0]?.targetFrameKey).toBe(recordedFrameSubstep?.frameKey);
 
-    // Bare advance refused — the iteration frame is collection pending.
-    const blocked = runCli('pass', workspace);
+    // Run-targeted bare-shaped advance refused — the iteration frame is
+    // collection pending.
+    const blocked = runCli(`pass --run ${parent!.id}`, workspace);
     expect(blocked.exitCode).toBe(1);
     expect(`${blocked.stdout}${blocked.stderr}`).toContain('DELEGATION_COLLECTION_PENDING');
   });

--- a/packages/cli/__tests__/integration/delegation-claim.test.ts
+++ b/packages/cli/__tests__/integration/delegation-claim.test.ts
@@ -325,7 +325,7 @@ rd echo --result pass
       expect(result.exitCode).toBe(0);
 
       // Explicit collect aggregates both reported outcomes: PASS ALL → CONTINUE → step 2.
-      result = runCli('collect --text', workspace);
+      result = runCli(`collect --text --run ${parentRunId}`, workspace);
       expect(result.exitCode).toBe(0);
 
       const updatedParent = await readRunbookState(workspace, parentRunId);
@@ -366,7 +366,7 @@ rd echo --result fail
       expect(result.exitCode).toBe(1);
 
       // Explicit collect aggregates the reported outcomes: FAIL ANY → STOP.
-      result = runCli('collect --text', workspace);
+      result = runCli(`collect --text --run ${parentRunId}`, workspace);
       expect(result.exitCode).toBe(1);
 
       // Parent should be stopped

--- a/packages/cli/__tests__/integration/delegation-h3-runbook-substep.test.ts
+++ b/packages/cli/__tests__/integration/delegation-h3-runbook-substep.test.ts
@@ -17,6 +17,7 @@ import {
   parseCliJsonObject,
   runCli,
   type TestWorkspace,
+  getActiveState,
 } from '../helpers/test-utils.js';
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -306,9 +307,10 @@ Done.
     expect(originalToken).toBeDefined();
     expect(originalToken).toMatch(/^rdtk_/);
 
-    // Bare `rd delegate` is idempotent on an auto-issued frontier: it echoes
-    // the existing token rather than re-issuing or throwing RD-813.
-    result = runCli('delegate', workspace);
+    // A run-targeted `rd delegate` is idempotent on an auto-issued frontier:
+    // it echoes the existing token rather than re-issuing or throwing RD-813.
+    const parentId = (await getActiveState(workspace))!.id;
+    result = runCli(`delegate --run ${parentId}`, workspace);
     expect(result.exitCode).toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).toMatch(/already-delegated/);
     expect(/rdtk_[A-Za-z0-9_]+/.exec(result.stdout)?.[0]).toBe(originalToken);
@@ -316,7 +318,7 @@ Done.
     // Explicit `--step` on an already-delegated substep is idempotent: it echoes
     // the existing in-flight token rather than re-issuing a duplicate delegation
     // or erroring RD-804.
-    result = runCli('delegate --step 1.1', workspace);
+    result = runCli(`delegate --step 1.1 --run ${parentId}`, workspace);
     expect(result.exitCode).toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).toMatch(/already-delegated/);
     const echoedToken = /rdtk_[A-Za-z0-9_]+/.exec(result.stdout)?.[0];
@@ -371,7 +373,10 @@ Done.
     let result = runCli('run --prompted parent.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
 
-    result = runCli('delegate explicit-child.runbook.md --step 1.1', workspace);
+    result = runCli(
+      `delegate explicit-child.runbook.md --step 1.1 --run ${(await getActiveState(workspace))!.id}`,
+      workspace,
+    );
     expect(result.exitCode).not.toBe(0);
     const envelope = parseCliJsonObject(result.stdout || result.stderr);
     expect(envelope).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-804' }));
@@ -396,7 +401,10 @@ Do some manual work here.
     let result = runCli('run --prompted parent.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
 
-    result = runCli('delegate explicit-child.runbook.md --step 1.1', workspace);
+    result = runCli(
+      `delegate explicit-child.runbook.md --step 1.1 --run ${(await getActiveState(workspace))!.id}`,
+      workspace,
+    );
     expect(result.exitCode).not.toBe(0);
     const envelope = parseCliJsonObject(result.stdout || result.stderr);
     expect(envelope).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-813' }));
@@ -415,7 +423,10 @@ Do some manual work here.
     result = runCli(`abort ${autoToken}`, workspace);
     expect(result.exitCode).toBe(0);
 
-    result = runCli('delegate child.runbook.md --step 1.1', workspace);
+    result = runCli(
+      `delegate child.runbook.md --step 1.1 --run ${(await getActiveState(workspace))!.id}`,
+      workspace,
+    );
     expect(result.exitCode).toBe(0);
     expect(JSON.parse(result.stdout).action).toBe('delegated');
 
@@ -445,8 +456,8 @@ Do some manual work here.
     let result = runCli('run --prompted parent.runbook.md', workspace);
     expect(result.exitCode).toBe(0);
 
-    // Step 1.1 is prose — pass it directly
-    result = runCli('pass --step 1.1', workspace);
+    // Step 1.1 is prose — pass it directly (run+step named authority post-R1)
+    result = runCli(`pass --step 1.1 --run ${(await getActiveState(workspace))!.id}`, workspace);
     expect(result.exitCode).toBe(0);
 
     const [token] = extractTokens(result.stdout);

--- a/packages/cli/__tests__/integration/delegation-inline-handoff.test.ts
+++ b/packages/cli/__tests__/integration/delegation-inline-handoff.test.ts
@@ -10,6 +10,7 @@ import {
   readRunbookState,
   runCliInProcess,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 import type { RunbookState } from '@rundown-org/core';
 
@@ -139,7 +140,7 @@ describe('delegation -> collect -> inline handoff', () => {
     expect(closed.exitCode).toBe(0);
 
     // Collect applies the reported outcome -> stage 1 PASS ALL -> CONTINUE -> stage 2.
-    const collected = await runCliInProcess('collect', workspace);
+    const collected = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(collected.exitCode).toBe(0);
 
     // The parent advanced into stage 2 (the inline gate stage), still running.
@@ -158,7 +159,7 @@ describe('delegation -> collect -> inline handoff', () => {
 
     // So a bare `rd pass` resolves the inline child's step, not the parent's
     // stage-2 composite substep (no rubber-stamp).
-    const pass = await runCliInProcess('pass', workspace);
+    const pass = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
     expect(pass.exitCode).toBe(0);
   }, 30_000);
 
@@ -182,7 +183,7 @@ describe('delegation -> collect -> inline handoff', () => {
     // JSON mode (no --text): collect applies the delegated outcome and advances
     // the parent into the inline gate stage, so the execution loop emits
     // step_entered / runbook_started for the launched inline child.
-    const collected = await runCliInProcess('collect', workspace);
+    const collected = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(collected.exitCode).toBe(0);
 
     const objects = parseStdoutObjects(collected.stdout);
@@ -260,7 +261,7 @@ describe('delegation -> collect -> inline handoff', () => {
     const closed = await runCliInProcess(['complete', '--claim-id', claimId], workspace);
     expect(closed.exitCode).toBe(0);
 
-    const collected = await runCliInProcess('collect', workspace);
+    const collected = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(collected.exitCode).toBe(0);
 
     const inlineChild = findInlineChild(await getAllStates(workspace), parentRunId);
@@ -275,7 +276,10 @@ describe('delegation -> collect -> inline handoff', () => {
     const childClosed = await runCliInProcess(['complete', '--claim-id', childClaimId], workspace);
     expect(childClosed.exitCode).toBe(0);
 
-    const childCollected = await runCliInProcess('collect', workspace);
+    const childCollected = await runCliInProcess(
+      await withRunTarget(['collect'], workspace),
+      workspace,
+    );
     expect(childCollected.exitCode).toBe(0);
 
     const parentAfter = await readRunbookState(workspace, parentRunId);
@@ -311,7 +315,7 @@ describe('delegation -> collect -> inline handoff', () => {
     const claimId = String(findActionOutput(claim.stdout)!.claim_id);
     const closed = await runCliInProcess(['complete', '--claim-id', claimId], workspace);
     expect(closed.exitCode).toBe(0);
-    const advanced = await runCliInProcess('collect', workspace);
+    const advanced = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(advanced.exitCode).toBe(0);
 
     const inlineChild = findInlineChild(await getAllStates(workspace), parentRunId);
@@ -330,7 +334,7 @@ describe('delegation -> collect -> inline handoff', () => {
     const childClosed = await runCliInProcess(['complete', '--claim-id', childClaimId], workspace);
     expect(childClosed.exitCode).toBe(0);
 
-    const collected = await runCliInProcess('collect', workspace);
+    const collected = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(collected.exitCode).toBe(0);
 
     const objects = parseStdoutObjects(collected.stdout);
@@ -393,14 +397,17 @@ describe('delegation -> collect -> inline handoff', () => {
     const closed = await runCliInProcess(['complete', '--claim-id', claimId], workspace);
     expect(closed.exitCode).toBe(0);
 
-    const collected = await runCliInProcess('collect', workspace);
+    const collected = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(collected.exitCode).toBe(0);
 
     const inlineChild = findInlineChild(await getAllStates(workspace), parentRunId);
     expect(inlineChild).toBeDefined();
     expect((await getActiveState(workspace))!.id).toBe(inlineChild!.id);
 
-    const close = await runCliInProcess(['complete', 'inline gate done'], workspace);
+    const close = await runCliInProcess(
+      await withRunTarget(['complete', 'inline gate done'], workspace),
+      workspace,
+    );
     expect(close.exitCode).toBe(0);
 
     const inlineAfter = await readRunbookState(workspace, inlineChild!.id);

--- a/packages/cli/__tests__/integration/delegation-propagation.test.ts
+++ b/packages/cli/__tests__/integration/delegation-propagation.test.ts
@@ -8,6 +8,7 @@ import {
   readSession,
   findActionOutput,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 import { writeFile, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -142,7 +143,7 @@ describe('Delegation propagation integration', () => {
       expect(sessionAfterChild.defaultStack).toEqual([parentRunId]);
 
       // `rd collect` applies the reported outcomes: PASS ALL → CONTINUE → step 2.
-      result = await runCliInProcess('collect', workspace);
+      result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(result.exitCode).toBe(0);
 
       const updatedParent = await readRunbookState(workspace, parentRunId);
@@ -165,7 +166,10 @@ describe('Delegation propagation integration', () => {
       expect(claimAction).not.toBeNull();
       const claimId = String(claimAction!.claim_id);
 
-      result = await runCliInProcess('pass', workspace);
+      // Post-R1 the guard needs named authority: a run-targeted bare-shaped
+      // advance still refuses with OPEN_DELEGATED_CHILDREN (naming authority
+      // does not skip collection discipline).
+      result = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
 
       expect(result.exitCode).toBe(1);
       const payload = JSON.parse(result.stdout) as {
@@ -197,7 +201,7 @@ describe('Delegation propagation integration', () => {
       expect(claimAction).not.toBeNull();
       const claimId = String(claimAction!.claim_id);
 
-      result = await runCliInProcess('fail', workspace);
+      result = await runCliInProcess(await withRunTarget(['fail'], workspace), workspace);
 
       expect(result.exitCode).toBe(1);
       const payload = JSON.parse(result.stdout) as { code?: string; error?: string };
@@ -224,7 +228,7 @@ describe('Delegation propagation integration', () => {
       result = await runCliInProcess(`claim ${token}`, workspace);
       expect(result.exitCode).toBe(0);
 
-      result = await runCliInProcess('collect', workspace);
+      result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
 
       const payload = JSON.parse(result.stdout) as { code?: string; error?: string };
       // Collect reached its own substep-resolution check (substep 1.2 is still
@@ -249,7 +253,10 @@ describe('Delegation propagation integration', () => {
       result = await runCliInProcess(`claim ${token}`, workspace);
       expect(result.exitCode).toBe(0);
 
-      result = await runCliInProcess('pass --step 1.2', workspace);
+      result = await runCliInProcess(
+        await withRunTarget(['pass', '--step', '1.2'], workspace),
+        workspace,
+      );
 
       // Not refused by the open-children guard, and the targeted transition runs.
       expect(result.stdout).not.toContain('OPEN_DELEGATED_CHILDREN');
@@ -277,8 +284,8 @@ describe('Delegation propagation integration', () => {
       expect(result.exitCode).toBe(0);
       const claimId = String(findActionOutput(result.stdout)!.claim_id);
 
-      // The bare parent advance must refuse.
-      result = await runCliInProcess('pass', workspace);
+      // The bare-shaped run-targeted parent advance must refuse.
+      result = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
       expect(result.exitCode).toBe(1);
       const payload = JSON.parse(result.stdout) as {
         code?: string;
@@ -333,7 +340,10 @@ describe('Delegation propagation integration', () => {
       expect(result.exitCode).toBe(0);
 
       // `rd collect` applies the reported outcomes: FAIL ANY (1.1 failed) → STOP.
-      result = await runCliInProcess('collect --text', workspace);
+      result = await runCliInProcess(
+        await withRunTarget(['collect', '--text'], workspace),
+        workspace,
+      );
 
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
@@ -376,7 +386,10 @@ describe('Delegation propagation integration', () => {
       expect(result.exitCode).toBe(0);
 
       // `rd collect` applies the reported outcomes: FAIL ANY (1.1 failed) → STOP.
-      result = await runCliInProcess('collect --text', workspace);
+      result = await runCliInProcess(
+        await withRunTarget(['collect', '--text'], workspace),
+        workspace,
+      );
 
       const updatedParent = await readRunbookState(workspace, parentRunId);
       expect(updatedParent).not.toBeNull();
@@ -481,7 +494,9 @@ describe('Delegation propagation integration', () => {
       expect(gpRows).toHaveLength(1);
 
       // A bare grandparent pass is refused while pending.
-      const blocked = await runCliInProcess('pass', workspace);
+      // Post-R1 the guard needs named authority; the bare-shaped run-targeted
+      // advance still refuses with the collection-pending guard.
+      const blocked = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
       expect(blocked.exitCode).toBe(1);
       expect((JSON.parse(blocked.stdout) as { code?: string }).code).toBe(
         'DELEGATION_COLLECTION_PENDING',
@@ -489,11 +504,14 @@ describe('Delegation propagation integration', () => {
 
       // Explicit collect applies the reported outcome and advances the
       // grandparent to its remaining substep (1.2 Verify, non-delegated).
-      const collected = await runCliInProcess('collect', workspace);
+      const collected = await runCliInProcess(
+        await withRunTarget(['collect'], workspace),
+        workspace,
+      );
       expect(collected.exitCode).toBe(0);
 
-      // Drive the grandparent's remaining substep to COMPLETE.
-      result = await runCliInProcess('pass --text', workspace);
+      // Drive the grandparent's remaining substep to COMPLETE (named authority).
+      result = await runCliInProcess(await withRunTarget(['pass', '--text'], workspace), workspace);
 
       // Verify grandparent completed
       const updatedGrandparent = await readRunbookState(workspace, grandparentRunId);
@@ -553,7 +571,7 @@ describe('Delegation propagation integration', () => {
 
       // Plan 5 (report-only): both outcomes are reported but uncollected, so the
       // parent is still on step 1. `rd collect` applies them and advances.
-      result = await runCliInProcess('collect', workspace);
+      result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(result.exitCode).toBe(0);
 
       // After collect, parent should advance past step 1
@@ -656,7 +674,7 @@ describe('Delegation propagation integration', () => {
 
       // Plan 5 (report-only): all three outcomes are reported but uncollected.
       // `rd collect` applies them: PASS ALL → COMPLETE.
-      result = await runCliInProcess('collect', workspace);
+      result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(result.exitCode).toBe(0);
 
       const finalParent = await readRunbookState(workspace, parentRunId);
@@ -761,7 +779,7 @@ describe('Delegation propagation integration', () => {
       // Plan 5: `rd collect` applies the reported outcome — it drains via
       // APPLY_CURRENT_RESOLVED_COMPLETION, merging finalVars into parent context
       // and advancing 1.1 PASS CONTINUE → substep 1.2.
-      result = await runCliInProcess('collect', workspace);
+      result = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
       expect(result.exitCode).toBe(0);
 
       // Parent now sits at substep 1.2 (1.1 PASS CONTINUE), and {{resultKey}}
@@ -775,8 +793,8 @@ describe('Delegation propagation integration', () => {
         expect.objectContaining({ resultKey: 'published-value' }),
       );
 
-      // Drive substep 1.2 → parent step 2.
-      result = await runCliInProcess('pass --text', workspace);
+      // Drive substep 1.2 → parent step 2 (named authority post-R1).
+      result = await runCliInProcess(await withRunTarget(['pass', '--text'], workspace), workspace);
       expect(result.exitCode).toBe(0);
 
       // Step 2's prompt should be templated with the propagated value.
@@ -821,10 +839,10 @@ describe('Delegation propagation integration', () => {
 
       const token = await getAutoIssuedToken();
 
-      // Manually complete the parent before claiming
-      result = await runCliInProcess('pass --text', workspace);
+      // Manually complete the parent before claiming (named authority post-R1)
+      result = await runCliInProcess(await withRunTarget(['pass', '--text'], workspace), workspace);
       expect(result.exitCode).toBe(0);
-      result = await runCliInProcess('pass --text', workspace);
+      result = await runCliInProcess(await withRunTarget(['pass', '--text'], workspace), workspace);
       expect(result.exitCode).toBe(0);
 
       // Now claim and complete child - parent already done.

--- a/packages/cli/__tests__/integration/explicit-run-targeting.test.ts
+++ b/packages/cli/__tests__/integration/explicit-run-targeting.test.ts
@@ -326,6 +326,32 @@ describe('explicit --run targeting (R1, #460)', () => {
     expect(targeted.exitCode).toBe(0);
   });
 
+  it('refuses a bare goto on a delegating run with ACTOR_CONTEXT_REQUIRED, while goto --run succeeds', async () => {
+    // Navigation is role-gated like an advance: a lingering child (or any
+    // caller without named authority) must not steer a delegating parent's
+    // cursor with a bare `goto`.
+    await setupDelegatingParent();
+    const parent = await getActiveState(workspace);
+    if (!parent) throw new Error('Expected active parent run');
+
+    const bare = await runCliInProcess(['goto', '2'], workspace);
+    expect(bare.exitCode).not.toBe(0);
+    const envelope = findErrorEnvelope(bare.stdout);
+    expect(envelope?.code).toBe('ACTOR_CONTEXT_REQUIRED');
+    // Decision 4 pinned: the refusal never echoes the target run id.
+    expect(JSON.stringify(envelope)).not.toContain(parent.id);
+
+    // No navigation occurred under the refusal.
+    const after = await getActiveState(workspace);
+    expect(after?.step).toBe(parent.step);
+
+    // The orchestrator names its authority and navigates the same run.
+    const targeted = await runCliInProcess(['goto', '2', '--run', parent.id], workspace);
+    expect(targeted.exitCode).toBe(0);
+    const navigated = await getActiveState(workspace);
+    expect(navigated?.step).toBe('2');
+  });
+
   it('surfaces a named-run failure for complete --run on unusable state instead of cleaning the default stack', async () => {
     // Two independent runs on the default stack: the NAMED run underneath, an
     // unrelated run on top. The named run's persisted state is corrupted and

--- a/packages/cli/__tests__/integration/explicit-run-targeting.test.ts
+++ b/packages/cli/__tests__/integration/explicit-run-targeting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { writeFile } from 'node:fs/promises';
+import { rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   createTestWorkspace,
@@ -9,6 +9,7 @@ import {
   getActiveState,
   parseConcatenatedJson,
   readRunbookState,
+  readSession,
   runCliInProcess,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
@@ -323,6 +324,35 @@ describe('explicit --run targeting (R1, #460)', () => {
     // The orchestrator lane still works.
     const targeted = await runCliInProcess(['pass', '--run', back.id], workspace);
     expect(targeted.exitCode).toBe(0);
+  });
+
+  it('surfaces a named-run failure for complete --run on unusable state instead of cleaning the default stack', async () => {
+    // Two independent runs on the default stack: the NAMED run underneath, an
+    // unrelated run on top. The named run's persisted state is corrupted and
+    // the top is orphaned (state file gone, session entry intact). A
+    // `complete --run <named>` must surface the named run's failure — it must
+    // NOT fall into bare-path orphan cleanup, pop the OTHER run's session
+    // entry, and exit 0 without terminating the named run.
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md', workspace);
+    const named = await getActiveState(workspace);
+    if (!named) throw new Error('Expected named run');
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md', workspace);
+    const top = await getActiveState(workspace);
+    if (!top) throw new Error('Expected top run');
+    expect(top.id).not.toBe(named.id);
+
+    await writeFile(join(workspace.statePath(), `${named.id}.json`), '{ not valid json');
+    await rm(join(workspace.statePath(), `${top.id}.json`));
+
+    const result = await runCliInProcess(['complete', '--run', named.id], workspace);
+
+    // The failure surfaces against the NAMED run and exits non-zero...
+    expect(result.exitCode).not.toBe(0);
+    expect(findErrorEnvelope(result.stdout)?.code).toBe('RUN_TARGET_UNAVAILABLE');
+    // ...and the orphaned top's session entry survives — no default-stack
+    // cleanup ran on behalf of a named-run target.
+    const session = await readSession(workspace);
+    expect(session.defaultStack).toContain(top.id);
   });
 
   it('never grants claim-lane authority to --run: a claimed child run id resolves RUN_TARGET_UNAVAILABLE', async () => {

--- a/packages/cli/__tests__/integration/explicit-run-targeting.test.ts
+++ b/packages/cli/__tests__/integration/explicit-run-targeting.test.ts
@@ -381,6 +381,65 @@ describe('explicit --run targeting (R1, #460)', () => {
     expect(session.defaultStack).toContain(top.id);
   });
 
+  it('run --prompted --step jumps a freshly created delegating-document run; a later bare goto is still gated (LOW-3 boundary)', async () => {
+    // Boundary pin for the run --prompted --step gate bypass (run.ts): the
+    // in-process jump targets only the run this invocation just minted, with
+    // the same authority `goto --run <own-id>` grants, so it is NOT routed
+    // through the run-navigation policy gate. The gate still owns every
+    // post-creation navigation of the same run.
+    const childContent = createRunbook({
+      title: 'Child',
+      steps: [{ title: 'Do work', pass: 'COMPLETE', content: 'Child prompt.' }],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'child.runbook.md'), childContent);
+    await writeFile(join(workspace.runbooksDir(), 'child.runbook.md'), childContent);
+    const parentContent = createRunbook({
+      title: 'Jump target delegator',
+      steps: [
+        { title: 'Prepare', pass: 'CONTINUE', content: 'Prepare.' },
+        {
+          title: 'Delegate later',
+          pass: 'CONTINUE',
+          substeps: [
+            { title: 'Child work', delegate: true, runbooks: ['runbooks/child.runbook.md'] },
+          ],
+        },
+        { title: 'After', pass: 'COMPLETE', content: 'Wrap up.' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'jump.runbook.md'), parentContent);
+
+    // The document authors a DELEGATE substep, so the run is delegating from
+    // birth (static clause a) — yet the creating invocation's --step jump
+    // succeeds without naming authority: the freshly minted id IS its
+    // authority, exactly as if it had passed `goto --run <own-id>`.
+    const start = await runCliInProcess(
+      ['run', '--prompted', 'runbooks/jump.runbook.md', '--step', '3'],
+      workspace,
+    );
+    expect(start.exitCode).toBe(0);
+    const state = await getActiveState(workspace);
+    if (!state) throw new Error('Expected active run after prompted start');
+    expect(state.step).toBe('3');
+
+    // Post-creation, the boundary holds: a bare goto on the same (delegating)
+    // run is refused by the run-navigation gate without echoing the run id...
+    const bare = await runCliInProcess(['goto', '1'], workspace);
+    expect(bare.exitCode).not.toBe(0);
+    const envelope = findErrorEnvelope(bare.stdout);
+    expect(envelope?.code).toBe('ACTOR_CONTEXT_REQUIRED');
+    expect(JSON.stringify(envelope)).not.toContain(state.id);
+    const unmoved = await getActiveState(workspace);
+    expect(unmoved?.step).toBe('3');
+
+    // ...while the equivalent named authority the creating process held
+    // implicitly succeeds explicitly.
+    const targeted = await runCliInProcess(['goto', '1', '--run', state.id], workspace);
+    expect(targeted.exitCode).toBe(0);
+    const after = await getActiveState(workspace);
+    expect(after?.step).toBe('1');
+  });
+
   it('never grants claim-lane authority to --run: a claimed child run id resolves RUN_TARGET_UNAVAILABLE', async () => {
     await setupDelegatingParent();
     const parent = await getActiveState(workspace);

--- a/packages/cli/__tests__/integration/explicit-run-targeting.test.ts
+++ b/packages/cli/__tests__/integration/explicit-run-targeting.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  createTestWorkspace,
+  createRunbook,
+  extractToken,
+  findActionOutput,
+  getActiveState,
+  parseConcatenatedJson,
+  readRunbookState,
+  runCliInProcess,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
+
+// R1 acceptance suite for explicit --run targeting (#460): ambient direct-CLI
+// trust over delegation-exposed runs is removed; orchestrators name their
+// authority with --run, delegated children keep --claim-id, and bare commands
+// remain acceptable only for standalone runs.
+
+interface ErrorEnvelope {
+  code?: string;
+  message?: string;
+  details?: Record<string, unknown>;
+}
+
+function findErrorEnvelope(stdout: string): ErrorEnvelope | undefined {
+  return parseConcatenatedJson(stdout).find(
+    (entry): entry is ErrorEnvelope =>
+      typeof entry === 'object' && entry !== null && (entry as { kind?: string }).kind === 'error',
+  );
+}
+
+function findDelegateToken(stdout: string): string | undefined {
+  for (const event of parseConcatenatedJson(stdout)) {
+    if (!event || typeof event !== 'object') continue;
+    const frontier = (event as { delegateFrontier?: Array<{ token?: string }> }).delegateFrontier;
+    const token = frontier?.[0]?.token;
+    if (typeof token === 'string') return token;
+  }
+  return undefined;
+}
+
+describe('explicit --run targeting (R1, #460)', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  /** Parent authoring one DELEGATE substep at step 1; child is a single prompt. */
+  async function setupDelegatingParent(): Promise<void> {
+    const childContent = createRunbook({
+      title: 'Child',
+      steps: [{ title: 'Do work', pass: 'COMPLETE', content: 'Child prompt.' }],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'child.runbook.md'), childContent);
+    await writeFile(join(workspace.runbooksDir(), 'child.runbook.md'), childContent);
+
+    const parentContent = createRunbook({
+      title: 'Parent',
+      steps: [
+        {
+          title: 'Delegate work',
+          pass: 'CONTINUE',
+          substeps: [
+            {
+              title: 'Child work',
+              delegate: true,
+              runbooks: ['runbooks/child.runbook.md'],
+            },
+          ],
+        },
+        { title: 'After', pass: 'COMPLETE', content: 'Wrap up.' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'parent.runbook.md'), parentContent);
+
+    const start = await runCliInProcess('run --prompted runbooks/parent.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+  }
+
+  it('refuses a lingering child agent bare pass and bare delegate against the parent, while --run succeeds (#460)', async () => {
+    await setupDelegatingParent();
+    const parent = await getActiveState(workspace);
+    if (!parent) throw new Error('Expected active parent run');
+
+    // The orchestrator names its authority to issue the delegation.
+    const issued = await runCliInProcess(['delegate', '--run', parent.id], workspace);
+    expect(issued.exitCode).toBe(0);
+    const token = extractToken(issued.stdout);
+    if (!token) throw new Error('Expected delegation token');
+
+    const claimed = await runCliInProcess(['claim', token], workspace);
+    expect(claimed.exitCode).toBe(0);
+    const claimId = String(findActionOutput(claimed.stdout)?.claim_id);
+    expect(claimId).toMatch(/^rdclm_/);
+
+    // The child closes its claim (reports pass to the parent).
+    const closed = await runCliInProcess(['pass', '--claim-id', claimId], workspace);
+    expect(closed.exitCode).toBe(0);
+
+    // The lingering child oversteps with bare commands — the #460 defect.
+    const barePass = await runCliInProcess(['pass'], workspace);
+    expect(barePass.exitCode).not.toBe(0);
+    const passEnvelope = findErrorEnvelope(barePass.stdout);
+    expect(passEnvelope?.code).toBe('ACTOR_CONTEXT_REQUIRED');
+    // Decision 4 pinned: the refusal must not hand the id back (accident
+    // barrier, not secrecy).
+    expect(JSON.stringify(passEnvelope)).not.toContain(parent.id);
+
+    const bareDelegate = await runCliInProcess(['delegate'], workspace);
+    expect(bareDelegate.exitCode).not.toBe(0);
+    expect(findErrorEnvelope(bareDelegate.stdout)?.code).toBe('ACTOR_CONTEXT_REQUIRED');
+
+    // No state mutation occurred under either refusal.
+    const after = await getActiveState(workspace);
+    expect(after?.step).toBe(parent.step);
+    expect(after?.lifecycle).toBe('running');
+
+    // The orchestrator names its authority and proceeds: collect the reported
+    // outcome, advancing the parent to step 2.
+    const collected = await runCliInProcess(['collect', '--run', parent.id], workspace);
+    expect(collected.exitCode).toBe(0);
+    const advanced = await getActiveState(workspace);
+    expect(advanced?.step).toBe('2');
+
+    // A run-targeted pass drives the parent even though it is delegating.
+    const targeted = await runCliInProcess(['pass', '--run', parent.id], workspace);
+    expect(targeted.exitCode).toBe(0);
+  });
+
+  it('keeps bare pass working end-to-end on a standalone run', async () => {
+    await runCliInProcess('run --prompted runbooks/simple.runbook.md --text', workspace);
+
+    const result = await runCliInProcess(['pass'], workspace);
+
+    expect(result.exitCode).toBe(0);
+    const state = await getActiveState(workspace);
+    expect(state?.step).toBe('2');
+  });
+
+  it('refuses bare pass on a not-yet-issued run whose DOCUMENT authors DELEGATE (static clause a)', async () => {
+    const childContent = createRunbook({
+      title: 'Child',
+      steps: [{ title: 'Do work', pass: 'COMPLETE', content: 'Child prompt.' }],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'child.runbook.md'), childContent);
+    await writeFile(join(workspace.runbooksDir(), 'child.runbook.md'), childContent);
+    const parentContent = createRunbook({
+      title: 'Late delegator',
+      steps: [
+        { title: 'Prepare', pass: 'CONTINUE', content: 'Prepare.' },
+        {
+          title: 'Delegate later',
+          pass: 'CONTINUE',
+          substeps: [
+            { title: 'Child work', delegate: true, runbooks: ['runbooks/child.runbook.md'] },
+          ],
+        },
+        { title: 'After', pass: 'COMPLETE', content: 'Wrap up.' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'late.runbook.md'), parentContent);
+    const start = await runCliInProcess('run --prompted runbooks/late.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+    const state = await getActiveState(workspace);
+    expect(state?.step).toBe('1');
+
+    // No delegation has been issued yet — the static document clause protects
+    // the run from step 1, so exposure cannot be raced by execution order.
+    const bare = await runCliInProcess(['pass'], workspace);
+    expect(bare.exitCode).not.toBe(0);
+    expect(findErrorEnvelope(bare.stdout)?.code).toBe('ACTOR_CONTEXT_REQUIRED');
+
+    // The orchestrator lane works.
+    const targeted = await runCliInProcess(['pass', '--run', state!.id], workspace);
+    expect(targeted.exitCode).toBe(0);
+  });
+
+  it('refuses bare pass on an inline-linked child stage and accepts --run <childRunId> (clause e)', async () => {
+    const stageContent = createRunbook({
+      name: 'stage',
+      title: 'Stage',
+      steps: [
+        { title: 'First', pass: 'CONTINUE', content: 'Stage prompt one.' },
+        { title: 'Second', pass: 'COMPLETE', content: 'Stage prompt two.' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'stage.runbook.md'), stageContent);
+    await writeFile(join(workspace.runbooksDir(), 'stage.runbook.md'), stageContent);
+    const rootContent = createRunbook({
+      title: 'Root',
+      steps: [
+        {
+          title: 'Compose',
+          pass: 'CONTINUE',
+          substeps: [{ title: 'Stage', runbooks: ['runbooks/stage.runbook.md'] }],
+        },
+        { title: 'After', pass: 'COMPLETE', content: 'Wrap up.' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'root.runbook.md'), rootContent);
+
+    // Starting the root auto-launches the inline stage; the stage becomes the
+    // active run and carries inline parent linkage.
+    const start = await runCliInProcess('run runbooks/root.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+    const stage = await getActiveState(workspace);
+    if (!stage) throw new Error('Expected active inline stage');
+    expect(stage.parentLinkage?.kind).toBe('inline');
+
+    const bare = await runCliInProcess(['pass'], workspace);
+    expect(bare.exitCode).not.toBe(0);
+    expect(findErrorEnvelope(bare.stdout)?.code).toBe('ACTOR_CONTEXT_REQUIRED');
+
+    const targeted = await runCliInProcess(['pass', '--run', stage.id], workspace);
+    expect(targeted.exitCode).toBe(0);
+    const after = await getActiveState(workspace);
+    expect(after?.step).toBe('2');
+  });
+
+  it('refuses a well-formed foreign --run id with RUN_TARGET_UNAVAILABLE', async () => {
+    await setupDelegatingParent();
+    const foreign = `rd_${'f'.repeat(32)}`;
+
+    const result = await runCliInProcess(['pass', '--run', foreign], workspace);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(findErrorEnvelope(result.stdout)?.code).toBe('RUN_TARGET_UNAVAILABLE');
+  });
+
+  it('refuses a lingering grandchild bare pass against an inline-composing ROOT after its stage completes (clause f)', async () => {
+    // The #460 pattern one level up: the root composes ONLY inline runbook-list
+    // stages (no DELEGATE in its own document). A stage delegates, its claimed
+    // grandchild lingers after the stage completes and pops — the root must
+    // refuse the grandchild's bare drive.
+    const leafContent = createRunbook({
+      name: 'leaf',
+      title: 'Leaf',
+      steps: [{ title: 'Work', pass: 'COMPLETE', content: 'Leaf prompt.' }],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'leaf.runbook.md'), leafContent);
+    await writeFile(join(workspace.runbooksDir(), 'leaf.runbook.md'), leafContent);
+    const stageContent = createRunbook({
+      name: 'stage',
+      title: 'Stage',
+      steps: [
+        {
+          title: 'Delegate leaf',
+          pass: 'COMPLETE',
+          substeps: [
+            { title: 'Leaf work', delegate: true, runbooks: ['runbooks/leaf.runbook.md'] },
+          ],
+        },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'stage.runbook.md'), stageContent);
+    await writeFile(join(workspace.runbooksDir(), 'stage.runbook.md'), stageContent);
+    const rootContent = createRunbook({
+      title: 'Root',
+      steps: [
+        {
+          title: 'Compose',
+          pass: 'CONTINUE',
+          substeps: [{ title: 'Stage', runbooks: ['runbooks/stage.runbook.md'] }],
+        },
+        { title: 'After', pass: 'COMPLETE', content: 'Wrap up.' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'root.runbook.md'), rootContent);
+
+    // Start the root: the stage auto-launches inline and auto-issues the
+    // delegation token on entering its DELEGATE step.
+    const start = await runCliInProcess('run runbooks/root.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+    const root = parseConcatenatedJson(start.stdout).find(
+      (event): event is { runbookId: string } =>
+        typeof event === 'object' &&
+        event !== null &&
+        (event as { type?: string }).type === 'runbook_started',
+    );
+    if (!root) throw new Error('Expected runbook_started event for the root');
+    const stage = await getActiveState(workspace);
+    if (!stage) throw new Error('Expected active inline stage');
+    const token = findDelegateToken(start.stdout);
+    if (!token) throw new Error('Expected auto-issued delegation token');
+
+    // Claim and close the grandchild leaf.
+    const claimed = await runCliInProcess(['claim', token], workspace);
+    expect(claimed.exitCode).toBe(0);
+    const claimId = String(findActionOutput(claimed.stdout)?.claim_id);
+    const closed = await runCliInProcess(['pass', '--claim-id', claimId], workspace);
+    expect(closed.exitCode).toBe(0);
+
+    // The orchestrator collects the stage; the stage completes and propagates
+    // inline to the root, which advances to step 2.
+    const collected = await runCliInProcess(['collect', '--run', stage.id], workspace);
+    expect(collected.exitCode).toBe(0);
+    const rootAfter = await readRunbookState(workspace, root.runbookId);
+    expect(rootAfter?.step).toBe('2');
+    expect(rootAfter?.lifecycle).toBe('running');
+
+    // Session-management cleanup of the completed stage (prune is the
+    // documented residual ambient lane) leaves the root as the active run.
+    const pruned = await runCliInProcess(['prune'], workspace);
+    expect(pruned.exitCode).toBe(0);
+    const back = await getActiveState(workspace);
+    if (!back) throw new Error('Expected the root to be active after pruning the stage');
+    expect(back.id).toBe(root.runbookId);
+    expect(back.step).toBe('2');
+
+    // The lingering grandchild bare-drives the root — refused (clause f: the
+    // root's inline substep record is sticky; its own document has no DELEGATE).
+    const bare = await runCliInProcess(['pass'], workspace);
+    expect(bare.exitCode).not.toBe(0);
+    expect(findErrorEnvelope(bare.stdout)?.code).toBe('ACTOR_CONTEXT_REQUIRED');
+
+    // The orchestrator lane still works.
+    const targeted = await runCliInProcess(['pass', '--run', back.id], workspace);
+    expect(targeted.exitCode).toBe(0);
+  });
+
+  it('never grants claim-lane authority to --run: a claimed child run id resolves RUN_TARGET_UNAVAILABLE', async () => {
+    await setupDelegatingParent();
+    const parent = await getActiveState(workspace);
+    if (!parent) throw new Error('Expected active parent run');
+
+    const issued = await runCliInProcess(['delegate', '--run', parent.id], workspace);
+    const token = extractToken(issued.stdout);
+    if (!token) throw new Error('Expected delegation token');
+    const claimed = await runCliInProcess(['claim', token], workspace);
+    const claimPayload = findActionOutput(claimed.stdout);
+    const claimId = String(claimPayload?.claim_id);
+    const childRunId = String(claimPayload?.run_id);
+    expect(childRunId).toMatch(/^rd_/);
+
+    // Claimed children are never defaultStack members, so --run can never
+    // substitute for --claim-id (pinning the invariant a future stack refactor
+    // could silently break).
+    const viaRun = await runCliInProcess(['pass', '--run', childRunId], workspace);
+    expect(viaRun.exitCode).not.toBe(0);
+    expect(findErrorEnvelope(viaRun.stdout)?.code).toBe('RUN_TARGET_UNAVAILABLE');
+
+    // The claim lane succeeds.
+    const viaClaim = await runCliInProcess(['pass', '--claim-id', claimId], workspace);
+    expect(viaClaim.exitCode).toBe(0);
+  });
+});

--- a/packages/cli/__tests__/integration/inline-child-launch.test.ts
+++ b/packages/cli/__tests__/integration/inline-child-launch.test.ts
@@ -374,7 +374,7 @@ Child prompt.
     expect(passChild.stdout).toContain('Reviewing');
   });
 
-  it('does not let bare pass skip a recovered unstarted inline child substep', async () => {
+  it('does not let a run-targeted pass skip a recovered unstarted inline child substep', async () => {
     await writeInlineParentAndChild();
 
     const start = await runCliInProcess(
@@ -422,7 +422,7 @@ Child prompt.
     );
   });
 
-  it('does not let bare fail skip a recovered unstarted inline child substep', async () => {
+  it('does not let a run-targeted fail skip a recovered unstarted inline child substep', async () => {
     await writeInlineParentAndChild();
 
     const start = await runCliInProcess(

--- a/packages/cli/__tests__/integration/inline-child-launch.test.ts
+++ b/packages/cli/__tests__/integration/inline-child-launch.test.ts
@@ -9,6 +9,7 @@ import {
   runCliInProcess,
   type TestWorkspace,
   writeSession,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 
 function flattenEvents(events: unknown[]): Record<string, unknown>[] {
@@ -167,7 +168,10 @@ Child prompt.
     const parentRunId = (await readSession(workspace)).active;
     if (!parentRunId) throw new Error('expected active parent runbook');
 
-    const passParentStep = await runCliInProcess('pass', workspace);
+    const passParentStep = await runCliInProcess(
+      await withRunTarget(['pass'], workspace),
+      workspace,
+    );
     const events = flattenEvents(parseConcatenatedJson(passParentStep.stdout));
 
     const inlineStepIndex = events.findIndex(
@@ -240,7 +244,7 @@ Child prompt.
       }),
     );
 
-    const passChild = await runCliInProcess('pass', workspace);
+    const passChild = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
     expect(passChild.exitCode).toBe(0);
     expect(passChild.stdout).toContain('Reviewing');
     expect(passChild.stdout).toContain('/plan.md');
@@ -299,7 +303,10 @@ Child prompt.
     const parentRunId = (await readSession(workspace)).active;
     if (!parentRunId) throw new Error('expected active parent runbook');
 
-    const passParentStep = await runCliInProcess('pass', workspace);
+    const passParentStep = await runCliInProcess(
+      await withRunTarget(['pass'], workspace),
+      workspace,
+    );
     expect(passParentStep.exitCode).toBe(0);
 
     const parentState = await readRunbookState(workspace, parentRunId);
@@ -347,7 +354,7 @@ Child prompt.
       JSON.stringify(mutatedParent, null, 2),
     );
 
-    const recover = await runCliInProcess('goto 2', workspace);
+    const recover = await runCliInProcess(await withRunTarget(['goto', '2'], workspace), workspace);
     expect(recover.exitCode).toBe(0);
     expect((await readSession(workspace)).active).toBe(childRunId);
 
@@ -362,7 +369,7 @@ Child prompt.
     };
     expect(repairedContext.context?.inlineLaunchIntent).toBeUndefined();
 
-    const passChild = await runCliInProcess('pass', workspace);
+    const passChild = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
     expect(passChild.exitCode).toBe(0);
     expect(passChild.stdout).toContain('Reviewing');
   });
@@ -378,7 +385,10 @@ Child prompt.
     const parentRunId = (await readSession(workspace)).active;
     if (!parentRunId) throw new Error('expected active parent runbook');
 
-    const passParentStep = await runCliInProcess('pass', workspace);
+    const passParentStep = await runCliInProcess(
+      await withRunTarget(['pass'], workspace),
+      workspace,
+    );
     expect(passParentStep.exitCode).toBe(0);
 
     const parentState = await readRunbookState(workspace, parentRunId);
@@ -390,7 +400,10 @@ Child prompt.
       defaultStack: [parentRunId],
     });
 
-    const passRecoveredParent = await runCliInProcess('pass', workspace);
+    const passRecoveredParent = await runCliInProcess(
+      await withRunTarget(['pass'], workspace),
+      workspace,
+    );
 
     expect(passRecoveredParent.exitCode).toBe(0);
     expect(passRecoveredParent.stdout).not.toContain('Reviewing');
@@ -420,7 +433,10 @@ Child prompt.
     const parentRunId = (await readSession(workspace)).active;
     if (!parentRunId) throw new Error('expected active parent runbook');
 
-    const passParentStep = await runCliInProcess('pass', workspace);
+    const passParentStep = await runCliInProcess(
+      await withRunTarget(['pass'], workspace),
+      workspace,
+    );
     expect(passParentStep.exitCode).toBe(0);
 
     await writeSession(workspace, {
@@ -428,7 +444,10 @@ Child prompt.
       defaultStack: [parentRunId],
     });
 
-    const failRecoveredParent = await runCliInProcess('fail', workspace);
+    const failRecoveredParent = await runCliInProcess(
+      await withRunTarget(['fail'], workspace),
+      workspace,
+    );
 
     expect(failRecoveredParent.exitCode).toBe(0);
     expect(failRecoveredParent.stdout).not.toContain('Reviewing');
@@ -500,14 +519,17 @@ Child prompt.
     const parentRunId = (await readSession(workspace)).active;
     if (!parentRunId) throw new Error('expected active parent runbook');
 
-    const passParentStep = await runCliInProcess('pass', workspace);
+    const passParentStep = await runCliInProcess(
+      await withRunTarget(['pass'], workspace),
+      workspace,
+    );
     expect(passParentStep.exitCode).toBe(0);
     const childRunId = (await readSession(workspace)).active;
     if (!childRunId || childRunId === parentRunId) {
       throw new Error('expected active inline child runbook');
     }
 
-    const passChild = await runCliInProcess('pass', workspace);
+    const passChild = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
     expect(passChild.exitCode).toBe(0);
 
     const parentState = await readRunbookState(workspace, parentRunId);
@@ -583,7 +605,7 @@ Child prompt.
 
     const start = await runCliInProcess('run --prompted runbooks/parent.runbook.md', workspace);
     expect(start.exitCode).toBe(0);
-    const passStart = await runCliInProcess('pass', workspace);
+    const passStart = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
     expect(passStart.exitCode).toBe(0);
 
     const session = await readSession(workspace);
@@ -592,7 +614,7 @@ Child prompt.
     const childBeforeFail = await readRunbookState(workspace, childRunId!);
     expect(childBeforeFail?.parentLinkage?.kind).toBe('inline');
 
-    const failChild = await runCliInProcess('fail', workspace);
+    const failChild = await runCliInProcess(await withRunTarget(['fail'], workspace), workspace);
     expect(failChild.exitCode).toBe(0);
 
     const parentRunId = childBeforeFail!.parentLinkage!.parentRunId;

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -6,6 +6,7 @@ import {
   getActiveState,
   readRunbookState,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 import { writeFile, readdir, readFile, realpath } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -422,7 +423,9 @@ Check manually.
       result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
       expect(result.exitCode).toBe(0);
 
-      result = await runCliInProcess('fail', workspace);
+      // Post-R1 an inline child is delegation-exposed (clause e): the runner
+      // names the run it drives.
+      result = await runCliInProcess(await withRunTarget(['fail'], workspace), workspace);
       expect(result.exitCode).toBe(0);
 
       const parentAfter = await readRunbookState(workspace, parentRunId);
@@ -856,7 +859,10 @@ Waiting.
     await runCliInProcess('run child-pass-unit-local.runbook.md --step 1.1', workspace);
     const child = await getActiveState(workspace);
 
-    const result = await runCliInProcess('pass', workspace);
+    // Post-R1 an inline child is delegation-exposed (clause e): the runner
+    // names the run it drives; the close still targets only the active inline
+    // unit and the parent advances normally.
+    const result = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
 
     expect(result.exitCode).toBe(0);
     const activeAfter = await getActiveState(workspace);

--- a/packages/cli/__tests__/integration/report-then-collect.test.ts
+++ b/packages/cli/__tests__/integration/report-then-collect.test.ts
@@ -9,6 +9,7 @@ import {
   parseConcatenatedJson,
   runCliInProcess,
   type TestWorkspace,
+  withRunTarget,
 } from '../helpers/test-utils.js';
 
 /**
@@ -84,9 +85,16 @@ describe('report-then-collect (single delegation level)', () => {
     'pass',
     'fail',
     'delegate',
-  ])('refuses bare rd %s while a reported outcome is uncollected', async (intent) => {
+  ])('refuses run-targeted bare-shaped rd %s while a reported outcome is uncollected', async (intent) => {
     await pendingParent();
-    const blocked = await runCliInProcess(intent, workspace); // bare, no --step/--claim-id
+    // Post-R1 a fully bare mutation is refused earlier by the role gate
+    // (ACTOR_CONTEXT_REQUIRED); the collection-pending guard is pinned on the
+    // named-authority form (bare-shaped: no --step/--claim-id).
+    const bare = await runCliInProcess(intent, workspace);
+    expect(bare.exitCode).toBe(1);
+    expect(emittedCodes(bare.stdout)).toContain('ACTOR_CONTEXT_REQUIRED');
+
+    const blocked = await runCliInProcess(await withRunTarget([intent], workspace), workspace);
     expect(blocked.exitCode).toBe(1);
     expect(emittedCodes(blocked.stdout)).toContain('DELEGATION_COLLECTION_PENDING');
   });
@@ -94,10 +102,10 @@ describe('report-then-collect (single delegation level)', () => {
   it('an explicit rd collect releases the pending state and advancing resumes', async () => {
     await pendingParent();
 
-    const collected = await runCliInProcess('collect', workspace);
+    const collected = await runCliInProcess(await withRunTarget(['collect'], workspace), workspace);
     expect(collected.exitCode).toBe(0);
 
-    const advanced = await runCliInProcess('pass', workspace);
+    const advanced = await runCliInProcess(await withRunTarget(['pass'], workspace), workspace);
     expect(advanced.exitCode).toBe(0);
     expect(emittedCodes(advanced.stdout)).not.toContain('DELEGATION_COLLECTION_PENDING');
   }, 30_000);

--- a/packages/cli/src/commands/artifact.ts
+++ b/packages/cli/src/commands/artifact.ts
@@ -50,6 +50,9 @@ async function resolveActiveArtifactState(): Promise<ActiveArtifactState> {
   const active = await resolveCommandTarget(sessionService, { allowStashed: true });
   if (active.kind === 'none') return { kind: 'none' };
   if (active.kind === 'stale_claim') return { kind: 'stale_claim', message: active.message };
+  // `unknown_run` carries no state; artifact never passes a runId, so this is
+  // unreachable today — guard the `.state` narrowing below (never crash).
+  if (active.kind === 'unknown_run') return { kind: 'none' };
   const workPath =
     typeof active.state.templateVars?.WorkPath === 'string'
       ? active.state.templateVars.WorkPath

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -433,11 +433,13 @@ async function runCollect(ctx: TransitionContext, options: CollectOptions): Prom
   const callerEvidence = readLifecycleCallerEvidence(
     ctx.claim
       ? {
-          claimId: ctx.claim.claimId,
-          tokenHash: ctx.claim.tokenHash,
-          controlledRunId: ctx.claim.childRunId,
+          claim: {
+            claimId: ctx.claim.claimId,
+            tokenHash: ctx.claim.tokenHash,
+            controlledRunId: ctx.claim.childRunId,
+          },
         }
-      : undefined,
+      : {},
   );
 
   const collectionService = new RunbookCollectionService({

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -389,9 +389,14 @@ function renderCollectOutcome(
       return true;
     case 'actor_context_required':
       // The merged `actor_context_required` member carries `{ kind; intent }`
-      // and has NO `targetRunId` field — do not read one off `outcome`.
+      // and has NO `targetRunId` field — and the envelope deliberately never
+      // echoes one (accident barrier; run ids are natively available from
+      // `rundown run` output and every event's runbookId).
       output.error(
-        'Actor context is required to collect delegation outcomes.',
+        'This run has delegation activity, so a bare `rundown collect` is refused. ' +
+          'Pass `--run <rd_…>` with the run id from your orchestration context (printed by ' +
+          '`rundown run` and carried as runbookId on every event), or `--claim-id <claimId>` ' +
+          'if you are collecting within delegated work.',
         'ACTOR_CONTEXT_REQUIRED',
       );
       output.flush();

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -73,6 +73,11 @@ export function registerCollectCommand(program: Command): void {
                 output.flush();
                 process.exitCode = 1;
                 return;
+              case 'unknown_run':
+                output.error(contextResult.message, 'RUN_TARGET_UNAVAILABLE');
+                output.flush();
+                process.exitCode = 1;
+                return;
               default: {
                 const _exhaustive: never = contextResult;
                 return _exhaustive;

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -23,6 +23,7 @@ import { buildTransitionContext, type TransitionContext } from '../helpers/trans
 import { resolveIndexOption, IndexOptionError } from '../helpers/index-option.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
 import { parseRunOption } from '../helpers/run-option.js';
+import { renderActorContextRequiredRefusal } from '../helpers/refusal-renderers.js';
 import { extractParentLinkage, propagateChildTerminal } from '../helpers/delegation-completion.js';
 
 /**
@@ -391,14 +392,10 @@ function renderCollectOutcome(
       // The merged `actor_context_required` member carries `{ kind; intent }`
       // and has NO `targetRunId` field — and the envelope deliberately never
       // echoes one (accident barrier; run ids are natively available from
-      // `rundown run` output and every event's runbookId).
-      output.error(
-        'This run has delegation activity, so a bare `rundown collect` is refused. ' +
-          'Pass `--run <rd_…>` with the run id from your orchestration context (printed by ' +
-          '`rundown run` and carried as runbookId on every event), or `--claim-id <claimId>` ' +
-          'if you are collecting within delegated work.',
-        'ACTOR_CONTEXT_REQUIRED',
-      );
+      // `rundown run` output and every event's runbookId). The shared renderer
+      // single-sources the remediation; only the trailing claim-lane verb
+      // differs for collect.
+      renderActorContextRequiredRefusal(output, 'collect', 'collecting within delegated work');
       output.flush();
       return true;
     case 'collect_requires_orchestrator':

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -12,6 +12,7 @@ import {
   type DelegationPolicyOutcome,
   type Frame,
   type FrameKey,
+  type RunId,
 } from '@rundown-org/core';
 import { parseStepIdFromString } from '@rundown-org/parser';
 import { readLifecycleCallerEvidence } from '../helpers/caller-evidence.js';
@@ -21,6 +22,7 @@ import { OutputEmitter } from '../services/output-emitter.js';
 import { buildTransitionContext, type TransitionContext } from '../helpers/transitions.js';
 import { resolveIndexOption, IndexOptionError } from '../helpers/index-option.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
+import { parseRunOption } from '../helpers/run-option.js';
 import { extractParentLinkage, propagateChildTerminal } from '../helpers/delegation-completion.js';
 
 /**
@@ -47,9 +49,16 @@ export function registerCollectCommand(program: Command): void {
     .option('--step <stepId>', 'Target specific DELEGATE step scope (e.g., "1" or "1.2")')
     .option('--index <number>', 'FOR loop iteration to target (requires --step on a FOR step)')
     .option('--claim-id <claimId>', 'Target a claimed delegated child runbook')
+    .option('--run <runId>', 'Name the run you control (explicit orchestrator targeting)')
     .option('--text', 'Output as human-readable text')
     .action(
-      async (options: { step?: string; index?: string; claimId?: string; text?: boolean }) => {
+      async (options: {
+        step?: string;
+        index?: string;
+        claimId?: string;
+        run?: string;
+        text?: boolean;
+      }) => {
         await withErrorHandling(
           async () => {
             const output = new OutputEmitter({ text: options.text, command: 'collect' });
@@ -57,8 +66,11 @@ export function registerCollectCommand(program: Command): void {
 
             const claimTarget = parseClaimIdOption(options.claimId, output);
             if (!claimTarget.ok) return;
+            const runTarget = parseRunOption(options.run, claimTarget.claimId, output);
+            if (!runTarget.ok) return;
             const contextResult = await buildTransitionContext(output, cwd, {
-              claimId: claimTarget.claimId,
+              ...(claimTarget.claimId !== undefined ? { claimId: claimTarget.claimId } : {}),
+              ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
             });
             switch (contextResult.kind) {
               case 'ready':
@@ -89,6 +101,7 @@ export function registerCollectCommand(program: Command): void {
               step: options.step,
               index: options.index,
               text: options.text,
+              ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
             });
 
             if (shouldExitWithError) {
@@ -109,6 +122,8 @@ interface CollectOptions {
   index?: string;
   /** True when `--text` is set (human-readable); false/undefined for JSON. */
   text?: boolean;
+  /** Validated `--run` run id supplying run-controller caller evidence. */
+  runId?: RunId;
 }
 
 /**
@@ -382,11 +397,10 @@ function renderCollectOutcome(
       output.flush();
       return true;
     case 'collect_requires_orchestrator':
-      output.error(
-        'rundown collect requires an actor that controls the target delegating run.',
-        'COLLECT_REQUIRES_ORCHESTRATOR',
-        { targetRunId: outcome.targetRunId },
-      );
+      // Core owns the remediation text (names both --run and --claim-id). The
+      // details deliberately do NOT echo the target run id (decision 4): the
+      // refusal is an accident barrier, not a lookup service.
+      output.error(outcome.message, 'COLLECT_REQUIRES_ORCHESTRATOR');
       output.flush();
       return true;
     case 'collection_failed':
@@ -439,7 +453,9 @@ async function runCollect(ctx: TransitionContext, options: CollectOptions): Prom
             controlledRunId: ctx.claim.childRunId,
           },
         }
-      : {},
+      : options.runId !== undefined
+        ? { runId: options.runId }
+        : {},
   );
 
   const collectionService = new RunbookCollectionService({

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -5,6 +5,7 @@ import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
+import { parseRunOption } from '../helpers/run-option.js';
 import { runSeamTerminal, handleTerminalRecovery } from '../helpers/terminal-command.js';
 
 /**
@@ -32,26 +33,35 @@ export function registerCompleteCommand(program: Command): void {
     .description('Force early completion of current runbook (runbooks auto-complete on final step)')
     .argument('[message]', 'Completion message')
     .option('--claim-id <claimId>', 'Target a claimed delegated child runbook')
+    .option('--run <runId>', 'Name the run you control (explicit orchestrator targeting)')
     .option('--text', 'Output as human-readable text')
-    .action(async (message: string | undefined, options: { claimId?: string; text?: boolean }) => {
-      await withErrorHandling(
-        async () => {
-          const output = new OutputEmitter({ text: options.text, command: 'complete' });
-          const cwd = getCwd();
-          const claimTarget = parseClaimIdOption(options.claimId, output);
-          if (!claimTarget.ok) return;
+    .action(
+      async (
+        message: string | undefined,
+        options: { claimId?: string; run?: string; text?: boolean },
+      ) => {
+        await withErrorHandling(
+          async () => {
+            const output = new OutputEmitter({ text: options.text, command: 'complete' });
+            const cwd = getCwd();
+            const claimTarget = parseClaimIdOption(options.claimId, output);
+            if (!claimTarget.ok) return;
+            const runTarget = parseRunOption(options.run, claimTarget.claimId, output);
+            if (!runTarget.ok) return;
 
-          try {
-            const { exitError } = await runSeamTerminal(output, cwd, 'complete', {
-              ...(claimTarget.claimId ? { claimId: claimTarget.claimId } : {}),
-              ...(message !== undefined ? { message } : {}),
-            });
-            if (exitError) process.exitCode = 1;
-          } catch (error: unknown) {
-            await handleTerminalRecovery('complete', error, output, cwd, claimTarget.claimId);
-          }
-        },
-        { text: options.text },
-      );
-    });
+            try {
+              const { exitError } = await runSeamTerminal(output, cwd, 'complete', {
+                ...(claimTarget.claimId ? { claimId: claimTarget.claimId } : {}),
+                ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
+                ...(message !== undefined ? { message } : {}),
+              });
+              if (exitError) process.exitCode = 1;
+            } catch (error: unknown) {
+              await handleTerminalRecovery('complete', error, output, cwd, claimTarget.claimId);
+            }
+          },
+          { text: options.text },
+        );
+      },
+    );
 }

--- a/packages/cli/src/commands/complete.ts
+++ b/packages/cli/src/commands/complete.ts
@@ -57,7 +57,10 @@ export function registerCompleteCommand(program: Command): void {
               });
               if (exitError) process.exitCode = 1;
             } catch (error: unknown) {
-              await handleTerminalRecovery('complete', error, output, cwd, claimTarget.claimId);
+              await handleTerminalRecovery('complete', error, output, cwd, {
+                ...(claimTarget.claimId ? { claimId: claimTarget.claimId } : {}),
+                ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
+              });
             }
           },
           { text: options.text },

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -34,6 +34,7 @@ import {
 } from '../helpers/option-utils.js';
 import { emitDelegationCollectionPendingError } from '../helpers/transitions.js';
 import { readLifecycleCallerEvidence } from '../helpers/caller-evidence.js';
+import { parseRunOption } from '../helpers/run-option.js';
 import type { TemplateVarValue, RetryLocator } from '@rundown-org/core';
 
 /**
@@ -45,6 +46,7 @@ import type { TemplateVarValue, RetryLocator } from '@rundown-org/core';
 interface DelegateActionOptions {
   step?: string;
   index?: string;
+  run?: string;
   retry?: boolean;
   input: string[];
   inputJson?: string[];
@@ -95,6 +97,7 @@ export function registerDelegateCommand(program: Command): void {
     .option('--step <stepId>', 'Step to delegate (e.g., 1.1 or 1.2.1 for step.iteration.substep)')
     .option('--index <number>', 'FOR loop iteration to target (requires --step)')
     .option('--retry', 'Retry an existing delegation: cancel and re-issue with a fresh token')
+    .option('--run <runId>', 'Name the run you control (explicit orchestrator targeting)')
     .addOption(
       new Option(
         '--input <key=value>',
@@ -159,6 +162,11 @@ export function registerDelegateCommand(program: Command): void {
 
           const cwd = getCwd();
 
+          // Delegate has no claim lane (validated above), so mutual exclusion
+          // is against `undefined`; this validates --run format only.
+          const runTarget = parseRunOption(options.run, undefined, output);
+          if (!runTarget.ok) return;
+
           const manager = new RunbookStateManager(cwd);
           const sessionService = new SessionService(manager);
 
@@ -197,7 +205,10 @@ export function registerDelegateCommand(program: Command): void {
 
             const outcome = await seam.issueDelegation({
               mode: 'retry',
-              callerEvidence: readLifecycleCallerEvidence(),
+              callerEvidence: readLifecycleCallerEvidence(
+                runTarget.runId !== undefined ? { runId: runTarget.runId } : {},
+              ),
+              ...(runTarget.runId !== undefined ? { targetRunId: runTarget.runId } : {}),
               locator,
               // Lazily parse --input* overrides (Category-A flag handling stays in
               // the CLI), deferred by the seam to AFTER the retry target is located
@@ -316,7 +327,10 @@ export function registerDelegateCommand(program: Command): void {
 
           const outcome = await seam.issueDelegation({
             mode: 'fresh',
-            callerEvidence: readLifecycleCallerEvidence(),
+            callerEvidence: readLifecycleCallerEvidence(
+              runTarget.runId !== undefined ? { runId: runTarget.runId } : {},
+            ),
+            ...(runTarget.runId !== undefined ? { targetRunId: runTarget.runId } : {}),
             ...(options.step ? { explicitStep: options.step } : {}),
             ...(explicitIteration !== undefined ? { explicitIteration } : {}),
             ...(runbookArg ? { requestedRunbook: runbookArg } : {}),

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -36,7 +36,7 @@ import { emitDelegationCollectionPendingError } from '../helpers/transitions.js'
 import { readLifecycleCallerEvidence } from '../helpers/caller-evidence.js';
 import { parseRunOption } from '../helpers/run-option.js';
 import { renderActorContextRequiredRefusal } from '../helpers/refusal-renderers.js';
-import type { TemplateVarValue, RetryLocator } from '@rundown-org/core';
+import type { CallerEvidence, RunId, TemplateVarValue, RetryLocator } from '@rundown-org/core';
 
 /**
  * Options accepted by `rd delegate` (covers both fresh-issue and --retry flows).
@@ -55,6 +55,25 @@ interface DelegateActionOptions {
   artifacts?: string[];
   artifactsJson?: string[];
   text?: boolean;
+}
+
+/**
+ * Derive the seam-call fields a validated `--run` id contributes: the typed
+ * caller evidence (run-controller when named, direct-CLI otherwise) and the
+ * explicit `targetRunId`. Single-sourced so the fresh-issue and `--retry`
+ * flows cannot drift on how named authority reaches the seam.
+ *
+ * @param runId - Validated `--run` id, or `undefined` for a bare invocation.
+ * @returns Spreadable `callerEvidence` (+ `targetRunId` when named) fields.
+ */
+function runTargetedSeamFields(runId: RunId | undefined): {
+  readonly callerEvidence: CallerEvidence;
+  readonly targetRunId?: RunId;
+} {
+  return {
+    callerEvidence: readLifecycleCallerEvidence(runId !== undefined ? { runId } : {}),
+    ...(runId !== undefined ? { targetRunId: runId } : {}),
+  };
 }
 
 function pushOptionValues(
@@ -206,10 +225,7 @@ export function registerDelegateCommand(program: Command): void {
 
             const outcome = await seam.issueDelegation({
               mode: 'retry',
-              callerEvidence: readLifecycleCallerEvidence(
-                runTarget.runId !== undefined ? { runId: runTarget.runId } : {},
-              ),
-              ...(runTarget.runId !== undefined ? { targetRunId: runTarget.runId } : {}),
+              ...runTargetedSeamFields(runTarget.runId),
               locator,
               // Lazily parse --input* overrides (Category-A flag handling stays in
               // the CLI), deferred by the seam to AFTER the retry target is located
@@ -246,11 +262,15 @@ export function registerDelegateCommand(program: Command): void {
                 // the active substep in resolveRetryLocator with its own message).
                 failRetry(output, '--retry requires an active runbook', 'NO_ACTIVE_RUNBOOK');
                 break;
-              case 'unknown-run':
-                output.error(
-                  `Run ${outcome.runId} is not part of this session's active stack.`,
-                  'RUN_TARGET_UNAVAILABLE',
-                );
+              case 'unknown_run':
+                // Core owns the cause-specific message (shared with pass/complete).
+                output.error(outcome.message, 'RUN_TARGET_UNAVAILABLE');
+                process.exitCode = 1;
+                break;
+              case 'run_target_mismatch':
+                // Fail-closed: `--run` named a run that does not own the retry
+                // token. Core owns the message (no owning-run-id echo).
+                output.error(outcome.message, 'RUN_TARGET_MISMATCH');
                 process.exitCode = 1;
                 break;
               case 'refused':
@@ -333,10 +353,7 @@ export function registerDelegateCommand(program: Command): void {
 
           const outcome = await seam.issueDelegation({
             mode: 'fresh',
-            callerEvidence: readLifecycleCallerEvidence(
-              runTarget.runId !== undefined ? { runId: runTarget.runId } : {},
-            ),
-            ...(runTarget.runId !== undefined ? { targetRunId: runTarget.runId } : {}),
+            ...runTargetedSeamFields(runTarget.runId),
             ...(options.step ? { explicitStep: options.step } : {}),
             ...(explicitIteration !== undefined ? { explicitIteration } : {}),
             ...(runbookArg ? { requestedRunbook: runbookArg } : {}),
@@ -352,11 +369,9 @@ export function registerDelegateCommand(program: Command): void {
             case 'no-active-runbook':
               output.noActiveRunbook('delegate');
               break;
-            case 'unknown-run':
-              output.error(
-                `Run ${outcome.runId} is not part of this session's active stack.`,
-                'RUN_TARGET_UNAVAILABLE',
-              );
+            case 'unknown_run':
+              // Core owns the cause-specific message (shared with pass/complete).
+              output.error(outcome.message, 'RUN_TARGET_UNAVAILABLE');
               process.exitCode = 1;
               break;
             case 'refused':
@@ -411,6 +426,7 @@ export function registerDelegateCommand(program: Command): void {
               break;
             case 'retried':
             case 'token-not-found':
+            case 'run_target_mismatch':
               // Retry-only outcomes; unreachable on the fresh-issue path.
               throw new Error(`Unexpected fresh delegate outcome: ${outcome.kind}`);
             default: {

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -234,6 +234,13 @@ export function registerDelegateCommand(program: Command): void {
                 // the active substep in resolveRetryLocator with its own message).
                 failRetry(output, '--retry requires an active runbook', 'NO_ACTIVE_RUNBOOK');
                 break;
+              case 'unknown-run':
+                output.error(
+                  `Run ${outcome.runId} is not part of this session's active stack.`,
+                  'RUN_TARGET_UNAVAILABLE',
+                );
+                process.exitCode = 1;
+                break;
               case 'refused':
                 if (outcome.policy.kind === 'delegation_collection_pending') {
                   emitDelegationCollectionPendingError(
@@ -324,6 +331,13 @@ export function registerDelegateCommand(program: Command): void {
           switch (outcome.kind) {
             case 'no-active-runbook':
               output.noActiveRunbook('delegate');
+              break;
+            case 'unknown-run':
+              output.error(
+                `Run ${outcome.runId} is not part of this session's active stack.`,
+                'RUN_TARGET_UNAVAILABLE',
+              );
+              process.exitCode = 1;
               break;
             case 'refused':
               if (outcome.policy.kind === 'delegation_collection_pending') {

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -35,6 +35,7 @@ import {
 import { emitDelegationCollectionPendingError } from '../helpers/transitions.js';
 import { readLifecycleCallerEvidence } from '../helpers/caller-evidence.js';
 import { parseRunOption } from '../helpers/run-option.js';
+import { renderActorContextRequiredRefusal } from '../helpers/refusal-renderers.js';
 import type { TemplateVarValue, RetryLocator } from '@rundown-org/core';
 
 /**
@@ -262,6 +263,11 @@ export function registerDelegateCommand(program: Command): void {
                     outcome.policy.message,
                   );
                   process.exitCode = 1;
+                } else if (outcome.policy.kind === 'actor_context_required') {
+                  // Post-flip: a bare retry on a delegation-exposed run needs
+                  // named authority (--run). No run-id echo (decision 4).
+                  renderActorContextRequiredRefusal(output, 'delegate');
+                  process.exitCode = 1;
                 } else {
                   throw new Error(`Unexpected delegate policy outcome: ${outcome.policy.kind}`);
                 }
@@ -362,6 +368,11 @@ export function registerDelegateCommand(program: Command): void {
                   outcome.policy.outcomeCompletionKeys,
                   outcome.policy.message,
                 );
+                process.exitCode = 1;
+              } else if (outcome.policy.kind === 'actor_context_required') {
+                // Post-flip: a bare delegate on a delegation-exposed run needs
+                // named authority (--run). No run-id echo (decision 4).
+                renderActorContextRequiredRefusal(output, 'delegate');
                 process.exitCode = 1;
               } else {
                 throw new Error(`Unexpected delegate policy outcome: ${outcome.policy.kind}`);

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -43,6 +43,11 @@ export function registerGotoCommand(program: Command): void {
                 output.flush();
                 process.exitCode = 1;
                 return;
+              case 'unknown_run':
+                output.error(contextResult.message, 'RUN_TARGET_UNAVAILABLE');
+                output.flush();
+                process.exitCode = 1;
+                return;
               default: {
                 const _exhaustive: never = contextResult;
                 return _exhaustive;

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -6,6 +6,8 @@ import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { buildGotoContext, validateGotoTarget, executeGoto } from '../helpers/goto-workflow.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
+import { parseRunOption } from '../helpers/run-option.js';
+import { renderActorContextRequiredRefusal } from '../helpers/refusal-renderers.js';
 
 /**
  * Registers the 'goto' command for jumping to specific steps.
@@ -17,9 +19,13 @@ export function registerGotoCommand(program: Command): void {
     .description('Jump to specific step (e.g., "3" or "3.1" for substep)')
     .option('--index <number>', 'FOR loop iteration to target')
     .option('--claim-id <claimId>', 'Target a claimed delegated child runbook')
+    .option('--run <runId>', 'Name the run you control (explicit orchestrator targeting)')
     .option('--text', 'Output as human-readable text')
     .action(
-      async (stepArg: string, options: { index?: string; claimId?: string; text?: boolean }) => {
+      async (
+        stepArg: string,
+        options: { index?: string; claimId?: string; run?: string; text?: boolean },
+      ) => {
         await withErrorHandling(
           async () => {
             const output = new OutputEmitter({ text: options.text, command: 'goto' });
@@ -27,8 +33,11 @@ export function registerGotoCommand(program: Command): void {
 
             const claimTarget = parseClaimIdOption(options.claimId, output);
             if (!claimTarget.ok) return;
+            const runTarget = parseRunOption(options.run, claimTarget.claimId, output);
+            if (!runTarget.ok) return;
             const contextResult = await buildGotoContext(output, cwd, {
-              claimId: claimTarget.claimId,
+              ...(claimTarget.claimId !== undefined ? { claimId: claimTarget.claimId } : {}),
+              ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
             });
             switch (contextResult.kind) {
               case 'ready':
@@ -45,6 +54,11 @@ export function registerGotoCommand(program: Command): void {
                 return;
               case 'unknown_run':
                 output.error(contextResult.message, 'RUN_TARGET_UNAVAILABLE');
+                output.flush();
+                process.exitCode = 1;
+                return;
+              case 'actor_context_required':
+                renderActorContextRequiredRefusal(output, 'goto', contextResult.targetRunId);
                 output.flush();
                 process.exitCode = 1;
                 return;

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -58,7 +58,7 @@ export function registerGotoCommand(program: Command): void {
                 process.exitCode = 1;
                 return;
               case 'actor_context_required':
-                renderActorContextRequiredRefusal(output, 'goto', contextResult.targetRunId);
+                renderActorContextRequiredRefusal(output, 'goto');
                 output.flush();
                 process.exitCode = 1;
                 return;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -8,6 +8,7 @@ import {
   DelegationLock,
   RunbookSyntaxError,
   RundownError,
+  classifyDelegationExposure,
   isNodeError,
   getErrorMessage,
   deriveActiveFrame,
@@ -282,6 +283,7 @@ export function registerRunCommand(program: Command): void {
                 output.flush();
                 process.exit(1);
               }
+              const gotoSteps = [...getRunbookFromState(gotoState, cwd)];
               const gotoCtx = {
                 output,
                 manager,
@@ -289,12 +291,19 @@ export function registerRunCommand(program: Command): void {
                 sessionService,
                 lifecycleService,
                 state: gotoState,
-                steps: [...getRunbookFromState(gotoState, cwd)],
+                steps: gotoSteps,
                 cwd,
                 terminalReleaseMode: await resolveTerminalReleaseModeForRunbook(
                   manager,
                   gotoState.id,
                 ),
+                // In-session `run --prompted --step` jump: same exposure input
+                // the goto context carries (event-time read, never persisted).
+                exposure: classifyDelegationExposure({
+                  state: gotoState,
+                  steps: gotoSteps,
+                  openClaims: await sessionService.listOpenClaimsForParent(gotoState.id),
+                }),
               };
 
               const validation = validateGotoTarget(options.step, gotoCtx.steps, options.index);

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -8,7 +8,6 @@ import {
   DelegationLock,
   RunbookSyntaxError,
   RundownError,
-  classifyDelegationExposure,
   isNodeError,
   getErrorMessage,
   deriveActiveFrame,
@@ -297,13 +296,6 @@ export function registerRunCommand(program: Command): void {
                   manager,
                   gotoState.id,
                 ),
-                // In-session `run --prompted --step` jump: same exposure input
-                // the goto context carries (event-time read, never persisted).
-                exposure: classifyDelegationExposure({
-                  state: gotoState,
-                  steps: gotoSteps,
-                  openClaims: await sessionService.listOpenClaimsForParent(gotoState.id),
-                }),
               };
 
               const validation = validateGotoTarget(options.step, gotoCtx.steps, options.index);

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -274,7 +274,24 @@ export function registerRunCommand(program: Command): void {
               }
             }
 
-            // If --step provided with --prompted and runbook is waiting, jump to the step
+            // If --step provided with --prompted and runbook is waiting, jump to the step.
+            //
+            // Deliberate run-navigation gate bypass, bounded by construction:
+            // unlike standalone `goto` (buildGotoContext → resolveCommandIntent
+            // with the run-navigation intent), this jump never consults the
+            // policy gate. It cannot reach a pre-existing run — result.stateId
+            // is the id startRunbook just minted via manager.create in this
+            // same invocation, never a session-stack or --run resolution — and
+            // the creator holding that in-process id has exactly the authority
+            // the gate grants `goto --run <own-id>`: run_controller evidence
+            // maps to trusted run controller regardless of exposure
+            // (actorContextFromEvidence). Gating here would refuse
+            // `run --prompted --step` on any document that authors a DELEGATE
+            // substep (delegating-from-birth static exposure) while the
+            // equivalent `goto --run <fresh-id>` succeeds — a refusal with no
+            // security content. Pinned by "run --prompted --step jumps a
+            // freshly created delegating-document run" in
+            // explicit-run-targeting.test.ts.
             if (options.step && options.prompted && result.loopResult === 'waiting') {
               const gotoState = await manager.load(result.stateId);
               if (!gotoState) {

--- a/packages/cli/src/commands/stash.ts
+++ b/packages/cli/src/commands/stash.ts
@@ -34,6 +34,9 @@ export function registerStashCommand(program: Command): void {
           switch (active.kind) {
             case 'claim':
             case 'default':
+            // `run` carries state like `default`; stash never passes a runId,
+            // so this arm is unreachable today (compile-level exhaustiveness).
+            case 'run':
               break;
             case 'none':
               output.noActiveRunbook();
@@ -42,6 +45,11 @@ export function registerStashCommand(program: Command): void {
             case 'stale_claim':
             case 'terminal_claim':
               output.error(active.message, 'CLAIMED_RUNBOOK_UNAVAILABLE');
+              output.flush();
+              process.exitCode = 1;
+              return;
+            case 'unknown_run':
+              output.error(active.message, 'RUN_TARGET_UNAVAILABLE');
               output.flush();
               process.exitCode = 1;
               return;

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -55,6 +55,9 @@ export function registerStatusCommand(program: Command): void {
           switch (active.kind) {
             case 'claim':
             case 'default':
+            // `run` carries state like `default`; status never passes a runId,
+            // so this arm is unreachable today (compile-level exhaustiveness).
+            case 'run':
               output.detail(
                 buildActiveStatus(
                   active.state,
@@ -84,6 +87,11 @@ export function registerStatusCommand(program: Command): void {
               break;
             case 'stale_claim':
               output.error(active.message, 'CLAIMED_RUNBOOK_UNAVAILABLE');
+              output.flush();
+              process.exitCode = 1;
+              return;
+            case 'unknown_run':
+              output.error(active.message, 'RUN_TARGET_UNAVAILABLE');
               output.flush();
               process.exitCode = 1;
               return;

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -50,7 +50,10 @@ export function registerStopCommand(program: Command): void {
               });
               if (exitError) process.exitCode = 1;
             } catch (error: unknown) {
-              await handleTerminalRecovery('stop', error, output, cwd, claimTarget.claimId);
+              await handleTerminalRecovery('stop', error, output, cwd, {
+                ...(claimTarget.claimId ? { claimId: claimTarget.claimId } : {}),
+                ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
+              });
             }
           },
           { text: options.text },

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -5,6 +5,7 @@ import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
+import { parseRunOption } from '../helpers/run-option.js';
 import { runSeamTerminal, handleTerminalRecovery } from '../helpers/terminal-command.js';
 
 /**
@@ -25,26 +26,35 @@ export function registerStopCommand(program: Command): void {
     .description('Abort current runbook')
     .argument('[message]', 'Stop message')
     .option('--claim-id <claimId>', 'Target a claimed delegated child runbook')
+    .option('--run <runId>', 'Name the run you control (explicit orchestrator targeting)')
     .option('--text', 'Output as human-readable text')
-    .action(async (message: string | undefined, options: { claimId?: string; text?: boolean }) => {
-      await withErrorHandling(
-        async () => {
-          const output = new OutputEmitter({ text: options.text, command: 'stop' });
-          const cwd = getCwd();
-          const claimTarget = parseClaimIdOption(options.claimId, output);
-          if (!claimTarget.ok) return;
+    .action(
+      async (
+        message: string | undefined,
+        options: { claimId?: string; run?: string; text?: boolean },
+      ) => {
+        await withErrorHandling(
+          async () => {
+            const output = new OutputEmitter({ text: options.text, command: 'stop' });
+            const cwd = getCwd();
+            const claimTarget = parseClaimIdOption(options.claimId, output);
+            if (!claimTarget.ok) return;
+            const runTarget = parseRunOption(options.run, claimTarget.claimId, output);
+            if (!runTarget.ok) return;
 
-          try {
-            const { exitError } = await runSeamTerminal(output, cwd, 'stop', {
-              ...(claimTarget.claimId ? { claimId: claimTarget.claimId } : {}),
-              ...(message !== undefined ? { message } : {}),
-            });
-            if (exitError) process.exitCode = 1;
-          } catch (error: unknown) {
-            await handleTerminalRecovery('stop', error, output, cwd, claimTarget.claimId);
-          }
-        },
-        { text: options.text },
-      );
-    });
+            try {
+              const { exitError } = await runSeamTerminal(output, cwd, 'stop', {
+                ...(claimTarget.claimId ? { claimId: claimTarget.claimId } : {}),
+                ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
+                ...(message !== undefined ? { message } : {}),
+              });
+              if (exitError) process.exitCode = 1;
+            } catch (error: unknown) {
+              await handleTerminalRecovery('stop', error, output, cwd, claimTarget.claimId);
+            }
+          },
+          { text: options.text },
+        );
+      },
+    );
 }

--- a/packages/cli/src/helpers/caller-evidence.ts
+++ b/packages/cli/src/helpers/caller-evidence.ts
@@ -1,6 +1,6 @@
 // packages/cli/src/helpers/caller-evidence.ts
 
-import type { CallerEvidence } from '@rundown-org/core';
+import type { CallerEvidence, RunId } from '@rundown-org/core';
 
 /**
  * Claim evidence reconstructed CLI-side from a resolved `--claim-id` record.
@@ -10,14 +10,28 @@ import type { CallerEvidence } from '@rundown-org/core';
  */
 export type ResolvedClaimEvidence = Omit<Extract<CallerEvidence, { kind: 'claim' }>, 'kind'>;
 
+/** Inputs for gathering direct-CLI lifecycle caller evidence. */
+export interface LifecycleEvidenceInput {
+  /** Resolved claim evidence when the command targets a claimed child via `--claim-id`. */
+  readonly claim?: ResolvedClaimEvidence;
+  /** Caller-named run authority from a validated `--run` flag. */
+  readonly runId?: RunId;
+}
+
 /**
  * Gather the typed caller evidence for a direct-CLI lifecycle command.
  *
- * The CLI is the trusted direct lane: a genuine direct-CLI invocation maps to
- * `{ kind: 'direct_cli' }`, which core resolves to a trusted run controller over
- * the active run. A `--claim-id` invocation instead carries claim evidence
- * (`claimId`, `tokenHash`, `controlledRunId`) reconstructed from the resolved
- * claim record, which core maps to a claim controller over the controlled run.
+ * Three lanes, in precedence order (exclusivity of `--run` / `--claim-id` is
+ * enforced upstream by `parseRunOption`, so at most one input is present):
+ *
+ * 1. **Claim** — a `--claim-id` invocation carries claim evidence (`claimId`,
+ *    `tokenHash`, `controlledRunId`) reconstructed from the resolved claim
+ *    record, which core maps to a claim controller over the controlled run.
+ * 2. **Run controller** — a `--run <rd_…>` invocation names the run the caller
+ *    claims authority over; core maps it to a trusted controller of exactly
+ *    that named run (`deriveEffectiveRole` refuses an id/target mismatch).
+ * 3. **Direct CLI** — a bare invocation maps to `{ kind: 'direct_cli' }`; core
+ *    decides whether that grants anything for the resolved target.
  *
  * The CLI process cannot itself distinguish a human invocation from a
  * subprocess-spawned one, so it does not try to: subprocess front ends (plugin /
@@ -25,13 +39,15 @@ export type ResolvedClaimEvidence = Omit<Extract<CallerEvidence, { kind: 'claim'
  * `@rundown-org/core` `bareRoleSpecificMutation`), leaving the CLI free to treat
  * its own bare invocation as direct-CLI. No source label is read or trusted.
  *
- * @param claim - Resolved claim evidence when the command targets a claimed
- *   child via `--claim-id`; omit for a bare direct-CLI invocation.
+ * @param input - Optional claim evidence and/or validated `--run` run id.
  * @returns Typed caller evidence for the core lifecycle command seam.
  */
-export function readLifecycleCallerEvidence(claim?: ResolvedClaimEvidence): CallerEvidence {
-  if (claim) {
-    return { kind: 'claim', ...claim };
+export function readLifecycleCallerEvidence(input: LifecycleEvidenceInput = {}): CallerEvidence {
+  if (input.claim) {
+    return { kind: 'claim', ...input.claim };
+  }
+  if (input.runId !== undefined) {
+    return { kind: 'run_controller', runId: input.runId };
   }
   return { kind: 'direct_cli' };
 }

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -720,6 +720,7 @@ async function runCommandWithTee(
  * @param transitions - Array to push extracted transitions into
  * @param tokens - Array to push captured delegation tokens into
  * @param claimIds - Array to push captured claim ids into
+ * @param runIds - Array to push captured run ids into (for `${RUN_ID}` substitution)
  * @param errors - Array to push captured JSON error responses into
  * @param warnings - Array to push captured JSON warning responses into
  * @param artifactEntries - Array to push captured artifact working sets into

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -562,6 +562,49 @@ export function substituteClaimIds(command: string, capturedClaimIds: readonly s
 }
 
 /**
+ * Substitute captured run id placeholders in a command string.
+ *
+ * `${RUN_ID}` maps to the first captured run id, `${RUN_ID_2}` maps to the
+ * second, and so on. Run ids are captured in emission order from
+ * `runbook_started` events (`runbookId`), so a scenario's own `rd run` start
+ * output supplies `${RUN_ID}` and later starts (inline children, claimed
+ * children) supply the higher indexes. Lets bundled scenario runbooks express
+ * orchestrator commands as `rd collect --run ${RUN_ID}` (post-R1 named
+ * authority). Mirrors {@link substituteClaimIds}.
+ *
+ * @param command - Command string with optional run id placeholders
+ * @param capturedRunIds - Run ids captured from earlier `runbook_started` events
+ * @returns Command string with run id placeholders substituted
+ * @throws {Error} If a placeholder references a run id that has not been captured
+ */
+export function substituteRunIds(command: string, capturedRunIds: readonly string[]): string {
+  return command.replace(/\$\{RUN_ID(?:_(\d+))?\}/g, (_match, index: string | undefined) => {
+    const offset = index === undefined ? 0 : Number(index) - 1;
+    if (offset < 0 || offset >= capturedRunIds.length) {
+      throw new Error(`Missing captured run id for \${RUN_ID${index ? `_${index}` : ''}}`);
+    }
+    return capturedRunIds[offset];
+  });
+}
+
+/**
+ * Capture a run id from a parsed `runbook_started` execution event.
+ *
+ * @param value - Parsed JSON value to inspect
+ * @param capturedRunIds - Array to append captured run ids into
+ */
+export function captureRunIdFromJsonObject(value: unknown, capturedRunIds: string[]): void {
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    (value as { type?: unknown }).type === 'runbook_started' &&
+    typeof (value as { runbookId?: unknown }).runbookId === 'string'
+  ) {
+    capturedRunIds.push((value as { runbookId: string }).runbookId);
+  }
+}
+
+/**
  * Capture a claim id from a parsed `rd claim` JSON object.
  *
  * @param value - Parsed JSON value to inspect
@@ -688,6 +731,7 @@ function processJsonObject(
   transitions: CapturedTransition[],
   tokens: string[],
   claimIds: string[],
+  runIds: string[],
   errors: CapturedError[],
   warnings: CapturedWarning[],
   artifactEntries: CapturedArtifactEntry[],
@@ -725,6 +769,7 @@ function processJsonObject(
     tokens.push(obj.token);
   }
   captureClaimIdFromJsonObject(obj, claimIds);
+  captureRunIdFromJsonObject(obj, runIds);
 
   if (obj.kind === 'error') {
     errors.push({
@@ -847,6 +892,7 @@ export function parseJsonLines(stdout: string): {
   terminal: 'COMPLETE' | 'STOP' | null;
   tokens: string[];
   claimIds: string[];
+  runIds: string[];
   errors: CapturedError[];
   warnings: CapturedWarning[];
   artifactEntries: CapturedArtifactEntry[];
@@ -855,6 +901,7 @@ export function parseJsonLines(stdout: string): {
   const transitions: CapturedTransition[] = [];
   const tokens: string[] = [];
   const claimIds: string[] = [];
+  const runIds: string[] = [];
   const errors: CapturedError[] = [];
   const warnings: CapturedWarning[] = [];
   const artifactEntries: CapturedArtifactEntry[] = [];
@@ -866,6 +913,7 @@ export function parseJsonLines(stdout: string): {
       terminal: null,
       tokens,
       claimIds,
+      runIds,
       errors,
       warnings,
       artifactEntries,
@@ -886,6 +934,7 @@ export function parseJsonLines(stdout: string): {
       transitions,
       tokens,
       claimIds,
+      runIds,
       errors,
       warnings,
       artifactEntries,
@@ -896,6 +945,7 @@ export function parseJsonLines(stdout: string): {
       terminal,
       tokens,
       claimIds,
+      runIds,
       errors,
       warnings,
       artifactEntries,
@@ -920,6 +970,7 @@ export function parseJsonLines(stdout: string): {
       transitions,
       tokens,
       claimIds,
+      runIds,
       errors,
       warnings,
       artifactEntries,
@@ -935,6 +986,7 @@ export function parseJsonLines(stdout: string): {
     terminal,
     tokens,
     claimIds,
+    runIds,
     errors,
     warnings,
     artifactEntries,
@@ -1411,6 +1463,7 @@ export function extractInputFileReferences(commands: string[]): string[] {
  * @param into.transitions - Step transitions accumulator
  * @param into.capturedTokens - Captured delegation tokens accumulator
  * @param into.capturedClaimIds - Captured claim IDs accumulator
+ * @param into.capturedRunIds - Captured run ids accumulator (runbook_started events)
  * @param into.errors - Captured JSON error responses accumulator
  * @param into.warnings - Captured JSON warning responses accumulator
  * @param into.artifactEntries - Captured artifact working-set accumulator
@@ -1423,6 +1476,7 @@ function aggregateJsonResult(
     transitions: CapturedTransition[];
     capturedTokens: string[];
     capturedClaimIds: string[];
+    capturedRunIds: string[];
     errors: CapturedError[];
     warnings: CapturedWarning[];
     artifactEntries: CapturedArtifactEntry[];
@@ -1437,6 +1491,9 @@ function aggregateJsonResult(
   }
   for (const claimId of jsonResult.claimIds) {
     into.capturedClaimIds.push(claimId);
+  }
+  for (const runId of jsonResult.runIds) {
+    into.capturedRunIds.push(runId);
   }
   for (const error of jsonResult.errors) {
     into.errors.push(error);
@@ -1472,6 +1529,7 @@ export async function executeCommandSequence(
 ): Promise<CommandSequenceResult> {
   const capturedTokens: string[] = [];
   const capturedClaimIds: string[] = [];
+  const capturedRunIds: string[] = [];
   const errors: CapturedError[] = [];
   const warnings: CapturedWarning[] = [];
   const transitions: CapturedTransition[] = [];
@@ -1505,10 +1563,11 @@ export async function executeCommandSequence(
     const trimmedRaw = rawCmd.trimStart();
     const expectsFailure = trimmedRaw.startsWith('! ');
     const commandText = expectsFailure ? trimmedRaw.slice(2).trimStart() : rawCmd;
-    // Token substitution — replace ${TOKEN}, ${TOKEN_2}, etc. with captured values
-    const tokenSubstituted = substituteClaimIds(
-      substituteTokens(commandText, capturedTokens),
-      capturedClaimIds,
+    // Token substitution — replace ${TOKEN}, ${CLAIM_ID}, ${RUN_ID} (and their
+    // _N indexed forms) with captured values.
+    const tokenSubstituted = substituteRunIds(
+      substituteClaimIds(substituteTokens(commandText, capturedTokens), capturedClaimIds),
+      capturedRunIds,
     );
     // Post-run artifact capture — resolve ${CAPTURE_ARTIFACT[_ARRAY]:<key>} from
     // the manifest a prior command produced (resolver injected by the harness).
@@ -1557,6 +1616,7 @@ export async function executeCommandSequence(
         transitions,
         capturedTokens,
         capturedClaimIds,
+        capturedRunIds,
         errors,
         warnings,
         artifactEntries,
@@ -1592,6 +1652,7 @@ export async function executeCommandSequence(
         transitions,
         capturedTokens,
         capturedClaimIds,
+        capturedRunIds,
         errors,
         warnings,
         artifactEntries,

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -69,7 +69,10 @@ export type GotoExecutionResult =
 /** Result of resolving the runbook target and building goto execution context. */
 export type BuildGotoContextResult =
   | { readonly kind: 'ready'; readonly ctx: GotoContext }
-  | Extract<CommandTargetResolution, { kind: 'none' | 'stale_claim' | 'terminal_claim' }>;
+  | Extract<
+      CommandTargetResolution,
+      { kind: 'none' | 'stale_claim' | 'terminal_claim' | 'unknown_run' }
+    >;
 
 /**
  * Resolve how terminal execution should remove a specific runbook from session targeting.
@@ -117,10 +120,14 @@ export async function buildGotoContext(
   switch (active.kind) {
     case 'claim':
     case 'default':
+    // Explicit `--run` target: behaves like `default` with the named state in
+    // hand (Task 3 mechanical arm; flag registration lands in Task 6).
+    case 'run':
       break;
     case 'none':
     case 'stale_claim':
     case 'terminal_claim':
+    case 'unknown_run':
       return active;
     default: {
       const _exhaustive: never = active;

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -9,18 +9,13 @@
  */
 
 import {
-  RunbookStateManager,
-  type RunbookActorService,
-  SessionService,
-  actorContextFromEvidence,
-  classifyDelegationExposure,
   parseStepIdFromString,
   stepIdToString,
   deriveGotoActionBlock,
-  resolveCommandTarget,
-  resolveCommandIntent,
-  type CommandTargetResolution,
-  type DelegationExposure,
+  type RunbookStateManager,
+  type RunbookActorService,
+  type SessionService,
+  type LifecycleNavigationOutcome,
   type ResolvedStep,
   type StepId,
   type RunbookState,
@@ -32,7 +27,7 @@ import { createCliRunbookActorService } from './actor-service-factory.js';
 import type { OutputEmitter } from '../services/output-emitter.js';
 import { createBridgedEmitter } from './execution-emitter.js';
 import { resolveIndexOption, IndexOptionError } from './index-option.js';
-import { getRunbookFromState } from './runbook-loader.js';
+import { buildNonDelegatingLifecycleSeam } from './lifecycle-seam-factory.js';
 import { readLifecycleCallerEvidence } from './caller-evidence.js';
 
 /**
@@ -55,13 +50,6 @@ export interface GotoContext {
   cwd: string;
   /** How terminal follow-on execution should release this runbook from session targeting. */
   terminalReleaseMode: ExecutionTerminalReleaseMode;
-  /**
-   * Delegation exposure of the resolved run, computed at context-build time.
-   * Held here for the trust-mapping call: the evidence mapping consumes it
-   * once `actorContextFromEvidence` becomes exposure-aware; until then it has
-   * no consumer beyond the run-navigation policy dispatch.
-   */
-  exposure: DelegationExposure;
 }
 
 /**
@@ -78,21 +66,18 @@ export type GotoExecutionResult =
   | { ok: true; loopResult: 'done' | 'stopped' | 'waiting' }
   | { ok: false; error: string; code: string };
 
-/** Result of resolving the runbook target and building goto execution context. */
+/**
+ * Result of resolving the runbook target and building goto execution context.
+ *
+ * The refusal members are exactly the core navigation seam's refusing
+ * outcomes (derived via `Exclude` so a new core refusal is a compile error in
+ * the goto command's exhaustive switch rather than a silent fall-through).
+ * `actor_context_required` deliberately carries no run id (accident barrier —
+ * the refusal must not hand a lingering child the id it needs to bypass it).
+ */
 export type BuildGotoContextResult =
   | { readonly kind: 'ready'; readonly ctx: GotoContext }
-  | Extract<
-      CommandTargetResolution,
-      { kind: 'none' | 'stale_claim' | 'terminal_claim' | 'unknown_run' }
-    >
-  | {
-      /**
-       * The run-navigation policy gate refused the caller's evidence.
-       * Deliberately carries no run id (accident barrier — the refusal must
-       * not hand a lingering child the id it needs to bypass it).
-       */
-      readonly kind: 'actor_context_required';
-    };
+  | Exclude<LifecycleNavigationOutcome, { kind: 'allowed' }>;
 
 /**
  * Resolve how terminal execution should remove a specific runbook from session targeting.
@@ -117,7 +102,11 @@ export async function resolveTerminalReleaseModeForRunbook(
 /**
  * Build context for goto command execution.
  *
- * Resolves active state, loads runbook steps, and creates required services.
+ * Dispatches target resolution and the run-navigation policy gate into the
+ * core lifecycle seam (`resolveRunNavigation`) — exactly as pass/fail dispatch
+ * into `runTransition` — and keeps only Category-A work here: typed caller
+ * evidence from the parsed flags, and assembling the execution context from
+ * the seam's `allowed` outcome.
  *
  * @param output - Output emitter for CLI output
  * @param cwd - Current working directory
@@ -138,71 +127,22 @@ export async function buildGotoContext(
   cwd: string,
   options: { readonly claimId?: ClaimId; readonly runId?: RunId } = {},
 ): Promise<BuildGotoContextResult> {
-  const manager = new RunbookStateManager(cwd);
-  const sessionService = new SessionService(manager);
-  const active = await resolveCommandTarget(sessionService, options);
+  const { manager, sessionService, seam } = buildNonDelegatingLifecycleSeam(cwd);
 
-  switch (active.kind) {
-    case 'claim':
-    case 'default':
-    // Explicit `--run` target: behaves like `default` with the named state in
-    // hand; the flag itself is parsed by the goto command (`parseRunOption`).
-    case 'run':
-      break;
-    case 'none':
-    case 'stale_claim':
-    case 'terminal_claim':
-    case 'unknown_run':
-      return active;
-    default: {
-      const _exhaustive: never = active;
-      return _exhaustive;
-    }
-  }
-
-  const state = active.state;
-  const terminalReleaseMode: ExecutionTerminalReleaseMode =
-    active.kind === 'claim' ? 'release-runbook' : 'stack-pop';
-  const readonlySteps = getRunbookFromState(state, cwd);
-  const steps = [...readonlySteps];
-  const actorService = createCliRunbookActorService(manager);
-
-  // Compute the resolved run's delegation exposure: consumed by the
-  // exposure-aware evidence mapping below and held on the goto context.
-  const openClaims = await sessionService.listOpenClaimsForParent(state.id);
-  const exposure = classifyDelegationExposure({ state, steps, openClaims });
-
-  // Run-navigation policy gate: goto is role-gated like an advance (unknown
-  // callers are refused) but exempt from the collection-pending / open-claims
-  // guards — navigation is operator control flow, not completion.
-  const evidence = readLifecycleCallerEvidence(
-    active.kind === 'claim'
-      ? {
-          claim: {
-            claimId: active.claimId,
-            tokenHash: active.claim.tokenHash,
-            controlledRunId: active.claim.childRunId,
-          },
-        }
-      : options.runId !== undefined
-        ? { runId: options.runId }
-        : {},
-  );
-  const actorContext = actorContextFromEvidence(evidence, { runId: state.id, exposure });
-  const policy = resolveCommandIntent({
-    actorContext,
-    intent: { kind: 'run-navigation', command: 'goto', targeted: true },
+  const outcome = await seam.resolveRunNavigation({
+    command: 'goto',
+    callerEvidence: readLifecycleCallerEvidence(
+      options.runId !== undefined ? { runId: options.runId } : {},
+    ),
     targetSelector:
-      active.kind === 'claim'
-        ? { kind: 'claim', claimId: active.claimId }
-        : active.kind === 'run'
-          ? { kind: 'run', runId: active.runId }
+      options.claimId !== undefined
+        ? { kind: 'claim', claimId: options.claimId }
+        : options.runId !== undefined
+          ? { kind: 'run', runId: options.runId }
           : { kind: 'default' },
-    targetState: state,
-    openClaims,
   });
-  if (policy.kind !== 'allowed') {
-    return { kind: 'actor_context_required' };
+  if (outcome.kind !== 'allowed') {
+    return outcome;
   }
 
   return {
@@ -210,13 +150,12 @@ export async function buildGotoContext(
     ctx: {
       output,
       manager,
-      actorService,
+      actorService: createCliRunbookActorService(manager),
       sessionService,
-      state,
-      steps,
+      state: outcome.state,
+      steps: [...outcome.steps],
       cwd,
-      terminalReleaseMode,
-      exposure,
+      terminalReleaseMode: outcome.terminalReleaseMode,
     },
   };
 }

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -86,10 +86,12 @@ export type BuildGotoContextResult =
       { kind: 'none' | 'stale_claim' | 'terminal_claim' | 'unknown_run' }
     >
   | {
-      /** The run-navigation policy gate refused the caller's evidence. */
+      /**
+       * The run-navigation policy gate refused the caller's evidence.
+       * Deliberately carries no run id (accident barrier — the refusal must
+       * not hand a lingering child the id it needs to bypass it).
+       */
       readonly kind: 'actor_context_required';
-      /** Run the refused navigation would have targeted. */
-      readonly targetRunId: RunId;
     };
 
 /**
@@ -165,10 +167,8 @@ export async function buildGotoContext(
   const steps = [...readonlySteps];
   const actorService = createCliRunbookActorService(manager);
 
-  // Compute the resolved run's delegation exposure and HOLD it on the context.
-  // The evidence mapping below still has its pre-exposure (evidence, targetRunId)
-  // signature, so the value's only consumer today is the context itself; the
-  // exposure-aware mapping consumes it when the direct_cli flip lands.
+  // Compute the resolved run's delegation exposure: consumed by the
+  // exposure-aware evidence mapping below and held on the goto context.
   const openClaims = await sessionService.listOpenClaimsForParent(state.id);
   const exposure = classifyDelegationExposure({ state, steps, openClaims });
 
@@ -188,7 +188,7 @@ export async function buildGotoContext(
         ? { runId: options.runId }
         : {},
   );
-  const actorContext = actorContextFromEvidence(evidence, state.id);
+  const actorContext = actorContextFromEvidence(evidence, { runId: state.id, exposure });
   const policy = resolveCommandIntent({
     actorContext,
     intent: { kind: 'run-navigation', command: 'goto', targeted: true },
@@ -202,7 +202,7 @@ export async function buildGotoContext(
     openClaims,
   });
   if (policy.kind !== 'allowed') {
-    return { kind: 'actor_context_required', targetRunId: state.id };
+    return { kind: 'actor_context_required' };
   }
 
   return {

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -12,11 +12,15 @@ import {
   RunbookStateManager,
   type RunbookActorService,
   SessionService,
+  actorContextFromEvidence,
+  classifyDelegationExposure,
   parseStepIdFromString,
   stepIdToString,
   deriveGotoActionBlock,
   resolveCommandTarget,
+  resolveCommandIntent,
   type CommandTargetResolution,
+  type DelegationExposure,
   type ResolvedStep,
   type StepId,
   type RunbookState,
@@ -29,6 +33,7 @@ import type { OutputEmitter } from '../services/output-emitter.js';
 import { createBridgedEmitter } from './execution-emitter.js';
 import { resolveIndexOption, IndexOptionError } from './index-option.js';
 import { getRunbookFromState } from './runbook-loader.js';
+import { readLifecycleCallerEvidence } from './caller-evidence.js';
 
 /**
  * Context for executing a goto operation.
@@ -50,6 +55,13 @@ export interface GotoContext {
   cwd: string;
   /** How terminal follow-on execution should release this runbook from session targeting. */
   terminalReleaseMode: ExecutionTerminalReleaseMode;
+  /**
+   * Delegation exposure of the resolved run, computed at context-build time.
+   * Held here for the trust-mapping call: the evidence mapping consumes it
+   * once `actorContextFromEvidence` becomes exposure-aware; until then it has
+   * no consumer beyond the run-navigation policy dispatch.
+   */
+  exposure: DelegationExposure;
 }
 
 /**
@@ -72,7 +84,13 @@ export type BuildGotoContextResult =
   | Extract<
       CommandTargetResolution,
       { kind: 'none' | 'stale_claim' | 'terminal_claim' | 'unknown_run' }
-    >;
+    >
+  | {
+      /** The run-navigation policy gate refused the caller's evidence. */
+      readonly kind: 'actor_context_required';
+      /** Run the refused navigation would have targeted. */
+      readonly targetRunId: RunId;
+    };
 
 /**
  * Resolve how terminal execution should remove a specific runbook from session targeting.
@@ -101,17 +119,22 @@ export async function resolveTerminalReleaseModeForRunbook(
  *
  * @param output - Output emitter for CLI output
  * @param cwd - Current working directory
- * @param options - Optional explicit claim-id target
+ * @param options - Optional explicit claim-id or run-id target
  * @param options.claimId - Claim id to resolve instead of the default stack
+ * @param options.runId - Run id (`--run`) to resolve instead of the default
+ *   stack; mutually exclusive with `claimId` (enforced upstream)
  * @returns Discriminated union: `{ kind: 'ready'; ctx }` when an active runbook
  *   was resolved and a goto context is available; `{ kind: 'none' }` when no
- *   active runbook exists; or `{ kind: 'stale_claim' | 'terminal_claim' }`
- *   when the supplied claim id cannot be used as a mutable child target.
+ *   active runbook exists; `{ kind: 'stale_claim' | 'terminal_claim' }` when
+ *   the supplied claim id cannot be used as a mutable child target;
+ *   `{ kind: 'unknown_run' }` for an unresolvable `--run` id; or
+ *   `{ kind: 'actor_context_required' }` when the run-navigation policy gate
+ *   refuses the caller's evidence.
  */
 export async function buildGotoContext(
   output: OutputEmitter,
   cwd: string,
-  options: { readonly claimId?: ClaimId } = {},
+  options: { readonly claimId?: ClaimId; readonly runId?: RunId } = {},
 ): Promise<BuildGotoContextResult> {
   const manager = new RunbookStateManager(cwd);
   const sessionService = new SessionService(manager);
@@ -121,7 +144,7 @@ export async function buildGotoContext(
     case 'claim':
     case 'default':
     // Explicit `--run` target: behaves like `default` with the named state in
-    // hand (Task 3 mechanical arm; flag registration lands in Task 6).
+    // hand; the flag itself is parsed by the goto command (`parseRunOption`).
     case 'run':
       break;
     case 'none':
@@ -142,6 +165,46 @@ export async function buildGotoContext(
   const steps = [...readonlySteps];
   const actorService = createCliRunbookActorService(manager);
 
+  // Compute the resolved run's delegation exposure and HOLD it on the context.
+  // The evidence mapping below still has its pre-exposure (evidence, targetRunId)
+  // signature, so the value's only consumer today is the context itself; the
+  // exposure-aware mapping consumes it when the direct_cli flip lands.
+  const openClaims = await sessionService.listOpenClaimsForParent(state.id);
+  const exposure = classifyDelegationExposure({ state, steps, openClaims });
+
+  // Run-navigation policy gate: goto is role-gated like an advance (unknown
+  // callers are refused) but exempt from the collection-pending / open-claims
+  // guards — navigation is operator control flow, not completion.
+  const evidence = readLifecycleCallerEvidence(
+    active.kind === 'claim'
+      ? {
+          claim: {
+            claimId: active.claimId,
+            tokenHash: active.claim.tokenHash,
+            controlledRunId: active.claim.childRunId,
+          },
+        }
+      : options.runId !== undefined
+        ? { runId: options.runId }
+        : {},
+  );
+  const actorContext = actorContextFromEvidence(evidence, state.id);
+  const policy = resolveCommandIntent({
+    actorContext,
+    intent: { kind: 'run-navigation', command: 'goto', targeted: true },
+    targetSelector:
+      active.kind === 'claim'
+        ? { kind: 'claim', claimId: active.claimId }
+        : active.kind === 'run'
+          ? { kind: 'run', runId: active.runId }
+          : { kind: 'default' },
+    targetState: state,
+    openClaims,
+  });
+  if (policy.kind !== 'allowed') {
+    return { kind: 'actor_context_required', targetRunId: state.id };
+  }
+
   return {
     kind: 'ready',
     ctx: {
@@ -153,6 +216,7 @@ export async function buildGotoContext(
       steps,
       cwd,
       terminalReleaseMode,
+      exposure,
     },
   };
 }

--- a/packages/cli/src/helpers/refusal-renderers.ts
+++ b/packages/cli/src/helpers/refusal-renderers.ts
@@ -10,7 +10,7 @@
 // Each renderer returns whether the refusal requests a non-zero exit code, so
 // callers can `return render…(…)` directly from their switch arm.
 
-import type { ClaimId, RunId } from '@rundown-org/core';
+import type { ClaimId } from '@rundown-org/core';
 import type { OutputEmitter } from '../services/output-emitter.js';
 
 /**
@@ -28,19 +28,28 @@ export function renderStaleClaimRefusal(output: OutputEmitter, message: string):
 /**
  * Render an actor-context-required refusal (`ACTOR_CONTEXT_REQUIRED`).
  *
+ * The envelope deliberately does NOT echo the target run id — in the message
+ * or the JSON details. Echoing it would convert the accident barrier into a
+ * copy-paste bypass for exactly the lingering-child agent it exists to stop.
+ * This is accident-proofing, not id secrecy: run ids are natively available
+ * from `rundown run` output, every event's `runbookId`, and claim output's
+ * `parent_run_id`; names are not capabilities.
+ *
  * @param output - Output emitter for CLI output.
  * @param commandName - The command that needs actor context (e.g. `pass`, `stop`).
- * @param targetRunId - The run the command would have acted on.
  * @returns `true` — always requests a non-zero exit code.
  */
 export function renderActorContextRequiredRefusal(
   output: OutputEmitter,
   commandName: string,
-  targetRunId: RunId,
 ): boolean {
-  output.error(`Actor context is required to ${commandName} this run.`, 'ACTOR_CONTEXT_REQUIRED', {
-    targetRunId,
-  });
+  output.error(
+    `This run has delegation activity, so a bare \`rundown ${commandName}\` is refused. ` +
+      'Pass `--run <rd_…>` with the run id from your orchestration context (printed by ' +
+      '`rundown run` and carried as runbookId on every event), or `--claim-id <claimId>` ' +
+      'if you are completing delegated work.',
+    'ACTOR_CONTEXT_REQUIRED',
+  );
   return true;
 }
 

--- a/packages/cli/src/helpers/refusal-renderers.ts
+++ b/packages/cli/src/helpers/refusal-renderers.ts
@@ -37,17 +37,21 @@ export function renderStaleClaimRefusal(output: OutputEmitter, message: string):
  *
  * @param output - Output emitter for CLI output.
  * @param commandName - The command that needs actor context (e.g. `pass`, `stop`).
+ * @param claimLanePurpose - Trailing verb phrase describing the `--claim-id`
+ *   lane's purpose for this command (defaults to the completion wording used by
+ *   pass/fail/complete/stop/delegate/goto; collect passes its own).
  * @returns `true` — always requests a non-zero exit code.
  */
 export function renderActorContextRequiredRefusal(
   output: OutputEmitter,
   commandName: string,
+  claimLanePurpose = 'completing delegated work',
 ): boolean {
   output.error(
     `This run has delegation activity, so a bare \`rundown ${commandName}\` is refused. ` +
       'Pass `--run <rd_…>` with the run id from your orchestration context (printed by ' +
       '`rundown run` and carried as runbookId on every event), or `--claim-id <claimId>` ' +
-      'if you are completing delegated work.',
+      `if you are ${claimLanePurpose}.`,
     'ACTOR_CONTEXT_REQUIRED',
   );
   return true;

--- a/packages/cli/src/helpers/run-option.ts
+++ b/packages/cli/src/helpers/run-option.ts
@@ -1,0 +1,42 @@
+// packages/cli/src/helpers/run-option.ts
+
+import { isRunId, type ClaimId, type RunId } from '@rundown-org/core';
+import type { OutputEmitter } from '../services/output-emitter.js';
+
+/**
+ * Parse and validate the `--run <rd_…>` option (Category-A flag parsing only).
+ *
+ * Validates format via core's `isRunId` and enforces mutual exclusion with
+ * `--claim-id`: an orchestrator names its own run, a delegated child names its
+ * claim — never both. On failure the error envelope is emitted and a non-zero
+ * exit code requested; the caller simply returns.
+ *
+ * @param raw - Raw `--run` value from Commander; `undefined` when absent
+ * @param claimId - Parsed `--claim-id` value, for the mutual-exclusion check
+ * @param output - Output emitter used to render validation failures
+ * @returns `{ ok: true }` (no `--run`), `{ ok: true, runId }` (validated), or
+ *   `{ ok: false }` after emitting the error
+ */
+export function parseRunOption(
+  raw: string | undefined,
+  claimId: ClaimId | undefined,
+  output: OutputEmitter,
+): { readonly ok: true; readonly runId?: RunId } | { readonly ok: false } {
+  if (raw === undefined) return { ok: true };
+  if (claimId !== undefined) {
+    output.error(
+      '--run and --claim-id are mutually exclusive: name the run you control with --run, or the claim you hold with --claim-id.',
+      'INVALID_SYNTAX',
+    );
+    output.flush();
+    process.exitCode = 1;
+    return { ok: false };
+  }
+  if (!isRunId(raw)) {
+    output.error('Invalid run id. Expected rd_<32 hex characters>.', 'INVALID_RUN_ID');
+    output.flush();
+    process.exitCode = 1;
+    return { ok: false };
+  }
+  return { ok: true, runId: raw };
+}

--- a/packages/cli/src/helpers/terminal-command.ts
+++ b/packages/cli/src/helpers/terminal-command.ts
@@ -129,7 +129,7 @@ export async function renderTerminalOutcome(
     case 'stale_claim':
       return renderStaleClaimRefusal(output, outcome.message);
     case 'actor_context_required':
-      return renderActorContextRequiredRefusal(output, command, outcome.targetRunId);
+      return renderActorContextRequiredRefusal(output, command);
     case 'delegation_collection_pending':
       emitDelegationCollectionPendingError(
         output,

--- a/packages/cli/src/helpers/terminal-command.ts
+++ b/packages/cli/src/helpers/terminal-command.ts
@@ -146,6 +146,9 @@ export async function renderTerminalOutcome(
     case 'already_terminal':
       output.noActiveRunbook(command, 'RUNBOOK_NOT_RUNNING');
       return false;
+    case 'unknown_run':
+      output.error(outcome.message, 'RUN_TARGET_UNAVAILABLE');
+      return true;
     case 'inline_plan_unavailable':
       // All three reasons (missing-inline-parent / inline-cycle / root-unavailable)
       // exit non-zero; the core-attached code is rendered as a flat passthrough.

--- a/packages/cli/src/helpers/terminal-command.ts
+++ b/packages/cli/src/helpers/terminal-command.ts
@@ -254,7 +254,10 @@ export async function runSeamTerminal(
   // reported as a removal (exit 0). An empty stack or a healthy top cleans
   // nothing and falls through to the normal `no active runbook` rendering. No
   // prior error exists here, so a guard failure may propagate normally.
-  if (outcome.kind === 'none' && options.claimId === undefined) {
+  // The `runId === undefined` leg is defensive hardening: `--run` targeting
+  // never returns `none` today (it refuses `unknown_run`), but if it ever did,
+  // default-stack cleanup must not run for a named-run target.
+  if (outcome.kind === 'none' && options.claimId === undefined && options.runId === undefined) {
     const cleanup = await cleanupOrphanedActiveStack(manager, sessionService);
     if (cleanup.kind === 'removed') {
       const removalMessage = 'Removed unusable runbook state from session';
@@ -270,6 +273,14 @@ export async function runSeamTerminal(
   return { manager, exitError };
 }
 
+/** Explicit target the failed terminal command was invoked with. */
+export interface TerminalRecoveryTarget {
+  /** Explicit claim id when the command targeted a claimed child (`--claim-id`). */
+  readonly claimId?: string;
+  /** Explicit run id when the command named its target (`--run`). */
+  readonly runId?: RunId;
+}
+
 /**
  * Recover from an unusable persisted snapshot surfaced by a terminal command.
  *
@@ -278,14 +289,18 @@ export async function runSeamTerminal(
  * cleanup and reports a clean removal, while the claim path maps the same
  * failure per command — `complete` to a `CLAIMED_RUNBOOK_UNAVAILABLE` error
  * (exit 1), `stop` to "no active runbook" (a claimed child that is no longer
- * usable is nothing to stop). Any other error is rethrown for the outer
+ * usable is nothing to stop). A `--run`-targeted failure NEVER runs
+ * default-stack orphan cleanup: the operator named a specific run, and popping
+ * whatever happens to sit on the default stack would report success without
+ * terminating the named run — the failure is surfaced against the named run
+ * instead (fail closed). Any other error is rethrown for the outer
  * `withErrorHandling` to render.
  *
  * @param command - The terminal command that failed (`complete` / `stop`).
  * @param error - The error thrown by the seam.
  * @param output - Output emitter for the recovery message.
  * @param cwd - Current working directory (used to build the cleanup manager).
- * @param claimId - Explicit claim id when the command targeted a claimed child.
+ * @param target - Explicit `--claim-id` / `--run` target the command carried.
  * @throws {unknown} Rethrows any error that is not a recoverable snapshot failure.
  */
 export async function handleTerminalRecovery(
@@ -293,20 +308,44 @@ export async function handleTerminalRecovery(
   error: unknown,
   output: OutputEmitter,
   cwd: string,
-  claimId: string | undefined,
+  target: TerminalRecoveryTarget = {},
 ): Promise<void> {
   // Claim path: orphan cleanup (a bare-command recovery) never applies to a
   // claim target, so an unusable snapshot maps to the command's claim outcome.
-  if (claimId !== undefined) {
+  if (target.claimId !== undefined) {
     if (error instanceof InvalidRunbookStateError) {
       if (command === 'complete') {
-        output.error(`Claimed runbook ${claimId} is unavailable`, 'CLAIMED_RUNBOOK_UNAVAILABLE');
+        output.error(
+          `Claimed runbook ${target.claimId} is unavailable`,
+          'CLAIMED_RUNBOOK_UNAVAILABLE',
+        );
         output.flush();
         process.exitCode = 1;
       } else {
         output.noActiveRunbook('stop');
         output.flush();
       }
+      return;
+    }
+    throw error;
+  }
+
+  // Run-targeted path: the operator NAMED the failing run, so default-stack
+  // orphan cleanup must never run — the default top may be a different run,
+  // and popping it would exit 0 without terminating the named run. Surface
+  // the failure against the named run instead (echoing only the id the caller
+  // themselves supplied).
+  if (target.runId !== undefined) {
+    if (
+      error instanceof InvalidRunbookStateError ||
+      (isError(error) && isRecoverableActiveStackError(error))
+    ) {
+      output.error(
+        `Run ${target.runId} has unusable persisted state; cannot ${command} it.`,
+        'RUN_TARGET_UNAVAILABLE',
+      );
+      output.flush();
+      process.exitCode = 1;
       return;
     }
     throw error;

--- a/packages/cli/src/helpers/terminal-command.ts
+++ b/packages/cli/src/helpers/terminal-command.ts
@@ -85,8 +85,13 @@ export class ForceTerminalEventBridge {
 
 /** CLI options forwarded to a terminal seam command. */
 export interface SeamTerminalOptions {
-  /** Explicit claim-id target (`--claim-id`). */
+  /** Explicit claim-id target (`--claim-id`). Mutually exclusive with `runId`. */
   readonly claimId?: ClaimId;
+  /**
+   * Explicit run target and named authority (`--run`). Mutually exclusive with
+   * `claimId` (enforced upstream by `parseRunOption`).
+   */
+  readonly runId?: RunId;
   /** Optional terminal message forwarded to the machine. */
   readonly message?: string;
 }
@@ -226,11 +231,15 @@ export async function runSeamTerminal(
 
   const targetSelector: CommandTargetSelector = options.claimId
     ? { kind: 'claim', claimId: options.claimId }
-    : { kind: 'default' };
+    : options.runId !== undefined
+      ? { kind: 'run', runId: options.runId }
+      : { kind: 'default' };
 
   const outcome = await seam.runTerminal({
     command,
-    callerEvidence: readLifecycleCallerEvidence(),
+    callerEvidence: readLifecycleCallerEvidence(
+      options.runId !== undefined ? { runId: options.runId } : {},
+    ),
     targetSelector,
     ...(options.message !== undefined ? { message: options.message } : {}),
     computeActionResult:

--- a/packages/cli/src/helpers/transition-command.ts
+++ b/packages/cli/src/helpers/transition-command.ts
@@ -12,6 +12,7 @@ import { runSeamTransition, type TransitionConfig } from './transitions.js';
 import { extractParentLinkage, propagateChildTerminal } from './delegation-completion.js';
 import { validateIndexRequiresStep } from './index-option.js';
 import { parseClaimIdOption } from './claim-id-option.js';
+import { parseRunOption } from './run-option.js';
 
 /**
  * Definition for a transition command (pass / fail).
@@ -54,6 +55,10 @@ const VALUE_TAKING_OPTION_PRESENTATION: Record<
   '--step': { value: 'stepId', description: 'Target specific substep' },
   '--index': { value: 'number', description: 'FOR loop iteration to target (requires --step)' },
   '--claim-id': { value: 'claimId', description: 'Target a claimed delegated child runbook' },
+  '--run': {
+    value: 'runId',
+    description: 'Name the run you control (explicit orchestrator targeting)',
+  },
 };
 
 /**
@@ -88,7 +93,13 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
   command
     .option('--text', 'Output as human-readable text')
     .action(
-      async (options: { step?: string; index?: string; claimId?: string; text?: boolean }) => {
+      async (options: {
+        step?: string;
+        index?: string;
+        claimId?: string;
+        run?: string;
+        text?: boolean;
+      }) => {
         await withErrorHandling(
           async () => {
             const output = new OutputEmitter({ text: options.text, command: def.name });
@@ -103,6 +114,8 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
             const cwd = getCwd();
             const claimTarget = parseClaimIdOption(options.claimId, output);
             if (!claimTarget.ok) return;
+            const runTarget = parseRunOption(options.run, claimTarget.claimId, output);
+            if (!runTarget.ok) return;
 
             const config = def.buildConfig();
 
@@ -114,6 +127,7 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
             // here we own the post-transition parent-propagation/exit-code contract.
             const { manager, applied, exitError } = await runSeamTransition(output, cwd, config, {
               ...(claimTarget.claimId !== undefined ? { claimId: claimTarget.claimId } : {}),
+              ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
               ...(options.step !== undefined ? { step: options.step } : {}),
               ...(options.index !== undefined ? { index: options.index } : {}),
             });

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -473,7 +473,7 @@ function renderRefusal(
       );
       return true;
     case 'actor_context_required':
-      return renderActorContextRequiredRefusal(output, config.commandName, outcome.targetRunId);
+      return renderActorContextRequiredRefusal(output, config.commandName);
     case 'unknown_run':
       output.error(outcome.message, 'RUN_TARGET_UNAVAILABLE');
       return true;

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -174,7 +174,10 @@ export interface TransitionContext {
  */
 export type BaseBuildTransitionContextResult =
   | { readonly kind: 'ready'; readonly ctx: TransitionContext }
-  | Extract<CommandTargetResolution, { kind: 'none' | 'stale_claim' | 'terminal_claim' }>;
+  | Extract<
+      CommandTargetResolution,
+      { kind: 'none' | 'stale_claim' | 'terminal_claim' | 'unknown_run' }
+    >;
 
 /**
  * Build transition execution context for the active or claimed runbook.
@@ -201,7 +204,7 @@ export async function buildTransitionContext(
   const sessionService = new SessionService(manager);
   const lifecycleService = new ExecutionLifecycleService(manager);
 
-  let resolvedKind: 'claim' | 'default';
+  let resolvedKind: 'claim' | 'default' | 'run';
   let state: RunbookState;
   // Resolved claim record, surfaced so the collect command can build a
   // claim-controller actor context; undefined for the default-stack target.
@@ -218,9 +221,16 @@ export async function buildTransitionContext(
       resolvedKind = active.kind;
       state = active.state;
       break;
+    case 'run':
+      // Explicit `--run` target: behaves like `default` with the named state
+      // in hand (Task 3 mechanical arm; flag registration lands in Task 5).
+      resolvedKind = active.kind;
+      state = active.state;
+      break;
     case 'none':
     case 'stale_claim':
     case 'terminal_claim':
+    case 'unknown_run':
       return active;
     default: {
       const _exhaustive: never = active;
@@ -454,6 +464,9 @@ function renderRefusal(
       return true;
     case 'actor_context_required':
       return renderActorContextRequiredRefusal(output, config.commandName, outcome.targetRunId);
+    case 'unknown_run':
+      output.error(outcome.message, 'RUN_TARGET_UNAVAILABLE');
+      return true;
     default: {
       const _exhaustive: never = outcome;
       return _exhaustive;

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -329,8 +329,13 @@ export function emitDelegationCollectionPendingError(
 
 /** CLI options forwarded to a pass/fail seam transition. */
 export interface SeamTransitionOptions {
-  /** Explicit claim-id target (`--claim-id`). */
+  /** Explicit claim-id target (`--claim-id`). Mutually exclusive with `runId`. */
   readonly claimId?: ClaimId;
+  /**
+   * Explicit run target and named authority (`--run`). Mutually exclusive with
+   * `claimId` (enforced upstream by `parseRunOption`).
+   */
+  readonly runId?: RunId;
   /** Explicit substep target (`--step`). */
   readonly step?: string;
   /** Raw `--index` value (requires `--step`). */
@@ -581,18 +586,29 @@ export async function runSeamTransition(
       stepId: options.step,
       ...(iteration !== undefined ? { iteration } : {}),
     };
+    // Selector precedence: claim → run → explicit-step. A run selector with an
+    // explicit target composes like claim+step does: the selector names the
+    // run, `explicitTarget` carries the step/index, and the seam derives
+    // `targeted` from the explicit target's presence (run+step keeps the
+    // targeted exemption from the collection guards).
     targetSelector = options.claimId
       ? { kind: 'claim', claimId: options.claimId }
-      : { kind: 'explicit-step', step: options.step };
+      : options.runId !== undefined
+        ? { kind: 'run', runId: options.runId }
+        : { kind: 'explicit-step', step: options.step };
   } else if (options.claimId) {
     targetSelector = { kind: 'claim', claimId: options.claimId };
+  } else if (options.runId !== undefined) {
+    targetSelector = { kind: 'run', runId: options.runId };
   } else {
     targetSelector = { kind: 'default' };
   }
 
   const outcome = await seam.runTransition({
     command: config.commandName,
-    callerEvidence: readLifecycleCallerEvidence(),
+    callerEvidence: readLifecycleCallerEvidence(
+      options.runId !== undefined ? { runId: options.runId } : {},
+    ),
     targetSelector,
     terminalPolicy: config.policy,
     computeActionResult: config.computeActionResult,

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -189,15 +189,17 @@ export type BaseBuildTransitionContextResult =
  *
  * @param output - Output emitter for CLI output
  * @param cwd - Current working directory
- * @param options - Optional explicit claim-id target
+ * @param options - Optional explicit claim-id or run-id target
  * @param options.claimId - Claim id to resolve instead of the default stack
+ * @param options.runId - Run id (`--run`) to resolve instead of the default
+ *   stack; mutually exclusive with `claimId` (enforced upstream)
  * @returns `{ kind: 'ready', ctx }` when a target is resolved, or a typed refusal
  * @throws {Error} if state is missing runbookSrc (corrupted state)
  */
 export async function buildTransitionContext(
   output: OutputEmitter,
   cwd: string,
-  options: { readonly claimId?: ClaimId } = {},
+  options: { readonly claimId?: ClaimId; readonly runId?: RunId } = {},
 ): Promise<BaseBuildTransitionContextResult> {
   const manager = new RunbookStateManager(cwd);
   const actorService = createCliRunbookActorService(manager);
@@ -210,7 +212,10 @@ export async function buildTransitionContext(
   // claim-controller actor context; undefined for the default-stack target.
   let claim: ClaimRecord | undefined;
 
-  const active = await resolveCommandTarget(sessionService, { claimId: options.claimId });
+  const active = await resolveCommandTarget(sessionService, {
+    ...(options.claimId !== undefined ? { claimId: options.claimId } : {}),
+    ...(options.runId !== undefined ? { runId: options.runId } : {}),
+  });
   switch (active.kind) {
     case 'claim':
       resolvedKind = active.kind;

--- a/packages/core/__tests__/runbook/actor-context.test.ts
+++ b/packages/core/__tests__/runbook/actor-context.test.ts
@@ -8,6 +8,8 @@ import {
   trustedRunControllerContext,
   UNKNOWN_ACTOR_CONTEXT,
   type CallerEvidence,
+  type DelegationExposure,
+  type EvidenceTarget,
   type RunbookState,
 } from '../../src/runbook/index.js';
 import { assertRunId } from '../../src/runbook/run-id.js';
@@ -20,6 +22,12 @@ const runIdA = assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
 const runIdB = assertRunId('rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
 const claimId = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
 const tokenHash = assertDelegationTokenHash(`sha256:${'a'.repeat(64)}`);
+
+const EXPOSURES: readonly DelegationExposure[] = ['standalone', 'delegating'];
+
+function target(runId = runIdA, exposure: DelegationExposure = 'standalone'): EvidenceTarget {
+  return { runId, exposure };
+}
 
 function baseState(id = runIdA): RunbookState {
   return {
@@ -44,60 +52,97 @@ function baseState(id = runIdA): RunbookState {
   };
 }
 
-describe('actorContextFromEvidence', () => {
-  it('maps direct CLI evidence to a trusted run controller for the target run', () => {
-    expect(actorContextFromEvidence({ kind: 'direct_cli' }, runIdA)).toEqual(
+describe('actorContextFromEvidence — the evidence × exposure truth table', () => {
+  it('keeps direct_cli trusted for a standalone target (solo-runbook convenience lane)', () => {
+    expect(actorContextFromEvidence({ kind: 'direct_cli' }, target(runIdA, 'standalone'))).toEqual(
       trustedRunControllerContext(runIdA),
     );
   });
 
-  it('maps complete claim evidence to a claim controller anchored on the controlled run', () => {
-    expect(
-      actorContextFromEvidence(
-        { kind: 'claim', claimId, tokenHash, controlledRunId: runIdB },
-        runIdA,
-      ),
-    ).toEqual(claimControllerContext({ claimId, tokenHash, controlledRunId: runIdB }));
-  });
-
-  it('maps plugin evidence without trusted metadata to the unknown singleton', () => {
-    expect(
-      actorContextFromEvidence(
-        { kind: 'plugin', agentId: 'agent-7', sessionId: 'session-9' },
-        runIdA,
-      ),
-    ).toBe(UNKNOWN_ACTOR_CONTEXT);
-  });
-
-  it('maps mcp evidence without trusted metadata to the unknown singleton', () => {
-    expect(actorContextFromEvidence({ kind: 'mcp', toolName: 'rd_pass' }, runIdA)).toBe(
+  it('maps direct_cli on a DELEGATING target to the unknown context — ambient trust removed (#460)', () => {
+    expect(actorContextFromEvidence({ kind: 'direct_cli' }, target(runIdA, 'delegating'))).toBe(
       UNKNOWN_ACTOR_CONTEXT,
     );
   });
 
-  it('maps unknown evidence to the unknown singleton', () => {
-    expect(actorContextFromEvidence({ kind: 'unknown' }, runIdA)).toBe(UNKNOWN_ACTOR_CONTEXT);
+  it.each(
+    EXPOSURES,
+  )('maps run_controller evidence to a trusted controller of the NAMED run for %s exposure', (exposure) => {
+    expect(
+      actorContextFromEvidence({ kind: 'run_controller', runId: runIdA }, target(runIdB, exposure)),
+    ).toEqual(trustedRunControllerContext(runIdA));
   });
 
-  it('maps run_controller evidence to a trusted controller of the NAMED run, not the target', () => {
-    expect(actorContextFromEvidence({ kind: 'run_controller', runId: runIdA }, runIdB)).toEqual(
-      trustedRunControllerContext(runIdA),
+  it.each(
+    EXPOSURES,
+  )('maps claim evidence to a claim controller anchored on the controlled run for %s exposure', (exposure) => {
+    expect(
+      actorContextFromEvidence(
+        { kind: 'claim', claimId, tokenHash, controlledRunId: runIdB },
+        target(runIdA, exposure),
+      ),
+    ).toEqual(claimControllerContext({ claimId, tokenHash, controlledRunId: runIdB }));
+  });
+
+  it.each(
+    EXPOSURES,
+  )('maps plugin evidence to the unknown singleton for %s exposure', (exposure) => {
+    expect(
+      actorContextFromEvidence(
+        { kind: 'plugin', agentId: 'agent-7', sessionId: 'session-9' },
+        target(runIdA, exposure),
+      ),
+    ).toBe(UNKNOWN_ACTOR_CONTEXT);
+  });
+
+  it.each(EXPOSURES)('maps mcp evidence to the unknown singleton for %s exposure', (exposure) => {
+    expect(
+      actorContextFromEvidence({ kind: 'mcp', toolName: 'rd_pass' }, target(runIdA, exposure)),
+    ).toBe(UNKNOWN_ACTOR_CONTEXT);
+  });
+
+  it.each(
+    EXPOSURES,
+  )('maps unknown evidence to the unknown singleton for %s exposure', (exposure) => {
+    expect(actorContextFromEvidence({ kind: 'unknown' }, target(runIdA, exposure))).toBe(
+      UNKNOWN_ACTOR_CONTEXT,
     );
   });
 
   it('derives orchestrator_for_target when run_controller evidence names the target run', () => {
-    const context = actorContextFromEvidence({ kind: 'run_controller', runId: runIdA }, runIdA);
+    const context = actorContextFromEvidence(
+      { kind: 'run_controller', runId: runIdA },
+      target(runIdA, 'delegating'),
+    );
     expect(deriveEffectiveRole(context, baseState(runIdA))).toBe('orchestrator_for_target');
   });
 
   it('derives unknown_for_target when run_controller evidence names a different run (wrong --run is refused downstream)', () => {
-    const context = actorContextFromEvidence({ kind: 'run_controller', runId: runIdB }, runIdA);
+    const context = actorContextFromEvidence(
+      { kind: 'run_controller', runId: runIdB },
+      target(runIdA, 'delegating'),
+    );
     expect(deriveEffectiveRole(context, baseState(runIdA))).toBe('unknown_for_target');
+  });
+
+  it('fails closed when exposure was classified for a different run than the one resolved (TOCTOU interleave)', () => {
+    // Trust minted against run A; the resolver independently resolved run B.
+    // deriveEffectiveRole compares actorContext.runId to the resolved target id
+    // and yields unknown_for_target — the stack mutating between the two
+    // lock-free reads can never transfer A's trust onto B.
+    const context = actorContextFromEvidence({ kind: 'direct_cli' }, target(runIdA, 'standalone'));
+    expect(deriveEffectiveRole(context, baseState(runIdB))).toBe('unknown_for_target');
   });
 });
 
+const exposureArb: fc.Arbitrary<DelegationExposure> = fc.constantFrom(
+  'standalone' as const,
+  'delegating' as const,
+);
+
 const callerEvidenceArb: fc.Arbitrary<CallerEvidence> = fc.oneof(
   fc.constant({ kind: 'direct_cli' } as const),
+  fc.constantFrom(runIdA, runIdB).map((runId) => ({ kind: 'run_controller' as const, runId })),
   fc.record({
     kind: fc.constant('plugin' as const),
     agentId: fc.option(fc.string(), { nil: undefined }),
@@ -126,26 +171,39 @@ const pluginMcpEvidenceArb: fc.Arbitrary<CallerEvidence> = fc.oneof(
 );
 
 describe('actorContextFromEvidence properties', () => {
-  it('totality: never throws for any generated caller evidence', () => {
+  it('totality: never throws for any generated caller evidence and exposure', () => {
     fc.assert(
-      fc.property(callerEvidenceArb, fc.constantFrom(runIdA, runIdB), (evidence, targetRunId) => {
-        expect(() => actorContextFromEvidence(evidence, targetRunId)).not.toThrow();
-      }),
+      fc.property(
+        callerEvidenceArb,
+        fc.constantFrom(runIdA, runIdB),
+        exposureArb,
+        (evidence, targetRunId, exposure) => {
+          expect(() =>
+            actorContextFromEvidence(evidence, { runId: targetRunId, exposure }),
+          ).not.toThrow();
+        },
+      ),
     );
   });
 
-  it('role composition: orchestrator_for_target iff direct CLI or claim on the target run', () => {
+  it('role composition: orchestrator_for_target iff (run_controller or claim naming the target) or (direct_cli on a standalone target)', () => {
     fc.assert(
-      fc.property(callerEvidenceArb, fc.constantFrom(runIdA, runIdB), (evidence, targetRunId) => {
-        const role = deriveEffectiveRole(
-          actorContextFromEvidence(evidence, targetRunId),
-          baseState(targetRunId),
-        );
-        const expectOrchestrator =
-          evidence.kind === 'direct_cli' ||
-          (evidence.kind === 'claim' && evidence.controlledRunId === targetRunId);
-        expect(role === 'orchestrator_for_target').toBe(expectOrchestrator);
-      }),
+      fc.property(
+        callerEvidenceArb,
+        fc.constantFrom(runIdA, runIdB),
+        exposureArb,
+        (evidence, targetRunId, exposure) => {
+          const role = deriveEffectiveRole(
+            actorContextFromEvidence(evidence, { runId: targetRunId, exposure }),
+            baseState(targetRunId),
+          );
+          const expectOrchestrator =
+            (evidence.kind === 'direct_cli' && exposure === 'standalone') ||
+            (evidence.kind === 'run_controller' && evidence.runId === targetRunId) ||
+            (evidence.kind === 'claim' && evidence.controlledRunId === targetRunId);
+          expect(role === 'orchestrator_for_target').toBe(expectOrchestrator);
+        },
+      ),
     );
   });
 
@@ -154,10 +212,11 @@ describe('actorContextFromEvidence properties', () => {
       fc.property(
         fc.constantFrom(runIdA, runIdB),
         fc.constantFrom(runIdA, runIdB),
-        (controlledRunId, targetRunId) => {
+        exposureArb,
+        (controlledRunId, targetRunId, exposure) => {
           const context = actorContextFromEvidence(
             { kind: 'claim', claimId, tokenHash, controlledRunId },
-            targetRunId,
+            { runId: targetRunId, exposure },
           );
           expect(context.kind).toBe('claim_controller');
           if (context.kind === 'claim_controller') {
@@ -173,10 +232,26 @@ describe('actorContextFromEvidence properties', () => {
       fc.property(
         pluginMcpEvidenceArb,
         fc.constantFrom(runIdA, runIdB),
-        (evidence, targetRunId) => {
-          expect(actorContextFromEvidence(evidence, targetRunId)).toBe(UNKNOWN_ACTOR_CONTEXT);
+        exposureArb,
+        (evidence, targetRunId, exposure) => {
+          expect(actorContextFromEvidence(evidence, { runId: targetRunId, exposure })).toBe(
+            UNKNOWN_ACTOR_CONTEXT,
+          );
         },
       ),
+    );
+  });
+
+  it('direct_cli never yields trust over a delegating target (always-strict, no carve-outs)', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(runIdA, runIdB), (targetRunId) => {
+        expect(
+          actorContextFromEvidence(
+            { kind: 'direct_cli' },
+            { runId: targetRunId, exposure: 'delegating' },
+          ),
+        ).toBe(UNKNOWN_ACTOR_CONTEXT);
+      }),
     );
   });
 });

--- a/packages/core/__tests__/runbook/actor-context.test.ts
+++ b/packages/core/__tests__/runbook/actor-context.test.ts
@@ -78,6 +78,22 @@ describe('actorContextFromEvidence', () => {
   it('maps unknown evidence to the unknown singleton', () => {
     expect(actorContextFromEvidence({ kind: 'unknown' }, runIdA)).toBe(UNKNOWN_ACTOR_CONTEXT);
   });
+
+  it('maps run_controller evidence to a trusted controller of the NAMED run, not the target', () => {
+    expect(actorContextFromEvidence({ kind: 'run_controller', runId: runIdA }, runIdB)).toEqual(
+      trustedRunControllerContext(runIdA),
+    );
+  });
+
+  it('derives orchestrator_for_target when run_controller evidence names the target run', () => {
+    const context = actorContextFromEvidence({ kind: 'run_controller', runId: runIdA }, runIdA);
+    expect(deriveEffectiveRole(context, baseState(runIdA))).toBe('orchestrator_for_target');
+  });
+
+  it('derives unknown_for_target when run_controller evidence names a different run (wrong --run is refused downstream)', () => {
+    const context = actorContextFromEvidence({ kind: 'run_controller', runId: runIdB }, runIdA);
+    expect(deriveEffectiveRole(context, baseState(runIdA))).toBe('unknown_for_target');
+  });
 });
 
 const callerEvidenceArb: fc.Arbitrary<CallerEvidence> = fc.oneof(

--- a/packages/core/__tests__/runbook/collection-service.properties.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.properties.test.ts
@@ -116,7 +116,9 @@ describe('RunbookCollectionService properties', () => {
         const outcome = await collectionService.collectDelegationOutcomes({
           targetState: state({ substepStates: doneSubstepStates(doneInFrame) }),
           steps,
-          callerEvidence: { kind: 'direct_cli' },
+          // Post-R1 the delegating fixture refuses bare direct-CLI evidence;
+          // the orchestrator names its run explicitly.
+          callerEvidence: { kind: 'run_controller', runId },
           frame: activeFrame(buildFrameKey('1'), 1),
         });
 
@@ -144,7 +146,9 @@ describe('RunbookCollectionService properties', () => {
         const outcome = await collectionService.collectDelegationOutcomes({
           targetState: state({ substepStates: doneSubstepStates(doneInOtherFrame, 2) }),
           steps,
-          callerEvidence: { kind: 'direct_cli' },
+          // Post-R1 the delegating fixture refuses bare direct-CLI evidence;
+          // the orchestrator names its run explicitly.
+          callerEvidence: { kind: 'run_controller', runId },
           frame: activeFrame(buildFrameKey('1'), 1),
         });
 

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -687,7 +687,7 @@ describe('RunbookCollectionService', () => {
     ).resolves.toEqual({
       kind: 'collect_requires_orchestrator',
       targetRunId: ancestorRunId,
-      message: expect.stringContaining('--run') as string,
+      message: expect.stringContaining('--run'),
     });
   });
 

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -661,6 +661,7 @@ describe('RunbookCollectionService', () => {
     ).resolves.toEqual({
       kind: 'collect_requires_orchestrator',
       targetRunId: ancestorRunId,
+      message: expect.stringContaining('--run') as string,
     });
   });
 

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -66,6 +66,13 @@ describe('RunbookCollectionService', () => {
     'sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
   );
 
+  // Post-R1, collection targets author DELEGATE and therefore classify
+  // `delegating`, so bare direct-CLI evidence no longer mints orchestrator
+  // trust — the orchestrator names its run explicitly (`--run` =>
+  // run_controller evidence). The behavioural suites below exercise the
+  // collection operation as that named orchestrator; the refusal twin pinning
+  // direct_cli on these fixtures lives in the policy-gate describe.
+  const ORCHESTRATOR_EVIDENCE: CallerEvidence = { kind: 'run_controller', runId };
   const DIRECT_CLI_EVIDENCE: CallerEvidence = { kind: 'direct_cli' };
 
   // Default runbook: step 1 delegates two substeps (PASS CONTINUE so a full
@@ -159,6 +166,25 @@ describe('RunbookCollectionService', () => {
     });
   });
 
+  it('refuses bare direct-CLI collection on a delegating target — ambient trust removed (#460)', async () => {
+    // The collection target authors DELEGATE substeps, so it classifies
+    // `delegating`; bare direct_cli evidence maps to the unknown context and
+    // the orchestrator gate refuses before inspecting any outcome state. The
+    // orchestrator lane is `run_controller` (--run); the child lane is claim.
+    await manager.save(state());
+
+    await expect(
+      collectionService.collectDelegationOutcomes({
+        targetState: state(),
+        steps,
+        callerEvidence: DIRECT_CLI_EVIDENCE,
+      }),
+    ).resolves.toEqual({
+      kind: 'actor_context_required',
+      intent: 'delegation-collection',
+    });
+  });
+
   it('reports missing outcomes for delegate substeps not yet resolved in the frame', async () => {
     // Neither delegate substep is `done` in the target frame, so both are
     // pending (the gate is per-frame `status === 'done'`, matching collect.ts).
@@ -169,7 +195,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
       }),
     ).resolves.toEqual({
       kind: 'missing_outcomes',
@@ -199,7 +225,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
       }),
     ).resolves.toMatchObject({
       kind: 'already_collected',
@@ -260,7 +286,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -409,7 +435,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -501,7 +527,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -569,7 +595,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -618,7 +644,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
         frame: activeFrame(frameKey, 1),
       }),
     ).resolves.toMatchObject({
@@ -673,7 +699,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
         stepName: 'does-not-exist',
       }),
     ).resolves.toEqual({
@@ -701,7 +727,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
       }),
     ).resolves.toMatchObject({
       kind: 'collection_failed',
@@ -727,7 +753,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
         frame: activeFrame(frameKey, 1),
       }),
     ).resolves.toEqual({
@@ -780,7 +806,7 @@ describe('RunbookCollectionService', () => {
     const result = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps: oneSubstepSteps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
     // Readiness must NOT refuse: the live row is the authoritative outcome signal,
@@ -905,7 +931,8 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: controlled,
       steps: oneSubstepSteps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      // Orchestrator evidence must name the TARGET run (the controlled run).
+      callerEvidence: { kind: 'run_controller', runId: controlledRunId },
       frame: activeFrame(buildFrameKey('1'), 1),
     });
 
@@ -931,7 +958,8 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: controlled,
       steps: oneSubstepSteps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      // Orchestrator evidence must name the TARGET run (the controlled run).
+      callerEvidence: { kind: 'run_controller', runId: controlledRunId },
       frame: activeFrame(buildFrameKey('1'), 1),
     });
 
@@ -990,7 +1018,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
       frame: exactFrame(inactiveKey, 2),
     });
 
@@ -1054,7 +1082,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
         frame: activeFrame(frameKey, 1),
       }),
     ).resolves.toEqual({
@@ -1100,7 +1128,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps: mixedSteps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
         frame: activeFrame(frameKey, 1),
       }),
     ).resolves.toEqual({
@@ -1139,7 +1167,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
       }),
     ).resolves.toEqual({
       kind: 'missing_outcomes',
@@ -1307,7 +1335,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
       }),
     ).resolves.toMatchObject({
       kind: 'already_collected',
@@ -1385,7 +1413,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -1447,7 +1475,7 @@ describe('RunbookCollectionService', () => {
       collectionService.collectDelegationOutcomes({
         targetState: target,
         steps,
-        callerEvidence: DIRECT_CLI_EVIDENCE,
+        callerEvidence: ORCHESTRATOR_EVIDENCE,
         frame: activeFrame(frameKey, 1),
       }),
     ).rejects.toThrow('Step "ghost" not found');
@@ -1480,7 +1508,7 @@ describe('RunbookCollectionService', () => {
     return collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
   }
@@ -1589,7 +1617,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
 
@@ -1654,7 +1682,7 @@ describe('RunbookCollectionService', () => {
     const outcome = await collectionService.collectDelegationOutcomes({
       targetState: target,
       steps,
-      callerEvidence: DIRECT_CLI_EVIDENCE,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
       frame: activeFrame(frameKey, 1),
     });
     return { outcome, observeEntrySpy, frontier, reEntryEffects };

--- a/packages/core/__tests__/runbook/command-policy.properties.test.ts
+++ b/packages/core/__tests__/runbook/command-policy.properties.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import fc from 'fast-check';
 import {
   activeFrame,
+  actorContextFromEvidence,
   assertRunId,
   buildCompletionKey,
   buildFrameKey,
@@ -12,7 +13,9 @@ import {
   trustedRunControllerContext,
   UNKNOWN_ACTOR_CONTEXT,
   type ActorContext,
+  type CallerEvidence,
   type CommandIntent,
+  type DelegationExposure,
   type RunbookState,
 } from '../../src/runbook/index.js';
 import { assertClaimId } from '../../src/runbook/claim-id.js';
@@ -201,6 +204,46 @@ describe('resolveCommandIntent properties', () => {
           (actorContext.kind === 'claim_controller' && actorContext.controlledRunId === targetId);
         expect(role === 'orchestrator_for_target').toBe(controlsTarget);
       }),
+    );
+  });
+
+  it('evidence role composition: orchestrator_for_target iff (run_controller or claim naming the target) or (direct_cli on a standalone target)', () => {
+    const evidenceArb: fc.Arbitrary<CallerEvidence> = fc.oneof(
+      fc.constant({ kind: 'direct_cli' } as const),
+      fc.constantFrom(runIdA, runIdB).map((runId) => ({ kind: 'run_controller' as const, runId })),
+      fc
+        .constantFrom(runIdA, runIdB)
+        .map((controlledRunId) => ({
+          kind: 'claim' as const,
+          claimId,
+          tokenHash,
+          controlledRunId,
+        })),
+      fc.constant({ kind: 'plugin' } as const),
+      fc.constant({ kind: 'mcp' } as const),
+      fc.constant({ kind: 'unknown' } as const),
+    );
+    const exposureArb: fc.Arbitrary<DelegationExposure> = fc.constantFrom(
+      'standalone' as const,
+      'delegating' as const,
+    );
+    fc.assert(
+      fc.property(
+        evidenceArb,
+        fc.constantFrom(runIdA, runIdB),
+        exposureArb,
+        (evidence, targetId, exposure) => {
+          const role = deriveEffectiveRole(
+            actorContextFromEvidence(evidence, { runId: targetId, exposure }),
+            baseState(targetId),
+          );
+          const expectOrchestrator =
+            (evidence.kind === 'direct_cli' && exposure === 'standalone') ||
+            (evidence.kind === 'run_controller' && evidence.runId === targetId) ||
+            (evidence.kind === 'claim' && evidence.controlledRunId === targetId);
+          expect(role === 'orchestrator_for_target').toBe(expectOrchestrator);
+        },
+      ),
     );
   });
 });

--- a/packages/core/__tests__/runbook/command-policy.properties.test.ts
+++ b/packages/core/__tests__/runbook/command-policy.properties.test.ts
@@ -18,7 +18,7 @@ import {
   type DelegationExposure,
   type RunbookState,
 } from '../../src/runbook/index.js';
-import { assertClaimId } from '../../src/runbook/claim-id.js';
+import { assertClaimId, type ClaimRecord } from '../../src/runbook/claim-id.js';
 import { assertDelegationTokenHash } from '../../src/runbook/delegation-token.js';
 import { brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
 
@@ -76,6 +76,23 @@ function pendingState(id = runIdA): RunbookState {
   };
 }
 
+/** Open claimed child of {@link runIdA}, used to arm the open-claims guard. */
+function openClaim(): ClaimRecord {
+  return {
+    kind: 'claim-record',
+    claimId,
+    childRunId: runIdB,
+    tokenHash,
+    parentRunId: runIdA,
+    parentStepId: '1',
+    parentStep: '1',
+    parentFrameKey: buildFrameKey('1'),
+    parentEntry: 1,
+    claimedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
 const actorContextArb: fc.Arbitrary<ActorContext> = fc.oneof(
   fc.constant(UNKNOWN_ACTOR_CONTEXT),
   fc.constantFrom(runIdA, runIdB).map((id) => trustedRunControllerContext(id)),
@@ -94,6 +111,16 @@ const intentArb: fc.Arbitrary<CommandIntent> = fc.oneof(
   fc.record({
     kind: fc.constant('delegation-issuance' as const),
     command: fc.constant('delegate' as const),
+    targeted: fc.boolean(),
+  }),
+  fc.record({
+    kind: fc.constant('terminal-run-force' as const),
+    command: fc.constantFrom('complete' as const, 'stop' as const),
+    targeted: fc.boolean(),
+  }),
+  fc.record({
+    kind: fc.constant('run-navigation' as const),
+    command: fc.constant('goto' as const),
     targeted: fc.boolean(),
   }),
   fc.constant({ kind: 'delegation-collection' } as const),
@@ -153,7 +180,7 @@ describe('resolveCommandIntent properties', () => {
     );
   });
 
-  it('never blocks a targeted advance/issuance with delegation_collection_pending', () => {
+  it('never blocks a targeted advance/issuance/terminal-force with delegation_collection_pending', () => {
     const targeted = fc.oneof(
       fc.record({
         kind: fc.constant('delegating-run-advance' as const),
@@ -163,6 +190,11 @@ describe('resolveCommandIntent properties', () => {
       fc.record({
         kind: fc.constant('delegation-issuance' as const),
         command: fc.constant('delegate' as const),
+        targeted: fc.constant(true),
+      }),
+      fc.record({
+        kind: fc.constant('terminal-run-force' as const),
+        command: fc.constantFrom('complete' as const, 'stop' as const),
         targeted: fc.constant(true),
       }),
     );
@@ -191,6 +223,45 @@ describe('resolveCommandIntent properties', () => {
             targetState: target,
           }).kind,
         ).not.toBe('delegation_collection_pending');
+      }),
+    );
+  });
+
+  it('exempts run-navigation from the collection-pending and open-claims guards for a controlling actor', () => {
+    // The run-navigation intent is documented as role-gated like an advance but
+    // exempt from the collection-pending and open-claims guards: navigation is
+    // operator control flow, not completion. Pin that a controlling actor's
+    // goto — bare or targeted — is allowed against a state that blocks a bare
+    // advance, with and without open claims.
+    const navigation = fc.record({
+      kind: fc.constant('run-navigation' as const),
+      command: fc.constant('goto' as const),
+      targeted: fc.boolean(),
+    });
+    const openClaimsArb = fc.constantFrom<readonly ClaimRecord[]>([], [openClaim()]);
+    const target = pendingState();
+    fc.assert(
+      fc.property(navigation, openClaimsArb, (intent, openClaims) => {
+        // Anchor: a bare advance against this state/claims combination is
+        // blocked, proving the guards genuinely fire for this fixture.
+        expect(
+          resolveCommandIntent({
+            actorContext: trustedRunControllerContext(runIdA),
+            intent: { kind: 'delegating-run-advance', command: 'pass', targeted: false },
+            targetSelector: { kind: 'default' },
+            targetState: target,
+            openClaims,
+          }).kind,
+        ).not.toBe('allowed');
+        expect(
+          resolveCommandIntent({
+            actorContext: trustedRunControllerContext(runIdA),
+            intent,
+            targetSelector: { kind: 'default' },
+            targetState: target,
+            openClaims,
+          }).kind,
+        ).toBe('allowed');
       }),
     );
   });

--- a/packages/core/__tests__/runbook/command-policy.properties.test.ts
+++ b/packages/core/__tests__/runbook/command-policy.properties.test.ts
@@ -211,14 +211,12 @@ describe('resolveCommandIntent properties', () => {
     const evidenceArb: fc.Arbitrary<CallerEvidence> = fc.oneof(
       fc.constant({ kind: 'direct_cli' } as const),
       fc.constantFrom(runIdA, runIdB).map((runId) => ({ kind: 'run_controller' as const, runId })),
-      fc
-        .constantFrom(runIdA, runIdB)
-        .map((controlledRunId) => ({
-          kind: 'claim' as const,
-          claimId,
-          tokenHash,
-          controlledRunId,
-        })),
+      fc.constantFrom(runIdA, runIdB).map((controlledRunId) => ({
+        kind: 'claim' as const,
+        claimId,
+        tokenHash,
+        controlledRunId,
+      })),
       fc.constant({ kind: 'plugin' } as const),
       fc.constant({ kind: 'mcp' } as const),
       fc.constant({ kind: 'unknown' } as const),

--- a/packages/core/__tests__/runbook/command-policy.test.ts
+++ b/packages/core/__tests__/runbook/command-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import {
   activeFrame,
+  actorContextFromEvidence,
   assertClaimId,
   assertDelegationTokenHash,
   assertRunId,
@@ -300,6 +301,42 @@ describe('resolveCommandIntent', () => {
         targetSelector: { kind: 'default' },
       }),
     ).toEqual({
+      kind: 'actor_context_required',
+      intent: 'delegation-collection',
+    });
+  });
+});
+
+describe('post-flip determinations', () => {
+  it('fails closed on a classify/resolve TOCTOU interleave: trust minted for run A is unknown_for_target against run B', () => {
+    // Exposure classification and target resolution are two lock-free reads.
+    // If the stack mutates between them (e.g. an inline child pops), the
+    // context minted against run A meets a resolved target run B — the id
+    // binding in deriveEffectiveRole, not luck, is what makes the double-read
+    // safe.
+    const contextForA = actorContextFromEvidence(
+      { kind: 'direct_cli' },
+      { runId: parentRunId, exposure: 'standalone' },
+    );
+    expect(deriveEffectiveRole(contextForA, state({ id: childRunId }))).toBe('unknown_for_target');
+  });
+
+  it('refuses a bare collect (direct_cli, unknown role) on a delegating parent with the --run remediation', () => {
+    // Post-flip, direct_cli on a delegating target maps to the unknown
+    // context; the delegation-collection branch routes through the
+    // orchestrator gate, which resolves an unknown role to
+    // actor_context_required (collect_requires_orchestrator is reserved for
+    // the delegated-relative role, whose message names --run — pinned above).
+    const outcome = resolveCommandIntent({
+      actorContext: actorContextFromEvidence(
+        { kind: 'direct_cli' },
+        { runId: parentRunId, exposure: 'delegating' },
+      ),
+      intent: { kind: 'delegation-collection' },
+      targetSelector: { kind: 'default' },
+      targetState: state(),
+    });
+    expect(outcome).toEqual({
       kind: 'actor_context_required',
       intent: 'delegation-collection',
     });

--- a/packages/core/__tests__/runbook/command-policy.test.ts
+++ b/packages/core/__tests__/runbook/command-policy.test.ts
@@ -283,6 +283,9 @@ describe('resolveCommandIntent', () => {
     ).toEqual({
       kind: 'collect_requires_orchestrator',
       targetRunId: parentRunId,
+      // The remediation names BOTH explicit-authority lanes and never echoes
+      // the target run id (decision 4 applies to this envelope too).
+      message: expect.stringContaining('--run') as string,
     });
   });
 

--- a/packages/core/__tests__/runbook/command-policy.test.ts
+++ b/packages/core/__tests__/runbook/command-policy.test.ts
@@ -286,7 +286,7 @@ describe('resolveCommandIntent', () => {
       targetRunId: parentRunId,
       // The remediation names BOTH explicit-authority lanes and never echoes
       // the target run id (decision 4 applies to this envelope too).
-      message: expect.stringContaining('--run') as string,
+      message: expect.stringContaining('--run'),
     });
   });
 

--- a/packages/core/__tests__/runbook/command-policy.test.ts
+++ b/packages/core/__tests__/runbook/command-policy.test.ts
@@ -306,6 +306,49 @@ describe('resolveCommandIntent', () => {
   });
 });
 
+describe('resolveCommandIntent run-navigation', () => {
+  it('refuses run-navigation without actor evidence', () => {
+    const outcome = resolveCommandIntent({
+      actorContext: UNKNOWN_ACTOR_CONTEXT,
+      intent: { kind: 'run-navigation', command: 'goto', targeted: true },
+      targetSelector: { kind: 'default' },
+      targetState: state(),
+    });
+    expect(outcome).toEqual({ kind: 'actor_context_required', intent: 'run-navigation' });
+  });
+
+  it('allows run-navigation for the trusted controller of the target', () => {
+    const outcome = resolveCommandIntent({
+      actorContext: trustedRunControllerContext(parentRunId),
+      intent: { kind: 'run-navigation', command: 'goto', targeted: true },
+      targetSelector: { kind: 'default' },
+      targetState: state(),
+    });
+    expect(outcome).toMatchObject({ kind: 'allowed', role: 'orchestrator_for_target' });
+  });
+
+  it('does not refuse run-navigation for pending collection (navigation is operator control flow, not completion)', () => {
+    const outcome = resolveCommandIntent({
+      actorContext: trustedRunControllerContext(parentRunId),
+      intent: { kind: 'run-navigation', command: 'goto', targeted: false },
+      targetSelector: { kind: 'default' },
+      targetState: stateWithReportedOutcome(),
+    });
+    expect(outcome).toMatchObject({ kind: 'allowed' });
+  });
+
+  it('does not refuse run-navigation for open claims (navigation is operator control flow, not completion)', () => {
+    const outcome = resolveCommandIntent({
+      actorContext: trustedRunControllerContext(parentRunId),
+      intent: { kind: 'run-navigation', command: 'goto', targeted: false },
+      targetSelector: { kind: 'default' },
+      targetState: state(),
+      openClaims: [claimRecord()],
+    });
+    expect(outcome).toMatchObject({ kind: 'allowed' });
+  });
+});
+
 describe('resolveCommandIntent terminal-run-force', () => {
   it('refuses a bare terminal force with no actor evidence as actor_context_required', () => {
     const outcome = resolveCommandIntent({

--- a/packages/core/__tests__/runbook/command-target-resolver.test.ts
+++ b/packages/core/__tests__/runbook/command-target-resolver.test.ts
@@ -85,8 +85,13 @@ function fakeReader(options: {
       }
       return options.active ?? null;
     },
-    async getRunById(runId) {
-      return options.runById?.[runId] ?? null;
+    async resolveRunningStackMember(runId) {
+      const state = options.runById?.[runId] ?? null;
+      if (!state) return { kind: 'not_on_stack' };
+      if (state.lifecycle !== 'running') {
+        return { kind: 'not_running', lifecycle: state.lifecycle };
+      }
+      return { kind: 'running', state };
     },
     async getActiveForClaimId(_claimId, includeOptions) {
       expect(_claimId).toBe(options.expectedClaimId ?? claimId);

--- a/packages/core/__tests__/runbook/command-target-resolver.test.ts
+++ b/packages/core/__tests__/runbook/command-target-resolver.test.ts
@@ -267,18 +267,35 @@ describe('resolveTransitionTarget', () => {
         command: 'pass',
       }),
     ).resolves.toEqual({
+      // Deliberately carries NO run id: the refusal is an accident barrier and
+      // must not hand the caller the id it needs to bypass it (decision 4).
       kind: 'actor_context_required',
-      targetRunId: parent.id,
     });
   });
 
-  it('skips the open delegated child guard for targeted transitions', async () => {
+  it('skips the open delegated child guard for targeted transitions (with trusted evidence)', async () => {
+    await expect(
+      resolveTransitionTarget(
+        fakeReader({ active: parent, openClaims: [claim], failOnOpenClaimRead: true }),
+        {
+          command: 'pass',
+          targeted: true,
+          actorContext: trustedRunControllerContext(parent.id),
+        },
+      ),
+    ).resolves.toEqual({ kind: 'default', state: parent });
+  });
+
+  it('refuses a targeted transition with no trusted evidence on a delegating run (--step is not authority)', async () => {
+    // The #460 child could as easily issue `rd pass --step N`: a step name is
+    // a completion target, not authority. The role gate applies to targeted
+    // and bare transitions alike; only the collection guards stay exempt.
     await expect(
       resolveTransitionTarget(
         fakeReader({ active: parent, openClaims: [claim], failOnOpenClaimRead: true }),
         { command: 'pass', targeted: true },
       ),
-    ).resolves.toEqual({ kind: 'default', state: parent });
+    ).resolves.toEqual({ kind: 'actor_context_required' });
   });
 
   it('resolves an explicit live claim without checking default stack or parent open claims', async () => {

--- a/packages/core/__tests__/runbook/command-target-resolver.test.ts
+++ b/packages/core/__tests__/runbook/command-target-resolver.test.ts
@@ -15,6 +15,7 @@ import {
   type ClaimRecord,
 } from '../../src/runbook/claim-id.js';
 import { assertDelegationTokenHash } from '../../src/runbook/delegation-token.js';
+import { assertRunId } from '../../src/runbook/run-id.js';
 import { RunbookStateManager } from '../../src/runbook/state.js';
 import { SessionService } from '../../src/runbook/session-service.js';
 import {
@@ -75,6 +76,7 @@ function fakeReader(options: {
   readonly expectedIncludeStashed?: boolean;
   readonly failOnDefaultRead?: boolean;
   readonly failOnOpenClaimRead?: boolean;
+  readonly runById?: Readonly<Record<string, RunbookState | null>>;
 }): CommandTargetReader {
   return {
     async getActive() {
@@ -82,6 +84,9 @@ function fakeReader(options: {
         throw new Error('default stack should not be inspected');
       }
       return options.active ?? null;
+    },
+    async getRunById(runId) {
+      return options.runById?.[runId] ?? null;
     },
     async getActiveForClaimId(_claimId, includeOptions) {
       expect(_claimId).toBe(options.expectedClaimId ?? claimId);
@@ -410,6 +415,120 @@ describe('resolveTransitionTarget', () => {
     const result = await resolveTransitionTarget(caseDef.reader, caseDef.options);
 
     expect(KNOWN_TRANSITION_KINDS.has(result.kind)).toBe(true);
+  });
+});
+
+describe('resolveTransitionTarget --run targeting', () => {
+  it('resolves --run to the named running stack member', async () => {
+    const resolution = await resolveTransitionTarget(
+      fakeReader({ runById: { [parent.id]: parent }, openClaims: [], failOnDefaultRead: true }),
+      {
+        command: 'pass',
+        runId: parent.id,
+        actorContext: trustedRunControllerContext(parent.id),
+      },
+    );
+    expect(resolution).toEqual({ kind: 'run', runId: parent.id, state: parent });
+  });
+
+  it('refuses a --run id that is not part of this session stack', async () => {
+    const foreign = assertRunId(`rd_${'f'.repeat(32)}`);
+    const resolution = await resolveTransitionTarget(
+      fakeReader({ runById: {}, failOnDefaultRead: true }),
+      {
+        command: 'pass',
+        runId: foreign,
+        actorContext: trustedRunControllerContext(foreign),
+      },
+    );
+    expect(resolution).toEqual({
+      kind: 'unknown_run',
+      runId: foreign,
+      message: `Run ${foreign} is not part of this session's active stack.`,
+    });
+  });
+
+  it('refuses a --run id whose run is terminal, mentioning its lifecycle', async () => {
+    const terminalParent = { ...parent, lifecycle: 'completed' } as RunbookState;
+    const resolution = await resolveTransitionTarget(
+      fakeReader({ runById: { [parent.id]: terminalParent }, failOnDefaultRead: true }),
+      {
+        command: 'pass',
+        runId: parent.id,
+        actorContext: trustedRunControllerContext(parent.id),
+      },
+    );
+    expect(resolution).toEqual({
+      kind: 'unknown_run',
+      runId: parent.id,
+      message: `Run ${parent.id} is completed.`,
+    });
+  });
+
+  it('still applies the open-children guard to a bare-shaped run-targeted advance', async () => {
+    // --run names authority; it does not skip the collection guards. A trusted
+    // controller of the target advancing bare-shaped over open claims refuses.
+    const resolution = await resolveTransitionTarget(
+      fakeReader({
+        runById: { [parent.id]: parent },
+        openClaims: [claim],
+        failOnDefaultRead: true,
+      }),
+      {
+        command: 'pass',
+        runId: parent.id,
+        actorContext: trustedRunControllerContext(parent.id),
+      },
+    );
+    expect(resolution).toEqual({
+      kind: 'open_delegated_children',
+      parentRunId: parent.id,
+      claims: [claim],
+    });
+  });
+
+  it('keeps the targeted exemption for a run-targeted transition carrying an explicit step target', async () => {
+    // Decision 3: `targeted` derives from the presence of an explicit step
+    // target, never from selector kind alone — pass --run <id> --step <n> is
+    // the sanctioned operator recovery and skips the collection guards.
+    const resolution = await resolveTransitionTarget(
+      fakeReader({
+        runById: { [parent.id]: parent },
+        openClaims: [claim],
+        failOnDefaultRead: true,
+        failOnOpenClaimRead: true,
+      }),
+      {
+        command: 'pass',
+        runId: parent.id,
+        targeted: true,
+        actorContext: trustedRunControllerContext(parent.id),
+      },
+    );
+    expect(resolution).toEqual({ kind: 'run', runId: parent.id, state: parent });
+  });
+});
+
+describe('resolveCommandTarget --run targeting', () => {
+  it('resolves --run to the named running stack member', async () => {
+    const resolution = await resolveCommandTarget(
+      fakeReader({ runById: { [parent.id]: parent }, failOnDefaultRead: true }),
+      { runId: parent.id },
+    );
+    expect(resolution).toEqual({ kind: 'run', runId: parent.id, state: parent });
+  });
+
+  it('refuses a --run id that does not resolve to a session-stack run', async () => {
+    const foreign = assertRunId(`rd_${'f'.repeat(32)}`);
+    const resolution = await resolveCommandTarget(
+      fakeReader({ runById: {}, failOnDefaultRead: true }),
+      { runId: foreign },
+    );
+    expect(resolution).toEqual({
+      kind: 'unknown_run',
+      runId: foreign,
+      message: `Run ${foreign} is not part of this session's active stack.`,
+    });
   });
 });
 

--- a/packages/core/__tests__/runbook/delegation-exposure.properties.test.ts
+++ b/packages/core/__tests__/runbook/delegation-exposure.properties.test.ts
@@ -153,11 +153,8 @@ function pendingOutcomeCompletions(): RunbookState['resolvedCompletions'] {
 function buildSteps(clauses: ExposureClauses, noise: ExposureNoise): readonly ResolvedStep[] {
   const steps: ResolvedStep[] = [];
   for (let index = 0; index < noise.plainStepCount; index++) {
-    steps.push(
-      index % 2 === 0
-        ? makeBaseStep({ name: `p${index}` })
-        : makeCommandStep({ name: `p${index}` }),
-    );
+    const name = `p${String(index)}`;
+    steps.push(index % 2 === 0 ? makeBaseStep({ name }) : makeCommandStep({ name }));
   }
   if (noise.plainSubstepStep) {
     steps.push(

--- a/packages/core/__tests__/runbook/delegation-exposure.properties.test.ts
+++ b/packages/core/__tests__/runbook/delegation-exposure.properties.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from '@jest/globals';
+import fc from 'fast-check';
+import type { ResolvedStep } from '@rundown-org/parser';
+import {
+  classifyDelegationExposure,
+  type DelegationExposureInput,
+} from '../../src/runbook/delegation-exposure.js';
+import type { ClaimRecord } from '../../src/runbook/claim-id.js';
+import { assertClaimId, assertRunId } from '../../src/runbook/index.js';
+import { assertDelegationTokenHash } from '../../src/runbook/delegation-token.js';
+import {
+  activeFrame,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+} from '../../src/runbook/targeting.js';
+import type { RunbookState, SubstepState } from '../../src/runbook/types.js';
+import { brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
+import {
+  makeBaseStep,
+  makeCommandStep,
+  makeContextSnapshot,
+  makeResolvedStepWithSubsteps,
+  makeStepDelegation,
+  makeSubstep,
+} from '../helpers/step-factories.js';
+
+const runId = assertRunId('rd_11111111111111111111111111111111');
+const parentRunId = assertRunId('rd_22222222222222222222222222222222');
+const childRunId = assertRunId('rd_33333333333333333333333333333333');
+const claimIdA = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
+const claimIdB = assertClaimId('rdclm_abcdefghijklmnopqrstu2');
+const tokenHash = assertDelegationTokenHash(`sha256:${'d'.repeat(64)}`);
+
+/**
+ * One flag per documented exposure clause of {@link classifyDelegationExposure}:
+ * (a) document DELEGATE substep, (b) open claims, (c) reported-but-uncollected
+ * outcome, (d) substep delegation record, (e) parent linkage, (f) inline
+ * composition — static runbook-list entries and runtime inline launch records.
+ */
+interface ExposureClauses {
+  readonly documentDelegateSubstep: boolean;
+  readonly documentRunbookList: boolean;
+  readonly openClaimCount: number;
+  readonly pendingOutcome: boolean;
+  readonly delegationRecord: boolean;
+  readonly inlineRecord: boolean;
+  readonly parentLinkage: 'none' | 'inline' | 'delegation';
+}
+
+/** Clause-independent input variation that must never affect the classification. */
+interface ExposureNoise {
+  readonly plainStepCount: number;
+  readonly plainSubstepStep: boolean;
+  readonly plainDoneSubstepRecord: boolean;
+  readonly recordStatus: 'running' | 'done';
+  readonly recordResult: 'pass' | 'fail';
+  readonly delegationCancelled: boolean;
+}
+
+const clausesArb: fc.Arbitrary<ExposureClauses> = fc.record({
+  documentDelegateSubstep: fc.boolean(),
+  documentRunbookList: fc.boolean(),
+  openClaimCount: fc.nat({ max: 2 }),
+  pendingOutcome: fc.boolean(),
+  delegationRecord: fc.boolean(),
+  inlineRecord: fc.boolean(),
+  parentLinkage: fc.constantFrom('none' as const, 'inline' as const, 'delegation' as const),
+});
+
+const noiseArb: fc.Arbitrary<ExposureNoise> = fc.record({
+  plainStepCount: fc.nat({ max: 2 }),
+  plainSubstepStep: fc.boolean(),
+  plainDoneSubstepRecord: fc.boolean(),
+  recordStatus: fc.constantFrom('running' as const, 'done' as const),
+  recordResult: fc.constantFrom('pass' as const, 'fail' as const),
+  delegationCancelled: fc.boolean(),
+});
+
+function anyClauseFires(clauses: ExposureClauses): boolean {
+  return (
+    clauses.documentDelegateSubstep ||
+    clauses.documentRunbookList ||
+    clauses.openClaimCount > 0 ||
+    clauses.pendingOutcome ||
+    clauses.delegationRecord ||
+    clauses.inlineRecord ||
+    clauses.parentLinkage !== 'none'
+  );
+}
+
+function makeOpenClaim(index: number): ClaimRecord {
+  return {
+    kind: 'claim-record',
+    claimId: index === 0 ? claimIdA : claimIdB,
+    childRunId,
+    tokenHash,
+    parentRunId: runId,
+    parentStepId: '1',
+    parentStep: '1',
+    parentFrameKey: buildFrameKey('1'),
+    parentEntry: 1,
+    claimedAt: '2026-07-03T00:00:00.000Z',
+    updatedAt: '2026-07-03T00:00:00.000Z',
+  };
+}
+
+function delegationSubstepRecord(noise: ExposureNoise): SubstepState {
+  return {
+    id: 'd1',
+    frameKey: buildFrameKey('1'),
+    status: noise.recordStatus,
+    ...(noise.recordStatus === 'done' ? { result: noise.recordResult } : {}),
+    delegation: makeStepDelegation({
+      childRunId,
+      cancelledAt: noise.delegationCancelled ? '2026-07-03T00:00:02.000Z' : null,
+    }),
+  };
+}
+
+function inlineSubstepRecord(noise: ExposureNoise): SubstepState {
+  return {
+    id: 'i1',
+    frameKey: buildFrameKey('1'),
+    status: noise.recordStatus,
+    ...(noise.recordStatus === 'done' ? { result: noise.recordResult } : {}),
+    inline: {
+      childRunbookPath: 'stage.runbook.md',
+      childRunbookRef: { source: 'project', path: 'stage.runbook.md' },
+      contextSnapshot: makeContextSnapshot(),
+      childRunId,
+      createdAt: '2026-07-03T00:00:00.000Z',
+      startedAt: '2026-07-03T00:00:01.000Z',
+    },
+  };
+}
+
+function pendingOutcomeCompletions(): RunbookState['resolvedCompletions'] {
+  const frame = activeFrame(buildFrameKey('1'), 1);
+  const key = buildCompletionKey(frame, '1');
+  return {
+    [key]: buildResolvedCompletion({
+      agentId: 'delegation',
+      result: 'pass',
+      targetStep: '1',
+      targetSubstep: '1',
+      targetFrame: frame,
+      completedAt: '2026-07-03T00:00:00.000Z',
+    }),
+  };
+}
+
+function buildSteps(clauses: ExposureClauses, noise: ExposureNoise): readonly ResolvedStep[] {
+  const steps: ResolvedStep[] = [];
+  for (let index = 0; index < noise.plainStepCount; index++) {
+    steps.push(
+      index % 2 === 0
+        ? makeBaseStep({ name: `p${index}` })
+        : makeCommandStep({ name: `p${index}` }),
+    );
+  }
+  if (noise.plainSubstepStep) {
+    steps.push(
+      makeResolvedStepWithSubsteps({ name: 'plain', substeps: [makeSubstep({ id: '1' })] }),
+    );
+  }
+  if (clauses.documentDelegateSubstep) {
+    steps.push(
+      makeResolvedStepWithSubsteps({
+        name: 'delegate',
+        substeps: [makeSubstep({ id: '1', delegate: true })],
+      }),
+    );
+  }
+  if (clauses.documentRunbookList) {
+    steps.push(
+      makeResolvedStepWithSubsteps({
+        name: 'compose',
+        substeps: [makeSubstep({ id: '1', runbooks: ['stage.runbook.md'] })],
+      }),
+    );
+  }
+  return steps;
+}
+
+function buildState(clauses: ExposureClauses, noise: ExposureNoise): RunbookState {
+  const substepStates: SubstepState[] = [];
+  if (noise.plainDoneSubstepRecord) {
+    substepStates.push({
+      id: 'n1',
+      frameKey: buildFrameKey('1'),
+      status: 'done',
+      result: noise.recordResult,
+    });
+  }
+  if (clauses.delegationRecord) {
+    substepStates.push(delegationSubstepRecord(noise));
+  }
+  if (clauses.inlineRecord) {
+    substepStates.push(inlineSubstepRecord(noise));
+  }
+  return {
+    id: runId,
+    runbook: { source: 'project', path: 'exposure-properties.md' },
+    runbookPath: 'exposure-properties.md',
+    step: '1',
+    stepName: 'Step',
+    retryCount: 0,
+    variables: brandStoredOutputsForTest({}),
+    steps: [],
+    lifecycle: 'running',
+    startedAt: '2026-07-03T00:00:00.000Z',
+    updatedAt: '2026-07-03T00:00:00.000Z',
+    activeFrameKey: buildFrameKey('1'),
+    activeEntry: 1,
+    frameEntryCounts: { [buildFrameKey('1')]: 1 },
+    substepStates,
+    resolvedCompletions: clauses.pendingOutcome ? pendingOutcomeCompletions() : {},
+    schemaVersion: 1,
+    frontmatterOutputs: [],
+    ...(clauses.parentLinkage === 'inline'
+      ? {
+          parentLinkage: {
+            kind: 'inline' as const,
+            parentRunId,
+            parentStepId: '1',
+            parentStep: '1',
+            parentFrameKey: buildFrameKey('1'),
+            parentEntry: 1,
+          },
+        }
+      : {}),
+    ...(clauses.parentLinkage === 'delegation'
+      ? {
+          parentLinkage: {
+            kind: 'delegation' as const,
+            tokenHash,
+            parentRunId,
+            parentStepId: '1',
+            parentStep: '1',
+            parentFrameKey: buildFrameKey('1'),
+            parentEntry: 1,
+          },
+        }
+      : {}),
+  };
+}
+
+function buildInput(clauses: ExposureClauses, noise: ExposureNoise): DelegationExposureInput {
+  return {
+    state: buildState(clauses, noise),
+    steps: buildSteps(clauses, noise),
+    openClaims: Array.from({ length: clauses.openClaimCount }, (_, index) => makeOpenClaim(index)),
+  };
+}
+
+/**
+ * State-derived sticky records that can be added to an existing input. Each
+ * corresponds to one of the classifier's monotone clauses (b, c, d, f-runtime).
+ */
+type StickyAddition = 'open-claim' | 'pending-outcome' | 'delegation-record' | 'inline-record';
+
+const additionsArb: fc.Arbitrary<readonly StickyAddition[]> = fc.uniqueArray(
+  fc.constantFrom<StickyAddition>(
+    'open-claim',
+    'pending-outcome',
+    'delegation-record',
+    'inline-record',
+  ),
+);
+
+function augmentInput(
+  input: DelegationExposureInput,
+  additions: readonly StickyAddition[],
+  noise: ExposureNoise,
+): DelegationExposureInput {
+  const extraSubstepStates: SubstepState[] = [];
+  if (additions.includes('delegation-record')) {
+    extraSubstepStates.push({ ...delegationSubstepRecord(noise), id: 'd2' });
+  }
+  if (additions.includes('inline-record')) {
+    extraSubstepStates.push({ ...inlineSubstepRecord(noise), id: 'i2' });
+  }
+  return {
+    state: {
+      ...input.state,
+      substepStates: [...(input.state.substepStates ?? []), ...extraSubstepStates],
+      resolvedCompletions: additions.includes('pending-outcome')
+        ? { ...input.state.resolvedCompletions, ...pendingOutcomeCompletions() }
+        : input.state.resolvedCompletions,
+    },
+    steps: input.steps,
+    openClaims: additions.includes('open-claim')
+      ? [...input.openClaims, makeOpenClaim(input.openClaims.length)]
+      : input.openClaims,
+  };
+}
+
+describe('classifyDelegationExposure properties', () => {
+  it('OR-composition: delegating iff at least one clause fires, standalone iff none', () => {
+    fc.assert(
+      fc.property(clausesArb, noiseArb, (clauses, noise) => {
+        const exposure = classifyDelegationExposure(buildInput(clauses, noise));
+        expect(exposure).toBe(anyClauseFires(clauses) ? 'delegating' : 'standalone');
+      }),
+    );
+  });
+
+  it('monotonic stickiness: adding claims, outcomes, or delegation/inline records never flips delegating to standalone', () => {
+    fc.assert(
+      fc.property(clausesArb, noiseArb, additionsArb, (clauses, noise, additions) => {
+        const base = buildInput(clauses, noise);
+        const before = classifyDelegationExposure(base);
+        const after = classifyDelegationExposure(augmentInput(base, additions, noise));
+        if (additions.length === 0) {
+          // No additions: classification is a pure function of the input.
+          expect(after).toBe(before);
+        } else {
+          // Every addition fires a monotone state-derived clause, so the
+          // augmented input is delegating regardless of the base — in
+          // particular, a delegating base can never decay to standalone.
+          expect(after).toBe('delegating');
+        }
+        if (before === 'delegating') {
+          expect(after).toBe('delegating');
+        }
+      }),
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/delegation-exposure.test.ts
+++ b/packages/core/__tests__/runbook/delegation-exposure.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from '@jest/globals';
+import type { ResolvedStep } from '@rundown-org/parser';
+import { classifyDelegationExposure } from '../../src/runbook/delegation-exposure.js';
+import type { ClaimRecord } from '../../src/runbook/claim-id.js';
+import { assertClaimId, assertRunId } from '../../src/runbook/index.js';
+import { assertDelegationTokenHash } from '../../src/runbook/delegation-token.js';
+import {
+  activeFrame,
+  buildCompletionKey,
+  buildFrameKey,
+  buildResolvedCompletion,
+} from '../../src/runbook/targeting.js';
+import type { RunbookState } from '../../src/runbook/types.js';
+import { brandStoredOutputsForTest } from '../../src/testing/effective-vars.js';
+import {
+  makeBaseStep,
+  makeCommandStep,
+  makeContextSnapshot,
+  makeResolvedStepWithSubsteps,
+  makeStepDelegation,
+  makeSubstep,
+} from '../helpers/step-factories.js';
+
+const runId = assertRunId('rd_11111111111111111111111111111111');
+const parentRunId = assertRunId('rd_22222222222222222222222222222222');
+const childRunId = assertRunId('rd_33333333333333333333333333333333');
+const claimId = assertClaimId('rdclm_abcdefghijklmnopqrstu1');
+const tokenHash = assertDelegationTokenHash(`sha256:${'d'.repeat(64)}`);
+
+/** Steps with no delegation or composition anywhere — includes substep-less members. */
+function plainSteps(): readonly ResolvedStep[] {
+  return [
+    makeBaseStep({ name: '1' }),
+    makeCommandStep({ name: '2' }),
+    makeResolvedStepWithSubsteps({ name: '3', substeps: [makeSubstep({ id: '1' })] }),
+  ];
+}
+
+function stepsWithDelegateSubstep(): readonly ResolvedStep[] {
+  return [
+    makeBaseStep({ name: '1' }),
+    makeResolvedStepWithSubsteps({
+      name: '2',
+      substeps: [makeSubstep({ id: '1', delegate: true })],
+    }),
+  ];
+}
+
+function stepsWithInlineRunbookListSubstep(): readonly ResolvedStep[] {
+  return [
+    makeBaseStep({ name: '1' }),
+    makeResolvedStepWithSubsteps({
+      name: '2',
+      substeps: [makeSubstep({ id: '1', runbooks: ['stage.runbook.md'] })],
+    }),
+  ];
+}
+
+function plainState(overrides: Partial<RunbookState> = {}): RunbookState {
+  return {
+    id: runId,
+    runbook: { source: 'project', path: 'exposure-test.md' },
+    runbookPath: 'exposure-test.md',
+    step: '1',
+    stepName: 'Step',
+    retryCount: 0,
+    variables: brandStoredOutputsForTest({}),
+    steps: [],
+    lifecycle: 'running',
+    startedAt: '2026-07-03T00:00:00.000Z',
+    updatedAt: '2026-07-03T00:00:00.000Z',
+    activeFrameKey: buildFrameKey('1'),
+    activeEntry: 1,
+    frameEntryCounts: { [buildFrameKey('1')]: 1 },
+    substepStates: [],
+    resolvedCompletions: {},
+    schemaVersion: 1,
+    frontmatterOutputs: [],
+    ...overrides,
+  };
+}
+
+function openClaim(): ClaimRecord {
+  return {
+    kind: 'claim-record',
+    claimId,
+    childRunId,
+    tokenHash,
+    parentRunId: runId,
+    parentStepId: '1',
+    parentStep: '1',
+    parentFrameKey: buildFrameKey('1'),
+    parentEntry: 1,
+    claimedAt: '2026-07-03T00:00:00.000Z',
+    updatedAt: '2026-07-03T00:00:00.000Z',
+  };
+}
+
+function stateWithPendingOutcome(): RunbookState {
+  const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+  return plainState({
+    resolvedCompletions: {
+      [key]: buildResolvedCompletion({
+        agentId: 'delegation',
+        result: 'pass',
+        targetStep: '1',
+        targetSubstep: '1',
+        targetFrame: activeFrame(buildFrameKey('1'), 1),
+        completedAt: '2026-07-03T00:00:00.000Z',
+      }),
+    },
+  });
+}
+
+function stateWithDoneDelegationSubstep(): RunbookState {
+  return plainState({
+    substepStates: [
+      {
+        id: '1',
+        frameKey: buildFrameKey('1'),
+        status: 'done',
+        result: 'pass',
+        delegation: makeStepDelegation({ childRunId }),
+      },
+    ],
+  });
+}
+
+function stateWithDoneInlineSubstep(): RunbookState {
+  return plainState({
+    substepStates: [
+      {
+        id: '1',
+        frameKey: buildFrameKey('1'),
+        status: 'done',
+        result: 'pass',
+        inline: {
+          childRunbookPath: 'stage.runbook.md',
+          childRunbookRef: { source: 'project', path: 'stage.runbook.md' },
+          contextSnapshot: makeContextSnapshot(),
+          childRunId,
+          createdAt: '2026-07-03T00:00:00.000Z',
+          startedAt: '2026-07-03T00:00:01.000Z',
+        },
+      },
+    ],
+  });
+}
+
+function stateWithInlineParentLinkage(): RunbookState {
+  return plainState({
+    parentLinkage: {
+      kind: 'inline',
+      parentRunId,
+      parentStepId: '1',
+      parentStep: '1',
+      parentFrameKey: buildFrameKey('1'),
+      parentEntry: 1,
+    },
+  });
+}
+
+function stateWithDelegationParentLinkage(): RunbookState {
+  return plainState({
+    parentLinkage: {
+      kind: 'delegation',
+      tokenHash,
+      parentRunId,
+      parentStepId: '1',
+      parentStep: '1',
+      parentFrameKey: buildFrameKey('1'),
+      parentEntry: 1,
+    },
+  });
+}
+
+describe('classifyDelegationExposure', () => {
+  it('classifies a linear runbook with no delegation anywhere as standalone', () => {
+    expect(
+      classifyDelegationExposure({ state: plainState(), steps: plainSteps(), openClaims: [] }),
+    ).toBe('standalone');
+  });
+
+  it('classifies a run whose document authors a DELEGATE substep as delegating (before any issuance)', () => {
+    expect(
+      classifyDelegationExposure({
+        state: plainState(),
+        steps: stepsWithDelegateSubstep(),
+        openClaims: [],
+      }),
+    ).toBe('delegating');
+  });
+
+  it('classifies a run with open claims as delegating', () => {
+    expect(
+      classifyDelegationExposure({
+        state: plainState(),
+        steps: plainSteps(),
+        openClaims: [openClaim()],
+      }),
+    ).toBe('delegating');
+  });
+
+  it('classifies a run with reported-but-uncollected outcomes as delegating', () => {
+    expect(
+      classifyDelegationExposure({
+        state: stateWithPendingOutcome(),
+        steps: plainSteps(),
+        openClaims: [],
+      }),
+    ).toBe('delegating');
+  });
+
+  it('stays delegating after claims close: substepState delegation history is sticky', () => {
+    expect(
+      classifyDelegationExposure({
+        state: stateWithDoneDelegationSubstep(),
+        steps: plainSteps(),
+        openClaims: [],
+      }),
+    ).toBe('delegating');
+  });
+
+  it('classifies an inline-linked child run as delegating', () => {
+    expect(
+      classifyDelegationExposure({
+        state: stateWithInlineParentLinkage(),
+        steps: plainSteps(),
+        openClaims: [],
+      }),
+    ).toBe('delegating');
+  });
+
+  it('classifies a delegation-linked (claimed child) run as delegating', () => {
+    expect(
+      classifyDelegationExposure({
+        state: stateWithDelegationParentLinkage(),
+        steps: plainSteps(),
+        openClaims: [],
+      }),
+    ).toBe('delegating');
+  });
+
+  it('classifies an inline-composing PARENT as delegating before any launch (static runbook-list clause f)', () => {
+    // Root run whose only composition is inline runbook-list entries — no
+    // DELEGATE substep, no claims, no pending outcomes, no parent linkage.
+    // Without clause (f) this classified standalone (the #460 pattern one
+    // level up: a lingering grandchild bare-drives the popped-back root).
+    expect(
+      classifyDelegationExposure({
+        state: plainState(),
+        steps: stepsWithInlineRunbookListSubstep(),
+        openClaims: [],
+      }),
+    ).toBe('delegating');
+  });
+
+  it('stays delegating after an inline stage completes: substepState inline records are sticky (clause f runtime signal)', () => {
+    expect(
+      classifyDelegationExposure({
+        state: stateWithDoneInlineSubstep(),
+        steps: plainSteps(),
+        openClaims: [],
+      }),
+    ).toBe('delegating');
+  });
+});

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -1072,6 +1072,55 @@ describe('RunbookLifecycleCommandService', () => {
       expect(retried.kind).toBe('retried');
     });
 
+    it('accepts a token retry whose --run matches the token-owning run', async () => {
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+      const first = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'run_controller', runId },
+      });
+      if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+      const retried = await localSeam.issueDelegation({
+        mode: 'retry',
+        callerEvidence: { kind: 'run_controller', runId },
+        targetRunId: first.parentRunId,
+        locator: { kind: 'token', token: first.token },
+      });
+      expect(retried.kind).toBe('retried');
+    });
+
+    it('refuses a token retry whose --run names a different run than the token owner (fail-closed)', async () => {
+      // An explicit `--run` is named authority over a specific run; a token
+      // owned by a DIFFERENT run must refuse rather than silently discard the
+      // named target — and the refusal must not echo the actual owning run id
+      // (accident barrier).
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+      const first = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'run_controller', runId },
+      });
+      if (first.kind !== 'delegated') throw new Error('expected delegated');
+      const otherRunId = assertRunId('rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'retry',
+        callerEvidence: { kind: 'run_controller', runId: otherRunId },
+        targetRunId: otherRunId,
+        locator: { kind: 'token', token: first.token },
+      });
+
+      expect(outcome.kind).toBe('run_target_mismatch');
+      if (outcome.kind !== 'run_target_mismatch') throw new Error('expected mismatch');
+      expect(outcome.runId).toBe(otherRunId);
+      // The message never leaks the token's actual owning run id.
+      expect(outcome.message).not.toContain(first.parentRunId);
+      // No re-mint happened: the persisted delegation still carries the
+      // original token hash.
+      const persisted = await manager.load(first.parentRunId);
+      const entry = findSubstepState(persisted?.substepStates ?? [], '1', buildFrameKey('1'));
+      expect(entry?.delegation?.tokenHash).toBe(first.tokenHash);
+    });
+
     it('rejects a token retry whose snapshot is missing `at` (fail closed, no legacy reconstruction)', async () => {
       // A persisted context snapshot ALWAYS records `at` (buildContextSnapshot
       // derives it unconditionally via deriveExecutionAt). A snapshot missing
@@ -1543,7 +1592,11 @@ describe('RunbookLifecycleCommandService', () => {
         targetRunId: foreignRunId,
       });
 
-      expect(outcome).toEqual({ kind: 'unknown-run', runId: foreignRunId });
+      expect(outcome).toEqual({
+        kind: 'unknown_run',
+        runId: foreignRunId,
+        message: `Run ${foreignRunId} is not part of this session's active stack.`,
+      });
     });
 
     it('forces the named run terminal via runTerminal --run', async () => {

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -1673,6 +1673,105 @@ describe('RunbookLifecycleCommandService', () => {
     });
   });
 
+  describe('resolveRunNavigation (goto seam)', () => {
+    const twoSteps: ResolvedStep[] = [
+      { kind: 'base', name: '1', description: 'one', transitions: tx('CONTINUE', 'STOP') },
+      { kind: 'base', name: '2', description: 'two', transitions: tx('COMPLETE', 'STOP') },
+    ];
+
+    it('allows bare navigation on a standalone run (stack-pop release)', async () => {
+      loadStepsImpl = () => twoSteps;
+      await activate(baseState());
+
+      const outcome = await seam.resolveRunNavigation({
+        command: 'goto',
+        callerEvidence: DIRECT_CLI,
+        targetSelector: { kind: 'default' },
+      });
+
+      expect(outcome.kind).toBe('allowed');
+      if (outcome.kind !== 'allowed') return;
+      expect(outcome.runId).toBe(runId);
+      expect(outcome.steps).toEqual(twoSteps);
+      expect(outcome.terminalReleaseMode).toBe('stack-pop');
+    });
+
+    it('refuses bare navigation on a delegation-exposed run with actor_context_required', async () => {
+      // Static clause a: the document authors a DELEGATE substep, so the run is
+      // delegation-exposed before any issuance — bare direct-CLI evidence maps
+      // to the unknown context and the run-navigation role gate refuses.
+      loadStepsImpl = () => [delegateStep('1', [delegateSubstep('1', 'child.md')])];
+      await activate(baseState());
+
+      const outcome = await seam.resolveRunNavigation({
+        command: 'goto',
+        callerEvidence: DIRECT_CLI,
+        targetSelector: { kind: 'default' },
+      });
+
+      expect(outcome).toEqual({ kind: 'actor_context_required' });
+    });
+
+    it('allows run-named navigation over the same delegation-exposed run', async () => {
+      loadStepsImpl = () => [delegateStep('1', [delegateSubstep('1', 'child.md')])];
+      await activate(baseState());
+
+      const outcome = await seam.resolveRunNavigation({
+        command: 'goto',
+        callerEvidence: { kind: 'run_controller', runId },
+        targetSelector: { kind: 'run', runId },
+      });
+
+      expect(outcome.kind).toBe('allowed');
+      if (outcome.kind !== 'allowed') return;
+      expect(outcome.runId).toBe(runId);
+    });
+
+    it('refuses an unknown --run id with the shared unknown_run refusal', async () => {
+      await activate(baseState());
+      const foreign = assertRunId('rd_99999999999999999999999999999999');
+
+      const outcome = await seam.resolveRunNavigation({
+        command: 'goto',
+        callerEvidence: { kind: 'run_controller', runId: foreign },
+        targetSelector: { kind: 'run', runId: foreign },
+      });
+
+      expect(outcome).toEqual({
+        kind: 'unknown_run',
+        runId: foreign,
+        message: `Run ${foreign} is not part of this session's active stack.`,
+      });
+    });
+
+    it('resolves a claim-targeted navigation to the claimed child with release-runbook', async () => {
+      loadStepsImpl = () => twoSteps;
+      await activate(baseState());
+      const childRunId = assertRunId('rd_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+      await manager.save(
+        baseState({
+          id: childRunId,
+          runbookPath: 'child.md',
+          parentLinkage: linkageFor(runId, 'a'),
+        }),
+      );
+      const claimed = assertClaimed(
+        await sessionService.claimRunbook(childRunId, linkageFor(runId, 'a')),
+      );
+
+      const outcome = await seam.resolveRunNavigation({
+        command: 'goto',
+        callerEvidence: DIRECT_CLI,
+        targetSelector: { kind: 'claim', claimId: claimed.claim.claimId },
+      });
+
+      expect(outcome.kind).toBe('allowed');
+      if (outcome.kind !== 'allowed') return;
+      expect(outcome.runId).toBe(childRunId);
+      expect(outcome.terminalReleaseMode).toBe('release-runbook');
+    });
+  });
+
   describe('top-level transition drive', () => {
     it('applies a PASS CONTINUE and instructs the loop to continue', async () => {
       const steps: ResolvedStep[] = [

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -354,7 +354,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
 
       expect(outcome.kind).toBe('delegated');
@@ -378,7 +378,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const fresh = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       expect(fresh.kind).toBe('delegated');
       if (fresh.kind !== 'delegated') throw new Error('expected delegated');
@@ -388,7 +388,7 @@ describe('RunbookLifecycleCommandService', () => {
       // Echo of the same delegation must surface the identical ref.
       const echo = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       expect(echo.kind).toBe('already-delegated');
       if (echo.kind !== 'already-delegated') throw new Error('expected echo');
@@ -402,7 +402,7 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam, deps } = await startSeamOnDelegateStep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (first.kind !== 'delegated') throw new Error('expected first delegated');
 
@@ -411,7 +411,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const second = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       expect(second.kind).toBe('already-delegated');
       if (second.kind !== 'already-delegated') throw new Error('expected echo');
@@ -422,7 +422,7 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam } = await startSeamOnDelegateStep(); // authored child is "child.md"
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         requestedRunbook: 'different.md',
       });
       expect(outcome.kind).toBe('error');
@@ -436,7 +436,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
 
       expect(outcome.kind).toBe('refused');
@@ -458,7 +458,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         requestedRunbook: 'child.md', // matches the authored child (no RD-822)
       });
 
@@ -474,7 +474,7 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam } = await startSeamOnMultiStepRunbook();
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         explicitStep: '2.2',
       });
       expect(outcome.kind).toBe('delegated');
@@ -488,7 +488,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         resolveExtraVars,
       });
 
@@ -500,14 +500,14 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam } = await startSeamOnDelegateStep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (first.kind !== 'delegated') throw new Error('expected first delegated');
 
       const resolveExtraVars = jest.fn(async () => undefined);
       const second = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         resolveExtraVars,
       });
 
@@ -545,7 +545,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         explicitStep: '1.1',
         explicitIteration: 2,
       });
@@ -565,13 +565,13 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam } = await startSeamOnDelegateStep();
       const fresh = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (fresh.kind !== 'delegated') throw new Error('expected delegated');
 
       const echo = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         requestedRunbook: 'child.md',
       });
       expect(echo.kind).toBe('already-delegated');
@@ -584,13 +584,13 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam } = await startSeamOnDelegateStep();
       const fresh = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (fresh.kind !== 'delegated') throw new Error('expected delegated');
 
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         requestedRunbook: 'other.md',
       });
       expect(outcome.kind).toBe('error');
@@ -602,7 +602,7 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam, manager: mgr, state } = await startSeamOnDelegateStep();
       const fresh = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (fresh.kind !== 'delegated') throw new Error('expected delegated');
 
@@ -618,7 +618,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         explicitStep: '1.1',
       });
       expect(outcome.kind).toBe('error');
@@ -657,7 +657,7 @@ describe('RunbookLifecycleCommandService', () => {
 
         const outcome = await localSeam.issueDelegation({
           mode: 'fresh',
-          callerEvidence: { kind: 'direct_cli' },
+          callerEvidence: { kind: 'run_controller', runId },
         });
         expect(outcome.kind).toBe('delegated');
         expect(calls).toEqual(['acquire', 'loadRun', 'persist', 'release']);
@@ -693,7 +693,7 @@ describe('RunbookLifecycleCommandService', () => {
 
         const outcome = await localSeam.issueDelegation({
           mode: 'fresh',
-          callerEvidence: { kind: 'direct_cli' },
+          callerEvidence: { kind: 'run_controller', runId },
         });
         expect(outcome.kind).toBe('already-delegated');
         if (outcome.kind !== 'already-delegated') throw new Error('expected echo');
@@ -715,7 +715,7 @@ describe('RunbookLifecycleCommandService', () => {
 
         const outcome = await localSeam.issueDelegation({
           mode: 'fresh',
-          callerEvidence: { kind: 'direct_cli' },
+          callerEvidence: { kind: 'run_controller', runId },
         });
         expect(outcome.kind).toBe('error');
         if (outcome.kind !== 'error') throw new Error('expected error');
@@ -731,7 +731,7 @@ describe('RunbookLifecycleCommandService', () => {
         const issue = (): ReturnType<typeof localSeam.issueDelegation> =>
           localSeam.issueDelegation({
             mode: 'fresh',
-            callerEvidence: { kind: 'direct_cli' },
+            callerEvidence: { kind: 'run_controller', runId },
             explicitStep: '1.1',
           });
         const [a, b] = await Promise.all([issue(), issue()]);
@@ -785,7 +785,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       expect(outcome.kind).toBe('delegated');
 
@@ -802,13 +802,13 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam } = await startSeamOnDelegateStep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (first.kind !== 'delegated') throw new Error('expected delegated');
 
       const retried = await localSeam.issueDelegation({
         mode: 'retry',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         locator: { kind: 'step', step: first.stepId },
       });
       expect(retried.kind).toBe('retried');
@@ -820,12 +820,12 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam } = await startSeamOnActiveDelegateSubstep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (first.kind !== 'delegated') throw new Error('expected delegated');
       const retried = await localSeam.issueDelegation({
         mode: 'retry',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         locator: { kind: 'active' },
       });
       expect(retried.kind).toBe('retried');
@@ -835,13 +835,13 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam } = await startSeamOnActiveForIterationSubstep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (first.kind !== 'delegated') throw new Error('expected delegated');
 
       const retried = await localSeam.issueDelegation({
         mode: 'retry',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         locator: { kind: 'active' },
       });
       expect(retried.kind).toBe('retried');
@@ -877,7 +877,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         explicitStep: '1.1',
         explicitIteration: 2,
       });
@@ -885,7 +885,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const retried = await localSeam.issueDelegation({
         mode: 'retry',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         locator: { kind: 'step', step: '1.1', iteration: 2 },
       });
       expect(retried.kind).toBe('retried');
@@ -898,7 +898,7 @@ describe('RunbookLifecycleCommandService', () => {
         const { seam: localSeam, deps } = await startSeamOnDelegateStep();
         const first = await localSeam.issueDelegation({
           mode: 'fresh',
-          callerEvidence: { kind: 'direct_cli' },
+          callerEvidence: { kind: 'run_controller', runId },
         });
         if (first.kind !== 'delegated') throw new Error('expected delegated');
 
@@ -924,7 +924,7 @@ describe('RunbookLifecycleCommandService', () => {
 
         const retried = await localSeam.issueDelegation({
           mode: 'retry',
-          callerEvidence: { kind: 'direct_cli' },
+          callerEvidence: { kind: 'run_controller', runId },
           locator: { kind: 'step', step: first.stepId },
         });
         expect(retried.kind).toBe('retried');
@@ -939,7 +939,7 @@ describe('RunbookLifecycleCommandService', () => {
         const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
         const first = await localSeam.issueDelegation({
           mode: 'fresh',
-          callerEvidence: { kind: 'direct_cli' },
+          callerEvidence: { kind: 'run_controller', runId },
         });
         if (first.kind !== 'delegated') throw new Error('expected delegated');
 
@@ -964,7 +964,7 @@ describe('RunbookLifecycleCommandService', () => {
 
         const outcome = await localSeam.issueDelegation({
           mode: 'retry',
-          callerEvidence: { kind: 'direct_cli' },
+          callerEvidence: { kind: 'run_controller', runId },
           locator: { kind: 'step', step: first.stepId },
         });
         expect(outcome.kind).toBe('error');
@@ -983,7 +983,7 @@ describe('RunbookLifecycleCommandService', () => {
         const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
         const first = await localSeam.issueDelegation({
           mode: 'fresh',
-          callerEvidence: { kind: 'direct_cli' },
+          callerEvidence: { kind: 'run_controller', runId },
         });
         if (first.kind !== 'delegated') throw new Error('expected delegated');
 
@@ -1000,7 +1000,7 @@ describe('RunbookLifecycleCommandService', () => {
 
         const outcome = await localSeam.issueDelegation({
           mode: 'retry',
-          callerEvidence: { kind: 'direct_cli' },
+          callerEvidence: { kind: 'run_controller', runId },
           locator: { kind: 'step', step: first.stepId },
         });
         expect(outcome.kind).toBe('error');
@@ -1022,19 +1022,19 @@ describe('RunbookLifecycleCommandService', () => {
         const { seam: localSeam, manager: m, state } = await startSeamOnDelegateStep();
         const setup = await localSeam.issueDelegation({
           mode: 'fresh',
-          callerEvidence: { kind: 'direct_cli' },
+          callerEvidence: { kind: 'run_controller', runId },
         });
         if (setup.kind !== 'delegated') throw new Error('expected delegated');
 
         const [freshOutcome, retryOutcome] = await Promise.all([
           localSeam.issueDelegation({
             mode: 'fresh',
-            callerEvidence: { kind: 'direct_cli' },
+            callerEvidence: { kind: 'run_controller', runId },
             explicitStep: '1.1',
           }),
           localSeam.issueDelegation({
             mode: 'retry',
-            callerEvidence: { kind: 'direct_cli' },
+            callerEvidence: { kind: 'run_controller', runId },
             locator: { kind: 'step', step: '1.1' },
           }),
         ]);
@@ -1061,12 +1061,12 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam } = await startSeamOnDelegateStep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (first.kind !== 'delegated') throw new Error('expected delegated');
       const retried = await localSeam.issueDelegation({
         mode: 'retry',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         locator: { kind: 'token', token: first.token },
       });
       expect(retried.kind).toBe('retried');
@@ -1081,7 +1081,7 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam, deps } = await startSeamOnDelegateStep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (first.kind !== 'delegated') throw new Error('expected delegated');
 
@@ -1101,7 +1101,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const outcome = await localSeamStale.issueDelegation({
         mode: 'retry',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         locator: { kind: 'token', token: first.token },
       });
 
@@ -1136,7 +1136,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         explicitStep: '1.1',
         explicitIteration: 2,
       });
@@ -1144,7 +1144,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const retried = await localSeam.issueDelegation({
         mode: 'retry',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         locator: { kind: 'token', token: first.token },
       });
       expect(retried.kind).toBe('retried');
@@ -1156,7 +1156,7 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam } = await startSeamOnDelegateStep();
       const outcome = await localSeam.issueDelegation({
         mode: 'retry',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         locator: { kind: 'token', token: 'rdtk_unknown00000000000000000000000000' },
       });
       expect(outcome.kind).toBe('token-not-found');
@@ -1170,7 +1170,7 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam, state: issuingRun } = await startSeamOnDelegateStep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (first.kind !== 'delegated') throw new Error('expected delegated');
 
@@ -1188,7 +1188,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const retried = await localSeam.issueDelegation({
         mode: 'retry',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         locator: { kind: 'token', token: first.token },
       });
 
@@ -1204,7 +1204,7 @@ describe('RunbookLifecycleCommandService', () => {
       const { seam: localSeam, manager: mgr, state } = await startSeamOnActiveDelegateSubstep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
       });
       if (first.kind !== 'delegated') throw new Error('expected delegated');
 
@@ -1237,7 +1237,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       const retried = await localSeam.issueDelegation({
         mode: 'retry',
-        callerEvidence: { kind: 'direct_cli' },
+        callerEvidence: { kind: 'run_controller', runId },
         locator: { kind: 'active' },
       });
       expect(retried.kind).toBe('retried');
@@ -1275,7 +1275,8 @@ describe('RunbookLifecycleCommandService', () => {
         targetSelector: { kind: 'default' },
         terminalPolicy: RELEASE_POLICY,
       });
-      expect(outcome).toEqual({ kind: 'actor_context_required', targetRunId: runId });
+      // Deliberately no run id on the refusal (accident barrier, decision 4).
+      expect(outcome).toEqual({ kind: 'actor_context_required' });
     });
 
     it('refuses a bare advance while delegation collection is pending', async () => {
@@ -1297,11 +1298,21 @@ describe('RunbookLifecycleCommandService', () => {
 
       const outcome = await seam.runTransition({
         command: 'pass',
-        callerEvidence: DIRECT_CLI,
+        // The pending-outcome run classifies `delegating`; the guard's subject
+        // needs named authority. The direct-CLI twin below pins the role gate.
+        callerEvidence: { kind: 'run_controller', runId },
         targetSelector: { kind: 'default' },
         terminalPolicy: RELEASE_POLICY,
       });
       expect(outcome.kind).toBe('delegation_collection_pending');
+
+      const bare = await seam.runTransition({
+        command: 'pass',
+        callerEvidence: DIRECT_CLI,
+        targetSelector: { kind: 'default' },
+        terminalPolicy: RELEASE_POLICY,
+      });
+      expect(bare).toEqual({ kind: 'actor_context_required' });
     });
 
     it('still refuses (does not throw) an explicit-step transition with no active run', async () => {
@@ -1553,6 +1564,42 @@ describe('RunbookLifecycleCommandService', () => {
       expect(named?.lifecycle).toBe('completed');
       const top = await manager.load(topRunId);
       expect(top?.lifecycle).toBe('running');
+    });
+
+    it('forces the whole contiguous-inline chain when --run names an inline chain member', async () => {
+      // The chain is one orchestrator's composition: naming the inline child
+      // carries derived authority over the walked-to root (never ambient —
+      // the root is reached by climbing inline linkage from the named run).
+      loadStepsImpl = () => twoSteps;
+      const rootId = assertRunId('rd_cccccccccccccccccccccccccccccccc');
+      const childId = assertRunId('rd_dddddddddddddddddddddddddddddddd');
+      await activate(baseState({ id: rootId }));
+      await activate(
+        baseState({
+          id: childId,
+          runbookPath: 'child.md',
+          parentLinkage: {
+            kind: 'inline',
+            parentRunId: rootId,
+            parentStepId: '1.1',
+            parentStep: '1',
+            parentFrameKey: buildFrameKey('1'),
+            parentEntry: 1,
+          },
+        }),
+      );
+
+      const outcome = await seam.runTerminal({
+        command: 'complete',
+        callerEvidence: { kind: 'run_controller', runId: childId },
+        targetSelector: { kind: 'run', runId: childId },
+      });
+
+      expect(outcome.kind).toBe('applied_bare');
+      if (outcome.kind !== 'applied_bare') return;
+      expect(outcome.rootRunId).toBe(rootId);
+      expect((await manager.load(childId))?.lifecycle).toBe('completed');
+      expect((await manager.load(rootId))?.lifecycle).toBe('completed');
     });
 
     it('refuses runTerminal --run for an id outside the session stack', async () => {
@@ -2529,7 +2576,9 @@ describe('RunbookLifecycleCommandService', () => {
 
       const outcome = await seam.runTransition({
         command: 'pass',
-        callerEvidence: DIRECT_CLI,
+        // The parent carries an inline substep record (clause f), so the
+        // reactivation subject needs named authority post-flip.
+        callerEvidence: { kind: 'run_controller', runId },
         targetSelector: { kind: 'default' },
         terminalPolicy: RELEASE_POLICY,
       });
@@ -2579,7 +2628,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       await seam.runTransition({
         command: 'pass',
-        callerEvidence: DIRECT_CLI,
+        callerEvidence: { kind: 'run_controller', runId },
         targetSelector: { kind: 'default' },
         terminalPolicy: RELEASE_POLICY,
       });
@@ -2598,7 +2647,7 @@ describe('RunbookLifecycleCommandService', () => {
 
       await seam.runTransition({
         command: 'pass',
-        callerEvidence: DIRECT_CLI,
+        callerEvidence: { kind: 'run_controller', runId },
         targetSelector: { kind: 'explicit-step', step: '1.1' },
         terminalPolicy: RELEASE_POLICY,
         explicitTarget: { stepId: '1.1' },
@@ -2620,7 +2669,10 @@ describe('RunbookLifecycleCommandService', () => {
 
       await seam.runTransition({
         command: 'pass',
-        callerEvidence: DIRECT_CLI,
+        // run_controller evidence maps directly (no classification read), so
+        // the drive-side single-resolution property stays observable; the
+        // direct_cli lane adds one classification read by design.
+        callerEvidence: { kind: 'run_controller', runId },
         targetSelector: { kind: 'default' },
         terminalPolicy: RELEASE_POLICY,
       });
@@ -2875,10 +2927,25 @@ describe('RunbookLifecycleCommandService', () => {
           callerEvidence: { kind: 'unknown' },
           targetSelector: { kind: 'default' },
         });
-        expect(out).toEqual({ kind: 'actor_context_required', targetRunId: ROOT });
+        // Deliberately no run id on the refusal (accident barrier, decision 4).
+        expect(out).toEqual({ kind: 'actor_context_required' });
       });
 
       it('bare stop refuses when the resolved root is collection pending (item 8)', async () => {
+        // The pending-outcome root classifies `delegating`, so the guard's
+        // subject needs named authority (run_controller); the bare direct-CLI
+        // twin below pins the role-gate refusal.
+        const root = collectionPendingState(ROOT);
+        installResolvedPlan(root, [root]);
+        const out = await seam.runTerminal({
+          command: 'stop',
+          callerEvidence: { kind: 'run_controller', runId: ROOT },
+          targetSelector: { kind: 'default' },
+        });
+        expect(out.kind).toBe('delegation_collection_pending');
+      });
+
+      it('refuses a bare direct-CLI stop on a collection-pending (delegating) root — ambient trust removed (#460)', async () => {
         const root = collectionPendingState(ROOT);
         installResolvedPlan(root, [root]);
         const out = await seam.runTerminal({
@@ -2886,7 +2953,7 @@ describe('RunbookLifecycleCommandService', () => {
           callerEvidence: DIRECT_CLI,
           targetSelector: { kind: 'default' },
         });
-        expect(out.kind).toBe('delegation_collection_pending');
+        expect(out).toEqual({ kind: 'actor_context_required' });
       });
 
       it('bare complete forces the chain descendant-to-root and records the root before release', async () => {

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -1383,6 +1383,196 @@ describe('RunbookLifecycleCommandService', () => {
     });
   });
 
+  describe('explicit --run targeting', () => {
+    const namedRunId = assertRunId('rd_77777777777777777777777777777777');
+    const topRunId = assertRunId('rd_88888888888888888888888888888888');
+    const foreignRunId = assertRunId('rd_99999999999999999999999999999999');
+
+    const twoSteps: ResolvedStep[] = [
+      { kind: 'base', name: '1', description: 'one', transitions: tx('CONTINUE', 'STOP') },
+      { kind: 'base', name: '2', description: 'two', transitions: tx('COMPLETE', 'STOP') },
+    ];
+
+    it('applies a run-targeted pass to the named run even when a different run is stack-top', async () => {
+      loadStepsImpl = () => twoSteps;
+      await activate(baseState({ id: namedRunId }));
+      await activate(baseState({ id: topRunId, runbookPath: 'top.md' }));
+
+      const outcome = await seam.runTransition({
+        command: 'pass',
+        callerEvidence: { kind: 'run_controller', runId: namedRunId },
+        targetSelector: { kind: 'run', runId: namedRunId },
+        terminalPolicy: RELEASE_POLICY,
+      });
+
+      expect(outcome.kind).toBe('applied');
+      if (outcome.kind !== 'applied') return;
+      expect(outcome.runId).toBe(namedRunId);
+      expect(outcome.updatedState?.step).toBe('2');
+      // The stack-top run was untouched.
+      const top = await manager.load(topRunId);
+      expect(top?.step).toBe('1');
+    });
+
+    it('refuses an unknown --run id with the typed unknown_run outcome', async () => {
+      loadStepsImpl = () => twoSteps;
+      await activate(baseState({ id: namedRunId }));
+
+      const outcome = await seam.runTransition({
+        command: 'pass',
+        callerEvidence: { kind: 'run_controller', runId: foreignRunId },
+        targetSelector: { kind: 'run', runId: foreignRunId },
+        terminalPolicy: RELEASE_POLICY,
+      });
+
+      expect(outcome).toEqual({
+        kind: 'unknown_run',
+        runId: foreignRunId,
+        message: `Run ${foreignRunId} is not part of this session's active stack.`,
+      });
+    });
+
+    it('refuses a bare-shaped run-targeted advance over open claims', async () => {
+      loadStepsImpl = () => twoSteps;
+      const childRunId = assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab');
+      await activate(baseState({ id: namedRunId }));
+      await manager.save(
+        baseState({
+          id: childRunId,
+          runbookPath: 'child.md',
+          parentLinkage: linkageFor(namedRunId, 'a'),
+        }),
+      );
+      assertClaimed(await sessionService.claimRunbook(childRunId, linkageFor(namedRunId, 'a')));
+
+      const outcome = await seam.runTransition({
+        command: 'pass',
+        callerEvidence: { kind: 'run_controller', runId: namedRunId },
+        targetSelector: { kind: 'run', runId: namedRunId },
+        terminalPolicy: RELEASE_POLICY,
+      });
+
+      expect(outcome.kind).toBe('open_delegated_children');
+    });
+
+    it('keeps the targeted exemption for run+step over pending outcomes (sanctioned operator recovery)', async () => {
+      const substepSteps: ResolvedStep[] = [
+        delegateStep('1', [delegateSubstep('1', 'child.md')]),
+        { kind: 'base', name: '2', description: 'two', transitions: tx('COMPLETE', 'STOP') },
+      ];
+      loadStepsImpl = () => substepSteps;
+      jest
+        .spyOn(completionService, 'recordManualCompletionUnlocked')
+        .mockResolvedValue({ status: 'recorded', key: 'k' });
+      jest.spyOn(completionService, 'drainResolvedCompletionsUnlocked').mockResolvedValue({
+        status: 'not_active',
+        frameKey: buildFrameKey('1'),
+        activeFrameKey: buildFrameKey('1'),
+        unresolved: 1,
+        applied: [],
+      });
+      const completionKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      await activate(
+        baseState({
+          id: namedRunId,
+          substep: '1',
+          resolvedCompletions: {
+            [completionKey]: buildResolvedCompletion({
+              agentId: 'delegation',
+              result: 'pass',
+              targetStep: '1',
+              targetSubstep: '1',
+              targetFrame: activeFrame(buildFrameKey('1'), 1),
+              completedAt: '2026-06-28T00:00:00.000Z',
+            }),
+          },
+        }),
+      );
+
+      const outcome = await seam.runTransition({
+        command: 'pass',
+        callerEvidence: { kind: 'run_controller', runId: namedRunId },
+        targetSelector: { kind: 'run', runId: namedRunId },
+        terminalPolicy: RELEASE_POLICY,
+        explicitTarget: { stepId: '1.1' },
+      });
+
+      expect(outcome.kind).toBe('applied');
+    });
+
+    it('mints a run-targeted delegation against the named run, not the stack top', async () => {
+      const namedState = baseState({ id: namedRunId });
+      await activate(namedState);
+      const { seam: localSeam } = buildIssuanceSeam(namedState, [
+        delegateStep('1', [delegateSubstep('1', 'child.md')]),
+      ]);
+      await activate(baseState({ id: topRunId, runbookPath: 'top.md' }));
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'run_controller', runId: namedRunId },
+        targetRunId: namedRunId,
+      });
+
+      expect(outcome.kind).toBe('delegated');
+      if (outcome.kind !== 'delegated') return;
+      expect(outcome.parentRunId).toBe(namedRunId);
+    });
+
+    it('refuses a delegation issuance naming a run outside the session stack', async () => {
+      const namedState = baseState({ id: namedRunId });
+      await activate(namedState);
+      const { seam: localSeam } = buildIssuanceSeam(namedState, [
+        delegateStep('1', [delegateSubstep('1', 'child.md')]),
+      ]);
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'run_controller', runId: foreignRunId },
+        targetRunId: foreignRunId,
+      });
+
+      expect(outcome).toEqual({ kind: 'unknown-run', runId: foreignRunId });
+    });
+
+    it('forces the named run terminal via runTerminal --run', async () => {
+      loadStepsImpl = () => twoSteps;
+      await activate(baseState({ id: namedRunId }));
+      await activate(baseState({ id: topRunId, runbookPath: 'top.md' }));
+
+      const outcome = await seam.runTerminal({
+        command: 'complete',
+        callerEvidence: { kind: 'run_controller', runId: namedRunId },
+        targetSelector: { kind: 'run', runId: namedRunId },
+      });
+
+      expect(outcome.kind).toBe('applied_bare');
+      if (outcome.kind !== 'applied_bare') return;
+      expect(outcome.rootRunId).toBe(namedRunId);
+      const named = await manager.load(namedRunId);
+      expect(named?.lifecycle).toBe('completed');
+      const top = await manager.load(topRunId);
+      expect(top?.lifecycle).toBe('running');
+    });
+
+    it('refuses runTerminal --run for an id outside the session stack', async () => {
+      loadStepsImpl = () => twoSteps;
+      await activate(baseState({ id: namedRunId }));
+
+      const outcome = await seam.runTerminal({
+        command: 'complete',
+        callerEvidence: { kind: 'run_controller', runId: foreignRunId },
+        targetSelector: { kind: 'run', runId: foreignRunId },
+      });
+
+      expect(outcome).toEqual({
+        kind: 'unknown_run',
+        runId: foreignRunId,
+        message: `Run ${foreignRunId} is not part of this session's active stack.`,
+      });
+    });
+  });
+
   describe('top-level transition drive', () => {
     it('applies a PASS CONTINUE and instructs the loop to continue', async () => {
       const steps: ResolvedStep[] = [

--- a/packages/core/__tests__/runbook/session-service.test.ts
+++ b/packages/core/__tests__/runbook/session-service.test.ts
@@ -144,6 +144,41 @@ describe('SessionService', () => {
     });
   });
 
+  describe('resolveRunningStackMember', () => {
+    it('resolves a running default-stack member', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      await sessionService.pushRunbook(state.id);
+
+      const member = await sessionService.resolveRunningStackMember(state.id);
+
+      expect(member.kind).toBe('running');
+      if (member.kind !== 'running') return;
+      expect(member.state.id).toBe(state.id);
+    });
+
+    it('splits "not on stack" from "not running": a foreign id is not_on_stack', async () => {
+      const foreign = brandRunIdForTest(`rd_${'f'.repeat(32)}`);
+
+      const member = await sessionService.resolveRunningStackMember(foreign);
+
+      expect(member).toEqual({ kind: 'not_on_stack' });
+    });
+
+    it('splits "not on stack" from "not running": a terminal stack member is not_running', async () => {
+      const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {
+        runbookPath: 'test.md',
+      });
+      await sessionService.pushRunbook(state.id);
+      await manager.update(state.id, { lifecycle: 'completed' });
+
+      const member = await sessionService.resolveRunningStackMember(state.id);
+
+      expect(member).toEqual({ kind: 'not_running', lifecycle: 'completed' });
+    });
+  });
+
   describe('Stash and pop operations', () => {
     it('stash saves current runbook and removes from stack', async () => {
       const state = await manager.create({ source: 'project', path: 'test.md' }, mockRunbook, {

--- a/packages/core/__tests__/runbook/subprocess-mutation-boundary.test.ts
+++ b/packages/core/__tests__/runbook/subprocess-mutation-boundary.test.ts
@@ -300,7 +300,12 @@ describe('PASS_FAIL_VALUE_TAKING_OPTION_NAMES (single source of truth)', () => {
     // The CLI's pass/fail registration derives its `.option(...)` calls from this
     // exact list (see transition-option-single-source.test.ts in the CLI). Pin it
     // here so a deliberate surface change is a visible, reviewed edit.
-    expect([...PASS_FAIL_VALUE_TAKING_OPTION_NAMES]).toEqual(['--step', '--index', '--claim-id']);
+    expect([...PASS_FAIL_VALUE_TAKING_OPTION_NAMES]).toEqual([
+      '--step',
+      '--index',
+      '--claim-id',
+      '--run',
+    ]);
   });
 
   it('every non-claim listed option causes its consumed value to be skipped by the claim scanner', () => {

--- a/packages/core/__tests__/runbook/subprocess-mutation-boundary.test.ts
+++ b/packages/core/__tests__/runbook/subprocess-mutation-boundary.test.ts
@@ -229,6 +229,55 @@ describe('bareRoleSpecificMutation', () => {
   });
 });
 
+describe('bareRoleSpecificMutation: explicit --run targeting', () => {
+  const runId = `rd_${'a'.repeat(32)}`;
+
+  it.each([
+    'pass',
+    'fail',
+    'complete',
+    'stop',
+    'collect',
+    'delegate',
+  ])('does not withhold a --run-targeted %s (explicit targeting is evidence, not ambient trust)', (command) => {
+    expect(bareRoleSpecificMutation([command, '--run', runId])).toBeUndefined();
+  });
+
+  it.each([
+    'pass',
+    'fail',
+    'complete',
+    'stop',
+    'collect',
+    'delegate',
+  ])('does not withhold the inline --run= form of %s', (command) => {
+    expect(bareRoleSpecificMutation([command, `--run=${runId}`])).toBeUndefined();
+  });
+
+  it('withholds when --run sits in a value slot (smuggling)', () => {
+    expect(bareRoleSpecificMutation(['pass', '--step', '--run'])).toBe('pass');
+    expect(bareRoleSpecificMutation(['pass', '--step', `--run=${runId}`])).toBe('pass');
+    expect(bareRoleSpecificMutation(['fail', '--index', '--run', runId])).toBe('fail');
+  });
+
+  it('withholds a --run token after the option terminator (positional, not a flag)', () => {
+    expect(bareRoleSpecificMutation(['pass', '--', '--run', runId])).toBe('pass');
+  });
+
+  it('exempts run-targeted mutations behind program-level global options', () => {
+    expect(bareRoleSpecificMutation(['--deny-all', 'pass', '--run', runId])).toBeUndefined();
+    expect(
+      bareRoleSpecificMutation(['--policy', 'foo.json', 'delegate', '--run', runId]),
+    ).toBeUndefined();
+  });
+
+  it('keeps withholding bare forms of all six commands', () => {
+    for (const command of ['pass', 'fail', 'complete', 'stop', 'collect', 'delegate']) {
+      expect(bareRoleSpecificMutation([command])).toBe(command);
+    }
+  });
+});
+
 describe('bareRoleSpecificMutation: program-level (global) options before the command', () => {
   // The rundown CLI accepts program-level options BEFORE the subcommand (e.g.
   // `rundown --deny-all pass`). The boundary must locate the ACTUAL command
@@ -318,6 +367,10 @@ describe('PASS_FAIL_VALUE_TAKING_OPTION_NAMES (single source of truth)', () => {
     // below), so it is excluded from the value-slot smuggling case.
     for (const option of PASS_FAIL_VALUE_TAKING_OPTION_NAMES) {
       if (option === '--claim-id') continue;
+      // `--run` in flag position is itself explicit-targeting evidence (its
+      // malformed value is rejected downstream by parseRunOption), so it is
+      // excluded from the value-slot smuggling case exactly like `--claim-id`.
+      if (option === '--run') continue;
       expect(bareRoleSpecificMutation(['pass', option, '--claim-id=foo'])).toBe('pass');
       expect(bareRoleSpecificMutation(['fail', option, '--claim-id', 'foo'])).toBe('fail');
     }

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -39,6 +39,7 @@ const CLISymbolicErrorCodeValues = [
   'ALREADY_STASHED',
   'NO_STASHED_RUNBOOK',
   'INVALID_CLAIM_ID',
+  'INVALID_RUN_ID',
   'INVALID_DELEGATE_CLAIM_ID',
   'CLAIMED_RUNBOOK_UNAVAILABLE',
   'DELEGATION_RESULT_CONFLICT',
@@ -101,6 +102,8 @@ export const CLIErrorCodes = {
   NO_STASHED_RUNBOOK: 'NO_STASHED_RUNBOOK',
   /** Claim id format is invalid */
   INVALID_CLAIM_ID: 'INVALID_CLAIM_ID',
+  /** Run id format is invalid */
+  INVALID_RUN_ID: 'INVALID_RUN_ID',
   /** Delegate does not accept claim-id targeting */
   INVALID_DELEGATE_CLAIM_ID: 'INVALID_DELEGATE_CLAIM_ID',
   /** Claimed runbook is missing, terminal, or otherwise unavailable */

--- a/packages/core/src/output/zod-schemas.ts
+++ b/packages/core/src/output/zod-schemas.ts
@@ -45,6 +45,7 @@ const CLISymbolicErrorCodeValues = [
   'OPEN_DELEGATED_CHILDREN',
   'DELEGATION_COLLECTION_PENDING',
   'ACTOR_CONTEXT_REQUIRED',
+  'RUN_TARGET_UNAVAILABLE',
   'COLLECT_REQUIRES_ORCHESTRATOR',
   'COLLECT_ALREADY_APPLIED',
   'COLLECT_OPERATION_FAILED',
@@ -112,6 +113,8 @@ export const CLIErrorCodes = {
   DELEGATION_COLLECTION_PENDING: 'DELEGATION_COLLECTION_PENDING',
   /** Actor context is required for the requested role-specific command */
   ACTOR_CONTEXT_REQUIRED: 'ACTOR_CONTEXT_REQUIRED',
+  /** The explicit --run target is not a running member of this session's stack */
+  RUN_TARGET_UNAVAILABLE: 'RUN_TARGET_UNAVAILABLE',
   /** Collection requires an actor that controls the target delegating run */
   COLLECT_REQUIRES_ORCHESTRATOR: 'COLLECT_REQUIRES_ORCHESTRATOR',
   /** Collection found no unapplied delegation outcomes and is an idempotent no-op. */

--- a/packages/core/src/runbook/actor-context.ts
+++ b/packages/core/src/runbook/actor-context.ts
@@ -1,4 +1,5 @@
 import type { ClaimId } from './claim-id.js';
+import type { DelegationExposure } from './delegation-exposure.js';
 import type { DelegationTokenHash } from './delegation-token.js';
 import type { RunId } from './run-id.js';
 
@@ -82,9 +83,12 @@ export function claimControllerContext(input: {
  * actor context and never a bare source label. Source tagging is not a trust
  * mechanism: `plugin` and `mcp` evidence — including any agent id, session id,
  * or tool name they carry — never grants run-controller trust on its own. The
- * only trust-granting variants are `direct_cli` (the local direct CLI
- * compatibility lane), `claim` (reconstructable claim-controller evidence),
- * and `run_controller` (caller-named run authority from an explicit `--run`).
+ * only trust-granting variants are `run_controller` (caller-named run
+ * authority from an explicit `--run`), `claim` (reconstructable
+ * claim-controller evidence), and `direct_cli` — the STANDALONE-run
+ * convenience lane only: on any delegation-exposed target the only
+ * trust-granting evidence is `run_controller` or `claim` ("everyone names
+ * their authority").
  *
  * Extend this envelope only when a frontend can supply real trusted controller
  * evidence; adding fields to `plugin` or `mcp` must not make them trusted by
@@ -134,30 +138,59 @@ export type CallerEvidence =
     };
 
 /**
+ * The resolved target a caller's evidence is mapped against: the run's id and
+ * its delegation exposure at decision time.
+ *
+ * The signature change to carry exposure is deliberately compile-breaking so
+ * every call site must supply it — invalid states unrepresentable. Exposure
+ * and target resolution may come from two separate lock-free reads; the id
+ * binding through `deriveEffectiveRole` (trust minted for run A is
+ * `unknown_for_target` against run B) is the fail-closed backstop for any
+ * interleave, and implementations should classify from the same
+ * `RunbookState` instance the resolver returns wherever it is already in
+ * hand.
+ */
+export interface EvidenceTarget {
+  /** Run the command targets. */
+  readonly runId: RunId;
+  /** The target run's delegation exposure, classified at decision time. */
+  readonly exposure: DelegationExposure;
+}
+
+/**
  * Map typed caller evidence to a target-relative {@link ActorContext}.
  *
  * Core owns this mapping so that frontends never construct trust directly.
- * `direct_cli` evidence yields a trusted run controller for `targetRunId`;
- * `run_controller` evidence yields a trusted run controller for the
- * evidence's own named `runId` (not `targetRunId` — `deriveEffectiveRole`
- * refuses a mismatch with the resolved target, so a wrong `--run` needs no
- * special case here); `claim` evidence yields a claim controller anchored on
- * the evidence's own `controlledRunId` (not `targetRunId`); every other
+ * `direct_cli` is the STANDALONE-run convenience lane only: it yields a
+ * trusted run controller for `target.runId` iff the target's exposure is
+ * `standalone`; on any delegation-exposed target it yields
+ * {@link UNKNOWN_ACTOR_CONTEXT} — the structural fix for #460 ("everyone
+ * names their authority"). `run_controller` evidence yields a trusted run
+ * controller for the evidence's own named `runId` (not the target —
+ * `deriveEffectiveRole` refuses a mismatch with the resolved target, so a
+ * wrong `--run` needs no special case here); `claim` evidence yields a claim
+ * controller anchored on the evidence's own `controlledRunId`; every other
  * variant — including `plugin` and `mcp` regardless of the metadata they
  * carry — yields {@link UNKNOWN_ACTOR_CONTEXT}.
  *
  * @param evidence - Typed caller evidence supplied by a frontend
- * @param targetRunId - Run the command targets, used only for `direct_cli`
+ * @param target - Resolved target run id plus its classified exposure
  * @returns The actor context core will evaluate against target-relative policy
  */
 export function actorContextFromEvidence(
   evidence: CallerEvidence,
-  targetRunId: RunId,
+  target: EvidenceTarget,
 ): ActorContext {
   switch (evidence.kind) {
     case 'direct_cli':
-      return trustedRunControllerContext(targetRunId);
+      // The standalone convenience lane. On a delegation-exposed target the
+      // ambient grant is gone — this arm is the structural fix for #460.
+      return target.exposure === 'standalone'
+        ? trustedRunControllerContext(target.runId)
+        : UNKNOWN_ACTOR_CONTEXT;
     case 'run_controller':
+      // Caller-named authority. deriveEffectiveRole refuses a mismatch with
+      // the resolved target, so no target comparison happens here.
       return trustedRunControllerContext(evidence.runId);
     case 'claim':
       return claimControllerContext({

--- a/packages/core/src/runbook/actor-context.ts
+++ b/packages/core/src/runbook/actor-context.ts
@@ -83,7 +83,8 @@ export function claimControllerContext(input: {
  * mechanism: `plugin` and `mcp` evidence — including any agent id, session id,
  * or tool name they carry — never grants run-controller trust on its own. The
  * only trust-granting variants are `direct_cli` (the local direct CLI
- * compatibility lane) and `claim` (reconstructable claim-controller evidence).
+ * compatibility lane), `claim` (reconstructable claim-controller evidence),
+ * and `run_controller` (caller-named run authority from an explicit `--run`).
  *
  * Extend this envelope only when a frontend can supply real trusted controller
  * evidence; adding fields to `plugin` or `mcp` must not make them trusted by
@@ -93,6 +94,15 @@ export type CallerEvidence =
   | {
       /** Direct local CLI invocation eligible for run-controller compatibility. */
       readonly kind: 'direct_cli';
+    }
+  | {
+      /**
+       * Caller-named run authority from an explicit `--run <rd_…>` target;
+       * trust-granting over the NAMED run only.
+       */
+      readonly kind: 'run_controller';
+      /** Run the caller names as both its authority and its target. */
+      readonly runId: RunId;
     }
   | {
       /** Claude Code plugin subprocess; metadata is descriptive only. */
@@ -128,10 +138,13 @@ export type CallerEvidence =
  *
  * Core owns this mapping so that frontends never construct trust directly.
  * `direct_cli` evidence yields a trusted run controller for `targetRunId`;
- * `claim` evidence yields a claim controller anchored on the evidence's own
- * `controlledRunId` (not `targetRunId`); every other variant — including
- * `plugin` and `mcp` regardless of the metadata they carry — yields
- * {@link UNKNOWN_ACTOR_CONTEXT}.
+ * `run_controller` evidence yields a trusted run controller for the
+ * evidence's own named `runId` (not `targetRunId` — `deriveEffectiveRole`
+ * refuses a mismatch with the resolved target, so a wrong `--run` needs no
+ * special case here); `claim` evidence yields a claim controller anchored on
+ * the evidence's own `controlledRunId` (not `targetRunId`); every other
+ * variant — including `plugin` and `mcp` regardless of the metadata they
+ * carry — yields {@link UNKNOWN_ACTOR_CONTEXT}.
  *
  * @param evidence - Typed caller evidence supplied by a frontend
  * @param targetRunId - Run the command targets, used only for `direct_cli`
@@ -144,6 +157,8 @@ export function actorContextFromEvidence(
   switch (evidence.kind) {
     case 'direct_cli':
       return trustedRunControllerContext(targetRunId);
+    case 'run_controller':
+      return trustedRunControllerContext(evidence.runId);
     case 'claim':
       return claimControllerContext({
         claimId: evidence.claimId,

--- a/packages/core/src/runbook/collection-service.ts
+++ b/packages/core/src/runbook/collection-service.ts
@@ -227,11 +227,12 @@ export async function collectDelegationOutcomes(
           'delegating',
   });
   // NOTE: the merged `resolveCommandIntent` input field is `targetSelector`
-  // (not `target`), and its selector kinds are `default` | `claim` |
-  // `explicit-step` — there is NO `run` selector kind. The resolved target run
-  // is passed separately as `targetState`. For collection the frontend has
-  // already resolved `--claim-id` (or the default stack) to a concrete run, so
-  // the selector is `default` and role derivation keys off `targetState`.
+  // (not `target`). The resolved target run is passed separately as
+  // `targetState`. For collection the frontend has already resolved
+  // `--claim-id`, `--run`, or the default stack to a concrete run before this
+  // call, so the selector here is always `default` and role derivation keys
+  // off `targetState` (a `run` selector kind exists on the union but is
+  // consumed upstream by the target resolver, never on this path).
   const policy = resolveCommandIntent({
     intent: { kind: 'delegation-collection' },
     // Equivalent mutants: `resolveCommandIntent` does not read `targetSelector` on

--- a/packages/core/src/runbook/collection-service.ts
+++ b/packages/core/src/runbook/collection-service.ts
@@ -1,5 +1,7 @@
 import { resolvedStepHasSubsteps } from '@rundown-org/parser';
 import { actorContextFromEvidence, type CallerEvidence } from './actor-context.js';
+import type { ClaimRecord } from './claim-id.js';
+import { classifyDelegationExposure } from './delegation-exposure.js';
 import type { RunbookActorService } from './actor-service.js';
 import type { DelegationPolicyOutcome } from './command-policy.js';
 import { resolveCommandIntent } from './command-policy.js';
@@ -53,6 +55,13 @@ export interface CollectDelegationOutcomesInput {
    * seam in lifecycle-command-service.ts).
    */
   readonly callerEvidence: CallerEvidence;
+  /**
+   * Open claimed children for the target run, when the caller already read
+   * them. Feeds the delegation-exposure classification for `direct_cli`
+   * evidence; defaults to none — a collect target authors DELEGATE, so the
+   * static document clause classifies it `delegating` regardless.
+   */
+  readonly openClaims?: readonly ClaimRecord[];
   /** Optional explicit step name. Defaults to the target run cursor. */
   readonly stepName?: string;
   /** Optional frame override for targeted FOR collection. */
@@ -198,10 +207,25 @@ export async function collectDelegationOutcomes(
   input: CollectDelegationOutcomesOperationInput,
 ): Promise<DelegationPolicyOutcome> {
   // Core owns the evidence->trust mapping: direct_cli yields a trusted run
-  // controller for the resolved target; claim evidence anchors on its own
-  // controlledRunId; plugin/mcp/unknown yield UNKNOWN_ACTOR_CONTEXT and are
-  // refused by the policy gate below (actor_context_required).
-  const actorContext = actorContextFromEvidence(input.callerEvidence, input.targetState.id);
+  // controller only when the resolved target classifies `standalone` (a
+  // collect target authors DELEGATE, so bare direct-CLI collect on a
+  // delegating parent is refused post-flip); run_controller anchors on its
+  // named run; claim evidence anchors on its own controlledRunId;
+  // plugin/mcp/unknown yield UNKNOWN_ACTOR_CONTEXT and are refused by the
+  // policy gate below (actor_context_required). Exposure is classified from
+  // the same targetState/steps this operation decides from.
+  const actorContext = actorContextFromEvidence(input.callerEvidence, {
+    runId: input.targetState.id,
+    exposure:
+      input.callerEvidence.kind === 'direct_cli'
+        ? classifyDelegationExposure({
+            state: input.targetState,
+            steps: input.steps,
+            openClaims: input.openClaims ?? [],
+          })
+        : // Fail-closed placeholder: only the direct_cli arm reads exposure.
+          'delegating',
+  });
   // NOTE: the merged `resolveCommandIntent` input field is `targetSelector`
   // (not `target`), and its selector kinds are `default` | `claim` |
   // `explicit-step` — there is NO `run` selector kind. The resolved target run

--- a/packages/core/src/runbook/command-policy.ts
+++ b/packages/core/src/runbook/command-policy.ts
@@ -43,6 +43,19 @@ export type CommandIntent =
   | {
       /** Collect command applying reported delegation outcomes. */
       readonly kind: 'delegation-collection';
+    }
+  | {
+      /**
+       * Goto navigating a run's cursor. Role-gated like an advance (unknown
+       * callers are refused), but exempt from the collection-pending and
+       * open-claims guards: navigation is operator control flow, not
+       * completion — it consumes no reported outcomes and closes no claims.
+       */
+      readonly kind: 'run-navigation';
+      /** Navigation command being evaluated. */
+      readonly command: 'goto';
+      /** True when the caller supplied an explicit target. */
+      readonly targeted: boolean;
     };
 
 /** Target selector shape parsed by a frontend before core policy evaluation. */

--- a/packages/core/src/runbook/command-policy.ts
+++ b/packages/core/src/runbook/command-policy.ts
@@ -62,6 +62,12 @@ export type CommandTargetSelector =
       readonly kind: 'explicit-step';
       /** Step id supplied by the caller. */
       readonly step: string;
+    }
+  | {
+      /** Explicit run-id target selector from `--run <rd_…>`. */
+      readonly kind: 'run';
+      /** Run id supplied by the caller as both target and named authority. */
+      readonly runId: RunId;
     };
 
 /** Input to the core command-policy decision point. */

--- a/packages/core/src/runbook/command-policy.ts
+++ b/packages/core/src/runbook/command-policy.ts
@@ -125,6 +125,13 @@ export type DelegationPolicyOutcome =
       readonly kind: 'collect_requires_orchestrator';
       /** Target run the caller attempted to collect into. */
       readonly targetRunId: RunId;
+      /**
+       * Operator-facing remediation naming both explicit-authority lanes
+       * (`--run` for orchestrators, `--claim-id` for delegated children). Never
+       * echoes the target run id — the refusal is an accident barrier and must
+       * not hand a lingering child a copy-paste bypass.
+       */
+      readonly message: typeof COLLECT_REQUIRES_ORCHESTRATOR_MESSAGE;
     }
   | {
       /** Bare mutation is blocked by unconsumed reported delegation outcomes. */
@@ -280,6 +287,21 @@ function allowed(
   };
 }
 
+/**
+ * Remediation message for the `collect_requires_orchestrator` refusal.
+ *
+ * Names BOTH explicit-authority lanes with wording consistent with the
+ * `RUN_TARGET_UNAVAILABLE` / `ACTOR_CONTEXT_REQUIRED` remediations, and never
+ * echoes the target run id (decision 4 — accident-proofing, not secrecy: run
+ * ids are natively available from `rundown run` output and every event's
+ * `runbookId`).
+ */
+export const COLLECT_REQUIRES_ORCHESTRATOR_MESSAGE =
+  'rundown collect requires an actor that controls the target delegating run. ' +
+  'Pass `--run <rd_…>` with the run id from your orchestration context (printed by ' +
+  '`rundown run` and carried as runbookId on every event) if you are the orchestrator, ' +
+  'or `--claim-id <claimId>` if you are collecting within delegated work.';
+
 function requireOrchestratorForCollection(
   role: EffectiveRole,
   intent: CommandIntent,
@@ -292,6 +314,7 @@ function requireOrchestratorForCollection(
   return {
     kind: 'collect_requires_orchestrator',
     targetRunId: targetState.id,
+    message: COLLECT_REQUIRES_ORCHESTRATOR_MESSAGE,
   };
 }
 

--- a/packages/core/src/runbook/command-target-resolver.ts
+++ b/packages/core/src/runbook/command-target-resolver.ts
@@ -314,7 +314,11 @@ async function resolveRunTarget(
     };
   }
   if (state.lifecycle !== 'running') {
-    return { kind: 'unknown_run', runId, message: `Run ${runId} is ${state.lifecycle}.` };
+    return {
+      kind: 'unknown_run',
+      runId,
+      message: `Run ${runId} is ${state.lifecycle ?? 'not running'}.`,
+    };
   }
   return { kind: 'run', runId, state };
 }

--- a/packages/core/src/runbook/command-target-resolver.ts
+++ b/packages/core/src/runbook/command-target-resolver.ts
@@ -3,6 +3,7 @@ import type { ClaimId, ClaimIdResolution, ClaimRecord } from './claim-id.js';
 import { resolveCommandIntent, type CommandTargetSelector } from './command-policy.js';
 import type { DELEGATION_COLLECTION_PENDING_MESSAGE } from './delegation-lifecycle-read-model.js';
 import type { RunId } from './run-id.js';
+import type { RunningStackMemberResolution } from './session-service.js';
 import type { RunbookState } from './types.js';
 
 /** Manual transition commands subject to the open-delegated-children guard. */
@@ -196,16 +197,16 @@ export interface CommandTargetReader {
   getActive(): Promise<RunbookState | null>;
 
   /**
-   * Resolve an explicit `--run` target to its live session-stack run state.
+   * Resolve an explicit `--run` target to a running session-stack member.
    *
    * Resolves only ids present on the session default stack — `--run` names
    * authority over a run this session is orchestrating; cross-session work
    * stays claim-based.
    *
    * @param runId - Run id supplied by the caller via `--run`
-   * @returns The run state, or `null` when the id is not an active stack member
+   * @returns Typed outcome splitting "not on stack" from "not running"
    */
-  getRunById(runId: RunId): Promise<RunbookState | null>;
+  resolveRunningStackMember(runId: RunId): Promise<RunningStackMemberResolution>;
 
   /**
    * Resolve an explicit claim id to its child runbook state or failure status.
@@ -288,10 +289,49 @@ async function resolveClaimTarget(
 }
 
 /**
+ * Map a refusing {@link RunningStackMemberResolution} to the shared
+ * `unknown_run` refusal shape.
+ *
+ * Single source of truth for the operator-facing `--run` refusal messages:
+ * `not_on_stack` (unknown id or missing state file) and `not_running`
+ * (terminal lifecycle) render distinct causes, and every consumer — target
+ * resolution, run-targeted terminals, delegation-issuance anchoring — refuses
+ * with the identical wording.
+ *
+ * @param runId - Run id named by the caller via `--run`
+ * @param member - The refusing stack-member resolution
+ * @returns The `unknown_run` refusal member shared across the outcome unions
+ */
+export function unknownRunRefusal(
+  runId: RunId,
+  member: Exclude<RunningStackMemberResolution, { kind: 'running' }>,
+): { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string } {
+  switch (member.kind) {
+    case 'not_on_stack':
+      return {
+        kind: 'unknown_run',
+        runId,
+        message: `Run ${runId} is not part of this session's active stack.`,
+      };
+    case 'not_running':
+      return {
+        kind: 'unknown_run',
+        runId,
+        message: `Run ${runId} is ${member.lifecycle ?? 'not running'}.`,
+      };
+    default: {
+      const _exhaustive: never = member;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
  * Shared head for resolving an explicit `--run` target for both resolvers.
  *
- * A `null` reader result (id not on the session stack, or missing state file)
- * and a non-`running` lifecycle both refuse as `unknown_run`; a running state
+ * Delegates the running-stack-member decision to the reader's
+ * {@link CommandTargetReader.resolveRunningStackMember} and maps a refusing
+ * outcome to `unknown_run` via {@link unknownRunRefusal}; a running state
  * resolves ready.
  *
  * @param targetReader - Read-side dependency used to resolve the run id
@@ -305,22 +345,11 @@ async function resolveRunTarget(
   | { readonly kind: 'run'; readonly runId: RunId; readonly state: RunbookState }
   | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
 > {
-  const state = await targetReader.getRunById(runId);
-  if (!state) {
-    return {
-      kind: 'unknown_run',
-      runId,
-      message: `Run ${runId} is not part of this session's active stack.`,
-    };
+  const member = await targetReader.resolveRunningStackMember(runId);
+  if (member.kind !== 'running') {
+    return unknownRunRefusal(runId, member);
   }
-  if (state.lifecycle !== 'running') {
-    return {
-      kind: 'unknown_run',
-      runId,
-      message: `Run ${runId} is ${state.lifecycle ?? 'not running'}.`,
-    };
-  }
-  return { kind: 'run', runId, state };
+  return { kind: 'run', runId, state: member.state };
 }
 
 /**

--- a/packages/core/src/runbook/command-target-resolver.ts
+++ b/packages/core/src/runbook/command-target-resolver.ts
@@ -1,6 +1,6 @@
 import { UNKNOWN_ACTOR_CONTEXT, type ActorContext } from './actor-context.js';
 import type { ClaimId, ClaimIdResolution, ClaimRecord } from './claim-id.js';
-import { resolveCommandIntent } from './command-policy.js';
+import { resolveCommandIntent, type CommandTargetSelector } from './command-policy.js';
 import type { DELEGATION_COLLECTION_PENDING_MESSAGE } from './delegation-lifecycle-read-model.js';
 import type { RunId } from './run-id.js';
 import type { RunbookState } from './types.js';
@@ -32,7 +32,26 @@ export type CommandTargetResolution =
     }
   | { readonly kind: 'default'; readonly state: RunbookState }
   | { readonly kind: 'none' }
-  | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string };
+  | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string }
+  | {
+      /** Ready resolution for an explicit `--run` target on the session stack. */
+      readonly kind: 'run';
+      /** Run id named by the caller. */
+      readonly runId: RunId;
+      /** Resolved running state of the named run. */
+      readonly state: RunbookState;
+    }
+  | {
+      /**
+       * Refusal: the named `--run` id is not a running member of this session's
+       * default stack (unknown id, missing state file, or terminal lifecycle).
+       */
+      readonly kind: 'unknown_run';
+      /** Run id named by the caller. */
+      readonly runId: RunId;
+      /** Operator-facing refusal message. */
+      readonly message: string;
+    };
 
 /** Claim-targeting outcomes only (no default-stack / open-children cases). */
 type ClaimTargetResolution = Extract<
@@ -97,12 +116,37 @@ export type TransitionTargetResolution =
       readonly kind: 'actor_context_required';
       /** Target run the refused transition would have advanced. */
       readonly targetRunId: RunId;
+    }
+  | {
+      /** Ready resolution for an explicit `--run` target on the session stack. */
+      readonly kind: 'run';
+      /** Run id named by the caller. */
+      readonly runId: RunId;
+      /** Resolved running state of the named run. */
+      readonly state: RunbookState;
+    }
+  | {
+      /**
+       * Refusal: the named `--run` id is not a running member of this session's
+       * default stack (unknown id, missing state file, or terminal lifecycle).
+       */
+      readonly kind: 'unknown_run';
+      /** Run id named by the caller. */
+      readonly runId: RunId;
+      /** Operator-facing refusal message. */
+      readonly message: string;
     };
 
 /** Options for {@link resolveCommandTarget}. */
 export interface ResolveCommandTargetOptions {
   /** Explicit claim id to target instead of the default stack. */
   readonly claimId?: ClaimId;
+  /**
+   * Explicit run id to target from `--run`. Mutually exclusive with `claimId`;
+   * the CLI enforces exclusivity — the resolver gives `claimId` precedence and
+   * never sees both.
+   */
+  readonly runId?: RunId;
   /**
    * When true, a stashed claimed child resolves as `claim` (read-only
    * inspection paths set this); when false (default) it resolves as
@@ -117,6 +161,12 @@ export interface ResolveTransitionTargetOptions {
   readonly command: TransitionCommandName;
   /** Explicit claim id to target instead of the default stack. */
   readonly claimId?: ClaimId;
+  /**
+   * Explicit run id to target from `--run`. Mutually exclusive with `claimId`;
+   * the CLI enforces exclusivity — the resolver gives `claimId` precedence and
+   * never sees both.
+   */
+  readonly runId?: RunId;
   /**
    * True when the caller supplied an explicit `--step` target. The
    * open-delegated-children refusal guards only *bare* pass/fail (an accidental
@@ -144,6 +194,18 @@ export interface CommandTargetReader {
    * @returns Active runbook state, or `null` when no default target exists
    */
   getActive(): Promise<RunbookState | null>;
+
+  /**
+   * Resolve an explicit `--run` target to its live session-stack run state.
+   *
+   * Resolves only ids present on the session default stack — `--run` names
+   * authority over a run this session is orchestrating; cross-session work
+   * stays claim-based.
+   *
+   * @param runId - Run id supplied by the caller via `--run`
+   * @returns The run state, or `null` when the id is not an active stack member
+   */
+  getRunById(runId: RunId): Promise<RunbookState | null>;
 
   /**
    * Resolve an explicit claim id to its child runbook state or failure status.
@@ -226,6 +288,38 @@ async function resolveClaimTarget(
 }
 
 /**
+ * Shared head for resolving an explicit `--run` target for both resolvers.
+ *
+ * A `null` reader result (id not on the session stack, or missing state file)
+ * and a non-`running` lifecycle both refuse as `unknown_run`; a running state
+ * resolves ready.
+ *
+ * @param targetReader - Read-side dependency used to resolve the run id
+ * @param runId - Explicit run id from `--run`
+ * @returns Ready `run` resolution or `unknown_run` refusal
+ */
+async function resolveRunTarget(
+  targetReader: CommandTargetReader,
+  runId: RunId,
+): Promise<
+  | { readonly kind: 'run'; readonly runId: RunId; readonly state: RunbookState }
+  | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
+> {
+  const state = await targetReader.getRunById(runId);
+  if (!state) {
+    return {
+      kind: 'unknown_run',
+      runId,
+      message: `Run ${runId} is not part of this session's active stack.`,
+    };
+  }
+  if (state.lifecycle !== 'running') {
+    return { kind: 'unknown_run', runId, message: `Run ${runId} is ${state.lifecycle}.` };
+  }
+  return { kind: 'run', runId, state };
+}
+
+/**
  * Resolve the runbook a targeting command should act on.
  *
  * Replaces the former CLI-only `resolveActiveRunbook`. Used by every command
@@ -233,7 +327,7 @@ async function resolveClaimTarget(
  * guard, which uses {@link resolveTransitionTarget}.
  *
  * @param targetReader - Read-side dependency used to read claim and default targets
- * @param options - Optional explicit claim id and stashed-visibility flag
+ * @param options - Optional explicit claim id / run id and stashed-visibility flag
  * @returns Discriminated target resolution
  */
 export async function resolveCommandTarget(
@@ -244,6 +338,9 @@ export async function resolveCommandTarget(
     return resolveClaimTarget(targetReader, options.claimId, {
       includeStashed: options.allowStashed === true,
     });
+  }
+  if (options.runId !== undefined) {
+    return resolveRunTarget(targetReader, options.runId);
   }
   const state = await targetReader.getActive();
   return state ? { kind: 'default', state } : { kind: 'none' };
@@ -303,6 +400,23 @@ export async function resolveTransitionTarget(
         };
   }
 
+  if (options.runId !== undefined) {
+    const run = await resolveRunTarget(targetReader, options.runId);
+    if (run.kind === 'unknown_run') {
+      return run;
+    }
+    // A run-shaped target flows through the SAME policy block as the default
+    // path — `--run` names authority, it does not bypass the collection guards.
+    if (!options.targeted) {
+      const refusal = await evaluateBareTransitionPolicy(targetReader, options, run.state, {
+        kind: 'run',
+        runId: run.runId,
+      });
+      if (refusal) return refusal;
+    }
+    return run;
+  }
+
   const active = await targetReader.getActive();
   if (!active) {
     return { kind: 'none' };
@@ -311,49 +425,75 @@ export async function resolveTransitionTarget(
   // Targeted (`--step`) transitions are deliberate and exempt from the
   // bare-only open-delegated-children refusal.
   if (!options.targeted) {
-    const openClaims = await targetReader.listOpenClaimsForParent(active.id);
-    const actorContext = options.actorContext ?? UNKNOWN_ACTOR_CONTEXT;
-    const policy = resolveCommandIntent({
-      actorContext,
-      intent: { kind: 'delegating-run-advance', command: options.command, targeted: false },
-      targetSelector: { kind: 'default' },
-      targetState: active,
-      openClaims,
+    const refusal = await evaluateBareTransitionPolicy(targetReader, options, active, {
+      kind: 'default',
     });
-    switch (policy.kind) {
-      case 'allowed':
-        break;
-      case 'delegation_collection_pending':
-        return {
-          kind: 'delegation_collection_pending',
-          parentRunId: policy.parentRunId,
-          outcomeCompletionKeys: policy.outcomeCompletionKeys,
-          message: policy.message,
-        };
-      case 'open_claims':
-        return { kind: 'open_delegated_children', parentRunId: active.id, claims: policy.claims };
-      case 'actor_context_required':
-        return { kind: 'actor_context_required', targetRunId: active.id };
-      case 'collect_requires_orchestrator':
-      case 'missing_outcomes':
-      case 'already_collected':
-      case 'collection_frame_not_active':
-      case 'collection_applied':
-      case 'collection_failed':
-        // Unreachable for a delegating-run-advance intent: the orchestrator gate
-        // and the collection-operation outcomes belong to the collection path
-        // only (emitted by collectDelegationOutcomes, never resolveCommandIntent).
-        // A real occurrence is an invariant violation, not an expected refusal,
-        // so it stays a throw.
-        throw new Error(`Unexpected transition policy outcome: ${policy.kind}`);
-      default: {
-        const _exhaustive: never = policy;
-        return _exhaustive;
-      }
-    }
+    if (refusal) return refusal;
   }
 
   return { kind: 'default', state: active };
+}
+
+/**
+ * Shared bare-transition policy block for the default and run-targeted paths.
+ *
+ * Runs `resolveCommandIntent` for a bare-shaped `delegating-run-advance` over
+ * the resolved target and maps refusing policy outcomes to their transition
+ * resolution members. Returns `undefined` when the policy allows the advance.
+ *
+ * @param targetReader - Read-side dependency used to list open claims
+ * @param options - Transition options carrying command and actor context
+ * @param target - Resolved target run state (default active or `--run`-named)
+ * @param targetSelector - Selector shape describing how the target was named
+ * @returns A refusing resolution, or `undefined` when allowed
+ * @throws {Error} On policy outcomes unreachable for a transition intent
+ */
+async function evaluateBareTransitionPolicy(
+  targetReader: CommandTargetReader,
+  options: ResolveTransitionTargetOptions,
+  target: RunbookState,
+  targetSelector: CommandTargetSelector,
+): Promise<TransitionTargetResolution | undefined> {
+  const openClaims = await targetReader.listOpenClaimsForParent(target.id);
+  const actorContext = options.actorContext ?? UNKNOWN_ACTOR_CONTEXT;
+  const policy = resolveCommandIntent({
+    actorContext,
+    intent: { kind: 'delegating-run-advance', command: options.command, targeted: false },
+    targetSelector,
+    targetState: target,
+    openClaims,
+  });
+  switch (policy.kind) {
+    case 'allowed':
+      return undefined;
+    case 'delegation_collection_pending':
+      return {
+        kind: 'delegation_collection_pending',
+        parentRunId: policy.parentRunId,
+        outcomeCompletionKeys: policy.outcomeCompletionKeys,
+        message: policy.message,
+      };
+    case 'open_claims':
+      return { kind: 'open_delegated_children', parentRunId: target.id, claims: policy.claims };
+    case 'actor_context_required':
+      return { kind: 'actor_context_required', targetRunId: target.id };
+    case 'collect_requires_orchestrator':
+    case 'missing_outcomes':
+    case 'already_collected':
+    case 'collection_frame_not_active':
+    case 'collection_applied':
+    case 'collection_failed':
+      // Unreachable for a delegating-run-advance intent: the orchestrator gate
+      // and the collection-operation outcomes belong to the collection path
+      // only (emitted by collectDelegationOutcomes, never resolveCommandIntent).
+      // A real occurrence is an invariant violation, not an expected refusal,
+      // so it stays a throw.
+      throw new Error(`Unexpected transition policy outcome: ${policy.kind}`);
+    default: {
+      const _exhaustive: never = policy;
+      return _exhaustive;
+    }
+  }
 }
 
 /**

--- a/packages/core/src/runbook/command-target-resolver.ts
+++ b/packages/core/src/runbook/command-target-resolver.ts
@@ -106,16 +106,16 @@ export type TransitionTargetResolution =
     }
   | {
       /**
-       * The caller supplied no trusted actor evidence for the resolved target, so
-       * a bare transition is refused. This is the strict-core default for a caller
-       * that passes no `actorContext`; the direct CLI maps its `direct_cli` caller
-       * evidence to a trusted run controller upstream and never reaches it.
-       * Returned (not thrown) so MCP/plugin/core adapters render the policy error
-       * consistently.
+       * The caller supplied no trusted actor evidence for the resolved target,
+       * so the transition is refused — targeted (`--step`) and bare alike: a
+       * step name is a completion target, not authority. Deliberately carries
+       * NO run id: echoing the target id would hand a lingering child agent a
+       * copy-paste bypass of the accident barrier (run ids are natively
+       * available from `rundown run` output and every event's `runbookId`).
+       * Returned (not thrown) so MCP/plugin/core adapters render the policy
+       * error consistently.
        */
       readonly kind: 'actor_context_required';
-      /** Target run the refused transition would have advanced. */
-      readonly targetRunId: RunId;
     }
   | {
       /** Ready resolution for an explicit `--run` target on the session stack. */
@@ -407,13 +407,11 @@ export async function resolveTransitionTarget(
     }
     // A run-shaped target flows through the SAME policy block as the default
     // path — `--run` names authority, it does not bypass the collection guards.
-    if (!options.targeted) {
-      const refusal = await evaluateBareTransitionPolicy(targetReader, options, run.state, {
-        kind: 'run',
-        runId: run.runId,
-      });
-      if (refusal) return refusal;
-    }
+    const refusal = await evaluateTransitionPolicy(targetReader, options, run.state, {
+      kind: 'run',
+      runId: run.runId,
+    });
+    if (refusal) return refusal;
     return run;
   }
 
@@ -422,43 +420,49 @@ export async function resolveTransitionTarget(
     return { kind: 'none' };
   }
 
-  // Targeted (`--step`) transitions are deliberate and exempt from the
-  // bare-only open-delegated-children refusal.
-  if (!options.targeted) {
-    const refusal = await evaluateBareTransitionPolicy(targetReader, options, active, {
-      kind: 'default',
-    });
-    if (refusal) return refusal;
-  }
+  // The role gate applies to targeted (`--step`) and bare transitions alike —
+  // "everyone names their authority": a step name is a completion target, not
+  // authority. Only the collection guards inside resolveCommandIntent key on
+  // `targeted` (a deliberate targeted completion keeps its exemption).
+  const refusal = await evaluateTransitionPolicy(targetReader, options, active, {
+    kind: 'default',
+  });
+  if (refusal) return refusal;
 
   return { kind: 'default', state: active };
 }
 
 /**
- * Shared bare-transition policy block for the default and run-targeted paths.
+ * Shared transition policy block for the default and run-targeted paths.
  *
- * Runs `resolveCommandIntent` for a bare-shaped `delegating-run-advance` over
- * the resolved target and maps refusing policy outcomes to their transition
- * resolution members. Returns `undefined` when the policy allows the advance.
+ * Always runs `resolveCommandIntent` for a `delegating-run-advance` over the
+ * resolved target — the role gate applies to targeted and bare transitions
+ * alike, while `targeted: true` continues to exempt only the
+ * collection-pending / open-claims guards. Maps refusing policy outcomes to
+ * their transition resolution members; returns `undefined` when allowed.
  *
  * @param targetReader - Read-side dependency used to list open claims
- * @param options - Transition options carrying command and actor context
+ * @param options - Transition options carrying command, targeting, and actor context
  * @param target - Resolved target run state (default active or `--run`-named)
  * @param targetSelector - Selector shape describing how the target was named
  * @returns A refusing resolution, or `undefined` when allowed
  * @throws {Error} On policy outcomes unreachable for a transition intent
  */
-async function evaluateBareTransitionPolicy(
+async function evaluateTransitionPolicy(
   targetReader: CommandTargetReader,
   options: ResolveTransitionTargetOptions,
   target: RunbookState,
   targetSelector: CommandTargetSelector,
 ): Promise<TransitionTargetResolution | undefined> {
-  const openClaims = await targetReader.listOpenClaimsForParent(target.id);
+  const targeted = options.targeted === true;
+  // Open claims feed only the bare-shaped open-children guard; a targeted
+  // transition is exempt from it, so the read is skipped (and reader fakes
+  // asserting "no open-claim read for targeted" stay valid).
+  const openClaims = targeted ? [] : await targetReader.listOpenClaimsForParent(target.id);
   const actorContext = options.actorContext ?? UNKNOWN_ACTOR_CONTEXT;
   const policy = resolveCommandIntent({
     actorContext,
-    intent: { kind: 'delegating-run-advance', command: options.command, targeted: false },
+    intent: { kind: 'delegating-run-advance', command: options.command, targeted },
     targetSelector,
     targetState: target,
     openClaims,
@@ -476,7 +480,7 @@ async function evaluateBareTransitionPolicy(
     case 'open_claims':
       return { kind: 'open_delegated_children', parentRunId: target.id, claims: policy.claims };
     case 'actor_context_required':
-      return { kind: 'actor_context_required', targetRunId: target.id };
+      return { kind: 'actor_context_required' };
     case 'collect_requires_orchestrator':
     case 'missing_outcomes':
     case 'already_collected':

--- a/packages/core/src/runbook/delegation-exposure.ts
+++ b/packages/core/src/runbook/delegation-exposure.ts
@@ -1,0 +1,72 @@
+import { resolvedStepHasSubsteps } from '@rundown-org/parser';
+import type { ResolvedStep } from '@rundown-org/parser';
+import type { ClaimRecord } from './claim-id.js';
+import { readDelegationCollectionPendingForPolicy } from './delegation-lifecycle-read-model.js';
+import type { RunbookState } from './types.js';
+
+/**
+ * Whether a run participates in delegation or composition and therefore
+ * requires named authority (`--run` / `--claim-id`) for mutations.
+ *
+ * `standalone` is the only exposure for which bare `direct_cli` evidence may
+ * still map to run-controller trust. Exposure is sticky by construction for
+ * every state-derived clause: delegation and inline substep-state records
+ * (clauses d/f) never decay for the life of the run. The document-derived
+ * static clauses (a and f's runbook-list signal) are re-parsed at decision
+ * time — see the classifier TSDoc for the mid-run document-edit caveat.
+ */
+export type DelegationExposure = 'delegating' | 'standalone';
+
+/** Input to {@link classifyDelegationExposure}. */
+export interface DelegationExposureInput {
+  /** Persisted run state for the run being classified. */
+  readonly state: RunbookState;
+  /** Resolved steps of the run's document (the seam's loadSteps result). */
+  readonly steps: readonly ResolvedStep[];
+  /** Open claimed children for this run (from listOpenClaimsForParent). */
+  readonly openClaims: readonly ClaimRecord[];
+}
+
+/**
+ * Classify a run's delegation exposure.
+ *
+ * A run is `delegating` iff any of: (a) its document authors a DELEGATE
+ * substep; (b) it has open claimed children; (c) it has reported-but-
+ * uncollected delegation outcomes; (d) any substep state carries a delegation
+ * record (sticky history); (e) it carries parent linkage (inline or
+ * delegation) — composed-pipeline stages are orchestrator-owned; (f) it
+ * composes children inline — statically, any substep carries runbook-list
+ * entries, or at runtime any substep state carries an inline launch record
+ * (sticky, like d). Clauses (a) and (f-static) are recomputed from the parsed
+ * document at decision time, so a mid-run edit of the runbook document can
+ * flip a not-yet-issued run's static exposure; every state-derived clause is
+ * monotone and never decays.
+ *
+ * @param input - State, parsed steps, and open claims for one run
+ * @returns The run's delegation exposure
+ */
+export function classifyDelegationExposure(input: DelegationExposureInput): DelegationExposure {
+  const { state, steps, openClaims } = input;
+  if (openClaims.length > 0) return 'delegating';
+  if (state.parentLinkage !== undefined) return 'delegating';
+  if (
+    state.substepStates?.some(
+      (substep) => substep.delegation !== undefined || substep.inline !== undefined,
+    )
+  ) {
+    return 'delegating';
+  }
+  if (readDelegationCollectionPendingForPolicy(state).pending) return 'delegating';
+  if (
+    steps.some(
+      (step) =>
+        resolvedStepHasSubsteps(step) &&
+        step.substeps.some(
+          (substep) => substep.delegate === true || (substep.runbooks?.length ?? 0) > 0,
+        ),
+    )
+  ) {
+    return 'delegating';
+  }
+  return 'standalone';
+}

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -107,6 +107,7 @@ export {
   type DelegationExposureInput,
 } from './delegation-exposure.js';
 export {
+  COLLECT_REQUIRES_ORCHESTRATOR_MESSAGE,
   deriveEffectiveRole,
   resolveCommandIntent,
   type CommandIntent,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -102,6 +102,11 @@ export {
   type EffectiveRole,
 } from './actor-context.js';
 export {
+  classifyDelegationExposure,
+  type DelegationExposure,
+  type DelegationExposureInput,
+} from './delegation-exposure.js';
+export {
   deriveEffectiveRole,
   resolveCommandIntent,
   type CommandIntent,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -78,6 +78,7 @@ export {
   type InlineForceTerminalKind,
   type ReleaseRunbookResult,
   type ReleaseRunbooksResult,
+  type RunningStackMemberResolution,
   type UnstashForClaimIdResult,
 } from './session-service.js';
 export {

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -100,6 +100,7 @@ export {
   type ActorContext,
   type CallerEvidence,
   type EffectiveRole,
+  type EvidenceTarget,
 } from './actor-context.js';
 export {
   classifyDelegationExposure,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -164,6 +164,8 @@ export {
   type DelegationIssuanceOutcome,
   type FindDelegationByToken,
   type LifecycleLoopDirective,
+  type LifecycleNavigationInput,
+  type LifecycleNavigationOutcome,
   type LifecycleTerminalInput,
   type LifecycleTerminalOutcome,
   type LifecycleTerminalReleaseMode,

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -21,6 +21,7 @@ import { Errors } from '../errors/factory.js';
 import type { RundownError } from '../errors/rundown-error.js';
 import { sameRunbookRef, type RunbookRef } from './runbook-ref.js';
 import {
+  resolveCommandTarget,
   resolveTerminalTarget,
   resolveTransitionTarget,
   unknownRunRefusal,
@@ -579,6 +580,68 @@ export type LifecycleTerminalOutcome =
       readonly forcedRunIds: readonly RunId[];
       /** Outcome of recording the forced root to its parent before release. */
       readonly reported: TerminalReportOutcome;
+    };
+
+/** Input to {@link RunbookLifecycleCommandService.resolveRunNavigation}. */
+export interface LifecycleNavigationInput {
+  /** The navigation command being run (currently only `goto`). */
+  readonly command: 'goto';
+  /** Typed caller evidence mapped to an actor context by core. */
+  readonly callerEvidence: CallerEvidence;
+  /**
+   * Target selector — `default`, `claim`, or `run`. An `explicit-step`
+   * selector is rejected by `resolveRunNavigation`: the navigation target
+   * (which step to jump to) is the command's positional argument, not a
+   * run selector.
+   */
+  readonly targetSelector: CommandTargetSelector;
+}
+
+/**
+ * Outcome of {@link RunbookLifecycleCommandService.resolveRunNavigation}.
+ *
+ * Refusal variants mirror the base {@link CommandTargetResolution} shapes; the
+ * `allowed` variant carries the resolved run, its parsed steps (derived
+ * in-seam via `loadSteps`), and the terminal release mode a follow-on
+ * execution loop should apply — everything the frontend needs to drive the
+ * navigation without re-resolving or re-gating anything.
+ */
+export type LifecycleNavigationOutcome =
+  /** No active runbook (bare path) to navigate. */
+  | { readonly kind: 'none' }
+  /** The targeted claim id does not resolve to a live claimed child. */
+  | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string }
+  | {
+      /** The targeted claim id points at a terminal (completed/stopped) child. */
+      readonly kind: 'terminal_claim';
+      readonly claimId: ClaimId;
+      readonly lifecycle: 'completed' | 'stopped';
+      readonly message: string;
+    }
+  | {
+      /** The explicit `--run` target is not a running member of the session stack. */
+      readonly kind: 'unknown_run';
+      /** Run id named by the caller. */
+      readonly runId: RunId;
+      /** Operator-facing refusal message from the resolver. */
+      readonly message: string;
+    }
+  /**
+   * The run-navigation policy gate refused the caller's evidence. Carries no
+   * run id (accident barrier — see the resolver member's rationale).
+   */
+  | { readonly kind: 'actor_context_required' }
+  | {
+      /** Navigation is allowed against the resolved run. */
+      readonly kind: 'allowed';
+      /** Run the navigation targets. */
+      readonly runId: RunId;
+      /** Resolved running state of the target run. */
+      readonly state: RunbookState;
+      /** Parsed steps of the target run, derived in-seam. */
+      readonly steps: readonly ResolvedStep[];
+      /** How a follow-on execution loop should release this run terminally. */
+      readonly terminalReleaseMode: LifecycleTerminalReleaseMode;
     };
 
 /**
@@ -1173,6 +1236,110 @@ export class RunbookLifecycleCommandService {
         throw new Error(`Unsupported terminal target selector: ${String(_exhaustive)}`);
       }
     }
+  }
+
+  /**
+   * Resolve the target and run the run-navigation policy gate for a goto.
+   *
+   * The single core seam for navigation authorization — the CLI dispatches
+   * into it exactly as pass/fail dispatch into {@link runTransition}, so a
+   * future policy input added to core applies to goto automatically. It
+   * resolves the selector through the shared target resolver, maps caller
+   * evidence to an actor context (a claim-resolved target contributes its own
+   * reconstructable claim evidence, exactly as the claim record proves control
+   * of the claimed child), and evaluates the `run-navigation` intent: goto is
+   * role-gated like an advance (unknown callers are refused) but exempt from
+   * the collection-pending / open-claims guards — navigation is operator
+   * control flow, not completion.
+   *
+   * The machine dispatch itself (`GOTO` + execution loop) stays with the
+   * frontend, which already drives it through `RunbookActorService` — this
+   * seam owns everything decision-shaped: resolution, evidence mapping, and
+   * policy.
+   *
+   * @param input - Command, caller evidence, and target selector.
+   * @returns A typed refusal or an `allowed` outcome carrying the resolved
+   *   run, its steps, and the terminal release mode.
+   * @throws {Error} When an `explicit-step` selector is supplied (the
+   *   navigation target is goto's positional argument, not a selector).
+   */
+  async resolveRunNavigation(input: LifecycleNavigationInput): Promise<LifecycleNavigationOutcome> {
+    const selector = input.targetSelector;
+    if (selector.kind === 'explicit-step') {
+      throw new Error('goto does not support --step run targeting');
+    }
+
+    const resolution = await resolveCommandTarget(this.#deps.sessionService, {
+      ...(selector.kind === 'claim' ? { claimId: selector.claimId } : {}),
+      ...(selector.kind === 'run' ? { runId: selector.runId } : {}),
+    });
+
+    switch (resolution.kind) {
+      case 'claim':
+      case 'default':
+      case 'run':
+        break;
+      case 'none':
+        return { kind: 'none' };
+      case 'stale_claim':
+        return { kind: 'stale_claim', claimId: resolution.claimId, message: resolution.message };
+      case 'terminal_claim':
+        return {
+          kind: 'terminal_claim',
+          claimId: resolution.claimId,
+          lifecycle: resolution.lifecycle,
+          message: resolution.message,
+        };
+      case 'unknown_run':
+        return { kind: 'unknown_run', runId: resolution.runId, message: resolution.message };
+      default: {
+        const _exhaustive: never = resolution;
+        return _exhaustive;
+      }
+    }
+
+    const state = resolution.state;
+    const steps = await this.#deps.loadSteps(state);
+
+    // A claim-resolved target carries its own claim evidence: the resolved
+    // claim record IS the caller's proof of control over the claimed child.
+    // Every other resolution evaluates the caller-supplied evidence against
+    // the resolved target (direct_cli consults exposure via the shared
+    // evidence-target derivation; run_controller binds to its named run).
+    const evidence: CallerEvidence =
+      resolution.kind === 'claim'
+        ? {
+            kind: 'claim',
+            claimId: resolution.claimId,
+            tokenHash: resolution.claim.tokenHash,
+            controlledRunId: resolution.claim.childRunId,
+          }
+        : input.callerEvidence;
+    const actorContext = actorContextFromEvidence(
+      evidence,
+      await this.#evidenceTargetFor(evidence, state, steps),
+    );
+
+    const policy = resolveCommandIntent({
+      actorContext,
+      intent: { kind: 'run-navigation', command: input.command, targeted: true },
+      targetSelector: selector,
+      targetState: state,
+    });
+    if (policy.kind !== 'allowed') {
+      // The only refusing outcome a run-navigation intent can produce is the
+      // role gate (navigation is exempt from the collection guards); carry no
+      // run id (accident barrier).
+      return { kind: 'actor_context_required' };
+    }
+
+    return {
+      kind: 'allowed',
+      runId: state.id,
+      state,
+      steps,
+      terminalReleaseMode: resolution.kind === 'claim' ? 'release-runbook' : 'stack-pop',
+    };
   }
 
   // Run-targeted terminal: resolve the named session-stack run, then feed it to

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -1324,16 +1324,20 @@ export class RunbookLifecycleCommandService {
   }
 
   // Map caller evidence to an actor context anchored on the resolved run.
-  // `direct_cli` evidence anchors on the active default run; `claim` evidence
-  // anchors on its own controlled run; everything else maps to the unknown
-  // context. Returns the unknown context when no anchor run exists (a direct-CLI
-  // caller with no active run is refused downstream as `none`).
+  // `direct_cli` evidence anchors on the active default run; `run_controller`
+  // evidence anchors on its own named run; `claim` evidence anchors on its own
+  // controlled run; everything else maps to the unknown context. Returns the
+  // unknown context when no anchor run exists (a direct-CLI caller with no
+  // active run is refused downstream as `none`).
   async #resolveActorContext(
     evidence: CallerEvidence,
     claimId: ClaimId | undefined,
   ): Promise<ActorContext> {
     if (evidence.kind === 'claim') {
       return actorContextFromEvidence(evidence, evidence.controlledRunId);
+    }
+    if (evidence.kind === 'run_controller') {
+      return actorContextFromEvidence(evidence, evidence.runId);
     }
     if (claimId !== undefined) {
       // Claim-targeted writes resolve through the resolver's claim path, which

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -207,6 +207,12 @@ export type DelegationIssuanceInput =
       readonly mode: 'fresh';
       /** Typed caller evidence mapped to an actor context for the policy gate. */
       readonly callerEvidence: CallerEvidence;
+      /**
+       * Explicit run id from `--run`. When present the issuance anchor is the
+       * named session-stack run instead of the active default; a missing or
+       * foreign id returns the `unknown-run` outcome.
+       */
+      readonly targetRunId?: RunId;
       /** Explicit step id from `--step`; `undefined` => bare inference. */
       readonly explicitStep?: string;
       /** Explicit FOR iteration from `--index`. */
@@ -232,6 +238,13 @@ export type DelegationIssuanceInput =
       readonly mode: 'retry';
       /** Typed caller evidence mapped to an actor context for the policy gate. */
       readonly callerEvidence: CallerEvidence;
+      /**
+       * Explicit run id from `--run`. Replaces the active-run anchor for the
+       * `step` / `active` locators; the `token` locator resolves cross-run by
+       * token scan and ignores it. A missing or foreign id returns the
+       * `unknown-run` outcome.
+       */
+      readonly targetRunId?: RunId;
       /** How the retry locates its target delegation. */
       readonly locator: RetryLocator;
       /**
@@ -279,6 +292,12 @@ export type DelegationIssuanceOutcome =
     }
   | { readonly kind: 'token-not-found'; readonly token: string }
   | { readonly kind: 'no-active-runbook' }
+  | {
+      /** The explicit `--run` target is not a running member of the session stack. */
+      readonly kind: 'unknown-run';
+      /** Run id named by the caller. */
+      readonly runId: RunId;
+    }
   | { readonly kind: 'refused'; readonly policy: DelegationPolicyOutcome }
   | { readonly kind: 'error'; readonly error: RundownError };
 
@@ -375,6 +394,14 @@ export type LifecycleTransitionOutcome =
     }
   | { readonly kind: 'actor_context_required'; readonly targetRunId: RunId }
   | {
+      /** The explicit `--run` target is not a running member of the session stack. */
+      readonly kind: 'unknown_run';
+      /** Run id named by the caller. */
+      readonly runId: RunId;
+      /** Operator-facing refusal message from the resolver. */
+      readonly message: string;
+    }
+  | {
       readonly kind: 'applied';
       /** Run the transition was applied to. */
       readonly runId: RunId;
@@ -412,7 +439,10 @@ export type LifecycleTransitionOutcome =
  * are therefore ready to drive (as opposed to refuse). Deriving this via
  * `Extract` makes adding a new ready kind a compile error in `#asRefusal`.
  */
-type ReadyTransitionResolution = Extract<TransitionTargetResolution, { kind: 'claim' | 'default' }>;
+type ReadyTransitionResolution = Extract<
+  TransitionTargetResolution,
+  { kind: 'claim' | 'default' | 'run' }
+>;
 
 /**
  * Result of classifying a transition target resolution: either a ready
@@ -463,6 +493,14 @@ export type LifecycleTerminalOutcome =
   | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string }
   /** Bare terminal needs actor context the caller evidence did not supply. */
   | { readonly kind: 'actor_context_required'; readonly targetRunId: RunId }
+  | {
+      /** The explicit `--run` target is not a running member of the session stack. */
+      readonly kind: 'unknown_run';
+      /** Run id named by the caller. */
+      readonly runId: RunId;
+      /** Operator-facing refusal message from the resolver. */
+      readonly message: string;
+    }
   | {
       /** Refused: the resolved root has reported-but-uncollected delegation outcomes. */
       readonly kind: 'delegation_collection_pending';
@@ -665,10 +703,14 @@ export class RunbookLifecycleCommandService {
   async issueDelegation(input: DelegationIssuanceInput): Promise<DelegationIssuanceOutcome> {
     if (input.mode === 'retry') return this.#issueRetry(input);
 
-    // Target identification only — the active run's id. Every state-dependent
+    // Target identification only — the anchor run's id (the `--run`-named
+    // session-stack member, or the active default). Every state-dependent
     // decision below runs against the locked re-read, not this snapshot.
-    const active = await this.#deps.sessionService.getActive();
-    if (!active) return { kind: 'no-active-runbook' };
+    const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
+    if (anchored.kind !== 'ok') {
+      return anchored.kind === 'unknown-run' ? anchored : { kind: 'no-active-runbook' };
+    }
+    const active = anchored.state;
     const activeId = active.id;
 
     // Resolve the requested positional (only) pre-lock: fs-only and
@@ -874,8 +916,11 @@ export class RunbookLifecycleCommandService {
       }
       stepLabel = snapshot.at;
     } else if (locator.kind === 'step') {
-      const active = await this.#deps.sessionService.getActive();
-      if (!active) return { kind: 'no-active-runbook' };
+      const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
+      if (anchored.kind !== 'ok') {
+        return anchored.kind === 'unknown-run' ? anchored : { kind: 'no-active-runbook' };
+      }
+      const active = anchored.state;
       targetState = active;
       const parsed = parseStepIdFromString(locator.step);
       const stepName = parsed?.step ?? locator.step;
@@ -900,8 +945,11 @@ export class RunbookLifecycleCommandService {
           ? deriveExecutionAt(stepName, parsed?.substep, locator.iteration)
           : locator.step;
     } else {
-      const active = await this.#deps.sessionService.getActive();
-      if (active?.substep === undefined) return { kind: 'no-active-runbook' };
+      const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
+      if (anchored.kind === 'unknown-run') return anchored;
+      if (anchored.kind === 'none') return { kind: 'no-active-runbook' };
+      const active = anchored.state;
+      if (active.substep === undefined) return { kind: 'no-active-runbook' };
       targetState = active;
       substepId = active.substep;
       // Surface the same canonical location used by token/step retries: an
@@ -1003,23 +1051,29 @@ export class RunbookLifecycleCommandService {
    */
   async runTransition(input: LifecycleTransitionInput): Promise<LifecycleTransitionOutcome> {
     const { sessionService } = this.#deps;
-    const targeted = input.targetSelector.kind === 'explicit-step';
+    // `targeted` derives from the presence of an explicit step target, never
+    // from the selector kind alone (decision 3): `pass --run <id> --step <n>`
+    // is targeted (the sanctioned operator recovery, exempt from the collection
+    // guards) while a bare-shaped `--run` advance is not and stays guarded.
+    const targeted = input.explicitTarget !== undefined;
     const claimId =
       input.targetSelector.kind === 'claim' ? input.targetSelector.claimId : undefined;
+    const runId = input.targetSelector.kind === 'run' ? input.targetSelector.runId : undefined;
 
     const actorContext = await this.#resolveActorContext(input.callerEvidence, claimId);
 
     const resolution = await resolveTransitionTarget(sessionService, {
       command: input.command,
       ...(claimId ? { claimId } : {}),
+      ...(runId ? { runId } : {}),
       targeted,
       actorContext,
     });
 
     const checked = this.#asRefusal(resolution);
     if (!checked.ready) return checked.outcome;
-    // The ready resolution carries the resolved run (claim / default), typed so
-    // `.state` is reachable with no cast.
+    // The ready resolution carries the resolved run (claim / default / run),
+    // typed so `.state` is reachable with no cast.
     const ready = checked.resolution;
 
     // A ready explicit-step transition must carry its raw explicit target.
@@ -1030,13 +1084,16 @@ export class RunbookLifecycleCommandService {
     // state-dependent validation of the target (step match, substep existence,
     // FOR bounds, frame construction) happens in-lock inside
     // #driveSubstepExplicit against the locked re-read.
-    if (targeted && input.explicitTarget === undefined) {
+    if (input.targetSelector.kind === 'explicit-step' && input.explicitTarget === undefined) {
       throw new Error('Explicit-step transition requires an explicit target');
     }
 
     const terminalReleaseMode: LifecycleTerminalReleaseMode =
       ready.kind === 'claim' ? 'release-runbook' : 'stack-pop';
-    const guardOpenChildren = ready.kind === 'default' && !targeted;
+    // The in-lock open-children re-check applies the same rule to a run-shaped
+    // ready resolution: guard when bare-shaped, exempt when the transition
+    // carries an explicit step target.
+    const guardOpenChildren = (ready.kind === 'default' || ready.kind === 'run') && !targeted;
 
     // Single resolution: derive the resolved run's steps in-seam from its
     // in-memory state, rather than taking `steps` as an input that would force the
@@ -1062,6 +1119,8 @@ export class RunbookLifecycleCommandService {
         return this.#driveTerminalClaim(input, input.targetSelector.claimId);
       case 'default':
         return this.#driveTerminalBare(input);
+      case 'run':
+        return this.#driveTerminalRun(input, input.targetSelector.runId);
       case 'explicit-step':
         throw new Error('complete/stop do not support --step targeting');
       default: {
@@ -1069,6 +1128,27 @@ export class RunbookLifecycleCommandService {
         throw new Error(`Unsupported terminal target selector: ${String(_exhaustive)}`);
       }
     }
+  }
+
+  // Run-targeted terminal: resolve the named session-stack run, then feed it to
+  // the existing inline force-terminal plan as the root anchor. Naming a run
+  // outside the stack (or a terminal one) refuses as `unknown_run`.
+  async #driveTerminalRun(
+    input: LifecycleTerminalInput,
+    runId: RunId,
+  ): Promise<LifecycleTerminalOutcome> {
+    const anchor = await this.#deps.sessionService.getRunById(runId);
+    if (!anchor) {
+      return {
+        kind: 'unknown_run',
+        runId,
+        message: `Run ${runId} is not part of this session's active stack.`,
+      };
+    }
+    if (anchor.lifecycle !== 'running') {
+      return { kind: 'unknown_run', runId, message: `Run ${runId} is ${anchor.lifecycle}.` };
+    }
+    return this.#driveTerminalBare(input, anchor);
   }
 
   // Claim-path terminal: resolve confirm/conflict, else FORCE the live child,
@@ -1171,10 +1251,14 @@ export class RunbookLifecycleCommandService {
 
   // Bare-cascade terminal: resolve the inline chain, gate the resolved root, force
   // descendant→root collecting observations, record the root outcome BEFORE
-  // releasing (root retains its tombstone; descendants delete).
-  async #driveTerminalBare(input: LifecycleTerminalInput): Promise<LifecycleTerminalOutcome> {
+  // releasing (root retains its tombstone; descendants delete). An optional
+  // `anchor` (from `--run`) replaces the active default as the chain start.
+  async #driveTerminalBare(
+    input: LifecycleTerminalInput,
+    anchor?: RunbookState,
+  ): Promise<LifecycleTerminalOutcome> {
     const { sessionService, actorService, completionService } = this.#deps;
-    const plan = await sessionService.resolveActiveInlineForceTerminalPlan(input.command);
+    const plan = await sessionService.resolveActiveInlineForceTerminalPlan(input.command, anchor);
 
     switch (plan.status) {
       case 'none':
@@ -1323,6 +1407,27 @@ export class RunbookLifecycleCommandService {
     };
   }
 
+  // Resolve the issuance anchor run: the `--run`-named session-stack member
+  // when a target run id is supplied (a missing/foreign/terminal id refuses as
+  // `unknown-run`), else the active default run (`none` when absent).
+  async #resolveIssuanceAnchor(
+    targetRunId: RunId | undefined,
+  ): Promise<
+    | { readonly kind: 'ok'; readonly state: RunbookState }
+    | { readonly kind: 'unknown-run'; readonly runId: RunId }
+    | { readonly kind: 'none' }
+  > {
+    if (targetRunId !== undefined) {
+      const named = await this.#deps.sessionService.getRunById(targetRunId);
+      if (!named || named.lifecycle !== 'running') {
+        return { kind: 'unknown-run', runId: targetRunId };
+      }
+      return { kind: 'ok', state: named };
+    }
+    const active = await this.#deps.sessionService.getActive();
+    return active ? { kind: 'ok', state: active } : { kind: 'none' };
+  }
+
   // Map caller evidence to an actor context anchored on the resolved run.
   // `direct_cli` evidence anchors on the active default run; `run_controller`
   // evidence anchors on its own named run; `claim` evidence anchors on its own
@@ -1357,9 +1462,19 @@ export class RunbookLifecycleCommandService {
     switch (resolution.kind) {
       case 'claim':
       case 'default':
+      case 'run':
         return { ready: true, resolution };
       case 'none':
         return { ready: false, outcome: { kind: 'none' } };
+      case 'unknown_run':
+        return {
+          ready: false,
+          outcome: {
+            kind: 'unknown_run',
+            runId: resolution.runId,
+            message: resolution.message,
+          },
+        };
       case 'stale_claim':
         return {
           ready: false,

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -1163,7 +1163,11 @@ export class RunbookLifecycleCommandService {
       };
     }
     if (anchor.lifecycle !== 'running') {
-      return { kind: 'unknown_run', runId, message: `Run ${runId} is ${anchor.lifecycle}.` };
+      return {
+        kind: 'unknown_run',
+        runId,
+        message: `Run ${runId} is ${anchor.lifecycle ?? 'not running'}.`,
+      };
     }
     return this.#driveTerminalBare(input, anchor);
   }
@@ -1483,7 +1487,7 @@ export class RunbookLifecycleCommandService {
   > {
     if (targetRunId !== undefined) {
       const named = await this.#deps.sessionService.getRunById(targetRunId);
-      if (!named || named.lifecycle !== 'running') {
+      if (named?.lifecycle !== 'running') {
         return { kind: 'unknown-run', runId: targetRunId };
       }
       return { kind: 'ok', state: named };

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -23,6 +23,7 @@ import { sameRunbookRef, type RunbookRef } from './runbook-ref.js';
 import {
   resolveTerminalTarget,
   resolveTransitionTarget,
+  unknownRunRefusal,
   type TerminalCommandName,
   type TransitionCommandName,
   type TransitionTargetResolution,
@@ -213,7 +214,7 @@ export type DelegationIssuanceInput =
       /**
        * Explicit run id from `--run`. When present the issuance anchor is the
        * named session-stack run instead of the active default; a missing or
-       * foreign id returns the `unknown-run` outcome.
+       * foreign id returns the `unknown_run` outcome.
        */
       readonly targetRunId?: RunId;
       /** Explicit step id from `--step`; `undefined` => bare inference. */
@@ -243,9 +244,10 @@ export type DelegationIssuanceInput =
       readonly callerEvidence: CallerEvidence;
       /**
        * Explicit run id from `--run`. Replaces the active-run anchor for the
-       * `step` / `active` locators; the `token` locator resolves cross-run by
-       * token scan and ignores it. A missing or foreign id returns the
-       * `unknown-run` outcome.
+       * `step` / `active` locators; a missing or foreign id returns the
+       * `unknown_run` outcome. The `token` locator resolves cross-run by token
+       * scan, then refuses with `run_target_mismatch` when the token's owning
+       * run differs from this id — named authority is never silently discarded.
        */
       readonly targetRunId?: RunId;
       /** How the retry locates its target delegation. */
@@ -297,9 +299,24 @@ export type DelegationIssuanceOutcome =
   | { readonly kind: 'no-active-runbook' }
   | {
       /** The explicit `--run` target is not a running member of the session stack. */
-      readonly kind: 'unknown-run';
+      readonly kind: 'unknown_run';
       /** Run id named by the caller. */
       readonly runId: RunId;
+      /** Operator-facing refusal message from the shared stack-member resolution. */
+      readonly message: string;
+    }
+  | {
+      /**
+       * Refusal: the retry token's owning run differs from the explicit `--run`
+       * target. Named authority is never silently discarded — a mismatch
+       * refuses (fail-closed). The message never echoes the token's actual
+       * owning run id (accident barrier — see the `unknown_run` rationale).
+       */
+      readonly kind: 'run_target_mismatch';
+      /** Run id named by the caller via `--run`. */
+      readonly runId: RunId;
+      /** Operator-facing refusal message. */
+      readonly message: string;
     }
   | { readonly kind: 'refused'; readonly policy: DelegationPolicyOutcome }
   | { readonly kind: 'error'; readonly error: RundownError };
@@ -711,7 +728,7 @@ export class RunbookLifecycleCommandService {
     // decision below runs against the locked re-read, not this snapshot.
     const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
     if (anchored.kind !== 'ok') {
-      return anchored.kind === 'unknown-run' ? anchored : { kind: 'no-active-runbook' };
+      return anchored.kind === 'unknown_run' ? anchored : { kind: 'no-active-runbook' };
     }
     const active = anchored.state;
     const activeId = active.id;
@@ -908,6 +925,17 @@ export class RunbookLifecycleCommandService {
     if (locator.kind === 'token') {
       const scan = await this.#deps.findDelegationByToken(locator.token);
       if (!scan) return { kind: 'token-not-found', token: locator.token };
+      // Fail-closed: an explicit `--run` that names a different run than the
+      // token's owner is refused, never silently discarded. The message echoes
+      // only the caller-supplied id — never the token's actual owning run
+      // (accident barrier).
+      if (input.targetRunId !== undefined && scan.parentState.id !== input.targetRunId) {
+        return {
+          kind: 'run_target_mismatch',
+          runId: input.targetRunId,
+          message: `Run ${input.targetRunId} does not own the supplied delegation token.`,
+        };
+      }
       targetState = scan.parentState;
       substepId = scan.substepId ?? scan.stepId;
       frameKey = scan.frameKey;
@@ -928,7 +956,7 @@ export class RunbookLifecycleCommandService {
     } else if (locator.kind === 'step') {
       const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
       if (anchored.kind !== 'ok') {
-        return anchored.kind === 'unknown-run' ? anchored : { kind: 'no-active-runbook' };
+        return anchored.kind === 'unknown_run' ? anchored : { kind: 'no-active-runbook' };
       }
       const active = anchored.state;
       targetState = active;
@@ -956,7 +984,7 @@ export class RunbookLifecycleCommandService {
           : locator.step;
     } else {
       const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
-      if (anchored.kind === 'unknown-run') return anchored;
+      if (anchored.kind === 'unknown_run') return anchored;
       if (anchored.kind === 'none') return { kind: 'no-active-runbook' };
       const active = anchored.state;
       if (active.substep === undefined) return { kind: 'no-active-runbook' };
@@ -1149,27 +1177,17 @@ export class RunbookLifecycleCommandService {
 
   // Run-targeted terminal: resolve the named session-stack run, then feed it to
   // the existing inline force-terminal plan as the root anchor. Naming a run
-  // outside the stack (or a terminal one) refuses as `unknown_run`.
+  // outside the stack (or a terminal one) refuses as `unknown_run` via the
+  // shared stack-member resolution.
   async #driveTerminalRun(
     input: LifecycleTerminalInput,
     runId: RunId,
   ): Promise<LifecycleTerminalOutcome> {
-    const anchor = await this.#deps.sessionService.getRunById(runId);
-    if (!anchor) {
-      return {
-        kind: 'unknown_run',
-        runId,
-        message: `Run ${runId} is not part of this session's active stack.`,
-      };
+    const member = await this.#deps.sessionService.resolveRunningStackMember(runId);
+    if (member.kind !== 'running') {
+      return unknownRunRefusal(runId, member);
     }
-    if (anchor.lifecycle !== 'running') {
-      return {
-        kind: 'unknown_run',
-        runId,
-        message: `Run ${runId} is ${anchor.lifecycle ?? 'not running'}.`,
-      };
-    }
-    return this.#driveTerminalBare(input, anchor);
+    return this.#driveTerminalBare(input, member.state);
   }
 
   // Claim-path terminal: resolve confirm/conflict, else FORCE the live child,
@@ -1477,20 +1495,22 @@ export class RunbookLifecycleCommandService {
 
   // Resolve the issuance anchor run: the `--run`-named session-stack member
   // when a target run id is supplied (a missing/foreign/terminal id refuses as
-  // `unknown-run`), else the active default run (`none` when absent).
+  // `unknown_run` via the shared stack-member resolution, carrying the same
+  // cause-specific message pass/complete refuse with), else the active default
+  // run (`none` when absent).
   async #resolveIssuanceAnchor(
     targetRunId: RunId | undefined,
   ): Promise<
     | { readonly kind: 'ok'; readonly state: RunbookState }
-    | { readonly kind: 'unknown-run'; readonly runId: RunId }
+    | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
     | { readonly kind: 'none' }
   > {
     if (targetRunId !== undefined) {
-      const named = await this.#deps.sessionService.getRunById(targetRunId);
-      if (named?.lifecycle !== 'running') {
-        return { kind: 'unknown-run', runId: targetRunId };
+      const member = await this.#deps.sessionService.resolveRunningStackMember(targetRunId);
+      if (member.kind !== 'running') {
+        return unknownRunRefusal(targetRunId, member);
       }
-      return { kind: 'ok', state: named };
+      return { kind: 'ok', state: member.state };
     }
     const active = await this.#deps.sessionService.getActive();
     return active ? { kind: 'ok', state: active } : { kind: 'none' };

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -2,9 +2,12 @@ import { parseStepIdFromString, resolvedStepHasSubsteps } from '@rundown-org/par
 import {
   UNKNOWN_ACTOR_CONTEXT,
   actorContextFromEvidence,
+  trustedRunControllerContext,
   type ActorContext,
   type CallerEvidence,
+  type EvidenceTarget,
 } from './actor-context.js';
+import { classifyDelegationExposure } from './delegation-exposure.js';
 import type { RunbookActorService } from './actor-service.js';
 import type { ClaimId, ClaimRecord } from './claim-id.js';
 import type { CommandTargetSelector, DelegationPolicyOutcome } from './command-policy.js';
@@ -392,7 +395,7 @@ export type LifecycleTransitionOutcome =
       readonly outcomeCompletionKeys: readonly string[];
       readonly message: typeof DELEGATION_COLLECTION_PENDING_MESSAGE;
     }
-  | { readonly kind: 'actor_context_required'; readonly targetRunId: RunId }
+  | { readonly kind: 'actor_context_required' }
   | {
       /** The explicit `--run` target is not a running member of the session stack. */
       readonly kind: 'unknown_run';
@@ -491,8 +494,8 @@ export type LifecycleTerminalOutcome =
   | { readonly kind: 'none' }
   /** The targeted claim id does not resolve to a live claimed child. */
   | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string }
-  /** Bare terminal needs actor context the caller evidence did not supply. */
-  | { readonly kind: 'actor_context_required'; readonly targetRunId: RunId }
+  /** Bare terminal needs actor context the caller evidence did not supply. Carries no run id (accident barrier — see the resolver member's rationale). */
+  | { readonly kind: 'actor_context_required' }
   | {
       /** The explicit `--run` target is not a running member of the session stack. */
       readonly kind: 'unknown_run';
@@ -739,14 +742,23 @@ export class RunbookLifecycleCommandService {
     const state = await this.#deps.loadRun(activeId);
     if (!state) return { kind: 'no-active-runbook' };
 
+    // Steps are loaded ABOVE the policy gate: direct_cli classification needs
+    // the parsed document (clause a/f static signals) as its input.
+    const steps = await this.#deps.loadSteps(state);
+
     // Policy gate — `targeted` means the operator named a specific step target
     // (an explicit `--step`). Only that exempts issuance from the bare-advance
     // collection-pending guard. A positional runbook arg is NOT a target: it
     // confirms the already-pending delegate substep (the bare path, subject to
     // RD-804/RD-822), so it stays `targeted: false` and remains gated. This
     // mirrors the pre-seam precheck, which keyed solely on `--step` absence.
+    // Classification is from the locked re-read (`state`) — the same instance
+    // the issuance resolution below decides from.
     const targeted = input.explicitStep !== undefined;
-    const actorContext = actorContextFromEvidence(input.callerEvidence, state.id);
+    const actorContext = actorContextFromEvidence(
+      input.callerEvidence,
+      await this.#evidenceTargetFor(input.callerEvidence, state, steps),
+    );
     const policy = resolveCommandIntent({
       actorContext,
       intent: { kind: 'delegation-issuance', command: 'delegate', targeted },
@@ -754,8 +766,6 @@ export class RunbookLifecycleCommandService {
       targetState: state,
     });
     if (policy.kind !== 'allowed') return { kind: 'refused', policy };
-
-    const steps = await this.#deps.loadSteps(state);
 
     // Frame key: an explicit --index scopes to a FOR iteration of the active
     // step; otherwise reuse the active frame. `--index` is pre-validated
@@ -980,9 +990,18 @@ export class RunbookLifecycleCommandService {
         : { kind: 'no-active-runbook' };
     }
 
+    // Steps are loaded ABOVE the policy gate: direct_cli classification needs
+    // the parsed document (clause a/f static signals) as its input.
+    const steps = await this.#deps.loadSteps(freshState);
+
     // Policy gate — `targeted: true` (a retry re-issues a specific delegation),
-    // so a pending collection does not refuse it.
-    const actorContext = actorContextFromEvidence(input.callerEvidence, freshState.id);
+    // so a pending collection does not refuse it. Classification is from the
+    // locked re-read (`freshState`) — the same instance retryDelegation
+    // decides from.
+    const actorContext = actorContextFromEvidence(
+      input.callerEvidence,
+      await this.#evidenceTargetFor(input.callerEvidence, freshState, steps),
+    );
     const policy = resolveCommandIntent({
       actorContext,
       intent: { kind: 'delegation-issuance', command: 'delegate', targeted: true },
@@ -990,8 +1009,6 @@ export class RunbookLifecycleCommandService {
       targetState: freshState,
     });
     if (policy.kind !== 'allowed') return { kind: 'refused', policy };
-
-    const steps = await this.#deps.loadSteps(freshState);
 
     // Resolve overrides only now — after the locator resolved and the gate
     // passed — so a bad `--input-file` (or other extra-var failure) cannot mask
@@ -1299,8 +1316,25 @@ export class RunbookLifecycleCommandService {
 
     // Gate the resolved ROOT before forcing (items 8 + 2-core). Root linkage is
     // delegation-or-none, so `terminal-run-force` targeted:false runs the
-    // actor-context + collection-pending gates on it.
-    const actorContext = actorContextFromEvidence(input.callerEvidence, plan.targetState.id);
+    // actor-context + collection-pending gates on it. Classification is from
+    // plan.targetState with the steps this gate already needs in scope.
+    //
+    // A contiguous-inline chain is one orchestrator's composition by
+    // construction (inline children run in the same agent session as their
+    // composer), so `run_controller` evidence naming ANY member of the walked
+    // chain names that composition: it is evaluated as controller of the
+    // walked-to root. This is explicit, derived authority — the chain was
+    // reached by climbing inline linkage from the named run — never ambient.
+    const rootSteps = await this.#deps.loadSteps(plan.targetState);
+    const evidence = input.callerEvidence;
+    const actorContext =
+      evidence.kind === 'run_controller' &&
+      plan.forceOrder.some((member) => member.id === evidence.runId)
+        ? trustedRunControllerContext(plan.targetState.id)
+        : actorContextFromEvidence(
+            evidence,
+            await this.#evidenceTargetFor(evidence, plan.targetState, rootSteps),
+          );
     const policy = resolveCommandIntent({
       actorContext,
       intent: { kind: 'terminal-run-force', command: input.command, targeted: false },
@@ -1311,7 +1345,7 @@ export class RunbookLifecycleCommandService {
       case 'allowed':
         break;
       case 'actor_context_required':
-        return { kind: 'actor_context_required', targetRunId: plan.targetState.id };
+        return { kind: 'actor_context_required' };
       case 'delegation_collection_pending':
         return {
           kind: 'delegation_collection_pending',
@@ -1407,6 +1441,36 @@ export class RunbookLifecycleCommandService {
     };
   }
 
+  // Build the EvidenceTarget for a resolved anchor run. Only `direct_cli`
+  // evidence consults exposure, so classification (a read-only event-time
+  // derivation: parsed steps + open claims + state — never persisted) runs for
+  // that lane alone; every other variant receives the fail-closed
+  // `'delegating'` placeholder, which its mapping arm never reads.
+  //
+  // Lock conventions: exposure classification is a read-only operation and
+  // must never be called while holding the SessionLock (write path); inside a
+  // held DelegationLock it is safe (session reads never acquire a lock;
+  // DelegationLock → CompletionLock ordering is unaffected).
+  //
+  // Document-edit caveat (clauses a/f-static): `steps` are re-parsed at
+  // decision time, so a mid-run edit of the runbook document can flip a
+  // not-yet-issued run's static exposure — accepted; every state-derived
+  // clause is monotone and never decays.
+  async #evidenceTargetFor(
+    evidence: CallerEvidence,
+    state: RunbookState,
+    steps: readonly ResolvedStep[],
+  ): Promise<EvidenceTarget> {
+    if (evidence.kind !== 'direct_cli') {
+      return { runId: state.id, exposure: 'delegating' };
+    }
+    const openClaims = await this.#deps.sessionService.listOpenClaimsForParent(state.id);
+    return {
+      runId: state.id,
+      exposure: classifyDelegationExposure({ state, steps, openClaims }),
+    };
+  }
+
   // Resolve the issuance anchor run: the `--run`-named session-stack member
   // when a target run id is supplied (a missing/foreign/terminal id refuses as
   // `unknown-run`), else the active default run (`none` when absent).
@@ -1429,20 +1493,36 @@ export class RunbookLifecycleCommandService {
   }
 
   // Map caller evidence to an actor context anchored on the resolved run.
-  // `direct_cli` evidence anchors on the active default run; `run_controller`
-  // evidence anchors on its own named run; `claim` evidence anchors on its own
-  // controlled run; everything else maps to the unknown context. Returns the
-  // unknown context when no anchor run exists (a direct-CLI caller with no
-  // active run is refused downstream as `none`).
+  // `direct_cli` evidence anchors on the active default run and is trusted
+  // only when that run classifies `standalone` (the flip — ambient trust over
+  // any delegation-exposed run is gone); `run_controller` evidence anchors on
+  // its own named run; `claim` evidence anchors on its own controlled run;
+  // everything else maps to the unknown context. Returns the unknown context
+  // when no anchor run exists (a direct-CLI caller with no active run is
+  // refused downstream as `none`).
+  //
+  // The classification here and the transition resolver's target resolution
+  // are two lock-free reads; classifying from the active anchor the resolver
+  // will re-resolve keeps them aligned in practice, and the
+  // deriveEffectiveRole id binding is the fail-closed backstop for any
+  // interleave (trust minted for run A is unknown_for_target against run B).
   async #resolveActorContext(
     evidence: CallerEvidence,
     claimId: ClaimId | undefined,
   ): Promise<ActorContext> {
     if (evidence.kind === 'claim') {
-      return actorContextFromEvidence(evidence, evidence.controlledRunId);
+      return actorContextFromEvidence(evidence, {
+        runId: evidence.controlledRunId,
+        // Fail-closed placeholder: the claim arm never reads exposure.
+        exposure: 'delegating',
+      });
     }
     if (evidence.kind === 'run_controller') {
-      return actorContextFromEvidence(evidence, evidence.runId);
+      return actorContextFromEvidence(evidence, {
+        runId: evidence.runId,
+        // Fail-closed placeholder: the run_controller arm never reads exposure.
+        exposure: 'delegating',
+      });
     }
     if (claimId !== undefined) {
       // Claim-targeted writes resolve through the resolver's claim path, which
@@ -1451,7 +1531,11 @@ export class RunbookLifecycleCommandService {
     }
     const active = await this.#deps.sessionService.getActive();
     if (!active) return UNKNOWN_ACTOR_CONTEXT;
-    return actorContextFromEvidence(evidence, active.id);
+    const steps = await this.#deps.loadSteps(active);
+    return actorContextFromEvidence(
+      evidence,
+      await this.#evidenceTargetFor(evidence, active, steps),
+    );
   }
 
   // Classify a resolution as either ready (carries the resolved run) or a typed
@@ -1527,7 +1611,7 @@ export class RunbookLifecycleCommandService {
       case 'actor_context_required':
         return {
           ready: false,
-          outcome: { kind: 'actor_context_required', targetRunId: resolution.targetRunId },
+          outcome: { kind: 'actor_context_required' },
         };
       default: {
         const _exhaustive: never = resolution;

--- a/packages/core/src/runbook/session-service.ts
+++ b/packages/core/src/runbook/session-service.ts
@@ -86,6 +86,34 @@ export interface ReleaseRunbooksResult {
   readonly nextDefaultRunbookId: RunId | null;
 }
 
+/**
+ * Typed outcome of resolving an explicit `--run` id to a running member of the
+ * session default stack.
+ *
+ * Single source of truth for the "resolve `--run` to a running stack member,
+ * else refuse" decision shared by target resolution
+ * (`resolveCommandTarget` / `resolveTransitionTarget`), run-targeted terminals,
+ * and delegation-issuance anchoring — so every command refuses the identical
+ * condition with the identical cause split.
+ */
+export type RunningStackMemberResolution =
+  | {
+      /** The named run is a running member of the session default stack. */
+      readonly kind: 'running';
+      /** Resolved running state of the named run. */
+      readonly state: RunbookState;
+    }
+  | {
+      /** The named id is not on the session default stack (or its state file is missing). */
+      readonly kind: 'not_on_stack';
+    }
+  | {
+      /** The named run is on the stack but not running (terminal or unset lifecycle). */
+      readonly kind: 'not_running';
+      /** The run's non-running lifecycle, when persisted. */
+      readonly lifecycle: RunbookState['lifecycle'];
+    };
+
 /** Result of restoring a stashed delegated child by claim id. */
 export type UnstashForClaimIdResult =
   | { readonly status: 'restored'; readonly claim: ClaimRecord; readonly state: RunbookState }
@@ -248,6 +276,27 @@ export class SessionService {
     const session = await this.manager.loadSession();
     if (!session.defaultStack.includes(runId)) return null;
     return this.manager.load(runId);
+  }
+
+  /**
+   * Resolve an explicit `--run` id to a running session-stack member, splitting
+   * the two refusal causes ("not on this session's stack" vs "on the stack but
+   * not running") into a typed outcome.
+   *
+   * Read-only: bypasses the session lock (consistent with {@link getRunById},
+   * which this composes). This is the single helper behind every command's
+   * `--run` target resolution, so the refusal specificity cannot drift between
+   * commands.
+   *
+   * @param runId - Run id supplied by the caller via `--run`
+   * @returns `running` with the resolved state, `not_on_stack`, or
+   *   `not_running` with the run's lifecycle
+   */
+  async resolveRunningStackMember(runId: RunId): Promise<RunningStackMemberResolution> {
+    const state = await this.getRunById(runId);
+    if (!state) return { kind: 'not_on_stack' };
+    if (state.lifecycle !== 'running') return { kind: 'not_running', lifecycle: state.lifecycle };
+    return { kind: 'running', state };
   }
 
   /**

--- a/packages/core/src/runbook/session-service.ts
+++ b/packages/core/src/runbook/session-service.ts
@@ -233,6 +233,24 @@ export class SessionService {
   }
 
   /**
+   * Resolve an explicit `--run` target to its live session-stack run state.
+   *
+   * Read-only: bypasses the session lock (consistent with {@link getActive}).
+   * Resolves only ids present on the session `defaultStack` (any depth) —
+   * `--run` names authority over a run this session is orchestrating;
+   * cross-session work stays claim-based. Claimed children are never stack
+   * members, so `--run` can never substitute for `--claim-id`.
+   *
+   * @param runId - Run id supplied by the caller via `--run`
+   * @returns The run state, or `null` when the id is not an active stack member
+   */
+  async getRunById(runId: RunId): Promise<RunbookState | null> {
+    const session = await this.manager.loadSession();
+    if (!session.defaultStack.includes(runId)) return null;
+    return this.manager.load(runId);
+  }
+
+  /**
    * Push a runbook onto the active runbook stack.
    *
    * Used when starting a new runbook or entering a nested/child runbook.
@@ -546,13 +564,16 @@ export class SessionService {
    * dedicated non-resolved status rather than guessing a target.
    *
    * @param kind - Force-terminal command kind driving the plan.
+   * @param anchor - Optional chain start (from an explicit `--run` target);
+   *   defaults to the active default-stack run when omitted.
    * @returns A discriminated plan describing the resolved chain or the reason
    *   resolution could not produce one.
    */
   async resolveActiveInlineForceTerminalPlan(
     kind: InlineForceTerminalKind,
+    anchor?: RunbookState,
   ): Promise<ActiveInlineForceTerminalPlan> {
-    const activeState = await this.getActive();
+    const activeState = anchor ?? (await this.getActive());
     if (!activeState) return { status: 'none', kind };
 
     const chain: RunbookState[] = [activeState];

--- a/packages/core/src/runbook/subprocess-mutation-boundary.ts
+++ b/packages/core/src/runbook/subprocess-mutation-boundary.ts
@@ -123,12 +123,17 @@ export function mutationCommandAliases(command: RoleSpecificMutationCommand): re
  * single token and therefore need no skip — only the space-forms advance past the
  * next token.
  */
-export const PASS_FAIL_VALUE_TAKING_OPTION_NAMES = ['--step', '--index', '--claim-id'] as const;
+export const PASS_FAIL_VALUE_TAKING_OPTION_NAMES = [
+  '--step',
+  '--index',
+  '--claim-id',
+  '--run',
+] as const;
 
 /**
  * A canonical value-taking `pass` / `fail` option long name (`--step`,
- * `--index`, or `--claim-id`). Lets the CLI registration key its presentation
- * metadata by these names so TypeScript forces full, exact coverage.
+ * `--index`, `--claim-id`, or `--run`). Lets the CLI registration key its
+ * presentation metadata by these names so TypeScript forces full, exact coverage.
  */
 export type PassFailValueTakingOptionName = (typeof PASS_FAIL_VALUE_TAKING_OPTION_NAMES)[number];
 

--- a/packages/core/src/runbook/subprocess-mutation-boundary.ts
+++ b/packages/core/src/runbook/subprocess-mutation-boundary.ts
@@ -4,10 +4,17 @@
 //
 // The plugin and MCP server reach the CLI by spawning a subprocess, so typed
 // `CallerEvidence` cannot cross the process boundary — a spawned `rd pass`
-// arrives as an ordinary `argv`, indistinguishable from a human invocation. A
-// bare (default-target) `rd pass` / `rd fail` / `rd delegate` maps to
-// `{ kind: 'direct_cli' }` and therefore to full `trusted_run_controller` trust;
-// a subprocess front end must not be able to mint that trust silently.
+// arrives as an ordinary `argv`, indistinguishable from a human invocation.
+//
+// DEFENSE-IN-DEPTH (post-R1): core itself now refuses ambient direct-CLI trust
+// on every delegation-exposed run (`actorContextFromEvidence` grants the
+// `direct_cli` lane only to standalone runs), so this boundary is no longer the
+// primary gate against the #460 takeover class. Its remaining job is narrower:
+// stop a spawned bare mutation from silently consuming the standalone-run
+// convenience lane, and keep refusals rendered at the front end (a clear typed
+// withhold instead of a downstream policy error). Explicitly-targeted
+// mutations — `--claim-id` (claim evidence) and `--run` (named run-controller
+// evidence) — carry their own authority and pass through.
 //
 // This predicate is the single source of truth for "which spawned commands carry
 // only direct-CLI trust and must be withheld at the front end." It is a pure
@@ -299,22 +306,65 @@ function carriesClaimEvidence(argv: readonly string[], commandIndex: number): bo
 }
 
 /**
+ * Whether a guarded mutation argv carries an explicit `--run` target in *flag
+ * position* (either `--run <value>` or `--run=<value>`).
+ *
+ * A `--run` mutation names its authority explicitly: core maps it to
+ * `run_controller` evidence over exactly the named run and refuses an
+ * id/target mismatch, so it never relies on ambient direct-CLI trust and is
+ * not bare. Mirrors {@link carriesClaimEvidence} exactly: the scan walks argv
+ * left-to-right, skips the value token consumed by each space-form
+ * value-taking option (the skip set already contains `--run` itself), and
+ * stops at the `--` option terminator — a `--run` token in a value slot or
+ * after the terminator is content, not evidence (fail-closed).
+ *
+ * @param argv - CLI argument vector (command optionally preceded by globals).
+ * @param commandIndex - Index of the command token in `argv` (from
+ *   {@link locateCommandIndex}). Scanning starts after it.
+ * @returns `true` when a real `--run` flag occupies a flag position.
+ */
+function carriesExplicitRunTarget(argv: readonly string[], commandIndex: number): boolean {
+  for (let i = commandIndex + 1; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--') {
+      // Option terminator: every later token is positional, never a flag.
+      return false;
+    }
+    if (arg === '--run' || arg.startsWith('--run=')) {
+      return true;
+    }
+    if (PASS_FAIL_VALUE_TAKING_OPTIONS.has(arg)) {
+      // Space-form value-taking option: skip its consumed value token so a
+      // `--run` sitting in that value slot is not misread as a flag.
+      i++;
+    }
+  }
+  return false;
+}
+
+/**
  * Classify a spawned CLI argv as a bare role-specific lifecycle mutation.
  *
  * A call is bare iff its command is `pass`, `fail`, `delegate`, `complete`,
- * `stop`, or `collect` and it carries no claim evidence. These are exactly the
- * invocations whose only available trust is direct-CLI, so a subprocess front
- * end (plugin / MCP) must withhold them rather than let them silently inherit
- * `{ kind: 'direct_cli' }` trust.
+ * `stop`, or `collect` and it carries neither claim evidence (`--claim-id`)
+ * nor an explicit run target (`--run`). These are exactly the invocations
+ * whose only available trust is direct-CLI, so a subprocess front end
+ * (plugin / MCP) must withhold them rather than let them silently inherit
+ * `{ kind: 'direct_cli' }` trust. This is defense-in-depth: core's
+ * exposure-conditional `direct_cli` mapping is the primary gate (it refuses
+ * ambient trust on every delegation-exposed run); the boundary keeps the
+ * standalone-run convenience lane from being consumed silently by a spawned
+ * subprocess and keeps the refusal front-end-rendered.
  *
- * `delegate` is claim-less and is ALWAYS bare: no `--claim-id` token can exempt
- * it. Every other guarded command (`pass` / `fail` / `complete` / `stop` /
- * `collect`) carries a legitimate `--claim-id` claim-controller form, and only a
- * real `--claim-id` flag in *flag position* exempts them — a
- * `--claim-id` token consumed as the value of a preceding value-taking option
- * (`--step`, `--index`, `--claim-id`) is not evidence (see
- * {@link carriesClaimEvidence}). The boundary fails closed: when claim evidence
- * cannot be confirmed in flag position, the call is treated as bare and
+ * `delegate` is claim-less (`--claim-id` never exempts it) but DOES carry the
+ * `--run` explicit-targeting form — a `--run`-carrying delegate names the run
+ * it issues from and is not bare. Every other guarded command (`pass` / `fail`
+ * / `complete` / `stop` / `collect`) is exempted by either a real `--claim-id`
+ * or a real `--run` flag in *flag position* — a token consumed as the value of
+ * a preceding value-taking option (`--step`, `--index`, `--claim-id`, `--run`)
+ * is not evidence (see {@link carriesClaimEvidence} /
+ * {@link carriesExplicitRunTarget}). The boundary fails closed: when neither
+ * form can be confirmed in flag position, the call is treated as bare and
  * withheld. Read-only / inspect commands fall outside this set entirely.
  *
  * The command token may be preceded by program-level global options
@@ -341,11 +391,17 @@ export function bareRoleSpecificMutation(
   if (command === undefined) {
     return undefined;
   }
-  // `delegate` has no claim form, so every subprocess `delegate` is bare and
-  // withheld — a stray `--claim-id` cannot make it claim-evidenced. Every other
-  // guarded command (`pass` / `fail` / `complete` / `stop` / `collect`) carries
-  // a legitimate `--claim-id` claim-controller form whose evidence is
-  // reconstructable CLI-side, so those are exempted here. See
+  // Explicit `--run` targeting exempts ALL six commands, including `delegate`
+  // (delegation issuance is the quintessential orchestrator mutation; naming
+  // the run is exactly the evidence the roadmap's explicit-`--run` path asks
+  // for). This is explicit targeting, not silent trust inheritance.
+  if (carriesExplicitRunTarget(argv, commandIndex)) {
+    return undefined;
+  }
+  // `delegate` has no claim form, so a `--claim-id` token never exempts it.
+  // Every other guarded command (`pass` / `fail` / `complete` / `stop` /
+  // `collect`) carries a legitimate `--claim-id` claim-controller form whose
+  // evidence is reconstructable CLI-side, so those are exempted here. See
   // docs/superpowers/specs/2026-06-28-plugin-mcp-caller-evidence-ingress-design.md
   // § Blocking scope.
   if (command !== 'delegate' && carriesClaimEvidence(argv, commandIndex)) {
@@ -415,8 +471,9 @@ export const SUBPROCESS_MUTATION_WITHHELD_CODE = 'SUBPROCESS_MUTATION_WITHHELD';
 
 /**
  * Build the human-readable refusal message for a withheld bare role-specific
- * mutation. Names the command and points to the `--claim-id` claim-evidence
- * alternative; never mentions a source label.
+ * mutation. Names the command and points to both explicit-targeting
+ * remediations — `--run` (named orchestrator authority) and `--claim-id`
+ * (claim evidence); never mentions a source label.
  *
  * @param command - The withheld role-specific mutation command.
  * @returns Single-line refusal message.
@@ -424,7 +481,8 @@ export const SUBPROCESS_MUTATION_WITHHELD_CODE = 'SUBPROCESS_MUTATION_WITHHELD';
 export function subprocessMutationWithheldMessage(command: RoleSpecificMutationCommand): string {
   return (
     `Refusing to run a bare \`rundown ${command}\` from a subprocess front end: it would ` +
-    `silently inherit direct-CLI trust over the active run. Resolve a delegated ` +
+    `silently inherit direct-CLI trust over the active run. Name the run you control with ` +
+    `\`rundown ${command} --run <rd_…>\`, resolve a delegated ` +
     `child with \`rundown ${command === 'delegate' ? 'pass' : command} --claim-id <claimId>\`, ` +
     `or run \`rundown ${command}\` directly.`
   );

--- a/packages/mcp/__tests__/tools.test.ts
+++ b/packages/mcp/__tests__/tools.test.ts
@@ -337,14 +337,14 @@ describe('subprocess trust boundary', () => {
     return JSON.parse(text);
   }
 
-  it('advertises the delegate tool as unavailable from the subprocess front end', () => {
-    // The delegate tool carries no claim form, so `bareRoleSpecificMutation`
-    // withholds every MCP-spawned `delegate` argv. The description must not
-    // promise an operation that is always refused; it must name the constraint
-    // and point at the honest path (run `rd delegate` directly).
+  it('advertises delegate as runId-gated: available WITH runId, withheld bare', () => {
+    // Post-R1 the delegate tool is available with explicit runId targeting
+    // (mapped to `--run`); a bare call is still withheld. The description must
+    // name both the constraint and the honest paths (runId, or run
+    // `rd delegate` directly).
     const { description } = RUNDOWN_TOOL_DEFINITIONS.delegate;
-    expect(description).toMatch(/unavailable/i);
-    expect(description).toMatch(/subprocess front end/i);
+    expect(description).toMatch(/runId/);
+    expect(description).toMatch(/withheld bare/i);
     expect(description).toMatch(/rundown delegate/);
   });
 
@@ -403,6 +403,51 @@ describe('subprocess trust boundary', () => {
     expect(runCli).toHaveBeenCalledWith([tool, '--claim-id', 'claim-1']);
     // The pass-through path surfaces the CLI's data payload to the MCP client.
     expect(parseToolResponse(res)).toEqual({ ok: true });
+  });
+
+  describe('explicit runId targeting', () => {
+    const runId = `rd_${'a'.repeat(32)}`;
+
+    it.each([
+      ['pass'],
+      ['fail'],
+      ['complete'],
+      ['stop'],
+      ['collect'],
+    ] as const)('forwards runId as --run argv on %s (explicit orchestrator targeting)', async (tool) => {
+      const runCli = jest.fn<RunCli>().mockResolvedValue({ success: true, data: { ok: true } });
+      const handlers = registerWithHandlers(runCli);
+
+      const res = await handlers.get(tool)?.({ runId });
+      expect(runCli).toHaveBeenCalledWith([tool, '--run', runId]);
+      expect(parseToolResponse(res)).toEqual({ ok: true });
+    });
+
+    it('forwards runId as --run argv on goto', async () => {
+      const runCli = jest.fn<RunCli>().mockResolvedValue({ success: true, data: { ok: true } });
+      const handlers = registerWithHandlers(runCli);
+
+      await handlers.get('goto')?.({ step: '3', runId });
+      expect(runCli).toHaveBeenCalledWith(['goto', '3', '--run', runId]);
+    });
+
+    it('spawns delegate WITH runId and keeps withholding it bare', async () => {
+      // The single most behavior-inverting MCP change in R1: delegate was
+      // withheld-always; an explicit runId names orchestrator authority and
+      // spawns, while the bare form stays withheld.
+      const runCli = jest.fn<RunCli>().mockResolvedValue({ success: true, data: { ok: true } });
+      const handlers = registerWithHandlers(runCli);
+
+      await handlers.get('delegate')?.({ runId });
+      expect(runCli).toHaveBeenCalledWith(['delegate', '--run', runId]);
+
+      runCli.mockClear();
+      const bare = await handlers.get('delegate')?.({});
+      expect(parseToolResponse(bare)).toEqual({
+        error: expect.stringContaining('subprocess front end') as string,
+      });
+      expect(runCli).not.toHaveBeenCalled();
+    });
   });
 
   it('withholds delegate when a claim-looking token is an input-file value', async () => {

--- a/packages/mcp/__tests__/tools.test.ts
+++ b/packages/mcp/__tests__/tools.test.ts
@@ -52,7 +52,12 @@ describe('buildRundownCommand', () => {
     ],
     [
       'delegate',
-      { retry: true, step: '4.1', inputJson: ['vars={"mode":"fast"}'], inputFile: ['vars.yaml'] },
+      {
+        retry: true,
+        step: '4.1',
+        inputJson: ['vars={"mode":"fast"}'],
+        inputFile: ['vars.yaml'],
+      },
       [
         'delegate',
         '--retry',
@@ -66,7 +71,10 @@ describe('buildRundownCommand', () => {
     ],
     [
       'claim',
-      { token: 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567', inputJson: ['items=["a"]'] },
+      {
+        token: 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+        inputJson: ['items=["a"]'],
+      },
       ['claim', 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567', '--input-json', 'items=["a"]'],
     ],
     [
@@ -97,7 +105,12 @@ describe('buildRundownCommand', () => {
 
   it('renders CLI data as MCP text without interpreting runbook state', () => {
     expect(createMcpTextResponse({ data: { action: 'PASS', to: '2' } })).toEqual({
-      content: [{ type: 'text', text: JSON.stringify({ action: 'PASS', to: '2' }, null, 2) }],
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ action: 'PASS', to: '2' }, null, 2),
+        },
+      ],
     });
   });
 
@@ -110,7 +123,12 @@ describe('buildRundownCommand', () => {
 
   it('renders CLI errors as MCP text without replacing error shape', () => {
     expect(createMcpTextResponse({ error: 'No active runbook' })).toEqual({
-      content: [{ type: 'text', text: JSON.stringify({ error: 'No active runbook' }, null, 2) }],
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ error: 'No active runbook' }, null, 2),
+        },
+      ],
     });
   });
 });
@@ -150,6 +168,41 @@ describe('inputSchema enforces index requires step', () => {
     const schema = RUNDOWN_TOOL_DEFINITIONS.goto.inputSchema;
     expect(schema.safeParse({ index: 3 }).success).toBe(false);
     expect(schema.safeParse({ step: '3.1', index: 2 }).success).toBe(true);
+  });
+});
+
+describe('inputSchema enforces claimId/runId mutual exclusion', () => {
+  // Every tool whose schema accepts both authorities. `--run` and `--claim-id`
+  // name two different authorities and the CLI refuses the pair; the schema
+  // must fail the conflict closed before the handler spawns anything.
+  const dualAuthorityTools = ['pass', 'fail', 'goto', 'complete', 'stop', 'collect'] as const;
+  const runId = `rd_${'a'.repeat(32)}`;
+  const claimId = 'rdclm_abcdefghijklmnopqrstu1';
+  // `goto` requires `step`; harmless extra field for the rest.
+  const withStep = { step: '3.1' };
+
+  describe.each(dualAuthorityTools)('%s', (tool) => {
+    const schema = RUNDOWN_TOOL_DEFINITIONS[tool].inputSchema;
+
+    it('accepts claimId alone', () => {
+      expect(schema.safeParse({ ...withStep, claimId }).success).toBe(true);
+    });
+
+    it('accepts runId alone', () => {
+      expect(schema.safeParse({ ...withStep, runId }).success).toBe(true);
+    });
+
+    it('rejects claimId + runId together with a clear conflict message', () => {
+      const result = schema.safeParse({ ...withStep, claimId, runId });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const conflictIssue = result.error.issues.find(
+          (issue) => issue.path.length === 1 && issue.path[0] === 'runId',
+        );
+        expect(conflictIssue).toBeDefined();
+        expect(conflictIssue?.message).toMatch(/claimId and runId are mutually exclusive/);
+      }
+    });
   });
 });
 
@@ -195,7 +248,9 @@ describe('registerRundownTools', () => {
     ).toBe(true);
     for (const tool of ['status', 'pass', 'fail', 'complete', 'stop'] as const) {
       expect(
-        RUNDOWN_TOOL_DEFINITIONS[tool].inputSchema.safeParse({ claimId: 'claim-1' }).success,
+        RUNDOWN_TOOL_DEFINITIONS[tool].inputSchema.safeParse({
+          claimId: 'claim-1',
+        }).success,
       ).toBe(true);
     }
     expect(RUNDOWN_TOOL_DEFINITIONS.goto.inputSchema.safeParse({ step: '3.1' }).success).toBe(true);
@@ -275,7 +330,12 @@ describe('registerRundownTools', () => {
     registerRundownTools(fakeServer, runCli);
 
     await expect(handlers.get('status')?.({})).resolves.toEqual({
-      content: [{ type: 'text', text: JSON.stringify({ error: 'transport down' }, null, 2) }],
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ error: 'transport down' }, null, 2),
+        },
+      ],
     });
   });
 
@@ -302,7 +362,53 @@ describe('registerRundownTools', () => {
     registerRundownTools(fakeServer, runCli);
 
     await expect(handlers.get(tool)?.({ index: 3 })).resolves.toMatchObject({
-      content: [{ type: 'text', text: expect.stringMatching(/index: index requires step/) }],
+      content: [
+        {
+          type: 'text',
+          text: expect.stringMatching(/index: index requires step/),
+        },
+      ],
+    });
+    expect(runCli).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'pass',
+    'fail',
+    'goto',
+    'complete',
+    'stop',
+    'collect',
+  ] as const)('%s handler rejects claimId + runId together before invoking the CLI', async (tool) => {
+    const handlers = new Map<string, (args: Record<string, unknown>) => Promise<unknown>>();
+    const fakeServer = {
+      registerTool: jest.fn(
+        (
+          name: string,
+          _config: unknown,
+          handler: (args: Record<string, unknown>) => Promise<unknown>,
+        ) => {
+          handlers.set(name, handler);
+        },
+      ),
+    };
+    const runCli = jest.fn<RunCli>();
+    registerRundownTools(fakeServer, runCli);
+
+    // Both authorities at once is always a conflict; it must fail closed at
+    // schema validation, never reach a spawned CLI to be refused post-spawn.
+    const res = await handlers.get(tool)?.({
+      step: '3.1',
+      claimId: 'rdclm_abcdefghijklmnopqrstu1',
+      runId: `rd_${'a'.repeat(32)}`,
+    });
+    expect(res).toMatchObject({
+      content: [
+        {
+          type: 'text',
+          text: expect.stringMatching(/runId: claimId and runId are mutually exclusive/),
+        },
+      ],
     });
     expect(runCli).not.toHaveBeenCalled();
   });
@@ -455,9 +561,17 @@ describe('subprocess trust boundary', () => {
     const handlers = registerWithHandlers(runCli);
 
     await expect(
-      handlers.get('delegate')?.({ runbook: 'child.md', inputFile: ['--claim-id=foo'] }),
+      handlers.get('delegate')?.({
+        runbook: 'child.md',
+        inputFile: ['--claim-id=foo'],
+      }),
     ).resolves.toMatchObject({
-      content: [{ type: 'text', text: expect.stringMatching(/does not accept --claim-id/) }],
+      content: [
+        {
+          type: 'text',
+          text: expect.stringMatching(/does not accept --claim-id/),
+        },
+      ],
     });
     expect(runCli).not.toHaveBeenCalled();
   });

--- a/packages/mcp/__tests__/tools.test.ts
+++ b/packages/mcp/__tests__/tools.test.ts
@@ -444,7 +444,7 @@ describe('subprocess trust boundary', () => {
       runCli.mockClear();
       const bare = await handlers.get('delegate')?.({});
       expect(parseToolResponse(bare)).toEqual({
-        error: expect.stringContaining('subprocess front end') as string,
+        error: expect.stringContaining('subprocess front end'),
       });
       expect(runCli).not.toHaveBeenCalled();
     });

--- a/packages/mcp/src/command-builder.ts
+++ b/packages/mcp/src/command-builder.ts
@@ -24,6 +24,12 @@ function pushClaimId(cmd: string[], input: Record<string, unknown>): void {
   if (typeof input.claimId === 'string') cmd.push('--claim-id', input.claimId);
 }
 
+// Map the optional `runId` input to `--run <rd_…>` (explicit orchestrator
+// targeting). String-ness only — the CLI validates the format via isRunId.
+function pushRunId(cmd: string[], input: Record<string, unknown>): void {
+  if (typeof input.runId === 'string') cmd.push('--run', input.runId);
+}
+
 /**
  * Build a Rundown CLI argv array for an MCP tool call.
  *
@@ -66,6 +72,7 @@ export function buildRundownCommand(
       const cmd = [tool];
       pushStepIndex(cmd, input);
       pushClaimId(cmd, input);
+      pushRunId(cmd, input);
       return cmd;
     }
     case 'goto': {
@@ -75,12 +82,14 @@ export function buildRundownCommand(
       const cmd = ['goto', input.step];
       if (typeof input.index === 'number') cmd.push('--index', String(input.index));
       pushClaimId(cmd, input);
+      pushRunId(cmd, input);
       return cmd;
     }
     case 'complete':
     case 'stop': {
       const cmd = typeof input.message === 'string' ? [tool, input.message] : [tool];
       pushClaimId(cmd, input);
+      pushRunId(cmd, input);
       return cmd;
     }
     case 'delegate': {
@@ -89,6 +98,7 @@ export function buildRundownCommand(
       if (typeof input.runbook === 'string') cmd.push(input.runbook);
       pushStepIndex(cmd, input);
       pushRepeatableInputs(cmd, input);
+      pushRunId(cmd, input);
       return cmd;
     }
     case 'claim': {
@@ -103,6 +113,7 @@ export function buildRundownCommand(
       const cmd = ['collect'];
       pushStepIndex(cmd, input);
       pushClaimId(cmd, input);
+      pushRunId(cmd, input);
       return cmd;
     }
   }

--- a/packages/mcp/src/tool-definitions.ts
+++ b/packages/mcp/src/tool-definitions.ts
@@ -15,6 +15,35 @@ const runIdShape = { runId: z.string().optional() } satisfies z.ZodRawShape;
 // between `stepIndexPair` and the `goto` schema.
 const optionalIndex = z.number().int().nonnegative().optional();
 
+// Mirrors the CLI's `--run` / `--claim-id` mutual exclusion (parseRunOption):
+// the two name different authorities (caller-named run control vs claim
+// evidence), so supplying both is always a conflict. Encoding it here fails
+// the pair closed at `tools/call` validation instead of post-spawn.
+const CLAIM_RUN_CONFLICT_MESSAGE =
+  'claimId and runId are mutually exclusive: name the run you control with runId, or the claim you hold with claimId.';
+
+/**
+ * Wrap a tool input schema that accepts both `claimId` and `runId` with the
+ * mutual-exclusion refinement, so the conflict is rejected at schema
+ * validation time (before the handler spawns the CLI).
+ *
+ * @param schema - Base input schema carrying optional `claimId` and `runId`.
+ * @returns Schema that additionally rejects `claimId` + `runId` together.
+ */
+function claimRunExclusive(
+  schema: z.ZodType<Record<string, unknown>>,
+): z.ZodType<Record<string, unknown>> {
+  return schema.superRefine((value, ctx) => {
+    if (value.claimId !== undefined && value.runId !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['runId'],
+        message: CLAIM_RUN_CONFLICT_MESSAGE,
+      });
+    }
+  });
+}
+
 /**
  * Build an input schema that pairs optional `step` with optional `index`, where
  * `index` is only valid when `step` is also present. The constraint is encoded
@@ -57,7 +86,10 @@ export const RUNDOWN_TOOL_DEFINITIONS: Record<RundownToolName, RundownToolDefini
   },
   list: {
     description: 'List runbooks',
-    inputSchema: z.object({ all: z.boolean().optional(), tags: z.string().optional() }),
+    inputSchema: z.object({
+      all: z.boolean().optional(),
+      tags: z.string().optional(),
+    }),
   },
   status: {
     description: 'Get current runbook state',
@@ -73,28 +105,42 @@ export const RUNDOWN_TOOL_DEFINITIONS: Record<RundownToolName, RundownToolDefini
   },
   pass: {
     description: 'Mark a step passed',
-    inputSchema: stepIndexPair({ ...claimIdShape, ...runIdShape }),
+    inputSchema: claimRunExclusive(stepIndexPair({ ...claimIdShape, ...runIdShape })),
   },
   fail: {
     description: 'Mark a step failed',
-    inputSchema: stepIndexPair({ ...claimIdShape, ...runIdShape }),
+    inputSchema: claimRunExclusive(stepIndexPair({ ...claimIdShape, ...runIdShape })),
   },
   goto: {
     description: 'Jump to a step',
-    inputSchema: z.object({
-      step: z.string(),
-      index: optionalIndex,
-      ...claimIdShape,
-      ...runIdShape,
-    }),
+    inputSchema: claimRunExclusive(
+      z.object({
+        step: z.string(),
+        index: optionalIndex,
+        ...claimIdShape,
+        ...runIdShape,
+      }),
+    ),
   },
   complete: {
     description: 'Force current runbook completion',
-    inputSchema: z.object({ message: z.string().optional(), ...claimIdShape, ...runIdShape }),
+    inputSchema: claimRunExclusive(
+      z.object({
+        message: z.string().optional(),
+        ...claimIdShape,
+        ...runIdShape,
+      }),
+    ),
   },
   stop: {
     description: 'Stop current runbook',
-    inputSchema: z.object({ message: z.string().optional(), ...claimIdShape, ...runIdShape }),
+    inputSchema: claimRunExclusive(
+      z.object({
+        message: z.string().optional(),
+        ...claimIdShape,
+        ...runIdShape,
+      }),
+    ),
   },
   delegate: {
     description: `Issue or retry a delegation for the run you control. Available WITH \`runId\` (explicit orchestrator targeting mapped to \`--run <rd_…>\`); withheld bare — a bare subprocess-spawned \`delegate\` would silently inherit direct-CLI trust over the active run, so it returns a withheld-mutation error without spawning the CLI. Supply the run id from your orchestration context (printed by \`rundown run\` and carried as runbookId on every event), or run \`rundown delegate\` directly in a trusted terminal.`,
@@ -114,7 +160,7 @@ export const RUNDOWN_TOOL_DEFINITIONS: Record<RundownToolName, RundownToolDefini
   },
   collect: {
     description: 'Aggregate a delegated step and advance through core',
-    inputSchema: stepIndexPair({ ...claimIdShape, ...runIdShape }),
+    inputSchema: claimRunExclusive(stepIndexPair({ ...claimIdShape, ...runIdShape })),
   },
 };
 

--- a/packages/mcp/src/tool-definitions.ts
+++ b/packages/mcp/src/tool-definitions.ts
@@ -7,6 +7,10 @@ const repeatableInputShape = {
   inputFile: z.array(z.string()).optional(),
 } satisfies z.ZodRawShape;
 const claimIdShape = { claimId: z.string().optional() } satisfies z.ZodRawShape;
+// Explicit run targeting (`--run <rd_…>`): names the run the caller controls.
+// MCP performs no validation beyond string-ness — the CLI validates format
+// (Category A stays in one place; malformed ids fail closed through isRunId).
+const runIdShape = { runId: z.string().optional() } satisfies z.ZodRawShape;
 // Shared `index` validator so the step/index constraint stays consistent
 // between `stepIndexPair` and the `goto` schema.
 const optionalIndex = z.number().int().nonnegative().optional();
@@ -69,11 +73,11 @@ export const RUNDOWN_TOOL_DEFINITIONS: Record<RundownToolName, RundownToolDefini
   },
   pass: {
     description: 'Mark a step passed',
-    inputSchema: stepIndexPair({ ...claimIdShape }),
+    inputSchema: stepIndexPair({ ...claimIdShape, ...runIdShape }),
   },
   fail: {
     description: 'Mark a step failed',
-    inputSchema: stepIndexPair({ ...claimIdShape }),
+    inputSchema: stepIndexPair({ ...claimIdShape, ...runIdShape }),
   },
   goto: {
     description: 'Jump to a step',
@@ -81,23 +85,25 @@ export const RUNDOWN_TOOL_DEFINITIONS: Record<RundownToolName, RundownToolDefini
       step: z.string(),
       index: optionalIndex,
       ...claimIdShape,
+      ...runIdShape,
     }),
   },
   complete: {
     description: 'Force current runbook completion',
-    inputSchema: z.object({ message: z.string().optional(), ...claimIdShape }),
+    inputSchema: z.object({ message: z.string().optional(), ...claimIdShape, ...runIdShape }),
   },
   stop: {
     description: 'Stop current runbook',
-    inputSchema: z.object({ message: z.string().optional(), ...claimIdShape }),
+    inputSchema: z.object({ message: z.string().optional(), ...claimIdShape, ...runIdShape }),
   },
   delegate: {
-    description: `Unavailable from the MCP subprocess front end. Delegation carries no claim evidence, so a subprocess-spawned \`delegate\` would silently inherit direct-CLI trust over the active run; this tool always returns a withheld-mutation error without spawning the CLI. To delegate a substep or retry an existing delegation, run \`rundown delegate\` directly in a trusted terminal.`,
+    description: `Issue or retry a delegation for the run you control. Available WITH \`runId\` (explicit orchestrator targeting mapped to \`--run <rd_…>\`); withheld bare — a bare subprocess-spawned \`delegate\` would silently inherit direct-CLI trust over the active run, so it returns a withheld-mutation error without spawning the CLI. Supply the run id from your orchestration context (printed by \`rundown run\` and carried as runbookId on every event), or run \`rundown delegate\` directly in a trusted terminal.`,
     inputSchema: stepIndexPair(
       {
         runbook: z.string().optional(),
         retry: z.boolean().optional(),
         ...repeatableInputShape,
+        ...runIdShape,
       },
       { strict: true },
     ),
@@ -108,7 +114,7 @@ export const RUNDOWN_TOOL_DEFINITIONS: Record<RundownToolName, RundownToolDefini
   },
   collect: {
     description: 'Aggregate a delegated step and advance through core',
-    inputSchema: stepIndexPair({ ...claimIdShape }),
+    inputSchema: stepIndexPair({ ...claimIdShape, ...runIdShape }),
   },
 };
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -42,13 +42,15 @@ export function registerRundownTools(server: RundownToolRegistrar, runCli: RunCl
         if (delegateValidation !== undefined) {
           return createMcpTextResponse({ error: delegateValidation.message });
         }
-        // Subprocess trust boundary: the MCP server spawns the CLI, so typed
-        // caller evidence cannot cross the process boundary. Bare `pass` /
-        // `fail` / `complete` / `stop` / `collect`, and every subprocess
-        // `delegate`, would silently inherit direct-CLI trust over the active
-        // run. Withhold them here rather than spawn them; only invocations with
-        // `--claim-id` carry independent claim evidence and pass through. See
-        // subprocess-mutation-boundary.ts.
+        // Subprocess trust boundary (defense-in-depth): the MCP server spawns
+        // the CLI, so typed caller evidence cannot cross the process boundary.
+        // Core itself is the primary gate — it refuses ambient direct-CLI
+        // trust on every delegation-exposed run — so this withhold only stops
+        // a bare `pass` / `fail` / `complete` / `stop` / `collect` / `delegate`
+        // from silently consuming the standalone-run convenience lane, and
+        // keeps the refusal front-end-rendered. Invocations carrying explicit
+        // targeting — `--claim-id` (claim evidence) or `--run` (named run
+        // authority) — pass through. See subprocess-mutation-boundary.ts.
         const withheld = bareRoleSpecificMutation(command);
         if (withheld !== undefined) {
           return createMcpTextResponse({ error: subprocessMutationWithheldMessage(withheld) });

--- a/runbooks/agent-dispatch/orchestrator.runbook.md
+++ b/runbooks/agent-dispatch/orchestrator.runbook.md
@@ -14,7 +14,7 @@ scenarios:
       - rd claim ${TOKEN_2}
       - rd pass --claim-id ${CLAIM_ID_2}
       - rd pass --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 ---
 

--- a/runbooks/agent-dispatch/ownership-refusal.runbook.md
+++ b/runbooks/agent-dispatch/ownership-refusal.runbook.md
@@ -15,7 +15,7 @@ scenarios:
       - "! rd pop"
       - rd pop --claim-id ${CLAIM_ID}
       - rd pass --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 ---
 

--- a/runbooks/agent-dispatch/sibling-fan-out.runbook.md
+++ b/runbooks/agent-dispatch/sibling-fan-out.runbook.md
@@ -14,7 +14,7 @@ scenarios:
       - rd claim ${TOKEN_2}
       - rd pass --claim-id ${CLAIM_ID}
       - rd pass --claim-id ${CLAIM_ID_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 ---
 

--- a/runbooks/composition/list-fail-any.runbook.md
+++ b/runbooks/composition/list-fail-any.runbook.md
@@ -9,15 +9,15 @@ scenarios:
     description: All child runbooks pass
     commands:
       - rd run --prompted list-fail-any.runbook.md
-      - rd pass
-      - rd pass
+      - rd pass --run ${RUN_ID_2}
+      - rd pass --run ${RUN_ID_3}
     result: COMPLETE
   child-fails:
     description: First child fails (FAIL STOP stops the child) but the parent's FAIL ANY absorbs it non-terminally and defers to the next sibling, so `rd fail` exits 0 (the orchestrated workflow is still progressing); after the remaining child passes, FAIL ANY aggregates to STOP
     commands:
       - rd run --prompted list-fail-any.runbook.md
-      - rd fail
-      - rd pass
+      - rd fail --run ${RUN_ID_2}
+      - rd pass --run ${RUN_ID_3}
     result: STOP
 ---
 

--- a/runbooks/composition/step-runbook-list.runbook.md
+++ b/runbooks/composition/step-runbook-list.runbook.md
@@ -34,9 +34,9 @@ scenarios:
     description: First child fails (FAIL STOP stops the child) but the parent's FAIL ANY absorbs it non-terminally and defers to the next sibling, so `rd fail` exits 0 (the orchestrated workflow is still progressing); after the remaining children pass, FAIL ANY aggregates to STOP
     commands:
       - rd run --prompted step-runbook-list.runbook.md
-      - rd fail
-      - rd pass
-      - rd pass
+      - rd fail --run ${RUN_ID_2}
+      - rd pass --run ${RUN_ID_3}
+      - rd pass --run ${RUN_ID_4}
     result: STOP
 tags:
   - composition

--- a/runbooks/delegation/delegate-abort.runbook.md
+++ b/runbooks/delegation/delegate-abort.runbook.md
@@ -10,7 +10,7 @@ scenarios:
     commands:
       - rd run --prompted delegate-abort.runbook.md
       - rd abort ${TOKEN}
-      - rd pass
+      - rd pass --run ${RUN_ID}
     result: COMPLETE
 ---
 

--- a/runbooks/delegation/delegate-basic.runbook.md
+++ b/runbooks/delegation/delegate-basic.runbook.md
@@ -10,7 +10,7 @@ scenarios:
     commands:
       - rd run delegate-basic.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
     expect:
       steps:

--- a/runbooks/delegation/delegate-claim-explicit-close.runbook.md
+++ b/runbooks/delegation/delegate-claim-explicit-close.runbook.md
@@ -15,7 +15,7 @@ scenarios:
       - rd pass --claim-id ${CLAIM_ID}
       - rd pass --claim-id ${CLAIM_ID}
       - rd pass --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:
@@ -28,7 +28,7 @@ scenarios:
       - rd run --prompted delegate-claim-explicit-close.runbook.md
       - rd claim ${TOKEN}
       - rd fail --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: STOP
       steps:
@@ -41,7 +41,7 @@ scenarios:
       - rd run --prompted delegate-claim-explicit-close.runbook.md
       - rd claim ${TOKEN}
       - rd stop --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: STOP
       steps:
@@ -54,7 +54,7 @@ scenarios:
       - rd run --prompted delegate-claim-explicit-close.runbook.md
       - rd claim ${TOKEN}
       - rd complete --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:
@@ -70,7 +70,7 @@ scenarios:
       - >-
         node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(".rundown/session.json","utf8")); const c=s.claims["${CLAIM_ID}"]; const child=JSON.parse(fs.readFileSync(`.rundown/runs/${c.childRunId}.json`,"utf8")); const parent=JSON.parse(fs.readFileSync(`.rundown/runs/${c.parentRunId}.json`,"utf8")); if (child.step !== "3") throw new Error(`child step=${child.step}`); if (parent.step !== "1") throw new Error(`parent step=${parent.step}`);'
       - rd pass --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/delegation/delegate-claim-parent-terminal.runbook.md
+++ b/runbooks/delegation/delegate-claim-parent-terminal.runbook.md
@@ -12,7 +12,7 @@ scenarios:
       - true delegation-child-manual-three-step.runbook.md
       - rd run --prompted delegate-claim-parent-terminal.runbook.md
       - rd claim ${TOKEN}
-      - rd complete
+      - rd complete --run ${RUN_ID}
       - "! rd pass --claim-id ${CLAIM_ID}"
     expect:
       result: COMPLETE
@@ -26,7 +26,7 @@ scenarios:
       - true delegation-child-manual-three-step.runbook.md
       - rd run --prompted delegate-claim-parent-terminal.runbook.md
       - rd claim ${TOKEN}
-      - rd complete
+      - rd complete --run ${RUN_ID}
       - "! rd fail --claim-id ${CLAIM_ID}"
     expect:
       result: COMPLETE
@@ -40,7 +40,7 @@ scenarios:
       - true delegation-child-manual-three-step.runbook.md
       - rd run --prompted delegate-claim-parent-terminal.runbook.md
       - rd claim ${TOKEN}
-      - rd complete
+      - rd complete --run ${RUN_ID}
       - "! rd goto 3 --claim-id ${CLAIM_ID}"
     expect:
       result: COMPLETE
@@ -54,7 +54,7 @@ scenarios:
       - true delegation-child-manual-three-step.runbook.md
       - rd run --prompted delegate-claim-parent-terminal.runbook.md
       - rd claim ${TOKEN}
-      - rd complete
+      - rd complete --run ${RUN_ID}
       - "! rd stop --claim-id ${CLAIM_ID}"
     expect:
       result: COMPLETE
@@ -68,7 +68,7 @@ scenarios:
       - true delegation-child-manual-three-step.runbook.md
       - rd run --prompted delegate-claim-parent-terminal.runbook.md
       - rd claim ${TOKEN}
-      - rd complete
+      - rd complete --run ${RUN_ID}
       - "! rd complete --claim-id ${CLAIM_ID}"
     expect:
       result: COMPLETE

--- a/runbooks/delegation/delegate-claim-stash-pop-resume.runbook.md
+++ b/runbooks/delegation/delegate-claim-stash-pop-resume.runbook.md
@@ -16,7 +16,7 @@ scenarios:
       - "! rd pass --claim-id ${CLAIM_ID}"
       - rd pop --claim-id ${CLAIM_ID}
       - rd complete --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       errors:

--- a/runbooks/delegation/delegate-failure-child-fails.runbook.md
+++ b/runbooks/delegation/delegate-failure-child-fails.runbook.md
@@ -10,7 +10,7 @@ scenarios:
     commands:
       - rd run delegate-failure-child-fails.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: STOP
 ---
 

--- a/runbooks/delegation/delegate-failure.runbook.md
+++ b/runbooks/delegation/delegate-failure.runbook.md
@@ -10,7 +10,7 @@ scenarios:
     commands:
       - rd run delegate-failure.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 ---
 

--- a/runbooks/delegation/delegate-for-loop.runbook.md
+++ b/runbooks/delegation/delegate-for-loop.runbook.md
@@ -11,9 +11,9 @@ scenarios:
     commands:
       - rd run delegate-for-loop.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
     expect:
       steps:

--- a/runbooks/delegation/delegate-hierarchy.runbook.md
+++ b/runbooks/delegation/delegate-hierarchy.runbook.md
@@ -11,7 +11,7 @@ scenarios:
       - rd run delegate-hierarchy.runbook.md
       - rd claim ${TOKEN}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 ---
 

--- a/runbooks/delegation/delegate-keyword-auto-issue.runbook.md
+++ b/runbooks/delegation/delegate-keyword-auto-issue.runbook.md
@@ -12,7 +12,7 @@ scenarios:
       - rd run delegate-keyword-auto-issue.runbook.md
       - rd claim ${TOKEN}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/delegation/delegate-keyword-collect-fail.runbook.md
+++ b/runbooks/delegation/delegate-keyword-collect-fail.runbook.md
@@ -12,7 +12,7 @@ scenarios:
       - rd run delegate-keyword-collect-fail.runbook.md
       - rd claim ${TOKEN}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: STOP
 ---

--- a/runbooks/delegation/delegate-keyword-collect-pass.runbook.md
+++ b/runbooks/delegation/delegate-keyword-collect-pass.runbook.md
@@ -12,7 +12,7 @@ scenarios:
       - rd run delegate-keyword-collect-pass.runbook.md
       - rd claim ${TOKEN}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/delegation/delegate-keyword-for-loop.runbook.md
+++ b/runbooks/delegation/delegate-keyword-for-loop.runbook.md
@@ -12,9 +12,9 @@ scenarios:
     commands:
       - rd run delegate-keyword-for-loop.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/delegation/delegate-keyword-h2-propagation-fail.runbook.md
+++ b/runbooks/delegation/delegate-keyword-h2-propagation-fail.runbook.md
@@ -12,7 +12,7 @@ scenarios:
       - rd run delegate-keyword-h2-propagation-fail.runbook.md
       - rd claim ${TOKEN}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: STOP
 ---

--- a/runbooks/delegation/delegate-keyword-h2-propagation.runbook.md
+++ b/runbooks/delegation/delegate-keyword-h2-propagation.runbook.md
@@ -12,7 +12,7 @@ scenarios:
       - rd run delegate-keyword-h2-propagation.runbook.md
       - rd claim ${TOKEN}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/delegation/delegate-keyword-h3-explicit.runbook.md
+++ b/runbooks/delegation/delegate-keyword-h3-explicit.runbook.md
@@ -12,7 +12,7 @@ scenarios:
       - rd run delegate-keyword-h3-explicit.runbook.md
       - rd claim ${TOKEN}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/delegation/delegate-keyword-mixed-substeps.runbook.md
+++ b/runbooks/delegation/delegate-keyword-mixed-substeps.runbook.md
@@ -11,8 +11,8 @@ scenarios:
     commands:
       - rd run delegate-keyword-mixed-substeps.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
-      - rd pass
+      - rd collect --run ${RUN_ID}
+      - rd pass --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/delegation/delegate-keyword-retry-exhausts.runbook.md
+++ b/runbooks/delegation/delegate-keyword-retry-exhausts.runbook.md
@@ -13,10 +13,10 @@ scenarios:
       - rd run --allow-all delegate-keyword-retry-exhausts.runbook.md
       - rd --allow-all claim ${TOKEN}
       - rd --allow-all claim ${TOKEN_2}
-      - rd --allow-all collect
+      - rd --allow-all collect --run ${RUN_ID}
       - rd --allow-all claim ${TOKEN_3}
       - rd --allow-all claim ${TOKEN_4}
-      - rd --allow-all collect
+      - rd --allow-all collect --run ${RUN_ID}
     expect:
       result: STOP
       steps:

--- a/runbooks/delegation/delegate-keyword-retry-recovers.runbook.md
+++ b/runbooks/delegation/delegate-keyword-retry-recovers.runbook.md
@@ -13,10 +13,10 @@ scenarios:
       - rd run --allow-all delegate-keyword-retry-recovers.runbook.md
       - rd --allow-all claim ${TOKEN}
       - rd --allow-all claim ${TOKEN_2}
-      - rd --allow-all collect
+      - rd --allow-all collect --run ${RUN_ID}
       - rd --allow-all claim ${TOKEN_3}
       - rd --allow-all claim ${TOKEN_4}
-      - rd --allow-all collect
+      - rd --allow-all collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/delegation/delegate-keyword-runbook-shorthand.runbook.md
+++ b/runbooks/delegation/delegate-keyword-runbook-shorthand.runbook.md
@@ -12,7 +12,7 @@ scenarios:
       - rd run delegate-keyword-runbook-shorthand.runbook.md
       - rd claim ${TOKEN}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/delegation/delegate-named-step.runbook.md
+++ b/runbooks/delegation/delegate-named-step.runbook.md
@@ -10,7 +10,7 @@ scenarios:
     commands:
       - rd run delegate-named-step.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 ---
 

--- a/runbooks/delegation/delegate-nested.runbook.md
+++ b/runbooks/delegation/delegate-nested.runbook.md
@@ -9,7 +9,7 @@ scenarios:
     commands:
       - rd run delegate-nested.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 ---
 

--- a/runbooks/delegation/delegate-open-children-guard.runbook.md
+++ b/runbooks/delegation/delegate-open-children-guard.runbook.md
@@ -17,6 +17,16 @@ scenarios:
       errors:
         - code: OPEN_DELEGATED_CHILDREN
           command: pass
+  bare-pass-refused-without-named-authority:
+    description: A bare rd pass with no --run/--claim-id is refused with ACTOR_CONTEXT_REQUIRED on a delegating run
+    commands:
+      - true delegation-child-manual-one-step.runbook.md
+      - rd run --prompted delegate-open-children-guard.runbook.md
+      - "! rd pass"
+    expect:
+      errors:
+        - code: ACTOR_CONTEXT_REQUIRED
+          command: pass
   bare-fail-refused-while-child-open:
     description: Bare rd fail is refused with OPEN_DELEGATED_CHILDREN while a claimed child is open
     commands:

--- a/runbooks/delegation/delegate-open-children-guard.runbook.md
+++ b/runbooks/delegation/delegate-open-children-guard.runbook.md
@@ -12,7 +12,7 @@ scenarios:
       - true delegation-child-manual-one-step.runbook.md
       - rd run --prompted delegate-open-children-guard.runbook.md
       - rd claim ${TOKEN}
-      - "! rd pass"
+      - "! rd pass --run ${RUN_ID}"
     expect:
       errors:
         - code: OPEN_DELEGATED_CHILDREN
@@ -23,7 +23,7 @@ scenarios:
       - true delegation-child-manual-one-step.runbook.md
       - rd run --prompted delegate-open-children-guard.runbook.md
       - rd claim ${TOKEN}
-      - "! rd fail"
+      - "! rd fail --run ${RUN_ID}"
     expect:
       errors:
         - code: OPEN_DELEGATED_CHILDREN

--- a/runbooks/delegation/delegate-prompted-for.runbook.md
+++ b/runbooks/delegation/delegate-prompted-for.runbook.md
@@ -12,7 +12,7 @@ scenarios:
     commands:
       - rd run delegate-prompted-for.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 
   resolved:
@@ -20,9 +20,9 @@ scenarios:
     commands:
       - rd run --input N=2 delegate-prompted-for.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
       - rd claim ${TOKEN_2}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
     expect:
       steps:

--- a/runbooks/delegation/delegate-substep-list-child-fails.runbook.md
+++ b/runbooks/delegation/delegate-substep-list-child-fails.runbook.md
@@ -11,7 +11,7 @@ scenarios:
       - rd run --prompted delegate-substep-list-child-fails.runbook.md
       - rd claim ${TOKEN}
       - rd fail --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: STOP
       steps:

--- a/runbooks/delegation/delegate-substep-list-non-delegate.runbook.md
+++ b/runbooks/delegation/delegate-substep-list-non-delegate.runbook.md
@@ -10,8 +10,8 @@ scenarios:
     description: rd delegate rejects a runbook-list substep that lacks DELEGATE
     commands:
       - rd run --prompted delegate-substep-list-non-delegate.runbook.md
-      - "! rd delegate --step 1.1"
-      - rd stop
+      - "! rd delegate --step 1.1 --run ${RUN_ID}"
+      - rd stop --run ${RUN_ID}
     expect:
       result: STOP
 ---

--- a/runbooks/delegation/delegate-substep-list.runbook.md
+++ b/runbooks/delegation/delegate-substep-list.runbook.md
@@ -11,7 +11,7 @@ scenarios:
       - rd run --prompted delegate-substep-list.runbook.md
       - rd claim ${TOKEN}
       - rd pass --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:
@@ -26,7 +26,7 @@ scenarios:
       - rd run --prompted delegate-substep-list.runbook.md
       - rd claim ${TOKEN}
       - rd pass --claim-id ${CLAIM_ID}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/delegation/delegate-typed-inheritance.runbook.md
+++ b/runbooks/delegation/delegate-typed-inheritance.runbook.md
@@ -10,7 +10,7 @@ scenarios:
     commands:
       - rd run delegate-typed-inheritance.runbook.md --input-json 'NumberValue=42' --input-json 'ArrayValue=["alpha","beta"]' --input-json 'ObjectValue={"count":2,"enabled":true}'
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 ---
 # Delegate Typed Inheritance

--- a/runbooks/delegation/delegate-with-vars.runbook.md
+++ b/runbooks/delegation/delegate-with-vars.runbook.md
@@ -9,7 +9,7 @@ scenarios:
     commands:
       - rd run delegate-with-vars.runbook.md
       - rd claim ${TOKEN} --input environment=staging
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 ---
 

--- a/runbooks/delegation/nested-runbook-defer-propagation.runbook.md
+++ b/runbooks/delegation/nested-runbook-defer-propagation.runbook.md
@@ -11,7 +11,7 @@ scenarios:
     commands:
       - rd run nested-runbook-defer-propagation.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/scenario-suite.yaml
+++ b/runbooks/scenario-suite.yaml
@@ -168,7 +168,7 @@ cases:
     commands:
       - "true # delegation-child-pass.runbook.md"
       - rd run delegate-basic.runbook.md
-      - rd delegate --step 1.1
+      - rd delegate --step 1.1 --run ${RUN_ID}
       - rd claim ${TOKEN}
     result: COMPLETE
 
@@ -188,7 +188,7 @@ cases:
       - "true # delegation-child-pass.runbook.md"
       - rd run --prompted delegate-abort.runbook.md
       - rd abort ${TOKEN}
-      - rd pass
+      - rd pass --run ${RUN_ID}
     result: COMPLETE
 
   # agent-dispatch/
@@ -437,7 +437,7 @@ cases:
     file: composition/step-runbook-list.runbook.md
     commands:
       - rd run --prompted step-runbook-list.runbook.md
-      - rd pass
-      - rd pass
-      - rd pass
+      - rd pass --run ${RUN_ID_2}
+      - rd pass --run ${RUN_ID_3}
+      - rd pass --run ${RUN_ID_4}
     result: COMPLETE

--- a/runbooks/scenario-suite.yaml
+++ b/runbooks/scenario-suite.yaml
@@ -191,6 +191,21 @@ cases:
       - rd pass --run ${RUN_ID}
     result: COMPLETE
 
+  delegate-bare-pass-refused:
+    description: >-
+      A bare rd pass (no --run / --claim-id) on a delegating run is refused
+      with ACTOR_CONTEXT_REQUIRED — mutations against delegation-exposed runs
+      require named authority.
+    file: delegation/delegate-open-children-guard.runbook.md
+    commands:
+      - "true # delegation-child-manual-one-step.runbook.md"
+      - rd run --prompted delegate-open-children-guard.runbook.md
+      - "! rd pass"
+    expect:
+      errors:
+        - code: ACTOR_CONTEXT_REQUIRED
+          command: pass
+
   # agent-dispatch/
   agent-dispatch-orchestrator-completed:
     description: Same orchestrator claims two children and completes them by claim id

--- a/runbooks/substeps/defer-mixed-delegation-local.runbook.md
+++ b/runbooks/substeps/defer-mixed-delegation-local.runbook.md
@@ -12,7 +12,7 @@ scenarios:
     commands:
       - rd run defer-mixed-delegation-local.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     expect:
       result: COMPLETE
       steps:

--- a/runbooks/variables/context-parent.runbook.md
+++ b/runbooks/variables/context-parent.runbook.md
@@ -9,7 +9,7 @@ scenarios:
     commands:
       - rd run context-parent.runbook.md
       - rd claim ${TOKEN}
-      - rd collect
+      - rd collect --run ${RUN_ID}
     result: COMPLETE
 ---
 


### PR DESCRIPTION
## Summary

**Cluster G tier 1** from the [delegation-lifecycle roadmap](docs/superpowers/plans/2026-07-03-delegation-lifecycle-roadmap-2.md) §1–2: the structural fix for #460. The ambient-trust lane is gone — bare `direct_cli` invocations no longer receive run-controller authority over whatever happens to be active.

Closes #460.

### The trust model after this PR

- **Delegated children** name their authority with `--claim-id` (unchanged).
- **Orchestrators** name theirs with the new `--run <rd_…>` flag on every run-driving command (`pass`, `fail`, `goto`, `complete`, `stop`, `collect`, `delegate`) — it both selects the target run and supplies the new `run_controller` `CallerEvidence` variant.
- **Bare commands on a delegation-exposed run refuse** with `ACTOR_CONTEXT_REQUIRED` and an actionable remediation naming both lanes. The refusal never echoes the target run id.
- **Bare commands remain valid only on `standalone` runs** — classified by a pure six-clause `classifyDelegationExposure` (authored DELEGATE substeps, open claims, collection-pending, sticky delegation history, inline parent-linkage, and static inline-composition runbook lists — clause six closes the inline-parent variant of #460 found in plan review). Exposure is sticky: claim closure and prune cannot flip a run back to standalone.
- **Always-strict**: no grace modes, no env escapes, no first-delegation exceptions — per the ratified design law. `--step` no longer bypasses the role gate (a step name is not authority).
- The A/E subprocess withhold sets remain as **defense-in-depth**; `goto` gains a `run-navigation` policy intent (it was previously ungated); MCP mutating tools take an explicit `runId`.
- One deliberate authority rule beyond the plan's letter, reviewed and documented in architecture.md: run-targeted terminals naming a **contiguous inline chain** member carry derived authority over the walked-to root — a delegation boundary always severs the chain, and claimed children can never be `--run` targets (both walls pinned by seam tests).

### Dogfood evidence

The flip went live against the very pipeline that built it: the orchestrator's bare `rundown collect` was refused mid-pipeline with the designed remediation, and the `--run`-targeted retry drove the pipeline to completion — including a 3m08s sandboxed verify gate and automatic inline completion propagation.

### Scope decisions recorded (plan Constraints / architecture.md)

- `stash`/`pop`/`prune` remain a documented **residual ambient lane** (session hygiene, not run-driving) — follow-up tracked in the roadmap; #556 filed for the inline-stage stack-release wart it surfaced.
- Names are not capabilities: `--run` ids are printed openly; tier-1 is accident-proofing. The capability upgrade is #540 (R4).
- **R1→R2 coupling:** the shipped skills/plugin hook texts still teach bare commands; R2 (skills/docs migration) must land in the same release line. The plan's Context carries the full handoff list.

### Process

Full `rundown:planning` pipeline: write-plan → 4-dimension review (**5 errors, 11 warnings** found — including a genuine classifier bypass, two compile-breaking omissions, and the plan's own verify gate depending on bare-command scenario fixtures) → all findings folded into the revised plan → delegated TDD implementation (11 planned commits; flip + 90-site test migration as one commit per review) → code review gate **PASSED (0 errors)** with the derived-authority deviation adversarially examined → verify.

### Verification

- `pnpm run verify` green at tip (all packages; typed lint, types, format, spell, docs-drift).
- `pnpm run test:integration` green (83 + 610). Scenario suites green with 37 bundled delegation runbooks migrated to `--run` via the new `${RUN_ID}` harness placeholder.
- Suites at tip: core 3,955 / CLI 2,853+ / MCP 86 / plugin 705 unit + 83 integration.
- Scoped CLI Stryker (via the #551 workaround): 83.95 overall, ≥ break threshold.
- New acceptance suite `explicit-run-targeting.test.ts`: the #460 reproduction verbatim, the no-echo pin, the claimed-child-unreachable pin, and the clause-f grandchild scenario.

### Review-noted deviations (all examined at the gate)

1. Unknown-role bare collect resolves to `actor_context_required` (not `collect_requires_orchestrator`) — judged the correct role-gate semantics; both messages name both lanes.
2. Stop-propagation tests rewritten to claim-path + collect (their bare flow was the pre-R1 world; one was quietly degenerate).
3. Tip fix-commits for typed-lint/type findings mean mid-series commits aren't all verify-green — series bisectability is imperfect; tip is clean (squash-merge makes this moot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit `--run <runId>` targeting across lifecycle commands (including `pass`, `fail`, `complete`, `stop`, `collect`, `delegate`, `goto`) and updated CLI help and MCP tool schemas to support it.
* **Bug Fixes**
  * Improved handling for invalid/unknown run targets (`INVALID_RUN_ID`, `RUN_TARGET_UNAVAILABLE`) and clarified refusal behavior for bare commands (now requires proper run/claim context).
  * Refusals/remediations no longer expose denied run identifiers, and run-scoped routing now consistently applies the intended target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->