### PR TITLE
[codex] Add Codex plugin Stage 1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "rundown-local",
+  "interface": {
+    "displayName": "Rundown Local"
+  },
+  "plugins": [
+    {
+      "name": "rundown",
+      "source": {
+        "source": "local",
+        "path": "./codex-plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -8,7 +8,7 @@
       "name": "rundown",
       "source": {
         "source": "local",
-        "path": "./codex-plugin"
+        "path": "./packages/claude-code-plugin/codex-plugin"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -406,3 +406,5 @@ chokepoints
 ungated
 remediations
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab
+linecap
+linejoin

--- a/docs/internal/docker.md
+++ b/docs/internal/docker.md
@@ -164,7 +164,8 @@ so it is unit-testable without a Docker build.
 The Claude entrypoint wires Rundown into the session with `--plugin-dir`. Codex
 plugins are installed through Codex marketplaces, so the Codex E2E entrypoint
 installs the repository's Codex plugin from the local `rundown-local`
-marketplace rooted at `/usr/local/share/rundown`.
+marketplace rooted at `/usr/local/share/rundown`, using the repo's
+`packages/claude-code-plugin/codex-plugin` layout inside that root.
 
 That plugin root contains:
 

--- a/docs/internal/docker.md
+++ b/docs/internal/docker.md
@@ -135,8 +135,8 @@ migrate, shim, or rewrite stale runbook state.
 | `docker-compose.e2e.yml`                       | Compose service with volume mounts                                                   |
 | `scripts/e2e-entrypoint.sh`                    | Container entrypoint (6-phase test runner)                                           |
 | `scripts/e2e-shell-entrypoint.sh`              | Container entrypoint (workspace setup + interactive claude)                          |
-| `scripts/e2e-codex-shell-entrypoint.sh`        | Container entrypoint (workspace setup + AGENTS.md install + interactive codex)       |
-| `scripts/e2e-codex-agents.md`                  | Rundown-aware `AGENTS.md` guidance copied into the Codex workspace                   |
+| `scripts/e2e-codex-shell-entrypoint.sh`        | Container entrypoint (workspace setup + Codex plugin install + interactive codex)    |
+| `scripts/e2e-codex-agents.md`                  | Fallback/debug Rundown CLI notes for Codex plugin-loading failures                   |
 | `tests/e2e/fixtures/test-app/`                 | Test fixture (Hono + SQLite REST API)                                                |
 | `scripts/__tests__/e2e-codex-harness.test.mjs` | Behavioral harness tests (run under `pnpm test` / `pnpm run verify` and CI)          |
 
@@ -159,16 +159,27 @@ Codex-authenticated machine never demands Claude auth, and `--bash` debug mode
 `scripts/lib/e2e-auth.sh` (`e2e_prepare_claude_auth`, `e2e_prepare_codex_auth`)
 so it is unit-testable without a Docker build.
 
-### Codex ↔ Rundown integration (AGENTS.md)
+### Codex <-> Rundown integration (plugin + MCP)
 
 The Claude entrypoint wires Rundown into the session with `--plugin-dir`. Codex
-has no plugin mechanism, so the harness uses the simplest explicit path Codex
-already supports: **Codex reads `AGENTS.md` from its working directory on
-startup.** `scripts/e2e-codex-shell-entrypoint.sh` copies the Rundown-aware
-guidance (`scripts/e2e-codex-agents.md`, baked into the image at
-`/usr/local/share/rundown/codex-agents.md`) into the workspace as `AGENTS.md`,
-so each Codex session starts with instructions for driving runbooks via the `rd`
-CLI. An `AGENTS.md` already present in a mounted project is preserved untouched.
+plugins are installed through Codex marketplaces, so the Codex E2E entrypoint
+installs the repository's Codex plugin from the local `rundown-local`
+marketplace rooted at `/usr/local/share/rundown`.
+
+That plugin root contains:
+
+- `.codex-plugin/plugin.json` for Codex plugin metadata
+- `skills/` for Rundown's Codex-facing skills
+- `.mcp.json` for the `rundown` MCP server
+- `runbooks/`, `templates/`, and `schemas/` used by plugin runbook discovery
+
+The entrypoint exports both `CODEX_PLUGIN_ROOT` and `RUNDOWN_PLUGIN_ROOT` before
+installing the plugin and launching Codex. The CLI still supports
+`CLAUDE_PLUGIN_ROOT` for Claude Code, but Codex no longer depends on Claude
+lifecycle environment variables for plugin runbook discovery.
+
+Stage 1 intentionally does not install Codex hooks. Delegation dispatch and
+closure enforcement parity remain Stage 2 work.
 
 ### E2E Coverage
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -612,6 +612,24 @@ Global install:
 }
 ```
 
+### Codex plugin config
+
+The Rundown Codex plugin references the existing stdio server through
+`.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rundown": {
+      "command": "rundown-mcp"
+    }
+  }
+}
+```
+
+This config does not change MCP semantics. The server remains a local stdio
+front end over the Rundown CLI.
+
 Project-scoped working directory:
 
 ```json

--- a/docs/superpowers/specs/2026-07-06-unified-claim-grants-design.md
+++ b/docs/superpowers/specs/2026-07-06-unified-claim-grants-design.md
@@ -1,0 +1,167 @@
+# Unified Claim Grants Design
+
+## Context
+
+Issue #574 replaces the superseded R4 public `runCapability` /
+`claim_capability` design with a single public authority primitive:
+`claim_id`.
+
+The security problem remains: plaintext identifiers such as `run_id` and
+persisted claim ids must not act as mutation authority. The replacement design
+keeps the public API simple while moving authority checks into core-owned claim
+verification and explicit grants.
+
+## Design Decision
+
+A claim is not an orchestrator claim or a delegated-child claim by kind. A claim
+is a bearer authority record. After the presented `claim_id` proves possession
+of its secret, the claim either grants the requested operation on the requested
+target or it does not.
+
+Core policy MUST NOT branch on a persisted `ClaimRecord.kind` such as
+`orchestrator` or `delegated-child`. Those names are roles, not authority
+primitives. Persisting them invites policy to infer permission from labels
+instead of from explicit grants.
+
+## Claim Shape
+
+The persisted record stores a lookup key, a non-reusable proof of the bearer
+secret, timestamps, and grants. It never stores the full bearer `claim_id`.
+
+```typescript
+interface ClaimRecord {
+  readonly claimKey: ClaimLookupKey;
+  readonly secretHash: ClaimSecretHash;
+  readonly grants: readonly ClaimGrant[];
+  readonly issuedAt: string;
+  readonly updatedAt: string;
+}
+```
+
+`claimKey` is a non-secret lookup value derived from or embedded in the public
+`claim_id`. `secretHash` verifies the secret part of the bearer value using
+constant-time comparison. The exact string encoding is an implementation detail,
+but the persisted session file must not contain a reusable bearer credential.
+
+## Grants
+
+Grants are explicit permissions over resources. They are data, not roles.
+
+Initial grant vocabulary:
+
+```typescript
+type ClaimGrant =
+  | { readonly action: 'mutate-run'; readonly runId: RunId }
+  | { readonly action: 'delegate-from-run'; readonly runId: RunId }
+  | { readonly action: 'collect-for-run'; readonly runId: RunId }
+  | { readonly action: 'abort-delegation'; readonly runId: RunId; readonly stepId?: string }
+  | { readonly action: 'retry-delegation'; readonly runId: RunId; readonly stepId?: string }
+  | {
+      readonly action: 'report-delegation-result';
+      readonly childRunId: RunId;
+      readonly parentRunId: RunId;
+      readonly tokenHash: DelegationTokenHash;
+    };
+```
+
+`rundown run <runbook>` mints a claim with grants over the started run, such as
+`mutate-run`, `delegate-from-run`, `collect-for-run`, and operator recovery
+grants.
+
+`rundown claim <delegation_token>` mints or refreshes a claim with grants over
+the claimed child run, such as `mutate-run` for the child and
+`report-delegation-result` for the parent linkage verified by the token.
+
+The distinction between these records is the grant set, not a claim kind.
+
+## Authorization Flow
+
+All actor mutations accept `--claim-id <claim_id>`.
+
+Core resolves and authorizes the command as follows:
+
+1. Parse the bearer `claim_id`.
+2. Resolve its non-secret lookup key to a persisted `ClaimRecord`.
+3. Verify the presented secret against `secretHash`.
+4. Resolve the requested mutation target from core state.
+5. Ask whether any grant authorizes the exact operation on the exact target.
+6. Refuse closed if parsing, lookup, proof verification, target resolution, or
+   grant matching fails.
+
+In pseudocode:
+
+```typescript
+function authorize(
+  claim: VerifiedClaim,
+  request: MutationRequest,
+): AuthorizationDecision {
+  return claim.grants.some((grant) => grantAllows(grant, request))
+    ? { kind: 'allowed' }
+    : { kind: 'denied', reason: 'claim_grant_required' };
+}
+```
+
+No frontend constructs trusted actor context directly. CLI, MCP, and plugin
+surfaces pass bearer claim evidence to core; core verifies it and derives the
+authorization decision.
+
+## Public API
+
+`run_id` remains an identifier only.
+
+`rundown run <runbook>` returns an initial `claim_id` for the created run.
+
+`rundown claim <delegation_token>` returns a `claim_id` for the claimed child
+work.
+
+Mutating commands use a single authority shape:
+
+```bash
+rundown pass --claim-id "$CLAIM_ID"
+rundown fail --claim-id "$CLAIM_ID"
+rundown delegate --claim-id "$CLAIM_ID" --step 2.1
+rundown collect --claim-id "$CLAIM_ID"
+rundown abort --claim-id "$CLAIM_ID" --step 2.1
+```
+
+Read-only commands may still expose identifiers where useful, but identifiers
+must not authorize mutation.
+
+## Recovery
+
+Abandoned child recovery is authorized by grants on the operator's current
+claim. It is not modeled by reading or synthesizing the child's bearer secret.
+
+For example, a claim with `abort-delegation` and `retry-delegation` grants may
+abort or retry the delegation it controls. A child claim that only grants
+`mutate-run` on the child and `report-delegation-result` cannot drive parent
+pipeline recovery unless it also has an explicit grant for that action.
+
+## Rejected Designs
+
+Separate public `--run-capability` and `--claim-capability` flags are rejected.
+They solve the bearer-secret problem but duplicate existing command concepts and
+make the public API harder to reason about.
+
+A persisted claim `kind` such as `orchestrator` or `delegated-child` is rejected.
+It turns authorization into role-label branching. The policy question is always
+whether the verified claim grants the requested action on the requested target.
+
+## Acceptance Criteria
+
+- `rundown run` returns a bearer `claim_id` usable for permitted mutations on
+  the created run.
+- `rundown claim <token>` returns a bearer `claim_id` usable for permitted
+  mutations on the claimed child.
+- All actor mutations accept `--claim-id`.
+- Core rejects identifier-only mutation authority.
+- Persisted session/run state stores only non-reusable claim proofs, lookup
+  keys, grants, and linkage data.
+- Reading `.rundown/session.json` does not reveal a reusable mutation
+  credential.
+- Authorization decisions are expressed as `VerifiedClaim + ClaimGrant[]`
+  checks, not `ClaimRecord.kind` checks.
+- Orchestrator/operator recovery is represented by explicit grants, not child
+  impersonation.
+- Documentation and tests no longer expose or require public
+  `runCapability` / `claim_capability` credentials.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "worktree": "bash scripts/worktree.sh",
-    "build": "pnpm --filter @rundown-org/parser build && pnpm --filter @rundown-org/core build && pnpm --filter @rundown-org/cli build && pnpm --filter @rundown-org/claude-code-plugin build && pnpm --filter @rundown-org/mcp build",
+    "build": "pnpm --filter @rundown-org/parser build && pnpm --filter @rundown-org/core build && pnpm --filter @rundown-org/cli build && pnpm --filter @rundown-org/mcp build && pnpm --filter @rundown-org/claude-code-plugin build",
     "build:site": "pnpm --filter site build",
     "build:all": "pnpm run build && pnpm --filter site build",
     "test": "pnpm run test:unit",

--- a/packages/claude-code-plugin/__tests__/commands/manifest.test.ts
+++ b/packages/claude-code-plugin/__tests__/commands/manifest.test.ts
@@ -129,6 +129,7 @@ describe('Plugin manifest surface', () => {
     expect(packageJson.bin).toEqual({
       rdpath: 'dist/rdpath.js',
       rdx: 'dist/rdx.js',
+      'rundown-mcp': 'dist/rundown-mcp.js',
     });
     // Pass keys as single-element arrays so Jest treats '.' / './cli' as literal
     // keys instead of dot-delimited property paths, and pin the resolved targets
@@ -145,6 +146,7 @@ describe('Plugin manifest surface', () => {
       'dist',
       'schemas',
       '.claude-plugin',
+      'codex-plugin',
       'examples',
       'hooks',
       'runbooks',

--- a/packages/claude-code-plugin/codex-plugin/.codex-plugin/plugin.json
+++ b/packages/claude-code-plugin/codex-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "rundown",
+  "version": "1.0.0",
+  "description": "Run Markdown runbooks through Rundown from Codex using skills and MCP tools.",
+  "author": {
+    "name": "Toby Hede",
+    "email": "toby@rundown.org",
+    "url": "https://github.com/rundown-org"
+  },
+  "homepage": "https://github.com/rundown-org/rundown",
+  "repository": "https://github.com/rundown-org/rundown",
+  "license": "MIT",
+  "keywords": ["rundown", "runbook", "codex", "mcp", "workflow"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Rundown",
+    "shortDescription": "Execute Markdown runbooks from Codex",
+    "longDescription": "Use Rundown to discover, start, inspect, and advance executable Markdown runbooks from Codex. The plugin supplies Codex skills for runbook workflows and the Rundown MCP server as the tool surface; runbook state and transitions remain owned by the Rundown CLI and core state machine.",
+    "developerName": "Rundown",
+    "category": "Developer Tools",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "defaultPrompt": [
+      "Run a Rundown runbook.",
+      "List available Rundown runbooks.",
+      "Start a Rundown planning workflow."
+    ],
+    "websiteURL": "https://github.com/rundown-org/rundown",
+    "privacyPolicyURL": "https://github.com/rundown-org/rundown",
+    "termsOfServiceURL": "https://github.com/rundown-org/rundown",
+    "brandColor": "#2563EB",
+    "composerIcon": "./assets/rundown.svg",
+    "logo": "./assets/rundown.svg",
+    "screenshots": []
+  }
+}

--- a/packages/claude-code-plugin/codex-plugin/.mcp.json
+++ b/packages/claude-code-plugin/codex-plugin/.mcp.json
@@ -1,7 +1,8 @@
 {
   "mcpServers": {
     "rundown": {
-      "command": "rundown-mcp"
+      "command": "node",
+      "args": ["${CODEX_PLUGIN_ROOT}/../dist/rundown-mcp.js"]
     }
   }
 }

--- a/packages/claude-code-plugin/codex-plugin/.mcp.json
+++ b/packages/claude-code-plugin/codex-plugin/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "rundown": {
+      "command": "rundown-mcp"
+    }
+  }
+}

--- a/packages/claude-code-plugin/codex-plugin/assets/rundown.svg
+++ b/packages/claude-code-plugin/codex-plugin/assets/rundown.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Rundown">
+  <rect width="64" height="64" rx="12" fill="#2563EB"/>
+  <path d="M18 18h28v6H18zM18 29h28v6H18zM18 40h18v6H18z" fill="#FFFFFF"/>
+  <path d="M42 38l5 5-5 5" fill="none" stroke="#FFFFFF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/claude-code-plugin/codex-plugin/runbooks/end-to-end-test/collate-files.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/end-to-end-test/collate-files.runbook.md
@@ -1,0 +1,55 @@
+---
+name: collate-files
+description: Read end-to-end workflow artifacts and write one collated review artifact.
+tags:
+  - meta
+  - e2e
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+OUTPUTS:
+  - CollatedReviewPath
+---
+
+# End-to-End Test Collate
+
+Collate review feedback into single structured review.
+
+
+## 1. Read the output schema
+- ARTIFACTS
+  - ReviewSchemaPath "schemas/review.schema.json"
+- PASS CONTINUE
+- FAIL STOP
+
+The schema defines the expected output structure.
+
+
+## 2. Write collated review
+- ARTIFACTS
+  - PlanPath
+  - ReviewSchemaPath
+  - ReviewPaths "*/end-to-end-test-review.json"
+  - CollatedReviewPath "end-to-end-test-collated-review.json"
+- PASS CONTINUE
+- FAIL STOP
+
+Read all review files: `{{ path ReviewPaths }}`.
+Merge findings from all reviews into a single canonical review document.
+
+Deduplicate equivalent findings — when multiple reviews identify the same issue, merge their descriptions, evidence, and rationale rather than discarding duplicates.
+The combined context may influence recommended actions.
+
+Write the collated JSON review to `{{ path CollatedReviewPath }}`.
+Follow the output schema from `{{ path ReviewSchemaPath }}`.
+
+
+
+## 3. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 2
+
+```bash
+rdx {{ path CollatedReviewPath }} --validate --schema review
+```

--- a/packages/claude-code-plugin/codex-plugin/runbooks/end-to-end-test/end-to-end-test.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/end-to-end-test/end-to-end-test.runbook.md
@@ -1,0 +1,55 @@
+---
+name: end-to-end-test
+description: Run an end-to-end workflow that mirrors planning with nested delegated reviews.
+OUTPUTS:
+  - FeedbackPath
+---
+
+# End-to-End Test Runbook
+
+Test the end-to-end runbook workflow and provide structured test & review feedback.
+
+
+## 1. Read the output schema
+- ARTIFACTS
+  - ReviewSchemaPath "schemas/review.schema.json"
+- PASS CONTINUE
+- FAIL STOP
+
+The schema defines the expected feedback output structure.
+
+
+## 2. Write
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- end-to-end-test/write-file.runbook.md
+
+
+## 3. Review
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- end-to-end-test/review-and-collate.runbook.md
+
+
+## 4. Write the feedback
+- ARTIFACTS
+  - ReviewSchemaPath
+  - CollatedReviewPath
+  - FeedbackPath "end-to-end-test-feedback.json"
+- PASS CONTINUE
+- FAIL STOP
+
+Read the collated review from `{{ path CollatedReviewPath }}`.
+Write the final feedback to `{{ path FeedbackPath }}` as JSON.
+Follow the output schema from `{{ path ReviewSchemaPath }}`.
+
+
+## 5. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 4
+
+```bash
+rdx {{ path FeedbackPath }} --validate --schema review
+```

--- a/packages/claude-code-plugin/codex-plugin/runbooks/end-to-end-test/review-and-collate.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/end-to-end-test/review-and-collate.runbook.md
@@ -1,0 +1,37 @@
+---
+name: review-and-collate
+description: Run the end-to-end review workflow and delegate the nested review.
+tags:
+  - meta
+  - e2e
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+OUTPUTS:
+  - ReviewPath
+  - CollatedReviewPath
+---
+
+# End-to-End Test Review and Collate
+
+Delegate subagents to review the plan and collate the reviews.
+
+
+## 1. Delegate subagents to review
+
+- ARTIFACTS
+  - PlanPath
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- end-to-end-test/review-file.runbook.md
+
+
+## 2. Delegate subagent to collate reviews
+- DELEGATE
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+- end-to-end-test/collate-files.runbook.md

--- a/packages/claude-code-plugin/codex-plugin/runbooks/end-to-end-test/review-file.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/end-to-end-test/review-file.runbook.md
@@ -1,0 +1,59 @@
+---
+name: review-file
+description: Read the plan artifact and write one nested review artifact.
+tags:
+  - meta
+  - e2e
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+OUTPUTS:
+  - ReviewPath
+---
+
+# End-to-End Test Review
+
+Review the plan and provide structured feedback.
+
+
+## 1. Read the output schema
+- ARTIFACTS
+  - ReviewSchemaPath "schemas/review.schema.json"
+- PASS CONTINUE
+- FAIL STOP
+
+The schema defines the expected feedback output structure.
+
+
+## 2. Read and review the plan
+- ARTIFACTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+Checklist:
+- Plan contains one task
+- File: `end-to-end-test.md`
+- Content: `This is the end-to-end test`
+
+
+## 3. Write review
+- ARTIFACTS
+  - PlanPath
+  - ReviewSchemaPath
+  - ReviewPath "end-to-end-test-review.json"
+- PASS CONTINUE
+- FAIL STOP
+
+Write a JSON review to `{{ path ReviewPath }}`.
+Follow the output schema from `{{ path ReviewSchemaPath }}`.
+
+
+## 4. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 3
+
+```bash
+rdx {{ path ReviewPath }} --validate --schema review
+```

--- a/packages/claude-code-plugin/codex-plugin/runbooks/end-to-end-test/write-file.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/end-to-end-test/write-file.runbook.md
@@ -1,0 +1,49 @@
+---
+name: write-file
+description: Write one simple plan artifact for the end-to-end workflow.
+tags:
+  - meta
+  - e2e
+OUTPUTS:
+  - PlanPath
+---
+
+# End-to-End Test Write Plan
+
+Write one small plan file for the end-to-end workflow.
+
+
+## 1. Read the plan schema
+- ARTIFACTS
+  - PlanSchemaPath "schemas/plan.schema.json"
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan schema.
+The schema defines the expected output structure for the plan.
+
+
+## 2. Write plan
+- ARTIFACTS
+  - PlanSchemaPath
+  - PlanPath "end-to-end-test-plan.json"
+- PASS CONTINUE
+- FAIL STOP
+
+Write a JSON implementation plan to `{{ path PlanPath }}`.
+Follow the plan output schema from `{{ path PlanSchemaPath }}`.
+
+The plan should contain one task.
+Task should write a file with the specified content.
+
+- File: `end-to-end-test.md`
+- Content: `This is the end-to-end test`
+
+
+## 3. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 2
+
+```bash
+rdx {{ path PlanPath }} --validate --schema plan
+```

--- a/packages/claude-code-plugin/codex-plugin/runbooks/meta/convert-skill.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/meta/convert-skill.runbook.md
@@ -1,0 +1,84 @@
+---
+name: convert-skill
+description: Distill a Claude skill into a house-style rundown runbook that orchestrates its workflow without duplicating context.
+skill: converting-skills-to-runbooks
+tags:
+  - meta
+INPUTS:
+  - SkillPath
+REQUIRED:
+  - SkillPath
+OUTPUTS:
+  - RunbookPath
+---
+
+# Convert Skill to Runbook
+
+Distill the skill at the input path into a house-style runbook that orchestrates its workflow. The runbook captures the sequence and coordinates artifacts; the skill keeps the context.
+
+
+## 1. Invoke the converting-skills-to-runbooks skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the converting-skills-to-runbooks skill. Internalize the mapping rules and the verification checklist — they define how a skill's workflow backbone becomes runbook steps and artifacts.
+
+Skill: `rundown:converting-skills-to-runbooks`
+
+
+## 2. Read the source skill
+- ARTIFACTS
+  - SkillPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the source skill at `{{ path SkillPath }}`.
+Separate the workflow backbone (ordered phases, gates, loops, fan-out, artifacts) from the domain context (rules, syntax, rationale, examples).
+The context stays in the skill; only the backbone becomes runbook steps.
+
+
+## 3. Map the backbone
+- PASS CONTINUE
+- FAIL STOP
+
+Map the backbone to runbook constructs, following the mapping rules:
+
+- Step 1 invokes and reads the source skill (`skill:` frontmatter + "Invoke and read").
+- Each backbone phase becomes one H2 step with a terse pointer or checklist body.
+- Artifacts become `ARTIFACTS` aliases plus an `INPUTS` / `OUTPUTS` / `REQUIRED` contract.
+- Fan-out becomes `- DELEGATE` steps with delegate-then-collate.
+- The final steps validate the output and `GOTO` the write step on failure.
+
+
+## 4. Write the runbook
+- ARTIFACTS
+  - RunbookPath "converted.runbook.md"
+- PASS CONTINUE
+- FAIL STOP
+
+Write the distilled runbook to `{{ path RunbookPath }}`.
+Reference the source skill from step 1; do not restate its context.
+If revising, address the issues identified by validation or the checklist.
+
+
+## 5. Check the runbook
+- PASS CONTINUE
+- FAIL GOTO 4
+
+```bash
+rundown check {{ path RunbookPath }}
+```
+
+
+## 6. Verify against the checklist
+- PASS COMPLETE
+- FAIL GOTO 4
+
+Verify the runbook against the conversion checklist (`references/checklist.md`):
+
+- [ ] Step 1 invokes and reads the source skill (`skill:` frontmatter set)
+- [ ] Every load-bearing phase maps to a step (backbone coverage)
+- [ ] No step body restates skill knowledge (no-duplication scan)
+- [ ] Artifacts use `{{ path Alias }}`; no hardcoded paths
+- [ ] `INPUTS` / `OUTPUTS` / `REQUIRED` and `ARTIFACTS` aliases are consistent
+- [ ] Produce → validate → retry loop present (`FAIL GOTO` the write step)

--- a/packages/claude-code-plugin/codex-plugin/runbooks/patterns/iterate-and-delegate.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/patterns/iterate-and-delegate.runbook.md
@@ -1,0 +1,28 @@
+---
+name: iterate-and-delegate
+description: Extract a work list, then delegate one worker per item.
+tags:
+  - patterns
+---
+
+# Iterate and Delegate
+
+## 1. Extract items
+- OUTPUTS
+  - Items
+- PASS CONTINUE
+- FAIL STOP
+
+```sh
+printf '["left","right"]' > "$RD_OUTPUTS_Items"
+```
+
+## 2. Process each item
+- FOR item IN {{ Items }}
+  - PASS DEFER
+  - FAIL BREAK
+- DELEGATE
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+- process-one-item.runbook.md

--- a/packages/claude-code-plugin/codex-plugin/runbooks/patterns/process-one-item.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/patterns/process-one-item.runbook.md
@@ -1,0 +1,18 @@
+---
+name: process-one-item
+description: Process a single item handed down from the loop.
+tags:
+  - patterns
+inputs:
+  - item
+required:
+  - item
+---
+
+# Process One Item
+
+## 1. Do the work
+- PASS COMPLETE
+- FAIL STOP
+
+Process item **{{ item }}** (iteration {{ Index }}).

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/address-review.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/address-review.runbook.md
@@ -1,0 +1,42 @@
+---
+name: address-review
+description: Resolve the error-level findings recorded by a code review, committing the fix.
+skill: executing-plans
+tags:
+  - planning
+INPUTS:
+  - PlanPath
+  - CodeReviewPath
+REQUIRED:
+  - PlanPath
+  - CodeReviewPath
+---
+
+# Address Review Findings
+
+Resolve the blocking findings from the code review.
+
+## 1. Invoke the Executing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the executing-plans skill. Internalize the per-task cycle and commit discipline.
+
+Skill: `rundown:executing-plans`
+
+
+## 2. Read the review and plan
+- ARTIFACTS
+  - PlanPath
+  - CodeReviewPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the recorded findings at `{{ path CodeReviewPath }}` and the plan at `{{ path PlanPath }}`.
+
+
+## 3. Resolve the findings
+- PASS COMPLETE
+- FAIL STOP
+
+Resolve every `error`-level finding, staying within the plan's intent. Add or update tests as needed, then commit the fix. Stop and escalate if a finding cannot be resolved within scope.

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/code-review.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/code-review.runbook.md
@@ -1,0 +1,89 @@
+---
+name: code-review
+description: Review implemented changes against the plan and record findings as a review document.
+tags:
+  - planning
+  - review
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+OUTPUTS:
+  - CodeReviewPath
+---
+
+# Code Review
+
+Review the implemented changes against the plan and record findings.
+
+## 1. Read the output schema
+- ARTIFACTS
+  - ReviewSchemaPath "schemas/review.schema.json"
+- PASS CONTINUE
+- FAIL STOP
+
+The schema defines the expected review output structure.
+
+
+## 2. Read the plan
+- ARTIFACTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan at `{{ path PlanPath }}`. It defines the intended changes to review against.
+
+
+## 3. Review the implemented changes
+- PASS CONTINUE
+- FAIL CONTINUE
+
+Review the working-tree changes against the plan:
+
+- Each planned task is implemented and matches its intent.
+- No unplanned or out-of-scope changes.
+- Tests cover the new behaviour and code follows project conventions.
+
+Record findings; do not gate here.
+
+
+## 4. Output Path
+- ARTIFACTS
+  - CodeReviewPath "code-review.json"
+- PASS CONTINUE
+- FAIL STOP
+
+{{ CodeReviewPath }}
+
+
+## 5. Write the review
+- ARTIFACTS
+  - PlanPath
+  - ReviewSchemaPath
+  - CodeReviewPath
+- PASS CONTINUE
+- FAIL STOP
+
+Write the review to `{{ path CodeReviewPath }}` as JSON, following the schema from `{{ path ReviewSchemaPath }}`. Use `level: "error"` for findings that must block, `warning` or `note` otherwise. An empty `items` array records a clean review.
+
+
+## 6. Check Schema
+- PASS CONTINUE
+- FAIL GOTO 5
+
+```bash
+{{ validateSchema CodeReviewPath }}
+```
+
+
+## 7. Gate the review
+- ARTIFACTS
+  - CodeReviewPath
+- PASS COMPLETE
+- FAIL STOP
+
+You recorded the review at `{{ path CodeReviewPath }}`. Render the verdict.
+
+Pass the gate when the review is clean — no findings that must block the work. Fail the gate when it holds blocking (`error`-level) findings the work must address before it can advance.
+
+A review that records blocking findings is a failing review. The verdict is yours to make from the recorded review; do not soften it to keep the work moving.

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/execute-plan.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/execute-plan.runbook.md
@@ -1,0 +1,60 @@
+---
+name: execute-plan
+description: Execute a reviewed plan — delegate implementation, then loop code review and verify gates until clean.
+skill: executing-plans
+tags:
+  - planning
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+OUTPUTS:
+  - CodeReviewPath
+---
+
+# Execute Plan
+
+Execute the plan, then hold the work to the review and verify gates.
+
+## 1. Invoke the Executing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the executing-plans skill. Internalize how implementation, review, and verification fit together.
+
+Skill: `rundown:executing-plans`
+
+
+## 2. Implement the plan
+- ARTIFACTS
+  - PlanPath
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- implement-plan.runbook.md
+
+
+## 3. Code review
+- DELEGATE
+- PASS ALL GOTO 5
+- FAIL ANY CONTINUE
+
+- code-review.runbook.md
+
+
+## 4. Address review findings
+- DELEGATE
+- PASS ALL GOTO 3
+- FAIL ANY STOP
+
+- address-review.runbook.md
+
+
+## 5. Verify
+- PASS COMPLETE
+- FAIL GOTO 4
+
+```bash
+npm run verify
+```

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/implement-plan.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/implement-plan.runbook.md
@@ -1,0 +1,39 @@
+---
+name: implement-plan
+description: Implement every task in a plan via the executing-plans skill, committing per task.
+skill: executing-plans
+tags:
+  - planning
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+---
+
+# Implement Plan
+
+Execute every task in the plan, following the executing-plans skill.
+
+## 1. Invoke the Executing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the executing-plans skill. Internalize the per-task cycle, commit discipline, and when to stop and escalate.
+
+Skill: `rundown:executing-plans`
+
+
+## 2. Read the plan
+- ARTIFACTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan at `{{ path PlanPath }}`. Review it critically before starting; if it has gaps that prevent starting, stop and escalate.
+
+
+## 3. Implement every task
+- PASS COMPLETE
+- FAIL STOP
+
+Work through the plan's tasks in order. For each task: follow its bite-sized steps exactly, run the verifications it specifies, and make its commit before the next task. Do not pause between tasks; stop only when blocked or when every task is complete.

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/planning.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/planning.runbook.md
@@ -1,0 +1,35 @@
+---
+name: planning
+description: Plan, review, and execute a body of work — write the plan, review it, then implement it behind review and verify gates.
+tags:
+  - planning
+OUTPUTS:
+  - PlanPath
+  - ReviewPlanPath
+  - CodeReviewPath
+---
+
+# Planning
+
+Plan a body of work, review the plan, then execute it.
+
+## 1. Write the plan
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- planning/write-plan.runbook.md
+
+
+## 2. Review the plan
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- planning/review-plan.runbook.md
+
+
+## 3. Execute the plan
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+- planning/execute-plan.runbook.md

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/review-plan.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/review-plan.runbook.md
@@ -1,0 +1,55 @@
+---
+name: review-plan
+description: Review and validate an implementation plan
+tags:
+  - planning
+  - review
+REQUIRED:
+  - PlanPath
+INPUTS:
+  - PlanPath
+OUTPUTS:
+  - ReviewPlanPath
+---
+
+
+# Review Implementation Plan
+
+Review the plan at the provided path.
+
+## 1. Find plan
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan from `{{ PlanPath }}`.
+
+## 2. Context and scope
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan and validate these elements exist and are coherent.
+
+Verify the plan includes:
+- A clear, concise description of the desired outcome.
+- Explicit success criteria
+- Clearly defined scope
+- Accurate assumptions about current state
+
+
+## 3. Delegate subagents to review the plan
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- review-plan-technical-accuracy.runbook.md
+- review-plan-structural-integrity.runbook.md
+- review-plan-build-runtime.runbook.md
+- review-plan-risk-safety.runbook.md
+
+
+## 4. Collate review findings
+- DELEGATE
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+- review-plan-collate.runbook.md

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/review/review-plan-build-runtime.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/review/review-plan-build-runtime.runbook.md
@@ -1,0 +1,65 @@
+---
+name: review-plan-build-runtime
+description: Verify build commands, test commands, dependencies, and environment in a plan
+tags:
+  - planning
+  - review
+
+---
+
+# Review Build and Runtime
+
+Verify that build, test, and runtime concerns are addressed.
+
+## 1. Find plan
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan at `{{ PlanPath }}`.
+
+
+## 2. Read the output schema
+- PASS CONTINUE
+- FAIL STOP
+
+```prompt
+{{ CLAUDE_PLUGIN_ROOT }}/schemas/review.schema.json
+```
+
+
+## 3. Are build and runtime concerns addressed?
+- PASS CONTINUE
+- FAIL CONTINUE
+
+- Build commands are correct for the project's build system and would produce expected outputs
+- Test commands reference the correct test framework, use proper flags, and target the right files
+- All dependencies (packages, tools, services) are available and version-compatible
+- Environment requirements (Node version, env vars, config files, credentials) are documented
+- Changes won't break CI/CD pipelines and any pipeline modifications are included
+
+
+## 4. Output Path
+- ARTIFACTS
+  - ReviewPath "review-plan-build-runtime.json"
+- PASS CONTINUE
+- FAIL STOP
+
+{{ ReviewPath }}
+
+
+## 5. Write the review
+- PASS CONTINUE
+- FAIL STOP
+
+Write the review to the output path as JSON.
+Follow the review output schema.
+Ensure any validation issues have been resolved.
+
+
+## 6. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 5
+
+```bash
+{{ validateSchema ReviewPath }}
+```

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/review/review-plan-collate.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/review/review-plan-collate.runbook.md
@@ -1,0 +1,73 @@
+---
+name: review-plan-collate
+description: Collate review findings and produce a canonical review document
+tags:
+  - planning
+  - review
+OUTPUTS:
+  - ReviewPlanPath
+---
+
+# Collate Plan Reviews
+
+Collate multiple plan reviews into a single canonical review document.
+
+## 1. Find reviews
+- ARTIFACTS
+  - Reviews "*/review-plan-*-*.json"
+- PASS CONTINUE
+- FAIL STOP
+
+The `Reviews` artifact set resolves every per-reviewer review file produced in
+this context. The cross-run selector `"*/review-plan-*-*.json"` desugars to
+`rd://artifacts/{{ContextId}}/*/review-plan-*-*.json` and queries the shared
+context manifest read-only — each reviewer runbook *produced* its row via its
+own `ARTIFACTS` directive, so no filesystem globbing is required. The resolved
+records are surfaced on `STEP_ENTERED.artifacts`. An empty set means there is
+nothing to collate.
+
+
+## 2. Read the output schema
+- PASS CONTINUE
+- FAIL STOP
+
+```prompt
+{{ CLAUDE_PLUGIN_ROOT }}/schemas/review.schema.json
+```
+
+
+## 3. Collate the review findings
+- PASS CONTINUE
+- FAIL STOP
+
+Read every review file in the `Reviews` artifact set resolved in step 1.
+Merge findings from all reviews into a single canonical review document.
+
+Deduplicate equivalent findings — when multiple reviews identify the same issue, merge their descriptions, evidence, and rationale rather than discarding duplicates.
+The combined context may influence recommended actions.
+
+
+## 4. Output Path
+- ARTIFACTS
+  - ReviewPlanPath "review-plan-collated.json"
+- PASS CONTINUE
+- FAIL STOP
+
+{{ ReviewPlanPath }}
+
+
+## 5. Write the collated review
+- PASS CONTINUE
+- FAIL STOP
+
+Write the collated review to the output path as JSON.
+Follow the review output schema.
+
+
+## 6. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 5
+
+```bash
+{{ validateSchema ReviewPlanPath }}
+```

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/review/review-plan-risk-safety.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/review/review-plan-risk-safety.runbook.md
@@ -1,0 +1,68 @@
+---
+name: review-plan-risk-safety
+description: Assess security, performance, breaking changes, and safety concerns in a plan
+tags:
+  - planning
+  - review
+---
+
+# Review Risk and Safety
+
+Assess risk, security, and safety concerns in the plan.
+
+## 1. Find plan
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan at `{{ PlanPath }}`.
+
+
+## 2. Read the output schema
+- PASS CONTINUE
+- FAIL STOP
+
+```prompt
+{{ CLAUDE_PLUGIN_ROOT }}/schemas/review.schema.json
+```
+
+
+## 3. Is the plan safe and risk-free?
+- PASS CONTINUE
+- FAIL CONTINUE
+
+- Security concerns are assessed: input validation, authentication, authorization, data exposure, injection risks
+- Performance-sensitive changes include benchmarks or impact analysis
+- All breaking changes to public APIs, data formats, or behavior are explicitly identified
+- Released public-surface breaking changes include a migration path or deprecation strategy
+- Persisted active runbook state is not a released public surface: stale `.rundown/` state must be rejected, pruned, and restarted rather than migrated or shimmed
+- Operations involving persistent data protect against corruption and data loss
+- Concurrent or parallel operations are safe from race conditions and resource conflicts
+- Failure scenarios have documented recovery procedures beyond "retry"
+- Changes include appropriate logging, metrics, or monitoring where observable behavior is touched
+
+
+## 4. Output Path
+- ARTIFACTS
+  - ReviewPath "review-plan-risk-safety.json"
+- PASS CONTINUE
+- FAIL STOP
+
+{{ ReviewPath }}
+
+
+## 5. Write the review
+- PASS CONTINUE
+- FAIL STOP
+
+Write the review to the output path as JSON.
+Follow the review output schema.
+Ensure any validation issues have been resolved.
+
+
+## 6. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 5
+
+```bash
+{{ validateSchema ReviewPath }}
+```

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/review/review-plan-structural-integrity.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/review/review-plan-structural-integrity.runbook.md
@@ -1,0 +1,69 @@
+---
+name: review-plan-structural-integrity
+description: Validate step ordering, dependencies, scope, and completeness of a plan
+tags:
+  - planning
+  - review
+---
+
+# Review Structural Integrity
+
+Validate the plan's structure, ordering, and completeness.
+
+## 1. Find plan
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan at `{{ PlanPath }}`.
+
+## 2. Read the output schema
+- PASS CONTINUE
+- FAIL STOP
+
+```prompt
+{{ CLAUDE_PLUGIN_ROOT }}/schemas/review.schema.json
+```
+
+
+## 3. Is the plan structurally sound?
+- PASS CONTINUE
+- FAIL CONTINUE
+
+- Steps are ordered so that each step's prerequisites are met by prior steps
+- Step dependencies form a DAG with no circular references
+- Each step has clear, testable completion criteria
+- No step is too large (should be split) or too small (should be merged)
+- Risky steps include error handling or fallback strategies
+- Destructive or hard-to-reverse operations have a rollback strategy
+- No gaps where intermediate steps are needed but missing
+- Steps that make changes are followed by verification steps
+- Success criteria, when all met, would achieve the stated goal
+- Critical steps identify what could go wrong and how the failure would manifest
+- Explicitly deferred work or known limitations are documented and tracked
+
+
+## 4. Output Path
+- ARTIFACTS
+  - ReviewPath "review-plan-structural-integrity.json"
+- PASS CONTINUE
+- FAIL STOP
+
+{{ ReviewPath }}
+
+
+## 5. Write the review
+- PASS CONTINUE
+- FAIL STOP
+
+Write the review to the output path as JSON.
+Follow the review output schema.
+Ensure any validation issues have been resolved.
+
+
+## 6. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 5
+
+```bash
+{{ validateSchema ReviewPath }}
+```

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/review/review-plan-technical-accuracy.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/review/review-plan-technical-accuracy.runbook.md
@@ -1,0 +1,63 @@
+---
+name: review-plan-technical-accuracy
+description: Verify file paths, symbols, imports, commands, and conventions in a plan
+tags:
+  - planning
+  - review
+---
+
+# Review Technical Accuracy
+
+Verify that all technical references in the plan are accurate.
+
+## 1. Find plan
+- PASS CONTINUE
+- FAIL STOP
+
+Read the plan at `{{ PlanPath }}`.
+
+
+## 2. Read the output schema
+- PASS CONTINUE
+- FAIL STOP
+
+```prompt
+{{ CLAUDE_PLUGIN_ROOT }}/schemas/review.schema.json
+```
+
+
+## 3. Is the plan technically accurate?
+- PASS CONTINUE
+- FAIL CONTINUE
+
+- File paths referenced in the plan exist in the codebase (source and test files)
+- Classes, functions, types, and symbols exist at the locations claimed
+- Import and module paths are valid and resolve correctly
+- Shell commands are syntactically valid and required tools are available
+- Proposed changes follow the project's established patterns and conventions
+
+
+## 4. Output Path
+- ARTIFACTS
+  - ReviewPath "review-plan-technical-accuracy.json"
+- PASS CONTINUE
+- FAIL STOP
+
+{{ ReviewPath }}
+
+
+## 5. Write the review
+- PASS CONTINUE
+- FAIL STOP
+
+Write the review to the output path as JSON.
+Follow the review output schema.
+
+
+## 6. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 5
+
+```bash
+{{ validateSchema ReviewPath }}
+```

--- a/packages/claude-code-plugin/codex-plugin/runbooks/planning/write-plan.runbook.md
+++ b/packages/claude-code-plugin/codex-plugin/runbooks/planning/write-plan.runbook.md
@@ -1,0 +1,112 @@
+---
+name: write-plan
+description: Write detailed implementation plans using the Writing Plans skill
+skill: writing-plans
+tags:
+  - planning
+OUTPUTS:
+  - PlanPath
+---
+
+# Write Plan
+
+## 1. Invoke the Writing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the writing-plans skill. Internalize the guidance — it defines the plan structure, TDD principles, and quality standards used throughout this runbook.
+
+Skill: `rundown:writing-plans`
+
+
+## 2. Review the plan schema
+- PASS CONTINUE
+- FAIL STOP
+
+Schema: `{{ CLAUDE_PLUGIN_ROOT }}/schemas/plan.schema.json`
+
+
+## 3. Check the Scope
+- PASS CONTINUE
+- FAIL STOP
+
+Assess and confirm the scope of the work.
+
+- Should the work be split into smaller deliverables?
+
+
+## 4. Gather Requirements
+- PASS CONTINUE
+- FAIL STOP
+
+Confirm the task or feature to be planned is clearly understood.
+
+- What is the goal?
+- What are the constraints and assumptions?
+- Are there any existing issues, design documents, specifications or other references?
+
+
+## 5. Research Codebase
+- PASS CONTINUE
+- FAIL STOP
+
+Read the relevant source files, tests, and documentation to confirm:
+
+- Patterns and conventions in the affected area
+- Existing types and abstractions that can be reused
+- Test structure and helpers
+- File organization (where new files go)
+
+
+## 6. Map File Structure
+- PASS CONTINUE
+- FAIL STOP
+
+Map the files to be created, edited, or deleted.
+The file structure mapping informs the task decomposition.
+Each task should produce self-contained changes that make sense independently.
+
+
+## 7. Output Path
+- ARTIFACTS
+  - PlanPath "plan.json"
+- PASS CONTINUE
+- FAIL STOP
+
+{{ PlanPath }}
+
+
+## 8. Write the plan
+- PASS CONTINUE
+- FAIL STOP
+
+Write the plan to the output path.
+Follow the structure and conventions from the writing-plans skill.
+If revising the plan, address the issues identified.
+
+
+## 9. Check Schema
+- PASS CONTINUE
+- FAIL GOTO 8
+
+```bash
+{{ validateSchema PlanPath }}
+```
+
+
+## 10. Verify Plan Structure
+
+- PASS COMPLETE
+- FAIL GOTO 8
+
+Verify the saved plan includes all required sections:
+
+- [ ] Goal — clear, testable, one sentence
+- [ ] Architecture & Approach
+- [ ] Constraints & Assumptions
+- [ ] Dependencies (Optional)
+- [ ] Context (Optional)
+- [ ] Files & Actions
+- [ ] Tasks decomposed into granular subtasks
+- [ ] Tasks structured with TDD principles
+- [ ] Tasks include atomic commit if required

--- a/packages/claude-code-plugin/codex-plugin/schemas/plan.schema.json
+++ b/packages/claude-code-plugin/codex-plugin/schemas/plan.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rundown.org/schemas/plan.schema.json",
+  "title": "Plan",
+  "description": "Implementation plan for the Rundown planning workflow.",
+  "type": "object",
+  "$defs": {
+    "FileEntry": {
+      "type": "object",
+      "required": ["path", "action"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?!\\/)(?![A-Za-z]:[\\/\\\\])(?!.*(?:^|\\/)\\.\\.(?:\\/|$))(?!.*\\\\)",
+          "description": "Relative file path from project root (e.g. src/foo.ts)"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Start line number (1-based)"
+        },
+        "end_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "End line number for ranges (1-based)"
+        },
+        "symbol": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Logical location name (function, class, type)"
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Construct type: function, type, class, module, method, member, variable, namespace"
+        },
+        "action": {
+          "type": "string",
+          "enum": ["create", "edit", "delete"]
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "name",
+    "meta",
+    "goal",
+    "architecture_and_approach",
+    "constraints_and_assumptions",
+    "files",
+    "tasks"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "const": "https://rundown.org/schemas/plan.schema.json",
+      "description": "Schema URI for editor autocomplete and rdx validation dispatch."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "meta": {
+      "type": "object",
+      "required": ["version"],
+      "properties": {
+        "version": {
+          "const": "1.0.0"
+        }
+      },
+      "additionalProperties": false
+    },
+    "goal": {
+      "type": "string",
+      "description": "Clear, concise description of the desired outcome"
+    },
+    "architecture_and_approach": {
+      "type": "string",
+      "description": "High-level solution design, critical components, data and integrations"
+    },
+    "constraints_and_assumptions": {
+      "type": "string",
+      "description": "Hard constraints and assumptions"
+    },
+    "dependencies": {
+      "type": "string",
+      "description": "Required services, frameworks, libraries, or upstream changes"
+    },
+    "context": {
+      "type": "string",
+      "description": "Additional context useful for implementation"
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/FileEntry" }
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "files", "subtasks"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "files": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/FileEntry" },
+            "description": "Files affected by this task. May be empty for research or config-only tasks; commit.files independently enforces staged files."
+          },
+          "subtasks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "description": {
+                  "type": "string",
+                  "description": "What this subtask does and how"
+                },
+                "code": {
+                  "type": "object",
+                  "required": ["language", "content"],
+                  "properties": {
+                    "language": { "type": "string", "minLength": 1 },
+                    "content": { "type": "string" }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "commit": {
+            "type": "object",
+            "required": ["files", "message"],
+            "properties": {
+              "files": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "File path to stage for commit"
+                }
+              },
+              "message": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/claude-code-plugin/codex-plugin/schemas/review.schema.json
+++ b/packages/claude-code-plugin/codex-plugin/schemas/review.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rundown.org/schemas/review.schema.json",
+  "title": "Review",
+  "description": "Structured review items for plan and code reviews. A review document records that a review was performed. An empty items array records that the review found no issues.",
+  "type": "object",
+  "required": ["meta", "items"],
+  "properties": {
+    "$schema": {
+      "$ref": "#/$defs/SchemaUri"
+    },
+    "meta": {
+      "$ref": "#/$defs/Meta"
+    },
+    "items": {
+      "$ref": "#/$defs/Items"
+    }
+  },
+  "additionalProperties": false,
+  "examples": [
+    {
+      "$schema": "https://rundown.org/schemas/review.schema.json",
+      "meta": {
+        "version": "1.0.0"
+      },
+      "items": []
+    },
+    {
+      "$schema": "https://rundown.org/schemas/review.schema.json",
+      "meta": {
+        "version": "1.0.0"
+      },
+      "items": [
+        {
+          "title": "Invalid persisted state migration",
+          "level": "error",
+          "description": "Plan modifies persisted active runbook state and proposes runtime migration or compatibility shims.",
+          "references": [
+            {
+              "uri": "packages/core/src/state.ts",
+              "line": 42
+            }
+          ],
+          "recommendation": "Reject invalid persisted state, surface a prune/restart recovery path, and remove migration code."
+        }
+      ]
+    }
+  ],
+  "$defs": {
+    "SchemaUri": {
+      "type": "string",
+      "format": "uri",
+      "const": "https://rundown.org/schemas/review.schema.json",
+      "description": "Schema URI for editor autocomplete and rdx validation dispatch."
+    },
+    "Meta": {
+      "type": "object",
+      "required": ["version"],
+      "properties": {
+        "version": {
+          "const": "1.0.0"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Item": {
+      "type": "object",
+      "required": ["title", "level", "description"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "level": {
+          "type": "string",
+          "enum": ["error", "warning", "note"]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "references": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Reference"
+          }
+        },
+        "recommendation": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "Items": {
+      "type": "array",
+      "description": "Review findings. An empty array indicates review found no issues.",
+      "items": {
+        "$ref": "#/$defs/Item"
+      }
+    },
+    "Reference": {
+      "type": "object",
+      "description": "A reference to a code location, document, or external resource. Uses uri as the universal identifier — file paths (relative or absolute) and absolute URIs are all valid.",
+      "required": ["uri"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "description": "File path (relative or absolute) or absolute URI"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Start line number (1-based)"
+        },
+        "end_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "End line number for ranges (1-based, must be >= line)"
+        },
+        "symbol": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Logical location name (function, class, type)"
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Construct type: function, type, class, module, method, member, variable, namespace"
+        }
+      },
+      "additionalProperties": false,
+      "dependentRequired": {
+        "end_line": ["line"]
+      }
+    }
+  }
+}

--- a/packages/claude-code-plugin/codex-plugin/skills/converting-skills-to-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/converting-skills-to-runbooks/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: converting-skills-to-runbooks
+description: Use when converting an existing Claude skill (SKILL.md) into a rundown runbook — distilling the skill's workflow backbone into orchestration steps and artifacts without duplicating the skill's context
+---
+
+# Converting Skills to Runbooks
+
+<important>
+## Runbook-Orchestrated Skill
+Load the execution protocol *before* starting the runbook:
+
+Load and follow the bundled `running-runbooks` skill before starting the
+runbook.
+
+Then start it:
+`rundown run rundown:convert-skill --input SkillPath=<path-to-SKILL.md>`
+</important>
+
+Distill a Claude skill into a rundown runbook that **orchestrates** its
+workflow. The runbook captures the high-level sequence of steps and coordinates
+the artifacts that flow between them. The skill keeps the context. The runbook
+references the skill; it does not restate it.
+
+Rundown's purpose is orchestrating workflow — not storing knowledge. A good
+converted runbook is short: it is the backbone of the skill, not a copy of it.
+
+## When to Use
+
+- Turning a process-shaped skill (ordered phases, gates, hand-offs, fan-out)
+  into an executable `.runbook.md`.
+- Giving an existing skill a runnable, artifact-coordinating front end that
+  subagents can step through.
+
+## When NOT to Use
+
+- Authoring a runbook from scratch with no source skill — use
+  [writing-runbooks](../writing-runbooks/SKILL.md).
+- Looking up runbook syntax — use
+  [writing-runbooks](../writing-runbooks/SKILL.md) and its
+  [house-style.md](../writing-runbooks/house-style.md).
+- Executing an existing runbook — use
+  [running-runbooks](../running-runbooks/SKILL.md).
+- A skill that is pure reference (no workflow backbone) — there is nothing to
+  orchestrate.
+
+## The Core Distinction
+
+Every `SKILL.md` holds two kinds of content. Conversion separates them.
+
+| In the skill                                                   | Becomes in the runbook                                                                       |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Workflow backbone: ordered phases, gates, "do X then Y", loops | H2 steps + `PASS`/`FAIL` transitions, `FOR` loops, `GOTO` retry loops                        |
+| Artifacts produced/consumed (plan, review, report)             | `ARTIFACTS` aliases + `INPUTS` / `OUTPUTS` / `REQUIRED` contract                             |
+| Fan-out ("dispatch a subagent per item")                       | `- DELEGATE` steps + delegate-then-collate                                                   |
+| Domain knowledge: rules, syntax, rationale, examples           | **Stays in the skill.** Step 1 says "Invoke and read the `<skill>` skill"; bodies point back |
+
+**The primary quality gate is the no-duplication scan.** If a step body is
+teaching, that content belongs in the skill — do not restate it in the runbook.
+Replace it with a pointer.
+
+## Procedure
+
+1. **Read the source skill.** Separate the backbone (the ordered "what to do")
+   from the context (the "how/why to think about it").
+2. **Open with a skill-invocation step.** Step 1 = "Invoke and read the
+   `<skill>` skill. Internalize the guidance." Set the `skill:` frontmatter
+   field. This is what lets every later step stay terse.
+3. **Map each backbone phase to one H2 step.** The body is a pointer or a
+   checklist, never the explanation. See
+   [references/mapping.md](references/mapping.md).
+4. **Coordinate artifacts.** Bind schemas read-only early; declare
+   produced/consumed files as `ARTIFACTS` aliases and an
+   `INPUTS`/`OUTPUTS`/`REQUIRED` contract; reference `{{ path Alias }}`, never a
+   hardcoded path.
+5. **Close with produce → validate → retry.** The last steps validate the output
+   and `FAIL GOTO` the write step.
+6. **Verify** against [references/checklist.md](references/checklist.md):
+   `rundown check` passes, every load-bearing phase is covered, and no step
+   duplicates skill context.
+
+## Worked Example
+
+The superpowers `writing-plans` skill distills to
+`runbooks/planning/write-plan.runbook.md`. Its step 1 is the move this skill
+generalizes:
+
+```markdown
+## 1. Invoke the Writing Plans skill
+- PASS CONTINUE
+- FAIL STOP
+
+Invoke and read the writing-plans skill. Internalize the guidance — it defines
+the plan structure, TDD principles, and quality standards used throughout this runbook.
+
+Skill: `rundown:writing-plans`
+```
+
+The `skill: writing-plans` **frontmatter** field (set in step 2 of the
+procedure) is the machine-parseable contract validated by the companion runbook;
+the `Skill:` line in the body above is human-facing context.
+
+Everything the skill _teaches_ (plan structure, TDD, no-placeholders) stays in
+the skill. The runbook only sequences: invoke skill → review schema → scope →
+requirements → research → map files → write → validate → verify.
+
+## Companion Runbook
+
+[`runbooks/meta/convert-skill.runbook.md`](../../runbooks/meta/convert-skill.runbook.md)
+orchestrates this conversion itself: invoke this skill → read the source skill →
+map the backbone → write the runbook → `rundown check` → verify against the
+checklist. Run it with `--input SkillPath=<path-to-SKILL.md>`.
+
+## Common Mistakes
+
+| Mistake                                           | Fix                                                     |
+| ------------------------------------------------- | ------------------------------------------------------- |
+| Step bodies restate the skill's rules/examples    | Replace with a pointer; the skill is read in step 1     |
+| No skill-invocation step / missing `skill:` field | Add step 1 "Invoke and read the `<skill>` skill"        |
+| Hardcoded artifact paths                          | Bind an `ARTIFACTS` alias, write to `{{ path Alias }}`  |
+| One mega-runbook for a multi-artifact skill       | One runbook, one artifact; compose leaves from a parent |
+| No validation loop                                | End with validate + `FAIL GOTO <write-step>`            |
+| Collating fan-out from the parent                 | Delegate the fan-out, then delegate collation           |
+
+## Reference
+
+- [writing-runbooks/house-style.md](../writing-runbooks/house-style.md) —
+  idiomatic runbook conventions
+- [writing-runbooks](../writing-runbooks/SKILL.md) — runbook syntax
+- Stage 1 delegated child dispatch note: automatic Codex child-agent
+  orchestration requires Stage 2 hook support
+- [running-runbooks](../running-runbooks/SKILL.md) — executing the produced
+  runbook
+- [writing-plans](../writing-plans/SKILL.md) — planning the work a runbook will
+  orchestrate
+- [references/mapping.md](references/mapping.md) — skill-element →
+  runbook-construct mapping
+- [references/checklist.md](references/checklist.md) — verification checklist

--- a/packages/claude-code-plugin/codex-plugin/skills/converting-skills-to-runbooks/references/checklist.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/converting-skills-to-runbooks/references/checklist.md
@@ -1,0 +1,43 @@
+# Conversion Verification Checklist
+
+Run this checklist on every converted runbook before considering it done. It
+adapts the superpowers writing-plans self-review to the skill-to-runbook
+transform: the "no placeholders" scan becomes a "no duplication" scan.
+
+## 1. Backbone coverage
+
+- [ ] Every load-bearing phase in the source skill maps to a step — or is
+      deliberately dropped because it is pure context (note which).
+- [ ] Steps are in the skill's intended order.
+
+## 2. No-duplication scan (primary gate)
+
+- [ ] Step 1 invokes and reads the source skill; the `skill:` frontmatter field
+      is set.
+- [ ] No step body restates the skill's rules, syntax, rationale, or examples.
+- [ ] Bodies are pointers or checklists, not explanations. If a body teaches,
+      move it back to the skill and leave a pointer.
+
+## 3. Contract consistency
+
+- [ ] Frontmatter `INPUTS` / `REQUIRED` / `OUTPUTS` match what the steps
+      actually consume and produce.
+- [ ] `REQUIRED` is a subset of `INPUTS`.
+- [ ] `ARTIFACTS` aliases are consistent across steps (same PascalCase name for
+      the same artifact).
+- [ ] Every artifact reference uses `{{ path Alias }}` — no hardcoded paths.
+
+## 4. House-style shape
+
+- [ ] Produce → validate → retry loop present (validate step `FAIL GOTO` the
+      write step).
+- [ ] Fan-out, if any, uses `- DELEGATE` + delegate-then-collate (never collate
+      from the parent).
+- [ ] Review-type steps use `FAIL CONTINUE` (record-don't-gate).
+- [ ] One runbook, one artifact (or a parent composing leaves).
+
+## 5. Machine validation
+
+- [ ] `rundown check <file>` passes.
+- [ ] `rundown resolve <file> --input <REQUIRED>=…` passes once required inputs
+      are supplied (skip if the runbook has no required inputs).

--- a/packages/claude-code-plugin/codex-plugin/skills/converting-skills-to-runbooks/references/mapping.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/converting-skills-to-runbooks/references/mapping.md
@@ -1,0 +1,49 @@
+# Mapping: Skill Elements → Runbook Constructs
+
+How each part of a `SKILL.md` maps into a house-style runbook. Read alongside
+[../../writing-runbooks/house-style.md](../../writing-runbooks/house-style.md).
+
+## Element mapping
+
+| Skill element                          | Runbook construct                                                     |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| The skill itself (its guidance)        | Step 1: "Invoke and read the `<skill>` skill" + `skill:` frontmatter  |
+| An ordered phase / numbered section    | One H2 step with `PASS`/`FAIL` transitions                            |
+| A gate ("only proceed if…")            | A step whose `FAIL` is `STOP` (or `GOTO` a fix step)                  |
+| "Repeat for each item"                 | `FOR var IN {{ source }}` on an H2 step with H3 substeps              |
+| "Dispatch a subagent per item"         | `- DELEGATE` step + a separate collation runbook                      |
+| A produced file (plan, review, report) | `ARTIFACTS Alias "file.json"` + write to `{{ path Alias }}`           |
+| A consumed/inherited file              | Naked `ARTIFACTS Alias` rehydration + frontmatter `INPUTS`/`REQUIRED` |
+| A structured-output schema             | Read-only `ARTIFACTS SchemaPath "schemas/x.schema.json"` bound early  |
+| A "self-review" / "verify" section     | A final step: validate + `PASS COMPLETE` / `FAIL GOTO <write-step>`   |
+| Rules, rationale, syntax, examples     | **Nothing** — stays in the skill; reference it, do not copy it        |
+
+## Mapping rules
+
+1. **Skill-invocation step first.** Step 1 invokes and reads the source skill
+   and sets the `skill:` frontmatter field. Every later body can then assume the
+   skill is in context and stay terse.
+2. **Bind schema/contract early.** If the skill produces a structured artifact,
+   bind its schema (read-only) before the write step.
+3. **One backbone phase → one H2 step.** Body is a terse pointer or checklist,
+   never the explanation.
+4. **Artifacts via `ARTIFACTS` + `{{ path Alias }}`.** PascalCase `*Path` /
+   `*Paths`; never hardcode a path.
+5. **Produce → validate → retry.** Final steps validate (`rundown check`, or
+   `rdx --validate --schema` / `{{ validateSchema Alias }}` for JSON artifacts)
+   with `PASS COMPLETE` / `FAIL GOTO <write-step>`.
+6. **Fan-out → delegate-then-collate.** Model parallel sub-work as `- DELEGATE`
+   steps with a separate collation runbook; never collate from the parent.
+7. **One runbook, one artifact.** If the skill produces several artifacts or has
+   independent sub-workflows, split into a parent + leaf runbooks composed from
+   the parent.
+8. **Record-don't-gate.** Review-type steps use `FAIL CONTINUE` so findings are
+   recorded without halting the run.
+
+## Decision: split or single?
+
+- Single runbook if the skill produces one artifact through one linear backbone.
+- Parent + leaves if the skill has independent sub-workflows, fans out, or emits
+  multiple artifacts. The parent composes leaves by listing their paths in a
+  step body; it does not re-derive their artifact paths — it consumes each
+  leaf's frontmatter `OUTPUTS`.

--- a/packages/claude-code-plugin/codex-plugin/skills/end-to-end-testing/SKILL.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/end-to-end-testing/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: end-to-end-testing
+description: Use when running the Rundown end-to-end test runbook and reporting structured feedback on the workflow.
+---
+
+# End-to-End Testing
+
+Run the end-to-end test through Rundown state. Do not improvise. Start:
+
+```bash
+rundown run rundown:end-to-end-test
+```
+
+## Flow
+
+- Parent, final feedback, `end-to-end-test/write-file.runbook.md`, and
+  `end-to-end-test/review-and-collate.runbook.md` run locally.
+- `end-to-end-test/review-file.runbook.md` and
+  `end-to-end-test/collate-files.runbook.md` are delegated by the review
+  wrapper.
+
+Only nested review and collation runbooks are delegated. If the wrapper
+completes before collate, report a defect; never delegate collation from the
+parent.
+
+## Operating Rules
+
+- Follow the active prompt. Use default JSON output; never add `--text` (it is
+  human-only output, not part of the agent protocol).
+- Treat `rundown run`, `rundown pass`, `rundown fail`, `rundown claim`, and
+  `rundown collect` output as the next context. Parent-side pass/fail/collect
+  carry `--run <rd_…>` (capture the run id from `rundown run` output, echoed as
+  `runbookId` on every event); child-side commands carry
+  `--claim-id <claim_id>`.
+- Use `rundown status` only to recover orientation after an error or
+  interruption.
+- Pass only after the current step is complete; fail when it cannot be completed
+  as written.
+- Preserve state on errors. Do not prune, clear, or delete `.rundown`.
+
+The DELEGATE step auto-issues a claim token (`delegations` in `rundown status`).
+Claim it:
+
+```bash
+rundown claim <token>                  # returns claim_id; dispatch the child to a subagent
+```
+
+Drive the claimed child like any runbook: advance each step with
+`rundown pass --claim-id <claim_id>` / `rundown fail --claim-id <claim_id>`.
+Prompted child steps need this claim-id transition to advance. On a
+delegation-exposed run, a bare `rundown pass`/`rundown fail` is refused with
+`ACTOR_CONTEXT_REQUIRED` regardless of claim state (exposure is sticky). A
+`--run`-targeted parent advance is additionally refused with
+`OPEN_DELEGATED_CHILDREN` while a claimed child is open.
+
+When the child's final step completes it auto-resolves its parent substep and
+the parent auto-aggregates and advances. `rundown pass/fail --claim-id` is
+idempotent on a resolved child, so it also confirms or overrides a child you
+stop early.
+
+## Artifacts
+
+Use rendered `{{ path Alias }}` paths.
+
+Expected artifacts:
+
+- `PlanSchemaPath`
+- `PlanPath`
+- `ReviewSchemaPath`
+- `ReviewPath`
+- `ReviewPaths`
+- `CollatedReviewPath`
+- `FeedbackPath`
+
+Do not rediscover paths or add artifact-only steps. Missing/wrong variables and
+write-one/check-another mismatches are defects.
+
+## Feedback
+
+Feedback must be JSON matching `review.schema.json`. Use empty `items` when
+there are no findings.
+
+Capture only concrete issues: unclear prompts, wrong delegation boundary,
+missing/wrong artifact variables, schema mismatches, required manual inference,
+failed commands with observed output.

--- a/packages/claude-code-plugin/codex-plugin/skills/executing-plans/SKILL.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/executing-plans/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: executing-plans
+description: Use when implementing a written plan task-by-task — the per-task cycle, commit discipline, and escalation rules that an execute-plan runbook orchestrates around.
+---
+
+# Executing Plans
+
+<important>
+## Runbook-Orchestrated Skill
+This runbook requires the plan's **artifact URI** as `PlanPath` — an `rd://…`
+value produced by `write-plan`, **not** a filesystem path. Resolve `PlanPath`
+first (ask the user if it is not already known). Load the execution protocol
+*before* starting, so you can handle delegated tasks the moment they appear:
+
+Load and follow the bundled `running-runbooks` skill before starting the
+runbook.
+
+Stage 1 does not provide Codex hook parity for delegated child dispatch. If this
+workflow reaches a delegated step that requires automatic child-agent
+orchestration, stop and report that Stage 2 delegation hook support is required.
+
+Then start it:
+
+- **Delegated pipeline** (`write-plan → execute-plan`): `PlanPath` is inherited
+  automatically — no explicit supply needed.
+- **Standalone**: pass the plan's artifact URI through the dedicated artifact
+  channel —
+  `rundown run rundown:execute-plan --artifacts PlanPath=<rd://… plan URI>`
+  (e.g. `--artifacts PlanPath=rd://artifacts/<ctx>/<run>/plan.json`). `PlanPath`
+  is declared `REQUIRED` and consumed as an `ARTIFACTS` input by the runbook, so
+  it must arrive as an `rd://` URI, not a filesystem path. Discover the alias
+  with `rundown artifact ls`, then read the `uri` field of
+  `rundown artifact uri PlanPath` (JSON is the default; agents do not add
+  `--text`).
+
+Capture the run id from `rundown run`: it is printed at start and echoed as
+`runbookId` on every event. This runbook delegates the implementer, so every
+orchestrator command must carry `--run <rd_…>`. </important>
+
+Implement a written plan one task at a time, holding each task to its own tests
+and committing as you go. This skill is the **context** an execution runbook
+orchestrates: how to do each task well. The
+[`execute-plan`](../../runbooks/planning/execute-plan.runbook.md) runbook owns
+the _sequence_ (implement → review → verify) and the _gates_; this skill owns
+the _craft_ of a single task.
+
+Rundown orchestrates workflow; it does not store craft. Keep the cycle here, not
+in the runbook.
+
+## When to Use
+
+- Implementing a plan produced by [writing-plans](../writing-plans/SKILL.md),
+  whether driven by the `execute-plan` runbook or by hand.
+- Resolving review findings against an already-implemented plan.
+
+## When NOT to Use
+
+- Writing the plan — use [writing-plans](../writing-plans/SKILL.md).
+- Authoring or sequencing the runbook that drives execution — use
+  [writing-runbooks](../writing-runbooks/SKILL.md).
+
+## The Per-Task Cycle
+
+Work the plan's tasks in order. For each task:
+
+1. **Follow its bite-sized steps exactly.** A well-written task is TDD-shaped:
+   write the failing test, run it red, implement the minimum, run it green.
+2. **Run the verifications the task specifies.** Do not skip them.
+3. **Commit per the task's `commit` block** before starting the next task.
+4. **Keep moving.** Do not pause between tasks to check in — execute the whole
+   plan. Stop only to escalate (below).
+
+## Commit Discipline
+
+One commit per task, staging exactly the files the task's `commit.files` lists,
+with the task's `commit.message`. Frequent, atomic commits keep the work
+bisectable and give the review and verify gates a clean history to act on.
+
+## Review and Verify Gates
+
+The `execute-plan` runbook reviews the implemented changes and runs
+`npm run verify` after implementation, looping a fix step until both are clean.
+Your responsibility is to make those gates _reachable_: leave the tree building,
+tests passing for the work you did, and changes scoped to the plan. When a gate
+sends work back (via `address-review`), resolve the recorded `error`-level
+findings without expanding scope.
+
+## When to Stop and Escalate
+
+Stop and ask rather than guess when:
+
+- A dependency, file, or symbol the plan references does not exist.
+- A task's instruction is ambiguous or contradicts the codebase.
+- A verification fails repeatedly and the fix is unclear.
+- The plan has a gap that prevents starting a task.
+
+Never start implementation on `main`/`master` without explicit consent.
+
+## Reference
+
+- [writing-plans](../writing-plans/SKILL.md) — produces the plan this skill
+  executes
+- [running-runbooks](../running-runbooks/SKILL.md) — executing the driving
+  runbook
+- Stage 1 delegated child dispatch note: automatic Codex child-agent
+  orchestration requires Stage 2 hook support
+- [composing-runbooks.md](../../../../docs/guides/composing-runbooks.md) — how
+  execute-plan composes the leaves

--- a/packages/claude-code-plugin/codex-plugin/skills/planning/SKILL.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/planning/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: planning
+description: Use when running the full plan → review → execute pipeline — write the plan, review it, then implement it behind review and verify gates. The top-level entrypoint that orchestrates writing-plans, plan review, and executing-plans end to end.
+use_when: Driving a body of work from a spec through to merged implementation.
+---
+
+# Planning
+
+<important>
+## Runbook-Orchestrated Skill
+Load the execution protocol *before* starting, so you can handle step 1 (a
+delegation) the moment it appears:
+
+Load and follow the bundled `running-runbooks` skill before starting the
+runbook.
+
+Stage 1 does not provide Codex hook parity for delegated child dispatch. If this
+workflow reaches a delegated step that requires automatic child-agent
+orchestration, stop and report that Stage 2 delegation hook support is required.
+
+Then start the runbook with exactly this command, no added flags:
+`rundown run rundown:planning`
+
+Capture the run id from that command: `rundown run` prints it at start and every
+event carries it as `runbookId`. This pipeline delegates (step 1), so every
+orchestrator command you issue — `collect`, `pass`, `goto` — must carry
+`--run <rd_…>`.
+
+JSON is the agent-facing default; `--text` is for humans/debugging only — do not
+add it here. </important>
+
+## Overview
+
+Take a body of work from idea to implementation through three gated stages:
+**write the plan**, **review the plan**, then **execute the plan**. This skill
+is the **entrypoint** that orchestrates the whole pipeline; the
+[`planning`](../../runbooks/planning/planning.runbook.md) runbook owns the
+_sequence_ and the _gates_, and each stage's craft lives in its own sibling
+skill.
+
+Rundown orchestrates workflow; it does not store craft. This skill names the
+pipeline and points at the stages — it does not duplicate them.
+
+## The Three Stages
+
+1. **Write the plan** — produce a clean, complete implementation plan
+   (delegated). Craft lives in [writing-plans](../writing-plans/SKILL.md); the
+   leaf is the `write-plan` runbook. The stage stops the pipeline on failure.
+2. **Review the plan** — run the plan through structural, technical,
+   build/runtime, and risk/safety reviewers, then collate. This stage composes
+   the `review-plan` runbook inline. It stops the pipeline on failure.
+3. **Execute the plan** — implement the plan task-by-task behind review and
+   verify gates. Craft lives in [executing-plans](../executing-plans/SKILL.md);
+   the stage composes the `execute-plan` runbook inline and completes the
+   pipeline on success.
+
+Every stage stops the pipeline on failure (`FAIL ANY STOP`); the final stage
+completes it (`PASS ALL COMPLETE`).
+
+## When to Use
+
+- Driving a body of work end to end: spec → plan → reviewed plan →
+  implementation.
+- When you want the review and verify gates between planning and merging, not
+  just stage 1.
+
+## When NOT to Use
+
+- Only writing a plan with no review/execute follow-through — use
+  [writing-plans](../writing-plans/SKILL.md) directly.
+- Only implementing an already-written, already-reviewed plan — use
+  [executing-plans](../executing-plans/SKILL.md).
+
+## Reference
+
+- [writing-plans](../writing-plans/SKILL.md) — stage 1 craft: authoring the plan
+- [executing-plans](../executing-plans/SKILL.md) — stage 3 craft: implementing
+  the plan
+- [running-runbooks](../running-runbooks/SKILL.md) — executing the driving
+  runbook
+- Stage 1 delegated child dispatch note: automatic Codex child-agent
+  orchestration requires Stage 2 hook support

--- a/packages/claude-code-plugin/codex-plugin/skills/rundown/SKILL.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/rundown/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: rundown
+description: Use when asked to run or start a Rundown runbook by name (e.g. "run the planning runbook", "start the deploy runbook") and no runbook is active yet. The launcher that resolves a runbook and begins execution. Invocable as /rundown <runbook>.
+---
+
+# Rundown Launcher
+
+The entrypoint for starting a runbook from a cold start. This skill resolves a
+runbook by name, starts it, and hands off to the execution protocol. It does not
+contain the protocol itself.
+
+## When to Use
+
+- A user asks to "run"/"start the X runbook" and no runbook is active yet.
+- Invoked directly as `/rundown <runbook>` with a runbook name.
+
+## When NOT to Use
+
+- A runbook is already active or CLI output asks for pass/fail — use
+  [running-runbooks](../running-runbooks/SKILL.md).
+- Authoring or editing a runbook file — use
+  [writing-runbooks](../writing-runbooks/SKILL.md).
+- A runbook has its own bootstrap skill (e.g. `planning`) — invoke that skill;
+  it starts itself.
+
+## Steps
+
+1. **Resolve the runbook.** If the name is ambiguous or you are unsure it
+   exists, list discoverable runbooks:
+
+   ```bash
+   rundown ls --all
+   ```
+
+   Names support `namespace:name` (e.g. `rundown:planning` for the plugin
+   source). A bare name resolves via the priority chain (project → plugin →
+   bundled).
+
+2. **Load the execution protocol — before starting.** So you are ready to
+   interpret the first step's output (including a delegation) the moment it
+   appears, rather than scrambling for the protocol after `rundown run` has
+   fired:
+
+   Load and follow the bundled `running-runbooks` skill before starting the
+   runbook.
+
+   If the runbook contains `- DELEGATE`, Stage 1 can show and operate on the
+   CLI/MCP output but does not provide Codex hook parity for automatic
+   child-agent dispatch or closure enforcement. Stop and report that Stage 2
+   delegation hook support is required before attempting automatic Codex
+   subagent orchestration.
+
+3. **Start it.**
+
+   ```bash
+   rundown run <name>
+   ```
+
+   Capture the run id when you start the runbook: `rundown run` prints it at
+   start and every subsequent event carries it as `runbookId`. You need it for
+   every mutating command you issue as the orchestrator of a delegation-exposed
+   run.
+
+   Pass inputs if the runbook requires them:
+
+   ```bash
+   rundown run <name> --input key=value
+   ```
+
+   If `rundown run` reports missing required inputs, supply them and re-run.
+
+4. **Execute.** Follow the loaded
+   [running-runbooks](../running-runbooks/SKILL.md) protocol: respond to each
+   step with `rundown pass` / `rundown fail` and trust Rundown for transitions.
+   On a delegation-exposed run (any runbook with a `- DELEGATE` step), these
+   become `rundown pass --run <rd_…>` / `rundown fail --run <rd_…>` — the bare
+   form is for standalone runs only and otherwise refuses with
+   `ACTOR_CONTEXT_REQUIRED`.
+
+## Reference
+
+- [running-runbooks](../running-runbooks/SKILL.md) — the execution protocol
+- [writing-runbooks](../writing-runbooks/SKILL.md) — authoring runbooks

--- a/packages/claude-code-plugin/codex-plugin/skills/running-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/running-runbooks/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: running-runbooks
+description: Use when stepping through a Rundown runbook that is already active or has just been started, when receiving delegation instructions with a claim token, or when rundown CLI commands appear in step output. For cold-start "run the X runbook" requests with nothing active, the rundown launcher skill starts the runbook first.
+---
+
+# Running Runbooks
+
+Rundown executes markdown runbooks step-by-step. The CLI controls progress — you
+follow the output and respond.
+
+In Codex, MCP tools are available when the bundled Rundown MCP server is loaded.
+Prefer those tools (`rundown.run`, `rundown.status`, `rundown.pass`,
+`rundown.fail`, etc.) when they are available. If MCP tools are unavailable in
+the current surface, use the `rundown` CLI directly. MCP and CLI routes are thin
+front ends over the same CLI/core state machine, and JSON remains the
+agent-facing output.
+
+Capture the run id when you start the runbook: `rundown run` prints it at start
+and every subsequent event carries it as `runbookId`. You need it for every
+mutating command you issue as the orchestrator of a delegation-exposed run
+(`--run <rd_…>`). A claimed child never needs it — a child names its own lane
+with `--claim-id <claim_id>`.
+
+## When to Use
+
+- A Rundown runbook is already active and needs step-by-step execution
+- CLI output from `rundown` asks for a pass/fail response, claim, status check,
+  or continuation
+- A delegated task arrives with a claim token and must be accepted, executed,
+  and reported back
+- A prompt or command output references Rundown step IDs, substeps, FOR loop
+  indexes, or claim IDs
+
+## When NOT to Use
+
+- Writing or editing runbook files — use the writing-runbooks skill instead
+- Orchestrating parent-side delegation to other agents — Stage 1 does not
+  provide Codex hook parity for delegated child dispatch
+- Planning work before authoring a runbook — use the writing-plans skill when
+  applicable
+- Running unrelated shell commands that are not part of a Rundown-controlled
+  workflow
+
+## Quick Reference
+
+```bash
+rundown run <file>                      # Start a runbook
+rundown run <file> --input k=v          # Start with input
+rundown run <file> --input-json k=json  # Start with JSON input
+rundown run <file> --input-file <path>  # Load inputs from YAML
+
+rundown pass                    # Mark step passed (aliases: yes, ok) — standalone run only
+rundown fail                    # Mark step failed (alias: no) — standalone run only
+
+rundown status                  # Show current state (JSON by default)
+rundown stop                    # Stop the active workflow; inside inline composition, targets the outermost contiguous-inline ancestor
+rundown complete                # Complete the active workflow; inside inline composition, targets the outermost contiguous-inline ancestor
+```
+
+The bare `rundown pass` / `rundown fail` / `rundown stop` / `rundown complete`
+forms above apply to a **standalone run** (one with no delegation activity). On
+a **delegation-exposed run** the bare form is refused with
+`ACTOR_CONTEXT_REQUIRED`; name your lane instead — orchestrators pass
+`--run <rd_…>`, delegated children pass `--claim-id <claim_id>`:
+
+```bash
+rundown pass --run <rd_…>        # Orchestrator advances the run it controls
+rundown pass --claim-id <claim_id>   # Delegated child reports its result
+```
+
+Inside inline-composed runbooks, use `rundown pass` or `rundown fail` to finish
+the current inline unit and let the parent continue (on a delegation-exposed
+composition, `--run <rd_…>` naming any member of the contiguous inline chain).
+Use `rundown complete` or `rundown stop` only when the intended outcome is to
+force the composed workflow terminal. Delegated children still use `--claim-id`
+and report to the parent; the parent advances on `rundown collect --run <rd_…>`.
+
+## How Steps Work
+
+Each step is one of two types:
+
+| Type        | What happens                  | What you do                                                     |
+| ----------- | ----------------------------- | --------------------------------------------------------------- |
+| **Command** | Executes automatically (bash) | Wait. Exit code determines result.                              |
+| **Prompt**  | Outputs instructions          | Follow the instructions, then `rundown pass` or `rundown fail`. |
+
+Default transitions:
+
+- **PASS** → advance to next step
+- **FAIL** → stop execution
+
+The runbook may override these (e.g., FAIL retries, GOTO a recovery step).
+**Trust Rundown for execution state and transitions** — it tells you what
+happened and what's next. Do not second-guess or work around the runbook's
+transition logic, even if the result seems unexpected. Still apply normal
+safety, permission, and policy checks before running commands or taking external
+actions.
+
+## Substeps
+
+Some steps contain substeps (e.g., step 2 has substeps 2.1, 2.2). When
+responding to substeps:
+
+```bash
+rundown pass --step 2.1         # Pass a specific substep
+rundown fail --step 2.2         # Fail a specific substep
+```
+
+## FOR Loops
+
+Steps with FOR loops repeat across iterations. Target a specific iteration with
+`--index` (requires `--step`):
+
+```bash
+rundown pass --step 2.1 --index 3    # Pass substep 2.1 at iteration 3
+rundown fail --step 2.1 --index 3    # Fail substep 2.1 at iteration 3
+```
+
+## Nested Runbooks
+
+**Inline linkage** is the default for runbook-list entries: no `- DELEGATE`, no
+token, the parent auto-launches the child in-session and records the parent
+linkage. Follow the output you receive — inline child runbooks launch
+automatically when the parent advances into a substep that references a nested
+runbook, with no manual `rundown run` command and no `rundown delegate` for
+these entries:
+
+```bash
+rundown pass    # advancing into the step that holds the inline substep auto-launches the child
+```
+
+The child:
+
+- Auto-starts and executes command steps
+- Presents prompted steps for you to follow
+- Automatically propagates its result to the parent substep on completion
+- Parent advances to the next step without manual `rundown pass`
+
+If the output provides a delegation token or tells you to delegate work, Stage 1
+can show and operate on the CLI/MCP output but does not provide Codex hook
+parity for automatic child-agent dispatch or closure enforcement. Stop and
+report that Stage 2 delegation hook support is required before attempting
+automatic Codex subagent orchestration.
+
+## Context Passing (OUTPUTS)
+
+Outputs declared by steps or child runbooks become available automatically to
+later steps. When a later step references a value such as `{{ PlanPath }}`,
+trust that Rundown has carried the declared output forward.
+
+Do not manually copy, forward, or re-enter output values unless the runbook
+output explicitly asks you to do so. Your job as a runner is to follow the CLI
+output and step instructions, not to manage variable plumbing.
+
+If `rundown run` or `rundown claim` reports missing required inputs, supply them
+operationally:
+
+```bash
+rundown run <file> --input key=value
+rundown run <file> --input-json key=json
+rundown run <file> --input-file <path>
+
+rundown claim <token> --input key=value
+rundown claim <token> --input-json key=json
+rundown claim <token> --input-file <path>
+```
+
+## Claiming Delegated Work
+
+When another agent delegates work to you, the plugin injects claim instructions
+automatically. The flow:
+
+1. You receive instructions containing a claim token
+2. Run `rundown claim <token>` to accept the work
+3. Follow the runbook steps (same as above — follow output, pass/fail), passing
+   `--claim-id <claim_id>` on **every** command
+4. Use `rundown pass --claim-id <claim_id>` or
+   `rundown fail --claim-id <claim_id>` to report your result back to the parent
+5. **Stop.** Once you have reported your claim's final result, your job is done
+   — end your turn and return control to the orchestrator that delegated you.
+
+Variables can be passed during claiming:
+
+```bash
+rundown claim <token> --input key=value
+rundown claim <token> --input-json key=json
+rundown claim <token> --input-file <path>
+```
+
+On a delegation-exposed run, every bare mutating command (`rundown pass`,
+`rundown fail`, `rundown goto`, `rundown collect`, `rundown complete`,
+`rundown stop`, `rundown delegate`) is refused with `ACTOR_CONTEXT_REQUIRED` —
+it does not silently target anything. Orchestrators pass `--run <rd_…>`;
+children pass `--claim-id <claim_id>`. Only a standalone run (no delegation
+activity) accepts the bare form.
+
+<important>
+**A claimed child stays inside its claim and stops when the claim ends.** You were dispatched to execute exactly one delegated runbook. When it completes (or fails), the parent pipeline may auto-advance into *its* next step — but those steps belong to the **orchestrator**, not to you. Do not keep going.
+
+- Pass `--claim-id <claim_id>` on **every** mutating `rundown` command for your
+  claimed work. **Never** issue a bare `rundown pass` / `rundown fail` /
+  `rundown goto` / `rundown collect` / `rundown complete` / `rundown stop` /
+  `rundown delegate` as a claimed child — on a delegation-exposed run the bare
+  form is refused with `ACTOR_CONTEXT_REQUIRED` (it does not silently drive the
+  parent), and the remediation names both lanes without ever echoing the run id.
+  Read-only commands like `rundown status` stay bare.
+- The "Complete ALL steps — do not abandon a runbook" rule applies to **your
+  claimed runbook only**, not to the parent that auto-advanced behind it.
+- After `rundown pass --claim-id` / `rundown fail --claim-id`, **end your
+turn.** Report your result in prose to whoever dispatched you; do not run
+further `rundown` commands.
+</important>
+
+Stage 1 does not provide Codex hook parity for delegated child dispatch. If this
+workflow reaches a delegated step that requires automatic child-agent
+orchestration, stop and report that Stage 2 delegation hook support is required.
+
+## State Management
+
+```bash
+rundown ls                # List active runbooks
+rundown stash             # Pause current runbook (stash)
+rundown pop               # Resume stashed runbook
+rundown prune             # Remove completed runbook state
+rundown prune --all       # Remove all runbook state
+```
+
+## Structured Output
+
+JSON is the agent-facing output format — every command emits machine-readable
+JSON by default:
+
+```bash
+rundown status           # Current state as JSON (default)
+rundown run <file>       # Execution events as JSON (default)
+```
+
+The `--text` flag exists only for humans reading output in a terminal; it is not
+part of the agent protocol. **Do not add `--text`** to any command — parse the
+JSON instead.
+
+## Rules
+
+- **Follow all step instructions exactly** — do not skip, improvise, or
+  reinterpret
+- **Never work around transitions** — if a FAIL handler retries or GOTOs, that
+  is correct behavior; do not override it
+- **Complete ALL steps** — do not abandon a runbook mid-execution
+- **Use the CLI** — always use `rundown pass`/`rundown fail` to respond, not
+  just verbal acknowledgment
+
+## Common Mistakes
+
+| Mistake                                               | Fix                                                                                                                      |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Verbal "done" instead of CLI                          | Always `rundown pass` or `rundown fail`                                                                                  |
+| Skipping steps                                        | Follow every step — runbook controls flow                                                                                |
+| Bare `rundown pass` with substeps active              | Use `rundown pass --step 2.1`                                                                                            |
+| Bare `rundown pass`/`rundown fail` in a claimed child | Use `rundown pass --claim-id <claim_id>` to report to the parent                                                         |
+| Bare mutating command on a delegation-exposed run     | Refused with `ACTOR_CONTEXT_REQUIRED`; name your lane — `--run <rd_…>` (orchestrator) or `--claim-id <claim_id>` (child) |
+| Claimed child keeps going after reporting             | Stop after `rundown pass --claim-id`; the parent's next steps belong to the orchestrator, not you                        |
+| Abandoning without `rundown stop`                     | Complete all steps or explicitly stop                                                                                    |
+
+## Reference
+
+- [Runbook patterns and examples](../../../../runbooks/README.md)
+- [Rundown specification](../../../../docs/spec/language.md)
+- [CLI reference](../../../../docs/reference/cli.md)
+- [Project overview and command list](../../../../CLAUDE.md)
+
+## Prompted Mode
+
+> Included for completeness. **Automatic execution is the default and the
+> typical usage** — reach for `--prompted` only when you explicitly need to step
+> through manually. Nothing above requires it.
+
+`--prompted` suppresses auto-execution: command steps do NOT run automatically —
+you see the command and advance manually with `rundown pass` / `rundown fail`.
+Use `--step <n>` to jump (requires `--prompted`).
+
+**Nested runbooks under `--prompted`.** Because auto-launch is suppressed,
+launch an inline child explicitly with `--step` pointing at the parent substep:
+
+```bash
+rundown run <child-runbook> --step 1.1
+```
+
+For a FOR loop iteration, add `--index`:
+
+```bash
+rundown run <child-runbook> --step 1.1 --index 3
+```

--- a/packages/claude-code-plugin/codex-plugin/skills/writing-plans/SKILL.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/writing-plans/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: writing-plans
+description: Write clean, clear, complete & comprehensive implementation plans that provide the complete context for an engineer with zero domain knowledge and no experience with the codebase.
+use_when: Writing detailed implementation plans.
+---
+
+# Writing Plans
+
+<important>
+## Runbook-Orchestrated Skill
+Load the execution protocol *before* starting the runbook:
+
+Load and follow the bundled `running-runbooks` skill before starting the
+runbook.
+
+Then start it: `rundown run rundown:write-plan` </important>
+
+## Overview
+
+Write clean, clear, complete & comprehensive implementation plans, assuming the
+target audience is an engineer with zero domain knowledge and no experience with
+the codebase.
+
+The plan should be structured into small, self-contained, granular tasks and
+subtasks.
+
+The plan should provide the complete context and document everything the
+implementing engineer needs to know:
+
+- all created, modified, and deleted files
+- detailed tests and code
+- reference documentation
+- required commands
+- other useful context
+
+Follow test-driven development (TDD) practices.
+
+Follow any project‑specific guidelines provided for this task.
+
+## Commitment
+
+### Announce at Start
+
+"I'm using the writing-plans skill to create the implementation plan."
+
+## Scope Check
+
+Before writing the plan, assess whether the work covers multiple independent
+subsystems. If so, recommend splitting into separate plans — each producing
+working, testable software independently.
+
+Indicators that the work should be split:
+
+- Changes span unrelated packages with no shared types or interfaces
+- Tasks have no ordering dependency between them
+- Each piece is independently mergeable and deployable
+
+## Research Codebase
+
+Read the relevant source files, tests, and documentation to understand:
+
+- Current architecture and patterns in the affected area
+- Existing types, interfaces, and conventions
+- Test patterns and coverage
+- Project standards and expectations
+
+Plans written without reading the code produce incorrect file paths, miss
+existing abstractions, and invent unnecessary ones.
+
+## File Structure Mapping
+
+Before defining tasks, map the files to be created, edited, or deleted. File
+structure mapping informs the task decomposition. Each task should produce
+self-contained changes that make sense independently.
+
+- Design units with clear boundaries and well-defined interfaces.
+- Each file should have one clear responsibility.
+- Prefer smaller, focused files to reduce context and make edits more reliable
+- Files that change together should live together. Split by responsibility, not
+  by technical layer.
+- Follow any established patterns in the existing codebase.
+- If the codebase uses large files, don't unilaterally restructure - but if a
+  file you're modifying has grown unwieldy, including a split in the plan is
+  reasonable.
+
+## Plan Structure & Content
+
+The plan includes these sections:
+
+### Goal
+
+Clear, concise description of the desired outcome.
+
+### Architecture & Approach
+
+High-level solution design, critical components, data and integrations.
+
+### Constraints & Assumptions
+
+Hard constraints and assumptions (performance, security, scalability,
+maintainability, etc).
+
+### Dependencies (Optional)
+
+Required services, frameworks, libraries, documentation, upstream changes, etc.
+
+### Context (Optional)
+
+Any additional useful context.
+
+## Task & Subtask Definitions
+
+### Granularity
+
+Decompose the work into small, self-contained, and granular tasks & subtasks.
+
+- A task contains a sequence of subtasks.
+- Each subtask is one action (2–5 minutes).
+- A task should map to a logical atomic commit.
+- Always include exact file paths.
+  - Eliminates ambiguity and reduces cognitive load.
+- Always include complete code and exact commands with expected output
+  - Ensure no interpretation required.
+- Always use symbols (function/class names) and not line numbers.
+  - Line numbers are brittle and drift.
+- Reference relevant skills with @ syntax.
+- Always follow the TDD cycle for each unit of behavior:
+  1. Write the failing test
+  2. Run it to confirm it fails
+  3. Implement the minimal code to make it pass
+  4. Run tests to verify the pass
+  5. Commit the passing test and implementation
+- The task should include a `commit` step specifying files to stage and the
+  commit message.
+
+### Exclusions
+
+- Avoid duplication (DRY)
+- Avoid scope creep and planning superfluous features (YAGNI)
+- Avoid unnecessary layers of abstraction (KISS, AHA)
+- Avoid trivial tasks ("save the file")
+- Avoid exposition and verbosity
+
+## JSON Output Format
+
+The canonical plan format is **JSON** conforming to the Plan JSON Schema.
+
+- `packages/claude-code-plugin/codex-plugin/schemas/plan.schema.json` in the
+  source repository, or `schemas/plan.schema.json` relative to the installed
+  Rundown Codex plugin root.
+
+### Example Task Definition
+
+```json
+{
+  "name": "Add Step ID Equality Check",
+  "files": [
+    { "path": "packages/parser/src/step-id.ts", "action": "edit" },
+    { "path": "packages/parser/__tests__/helpers.test.ts", "action": "edit" }
+  ],
+  "subtasks": [
+    {
+      "name": "Write failing test",
+      "code": {
+        "language": "typescript",
+        "content": "describe('stepIdEquals', () => {\n  it('returns true for equal numeric steps', () => {\n    expect(stepIdEquals({ step: '1' }, { step: '1' })).toBe(true);\n  });\n\n  it('returns false for different steps', () => {\n    expect(stepIdEquals({ step: '1' }, { step: '2' })).toBe(false);\n  });\n});"
+      }
+    },
+    {
+      "name": "Run to confirm failure",
+      "description": "Expected: tests fail (stepIdEquals not yet implemented).",
+      "code": {
+        "language": "bash",
+        "content": "npm test -- helpers.test.ts"
+      }
+    },
+    {
+      "name": "Implement",
+      "description": "In packages/parser/src/step-id.ts, add the stepIdEquals function.",
+      "code": {
+        "language": "typescript",
+        "content": "export function stepIdEquals(a: StepId, b: StepId): boolean {\n  return a.step === b.step && a.substep === b.substep;\n}"
+      }
+    },
+    {
+      "name": "Run tests to verify pass",
+      "description": "Expected: all tests pass.",
+      "code": {
+        "language": "bash",
+        "content": "npm test -- helpers.test.ts"
+      }
+    }
+  ],
+  "commit": {
+    "files": [
+      "packages/parser/src/step-id.ts",
+      "packages/parser/__tests__/helpers.test.ts"
+    ],
+    "message": "feat(parser): add stepIdEquals helper"
+  }
+}
+```

--- a/packages/claude-code-plugin/codex-plugin/skills/writing-runbooks/SKILL.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/writing-runbooks/SKILL.md
@@ -1,0 +1,512 @@
+---
+name: writing-runbooks
+description: Use when creating, editing, or authoring rundown runbook files (.runbook.md), or when needing runbook format syntax reference
+---
+
+# Writing Runbooks
+
+Rundown runbooks are markdown files (`.runbook.md`) that define executable
+step-by-step workflows. Steps combine human-readable instructions with
+machine-executable commands and deterministic control flow.
+
+## When to Use
+
+- Creating a new `.runbook.md` file from scratch
+- Editing or refactoring an existing runbook's steps, transitions,
+  `INPUTS`/`OUTPUTS`, `ARTIFACTS`, or FOR loops
+- Looking up Rundown format syntax (directives, transitions, artifacts,
+  delegation, frontmatter)
+
+## When NOT to Use
+
+- Executing or stepping through an active runbook — use the
+  [running-runbooks](../running-runbooks/SKILL.md) skill instead
+- Orchestrating parent-side delegation to child agents — Stage 1 does not
+  provide Codex hook parity for delegated child dispatch
+- Planning the work before a runbook exists — use the
+  [writing-plans](../writing-plans/SKILL.md) skill when applicable
+
+## House Style
+
+This skill documents Rundown _syntax_. For the idiomatic _conventions_ — how the
+directives combine in practice — follow **[house-style.md](house-style.md)**,
+distilled from the canonical `end-to-end-test/` and `planning/` plugin runbooks.
+Read it before authoring a new runbook. Headline conventions:
+
+- **Schema-first artifact pipeline:** bind the schema (step 1) → rehydrate
+  inputs → write to `{{ path Alias }}` → validate with `PASS COMPLETE` /
+  `FAIL GOTO <write-step>` (produce → validate → retry loop).
+- **One runbook, one artifact** with a full frontmatter contract (`INPUTS` /
+  `REQUIRED` / `OUTPUTS`); compose small leaves from a parent.
+- **Reference `{{ path Alias }}`, never hardcoded paths;** aliases are
+  PascalCase `*Path` / `*Paths`.
+- **Delegate the fan-out, then delegate collation** — never collate from the
+  parent.
+- **Record-don't-gate review steps** use `FAIL CONTINUE`.
+
+## Quick Reference
+
+````markdown
+---
+name: my-runbook
+description: What this runbook does
+tags:
+  - category
+INPUTS:
+  - environment
+  - PlanPath
+REQUIRED:
+  - PlanPath
+---
+
+# Runbook Title
+
+Optional description.
+
+## 1. Step name
+- PASS CONTINUE
+- FAIL STOP
+
+Instructions for the step.
+
+## 2. Auto-execute step
+
+```bash
+npm test
+```
+````
+
+All frontmatter fields are optional (open schema). Place project runbooks in
+`.rundown/runbooks/` for discovery (`rundown ls --all`).
+
+### Frontmatter casing convention
+
+| Casing        | Fields                                                      | Reason                                                                                      |
+| ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **UPPERCASE** | `INPUTS`, `OUTPUTS`, `REQUIRED`                             | Load-bearing runtime parameters; mirrors the step-level `- OUTPUTS`/`- FOR` directive style |
+| **lowercase** | `name`, `description`, `version`, `author`, `tags`, `skill` | Static metadata                                                                             |
+
+Validate with: `rundown check <file>` and `rundown resolve <file>`
+
+## Steps
+
+### Identifiers
+
+Prefer numeric step IDs for ordinary sequential workflows:
+
+```markdown
+## 1. Install dependencies
+## 2. Run tests
+```
+
+Use named IDs when a step is mainly a `GOTO` target:
+
+```markdown
+## FixFailure. Repair failing checks
+- PASS GOTO 2
+- FAIL STOP
+```
+
+Avoid transition and action words as IDs (`PASS`, `FAIL`, `CONTINUE`, `STOP`,
+`GOTO`, `RETRY`, etc.). Run `rundown check <file>` after editing; it catches
+invalid IDs and malformed transitions.
+
+Separators between ID and title are flexible: `.`, `:`, `-`, `)`, or space.
+
+### Content Order (strict)
+
+Within a step, put directives before the body:
+
+````markdown
+## 1. Produce a plan
+- OUTPUTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+```bash
+printf '%s\n' "plan.md" > "$RD_OUTPUTS_PlanPath"
+```
+````
+
+FOR steps put iteration transitions under the `FOR` directive and use substeps:
+
+```markdown
+## 2. Review files
+- FOR file IN {{ files }}
+  - PASS DEFER
+  - FAIL DEFER
+
+### 2.1 Review current file
+Review {{ file }}.
+```
+
+### Step Types
+
+| Type             | Contains                                          | Behavior                                  |
+| ---------------- | ------------------------------------------------- | ----------------------------------------- |
+| **Command**      | `bash`/`sh`/`shell` code block (case-insensitive) | Auto-executes; exit code → pass/fail      |
+| **Prompt**       | Text instructions                                 | Requires `rundown pass` or `rundown fail` |
+| **Display-only** | `bash prompt`, `prompt`, `json`, `yaml` blocks    | Displayed, NOT executed                   |
+
+## Context Passing
+
+Data flows forward by author contract:
+
+1. Declare the output name on the producing step.
+2. The command writes the value to `RD_OUTPUTS_<Name>`.
+3. Later steps read it with `{{ Name }}`.
+4. Frontmatter `OUTPUTS:` exports selected values to a parent/delegating
+   runbook.
+
+### Step/Substep `ARTIFACTS`
+
+`ARTIFACTS` declares structured artifact aliases for the step or substep being
+entered. It is valid only on H2 steps and H3 substeps, never in frontmatter, and
+must be the first directive after the heading.
+
+````markdown
+## 2. Write plan
+- ARTIFACTS
+  - PlanPath "plan.json"
+- PASS CONTINUE
+- FAIL STOP
+
+```bash
+printf '{"ok":true}\n' > "{{ path PlanPath }}"
+```
+````
+
+`ARTIFACTS` resolves at step/substep entry, writes structured artifact variables
+and manifest rows, and emits the resolved records on `STEP_ENTERED.artifacts`.
+It does not write artifact file contents. Producers write managed artifact
+content to the local path rendered by `{{ path Alias }}`.
+
+Artifact token forms:
+
+- `Name` — naked assertion/rehydration for an already-bound artifact reference;
+  not shorthand creation.
+- `Name "plan.json"` — managed artifact key for the current context/run.
+- `Name "review-*.json"` — wildcard selector; read-only, does not create
+  records. May resolve to `[]`, one record, or many records.
+- `Name "schemas/file.json"` — existing file reference.
+- `Name "/abs/path/file.json"` — absolute file reference.
+- `Name "rd://artifacts/<ctx>/<run>/<key>"` — exact artifact URI or selector
+  URI.
+
+Tokens are double-quoted only. Missing, denied, or out-of-root path-like
+references fail visibly at resolution. Same-name `ARTIFACTS` and `OUTPUTS` are
+allowed, but `OUTPUTS` overwrites the structured artifact value after command
+completion, so avoid that as a default pattern.
+
+Artifact rendering helpers:
+
+| Template                 | Renders                                         |
+| ------------------------ | ----------------------------------------------- |
+| `{{ Alias }}`            | Local filesystem path value(s) (direct alias)   |
+| `{{ path Alias }}`       | Local filesystem path value(s)                  |
+| `{{ artifact Alias }}`   | Artifact URI value(s)                           |
+| `{{ path "file.json" }}` | Local path only; does not create a manifest row |
+
+For wildcard aliases that resolve to arrays, `{{ path Reviews }}` renders a JSON
+array of paths. Arrays can be used as `FOR` data sources when that matches the
+workflow.
+
+Producer example:
+
+````markdown
+## 1. Produce plan
+- ARTIFACTS
+  - PlanPath "plan.json"
+- PASS CONTINUE
+- FAIL STOP
+
+```bash
+printf '{"ok":true}\n' > "{{ path PlanPath }}"
+```
+````
+
+Consumer/rehydration example:
+
+```markdown
+## 1. Review plan
+- ARTIFACTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+Read the inherited plan from `{{ path PlanPath }}`.
+```
+
+### Step/Substep `OUTPUTS`
+
+`OUTPUTS` declares the name-only values a step or substep publishes for later
+steps. The command writes each value to its `RD_OUTPUTS_<Name>` channel; Rundown
+merges them after the command completes. Do not write managed artifact contents
+to `RD_OUTPUTS_*` — write artifact files to `{{ path Alias }}`.
+
+````markdown
+## 7. Capture summary
+- OUTPUTS
+  - Summary
+- PASS CONTINUE
+- FAIL STOP
+
+```bash
+printf 'ready\n' > "$RD_OUTPUTS_Summary"
+```
+````
+
+After the step passes or fails, later steps can use `{{ Summary }}`.
+
+### Frontmatter `OUTPUTS:` — exporting to the parent
+
+Declares which values the runbook exports when it completes. A parent or
+delegating runbook can receive these values and use them as variables.
+
+```yaml
+---
+name: write-plan
+OUTPUTS:
+  - PlanPath
+---
+```
+
+Combine frontmatter `OUTPUTS:` with a step-level `OUTPUTS` or `ARTIFACTS`
+declaration so the runbook produces the value before completion.
+
+### Frontmatter `INPUTS:` and `REQUIRED:` — declaring what a runbook needs
+
+```yaml
+---
+name: review-plan
+INPUTS:
+  - PlanPath
+  - environment
+REQUIRED:
+  - PlanPath
+---
+```
+
+- `INPUTS:` is a YAML sequence of variable names the runbook accepts.
+  Declarations only — entries do not carry values.
+- `REQUIRED:` is a subset of `INPUTS:`. `rundown check <file>` reports a
+  required name that is not declared as an input. `rundown resolve <file>`
+  reports required inputs that do not have values.
+
+Defaults are not carried in frontmatter. Provide values via `--input`,
+`--input-json`, `--input-file`, `RD_INPUT_*` env, parent-forwarded variables
+(from a parent runbook's `OUTPUTS:`), or project `.rundown/config.yaml`.
+
+Variable resolution precedence (highest → lowest): explicit invocation values
+(`--input`, `--input-json`, `--input-file`), plugin variables, `RD_INPUT_*`,
+inherited delegation variables, project `.rundown/config.yaml`, built-in
+defaults, context-output fill-gap values.
+
+## Transitions
+
+Syntax: `- RESULT [AGGREGATION] ACTION [message]`
+
+### Actions
+
+| Action           | Effect                                             |
+| ---------------- | -------------------------------------------------- |
+| `CONTINUE`       | Proceed to next step                               |
+| `STOP [msg]`     | Terminate (failure)                                |
+| `COMPLETE [msg]` | Terminate (success)                                |
+| `GOTO target`    | Jump to step/substep                               |
+| `RETRY N action` | Retry N times, then fallback action                |
+| `DEFER`          | Pass result up for aggregation (substeps/FOR only) |
+| `NEXT`           | Skip to next iteration (FOR only)                  |
+| `BREAK`          | Exit loop (FOR only)                               |
+
+### Defaults
+
+- If only PASS defined: FAIL defaults to STOP
+- If only FAIL defined: PASS defaults to CONTINUE
+- If neither defined: PASS CONTINUE, FAIL STOP
+
+### Aliases
+
+`YES`/`NO` are aliases for `PASS`/`FAIL` (e.g., `- YES GOTO 1`,
+`- NO STOP "Unable to fix"`).
+
+## Substeps
+
+Nested steps within a parent step, using H3 headers:
+
+```markdown
+## 2. Review changes
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 2.1 Code review
+Review the implementation.
+
+### 2.2 Test review
+Verify test coverage.
+```
+
+### Aggregation
+
+| Modifier                | Meaning                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `PASS ALL` / `FAIL ANY` | Every substep must pass; any failed substep makes the parent fail (default)    |
+| `PASS ANY` / `FAIL ALL` | One successful substep is enough; the parent fails only if every substep fails |
+
+Standalone `- DEFER` shorthand expands to `- PASS DEFER` + `- FAIL DEFER`.
+
+## DELEGATE
+
+Use bare `- DELEGATE` to delegate a step or substep. `DELEGATE value` is
+invalid. Place `- DELEGATE` after `FOR` on H2 steps and after `OUTPUTS` on H3
+substeps, before transitions, prompt text, or body content.
+
+An H2 `DELEGATE` propagates to its substeps. Delegated targets must resolve to
+runbooks; do not use delegation for arbitrary files or commands.
+
+## FOR Loops
+
+Repeat a step across iterations:
+
+```markdown
+## 3. Process items
+- FOR item IN 1 TO 5
+  - PASS DEFER
+  - FAIL DEFER
+
+### 3.1 Handle item
+Process {{ item }}.
+```
+
+### FOR Syntax
+
+| Form          | Example                             |
+| ------------- | ----------------------------------- |
+| Named range   | `FOR i IN 1 TO 10`                  |
+| Unnamed range | `FOR 1 TO 5`                        |
+| Shorthand     | `FOR 5` (same as `FOR 1 TO 5`)      |
+| Descending    | `FOR i IN 10 TO 1`                  |
+| Data source   | `FOR item IN {{ items }}`           |
+| Windowed      | `FOR item IN 1 TO 3 OF {{ items }}` |
+
+- FOR steps MUST have substeps
+- Loop variable available as `{{ var }}` in substeps
+- Iteration-level transitions nest under the FOR clause
+- Data source FOR requires a named variable
+
+## Template Variables
+
+Use `{{ variableName }}` syntax. See
+[CLAUDE.md — Template Variables](../../../../CLAUDE.md#template-variables) for
+full reference.
+
+Key authoring notes:
+
+- Undefined variables preserved as literal `{{ variable }}` text
+- Frontmatter `INPUTS:` declares names only — defaults come from
+  `.rundown/config.yaml`, `--input`, `--input-json`, `--input-file`, or
+  `RD_INPUT_*` env
+- Data sources for FOR loops: use `--input-json` for inline arrays, or
+  `.rundown/config.yaml` / `--input-file` for arrays and `file:` values
+
+## Common Mistakes
+
+| Mistake                                                         | Fix                                                                                                                                                         |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| H4+ headings                                                    | Only H1 (title), H2 (steps), H3 (substeps)                                                                                                                  |
+| Command block + substeps in same step                           | Choose one — cannot mix                                                                                                                                     |
+| ARTIFACTS after OUTPUTS or transitions                          | H2 order: ARTIFACTS → OUTPUTS → FOR → DELEGATE → transitions → prompt → body. H3 order omits FOR.                                                           |
+| OUTPUTS expression form in a step/substep (`- Name {{ expr }}`) | Step/substep `OUTPUTS` entries are bare names only. Use frontmatter `OUTPUTS:` for export expressions.                                                      |
+| Writing artifact contents to `RD_OUTPUTS_*`                     | Write managed artifact files to `{{ path ArtifactAlias }}`. Use `RD_OUTPUTS_*` only for command output channel values.                                      |
+| Using naked `ARTIFACTS` as creation (`- PlanPath`)              | Naked `ARTIFACTS` asserts/rehydrates an already-bound artifact reference. Use `- PlanPath "plan.json"` to create a managed artifact record.                 |
+| Assuming `FOR` works on substeps                                | `FOR` is valid only on H2 steps. Put iteration on the parent step and work inside H3 substeps.                                                              |
+| Writing `DELEGATE value`                                        | Use bare `- DELEGATE`; the target is resolved from the delegated step/substep context.                                                                      |
+| Confusing artifact URI and path rendering                       | `{{ Alias }}` (direct) and `{{ path Alias }}` render local filesystem paths; only `{{ artifact Alias }}` renders artifact URI values.                       |
+| Broken fenced examples inside fenced docs                       | When documenting a runbook inside a code fence, use a longer outer fence, such as four backticks around examples containing triple-backtick command blocks. |
+| Reserved word as step ID                                        | `PASS`, `FAIL`, `CONTINUE`, etc. are reserved                                                                                                               |
+| `INPUTS:` written as a key→default map (`VarName: default`)     | `INPUTS:` is a YAML sequence of bare names (`- VarName`). Defaults live in config / `--input-file` / `--input-json` / env, not in frontmatter.              |
+| Name in `REQUIRED:` not declared in `INPUTS:`                   | `REQUIRED:` must be a subset of `INPUTS:`. Add the name to `INPUTS:` too.                                                                                   |
+| Skipping `rundown check`                                        | Always validate: `rundown check <file>`                                                                                                                     |
+
+## Companion Bootstrap Skill
+
+A runbook becomes runnable from natural language by giving it a **companion
+bootstrap skill** — a small `SKILL.md` whose `description` triggers on the user
+intent the runbook serves. The skill is a pre-bound variant of the generic
+`rundown` launcher: its body tells the orchestrating agent to start _this_
+runbook and hand off to `running-runbooks`.
+
+The orchestrating agent loads the execution protocol _first_, then starts the
+runbook — the skill instructs, the agent runs `rundown run`. Loading the
+protocol before the run is deliberate: the agent must be ready to interpret the
+first step's output (including a delegation) the moment it appears, not scramble
+for the protocol after `rundown run` has already fired. Nothing auto-starts a
+runbook behind the agent's back.
+
+Create one for common, named runbooks (e.g. `planning`). One-off project
+runbooks don't need their own skill — the generic `rundown` launcher starts any
+runbook by name.
+
+### Template
+
+Place at `skills/<skill-name>/SKILL.md` (directory name must equal `name:`):
+
+```markdown
+---
+name: <skill-name>
+description: Use when <the user need this runbook serves, in trigger terms>.
+---
+
+# <Skill Title>
+
+<important>
+## Runbook-Orchestrated Skill
+Load the execution protocol *before* starting the runbook:
+
+Load and follow the bundled `running-runbooks` skill before starting the runbook.
+
+Stage 1 does not provide Codex hook parity for delegated child dispatch. If this workflow reaches a delegated step that requires automatic child-agent orchestration, stop and report that Stage 2 delegation hook support is required.
+
+Then start it: `rundown run <runbook-name>`
+</important>
+
+<One or two sentences: what this runbook does and when to reach for it.>
+
+## When to Use
+- <intent that should start this runbook>
+
+## When NOT to Use
+- <adjacent intent that belongs to a sibling skill>
+
+## Reference
+- [running-runbooks](../running-runbooks/SKILL.md) — the execution protocol
+<plus sibling skills per the heuristics below>
+```
+
+Use the `namespace:name` form (e.g. `rundown:planning`) when the runbook ships
+with the plugin. If the runbook needs inputs, include them on the command (e.g.
+`rundown run rundown:convert-skill --input SkillPath=<path>`). Do **not**
+restate the runbook's steps in the skill — the runbook owns the sequence; the
+skill names the intent and points at the craft skills.
+
+### Sibling-skill heuristics
+
+Decide which skills the bootstrap skill references by what the runbook contains:
+
+| If the runbook…                                     | Reference                                                                                   |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| (always)                                            | [running-runbooks](../running-runbooks/SKILL.md) — the execution protocol                   |
+| contains a `- DELEGATE` directive                   | Stage 2 Codex delegation hook support                                                       |
+| writes, reviews, or executes a plan (plan pipeline) | [writing-plans](../writing-plans/SKILL.md) / [executing-plans](../executing-plans/SKILL.md) |
+
+Extend this table as new craft skills are added. The rule: reference the skill
+that owns the _craft_ for each thing the runbook does; never duplicate it.
+
+## Reference
+
+- [Rundown specification](../../../../docs/spec/language.md)
+- [Runbook patterns and examples](../../../../runbooks/README.md)
+- [Worked examples](../../examples/) — standalone demo runbooks
+  (`create-worktree`, `pr-feedback`) to read as teaching material
+- [Template variables](../../../../CLAUDE.md#template-variables)

--- a/packages/claude-code-plugin/codex-plugin/skills/writing-runbooks/house-style.md
+++ b/packages/claude-code-plugin/codex-plugin/skills/writing-runbooks/house-style.md
@@ -1,0 +1,222 @@
+# Runbook House Style
+
+Idiomatic conventions distilled from the canonical plugin runbooks —
+`packages/claude-code-plugin/runbooks/end-to-end-test/*` and
+`packages/claude-code-plugin/runbooks/planning/*`. These runbooks are the
+reference style; mirror them.
+
+`SKILL.md` documents the _syntax_ of each directive. This guide documents how
+the pieces _combine_ — the patterns to reach for first when authoring a new
+runbook. When in doubt, open a sibling runbook in those directories and match
+it. For _inter_-runbook composition (pipelines, gate loops, the leaf-delegate /
+orchestrator-compose discipline) see
+[docs/guides/composing-runbooks.md](../../../../docs/guides/composing-runbooks.md).
+
+## The core idiom: schema-first artifact pipeline
+
+Almost every artifact-producing ("leaf") runbook follows the same four-phase
+shape:
+
+1. **Bind the schema** — first step is read-only, binds a `*SchemaPath` artifact
+   (or shows the schema in a `prompt` block). Body: "The schema defines the
+   expected output structure."
+2. **Rehydrate inputs** — naked `ARTIFACTS` aliases pull inherited input
+   artifacts in for reading.
+3. **Write the output** — bind the managed output artifact (`Alias "file.json"`)
+   and write to `{{ path Alias }}` against the schema.
+4. **Validate and loop back** — final step runs the validator with
+   `PASS COMPLETE` / `FAIL GOTO <write-step>`, forming a self-correcting produce
+   → validate → retry loop.
+
+Worked example — a complete leaf runbook in house style:
+
+````markdown
+---
+name: review-file
+description: Read the plan artifact and write one nested review artifact.
+tags:
+  - meta
+  - e2e
+INPUTS:
+  - PlanPath
+REQUIRED:
+  - PlanPath
+OUTPUTS:
+  - ReviewPath
+---
+
+# End-to-End Test Review
+
+Review the plan and provide structured feedback.
+
+## 1. Read the output schema
+- ARTIFACTS
+  - ReviewSchemaPath "schemas/review.schema.json"
+- PASS CONTINUE
+- FAIL STOP
+
+The schema defines the expected feedback output structure.
+
+## 2. Read and review the plan
+- ARTIFACTS
+  - PlanPath
+- PASS CONTINUE
+- FAIL STOP
+
+Review the plan at `{{ path PlanPath }}` against the criteria.
+
+## 3. Write review
+- ARTIFACTS
+  - PlanPath
+  - ReviewSchemaPath
+  - ReviewPath "end-to-end-test-review.json"
+- PASS CONTINUE
+- FAIL STOP
+
+Write a JSON review to `{{ path ReviewPath }}`.
+Follow the output schema from `{{ path ReviewSchemaPath }}`.
+
+## 4. Check Schema
+- PASS COMPLETE
+- FAIL GOTO 3
+
+```bash
+rdx {{ path ReviewPath }} --validate --schema review
+```
+````
+
+The validate step is also written `{{ validateSchema ReviewPath }}` — a built-in
+helper that renders the complete `rdx --validate <path>` command. Use the helper
+when the schema is embedded in the artifact (`"$schema"` field); use the
+explicit `rdx ... --schema <name>` form when naming the schema directly.
+
+## Conventions
+
+### One runbook, one artifact
+
+Keep runbooks small and single-purpose. Each produces one artifact and declares
+the full contract in frontmatter: `INPUTS` / `REQUIRED` for what it consumes,
+`OUTPUTS` for what it publishes. A parent composes these leaves; it does not
+re-derive their paths.
+
+| Runbook         | Consumes                             | Produces             |
+| --------------- | ------------------------------------ | -------------------- |
+| `write-file`    | —                                    | `PlanPath`           |
+| `review-file`   | `PlanPath`                           | `ReviewPath`         |
+| `collate-files` | `PlanPath`, `ReviewPaths` (wildcard) | `CollatedReviewPath` |
+| parent          | `CollatedReviewPath`                 | `FeedbackPath`       |
+
+### Artifacts
+
+| Role       | Form                            | Use                                                                       |
+| ---------- | ------------------------------- | ------------------------------------------------------------------------- |
+| Producer   | `Alias "file.json"`             | Create/bind the managed artifact, then write to `{{ path Alias }}`        |
+| Consumer   | `Alias` (naked)                 | Rehydrate an inherited artifact for reading                               |
+| Schema     | `Alias "schemas/x.schema.json"` | Read-only file reference, bound in step 1                                 |
+| Collection | `Alias "*/file.json"`           | Wildcard selector; gathers many → `{{ path Alias }}` renders a JSON array |
+
+- Always reference `{{ path Alias }}` in bodies and commands — never hardcode a
+  path.
+- Alias names are PascalCase ending in `Path` / `Paths` (`PlanPath`,
+  `ReviewSchemaPath`, `ReviewPaths`, `CollatedReviewPath`, `FeedbackPath`).
+- Schema files are named `<thing>.schema.json` and validated with
+  `--schema <thing>`.
+- A dedicated `## N. Output Path` step that binds the managed artifact
+  (`- ARTIFACTS` / `Alias "file.json"`) with a body of just `{{ Alias }}` is
+  idiomatic when you want the path surfaced before a separate write step.
+
+### Steps & layout
+
+- Step 1 binds the schema; the last step validates. Everything else sits
+  between.
+- Blank line after the heading, the directive block, a blank line, then the
+  prose body. Two blank lines between steps.
+- State aggregation explicitly on composition/delegation steps even when it is
+  the default: `- PASS ALL CONTINUE` / `- FAIL ANY STOP`.
+- Bodies are short and imperative. Verification/review criteria are `-` bullet
+  lists or `- [ ]` checklists.
+
+### Transitions
+
+- **Produce → validate → retry:** the validate step uses `PASS COMPLETE` (or
+  `CONTINUE`) and `FAIL GOTO <write-step>` so a malformed artifact loops back to
+  be rewritten.
+- **Review/record steps use `FAIL CONTINUE`:** a step that records findings
+  (rather than gating) proceeds whether the assessment passed or failed —
+  `- PASS CONTINUE` / `- FAIL CONTINUE`. The finding is captured in the output
+  artifact, not enforced by stopping.
+- **Terminal messages:** include a human-readable reason on `STOP` / `COMPLETE`
+  in human-facing runbooks (`FAIL STOP "CI builds must pass before review."`).
+  Artifact-pipeline steps that are not human-driven use bare `STOP` /
+  `COMPLETE`.
+
+### Composition & delegation
+
+Run child runbooks by listing their paths in an H2 step body:
+
+```markdown
+## 2. Write
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- end-to-end-test/write-file.runbook.md
+```
+
+Add bare `- DELEGATE` to push the children to subagents instead of running
+inline. The idiomatic shape is a wrapper that **delegates the fan-out review,
+then delegates collation** as a second step — never collate from the parent:
+
+```markdown
+## 1. Delegate subagents to review
+- ARTIFACTS
+  - PlanPath
+- DELEGATE
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+- review-plan-technical-accuracy.runbook.md
+- review-plan-structural-integrity.runbook.md
+- review-plan-build-runtime.runbook.md
+- review-plan-risk-safety.runbook.md
+
+## 2. Collate review findings
+- DELEGATE
+- PASS ALL COMPLETE
+- FAIL ANY STOP
+
+- review-plan-collate.runbook.md
+```
+
+The collation runbook gathers siblings with a **cross-run wildcard artifact
+selector** (`Reviews "*/review-plan-*.json"`), merges, deduplicates equivalent
+findings, and validates against the shared schema. The selector desugars to
+`rd://artifacts/{{ContextId}}/*/review-plan-*.json` and resolves the sibling
+runs' _produced_ artifact rows read-only from the shared-context manifest — no
+filesystem globbing. ARTIFACTS is the canonical discovery mechanism; do **not**
+reach for `rdpath find` to discover sibling artifacts.
+
+### Validation & discovery helpers
+
+| Helper                                            | Renders / does                                                                                                                                                                                      |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{{ validateSchema Alias }}`                      | Complete `rdx --validate <path>` command (schema from the artifact's `"$schema"`)                                                                                                                   |
+| `rdx {{ path Alias }} --validate --schema <name>` | Explicit-schema validation                                                                                                                                                                          |
+| `Alias "*/<glob>"` (cross-run ARTIFACTS selector) | Resolves matching sibling-run artifacts from the shared-context manifest read-only — the canonical discovery mechanism. An empty set means "nothing to collate"; no filesystem globbing or `rdpath` |
+
+### Skills as steps
+
+A runbook can require a skill: declare `skill: <name>` in frontmatter and make
+step 1 invoke it (`Skill: rundown:writing-plans`) so the agent internalizes the
+guidance before producing the artifact.
+
+## Common house-style mistakes
+
+| Mistake                                           | House style                                                                          |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Hardcoding an output path in a command            | Bind the artifact, write to `{{ path Alias }}`                                       |
+| Multi-purpose runbook producing several artifacts | One runbook, one artifact; compose leaves from a parent                              |
+| Write step with no validation                     | Always end with a `Check Schema` step that `GOTO`s back to the write step on failure |
+| `FAIL STOP` on a review/record step               | Use `FAIL CONTINUE` — record the finding, don't gate                                 |
+| Collating from the parent runbook                 | Delegate review, then delegate a dedicated collation runbook                         |
+| Re-deriving child artifact paths in the parent    | Consume the child's declared `OUTPUTS`; do not add artifact-only steps               |
+| Omitting the frontmatter contract                 | Declare `INPUTS` / `REQUIRED` / `OUTPUTS` on every composed/delegated runbook        |

--- a/packages/claude-code-plugin/codex-plugin/templates/planning/plan.template.md
+++ b/packages/claude-code-plugin/codex-plugin/templates/planning/plan.template.md
@@ -1,0 +1,82 @@
+---
+name: Implementation Plan Template
+description: Template showing the rendered Markdown structure for implementation plans. The canonical format is JSON validated against schemas/plan.schema.json.
+use_when: Writing detailed implementation plans.
+version: 1.0.0
+---
+
+# {{ FeatureName }} Implementation Plan
+
+## Goal
+
+<!-- Clear, concise description of the desired outcome -->
+
+{{ Goal }}
+
+## Architecture & Approach
+
+<!-- High-level solution design, critical components, data and integrations. -->
+
+{{ Architecture }}
+
+## Constraints & Assumptions
+
+<!-- Hard constraints and assumptions (performance, security, scalability, maintainability, etc) -->
+
+{{ Constraints }}
+
+## Dependencies (Optional)
+
+<!-- Required services, frameworks, libraries, documentation, upstream changes, etc  -->
+
+{{ Dependencies }}
+
+## Context (Optional)
+
+<!-- Any additional useful context. -->
+<!-- {{ Context }} -->
+
+## Scope Assessment
+
+<!-- Brief note on whether the work was scoped to a single plan or split. -->
+
+---
+
+## File Structure
+
+<!-- All files to be created, modified, or deleted. -->
+
+| File           | Disposition              | Notes                       |
+| -------------- | ------------------------ | --------------------------- |
+| `path/to/file` | Create / Modify / Delete | Affected symbols or purpose |
+
+## {{ TaskNumber }}. {{ TaskName }}
+
+<!--
+IMPORTANT:
+  - Always include exact file paths.
+  - Always include exact commands.
+  - Always use symbols (function/class names) instead of line numbers.
+  - Always use Test-Driven Development (test/fail/implement/verify/commit)
+-->
+
+### Files
+
+<!-- List of created, modified, deleted files with disposition -->
+
+- `{{ Path }}` (create/modify/delete)
+
+### {{ TaskNumber }}.{{ SubtaskNumber }} {{ SubtaskName }}
+
+{{ SubTask Description }}
+
+```{{ Language }}
+{{ Code }}
+```
+
+### {{ TaskNumber }}.N Commit
+
+```bash
+git add {{ files }}
+git commit -m "{{ message }}"
+```

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "bin": {
     "rdpath": "dist/rdpath.js",
-    "rdx": "dist/rdx.js"
+    "rdx": "dist/rdx.js",
+    "rundown-mcp": "dist/rundown-mcp.js"
   },
   "main": "dist/cli.js",
   "types": "dist/index.d.ts",

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -22,6 +22,7 @@
     "dist",
     "schemas",
     ".claude-plugin",
+    "codex-plugin",
     "examples",
     "hooks",
     "runbooks",
@@ -67,6 +68,7 @@
   "dependencies": {
     "@rundown-org/cli": "*",
     "@rundown-org/core": "*",
+    "@rundown-org/mcp": "*",
     "commander": "^15.0.0",
     "js-yaml": "^5.2.0",
     "zod": "^4.4.3"

--- a/packages/claude-code-plugin/src/rundown-mcp.ts
+++ b/packages/claude-code-plugin/src/rundown-mcp.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { main } from '@rundown-org/mcp';
+import { getErrorMessage } from './shared/errors.js';
+
+main().catch((error: unknown) => {
+  console.error(getErrorMessage(error));
+  process.exit(1);
+});

--- a/packages/cli/__tests__/helpers/plugin-root.test.ts
+++ b/packages/cli/__tests__/helpers/plugin-root.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, jest } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 
 // Mock node:fs — control existsSync for sibling discovery
 const mockExistsSync = jest.fn<(path: string) => boolean>();
@@ -10,16 +10,36 @@ jest.unstable_mockModule('node:fs', () => ({
 const { getPluginRoot, _resetPluginRootCache } = await import('../../src/helpers/plugin-root.js');
 
 describe('getPluginRoot()', () => {
-  let originalEnv: string | undefined;
+  let originalClaudePluginRoot: string | undefined;
+  let originalCodexPluginRoot: string | undefined;
+  let originalRundownPluginRoot: string | undefined;
+
+  beforeEach(() => {
+    originalClaudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+    originalCodexPluginRoot = process.env.CODEX_PLUGIN_ROOT;
+    originalRundownPluginRoot = process.env.RUNDOWN_PLUGIN_ROOT;
+  });
 
   afterEach(() => {
     // Restore env
-    if (originalEnv !== undefined) {
-      process.env.CLAUDE_PLUGIN_ROOT = originalEnv;
+    if (originalClaudePluginRoot !== undefined) {
+      process.env.CLAUDE_PLUGIN_ROOT = originalClaudePluginRoot;
     } else {
       delete process.env.CLAUDE_PLUGIN_ROOT;
     }
-    originalEnv = undefined;
+    if (originalCodexPluginRoot !== undefined) {
+      process.env.CODEX_PLUGIN_ROOT = originalCodexPluginRoot;
+    } else {
+      delete process.env.CODEX_PLUGIN_ROOT;
+    }
+    if (originalRundownPluginRoot !== undefined) {
+      process.env.RUNDOWN_PLUGIN_ROOT = originalRundownPluginRoot;
+    } else {
+      delete process.env.RUNDOWN_PLUGIN_ROOT;
+    }
+    originalClaudePluginRoot = undefined;
+    originalCodexPluginRoot = undefined;
+    originalRundownPluginRoot = undefined;
 
     // Reset cache between tests
     _resetPluginRootCache();
@@ -27,14 +47,12 @@ describe('getPluginRoot()', () => {
   });
 
   it('returns CLAUDE_PLUGIN_ROOT env var when set', () => {
-    originalEnv = process.env.CLAUDE_PLUGIN_ROOT;
     process.env.CLAUDE_PLUGIN_ROOT = '/custom/plugin/root';
 
     expect(getPluginRoot()).toBe('/custom/plugin/root');
   });
 
   it('env var is not cached — changing it between calls returns new value', () => {
-    originalEnv = process.env.CLAUDE_PLUGIN_ROOT;
     process.env.CLAUDE_PLUGIN_ROOT = '/first';
     expect(getPluginRoot()).toBe('/first');
 
@@ -42,9 +60,34 @@ describe('getPluginRoot()', () => {
     expect(getPluginRoot()).toBe('/second');
   });
 
-  it('returns sibling plugin path when existsSync returns true', () => {
-    originalEnv = process.env.CLAUDE_PLUGIN_ROOT;
+  it('returns CODEX_PLUGIN_ROOT env var when Claude root is unset', () => {
     delete process.env.CLAUDE_PLUGIN_ROOT;
+    process.env.CODEX_PLUGIN_ROOT = '/codex/plugin/root';
+    process.env.RUNDOWN_PLUGIN_ROOT = '/neutral/plugin/root';
+
+    expect(getPluginRoot()).toBe('/codex/plugin/root');
+  });
+
+  it('returns RUNDOWN_PLUGIN_ROOT env var when Claude and Codex roots are unset', () => {
+    delete process.env.CLAUDE_PLUGIN_ROOT;
+    delete process.env.CODEX_PLUGIN_ROOT;
+    process.env.RUNDOWN_PLUGIN_ROOT = '/neutral/plugin/root';
+
+    expect(getPluginRoot()).toBe('/neutral/plugin/root');
+  });
+
+  it('keeps CLAUDE_PLUGIN_ROOT as highest priority for compatibility', () => {
+    process.env.CLAUDE_PLUGIN_ROOT = '/claude/plugin/root';
+    process.env.CODEX_PLUGIN_ROOT = '/codex/plugin/root';
+    process.env.RUNDOWN_PLUGIN_ROOT = '/neutral/plugin/root';
+
+    expect(getPluginRoot()).toBe('/claude/plugin/root');
+  });
+
+  it('returns sibling plugin path when existsSync returns true', () => {
+    delete process.env.CLAUDE_PLUGIN_ROOT;
+    delete process.env.CODEX_PLUGIN_ROOT;
+    delete process.env.RUNDOWN_PLUGIN_ROOT;
     mockExistsSync.mockReturnValue(true);
 
     const result = getPluginRoot();
@@ -59,16 +102,18 @@ describe('getPluginRoot()', () => {
   });
 
   it('returns null when existsSync returns false and env var unset', () => {
-    originalEnv = process.env.CLAUDE_PLUGIN_ROOT;
     delete process.env.CLAUDE_PLUGIN_ROOT;
+    delete process.env.CODEX_PLUGIN_ROOT;
+    delete process.env.RUNDOWN_PLUGIN_ROOT;
     mockExistsSync.mockReturnValue(false);
 
     expect(getPluginRoot()).toBeNull();
   });
 
   it('caches sibling discovery result — second call skips filesystem', () => {
-    originalEnv = process.env.CLAUDE_PLUGIN_ROOT;
     delete process.env.CLAUDE_PLUGIN_ROOT;
+    delete process.env.CODEX_PLUGIN_ROOT;
+    delete process.env.RUNDOWN_PLUGIN_ROOT;
     mockExistsSync.mockReturnValue(true);
 
     getPluginRoot();
@@ -79,8 +124,9 @@ describe('getPluginRoot()', () => {
   });
 
   it('_resetPluginRootCache clears cache so next call re-discovers', () => {
-    originalEnv = process.env.CLAUDE_PLUGIN_ROOT;
     delete process.env.CLAUDE_PLUGIN_ROOT;
+    delete process.env.CODEX_PLUGIN_ROOT;
+    delete process.env.RUNDOWN_PLUGIN_ROOT;
     mockExistsSync.mockReturnValue(false);
 
     expect(getPluginRoot()).toBeNull();
@@ -94,8 +140,9 @@ describe('getPluginRoot()', () => {
   });
 
   it('env var takes precedence over cached sibling result', () => {
-    originalEnv = process.env.CLAUDE_PLUGIN_ROOT;
     delete process.env.CLAUDE_PLUGIN_ROOT;
+    delete process.env.CODEX_PLUGIN_ROOT;
+    delete process.env.RUNDOWN_PLUGIN_ROOT;
     mockExistsSync.mockReturnValue(true);
 
     // First call populates cache via sibling discovery

--- a/packages/cli/__tests__/helpers/resolve-runbook.test.ts
+++ b/packages/cli/__tests__/helpers/resolve-runbook.test.ts
@@ -10,22 +10,36 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { runbooksDir } from '@rundown-org/core';
 
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
 describe('resolveRunbookFile', () => {
   let testDir: string;
   let originalPluginRoot: string | undefined;
+  let originalCodexPluginRoot: string | undefined;
+  let originalRundownPluginRoot: string | undefined;
   let originalBundledRunbooksPath: string | undefined;
 
   beforeEach(async () => {
     testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'resolve-test-'));
     // Save original env to restore in afterEach
     originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+    originalCodexPluginRoot = process.env.CODEX_PLUGIN_ROOT;
+    originalRundownPluginRoot = process.env.RUNDOWN_PLUGIN_ROOT;
     originalBundledRunbooksPath = process.env.BUNDLED_RUNBOOKS_PATH;
   });
 
   afterEach(async () => {
     // Restore env BEFORE cleanup to prevent bleeding into other tests
-    process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
-    process.env.BUNDLED_RUNBOOKS_PATH = originalBundledRunbooksPath;
+    restoreEnv('CLAUDE_PLUGIN_ROOT', originalPluginRoot);
+    restoreEnv('CODEX_PLUGIN_ROOT', originalCodexPluginRoot);
+    restoreEnv('RUNDOWN_PLUGIN_ROOT', originalRundownPluginRoot);
+    restoreEnv('BUNDLED_RUNBOOKS_PATH', originalBundledRunbooksPath);
     await fs.rm(testDir, { recursive: true, force: true });
   });
 
@@ -169,6 +183,32 @@ describe('resolveRunbookFile', () => {
       const result = await resolveRunbookFile(testDir, 'rundown:review-plan');
       expect(result).not.toBeNull();
       expect(result!.path).toBe(path.join(planningDir, 'review-plan.runbook.md'));
+    });
+
+    it('resolves rundown:name from CODEX_PLUGIN_ROOT', async () => {
+      const codexPluginRoot = path.join(testDir, 'codex-plugin');
+      const planningDir = path.join(codexPluginRoot, 'runbooks/planning');
+      await fs.mkdir(planningDir, { recursive: true });
+      await fs.writeFile(
+        path.join(planningDir, 'codex-demo.runbook.md'),
+        `# Codex Demo
+
+## 1. Prompt
+- PASS COMPLETE
+- FAIL STOP
+
+Confirm Codex plugin discovery works.
+`,
+      );
+
+      delete process.env.CLAUDE_PLUGIN_ROOT;
+      process.env.CODEX_PLUGIN_ROOT = codexPluginRoot;
+
+      const result = await resolveRunbookFile(testDir, 'rundown:codex-demo');
+
+      expect(result?.source).toBe('plugin');
+      expect(result?.sourceRoot).toBe(path.join(codexPluginRoot, 'runbooks'));
+      expect(result?.path).toBe(path.join(planningDir, 'codex-demo.runbook.md'));
     });
 
     it('returns null when namespaced runbook not found in target source', async () => {

--- a/packages/cli/src/helpers/plugin-root.ts
+++ b/packages/cli/src/helpers/plugin-root.ts
@@ -12,8 +12,10 @@ let cached: string | null | undefined;
  * Resolve the plugin root directory.
  *
  * Priority:
- * 1. `CLAUDE_PLUGIN_ROOT` environment variable (set by Claude Code during hook dispatch)
- * 2. Sibling package discovery — `@rundown-org/claude-code-plugin` installed alongside the CLI
+ * 1. `CLAUDE_PLUGIN_ROOT` environment variable (set by Claude Code)
+ * 2. `CODEX_PLUGIN_ROOT` environment variable (set by Codex plugin launchers)
+ * 3. `RUNDOWN_PLUGIN_ROOT` environment variable (neutral host-provided plugin root)
+ * 4. Sibling package discovery — `@rundown-org/claude-code-plugin` installed alongside the CLI
  *
  * The sibling discovery works because both `@rundown-org/cli` and
  * `@rundown-org/claude-code-plugin` are installed in the same global
@@ -23,9 +25,14 @@ let cached: string | null | undefined;
  * @returns Absolute path to the plugin root directory, or null if not found
  */
 export function getPluginRoot(): string | null {
-  // Environment variable takes precedence (always re-read, may change)
-  const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
-  if (envRoot) return envRoot;
+  const claudeRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (claudeRoot) return claudeRoot;
+
+  const codexRoot = process.env.CODEX_PLUGIN_ROOT;
+  if (codexRoot) return codexRoot;
+
+  const rundownRoot = process.env.RUNDOWN_PLUGIN_ROOT;
+  if (rundownRoot) return rundownRoot;
 
   // Return cached sibling discovery result
   if (cached !== undefined) return cached;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@rundown-org/core':
         specifier: '*'
         version: link:../core
+      '@rundown-org/mcp':
+        specifier: '*'
+        version: link:../mcp
       commander:
         specifier: ^15.0.0
         version: 15.0.0

--- a/scripts/Dockerfile.verify
+++ b/scripts/Dockerfile.verify
@@ -61,13 +61,15 @@ COPY dist/rundown-org-parser-*.tgz /tmp/tarballs/
 COPY dist/rundown-org-core-*.tgz /tmp/tarballs/
 COPY dist/rundown-org-cli-*.tgz /tmp/tarballs/
 COPY dist/rundown-org-claude-code-plugin-*.tgz /tmp/tarballs/
+COPY dist/rundown-org-mcp-*.tgz /tmp/tarballs/
 
 # Install packages globally from tarballs (dependencies declared in package.json)
 RUN npm install -g \
     /tmp/tarballs/rundown-org-parser-*.tgz \
     /tmp/tarballs/rundown-org-core-*.tgz \
     /tmp/tarballs/rundown-org-cli-*.tgz \
-    /tmp/tarballs/rundown-org-claude-code-plugin-*.tgz && \
+    /tmp/tarballs/rundown-org-claude-code-plugin-*.tgz \
+    /tmp/tarballs/rundown-org-mcp-*.tgz && \
     rm -rf /tmp/tarballs
 
 USER testuser

--- a/scripts/Dockerfile.verify
+++ b/scripts/Dockerfile.verify
@@ -96,7 +96,7 @@ COPY --chmod=755 scripts/e2e-codex-shell-entrypoint.sh /usr/local/bin/e2e-codex-
 
 # Rundown Codex plugin root. Stage 1 uses plugin metadata, bundled skills, and
 # MCP config; it intentionally does not install Codex hooks.
-COPY --chown=testuser:testuser packages/claude-code-plugin/codex-plugin /usr/local/share/rundown/codex-plugin
+COPY --chown=testuser:testuser packages/claude-code-plugin/codex-plugin /usr/local/share/rundown/packages/claude-code-plugin/codex-plugin
 
 # Local Codex marketplace used by the E2E entrypoint to install the plugin
 # through Codex's supported plugin flow.

--- a/scripts/Dockerfile.verify
+++ b/scripts/Dockerfile.verify
@@ -94,9 +94,16 @@ COPY --chmod=755 scripts/e2e-entrypoint.sh /usr/local/bin/e2e-entrypoint.sh
 COPY --chmod=755 scripts/e2e-shell-entrypoint.sh /usr/local/bin/e2e-shell-entrypoint.sh
 COPY --chmod=755 scripts/e2e-codex-shell-entrypoint.sh /usr/local/bin/e2e-codex-shell-entrypoint.sh
 
-# Rundown-aware Codex guidance. The Codex entrypoint copies this into the
-# session workspace as AGENTS.md, which Codex reads on startup. This is the
-# Codex equivalent of the Claude entrypoint's --plugin-dir wiring.
+# Rundown Codex plugin root. Stage 1 uses plugin metadata, bundled skills, and
+# MCP config; it intentionally does not install Codex hooks.
+COPY --chown=testuser:testuser packages/claude-code-plugin/codex-plugin /usr/local/share/rundown/codex-plugin
+
+# Local Codex marketplace used by the E2E entrypoint to install the plugin
+# through Codex's supported plugin flow.
+COPY --chown=testuser:testuser .agents/plugins/marketplace.json /usr/local/share/rundown/.agents/plugins/marketplace.json
+
+# Fallback/debug guidance only. The Codex entrypoint does not install this into
+# project workspaces during the normal plugin-based Stage 1 flow.
 COPY --chmod=644 scripts/e2e-codex-agents.md /usr/local/share/rundown/codex-agents.md
 
 # Copy test app fixture

--- a/scripts/__tests__/e2e-codex-harness.test.mjs
+++ b/scripts/__tests__/e2e-codex-harness.test.mjs
@@ -290,7 +290,10 @@ test('repo-local Codex marketplace source path resolves from the checkout root',
   const marketplace = JSON.parse(await readRepoFile('.agents/plugins/marketplace.json'));
   const sourcePath = marketplace.plugins[0].source.path;
 
-  assert.equal(join(repoRoot, sourcePath), join(repoRoot, 'packages/claude-code-plugin/codex-plugin'));
+  assert.equal(
+    join(repoRoot, sourcePath),
+    join(repoRoot, 'packages/claude-code-plugin/codex-plugin'),
+  );
   assert.equal(
     join(repoRoot, sourcePath, '.codex-plugin', 'plugin.json'),
     join(repoRoot, 'packages/claude-code-plugin/codex-plugin', '.codex-plugin', 'plugin.json'),

--- a/scripts/__tests__/e2e-codex-harness.test.mjs
+++ b/scripts/__tests__/e2e-codex-harness.test.mjs
@@ -212,6 +212,31 @@ test('e2e image installs Codex CLI, ships the Codex entrypoint, and the Codex AG
   );
 });
 
+test('Rundown Claude plugin package also ships a Codex plugin surface', async () => {
+  const manifest = JSON.parse(
+    await readRepoFile('packages/claude-code-plugin/codex-plugin/.codex-plugin/plugin.json'),
+  );
+  const mcp = JSON.parse(await readRepoFile('packages/claude-code-plugin/codex-plugin/.mcp.json'));
+  const pluginPackage = JSON.parse(await readRepoFile('packages/claude-code-plugin/package.json'));
+
+  assert.equal(manifest.name, 'rundown');
+  assert.equal(manifest.skills, './skills/');
+  assert.equal(manifest.mcpServers, './.mcp.json');
+  assert.equal(manifest.interface.displayName, 'Rundown');
+  assert.equal(manifest.interface.category, 'Developer Tools');
+  assert.match(manifest.interface.longDescription, /runbook/i);
+  assert.ok(manifest.interface.capabilities.includes('Interactive'));
+  assert.equal(manifest.interface.logo, './assets/rundown.svg');
+  assert.equal(manifest.interface.composerIcon, './assets/rundown.svg');
+
+  assert.deepEqual(mcp.mcpServers.rundown, {
+    command: 'rundown-mcp',
+  });
+
+  assert.ok(pluginPackage.files.includes('codex-plugin'));
+  assert.equal(pluginPackage.dependencies['@rundown-org/mcp'], '*');
+});
+
 test('e2e shell wrapper selects Claude or Codex entrypoint', async () => {
   const shellScript = await readRepoFile('scripts/e2e-shell.sh');
 

--- a/scripts/__tests__/e2e-codex-harness.test.mjs
+++ b/scripts/__tests__/e2e-codex-harness.test.mjs
@@ -221,6 +221,38 @@ test('E2E local image packs and installs the Rundown MCP server', async () => {
   assert.match(dockerfile, /\/tmp\/tarballs\/rundown-org-mcp-\*\.tgz/);
 });
 
+test('E2E image copies the Rundown Codex plugin root', async () => {
+  const dockerfile = await readRepoFile('scripts/Dockerfile.verify');
+
+  assert.match(
+    dockerfile,
+    /packages\/claude-code-plugin\/codex-plugin \/usr\/local\/share\/rundown\/codex-plugin/,
+  );
+  assert.match(
+    dockerfile,
+    /\.agents\/plugins\/marketplace\.json \/usr\/local\/share\/rundown\/\.agents\/plugins\/marketplace\.json/,
+  );
+});
+
+test('repo-local Codex marketplace exposes the Rundown plugin', async () => {
+  const marketplace = JSON.parse(await readRepoFile('.agents/plugins/marketplace.json'));
+
+  assert.equal(marketplace.name, 'rundown-local');
+  assert.equal(marketplace.interface.displayName, 'Rundown Local');
+  assert.deepEqual(marketplace.plugins[0], {
+    name: 'rundown',
+    source: {
+      source: 'local',
+      path: './codex-plugin',
+    },
+    policy: {
+      installation: 'AVAILABLE',
+      authentication: 'ON_INSTALL',
+    },
+    category: 'Developer Tools',
+  });
+});
+
 test('Rundown Claude plugin package also ships a Codex plugin surface', async () => {
   const manifest = JSON.parse(
     await readRepoFile('packages/claude-code-plugin/codex-plugin/.codex-plugin/plugin.json'),
@@ -490,7 +522,7 @@ for (const agent of ['codex', 'claude']) {
   });
 }
 
-// ── Codex entrypoint: auth, launch, AGENTS.md integration, no plugin dir ─────
+// ── Codex entrypoint: auth, launch, plugin marketplace integration ──────────
 
 test('Codex shell entrypoint validates auth and launches Codex in the workspace', async () => {
   const entrypoint = await readRepoFile('scripts/e2e-codex-shell-entrypoint.sh');
@@ -503,27 +535,34 @@ test('Codex shell entrypoint validates auth and launches Codex in the workspace'
   assert.match(entrypoint, /--ask-for-approval never/);
 });
 
-test('Codex shell entrypoint installs Rundown AGENTS.md and drops the unused plugin lookup', async () => {
+test('Codex shell entrypoint installs the local Rundown Codex plugin and exports MCP env', async () => {
   const entrypoint = await readRepoFile('scripts/e2e-codex-shell-entrypoint.sh');
 
-  // Rundown integration: AGENTS.md is copied into the workspace (Codex reads it).
-  assert.match(entrypoint, /CODEX_AGENTS_SOURCE="\/usr\/local\/share\/rundown\/codex-agents\.md"/);
-  assert.match(entrypoint, /cp "\$CODEX_AGENTS_SOURCE" "\$WORKSPACE\/AGENTS\.md"/);
+  assert.match(entrypoint, /PLUGIN_DIR="\/usr\/local\/share\/rundown\/codex-plugin"/);
+  assert.match(entrypoint, /MARKETPLACE_ROOT="\/usr\/local\/share\/rundown"/);
+  assert.match(entrypoint, /export CODEX_PLUGIN_ROOT="\$PLUGIN_DIR"/);
+  assert.match(entrypoint, /export RUNDOWN_PLUGIN_ROOT="\$PLUGIN_DIR"/);
+  assert.match(entrypoint, /codex plugin marketplace add "\$MARKETPLACE_ROOT"/);
+  assert.match(entrypoint, /codex plugin add rundown@rundown-local/);
+  assert.doesNotMatch(entrypoint, /--plugin-dir/);
+  assert.match(entrypoint, /command -v rundown-mcp/);
+  assert.match(entrypoint, /Plugin:    \$PLUGIN_DIR/);
+  assert.match(entrypoint, /Marketplace: \$MARKETPLACE_ROOT\/\.agents\/plugins\/marketplace\.json/);
+  assert.match(entrypoint, /MCP:/);
 
-  // The Claude plugin directory resolution is unused for Codex and must be gone.
-  assert.doesNotMatch(entrypoint, /claude-code-plugin/);
-  assert.doesNotMatch(entrypoint, /PLUGIN_DIR/);
-  assert.doesNotMatch(entrypoint, /npm root -g/);
+  assert.doesNotMatch(entrypoint, /CODEX_AGENTS_SOURCE=/);
+  assert.doesNotMatch(entrypoint, /cp "\$CODEX_AGENTS_SOURCE" "\$WORKSPACE\/AGENTS\.md"/);
 });
 
-test('Codex AGENTS.md guidance teaches the rd runbook loop', async () => {
+test('Codex AGENTS.md guidance is fallback CLI guidance', async () => {
   const agents = await readRepoFile('scripts/e2e-codex-agents.md');
 
-  assert.match(agents, /AGENTS\.md/);
-  assert.match(agents, /rd run/);
-  assert.match(agents, /rd status/);
-  assert.match(agents, /rd pass/);
-  assert.match(agents, /rd fail/);
+  assert.match(agents, /fallback notes/);
+  assert.match(agents, /rundown run/);
+  assert.match(agents, /rundown status/);
+  assert.match(agents, /rundown pass/);
+  assert.match(agents, /rundown fail/);
+  assert.doesNotMatch(agents, /\brd\s/);
 });
 
 test('Codex shell entrypoint exports experimental SQLite for mounted and fixture workspaces', async () => {

--- a/scripts/__tests__/e2e-codex-harness.test.mjs
+++ b/scripts/__tests__/e2e-codex-harness.test.mjs
@@ -237,6 +237,47 @@ test('Rundown Claude plugin package also ships a Codex plugin surface', async ()
   assert.equal(pluginPackage.dependencies['@rundown-org/mcp'], '*');
 });
 
+test('Codex plugin bundles Rundown skills without Claude-only syntax', async () => {
+  const expectedSkills = [
+    'rundown',
+    'running-runbooks',
+    'writing-runbooks',
+    'planning',
+    'executing-plans',
+    'writing-plans',
+    'converting-skills-to-runbooks',
+    'end-to-end-testing',
+  ];
+
+  for (const skill of expectedSkills) {
+    const skillText = await readRepoFile(
+      `packages/claude-code-plugin/codex-plugin/skills/${skill}/SKILL.md`,
+    );
+    assert.match(skillText, /^---\nname:/);
+    assert.doesNotMatch(skillText, /CLAUDE_PLUGIN_ROOT/);
+    assert.doesNotMatch(skillText, /Skill\(skill: "rundown:/);
+    assert.doesNotMatch(skillText, /Claude Code lifecycle|SubagentStop|PreToolUse/);
+    assert.match(skillText, /rundown/);
+  }
+
+  const running = await readRepoFile(
+    'packages/claude-code-plugin/codex-plugin/skills/running-runbooks/SKILL.md',
+  );
+  assert.match(running, /MCP tools are available/);
+  assert.match(running, /rundown run/);
+  assert.match(running, /rundown pass/);
+  assert.match(running, /rundown fail/);
+
+  const delegating = await readRepoFile(
+    'packages/claude-code-plugin/codex-plugin/skills/delegating-runbooks/SKILL.md',
+  ).catch(() => '');
+  assert.equal(
+    delegating,
+    '',
+    'Stage 1 must not ship automatic delegation orchestration as a Codex skill',
+  );
+});
+
 test('e2e shell wrapper selects Claude or Codex entrypoint', async () => {
   const shellScript = await readRepoFile('scripts/e2e-shell.sh');
 

--- a/scripts/__tests__/e2e-codex-harness.test.mjs
+++ b/scripts/__tests__/e2e-codex-harness.test.mjs
@@ -221,6 +221,19 @@ test('E2E local image packs and installs the Rundown MCP server', async () => {
   assert.match(dockerfile, /\/tmp\/tarballs\/rundown-org-mcp-\*\.tgz/);
 });
 
+test('Rundown MCP tool surface includes Stage 1 execution tools', async () => {
+  const definitions = await readRepoFile('packages/mcp/src/tool-definitions.ts');
+  const tools = ['validate', 'list', 'status', 'run', 'pass', 'fail', 'goto', 'complete', 'stop'];
+
+  for (const tool of tools) {
+    assert.match(definitions, new RegExp(`${tool}: \\{`));
+  }
+
+  assert.match(definitions, /description: 'Start or enter a runbook'/);
+  assert.match(definitions, /description: 'Mark a step passed'/);
+  assert.match(definitions, /description: 'Mark a step failed'/);
+});
+
 test('E2E image copies the Rundown Codex plugin root', async () => {
   const dockerfile = await readRepoFile('scripts/Dockerfile.verify');
 

--- a/scripts/__tests__/e2e-codex-harness.test.mjs
+++ b/scripts/__tests__/e2e-codex-harness.test.mjs
@@ -18,6 +18,16 @@ async function readRepoFile(path) {
   return readFile(join(repoRoot, path), 'utf-8');
 }
 
+function parseLocalPackageList(source) {
+  const match = source.match(/RUNDOWN_LOCAL_PACKAGES=\(([^)]*)\)/);
+  assert.ok(match, 'scripts/lib/local-packages.sh must define RUNDOWN_LOCAL_PACKAGES');
+  return match[1].trim().split(/\s+/).filter(Boolean);
+}
+
+function packageTarballName(pkg) {
+  return `rundown-org-${pkg}`;
+}
+
 /**
  * Run scripts/e2e-shell.sh inside an isolated ROOT_DIR that contains NO
  * credential directories (.claude-docker / .codex-docker), with `docker`
@@ -212,13 +222,23 @@ test('e2e image installs Codex CLI, ships the Codex entrypoint, and the Codex AG
   );
 });
 
-test('E2E local image packs and installs the Rundown MCP server', async () => {
+test('local Docker tarball producers share the Dockerfile package list', async () => {
   const build = await readRepoFile('scripts/build-e2e.sh');
+  const verify = await readRepoFile('scripts/verify-install.sh');
   const dockerfile = await readRepoFile('scripts/Dockerfile.verify');
+  const packageList = parseLocalPackageList(await readRepoFile('scripts/lib/local-packages.sh'));
 
-  assert.match(build, /for pkg in parser core cli claude-code-plugin mcp; do/);
-  assert.match(dockerfile, /COPY dist\/rundown-org-mcp-\*\.tgz \/tmp\/tarballs\//);
-  assert.match(dockerfile, /\/tmp\/tarballs\/rundown-org-mcp-\*\.tgz/);
+  assert.match(build, /\. "\$SCRIPT_DIR\/lib\/local-packages\.sh"/);
+  assert.match(verify, /\. "\$SCRIPT_DIR\/lib\/local-packages\.sh"/);
+  assert.match(build, /pack_rundown_local_packages "\$dist_abs"/);
+  assert.match(verify, /pack_rundown_local_packages "\$dist_abs"/);
+  assert.ok(packageList.includes('mcp'), 'local Docker package list must include mcp');
+
+  for (const pkg of packageList) {
+    const tarball = packageTarballName(pkg);
+    assert.match(dockerfile, new RegExp(`COPY dist/${tarball}-\\*\\.tgz /tmp/tarballs/`));
+    assert.match(dockerfile, new RegExp(`/tmp/tarballs/${tarball}-\\*\\.tgz`));
+  }
 });
 
 test('Rundown MCP tool surface includes Stage 1 execution tools', async () => {
@@ -289,6 +309,7 @@ test('Rundown Claude plugin package also ships a Codex plugin surface', async ()
 
   assert.ok(pluginPackage.files.includes('codex-plugin'));
   assert.equal(pluginPackage.dependencies['@rundown-org/mcp'], '*');
+  assert.equal(pluginPackage.bin['rundown-mcp'], 'dist/rundown-mcp.js');
 });
 
 test('Codex plugin bundles Rundown skills without Claude-only syntax', async () => {

--- a/scripts/__tests__/e2e-codex-harness.test.mjs
+++ b/scripts/__tests__/e2e-codex-harness.test.mjs
@@ -212,6 +212,15 @@ test('e2e image installs Codex CLI, ships the Codex entrypoint, and the Codex AG
   );
 });
 
+test('E2E local image packs and installs the Rundown MCP server', async () => {
+  const build = await readRepoFile('scripts/build-e2e.sh');
+  const dockerfile = await readRepoFile('scripts/Dockerfile.verify');
+
+  assert.match(build, /for pkg in parser core cli claude-code-plugin mcp; do/);
+  assert.match(dockerfile, /COPY dist\/rundown-org-mcp-\*\.tgz \/tmp\/tarballs\//);
+  assert.match(dockerfile, /\/tmp\/tarballs\/rundown-org-mcp-\*\.tgz/);
+});
+
 test('Rundown Claude plugin package also ships a Codex plugin surface', async () => {
   const manifest = JSON.parse(
     await readRepoFile('packages/claude-code-plugin/codex-plugin/.codex-plugin/plugin.json'),

--- a/scripts/__tests__/e2e-codex-harness.test.mjs
+++ b/scripts/__tests__/e2e-codex-harness.test.mjs
@@ -259,7 +259,7 @@ test('E2E image copies the Rundown Codex plugin root', async () => {
 
   assert.match(
     dockerfile,
-    /packages\/claude-code-plugin\/codex-plugin \/usr\/local\/share\/rundown\/codex-plugin/,
+    /packages\/claude-code-plugin\/codex-plugin \/usr\/local\/share\/rundown\/packages\/claude-code-plugin\/codex-plugin/,
   );
   assert.match(
     dockerfile,
@@ -276,7 +276,7 @@ test('repo-local Codex marketplace exposes the Rundown plugin', async () => {
     name: 'rundown',
     source: {
       source: 'local',
-      path: './codex-plugin',
+      path: './packages/claude-code-plugin/codex-plugin',
     },
     policy: {
       installation: 'AVAILABLE',
@@ -284,6 +284,17 @@ test('repo-local Codex marketplace exposes the Rundown plugin', async () => {
     },
     category: 'Developer Tools',
   });
+});
+
+test('repo-local Codex marketplace source path resolves from the checkout root', async () => {
+  const marketplace = JSON.parse(await readRepoFile('.agents/plugins/marketplace.json'));
+  const sourcePath = marketplace.plugins[0].source.path;
+
+  assert.equal(join(repoRoot, sourcePath), join(repoRoot, 'packages/claude-code-plugin/codex-plugin'));
+  assert.equal(
+    join(repoRoot, sourcePath, '.codex-plugin', 'plugin.json'),
+    join(repoRoot, 'packages/claude-code-plugin/codex-plugin', '.codex-plugin', 'plugin.json'),
+  );
 });
 
 test('Rundown Claude plugin package also ships a Codex plugin surface', async () => {
@@ -304,7 +315,8 @@ test('Rundown Claude plugin package also ships a Codex plugin surface', async ()
   assert.equal(manifest.interface.composerIcon, './assets/rundown.svg');
 
   assert.deepEqual(mcp.mcpServers.rundown, {
-    command: 'rundown-mcp',
+    command: 'node',
+    args: ['${CODEX_PLUGIN_ROOT}/../dist/rundown-mcp.js'],
   });
 
   assert.ok(pluginPackage.files.includes('codex-plugin'));
@@ -572,7 +584,10 @@ test('Codex shell entrypoint validates auth and launches Codex in the workspace'
 test('Codex shell entrypoint installs the local Rundown Codex plugin and exports MCP env', async () => {
   const entrypoint = await readRepoFile('scripts/e2e-codex-shell-entrypoint.sh');
 
-  assert.match(entrypoint, /PLUGIN_DIR="\/usr\/local\/share\/rundown\/codex-plugin"/);
+  assert.match(
+    entrypoint,
+    /PLUGIN_DIR="\/usr\/local\/share\/rundown\/packages\/claude-code-plugin\/codex-plugin"/,
+  );
   assert.match(entrypoint, /MARKETPLACE_ROOT="\/usr\/local\/share\/rundown"/);
   assert.match(entrypoint, /export CODEX_PLUGIN_ROOT="\$PLUGIN_DIR"/);
   assert.match(entrypoint, /export RUNDOWN_PLUGIN_ROOT="\$PLUGIN_DIR"/);

--- a/scripts/build-e2e.sh
+++ b/scripts/build-e2e.sh
@@ -58,7 +58,7 @@ dist_abs="$(cd dist && pwd)"
 
 # pnpm pack has no workspace selector (--filter rejects `pack`), so pack each
 # package from inside its directory, writing to the absolute dist/ path.
-for pkg in parser core cli claude-code-plugin; do
+for pkg in parser core cli claude-code-plugin mcp; do
   log "  Packing packages/$pkg..."
   ( cd "packages/$pkg" && pnpm pack --pack-destination "$dist_abs" )
 done

--- a/scripts/build-e2e.sh
+++ b/scripts/build-e2e.sh
@@ -26,6 +26,9 @@ e2e_log() { log "$*"; }
 # Shared rd-landlock toolchain guard + build (see lib/native-build.sh).
 # shellcheck source=scripts/lib/native-build.sh
 . "$SCRIPT_DIR/lib/native-build.sh"
+# Shared package list for local Docker tarball builds.
+# shellcheck source=scripts/lib/local-packages.sh
+. "$SCRIPT_DIR/lib/local-packages.sh"
 
 # Which agent will actually launch. Defaults to claude for backward
 # compatibility with callers that don't set RUNDOWN_E2E_AGENT.
@@ -56,12 +59,7 @@ mkdir -p dist
 rm -f dist/*.tgz
 dist_abs="$(cd dist && pwd)"
 
-# pnpm pack has no workspace selector (--filter rejects `pack`), so pack each
-# package from inside its directory, writing to the absolute dist/ path.
-for pkg in parser core cli claude-code-plugin mcp; do
-  log "  Packing packages/$pkg..."
-  ( cd "packages/$pkg" && pnpm pack --pack-destination "$dist_abs" )
-done
+pack_rundown_local_packages "$dist_abs"
 
 log "Tarballs:"
 ls -la dist/*.tgz

--- a/scripts/e2e-codex-agents.md
+++ b/scripts/e2e-codex-agents.md
@@ -1,42 +1,16 @@
-# Rundown-aware Codex session (E2E harness)
+# Rundown-aware Codex fallback notes
 
-This `AGENTS.md` is placed in the Codex working directory by the Rundown E2E
-harness (`scripts/e2e-codex-shell-entrypoint.sh`). Codex reads `AGENTS.md` from
-the working directory on startup, so these instructions are how the harness
-wires Rundown into a Codex session — the equivalent of `--plugin-dir` for the
-Claude entrypoint.
+The Stage 1 Codex integration is the Rundown Codex plugin, installed by the E2E
+entrypoint from the local `rundown-local` Codex marketplace. The plugin provides
+bundled skills and an MCP server config for `rundown-mcp`.
 
-## What Rundown gives you here
+If plugin loading is unavailable while debugging, use the `rundown` CLI
+directly:
 
-Rundown is installed globally in this container. The `rd` (alias `rundown`) CLI
-drives runbook execution through a state machine: you ask the CLI what to do
-next, perform the step, then report the result back. The CLI tracks state in
-`.rundown/` so progress survives across commands.
+1. Discover runbooks: `rundown ls --all`
+2. Start a runbook: `rundown run rundown:write-plan`
+3. Inspect current state: `rundown status`
+4. Report outcomes with `rundown pass` or `rundown fail`
 
-## Core loop
-
-1. Discover runbooks: `rd ls --all`
-2. Start a runbook: `rd run <name>` (JSON output by default; add `--text` for
-   human-readable events).
-3. Inspect current state at any time: `rd status`
-4. Perform the step the runbook describes, then report the outcome:
-   - `rd pass` — the step succeeded; advance.
-   - `rd fail` — the step failed; the runbook's handler decides what happens.
-5. Repeat until the runbook completes. Runbooks auto-complete on the final step;
-   `rd complete` forces early completion and `rd stop [message]` aborts.
-
-## Useful commands
-
-- `rd check <file>` — validate a runbook without running it.
-- `rd goto <step>` — jump to a step (e.g. `rd goto 3` or `rd goto 3.1`).
-- `rd resolve <file>` — resolve and validate variables and data sources.
-- `rd ls` — list active runbooks; `rd prune` clears completed/stopped state.
-
-## Rules
-
-- Always invoke the `rd` CLI to advance runbook state. Do not hand-edit files
-  under `.rundown/` — that is the state machine's persisted state.
-- Treat **result** (pass/fail), **handler** (configured result→action mapping),
-  and **action** (what happens next) as distinct. You only report results; the
-  runbook decides the action.
-- Run `rd status` whenever you are unsure of the current step.
+JSON is the default agent-facing output. Do not add `--text` unless a human is
+debugging output formatting.

--- a/scripts/e2e-codex-shell-entrypoint.sh
+++ b/scripts/e2e-codex-shell-entrypoint.sh
@@ -20,7 +20,7 @@ hr()  { echo "----------------------------------------------------------------";
 # paths inherit it.
 export NODE_OPTIONS="--experimental-sqlite"
 
-PLUGIN_DIR="/usr/local/share/rundown/codex-plugin"
+PLUGIN_DIR="/usr/local/share/rundown/packages/claude-code-plugin/codex-plugin"
 MARKETPLACE_ROOT="/usr/local/share/rundown"
 export CODEX_PLUGIN_ROOT="$PLUGIN_DIR"
 export RUNDOWN_PLUGIN_ROOT="$PLUGIN_DIR"

--- a/scripts/e2e-codex-shell-entrypoint.sh
+++ b/scripts/e2e-codex-shell-entrypoint.sh
@@ -5,10 +5,9 @@
 #   - If /home/testuser/project exists (mounted via -v), use it directly
 #   - Otherwise, copy the built-in test-app fixture to /tmp/test-workspace
 #
-# Rundown integration: Codex reads AGENTS.md from its working directory on
-# startup. The harness copies a Rundown-specific AGENTS.md into the workspace so
-# the Codex session starts with instructions for driving runbooks via the `rd`
-# CLI. This is the Codex equivalent of the Claude entrypoint's --plugin-dir.
+# Rundown integration: the E2E image ships a local Codex marketplace and the
+# Rundown Codex plugin root. The entrypoint installs that plugin through Codex's
+# supported marketplace flow before launching the interactive session.
 #
 # Changes to a mounted project persist back to the host filesystem.
 set -euo pipefail
@@ -16,13 +15,15 @@ set -euo pipefail
 log() { echo "[rundown-codex-shell] $*"; }
 hr()  { echo "----------------------------------------------------------------"; }
 
-# Source guidance baked into the image (see scripts/Dockerfile.verify).
-CODEX_AGENTS_SOURCE="/usr/local/share/rundown/codex-agents.md"
-
 # Required by the rundown CLI's SQLite-backed state on Node's experimental
 # driver. Exported up front so both the mounted-project and built-in-fixture
 # paths inherit it.
 export NODE_OPTIONS="--experimental-sqlite"
+
+PLUGIN_DIR="/usr/local/share/rundown/codex-plugin"
+MARKETPLACE_ROOT="/usr/local/share/rundown"
+export CODEX_PLUGIN_ROOT="$PLUGIN_DIR"
+export RUNDOWN_PLUGIN_ROOT="$PLUGIN_DIR"
 
 # 1. Determine workspace
 
@@ -51,25 +52,7 @@ fi
 
 cd "$WORKSPACE"
 
-# 2. Install Rundown-aware Codex guidance (AGENTS.md)
-#
-# Codex reads AGENTS.md from the working directory. Placing the Rundown guidance
-# here is the explicit Codex<->Rundown integration mechanism. An existing
-# AGENTS.md in a mounted project is preserved (never overwritten); the harness
-# guidance is only written when none is present.
-
-if [ -f "$CODEX_AGENTS_SOURCE" ]; then
-  if [ -f "$WORKSPACE/AGENTS.md" ]; then
-    log "AGENTS.md already present in workspace; leaving it untouched."
-  else
-    cp "$CODEX_AGENTS_SOURCE" "$WORKSPACE/AGENTS.md"
-    log "Installed Rundown-aware AGENTS.md into workspace."
-  fi
-else
-  log "WARNING: Rundown Codex guidance not found at $CODEX_AGENTS_SOURCE"
-fi
-
-# 3. Check credentials
+# 2. Check credentials
 
 CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
 AUTH_FILE="$CODEX_DIR/auth.json"
@@ -80,13 +63,35 @@ if [ ! -f "$AUTH_FILE" ]; then
   exit 1
 fi
 
-# 4. Launch Codex CLI
+if [ ! -f "$PLUGIN_DIR/.codex-plugin/plugin.json" ]; then
+  log "ERROR: Codex plugin manifest not found at $PLUGIN_DIR/.codex-plugin/plugin.json"
+  exit 1
+fi
+
+if [ ! -f "$MARKETPLACE_ROOT/.agents/plugins/marketplace.json" ]; then
+  log "ERROR: Codex marketplace not found at $MARKETPLACE_ROOT/.agents/plugins/marketplace.json"
+  exit 1
+fi
+
+# The Codex plugin's .mcp.json starts the same stdio MCP server exposed by the
+# @rundown-org/mcp package. The server remains a thin facade over the CLI; this
+# preflight only proves the binary is installed, not that Codex hooks exist.
+if ! command -v rundown-mcp >/dev/null 2>&1; then
+  log "ERROR: rundown-mcp is not available on PATH"
+  exit 1
+fi
+
+codex plugin marketplace add "$MARKETPLACE_ROOT" >/dev/null
+codex plugin add rundown@rundown-local >/dev/null
+
+# 3. Launch Codex CLI
 
 hr
 log "Workspace: $(pwd)"
-log "AGENTS.md: $WORKSPACE/AGENTS.md"
+log "Plugin:    $PLUGIN_DIR"
+log "Marketplace: $MARKETPLACE_ROOT/.agents/plugins/marketplace.json"
+log "MCP:       $(command -v rundown-mcp 2>/dev/null || echo 'missing')"
 log "Codex:     $(codex --version 2>/dev/null || echo 'unknown')"
-log "rd:        $(rd --version 2>/dev/null || echo 'unknown')"
 hr
 log "Starting interactive Codex CLI session..."
 echo ""

--- a/scripts/lib/local-packages.sh
+++ b/scripts/lib/local-packages.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Shared package list for local Docker tarball builds.
+#
+# scripts/Dockerfile.verify consumes these tarballs in its `local` stage. Keep
+# both local verifiers sourcing this file so a new Docker COPY requirement cannot
+# be added to only one build path.
+
+RUNDOWN_LOCAL_PACKAGES=(parser core cli claude-code-plugin mcp)
+
+pack_rundown_local_packages() {
+  local dist_abs="$1"
+
+  # pnpm pack has no workspace selector (--filter rejects `pack`), so pack each
+  # package from inside its directory, writing to the absolute dist/ path.
+  for pkg in "${RUNDOWN_LOCAL_PACKAGES[@]}"; do
+    log "  Packing packages/$pkg..."
+    ( cd "packages/$pkg" && pnpm pack --pack-destination "$dist_abs" )
+  done
+}

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -15,6 +15,9 @@ hr()   { echo "═════════════════════�
 # Shared rd-landlock toolchain guard + build (see lib/native-build.sh).
 # shellcheck source=scripts/lib/native-build.sh
 . "$SCRIPT_DIR/lib/native-build.sh"
+# Shared package list for local Docker tarball builds.
+# shellcheck source=scripts/lib/local-packages.sh
+. "$SCRIPT_DIR/lib/local-packages.sh"
 
 # ── Validate mode ────────────────────────────────────────────────────────────
 
@@ -47,12 +50,7 @@ if [ "$MODE" = "local" ]; then
   rm -f dist/*.tgz
   dist_abs="$(cd dist && pwd)"
 
-  # pnpm pack has no workspace selector (--filter rejects `pack`), so pack each
-  # package from inside its directory, writing to the absolute dist/ path.
-  for pkg in parser core cli claude-code-plugin; do
-    log "  Packing packages/$pkg..."
-    ( cd "packages/$pkg" && pnpm pack --pack-destination "$dist_abs" )
-  done
+  pack_rundown_local_packages "$dist_abs"
 
   log "Tarballs:"
   ls -la dist/*.tgz


### PR DESCRIPTION
## Summary

Adds the Stage 1 Codex plugin surface for Rundown alongside the existing Claude plugin package.

This includes:
- a Codex plugin manifest and local Codex marketplace entry
- bundled Rundown Codex skills
- Codex plugin root discovery in the CLI
- Docker E2E support for launching Codex with the local plugin
- Codex MCP execution-surface tests and documentation
- review fixes for local Docker tarball packaging and the plugin-owned MCP launcher

## Why

Codex needs a first-class Rundown plugin surface that can install and run from the plugin package without relying on Claude-specific plugin paths or globally leaked dependency binaries.

The final review fix also removes the duplicated local Docker package lists by making both local tarball producers source the same package list used to satisfy `scripts/Dockerfile.verify`.

## Validation

- `pnpm --filter @rundown-org/claude-code-plugin test -- manifest.test.ts`
- `pnpm --filter @rundown-org/claude-code-plugin check:types`
- `pnpm run test:unit:scripts` (`161` passing tests)
- `pnpm run build`

Note: the local Docker E2E image build was previously blocked in this environment before Docker by the missing Rust/cargo-zigbuild native toolchain prerequisite.