### PR TITLE
[codex] migrate docs to explicit run targeting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,10 +161,16 @@ duplicate or reconstruct it here.** When stepping through a runbook, follow the
 `rundown pass`/`rundown fail`, claim/delegate, JSON vs `--text`) rather than the
 raw flag list.
 
+Post-R1, mutating commands on delegation-exposed runs must name their authority:
+orchestrators pass `--run <rd_…>` (run id from `rundown run` output /
+`runbookId` on events), children pass `--claim-id`; bare forms refuse with
+`ACTOR_CONTEXT_REQUIRED`. Read-only commands stay bare.
+
 - [docs/reference/cli.md](docs/reference/cli.md) — every `rundown`/`rd` command
   (run, pass/fail, goto, status, stop, complete, stash/pop, ls, check, resolve,
   echo, prune, scenario, scenario-suite, prompt, delegate, claim, abort,
-  collect) with flags and `--step` / `--index` / `--claim-id` semantics
+  collect) with flags and `--run` / `--step` / `--index` / `--claim-id`
+  semantics
 - [docs/spec/cli-output.md](docs/spec/cli-output.md) — `--schema` JSON-output
   schemas for programmatic validation
 - [docs/reference/security.md](docs/reference/security.md) — policy flags

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -761,6 +761,8 @@ Two companion CLIs ship alongside `rundown`:
 | `rundown pass --run <rd_…>`                                | Orchestrator lane: advance the run you control                                    |
 | `rundown fail --run <rd_…>`                                | Orchestrator lane: record a failing advance on the run you control                |
 | `rundown goto <step> --run <rd_…>`                         | Orchestrator lane: jump within the run you control (run-navigation policy gate)   |
+| `rundown complete --run <rd_…>`                            | Orchestrator lane: complete the run you control                                   |
+| `rundown stop --run <rd_…>`                                | Orchestrator lane: stop the run you control                                       |
 | `rundown abort <token>`                                    | Cancel a delegation token                                                         |
 | `rundown abort <token> --force`                            | Cancel a claimed delegation                                                       |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -255,6 +255,16 @@ Marks the runbook as stopped, preserves the stopped state file for inspection,
 and removes it from the active session stack. Bare `rundown stop` is a failure
 terminal and exits non-zero.
 
+**Flags:**
+
+- `--run <runId>` — Name the run you control (explicit orchestrator targeting).
+- `--claim-id <claimId>` — Target a claimed delegated child runbook.
+
+On a delegation-exposed run the bare form is refused with
+`ACTOR_CONTEXT_REQUIRED`; pass `--run <rd_…>` (orchestrator) or
+`--claim-id <claim_id>` (delegated child). Standalone runs (no delegation
+activity) still accept the bare form.
+
 <a id="force-terminal-targeting"></a>
 
 When the active runbook is an inline-composed child, bare `rundown complete` and
@@ -264,7 +274,7 @@ running inline descendants remain under a terminal parent.
 
 This targeting rule stops at delegation boundaries. If the inline root is a
 delegated child, it reports its terminal outcome to the delegating parent, and
-the delegating parent advances only after `rundown collect`.
+the delegating parent advances only after `rundown collect --run <rd_…>`.
 
 `--claim-id` keeps delegated-child scope: `rundown complete --claim-id <id>` and
 `rundown stop --claim-id <id>` target that claimed child directly.
@@ -291,7 +301,18 @@ scenarios.
 ```bash
 rundown complete                            # Force completion from current step
 rundown complete "Skipping remaining steps" # Complete with message
+rundown complete --run <rd_…>               # Orchestrator-targeted completion
 ```
+
+**Flags:**
+
+- `--run <runId>` — Name the run you control (explicit orchestrator targeting).
+- `--claim-id <claimId>` — Target a claimed delegated child runbook.
+
+On a delegation-exposed run the bare form is refused with
+`ACTOR_CONTEXT_REQUIRED`; pass `--run <rd_…>` (orchestrator) or
+`--claim-id <claim_id>` (delegated child). Standalone runs still accept the bare
+form.
 
 **When to use:**
 
@@ -315,6 +336,8 @@ Signal successful step completion.
 rundown pass
 rundown pass --step 2.1              # Target a specific substep
 rundown pass --step 2.1 --index 3    # Target substep at FOR iteration 3
+rundown pass --run <rd_…>            # Orchestrator-targeted advance
+rundown pass --claim-id <claim_id>   # Delegated child reports its result
 ```
 
 **Aliases:** `rundown yes`, `rundown ok`
@@ -323,6 +346,13 @@ rundown pass --step 2.1 --index 3    # Target substep at FOR iteration 3
 
 - `--step <stepId>` — Target a specific substep (not the currently active one).
 - `--index <number>` — FOR loop iteration to target (requires `--step`).
+- `--run <runId>` — Name the run you control (explicit orchestrator targeting).
+- `--claim-id <claimId>` — Target a claimed delegated child runbook.
+
+On a delegation-exposed run the bare form is refused with
+`ACTOR_CONTEXT_REQUIRED`; pass `--run <rd_…>` (orchestrator) or
+`--claim-id <claim_id>` (delegated child). Standalone runs still accept the bare
+form.
 
 **Behavior:**
 
@@ -339,6 +369,8 @@ Signal step failure.
 rundown fail
 rundown fail --step 2.1              # Target a specific substep
 rundown fail --step 2.1 --index 3    # Target substep at FOR iteration 3
+rundown fail --run <rd_…>            # Orchestrator-targeted advance
+rundown fail --claim-id <claim_id>   # Delegated child reports its result
 ```
 
 **Alias:** `rundown no`
@@ -347,6 +379,13 @@ rundown fail --step 2.1 --index 3    # Target substep at FOR iteration 3
 
 - `--step <stepId>` — Target a specific substep (not the currently active one).
 - `--index <number>` — FOR loop iteration to target (requires `--step`).
+- `--run <runId>` — Name the run you control (explicit orchestrator targeting).
+- `--claim-id <claimId>` — Target a claimed delegated child runbook.
+
+On a delegation-exposed run the bare form is refused with
+`ACTOR_CONTEXT_REQUIRED`; pass `--run <rd_…>` (orchestrator) or
+`--claim-id <claim_id>` (delegated child). Standalone runs still accept the bare
+form.
 
 **Behavior:**
 
@@ -387,7 +426,7 @@ inline and delegation children differ. An inline child shares one process with
 its parent, so the exit code reflects the whole inline chain. A delegated child
 runs in its own worker process, so closing it halts _that_ process's workflow
 (exit non-zero on its own STOP) while the delegating parent advances later, in a
-different process, via `rundown collect`.
+different process, via `rundown collect --run <rd_…>`.
 
 #### `rundown goto <step>` - Jump to Step
 
@@ -397,12 +436,21 @@ Navigate directly to a step.
 rundown goto 3                # Jump to step 3
 rundown goto 3.1              # Jump to substep 3.1
 rundown goto 3 --index 2      # Jump to step 3 and enter FOR iteration 2
+rundown goto 3 --run <rd_…>   # Orchestrator-targeted jump
 ```
 
 **Flags:**
 
 - `--index <number>` — For FOR-annotated targets, enter the loop at the
   specified iteration.
+- `--run <runId>` — Name the run you control (explicit orchestrator targeting).
+- `--claim-id <claimId>` — Target a claimed delegated child runbook.
+
+On a delegation-exposed run the bare form is refused with
+`ACTOR_CONTEXT_REQUIRED`; pass `--run <rd_…>` (orchestrator) or
+`--claim-id <claim_id>` (delegated child). `goto` is additionally gated behind
+the `run-navigation` policy intent — the run's policy must grant navigation for
+the jump to be allowed.
 
 **Restrictions:**
 
@@ -708,6 +756,11 @@ Two companion CLIs ship alongside `rundown`:
 | `rundown pop --claim-id <claim_id>`                        | Restore a stashed claimed child runbook                                           |
 | `rundown stop --claim-id <claim_id>`                       | Stop a claimed child runbook                                                      |
 | `rundown complete --claim-id <claim_id>`                   | Complete a claimed child runbook                                                  |
+| `rundown delegate --step <id> --run <rd_…>`                | Orchestrator lane: delegate on a delegation-exposed run you control               |
+| `rundown collect --run <rd_…>`                             | Orchestrator lane: aggregate delegated results for the run you control            |
+| `rundown pass --run <rd_…>`                                | Orchestrator lane: advance the run you control                                    |
+| `rundown fail --run <rd_…>`                                | Orchestrator lane: record a failing advance on the run you control                |
+| `rundown goto <step> --run <rd_…>`                         | Orchestrator lane: jump within the run you control (run-navigation policy gate)   |
 | `rundown abort <token>`                                    | Cancel a delegation token                                                         |
 | `rundown abort <token> --force`                            | Cancel a claimed delegation                                                       |
 
@@ -746,6 +799,12 @@ Delegation semantics:
 - Child runbook uses `rundown pass --claim-id <claim_id>` /
   `rundown fail --claim-id <claim_id>` to report its outcome. Other
   claim-targeted lifecycle commands use the same explicit child routing.
+- Orchestrator lane: on a delegation-exposed run every mutating command
+  (`delegate`, `collect`, `pass`, `fail`, `goto`, `complete`, `stop`) must name
+  the run you control with `--run <rd_…>`; the bare form is refused with
+  `ACTOR_CONTEXT_REQUIRED`. The run id is printed by `rundown run` at start and
+  carried as `runbookId` on every event. The refusal remediation names both
+  lanes and never echoes the target run id.
 - Completion routing is frame + entry aware (`frame + entry + substep`) to
   prevent stale re-entry completions from being applied.
 - Claimed children are routed by claim id, not by the shared stack.
@@ -763,6 +822,12 @@ Delegation semantics:
 ---
 
 ## Common Tasks
+
+These examples assume a **standalone run** (no delegation activity), so the bare
+transition forms apply. On a delegation-exposed run the bare form is refused
+with `ACTOR_CONTEXT_REQUIRED`; see [Delegation Patterns](#delegation-patterns)
+for the `--run <rd_…>` (orchestrator) and `--claim-id <claim_id>` (child)
+targeted forms.
 
 ### Task: Run a Simple Sequential Runbook
 
@@ -875,11 +940,12 @@ Main agent runs runbook, dispatches subagents for substeps.
 **Command sequence:**
 
 ```bash
-# 1. Main agent starts parent runbook
+# 1. Main agent starts parent runbook, capturing the run id it prints
+#    (also carried as runbookId on every subsequent event)
 rundown run runbook.runbook.md
 
-# 2. At substep, main agent delegates to child runbook
-rundown delegate task.runbook.md --step 2.1
+# 2. At substep, main agent delegates to child runbook, naming the run it controls
+rundown delegate task.runbook.md --step 2.1 --run <rd_…>
 
 # 3. Subagent claims the delegation token
 rundown claim <token>
@@ -888,6 +954,9 @@ rundown claim <token>
 
 # 5. Subagent reports result using the claim_id returned by rundown claim
 rundown pass --claim-id <claim_id>    # or: rundown fail --claim-id <claim_id>
+
+# 6. Main agent advances its own run with --run once the child has reported
+rundown pass --run <rd_…>             # or: rundown collect --run <rd_…>
 ```
 
 **Key points:**
@@ -900,6 +969,10 @@ rundown pass --claim-id <claim_id>    # or: rundown fail --claim-id <claim_id>
 - The delegation token printed by `delegate` is passed to `claim` by the
   subagent
 - The `claim_id` printed by `claim` is passed to every child-targeting command
+- Orchestrator lane: capture the run id from `rundown run` (echoed as
+  `runbookId` on every event) and pass `--run <rd_…>` on every orchestrator
+  mutation (`delegate`, `collect`, `pass`, `fail`, `goto`); the bare form is
+  refused with `ACTOR_CONTEXT_REQUIRED` on a delegation-exposed run
 - Child uses `rundown pass --claim-id <claim_id>` /
   `rundown fail --claim-id <claim_id>`
 - Completions are validated against frame + entry identity; stale completions
@@ -922,7 +995,9 @@ If more remain: `rundown goto 3`
 If complete: `rundown pass`
 ```
 
-Agent reads step, evaluates condition, runs appropriate CLI command.
+Agent reads step, evaluates condition, runs appropriate CLI command. On a
+delegation-exposed run these become `rundown goto 3 --run <rd_…>` and
+`rundown pass --run <rd_…>`; the bare forms shown apply to a standalone run.
 
 ---
 
@@ -1052,14 +1127,18 @@ JSON output compatibility:
 
 ### Common Errors and Resolutions
 
-| Error                                       | Cause                                      | Resolution                                                   |
-| ------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------ |
-| "No active runbook"                         | No runbook in stack                        | Run `rundown run <file>`                                     |
-| "Runbook file not found"                    | Missing runbook                            | Check file path                                              |
-| "Step N does not exist"                     | Invalid GOTO target                        | Check step numbers                                           |
-| "Invalid step target"                       | Bad goto format                            | Use "N" or "N.M"                                             |
-| "FOR loop references undefined data source" | Sourced FOR clause without matching source | Define source via --input-json, config.yaml, or --input-file |
-| "File drift detected"                       | Data file changed during iteration         | Ensure file stability or restart runbook                     |
+| Error                                       | Cause                                                                    | Resolution                                                                                                            |
+| ------------------------------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| "No active runbook"                         | No runbook in stack                                                      | Run `rundown run <file>`                                                                                              |
+| "Runbook file not found"                    | Missing runbook                                                          | Check file path                                                                                                       |
+| "Step N does not exist"                     | Invalid GOTO target                                                      | Check step numbers                                                                                                    |
+| "Invalid step target"                       | Bad goto format                                                          | Use "N" or "N.M"                                                                                                      |
+| "FOR loop references undefined data source" | Sourced FOR clause without matching source                               | Define source via --input-json, config.yaml, or --input-file                                                          |
+| "File drift detected"                       | Data file changed during iteration                                       | Ensure file stability or restart runbook                                                                              |
+| `ACTOR_CONTEXT_REQUIRED`                    | Bare mutating command on a delegation-exposed run                        | Name your lane: `--run <rd_…>` (orchestrator) or `--claim-id <claim_id>` (delegated child)                            |
+| `RUN_TARGET_UNAVAILABLE`                    | `--run` target is not a running member of this session's stack           | Use a run id from the active session stack (claimed children are never stack members — target them with `--claim-id`) |
+| `INVALID_RUN_ID`                            | Malformed `--run` value                                                  | Supply a valid run id — `rd_<32 hex characters>`                                                                      |
+| `COLLECT_REQUIRES_ORCHESTRATOR`             | `rundown collect` without an actor controlling the target delegating run | Run `collect` as the orchestrator of the delegating run (`--run <rd_…>`)                                              |
 
 ### State Recovery
 
@@ -1091,11 +1170,15 @@ rundown run <file>           # Start runbook
 rundown stop [message]       # Abort runbook with optional message
 rundown complete [message]   # Force early completion (auto-complete on final step)
 
-# Transitions
+# Transitions (bare forms below are standalone-run only; a delegation-exposed
+# run refuses them with ACTOR_CONTEXT_REQUIRED — name your lane instead)
 rundown pass                 # Step succeeded (aliases: yes, ok)
 rundown fail                 # Step failed (alias: no)
 rundown goto <N>             # Jump to step N
 rundown goto <N.M>           # Jump to substep N.M
+rundown pass --run <rd_…>    # Orchestrator advance (delegation-exposed run)
+rundown collect --run <rd_…> # Orchestrator aggregates delegated results
+rundown goto <N> --run <rd_…># Orchestrator jump (run-navigation policy gate)
 
 # Status
 rundown status               # Show current state
@@ -1124,12 +1207,12 @@ rundown scenario-suite run <suite>     # Execute suite case(s)
 rdpath --dir <path>          # Path assembly tool (see docs/reference/rdpath.md)
 rdx <file>                   # Render JSON to Markdown (see docs/reference/rdx.md)
 
-# Delegation
-rundown delegate                        # Infer child runbook + substep from state
-rundown delegate --step <id>            # Infer child runbook from substep
-rundown delegate <runbook> --step <id>  # Delegate substep to explicit child runbook
-rundown delegate --retry <token>        # Retry delegation: cancel and re-issue
-rundown delegate --retry --step <id>    # Retry delegation on a substep
+# Delegation (orchestrator commands on a delegation-exposed run carry
+# --run <rd_…>; capture the run id from `rundown run` / event `runbookId`)
+rundown delegate --step <id> --run <rd_…>         # Delegate on the run you control
+rundown delegate <runbook> --step <id> --run <rd_…>  # Explicit child runbook
+rundown delegate --retry <token> --run <rd_…>     # Retry: cancel and re-issue
+rundown collect --run <rd_…>            # Aggregate delegated results
 rundown claim <token>                   # Claim delegation token and return claim_id
 rundown status --claim-id <claim_id>    # Inspect claimed child
 rundown pass --claim-id <claim_id>      # Complete claimed child with PASS

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -106,15 +106,16 @@ explicitly, in one of two lanes:
   targeting of the run you control; the run id is printed by `rundown run` and
   carried as `runbookId` on every event).
 
-A call carrying either `claimId` OR `runId` passes through on all six mutating
-commands — `pass`, `fail`, `complete`, `stop`, `collect`, and `delegate`
-(`delegate` accepts the run lane only; see [§5.11](#delegate)). Only the
-**bare** form (neither `claimId` nor `runId`) is withheld in-process, refused
-without invoking the CLI (see [§5.6](#pass), [§5.7](#fail), [§5.11](#delegate),
-and [§5.13](#collect)). `claimId` and `runId` are mutually exclusive: supplying
-both is a validation error surfaced on the `runId` path, rejected before the CLI
-is invoked. Tools that exist purely for local session management, destructive
-state operations, or authoring helpers are CLI-only (see
+A call carrying either `claimId` OR `runId` passes through on the shared
+mutating commands — `pass`, `fail`, `complete`, `stop`, and `collect`.
+`delegate` is the exception: it accepts the run lane only, because delegation is
+an orchestrator action (see [§5.11](#delegate)). Only the **bare** form (neither
+`claimId` nor `runId`, or no `runId` for `delegate`) is withheld in-process,
+refused without invoking the CLI (see [§5.6](#pass), [§5.7](#fail),
+[§5.11](#delegate), and [§5.13](#collect)). `claimId` and `runId` are mutually
+exclusive: supplying both is a validation error surfaced on the `runId` path,
+rejected before the CLI is invoked. Tools that exist purely for local session
+management, destructive state operations, or authoring helpers are CLI-only (see
 [§5.14](#unsupported-cli-operations)).
 
 The server MUST register exactly the following tools:

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -91,36 +91,48 @@ state semantics are inherited from the CLI process and are defined by
 The MCP server mirrors the agent-facing CLI surface, mapping tools to CLI
 subcommands so that agent clients have broadly the same execution and
 coordination capabilities as a human at the terminal, EXCEPT that a subprocess
-mutation boundary withholds unclaimed lifecycle mutations. Because the MCP
-server reaches the CLI by spawning a subprocess, typed caller evidence cannot
-cross the process boundary: a spawned `rundown pass` / `rundown fail` /
-`rundown delegate` arrives as an ordinary `argv`, indistinguishable from a human
-at the terminal, and would silently inherit direct-CLI trust
-(`trusted_run_controller`) over the active run. The server therefore withholds
-bare `pass` / `fail` / `complete` / `stop` / `collect` (without claim evidence)
-and every `delegate` call, refusing them in-process without invoking the CLI
-(see [§5.6](#pass), [§5.7](#fail), [§5.11](#delegate), and [§5.13](#collect)).
-Only `pass` / `fail` / `complete` / `stop` / `collect` carrying a real
-`--claim-id` present independent claim evidence and pass through. Tools that
-exist purely for local session management, destructive state operations, or
-authoring helpers are CLI-only (see [§5.14](#unsupported-cli-operations)).
+mutation boundary withholds ambient lifecycle mutations that name no lane.
+Because the MCP server reaches the CLI by spawning a subprocess, typed caller
+evidence cannot cross the process boundary: a spawned `rundown pass` /
+`rundown fail` / `rundown delegate` arrives as an ordinary `argv`,
+indistinguishable from a human at the terminal, and a **bare** one would
+silently inherit direct-CLI trust (`trusted_run_controller`) over the active
+run. The boundary therefore requires every mutating call to name its authority
+explicitly, in one of two lanes:
+
+- **Claim lane** — a real `claimId`, mapped to `--claim-id <claim_id>`
+  (independent claim-controller evidence for a delegated child).
+- **Run lane** — a real `runId`, mapped to `--run <rd_…>` (explicit orchestrator
+  targeting of the run you control; the run id is printed by `rundown run` and
+  carried as `runbookId` on every event).
+
+A call carrying either `claimId` OR `runId` passes through on all six mutating
+commands — `pass`, `fail`, `complete`, `stop`, `collect`, and `delegate`
+(`delegate` accepts the run lane only; see [§5.11](#delegate)). Only the
+**bare** form (neither `claimId` nor `runId`) is withheld in-process, refused
+without invoking the CLI (see [§5.6](#pass), [§5.7](#fail), [§5.11](#delegate),
+and [§5.13](#collect)). `claimId` and `runId` are mutually exclusive: supplying
+both is a validation error surfaced on the `runId` path, rejected before the CLI
+is invoked. Tools that exist purely for local session management, destructive
+state operations, or authoring helpers are CLI-only (see
+[§5.14](#unsupported-cli-operations)).
 
 The server MUST register exactly the following tools:
 
-| Tool                    | Required parameters | Optional parameters                                                    | CLI mapping                                                                                                                        |
-| ----------------------- | ------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| [`validate`](#validate) | `file`              | —                                                                      | `rundown check <file>`                                                                                                             |
-| [`list`](#list)         | —                   | `all`, `tags`                                                          | `rundown ls [--all] [--tags <tags>]`                                                                                               |
-| [`status`](#status)     | —                   | `claimId`                                                              | `rundown status [--claim-id <id>]`                                                                                                 |
-| [`run`](#run)           | —                   | `file`, `prompted`, `step`, `index`, `input`, `inputJson`, `inputFile` | `rundown run [<file>] [--prompted] [--step <id>] [--index <n>] [--input ...] [--input-json ...] [--input-file ...]`                |
-| [`pass`](#pass)         | —                   | `step`, `index`, `claimId`                                             | `rundown pass [--step <id>] [--index <n>] [--claim-id <id>]` — bare form (no `claimId`) withheld in-process ([§5.6](#pass))        |
-| [`fail`](#fail)         | —                   | `step`, `index`, `claimId`                                             | `rundown fail [--step <id>] [--index <n>] [--claim-id <id>]` — bare form (no `claimId`) withheld in-process ([§5.7](#fail))        |
-| [`goto`](#goto)         | `step`              | `index`, `claimId`                                                     | `rundown goto <step> [--index <n>] [--claim-id <id>]`                                                                              |
-| [`complete`](#complete) | —                   | `message`, `claimId`                                                   | `rundown complete [<message>] [--claim-id <id>]`                                                                                   |
-| [`stop`](#stop)         | —                   | `message`, `claimId`                                                   | `rundown stop [<message>] [--claim-id <id>]`                                                                                       |
-| [`delegate`](#delegate) | —                   | `runbook`, `step`, `index`, `retry`, `input`, `inputJson`, `inputFile` | Always withheld in-process; never invokes the CLI ([§5.11](#delegate))                                                             |
-| [`claim`](#claim)       | `token`             | `input`, `inputJson`, `inputFile`                                      | `rundown claim <token> [--input ...] [--input-json ...] [--input-file ...]`                                                        |
-| [`collect`](#collect)   | —                   | `step`, `index`, `claimId`                                             | `rundown collect [--step <id>] [--index <n>] [--claim-id <id>]` — bare form (no `claimId`) withheld in-process ([§5.13](#collect)) |
+| Tool                    | Required parameters | Optional parameters                                                             | CLI mapping                                                                                                                                                      |
+| ----------------------- | ------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`validate`](#validate) | `file`              | —                                                                               | `rundown check <file>`                                                                                                                                           |
+| [`list`](#list)         | —                   | `all`, `tags`                                                                   | `rundown ls [--all] [--tags <tags>]`                                                                                                                             |
+| [`status`](#status)     | —                   | `claimId`                                                                       | `rundown status [--claim-id <id>]`                                                                                                                               |
+| [`run`](#run)           | —                   | `file`, `prompted`, `step`, `index`, `input`, `inputJson`, `inputFile`          | `rundown run [<file>] [--prompted] [--step <id>] [--index <n>] [--input ...] [--input-json ...] [--input-file ...]`                                              |
+| [`pass`](#pass)         | —                   | `step`, `index`, `claimId`, `runId`                                             | `rundown pass [--step <id>] [--index <n>] [--claim-id <id>] [--run <rd_…>]` — bare form (no `claimId` and no `runId`) withheld in-process ([§5.6](#pass))        |
+| [`fail`](#fail)         | —                   | `step`, `index`, `claimId`, `runId`                                             | `rundown fail [--step <id>] [--index <n>] [--claim-id <id>] [--run <rd_…>]` — bare form (no `claimId` and no `runId`) withheld in-process ([§5.7](#fail))        |
+| [`goto`](#goto)         | `step`              | `index`, `claimId`, `runId`                                                     | `rundown goto <step> [--index <n>] [--claim-id <id>] [--run <rd_…>]`                                                                                             |
+| [`complete`](#complete) | —                   | `message`, `claimId`, `runId`                                                   | `rundown complete [<message>] [--claim-id <id>] [--run <rd_…>]` — bare form withheld in-process ([§5.9](#complete))                                              |
+| [`stop`](#stop)         | —                   | `message`, `claimId`, `runId`                                                   | `rundown stop [<message>] [--claim-id <id>] [--run <rd_…>]` — bare form withheld in-process ([§5.10](#stop))                                                     |
+| [`delegate`](#delegate) | —                   | `runbook`, `step`, `index`, `retry`, `runId`, `input`, `inputJson`, `inputFile` | `rundown delegate … --run <rd_…>` when `runId` is supplied; bare form (no `runId`) withheld in-process ([§5.11](#delegate))                                      |
+| [`claim`](#claim)       | `token`             | `input`, `inputJson`, `inputFile`                                               | `rundown claim <token> [--input ...] [--input-json ...] [--input-file ...]`                                                                                      |
+| [`collect`](#collect)   | —                   | `step`, `index`, `claimId`, `runId`                                             | `rundown collect [--step <id>] [--index <n>] [--claim-id <id>] [--run <rd_…>]` — bare form (no `claimId` and no `runId`) withheld in-process ([§5.13](#collect)) |
 
 Parameter types are defined per tool below. The server MUST validate tool inputs
 against the declared schema and reject inputs that fail validation without
@@ -191,20 +203,23 @@ and apply unchanged when variables are supplied through MCP.
 
 Mark a step as passed.
 
-| Parameter | Type        | Required | Behavior                                                                                  |
-| --------- | ----------- | -------- | ----------------------------------------------------------------------------------------- |
-| `step`    | string      | No       | When set, forwarded as `--step <value>` to target a specific substep.                     |
-| `index`   | integer ≥ 0 | No       | When set, forwarded as `--index <value>` to target a FOR-loop iteration. Requires `step`. |
-| `claimId` | string      | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.               |
+| Parameter | Type        | Required | Behavior                                                                                                                       |
+| --------- | ----------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `step`    | string      | No       | When set, forwarded as `--step <value>` to target a specific substep.                                                          |
+| `index`   | integer ≥ 0 | No       | When set, forwarded as `--index <value>` to target a FOR-loop iteration. Requires `step`.                                      |
+| `claimId` | string      | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.                                                    |
+| `runId`   | string      | No       | When set, forwarded as `--run <value>` (`rd_<32 hex>`) for explicit orchestrator targeting. Mutually exclusive with `claimId`. |
 
-Over MCP, `pass` REQUIRES claim evidence: a bare `pass` without a real `claimId`
-is classified as a subprocess lifecycle mutation and withheld in-process — the
-server MUST return a withheld-mutation `error` payload WITHOUT invoking the CLI.
-A spawned bare `rundown pass` would silently inherit direct-CLI
-(`trusted_run_controller`) trust over the active run, which a subprocess front
-end MUST NOT be able to mint. Only a `pass` carrying a real `claimId` presents
-independent claim-controller evidence and is forwarded to the CLI. To mark a
-non-delegated step passed, run `rundown pass` directly in a trusted terminal.
+Over MCP, `pass` REQUIRES explicit targeting: a bare `pass` without a real
+`claimId` or `runId` is classified as a subprocess lifecycle mutation and
+withheld in-process — the server MUST return a withheld-mutation `error` payload
+WITHOUT invoking the CLI. A spawned bare `rundown pass` would silently inherit
+direct-CLI (`trusted_run_controller`) trust over the active run, which a
+subprocess front end MUST NOT be able to mint. Either lane exempts the call: a
+`pass` carrying a real `claimId` presents independent claim-controller evidence,
+and a `pass` carrying a real `runId` names the run the orchestrator controls
+(`--run <rd_…>`); either is forwarded to the CLI. To mark a non-delegated
+standalone step passed, run `rundown pass` directly in a trusted terminal.
 
 <a id="fail"></a>
 
@@ -212,19 +227,22 @@ non-delegated step passed, run `rundown pass` directly in a trusted terminal.
 
 Mark a step as failed.
 
-| Parameter | Type        | Required | Behavior                                                                                  |
-| --------- | ----------- | -------- | ----------------------------------------------------------------------------------------- |
-| `step`    | string      | No       | When set, forwarded as `--step <value>` to target a specific substep.                     |
-| `index`   | integer ≥ 0 | No       | When set, forwarded as `--index <value>` to target a FOR-loop iteration. Requires `step`. |
-| `claimId` | string      | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.               |
+| Parameter | Type        | Required | Behavior                                                                                                                       |
+| --------- | ----------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `step`    | string      | No       | When set, forwarded as `--step <value>` to target a specific substep.                                                          |
+| `index`   | integer ≥ 0 | No       | When set, forwarded as `--index <value>` to target a FOR-loop iteration. Requires `step`.                                      |
+| `claimId` | string      | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.                                                    |
+| `runId`   | string      | No       | When set, forwarded as `--run <value>` (`rd_<32 hex>`) for explicit orchestrator targeting. Mutually exclusive with `claimId`. |
 
-Over MCP, `fail` REQUIRES claim evidence, exactly as [`pass`](#pass): a bare
-`fail` without a real `claimId` is classified as a subprocess lifecycle mutation
-and withheld in-process — the server MUST return a withheld-mutation `error`
-payload WITHOUT invoking the CLI, because a spawned bare `rundown fail` would
-silently inherit direct-CLI (`trusted_run_controller`) trust over the active
-run. Only a `fail` carrying a real `claimId` is forwarded to the CLI. To mark a
-non-delegated step failed, run `rundown fail` directly in a trusted terminal.
+Over MCP, `fail` REQUIRES explicit targeting, exactly as [`pass`](#pass): a bare
+`fail` without a real `claimId` or `runId` is classified as a subprocess
+lifecycle mutation and withheld in-process — the server MUST return a
+withheld-mutation `error` payload WITHOUT invoking the CLI, because a spawned
+bare `rundown fail` would silently inherit direct-CLI (`trusted_run_controller`)
+trust over the active run. Either a real `claimId` (claim lane) or a real
+`runId` (orchestrator lane, `--run <rd_…>`) is forwarded to the CLI. To mark a
+non-delegated standalone step failed, run `rundown fail` directly in a trusted
+terminal.
 
 <a id="goto"></a>
 
@@ -232,11 +250,16 @@ non-delegated step failed, run `rundown fail` directly in a trusted terminal.
 
 Jump to a step.
 
-| Parameter | Type        | Required | Behavior                                                                          |
-| --------- | ----------- | -------- | --------------------------------------------------------------------------------- |
-| `step`    | string      | Yes      | Target step (for example `"3"` or `"2.1"`), forwarded verbatim to `rundown goto`. |
-| `index`   | integer ≥ 0 | No       | When set, forwarded as `--index <value>` to target a FOR-loop iteration.          |
-| `claimId` | string      | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.       |
+| Parameter | Type        | Required | Behavior                                                                                                                                                                                               |
+| --------- | ----------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `step`    | string      | Yes      | Target step (for example `"3"` or `"2.1"`), forwarded verbatim to `rundown goto`.                                                                                                                      |
+| `index`   | integer ≥ 0 | No       | When set, forwarded as `--index <value>` to target a FOR-loop iteration.                                                                                                                               |
+| `claimId` | string      | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.                                                                                                                            |
+| `runId`   | string      | No       | When set, forwarded as `--run <value>` (`rd_<32 hex>`) for explicit orchestrator targeting. Mutually exclusive with `claimId`. `goto` is additionally gated behind the `run-navigation` policy intent. |
+
+Over MCP, `goto` follows the same two-lane rule as [`pass`](#pass): a bare jump
+(no `claimId` and no `runId`) on a delegation-exposed run is withheld
+in-process; name the claim lane (`claimId`) or the orchestrator lane (`runId`).
 
 <a id="complete"></a>
 
@@ -244,13 +267,18 @@ Jump to a step.
 
 Force early completion of the active runbook.
 
-| Parameter | Type   | Required | Behavior                                                                      |
-| --------- | ------ | -------- | ----------------------------------------------------------------------------- |
-| `message` | string | No       | When set, forwarded as the positional message argument to `rundown complete`. |
-| `claimId` | string | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.   |
+| Parameter | Type   | Required | Behavior                                                                                                                       |
+| --------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `message` | string | No       | When set, forwarded as the positional message argument to `rundown complete`.                                                  |
+| `claimId` | string | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.                                                    |
+| `runId`   | string | No       | When set, forwarded as `--run <value>` (`rd_<32 hex>`) for explicit orchestrator targeting. Mutually exclusive with `claimId`. |
 
-Without `claimId`, this mirrors bare `rundown complete`: inside inline
-composition it targets the outermost contiguous-inline ancestor. See
+Without `claimId` or `runId`, this mirrors bare `rundown complete`, which is
+withheld at the boundary (and, since R1, refused by core on any
+delegation-exposed run with `ACTOR_CONTEXT_REQUIRED`). Supply the claim lane
+(`claimId`) or the orchestrator lane (`runId` → `--run <rd_…>`) to forward the
+call. When forwarded, bare `rundown complete` inside inline composition targets
+the outermost contiguous-inline ancestor. See
 [docs/reference/cli.md](cli.md#force-terminal-targeting) for force-terminal
 targeting semantics.
 
@@ -260,13 +288,18 @@ targeting semantics.
 
 Abort the active runbook.
 
-| Parameter | Type   | Required | Behavior                                                                    |
-| --------- | ------ | -------- | --------------------------------------------------------------------------- |
-| `message` | string | No       | When set, forwarded as the positional message argument to `rundown stop`.   |
-| `claimId` | string | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim. |
+| Parameter | Type   | Required | Behavior                                                                                                                       |
+| --------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `message` | string | No       | When set, forwarded as the positional message argument to `rundown stop`.                                                      |
+| `claimId` | string | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.                                                    |
+| `runId`   | string | No       | When set, forwarded as `--run <value>` (`rd_<32 hex>`) for explicit orchestrator targeting. Mutually exclusive with `claimId`. |
 
-Without `claimId`, this mirrors bare `rundown stop`: it is a failure terminal
-that exits non-zero, and inside inline composition it targets the outermost
+Without `claimId` or `runId`, this mirrors bare `rundown stop`, which is
+withheld at the boundary (and, since R1, refused by core on any
+delegation-exposed run with `ACTOR_CONTEXT_REQUIRED`). Supply the claim lane
+(`claimId`) or the orchestrator lane (`runId` → `--run <rd_…>`) to forward the
+call. When forwarded, bare `rundown stop` is a failure terminal that exits
+non-zero, and inside inline composition it targets the outermost
 contiguous-inline ancestor. See
 [docs/reference/cli.md](cli.md#force-terminal-targeting) for force-terminal
 targeting semantics.
@@ -275,31 +308,30 @@ targeting semantics.
 
 ### 5.11 `delegate`
 
-**Unavailable from the MCP subprocess front end.** Every `delegate` call is
-withheld: the server MUST return a withheld-mutation `error` payload WITHOUT
-spawning the CLI. Delegation carries no claim evidence, so a subprocess-spawned
-`delegate` would silently inherit direct-CLI (`trusted_run_controller`) trust
-over the active run — a trust a subprocess front end MUST NOT be able to mint.
-Unlike [`pass`](#pass) / [`fail`](#fail), no parameter (including `--claim-id`,
-which the schema rejects on `delegate`) can exempt a `delegate` call; it is
-always classified as a bare lifecycle mutation.
+**Available WITH `runId`; the bare form is withheld.** A `delegate` call that
+names the run the orchestrator controls (`runId`, mapped to `--run <rd_…>`) is
+forwarded to the CLI. A **bare** `delegate` (no `runId`) is withheld: the server
+MUST return a withheld-mutation `error` payload WITHOUT spawning the CLI,
+because a subprocess-spawned bare `delegate` would silently inherit direct-CLI
+(`trusted_run_controller`) trust over the active run — a trust a subprocess
+front end MUST NOT be able to mint. `claimId` is **schema-rejected** on
+`delegate` (delegation is an orchestrator action, not a claim-holder action), so
+the claim lane cannot exempt a `delegate` call — only the run lane can.
 
-The tool is still registered so its refusal is discoverable, and its schema
-declares the following parameters, but they never reach the CLI:
+| Parameter   | Type        | Required | Behavior                                                                                        |
+| ----------- | ----------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `runbook`   | string      | No       | Positional runbook argument forwarded to `rundown delegate`.                                    |
+| `step`      | string      | No       | Substep being delegated, forwarded as `--step <value>`.                                         |
+| `index`     | integer ≥ 0 | No       | FOR-loop targeting, forwarded as `--index <value>`. Requires `step`.                            |
+| `retry`     | boolean     | No       | Retry an existing delegation, forwarded as `--retry`.                                           |
+| `runId`     | string      | No       | Run you control (`rd_<32 hex>`), forwarded as `--run <value>`. Required to exempt the withhold. |
+| `input`     | string[]    | No       | `--input <value>` arguments.                                                                    |
+| `inputJson` | string[]    | No       | `--input-json <value>` arguments.                                                               |
+| `inputFile` | string[]    | No       | `--input-file <path>` arguments.                                                                |
 
-| Parameter   | Type        | Required | Behavior                                                         |
-| ----------- | ----------- | -------- | ---------------------------------------------------------------- |
-| `runbook`   | string      | No       | Positional runbook argument, were the call not withheld.         |
-| `step`      | string      | No       | Substep being delegated, were the call not withheld.             |
-| `index`     | integer ≥ 0 | No       | FOR-loop targeting, were the call not withheld. Requires `step`. |
-| `retry`     | boolean     | No       | Retry an existing delegation, were the call not withheld.        |
-| `input`     | string[]    | No       | `--input <value>` arguments, were the call not withheld.         |
-| `inputJson` | string[]    | No       | `--input-json <value>` arguments, were the call not withheld.    |
-| `inputFile` | string[]    | No       | `--input-file <path>` arguments, were the call not withheld.     |
-
-To delegate a substep or retry an existing delegation, run `rundown delegate`
-directly in a trusted terminal. Delegation semantics — token issuance, claim
-lifecycle, abort, collection — are defined by
+To delegate or retry from a plain terminal instead, run `rundown delegate`
+directly. Delegation semantics — token issuance, claim lifecycle, abort,
+collection — are defined by
 [docs/reference/cli.md Delegation Commands](cli.md#delegation-commands).
 
 <a id="claim"></a>
@@ -321,23 +353,27 @@ Claim a delegation token and launch the child runbook.
 
 Aggregate a delegated step and advance the parent runbook through core.
 
-| Parameter | Type        | Required | Behavior                                                                               |
-| --------- | ----------- | -------- | -------------------------------------------------------------------------------------- |
-| `step`    | string      | No       | When set, forwarded as `--step <value>` to scope the collection to a specific substep. |
-| `index`   | integer ≥ 0 | No       | When set, forwarded as `--index <value>` for FOR-loop targeting. Requires `step`.      |
-| `claimId` | string      | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.            |
+| Parameter | Type        | Required | Behavior                                                                                                                       |
+| --------- | ----------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `step`    | string      | No       | When set, forwarded as `--step <value>` to scope the collection to a specific substep.                                         |
+| `index`   | integer ≥ 0 | No       | When set, forwarded as `--index <value>` for FOR-loop targeting. Requires `step`.                                              |
+| `claimId` | string      | No       | When set, forwarded as `--claim-id <value>` to scope to a delegation claim.                                                    |
+| `runId`   | string      | No       | When set, forwarded as `--run <value>` (`rd_<32 hex>`) for explicit orchestrator targeting. Mutually exclusive with `claimId`. |
 
-Over MCP, `collect` REQUIRES claim evidence: a bare `collect` without a real
-`claimId` is classified as a subprocess lifecycle mutation and withheld
-in-process — the server MUST return a withheld-mutation `error` payload WITHOUT
-invoking the CLI. A spawned bare `rundown collect` would silently inherit
-direct-CLI (`trusted_run_controller`) trust over the delegating run and drive
-parent aggregation that is orchestrator-only. Only a `collect` carrying a real
-`claimId` presents independent claim-controller evidence — collecting
-delegations issued by the claimed run itself — and is forwarded to the CLI;
-collection into an ancestor remains refused by core policy
-(`COLLECT_REQUIRES_ORCHESTRATOR`). To aggregate a delegated step on the parent,
-run `rundown collect` directly in a trusted terminal.
+Over MCP, `collect` REQUIRES explicit targeting: a bare `collect` without a real
+`claimId` or `runId` is classified as a subprocess lifecycle mutation and
+withheld in-process — the server MUST return a withheld-mutation `error` payload
+WITHOUT invoking the CLI. A spawned bare `rundown collect` would silently
+inherit direct-CLI (`trusted_run_controller`) trust over the delegating run and
+drive parent aggregation that is orchestrator-only. Two lanes exempt the call: a
+`collect` carrying a real `claimId` presents independent claim-controller
+evidence — collecting delegations issued by the claimed run itself — and a
+`collect` carrying a real `runId` names the delegating run the orchestrator
+controls (`--run <rd_…>`). Collection still requires an actor controlling the
+target delegating run: collecting into an ancestor the caller does not control
+remains refused by core policy (`COLLECT_REQUIRES_ORCHESTRATOR`). To aggregate a
+delegated step on the parent from a plain terminal, run `rundown collect`
+directly.
 
 <a id="unsupported-cli-operations"></a>
 

--- a/docs/spec/cli-output.md
+++ b/docs/spec/cli-output.md
@@ -409,6 +409,10 @@ for delegated child work.
 
 ## pass
 
+On a delegation-exposed run the bare form fails with `ACTOR_CONTEXT_REQUIRED` —
+see [Error Output](#actor-context-required). Name your lane with `--run <rd_…>`
+(orchestrator) or `--claim-id <claimId>` (delegated child).
+
 ### `rundown pass`
 
 The `action` field shows the transition (e.g., "CONTINUE" to next step, "GOTO 3"
@@ -455,6 +459,10 @@ by `claim_id` instead of the default stack.
 ---
 
 ## fail
+
+On a delegation-exposed run the bare form fails with `ACTOR_CONTEXT_REQUIRED` —
+see [Error Output](#actor-context-required). Name your lane with `--run <rd_…>`
+(orchestrator) or `--claim-id <claimId>` (delegated child).
 
 The `action` field shows the transition (e.g., "RETRY (1/3)" for retry, "STOP"
 for stopping).
@@ -519,6 +527,11 @@ by `claim_id` instead of the default stack.
 
 ## goto
 
+On a delegation-exposed run the bare form fails with `ACTOR_CONTEXT_REQUIRED` —
+see [Error Output](#actor-context-required). Name your lane with `--run <rd_…>`
+(orchestrator) or `--claim-id <claimId>` (delegated child). `goto` is
+additionally gated behind the `run-navigation` policy intent.
+
 ### `rundown goto <step>`
 
 The `action` field is combined (e.g., "GOTO 3"), not a separate `target` field.
@@ -556,6 +569,10 @@ Step description.
 ---
 
 ## stop
+
+On a delegation-exposed run the bare form fails with `ACTOR_CONTEXT_REQUIRED` —
+see [Error Output](#actor-context-required). Name your lane with `--run <rd_…>`
+(orchestrator) or `--claim-id <claimId>` (delegated child).
 
 ### `rundown stop [message]`
 
@@ -598,6 +615,10 @@ Bare `rundown stop` emits newline-delimited JSON: the streamed
 ---
 
 ## complete
+
+On a delegation-exposed run the bare form fails with `ACTOR_CONTEXT_REQUIRED` —
+see [Error Output](#actor-context-required). Name your lane with `--run <rd_…>`
+(orchestrator) or `--claim-id <claimId>` (delegated child).
 
 ### `rundown complete [message]`
 
@@ -1069,5 +1090,116 @@ Error: Runbook file not found: missing.runbook.md
   "error": "Runbook not found: missing.runbook.md",
   "code": "RUNBOOK_NOT_FOUND",
   "command": "run"
+}
+```
+
+<!--
+  RUN_TARGET_MISMATCH is intentionally NOT documented here. It is emitted by
+  `rundown delegate --retry <token> --run <rd_…>` (packages/cli/src/commands/delegate.ts,
+  case 'run_target_mismatch') when the named run does not own the token, but it is
+  NOT registered in CLISymbolicErrorCodeValues (packages/core/src/output/zod-schemas.ts),
+  so its envelope fails ErrorCodeSchema / --schema validation. Documenting it would
+  document a schema-invalid envelope. Pending the follow-up enum-registration issue
+  (see the R2 plan, Open Question 1), it is deliberately left out.
+-->
+
+### Actor context required
+
+A bare mutating command (`pass`, `fail`, `goto`, `collect`, `complete`, `stop`,
+`delegate`) issued against a **delegation-exposed** run. Exposure is sticky, so
+the refusal persists after claims close and after `rundown prune`. The
+remediation names both explicit-authority lanes and **never echoes the target
+run id** (accident-proofing, not id secrecy — run ids are natively available
+from `rundown run` output and every event's `runbookId`); this no-echo property
+is pinned by the explicit-run-targeting tests.
+
+**Text:**
+
+```text
+Error: This run has delegation activity, so a bare `rundown pass` is refused. Pass `--run <rd_…>` with the run id from your orchestration context (printed by `rundown run` and carried as runbookId on every event), or `--claim-id <claimId>` if you are completing delegated work.
+Code: ACTOR_CONTEXT_REQUIRED
+```
+
+**JSON:**
+
+```json
+{
+  "kind": "error",
+  "error": "This run has delegation activity, so a bare `rundown pass` is refused. Pass `--run <rd_…>` with the run id from your orchestration context (printed by `rundown run` and carried as runbookId on every event), or `--claim-id <claimId>` if you are completing delegated work.",
+  "code": "ACTOR_CONTEXT_REQUIRED",
+  "command": "pass"
+}
+```
+
+### Run target unavailable
+
+The `--run` id supplied is not a running member of this session's active stack.
+Claimed delegated children are never stack members — target them with
+`--claim-id` instead. The message names the caller-supplied id (the caller
+already holds it); it does not reveal any run the caller did not name.
+
+**Text:**
+
+```text
+Error: Run rd_9e725b142d81dabcefb9e04919568fcd is not part of this session's active stack.
+Code: RUN_TARGET_UNAVAILABLE
+```
+
+**JSON:**
+
+```json
+{
+  "kind": "error",
+  "error": "Run rd_9e725b142d81dabcefb9e04919568fcd is not part of this session's active stack.",
+  "code": "RUN_TARGET_UNAVAILABLE",
+  "command": "pass"
+}
+```
+
+### Invalid run id
+
+The `--run` value is malformed. A run id is `rd_` followed by 32 hexadecimal
+characters.
+
+**Text:**
+
+```text
+Error: Invalid run id. Expected rd_<32 hex characters>.
+Code: INVALID_RUN_ID
+```
+
+**JSON:**
+
+```json
+{
+  "kind": "error",
+  "error": "Invalid run id. Expected rd_<32 hex characters>.",
+  "code": "INVALID_RUN_ID",
+  "command": "pass"
+}
+```
+
+### Collect requires orchestrator
+
+`rundown collect` was issued by an actor that does not control the target
+delegating run. Collection is an orchestrator action; a claimant may collect
+only delegations issued by its own claimed run. Like the other refusals, the
+message names both lanes and never echoes the target run id.
+
+**Text:**
+
+```text
+Error: rundown collect requires an actor that controls the target delegating run. Pass `--run <rd_…>` with the run id from your orchestration context (printed by `rundown run` and carried as runbookId on every event) if you are the orchestrator, or `--claim-id <claimId>` if you are collecting within delegated work.
+Code: COLLECT_REQUIRES_ORCHESTRATOR
+```
+
+**JSON:**
+
+```json
+{
+  "kind": "error",
+  "error": "rundown collect requires an actor that controls the target delegating run. Pass `--run <rd_…>` with the run id from your orchestration context (printed by `rundown run` and carried as runbookId on every event) if you are the orchestrator, or `--claim-id <claimId>` if you are collecting within delegated work.",
+  "code": "COLLECT_REQUIRES_ORCHESTRATOR",
+  "command": "collect"
 }
 ```

--- a/packages/claude-code-plugin/__tests__/skills/claim-guidance.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/claim-guidance.test.ts
@@ -62,4 +62,28 @@ describe('delegated runbook claim guidance', () => {
       expect(claim).not.toMatch(/rundown fail\s+(?:#|$)/m);
     }
   });
+
+  it('documents every delegation-exposed bare mutating command as refused', () => {
+    const claim = section(readSkill('running-runbooks/SKILL.md'), '## Claiming Delegated Work');
+
+    expect(claim).not.toBe('');
+    for (const command of ['pass', 'fail', 'goto', 'collect', 'complete', 'stop', 'delegate']) {
+      expect(claim).toContain(`rundown ${command}`);
+    }
+    expect(claim).toContain('ACTOR_CONTEXT_REQUIRED');
+    expect(claim).toContain('--run <rd_…>');
+    expect(claim).toContain('--claim-id <claim_id>');
+  });
+
+  it('keeps delegation idempotency examples aligned with delegate output and retry forms', () => {
+    const delegate = section(
+      readSkill('delegating-runbooks/SKILL.md'),
+      '### 1. Delegate a substep',
+    );
+
+    expect(delegate).not.toBe('');
+    expect(delegate).toContain('action: "already-delegated"');
+    expect(delegate).not.toContain('command: "already-delegated"');
+    expect(delegate).toContain('rundown delegate --retry --run <rd_…>');
+  });
 });

--- a/packages/claude-code-plugin/__tests__/skills/end-to-end-testing.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/end-to-end-testing.test.ts
@@ -49,8 +49,11 @@ describe('end-to-end-testing skill', () => {
     // children — prompted claimed children need it to advance at all.
     expect(skill).not.toMatch(/only for a child you stop early/i);
     expect(skill).not.toMatch(/reserved for stopped children/i);
-    // A bare pass/fail targets the parent, not the claimed child.
-    expect(skill).toMatch(/bare `rundown pass`\/`rundown fail` targets the parent/i);
+    // On a delegation-exposed run a bare pass/fail is refused (ACTOR_CONTEXT_REQUIRED),
+    // not silently routed to the parent; the child must name its --claim-id lane.
+    expect(skill).toMatch(
+      /bare `rundown pass`\/`rundown fail` is refused with `ACTOR_CONTEXT_REQUIRED`/i,
+    );
   });
 
   it('uses transition output as the normal agent context', () => {
@@ -69,6 +72,10 @@ describe('end-to-end-testing skill', () => {
   it('stays terse for agent use', () => {
     const wordCount = readSkill().trim().split(/\s+/u).length;
 
-    expect(wordCount).toBeLessThanOrEqual(350);
+    // Cap raised 350 -> 400 in the R2 explicit-targeting migration: the post-R1
+    // refusal model (ACTOR_CONTEXT_REQUIRED, sticky exposure, --run/--claim-id
+    // lane split) is load-bearing agent guidance and cannot be expressed within
+    // the old budget without dropping correctness.
+    expect(wordCount).toBeLessThanOrEqual(400);
   });
 });

--- a/packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts
+++ b/packages/claude-code-plugin/__tests__/skills/executing-plans.test.ts
@@ -21,10 +21,11 @@ describe('executing-plans skill', () => {
   it('declares the runbook entrypoint with its required PlanPath artifact URI', () => {
     const skill = readSkill();
     // execute-plan declares PlanPath REQUIRED and consumes it as an ARTIFACT, so
-    // a standalone start must supply the plan's rd:// artifact URI — a bare
-    // filesystem path (or bare `rundown run`) fails before the runbook activates.
+    // a standalone start must supply the plan's rd:// artifact URI through the
+    // dedicated artifact channel — a bare filesystem path (or bare `rundown
+    // run`) fails before the runbook activates.
     expect(skill).toMatch(
-      /rundown run rundown:execute-plan --input PlanPath=<rd:\/\/[^>]*plan URI>/,
+      /rundown run rundown:execute-plan --artifacts PlanPath=<rd:\/\/[^>]*plan URI>/,
     );
     expect(skill).toMatch(/Resolve `PlanPath`\s+first/);
     // Points the implementer at the inspection commands that yield the URI.

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/rundown.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/rundown.test.ts
@@ -130,6 +130,7 @@ describe('rundown', () => {
       ['pass'],
       ['fail'],
       ['delegate'],
+      ['goto'],
       ['collect'],
     ])('withholds a bare %s mutation instead of spawning the CLI', (command) => {
       const mockExec = mockExecFileSync('should not run');

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
@@ -67,7 +67,7 @@ const VALID_TOKEN = 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 const VALID_TOKEN_HASH = realHashDelegationToken(VALID_TOKEN);
 
 const CLAIM_VIOLATION =
-  'Delegated Rundown work was active when the subagent stopped. Run `rundown status` to discover the active delegation, then close it explicitly: if a claim id was issued (the subagent ran `rundown claim`), use `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>`; if the token was never claimed, retry with `rundown delegate --retry` or cancel with `rundown abort <token>`.';
+  'Delegated Rundown work was active when the subagent stopped. Run `rundown status` to discover the active delegation, then close it explicitly in your own lane: if a claim id was issued (the subagent ran `rundown claim`), use `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>`; if the token was never claimed, either claim and close it — `rundown claim <rdtk_…>` then `rundown pass --claim-id <claim_id>` — or leave it unclaimed and report the token back so the orchestrator can `rundown delegate --retry <token> --run <rd_…>` from its own context. Cancel with `rundown abort <token>`.';
 const UNKNOWN_CONTEXT =
   'Subagent stopped with an active delegation. Unable to verify child runbook state — check with `rundown status`.';
 

--- a/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
+++ b/packages/claude-code-plugin/__tests__/workflow/hooks/subagent-stop.test.ts
@@ -67,7 +67,7 @@ const VALID_TOKEN = 'rdtk_ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 const VALID_TOKEN_HASH = realHashDelegationToken(VALID_TOKEN);
 
 const CLAIM_VIOLATION =
-  'Delegated Rundown work was active when the subagent stopped. Run `rundown status` to discover the active delegation, then close it explicitly in your own lane: if a claim id was issued (the subagent ran `rundown claim`), use `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>`; if the token was never claimed, either claim and close it — `rundown claim <rdtk_…>` then `rundown pass --claim-id <claim_id>` — or leave it unclaimed and report the token back so the orchestrator can `rundown delegate --retry <token> --run <rd_…>` from its own context. Cancel with `rundown abort <token>`.';
+  'Delegated Rundown work was active when the subagent stopped. Run `rundown status` to discover the active delegation, then close it explicitly in your own lane: if a claim id was issued (the subagent ran `rundown claim`), use `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>`; if the token was never claimed, either claim and close it — `rundown claim <rdtk_…>` then `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>` — or leave it unclaimed and report the token back so the orchestrator can `rundown delegate --retry <token> --run <rd_…>` from its own context. Cancel with `rundown abort <token>`.';
 const UNKNOWN_CONTEXT =
   'Subagent stopped with an active delegation. Unable to verify child runbook state — check with `rundown status`.';
 
@@ -118,6 +118,18 @@ describe('handleSubagentStop', () => {
 
     expect(result).toEqual({ violation: CLAIM_VIOLATION });
     expect(mockSet).toHaveBeenCalledWith('metadata', { other_key: 'preserved' });
+  });
+
+  it('tells an unclaimed child to claim and close with either claim-id result', async () => {
+    setGet(session, 'metadata', {
+      delegation_active_token: VALID_TOKEN_HASH,
+    });
+
+    const result = await handleSubagentStop(createLegacySubagentStopInput());
+
+    expect(result.violation).toContain(
+      '`rundown claim <rdtk_…>` then `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>`',
+    );
   });
 
   it('normalizes raw legacy global delegation token metadata before validation', async () => {

--- a/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
@@ -66,7 +66,7 @@ On a standalone run with no delegation activity, bare `rundown delegate` / `rund
 
 ## Delegation Flow
 
-```
+```text
 Parent                          Child
   |                               |
   |  rundown delegate --step 2.1 --run <rd_…>

--- a/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/delegating-runbooks/SKILL.md
@@ -9,10 +9,30 @@ Rundown delegation dispatches substeps to child agents. The parent delegates, a 
 
 To walk the child runbook inline instead of dispatching a subagent, omit `- DELEGATE` — see the inline-linkage pattern in [running-runbooks](../running-runbooks/SKILL.md#nested-runbooks).
 
+## Choreography
+
+Capture the run id when you start the runbook: `rundown run` prints it at start and every subsequent event carries it as `runbookId`. You need it for every mutating command you issue as the orchestrator. A delegation-exposed run refuses bare mutating commands, so each lane names its own authority:
+
+```bash
+# Orchestrator lane — driving a delegation-exposed run
+rundown run rundown:planning        # capture the run id (printed at start; runbookId on every event)
+rundown delegate --step 1.1 --run <rd_…>
+rundown collect --run <rd_…>
+rundown pass --run <rd_…>
+
+# Child lane — completing delegated work
+rundown claim <rdtk_…>              # capture claim_id from the output
+rundown pass --claim-id <claim_id>
+
+# Read-only commands stay bare
+rundown status
+rundown ls
+```
+
 ## When to Use
 
 - Orchestrating multi-agent work where substeps are dispatched to separate child agents
-- A runbook step carries `- DELEGATE` and a token (`rdtk_...`) must be issued and dispatched
+- A runbook step carries `- DELEGATE`; entering it auto-issues a token (`rdtk_...`) that must be dispatched
 - Managing the parent side of delegation: issuing, monitoring, aborting, or aggregating delegated substeps
 - Fanning out independent substeps (or FOR-loop iterations) to run concurrently across agents
 
@@ -26,25 +46,30 @@ To walk the child runbook inline instead of dispatching a subagent, omit `- DELE
 ## Quick Reference
 
 ```bash
-rundown delegate                                  # Infer substep and runbook from state
-rundown delegate --step 2.1                       # Delegate specific substep
-rundown delegate <runbook> --step 2.1             # Explicit runbook and substep
-rundown delegate --step 2.1 --input k=v           # With input
-rundown delegate --step 2.1 --input-json k=json   # With JSON input
-rundown delegate --step 2.1 --input-file <path>   # Inputs from YAML
+# Orchestrator commands name the run you control with --run <rd_…>
+rundown delegate --step 2.1 --run <rd_…>              # Delegate specific substep
+rundown delegate <runbook> --step 2.1 --run <rd_…>   # Explicit runbook and substep
+rundown delegate --step 2.1 --input k=v --run <rd_…> # With input
+rundown delegate --step 2.1 --input-json k=json --run <rd_…>  # With JSON input
+rundown delegate --step 2.1 --input-file <path> --run <rd_…>  # Inputs from YAML
+rundown collect --run <rd_…>               # Aggregate delegated results
+rundown pass --run <rd_…>                  # Advance the run you orchestrate
 
 rundown abort <token>                      # Cancel unclaimed delegation
 rundown abort <token> --force              # Cancel claimed delegation
 
 rundown status                             # Monitor delegation state (JSON by default)
+rundown ls                                 # List runbooks (read-only, stays bare)
 ```
+
+On a standalone run with no delegation activity, bare `rundown delegate` / `rundown pass` still work; the `--run <rd_…>` form is required once the run is delegation-exposed. Read-only commands (`rundown status`, `rundown ls`) stay bare everywhere.
 
 ## Delegation Flow
 
 ```
 Parent                          Child
   |                               |
-  |  rundown delegate --step 2.1       |
+  |  rundown delegate --step 2.1 --run <rd_…>
   |  --> token issued             |
   |                               |
   |  Dispatch agent with token    |
@@ -54,8 +79,8 @@ Parent                          Child
   |                               |
   |                               |  ... does work ...
   |                               |
-  |                               |  rundown pass (or rundown fail)
-  |  ←-------------------------   |
+  |                               |  rundown pass --claim-id <claim_id>
+  |  ←-------------------------   |  (or rundown fail --claim-id <claim_id>)
   |  Result propagates to step    |
   |                               |
 ```
@@ -65,30 +90,30 @@ Parent                          Child
 ### 1. Delegate a substep
 
 ```bash
-# Infer everything from current state
-rundown delegate
-
 # Explicit substep
-rundown delegate --step 2.1
+rundown delegate --step 2.1 --run <rd_…>
 
 # Explicit runbook + substep
-rundown delegate my-runbook --step 2.1
+rundown delegate my-runbook --step 2.1 --run <rd_…>
 
 # With inputs
-rundown delegate --step 2.1 --input environment=staging
-rundown delegate --step 2.1 --input-json config='{"debug":true}'
+rundown delegate --step 2.1 --input environment=staging --run <rd_…>
+rundown delegate --step 2.1 --input-json config='{"debug":true}' --run <rd_…>
 ```
 
-The `delegate` command issues a token (`rdtk_...`) and queues the substep for external execution.
+**Delegate is an idempotent confirm / re-issue — not the minting step.** Entering
+a delegating step auto-issues its frontier tokens, so `rundown delegate --step X
+--run <rd_…>` on an already-entered step returns `action: "already-delegated"`,
+echoing the existing token (`rdtk_...`) rather than minting a new one. Use it to
+read the token, and `--retry` to re-issue after a failed dispatch (#522).
 
-`rundown delegate` is **idempotent** in every form — bare, `--step S`, and the
-positional `rundown delegate <runbook>` alike: when the target substep already
-carries an in-flight (auto-issued, unclaimed) delegation, it echoes the
-existing token (`action: "already-delegated"`) instead of erroring. Re-issuing
-a fresh token requires `--retry`. Naming a **different** runbook than the
-in-flight one is a conflict (RD-804). Targeting a delegation already
-**claimed** by a live child is refused (RD-811) — recover with
-`rundown abort <token> --force` or `rundown delegate --retry`.
+This idempotency holds in every form — `--step S` and the positional
+`rundown delegate <runbook>` alike: when the target substep already carries an
+in-flight (auto-issued, unclaimed) delegation, it echoes the existing token
+instead of erroring. Naming a **different** runbook than the in-flight one is a
+conflict (RD-804). Targeting a delegation already **claimed** by a live child is
+refused (RD-811) — recover with `rundown abort <token> --force` or
+`rundown delegate --retry --run <rd_…>`.
 
 **Constraints:**
 - `--step` must target the active step frontier
@@ -135,14 +160,20 @@ rundown fail --claim-id <claim_id>     # Report failure
 
 When the child calls `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>`, the result flows back to the parent's substep. The parent step's aggregation rules determine the overall outcome. **The child's job ends there** — once its claim is reported, it must stop and return control to the orchestrator. The orchestrator (you, the parent side) drives every subsequent step, including any stage the parent auto-advances into.
 
-Always target the child with `--claim-id`. Core Rundown refuses a bare `rundown pass`/`rundown fail` against the parent while a claimed child is open; if you see `OPEN_DELEGATED_CHILDREN`, rerun the command with the child `--claim-id`. Note the guard only protects against bare commands *while a claim is open* — after a child closes its claim, bare commands fall through to the parent's default-active runbook with no guard, so a child that keeps running can silently drive the parent pipeline. A claimed child must therefore stop the moment it reports its result.
+On a delegation-exposed run, every bare mutating command (`rundown pass`, `rundown fail`, `rundown goto`, `rundown collect`, `rundown complete`, `rundown stop`, `rundown delegate`) is refused with `ACTOR_CONTEXT_REQUIRED`. Exposure is sticky: claim closure and prune never flip a run back to standalone, so the bare form never "falls through" to the parent. The remediation names both lanes — `--run <rd_…>` for the orchestrator, `--claim-id <claim_id>` for a child — and deliberately never echoes the target run id. Target the child with `--claim-id` and the orchestrator with `--run`; a claimed child must still stop the moment it reports its result.
+
+`OPEN_DELEGATED_CHILDREN` is a separate, still-current guard: a `--run`-targeted parent advance is refused while a claimed child is open. If you see it, wait for the child to report (or `rundown abort <token> --force`) before advancing the parent with `--run <rd_…>`.
+
+### Inline composition and derived authority
+
+When a delegation-exposed step links child runbooks **inline** (no `- DELEGATE`), a bare `rundown pass` on an inline unit is refused too. `--run <rd_…>` naming any member of a contiguous inline composition chain carries controller authority over the chain's walked-to root, so one `--run` targeting the chain advances the inline unit you are on. A delegation boundary severs the chain: claimed children are never `--run`-reachable (they are not members of the default stack — reach them only with their `--claim-id`). Run ids are not secrets; they are freely available from `rundown run` output and every event's `runbookId` (names are not capabilities), so `--run` names authority you already hold — it does not grant it.
 
 ## FOR Loop Delegation
 
 Without `--index`, delegation targets the active iteration. Use `--index` to target a specific iteration:
 
 ```bash
-rundown delegate --step 2.1 --index 3
+rundown delegate --step 2.1 --index 3 --run <rd_…>
 ```
 
 Each iteration maintains independent delegation state, so iterations can be delegated to different agents for parallel processing.
@@ -168,8 +199,8 @@ Each child gets its own `RunId`. `ContextId` stays stable across the delegation 
 Explicit inputs override inherited values:
 
 ```bash
-rundown delegate --step 2.1 --input environment=staging
-rundown delegate --step 2.1 --input-json config='{"debug":true}'
+rundown delegate --step 2.1 --input environment=staging --run <rd_…>
+rundown delegate --step 2.1 --input-json config='{"debug":true}' --run <rd_…>
 ```
 
 ## Context Passing (OUTPUTS)
@@ -231,9 +262,9 @@ See [Template Variables](../../../../CLAUDE.md#template-variables) and [Context 
 **Parallel fan-out:** Delegate multiple substeps simultaneously — all children work concurrently, parent aggregates results via ALL/ANY:
 
 ```bash
-rundown delegate --step 2.1
-rundown delegate --step 2.2
-rundown delegate --step 2.3
+rundown delegate --step 2.1 --run <rd_…>
+rundown delegate --step 2.2 --run <rd_…>
+rundown delegate --step 2.3 --run <rd_…>
 ```
 
 **Nested:** A child can itself delegate, creating a delegation tree. ContextId flows through the tree for correlation.

--- a/packages/claude-code-plugin/skills/end-to-end-testing/SKILL.md
+++ b/packages/claude-code-plugin/skills/end-to-end-testing/SKILL.md
@@ -20,8 +20,8 @@ Only nested review and collation runbooks are delegated. If the wrapper complete
 
 ## Operating Rules
 
-- Follow the active prompt. Use default JSON output; pass `--text` only when debugging.
-- Treat `rundown run`, `rundown pass`, `rundown fail`, `rundown claim`, and `rundown collect` output as the next context.
+- Follow the active prompt. Use default JSON output; never add `--text` (it is human-only output, not part of the agent protocol).
+- Treat `rundown run`, `rundown pass`, `rundown fail`, `rundown claim`, and `rundown collect` output as the next context. Parent-side pass/fail/collect carry `--run <rd_…>` (capture the run id from `rundown run` output, echoed as `runbookId` on every event); child-side commands carry `--claim-id <claim_id>`.
 - Use `rundown status` only to recover orientation after an error or interruption.
 - Pass only after the current step is complete; fail when it cannot be completed as written.
 - Preserve state on errors. Do not prune, clear, or delete `.rundown`.
@@ -32,7 +32,7 @@ The DELEGATE step auto-issues a claim token (`delegations` in `rundown status`).
 rundown claim <token>                  # returns claim_id; dispatch the child to a subagent
 ```
 
-Drive the claimed child like any runbook: advance each step with `rundown pass --claim-id <claim_id>` / `rundown fail --claim-id <claim_id>`. Prompted child steps need this claim-id transition to advance. A bare `rundown pass`/`rundown fail` targets the parent; core refuses it while a claimed child is open (`OPEN_DELEGATED_CHILDREN`).
+Drive the claimed child like any runbook: advance each step with `rundown pass --claim-id <claim_id>` / `rundown fail --claim-id <claim_id>`. Prompted child steps need this claim-id transition to advance. On a delegation-exposed run, a bare `rundown pass`/`rundown fail` is refused with `ACTOR_CONTEXT_REQUIRED` regardless of claim state (exposure is sticky). A `--run`-targeted parent advance is additionally refused with `OPEN_DELEGATED_CHILDREN` while a claimed child is open.
 
 When the child's final step completes it auto-resolves its parent substep and the parent auto-aggregates and advances. `rundown pass/fail --claim-id` is idempotent on a resolved child, so it also confirms or overrides a child you stop early.
 

--- a/packages/claude-code-plugin/skills/executing-plans/SKILL.md
+++ b/packages/claude-code-plugin/skills/executing-plans/SKILL.md
@@ -16,12 +16,20 @@ first (ask the user if it is not already known). Load the execution protocol
 2. `Skill(skill: "rundown:delegating-runbooks")` — this runbook delegates
 3. Then start it:
    - **Delegated pipeline** (`write-plan → execute-plan`): `PlanPath` is
-     inherited automatically — no `--input` needed.
-   - **Standalone**: pass the plan's artifact URI —
-     `rundown run rundown:execute-plan --input PlanPath=<rd://… plan URI>`. Discover
-     the alias with `rundown artifact ls`, then read the `uri` field of
+     inherited automatically — no explicit supply needed.
+   - **Standalone**: pass the plan's artifact URI through the dedicated artifact
+     channel —
+     `rundown run rundown:execute-plan --artifacts PlanPath=<rd://… plan URI>`
+     (e.g. `--artifacts PlanPath=rd://artifacts/<ctx>/<run>/plan.json`).
+     `PlanPath` is declared `REQUIRED` and consumed as an `ARTIFACTS` input by
+     the runbook, so it must arrive as an `rd://` URI, not a filesystem path.
+     Discover the alias with `rundown artifact ls`, then read the `uri` field of
      `rundown artifact uri PlanPath` (JSON is the default; agents do not add
      `--text`).
+
+   Capture the run id from `rundown run`: it is printed at start and echoed as
+   `runbookId` on every event. This runbook delegates the implementer, so every
+   orchestrator command must carry `--run <rd_…>`.
 </important>
 
 Implement a written plan one task at a time, holding each task to its own tests and committing as you go. This skill is the **context** an execution runbook orchestrates: how to do each task well. The [`execute-plan`](../../runbooks/planning/execute-plan.runbook.md) runbook owns the *sequence* (implement → review → verify) and the *gates*; this skill owns the *craft* of a single task.

--- a/packages/claude-code-plugin/skills/planning/SKILL.md
+++ b/packages/claude-code-plugin/skills/planning/SKILL.md
@@ -15,6 +15,8 @@ delegation) the moment it appears:
 2. `Skill(skill: "rundown:delegating-runbooks")` — step 1 delegates
 3. Then start the runbook with exactly this command, no added flags: `rundown run rundown:planning`
 
+Capture the run id from that command: `rundown run` prints it at start and every event carries it as `runbookId`. This pipeline delegates (step 1), so every orchestrator command you issue — `collect`, `pass`, `goto` — must carry `--run <rd_…>`.
+
 JSON is the agent-facing default; `--text` is for humans/debugging only — do not add it here.
 </important>
 

--- a/packages/claude-code-plugin/skills/rundown/SKILL.md
+++ b/packages/claude-code-plugin/skills/rundown/SKILL.md
@@ -57,6 +57,11 @@ contain the protocol itself.
    rundown run <name>
    ```
 
+   Capture the run id when you start the runbook: `rundown run` prints it at
+   start and every subsequent event carries it as `runbookId`. You need it for
+   every mutating command you issue as the orchestrator of a delegation-exposed
+   run.
+
    Pass inputs if the runbook requires them:
 
    ```bash
@@ -68,6 +73,10 @@ contain the protocol itself.
 4. **Execute.** Follow the loaded
    [running-runbooks](../running-runbooks/SKILL.md) protocol: respond to each
    step with `rundown pass` / `rundown fail` and trust Rundown for transitions.
+   On a delegation-exposed run (any runbook with a `- DELEGATE` step), these
+   become `rundown pass --run <rd_…>` / `rundown fail --run <rd_…>` — the bare
+   form is for standalone runs only and otherwise refuses with
+   `ACTOR_CONTEXT_REQUIRED`.
 
 ## Reference
 

--- a/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
@@ -142,12 +142,12 @@ rundown claim <token> --input-json key=json
 rundown claim <token> --input-file <path>
 ```
 
-On a delegation-exposed run, bare `rundown pass` / `rundown fail` are refused with `ACTOR_CONTEXT_REQUIRED` — they do not silently target anything. Orchestrators pass `--run <rd_…>`; children pass `--claim-id <claim_id>`. Only a standalone run (no delegation activity) accepts the bare form.
+On a delegation-exposed run, every bare mutating command (`rundown pass`, `rundown fail`, `rundown goto`, `rundown collect`, `rundown complete`, `rundown stop`, `rundown delegate`) is refused with `ACTOR_CONTEXT_REQUIRED` — it does not silently target anything. Orchestrators pass `--run <rd_…>`; children pass `--claim-id <claim_id>`. Only a standalone run (no delegation activity) accepts the bare form.
 
 <important>
 **A claimed child stays inside its claim and stops when the claim ends.** You were dispatched to execute exactly one delegated runbook. When it completes (or fails), the parent pipeline may auto-advance into *its* next step — but those steps belong to the **orchestrator**, not to you. Do not keep going.
 
-- Pass `--claim-id <claim_id>` on **every** mutating `rundown` command for your claimed work. **Never** issue a bare `rundown pass` / `rundown fail` / `rundown delegate` as a claimed child — on a delegation-exposed run the bare form is refused with `ACTOR_CONTEXT_REQUIRED` (it does not silently drive the parent), and the remediation names both lanes without ever echoing the run id. Read-only commands like `rundown status` stay bare.
+- Pass `--claim-id <claim_id>` on **every** mutating `rundown` command for your claimed work. **Never** issue a bare `rundown pass` / `rundown fail` / `rundown goto` / `rundown collect` / `rundown complete` / `rundown stop` / `rundown delegate` as a claimed child — on a delegation-exposed run the bare form is refused with `ACTOR_CONTEXT_REQUIRED` (it does not silently drive the parent), and the remediation names both lanes without ever echoing the run id. Read-only commands like `rundown status` stay bare.
 - The "Complete ALL steps — do not abandon a runbook" rule applies to **your claimed runbook only**, not to the parent that auto-advanced behind it.
 - After `rundown pass --claim-id` / `rundown fail --claim-id`, **end your turn.** Report your result in prose to whoever dispatched you; do not run further `rundown` commands.
 </important>

--- a/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/skills/running-runbooks/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: running-runbooks
-description: Use when stepping through a Rundown runbook that is already active or has just been started, when receiving delegation instructions with a claim token, or when rd/rundown CLI commands appear in step output. For cold-start "run the X runbook" requests with nothing active, the rundown launcher skill starts the runbook first.
+description: Use when stepping through a Rundown runbook that is already active or has just been started, when receiving delegation instructions with a claim token, or when rundown CLI commands appear in step output. For cold-start "run the X runbook" requests with nothing active, the rundown launcher skill starts the runbook first.
 ---
 
 # Running Runbooks
 
 Rundown executes markdown runbooks step-by-step. The CLI controls progress — you follow the output and respond.
+
+Capture the run id when you start the runbook: `rundown run` prints it at start and every subsequent event carries it as `runbookId`. You need it for every mutating command you issue as the orchestrator of a delegation-exposed run (`--run <rd_…>`). A claimed child never needs it — a child names its own lane with `--claim-id <claim_id>`.
 
 ## When to Use
 
@@ -29,19 +31,31 @@ rundown run <file> --input k=v          # Start with input
 rundown run <file> --input-json k=json  # Start with JSON input
 rundown run <file> --input-file <path>  # Load inputs from YAML
 
-rundown pass                    # Mark step passed (aliases: yes, ok)
-rundown fail                    # Mark step failed (alias: no)
+rundown pass                    # Mark step passed (aliases: yes, ok) — standalone run only
+rundown fail                    # Mark step failed (alias: no) — standalone run only
 
 rundown status                  # Show current state (JSON by default)
 rundown stop                    # Stop the active workflow; inside inline composition, targets the outermost contiguous-inline ancestor
 rundown complete                # Complete the active workflow; inside inline composition, targets the outermost contiguous-inline ancestor
 ```
 
+The bare `rundown pass` / `rundown fail` / `rundown stop` / `rundown complete`
+forms above apply to a **standalone run** (one with no delegation activity). On a
+**delegation-exposed run** the bare form is refused with `ACTOR_CONTEXT_REQUIRED`;
+name your lane instead — orchestrators pass `--run <rd_…>`, delegated children pass
+`--claim-id <claim_id>`:
+
+```bash
+rundown pass --run <rd_…>        # Orchestrator advances the run it controls
+rundown pass --claim-id <claim_id>   # Delegated child reports its result
+```
+
 Inside inline-composed runbooks, use `rundown pass` or `rundown fail` to finish the
-current inline unit and let the parent continue. Use bare `rundown complete` or
-bare `rundown stop` only when the intended outcome is to force the composed workflow
-terminal. Delegated children still use `--claim-id` and report to the parent;
-the parent advances on `rundown collect`.
+current inline unit and let the parent continue (on a delegation-exposed
+composition, `--run <rd_…>` naming any member of the contiguous inline chain).
+Use `rundown complete` or `rundown stop` only when the intended outcome is to
+force the composed workflow terminal. Delegated children still use `--claim-id`
+and report to the parent; the parent advances on `rundown collect --run <rd_…>`.
 
 ## How Steps Work
 
@@ -128,12 +142,12 @@ rundown claim <token> --input-json key=json
 rundown claim <token> --input-file <path>
 ```
 
-Plain `rundown pass` and `rundown fail` target the default active runbook, not claimed delegated children.
+On a delegation-exposed run, bare `rundown pass` / `rundown fail` are refused with `ACTOR_CONTEXT_REQUIRED` — they do not silently target anything. Orchestrators pass `--run <rd_…>`; children pass `--claim-id <claim_id>`. Only a standalone run (no delegation activity) accepts the bare form.
 
 <important>
 **A claimed child stays inside its claim and stops when the claim ends.** You were dispatched to execute exactly one delegated runbook. When it completes (or fails), the parent pipeline may auto-advance into *its* next step — but those steps belong to the **orchestrator**, not to you. Do not keep going.
 
-- Pass `--claim-id <claim_id>` on **every** `rundown` command for your claimed work. **Never** issue a bare `rundown pass` / `rundown fail` / `rundown delegate` / `rundown status` as a claimed child — bare commands target the shared default-active runbook (the *parent's* pipeline), so a bare command silently drives work that is not yours.
+- Pass `--claim-id <claim_id>` on **every** mutating `rundown` command for your claimed work. **Never** issue a bare `rundown pass` / `rundown fail` / `rundown delegate` as a claimed child — on a delegation-exposed run the bare form is refused with `ACTOR_CONTEXT_REQUIRED` (it does not silently drive the parent), and the remediation names both lanes without ever echoing the run id. Read-only commands like `rundown status` stay bare.
 - The "Complete ALL steps — do not abandon a runbook" rule applies to **your claimed runbook only**, not to the parent that auto-advanced behind it.
 - After `rundown pass --claim-id` / `rundown fail --claim-id`, **end your turn.** Report your result in prose to whoever dispatched you; do not run further `rundown` commands.
 </important>
@@ -178,6 +192,7 @@ the JSON instead.
 | Skipping steps | Follow every step — runbook controls flow |
 | Bare `rundown pass` with substeps active | Use `rundown pass --step 2.1` |
 | Bare `rundown pass`/`rundown fail` in a claimed child | Use `rundown pass --claim-id <claim_id>` to report to the parent |
+| Bare mutating command on a delegation-exposed run | Refused with `ACTOR_CONTEXT_REQUIRED`; name your lane — `--run <rd_…>` (orchestrator) or `--claim-id <claim_id>` (child) |
 | Claimed child keeps going after reporting | Stop after `rundown pass --claim-id`; the parent's next steps belong to the orchestrator, not you |
 | Abandoning without `rundown stop` | Complete all steps or explicitly stop |
 

--- a/packages/claude-code-plugin/src/workflow/hooks/rundown.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/rundown.ts
@@ -48,9 +48,13 @@ export interface RundownExecOptions {
  * @param cwd - Working directory for the command
  * @param execOptions - Optional execution settings such as environment overrides
  * @returns Command output as string
- * @throws {Error} If `args` is a bare (no `--claim-id`) `pass` / `fail` /
- *   `delegate` mutation — the subprocess trust boundary withholds it rather than
- *   let it silently inherit direct-CLI trust.
+ * @throws {Error} If `args` is a bare (no `--claim-id` and no `--run`)
+ *   role-specific mutation — the subprocess trust boundary withholds it rather
+ *   than let it silently inherit direct-CLI trust. The guarded set is the full
+ *   withhold set defined by `subprocess-mutation-boundary.ts` (after alias
+ *   canonicalization): `pass`, `fail`, `delegate`, `complete`, `stop`,
+ *   `collect`. Explicit targeting — `--claim-id` (claim evidence) or `--run`
+ *   (named run authority) — exempts the call.
  */
 export function rundown(args: string[], cwd: string, execOptions: RundownExecOptions = {}): string {
   const delegateValidation = delegateClaimIdValidationError(args);

--- a/packages/claude-code-plugin/src/workflow/hooks/rundown.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/rundown.ts
@@ -52,9 +52,9 @@ export interface RundownExecOptions {
  *   role-specific mutation — the subprocess trust boundary withholds it rather
  *   than let it silently inherit direct-CLI trust. The guarded set is the full
  *   withhold set defined by `subprocess-mutation-boundary.ts` (after alias
- *   canonicalization): `pass`, `fail`, `delegate`, `complete`, `stop`,
- *   `collect`. Explicit targeting — `--claim-id` (claim evidence) or `--run`
- *   (named run authority) — exempts the call.
+ *   canonicalization): `pass`, `fail`, `delegate`, `goto`, `complete`,
+ *   `stop`, `collect`. Explicit targeting — `--claim-id` (claim evidence) or
+ *   `--run` (named run authority) — exempts the call.
  */
 export function rundown(args: string[], cwd: string, execOptions: RundownExecOptions = {}): string {
   const delegateValidation = delegateClaimIdValidationError(args);

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -151,10 +151,14 @@ async function consumedDelegationStillRequiresClosure(
  *   matching delegated child has already reached a terminal lifecycle or the
  *   delegation was cancelled.
  * - **Token consumed and still open** (default): returns a `violation`
- *   requiring the delegated work to be closed explicitly. The message covers
- *   both states the consumed token may be in: claimed (recovered via `rundown pass`
- *   / `rundown fail --claim-id`) or unclaimed (recovered via `rundown delegate --retry`
- *   or `rundown abort <token>`).
+ *   requiring the delegated work to be closed explicitly. The message is read by
+ *   the stopping subagent (the child), so it keeps that agent in its own lane:
+ *   claimed work is recovered via `rundown pass` / `rundown fail --claim-id`, and
+ *   an unclaimed token is either claimed and closed the same way, or reported
+ *   back so the orchestrator retries it from its own context with
+ *   `rundown delegate --retry <token> --run <rd_…>` (or `rundown abort <token>`).
+ *   The child is never told to name the parent run — that is the orchestrator's
+ *   lane, not the child's.
  *
  * Never destroys child runbook state.
  *
@@ -193,6 +197,6 @@ export async function handleSubagentStop(input: HookInput): Promise<SubagentStop
 
   return {
     violation:
-      'Delegated Rundown work was active when the subagent stopped. Run `rundown status` to discover the active delegation, then close it explicitly: if a claim id was issued (the subagent ran `rundown claim`), use `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>`; if the token was never claimed, retry with `rundown delegate --retry` or cancel with `rundown abort <token>`.',
+      'Delegated Rundown work was active when the subagent stopped. Run `rundown status` to discover the active delegation, then close it explicitly in your own lane: if a claim id was issued (the subagent ran `rundown claim`), use `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>`; if the token was never claimed, either claim and close it — `rundown claim <rdtk_…>` then `rundown pass --claim-id <claim_id>` — or leave it unclaimed and report the token back so the orchestrator can `rundown delegate --retry <token> --run <rd_…>` from its own context. Cancel with `rundown abort <token>`.',
   };
 }

--- a/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
+++ b/packages/claude-code-plugin/src/workflow/hooks/subagent-stop.ts
@@ -153,9 +153,10 @@ async function consumedDelegationStillRequiresClosure(
  * - **Token consumed and still open** (default): returns a `violation`
  *   requiring the delegated work to be closed explicitly. The message is read by
  *   the stopping subagent (the child), so it keeps that agent in its own lane:
- *   claimed work is recovered via `rundown pass` / `rundown fail --claim-id`, and
- *   an unclaimed token is either claimed and closed the same way, or reported
- *   back so the orchestrator retries it from its own context with
+ *   claimed work is recovered via `rundown pass --claim-id` or
+ *   `rundown fail --claim-id`, and an unclaimed token is either claimed and
+ *   closed the same way, or reported back so the orchestrator retries it from
+ *   its own context with
  *   `rundown delegate --retry <token> --run <rd_…>` (or `rundown abort <token>`).
  *   The child is never told to name the parent run — that is the orchestrator's
  *   lane, not the child's.
@@ -197,6 +198,6 @@ export async function handleSubagentStop(input: HookInput): Promise<SubagentStop
 
   return {
     violation:
-      'Delegated Rundown work was active when the subagent stopped. Run `rundown status` to discover the active delegation, then close it explicitly in your own lane: if a claim id was issued (the subagent ran `rundown claim`), use `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>`; if the token was never claimed, either claim and close it — `rundown claim <rdtk_…>` then `rundown pass --claim-id <claim_id>` — or leave it unclaimed and report the token back so the orchestrator can `rundown delegate --retry <token> --run <rd_…>` from its own context. Cancel with `rundown abort <token>`.',
+      'Delegated Rundown work was active when the subagent stopped. Run `rundown status` to discover the active delegation, then close it explicitly in your own lane: if a claim id was issued (the subagent ran `rundown claim`), use `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>`; if the token was never claimed, either claim and close it — `rundown claim <rdtk_…>` then `rundown pass --claim-id <claim_id>` or `rundown fail --claim-id <claim_id>` — or leave it unclaimed and report the token back so the orchestrator can `rundown delegate --retry <token> --run <rd_…>` from its own context. Cancel with `rundown abort <token>`.',
   };
 }

--- a/packages/core/__tests__/runbook/subprocess-mutation-boundary.test.ts
+++ b/packages/core/__tests__/runbook/subprocess-mutation-boundary.test.ts
@@ -13,8 +13,8 @@ import {
 } from '../../src/runbook/subprocess-mutation-boundary.js';
 
 // Subprocess trust boundary coverage. A plugin/MCP front end spawns the CLI, so
-// a bare (default-target) `rd pass` / `rd fail` / `rd delegate` / `rd complete`
-// / `rd stop` / `rd collect` would silently inherit direct-CLI trust.
+// a bare (default-target) `rd pass` / `rd fail` / `rd delegate` / `rd goto`
+// / `rd complete` / `rd stop` / `rd collect` would silently inherit direct-CLI trust.
 // `bareRoleSpecificMutation` is the single source of truth for which spawned
 // argv must be withheld; `--claim-id` mutations carry independent claim
 // evidence and must survive the boundary.
@@ -24,6 +24,7 @@ describe('bareRoleSpecificMutation', () => {
     [['pass'], 'pass'],
     [['fail'], 'fail'],
     [['delegate'], 'delegate'],
+    [['goto', '3'], 'goto'],
     [['pass', '--step', '2.1'], 'pass'],
     [['fail', '--step', '2.1', '--index', '3'], 'fail'],
     [['delegate', 'child.md', '--step', '1.1'], 'delegate'],
@@ -74,7 +75,6 @@ describe('bareRoleSpecificMutation', () => {
     [['ls', '--all']],
     [['run', 'workflow.md']],
     [['claim', 'rd_tok_abc']],
-    [['goto', '3.1']],
     [[]],
   ])('does not withhold the non-role-specific call %j', (argv) => {
     expect(bareRoleSpecificMutation(argv)).toBeUndefined();
@@ -164,7 +164,7 @@ describe('bareRoleSpecificMutation', () => {
     // For each canonical mutation, every registered alias must normalize back to
     // it so no alias form can slip a bare mutation past the boundary.
     const aliasPairs = (
-      ['pass', 'fail', 'delegate', 'complete', 'stop', 'collect'] as const
+      ['pass', 'fail', 'delegate', 'goto', 'complete', 'stop', 'collect'] as const
     ).flatMap((canonical) =>
       mutationCommandAliases(canonical).map((alias) => [alias, canonical] as const),
     );
@@ -239,6 +239,7 @@ describe('bareRoleSpecificMutation: explicit --run targeting', () => {
     'stop',
     'collect',
     'delegate',
+    'goto',
   ])('does not withhold a --run-targeted %s (explicit targeting is evidence, not ambient trust)', (command) => {
     expect(bareRoleSpecificMutation([command, '--run', runId])).toBeUndefined();
   });
@@ -250,6 +251,7 @@ describe('bareRoleSpecificMutation: explicit --run targeting', () => {
     'stop',
     'collect',
     'delegate',
+    'goto',
   ])('does not withhold the inline --run= form of %s', (command) => {
     expect(bareRoleSpecificMutation([command, `--run=${runId}`])).toBeUndefined();
   });
@@ -272,7 +274,7 @@ describe('bareRoleSpecificMutation: explicit --run targeting', () => {
   });
 
   it('keeps withholding bare forms of all six commands', () => {
-    for (const command of ['pass', 'fail', 'complete', 'stop', 'collect', 'delegate']) {
+    for (const command of ['pass', 'fail', 'complete', 'stop', 'collect', 'delegate', 'goto']) {
       expect(bareRoleSpecificMutation([command])).toBe(command);
     }
   });
@@ -304,6 +306,9 @@ describe('bareRoleSpecificMutation: program-level (global) options before the co
     [['--no-color', 'no'], 'fail'],
     // Stacked globals before the command.
     [['--no-color', '--policy', 'x.json', '--deny-all', 'pass'], 'pass'],
+    // A `goto` step target that looks like another mutation is still just the
+    // value for a bare `goto`; the command itself must be withheld.
+    [['--no-color', 'goto', 'pass'], 'goto'],
   ])('withholds %j as a bare mutation of %s located behind globals', (argv, expected) => {
     expect(bareRoleSpecificMutation(argv)).toBe(expected);
   });
@@ -315,8 +320,6 @@ describe('bareRoleSpecificMutation: program-level (global) options before the co
     [['--deny-all', 'ls', '--all']],
     // `pass` as a `run` filename argument is not a command-position `pass`.
     [['--no-color', 'run', 'pass.md']],
-    // `pass` as a `goto` step target is not a command-position `pass`.
-    [['--no-color', 'goto', 'pass']],
     // A mutation's legitimate `--claim-id` still exempts it behind globals.
     [['--no-color', 'pass', '--claim-id', 'c']],
     [['--policy', 'x.json', 'fail', '--claim-id=c']],
@@ -395,6 +398,7 @@ describe('mutationCommandAliases', () => {
     ['pass', ['yes', 'ok']],
     ['fail', ['no']],
     ['delegate', []],
+    ['goto', []],
     // Terminal commands carry NO aliases (decision #5): `done` is the [message]
     // positional, not an alias — pin the no-alias contract so a regression fails here.
     ['complete', []],

--- a/packages/core/src/runbook/subprocess-mutation-boundary.ts
+++ b/packages/core/src/runbook/subprocess-mutation-boundary.ts
@@ -32,6 +32,7 @@ export type RoleSpecificMutationCommand =
   | 'pass'
   | 'fail'
   | 'delegate'
+  | 'goto'
   | 'complete'
   | 'stop'
   | 'collect';
@@ -40,6 +41,7 @@ const ROLE_SPECIFIC_MUTATION_COMMANDS: ReadonlySet<RoleSpecificMutationCommand> 
   'pass',
   'fail',
   'delegate',
+  'goto',
   'complete',
   'stop',
   'collect',
@@ -63,6 +65,7 @@ const MUTATION_COMMAND_ALIASES: Readonly<Record<RoleSpecificMutationCommand, rea
   pass: ['yes', 'ok'],
   fail: ['no'],
   delegate: [],
+  goto: [],
   // No aliases (decision #5): `done` is the `[message]` positional, not an alias.
   complete: [],
   stop: [],


### PR DESCRIPTION
## Summary

Updates the shipped plugin skills, hook guidance, and reference documentation to the post-R1 explicit targeting model:

- orchestrators name their lane with `--run <rd_…>`
- delegated children use `--claim-id <claim_id>`
- bare mutating commands on delegation-exposed runs document `ACTOR_CONTEXT_REQUIRED`
- MCP docs now cover `runId` targeting and complete/stop/collect boundary behavior
- executing-plans now teaches `--artifacts PlanPath=...` instead of the legacy `--input` form

Closes #522.
Closes #516.
Closes #538.

## Follow-up

Tracked separately in #559: `RUN_TARGET_MISMATCH` is emitted by `delegate --retry --run` but is not registered in `CLISymbolicErrorCodeValues`, so this PR intentionally does not document it as a schema-valid error envelope.

## Validation

- `pnpm --filter @rundown-org/claude-code-plugin test -- claim-guidance executing-plans end-to-end-testing subagent-stop`
- `pnpm run check:docs:cli-help`
- `pnpm run check:md`
- `pnpm run check:spell`
- `pnpm run verify`
- `coderabbit review --agent --base main` with nonblocking docs findings addressed in `10b89b840`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended delegation-aware rundown command routing to consistently use explicit lanes for orchestrator (`--run <rd_…>`) and delegated children (`--claim-id <claim_id>`), including `goto`.
* **Bug Fixes**
  * Bare mutating rundown commands on delegation-exposed runs are now refused with `ACTOR_CONTEXT_REQUIRED`, with clearer remediation guidance.
* **Documentation**
  * Updated CLI, MCP, and skill docs to distinguish standalone vs. delegation-exposed behavior, including expanded error examples and updated quick-reference transitions.
* **Tests**
  * Updated and expanded coverage for delegation context enforcement and `goto` trust-boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->