### PR TITLE
[codex] collect JSON stream separation

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -766,6 +766,10 @@ Two companion CLIs ship alongside `rundown`:
 | `rundown abort <token>`                                    | Cancel a delegation token                                                         |
 | `rundown abort <token> --force`                            | Cancel or clean up a claimed delegation                                           |
 
+`rundown collect` may continue execution into the next command step after
+aggregation. In default JSON mode, bytes written by that command step are
+reported on stderr; stdout remains parseable JSON/JSONL for agents.
+
 Delegation semantics:
 
 - Manual delegation requires an authored delegation target: the target substep

--- a/docs/spec/cli-output.md
+++ b/docs/spec/cli-output.md
@@ -298,6 +298,12 @@ Event type names are lowercase snake_case, and event payload fields are
 flattened onto the JSONL object alongside envelope fields such as `timestamp`,
 `runbookId`, `runbook`, and `seq`. The final line is a terminal lifecycle event.
 
+In machine-readable mode, stdout is reserved for Rundown JSON/JSONL output. When
+a command step executes as part of a Rundown command that emits structured
+output, the child command's stdout and stderr are passed through on stderr so
+arbitrary command bytes cannot corrupt the JSON stream. `--text` preserves the
+human terminal behavior.
+
 ```jsonl
 {"type":"runbook_started","prompted":false,"statePath":".rundown/runs/rd_0123456789abcdef0123456789abcdef.json","timestamp":"2026-05-07T00:00:00.000Z","runbookId":"rd_0123456789abcdef0123456789abcdef","runbook":{"source":"project","path":"runbooks/deploy.runbook.md"},"seq":1}
 {"type":"step_entered","position":{"current":"1","total":1},"stepName":"1","description":"First Step","hasCommand":true,"commandCode":"echo \"hello\"","commandLang":"bash","isSubstep":false,"prompted":false,"artifacts":{},"timestamp":"2026-05-07T00:00:00.000Z","runbookId":"rd_0123456789abcdef0123456789abcdef","runbook":{"source":"project","path":"runbooks/deploy.runbook.md"},"seq":2}

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -999,15 +999,6 @@ describe('collect command', () => {
     }, 20_000);
 
     it('keeps JSON stdout parseable when collect advances into a command that writes stdout and stderr', async () => {
-      await writeFile(
-        join(workspace.cwd, 'noisy-command.mjs'),
-        [
-          "process.stdout.write(Buffer.from('434f4d4d414e445f5354444f55540a', 'hex').toString());",
-          "process.stderr.write(Buffer.from('434f4d4d414e445f5354444552520a', 'hex').toString());",
-          '',
-        ].join('\n'),
-      );
-
       const parent = [
         '# Parent',
         '',
@@ -1028,7 +1019,8 @@ describe('collect command', () => {
         '- FAIL STOP',
         '',
         '```bash',
-        'node noisy-command.mjs',
+        "printf '\\103\\117\\115\\115\\101\\116\\104\\137\\123\\124\\104\\117\\125\\124\\012'",
+        "printf '\\103\\117\\115\\115\\101\\116\\104\\137\\123\\124\\104\\105\\122\\122\\012' >&2",
         '```',
         '',
       ].join('\n');
@@ -1083,7 +1075,7 @@ describe('collect command', () => {
       const passed = runCli(`pass --claim-id ${claimId}`, workspace);
       expect(passed.exitCode).toBe(0);
 
-      const collected = runCli(`collect --run ${runId}`, workspace);
+      const collected = runCli(`collect --run ${runId} --allow-run printf --no-sandbox`, workspace);
       expect(collected.exitCode).toBe(0);
       expect(collected.stdout).not.toContain('COMMAND_STDOUT');
       expect(collected.stdout).not.toContain('COMMAND_STDERR');

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -999,6 +999,15 @@ describe('collect command', () => {
     }, 20_000);
 
     it('keeps JSON stdout parseable when collect advances into a command that writes stdout and stderr', async () => {
+      await writeFile(
+        join(workspace.cwd, 'noisy-command.mjs'),
+        [
+          "process.stdout.write(Buffer.from('434f4d4d414e445f5354444f55540a', 'hex').toString());",
+          "process.stderr.write(Buffer.from('434f4d4d414e445f5354444552520a', 'hex').toString());",
+          '',
+        ].join('\n'),
+      );
+
       const parent = [
         '# Parent',
         '',
@@ -1019,7 +1028,7 @@ describe('collect command', () => {
         '- FAIL STOP',
         '',
         '```bash',
-        "node -e \"process.stdout.write(Buffer.from('434f4d4d414e445f5354444f55540a', 'hex').toString()); process.stderr.write(Buffer.from('434f4d4d414e445f5354444552520a', 'hex').toString())\"",
+        'node noisy-command.mjs',
         '```',
         '',
       ].join('\n');

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -21,6 +21,7 @@ import { registerCollectCommand } from '../../src/commands/collect.js';
 import {
   createTestWorkspace,
   createRunbook,
+  runCli,
   runCliInProcess,
   getActiveState,
   withRunTarget,
@@ -996,6 +997,95 @@ describe('collect command', () => {
       ) as Record<string, unknown>;
       expect(collectedParent.step).toBe('2');
     }, 20_000);
+
+    it('keeps JSON stdout parseable when collect advances into a command that writes stdout and stderr', async () => {
+      const parent = [
+        '# Parent',
+        '',
+        '## 1. Fan-out',
+        '',
+        '- PASS ALL CONTINUE',
+        '- FAIL ANY STOP',
+        '',
+        '### 1.1 Child',
+        '',
+        '- DELEGATE',
+        '',
+        '- child.runbook.md',
+        '',
+        '## 2. Emits bytes',
+        '',
+        '- PASS COMPLETE',
+        '- FAIL STOP',
+        '',
+        '```bash',
+        "node -e \"process.stdout.write(Buffer.from('434f4d4d414e445f5354444f55540a', 'hex').toString()); process.stderr.write(Buffer.from('434f4d4d414e445f5354444552520a', 'hex').toString())\"",
+        '```',
+        '',
+      ].join('\n');
+
+      const child = ['# Child', '', '## 1. Done', '', '- PASS COMPLETE', '', 'Done.', ''].join(
+        '\n',
+      );
+
+      await writeFile(join(workspace.runbooksDir(), 'parent.runbook.md'), parent);
+      await writeFile(join(workspace.runbooksDir(), 'child.runbook.md'), child);
+
+      const start = runCli('run parent.runbook.md', workspace);
+      expect(start.exitCode).toBe(0);
+      const started = parseConcatenatedJson(start.stdout).find(
+        (event): event is Record<string, unknown> =>
+          typeof event === 'object' && event !== null && event.type === 'runbook_started',
+      );
+      const runId = String(started?.runbookId);
+      expect(runId).toMatch(/^rd_/);
+
+      type FrontierEntry = { token: string };
+      type StepEnteredEvent = {
+        type?: string;
+        delegateFrontier?: FrontierEntry[];
+      };
+
+      function findFrontierInEvents(events: unknown[]): FrontierEntry[] | undefined {
+        for (const ev of events) {
+          if (Array.isArray(ev)) {
+            const nested = findFrontierInEvents(ev);
+            if (nested) return nested;
+          } else if (ev && typeof ev === 'object') {
+            const e = ev as StepEnteredEvent;
+            if (e.type === 'step_entered' && e.delegateFrontier) {
+              return e.delegateFrontier;
+            }
+          }
+        }
+        return undefined;
+      }
+
+      const token = String(findFrontierInEvents(parseConcatenatedJson(start.stdout))?.[0]?.token);
+      expect(token).toMatch(/^rdtk_/);
+
+      const claim = runCli(`claim ${token}`, workspace);
+      expect(claim.exitCode).toBe(0);
+      const claimId = String(findActionOutput(claim.stdout)?.claim_id);
+      expect(claimId).toMatch(/^rdclm_/);
+
+      const passed = runCli(`pass --claim-id ${claimId}`, workspace);
+      expect(passed.exitCode).toBe(0);
+
+      const collected = runCli(`collect --run ${runId}`, workspace);
+      expect(collected.exitCode).toBe(0);
+      expect(collected.stdout).not.toContain('COMMAND_STDOUT');
+      expect(collected.stdout).not.toContain('COMMAND_STDERR');
+      expect(collected.stderr).toContain('COMMAND_STDOUT');
+      expect(collected.stderr).toContain('COMMAND_STDERR');
+
+      const objects = parseConcatenatedJson(collected.stdout);
+      expect(objects.at(-1)).toMatchObject({
+        kind: 'collect',
+        action: 'collect',
+        status: 'applied',
+      });
+    });
   });
 
   describe('error cases', () => {

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -1034,8 +1034,10 @@ describe('collect command', () => {
       const start = runCli('run parent.runbook.md', workspace);
       expect(start.exitCode).toBe(0);
       const started = parseConcatenatedJson(start.stdout).find(
-        (event): event is Record<string, unknown> =>
-          typeof event === 'object' && event !== null && event.type === 'runbook_started',
+        (event): event is Record<string, unknown> => {
+          if (typeof event !== 'object' || event === null) return false;
+          return (event as Record<string, unknown>).type === 'runbook_started';
+        },
       );
       const runId = String(started?.runbookId);
       expect(runId).toMatch(/^rd_/);

--- a/packages/cli/__tests__/commands/collect.test.ts
+++ b/packages/cli/__tests__/commands/collect.test.ts
@@ -998,7 +998,7 @@ describe('collect command', () => {
       expect(collectedParent.step).toBe('2');
     }, 20_000);
 
-    it('keeps JSON stdout parseable when collect advances into a command that writes stdout and stderr', async () => {
+    async function setupCollectAdvancesIntoCommand(): Promise<{ runId: string }> {
       const parent = [
         '# Parent',
         '',
@@ -1075,6 +1075,12 @@ describe('collect command', () => {
       const passed = runCli(`pass --claim-id ${claimId}`, workspace);
       expect(passed.exitCode).toBe(0);
 
+      return { runId };
+    }
+
+    it('keeps JSON stdout parseable when collect advances into a command that writes stdout and stderr', async () => {
+      const { runId } = await setupCollectAdvancesIntoCommand();
+
       const collected = runCli(`collect --run ${runId} --allow-run printf --no-sandbox`, workspace);
       expect(collected.exitCode).toBe(0);
       expect(collected.stdout).not.toContain('COMMAND_STDOUT');
@@ -1088,6 +1094,21 @@ describe('collect command', () => {
         action: 'collect',
         status: 'applied',
       });
+    });
+
+    it('routes command stdout and stderr separately when collect text output advances into a command', async () => {
+      const { runId } = await setupCollectAdvancesIntoCommand();
+
+      const collected = runCli(
+        `collect --run ${runId} --text --allow-run printf --no-sandbox`,
+        workspace,
+      );
+
+      expect(collected.exitCode).toBe(0);
+      expect(collected.stdout).toContain('COMMAND_STDOUT');
+      expect(collected.stdout).not.toContain('COMMAND_STDERR');
+      expect(collected.stderr).toContain('COMMAND_STDERR');
+      expect(collected.stderr).not.toContain('COMMAND_STDOUT');
     });
   });
 

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -434,7 +434,7 @@ describe('run --step inline linkage (sandbox-visible coverage)', () => {
           title: 'Execute',
           pass: 'COMPLETE',
           command:
-            "node -e \"process.stdout.write(['INLINE','STDOUT'].join('_')); process.stderr.write(['INLINE','STDERR'].join('_'))\"",
+            'OUT=INLINE_$(printf STDOUT); ERR=INLINE_$(printf STDERR); printf %s "$OUT"; printf %s "$ERR" >&2',
         },
       ],
     });
@@ -528,7 +528,10 @@ describe('run --step inline linkage (sandbox-visible coverage)', () => {
       await startSubstepParent();
       await writeNoisyPassingChild();
 
-      const result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+      const result = await runCliInProcess(
+        'run child.runbook.md --step 1.1 --allow-run printf --no-sandbox',
+        workspace,
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('INLINE_STDOUT');

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -9,7 +9,9 @@ import {
 import {
   createTestWorkspace,
   createRunbook,
+  runCli,
   runCliInProcess,
+  parseConcatenatedJson,
   readSession,
   getActiveState,
   readRunbookState,
@@ -82,6 +84,34 @@ describe('start command', () => {
   });
 
   describe('file mode', () => {
+    it('keeps JSON stdout parseable when a command writes stdout and stderr', async () => {
+      const runbook = [
+        '# Noisy Run',
+        '',
+        '## 1. Emits bytes',
+        '',
+        '- PASS COMPLETE',
+        '- FAIL STOP',
+        '',
+        '```bash',
+        "node -e \"process.stdout.write(Buffer.from('52554e5f5354444f55540a', 'hex').toString()); process.stderr.write(Buffer.from('52554e5f5354444552520a', 'hex').toString())\"",
+        '```',
+        '',
+      ].join('\n');
+
+      await writeFile(join(workspace.runbooksDir(), 'noisy.runbook.md'), runbook);
+
+      const result = runCli('run noisy.runbook.md', workspace);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain('RUN_STDOUT');
+      expect(result.stdout).not.toContain('RUN_STDERR');
+      expect(result.stderr).toContain('RUN_STDOUT');
+      expect(result.stderr).toContain('RUN_STDERR');
+
+      const objects = parseConcatenatedJson(result.stdout);
+      expect(objects.at(-1)).toMatchObject({ type: 'runbook_completed' });
+    });
+
     it('creates runbook state from valid runbook file', async () => {
       const result = await runCliInProcess(
         'run --prompted runbooks/simple.runbook.md --text',

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -85,6 +85,15 @@ describe('start command', () => {
 
   describe('file mode', () => {
     it('keeps JSON stdout parseable when a command writes stdout and stderr', async () => {
+      await writeFile(
+        join(workspace.cwd, 'noisy-command.mjs'),
+        [
+          "process.stdout.write(Buffer.from('52554e5f5354444f55540a', 'hex').toString());",
+          "process.stderr.write(Buffer.from('52554e5f5354444552520a', 'hex').toString());",
+          '',
+        ].join('\n'),
+      );
+
       const runbook = [
         '# Noisy Run',
         '',
@@ -94,7 +103,7 @@ describe('start command', () => {
         '- FAIL STOP',
         '',
         '```bash',
-        "node -e \"process.stdout.write(Buffer.from('52554e5f5354444f55540a', 'hex').toString()); process.stderr.write(Buffer.from('52554e5f5354444552520a', 'hex').toString())\"",
+        'node noisy-command.mjs',
         '```',
         '',
       ].join('\n');

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -425,6 +425,22 @@ describe('run --step inline linkage (sandbox-visible coverage)', () => {
     await writeFile(join(workspace.cwd, 'child.runbook.md'), content);
   }
 
+  /** Write a child that emits command stdout/stderr while passing. */
+  async function writeNoisyPassingChild(): Promise<void> {
+    const content = createRunbook({
+      title: 'Child',
+      steps: [
+        {
+          title: 'Execute',
+          pass: 'COMPLETE',
+          command:
+            "node -e \"process.stdout.write(['INLINE','STDOUT'].join('_')); process.stderr.write(['INLINE','STDERR'].join('_'))\"",
+        },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'child.runbook.md'), content);
+  }
+
   /** Write a single-step auto-executing child that fails and stops. */
   async function writeStoppingChild(): Promise<void> {
     const content = createRunbook({
@@ -506,6 +522,19 @@ describe('run --step inline linkage (sandbox-visible coverage)', () => {
       const childState = await findChildState(parentRunId);
       expect(childState).not.toBeNull();
       expect(childState!.lifecycle).toBe('completed');
+    });
+
+    it('routes fresh inline child command output away from JSON stdout', async () => {
+      await startSubstepParent();
+      await writeNoisyPassingChild();
+
+      const result = await runCliInProcess('run child.runbook.md --step 1.1', workspace);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain('INLINE_STDOUT');
+      expect(result.stdout).not.toContain('INLINE_STDERR');
+      expect(result.stderr).toContain('INLINE_STDOUT');
+      expect(result.stderr).toContain('INLINE_STDERR');
     });
 
     it('inline child inherits parent template variables', async () => {

--- a/packages/cli/__tests__/commands/run.test.ts
+++ b/packages/cli/__tests__/commands/run.test.ts
@@ -85,15 +85,6 @@ describe('start command', () => {
 
   describe('file mode', () => {
     it('keeps JSON stdout parseable when a command writes stdout and stderr', async () => {
-      await writeFile(
-        join(workspace.cwd, 'noisy-command.mjs'),
-        [
-          "process.stdout.write(Buffer.from('52554e5f5354444f55540a', 'hex').toString());",
-          "process.stderr.write(Buffer.from('52554e5f5354444552520a', 'hex').toString());",
-          '',
-        ].join('\n'),
-      );
-
       const runbook = [
         '# Noisy Run',
         '',
@@ -103,14 +94,15 @@ describe('start command', () => {
         '- FAIL STOP',
         '',
         '```bash',
-        'node noisy-command.mjs',
+        "printf '\\122\\125\\116\\137\\123\\124\\104\\117\\125\\124\\012'",
+        "printf '\\122\\125\\116\\137\\123\\124\\104\\105\\122\\122\\012' >&2",
         '```',
         '',
       ].join('\n');
 
       await writeFile(join(workspace.runbooksDir(), 'noisy.runbook.md'), runbook);
 
-      const result = runCli('run noisy.runbook.md', workspace);
+      const result = runCli('run --allow-run printf --no-sandbox noisy.runbook.md', workspace);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('RUN_STDOUT');
       expect(result.stdout).not.toContain('RUN_STDERR');

--- a/packages/cli/__tests__/commands/scenario-suite.test.ts
+++ b/packages/cli/__tests__/commands/scenario-suite.test.ts
@@ -708,7 +708,8 @@ cases:
         throw new Error(result.stdout + result.stderr);
       }
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('schema=root-schema');
+      expect(result.stdout).not.toContain('schema=root-schema');
+      expect(result.stderr).toContain('schema=root-schema');
     }, 30000);
 
     it('reports missing static relative ARTIFACTS fixtures before execution', async () => {
@@ -776,7 +777,8 @@ cases:
         throw new Error(result.stdout + result.stderr);
       }
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('schema=nested-schema');
+      expect(result.stdout).not.toContain('schema=nested-schema');
+      expect(result.stderr).toContain('schema=nested-schema');
       expect(result.stdout).not.toContain('schema=root-schema');
     }, 30000);
 

--- a/packages/cli/__tests__/helpers/transition-boundary.test.ts
+++ b/packages/cli/__tests__/helpers/transition-boundary.test.ts
@@ -63,6 +63,17 @@ describe('CLI transition boundary', () => {
     expect(source).not.toMatch(/parseActionType\s*\(/);
   });
 
+  it('passes command stream options into fresh inline child launches', async () => {
+    const source = await readFile(
+      new URL('../../src/services/execution.ts', import.meta.url),
+      'utf8',
+    );
+
+    expect(source).toMatch(
+      /const launchResult = await startRunbook\(\s*\{\s*output,\s*manager,\s*actorService,\s*sessionService,\s*lifecycleService: new ExecutionLifecycleService\(manager\),\s*cwd,\s*commandStreamOptions,\s*\}/,
+    );
+  });
+
   it('does not send COMMAND_RESULT or inline command observation payloads from CLI execution code', async () => {
     const source = await readFile(
       new URL('../../src/services/execution.ts', import.meta.url),

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -2568,7 +2568,7 @@ describe('executeCommandWithPolicyCheck', () => {
 
     await executeCommandWithPolicyCheck(command, cwd);
 
-    expect(core.executeCommand).toHaveBeenCalledWith(command, cwd);
+    expect(core.executeCommand).toHaveBeenCalledWith(command, cwd, undefined, {});
     expect(core.executeCommandWithEnv).not.toHaveBeenCalled();
     expect(core.executeCommandWithPolicy).not.toHaveBeenCalled();
   });
@@ -2624,6 +2624,7 @@ describe('executeCommandWithPolicyCheck', () => {
       command,
       cwd,
       expect.objectContaining({ RD_OUTPUTS_Foo: '/tmp/foo' }),
+      {},
     );
     expect(core.executeCommand).not.toHaveBeenCalled();
     expect(core.executeCommandWithPolicy).not.toHaveBeenCalled();

--- a/packages/cli/__tests__/services/execution-loop.test.ts
+++ b/packages/cli/__tests__/services/execution-loop.test.ts
@@ -57,8 +57,11 @@ const consumeResolvedCompletionFn = mockFn<(id: string) => Promise<unknown>>();
 consumeResolvedCompletionFn.mockResolvedValue(null);
 const completionDrainResolvedCompletionsFn =
   mockFn<(args: Record<string, unknown>) => Promise<Record<string, unknown>>>();
+const recordChildCompletionFn =
+  mockFn<(args: Record<string, unknown>) => Promise<'recorded' | 'blocked'>>();
 const mockCompletionService = {
   drainResolvedCompletions: completionDrainResolvedCompletionsFn,
+  recordChildCompletion: recordChildCompletionFn,
 };
 
 const mockLifecycleService = {
@@ -343,6 +346,8 @@ describe('runExecutionLoop', () => {
       unresolved: 0,
       applied: [],
     }));
+    mockCompletionService.recordChildCompletion.mockReset();
+    mockCompletionService.recordChildCompletion.mockResolvedValue('recorded');
 
     mockActorService.sendAndSync.mockReset();
     mockActorService.getContextSnapshot.mockReset();
@@ -2198,6 +2203,124 @@ describe('runExecutionLoop', () => {
     expect(mockActorService.sendAndSync).toHaveBeenNthCalledWith(2, runbookId, inlineSteps, {
       type: 'INLINE_LAUNCH_CONSUMED',
     });
+  });
+
+  it('propagates blocked inline child terminal instead of treating child completion as success', async () => {
+    const childRunId = actualCore.assertRunId(`rd_${'2'.repeat(32)}`);
+    const inlineLaunch = {
+      parentRunId: runbookId,
+      parentStepId: '1',
+      parentStep: '1',
+      parentFrameKey: '1|',
+      parentEntry: 1,
+      childRunId,
+      childRunbookPath: 'child.runbook.md',
+      childRunbookRef: { source: 'project', path: 'child.runbook.md' },
+      contextSnapshot: {
+        RunId: runbookId,
+        ContextId: 'ctx-unit',
+        WorkPath: '.rundown/work',
+      },
+    };
+    const inlineSteps: LooseStep[] = [
+      {
+        kind: 'substeps',
+        name: '1',
+        description: 'Parent step',
+        substeps: [
+          {
+            id: '1',
+            description: 'Inline child',
+            runbooks: ['child.runbook.md'],
+            transitions: { pass: { next: 'COMPLETE' }, fail: { next: 'STOP' } },
+          },
+        ],
+        transitions: { pass: { next: 'COMPLETE' }, fail: { next: 'STOP' } },
+      },
+    ];
+    const parentLinkage = {
+      kind: 'inline',
+      parentRunId: runbookId,
+      parentStepId: '1',
+      parentStep: '1',
+      parentFrameKey: '1|',
+      parentEntry: 1,
+    };
+    const parentState = makeLoopState('1', {
+      lifecycle: 'running',
+      substep: '1',
+      activeFrameKey: '1|',
+      activeEntry: 1,
+      substepStates: [
+        {
+          id: '1',
+          frameKey: '1|',
+          status: 'running',
+          inline: {
+            childRunbookPath: 'child.runbook.md',
+            childRunbookRef: { source: 'project', path: 'child.runbook.md' },
+            contextSnapshot: inlineLaunch.contextSnapshot,
+            childRunId,
+            createdAt: '2026-05-30T00:00:00.000Z',
+            startedAt: '2026-05-30T00:00:01.000Z',
+          },
+        },
+      ],
+      snapshot: { context: { inlineLaunchIntent: inlineLaunch } },
+    });
+    const existingChild = {
+      ...makeLoopState('1', {
+        id: childRunId,
+        lifecycle: 'completed',
+        parentLinkage,
+      }),
+      runbookSrc: '## 1. Child\nDone',
+    };
+
+    mockManager.load
+      .mockResolvedValueOnce(parentState)
+      .mockResolvedValueOnce(parentState)
+      .mockResolvedValueOnce(existingChild)
+      .mockResolvedValue(existingChild);
+    mockSessionService.getActive.mockResolvedValueOnce({ id: runbookId });
+    mockActorService.observeExecutionUnitEntry.mockResolvedValueOnce([
+      {
+        kind: 'execution_observation',
+        event: {
+          type: 'STEP_ENTERED',
+          payload: {
+            position: { current: '1.1', total: 1 },
+            stepName: '1',
+            description: 'Inline child',
+            isSubstep: true,
+            inlineLaunch,
+          },
+        },
+      },
+    ]);
+    mockActorService.sendAndSync.mockResolvedValueOnce({ state: parentState, snapshot: {} });
+    mockCompletionService.recordChildCompletion.mockResolvedValueOnce('blocked');
+    const output = {
+      executionEvent: jest.fn(),
+      flush: jest.fn(),
+    };
+
+    const result = await runExecutionLoop(
+      asManager(mockManager),
+      runbookId,
+      asSteps(inlineSteps),
+      mockManager.cwd,
+      false,
+      asEmitter(mockEmitter),
+      { output: output as never },
+    );
+
+    expect(result).toBe('stopped');
+    expect(mockCompletionService.recordChildCompletion).toHaveBeenCalledWith({
+      childState: existingChild,
+      result: 'pass',
+    });
+    expect(output.flush).toHaveBeenCalled();
   });
 
   it('does not consume existing inline child intent when session activation fails', async () => {

--- a/packages/cli/__tests__/services/execution-policy-gate.invariant.test.ts
+++ b/packages/cli/__tests__/services/execution-policy-gate.invariant.test.ts
@@ -114,7 +114,7 @@ describe('executeCommandWithPolicyCheck — CLI seam invariant', () => {
     expect(executeCommandWithPolicyMock).not.toHaveBeenCalled();
     expect(getPolicyEvaluatorMock).not.toHaveBeenCalled();
     // With no rdInjected, the no-env un-gated path is used.
-    expect(executeCommandMock).toHaveBeenCalledWith('git status', '/work');
+    expect(executeCommandMock).toHaveBeenCalledWith('git status', '/work', undefined, {});
   });
 
   // Property 5b corollary — trust path with rdInjected still bypasses the gate.

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -9,6 +9,7 @@ import { createCliRunbookActorService } from '../helpers/actor-service-factory.j
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
+import { commandStreamOptionsForOutputMode } from '../services/execution.js';
 import {
   parseArtifactJsonOption,
   parseArtifactOption,
@@ -190,6 +191,7 @@ export function registerClaimCommand(program: Command): void {
             const actorService = createCliRunbookActorService(manager);
             const sessionService = new SessionService(manager);
             const lifecycleService = new ExecutionLifecycleService(manager);
+            const commandStreamOptions = commandStreamOptionsForOutputMode(options.text);
 
             const ctx: RunPipelineContext = {
               output,
@@ -198,6 +200,7 @@ export function registerClaimCommand(program: Command): void {
               sessionService,
               lifecycleService,
               cwd,
+              commandStreamOptions,
             };
 
             const inputOpts = {
@@ -225,7 +228,13 @@ export function registerClaimCommand(program: Command): void {
             if (result.loopResult === 'done' || result.loopResult === 'stopped') {
               const childState = await manager.load(result.childRunId);
               if (childState && extractParentLinkage(childState)) {
-                await propagateChildTerminal(childState, undefined, cwd, output);
+                await propagateChildTerminal(
+                  childState,
+                  undefined,
+                  cwd,
+                  output,
+                  commandStreamOptions,
+                );
               }
             }
 

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -13,7 +13,6 @@ import {
   type Frame,
   type FrameKey,
   type RunId,
-  type CommandExecutionStreamOptions,
 } from '@rundown-org/core';
 import { parseStepIdFromString } from '@rundown-org/parser';
 import { readLifecycleCallerEvidence } from '../helpers/caller-evidence.js';
@@ -106,7 +105,6 @@ export function registerCollectCommand(program: Command): void {
               step: options.step,
               index: options.index,
               text: options.text,
-              commandStreamOptions,
               ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
             });
 
@@ -128,8 +126,6 @@ interface CollectOptions {
   index?: string;
   /** True when `--text` is set (human-readable); false/undefined for JSON. */
   text?: boolean;
-  /** Runtime-only routing for command subprocess stdout/stderr. */
-  commandStreamOptions?: CommandExecutionStreamOptions;
   /** Validated `--run` run id supplying run-controller caller evidence. */
   runId?: RunId;
 }
@@ -444,8 +440,16 @@ function renderCollectOutcome(
  * @returns True if the command should set a non-zero exit code
  */
 async function runCollect(ctx: TransitionContext, options: CollectOptions): Promise<boolean> {
-  const { output, manager, actorService, lifecycleService, state, steps, cwd } = ctx;
-  const { commandStreamOptions } = options;
+  const {
+    output,
+    manager,
+    actorService,
+    lifecycleService,
+    state,
+    steps,
+    cwd,
+    commandStreamOptions,
+  } = ctx;
 
   const scope = resolveCollectScope(state, options, output);
   if (!scope) return true;

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -13,12 +13,14 @@ import {
   type Frame,
   type FrameKey,
   type RunId,
+  type CommandExecutionStreamOptions,
 } from '@rundown-org/core';
 import { parseStepIdFromString } from '@rundown-org/parser';
 import { readLifecycleCallerEvidence } from '../helpers/caller-evidence.js';
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
+import { commandStreamOptionsForOutputMode } from '../services/execution.js';
 import { buildTransitionContext, type TransitionContext } from '../helpers/transitions.js';
 import { resolveIndexOption, IndexOptionError } from '../helpers/index-option.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
@@ -64,6 +66,7 @@ export function registerCollectCommand(program: Command): void {
           async () => {
             const output = new OutputEmitter({ text: options.text, command: 'collect' });
             const cwd = getCwd();
+            const commandStreamOptions = commandStreamOptionsForOutputMode(options.text);
 
             const claimTarget = parseClaimIdOption(options.claimId, output);
             if (!claimTarget.ok) return;
@@ -72,6 +75,7 @@ export function registerCollectCommand(program: Command): void {
             const contextResult = await buildTransitionContext(output, cwd, {
               ...(claimTarget.claimId !== undefined ? { claimId: claimTarget.claimId } : {}),
               ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
+              commandStreamOptions,
             });
             switch (contextResult.kind) {
               case 'ready':
@@ -102,6 +106,7 @@ export function registerCollectCommand(program: Command): void {
               step: options.step,
               index: options.index,
               text: options.text,
+              commandStreamOptions,
               ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
             });
 
@@ -123,6 +128,8 @@ interface CollectOptions {
   index?: string;
   /** True when `--text` is set (human-readable); false/undefined for JSON. */
   text?: boolean;
+  /** Runtime-only routing for command subprocess stdout/stderr. */
+  commandStreamOptions?: CommandExecutionStreamOptions;
   /** Validated `--run` run id supplying run-controller caller evidence. */
   runId?: RunId;
 }
@@ -438,6 +445,7 @@ function renderCollectOutcome(
  */
 async function runCollect(ctx: TransitionContext, options: CollectOptions): Promise<boolean> {
   const { output, manager, actorService, lifecycleService, state, steps, cwd } = ctx;
+  const { commandStreamOptions } = options;
 
   const scope = resolveCollectScope(state, options, output);
   if (!scope) return true;
@@ -530,9 +538,7 @@ async function runCollect(ctx: TransitionContext, options: CollectOptions): Prom
         {
           terminalReleaseMode: 'release-runbook',
           output,
-          commandStreamOptions: {
-            commandOutput: options.text ? 'inherit' : 'stderr',
-          },
+          commandStreamOptions,
         },
       );
       // Do NOT early-return on a stopped loop: the run may have reached a
@@ -558,7 +564,13 @@ async function runCollect(ctx: TransitionContext, options: CollectOptions): Prom
     linkage &&
     (terminal.lifecycle === 'completed' || terminal.lifecycle === 'stopped')
   ) {
-    const propagation = await propagateChildTerminal(terminal, undefined, cwd, output);
+    const propagation = await propagateChildTerminal(
+      terminal,
+      undefined,
+      cwd,
+      output,
+      commandStreamOptions,
+    );
     // Inline propagation may itself drive the parent terminal (STOP) — its
     // outcome decides the exit code for inline, ORed with a stopped loop.
     // Delegation propagation is report-only (no parent advancement) but can

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -527,7 +527,13 @@ async function runCollect(ctx: TransitionContext, options: CollectOptions): Prom
         cwd,
         !!advanced.prompted,
         emitter,
-        { terminalReleaseMode: 'release-runbook', output },
+        {
+          terminalReleaseMode: 'release-runbook',
+          output,
+          commandStreamOptions: {
+            commandOutput: options.text ? 'inherit' : 'stderr',
+          },
+        },
       );
       // Do NOT early-return on a stopped loop: the run may have reached a
       // terminal state INSIDE the loop and still owe its parent a propagation

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -4,6 +4,7 @@ import type { Command } from 'commander';
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
+import { commandStreamOptionsForOutputMode } from '../services/execution.js';
 import { buildGotoContext, validateGotoTarget, executeGoto } from '../helpers/goto-workflow.js';
 import { parseClaimIdOption } from '../helpers/claim-id-option.js';
 import { parseRunOption } from '../helpers/run-option.js';
@@ -38,6 +39,7 @@ export function registerGotoCommand(program: Command): void {
             const contextResult = await buildGotoContext(output, cwd, {
               ...(claimTarget.claimId !== undefined ? { claimId: claimTarget.claimId } : {}),
               ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
+              commandStreamOptions: commandStreamOptionsForOutputMode(options.text),
             });
             switch (contextResult.kind) {
               case 'ready':

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -53,6 +53,7 @@ import {
 } from '../helpers/index-option.js';
 import { propagateChildTerminal } from '../helpers/delegation-completion.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
+import { commandStreamOptionsForOutputMode } from '../services/execution.js';
 
 /**
  * Registers the 'run' command for starting runbooks.
@@ -128,6 +129,7 @@ export function registerRunCommand(program: Command): void {
           const sessionService = new SessionService(manager);
           const lifecycleService = new ExecutionLifecycleService(manager);
 
+          const commandStreamOptions = commandStreamOptionsForOutputMode(options.text);
           const ctx: RunPipelineContext = {
             output,
             manager,
@@ -135,6 +137,7 @@ export function registerRunCommand(program: Command): void {
             sessionService,
             lifecycleService,
             cwd,
+            commandStreamOptions,
           };
 
           // Validate --index requires --step
@@ -263,6 +266,7 @@ export function registerRunCommand(program: Command): void {
                     undefined,
                     cwd,
                     output,
+                    commandStreamOptions,
                   );
                   if (propOutcome === 'stopped' || propOutcome === 'blocked') {
                     output.flush();

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -28,6 +28,7 @@ import {
   projectDelegationTerminalOutcome,
   type RunbookState,
   type ParentLinkage,
+  type CommandExecutionStreamOptions,
 } from '@rundown-org/core';
 import { createCliRunbookActorService } from './actor-service-factory.js';
 import type { OutputEmitter } from '../services/output-emitter.js';
@@ -145,6 +146,8 @@ export async function reportTerminalToDelegatingRun(
  * @param result - Terminal result of the child ('pass' or 'fail')
  * @param cwd - Current working directory
  * @param output - Output emitter for CLI output
+ * @param commandStreamOptions - Runtime-only routing for command subprocess
+ * stdout/stderr while inline propagation continues the parent
  * @returns 'handled' when the parent was advanced (or is waiting on siblings),
  *          'stopped' when advancing the parent reached a STOP terminal,
  *          'not-applicable' when the child has no parent linkage
@@ -155,6 +158,7 @@ export async function advanceParentForInlineChild(
   result: 'pass' | 'fail' | undefined,
   cwd: string,
   output: OutputEmitter,
+  commandStreamOptions?: CommandExecutionStreamOptions,
 ): Promise<TerminalPropagationResult> {
   const linkage = extractParentLinkage(childState);
   // This is the INLINE flow-back path only. Delegation linkage shares the same
@@ -239,7 +243,7 @@ export async function advanceParentForInlineChild(
     await sessionService.releaseRunbook(parentRunId);
     const freshParent = await manager.load(parentRunId);
     const propagated = freshParent
-      ? await propagateChildTerminal(freshParent, undefined, cwd, output)
+      ? await propagateChildTerminal(freshParent, undefined, cwd, output, commandStreamOptions)
       : 'not-applicable';
     output.flush();
     return propagated === 'blocked' ? 'blocked' : 'stopped';
@@ -248,7 +252,7 @@ export async function advanceParentForInlineChild(
     await sessionService.releaseRunbook(parentRunId);
     const freshParent = await manager.load(parentRunId);
     const propagated = freshParent
-      ? await propagateChildTerminal(freshParent, undefined, cwd, output)
+      ? await propagateChildTerminal(freshParent, undefined, cwd, output, commandStreamOptions)
       : 'not-applicable';
     output.flush();
     if (propagated === 'blocked') return 'blocked';
@@ -276,21 +280,21 @@ export async function advanceParentForInlineChild(
       cwd,
       !!loopState.prompted,
       emitter,
-      { terminalReleaseMode: 'release-runbook', output },
+      { terminalReleaseMode: 'release-runbook', output, commandStreamOptions },
     );
     output.flush();
 
     if (loopResult === 'stopped') {
       const terminalParent = await manager.load(parentRunId);
       const propagated = terminalParent
-        ? await propagateChildTerminal(terminalParent, undefined, cwd, output)
+        ? await propagateChildTerminal(terminalParent, undefined, cwd, output, commandStreamOptions)
         : 'not-applicable';
       return propagated === 'blocked' ? 'blocked' : 'stopped';
     }
     if (loopResult === 'done') {
       const terminalParent = await manager.load(parentRunId);
       const propagated = terminalParent
-        ? await propagateChildTerminal(terminalParent, undefined, cwd, output)
+        ? await propagateChildTerminal(terminalParent, undefined, cwd, output, commandStreamOptions)
         : 'not-applicable';
       if (propagated === 'blocked') return 'blocked';
       if (propagated === 'stopped') return 'stopped';
@@ -327,6 +331,8 @@ export async function advanceParentForInlineChild(
  * @param result - Terminal result of the child ('pass' or 'fail')
  * @param cwd - Current working directory
  * @param output - Output emitter for CLI output
+ * @param commandStreamOptions - Runtime-only routing for command subprocess
+ * stdout/stderr while inline propagation continues the parent
  * @returns 'not-applicable' when the child has no parent linkage; for inline,
  *          'handled' or 'stopped' (advancing the parent reached a STOP terminal);
  *          for delegation, 'reported' (the delegating run is collection pending)
@@ -337,10 +343,11 @@ export async function propagateChildTerminal(
   result: 'pass' | 'fail' | undefined,
   cwd: string,
   output: OutputEmitter,
+  commandStreamOptions?: CommandExecutionStreamOptions,
 ): Promise<TerminalPropagationResult> {
   const linkage = extractParentLinkage(childState);
   if (!linkage) return 'not-applicable';
   return linkage.kind === 'inline'
-    ? advanceParentForInlineChild(childState, result, cwd, output)
+    ? advanceParentForInlineChild(childState, result, cwd, output, commandStreamOptions)
     : reportTerminalToDelegatingRun(childState, result, cwd, output);
 }

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -21,6 +21,7 @@ import {
   type RunbookState,
   type ClaimId,
   type RunId,
+  type CommandExecutionStreamOptions,
 } from '@rundown-org/core';
 import { runExecutionLoop, type ExecutionTerminalReleaseMode } from '../services/execution.js';
 import { createCliRunbookActorService } from './actor-service-factory.js';
@@ -50,6 +51,8 @@ export interface GotoContext {
   cwd: string;
   /** How terminal follow-on execution should release this runbook from session targeting. */
   terminalReleaseMode: ExecutionTerminalReleaseMode;
+  /** Runtime-only routing for command subprocess stdout/stderr. */
+  commandStreamOptions?: CommandExecutionStreamOptions;
 }
 
 /**
@@ -114,6 +117,8 @@ export async function resolveTerminalReleaseModeForRunbook(
  * @param options.claimId - Claim id to resolve instead of the default stack
  * @param options.runId - Run id (`--run`) to resolve instead of the default
  *   stack; mutually exclusive with `claimId` (enforced upstream)
+ * @param options.commandStreamOptions - Runtime-only routing for command
+ * subprocess stdout/stderr while goto continues execution
  * @returns Discriminated union: `{ kind: 'ready'; ctx }` when an active runbook
  *   was resolved and a goto context is available; `{ kind: 'none' }` when no
  *   active runbook exists; `{ kind: 'stale_claim' | 'terminal_claim' }` when
@@ -125,7 +130,11 @@ export async function resolveTerminalReleaseModeForRunbook(
 export async function buildGotoContext(
   output: OutputEmitter,
   cwd: string,
-  options: { readonly claimId?: ClaimId; readonly runId?: RunId } = {},
+  options: {
+    readonly claimId?: ClaimId;
+    readonly runId?: RunId;
+    readonly commandStreamOptions?: CommandExecutionStreamOptions;
+  } = {},
 ): Promise<BuildGotoContextResult> {
   const { manager, sessionService, seam } = buildNonDelegatingLifecycleSeam(cwd);
 
@@ -156,6 +165,7 @@ export async function buildGotoContext(
       steps: [...outcome.steps],
       cwd,
       terminalReleaseMode: outcome.terminalReleaseMode,
+      commandStreamOptions: options.commandStreamOptions,
     },
   };
 }
@@ -295,7 +305,11 @@ export async function executeGoto(ctx: GotoContext, target: StepId): Promise<Got
     cwd,
     !!state.prompted,
     emitter,
-    { terminalReleaseMode: ctx.terminalReleaseMode, output },
+    {
+      terminalReleaseMode: ctx.terminalReleaseMode,
+      output,
+      commandStreamOptions: ctx.commandStreamOptions,
+    },
   );
 
   return { ok: true, loopResult };

--- a/packages/cli/src/helpers/runbook-pipeline.ts
+++ b/packages/cli/src/helpers/runbook-pipeline.ts
@@ -39,6 +39,7 @@ import {
   type TemplateVarValue,
   type VariableValue,
   type RoutedVariableValue,
+  type CommandExecutionStreamOptions,
   generateRunId,
   partitionVariables,
   prepareParsedRunbook,
@@ -106,6 +107,8 @@ export interface RunPipelineContext {
   lifecycleService: ExecutionLifecycleService;
   /** Current working directory for file resolution */
   cwd: string;
+  /** Runtime-only routing for command subprocess stdout/stderr. */
+  commandStreamOptions?: CommandExecutionStreamOptions;
 }
 
 /** Template variables available after runbook resolution but before execution starts. */
@@ -1028,6 +1031,7 @@ async function launchRunbook(
       terminalReleaseMode:
         options.sessionActivation?.kind === 'none' ? 'release-runbook' : 'stack-pop',
       output,
+      commandStreamOptions: ctx.commandStreamOptions,
     },
   );
 

--- a/packages/cli/src/helpers/transition-command.ts
+++ b/packages/cli/src/helpers/transition-command.ts
@@ -8,6 +8,7 @@ import {
 import { getCwd } from './context.js';
 import { withErrorHandling } from './wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
+import { commandStreamOptionsForOutputMode } from '../services/execution.js';
 import { runSeamTransition, type TransitionConfig } from './transitions.js';
 import { extractParentLinkage, propagateChildTerminal } from './delegation-completion.js';
 import { validateIndexRequiresStep } from './index-option.js';
@@ -125,11 +126,13 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
             // work: cursor parsing, output rendering, and the execution loop. The
             // seam renders refusals/applied events itself (inside runSeamTransition);
             // here we own the post-transition parent-propagation/exit-code contract.
+            const commandStreamOptions = commandStreamOptionsForOutputMode(options.text);
             const { manager, applied, exitError } = await runSeamTransition(output, cwd, config, {
               ...(claimTarget.claimId !== undefined ? { claimId: claimTarget.claimId } : {}),
               ...(runTarget.runId !== undefined ? { runId: runTarget.runId } : {}),
               ...(options.step !== undefined ? { step: options.step } : {}),
               ...(options.index !== undefined ? { index: options.index } : {}),
+              commandStreamOptions,
             });
 
             // Exit-code contract: when this runbook is a delegated child whose
@@ -163,6 +166,7 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
                     def.name,
                     cwd,
                     output,
+                    commandStreamOptions,
                   );
                   if (linkage.kind === 'inline') {
                     shouldExitWithError = propagation === 'stopped' || propagation === 'blocked';

--- a/packages/cli/src/helpers/transitions.ts
+++ b/packages/cli/src/helpers/transitions.ts
@@ -26,6 +26,7 @@ import {
   type RunbookState,
   type ClaimId,
   type RunId,
+  type CommandExecutionStreamOptions,
   type LifecycleTransitionOutcome,
   type TransitionObservationEvent,
 } from '@rundown-org/core';
@@ -145,6 +146,8 @@ export interface TransitionContext {
   cwd: string;
   /** How terminal follow-on execution should release this runbook from session targeting. */
   terminalReleaseMode: ExecutionTerminalReleaseMode;
+  /** Runtime-only routing for command subprocess stdout/stderr. */
+  commandStreamOptions?: CommandExecutionStreamOptions;
   /**
    * When true, the decisive parent-advance write is run through
    * {@link SessionService.runGuardedParentAdvance} so the open-delegated-children
@@ -193,13 +196,19 @@ export type BaseBuildTransitionContextResult =
  * @param options.claimId - Claim id to resolve instead of the default stack
  * @param options.runId - Run id (`--run`) to resolve instead of the default
  *   stack; mutually exclusive with `claimId` (enforced upstream)
+ * @param options.commandStreamOptions - Runtime-only routing for command
+ * subprocess stdout/stderr while transition follow-on execution continues
  * @returns `{ kind: 'ready', ctx }` when a target is resolved, or a typed refusal
  * @throws {Error} if state is missing runbookSrc (corrupted state)
  */
 export async function buildTransitionContext(
   output: OutputEmitter,
   cwd: string,
-  options: { readonly claimId?: ClaimId; readonly runId?: RunId } = {},
+  options: {
+    readonly claimId?: ClaimId;
+    readonly runId?: RunId;
+    readonly commandStreamOptions?: CommandExecutionStreamOptions;
+  } = {},
 ): Promise<BaseBuildTransitionContextResult> {
   const manager = new RunbookStateManager(cwd);
   const actorService = createCliRunbookActorService(manager);
@@ -260,6 +269,7 @@ export async function buildTransitionContext(
       steps,
       cwd,
       terminalReleaseMode,
+      commandStreamOptions: options.commandStreamOptions,
       // Base-path callers (collect) are exempt from the bare-pass/fail
       // open-delegated-children guard by construction.
       guardOpenChildren: false,
@@ -345,6 +355,8 @@ export interface SeamTransitionOptions {
   readonly step?: string;
   /** Raw `--index` value (requires `--step`). */
   readonly index?: string;
+  /** Runtime-only routing for command subprocess stdout/stderr. */
+  readonly commandStreamOptions?: CommandExecutionStreamOptions;
 }
 
 /**
@@ -493,6 +505,7 @@ async function renderApplied(
   config: TransitionConfig,
   manager: RunbookStateManager,
   outcome: Extract<LifecycleTransitionOutcome, { kind: 'applied' }>,
+  commandStreamOptions?: CommandExecutionStreamOptions,
 ): Promise<{ readonly status: 'continue' | 'stopped'; readonly runId: RunId }> {
   if (outcome.duplicate) {
     output.status(config.commandName, `Completion already recorded for ${outcome.duplicate.at}`, {
@@ -535,7 +548,11 @@ async function renderApplied(
         cwd,
         outcome.loop.prompted,
         emitter,
-        { terminalReleaseMode: outcome.terminalReleaseMode, output },
+        {
+          terminalReleaseMode: outcome.terminalReleaseMode,
+          output,
+          commandStreamOptions,
+        },
       );
       if (loopResult === 'stopped') status = 'stopped';
     }
@@ -626,7 +643,14 @@ export async function runSeamTransition(
     return { manager, exitError };
   }
 
-  const applied = await renderApplied(output, cwd, config, manager, outcome);
+  const applied = await renderApplied(
+    output,
+    cwd,
+    config,
+    manager,
+    outcome,
+    options.commandStreamOptions,
+  );
   output.flush();
   return { manager, applied, exitError: applied.status === 'stopped' };
 }

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -23,6 +23,7 @@ import {
   type ExecutionResult,
   type CommandExecutionServices,
   type ExecutionObservationEffect,
+  type CommandExecutionStreamOptions,
   executeCommand,
   executeCommandWithEnv,
   executeCommandWithPolicy,
@@ -223,6 +224,8 @@ export interface ExecutionLoopOptions {
   readonly actorService?: RunbookActorService;
   /** Optional command services test seam. */
   readonly commandServices?: CommandExecutionServices;
+  /** Runtime-only routing for command subprocess stdout/stderr. */
+  readonly commandStreamOptions?: CommandExecutionStreamOptions;
   /** Output emitter used when the loop launches an inline child runbook. */
   readonly output?: OutputEmitter;
 }
@@ -237,6 +240,7 @@ interface InlineLaunchArgs {
   readonly intent: InlineLaunchIntent;
   readonly prompted: boolean;
   readonly output: OutputEmitter;
+  readonly commandStreamOptions?: CommandExecutionStreamOptions;
 }
 
 async function applyExecutionTerminalRelease(
@@ -255,14 +259,16 @@ async function applyExecutionTerminalRelease(
   await sessionService.popRunbook();
 }
 
-function createCliCommandServices(): CommandExecutionServices {
+function createCliCommandServices(
+  streamOptions: CommandExecutionStreamOptions = {},
+): CommandExecutionServices {
   return {
     runInternalCommand: async ({ command, cwd, rdInjected }) => {
       if (!isInternalRdCommand(command)) return null;
       return executeRdCommandInternal(command, cwd, rdInjected);
     },
     runExternalCommand: async ({ command, cwd, runbookPath, rdInjected }) =>
-      executeCommandWithPolicyCheck(command, cwd, runbookPath, rdInjected),
+      executeCommandWithPolicyCheck(command, cwd, runbookPath, rdInjected, streamOptions),
   };
 }
 
@@ -429,6 +435,7 @@ async function launchInlineChildFromIntent({
   intent,
   prompted,
   output,
+  commandStreamOptions,
 }: InlineLaunchArgs): Promise<'done' | 'stopped' | 'waiting'> {
   const parentLinkage: InlineLinkage = {
     kind: 'inline',
@@ -550,7 +557,7 @@ async function launchInlineChildFromIntent({
         cwd,
         !!existingChild.prompted,
         createBridgedEmitter(existingChild, output),
-        { output },
+        { output, commandStreamOptions },
       );
       return await propagateInlineChildTerminalResult({
         manager,
@@ -996,9 +1003,10 @@ export async function runExecutionLoop(
       ? EXECUTION_TERMINAL_NO_STACK_POLICY
       : EXECUTION_TERMINAL_POLICY;
 
+  const commandServices =
+    options.commandServices ?? createCliCommandServices(options.commandStreamOptions);
   const actorService =
-    options.actorService ??
-    createCliRunbookActorService(manager, options.commandServices ?? createCliCommandServices());
+    options.actorService ?? createCliRunbookActorService(manager, commandServices);
   const sessionService = new SessionService(manager);
   const lifecycleService = new ExecutionLifecycleService(manager);
   const ensuredInitial = await lifecycleService.ensureActiveEntry(runbookId, undefined, state);
@@ -1280,6 +1288,7 @@ export async function runExecutionLoop(
         intent: inlineLaunch,
         prompted,
         output: options.output,
+        commandStreamOptions: options.commandStreamOptions,
       });
     }
 
@@ -1450,6 +1459,7 @@ export function buildMetadata(state: RunbookState): RunbookMetadata {
  * @param cwd - Working directory for execution
  * @param runbookPath - Optional runbook file path for override matching
  * @param rdInjected - Optional rundown-injected env vars (`RD_OUTPUTS_*`, `RD_WORK_PATH`, etc.) merged into the child process environment
+ * @param streamOptions - Runtime-only routing for command subprocess stdout/stderr
  * @returns Execution result
  */
 export async function executeCommandWithPolicyCheck(
@@ -1457,6 +1467,7 @@ export async function executeCommandWithPolicyCheck(
   cwd: string,
   runbookPath?: string,
   rdInjected?: Record<string, string>,
+  streamOptions: CommandExecutionStreamOptions = {},
 ): Promise<ExecutionResult> {
   // Check if policy enforcement is active
   if (!isPolicyEnforced()) {
@@ -1465,9 +1476,9 @@ export async function executeCommandWithPolicyCheck(
     // file-backed OUTPUTS channels are visible to the subprocess.
     if (rdInjected && Object.keys(rdInjected).length > 0) {
       const env = { ...process.env, ...rdInjected } as Record<string, string>;
-      return executeCommandWithEnv(command, cwd, env);
+      return executeCommandWithEnv(command, cwd, env, streamOptions);
     }
-    return executeCommand(command, cwd);
+    return executeCommand(command, cwd, undefined, streamOptions);
   }
 
   // Get evaluator and set runbook path for override matching
@@ -1486,5 +1497,6 @@ export async function executeCommandWithPolicyCheck(
     rdInjected,
     sandbox: sandboxOpts.sandbox,
     sandboxStrict: sandboxOpts.sandboxStrict,
+    streamOptions,
   });
 }

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -78,6 +78,18 @@ export type { ExecutionVarValue, StepVariables, TemplateVariables } from './exec
 export { buildStepVariables };
 
 /**
+ * Select command subprocess stream routing for a CLI output mode.
+ *
+ * @param text - Whether the surrounding command is rendering human-readable text
+ * @returns Runtime-only command stream options for execution services
+ */
+export function commandStreamOptionsForOutputMode(
+  text: boolean | undefined,
+): CommandExecutionStreamOptions {
+  return { commandOutput: text ? 'inherit' : 'stderr' };
+}
+
+/**
  * Find a step by name, throwing if not found.
  *
  * Replaces silent `steps[0]` fallbacks that mask state corruption.
@@ -367,8 +379,9 @@ async function propagateInlineChildTerminalResult(args: {
   readonly loopResult: 'done' | 'stopped' | 'waiting';
   readonly cwd: string;
   readonly output: OutputEmitter;
+  readonly commandStreamOptions?: CommandExecutionStreamOptions;
 }): Promise<'done' | 'stopped' | 'waiting'> {
-  const { manager, childRunId, loopResult, cwd, output } = args;
+  const { manager, childRunId, loopResult, cwd, output, commandStreamOptions } = args;
   if (loopResult !== 'done' && loopResult !== 'stopped') return loopResult;
 
   const childState = await manager.load(childRunId);
@@ -378,10 +391,17 @@ async function propagateInlineChildTerminalResult(args: {
   // same orchestrator that ran the child advances the parent here. Drain and
   // advance the parent immediately (there is no separate `rd collect` for
   // inline). The child's own loopResult governs the result here unless advancing
-  // the parent reaches a STOP terminal, which surfaces as 'stopped'.
+  // the parent reaches a STOP or blocked terminal, both of which surface to the
+  // execution loop as 'stopped'.
   const { propagateChildTerminal } = await import('../helpers/delegation-completion.js');
-  const propagated = await propagateChildTerminal(childState, undefined, cwd, output);
-  return propagated === 'stopped' ? 'stopped' : loopResult;
+  const propagated = await propagateChildTerminal(
+    childState,
+    undefined,
+    cwd,
+    output,
+    commandStreamOptions,
+  );
+  return propagated === 'stopped' || propagated === 'blocked' ? 'stopped' : loopResult;
 }
 
 async function consumeInlineLaunchIntent(args: {
@@ -565,6 +585,7 @@ async function launchInlineChildFromIntent({
         loopResult,
         cwd,
         output,
+        commandStreamOptions,
       });
     }
 
@@ -682,6 +703,7 @@ async function launchInlineChildFromIntent({
         loopResult: launchResult.loopResult,
         cwd,
         output,
+        commandStreamOptions,
       });
     }
 

--- a/packages/cli/src/services/execution.ts
+++ b/packages/cli/src/services/execution.ts
@@ -657,6 +657,7 @@ async function launchInlineChildFromIntent({
         sessionService,
         lifecycleService: new ExecutionLifecycleService(manager),
         cwd,
+        commandStreamOptions,
       },
       prepared.prepared,
       {

--- a/packages/core/__tests__/policy/evaluator.test.ts
+++ b/packages/core/__tests__/policy/evaluator.test.ts
@@ -119,6 +119,38 @@ describe('PolicyEvaluator', () => {
       });
     });
 
+    it('should expose runtime grants separately from persisted sandbox grants', () => {
+      const policy: PolicyConfig = {
+        ...DEFAULT_POLICY,
+        default: {
+          ...DEFAULT_POLICY.default,
+          read: { allow: ['/configured/read/**'], deny: ['/denied/read/**'] },
+        },
+        grants: [
+          {
+            type: 'read',
+            pattern: '/persisted/read/**',
+            scope: 'session',
+            grantedAt: new Date().toISOString(),
+          },
+        ],
+      };
+      const evaluator = new PolicyEvaluator(policy, {
+        repoRoot,
+        cliGrants: {
+          read: ['/cli/read/**'],
+        },
+      });
+
+      evaluator.addSessionGrant('read', '/session/read/**');
+
+      expect(evaluator.getSandboxRules('read')).toEqual({
+        allow: ['/configured/read/**', '/persisted/read/**', '/cli/read/**', '/session/read/**'],
+        deny: ['/denied/read/**'],
+        runtimeGrantAllow: ['/cli/read/**', '/session/read/**'],
+      });
+    });
+
     it('should respect CLI grants', () => {
       const evaluator = new PolicyEvaluator(DEFAULT_POLICY, {
         repoRoot,

--- a/packages/core/__tests__/runbook/executor.test.ts
+++ b/packages/core/__tests__/runbook/executor.test.ts
@@ -1,14 +1,22 @@
 import * as os from 'node:os';
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import {
-  executeCommand,
-  executeCommandWithPolicy,
-  executeCommandWithEnv,
-  POLICY_DENIED_EXIT_CODE,
-} from '../../src/runbook/executor.js';
 import { PolicyEvaluator } from '../../src/policy/evaluator.js';
 import { DEFAULT_POLICY, type PolicyConfig } from '../../src/policy/schema.js';
 import type { PolicyPrompter } from '../../src/policy/prompter.js';
+import type { spawn as nodeSpawn } from 'node:child_process';
+
+const actualChildProcess = await import('node:child_process');
+const spawnMock = jest.fn((...args: Parameters<typeof nodeSpawn>) =>
+  actualChildProcess.spawn(...args),
+);
+
+jest.unstable_mockModule('node:child_process', () => ({
+  ...actualChildProcess,
+  spawn: spawnMock,
+}));
+
+const { executeCommand, executeCommandWithPolicy, executeCommandWithEnv, POLICY_DENIED_EXIT_CODE } =
+  await import('../../src/runbook/executor.js');
 
 /**
  * Creates a mock PolicyPrompter for testing.
@@ -32,6 +40,10 @@ function createMockPrompter(requestPermissionResult: {
 }
 
 describe('executeCommand', () => {
+  beforeEach(() => {
+    spawnMock.mockClear();
+  });
+
   it('returns success true for exit code 0', async () => {
     // Use node for cross-platform compatibility
     const result = await executeCommand('node -e "process.exit(0)"', process.cwd());
@@ -109,6 +121,11 @@ describe('executeCommand', () => {
       );
 
       expect(result.success).toBe(true);
+      expect(spawnMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({ stdio: 'inherit' }),
+      );
       expect(stdoutWrite).not.toHaveBeenCalledWith(expect.stringContaining('default-out'));
       expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining('default-out'));
     } finally {

--- a/packages/core/__tests__/runbook/executor.test.ts
+++ b/packages/core/__tests__/runbook/executor.test.ts
@@ -74,6 +74,48 @@ describe('executeCommand', () => {
     expect(result.success).toBe(true);
     expect(result.exitCode).toBe(0);
   });
+
+  it('routes command stdout and stderr to process stderr when commandOutput is stderr', async () => {
+    const stdoutWrite = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      const result = await executeCommand(
+        "node -e \"process.stdout.write('out-from-command'); process.stderr.write('err-from-command')\"",
+        process.cwd(),
+        undefined,
+        { commandOutput: 'stderr' },
+      );
+
+      expect(result.success).toBe(true);
+      expect(stdoutWrite).not.toHaveBeenCalledWith(expect.stringContaining('out-from-command'));
+      const stderrChunks = stderrWrite.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(stderrChunks).toContain('out-from-command');
+      expect(stderrChunks).toContain('err-from-command');
+    } finally {
+      stdoutWrite.mockRestore();
+      stderrWrite.mockRestore();
+    }
+  });
+
+  it('keeps inherited command stdio as the default stream policy', async () => {
+    const stdoutWrite = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      const result = await executeCommand(
+        'node -e "process.stdout.write(\'default-out\')"',
+        process.cwd(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(stdoutWrite).not.toHaveBeenCalledWith(expect.stringContaining('default-out'));
+      expect(stderrWrite).not.toHaveBeenCalledWith(expect.stringContaining('default-out'));
+    } finally {
+      stdoutWrite.mockRestore();
+      stderrWrite.mockRestore();
+    }
+  });
 });
 
 describe('executeCommandWithPolicy', () => {

--- a/packages/core/__tests__/sandbox/linux-execute.test.ts
+++ b/packages/core/__tests__/sandbox/linux-execute.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events';
 import { fileURLToPath } from 'node:url';
 import { chmodSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { pipeCommandOutputToStderr } from '../../src/runbook/command-stream-policy.js';
 import { LandlockSandbox, type LandlockSandboxOptions } from '../../src/sandbox/linux.js';
 import type { SandboxOptions } from '../../src/sandbox/types.js';
 
@@ -192,6 +193,7 @@ describe('LandlockSandbox.execute applied path', () => {
 
   it('uses fd 1 and fd 2 pipes for stderr command output while preserving fd 3 and fd 4 protocol pipes', async () => {
     let capturedStdio: unknown;
+    const stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
     const child = new EventEmitter() as EventEmitter & {
       stdio: Array<unknown>;
       unref: jest.Mock;
@@ -208,6 +210,8 @@ describe('LandlockSandbox.execute applied path', () => {
     const spawnMock = jest.fn((_command: string, _args: string[], options: SpawnOptions) => {
       capturedStdio = options.stdio;
       process.nextTick(() => {
+        (child.stdio[1] as EventEmitter).emit('data', 'linux-out');
+        (child.stdio[2] as EventEmitter).emit('data', 'linux-err');
         (child.stdio[4] as EventEmitter).emit(
           'data',
           '{"status":"applied","abi":3,"downgraded":false,"network":"deny"}\n',
@@ -217,18 +221,67 @@ describe('LandlockSandbox.execute applied path', () => {
       return child as unknown as ChildProcess;
     });
 
-    const sandbox = new LandlockSandbox({
-      helperPath: FAKE,
-      probeEnv: { FAKE_PROBE_JSON: '{"available":true,"abi":3}' },
-      spawn: spawnMock as unknown as LandlockSandboxOptions['spawn'],
+    try {
+      const sandbox = new LandlockSandbox({
+        helperPath: FAKE,
+        probeEnv: { FAKE_PROBE_JSON: '{"available":true,"abi":3}' },
+        spawn: spawnMock as unknown as LandlockSandboxOptions['spawn'],
+      });
+
+      const result = await sandbox.execute('printf linux-out', {
+        ...base,
+        commandOutput: 'stderr',
+      });
+
+      expect(result.success).toBe(true);
+      expect(capturedStdio).toEqual(['inherit', 'pipe', 'pipe', 'pipe', 'pipe']);
+      const stderrChunks = stderrWrite.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(stderrChunks).toContain('linux-out');
+      expect(stderrChunks).toContain('linux-err');
+    } finally {
+      stderrWrite.mockRestore();
+    }
+  });
+});
+
+describe('pipeCommandOutputToStderr', () => {
+  const createCommandStream = () =>
+    Object.assign(new EventEmitter(), {
+      pipe: jest.fn(),
     });
 
-    const result = await sandbox.execute('printf linux-out', {
-      ...base,
-      commandOutput: 'stderr',
-    });
+  it('uses pipe forwarding to process.stderr when stderr routing is enabled', () => {
+    const stdout = createCommandStream();
+    const stderr = createCommandStream();
+    const child = { stdout, stderr } as unknown as ChildProcess;
 
-    expect(result.success).toBe(true);
-    expect(capturedStdio).toEqual(['inherit', 'pipe', 'pipe', 'pipe', 'pipe']);
+    pipeCommandOutputToStderr(child, 'stderr');
+
+    expect(stdout.pipe).toHaveBeenCalledWith(process.stderr, { end: false });
+    expect(stderr.pipe).toHaveBeenCalledWith(process.stderr, { end: false });
+  });
+
+  it('does not attach stream forwarding when stderr routing is disabled', () => {
+    const stdout = createCommandStream();
+    const stderr = createCommandStream();
+    const child = { stdout, stderr } as unknown as ChildProcess;
+
+    pipeCommandOutputToStderr(child, undefined);
+
+    expect(stdout.pipe).not.toHaveBeenCalled();
+    expect(stderr.pipe).not.toHaveBeenCalled();
+    expect(stdout.listenerCount('error')).toBe(0);
+    expect(stderr.listenerCount('error')).toBe(0);
+  });
+
+  it('handles command stream errors when stderr routing is enabled', () => {
+    const stdout = createCommandStream();
+    const stderr = createCommandStream();
+    const child = { stdout, stderr } as unknown as ChildProcess;
+
+    pipeCommandOutputToStderr(child, 'stderr');
+
+    expect(() => stdout.emit('error', new Error('stdout reset'))).not.toThrow();
+    expect(() => stderr.emit('error', new Error('stderr reset'))).not.toThrow();
   });
 });

--- a/packages/core/__tests__/sandbox/linux-execute.test.ts
+++ b/packages/core/__tests__/sandbox/linux-execute.test.ts
@@ -194,14 +194,32 @@ describe('LandlockSandbox.execute applied path', () => {
   it('uses fd 1 and fd 2 pipes for stderr command output while preserving fd 3 and fd 4 protocol pipes', async () => {
     let capturedStdio: unknown;
     const stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const createCommandStream = () => {
+      const emitter = new EventEmitter();
+      return Object.assign(emitter, {
+        destroy: jest.fn(),
+        pipe: jest.fn((dest: NodeJS.WritableStream, _options?: { end?: boolean }) => {
+          emitter.on('data', (chunk: Buffer | string) => {
+            dest.write(chunk);
+          });
+          return dest;
+        }),
+      });
+    };
+    const commandStdout = createCommandStream();
+    const commandStderr = createCommandStream();
     const child = new EventEmitter() as EventEmitter & {
+      stdout: typeof commandStdout;
+      stderr: typeof commandStderr;
       stdio: Array<unknown>;
       unref: jest.Mock;
     };
+    child.stdout = commandStdout;
+    child.stderr = commandStderr;
     child.stdio = [
       null,
-      Object.assign(new EventEmitter(), { destroy: jest.fn() }),
-      Object.assign(new EventEmitter(), { destroy: jest.fn() }),
+      commandStdout,
+      commandStderr,
       Object.assign(new EventEmitter(), { write: jest.fn(), end: jest.fn(), destroy: jest.fn() }),
       Object.assign(new EventEmitter(), { setEncoding: jest.fn(), destroy: jest.fn() }),
     ];
@@ -210,8 +228,8 @@ describe('LandlockSandbox.execute applied path', () => {
     const spawnMock = jest.fn((_command: string, _args: string[], options: SpawnOptions) => {
       capturedStdio = options.stdio;
       process.nextTick(() => {
-        (child.stdio[1] as EventEmitter).emit('data', 'linux-out');
-        (child.stdio[2] as EventEmitter).emit('data', 'linux-err');
+        child.stdout.emit('data', 'linux-out');
+        child.stderr.emit('data', 'linux-err');
         (child.stdio[4] as EventEmitter).emit(
           'data',
           '{"status":"applied","abi":3,"downgraded":false,"network":"deny"}\n',
@@ -235,9 +253,13 @@ describe('LandlockSandbox.execute applied path', () => {
 
       expect(result.success).toBe(true);
       expect(capturedStdio).toEqual(['inherit', 'pipe', 'pipe', 'pipe', 'pipe']);
+      expect(commandStdout.pipe).toHaveBeenCalledWith(process.stderr, { end: false });
+      expect(commandStderr.pipe).toHaveBeenCalledWith(process.stderr, { end: false });
       const stderrChunks = stderrWrite.mock.calls.map(([chunk]) => String(chunk)).join('');
       expect(stderrChunks).toContain('linux-out');
       expect(stderrChunks).toContain('linux-err');
+      expect(() => commandStdout.emit('error', new Error('stdout reset'))).not.toThrow();
+      expect(() => commandStderr.emit('error', new Error('stderr reset'))).not.toThrow();
     } finally {
       stderrWrite.mockRestore();
     }

--- a/packages/core/__tests__/sandbox/linux-execute.test.ts
+++ b/packages/core/__tests__/sandbox/linux-execute.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import { fileURLToPath } from 'node:url';
 import { chmodSync } from 'node:fs';
 import { dirname } from 'node:path';
-import { LandlockSandbox } from '../../src/sandbox/linux.js';
+import { LandlockSandbox, type LandlockSandboxOptions } from '../../src/sandbox/linux.js';
 import type { SandboxOptions } from '../../src/sandbox/types.js';
 
 const FAKE = fileURLToPath(new URL('./fixtures/fake-helper.mjs', import.meta.url));
@@ -187,4 +189,46 @@ describe('LandlockSandbox.execute applied path', () => {
     // Let any late pipe 'error' surface before the test ends.
     await new Promise((res) => setTimeout(res, 250));
   }, 10000);
+
+  it('uses fd 1 and fd 2 pipes for stderr command output while preserving fd 3 and fd 4 protocol pipes', async () => {
+    let capturedStdio: unknown;
+    const child = new EventEmitter() as EventEmitter & {
+      stdio: Array<unknown>;
+      unref: jest.Mock;
+    };
+    child.stdio = [
+      null,
+      Object.assign(new EventEmitter(), { destroy: jest.fn() }),
+      Object.assign(new EventEmitter(), { destroy: jest.fn() }),
+      Object.assign(new EventEmitter(), { write: jest.fn(), end: jest.fn(), destroy: jest.fn() }),
+      Object.assign(new EventEmitter(), { setEncoding: jest.fn(), destroy: jest.fn() }),
+    ];
+    child.unref = jest.fn();
+
+    const spawnMock = jest.fn((_command: string, _args: string[], options: SpawnOptions) => {
+      capturedStdio = options.stdio;
+      process.nextTick(() => {
+        (child.stdio[4] as EventEmitter).emit(
+          'data',
+          '{"status":"applied","abi":3,"downgraded":false,"network":"deny"}\n',
+        );
+        child.emit('close', 0);
+      });
+      return child as unknown as ChildProcess;
+    });
+
+    const sandbox = new LandlockSandbox({
+      helperPath: FAKE,
+      probeEnv: { FAKE_PROBE_JSON: '{"available":true,"abi":3}' },
+      spawn: spawnMock as unknown as LandlockSandboxOptions['spawn'],
+    });
+
+    const result = await sandbox.execute('printf linux-out', {
+      ...base,
+      commandOutput: 'stderr',
+    });
+
+    expect(result.success).toBe(true);
+    expect(capturedStdio).toEqual(['inherit', 'pipe', 'pipe', 'pipe', 'pipe']);
+  });
 });

--- a/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
+++ b/packages/core/__tests__/sandbox/macos.enforcement.integration.test.ts
@@ -19,7 +19,7 @@ const required = process.env.RUNDOWN_REQUIRE_SEATBELT === '1';
 
 type SandboxOptionsWithNetwork = SandboxOptions & { network: 'deny' | 'allow' };
 
-function metadataAncestorsFor(path: string): string[] {
+function metadataPathAndAncestorsFor(path: string): string[] {
   const ancestors: string[] = [];
   let current = path;
   while (current !== dirname(current)) {
@@ -29,8 +29,8 @@ function metadataAncestorsFor(path: string): string[] {
   return ancestors.filter((ancestor) => ancestor !== '/');
 }
 
-function uniqueMetadataAncestorsFor(paths: readonly string[]): string[] {
-  return [...new Set(paths.flatMap((path) => metadataAncestorsFor(path)))];
+function uniqueMetadataPathsAndAncestorsFor(paths: readonly string[]): string[] {
+  return [...new Set(paths.flatMap((path) => metadataPathAndAncestorsFor(path)))];
 }
 
 if (!availability.available) {
@@ -73,7 +73,7 @@ if (!availability.available) {
         repoRoot: repoCwd,
         readOnlyPaths: [repoCwd, grantedReadDir],
         readWritePaths: [grantedWriteDir],
-        metadataReadPaths: uniqueMetadataAncestorsFor([repoCwd, root]),
+        metadataReadPaths: uniqueMetadataPathsAndAncestorsFor([repoCwd, root]),
         denyPaths: [],
         denyPatterns: [],
         env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
@@ -142,7 +142,7 @@ if (!availability.available) {
           repoRoot: repoCwd,
           readOnlyPaths: [repoCwd],
           readWritePaths: [],
-          metadataReadPaths: metadataAncestorsFor(repoCwd),
+          metadataReadPaths: metadataPathAndAncestorsFor(repoCwd),
           denyPaths: [],
           denyPatterns: [],
           env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },

--- a/packages/core/__tests__/sandbox/macos.test.ts
+++ b/packages/core/__tests__/sandbox/macos.test.ts
@@ -684,7 +684,9 @@ describe('SeatbeltSandbox', () => {
         stderr: new EventEmitter(),
         on: jest.fn((event: string, callback: (arg?: number | Error) => void) => {
           if (event === 'close') {
-            closeCallbacks.push(() => callback(0));
+            closeCallbacks.push(() => {
+              callback(0);
+            });
           }
           return mockChild;
         }),

--- a/packages/core/__tests__/sandbox/macos.test.ts
+++ b/packages/core/__tests__/sandbox/macos.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { EventEmitter } from 'node:events';
 import { dirname } from 'node:path';
 import type { SandboxOptions } from '../../src/sandbox/types.js';
 
@@ -664,6 +665,54 @@ describe('SeatbeltSandbox', () => {
           }),
         }),
       );
+    });
+
+    it('pipes sandboxed command stdout and stderr to stderr when commandOutput is stderr', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      (existsSync as jest.Mock).mockReturnValue(true);
+      (writeFileSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+      (unlinkSync as jest.Mock).mockImplementation(() => {
+        /* noop */
+      });
+
+      const sandbox = new SeatbeltSandbox();
+      const closeCallbacks: Array<() => void> = [];
+      const mockChild = {
+        stdout: new EventEmitter(),
+        stderr: new EventEmitter(),
+        on: jest.fn((event: string, callback: (arg?: number | Error) => void) => {
+          if (event === 'close') {
+            closeCallbacks.push(() => callback(0));
+          }
+          return mockChild;
+        }),
+      };
+      (spawn as jest.Mock).mockReturnValue(mockChild);
+      const stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const promise = sandbox.execute('echo hi', {
+          ...mockOptions,
+          commandOutput: 'stderr',
+        });
+
+        mockChild.stdout.emit('data', 'sandbox-out');
+        mockChild.stderr.emit('data', 'sandbox-err');
+        for (const close of closeCallbacks) close();
+
+        await expect(promise).resolves.toMatchObject({ success: true });
+        expect(spawn).toHaveBeenCalledWith(
+          '/usr/bin/sandbox-exec',
+          expect.any(Array),
+          expect.objectContaining({ stdio: ['inherit', 'pipe', 'pipe'] }),
+        );
+        expect(stderrWrite).toHaveBeenCalledWith('sandbox-out');
+        expect(stderrWrite).toHaveBeenCalledWith('sandbox-err');
+      } finally {
+        stderrWrite.mockRestore();
+      }
     });
 
     it('writes explicit deny rules into the generated profile', async () => {

--- a/packages/core/src/runbook/command-stream-policy.ts
+++ b/packages/core/src/runbook/command-stream-policy.ts
@@ -1,0 +1,43 @@
+import type { ChildProcess, StdioOptions } from 'node:child_process';
+
+/**
+ * Runtime routing for stdout/stderr emitted by a command subprocess.
+ */
+export type CommandOutputStreamPolicy = 'inherit' | 'stderr';
+
+/**
+ * Runtime-only stream options for command subprocess execution.
+ */
+export interface CommandExecutionStreamOptions {
+  /** Where command stdout/stderr should be routed. Defaults to inherited stdio. */
+  readonly commandOutput?: CommandOutputStreamPolicy;
+}
+
+/**
+ * Convert a command output policy into Node stdio options.
+ *
+ * @param policy - Runtime stream routing policy, or undefined for inherited stdio.
+ * @returns Stdio configuration for `child_process.spawn`.
+ */
+export function stdioForCommandOutput(policy: CommandOutputStreamPolicy | undefined): StdioOptions {
+  return policy === 'stderr' ? ['inherit', 'pipe', 'pipe'] : 'inherit';
+}
+
+/**
+ * Forward piped command stdout/stderr chunks to the parent stderr stream.
+ *
+ * @param child - Spawned command process.
+ * @param policy - Runtime stream routing policy, or undefined for inherited stdio.
+ */
+export function pipeCommandOutputToStderr(
+  child: ChildProcess,
+  policy: CommandOutputStreamPolicy | undefined,
+): void {
+  if (policy !== 'stderr') return;
+  child.stdout?.on('data', (chunk: Buffer | string) => {
+    process.stderr.write(chunk);
+  });
+  child.stderr?.on('data', (chunk: Buffer | string) => {
+    process.stderr.write(chunk);
+  });
+}

--- a/packages/core/src/runbook/command-stream-policy.ts
+++ b/packages/core/src/runbook/command-stream-policy.ts
@@ -34,10 +34,20 @@ export function pipeCommandOutputToStderr(
   policy: CommandOutputStreamPolicy | undefined,
 ): void {
   if (policy !== 'stderr') return;
-  child.stdout?.on('data', (chunk: Buffer | string) => {
-    process.stderr.write(chunk);
+  forwardCommandStreamToStderr(child.stdout);
+  forwardCommandStreamToStderr(child.stderr);
+}
+
+function forwardCommandStreamToStderr(stream: ChildProcess['stdout']): void {
+  if (!stream) return;
+  stream.on('error', () => {
+    /* Stream errors are already reflected in command lifecycle events. */
   });
-  child.stderr?.on('data', (chunk: Buffer | string) => {
+  if (typeof stream.pipe === 'function') {
+    stream.pipe(process.stderr, { end: false });
+    return;
+  }
+  stream.on('data', (chunk: Buffer | string) => {
     process.stderr.write(chunk);
   });
 }

--- a/packages/core/src/runbook/executor.ts
+++ b/packages/core/src/runbook/executor.ts
@@ -271,6 +271,7 @@ export async function executeCommandWithPolicy(
         extraReadWritePaths: extractRundownSandboxWritePaths(rdInjected),
       });
       sandboxOptions.env = finalEnv;
+      sandboxOptions.commandOutput = streamOptions.commandOutput;
 
       const result = await executeWithSandbox(command, sandboxOptions);
       return {

--- a/packages/core/src/runbook/executor.ts
+++ b/packages/core/src/runbook/executor.ts
@@ -5,6 +5,11 @@ import type { PolicyEvaluator, PolicyPrompter, PolicyDecision } from '../policy/
 import type { NetworkPolicy } from '../policy/schema.js';
 import { executeWithSandbox, isSandboxAvailable } from '../sandbox/index.js';
 import { policyToSandboxOptions } from '../sandbox/policy-mapper.js';
+import {
+  pipeCommandOutputToStderr,
+  stdioForCommandOutput,
+  type CommandExecutionStreamOptions,
+} from './command-stream-policy.js';
 
 /**
  * Result of executing a shell command.
@@ -46,6 +51,8 @@ export interface PolicyExecutionOptions {
   rdInjected?: Record<string, string>;
   /** Enable OS-level sandbox for file access enforcement (default: true on supported platforms) */
   sandbox?: boolean;
+  /** Runtime-only routing for command subprocess stdout/stderr. */
+  streamOptions?: CommandExecutionStreamOptions;
   /**
    * Require the OS sandbox: fail closed when sandboxing is enabled but
    * unavailable instead of running unsandboxed (default: true).
@@ -101,6 +108,7 @@ export function executeCommand(
   command: string,
   cwd: string,
   rdInjected?: Record<string, string>,
+  streamOptions: CommandExecutionStreamOptions = {},
 ): Promise<ExecutionResult> {
   return new Promise((resolve) => {
     // Build PATH that includes node_modules/.bin for local package binaries
@@ -121,9 +129,10 @@ export function executeCommand(
 
     const child = spawn(shell, shellArgs, {
       cwd,
-      stdio: 'inherit',
+      stdio: stdioForCommandOutput(streamOptions.commandOutput),
       env,
     });
+    pipeCommandOutputToStderr(child, streamOptions.commandOutput);
 
     child.on('close', (code) => {
       resolve({
@@ -188,11 +197,19 @@ export async function executeCommandWithPolicy(
   cwd: string,
   options: PolicyExecutionOptions = {},
 ): Promise<ExecutionResult> {
-  const { evaluator, prompter, env, rdInjected, sandbox = true, sandboxStrict = true } = options;
+  const {
+    evaluator,
+    prompter,
+    env,
+    rdInjected,
+    sandbox = true,
+    sandboxStrict = true,
+    streamOptions = {},
+  } = options;
 
   // If no evaluator, execute without policy checks
   if (!evaluator) {
-    const result = await executeCommand(command, cwd, rdInjected);
+    const result = await executeCommand(command, cwd, rdInjected, streamOptions);
     return { ...result, networkSandboxed: false };
   }
 
@@ -305,7 +322,7 @@ export async function executeCommandWithPolicy(
   }
 
   // Execute without sandbox
-  const result = await executeCommandWithEnv(command, cwd, finalEnv);
+  const result = await executeCommandWithEnv(command, cwd, finalEnv, streamOptions);
   return {
     ...result,
     sandboxed: false,
@@ -326,6 +343,7 @@ export function executeCommandWithEnv(
   command: string,
   cwd: string,
   env: Record<string, string>,
+  streamOptions: CommandExecutionStreamOptions = {},
 ): Promise<ExecutionResult> {
   return new Promise((resolve) => {
     const binPath = path.join(cwd, 'node_modules', '.bin');
@@ -344,9 +362,10 @@ export function executeCommandWithEnv(
 
     const child = spawn(shell, shellArgs, {
       cwd,
-      stdio: 'inherit',
+      stdio: stdioForCommandOutput(streamOptions.commandOutput),
       env: finalEnv,
     });
+    pipeCommandOutputToStderr(child, streamOptions.commandOutput);
 
     child.on('close', (code) => {
       resolve({

--- a/packages/core/src/runbook/executor.ts
+++ b/packages/core/src/runbook/executor.ts
@@ -102,6 +102,7 @@ function extractRundownSandboxWritePaths(rdInjected?: Record<string, string>): s
  * @param command - The shell command to execute
  * @param cwd - Working directory for execution
  * @param rdInjected - Optional Rundown-injected env vars (e.g. RD_WORK_PATH) merged after PATH
+ * @param streamOptions - Runtime-only routing for command subprocess stdout/stderr
  * @returns Promise resolving to ExecutionResult with success status and exit code
  */
 export function executeCommand(
@@ -338,6 +339,7 @@ export async function executeCommandWithPolicy(
  * @param command - The shell command to execute
  * @param cwd - Working directory for execution
  * @param env - Custom environment variables
+ * @param streamOptions - Runtime-only routing for command subprocess stdout/stderr
  * @returns Promise resolving to ExecutionResult
  */
 export function executeCommandWithEnv(

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -1,5 +1,11 @@
 export type * from './types.js';
 export {
+  pipeCommandOutputToStderr,
+  stdioForCommandOutput,
+  type CommandExecutionStreamOptions,
+  type CommandOutputStreamPolicy,
+} from './command-stream-policy.js';
+export {
   createJsonArrayStream,
   isJsonObject,
   isJsonArray,

--- a/packages/core/src/sandbox/linux.ts
+++ b/packages/core/src/sandbox/linux.ts
@@ -10,7 +10,7 @@
  * @module
  */
 
-import { spawn, spawnSync } from 'node:child_process';
+import { spawn as nodeSpawn, spawnSync } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import type { Readable, Writable } from 'node:stream';
 import { existsSync } from 'node:fs';
@@ -68,6 +68,8 @@ export interface LandlockSandboxOptions {
   teardownGraceMs?: number;
   /** Max wait (ms) for confirmed reap before teardown is declared failed; default 5000. */
   teardownReapMs?: number;
+  /** Test seam: child process spawn implementation. */
+  readonly spawn?: typeof nodeSpawn;
 }
 
 /** The JSON spec written to the helper's fd 3. */
@@ -267,6 +269,7 @@ export class LandlockSandbox implements SandboxImplementation {
   private readonly extraStdioFd?: number;
   private readonly teardownGraceMs: number;
   private readonly teardownReapMs: number;
+  private readonly spawn: typeof nodeSpawn;
 
   /**
    * Construct a LandlockSandbox.
@@ -279,7 +282,7 @@ export class LandlockSandbox implements SandboxImplementation {
    *   `extraStdioFd` appends an extra inherited stdio fd (fd 5) to the
    *   helper spawn; `teardownGraceMs` / `teardownReapMs` override the
    *   SIGTERM→SIGKILL grace and the confirmed-reap window used by
-   *   `terminateGroup`.
+   *   `terminateGroup`; `spawn` overrides child process creation for tests.
    */
   constructor(opts: LandlockSandboxOptions = {}) {
     const distRoot = opts.distRoot ?? defaultDistRoot();
@@ -290,6 +293,7 @@ export class LandlockSandbox implements SandboxImplementation {
     this.extraStdioFd = opts.extraStdioFd;
     this.teardownGraceMs = opts.teardownGraceMs ?? 1000;
     this.teardownReapMs = opts.teardownReapMs ?? 5000;
+    this.spawn = opts.spawn ?? nodeSpawn;
   }
 
   /**
@@ -478,19 +482,21 @@ export class LandlockSandbox implements SandboxImplementation {
       };
       const spec = buildSpec(command, options);
 
-      // fds 0/1/2 inherited; fd 3 = spec-in; fd 4 = status-out; detached so the
-      // helper leads its own process group (see terminateGroup, Task 19).
+      // fd 0 is inherited; fds 1/2 are command output streams; fd 3 = spec-in;
+      // fd 4 = status-out; detached so the helper leads its own process group
+      // (see terminateGroup, Task 19).
+      const commandOutput = options.commandOutput === 'stderr' ? 'pipe' : 'inherit';
       const stdio: Array<'inherit' | 'pipe' | number> = [
         'inherit',
-        'inherit',
-        'inherit',
+        commandOutput,
+        commandOutput,
         'pipe',
         'pipe',
       ];
       if (this.extraStdioFd !== undefined) {
         stdio.push(this.extraStdioFd); // fd 5 for tests
       }
-      const child = spawn(this.helperPath!, [], {
+      const child = this.spawn(this.helperPath!, [], {
         cwd: options.cwd,
         env,
         stdio,
@@ -504,6 +510,17 @@ export class LandlockSandbox implements SandboxImplementation {
 
       const specPipe = child.stdio[3] as Writable;
       const statusPipe = child.stdio[4] as Readable;
+      const commandStdout = child.stdio[1] as Readable | null;
+      const commandStderr = child.stdio[2] as Readable | null;
+
+      if (options.commandOutput === 'stderr') {
+        commandStdout?.on('data', (chunk: Buffer | string) => {
+          process.stderr.write(chunk);
+        });
+        commandStderr?.on('data', (chunk: Buffer | string) => {
+          process.stderr.write(chunk);
+        });
+      }
 
       // A helper that dies (or is torn down by terminateGroup) with fd-3/fd-4
       // data in flight surfaces EPIPE/ECONNRESET on these streams. A stream
@@ -535,6 +552,8 @@ export class LandlockSandbox implements SandboxImplementation {
         // handle so a helper that outlives the decision (e.g. an unkillable
         // group whose reap was not confirmed) cannot keep the event loop
         // alive through leaked stdio or process handles.
+        commandStdout?.destroy();
+        commandStderr?.destroy();
         specPipe.destroy();
         statusPipe.destroy();
         child.unref();

--- a/packages/core/src/sandbox/linux.ts
+++ b/packages/core/src/sandbox/linux.ts
@@ -18,6 +18,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { logger } from '../logger.js';
 import { getErrorMessage } from '../errors.js';
+import { pipeCommandOutputToStderr } from '../runbook/command-stream-policy.js';
 import type {
   SandboxOptions,
   SandboxExecutionResult,
@@ -513,14 +514,7 @@ export class LandlockSandbox implements SandboxImplementation {
       const commandStdout = child.stdio[1];
       const commandStderr = child.stdio[2];
 
-      if (options.commandOutput === 'stderr') {
-        commandStdout?.on('data', (chunk: Buffer | string) => {
-          process.stderr.write(chunk);
-        });
-        commandStderr?.on('data', (chunk: Buffer | string) => {
-          process.stderr.write(chunk);
-        });
-      }
+      pipeCommandOutputToStderr(child, options.commandOutput);
 
       // A helper that dies (or is torn down by terminateGroup) with fd-3/fd-4
       // data in flight surfaces EPIPE/ECONNRESET on these streams. A stream

--- a/packages/core/src/sandbox/linux.ts
+++ b/packages/core/src/sandbox/linux.ts
@@ -510,8 +510,8 @@ export class LandlockSandbox implements SandboxImplementation {
 
       const specPipe = child.stdio[3] as Writable;
       const statusPipe = child.stdio[4] as Readable;
-      const commandStdout = child.stdio[1] as Readable | null;
-      const commandStderr = child.stdio[2] as Readable | null;
+      const commandStdout = child.stdio[1];
+      const commandStderr = child.stdio[2];
 
       if (options.commandOutput === 'stderr') {
         commandStdout?.on('data', (chunk: Buffer | string) => {

--- a/packages/core/src/sandbox/macos.ts
+++ b/packages/core/src/sandbox/macos.ts
@@ -13,6 +13,10 @@ import { writeFileSync, unlinkSync, existsSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { isError } from '../errors.js';
+import {
+  pipeCommandOutputToStderr,
+  stdioForCommandOutput,
+} from '../runbook/command-stream-policy.js';
 import { collectAncestorPaths } from './path-utils.js';
 import type {
   SandboxOptions,
@@ -446,9 +450,10 @@ export class SeatbeltSandbox implements SandboxImplementation {
 
       const child = spawn('/usr/bin/sandbox-exec', ['-f', profilePath, '/bin/sh', '-c', command], {
         cwd: options.cwd,
-        stdio: 'inherit',
+        stdio: stdioForCommandOutput(options.commandOutput),
         env: enhancedEnv,
       });
+      pipeCommandOutputToStderr(child, options.commandOutput);
 
       child.on('close', (code) => {
         // Exit code 1 with sandbox-exec can mean sandbox violation

--- a/packages/core/src/sandbox/types.ts
+++ b/packages/core/src/sandbox/types.ts
@@ -8,6 +8,8 @@
  * @module
  */
 
+import type { CommandOutputStreamPolicy } from '../runbook/command-stream-policy.js';
+
 /**
  * Network access posture for OS-sandboxed commands.
  */
@@ -50,6 +52,9 @@ export interface SandboxOptions {
 
   /** Network access posture for this sandboxed execution */
   network: SandboxNetworkPolicy;
+
+  /** Runtime-only routing for command stdout/stderr. */
+  commandOutput?: CommandOutputStreamPolicy;
 
   /** Whether to allow execution without sandbox if unavailable */
   allowUnsandboxed?: boolean;


### PR DESCRIPTION
## Summary

Separates machine-readable JSON output from child command output in Rundown command execution.

This adds a core command stream policy, routes sandbox and CLI command execution through it, and applies JSON-mode stream routing across the normal `rundown run` execution paths as well as collect, pass/fail, goto, claim, and inline-child propagation.

## Root Cause

The initial collect-focused implementation passed stream routing options only from `rundown collect`. Other structured-output execution paths, especially `rundown run`, still reached the execution loop without command stream options, so a command step writing to stdout could corrupt the JSONL event stream.

## User Impact

In JSON mode, Rundown now reserves stdout for structured command output and routes subprocess stdout/stderr to stderr. Text mode keeps inherited command output for human-readable transcripts.

## Validation

- `pnpm --filter @rundown-org/cli test:unit -- --runInBand packages/cli/__tests__/commands/run.test.ts -t "keeps JSON stdout parseable"`
- `pnpm --filter @rundown-org/cli test:unit -- --runInBand packages/cli/__tests__/commands/run.test.ts packages/cli/__tests__/commands/claim.test.ts packages/cli/__tests__/commands/collect.test.ts packages/cli/__tests__/commands/goto.test.ts`
- `pnpm --filter @rundown-org/cli test:unit -- --runInBand packages/cli/__tests__/commands/scenario-suite.test.ts -t "static relative ARTIFACTS|nested runbook ARTIFACTS"`
- `pnpm run verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime stdout/stderr stream routing for spawned command execution, preserving machine-readable JSON/JSONL on `stdout` while redirecting command output to `stderr` (unless `--text` is used).
  * Wired consistently through `run`, `collect`, `claim`, `goto`, and transition/inline-step flows.
* **Bug Fixes**
  * Prevents JSON/JSONL corruption when commands write to both stdout and stderr; scenario-suite schema verification now emits to `stderr`.
  * Improved inline-propagation state handling for blocked children.
* **Documentation**
  * Clarified `rundown collect` and `rundown run` machine-readable stdout/stderr behavior.
* **Tests**
  * Expanded end-to-end and sandboxed execution assertions for correct stream routing and policy behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->