### PR TITLE
[codex] fix delegated command stop recovery semantics

### DIFF
--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -205,6 +205,21 @@ The leaf also invokes `commandExecActor` directly to execute the step's command;
 that actor's completion produces the `COMMAND_RESULT` event the capture flow
 consumes (see [§ CLI ↔ Core Event Boundary](#cli--core-event-boundary)).
 
+### Delegated Command Infrastructure Terminals
+
+Command execution is a machine-owned Category C side effect. The command actor
+can produce authored runbook outcomes (`pass` and `fail`) or command
+infrastructure terminal reasons such as `POLICY_DENIED` and
+`COMMAND_EXECUTION_FAILED`. Delegation propagation projects terminal children
+through `projectDelegationTerminalOutcome`; it must not infer delegated `fail`
+from `lifecycle: stopped` alone.
+
+Policy denial and command execution failure leave the linked child terminal for
+operator recovery. A retry over that terminal linked child supersedes stale
+delegation outcomes and removes the stale claim record without deleting the
+child state file. `abort --force` can also cancel the resolved linked delegation
+without recording a fresh delegated fail.
+
 On `COMMAND_RESULT` the leaf transitions to its relative child
 (`target: '.__capture'`). `__capture` invokes `outputCaptureActor`; its `input`
 carries `{ channels, result }` read from the entering event. The actor reads

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -740,7 +740,7 @@ Two companion CLIs ship alongside `rundown`:
 | `rundown delegate --step <id>`                             | Infer child runbook from the DELEGATE substep's `runbooks:` field                 |
 | `rundown delegate <runbook> --step <id>`                   | Delegate substep to an explicit child runbook                                     |
 | `rundown delegate <runbook> --step <id> --input key=value` | Delegate with variables (`--input`/`--input-json`/`--input-file`, all repeatable) |
-| `rundown delegate --retry <token>`                         | Retry a delegation: cancel and re-issue with a fresh token                        |
+| `rundown delegate --retry <token>`                         | Retry a delegation: supersede and re-issue with a fresh token                     |
 | `rundown delegate --retry --step <id>`                     | Retry the delegation on a substep                                                 |
 | `rundown delegate --retry --step <id> --index <n>`         | Retry a delegation within a FOR iteration                                         |
 | `rundown delegate --retry`                                 | Retry the delegation inferred from the active substep                             |
@@ -764,7 +764,7 @@ Two companion CLIs ship alongside `rundown`:
 | `rundown complete --run <rd_…>`                            | Orchestrator lane: complete the run you control                                   |
 | `rundown stop --run <rd_…>`                                | Orchestrator lane: stop the run you control                                       |
 | `rundown abort <token>`                                    | Cancel a delegation token                                                         |
-| `rundown abort <token> --force`                            | Cancel a claimed delegation                                                       |
+| `rundown abort <token> --force`                            | Cancel or clean up a claimed delegation                                           |
 
 Delegation semantics:
 
@@ -789,13 +789,17 @@ Delegation semantics:
   without minting or exposing a token.
 - Targeting a substep whose delegation is **claimed** by a live child fails with
   RD-811 (`DELEGATION_ALREADY_CLAIMED`) — a fresh mint would orphan the running
-  child. Recover explicitly with `rd abort <token> --force` then re-delegate, or
-  `rd delegate --retry`.
-- `delegate --retry` cancels an existing delegation and re-issues it with a
-  fresh token. The target is resolved from a token positional, from `--step`
-  (optionally with `--index` for a FOR iteration), or inferred from the active
-  substep. `--input`/`--input-json`/`--input-file` supply variable overrides on
-  the re-issued delegation.
+  child. Recover explicitly with `rundown abort <token> --force` then
+  re-delegate, or `rundown delegate --retry`.
+- `rundown delegate --retry <token>` refuses a live claimed child, but can
+  supersede a terminal linked child and mint a fresh token. The target is
+  resolved from a token positional, from `--step` (optionally with `--index` for
+  a FOR iteration), or inferred from the active substep.
+  `--input`/`--input-json`/`--input-file` supply variable overrides on the
+  re-issued delegation.
+- `rundown abort <token> --force` cancels an active claimed child as fail. When
+  the linked child is already terminal or already reported, it performs cleanup
+  without recording a duplicate fail.
 - `claim` uses the delegation token (printed by `delegate`) to launch the child
   runbook and returns a stable `claim_id`.
 - Child runbook uses `rundown pass --claim-id <claim_id>` /

--- a/packages/cli/__tests__/commands/abort.test.ts
+++ b/packages/cli/__tests__/commands/abort.test.ts
@@ -556,6 +556,35 @@ describe('abort command - unit tests', () => {
       expect(result.stdout).not.toContain('FAILED     step 1');
     });
 
+    it('preserves JSON envelope when force-aborting an already reported linked child', async () => {
+      const token = await setupDelegation();
+
+      const claim = await runCliInProcess(`claim ${token}`, workspace);
+      expect(claim.exitCode).toBe(0);
+      const claimOutput = findActionOutput(claim.stdout);
+      expect(typeof claimOutput?.claim_id).toBe('string');
+      expect(typeof claimOutput?.run_id).toBe('string');
+      const childRunId = String(claimOutput!.run_id);
+
+      const failed = await runCliInProcess(
+        `fail --claim-id ${String(claimOutput!.claim_id)}`,
+        workspace,
+      );
+      expect(failed.exitCode).toBe(1);
+
+      const result = await runCliInProcess(`abort ${token} --force`, workspace);
+      expect(result.exitCode).toBe(0);
+      const output = findActionOutput(result.stdout);
+      expect(output).toEqual(
+        expect.objectContaining({
+          action: 'abort',
+          status: 'cancelled',
+          force: true,
+          childRunId,
+        }),
+      );
+    });
+
     it('abort preserves parent runbook state', async () => {
       const token = await setupDelegation();
 

--- a/packages/cli/__tests__/commands/abort.test.ts
+++ b/packages/cli/__tests__/commands/abort.test.ts
@@ -536,6 +536,26 @@ describe('abort command - unit tests', () => {
       expect(result.exitCode).toBe(0);
     });
 
+    it('renders cleanup-only text when force-aborting an already reported linked child', async () => {
+      const token = await setupDelegation();
+
+      const claim = await runCliInProcess(`claim ${token}`, workspace);
+      expect(claim.exitCode).toBe(0);
+      const claimOutput = findActionOutput(claim.stdout);
+      expect(typeof claimOutput?.claim_id).toBe('string');
+
+      const failed = await runCliInProcess(
+        `fail --claim-id ${String(claimOutput!.claim_id)}`,
+        workspace,
+      );
+      expect(failed.exitCode).toBe(1);
+
+      const result = await runCliInProcess(`abort ${token} --force --text`, workspace);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('CANCELLED');
+      expect(result.stdout).not.toContain('FAILED     step 1');
+    });
+
     it('abort preserves parent runbook state', async () => {
       const token = await setupDelegation();
 

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -20,6 +20,7 @@ import type {
   SessionService as SessionServiceType,
   ExecutionLifecycleService as ExecutionLifecycleServiceType,
   DelegationLock as DelegationLockType,
+  DelegationTerminalProjection,
 } from '@rundown-org/core';
 import type { OutputEmitter } from '../../src/services/output-emitter.js';
 
@@ -43,11 +44,12 @@ function upsertSubstepStateForTest(
 }
 
 const mockCreateCliRunbookActorService = mockFn<() => RunbookActorServiceType>();
-const mockProjectDelegationTerminalOutcome = jest.fn(
-  (_childState: RunbookState, explicitResult?: 'pass' | 'fail') =>
-    explicitResult === undefined
-      ? { kind: 'not_terminal' as const }
-      : { kind: 'outcome' as const, result: explicitResult },
+const mockProjectDelegationTerminalOutcome = jest.fn<
+  (childState: RunbookState, explicitResult?: 'pass' | 'fail') => DelegationTerminalProjection
+>((_childState: RunbookState, explicitResult?: 'pass' | 'fail') =>
+  explicitResult === undefined
+    ? { kind: 'not_terminal' as const }
+    : { kind: 'outcome' as const, result: explicitResult },
 );
 
 // Mock @rundown-org/core. The report-only helper (Plan 5) constructs only

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -707,6 +707,52 @@ describe('advanceParentForInlineChild', () => {
     expect(result).toBe('stopped');
   });
 
+  it('uses terminal parent projection after loop stop instead of forcing fail', async () => {
+    const childState = makeState(CHILD_RUN_ID, {
+      lifecycle: 'completed',
+      parentLinkage: makeInlineLinkage(),
+    });
+    const terminalParent = makeState(PARENT_RUN_ID, {
+      lifecycle: 'stopped',
+      parentLinkage: makeDelegationLinkage({ parentRunId: GRANDPARENT_RUN_ID }),
+      lastAction: {
+        type: 'POLICY_DENIED',
+        origin: 'direct',
+        message: 'blocked by policy',
+      },
+    });
+    const manager = makeManager(new Map([[PARENT_RUN_ID, terminalParent]]));
+    const output = makeOutput();
+    const recordChildCompletion = wireMocks(manager, makeLifecycleService());
+
+    jest.mocked(drainResolvedCompletions).mockResolvedValue({
+      unresolved: 0,
+      status: 'continue',
+      applied: 1,
+      state: terminalParent,
+    });
+    jest.mocked(runExecutionLoop).mockResolvedValue('stopped');
+    mockProjectDelegationTerminalOutcome.mockReturnValueOnce({
+      kind: 'outcome',
+      result: 'pass',
+    });
+    mockProjectDelegationTerminalOutcome.mockReturnValueOnce({
+      kind: 'command_infrastructure',
+      reason: 'policy_denied',
+      message: 'blocked by policy',
+    });
+
+    const result = await advanceParentForInlineChild(childState, 'pass', '/test', output);
+
+    expect(result).toBe('blocked');
+    const lastProjectionCall = mockProjectDelegationTerminalOutcome.mock.calls.at(-1);
+    expect(lastProjectionCall).toEqual([terminalParent, undefined]);
+    expect(recordChildCompletion).not.toHaveBeenCalledWith({
+      childState: terminalParent,
+      result: 'fail',
+    });
+  });
+
   it('returns handled when the post-apply execution loop completes normally', async () => {
     const childState = makeState(CHILD_RUN_ID, {
       lifecycle: 'completed',

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -43,6 +43,12 @@ function upsertSubstepStateForTest(
 }
 
 const mockCreateCliRunbookActorService = mockFn<() => RunbookActorServiceType>();
+const mockProjectDelegationTerminalOutcome = jest.fn(
+  (_childState: RunbookState, explicitResult?: 'pass' | 'fail') =>
+    explicitResult === undefined
+      ? { kind: 'not_terminal' as const }
+      : { kind: 'outcome' as const, result: explicitResult },
+);
 
 // Mock @rundown-org/core. The report-only helper (Plan 5) constructs only
 // RunbookStateManager, ExecutionLifecycleService, and RunbookCompletionService;
@@ -57,6 +63,7 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   RunbookCollectionService: jest.fn(),
   SessionService: jest.fn(),
   ExecutionLifecycleService: jest.fn(),
+  projectDelegationTerminalOutcome: mockProjectDelegationTerminalOutcome,
   // advanceParentForInlineChild lazily constructs a bridged emitter; a no-op
   // stub satisfies the link check (these tests assert on drain/loop branches).
   ExecutionEventEmitter: jest.fn().mockImplementation(() => ({ subscribe: jest.fn() })),
@@ -298,7 +305,8 @@ function wireMocks(
       | 'recorded'
       | 'duplicate'
       | 'not-applicable'
-      | 'cancelled';
+      | 'cancelled'
+      | 'blocked';
   } = {},
 ): RecordChildCompletionMock {
   const MockManagerClass = core.RunbookStateManager as unknown as jest.Mock<
@@ -337,6 +345,12 @@ function wireMocks(
 
 beforeEach(() => {
   jest.resetAllMocks();
+  mockProjectDelegationTerminalOutcome.mockImplementation(
+    (_childState: RunbookState, explicitResult?: 'pass' | 'fail') =>
+      explicitResult === undefined
+        ? { kind: 'not_terminal' as const }
+        : { kind: 'outcome' as const, result: explicitResult },
+  );
   mockCreateCliRunbookActorService.mockImplementation(() => makeActorDouble());
   jest.mocked(drainResolvedCompletions).mockResolvedValue({
     unresolved: 0,
@@ -392,6 +406,79 @@ describe('reportTerminalToDelegatingRun', () => {
     const freshParent = await manager.load(PARENT_RUN_ID);
     expect(freshParent?.step).toBe('1');
     expect(output.flush).toHaveBeenCalled();
+  });
+
+  it('blocks report-only propagation for policy-denied child terminals', async () => {
+    const childState = makeState(CHILD_RUN_ID, {
+      lifecycle: 'stopped',
+      parentLinkage: makeDelegationLinkage(),
+      lastAction: {
+        type: 'POLICY_DENIED',
+        origin: 'direct',
+        message: 'blocked by policy',
+      },
+    });
+    const manager = makeManager(new Map());
+    const output = makeOutput();
+    const recordChildCompletion = wireMocks(manager, makeLifecycleService());
+    mockProjectDelegationTerminalOutcome.mockReturnValueOnce({
+      kind: 'command_infrastructure',
+      reason: 'policy_denied',
+      message: 'blocked by policy',
+    });
+
+    const result = await reportTerminalToDelegatingRun(childState, undefined, '/test', output);
+
+    expect(result).toBe('blocked');
+    expect(recordChildCompletion).not.toHaveBeenCalled();
+    expect(output.flush).toHaveBeenCalled();
+  });
+
+  it('blocks report-only propagation for command execution failures', async () => {
+    const childState = makeState(CHILD_RUN_ID, {
+      lifecycle: 'stopped',
+      parentLinkage: makeDelegationLinkage(),
+      lastAction: {
+        type: 'COMMAND_EXECUTION_FAILED',
+        origin: 'direct',
+        message: 'Timeout of 30000 ms exceeded',
+      },
+    });
+    const manager = makeManager(new Map());
+    const output = makeOutput();
+    const recordChildCompletion = wireMocks(manager, makeLifecycleService());
+    mockProjectDelegationTerminalOutcome.mockReturnValueOnce({
+      kind: 'command_infrastructure',
+      reason: 'command_execution_failed',
+      message: 'Timeout of 30000 ms exceeded',
+    });
+
+    const result = await reportTerminalToDelegatingRun(childState, undefined, '/test', output);
+
+    expect(result).toBe('blocked');
+    expect(recordChildCompletion).not.toHaveBeenCalled();
+    expect(output.flush).toHaveBeenCalled();
+  });
+
+  it('still records explicit fail when the caller supplies fail', async () => {
+    const childState = makeState(CHILD_RUN_ID, {
+      lifecycle: 'stopped',
+      parentLinkage: makeDelegationLinkage(),
+      lastAction: {
+        type: 'POLICY_DENIED',
+        origin: 'direct',
+        message: 'blocked by policy',
+      },
+    });
+    const manager = makeManager(new Map());
+    const output = makeOutput();
+    const recordChildCompletion = wireMocks(manager, makeLifecycleService());
+    mockProjectDelegationTerminalOutcome.mockReturnValueOnce({ kind: 'outcome', result: 'fail' });
+
+    const result = await reportTerminalToDelegatingRun(childState, 'fail', '/test', output);
+
+    expect(result).toBe('reported');
+    expect(recordChildCompletion).toHaveBeenCalledWith({ childState, result: 'fail' });
   });
 
   it('returns not-applicable when the child has no parent linkage', async () => {

--- a/packages/cli/__tests__/integration/delegate-workflow.test.ts
+++ b/packages/cli/__tests__/integration/delegate-workflow.test.ts
@@ -1521,10 +1521,9 @@ describe('DELEGATE re-entry and retry', () => {
     await workspace.cleanup();
     workspace = await createTestWorkspace();
 
-    // State 3: PASSED but still linked. Claim ss1 + pass. The propagated
-    // result is present, but childRunId remains linked until collection/abort
-    // clears the ownership path, so retry must refuse rather than discard the
-    // recorded result.
+    // State 3: PASSED but still linked. Claim ss1 + pass. The child is terminal,
+    // so retry supersedes the stale outcome and mints a fresh token without
+    // deleting the child diagnostic state.
     {
       const { parentRunId, token1 } = await setupRetryParent();
       let r = await runCliInProcess(`claim ${token1}`, workspace);
@@ -1550,10 +1549,10 @@ describe('DELEGATE re-entry and retry', () => {
         await withRunTarget(['delegate', '--retry', token1], workspace),
         workspace,
       );
-      expect(retry.exitCode).not.toBe(0);
-      const out = parseCliJsonObject(retry.stdout || retry.stderr);
-      expect(out).toEqual(expect.objectContaining({ kind: 'error', code: 'RD-823' }));
-      expect(JSON.stringify(out)).toContain(String(childRunId));
+      expect(retry.exitCode).toBe(0);
+      const out = parseCliJsonObject(retry.stdout);
+      expect(out).toEqual(expect.objectContaining({ kind: 'delegate', action: 'retried' }));
+      expect(String(out.token)).toMatch(/^rdtk_/);
 
       const postState = await readRunbookState(workspace, parentRunId);
       const postSubsteps = postState?.substepStates as Array<Record<string, unknown>> | undefined;
@@ -1561,8 +1560,8 @@ describe('DELEGATE re-entry and retry', () => {
         string,
         unknown
       >;
-      expect(postDel.tokenHash).toBe(priorHash);
-      expect(postDel.childRunId).toBe(childRunId);
+      expect(postDel.tokenHash).not.toBe(priorHash);
+      expect(postDel.childRunId).toBeNull();
     }
   }, 60_000);
 

--- a/packages/cli/__tests__/integration/delegation-abort.test.ts
+++ b/packages/cli/__tests__/integration/delegation-abort.test.ts
@@ -188,6 +188,35 @@ describe('Delegation abort integration', () => {
     expect(`${blocked.stdout}${blocked.stderr}`).toContain('DELEGATION_COLLECTION_PENDING');
   });
 
+  it('force-aborts a resolved failed linked child without RD-812', async () => {
+    const token = await setupDelegation();
+    const parentId = (await getActiveState(workspace))!.id;
+
+    const claim = runCli(`claim ${token}`, workspace);
+    expect(claim.exitCode).toBe(0);
+    const claimPayload = parseConcatenatedJson(claim.stdout).find(
+      (value): value is Record<string, unknown> =>
+        typeof value === 'object' && value !== null && 'claim_id' in value,
+    );
+    expect(claimPayload).toBeDefined();
+    const claimId = String(claimPayload.claim_id);
+
+    const failed = runCli(`fail --claim-id ${claimId}`, workspace);
+    expect(failed.exitCode).toBe(1);
+
+    const result = runCli(`abort ${token} --force`, workspace);
+    expect(result.exitCode).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).not.toContain('RD-812');
+
+    const parent = await readRunbookState(workspace, parentId);
+    const rows = Object.values(parent!.resolvedCompletions ?? {}).filter(
+      (row) => row.agentId === 'delegation',
+    );
+    expect(rows).toHaveLength(0);
+    const entry = parent!.substepStates?.find((state) => state.id === '1');
+    expect(entry?.delegation?.cancelledAt).not.toBeNull();
+  });
+
   it('force abort inside a FOR iteration leaves that iteration frame collection pending', async () => {
     await writeChildRunbook();
     // A FOR step that fans out a single delegated substep per iteration. The

--- a/packages/cli/__tests__/integration/delegation-abort.test.ts
+++ b/packages/cli/__tests__/integration/delegation-abort.test.ts
@@ -198,7 +198,9 @@ describe('Delegation abort integration', () => {
       (value): value is Record<string, unknown> =>
         typeof value === 'object' && value !== null && 'claim_id' in value,
     );
-    expect(claimPayload).toBeDefined();
+    if (claimPayload === undefined) {
+      throw new Error('expected claim payload');
+    }
     const claimId = String(claimPayload.claim_id);
 
     const failed = runCli(`fail --claim-id ${claimId}`, workspace);

--- a/packages/cli/__tests__/integration/recovery-semantics.test.ts
+++ b/packages/cli/__tests__/integration/recovery-semantics.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  createRunbook,
+  createTestWorkspace,
+  findActionOutput,
+  getActiveState,
+  parseCliJsonObject,
+  readRunbookState,
+  runCli,
+  runCliInProcess,
+  type TestWorkspace,
+  withRunTarget,
+} from '../helpers/test-utils.js';
+
+describe('recovery semantics for delegated command infrastructure stops', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  async function writePolicyDeniedParentAndChild(): Promise<void> {
+    await writeFile(
+      join(workspace.cwd, 'parent.runbook.md'),
+      createRunbook({
+        title: 'Parent',
+        steps: [
+          {
+            title: 'Delegate work',
+            pass: 'CONTINUE',
+            fail: 'STOP',
+            substeps: [
+              {
+                title: 'Child',
+                delegate: true,
+                runbooks: ['child.runbook.md'],
+                content: 'Child should be recoverable.',
+              },
+            ],
+          },
+          { title: 'Done', pass: 'COMPLETE', content: 'Done.' },
+        ],
+      }),
+    );
+    const child = [
+      '# Child',
+      '',
+      '## 1. Denied command',
+      '',
+      '- PASS COMPLETE',
+      '- FAIL STOP',
+      '',
+      '```bash',
+      'node -e "console.log(42)"',
+      '```',
+      '',
+    ].join('\n');
+    await writeFile(join(workspace.cwd, 'child.runbook.md'), child);
+    await writeFile(join(workspace.runbooksDir(), 'child.runbook.md'), child);
+  }
+
+  it('does not report delegated fail when a child command is policy denied', async () => {
+    await writePolicyDeniedParentAndChild();
+
+    const start = runCli('run parent.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+    const parentId = (await getActiveState(workspace))!.id;
+    const token = (await getActiveState(workspace))!.substepStates?.[0]?.delegation?.token;
+    expect(token).toMatch(/^rdtk_/);
+
+    const claim = await runCliInProcess(['claim', String(token), '--deny-all'], workspace);
+    expect(claim.exitCode).toBe(1);
+    const claimPayload = findActionOutput(claim.stdout);
+    const claimId = String(claimPayload!.claim_id);
+    const childRunId = String(claimPayload!.run_id);
+    expect(claimId).toMatch(/^rdclm_/);
+
+    const child = await readRunbookState(workspace, childRunId);
+    expect(child?.lifecycle).toBe('stopped');
+    expect(child?.lastAction).toEqual(expect.objectContaining({ type: 'POLICY_DENIED' }));
+
+    const parent = await readRunbookState(workspace, parentId);
+    const rows = Object.values(parent!.resolvedCompletions ?? {}).filter(
+      (row) => row.agentId === 'delegation',
+    );
+    expect(rows).toHaveLength(0);
+    const entry = parent!.substepStates?.find((state) => state.id === '1');
+    expect(entry?.delegation?.childRunId).toBe(childRunId);
+    expect(entry?.result).toBeUndefined();
+  });
+
+  it('retries after policy-denied child terminal without full parent restart', async () => {
+    await writePolicyDeniedParentAndChild();
+
+    const start = runCli('run parent.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+    const parentId = (await getActiveState(workspace))!.id;
+    const token = String((await getActiveState(workspace))!.substepStates?.[0]?.delegation?.token);
+
+    const claim = await runCliInProcess(['claim', token, '--deny-all'], workspace);
+    const claimPayload = findActionOutput(claim.stdout)!;
+    expect(String(claimPayload.claim_id)).toMatch(/^rdclm_/);
+
+    const retry = await runCliInProcess(
+      await withRunTarget(['delegate', '--retry', token], workspace),
+      workspace,
+    );
+
+    expect(retry.exitCode).toBe(0);
+    const retryPayload = parseCliJsonObject(retry.stdout);
+    expect(retryPayload).toEqual(expect.objectContaining({ action: 'retried' }));
+    expect(String(retryPayload.token)).toMatch(/^rdtk_/);
+    const parent = await readRunbookState(workspace, parentId);
+    const rows = Object.values(parent!.resolvedCompletions ?? {}).filter(
+      (row) => row.agentId === 'delegation',
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('force-aborts a policy-denied linked child without recording delegated fail', async () => {
+    await writePolicyDeniedParentAndChild();
+
+    const start = runCli('run parent.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+    const parentId = (await getActiveState(workspace))!.id;
+    const token = String((await getActiveState(workspace))!.substepStates?.[0]?.delegation?.token);
+
+    const claim = await runCliInProcess(['claim', token, '--deny-all'], workspace);
+    expect(claim.exitCode).toBe(1);
+    const claimPayload = findActionOutput(claim.stdout)!;
+    const childRunId = String(claimPayload.run_id);
+    const child = await readRunbookState(workspace, childRunId);
+    expect(child?.lastAction).toEqual(expect.objectContaining({ type: 'POLICY_DENIED' }));
+
+    const abort = await runCliInProcess(['abort', token, '--force'], workspace);
+    expect(abort.exitCode).toBe(0);
+    expect(`${abort.stdout}${abort.stderr}`).not.toContain('RD-812');
+
+    const parent = await readRunbookState(workspace, parentId);
+    const rows = Object.values(parent!.resolvedCompletions ?? {}).filter(
+      (row) => row.agentId === 'delegation',
+    );
+    expect(rows).toHaveLength(0);
+    const entry = parent!.substepStates?.find((state) => state.id === '1');
+    expect(entry?.delegation?.cancelledAt).not.toBeNull();
+  });
+});

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -1394,6 +1394,53 @@ describe('runExecutionLoop', () => {
     ).toHaveLength(0);
   });
 
+  it('emits command_execution_failed for stopped command infrastructure state without transition events', async () => {
+    mockManager.load.mockResolvedValue(
+      makeLoopState('1', {
+        lifecycle: 'stopped',
+        lastAction: {
+          type: 'COMMAND_EXECUTION_FAILED',
+          origin: 'direct',
+          message: 'Timeout of 30000 ms exceeded',
+        },
+        snapshot: {
+          status: 'active',
+          value: { 'step::1': 'idle' },
+          context: {
+            lastAction: {
+              type: 'COMMAND_EXECUTION_FAILED',
+              origin: 'direct',
+              message: 'Timeout of 30000 ms exceeded',
+            },
+          },
+        },
+      }),
+    );
+
+    const result = await runExecutionLoop(
+      asManager(mockManager),
+      runbookId,
+      asSteps(steps),
+      '/tmp',
+      false,
+      asEmitter(mockEmitter),
+    );
+
+    expect(result).toBe('stopped');
+    expect(mockEmitter.emit).toHaveBeenCalledWith({
+      type: 'RUNBOOK_STOPPED',
+      payload: expect.objectContaining({
+        reason: 'command_execution_failed',
+        message: 'Timeout of 30000 ms exceeded',
+      }),
+    });
+    expect(
+      (mockEmitter.emit as jest.Mock).mock.calls.filter(
+        (c) => (c[0] as { type?: string } | undefined)?.type === 'STEP_TRANSITIONED',
+      ),
+    ).toHaveLength(0);
+  });
+
   it('emits RUNBOOK_STOPPED when lifecycle is stopped and snapshot has no lastAction', async () => {
     mockManager.load.mockResolvedValue(
       makeLoopState('1', {

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -9,6 +9,7 @@ import {
   Errors,
   type RunId,
   type RunbookState,
+  type ForceAbortLinkedChildCleanupResult,
 } from '@rundown-org/core';
 import { getCwd } from '../helpers/context.js';
 import { buildNonDelegatingLifecycleSeam } from '../helpers/lifecycle-seam-factory.js';
@@ -86,6 +87,7 @@ export function registerAbortCommand(program: Command): void {
           let freshParent: RunbookState | null = null;
           let childRunId: RunId | null = null;
           let childRunbookPath: string = scanResult.delegation.childRunbookPath;
+          let forceCleanupResult: ForceAbortLinkedChildCleanupResult = { kind: 'none' };
 
           {
             // 4. Re-load parent state under lock
@@ -157,7 +159,7 @@ export function registerAbortCommand(program: Command): void {
             // 8. If force + childRunId: clean up the linked child through the
             // core lifecycle seam while this command still holds DelegationLock.
             if (options.force && childRunId) {
-              await lifecycleCommandService.cleanupForceAbortedLinkedChild({
+              forceCleanupResult = await lifecycleCommandService.cleanupForceAbortedLinkedChild({
                 parentState: freshParent,
                 childRunId,
                 frameKey: scanFrameKey,
@@ -191,8 +193,15 @@ export function registerAbortCommand(program: Command): void {
             });
           } else {
             if (options.force && childRunId) {
-              output.message(`CANCELLED  ${hint} (in-flight, child run stopped)`, 'warning');
-              output.message(`FAILED     step ${targetSubstepId} (delegation cancelled)`, 'error');
+              if (forceCleanupResult.kind === 'active_child_failed') {
+                output.message(`CANCELLED  ${hint} (in-flight, child run stopped)`, 'warning');
+                output.message(
+                  `FAILED     step ${targetSubstepId} (delegation cancelled)`,
+                  'error',
+                );
+              } else {
+                output.message(`CANCELLED  ${hint} (linked child cleaned up)`, 'warning');
+              }
             } else {
               output.message(
                 `CANCELLED  ${hint} (pending delegation to ${childRunbookPath})`,

--- a/packages/cli/src/commands/abort.ts
+++ b/packages/cli/src/commands/abort.ts
@@ -1,9 +1,5 @@
 import type { Command } from 'commander';
 import {
-  RunbookStateManager,
-  SessionService,
-  ExecutionLifecycleService,
-  RunbookCompletionService,
   DelegationScanService,
   DelegationLock,
   abortDelegation,
@@ -11,17 +7,11 @@ import {
   isDelegationToken,
   truncateDelegationToken,
   Errors,
-  activeFrame,
-  buildCompletionKey,
-  deriveActiveFrame,
-  exactFrame,
-  inactiveFrame,
   type RunId,
   type RunbookState,
-  type FrameKey,
 } from '@rundown-org/core';
-import { createCliRunbookActorService } from '../helpers/actor-service-factory.js';
 import { getCwd } from '../helpers/context.js';
+import { buildNonDelegatingLifecycleSeam } from '../helpers/lifecycle-seam-factory.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 
@@ -34,15 +24,13 @@ import { OutputEmitter } from '../services/output-emitter.js';
  *  2. Scan state for matching token hash
  *  3. Acquire delegation lock
  *  4. Re-load parent state under lock
- *  5. Check if already resolved
- *  6. Call `abortDelegation()` pure function
- *  7. Handle early-exit results (already_cancelled, needs_force)
- *  8. Persist updated parent state
- *  9. If force + childRunId: stop child run and record fail completion
- * 10. Release lock
- * 11. Report-only (Plan 5): the fail outcome recorded in step 9 already leaves
- *     the delegating run collection pending — no drain/apply/cascade here
- * 12. Output result
+ *  5. Call `abortDelegation()` pure function
+ *  6. Handle early-exit results (already_cancelled, needs_force)
+ *  7. Persist updated parent state
+ *  8. If force + childRunId: clean up through the lifecycle command seam
+ *  9. Release lock
+ * 10. Report-only: no drain/apply/cascade here
+ * 11. Output result
  *
  * @module commands/abort
  */
@@ -67,7 +55,7 @@ export function registerAbortCommand(program: Command): void {
         async () => {
           const output = new OutputEmitter({ text: options.text, command: 'abort' });
           const cwd = getCwd();
-          const manager = new RunbookStateManager(cwd);
+          const { manager, seam: lifecycleCommandService } = buildNonDelegatingLifecycleSeam(cwd);
           const hint = truncateDelegationToken(token);
 
           // 1. Validate token format
@@ -99,43 +87,6 @@ export function registerAbortCommand(program: Command): void {
           let childRunId: RunId | null = null;
           let childRunbookPath: string = scanResult.delegation.childRunbookPath;
 
-          /**
-           * Check whether a resolved completion exists for a substep in a given frame.
-           *
-           * Checks both the exact entry key and the sentinel key so completions
-           * recorded against non-active frames (which always use SENTINEL_ENTRY)
-           * are found correctly.
-           *
-           * @param lifecycleService - Lifecycle service for completion lookup
-           * @param runbookId - Parent runbook ID
-           * @param state - Current parent runbook state
-           * @param frameKey - FOR-frame key to check
-           * @param substepId - Substep identifier to check
-           * @returns True if a resolved completion exists under either key
-           */
-          async function hasResolvedCompletion(
-            lifecycleService: ExecutionLifecycleService,
-            runbookId: string,
-            state: RunbookState,
-            frameKey: FrameKey,
-            substepId: string,
-          ): Promise<boolean> {
-            const activeFrameKey = state.activeFrameKey ?? deriveActiveFrame(state).frameKey;
-            const isActiveFrame = activeFrameKey === frameKey;
-            const entry = isActiveFrame
-              ? (state.activeEntry ?? 1)
-              : (state.frameEntryCounts?.[frameKey] ?? 1);
-            const exactFrameTarget = isActiveFrame
-              ? activeFrame(frameKey, entry)
-              : exactFrame(frameKey, entry);
-            const exactKey = buildCompletionKey(exactFrameTarget, substepId);
-            const sentinelKey = buildCompletionKey(inactiveFrame(frameKey), substepId);
-            return (
-              !!(await lifecycleService.getResolvedCompletion(runbookId, exactKey)) ||
-              !!(await lifecycleService.getResolvedCompletion(runbookId, sentinelKey))
-            );
-          }
-
           {
             // 4. Re-load parent state under lock
             freshParent = await manager.load(parentState.id);
@@ -156,23 +107,7 @@ export function registerAbortCommand(program: Command): void {
 
             childRunbookPath = freshDelegation.childRunbookPath;
 
-            // 5. Check if already resolved (has resolved completion) when force + claimed
-            if (options.force && freshDelegation.childRunId) {
-              const lifecycleService = new ExecutionLifecycleService(manager);
-              if (
-                await hasResolvedCompletion(
-                  lifecycleService,
-                  freshParent.id,
-                  freshParent,
-                  scanFrameKey,
-                  targetSubstepId,
-                )
-              ) {
-                throw Errors.delegationAlreadyResolved(targetSubstepId);
-              }
-            }
-
-            // 6. Call abortDelegation() pure function (frame-scoped)
+            // 5. Call abortDelegation() pure function (frame-scoped)
             abortResult = abortDelegation({
               parentState: freshParent,
               substepId: targetSubstepId,
@@ -180,7 +115,7 @@ export function registerAbortCommand(program: Command): void {
               frameKey: scanFrameKey,
             });
 
-            // 7. Handle all four variants exhaustively
+            // 6. Handle all four variants exhaustively
             switch (abortResult.status) {
               case 'not_found':
                 // Rethrow so withErrorHandling surfaces the RD-801 envelope —
@@ -212,85 +147,36 @@ export function registerAbortCommand(program: Command): void {
               }
             }
 
-            // 8. Persist updated parent state
+            // 7. Persist updated parent state
             await manager.update(freshParent.id, {
               substepStates: abortResult.updatedSubstepStates,
             });
 
             childRunId = freshDelegation.childRunId ?? null;
 
-            // 9. If force + childRunId: stop child run and record fail completion
+            // 8. If force + childRunId: clean up the linked child through the
+            // core lifecycle seam while this command still holds DelegationLock.
             if (options.force && childRunId) {
-              // Capture child linkage BEFORE deleting child state — we need it
-              // to drive `recordChildCompletionUnlocked` along the child path.
-              const childState = await manager.load(childRunId);
-
-              // Stop child run: delete state, pop session
-              if (childState) {
-                await manager.delete(childRunId);
-                const sessionService = new SessionService(manager);
-                await sessionService.releaseRunbook(childRunId);
-              }
-
-              const lifecycleService = new ExecutionLifecycleService(manager);
-              const completionService = new RunbookCompletionService(
-                manager,
-                lifecycleService,
-                createCliRunbookActorService(manager),
-              );
-
-              // Plan Task 11: when a linked child state exists, route through
-              // the child-recording path so `finalVars`, parentLinkage handling,
-              // and SubstepState `{ status: 'done', result }` propagation all
-              // happen via the same core code as normal child completion. The
-              // unlocked variant is required because `abort.ts` already holds
-              // the parent DelegationLock — calling the locking
-              // `recordChildCompletion` here would deadlock.
-              if (childState?.parentLinkage) {
-                // `ignoreCancellation: true` is required here: step 8 above
-                // persisted `cancelledAt` on the parent substep *as* this
-                // abort's propagation event. Without the override,
-                // `recordChildCompletionUnlocked` would short-circuit to
-                // `'cancelled'` and the parent would never receive FAIL.
-                await completionService.recordChildCompletionUnlocked({
-                  childState,
-                  result: 'fail',
-                  ignoreCancellation: true,
-                });
-              } else {
-                // No linked child state — fall back to the parent-substep
-                // recording helper.
-                const activeFrameKey =
-                  freshParent.activeFrameKey ?? deriveActiveFrame(freshParent).frameKey;
-                const isActiveFrame = activeFrameKey === scanFrameKey;
-                await completionService.recordManualCompletion({
-                  runbookId: freshParent.id,
-                  currentState: freshParent,
-                  targetStep: freshParent.step,
-                  targetSubstep: targetSubstepId,
-                  targetFrame: isActiveFrame
-                    ? activeFrame(scanFrameKey, freshParent.activeEntry ?? 1)
-                    : inactiveFrame(scanFrameKey),
-                  result: 'fail',
-                  agentId: 'delegation',
-                });
-              }
+              await lifecycleCommandService.cleanupForceAbortedLinkedChild({
+                parentState: freshParent,
+                childRunId,
+                frameKey: scanFrameKey,
+                substepId: targetSubstepId,
+              });
             }
           }
 
-          // 10. Release the lock before the output work below.
+          // 9. Release the lock before the output work below.
           //     (The `await using` guard above re-releases idempotently if an
           //     early throw skips this.)
           await _lockGuard.release();
 
-          // 11. Report-only (Plan 5): the FAIL outcome was already recorded onto
-          //     the delegating run inside the lock (step 9, via
-          //     `recordChildCompletionUnlocked` / `recordManualCompletion`). That
-          //     recorded row leaves the delegating run collection pending — its
-          //     orchestrator must run `rd collect`. We do NOT drain, apply, or
-          //     cascade here; force-abort reports and stops.
+          // 10. Report-only: cleanup already happened inside the lock. Active
+          //     children record explicit FAIL; terminal/missing children have
+          //     stale outcome rows superseded. We do NOT drain, apply, or
+          //     cascade here.
 
-          // 12. Output result
+          // 11. Output result
           if (!options.text) {
             output.json({
               kind: 'abort',

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -225,8 +225,7 @@ export function registerClaimCommand(program: Command): void {
             if (result.loopResult === 'done' || result.loopResult === 'stopped') {
               const childState = await manager.load(result.childRunId);
               if (childState && extractParentLinkage(childState)) {
-                const propResult = childState.lifecycle === 'completed' ? 'pass' : 'fail';
-                await propagateChildTerminal(childState, propResult, cwd, output);
+                await propagateChildTerminal(childState, undefined, cwd, output);
               }
             }
 

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -552,14 +552,13 @@ async function runCollect(ctx: TransitionContext, options: CollectOptions): Prom
     linkage &&
     (terminal.lifecycle === 'completed' || terminal.lifecycle === 'stopped')
   ) {
-    const result = terminal.lifecycle === 'completed' ? 'pass' : 'fail';
-    const propagation = await propagateChildTerminal(terminal, result, cwd, output);
+    const propagation = await propagateChildTerminal(terminal, undefined, cwd, output);
     // Inline propagation may itself drive the parent terminal (STOP) — its
     // outcome decides the exit code for inline, ORed with a stopped loop.
     // Delegation propagation is report-only (no parent advancement) but can
     // still surface a STOP exit.
     if (linkage.kind === 'inline') {
-      exitWithError = propagation === 'stopped' || loopStopped;
+      exitWithError = propagation === 'stopped' || propagation === 'blocked' || loopStopped;
     } else if (propagation === 'stopped') {
       exitWithError = true;
     }

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -508,6 +508,9 @@ function buildDelegateSeam(
     lifecycleService,
     completionService: new RunbookCompletionService(manager, lifecycleService, actorService),
     loadRun: async (id) => (await manager.load(id)) ?? undefined,
+    deleteRun: async (id) => {
+      await manager.delete(id);
+    },
     loadSteps: (s) => getRunbookFromState(s, cwd),
     resolveChildRunbook: async (name) => {
       const resolved = await resolveRunbookFile(cwd, name);

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -258,15 +258,13 @@ export function registerRunCommand(program: Command): void {
                 const isTerminal =
                   childState.lifecycle === 'completed' || childState.lifecycle === 'stopped';
                 if (isTerminal) {
-                  const propResult: 'pass' | 'fail' =
-                    childState.lifecycle === 'completed' ? 'pass' : 'fail';
                   const propOutcome = await propagateChildTerminal(
                     childState,
-                    propResult,
+                    undefined,
                     cwd,
                     output,
                   );
-                  if (propOutcome === 'stopped') {
+                  if (propOutcome === 'stopped' || propOutcome === 'blocked') {
                     output.flush();
                     process.exit(1);
                   }

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -25,12 +25,20 @@ import {
   RunbookStateManager,
   ExecutionLifecycleService,
   RunbookCompletionService,
+  projectDelegationTerminalOutcome,
   type RunbookState,
   type ParentLinkage,
 } from '@rundown-org/core';
 import { createCliRunbookActorService } from './actor-service-factory.js';
 import type { OutputEmitter } from '../services/output-emitter.js';
 import type { TransitionOrchestrationPolicy } from './transition-orchestrator.js';
+
+export type TerminalPropagationResult =
+  | 'reported'
+  | 'handled'
+  | 'stopped'
+  | 'blocked'
+  | 'not-applicable';
 
 /**
  * Extract the discriminated parent linkage from a child state.
@@ -69,19 +77,33 @@ export function extractParentLinkage(state: RunbookState): ParentLinkage | undef
  */
 export async function reportTerminalToDelegatingRun(
   childState: RunbookState,
-  result: 'pass' | 'fail',
+  result: 'pass' | 'fail' | undefined,
   cwd: string,
   output: OutputEmitter,
-): Promise<'reported' | 'not-applicable'> {
+): Promise<TerminalPropagationResult> {
   const linkage = extractParentLinkage(childState);
   if (linkage?.kind !== 'delegation') return 'not-applicable';
+
+  const projection = projectDelegationTerminalOutcome(childState, result);
+  if (projection.kind === 'not_terminal') return 'not-applicable';
+  if (projection.kind === 'command_infrastructure') {
+    output.flush();
+    return 'blocked';
+  }
 
   const manager = new RunbookStateManager(cwd);
   const actorService = createCliRunbookActorService(manager);
   const lifecycleService = new ExecutionLifecycleService(manager);
   const completionService = new RunbookCompletionService(manager, lifecycleService, actorService);
 
-  const recorded = await completionService.recordChildCompletion({ childState, result });
+  const recorded = await completionService.recordChildCompletion({
+    childState,
+    result: projection.result,
+  });
+  if (recorded === 'blocked') {
+    output.flush();
+    return 'blocked';
+  }
   // 'not-applicable' means the child had no linkage to report against (the
   // early guard above already handled the common case; core re-checks). Every
   // other outcome — 'recorded', 'duplicate', and 'cancelled' — means there is
@@ -127,10 +149,10 @@ export async function reportTerminalToDelegatingRun(
  */
 export async function advanceParentForInlineChild(
   childState: RunbookState,
-  result: 'pass' | 'fail',
+  result: 'pass' | 'fail' | undefined,
   cwd: string,
   output: OutputEmitter,
-): Promise<'handled' | 'stopped' | 'not-applicable'> {
+): Promise<TerminalPropagationResult> {
   const linkage = extractParentLinkage(childState);
   // This is the INLINE flow-back path only. Delegation linkage shares the same
   // base fields (parentRunId/parentFrameKey/parentEntry), so a delegation-linked
@@ -138,6 +160,13 @@ export async function advanceParentForInlineChild(
   // report-then-collect contract that leaves a delegating parent collection
   // pending until `rd collect`. Narrow to inline and refuse anything else.
   if (linkage?.kind !== 'inline') return 'not-applicable';
+
+  const projection = projectDelegationTerminalOutcome(childState, result);
+  if (projection.kind === 'not_terminal') return 'not-applicable';
+  if (projection.kind === 'command_infrastructure') {
+    output.flush();
+    return 'blocked';
+  }
 
   const { SessionService, exactFrame } = await import('@rundown-org/core');
   const { drainResolvedCompletions, runExecutionLoop } = await import('../services/execution.js');
@@ -158,13 +187,20 @@ export async function advanceParentForInlineChild(
     lifecycleService,
     parentActorService,
   );
-  const recorded = await completionService.recordChildCompletion({ childState, result });
+  const recorded = await completionService.recordChildCompletion({
+    childState,
+    result: projection.result,
+  });
   if (recorded === 'not-applicable') return 'not-applicable';
   if (recorded === 'cancelled') return 'handled';
+  if (recorded === 'blocked') {
+    output.flush();
+    return 'blocked';
+  }
 
   // Drain resolved completions on the parent after core-owned recording.
   const transitionConfig =
-    result === 'pass' ? createPassTransitionConfig() : createFailTransitionConfig();
+    projection.result === 'pass' ? createPassTransitionConfig() : createFailTransitionConfig();
 
   // Inline advance: never release during drain. Session release is handled
   // explicitly on the terminal branches below and by runExecutionLoop.
@@ -289,10 +325,10 @@ export async function advanceParentForInlineChild(
  */
 export async function propagateChildTerminal(
   childState: RunbookState,
-  result: 'pass' | 'fail',
+  result: 'pass' | 'fail' | undefined,
   cwd: string,
   output: OutputEmitter,
-): Promise<'reported' | 'handled' | 'stopped' | 'not-applicable'> {
+): Promise<TerminalPropagationResult> {
   const linkage = extractParentLinkage(childState);
   if (!linkage) return 'not-applicable';
   return linkage.kind === 'inline'

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -33,6 +33,9 @@ import { createCliRunbookActorService } from './actor-service-factory.js';
 import type { OutputEmitter } from '../services/output-emitter.js';
 import type { TransitionOrchestrationPolicy } from './transition-orchestrator.js';
 
+/**
+ * Result returned after attempting to propagate a terminal child run to its parent.
+ */
 export type TerminalPropagationResult =
   | 'reported'
   | 'handled'

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -238,17 +238,20 @@ export async function advanceParentForInlineChild(
   if (drained.status === 'stopped') {
     await sessionService.releaseRunbook(parentRunId);
     const freshParent = await manager.load(parentRunId);
-    if (freshParent) await propagateChildTerminal(freshParent, 'fail', cwd, output);
+    const propagated = freshParent
+      ? await propagateChildTerminal(freshParent, undefined, cwd, output)
+      : 'not-applicable';
     output.flush();
-    return 'stopped';
+    return propagated === 'blocked' ? 'blocked' : 'stopped';
   }
   if (drained.status === 'done') {
     await sessionService.releaseRunbook(parentRunId);
     const freshParent = await manager.load(parentRunId);
     const propagated = freshParent
-      ? await propagateChildTerminal(freshParent, 'pass', cwd, output)
+      ? await propagateChildTerminal(freshParent, undefined, cwd, output)
       : 'not-applicable';
     output.flush();
+    if (propagated === 'blocked') return 'blocked';
     if (propagated === 'stopped') return 'stopped';
     return 'handled';
   }
@@ -279,14 +282,17 @@ export async function advanceParentForInlineChild(
 
     if (loopResult === 'stopped') {
       const terminalParent = await manager.load(parentRunId);
-      if (terminalParent) await propagateChildTerminal(terminalParent, 'fail', cwd, output);
-      return 'stopped';
+      const propagated = terminalParent
+        ? await propagateChildTerminal(terminalParent, undefined, cwd, output)
+        : 'not-applicable';
+      return propagated === 'blocked' ? 'blocked' : 'stopped';
     }
     if (loopResult === 'done') {
       const terminalParent = await manager.load(parentRunId);
       const propagated = terminalParent
-        ? await propagateChildTerminal(terminalParent, 'pass', cwd, output)
+        ? await propagateChildTerminal(terminalParent, undefined, cwd, output)
         : 'not-applicable';
+      if (propagated === 'blocked') return 'blocked';
       if (propagated === 'stopped') return 'stopped';
     }
     return 'handled';

--- a/packages/cli/src/helpers/lifecycle-seam-factory.ts
+++ b/packages/cli/src/helpers/lifecycle-seam-factory.ts
@@ -62,6 +62,9 @@ export function buildNonDelegatingLifecycleSeam(cwd: string): NonDelegatingLifec
     lifecycleService,
     completionService,
     loadRun: async (id) => (await manager.load(id)) ?? undefined,
+    deleteRun: async (id) => {
+      await manager.delete(id);
+    },
     loadSteps: (state) => getRunbookFromState(state, cwd),
     resolveChildRunbook: refuseIssuance,
     persistIssuedSubstep: refuseIssuance,

--- a/packages/cli/src/helpers/transition-command.ts
+++ b/packages/cli/src/helpers/transition-command.ts
@@ -158,15 +158,14 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
                 const isTerminal =
                   freshState.lifecycle === 'completed' || freshState.lifecycle === 'stopped';
                 if (isTerminal) {
-                  const propResult = freshState.lifecycle === 'completed' ? 'pass' : 'fail';
                   const propagation = await propagateChildTerminal(
                     freshState,
-                    propResult,
+                    def.name,
                     cwd,
                     output,
                   );
                   if (linkage.kind === 'inline') {
-                    shouldExitWithError = propagation === 'stopped';
+                    shouldExitWithError = propagation === 'stopped' || propagation === 'blocked';
                   } else if (propagation === 'stopped') {
                     shouldExitWithError = true;
                   }

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -373,12 +373,7 @@ async function propagateInlineChildTerminalResult(args: {
   // inline). The child's own loopResult governs the result here unless advancing
   // the parent reaches a STOP terminal, which surfaces as 'stopped'.
   const { propagateChildTerminal } = await import('../helpers/delegation-completion.js');
-  const propagated = await propagateChildTerminal(
-    childState,
-    loopResult === 'done' ? 'pass' : 'fail',
-    cwd,
-    output,
-  );
+  const propagated = await propagateChildTerminal(childState, undefined, cwd, output);
   return propagated === 'stopped' ? 'stopped' : loopResult;
 }
 

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -5,9 +5,6 @@ import {
   buildStepPosition,
   type ActionType,
   extractLastMessage,
-  extractLastAction,
-  deriveStoppedReason,
-  extractInternalFailureMessage,
   extractRetryDisplayCount,
   extractRetryMax,
   formatActionForDisplay,
@@ -55,6 +52,7 @@ import {
   isRunbookComplete,
   expandLoopVariables,
   expandLoopVariablesForCommand,
+  deriveTerminalDrainObservationEvent,
 } from '@rundown-org/core';
 import { resolvedStepHasSubsteps, type OutputDeclaration } from '@rundown-org/parser';
 import { isInternalRdCommand, executeRdCommandInternal } from './internal-commands.js';
@@ -1009,10 +1007,10 @@ export async function runExecutionLoop(
   if (currentState.lifecycle === 'stopped') {
     const terminalSnap = asTerminalSnapshotOrDefault(currentState.snapshot);
     const snapIsTerminal = isRunbookStopped(terminalSnap) || isRunbookComplete(terminalSnap);
+    const currentStepForProjection = findStepOrThrow(steps, currentState.step);
 
     if (snapIsTerminal) {
       // Machine-driven stop: delegate to core projection
-      const currentStepForProjection = findStepOrThrow(steps, currentState.step);
       const observation = deriveTransitionObservation({
         steps,
         currentStep: currentStepForProjection,
@@ -1043,26 +1041,18 @@ export async function runExecutionLoop(
       // CLI-owned stop: XState machine was never transitioned to STOPPED.
       // The persisted snapshot is non-terminal (e.g. policy denial or
       // delegation-resolution failure wrote lifecycle:'stopped' without
-      // driving the machine to its STOPPED state). Emit RUNBOOK_STOPPED
-      // directly from the persisted step position.
-      const position = buildStepPosition(
-        currentState.step,
-        countNumberedSteps(steps),
-        currentState.substep,
-        currentState.forStack,
-      );
-      const lastAction = extractLastAction(currentState.snapshot);
-      const reason = deriveStoppedReason(lastAction);
-      const message =
-        extractInternalFailureMessage(lastAction) ?? extractLastMessage(currentState.snapshot);
-      emitter.emit({
-        type: 'RUNBOOK_STOPPED',
-        payload: {
-          position,
-          reason,
-          message,
-        },
+      // driving the machine to its STOPPED state). Core still owns the
+      // terminal observation projection; the CLI only emits it.
+      const event = deriveTerminalDrainObservationEvent({
+        steps,
+        currentStep: currentStepForProjection,
+        previousState: currentState,
+        updatedState: currentState,
+        snapshot: currentState.snapshot,
+        status: 'stopped',
+        result: 'fail',
       });
+      emitter.emit(event);
     }
 
     await applyExecutionTerminalRelease(sessionService, runbookId, terminalReleaseMode);

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -5,6 +5,9 @@ import {
   buildStepPosition,
   type ActionType,
   extractLastMessage,
+  extractLastAction,
+  deriveStoppedReason,
+  extractInternalFailureMessage,
   extractRetryDisplayCount,
   extractRetryMax,
   formatActionForDisplay,
@@ -1048,12 +1051,15 @@ export async function runExecutionLoop(
         currentState.substep,
         currentState.forStack,
       );
-      const message = extractLastMessage(currentState.snapshot);
+      const lastAction = extractLastAction(currentState.snapshot);
+      const reason = deriveStoppedReason(lastAction);
+      const message =
+        extractInternalFailureMessage(lastAction) ?? extractLastMessage(currentState.snapshot);
       emitter.emit({
         type: 'RUNBOOK_STOPPED',
         payload: {
           position,
-          reason: 'fail_transition',
+          reason,
           message,
         },
       });

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -925,6 +925,35 @@ describe('RunbookCollectionService', () => {
     });
   });
 
+  it('does not report delegated fail for policy-denied terminal children', async () => {
+    const ancestor = state({ id: ancestorRunId, resolvedCompletions: {} });
+    await manager.save(ancestor);
+    const { controlled } = await seedTerminalControlled('stopped', 'fail', {
+      parentLinkage: delegationLinkage,
+      lastAction: {
+        type: 'POLICY_DENIED',
+        origin: 'direct',
+        message: 'blocked by policy',
+      },
+    });
+
+    const recorded = await collectionService.collectDelegationOutcomes({
+      targetState: controlled,
+      steps: oneSubstepSteps,
+      callerEvidence: { kind: 'claim', claimId, tokenHash, controlledRunId },
+      frame: activeFrame(buildFrameKey('1'), 1),
+    });
+
+    expect(recorded).toMatchObject({
+      kind: 'collection_applied',
+      reportedTerminalOutcome: false,
+    });
+    const expectedKey = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1.1');
+    await expect(
+      lifecycleService.getResolvedCompletion(ancestorRunId, expectedKey),
+    ).resolves.toBeNull();
+  });
+
   it('reports reportedTerminalOutcome:false for a terminal ROOT run (no parentLinkage)', async () => {
     const { controlled } = await seedTerminalControlled('completed', 'pass');
 

--- a/packages/core/__tests__/runbook/compiler-command-exec.test.ts
+++ b/packages/core/__tests__/runbook/compiler-command-exec.test.ts
@@ -132,10 +132,15 @@ describe('compiled machine command execution', () => {
 
     const snapshot = actor.getPersistedSnapshot() as unknown as {
       value: unknown;
-      context: { lifecycle: string; lastAction?: { type: string; message?: string } };
+      context: {
+        lifecycle: string;
+        lastAction?: { type: string; message?: string };
+        lastResult?: string;
+      };
     };
     expect(snapshot.value).toBe('STOPPED');
     expect(snapshot.context.lifecycle).toBe('stopped');
+    expect(snapshot.context.lastResult).toBeUndefined();
     expect(snapshot.context.lastAction).toEqual({
       type: 'POLICY_DENIED',
       message: 'blocked by test policy',
@@ -174,10 +179,15 @@ describe('compiled machine command execution', () => {
 
     const snapshot = actor.getPersistedSnapshot() as unknown as {
       value: unknown;
-      context: { lifecycle: string; lastAction?: { type: string; message?: string } };
+      context: {
+        lifecycle: string;
+        lastAction?: { type: string; message?: string };
+        lastResult?: string;
+      };
     };
     expect(snapshot.value).toBe('STOPPED');
     expect(snapshot.context.lifecycle).toBe('stopped');
+    expect(snapshot.context.lastResult).toBeUndefined();
     expect(snapshot.context.lastAction).toEqual({
       type: 'COMMAND_EXECUTION_FAILED',
       message: 'spawn subsystem unavailable',

--- a/packages/core/__tests__/runbook/completion-service.properties.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.properties.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from '@jest/globals';
+import fc from 'fast-check';
+import { projectDelegationTerminalOutcome, type RunbookState } from '../../src/runbook/index.js';
+
+const terminalInfrastructureAction = fc.constantFrom(
+  {
+    type: 'POLICY_DENIED' as const,
+    origin: 'direct' as const,
+    message: 'blocked by policy',
+  },
+  {
+    type: 'COMMAND_EXECUTION_FAILED' as const,
+    origin: 'direct' as const,
+    message: 'Timeout of 30000 ms exceeded',
+  },
+);
+
+function state(overrides: Partial<RunbookState>): RunbookState {
+  return {
+    id: 'rd_property000000000000000000000000' as RunbookState['id'],
+    runbookPath: 'property.runbook.md',
+    runbookSrc: '# Property\n\n## 1. Step\n',
+    step: '1',
+    lifecycle: 'running',
+    variables: {} as RunbookState['variables'],
+    startedAt: '2026-07-05T00:00:00.000Z',
+    updatedAt: '2026-07-05T00:00:00.000Z',
+    ...overrides,
+  } as RunbookState;
+}
+
+describe('projectDelegationTerminalOutcome properties', () => {
+  it('never infers delegated fail for command infrastructure stopped states', () => {
+    fc.assert(
+      fc.property(terminalInfrastructureAction, (lastAction) => {
+        expect(
+          projectDelegationTerminalOutcome(state({ lifecycle: 'stopped', lastAction })),
+        ).toEqual(
+          expect.objectContaining({
+            kind: 'command_infrastructure',
+          }),
+        );
+      }),
+    );
+  });
+
+  it('always lets explicit operator results override inferred infrastructure state', () => {
+    fc.assert(
+      fc.property(
+        terminalInfrastructureAction,
+        fc.constantFrom<'pass' | 'fail'>('pass', 'fail'),
+        (lastAction, explicitResult) => {
+          expect(
+            projectDelegationTerminalOutcome(
+              state({ lifecycle: 'stopped', lastAction }),
+              explicitResult,
+            ),
+          ).toEqual({ kind: 'outcome', result: explicitResult });
+        },
+      ),
+    );
+  });
+});

--- a/packages/core/__tests__/runbook/completion-service.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.test.ts
@@ -1560,6 +1560,42 @@ describe('RunbookCompletionService', () => {
       );
     });
 
+    it('supersedes a pending delegation outcome for one substep without touching siblings', async () => {
+      const current = state();
+      const frameKey = buildFrameKey('1');
+      const key1 = buildCompletionKey(activeFrame(frameKey, 1), '1');
+      const key2 = buildCompletionKey(activeFrame(frameKey, 1), '2');
+      await manager.save({
+        ...current,
+        resolvedCompletions: {
+          [key1]: buildResolvedCompletion({
+            agentId: 'delegation',
+            result: 'fail',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrame: activeFrame(frameKey, 1),
+          }),
+          [key2]: buildResolvedCompletion({
+            agentId: 'delegation',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '2',
+            targetFrame: activeFrame(frameKey, 1),
+          }),
+        },
+      });
+
+      const removed = await service.supersedeDelegationOutcomeUnlocked({
+        runbookId,
+        frameKey,
+        substepId: '1',
+      });
+
+      expect(removed).toBe(1);
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key1)).resolves.toBeNull();
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key2)).resolves.not.toBeNull();
+    });
+
     it('inline child completion records agentId as inline', async () => {
       // Parent has substep but no delegation — inline child has linkage kind: 'inline'.
       const parent = state({

--- a/packages/core/__tests__/runbook/completion-service.test.ts
+++ b/packages/core/__tests__/runbook/completion-service.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import {
   assertDelegationTokenHash,
   lifecycleToDelegationOutcome,
+  projectDelegationTerminalOutcome,
   RunbookActorService,
   RunbookCompletionService,
   RunbookStateManager,
@@ -109,6 +110,80 @@ describe('RunbookCompletionService', () => {
     ['running', undefined],
   ] as const)('maps lifecycle %s to delegation outcome %s', (lifecycle, expectedOutcome) => {
     expect(lifecycleToDelegationOutcome(lifecycle)).toBe(expectedOutcome);
+  });
+
+  describe('projectDelegationTerminalOutcome', () => {
+    it('projects completed children as delegated pass', () => {
+      expect(projectDelegationTerminalOutcome(state({ lifecycle: 'completed' }))).toEqual({
+        kind: 'outcome',
+        result: 'pass',
+      });
+    });
+
+    it('projects ordinary stopped children as delegated fail', () => {
+      expect(
+        projectDelegationTerminalOutcome(
+          state({
+            lifecycle: 'stopped',
+            lastAction: { type: 'STOP', origin: 'direct' },
+          }),
+        ),
+      ).toEqual({ kind: 'outcome', result: 'fail' });
+    });
+
+    it('does not project POLICY_DENIED as delegated fail', () => {
+      expect(
+        projectDelegationTerminalOutcome(
+          state({
+            lifecycle: 'stopped',
+            lastAction: {
+              type: 'POLICY_DENIED',
+              origin: 'direct',
+              message: 'blocked by policy',
+            },
+          }),
+        ),
+      ).toEqual({
+        kind: 'command_infrastructure',
+        reason: 'policy_denied',
+        message: 'blocked by policy',
+      });
+    });
+
+    it('does not project COMMAND_EXECUTION_FAILED as delegated fail', () => {
+      expect(
+        projectDelegationTerminalOutcome(
+          state({
+            lifecycle: 'stopped',
+            lastAction: {
+              type: 'COMMAND_EXECUTION_FAILED',
+              origin: 'direct',
+              message: 'Timeout of 30000 ms exceeded',
+            },
+          }),
+        ),
+      ).toEqual({
+        kind: 'command_infrastructure',
+        reason: 'command_execution_failed',
+        message: 'Timeout of 30000 ms exceeded',
+      });
+    });
+
+    it('lets explicit operator results override infrastructure projection', () => {
+      expect(
+        projectDelegationTerminalOutcome(
+          state({
+            lifecycle: 'stopped',
+            lastAction: {
+              type: 'POLICY_DENIED',
+              origin: 'direct',
+              message: 'blocked by policy',
+            },
+          }),
+          'fail',
+        ),
+      ).toEqual({ kind: 'outcome', result: 'fail' });
+    });
   });
 
   it('records non-active manual completions with sentinel entry and exact/sentinel duplicate detection', async () => {
@@ -1413,6 +1488,75 @@ describe('RunbookCompletionService', () => {
         expect.objectContaining({
           substepStates: [expect.objectContaining({ id: '1', status: 'done', result: 'fail' })],
         }),
+      );
+    });
+
+    it('does not record delegated fail for an inferred policy-denied terminal child', async () => {
+      const parent = makeParentWithDelegation();
+      await manager.save(parent);
+      const child = makeChildWithDelegationLinkage();
+
+      const result = await service.recordChildCompletion({
+        childState: {
+          ...child,
+          lifecycle: 'stopped',
+          lastAction: {
+            type: 'POLICY_DENIED',
+            origin: 'direct',
+            message: 'blocked by policy',
+          },
+        },
+      });
+
+      expect(result).toBe('blocked');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toBeNull();
+    });
+
+    it('does not record delegated fail for an inferred command execution failure child', async () => {
+      const parent = makeParentWithDelegation();
+      await manager.save(parent);
+      const child = makeChildWithDelegationLinkage();
+
+      const result = await service.recordChildCompletion({
+        childState: {
+          ...child,
+          lifecycle: 'stopped',
+          lastAction: {
+            type: 'COMMAND_EXECUTION_FAILED',
+            origin: 'direct',
+            message: 'Timeout of 30000 ms exceeded',
+          },
+        },
+      });
+
+      expect(result).toBe('blocked');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toBeNull();
+    });
+
+    it('still records explicit fail for policy-denied children when a caller forces fail', async () => {
+      const parent = makeParentWithDelegation();
+      await manager.save(parent);
+      const child = makeChildWithDelegationLinkage();
+
+      const result = await service.recordChildCompletion({
+        childState: {
+          ...child,
+          lifecycle: 'stopped',
+          lastAction: {
+            type: 'POLICY_DENIED',
+            origin: 'direct',
+            message: 'blocked by policy',
+          },
+        },
+        result: 'fail',
+      });
+
+      expect(result).toBe('recorded');
+      const key = buildCompletionKey(activeFrame(buildFrameKey('1'), 1), '1');
+      await expect(lifecycleService.getResolvedCompletion(runbookId, key)).resolves.toEqual(
+        expect.objectContaining({ result: 'fail', agentId: 'delegation' }),
       );
     });
 

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -871,7 +871,7 @@ describe('RunbookLifecycleCommandService', () => {
             parentStep: '1',
             parentFrameKey: buildFrameKey('1'),
             parentEntry: 1,
-            tokenHash: first.tokenHash,
+            tokenHash: assertDelegationTokenHash(first.tokenHash),
           },
         }),
       );

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -831,6 +831,123 @@ describe('RunbookLifecycleCommandService', () => {
       expect(retried.kind).toBe('retried');
     });
 
+    it('retries a linked terminal child without orphaning an active child', async () => {
+      const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
+      const first = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'run_controller', runId },
+      });
+      if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+      const keyForSubstep = (substepId: string) =>
+        buildCompletionKey(activeFrame(buildFrameKey('1'), 1), substepId);
+      const childRunId = assertRunId('rd_33333333333333333333333333333333');
+      await mgr.updateWithState(state.id, (current) => ({
+        substepStates: (current.substepStates ?? []).map((entry) =>
+          entry.delegation?.token === first.token
+            ? {
+                ...entry,
+                status: 'done',
+                result: 'fail',
+                delegation: { ...entry.delegation, token: undefined, childRunId },
+              }
+            : entry,
+        ),
+      }));
+      await mgr.save(
+        baseState({
+          id: childRunId,
+          lifecycle: 'stopped',
+          parentLinkage: linkageFor(state.id, '1'),
+          lastAction: {
+            type: 'POLICY_DENIED',
+            origin: 'direct',
+            message: 'blocked by policy',
+          },
+        }),
+      );
+      const parentWithLinkedChild = await mgr.load(state.id);
+      if (!parentWithLinkedChild) throw new Error('expected persisted parent');
+      await mgr.save({
+        ...parentWithLinkedChild,
+        resolvedCompletions: {
+          [keyForSubstep('1')]: buildResolvedCompletion({
+            agentId: 'delegation',
+            result: 'fail',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
+            completedAt: '2026-07-05T00:00:00.000Z',
+          }),
+          [keyForSubstep('2')]: buildResolvedCompletion({
+            agentId: 'delegation',
+            result: 'pass',
+            targetStep: '1',
+            targetSubstep: '2',
+            targetFrame: activeFrame(buildFrameKey('1'), 1),
+            completedAt: '2026-07-05T00:00:00.000Z',
+          }),
+        },
+      });
+      const releaseSpy = jest.spyOn(deps.sessionService, 'releaseRunbook');
+
+      const retried = await localSeam.issueDelegation({
+        mode: 'retry',
+        callerEvidence: { kind: 'run_controller', runId },
+        locator: { kind: 'step', step: first.stepId },
+      });
+
+      expect(retried.kind).toBe('retried');
+      expect(releaseSpy).toHaveBeenCalledWith(childRunId);
+      const persisted = await mgr.load(state.id);
+      const entry = persisted?.substepStates?.find((s) => s.id === '1');
+      expect(entry?.delegation?.childRunId).toBeNull();
+      expect(entry?.delegation?.tokenHash).not.toBe(first.tokenHash);
+      await expect(
+        deps.lifecycleService.getResolvedCompletion(state.id, keyForSubstep('1')),
+      ).resolves.toBeNull();
+      await expect(
+        deps.lifecycleService.getResolvedCompletion(state.id, keyForSubstep('2')),
+      ).resolves.not.toBeNull();
+    });
+
+    it('continues to refuse retry over a running linked child', async () => {
+      const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
+      const first = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'run_controller', runId },
+      });
+      if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+      const childRunId = assertRunId('rd_44444444444444444444444444444444');
+      deps.delegationLock = {
+        acquire: async () => {
+          await mgr.updateWithState(state.id, (current) => ({
+            substepStates: (current.substepStates ?? []).map((entry) =>
+              entry.delegation?.token === first.token
+                ? {
+                    ...entry,
+                    delegation: { ...entry.delegation, token: undefined, childRunId },
+                  }
+                : entry,
+            ),
+          }));
+          await mgr.save(baseState({ id: childRunId, lifecycle: 'running' }));
+        },
+        release: async () => {},
+      };
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'retry',
+        callerEvidence: { kind: 'run_controller', runId },
+        locator: { kind: 'step', step: first.stepId },
+      });
+
+      expect(outcome.kind).toBe('error');
+      if (outcome.kind !== 'error') throw new Error('expected error');
+      expect(outcome.error.code).toBe('RD-823');
+    });
+
     it('preserves the FOR iteration in the active retry label', async () => {
       const { seam: localSeam } = await startSeamOnActiveForIterationSubstep();
       const first = await localSeam.issueDelegation({

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -144,6 +144,9 @@ describe('RunbookLifecycleCommandService', () => {
       lifecycleService,
       completionService,
       loadRun: async (id) => (await manager.load(id)) ?? undefined,
+      deleteRun: async (id) => {
+        await manager.delete(id);
+      },
       loadSteps: (state) => {
         loadStepsArgs.push(state);
         return loadStepsImpl(state);
@@ -224,6 +227,9 @@ describe('RunbookLifecycleCommandService', () => {
       lifecycleService,
       completionService,
       loadRun: async (id) => (await manager.load(id)) ?? undefined,
+      deleteRun: async (id) => {
+        await manager.delete(id);
+      },
       loadSteps: () => steps,
       // Resolve by name so a positional naming a *different* runbook produces a
       // distinct ref (drives the RD-822 mismatch path).
@@ -1414,6 +1420,101 @@ describe('RunbookLifecycleCommandService', () => {
     });
   });
 
+  describe('cleanupForceAbortedLinkedChild', () => {
+    it('force-abort cleanup records explicit fail for running linked child', async () => {
+      const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
+      const childRunId = assertRunId('rd_ab0a0000000000000000000000000000');
+      await mgr.save(
+        baseState({
+          id: childRunId,
+          lifecycle: 'running',
+          parentLinkage: linkageFor(state.id, '1'),
+        }),
+      );
+      const deleteSpy = jest.spyOn(deps, 'deleteRun');
+
+      const result = await localSeam.cleanupForceAbortedLinkedChild({
+        parentState: state,
+        childRunId,
+        frameKey: buildFrameKey('1'),
+        substepId: '1',
+      });
+
+      expect(result).toEqual({ kind: 'active_child_failed', childRunId });
+      expect(deleteSpy).toHaveBeenCalledWith(childRunId);
+    });
+
+    it('force-abort cleanup supersedes terminal linked child outcome without deleting diagnostics', async () => {
+      const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
+      const childRunId = assertRunId('rd_ab0b0000000000000000000000000000');
+      const frameKey = buildFrameKey('1');
+      const key = buildCompletionKey(activeFrame(frameKey, 1), '1');
+      await mgr.save(
+        baseState({
+          id: childRunId,
+          lifecycle: 'stopped',
+          parentLinkage: linkageFor(state.id, '1'),
+        }),
+      );
+      const persisted = await mgr.load(state.id);
+      if (!persisted) throw new Error('expected persisted state');
+      await mgr.save({
+        ...persisted,
+        resolvedCompletions: {
+          [key]: buildResolvedCompletion({
+            agentId: 'delegation',
+            result: 'fail',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrame: activeFrame(frameKey, 1),
+          }),
+        },
+      });
+
+      const result = await localSeam.cleanupForceAbortedLinkedChild({
+        parentState: state,
+        childRunId,
+        frameKey,
+        substepId: '1',
+      });
+
+      expect(result).toEqual({ kind: 'terminal_child_cleaned', childRunId });
+      await expect(mgr.load(childRunId)).resolves.not.toBeNull();
+      await expect(deps.lifecycleService.getResolvedCompletion(state.id, key)).resolves.toBeNull();
+    });
+
+    it('force-abort cleanup supersedes stale outcome for missing linked child', async () => {
+      const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
+      const childRunId = assertRunId('rd_ab0c0000000000000000000000000000');
+      const frameKey = buildFrameKey('1');
+      const key = buildCompletionKey(activeFrame(frameKey, 1), '1');
+      const persisted = await mgr.load(state.id);
+      if (!persisted) throw new Error('expected persisted state');
+      await mgr.save({
+        ...persisted,
+        resolvedCompletions: {
+          [key]: buildResolvedCompletion({
+            agentId: 'delegation',
+            result: 'fail',
+            targetStep: '1',
+            targetSubstep: '1',
+            targetFrame: activeFrame(frameKey, 1),
+          }),
+        },
+      });
+
+      const result = await localSeam.cleanupForceAbortedLinkedChild({
+        parentState: state,
+        childRunId,
+        frameKey,
+        substepId: '1',
+      });
+
+      expect(result).toEqual({ kind: 'missing_child_cleaned', childRunId });
+      await expect(deps.lifecycleService.getResolvedCompletion(state.id, key)).resolves.toBeNull();
+    });
+  });
+
   describe('runTransition refusals', () => {
     const steps: ResolvedStep[] = [
       { kind: 'base', name: '1', description: 'one', transitions: tx('CONTINUE', 'STOP') },
@@ -2383,6 +2484,9 @@ describe('RunbookLifecycleCommandService', () => {
         lifecycleService,
         completionService,
         loadRun: async (id) => (await manager.load(id)) ?? undefined,
+        deleteRun: async (id) => {
+          await manager.delete(id);
+        },
         loadSteps: () => steps,
         resolveChildRunbook: async () => undefined,
         persistIssuedSubstep: async () => {},

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -837,7 +837,7 @@ describe('RunbookLifecycleCommandService', () => {
       expect(retried.kind).toBe('retried');
     });
 
-    it('retries a linked terminal child without orphaning an active child', async () => {
+    it('retries a linked terminal child without allowing the stale child to re-report', async () => {
       const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
@@ -863,13 +863,8 @@ describe('RunbookLifecycleCommandService', () => {
       await mgr.save(
         baseState({
           id: childRunId,
-          lifecycle: 'stopped',
+          lifecycle: 'completed',
           parentLinkage: linkageFor(state.id, '1'),
-          lastAction: {
-            type: 'POLICY_DENIED',
-            origin: 'direct',
-            message: 'blocked by policy',
-          },
         }),
       );
       const parentWithLinkedChild = await mgr.load(state.id);
@@ -915,6 +910,15 @@ describe('RunbookLifecycleCommandService', () => {
       await expect(
         deps.lifecycleService.getResolvedCompletion(state.id, keyForSubstep('2')),
       ).resolves.not.toBeNull();
+
+      const terminalChild = await mgr.load(childRunId);
+      if (!terminalChild) throw new Error('expected terminal child to remain for diagnostics');
+      await expect(
+        deps.completionService.recordChildCompletion({ childState: terminalChild }),
+      ).resolves.toBe('not-applicable');
+      await expect(
+        deps.lifecycleService.getResolvedCompletion(state.id, keyForSubstep('1')),
+      ).resolves.toBeNull();
     });
 
     it('continues to refuse retry over a running linked child', async () => {

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -864,7 +864,15 @@ describe('RunbookLifecycleCommandService', () => {
         baseState({
           id: childRunId,
           lifecycle: 'completed',
-          parentLinkage: linkageFor(state.id, '1'),
+          parentLinkage: {
+            kind: 'delegation',
+            parentRunId: state.id,
+            parentStepId: '1',
+            parentStep: '1',
+            parentFrameKey: buildFrameKey('1'),
+            parentEntry: 1,
+            tokenHash: first.tokenHash,
+          },
         }),
       );
       const parentWithLinkedChild = await mgr.load(state.id);

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -966,6 +966,48 @@ describe('RunbookLifecycleCommandService', () => {
       expect(outcome.error.code).toBe('RD-823');
     });
 
+    it('continues to refuse retry when the linked child state is missing', async () => {
+      const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
+      const first = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'run_controller', runId },
+      });
+      if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+      const childRunId = assertRunId('rd_55555555555555555555555555555555');
+      const releaseSpy = jest.spyOn(deps.sessionService, 'releaseRunbook');
+      deps.delegationLock = {
+        acquire: async () => {
+          await mgr.updateWithState(state.id, (current) => ({
+            substepStates: (current.substepStates ?? []).map((entry) =>
+              entry.delegation?.token === first.token
+                ? {
+                    ...entry,
+                    delegation: { ...entry.delegation, token: undefined, childRunId },
+                  }
+                : entry,
+            ),
+          }));
+        },
+        release: async () => {},
+      };
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'retry',
+        callerEvidence: { kind: 'run_controller', runId },
+        locator: { kind: 'step', step: first.stepId },
+      });
+
+      expect(outcome.kind).toBe('error');
+      if (outcome.kind !== 'error') throw new Error('expected error');
+      expect(outcome.error.code).toBe('RD-823');
+      const persisted = await mgr.load(state.id);
+      const entry = persisted?.substepStates?.find((substep) => substep.id === '1');
+      expect(entry?.delegation?.childRunId).toBe(childRunId);
+      expect(entry?.delegation?.tokenHash).toBe(first.tokenHash);
+      expect(releaseSpy).not.toHaveBeenCalledWith(childRunId);
+    });
+
     it('preserves the FOR iteration in the active retry label', async () => {
       const { seam: localSeam } = await startSeamOnActiveForIterationSubstep();
       const first = await localSeam.issueDelegation({

--- a/packages/core/src/runbook/collection-service.ts
+++ b/packages/core/src/runbook/collection-service.ts
@@ -5,7 +5,7 @@ import { classifyDelegationExposure } from './delegation-exposure.js';
 import type { RunbookActorService } from './actor-service.js';
 import type { DelegationPolicyOutcome } from './command-policy.js';
 import { resolveCommandIntent } from './command-policy.js';
-import { lifecycleToDelegationOutcome } from './completion-service.js';
+import { projectDelegationTerminalOutcome } from './completion-service.js';
 import type { AppliedResolvedCompletion } from './completion-service.js';
 import type { RunbookCompletionService } from './completion-service.js';
 import { isPostDelegateAggregationCursor } from './delegation-inference.js';
@@ -551,14 +551,10 @@ async function reportTerminalOutcomeToDelegatingRun(
   // synchronously elsewhere and must not record a delegation outcome; a
   // root run has no linkage. Both are filtered by this guard.
   if (terminalState.parentLinkage?.kind !== 'delegation') return false;
-  // Reuse the canonical lifecycle→outcome mapping instead of hand-rolling
-  // `lifecycle === 'completed' ? 'pass' : 'fail'`. It returns `undefined` for
-  // any non-terminal lifecycle, which also serves as the terminal guard.
-  const result = lifecycleToDelegationOutcome(terminalState.lifecycle);
-  if (!result) return false;
+  const projection = projectDelegationTerminalOutcome(terminalState);
+  if (projection.kind !== 'outcome') return false;
   const recorded = await input.completionService.recordChildCompletion({
     childState: terminalState,
-    result,
   });
   return recorded === 'recorded';
 }

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -662,6 +662,35 @@ export class RunbookCompletionService {
   }
 
   /**
+   * Consume stale delegated outcome rows for a substep.
+   *
+   * Caller must already hold the parent run's DelegationLock. This method is
+   * intentionally unlocked because retry and force-abort cleanup already
+   * execute inside that lock and a second acquisition would deadlock.
+   *
+   * @param args - Parent run id, frame, and substep whose delegated rows are stale.
+   * @returns Number of rows consumed.
+   */
+  async supersedeDelegationOutcomeUnlocked(args: {
+    readonly runbookId: RunId;
+    readonly frameKey: FrameKey;
+    readonly substepId: string;
+  }): Promise<number> {
+    const rows = await this.lifecycleService.listResolvedCompletionsForFrameObservation(
+      args.runbookId,
+      args.frameKey,
+    );
+    let removed = 0;
+    for (const { key, completion } of rows) {
+      if (completion.targetSubstep === args.substepId && completion.agentId === 'delegation') {
+        const consumed = await this.lifecycleService.consumeResolvedCompletion(args.runbookId, key);
+        if (consumed) removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  /**
    * Drain active-frame resolved completions into the runbook state machine.
    *
    * Acquires the run {@link CompletionLock} for the duration of the drain

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -636,9 +636,11 @@ export class RunbookCompletionService {
       linkage.parentStepId,
       frameKey,
     );
+    const currentTokenHash = substepState?.delegation?.tokenHash;
     if (
       linkage.kind === 'delegation' &&
-      substepState?.delegation?.tokenHash !== linkage.tokenHash
+      currentTokenHash !== undefined &&
+      currentTokenHash !== linkage.tokenHash
     ) {
       return 'not-applicable';
     }

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -638,6 +638,12 @@ export class RunbookCompletionService {
     );
     if (
       linkage.kind === 'delegation' &&
+      substepState?.delegation?.tokenHash !== linkage.tokenHash
+    ) {
+      return 'not-applicable';
+    }
+    if (
+      linkage.kind === 'delegation' &&
       substepState?.delegation?.cancelledAt &&
       !args.ignoreCancellation
     ) {

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -131,7 +131,7 @@ export function projectDelegationTerminalOutcome(
     const message =
       extractInternalFailureMessage(childState.lastAction) ??
       (childState.lastAction && 'message' in childState.lastAction
-        ? String(childState.lastAction.message)
+        ? childState.lastAction.message
         : stoppedReason);
     return {
       kind: 'command_infrastructure',
@@ -677,6 +677,9 @@ export class RunbookCompletionService {
    * execute inside that lock and a second acquisition would deadlock.
    *
    * @param args - Parent run id, frame, and substep whose delegated rows are stale.
+   * @param args.runbookId - Parent run id containing stale delegated outcome rows.
+   * @param args.frameKey - Parent frame key containing the target substep.
+   * @param args.substepId - Parent substep id whose delegated rows are stale.
    * @returns Number of rows consumed.
    */
   async supersedeDelegationOutcomeUnlocked(args: {

--- a/packages/core/src/runbook/completion-service.ts
+++ b/packages/core/src/runbook/completion-service.ts
@@ -19,6 +19,7 @@ import {
   type Frame,
   type FrameKey,
 } from './targeting.js';
+import { deriveStoppedReason, extractInternalFailureMessage } from './transition-kernel.js';
 import type {
   DelegationOutcome,
   ResolvedCompletion,
@@ -87,6 +88,59 @@ export function lifecycleToDelegationOutcome(
   if (lifecycle === 'completed') return 'pass';
   if (lifecycle === 'stopped') return 'fail';
   return undefined;
+}
+
+/** Projected terminal state for a delegation-linked child run. */
+export type DelegationTerminalProjection =
+  | { readonly kind: 'outcome'; readonly result: DelegationOutcome }
+  | {
+      readonly kind: 'command_infrastructure';
+      readonly reason: 'policy_denied' | 'command_execution_failed';
+      readonly message: string;
+    }
+  | { readonly kind: 'not_terminal' };
+
+/**
+ * Project a child run terminal state into its delegated parent outcome.
+ *
+ * Explicit operator results preserve the authored RESULT semantics. Inferred
+ * reporting distinguishes command infrastructure stops from authored delegated
+ * `fail` so recovery paths can leave the parent unadvanced.
+ *
+ * @param childState - Child run state being reported.
+ * @param explicitResult - Optional explicit operator result to report.
+ * @returns Projection describing the reportable delegated outcome, a blocked
+ *   command-infrastructure terminal, or a non-terminal state.
+ */
+export function projectDelegationTerminalOutcome(
+  childState: RunbookState,
+  explicitResult?: DelegationOutcome,
+): DelegationTerminalProjection {
+  if (explicitResult !== undefined) {
+    return { kind: 'outcome', result: explicitResult };
+  }
+  if (childState.lifecycle === 'completed') {
+    return { kind: 'outcome', result: 'pass' };
+  }
+  if (childState.lifecycle !== 'stopped') {
+    return { kind: 'not_terminal' };
+  }
+
+  const stoppedReason = deriveStoppedReason(childState.lastAction);
+  if (stoppedReason === 'policy_denied' || stoppedReason === 'command_execution_failed') {
+    const message =
+      extractInternalFailureMessage(childState.lastAction) ??
+      (childState.lastAction && 'message' in childState.lastAction
+        ? String(childState.lastAction.message)
+        : stoppedReason);
+    return {
+      kind: 'command_infrastructure',
+      reason: stoppedReason,
+      message,
+    };
+  }
+
+  return { kind: 'outcome', result: 'fail' };
 }
 
 /**
@@ -531,12 +585,14 @@ export class RunbookCompletionService {
    * - `'duplicate'` — an equivalent outcome row already existed; no write.
    * - `'cancelled'` — the parent substep was ordinarily cancelled, so no fail
    *   outcome is written (preserving the cancellation split).
+   * - `'blocked'` — the child stopped for command infrastructure reasons that
+   *   must remain recoverable instead of becoming delegated fail.
    * - `'not-applicable'` — the child carries no parent linkage (or no terminal
    *   result), so there is nothing to report.
    */
   async recordChildCompletion(
     args: RecordChildCompletionArgs,
-  ): Promise<'recorded' | 'duplicate' | 'not-applicable' | 'cancelled'> {
+  ): Promise<'recorded' | 'duplicate' | 'not-applicable' | 'cancelled' | 'blocked'> {
     const linkage = args.childState.parentLinkage;
     if (!linkage) return 'not-applicable';
     assertCompleteParentLinkage(args.childState);
@@ -561,11 +617,13 @@ export class RunbookCompletionService {
    */
   async recordChildCompletionUnlocked(
     args: RecordChildCompletionArgs,
-  ): Promise<'recorded' | 'duplicate' | 'not-applicable' | 'cancelled'> {
+  ): Promise<'recorded' | 'duplicate' | 'not-applicable' | 'cancelled' | 'blocked'> {
     if (!args.childState.parentLinkage) return 'not-applicable';
     const linkage = assertCompleteParentLinkage(args.childState);
-    const result = args.result ?? lifecycleToDelegationOutcome(args.childState.lifecycle);
-    if (!result) return 'not-applicable';
+    const projection = projectDelegationTerminalOutcome(args.childState, args.result);
+    if (projection.kind === 'not_terminal') return 'not-applicable';
+    if (projection.kind === 'command_infrastructure') return 'blocked';
+    const result = projection.result;
 
     const parentState = await this.manager.load(linkage.parentRunId);
     if (!parentState) return 'not-applicable';

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -137,6 +137,7 @@ export {
   RunbookCompletionService,
   brandCurrentCursorResolvedCompletionForTest,
   lifecycleToDelegationOutcome,
+  projectDelegationTerminalOutcome,
   // Deprecated alias kept on the public surface for callers still on generic
   // result terminology; the re-export itself must not trip no-deprecated.
   // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -144,6 +145,7 @@ export {
   type AppliedResolvedCompletion,
   type CompletionTargetMismatch,
   type CurrentCursorResolvedCompletion,
+  type DelegationTerminalProjection,
   type DrainResolvedCompletionsArgs,
   type DrainResolvedCompletionsResult,
   type RecordChildCompletionArgs,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -165,6 +165,7 @@ export {
   type DelegationIssuanceInput,
   type DelegationIssuanceOutcome,
   type FindDelegationByToken,
+  type ForceAbortLinkedChildCleanupResult,
   type LifecycleLoopDirective,
   type LifecycleNavigationInput,
   type LifecycleNavigationOutcome,

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -1198,23 +1198,16 @@ export class RunbookLifecycleCommandService {
       return { kind: 'active_child_failed', childRunId: args.childRunId };
     }
 
-    if (childIsTerminal) {
-      await this.#deps.sessionService.releaseRunbook(args.childRunId);
-      await this.#deps.completionService.supersedeDelegationOutcomeUnlocked({
-        runbookId: args.parentState.id,
-        frameKey: args.frameKey,
-        substepId: args.substepId,
-      });
-      return { kind: 'terminal_child_cleaned', childRunId: args.childRunId };
-    }
-
     await this.#deps.sessionService.releaseRunbook(args.childRunId);
     await this.#deps.completionService.supersedeDelegationOutcomeUnlocked({
       runbookId: args.parentState.id,
       frameKey: args.frameKey,
       substepId: args.substepId,
     });
-    return { kind: 'missing_child_cleaned', childRunId: args.childRunId };
+    return {
+      kind: childIsTerminal ? 'terminal_child_cleaned' : 'missing_child_cleaned',
+      childRunId: args.childRunId,
+    };
   }
 
   /**

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -2381,15 +2381,11 @@ export class RunbookLifecycleCommandService {
     frameKey: FrameKey,
     substepId: string,
   ): Promise<void> {
-    const rows = await this.#deps.lifecycleService.listResolvedCompletionsForFrameObservation(
-      runId,
+    await this.#deps.completionService.supersedeDelegationOutcomeUnlocked({
+      runbookId: runId,
       frameKey,
-    );
-    for (const { key, completion } of rows) {
-      if (completion.targetSubstep === substepId && completion.agentId === 'delegation') {
-        await this.#deps.lifecycleService.consumeResolvedCompletion(runId, key);
-      }
-    }
+      substepId,
+    });
   }
 
   // Acquire the per-parent-run DelegationLock, wrapping the held lock as a

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -1168,6 +1168,10 @@ export class RunbookLifecycleCommandService {
    * deleting terminal diagnostic state.
    *
    * @param args - Parent, child, frame, and substep cleanup target.
+   * @param args.parentState - Parent state whose linked delegation is being cleaned up.
+   * @param args.childRunId - Linked child run id, or null when no child was recorded.
+   * @param args.frameKey - Parent frame key containing the delegated substep.
+   * @param args.substepId - Parent substep id being force-aborted.
    * @returns Cleanup branch that ran.
    */
   async cleanupForceAbortedLinkedChild(args: {

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -1107,11 +1107,21 @@ export class RunbookLifecycleCommandService {
     // `no-active-runbook` / refusal). Mirrors the fresh path's lazy seam.
     const overrides = await input.resolveOverrides?.();
 
+    const targetSubstep = freshState.substepStates?.find(
+      (entry) => entry.id === substepId && entry.frameKey === frameKey,
+    );
+    const linkedChildRunId = targetSubstep?.delegation?.childRunId ?? null;
+    const linkedChild = linkedChildRunId ? await this.#deps.loadRun(linkedChildRunId) : undefined;
+    const linkedChildTerminal =
+      linkedChild?.lifecycle === 'completed' || linkedChild?.lifecycle === 'stopped';
+    const allowLinkedChildRun = linkedChildTerminal;
+
     const result = retryDelegation(
       {
         state: freshState,
         substepId,
         frameKey,
+        allowLinkedChildRun,
         ...(overrides ? { overrides } : {}),
       },
       steps,
@@ -1121,6 +1131,9 @@ export class RunbookLifecycleCommandService {
     if (result.status !== 'retried') return { kind: 'error', error: result.error };
 
     await this.#supersedePendingOutcome(targetState.id, frameKey, substepId);
+    if (linkedChildRunId && allowLinkedChildRun) {
+      await this.#deps.sessionService.releaseRunbook(linkedChildRunId);
+    }
     await this.#persistIssuedSubstep(
       freshState.id,
       result.updatedSubstepStates,

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -88,6 +88,8 @@ export interface RunbookLifecycleCommandServiceDependencies {
    * test doubles stay trivial.
    */
   readonly loadRun: (runId: RunId) => Promise<RunbookState | undefined>;
+  /** Delete a persisted run state by id. Used only for active-child force abort cleanup. */
+  readonly deleteRun: (runId: RunId) => Promise<void>;
   /**
    * Derive the parsed steps for a resolved run from its in-memory state.
    *
@@ -321,6 +323,13 @@ export type DelegationIssuanceOutcome =
     }
   | { readonly kind: 'refused'; readonly policy: DelegationPolicyOutcome }
   | { readonly kind: 'error'; readonly error: RundownError };
+
+/** Result of cleaning up a force-aborted linked child delegation. */
+export type ForceAbortLinkedChildCleanupResult =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'active_child_failed'; readonly childRunId: RunId }
+  | { readonly kind: 'terminal_child_cleaned'; readonly childRunId: RunId }
+  | { readonly kind: 'missing_child_cleaned'; readonly childRunId: RunId };
 
 /**
  * Terminal side-effect policy applied when a transition reaches a terminal state.
@@ -1149,6 +1158,59 @@ export class RunbookLifecycleCommandService {
       tokenHash: result.tokenHash,
       parentRunId: freshState.id,
     };
+  }
+
+  /**
+   * Clean up a force-aborted linked child while the caller holds DelegationLock.
+   *
+   * Active children are explicitly failed and deleted. Terminal or missing
+   * linked children have any stale delegated outcome rows superseded without
+   * deleting terminal diagnostic state.
+   *
+   * @param args - Parent, child, frame, and substep cleanup target.
+   * @returns Cleanup branch that ran.
+   */
+  async cleanupForceAbortedLinkedChild(args: {
+    readonly parentState: RunbookState;
+    readonly childRunId: RunId | null;
+    readonly frameKey: FrameKey;
+    readonly substepId: string;
+  }): Promise<ForceAbortLinkedChildCleanupResult> {
+    if (!args.childRunId) return { kind: 'none' };
+
+    const childState = await this.#deps.loadRun(args.childRunId);
+    const childIsActive = childState?.lifecycle === 'running';
+    const childIsTerminal =
+      childState?.lifecycle === 'completed' || childState?.lifecycle === 'stopped';
+
+    if (childIsActive) {
+      await this.#deps.deleteRun(args.childRunId);
+      await this.#deps.sessionService.releaseRunbook(args.childRunId);
+      await this.#deps.completionService.recordChildCompletionUnlocked({
+        childState,
+        result: 'fail',
+        ignoreCancellation: true,
+      });
+      return { kind: 'active_child_failed', childRunId: args.childRunId };
+    }
+
+    if (childIsTerminal) {
+      await this.#deps.sessionService.releaseRunbook(args.childRunId);
+      await this.#deps.completionService.supersedeDelegationOutcomeUnlocked({
+        runbookId: args.parentState.id,
+        frameKey: args.frameKey,
+        substepId: args.substepId,
+      });
+      return { kind: 'terminal_child_cleaned', childRunId: args.childRunId };
+    }
+
+    await this.#deps.sessionService.releaseRunbook(args.childRunId);
+    await this.#deps.completionService.supersedeDelegationOutcomeUnlocked({
+      runbookId: args.parentState.id,
+      frameKey: args.frameKey,
+      substepId: args.substepId,
+    });
+    return { kind: 'missing_child_cleaned', childRunId: args.childRunId };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Keep delegated command-infrastructure stops from being inferred as delegated fail.
- Add core projection/supersession paths for retry and force-abort recovery over terminal linked children.
- Pin policy-denied and command-execution-failed delegated recovery with unit, integration, property, and docs coverage.

## Root Cause
The CLI previously treated a delegated child with lifecycle stopped as enough evidence to report delegated fail upward. That conflated authored runbook failure with command infrastructure terminals such as POLICY_DENIED and COMMAND_EXECUTION_FAILED, causing parents to consume false delegated failures and blocking recovery.

A follow-up verification regression also showed the stale-child guard was initially too broad: it rejected ordinary terminal collection when the parent had no current delegation record. The guard now rejects only when a current parent delegation token exists and differs from the child linkage token.

## Validation
- pnpm run verify
- pnpm run test:property
- Focused core unit/property suites for completion, collection, lifecycle, delegation, command execution, and actor service
- Focused CLI unit and integration suites for delegation completion, execution loop, recovery semantics, delegate workflow, and delegation abort

## Notes
- Draft PR opened from branch recovery-semantics.
- The local untracked plan file docs/superpowers/plans/2026-07-05-recovery-semantics.md is intentionally not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced delegated command recovery: `delegate --retry` can now supersede stale linked outcomes and proceed without restarting the parent.
* **Bug Fixes**
  * Improved terminal propagation: infrastructure-related “stopped” outcomes are treated as recoverable/blocked rather than standard delegation failures, preventing duplicate fail recording.
  * Refined force-abort behavior for linked children, including correct cleanup/cancellation without triggering prior resolution errors; updated `abort --force --text` output.
* **Documentation**
  * Updated CLI and architecture docs to reflect the new retry/force-abort semantics and delegation outcome handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->