### PR TITLE
Fix sandbox policy coherence

### DIFF
--- a/docs/superpowers/plans/2026-07-05-sb-sandbox-policy-coherence.md
+++ b/docs/superpowers/plans/2026-07-05-sb-sandbox-policy-coherence.md
@@ -1,0 +1,1179 @@
+# SB Sandbox Policy Coherence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make CLI `--allow-*` filesystem grants reach OS sandbox enforcement, normalize sandbox grant paths across macOS realpath aliases, and allow Seatbelt metadata traversal needed for Node module resolution under `/Users`.
+
+**Architecture:** Keep the CLI a thin policy-context constructor: `--allow-*` continues to enter core through `PolicyEvaluatorOptions.cliGrants`. Core exposes a sandbox-facing effective rule view that includes runtime grants, the sandbox mapper canonicalizes grant roots once, and the macOS Seatbelt backend emits metadata-only ancestor permissions without granting file contents. Integration tests prove policy grants produce real syscall success under the platform sandbox.
+
+**Tech Stack:** TypeScript / Node 24, Jest ESM tests, `@rundown-org/core` policy and sandbox layers, macOS Seatbelt (`sandbox-exec`), Linux Landlock helper integration tests.
+
+---
+
+## Scope
+
+Issues: #549, #550, #552.
+
+In scope:
+
+- #550: CLI `--allow-read` and `--allow-write` grants must be visible to sandbox profile generation.
+- #552: sandbox grant paths must be realpath-normalized so `/var/folders/...` and `/private/var/folders/...` match consistently.
+- #549: Seatbelt profiles must include metadata-only read access for required `/Users` ancestors so Node can traverse to repo scripts and modules.
+- Add integration coverage proving grant-to-syscall success.
+
+Out of scope:
+
+- Do not depend on R2 or R3 branches.
+- Do not add CLI-specific sandbox workarounds.
+- Do not alter command-step lifecycle/recovery semantics for #545/#547/#520.
+- Do not migrate persisted runbook state.
+
+## File Structure
+
+### Modified
+
+- `packages/core/src/policy/evaluator.ts` — expose sandbox-relevant read/write rules that include CLI and session grants while preserving `getEffectiveRules()` for existing policy-only callers, and separately identify higher-precedence runtime grants.
+- `packages/core/src/sandbox/policy-mapper.ts` — use sandbox-relevant rules, canonicalize allow/deny roots, filter deny paths that are covered by higher-precedence runtime grants, compute metadata-only ancestor paths, and return them in `SandboxOptions`.
+- `packages/core/src/sandbox/types.ts` — add `metadataReadPaths?: string[]` with TSDoc.
+- `packages/core/src/sandbox/macos.ts` — emit `file-read-metadata` literal rules for `metadataReadPaths` and keep content grants scoped to read/read-write paths.
+- `packages/core/__tests__/sandbox/policy-mapper.test.ts` — mapper regression coverage for CLI/session grants and canonical path behavior.
+- `packages/core/__tests__/sandbox/macos.test.ts` — mocked Seatbelt profile coverage for metadata rules and canonical aliases.
+- `packages/core/__tests__/sandbox/linux-spec-builder.test.ts` — prove Landlock ignores `metadataReadPaths` and still classifies read/write grants correctly.
+
+### Created
+
+- `packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts` — real Seatbelt grant-to-syscall tests, skipped when not on macOS or Seatbelt is unavailable unless explicitly required.
+- `packages/cli/__tests__/integration/sandbox-policy-grants.test.ts` — CLI command-step coverage proving `--allow-read` / `--allow-write` reach sandboxed execution on hosts with an available sandbox.
+
+---
+
+## Task 1: Make Runtime Grants Visible To Sandbox Mapping
+
+**Files:**
+
+- Modify: `packages/core/src/policy/evaluator.ts`
+- Modify: `packages/core/src/sandbox/policy-mapper.ts`
+- Test: `packages/core/__tests__/sandbox/policy-mapper.test.ts`
+
+- [ ] **Step 1: Add failing mapper tests for CLI grants**
+
+Add these tests inside `describe('policyToSandboxOptions', ...)` in `packages/core/__tests__/sandbox/policy-mapper.test.ts`:
+
+```typescript
+  it('includes CLI read grants in sandbox read-only paths', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: [] },
+        write: { allow: [], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, {
+      repoRoot: '/repo',
+      cliGrants: { read: ['/repo/schema.json'] },
+    });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.readOnlyPaths).toContain('/repo/schema.json');
+    expect(options.readWritePaths).not.toContain('/repo/schema.json');
+  });
+
+  it('includes CLI write grants in sandbox read-write paths', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: [] },
+        write: { allow: [], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, {
+      repoRoot: '/repo',
+      cliGrants: { write: ['/repo/dist/**'] },
+    });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.readWritePaths).toContain('/repo/dist');
+    expect(options.readOnlyPaths).not.toContain('/repo/dist');
+  });
+
+  it('does not emit deny paths that are covered by a higher-precedence CLI read grant', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: ['/repo/.env'] },
+        write: { allow: [], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, {
+      repoRoot: '/repo',
+      cliGrants: { read: ['/repo/.env'] },
+    });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.readOnlyPaths).toContain('/repo/.env');
+    expect(options.denyPaths).not.toContain('/repo/.env');
+    expect(options.denyPatterns).not.toContain('/repo/.env');
+  });
+
+  it('does not emit deny paths that are covered by a higher-precedence session write grant', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: [] },
+        write: { allow: [], deny: ['/repo/dist/secret.txt'] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, { repoRoot: '/repo' });
+    evaluator.addSessionGrant('write', '/repo/dist/secret.txt');
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.readWritePaths).toContain('/repo/dist/secret.txt');
+    expect(options.denyPaths).not.toContain('/repo/dist/secret.txt');
+    expect(options.denyPatterns).not.toContain('/repo/dist/secret.txt');
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- --runTestsByPath packages/core/__tests__/sandbox/policy-mapper.test.ts
+```
+
+Expected: the new grant visibility tests fail because `policyToSandboxOptions()` uses `getEffectiveRules()`, which does not include `cliGrants` or session grants. The new grant-over-deny tests fail because configured deny paths are still emitted into the sandbox even when a higher-precedence runtime grant covers the same path.
+
+- [ ] **Step 3: Add a sandbox-facing rule method**
+
+In `packages/core/src/policy/evaluator.ts`, add this exported interface after `PolicyEvaluatorOptions`:
+
+```typescript
+/**
+ * Permission rules used by OS sandbox generation.
+ *
+ * `allow` contains every path that should be granted to the sandbox. `deny`
+ * contains configured deny rules. `runtimeGrantAllow` contains only
+ * higher-precedence CLI/session grants, so the sandbox mapper can keep deny
+ * generation coherent with evaluator precedence.
+ */
+export interface SandboxPermissionRules extends PermissionRules {
+  /** Higher-precedence CLI/session grants that must override configured denies. */
+  runtimeGrantAllow: string[];
+}
+```
+
+Then add this method after `getEffectiveRules(...)`:
+
+```typescript
+  /**
+   * Get permission rules for OS sandbox generation.
+   *
+   * This includes static policy rules, persisted grants, CLI grants, and
+   * session grants. Runtime grants must reach the OS sandbox because command
+   * steps are child processes and file access inside them is enforced by the
+   * sandbox backend, not by per-path evaluator checks.
+   *
+   * @param type - Permission type to resolve.
+   * @returns Permission rules relevant to sandbox allow-list and deny generation.
+   */
+  getSandboxRules(type: 'read' | 'write'): SandboxPermissionRules {
+    const rules = this.getEffectiveRules(type);
+    const cliGrants = this.options.cliGrants?.[type] ?? [];
+    const sessionGrants = this.sessionGrants
+      .filter((grant) => grant.type === type)
+      .map((grant) => grant.pattern);
+
+    const runtimeGrantAllow = [...cliGrants, ...sessionGrants];
+
+    return {
+      allow: [...rules.allow, ...runtimeGrantAllow],
+      deny: rules.deny,
+      runtimeGrantAllow,
+    };
+  }
+```
+
+- [ ] **Step 4: Use sandbox-facing rules in the mapper**
+
+In `packages/core/src/sandbox/policy-mapper.ts`, replace:
+
+```typescript
+  const readRules = evaluator.getEffectiveRules('read');
+  const writeRules = evaluator.getEffectiveRules('write');
+```
+
+with:
+
+```typescript
+  const readRules = evaluator.getSandboxRules('read');
+  const writeRules = evaluator.getSandboxRules('write');
+```
+
+Add this helper near `buildSandboxPathSets(...)`:
+
+```typescript
+function filterDenyPathsCoveredByRuntimeGrants(
+  denyPaths: readonly string[],
+  runtimeGrantPaths: readonly string[],
+): string[] {
+  return denyPaths.filter((denyPath) => {
+    return !runtimeGrantPaths.some((grantPath) => isWithinRoot(denyPath, grantPath));
+  });
+}
+
+function filterDenyPatternsCoveredByRuntimeGrants(
+  denyPatterns: readonly string[],
+  runtimeGrantPaths: readonly string[],
+): string[] {
+  return denyPatterns.filter((denyPattern) => {
+    if (hasGlob(denyPattern)) {
+      return true;
+    }
+    return !runtimeGrantPaths.some((grantPath) => isWithinRoot(denyPattern, grantPath));
+  });
+}
+```
+
+After `denyPatterns` and `denyPaths` are computed, add:
+
+```typescript
+  const runtimeGrantPaths = resolvePathPatterns(
+    [...readRules.runtimeGrantAllow, ...writeRules.runtimeGrantAllow],
+    repoRoot,
+    tmpDir,
+  );
+  const effectiveDenyPatterns = filterDenyPatternsCoveredByRuntimeGrants(
+    denyPatterns,
+    runtimeGrantPaths,
+  );
+  const effectiveDenyPaths = filterDenyPathsCoveredByRuntimeGrants(denyPaths, runtimeGrantPaths);
+```
+
+Return `effectiveDenyPaths` instead of raw `denyPaths`:
+
+```typescript
+    denyPaths: [...new Set(effectiveDenyPaths)],
+    denyPatterns: [...new Set(effectiveDenyPatterns)],
+```
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- --runTestsByPath packages/core/__tests__/sandbox/policy-mapper.test.ts
+```
+
+Expected: `policy-mapper.test.ts` passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/policy/evaluator.ts packages/core/src/sandbox/policy-mapper.ts packages/core/__tests__/sandbox/policy-mapper.test.ts
+git commit -m "fix: include runtime grants in sandbox policy mapping"
+```
+
+---
+
+## Task 2: Canonicalize Sandbox Grant Paths
+
+**Files:**
+
+- Modify: `packages/core/src/sandbox/policy-mapper.ts`
+- Test: `packages/core/__tests__/sandbox/policy-mapper.test.ts`
+
+- [ ] **Step 1: Add failing tests for canonical grant paths**
+
+Add these imports to `packages/core/__tests__/sandbox/policy-mapper.test.ts` if they are not already present:
+
+```typescript
+import { realpath, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+```
+
+Add these tests inside `describe('policyToSandboxOptions', ...)`:
+
+```typescript
+  it('realpath-normalizes read grants that pass through a symlink', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const aliasRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-alias-'));
+    try {
+      const dir = join(repoRoot, 'schema-dir');
+      await mkdir(dir);
+      const alias = join(aliasRoot, 'schema-link');
+      await symlink(dir, alias);
+      const canonicalDir = await realpath(dir);
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [join(alias, '**')], deny: [] },
+          write: { allow: [], deny: [] },
+        },
+      };
+      const evaluator = new PolicyEvaluator(policy, { repoRoot });
+
+      const options = policyToSandboxOptions(evaluator, {
+        cwd: repoRoot,
+        repoRoot,
+      });
+
+      expect(options.readOnlyPaths).toContain(canonicalDir);
+      expect(options.readOnlyPaths).not.toContain(alias);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(aliasRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('realpath-normalizes future write grants through the nearest existing symlink ancestor', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const aliasRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-alias-'));
+    try {
+      const dist = join(repoRoot, 'dist');
+      await mkdir(dist);
+      const alias = join(aliasRoot, 'dist-link');
+      await symlink(dist, alias);
+      const futurePath = join(alias, 'new-file.txt');
+      const canonicalRepo = await realpath(repoRoot);
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [], deny: [] },
+          write: { allow: [futurePath], deny: [] },
+        },
+      };
+      const evaluator = new PolicyEvaluator(policy, { repoRoot });
+
+      const options = policyToSandboxOptions(evaluator, {
+        cwd: repoRoot,
+        repoRoot,
+      });
+
+      expect(options.readWritePaths).toContain(join(canonicalRepo, 'dist', 'new-file.txt'));
+      expect(options.readWritePaths).not.toContain(futurePath);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(aliasRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes the macOS tmpdir alias from /var/folders to /private/var/folders when present', async () => {
+    const tmp = tmpdir();
+    if (process.platform !== 'darwin' || !tmp.startsWith('/var/folders/')) {
+      return;
+    }
+    const canonicalTmp = await realpath(tmp);
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: [] },
+        write: { allow: ['{tmp}/rundown-sandbox-test/**'], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, {
+      repoRoot: '/repo',
+      tmpDir: tmp,
+    });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+      tmpDir: tmp,
+    });
+
+    expect(options.readWritePaths).toContain(join(canonicalTmp, 'rundown-sandbox-test'));
+    expect(options.readWritePaths).not.toContain(join(tmp, 'rundown-sandbox-test'));
+  });
+
+  it('applies the same canonicalization to policyConfigToSandboxOptions', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const aliasRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-alias-'));
+    try {
+      const dir = join(repoRoot, 'raw-policy-read');
+      await mkdir(dir);
+      const alias = join(aliasRoot, 'raw-policy-link');
+      await symlink(dir, alias);
+      const canonicalDir = await realpath(dir);
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [join(alias, '**')], deny: [] },
+          write: { allow: [], deny: [] },
+        },
+      };
+
+      const options = policyConfigToSandboxOptions(policy, {
+        cwd: repoRoot,
+        repoRoot,
+      });
+
+      expect(options.readOnlyPaths).toContain(canonicalDir);
+      expect(options.readOnlyPaths).not.toContain(alias);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(aliasRoot, { recursive: true, force: true });
+    }
+  });
+```
+
+- [ ] **Step 2: Run tests to verify failure or missing normalization**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- --runTestsByPath packages/core/__tests__/sandbox/policy-mapper.test.ts
+```
+
+Expected: the symlink tests fail before canonicalization is implemented because sandbox paths keep the symlink spelling. On macOS with `/var/folders` tmpdirs, the tmp alias test fails before the fix because the mapper emits `/var/folders/...` instead of `/private/var/folders/...`.
+
+- [ ] **Step 3: Add canonicalization helpers**
+
+In `packages/core/src/sandbox/policy-mapper.ts`, add these helpers near `resolveCanonicalPath(...)`:
+
+```typescript
+function resolveCanonicalPathForGrant(value: string): string {
+  const absolute = path.resolve(value);
+  try {
+    return fs.realpathSync(absolute);
+  } catch {
+    const parent = path.dirname(absolute);
+    if (parent === absolute) {
+      return absolute;
+    }
+    return path.join(resolveCanonicalPathForGrant(parent), path.basename(absolute));
+  }
+}
+
+function normalizeSandboxPathList(paths: readonly string[]): string[] {
+  const normalized = new Set<string>();
+  for (const candidate of paths) {
+    normalized.add(resolveCanonicalPathForGrant(candidate));
+  }
+  return [...normalized];
+}
+```
+
+- [ ] **Step 4: Normalize allow paths and deny paths before set construction**
+
+In `policyToSandboxOptions(...)`, replace:
+
+```typescript
+  const readAllowPaths = resolvePathPatterns(readRules.allow, repoRoot, tmpDir);
+  const writeAllowPaths = resolvePathPatterns(writeRules.allow, repoRoot, tmpDir);
+```
+
+with:
+
+```typescript
+  const readAllowPaths = normalizeSandboxPathList(
+    resolvePathPatterns(readRules.allow, repoRoot, tmpDir),
+  );
+  const writeAllowPaths = normalizeSandboxPathList(
+    resolvePathPatterns(writeRules.allow, repoRoot, tmpDir),
+  );
+```
+
+Replace:
+
+```typescript
+    denyPaths: [...new Set(effectiveDenyPaths)],
+```
+
+with:
+
+```typescript
+    denyPaths: normalizeSandboxPathList(effectiveDenyPaths),
+```
+
+Also update the `runtimeGrantPaths` calculation added in Task 1 from:
+
+```typescript
+  const runtimeGrantPaths = resolvePathPatterns(
+    [...readRules.runtimeGrantAllow, ...writeRules.runtimeGrantAllow],
+    repoRoot,
+    tmpDir,
+  );
+```
+
+to:
+
+```typescript
+  const runtimeGrantPaths = normalizeSandboxPathList(
+    resolvePathPatterns(
+      [...readRules.runtimeGrantAllow, ...writeRules.runtimeGrantAllow],
+      repoRoot,
+      tmpDir,
+    ),
+  );
+```
+
+Make the same normalization changes in `policyConfigToSandboxOptions(...)`: normalize `readAllowPaths`, `writeAllowPaths`, and returned `denyPaths` with `normalizeSandboxPathList(...)`. There are no runtime grants in the raw-policy path, so it does not use `getSandboxRules(...)` or the runtime-grant deny filters.
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- --runTestsByPath packages/core/__tests__/sandbox/policy-mapper.test.ts
+```
+
+Expected: `policy-mapper.test.ts` passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/sandbox/policy-mapper.ts packages/core/__tests__/sandbox/policy-mapper.test.ts
+git commit -m "fix: canonicalize sandbox grant paths"
+```
+
+---
+
+## Task 3: Add Seatbelt Metadata Ancestor Grants
+
+**Files:**
+
+- Modify: `packages/core/src/sandbox/types.ts`
+- Modify: `packages/core/src/sandbox/policy-mapper.ts`
+- Modify: `packages/core/src/sandbox/macos.ts`
+- Test: `packages/core/__tests__/sandbox/policy-mapper.test.ts`
+- Test: `packages/core/__tests__/sandbox/macos.test.ts`
+- Test: `packages/core/__tests__/sandbox/linux-spec-builder.test.ts`
+
+- [ ] **Step 1: Add failing mapper test for metadata paths**
+
+Add this test inside `describe('policyToSandboxOptions', ...)`:
+
+```typescript
+  it('includes metadata-read ancestors for sandbox grant roots', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: ['/Users/alice/project/schema.json'], deny: [] },
+        write: { allow: ['/Users/alice/project/dist/**'], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, { repoRoot: '/Users/alice/project' });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/Users/alice/project',
+      repoRoot: '/Users/alice/project',
+    });
+
+    expect(options.metadataReadPaths).toEqual(
+      expect.arrayContaining(['/Users', '/Users/alice', '/Users/alice/project']),
+    );
+  });
+```
+
+- [ ] **Step 2: Add failing Seatbelt profile test**
+
+Add this test inside `describe('execute', ...)` in `packages/core/__tests__/sandbox/macos.test.ts`:
+
+```typescript
+    it('writes metadata-only ancestor rules into the generated profile', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      (existsSync as jest.Mock).mockReturnValue(true);
+      (writeFileSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+      (unlinkSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+
+      const mockChild = {
+        on: jest.fn((event: string, callback: (arg?: number | Error) => void) => {
+          if (event === 'close') {
+            process.nextTick(() => {
+              callback(0);
+            });
+          }
+          return mockChild;
+        }),
+      };
+      (spawn as jest.Mock).mockReturnValue(mockChild);
+
+      const sandbox = new SeatbeltSandbox();
+      await sandbox.execute('node script.js', {
+        ...mockOptions,
+        metadataReadPaths: ['/Users', '/Users/test', '/Users/test/project'],
+      });
+
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(literal "/Users/test/project")'),
+        expect.any(Object),
+      );
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(allow file-read-metadata'),
+        expect.any(Object),
+      );
+    });
+```
+
+- [ ] **Step 3: Add `metadataReadPaths` to `SandboxOptions`**
+
+In `packages/core/src/sandbox/types.ts`, add this property after `readWritePaths`:
+
+```typescript
+  /**
+   * Paths that should allow metadata-only reads such as stat/lstat traversal.
+   *
+   * Seatbelt needs this for ancestor directories (for example `/Users` and
+   * `/Users/name`) so runtimes can resolve allowed descendants without gaining
+   * permission to read ancestor file contents. Backends that cannot express
+   * metadata-only rights ignore this field.
+   */
+  metadataReadPaths?: string[];
+```
+
+- [ ] **Step 4: Compute metadata ancestors in the mapper**
+
+In `packages/core/src/sandbox/policy-mapper.ts`, add:
+
+```typescript
+function collectAncestorPaths(paths: readonly string[]): string[] {
+  const ancestors = new Set<string>();
+  for (const candidate of paths) {
+    let current = path.dirname(candidate);
+    while (current !== path.dirname(current)) {
+      ancestors.add(current);
+      current = path.dirname(current);
+    }
+  }
+  ancestors.delete(path.sep);
+  return [...ancestors].sort((a, b) => a.length - b.length);
+}
+```
+
+Before the `return` in `policyToSandboxOptions(...)`, add:
+
+```typescript
+  const metadataReadPaths = collectAncestorPaths([
+    repoRoot,
+    options.cwd,
+    tmpDir,
+    ...readOnlyPaths,
+    ...readWritePaths,
+  ]);
+```
+
+Add this field to the returned object:
+
+```typescript
+    metadataReadPaths,
+```
+
+Apply the same `metadataReadPaths` computation in `policyConfigToSandboxOptions(...)`, using that function's `repoRoot`, `options.cwd`, `tmpDir`, `readOnlyPaths`, and `readWritePaths`.
+
+- [ ] **Step 5: Emit metadata rules in Seatbelt**
+
+In `packages/core/src/sandbox/macos.ts`, add this block in `generateSeatbeltProfile(...)` after `denyRules` is built:
+
+```typescript
+  const metadataReadRules = (options.metadataReadPaths ?? [])
+    .map((p) => `  (literal "${escapePath(p)}")`)
+    .join('\n');
+```
+
+Replace the existing hard-coded metadata block:
+
+```scheme
+(allow file-read-metadata
+  (subpath "/private/var")
+)
+```
+
+with:
+
+```scheme
+(allow file-read-metadata
+  (subpath "/private/var")
+${metadataReadRules}
+)
+```
+
+- [ ] **Step 6: Keep Linux behavior explicit**
+
+In `packages/core/__tests__/sandbox/linux-spec-builder.test.ts`, update the `base` options with:
+
+```typescript
+  metadataReadPaths: ['/repo-parent'],
+```
+
+Add this assertion to the `classifies grants and derives strict from allowUnsandboxed` test:
+
+```typescript
+    expect(spec.ro).not.toContain('/repo-parent');
+    expect(spec.rw).not.toContain('/repo-parent');
+```
+
+No production Linux change is required because `buildSpec(...)` does not read `metadataReadPaths`.
+
+- [ ] **Step 7: Run targeted tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- --runTestsByPath packages/core/__tests__/sandbox/policy-mapper.test.ts packages/core/__tests__/sandbox/macos.test.ts packages/core/__tests__/sandbox/linux-spec-builder.test.ts
+```
+
+Expected: all targeted tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/sandbox/types.ts packages/core/src/sandbox/policy-mapper.ts packages/core/src/sandbox/macos.ts packages/core/__tests__/sandbox/policy-mapper.test.ts packages/core/__tests__/sandbox/macos.test.ts packages/core/__tests__/sandbox/linux-spec-builder.test.ts
+git commit -m "fix: grant Seatbelt metadata traversal for sandbox paths"
+```
+
+---
+
+## Task 4: Add Real Seatbelt Grant-To-Syscall Integration Coverage
+
+**Files:**
+
+- Create: `packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts`
+
+- [ ] **Step 1: Create the macOS integration test**
+
+Create `packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts`:
+
+```typescript
+/**
+ * Real-enforcement integration test for the macOS Seatbelt sandbox.
+ *
+ * Behaviour by environment:
+ *   - Seatbelt available -> assert real grant-to-syscall success.
+ *   - Seatbelt unavailable/non-macOS -> skip so CI and Linux dev machines stay green.
+ *   - RUNDOWN_REQUIRE_SEATBELT=1 and unavailable -> fail.
+ */
+import { afterAll, describe, expect, it } from '@jest/globals';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  realpathSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { SeatbeltSandbox } from '../../src/sandbox/macos.js';
+import type { SandboxOptions } from '../../src/sandbox/types.js';
+
+const sandbox = new SeatbeltSandbox();
+const availability = await sandbox.getAvailability();
+const required = process.env.RUNDOWN_REQUIRE_SEATBELT === '1';
+
+function metadataAncestorsFor(path: string): string[] {
+  const ancestors: string[] = [];
+  let current = path;
+  while (current !== dirname(current)) {
+    ancestors.unshift(current);
+    current = dirname(current);
+  }
+  return ancestors.filter((ancestor) => ancestor !== '/');
+}
+
+if (!availability.available) {
+  const reason = availability.reason ?? 'unknown reason';
+  if (required) {
+    describe('SeatbeltSandbox real enforcement (integration)', () => {
+      it('Seatbelt must be available when RUNDOWN_REQUIRE_SEATBELT=1', () => {
+        throw new Error(`Expected a working Seatbelt sandbox but it is unavailable: ${reason}`);
+      });
+    });
+  } else {
+    console.info(`[seatbelt-integration] skipped - sandbox unavailable: ${reason}`);
+    describe.skip(`SeatbeltSandbox real enforcement (integration) - ${reason}`, () => {
+      it('enforces filesystem policy', () => {
+        /* skipped */
+      });
+    });
+  }
+} else {
+  describe('SeatbeltSandbox real enforcement (integration)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rundown-seatbelt-it-'));
+    const grantedReadDir = join(root, 'read');
+    const grantedWriteDir = join(root, 'write');
+    const secretDir = join(root, 'secret');
+    mkdirSync(grantedReadDir);
+    mkdirSync(grantedWriteDir);
+    mkdirSync(secretDir);
+    writeFileSync(join(grantedReadDir, 'ok.txt'), 'ok');
+    writeFileSync(join(secretDir, 'secret.txt'), 'top secret');
+
+    afterAll(() => {
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    const run = (command: string, options: Partial<SandboxOptions> = {}) =>
+      sandbox.execute(command, {
+        cwd: root,
+        repoRoot: root,
+        readOnlyPaths: [grantedReadDir],
+        readWritePaths: [grantedWriteDir],
+        metadataReadPaths: [root, grantedReadDir, grantedWriteDir],
+        denyPaths: [],
+        denyPatterns: [],
+        env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+        allowUnsandboxed: false,
+        ...options,
+      } satisfies SandboxOptions);
+
+    it('allows a real read syscall inside a granted read-only path', async () => {
+      const result = await run(
+        `node -e "const fs=require('fs'); process.stdout.write(fs.readFileSync(${JSON.stringify(
+          join(grantedReadDir, 'ok.txt'),
+        )}, 'utf8'))"`,
+      );
+
+      expect(result.sandboxed).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(result.success).toBe(true);
+    });
+
+    it('allows a real write syscall inside a granted read-write path', async () => {
+      const target = join(grantedWriteDir, 'written.txt');
+      const result = await run(
+        `node -e "require('fs').writeFileSync(${JSON.stringify(target)}, 'written')"`,
+      );
+
+      expect(result.sandboxed).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(result.success).toBe(true);
+      expect(readFileSync(target, 'utf8')).toBe('written');
+    });
+
+    it('blocks a real read syscall outside granted paths', async () => {
+      const result = await run(
+        `node -e "require('fs').readFileSync(${JSON.stringify(join(secretDir, 'secret.txt'))})"`,
+      );
+
+      expect(result.sandboxed).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it('allows Node startup and cwd package reads from a /Users-rooted repo using metadata ancestors', async () => {
+      const repoCwd = realpathSync(process.cwd());
+      if (!repoCwd.startsWith('/Users/')) {
+        console.info(`[seatbelt-integration] skipped /Users metadata case for cwd ${repoCwd}`);
+        return;
+      }
+
+      const result = await sandbox.execute(
+        'node -e "require(\'fs\').readFileSync(require.resolve(\'./package.json\'), \'utf8\')"',
+        {
+          cwd: repoCwd,
+          repoRoot: repoCwd,
+          readOnlyPaths: [repoCwd],
+          readWritePaths: [],
+          metadataReadPaths: metadataAncestorsFor(repoCwd),
+          denyPaths: [],
+          denyPatterns: [],
+          env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+          allowUnsandboxed: false,
+        } satisfies SandboxOptions,
+      );
+
+      expect(result.sandboxed).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(result.success).toBe(true);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the new integration test**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- --runTestsByPath packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
+```
+
+Expected on macOS with Seatbelt: tests pass and prove actual syscall success/failure. Expected elsewhere: suite is skipped unless `RUNDOWN_REQUIRE_SEATBELT=1`.
+
+- [ ] **Step 3: Keep Landlock real enforcement green**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- --runTestsByPath packages/core/__tests__/sandbox/linux.enforcement.integration.test.ts
+```
+
+Expected on Linux with Landlock: tests pass. Expected elsewhere: existing suite skips unless `RUNDOWN_REQUIRE_LANDLOCK=1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
+git commit -m "test: cover real sandbox grant enforcement"
+```
+
+---
+
+## Task 5: Add CLI Command-Step Reproduction Coverage
+
+**Files:**
+
+- Create: `packages/cli/__tests__/integration/sandbox-policy-grants.test.ts`
+
+- [ ] **Step 1: Write integration tests that exercise CLI grants through command steps**
+
+Create `packages/cli/__tests__/integration/sandbox-policy-grants.test.ts`:
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { checkSandboxAvailability } from '@rundown-org/core';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  createTestWorkspace,
+  runCliInProcess,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
+
+const availability = await checkSandboxAvailability();
+const required = process.env.RUNDOWN_REQUIRE_SANDBOX === '1';
+
+if (!availability.available) {
+  const reason = availability.reason ?? 'unknown reason';
+  if (required) {
+    describe('sandbox policy grants integration', () => {
+      it('sandbox must be available when RUNDOWN_REQUIRE_SANDBOX=1', () => {
+        throw new Error(`Expected a working sandbox but it is unavailable: ${reason}`);
+      });
+    });
+  } else {
+    console.info(`[sandbox-policy-grants] skipped - sandbox unavailable: ${reason}`);
+    describe.skip(`sandbox policy grants integration - ${reason}`, () => {
+      it('exercises CLI grants under OS sandboxing', () => {
+        /* skipped */
+      });
+    });
+  }
+} else {
+  describe('sandbox policy grants integration', () => {
+    let workspace: TestWorkspace;
+
+    beforeEach(async () => {
+      workspace = await createTestWorkspace();
+    });
+
+    afterEach(async () => {
+      await workspace.cleanup();
+    });
+
+    it('lets --allow-read reach a sandboxed command step', async () => {
+      const inputPath = join(workspace.cwd, 'schema.json');
+      await writeFile(inputPath, '{"ok":true}');
+      await writeFile(
+        join(workspace.cwd, 'read-grant.runbook.md'),
+        [
+          '# Read grant',
+          '',
+          '## 1. Read schema',
+          '- PASS COMPLETE',
+          '',
+          '```bash',
+          `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync(${JSON.stringify(inputPath)}, 'utf8'))"`,
+          '```',
+          '',
+        ].join('\n'),
+      );
+
+      const result = await runCliInProcess(
+        [
+          'run',
+          'read-grant.runbook.md',
+          '--yes',
+          '--sandbox',
+          '--allow-run',
+          'node',
+          '--allow-read',
+          inputPath,
+        ],
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('lets --allow-write reach a sandboxed command step', async () => {
+      const outputDir = join(workspace.cwd, 'dist');
+      const outputPath = join(outputDir, 'out.txt');
+      await mkdir(outputDir);
+      await writeFile(
+        join(workspace.cwd, 'write-grant.runbook.md'),
+        [
+          '# Write grant',
+          '',
+          '## 1. Write output',
+          '- PASS COMPLETE',
+          '',
+          '```bash',
+          `node -e "require('fs').writeFileSync(${JSON.stringify(outputPath)}, 'ok')"`,
+          '```',
+          '',
+        ].join('\n'),
+      );
+
+      const result = await runCliInProcess(
+        [
+          'run',
+          'write-grant.runbook.md',
+          '--yes',
+          '--sandbox',
+          '--allow-run',
+          'node',
+          '--allow-write',
+          outputDir,
+        ],
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(await readFile(outputPath, 'utf8')).toBe('ok');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the CLI integration tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli test:integration -- --runTestsByPath packages/cli/__tests__/integration/sandbox-policy-grants.test.ts
+```
+
+Expected: both tests pass on hosts with a supported sandbox. On unsupported hosts, the suite skips unless `RUNDOWN_REQUIRE_SANDBOX=1`, in which case it fails with the sandbox availability reason.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/__tests__/integration/sandbox-policy-grants.test.ts
+git commit -m "test: prove CLI grants reach sandboxed command steps"
+```
+
+---
+
+## Task 6: Dogfood Reproduction And Verification
+
+**Files:**
+
+- No source files.
+
+- [ ] **Step 1: Build packages**
+
+Run:
+
+```bash
+pnpm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 2: Reproduce rdx validate gate under sandbox**
+
+Create `/tmp/sb-rdx-repro.runbook.md`:
+
+````markdown
+# SB rdx validate repro
+
+## 1. Validate docs
+- PASS COMPLETE
+
+```bash
+rdx --validate docs/superpowers/plans/2026-07-05-delegation-lifecycle-roadmap-4.md
+```
+````
+
+Run:
+
+```bash
+rundown run /tmp/sb-rdx-repro.runbook.md --yes --allow-run rdx,node --allow-read "$PWD" --allow-write "$PWD" --sandbox
+```
+
+Expected: command step succeeds or fails only for an actual `rdx --validate` content error, not for sandbox file-access denial.
+
+- [ ] **Step 3: Reproduce verify gate under sandbox**
+
+Create `/tmp/sb-verify-repro.runbook.md`:
+
+````markdown
+# SB verify repro
+
+## 1. Verify
+- PASS COMPLETE
+
+```bash
+pnpm run verify
+```
+````
+
+Run:
+
+```bash
+rundown run /tmp/sb-verify-repro.runbook.md --yes --allow-run pnpm,node,npm --allow-read "$PWD" --allow-write "$PWD" --sandbox
+```
+
+Expected: `pnpm run verify` starts normally under the sandbox. Any failure must be a real verification failure, not `EPERM` from missing `/Users` metadata traversal or missing grant propagation.
+
+- [ ] **Step 4: Run targeted regression tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/core test:unit -- --runTestsByPath packages/core/__tests__/sandbox/policy-mapper.test.ts packages/core/__tests__/sandbox/macos.test.ts packages/core/__tests__/sandbox/linux-spec-builder.test.ts packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts packages/core/__tests__/sandbox/linux.enforcement.integration.test.ts
+```
+
+Expected: all targeted core tests pass, with platform-specific enforcement tests skipped only when their backend is unavailable and the corresponding `RUNDOWN_REQUIRE_*` env var is not set.
+
+- [ ] **Step 5: Run full pre-PR verification**
+
+Run:
+
+```bash
+pnpm run verify
+```
+
+Expected: verify passes.
+
+---
+
+## Self-Review Notes
+
+- #550 coverage: Task 1 and Task 5 prove CLI grants reach `SandboxOptions` and command-step execution.
+- #552 coverage: Task 2 canonicalizes all sandbox grant roots, including future write targets via nearest-existing ancestor reconstruction.
+- #549 coverage: Task 3 adds metadata-only ancestors and Task 4 proves real Node filesystem syscalls work under Seatbelt.
+- Architecture: no CLI workaround; policy construction stays in CLI, behavior-bearing grant mapping lives in core policy/sandbox layers.
+- Runtime grant precedence: Task 1 adds explicit CLI/session grant-over-deny mapper tests and a sandbox-facing rule model so emitted deny rules stay coherent with `PolicyEvaluator.checkPath()`.

--- a/docs/superpowers/plans/2026-07-05-sb-sandbox-policy-coherence.md
+++ b/docs/superpowers/plans/2026-07-05-sb-sandbox-policy-coherence.md
@@ -1154,9 +1154,10 @@ Run:
 
 ```bash
 pnpm --filter @rundown-org/core test:unit -- --runTestsByPath packages/core/__tests__/sandbox/policy-mapper.test.ts packages/core/__tests__/sandbox/macos.test.ts packages/core/__tests__/sandbox/linux-spec-builder.test.ts packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts packages/core/__tests__/sandbox/linux.enforcement.integration.test.ts
+pnpm --filter @rundown-org/core test:property
 ```
 
-Expected: all targeted core tests pass, with platform-specific enforcement tests skipped only when their backend is unavailable and the corresponding `RUNDOWN_REQUIRE_*` env var is not set.
+Expected: all targeted core tests and property tests pass, with platform-specific enforcement tests skipped only when their backend is unavailable and the corresponding `RUNDOWN_REQUIRE_*` env var is not set.
 
 - [ ] **Step 5: Run full pre-PR verification**
 

--- a/docs/superpowers/plans/2026-07-05-sb-sandbox-policy-coherence.md
+++ b/docs/superpowers/plans/2026-07-05-sb-sandbox-policy-coherence.md
@@ -658,7 +658,7 @@ In `packages/core/src/sandbox/policy-mapper.ts`, add:
 
 ```typescript
 function collectAncestorPaths(paths: readonly string[]): string[] {
-  const ancestors = new Set<string>();
+  const ancestors = new Set<string>(paths);
   for (const candidate of paths) {
     let current = path.dirname(candidate);
     while (current !== path.dirname(current)) {

--- a/packages/cli/__tests__/integration/sandbox-policy-grants.test.ts
+++ b/packages/cli/__tests__/integration/sandbox-policy-grants.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import { checkSandboxAvailability } from '@rundown-org/core';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { createTestWorkspace, runCliInProcess, type TestWorkspace } from '../helpers/test-utils.js';
+import {
+  createTestWorkspace,
+  parseJsonEvents,
+  runCliInProcess,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
 
 const availability = await checkSandboxAvailability();
 const required = process.env.RUNDOWN_REQUIRE_SANDBOX === '1';
@@ -53,6 +58,42 @@ if (!availability.available) {
       );
     }
 
+    async function writePolicyWithFileGrants(args: {
+      readAllow?: string[];
+      writeAllow?: string[];
+    }): Promise<void> {
+      await writeFile(
+        join(workspace.cwd, '.rundownrc.json'),
+        JSON.stringify({
+          version: 1,
+          default: {
+            mode: 'deny',
+            run: { allow: ['node'], deny: [] },
+            read: { allow: args.readAllow ?? [], deny: [] },
+            write: { allow: args.writeAllow ?? [], deny: [] },
+            env: { allow: ['PATH', 'HOME', 'TMPDIR', 'TMP', 'TEMP'], deny: [] },
+          },
+          overrides: [],
+          grants: [],
+        }),
+      );
+    }
+
+    function expectSandboxedCommandCompleted(stdout: string, success: boolean): void {
+      const event = parseJsonEvents(stdout).find((candidate) => {
+        return candidate.type === 'command_completed';
+      });
+      expect(event).toBeDefined();
+      expect(event).toEqual(
+        expect.objectContaining({
+          type: 'command_completed',
+          sandboxed: true,
+          success,
+          policyDenied: false,
+        }),
+      );
+    }
+
     it('lets --allow-read reach a sandboxed command step', async () => {
       await writeDenyByDefaultPolicy();
       const inputPath = join(workspace.cwd, 'schema-secret.json');
@@ -89,6 +130,7 @@ if (!availability.available) {
       );
 
       expect(result.exitCode).toBe(0);
+      expectSandboxedCommandCompleted(result.stdout, true);
 
       await writeFile(
         join(workspace.cwd, 'read-denied.runbook.md'),
@@ -113,6 +155,7 @@ if (!availability.available) {
       );
 
       expect(denied.exitCode).not.toBe(0);
+      expectSandboxedCommandCompleted(denied.stdout, false);
     });
 
     it('lets --allow-write reach a sandboxed command step', async () => {
@@ -150,6 +193,7 @@ if (!availability.available) {
       );
 
       expect(result.exitCode).toBe(0);
+      expectSandboxedCommandCompleted(result.stdout, true);
       expect(await readFile(outputPath, 'utf8')).toBe('ok');
 
       const deniedPath = join(outputDir, 'denied.txt');
@@ -174,6 +218,44 @@ if (!availability.available) {
       );
 
       expect(denied.exitCode).not.toBe(0);
+      expectSandboxedCommandCompleted(denied.stdout, false);
+    });
+
+    it('lets policy-file read and write grants reach sandboxed command steps', async () => {
+      const inputPath = join(workspace.cwd, 'policy-schema.json');
+      const outputDir = join(workspace.cwd, 'policy-dist');
+      const outputPath = join(outputDir, 'out.txt');
+      await mkdir(outputDir);
+      await writeFile(inputPath, '{"ok":true}');
+      await writePolicyWithFileGrants({
+        readAllow: [inputPath],
+        writeAllow: [`${outputDir}/**`],
+      });
+      await writeFile(
+        join(workspace.cwd, 'policy-grants.runbook.md'),
+        [
+          '# Policy grants',
+          '',
+          '## 1. Read and write',
+          '- PASS COMPLETE',
+          '',
+          '```bash',
+          `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync(${JSON.stringify(
+            inputPath,
+          )}, "utf8")); fs.writeFileSync(${JSON.stringify(outputPath)}, "ok")'`,
+          '```',
+          '',
+        ].join('\n'),
+      );
+
+      const result = await runCliInProcess(
+        ['run', 'policy-grants.runbook.md', '--yes', '--sandbox', '--allow-run', 'node'],
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      expectSandboxedCommandCompleted(result.stdout, true);
+      expect(await readFile(outputPath, 'utf8')).toBe('ok');
     });
   });
 }

--- a/packages/cli/__tests__/integration/sandbox-policy-grants.test.ts
+++ b/packages/cli/__tests__/integration/sandbox-policy-grants.test.ts
@@ -35,8 +35,27 @@ if (!availability.available) {
       await workspace.cleanup();
     });
 
+    async function writeDenyByDefaultPolicy(): Promise<void> {
+      await writeFile(
+        join(workspace.cwd, '.rundownrc.json'),
+        JSON.stringify({
+          version: 1,
+          default: {
+            mode: 'deny',
+            run: { allow: ['node'], deny: [] },
+            read: { allow: [], deny: [] },
+            write: { allow: [], deny: [] },
+            env: { allow: ['PATH', 'HOME', 'TMPDIR', 'TMP', 'TEMP'], deny: [] },
+          },
+          overrides: [],
+          grants: [],
+        }),
+      );
+    }
+
     it('lets --allow-read reach a sandboxed command step', async () => {
-      const inputPath = join(workspace.cwd, 'schema.json');
+      await writeDenyByDefaultPolicy();
+      const inputPath = join(workspace.cwd, 'schema-secret.json');
       await writeFile(inputPath, '{"ok":true}');
       await writeFile(
         join(workspace.cwd, 'read-grant.runbook.md'),
@@ -70,9 +89,34 @@ if (!availability.available) {
       );
 
       expect(result.exitCode).toBe(0);
+
+      await writeFile(
+        join(workspace.cwd, 'read-denied.runbook.md'),
+        [
+          '# Read grant',
+          '',
+          '## 1. Read schema',
+          '- PASS COMPLETE',
+          '',
+          '```bash',
+          `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync(${JSON.stringify(
+            inputPath,
+          )}, "utf8"))'`,
+          '```',
+          '',
+        ].join('\n'),
+      );
+
+      const denied = await runCliInProcess(
+        ['run', 'read-denied.runbook.md', '--yes', '--sandbox', '--allow-run', 'node'],
+        workspace,
+      );
+
+      expect(denied.exitCode).not.toBe(0);
     });
 
     it('lets --allow-write reach a sandboxed command step', async () => {
+      await writeDenyByDefaultPolicy();
       const outputDir = join(workspace.cwd, 'dist');
       const outputPath = join(outputDir, 'out.txt');
       await mkdir(outputDir);
@@ -107,6 +151,29 @@ if (!availability.available) {
 
       expect(result.exitCode).toBe(0);
       expect(await readFile(outputPath, 'utf8')).toBe('ok');
+
+      const deniedPath = join(outputDir, 'denied.txt');
+      await writeFile(
+        join(workspace.cwd, 'write-denied.runbook.md'),
+        [
+          '# Write grant',
+          '',
+          '## 1. Write output',
+          '- PASS COMPLETE',
+          '',
+          '```bash',
+          `node -e 'require("fs").writeFileSync(${JSON.stringify(deniedPath)}, "ok")'`,
+          '```',
+          '',
+        ].join('\n'),
+      );
+
+      const denied = await runCliInProcess(
+        ['run', 'write-denied.runbook.md', '--yes', '--sandbox', '--allow-run', 'node'],
+        workspace,
+      );
+
+      expect(denied.exitCode).not.toBe(0);
     });
   });
 }

--- a/packages/cli/__tests__/integration/sandbox-policy-grants.test.ts
+++ b/packages/cli/__tests__/integration/sandbox-policy-grants.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { checkSandboxAvailability } from '@rundown-org/core';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createTestWorkspace, runCliInProcess, type TestWorkspace } from '../helpers/test-utils.js';
+
+const availability = await checkSandboxAvailability();
+const required = process.env.RUNDOWN_REQUIRE_SANDBOX === '1';
+
+if (!availability.available) {
+  const reason = availability.reason ?? 'unknown reason';
+  if (required) {
+    describe('sandbox policy grants integration', () => {
+      it('sandbox must be available when RUNDOWN_REQUIRE_SANDBOX=1', () => {
+        throw new Error(`Expected a working sandbox but it is unavailable: ${reason}`);
+      });
+    });
+  } else {
+    console.info(`[sandbox-policy-grants] skipped - sandbox unavailable: ${reason}`);
+    describe.skip(`sandbox policy grants integration - ${reason}`, () => {
+      it('exercises CLI grants under OS sandboxing', () => {
+        /* skipped */
+      });
+    });
+  }
+} else {
+  describe('sandbox policy grants integration', () => {
+    let workspace: TestWorkspace;
+
+    beforeEach(async () => {
+      workspace = await createTestWorkspace();
+    });
+
+    afterEach(async () => {
+      await workspace.cleanup();
+    });
+
+    it('lets --allow-read reach a sandboxed command step', async () => {
+      const inputPath = join(workspace.cwd, 'schema.json');
+      await writeFile(inputPath, '{"ok":true}');
+      await writeFile(
+        join(workspace.cwd, 'read-grant.runbook.md'),
+        [
+          '# Read grant',
+          '',
+          '## 1. Read schema',
+          '- PASS COMPLETE',
+          '',
+          '```bash',
+          `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync(${JSON.stringify(
+            inputPath,
+          )}, "utf8"))'`,
+          '```',
+          '',
+        ].join('\n'),
+      );
+
+      const result = await runCliInProcess(
+        [
+          'run',
+          'read-grant.runbook.md',
+          '--yes',
+          '--sandbox',
+          '--allow-run',
+          'node',
+          '--allow-read',
+          inputPath,
+        ],
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('lets --allow-write reach a sandboxed command step', async () => {
+      const outputDir = join(workspace.cwd, 'dist');
+      const outputPath = join(outputDir, 'out.txt');
+      await mkdir(outputDir);
+      await writeFile(
+        join(workspace.cwd, 'write-grant.runbook.md'),
+        [
+          '# Write grant',
+          '',
+          '## 1. Write output',
+          '- PASS COMPLETE',
+          '',
+          '```bash',
+          `node -e 'require("fs").writeFileSync(${JSON.stringify(outputPath)}, "ok")'`,
+          '```',
+          '',
+        ].join('\n'),
+      );
+
+      const result = await runCliInProcess(
+        [
+          'run',
+          'write-grant.runbook.md',
+          '--yes',
+          '--sandbox',
+          '--allow-run',
+          'node',
+          '--allow-write',
+          outputDir,
+        ],
+        workspace,
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(await readFile(outputPath, 'utf8')).toBe('ok');
+    });
+  });
+}

--- a/packages/cli/__tests__/integration/sandbox-policy-scenarios.test.ts
+++ b/packages/cli/__tests__/integration/sandbox-policy-scenarios.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { checkSandboxAvailability } from '@rundown-org/core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  createTestWorkspace,
+  parseCliJsonObject,
+  runCli,
+  type TestWorkspace,
+} from '../helpers/test-utils.js';
+
+const availability = await checkSandboxAvailability();
+const required = process.env.RUNDOWN_REQUIRE_SANDBOX === '1';
+
+if (!availability.available) {
+  const reason = availability.reason ?? 'unknown reason';
+  if (required) {
+    describe('sandbox policy scenario coverage', () => {
+      it('sandbox must be available when RUNDOWN_REQUIRE_SANDBOX=1', () => {
+        throw new Error(`Expected a working sandbox but it is unavailable: ${reason}`);
+      });
+    });
+  } else {
+    console.info(`[sandbox-policy-scenarios] skipped - sandbox unavailable: ${reason}`);
+    describe.skip(`sandbox policy scenario coverage - ${reason}`, () => {
+      it('runs sandbox policy scenarios', () => {
+        /* skipped */
+      });
+    });
+  }
+} else {
+  describe('sandbox policy scenario coverage', () => {
+    let workspace: TestWorkspace;
+
+    beforeEach(async () => {
+      workspace = await createTestWorkspace();
+      await writeScenarioRunbooks(workspace);
+    });
+
+    afterEach(async () => {
+      await workspace.cleanup();
+    });
+
+    it.each([
+      'allow-read',
+      'allow-write',
+      'deny-read',
+      'deny-write',
+    ])('scenario: %s', (scenarioName) => {
+      const result = runCli(
+        ['scenario', 'run', 'sandbox-policy-scenarios.runbook.md', scenarioName],
+        workspace,
+      );
+
+      const output = parseCliJsonObject(result.stdout);
+      if (scenarioName.startsWith('allow-')) {
+        expect(result.exitCode).toBe(0);
+        expect(output).toEqual(
+          expect.objectContaining({ result: true, expected: 'COMPLETE', actual: 'COMPLETE' }),
+        );
+      } else {
+        expect(result.exitCode).toBe(0);
+        expect(output).toEqual(
+          expect.objectContaining({ result: true, expected: 'STOP', actual: 'STOP' }),
+        );
+      }
+    });
+  });
+}
+
+async function writeScenarioRunbooks(workspace: TestWorkspace): Promise<void> {
+  const inputPath = join(workspace.cwd, 'scenario-schema.json');
+  const outputDir = join(workspace.cwd, 'scenario-dist');
+  const outputPath = join(outputDir, 'out.txt');
+  const deniedOutputPath = join(outputDir, 'denied.txt');
+  const restrictivePolicy = JSON.stringify({
+    version: 1,
+    default: {
+      mode: 'deny',
+      run: { allow: ['node'], deny: [] },
+      read: { allow: [], deny: [] },
+      write: { allow: [], deny: [] },
+      env: { allow: ['PATH', 'HOME', 'TMPDIR', 'TMP', 'TEMP'], deny: [] },
+    },
+    overrides: [],
+    grants: [],
+  });
+  const writePolicyCommand = `node -e 'require("fs").writeFileSync(".rundownrc.json", ${JSON.stringify(
+    restrictivePolicy,
+  )})'`;
+  await mkdir(outputDir);
+  await writeFile(inputPath, '{"ok":true}');
+  await writeFile(
+    join(workspace.cwd, 'sandbox-read.runbook.md'),
+    [
+      '# Sandbox Read',
+      '',
+      '## 1. Read schema',
+      '- PASS COMPLETE',
+      '- FAIL STOP',
+      '',
+      '```bash',
+      `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync(${JSON.stringify(
+        inputPath,
+      )}, "utf8"))'`,
+      '```',
+      '',
+    ].join('\n'),
+  );
+  await writeFile(
+    join(workspace.cwd, 'sandbox-write.runbook.md'),
+    [
+      '# Sandbox Write',
+      '',
+      '## 1. Write output',
+      '- PASS COMPLETE',
+      '- FAIL STOP',
+      '',
+      '```bash',
+      `node -e 'require("fs").writeFileSync(${JSON.stringify(outputPath)}, "ok")'`,
+      '```',
+      '',
+    ].join('\n'),
+  );
+  await writeFile(
+    join(workspace.cwd, 'sandbox-write-denied.runbook.md'),
+    [
+      '# Sandbox Write Denied',
+      '',
+      '## 1. Write denied output',
+      '- PASS COMPLETE',
+      '- FAIL STOP',
+      '',
+      '```bash',
+      `node -e 'require("fs").writeFileSync(${JSON.stringify(deniedOutputPath)}, "ok")'`,
+      '```',
+      '',
+    ].join('\n'),
+  );
+  await writeFile(
+    join(workspace.cwd, 'sandbox-policy-scenarios.runbook.md'),
+    [
+      '---',
+      'name: sandbox-policy-scenarios',
+      'scenarios:',
+      '  allow-read:',
+      '    description: CLI read grant reaches sandbox execution through scenario run',
+      '    commands:',
+      `      - ${writePolicyCommand}`,
+      `      - rd run sandbox-read.runbook.md --yes --sandbox --allow-run node --allow-read ${inputPath}`,
+      '    result: COMPLETE',
+      '  allow-write:',
+      '    description: CLI write grant reaches sandbox execution through scenario run',
+      '    commands:',
+      `      - ${writePolicyCommand}`,
+      `      - rd run sandbox-write.runbook.md --yes --sandbox --allow-run node --allow-write ${outputDir}`,
+      '    result: COMPLETE',
+      '  deny-read:',
+      '    description: Missing read grant fails under sandbox execution through scenario run',
+      '    commands:',
+      `      - ${writePolicyCommand}`,
+      '      - "! rd run sandbox-read.runbook.md --yes --sandbox --allow-run node"',
+      '    result: STOP',
+      '  deny-write:',
+      '    description: Missing write grant fails under sandbox execution through scenario run',
+      '    commands:',
+      `      - ${writePolicyCommand}`,
+      '      - "! rd run sandbox-write-denied.runbook.md --yes --sandbox --allow-run node"',
+      '    result: STOP',
+      '---',
+      '# Sandbox Policy Scenarios',
+      '',
+      '## 1. Placeholder',
+      '- PASS COMPLETE',
+      '',
+      'Scenario container.',
+      '',
+    ].join('\n'),
+  );
+}

--- a/packages/core/__tests__/policy/evaluator.test.ts
+++ b/packages/core/__tests__/policy/evaluator.test.ts
@@ -97,6 +97,28 @@ describe('PolicyEvaluator', () => {
       expect(decision.reason).toContain('--deny-all');
     });
 
+    it('should apply global overrides to sandbox path rules', () => {
+      const allowAllEvaluator = new PolicyEvaluator(DEFAULT_POLICY, {
+        repoRoot,
+        allowAll: true,
+      });
+      const denyAllEvaluator = new PolicyEvaluator(DEFAULT_POLICY, {
+        repoRoot,
+        denyAll: true,
+      });
+
+      expect(allowAllEvaluator.getSandboxRules('read')).toEqual({
+        allow: ['/**'],
+        deny: [],
+        runtimeGrantAllow: ['/**'],
+      });
+      expect(denyAllEvaluator.getSandboxRules('read')).toEqual({
+        allow: [],
+        deny: ['/**'],
+        runtimeGrantAllow: [],
+      });
+    });
+
     it('should respect CLI grants', () => {
       const evaluator = new PolicyEvaluator(DEFAULT_POLICY, {
         repoRoot,

--- a/packages/core/__tests__/sandbox/linux-spec-builder.test.ts
+++ b/packages/core/__tests__/sandbox/linux-spec-builder.test.ts
@@ -14,6 +14,7 @@ const base: SandboxOptions = {
   repoRoot: '/repo',
   readOnlyPaths: ['/repo'],
   readWritePaths: ['/repo/dist'],
+  metadataReadPaths: ['/repo-parent'],
   denyPaths: [],
   denyPatterns: [],
   env: {},
@@ -33,6 +34,8 @@ describe('buildSpec', () => {
     expect(spec.rox).toEqual(expect.arrayContaining(['/usr', '/bin']));
     expect(spec.ro).toEqual(expect.arrayContaining(['/repo', '/etc']));
     expect(spec.rw).toEqual(expect.arrayContaining(['/repo/dist', '/dev/null']));
+    expect(spec.ro).not.toContain('/repo-parent');
+    expect(spec.rw).not.toContain('/repo-parent');
   });
 
   it('sets strict=false when allowUnsandboxed', () => {

--- a/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
+++ b/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
@@ -68,7 +68,7 @@ if (!availability.available) {
     });
 
     const run = (command: string, options: Partial<SandboxOptionsWithNetwork> = {}) => {
-      const sandboxOptions = {
+      const sandboxOptions: SandboxOptionsWithNetwork = {
         cwd: repoCwd,
         repoRoot: repoCwd,
         readOnlyPaths: [repoCwd, grantedReadDir],
@@ -80,7 +80,7 @@ if (!availability.available) {
         allowUnsandboxed: false,
         ...options,
         network: options.network ?? 'deny',
-      } as SandboxOptions;
+      };
 
       return sandbox.execute(command, sandboxOptions);
     };
@@ -135,20 +135,21 @@ if (!availability.available) {
     usersMetadataIt(
       'allows Node startup and cwd package reads from a /Users-rooted repo using metadata ancestors',
       async () => {
+        const sandboxOptions: SandboxOptionsWithNetwork = {
+          cwd: repoCwd,
+          repoRoot: repoCwd,
+          readOnlyPaths: [repoCwd],
+          readWritePaths: [],
+          metadataReadPaths: metadataAncestorsFor(repoCwd),
+          denyPaths: [],
+          denyPatterns: [],
+          env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+          allowUnsandboxed: false,
+          network: 'deny',
+        };
         const result = await sandbox.execute(
           "node -e \"require('fs').readFileSync(require.resolve('./package.json'), 'utf8')\"",
-          {
-            cwd: repoCwd,
-            repoRoot: repoCwd,
-            readOnlyPaths: [repoCwd],
-            readWritePaths: [],
-            metadataReadPaths: metadataAncestorsFor(repoCwd),
-            denyPaths: [],
-            denyPatterns: [],
-            env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
-            allowUnsandboxed: false,
-            network: 'deny',
-          } as SandboxOptions,
+          sandboxOptions,
         );
 
         expect(result.sandboxed).toBe(true);

--- a/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
+++ b/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
@@ -17,6 +17,8 @@ const sandbox = new SeatbeltSandbox();
 const availability = await sandbox.getAvailability();
 const required = process.env.RUNDOWN_REQUIRE_SEATBELT === '1';
 
+type SandboxOptionsWithNetwork = SandboxOptions & { network: 'deny' | 'allow' };
+
 function metadataAncestorsFor(path: string): string[] {
   const ancestors: string[] = [];
   let current = path;
@@ -65,8 +67,8 @@ if (!availability.available) {
       rmSync(root, { recursive: true, force: true });
     });
 
-    const run = (command: string, options: Partial<SandboxOptions> = {}) =>
-      sandbox.execute(command, {
+    const run = (command: string, options: Partial<SandboxOptionsWithNetwork> = {}) => {
+      const sandboxOptions = {
         cwd: repoCwd,
         repoRoot: repoCwd,
         readOnlyPaths: [repoCwd, grantedReadDir],
@@ -77,7 +79,11 @@ if (!availability.available) {
         env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
         allowUnsandboxed: false,
         ...options,
-      } satisfies SandboxOptions);
+        network: options.network ?? 'deny',
+      } as SandboxOptions;
+
+      return sandbox.execute(command, sandboxOptions);
+    };
 
     it(
       'allows a real read syscall inside a granted read-only path',
@@ -141,7 +147,8 @@ if (!availability.available) {
             denyPatterns: [],
             env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
             allowUnsandboxed: false,
-          } satisfies SandboxOptions,
+            network: 'deny',
+          } as SandboxOptions,
         );
 
         expect(result.sandboxed).toBe(true);

--- a/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
+++ b/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
@@ -121,12 +121,14 @@ if (!availability.available) {
       'blocks a real read syscall outside granted paths',
       async () => {
         const result = await run(
-          `node -e 'require("fs").readFileSync(${JSON.stringify(join(secretDir, 'secret.txt'))})'`,
+          `node -e 'try { require("fs").readFileSync(${JSON.stringify(
+            join(secretDir, 'secret.txt'),
+          )}); process.exit(44); } catch (error) { if (error && (error.code === "EPERM" || error.code === "EACCES")) process.exit(42); console.error(error && error.code ? error.code : error); process.exit(43); }'`,
         );
 
         expect(result.sandboxed).toBe(true);
         expect(result.success).toBe(false);
-        expect(result.exitCode).not.toBe(0);
+        expect(result.exitCode).toBe(42);
       },
       realExecutionTimeoutMs,
     );

--- a/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
+++ b/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
@@ -49,6 +49,7 @@ if (!availability.available) {
   }
 } else {
   describe('SeatbeltSandbox real enforcement (integration)', () => {
+    const realExecutionTimeoutMs = 30_000;
     const repoCwd = realpathSync(process.cwd());
     const root = realpathSync(mkdtempSync(join(tmpdir(), 'rundown-seatbelt-it-')));
     const grantedReadDir = join(root, 'read');
@@ -78,64 +79,76 @@ if (!availability.available) {
         ...options,
       } satisfies SandboxOptions);
 
-    it('allows a real read syscall inside a granted read-only path', async () => {
-      const result = await run(
-        `node -e 'const fs=require("fs"); process.stdout.write(fs.readFileSync(${JSON.stringify(
-          join(grantedReadDir, 'ok.txt'),
-        )}, "utf8"))'`,
-      );
+    it(
+      'allows a real read syscall inside a granted read-only path',
+      async () => {
+        const result = await run(
+          `node -e 'const fs=require("fs"); process.stdout.write(fs.readFileSync(${JSON.stringify(
+            join(grantedReadDir, 'ok.txt'),
+          )}, "utf8"))'`,
+        );
 
-      expect(result.sandboxed).toBe(true);
-      expect(result.exitCode).toBe(0);
-      expect(result.success).toBe(true);
-    });
+        expect(result.sandboxed).toBe(true);
+        expect(result.exitCode).toBe(0);
+        expect(result.success).toBe(true);
+      },
+      realExecutionTimeoutMs,
+    );
 
-    it('allows a real write syscall inside a granted read-write path', async () => {
-      const target = join(grantedWriteDir, 'written.txt');
-      const result = await run(
-        `node -e 'require("fs").writeFileSync(${JSON.stringify(target)}, "written")'`,
-      );
+    it(
+      'allows a real write syscall inside a granted read-write path',
+      async () => {
+        const target = join(grantedWriteDir, 'written.txt');
+        const result = await run(
+          `node -e 'require("fs").writeFileSync(${JSON.stringify(target)}, "written")'`,
+        );
 
-      expect(result.sandboxed).toBe(true);
-      expect(result.exitCode).toBe(0);
-      expect(result.success).toBe(true);
-      expect(readFileSync(target, 'utf8')).toBe('written');
-    });
+        expect(result.sandboxed).toBe(true);
+        expect(result.exitCode).toBe(0);
+        expect(result.success).toBe(true);
+        expect(readFileSync(target, 'utf8')).toBe('written');
+      },
+      realExecutionTimeoutMs,
+    );
 
-    it('blocks a real read syscall outside granted paths', async () => {
-      const result = await run(
-        `node -e 'require("fs").readFileSync(${JSON.stringify(join(secretDir, 'secret.txt'))})'`,
-      );
+    it(
+      'blocks a real read syscall outside granted paths',
+      async () => {
+        const result = await run(
+          `node -e 'require("fs").readFileSync(${JSON.stringify(join(secretDir, 'secret.txt'))})'`,
+        );
 
-      expect(result.sandboxed).toBe(true);
-      expect(result.success).toBe(false);
-      expect(result.exitCode).not.toBe(0);
-    });
+        expect(result.sandboxed).toBe(true);
+        expect(result.success).toBe(false);
+        expect(result.exitCode).not.toBe(0);
+      },
+      realExecutionTimeoutMs,
+    );
 
-    it('allows Node startup and cwd package reads from a /Users-rooted repo using metadata ancestors', async () => {
-      if (!repoCwd.startsWith('/Users/')) {
-        console.info(`[seatbelt-integration] skipped /Users metadata case for cwd ${repoCwd}`);
-        return;
-      }
+    const usersMetadataIt = repoCwd.startsWith('/Users/') ? it : it.skip;
+    usersMetadataIt(
+      'allows Node startup and cwd package reads from a /Users-rooted repo using metadata ancestors',
+      async () => {
+        const result = await sandbox.execute(
+          "node -e \"require('fs').readFileSync(require.resolve('./package.json'), 'utf8')\"",
+          {
+            cwd: repoCwd,
+            repoRoot: repoCwd,
+            readOnlyPaths: [repoCwd],
+            readWritePaths: [],
+            metadataReadPaths: metadataAncestorsFor(repoCwd),
+            denyPaths: [],
+            denyPatterns: [],
+            env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+            allowUnsandboxed: false,
+          } satisfies SandboxOptions,
+        );
 
-      const result = await sandbox.execute(
-        "node -e \"require('fs').readFileSync(require.resolve('./package.json'), 'utf8')\"",
-        {
-          cwd: repoCwd,
-          repoRoot: repoCwd,
-          readOnlyPaths: [repoCwd],
-          readWritePaths: [],
-          metadataReadPaths: metadataAncestorsFor(repoCwd),
-          denyPaths: [],
-          denyPatterns: [],
-          env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
-          allowUnsandboxed: false,
-        } satisfies SandboxOptions,
-      );
-
-      expect(result.sandboxed).toBe(true);
-      expect(result.exitCode).toBe(0);
-      expect(result.success).toBe(true);
-    });
+        expect(result.sandboxed).toBe(true);
+        expect(result.exitCode).toBe(0);
+        expect(result.success).toBe(true);
+      },
+      realExecutionTimeoutMs,
+    );
   });
 }

--- a/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
+++ b/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Real-enforcement integration test for the macOS Seatbelt sandbox.
+ *
+ * Behaviour by environment:
+ *   - Seatbelt available -> assert real grant-to-syscall success.
+ *   - Seatbelt unavailable/non-macOS -> skip so CI and Linux dev machines stay green.
+ *   - RUNDOWN_REQUIRE_SEATBELT=1 and unavailable -> fail.
+ */
+import { afterAll, describe, expect, it } from '@jest/globals';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { SeatbeltSandbox } from '../../src/sandbox/macos.js';
+import type { SandboxOptions } from '../../src/sandbox/types.js';
+
+const sandbox = new SeatbeltSandbox();
+const availability = await sandbox.getAvailability();
+const required = process.env.RUNDOWN_REQUIRE_SEATBELT === '1';
+
+function metadataAncestorsFor(path: string): string[] {
+  const ancestors: string[] = [];
+  let current = path;
+  while (current !== dirname(current)) {
+    ancestors.unshift(current);
+    current = dirname(current);
+  }
+  return ancestors.filter((ancestor) => ancestor !== '/');
+}
+
+function uniqueMetadataAncestorsFor(paths: readonly string[]): string[] {
+  return [...new Set(paths.flatMap((path) => metadataAncestorsFor(path)))];
+}
+
+if (!availability.available) {
+  const reason = availability.reason ?? 'unknown reason';
+  if (required) {
+    describe('SeatbeltSandbox real enforcement (integration)', () => {
+      it('Seatbelt must be available when RUNDOWN_REQUIRE_SEATBELT=1', () => {
+        throw new Error(`Expected a working Seatbelt sandbox but it is unavailable: ${reason}`);
+      });
+    });
+  } else {
+    console.info(`[seatbelt-integration] skipped - sandbox unavailable: ${reason}`);
+    describe.skip(`SeatbeltSandbox real enforcement (integration) - ${reason}`, () => {
+      it('enforces filesystem policy', () => {
+        /* skipped */
+      });
+    });
+  }
+} else {
+  describe('SeatbeltSandbox real enforcement (integration)', () => {
+    const repoCwd = realpathSync(process.cwd());
+    const root = realpathSync(mkdtempSync(join(tmpdir(), 'rundown-seatbelt-it-')));
+    const grantedReadDir = join(root, 'read');
+    const grantedWriteDir = join(root, 'write');
+    const secretDir = join(root, 'secret');
+    mkdirSync(grantedReadDir);
+    mkdirSync(grantedWriteDir);
+    mkdirSync(secretDir);
+    writeFileSync(join(grantedReadDir, 'ok.txt'), 'ok');
+    writeFileSync(join(secretDir, 'secret.txt'), 'top secret');
+
+    afterAll(() => {
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    const run = (command: string, options: Partial<SandboxOptions> = {}) =>
+      sandbox.execute(command, {
+        cwd: repoCwd,
+        repoRoot: repoCwd,
+        readOnlyPaths: [repoCwd, grantedReadDir],
+        readWritePaths: [grantedWriteDir],
+        metadataReadPaths: uniqueMetadataAncestorsFor([repoCwd, root]),
+        denyPaths: [],
+        denyPatterns: [],
+        env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+        allowUnsandboxed: false,
+        ...options,
+      } satisfies SandboxOptions);
+
+    it('allows a real read syscall inside a granted read-only path', async () => {
+      const result = await run(
+        `node -e 'const fs=require("fs"); process.stdout.write(fs.readFileSync(${JSON.stringify(
+          join(grantedReadDir, 'ok.txt'),
+        )}, "utf8"))'`,
+      );
+
+      expect(result.sandboxed).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(result.success).toBe(true);
+    });
+
+    it('allows a real write syscall inside a granted read-write path', async () => {
+      const target = join(grantedWriteDir, 'written.txt');
+      const result = await run(
+        `node -e 'require("fs").writeFileSync(${JSON.stringify(target)}, "written")'`,
+      );
+
+      expect(result.sandboxed).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(result.success).toBe(true);
+      expect(readFileSync(target, 'utf8')).toBe('written');
+    });
+
+    it('blocks a real read syscall outside granted paths', async () => {
+      const result = await run(
+        `node -e 'require("fs").readFileSync(${JSON.stringify(join(secretDir, 'secret.txt'))})'`,
+      );
+
+      expect(result.sandboxed).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it('allows Node startup and cwd package reads from a /Users-rooted repo using metadata ancestors', async () => {
+      if (!repoCwd.startsWith('/Users/')) {
+        console.info(`[seatbelt-integration] skipped /Users metadata case for cwd ${repoCwd}`);
+        return;
+      }
+
+      const result = await sandbox.execute(
+        "node -e \"require('fs').readFileSync(require.resolve('./package.json'), 'utf8')\"",
+        {
+          cwd: repoCwd,
+          repoRoot: repoCwd,
+          readOnlyPaths: [repoCwd],
+          readWritePaths: [],
+          metadataReadPaths: metadataAncestorsFor(repoCwd),
+          denyPaths: [],
+          denyPatterns: [],
+          env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+          allowUnsandboxed: false,
+        } satisfies SandboxOptions,
+      );
+
+      expect(result.sandboxed).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(result.success).toBe(true);
+    });
+  });
+}

--- a/packages/core/__tests__/sandbox/macos.test.ts
+++ b/packages/core/__tests__/sandbox/macos.test.ts
@@ -234,6 +234,46 @@ describe('SeatbeltSandbox', () => {
       expect(unlinkSync).toHaveBeenCalled();
     });
 
+    it('writes metadata-only ancestor rules into the generated profile', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      (existsSync as jest.Mock).mockReturnValue(true);
+      (writeFileSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+      (unlinkSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+
+      const mockChild = {
+        on: jest.fn((event: string, callback: (arg?: number | Error) => void) => {
+          if (event === 'close') {
+            process.nextTick(() => {
+              callback(0);
+            });
+          }
+          return mockChild;
+        }),
+      };
+      (spawn as jest.Mock).mockReturnValue(mockChild);
+
+      const sandbox = new SeatbeltSandbox();
+      await sandbox.execute('node script.js', {
+        ...mockOptions,
+        metadataReadPaths: ['/Users', '/Users/test', '/Users/test/project'],
+      });
+
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(literal "/Users/test/project")'),
+        expect.any(Object),
+      );
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(allow file-read-metadata'),
+        expect.any(Object),
+      );
+    });
+
     it('handles non-zero exit code', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
       (existsSync as jest.Mock).mockReturnValue(true);

--- a/packages/core/__tests__/sandbox/macos.test.ts
+++ b/packages/core/__tests__/sandbox/macos.test.ts
@@ -295,12 +295,17 @@ describe('SeatbeltSandbox', () => {
       );
       expect(writeFileSync).toHaveBeenCalledWith(
         expect.any(String),
+        expect.stringContaining('(literal "/Users/test/.cache/node/corepack")'),
+        expect.any(Object),
+      );
+      expect(writeFileSync).not.toHaveBeenCalledWith(
+        expect.any(String),
         expect.stringContaining('(subpath "/Users/test/.cache/node/corepack")'),
         expect.any(Object),
       );
     });
 
-    it('uses the sandbox command HOME for package manager execution paths', async () => {
+    it('uses the sandbox command HOME for package manager metadata paths', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
       (existsSync as jest.Mock).mockReturnValue(true);
       (writeFileSync as jest.Mock).mockImplementation(() => {
@@ -329,6 +334,11 @@ describe('SeatbeltSandbox', () => {
       });
 
       expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(literal "/tmp/rundown-home/.cache/node/corepack")'),
+        expect.any(Object),
+      );
+      expect(writeFileSync).not.toHaveBeenCalledWith(
         expect.any(String),
         expect.stringContaining('(subpath "/tmp/rundown-home/.cache/node/corepack")'),
         expect.any(Object),

--- a/packages/core/__tests__/sandbox/macos.test.ts
+++ b/packages/core/__tests__/sandbox/macos.test.ts
@@ -260,12 +260,22 @@ describe('SeatbeltSandbox', () => {
       const sandbox = new SeatbeltSandbox();
       await sandbox.execute('node script.js', {
         ...mockOptions,
-        metadataReadPaths: ['/Users', '/Users/test', '/Users/test/project'],
+        metadataReadPaths: ['/Users/test/project'],
       });
 
       expect(writeFileSync).toHaveBeenCalledWith(
         expect.any(String),
         expect.stringContaining('(literal "/Users/test/project")'),
+        expect.any(Object),
+      );
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(literal "/Users/test")'),
+        expect.any(Object),
+      );
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(literal "/Users")'),
         expect.any(Object),
       );
       expect(writeFileSync).toHaveBeenCalledWith(
@@ -283,13 +293,83 @@ describe('SeatbeltSandbox', () => {
         expect.stringContaining(`(literal "${dirname(dirname(dirname(process.execPath)))}")`),
         expect.any(Object),
       );
-      if (process.env.HOME) {
-        expect(writeFileSync).toHaveBeenCalledWith(
-          expect.any(String),
-          expect.stringContaining(`(subpath "${process.env.HOME}/.cache/node/corepack")`),
-          expect.any(Object),
-        );
-      }
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(subpath "/Users/test/.cache/node/corepack")'),
+        expect.any(Object),
+      );
+    });
+
+    it('uses the sandbox command HOME for package manager execution paths', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      (existsSync as jest.Mock).mockReturnValue(true);
+      (writeFileSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+      (unlinkSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+
+      const mockChild = {
+        on: jest.fn((event: string, callback: (arg?: number | Error) => void) => {
+          if (event === 'close') {
+            process.nextTick(() => {
+              callback(0);
+            });
+          }
+          return mockChild;
+        }),
+      };
+      (spawn as jest.Mock).mockReturnValue(mockChild);
+
+      const sandbox = new SeatbeltSandbox();
+      await sandbox.execute('node script.js', {
+        ...mockOptions,
+        env: { PATH: '/usr/bin', HOME: '/tmp/rundown-home' },
+      });
+
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(subpath "/tmp/rundown-home/.cache/node/corepack")'),
+        expect.any(Object),
+      );
+    });
+
+    it('does not grant broad process wildcard rights', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      (existsSync as jest.Mock).mockReturnValue(true);
+      (writeFileSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+      (unlinkSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+
+      const mockChild = {
+        on: jest.fn((event: string, callback: (arg?: number | Error) => void) => {
+          if (event === 'close') {
+            process.nextTick(() => {
+              callback(0);
+            });
+          }
+          return mockChild;
+        }),
+      };
+      (spawn as jest.Mock).mockReturnValue(mockChild);
+
+      const sandbox = new SeatbeltSandbox();
+      await sandbox.execute('node script.js', mockOptions);
+
+      expect(writeFileSync).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(allow process*)'),
+        expect.any(Object),
+      );
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('(allow process-exec process-fork)'),
+        expect.any(Object),
+      );
     });
 
     it('handles non-zero exit code', async () => {

--- a/packages/core/__tests__/sandbox/macos.test.ts
+++ b/packages/core/__tests__/sandbox/macos.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { dirname } from 'node:path';
 import type { SandboxOptions } from '../../src/sandbox/types.js';
 
 // Mock child_process
@@ -269,9 +270,26 @@ describe('SeatbeltSandbox', () => {
       );
       expect(writeFileSync).toHaveBeenCalledWith(
         expect.any(String),
+        expect.stringContaining('(literal "/usr/bin")'),
+        expect.any(Object),
+      );
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
         expect.stringContaining('(allow file-read-metadata'),
         expect.any(Object),
       );
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining(`(literal "${dirname(dirname(dirname(process.execPath)))}")`),
+        expect.any(Object),
+      );
+      if (process.env.HOME) {
+        expect(writeFileSync).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.stringContaining(`(subpath "${process.env.HOME}/.cache/node/corepack")`),
+          expect.any(Object),
+        );
+      }
     });
 
     it('handles non-zero exit code', async () => {

--- a/packages/core/__tests__/sandbox/policy-mapper.properties.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.properties.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from '@jest/globals';
+import fc from 'fast-check';
+import { PolicyEvaluator } from '../../src/policy/evaluator.js';
+import { DEFAULT_POLICY, type PolicyConfig } from '../../src/policy/schema.js';
+import {
+  policyConfigToSandboxOptions,
+  policyToSandboxOptions,
+} from '../../src/sandbox/policy-mapper.js';
+
+const repoRoot = '/repo';
+
+const segmentArb = fc
+  .stringMatching(/^[a-z][a-z0-9_-]{0,8}$/)
+  .filter((segment) => segment !== '.' && segment !== '..');
+
+const relativePathArb = fc
+  .array(segmentArb, { minLength: 1, maxLength: 4 })
+  .map((segments) => segments.join('/'));
+
+function pathFor(relativePath: string): string {
+  return `${repoRoot}/${relativePath}`;
+}
+
+function policyWithRules(args: {
+  readAllow?: string[];
+  readDeny?: string[];
+  writeAllow?: string[];
+  writeDeny?: string[];
+}): PolicyConfig {
+  return {
+    ...DEFAULT_POLICY,
+    default: {
+      ...DEFAULT_POLICY.default,
+      read: { allow: args.readAllow ?? [], deny: args.readDeny ?? [] },
+      write: { allow: args.writeAllow ?? [], deny: args.writeDeny ?? [] },
+    },
+  };
+}
+
+function ancestorPaths(candidate: string): string[] {
+  const parts = candidate.split('/').filter(Boolean);
+  const ancestors: string[] = [];
+  for (let i = 1; i <= parts.length; i += 1) {
+    ancestors.push(`/${parts.slice(0, i).join('/')}`);
+  }
+  return ancestors;
+}
+
+describe('policyToSandboxOptions properties', () => {
+  it('write grants win over read-only grants for the same root', () => {
+    fc.assert(
+      fc.property(relativePathArb, (relativePath) => {
+        const grantRoot = pathFor(relativePath);
+        const policy = policyWithRules({
+          readAllow: [`${grantRoot}/**`],
+          writeAllow: [`${grantRoot}/**`],
+        });
+        const evaluator = new PolicyEvaluator(policy, { repoRoot });
+
+        const options = policyToSandboxOptions(evaluator, { cwd: repoRoot, repoRoot });
+
+        expect(options.readWritePaths).toContain(grantRoot);
+        expect(options.readOnlyPaths).not.toContain(grantRoot);
+      }),
+    );
+  });
+
+  it('runtime grants remove covered concrete deny paths', () => {
+    fc.assert(
+      fc.property(relativePathArb, segmentArb, (relativePath, fileName) => {
+        const grantRoot = pathFor(relativePath);
+        const deniedPath = `${grantRoot}/${fileName}`;
+        const policy = policyWithRules({
+          readDeny: [deniedPath],
+        });
+        const evaluator = new PolicyEvaluator(policy, {
+          repoRoot,
+          cliGrants: { read: [grantRoot] },
+        });
+
+        const options = policyToSandboxOptions(evaluator, { cwd: repoRoot, repoRoot });
+
+        expect(options.readOnlyPaths).toContain(grantRoot);
+        expect(options.denyPaths).not.toContain(deniedPath);
+        expect(options.denyPatterns).not.toContain(deniedPath);
+      }),
+    );
+  });
+
+  it('metadata read paths include every grant root and ancestor except filesystem root', () => {
+    fc.assert(
+      fc.property(relativePathArb, relativePathArb, (readRelativePath, writeRelativePath) => {
+        const readRoot = pathFor(readRelativePath);
+        const writeRoot = pathFor(writeRelativePath);
+        const policy = policyWithRules({
+          readAllow: [`${readRoot}/**`],
+          writeAllow: [`${writeRoot}/**`],
+        });
+        const evaluator = new PolicyEvaluator(policy, { repoRoot });
+
+        const options = policyToSandboxOptions(evaluator, { cwd: repoRoot, repoRoot });
+
+        for (const expected of [...ancestorPaths(readRoot), ...ancestorPaths(writeRoot)]) {
+          expect(options.metadataReadPaths).toContain(expected);
+        }
+        expect(options.metadataReadPaths).not.toContain('/');
+      }),
+    );
+  });
+
+  it('canonicalized raw-policy grants are stable when mapped back through policy config', () => {
+    fc.assert(
+      fc.property(relativePathArb, relativePathArb, (readRelativePath, writeRelativePath) => {
+        const first = policyConfigToSandboxOptions(
+          policyWithRules({
+            readAllow: [`${pathFor(readRelativePath)}/**`],
+            writeAllow: [`${pathFor(writeRelativePath)}/**`],
+          }),
+          { cwd: repoRoot, repoRoot },
+        );
+        const second = policyConfigToSandboxOptions(
+          policyWithRules({
+            readAllow: first.readOnlyPaths,
+            writeAllow: first.readWritePaths,
+          }),
+          { cwd: repoRoot, repoRoot },
+        );
+
+        expect(second.readOnlyPaths).toEqual(first.readOnlyPaths);
+        expect(second.readWritePaths).toEqual(first.readWritePaths);
+      }),
+    );
+  });
+});

--- a/packages/core/__tests__/sandbox/policy-mapper.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.test.ts
@@ -528,6 +528,26 @@ describe('policyToSandboxOptions', () => {
     expect(options.denyPatterns).not.toContain('/repo/dist/secret.txt');
   });
 
+  it('retains configured deny paths when no runtime grant covers them', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: ['/repo/.env'] },
+        write: { allow: [], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, { repoRoot: '/repo' });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.denyPaths).toContain('/repo/.env');
+    expect(options.denyPatterns).toContain('/repo/.env');
+  });
+
   it('filters alias-spelled deny paths covered by canonical runtime grants', async () => {
     const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
     const aliasRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-alias-'));
@@ -672,34 +692,37 @@ describe('policyToSandboxOptions', () => {
     }
   });
 
-  it('normalizes the macOS tmpdir alias from /var/folders to /private/var/folders when present', async () => {
-    const tmp = tmpdir();
-    if (process.platform !== 'darwin' || !tmp.startsWith('/var/folders/')) {
-      return;
-    }
-    const canonicalTmp = await realpath(tmp);
-    const policy: PolicyConfig = {
-      ...DEFAULT_POLICY,
-      default: {
-        ...DEFAULT_POLICY.default,
-        read: { allow: [], deny: [] },
-        write: { allow: ['{tmp}/rundown-sandbox-test/**'], deny: [] },
-      },
-    };
-    const evaluator = new PolicyEvaluator(policy, {
-      repoRoot: '/repo',
-      tmpDir: tmp,
-    });
+  const macOSTmpAliasIt =
+    process.platform === 'darwin' && tmpdir().startsWith('/var/folders/') ? it : it.skip;
 
-    const options = policyToSandboxOptions(evaluator, {
-      cwd: '/repo',
-      repoRoot: '/repo',
-      tmpDir: tmp,
-    });
+  macOSTmpAliasIt(
+    'normalizes the macOS tmpdir alias from /var/folders to /private/var/folders when present',
+    async () => {
+      const tmp = tmpdir();
+      const canonicalTmp = await realpath(tmp);
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [], deny: [] },
+          write: { allow: ['{tmp}/rundown-sandbox-test/**'], deny: [] },
+        },
+      };
+      const evaluator = new PolicyEvaluator(policy, {
+        repoRoot: '/repo',
+        tmpDir: tmp,
+      });
 
-    expect(options.readWritePaths).toContain(join(canonicalTmp, 'rundown-sandbox-test'));
-    expect(options.readWritePaths).not.toContain(join(tmp, 'rundown-sandbox-test'));
-  });
+      const options = policyToSandboxOptions(evaluator, {
+        cwd: '/repo',
+        repoRoot: '/repo',
+        tmpDir: tmp,
+      });
+
+      expect(options.readWritePaths).toContain(join(canonicalTmp, 'rundown-sandbox-test'));
+      expect(options.readWritePaths).not.toContain(join(tmp, 'rundown-sandbox-test'));
+    },
+  );
 
   it('applies the same canonicalization to policyConfigToSandboxOptions', async () => {
     const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));

--- a/packages/core/__tests__/sandbox/policy-mapper.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { join, dirname } from 'node:path';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
-import type { Stats } from 'node:fs';
+import { join, dirname, basename, resolve } from 'node:path';
+import { mkdtemp, rm, writeFile, mkdir, realpath, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { realpathSync, type Stats } from 'node:fs';
 import {
   policyToSandboxOptions,
   policyConfigToSandboxOptions,
@@ -12,6 +13,19 @@ import {
   DEFAULT_POLICY_LINUX,
   type PolicyConfig,
 } from '../../src/policy/schema.js';
+
+function canonicalPathForTest(value: string): string {
+  const absolute = resolve(value);
+  try {
+    return realpathSync(absolute);
+  } catch {
+    const parent = dirname(absolute);
+    if (parent === absolute) {
+      return absolute;
+    }
+    return join(canonicalPathForTest(parent), basename(absolute));
+  }
+}
 
 describe('policyToSandboxOptions', () => {
   it('returns minimal options for default policy', () => {
@@ -203,7 +217,7 @@ describe('policyToSandboxOptions', () => {
       tmpDir: '/var/tmp',
     });
 
-    expect(options.readWritePaths).toContain('/var/tmp/cache');
+    expect(options.readWritePaths).toContain(canonicalPathForTest('/var/tmp/cache'));
   });
 
   it('passes through allowUnsandboxed option', () => {
@@ -464,6 +478,131 @@ describe('policyToSandboxOptions', () => {
     expect(options.denyPatterns).not.toContain('/repo/dist/secret.txt');
   });
 
+  it('realpath-normalizes read grants that pass through a symlink', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const aliasRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-alias-'));
+    try {
+      const dir = join(repoRoot, 'schema-dir');
+      await mkdir(dir);
+      const alias = join(aliasRoot, 'schema-link');
+      await symlink(dir, alias);
+      const canonicalDir = await realpath(dir);
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [join(alias, '**')], deny: [] },
+          write: { allow: [], deny: [] },
+        },
+      };
+      const evaluator = new PolicyEvaluator(policy, { repoRoot });
+
+      const options = policyToSandboxOptions(evaluator, {
+        cwd: repoRoot,
+        repoRoot,
+      });
+
+      expect(options.readOnlyPaths).toContain(canonicalDir);
+      expect(options.readOnlyPaths).not.toContain(alias);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(aliasRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('realpath-normalizes future write grants through the nearest existing symlink ancestor', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const aliasRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-alias-'));
+    try {
+      const dist = join(repoRoot, 'dist');
+      await mkdir(dist);
+      const alias = join(aliasRoot, 'dist-link');
+      await symlink(dist, alias);
+      const futurePath = join(alias, 'new-file.txt');
+      const canonicalRepo = await realpath(repoRoot);
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [], deny: [] },
+          write: { allow: [futurePath], deny: [] },
+        },
+      };
+      const evaluator = new PolicyEvaluator(policy, { repoRoot });
+
+      const options = policyToSandboxOptions(evaluator, {
+        cwd: repoRoot,
+        repoRoot,
+      });
+
+      expect(options.readWritePaths).toContain(join(canonicalRepo, 'dist', 'new-file.txt'));
+      expect(options.readWritePaths).not.toContain(futurePath);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(aliasRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes the macOS tmpdir alias from /var/folders to /private/var/folders when present', async () => {
+    const tmp = tmpdir();
+    if (process.platform !== 'darwin' || !tmp.startsWith('/var/folders/')) {
+      return;
+    }
+    const canonicalTmp = await realpath(tmp);
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: [] },
+        write: { allow: ['{tmp}/rundown-sandbox-test/**'], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, {
+      repoRoot: '/repo',
+      tmpDir: tmp,
+    });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+      tmpDir: tmp,
+    });
+
+    expect(options.readWritePaths).toContain(join(canonicalTmp, 'rundown-sandbox-test'));
+    expect(options.readWritePaths).not.toContain(join(tmp, 'rundown-sandbox-test'));
+  });
+
+  it('applies the same canonicalization to policyConfigToSandboxOptions', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const aliasRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-alias-'));
+    try {
+      const dir = join(repoRoot, 'raw-policy-read');
+      await mkdir(dir);
+      const alias = join(aliasRoot, 'raw-policy-link');
+      await symlink(dir, alias);
+      const canonicalDir = await realpath(dir);
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [join(alias, '**')], deny: [] },
+          write: { allow: [], deny: [] },
+        },
+      };
+
+      const options = policyConfigToSandboxOptions(policy, {
+        cwd: repoRoot,
+        repoRoot,
+      });
+
+      expect(options.readOnlyPaths).toContain(canonicalDir);
+      expect(options.readOnlyPaths).not.toContain(alias);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(aliasRoot, { recursive: true, force: true });
+    }
+  });
+
   it('rejects out-of-root extra read-write paths in policyToSandboxOptions', async () => {
     const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
     const outsidePath = join(dirname(repoRoot), 'outside.txt');
@@ -657,7 +796,7 @@ describe('extractBasePath behavior', () => {
       cwd: '/test',
     });
 
-    expect(options.readOnlyPaths).toContain('/home/user');
+    expect(options.readOnlyPaths).toContain(canonicalPathForTest('/home/user'));
   });
 
   it('extracts base path from glob with *.ext', () => {
@@ -680,7 +819,7 @@ describe('extractBasePath behavior', () => {
       cwd: '/test',
     });
 
-    expect(options.readOnlyPaths).toContain('/home/user');
+    expect(options.readOnlyPaths).toContain(canonicalPathForTest('/home/user'));
   });
 
   it('returns path as-is when no glob characters', () => {
@@ -703,7 +842,7 @@ describe('extractBasePath behavior', () => {
       cwd: '/test',
     });
 
-    expect(options.readOnlyPaths).toContain('/home/user/specific-file.txt');
+    expect(options.readOnlyPaths).toContain(canonicalPathForTest('/home/user/specific-file.txt'));
   });
 
   it('handles glob in middle of path', () => {
@@ -726,6 +865,6 @@ describe('extractBasePath behavior', () => {
       cwd: '/test',
     });
 
-    expect(options.readOnlyPaths).toContain('/home');
+    expect(options.readOnlyPaths).toContain(canonicalPathForTest('/home'));
   });
 });

--- a/packages/core/__tests__/sandbox/policy-mapper.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.test.ts
@@ -528,6 +528,85 @@ describe('policyToSandboxOptions', () => {
     expect(options.denyPatterns).not.toContain('/repo/dist/secret.txt');
   });
 
+  it('filters alias-spelled deny paths covered by canonical runtime grants', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const aliasRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-alias-'));
+    try {
+      const secrets = join(repoRoot, 'secrets');
+      await mkdir(secrets);
+      const target = join(secrets, '.env');
+      await writeFile(target, 'token');
+      const alias = join(aliasRoot, 'secrets-link');
+      await symlink(secrets, alias);
+      const aliasTarget = join(alias, '.env');
+      const canonicalTarget = await realpath(target);
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [], deny: [aliasTarget] },
+          write: { allow: [], deny: [] },
+        },
+      };
+      const evaluator = new PolicyEvaluator(policy, {
+        repoRoot,
+        cliGrants: { read: [canonicalTarget] },
+      });
+
+      const options = policyToSandboxOptions(evaluator, {
+        cwd: repoRoot,
+        repoRoot,
+      });
+
+      expect(options.readOnlyPaths).toContain(canonicalTarget);
+      expect(options.denyPaths).not.toContain(canonicalTarget);
+      expect(options.denyPaths).not.toContain(aliasTarget);
+      expect(options.denyPatterns).not.toContain(aliasTarget);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(aliasRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('filters alias-spelled deny glob patterns covered by canonical runtime grants', async () => {
+    const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
+    const aliasRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-alias-'));
+    try {
+      const secrets = join(repoRoot, 'secrets');
+      await mkdir(secrets);
+      const target = join(secrets, '.env');
+      await writeFile(target, 'token');
+      const alias = join(aliasRoot, 'secrets-link');
+      await symlink(secrets, alias);
+      const denyPattern = join(alias, '**');
+      const canonicalSecrets = await realpath(secrets);
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: [], deny: [denyPattern] },
+          write: { allow: [], deny: [] },
+        },
+      };
+      const evaluator = new PolicyEvaluator(policy, {
+        repoRoot,
+        cliGrants: { read: [canonicalSecrets] },
+      });
+
+      const options = policyToSandboxOptions(evaluator, {
+        cwd: repoRoot,
+        repoRoot,
+      });
+
+      expect(options.readOnlyPaths).toContain(canonicalSecrets);
+      expect(options.denyPaths).not.toContain(canonicalSecrets);
+      expect(options.denyPatterns).not.toContain(denyPattern);
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(aliasRoot, { recursive: true, force: true });
+    }
+  });
+
   it('realpath-normalizes read grants that pass through a symlink', async () => {
     const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
     const aliasRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-alias-'));

--- a/packages/core/__tests__/sandbox/policy-mapper.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.test.ts
@@ -432,6 +432,56 @@ describe('policyToSandboxOptions', () => {
     expect(options.readOnlyPaths).not.toContain('/repo/dist');
   });
 
+  it('maps allowAll to broad sandbox read and write grants', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: ['/repo/.env'] },
+        write: { allow: [], deny: ['/repo/dist/secret.txt'] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, {
+      repoRoot: '/repo',
+      allowAll: true,
+    });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.readWritePaths).toContain('/');
+    expect(options.readOnlyPaths).not.toContain('/');
+    expect(options.denyPatterns).toEqual([]);
+    expect(options.denyPaths).toEqual([]);
+  });
+
+  it('maps denyAll to empty sandbox grants', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: ['/repo/**'], deny: [] },
+        write: { allow: ['/repo/dist/**'], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, {
+      repoRoot: '/repo',
+      denyAll: true,
+    });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.readOnlyPaths).toEqual([]);
+    expect(options.readWritePaths).toEqual([]);
+    expect(options.denyPatterns).toEqual(['/**']);
+    expect(options.denyPaths).toEqual([]);
+  });
+
   it('does not emit deny paths that are covered by a higher-precedence CLI read grant', () => {
     const policy: PolicyConfig = {
       ...DEFAULT_POLICY,
@@ -603,6 +653,32 @@ describe('policyToSandboxOptions', () => {
     }
   });
 
+  it('includes metadata-read ancestors and grant roots for raw policy sandbox options', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: ['/Users/alice/project/schema.json'], deny: [] },
+        write: { allow: ['/Users/alice/project/dist/**'], deny: [] },
+      },
+    };
+
+    const options = policyConfigToSandboxOptions(policy, {
+      cwd: '/Users/alice/project',
+      repoRoot: '/Users/alice/project',
+    });
+
+    expect(options.metadataReadPaths).toEqual(
+      expect.arrayContaining([
+        '/Users',
+        '/Users/alice',
+        '/Users/alice/project',
+        '/Users/alice/project/schema.json',
+        '/Users/alice/project/dist',
+      ]),
+    );
+  });
+
   it('includes metadata-read ancestors for sandbox grant roots', () => {
     const policy: PolicyConfig = {
       ...DEFAULT_POLICY,
@@ -621,6 +697,9 @@ describe('policyToSandboxOptions', () => {
 
     expect(options.metadataReadPaths).toEqual(
       expect.arrayContaining(['/Users', '/Users/alice', '/Users/alice/project']),
+    );
+    expect(options.metadataReadPaths).toEqual(
+      expect.arrayContaining(['/Users/alice/project/schema.json', '/Users/alice/project/dist']),
     );
   });
 

--- a/packages/core/__tests__/sandbox/policy-mapper.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.test.ts
@@ -603,6 +603,27 @@ describe('policyToSandboxOptions', () => {
     }
   });
 
+  it('includes metadata-read ancestors for sandbox grant roots', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: ['/Users/alice/project/schema.json'], deny: [] },
+        write: { allow: ['/Users/alice/project/dist/**'], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, { repoRoot: '/Users/alice/project' });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/Users/alice/project',
+      repoRoot: '/Users/alice/project',
+    });
+
+    expect(options.metadataReadPaths).toEqual(
+      expect.arrayContaining(['/Users', '/Users/alice', '/Users/alice/project']),
+    );
+  });
+
   it('rejects out-of-root extra read-write paths in policyToSandboxOptions', async () => {
     const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
     const outsidePath = join(dirname(repoRoot), 'outside.txt');

--- a/packages/core/__tests__/sandbox/policy-mapper.test.ts
+++ b/packages/core/__tests__/sandbox/policy-mapper.test.ts
@@ -372,6 +372,98 @@ describe('policyToSandboxOptions', () => {
     expect(options.readOnlyPaths).toContain('/repo/granted');
   });
 
+  it('includes CLI read grants in sandbox read-only paths', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: [] },
+        write: { allow: [], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, {
+      repoRoot: '/repo',
+      cliGrants: { read: ['/repo/schema.json'] },
+    });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.readOnlyPaths).toContain('/repo/schema.json');
+    expect(options.readWritePaths).not.toContain('/repo/schema.json');
+  });
+
+  it('includes CLI write grants in sandbox read-write paths', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: [] },
+        write: { allow: [], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, {
+      repoRoot: '/repo',
+      cliGrants: { write: ['/repo/dist/**'] },
+    });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.readWritePaths).toContain('/repo/dist');
+    expect(options.readOnlyPaths).not.toContain('/repo/dist');
+  });
+
+  it('does not emit deny paths that are covered by a higher-precedence CLI read grant', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: ['/repo/.env'] },
+        write: { allow: [], deny: [] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, {
+      repoRoot: '/repo',
+      cliGrants: { read: ['/repo/.env'] },
+    });
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.readOnlyPaths).toContain('/repo/.env');
+    expect(options.denyPaths).not.toContain('/repo/.env');
+    expect(options.denyPatterns).not.toContain('/repo/.env');
+  });
+
+  it('does not emit deny paths that are covered by a higher-precedence session write grant', () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY,
+      default: {
+        ...DEFAULT_POLICY.default,
+        read: { allow: [], deny: [] },
+        write: { allow: [], deny: ['/repo/dist/secret.txt'] },
+      },
+    };
+    const evaluator = new PolicyEvaluator(policy, { repoRoot: '/repo' });
+    evaluator.addSessionGrant('write', '/repo/dist/secret.txt');
+
+    const options = policyToSandboxOptions(evaluator, {
+      cwd: '/repo',
+      repoRoot: '/repo',
+    });
+
+    expect(options.readWritePaths).toContain('/repo/dist/secret.txt');
+    expect(options.denyPaths).not.toContain('/repo/dist/secret.txt');
+    expect(options.denyPatterns).not.toContain('/repo/dist/secret.txt');
+  });
+
   it('rejects out-of-root extra read-write paths in policyToSandboxOptions', async () => {
     const repoRoot = await mkdtemp(join(process.cwd(), 'policy-mapper-'));
     const outsidePath = join(dirname(repoRoot), 'outside.txt');

--- a/packages/core/src/policy/evaluator.ts
+++ b/packages/core/src/policy/evaluator.ts
@@ -58,6 +58,19 @@ export interface PolicyEvaluatorOptions {
 }
 
 /**
+ * Permission rules used by OS sandbox generation.
+ *
+ * `allow` contains every path that should be granted to the sandbox. `deny`
+ * contains configured deny rules. `runtimeGrantAllow` contains only
+ * higher-precedence CLI/session grants, so the sandbox mapper can keep deny
+ * generation coherent with evaluator precedence.
+ */
+export interface SandboxPermissionRules extends PermissionRules {
+  /** Higher-precedence CLI/session grants that must override configured denies. */
+  runtimeGrantAllow: string[];
+}
+
+/**
  * Policy evaluator for checking permissions.
  *
  * Evaluates commands, paths, and environment variables against the policy
@@ -536,6 +549,33 @@ export class PolicyEvaluator {
     }
 
     return rules;
+  }
+
+  /**
+   * Get permission rules for OS sandbox generation.
+   *
+   * This includes static policy rules, persisted grants, CLI grants, and
+   * session grants. Runtime grants must reach the OS sandbox because command
+   * steps are child processes and file access inside them is enforced by the
+   * sandbox backend, not by per-path evaluator checks.
+   *
+   * @param type - Permission type to resolve.
+   * @returns Permission rules relevant to sandbox allow-list and deny generation.
+   */
+  getSandboxRules(type: 'read' | 'write'): SandboxPermissionRules {
+    const rules = this.getEffectiveRules(type);
+    const cliGrants = this.options.cliGrants?.[type] ?? [];
+    const sessionGrants = this.sessionGrants
+      .filter((grant) => grant.type === type)
+      .map((grant) => grant.pattern);
+
+    const runtimeGrantAllow = [...cliGrants, ...sessionGrants];
+
+    return {
+      allow: [...rules.allow, ...runtimeGrantAllow],
+      deny: rules.deny,
+      runtimeGrantAllow,
+    };
   }
 
   /**

--- a/packages/core/src/policy/evaluator.ts
+++ b/packages/core/src/policy/evaluator.ts
@@ -563,6 +563,22 @@ export class PolicyEvaluator {
    * @returns Permission rules relevant to sandbox allow-list and deny generation.
    */
   getSandboxRules(type: 'read' | 'write'): SandboxPermissionRules {
+    if (this.options.denyAll) {
+      return {
+        allow: [],
+        deny: ['/**'],
+        runtimeGrantAllow: [],
+      };
+    }
+
+    if (this.options.allowAll) {
+      return {
+        allow: ['/**'],
+        deny: [],
+        runtimeGrantAllow: ['/**'],
+      };
+    }
+
     const rules = this.getEffectiveRules(type);
     const cliGrants = this.options.cliGrants?.[type] ?? [];
     const sessionGrants = this.sessionGrants

--- a/packages/core/src/sandbox/macos.ts
+++ b/packages/core/src/sandbox/macos.ts
@@ -63,7 +63,7 @@ function getNodeExecutionPaths(): string[] {
   return paths;
 }
 
-function getPackageManagerExecutionPaths(env: Partial<Record<string, string>>): string[] {
+function getPackageManagerMetadataPaths(env: Partial<Record<string, string>>): string[] {
   const paths: string[] = [];
   const home = env.HOME ?? process.env.HOME;
   if (home) {
@@ -172,10 +172,7 @@ function generateSeatbeltProfile(options: SandboxOptions): string {
     .join('\n');
 
   // Get Node.js execution paths dynamically
-  const executionPaths = [
-    ...getNodeExecutionPaths(),
-    ...getPackageManagerExecutionPaths(options.env),
-  ];
+  const executionPaths = getNodeExecutionPaths();
 
   // Add the script directory if available (for symlinked CLI)
   const scriptDir = getScriptDirectory();
@@ -189,7 +186,12 @@ function generateSeatbeltProfile(options: SandboxOptions): string {
     .join('\n');
 
   const pathLookupDirs = getPathLookupDirectories(options.env);
-  const metadataPathCandidates = [...(options.metadataReadPaths ?? []), ...pathLookupDirs];
+  const packageManagerMetadataPaths = getPackageManagerMetadataPaths(options.env);
+  const metadataPathCandidates = [
+    ...(options.metadataReadPaths ?? []),
+    ...pathLookupDirs,
+    ...packageManagerMetadataPaths,
+  ];
   const metadataReadPaths = [
     ...metadataPathCandidates,
     ...collectAncestorPaths([...executionPaths, ...metadataPathCandidates]),

--- a/packages/core/src/sandbox/macos.ts
+++ b/packages/core/src/sandbox/macos.ts
@@ -13,6 +13,7 @@ import { writeFileSync, unlinkSync, existsSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { isError } from '../errors.js';
+import { collectAncestorPaths } from './path-utils.js';
 import type {
   SandboxOptions,
   SandboxExecutionResult,
@@ -118,19 +119,6 @@ function getScriptDirectory(): string | null {
 
   cachedScriptDir = '';
   return null;
-}
-
-function collectAncestorPaths(paths: readonly string[]): string[] {
-  const ancestors = new Set<string>(paths);
-  for (const candidate of paths) {
-    let current = dirname(candidate);
-    while (current !== dirname(current)) {
-      ancestors.add(current);
-      current = dirname(current);
-    }
-  }
-  ancestors.delete('/');
-  return [...ancestors].sort((a, b) => a.length - b.length);
 }
 
 /**

--- a/packages/core/src/sandbox/macos.ts
+++ b/packages/core/src/sandbox/macos.ts
@@ -63,6 +63,20 @@ function getNodeExecutionPaths(): string[] {
   return paths;
 }
 
+function getPackageManagerExecutionPaths(): string[] {
+  const paths: string[] = [];
+  const home = process.env.HOME;
+  if (home) {
+    paths.push(join(home, '.cache', 'node', 'corepack'));
+  }
+  return paths;
+}
+
+function getPathLookupDirectories(env: Partial<Record<string, string>>): string[] {
+  const pathValue = env.PATH ?? env.Path ?? process.env.PATH ?? process.env.Path ?? '';
+  return pathValue.split(':').filter((entry) => entry.length > 0);
+}
+
 /**
  * Cached script directory path (computed once)
  */
@@ -106,6 +120,19 @@ function getScriptDirectory(): string | null {
   return null;
 }
 
+function collectAncestorPaths(paths: readonly string[]): string[] {
+  const ancestors = new Set<string>();
+  for (const candidate of paths) {
+    let current = dirname(candidate);
+    while (current !== dirname(current)) {
+      ancestors.add(current);
+      current = dirname(current);
+    }
+  }
+  ancestors.delete('/');
+  return [...ancestors].sort((a, b) => a.length - b.length);
+}
+
 /**
  * Generate a Seatbelt profile for the given sandbox options.
  *
@@ -144,12 +171,8 @@ function generateSeatbeltProfile(options: SandboxOptions): string {
     ])
     .join('\n');
 
-  const metadataReadRules = (options.metadataReadPaths ?? [])
-    .map((p) => `  (literal "${escapePath(p)}")`)
-    .join('\n');
-
   // Get Node.js execution paths dynamically
-  const executionPaths = getNodeExecutionPaths();
+  const executionPaths = [...getNodeExecutionPaths(), ...getPackageManagerExecutionPaths()];
 
   // Add the script directory if available (for symlinked CLI)
   const scriptDir = getScriptDirectory();
@@ -160,6 +183,16 @@ function generateSeatbeltProfile(options: SandboxOptions): string {
   const nodePathRules = executionPaths
     .filter((p) => p) // Remove empty strings
     .map((p) => `  (subpath "${escapePath(p)}")`)
+    .join('\n');
+
+  const pathLookupDirs = getPathLookupDirectories(options.env);
+  const metadataReadPaths = [
+    ...(options.metadataReadPaths ?? []),
+    ...pathLookupDirs,
+    ...collectAncestorPaths([...executionPaths, ...pathLookupDirs]),
+  ];
+  const metadataReadRules = [...new Set(metadataReadPaths)]
+    .map((p) => `  (literal "${escapePath(p)}")`)
     .join('\n');
 
   // Note: Seatbelt doesn't have a direct "deny subpath" after allowing parent.
@@ -173,8 +206,7 @@ function generateSeatbeltProfile(options: SandboxOptions): string {
 (deny default)
 
 ;; Allow process execution
-(allow process-exec)
-(allow process-fork)
+(allow process*)
 
 ;; Allow basic system operations
 (allow sysctl-read)

--- a/packages/core/src/sandbox/macos.ts
+++ b/packages/core/src/sandbox/macos.ts
@@ -63,9 +63,9 @@ function getNodeExecutionPaths(): string[] {
   return paths;
 }
 
-function getPackageManagerExecutionPaths(): string[] {
+function getPackageManagerExecutionPaths(env: Partial<Record<string, string>>): string[] {
   const paths: string[] = [];
-  const home = process.env.HOME;
+  const home = env.HOME ?? process.env.HOME;
   if (home) {
     paths.push(join(home, '.cache', 'node', 'corepack'));
   }
@@ -121,7 +121,7 @@ function getScriptDirectory(): string | null {
 }
 
 function collectAncestorPaths(paths: readonly string[]): string[] {
-  const ancestors = new Set<string>();
+  const ancestors = new Set<string>(paths);
   for (const candidate of paths) {
     let current = dirname(candidate);
     while (current !== dirname(current)) {
@@ -172,7 +172,10 @@ function generateSeatbeltProfile(options: SandboxOptions): string {
     .join('\n');
 
   // Get Node.js execution paths dynamically
-  const executionPaths = [...getNodeExecutionPaths(), ...getPackageManagerExecutionPaths()];
+  const executionPaths = [
+    ...getNodeExecutionPaths(),
+    ...getPackageManagerExecutionPaths(options.env),
+  ];
 
   // Add the script directory if available (for symlinked CLI)
   const scriptDir = getScriptDirectory();
@@ -186,10 +189,10 @@ function generateSeatbeltProfile(options: SandboxOptions): string {
     .join('\n');
 
   const pathLookupDirs = getPathLookupDirectories(options.env);
+  const metadataPathCandidates = [...(options.metadataReadPaths ?? []), ...pathLookupDirs];
   const metadataReadPaths = [
-    ...(options.metadataReadPaths ?? []),
-    ...pathLookupDirs,
-    ...collectAncestorPaths([...executionPaths, ...pathLookupDirs]),
+    ...metadataPathCandidates,
+    ...collectAncestorPaths([...executionPaths, ...metadataPathCandidates]),
   ];
   const metadataReadRules = [...new Set(metadataReadPaths)]
     .map((p) => `  (literal "${escapePath(p)}")`)
@@ -206,7 +209,7 @@ function generateSeatbeltProfile(options: SandboxOptions): string {
 (deny default)
 
 ;; Allow process execution
-(allow process*)
+(allow process-exec process-fork)
 
 ;; Allow basic system operations
 (allow sysctl-read)

--- a/packages/core/src/sandbox/macos.ts
+++ b/packages/core/src/sandbox/macos.ts
@@ -144,6 +144,10 @@ function generateSeatbeltProfile(options: SandboxOptions): string {
     ])
     .join('\n');
 
+  const metadataReadRules = (options.metadataReadPaths ?? [])
+    .map((p) => `  (literal "${escapePath(p)}")`)
+    .join('\n');
+
   // Get Node.js execution paths dynamically
   const executionPaths = getNodeExecutionPaths();
 
@@ -202,6 +206,7 @@ function generateSeatbeltProfile(options: SandboxOptions): string {
 ;; but does NOT allow reading file contents (file-read-data)
 (allow file-read-metadata
   (subpath "/private/var")
+${metadataReadRules}
 )
 
 ;; Allow /dev access for stdio

--- a/packages/core/src/sandbox/path-utils.ts
+++ b/packages/core/src/sandbox/path-utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared path helpers for sandbox policy construction.
+ *
+ * @module
+ */
+
+import { dirname, sep } from 'node:path';
+
+/**
+ * Collect each path plus its non-root ancestor directories.
+ *
+ * @param paths - Concrete paths that need metadata traversal support.
+ * @returns Unique paths and ancestors ordered from shortest to longest.
+ */
+export function collectAncestorPaths(paths: readonly string[]): string[] {
+  const ancestors = new Set<string>(paths);
+  for (const candidate of paths) {
+    let current = dirname(candidate);
+    while (current !== dirname(current)) {
+      ancestors.add(current);
+      current = dirname(current);
+    }
+  }
+  ancestors.delete(sep);
+  return [...ancestors].sort((a, b) => a.length - b.length);
+}

--- a/packages/core/src/sandbox/policy-mapper.ts
+++ b/packages/core/src/sandbox/policy-mapper.ts
@@ -150,6 +150,19 @@ function normalizeSandboxPathList(paths: readonly string[]): string[] {
   return [...normalized];
 }
 
+function collectAncestorPaths(paths: readonly string[]): string[] {
+  const ancestors = new Set<string>();
+  for (const candidate of paths) {
+    let current = path.dirname(candidate);
+    while (current !== path.dirname(current)) {
+      ancestors.add(current);
+      current = path.dirname(current);
+    }
+  }
+  ancestors.delete(path.sep);
+  return [...ancestors].sort((a, b) => a.length - b.length);
+}
+
 function normalizeExtraReadWritePath(candidate: string, repoRoot: string, cwd: string): string {
   const absoluteCandidate = path.isAbsolute(candidate)
     ? candidate
@@ -386,12 +399,20 @@ export function policyToSandboxOptions(
     runtimeGrantPaths,
   );
   const effectiveDenyPaths = filterDenyPathsCoveredByRuntimeGrants(denyPaths, runtimeGrantPaths);
+  const metadataReadPaths = collectAncestorPaths([
+    repoRoot,
+    options.cwd,
+    tmpDir,
+    ...readOnlyPaths,
+    ...readWritePaths,
+  ]);
 
   return {
     cwd: options.cwd,
     repoRoot,
     readOnlyPaths,
     readWritePaths,
+    metadataReadPaths,
     denyPatterns: [...new Set(effectiveDenyPatterns)],
     denyPaths: normalizeSandboxPathList(effectiveDenyPaths),
     env: {},
@@ -441,12 +462,20 @@ export function policyConfigToSandboxOptions(
     repoRoot,
     options.cwd,
   );
+  const metadataReadPaths = collectAncestorPaths([
+    repoRoot,
+    options.cwd,
+    tmpDir,
+    ...readOnlyPaths,
+    ...readWritePaths,
+  ]);
 
   return {
     cwd: options.cwd,
     repoRoot,
     readOnlyPaths,
     readWritePaths,
+    metadataReadPaths,
     denyPatterns: [...new Set(denyPatterns)],
     denyPaths: normalizeSandboxPathList(denyPaths),
     env: {},

--- a/packages/core/src/sandbox/policy-mapper.ts
+++ b/packages/core/src/sandbox/policy-mapper.ts
@@ -129,6 +129,27 @@ function resolveCanonicalPath(value: string): string {
   }
 }
 
+function resolveCanonicalPathForGrant(value: string): string {
+  const absolute = path.resolve(value);
+  try {
+    return fs.realpathSync(absolute);
+  } catch {
+    const parent = path.dirname(absolute);
+    if (parent === absolute) {
+      return absolute;
+    }
+    return path.join(resolveCanonicalPathForGrant(parent), path.basename(absolute));
+  }
+}
+
+function normalizeSandboxPathList(paths: readonly string[]): string[] {
+  const normalized = new Set<string>();
+  for (const candidate of paths) {
+    normalized.add(resolveCanonicalPathForGrant(candidate));
+  }
+  return [...normalized];
+}
+
 function normalizeExtraReadWritePath(candidate: string, repoRoot: string, cwd: string): string {
   const absoluteCandidate = path.isAbsolute(candidate)
     ? candidate
@@ -327,8 +348,12 @@ export function policyToSandboxOptions(
   const writeRules = evaluator.getSandboxRules('write');
 
   // Resolve read-only paths (from read.allow minus write.allow)
-  const readAllowPaths = resolvePathPatterns(readRules.allow, repoRoot, tmpDir);
-  const writeAllowPaths = resolvePathPatterns(writeRules.allow, repoRoot, tmpDir);
+  const readAllowPaths = normalizeSandboxPathList(
+    resolvePathPatterns(readRules.allow, repoRoot, tmpDir),
+  );
+  const writeAllowPaths = normalizeSandboxPathList(
+    resolvePathPatterns(writeRules.allow, repoRoot, tmpDir),
+  );
   const extraReadWritePaths = normalizeExtraReadWritePaths(
     options.extraReadWritePaths,
     repoRoot,
@@ -349,10 +374,12 @@ export function policyToSandboxOptions(
     repoRoot,
     options.cwd,
   );
-  const runtimeGrantPaths = resolvePathPatterns(
-    [...readRules.runtimeGrantAllow, ...writeRules.runtimeGrantAllow],
-    repoRoot,
-    tmpDir,
+  const runtimeGrantPaths = normalizeSandboxPathList(
+    resolvePathPatterns(
+      [...readRules.runtimeGrantAllow, ...writeRules.runtimeGrantAllow],
+      repoRoot,
+      tmpDir,
+    ),
   );
   const effectiveDenyPatterns = filterDenyPatternsCoveredByRuntimeGrants(
     denyPatterns,
@@ -366,7 +393,7 @@ export function policyToSandboxOptions(
     readOnlyPaths,
     readWritePaths,
     denyPatterns: [...new Set(effectiveDenyPatterns)],
-    denyPaths: [...new Set(effectiveDenyPaths)],
+    denyPaths: normalizeSandboxPathList(effectiveDenyPaths),
     env: {},
     allowUnsandboxed: options.allowUnsandboxed,
   };
@@ -388,8 +415,12 @@ export function policyConfigToSandboxOptions(
   const repoRoot = options.repoRoot ?? options.cwd;
   const tmpDir = options.tmpDir ?? os.tmpdir();
 
-  const readAllowPaths = resolvePathPatterns(policy.default.read.allow, repoRoot, tmpDir);
-  const writeAllowPaths = resolvePathPatterns(policy.default.write.allow, repoRoot, tmpDir);
+  const readAllowPaths = normalizeSandboxPathList(
+    resolvePathPatterns(policy.default.read.allow, repoRoot, tmpDir),
+  );
+  const writeAllowPaths = normalizeSandboxPathList(
+    resolvePathPatterns(policy.default.write.allow, repoRoot, tmpDir),
+  );
   const extraReadWritePaths = normalizeExtraReadWritePaths(
     options.extraReadWritePaths,
     repoRoot,
@@ -417,7 +448,7 @@ export function policyConfigToSandboxOptions(
     readOnlyPaths,
     readWritePaths,
     denyPatterns: [...new Set(denyPatterns)],
-    denyPaths: [...new Set(denyPaths)],
+    denyPaths: normalizeSandboxPathList(denyPaths),
     env: {},
     allowUnsandboxed: options.allowUnsandboxed,
   };

--- a/packages/core/src/sandbox/policy-mapper.ts
+++ b/packages/core/src/sandbox/policy-mapper.ts
@@ -151,7 +151,7 @@ function normalizeSandboxPathList(paths: readonly string[]): string[] {
 }
 
 function collectAncestorPaths(paths: readonly string[]): string[] {
-  const ancestors = new Set<string>();
+  const ancestors = new Set<string>(paths);
   for (const candidate of paths) {
     let current = path.dirname(candidate);
     while (current !== path.dirname(current)) {

--- a/packages/core/src/sandbox/policy-mapper.ts
+++ b/packages/core/src/sandbox/policy-mapper.ts
@@ -15,6 +15,7 @@ import type { PolicyEvaluator } from '../policy/evaluator.js';
 import type { PolicyConfig } from '../policy/schema.js';
 import type { SandboxOptions } from './types.js';
 import { logger } from '../logger.js';
+import { collectAncestorPaths } from './path-utils.js';
 
 /**
  * Options for creating sandbox options from policy.
@@ -148,19 +149,6 @@ function normalizeSandboxPathList(paths: readonly string[]): string[] {
     normalized.add(resolveCanonicalPathForGrant(candidate));
   }
   return [...normalized];
-}
-
-function collectAncestorPaths(paths: readonly string[]): string[] {
-  const ancestors = new Set<string>(paths);
-  for (const candidate of paths) {
-    let current = path.dirname(candidate);
-    while (current !== path.dirname(current)) {
-      ancestors.add(current);
-      current = path.dirname(current);
-    }
-  }
-  ancestors.delete(path.sep);
-  return [...ancestors].sort((a, b) => a.length - b.length);
 }
 
 function normalizeExtraReadWritePath(candidate: string, repoRoot: string, cwd: string): string {

--- a/packages/core/src/sandbox/policy-mapper.ts
+++ b/packages/core/src/sandbox/policy-mapper.ts
@@ -186,6 +186,27 @@ function buildSandboxPathSets(
   };
 }
 
+function filterDenyPathsCoveredByRuntimeGrants(
+  denyPaths: readonly string[],
+  runtimeGrantPaths: readonly string[],
+): string[] {
+  return denyPaths.filter((denyPath) => {
+    return !runtimeGrantPaths.some((grantPath) => isWithinRoot(denyPath, grantPath));
+  });
+}
+
+function filterDenyPatternsCoveredByRuntimeGrants(
+  denyPatterns: readonly string[],
+  runtimeGrantPaths: readonly string[],
+): string[] {
+  return denyPatterns.filter((denyPattern) => {
+    if (hasGlob(denyPattern)) {
+      return true;
+    }
+    return !runtimeGrantPaths.some((grantPath) => isWithinRoot(denyPattern, grantPath));
+  });
+}
+
 function selectExpansionRoots(roots: string[], repoRoot: string, cwd: string): string[] {
   return [...new Set(roots)].filter((root) => {
     return isWithinRoot(root, repoRoot) || isWithinRoot(root, cwd);
@@ -302,8 +323,8 @@ export function policyToSandboxOptions(
   const repoRoot = options.repoRoot ?? options.cwd;
   const tmpDir = options.tmpDir ?? os.tmpdir();
 
-  const readRules = evaluator.getEffectiveRules('read');
-  const writeRules = evaluator.getEffectiveRules('write');
+  const readRules = evaluator.getSandboxRules('read');
+  const writeRules = evaluator.getSandboxRules('write');
 
   // Resolve read-only paths (from read.allow minus write.allow)
   const readAllowPaths = resolvePathPatterns(readRules.allow, repoRoot, tmpDir);
@@ -328,14 +349,24 @@ export function policyToSandboxOptions(
     repoRoot,
     options.cwd,
   );
+  const runtimeGrantPaths = resolvePathPatterns(
+    [...readRules.runtimeGrantAllow, ...writeRules.runtimeGrantAllow],
+    repoRoot,
+    tmpDir,
+  );
+  const effectiveDenyPatterns = filterDenyPatternsCoveredByRuntimeGrants(
+    denyPatterns,
+    runtimeGrantPaths,
+  );
+  const effectiveDenyPaths = filterDenyPathsCoveredByRuntimeGrants(denyPaths, runtimeGrantPaths);
 
   return {
     cwd: options.cwd,
     repoRoot,
     readOnlyPaths,
     readWritePaths,
-    denyPatterns: [...new Set(denyPatterns)],
-    denyPaths: [...new Set(denyPaths)],
+    denyPatterns: [...new Set(effectiveDenyPatterns)],
+    denyPaths: [...new Set(effectiveDenyPaths)],
     env: {},
     allowUnsandboxed: options.allowUnsandboxed,
   };

--- a/packages/core/src/sandbox/policy-mapper.ts
+++ b/packages/core/src/sandbox/policy-mapper.ts
@@ -234,11 +234,30 @@ function filterDenyPatternsCoveredByRuntimeGrants(
   runtimeGrantPaths: readonly string[],
 ): string[] {
   return denyPatterns.filter((denyPattern) => {
-    if (hasGlob(denyPattern)) {
+    const comparisonPath = canonicalComparisonPathForDenyPattern(denyPattern);
+    if (comparisonPath === undefined) {
       return true;
     }
-    return !runtimeGrantPaths.some((grantPath) => isWithinRoot(denyPattern, grantPath));
+    return !runtimeGrantPaths.some((grantPath) => isWithinRoot(comparisonPath, grantPath));
   });
+}
+
+function canonicalComparisonPathForDenyPattern(denyPattern: string): string | undefined {
+  if (!hasGlob(denyPattern)) {
+    return resolveCanonicalPathForGrant(denyPattern);
+  }
+
+  const basePath = extractBasePath(denyPattern);
+  if (
+    basePath === '.' ||
+    basePath === path.sep ||
+    basePath.includes('*') ||
+    basePath.includes('?')
+  ) {
+    return undefined;
+  }
+
+  return resolveCanonicalPathForGrant(basePath);
 }
 
 function selectExpansionRoots(roots: string[], repoRoot: string, cwd: string): string[] {
@@ -394,11 +413,15 @@ export function policyToSandboxOptions(
       tmpDir,
     ),
   );
+  const canonicalDenyPaths = normalizeSandboxPathList(denyPaths);
   const effectiveDenyPatterns = filterDenyPatternsCoveredByRuntimeGrants(
     denyPatterns,
     runtimeGrantPaths,
   );
-  const effectiveDenyPaths = filterDenyPathsCoveredByRuntimeGrants(denyPaths, runtimeGrantPaths);
+  const effectiveDenyPaths = filterDenyPathsCoveredByRuntimeGrants(
+    canonicalDenyPaths,
+    runtimeGrantPaths,
+  );
   const metadataReadPaths = collectAncestorPaths([
     repoRoot,
     options.cwd,
@@ -414,7 +437,7 @@ export function policyToSandboxOptions(
     readWritePaths,
     metadataReadPaths,
     denyPatterns: [...new Set(effectiveDenyPatterns)],
-    denyPaths: normalizeSandboxPathList(effectiveDenyPaths),
+    denyPaths: effectiveDenyPaths,
     env: {},
     allowUnsandboxed: options.allowUnsandboxed,
   };

--- a/packages/core/src/sandbox/types.ts
+++ b/packages/core/src/sandbox/types.ts
@@ -24,6 +24,16 @@ export interface SandboxOptions {
   /** Paths that should be writable (read-write access) */
   readWritePaths: string[];
 
+  /**
+   * Paths that should allow metadata-only reads such as stat/lstat traversal.
+   *
+   * Seatbelt needs this for ancestor directories (for example `/Users` and
+   * `/Users/name`) so runtimes can resolve allowed descendants without gaining
+   * permission to read ancestor file contents. Backends that cannot express
+   * metadata-only rights ignore this field.
+   */
+  metadataReadPaths?: string[];
+
   /** Paths that should be explicitly denied (overrides allow) */
   denyPaths: string[];
 


### PR DESCRIPTION
# Summary
- align sandbox rule generation with global allow-all and deny-all policy overrides
- include metadata grant roots as well as ancestors in sandbox metadata reads
- tighten macOS Seatbelt profile generation and add regression coverage for grant enforcement

Fixes #549
Fixes #550
Fixes #552

## Testing

- [ ] `pnpm run verify`

Targeted tests or checks:

- [x] `pnpm --filter @rundown-org/core test:unit -- --runTestsByPath packages/core/__tests__/sandbox/policy-mapper.test.ts packages/core/__tests__/sandbox/macos.test.ts packages/core/__tests__/sandbox/linux-spec-builder.test.ts packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts`
- [x] `pnpm --filter @rundown-org/core test:property`
- [x] `pnpm --filter @rundown-org/core check:types`
- [x] `pnpm run check:format`

## Review Notes

Check all that apply:

- [ ] Public CLI behavior changed; docs and JSON schema output were checked.
- [ ] Runbook syntax or parser behavior changed; `docs/spec/language.md`,
      `docs/spec/grammar.md`, and runbook fixtures were checked.
- [ ] Persisted runbook state changed; stale-state handling follows the
      no-migration rule.
- [x] Security policy, sandbox, path resolution, or command execution changed;
      traversal, symlink escape, deny precedence, env leakage, and fail-closed
      behavior were checked.
- [ ] GitHub Actions changed; actions remain SHA-pinned with version comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox permissions now flow more consistently into OS-level enforcement, improving support for allowed file reads and writes in sandboxed commands.
  * Added broader metadata-only path handling so tools can traverse parent directories without exposing their contents.

* **Bug Fixes**
  * Improved path handling to use canonical locations, reducing mismatches with symlinks and macOS temporary directories.
  * Tightened sandbox behavior on macOS and Linux so denied access is enforced more reliably while keeping permitted paths working.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->