### PR TITLE
fix: inline lifecycle hygiene — collect-driven release + goto propagation (#556, #553, #521)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-delegate-claim-anchored-issuance.md
+++ b/docs/superpowers/plans/2026-07-15-delegate-claim-anchored-issuance.md
@@ -124,7 +124,7 @@ Run: `pnpm --filter @rundown-org/core exec jest lifecycle-command-service.test.t
 Expected: FAIL. Before the fix the seam anchors the active default (`otherRunId`); the authorization gate then rejects the claim's missing `delegate-from-run` grant for that run, so `outcome.kind` is `'refused'` — the `expect(outcome.kind).toBe('delegated')` assertion fails.
 
 > The fall-through test (`falls through … when the claim's controlled run is terminal`) already PASSES before the fix — before the branch exists the seam always anchors the active default, which is exactly what it asserts. That is intended: it is a mutation-killing / invariant guard, not a red→green driver. Confirm it stays green after Step 3-4.
-
+>
 > **Jest invocation:** use `exec jest <path> -t "<name>"`, NOT `test -- <path> -t "<name>"`. Both packages define `"test": "jest"`, so the script form forwards a literal `--` into jest 30, which then treats `-t` and the name as positional path patterns — the name filter is silently dropped and a mistyped red-test name matches nothing yet reports green. `exec jest` bypasses the script indirection.
 
 - [ ] **Step 3: Add the claim-anchored branch to `#resolveIssuanceAnchor`**
@@ -276,7 +276,7 @@ Add to `packages/cli/__tests__/integration/delegate-workflow.test.ts`, inside th
     // run.ts:66; mirrors how setupParentWithChildren keeps the parent alive).
     const other = createRunbook({
       title: 'Other',
-      steps: [{ title: 'Only', pass: 'COMPLETE', command: 'rd echo --result pass' }],
+      steps: [{ title: 'Only', pass: 'COMPLETE', command: 'rundown echo --result pass' }],
     });
     await writeFile(join(workspace.cwd, 'runbooks', 'other.runbook.md'), other);
     const otherStart = await runCliInProcess('run --prompted runbooks/other.runbook.md', workspace);

--- a/docs/superpowers/plans/2026-07-15-delegate-claim-anchored-issuance.md
+++ b/docs/superpowers/plans/2026-07-15-delegate-claim-anchored-issuance.md
@@ -1,0 +1,364 @@
+# Delegate Claim-Anchored Issuance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `rundown delegate --claim-id <A>` (no `--run`) issue its delegation from the run claim A controls, matching every other mutating command — instead of silently anchoring on the active default run (#586).
+
+**Architecture:** The fix is entirely in `@rundown-org/core`. The CLI already hands the claim to the seam as `callerEvidence` (a `claim_bearer` carrying the claim id); the seam's anchor resolver `#resolveIssuanceAnchor` just never uses it for target selection — it resolves the issuance anchor from `--run`-or-active only. We teach the anchor resolver to consult the claim: when a bearer claim is presented and no `--run` is named, resolve the anchor from the claim's controlled run via the same `resolveCommandTarget` seam the transition commands use. `#resolveIssuanceAnchor` is shared by three call sites — fresh issuance (`:847`) and the two retry locators that resolve an anchor, step (`:1080`) and inferred-active (`:1109`) — and all three carry the identical divergence, so all three pass `callerEvidence` (the token retry locator at `:1048` never calls the method and is untouched, correctly — it has its own `run_target_mismatch` token-scan semantics). `callerEvidence` becomes a **required** parameter: every caller already has `input.callerEvidence`, so making it required (not optional-defaulted) means the fresh/retry distinction is not a convention a future edit can silently break — omission is a compile error. The claim branch is purely additive — it diverts to the controlled run only when the claim resolves to a live claimed run; every other case (stale claim, terminal-controlled run, stashed child, non-claim evidence) falls through to the pre-existing active-default anchor and the unchanged authorization gate, so no existing behavior changes.
+
+**Tech Stack:** TypeScript, XState (core state machine — not touched here), Jest (unit + integration), pnpm workspaces. Packages: `@rundown-org/core` (the `RunbookLifecycleCommandService` seam), `@rundown-org/cli` (thin front end — no production change, integration coverage only).
+
+## Global Constraints
+
+- **State machine drives Rundown logic; the CLI is a thin wrapper.** The target-selection fix is runbook-program logic and belongs in core. The CLI is not touched for production code — it already passes the claim as `callerEvidence`. (CLAUDE.md Architectural Principles.)
+- **Type-driven dispatch; the claim is the target when present.** Anchor selection dispatches on the resolved `CommandTargetResolution.kind`, never on ad-hoc string checks. (CLAUDE.md Design Principles.)
+- **Fix all three anchor call sites; `callerEvidence` is required, not optional.** `#resolveIssuanceAnchor` is called from three sites — fresh (`:847`), retry-step (`:1080`), retry-active (`:1109`) — and all three carry the same #586 divergence, so all three pass `input.callerEvidence`. Making the parameter REQUIRED (not optional-defaulted) is deliberate: `DelegationIssuanceInput` always carries `callerEvidence` on both `fresh` and `retry` variants, so there is no caller that legitimately omits it, and a required param turns "did this call site forget to anchor on the claim?" into a compile error instead of a prose convention. The retry **token** locator (`:1048`) does NOT call `#resolveIssuanceAnchor` (it scans by token and owns `run_target_mismatch`), so it is genuinely out of scope and unchanged.
+- **`--run` and `--claim-id` are mutually exclusive at the CLI.** `delegateSeamFields` (`packages/cli/src/commands/delegate.ts:79-91`) produces `callerEvidence` (for a claim) OR `targetRunId` (for `--run`) — never both, on both the fresh and retry flows. The seam relies on this: the `--run` branch returns first, so the claim branch is reached only when no `--run` was named. Do not add a redundant guard.
+- **Test layers (explicit).** This change is pinned at the unit layer (core seam: claim-anchoring on fresh AND retry-step, plus the stale/terminal fall-through) and the integration layer (end-to-end CLI red→green). **No property test** is added — the two existing delegation property suites (`delegation-exposure.properties.test.ts`, `delegation-inference.properties.test.ts`) cover pure classifiers, not the anchor seam, and the anchor input space (claim controls {active, non-active-live, terminal/stale}) is small and enumerable, so example unit tests pin it more precisely than fast-check over a stateful `SessionService`. **No scenario test** is added — the scenario system drives single-runbook demo transcripts; #586 is a multi-run session arrangement (a controlled-but-not-active run competing with a different active default) that a single-runbook transcript cannot express.
+- **Never migrate persisted runbook state.** No persisted-state shape changes. This is pure read-side target selection.
+- **JSON output by default.** The CLI integration test asserts the default JSON envelope (`findActionOutput`), not `--text`.
+
+---
+
+## Background: why the bug exists
+
+`issueDelegation` (fresh) resolves its issuance anchor at `lifecycle-command-service.ts:847`:
+
+```typescript
+const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
+```
+
+`#resolveIssuanceAnchor` (`:1939-1955`) only knows about `targetRunId` (the `--run` selector). When `targetRunId` is `undefined` — which it always is on the `--claim-id` path, because `delegateSeamFields` maps a `claim` target to `callerEvidence` alone — it falls back to `getActive()` (the active default run). So `delegate --claim-id A` anchors on whatever run happens to be active, ignoring that claim A unambiguously names run A via its `controlledRunId`.
+
+Every transition command avoids this: `runTransition` (`:1307`) and `resolveRunNavigation` (`:1515`) resolve their target through `resolveCommandTarget(sessionService, { claimId })`, which calls `getActiveForClaimId` → loads `record.controlledRunId` directly (`session-service.ts:594`, independent of the session stack) and returns `{ kind: 'claim', state }` where `state` is the controlled run. `delegate` is the one mutating command that doesn't. This plan closes that divergence.
+
+**The divergence is shared by fresh AND the two retry anchor locators.** `#resolveIssuanceAnchor(input.targetRunId)` is called at three sites: fresh issuance (`:847`), the retry `step` locator (`:1080`), and the retry inferred-`active` locator (`:1109`). All three fall back to `getActive()` and none consults the claim, so `delegate --step 1.1 --claim-id A` (fresh) and `delegate --retry --step 1.1 --claim-id A` (retry) both mis-anchor when A is controlled-but-not-active. The retry `token` locator (`:1048`) is the ONE that is genuinely different — it scans by token and enforces `run_target_mismatch` against `--run`, never calling `#resolveIssuanceAnchor`. So the fix passes `input.callerEvidence` at all three anchor call sites and leaves the token locator alone. (An earlier draft scoped this to fresh-only and justified the exclusion by "retry has distinct token-scan semantics"; that reasoning is true only of the token locator, not the step/active locators, so it is corrected here — the fix now covers the full root cause.)
+
+**Before-fix behavior for the fixed case** (claim A controls a non-active run, B is active): the seam anchors B, then the authorization gate checks claim A's `delegate-from-run` grant against B, which claim A does not hold → refuses `claim_grant_required` (exit 1). **After fix:** anchors A → gate checks the grant against A, which the run-control claim holds → issues from A. The test layers below pin exactly this red→green on both the fresh and retry-step paths.
+
+---
+
+## File Structure
+
+- `packages/core/src/runbook/lifecycle-command-service.ts` — add a REQUIRED `callerEvidence` parameter to `#resolveIssuanceAnchor`; add a claim-anchored branch that resolves the controlled run via `resolveCommandTarget`; pass `input.callerEvidence` from all three anchor call sites (`:847` fresh, `:1080` retry-step, `:1109` retry-active). (#586 production change — the only file.)
+- `packages/core/__tests__/runbook/lifecycle-command-service.test.ts` — add three failing-first unit tests: (1) a claim whose controlled run is NOT the active default anchors the controlled run on the FRESH path; (2) the same on the RETRY-step path; (3) a claim whose controlled run is TERMINAL falls through to the active default and is refused by the gate (pins the additive-only invariant and kills the inner-guard mutant). (#586 unit coverage.)
+- `packages/cli/__tests__/integration/delegate-workflow.test.ts` — add an end-to-end regression test: with a controlled-but-not-active parent run and a different (still-running, `--prompted`) active default run, `delegate --step 1.1 --claim-id <A>` issues against run A. (#586 integration coverage — no new production code.)
+
+---
+
+## Task 1: Core anchors issuance on the claim's controlled run — fresh + retry (#586)
+
+**Files:**
+- Modify: `packages/core/src/runbook/lifecycle-command-service.ts:847` (fresh call site), `:1080` (retry-step call site), `:1109` (retry-active call site), `:1939-1955` (`#resolveIssuanceAnchor`)
+- Test: `packages/core/__tests__/runbook/lifecycle-command-service.test.ts` (fresh + fall-through tests in the `issueDelegation (fresh)` describe at `:366+`; retry test in the `issueDelegation (retry)` describe — find it with `grep -n "describe('issueDelegation (retry)'" packages/core/__tests__/runbook/lifecycle-command-service.test.ts`)
+
+**Interfaces:**
+- Consumes: `resolveCommandTarget` (already imported at `lifecycle-command-service.ts:27`), `CallerEvidence` (already imported and used across the input types), `RunbookState`, `RunId` (already in scope).
+- Produces: `#resolveIssuanceAnchor(targetRunId: RunId | undefined, callerEvidence: CallerEvidence)` — `callerEvidence` is REQUIRED (see Global Constraints). The return type is unchanged (`{ kind: 'ok'; state } | { kind: 'unknown_run'; runId; message } | { kind: 'none' }`). All three call sites pass `input.callerEvidence`.
+
+- [ ] **Step 1: Write the failing core unit test**
+
+Add this test inside the existing `describe('issueDelegation (fresh)', ...)` block (the block opens at `packages/core/__tests__/runbook/lifecycle-command-service.test.ts:366`), after the first "delegates" success test. It reuses the suite's own fixtures — `startSeamOnDelegateStep` (`:280`, activates run `runId` on a DELEGATE step and mints its run-control claim), `baseState` (`:172`), `activate` (`:196`, pushes a run and mints its run-control claim), `runControlEvidence` (`:209`, returns `{ kind: 'claim_bearer', claimId }` for a run), and `assertRunId` (already imported; used at `:133`). Do not invent new helpers.
+
+```typescript
+    it('anchors fresh issuance on the claim\'s controlled run, not the active default (#586)', async () => {
+      // Run `runId` is activated with an authored DELEGATE substep and its own
+      // run-control claim.
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+
+      // A DIFFERENT run is then activated, so `runId` is controlled-but-not-active:
+      // getActive() now returns this run, not `runId`.
+      const otherRunId = assertRunId('rd_22222222222222222222222222222222');
+      const activeDefault = baseState({ id: otherRunId, runbookPath: 'other.md' });
+      await activate(activeDefault);
+
+      // Delegating with `runId`'s run-control claim (NO --run) must anchor on
+      // `runId` — the run the claim controls — not on the active default.
+      const outcome = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: runControlEvidence(runId),
+      });
+
+      expect(outcome.kind).toBe('delegated');
+      if (outcome.kind !== 'delegated') throw new Error('expected delegated');
+      // The load-bearing assertion: issuance anchored on the CONTROLLED run
+      // (`runId`), not the active default (`otherRunId`). Before the fix the seam
+      // anchors `otherRunId`, whose run the claim lacks a grant for, and the
+      // outcome is `refused` (claim_grant_required) — so this expectation fails.
+      expect(outcome.parentRunId).toBe(runId);
+    });
+```
+
+Then add the fall-through test — REQUIRED, not optional. It pins the plan's load-bearing "additive only: a claim that does NOT resolve to a live claimed run falls through to the active-default anchor and the unchanged gate" invariant, AND kills the surviving `target.kind === 'claim' → true` mutant that the claim-anchoring test above does not (that test only ever presents a live `claim` resolution). Add it directly after:
+
+```typescript
+    it('falls through to the active default when the claim\'s controlled run is terminal (#586)', async () => {
+      // The run `runId` is activated with a DELEGATE step and its run-control
+      // claim, then driven terminal — so the claim resolves to `terminal_claim`,
+      // NOT `claim`. A different run is the active default.
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+      await manager.updateWithState(runId, () => ({ lifecycle: 'completed' as const }));
+      const otherRunId = assertRunId('rd_33333333333333333333333333333333');
+      await activate(baseState({ id: otherRunId, runbookPath: 'other.md' }));
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: runControlEvidence(runId),
+      });
+
+      // The terminal claim does NOT divert the anchor: the seam falls through to
+      // the active default (`otherRunId`), and because the claim holds no
+      // `delegate-from-run` grant for it, the unchanged gate refuses. A mutant
+      // forcing `target.kind === 'claim'` true would anchor `runId` and produce a
+      // different outcome, so this assertion kills it.
+      expect(outcome.kind).toBe('refused');
+      if (outcome.kind !== 'refused') throw new Error('expected refused');
+      expect(outcome.policy.kind).toBe('claim_grant_required');
+    });
+```
+
+- [ ] **Step 2: Run both fresh-path tests to verify they fail as expected**
+
+Run: `pnpm --filter @rundown-org/core exec jest lifecycle-command-service.test.ts -t "anchors fresh issuance on the claim"`
+
+Expected: FAIL. Before the fix the seam anchors the active default (`otherRunId`); the authorization gate then rejects the claim's missing `delegate-from-run` grant for that run, so `outcome.kind` is `'refused'` — the `expect(outcome.kind).toBe('delegated')` assertion fails.
+
+> The fall-through test (`falls through … when the claim's controlled run is terminal`) already PASSES before the fix — before the branch exists the seam always anchors the active default, which is exactly what it asserts. That is intended: it is a mutation-killing / invariant guard, not a red→green driver. Confirm it stays green after Step 3-4.
+
+> **Jest invocation:** use `exec jest <path> -t "<name>"`, NOT `test -- <path> -t "<name>"`. Both packages define `"test": "jest"`, so the script form forwards a literal `--` into jest 30, which then treats `-t` and the name as positional path patterns — the name filter is silently dropped and a mistyped red-test name matches nothing yet reports green. `exec jest` bypasses the script indirection.
+
+- [ ] **Step 3: Add the claim-anchored branch to `#resolveIssuanceAnchor`**
+
+In `packages/core/src/runbook/lifecycle-command-service.ts`, change `#resolveIssuanceAnchor` (`:1939-1955`) to take a REQUIRED `callerEvidence` and consult the claim when no `--run` was named. Replace the whole method:
+
+```typescript
+  // Resolve the issuance anchor run. Precedence:
+  //   1. `--run <id>`: the named session-stack member (a missing/foreign/terminal
+  //      id refuses as `unknown_run`, carrying the same cause-specific message
+  //      pass/complete refuse with).
+  //   2. A presented bearer claim (no `--run`): the claim's controlled run,
+  //      resolved via the same `resolveCommandTarget` seam every transition
+  //      command uses (`getActiveForClaimId` -> `record.controlledRunId`). This is
+  //      the #586 fix: a claim unambiguously names its run, so `delegate
+  //      --claim-id A` issues from A even when A is not the active default. The
+  //      divert is ADDITIVE — only a live `claim` resolution anchors here; a
+  //      stale/terminal/stashed claim falls through to (3), where the unchanged
+  //      authorization gate refuses it exactly as before.
+  //   3. The active default run (`none` when absent) — the pre-existing bare path.
+  async #resolveIssuanceAnchor(
+    targetRunId: RunId | undefined,
+    callerEvidence: CallerEvidence,
+  ): Promise<
+    | { readonly kind: 'ok'; readonly state: RunbookState }
+    | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
+    | { readonly kind: 'none' }
+  > {
+    if (targetRunId !== undefined) {
+      const member = await this.#deps.sessionService.resolveRunningStackMember(targetRunId);
+      if (member.kind !== 'running') {
+        return unknownRunRefusal(targetRunId, member);
+      }
+      return { kind: 'ok', state: member.state };
+    }
+    if (callerEvidence.kind === 'claim_bearer') {
+      const target = await resolveCommandTarget(this.#deps.sessionService, {
+        claimId: callerEvidence.claimId,
+      });
+      if (target.kind === 'claim') {
+        return { kind: 'ok', state: target.state };
+      }
+    }
+    const active = await this.#deps.sessionService.getActive();
+    return active ? { kind: 'ok', state: active } : { kind: 'none' };
+  }
+```
+
+- [ ] **Step 4: Pass the caller evidence from all three anchor call sites**
+
+`#resolveIssuanceAnchor` is now called with two arguments everywhere it resolves an anchor. There are exactly three such call sites (the retry `token` locator at `:1048` does not call it — leave it alone). At each, change:
+
+```typescript
+    const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
+```
+
+to:
+
+```typescript
+    const anchored = await this.#resolveIssuanceAnchor(input.targetRunId, input.callerEvidence);
+```
+
+The three sites are: `:847` (fresh, in `issueDelegation`), `:1080` (retry `step` locator, in `#issueRetry`), and `:1109` (retry inferred-`active` locator, in `#issueRetry`). Because the parameter is now required, TypeScript flags any site still passing one argument — a compile error is the guard that no anchor call site was missed. Confirm the token locator (`:1048`) was not touched.
+
+- [ ] **Step 5: Write the failing RETRY-path claim-anchoring test**
+
+Add to `packages/core/__tests__/runbook/lifecycle-command-service.test.ts` inside the `describe('issueDelegation (retry)', ...)` block. This proves the `:1080` retry-step call site is fixed (its own red→green), mirroring the fresh test: run `runId` is controlled-but-not-active, and `--retry --step 1.1 --claim-id runId` must anchor and re-issue against `runId`. Use the suite's retry fixture that stands up an active DELEGATE runbook with an already-issued substep (grep for the existing retry success test — e.g. `grep -n "retried" packages/core/__tests__/runbook/lifecycle-command-service.test.ts` — and mirror its setup, which activates `runId` on a DELEGATE step with an issued token). After that setup, activate a second run so `runId` is no longer the active default, then:
+
+```typescript
+      const outcome = await localSeam.issueDelegation({
+        mode: 'retry',
+        callerEvidence: runControlEvidence(runId),
+        locator: { kind: 'step', step: '1.1' },
+        resolveOverrides: async () => undefined,
+      });
+
+      expect(outcome.kind).toBe('retried');
+      if (outcome.kind !== 'retried') throw new Error('expected retried');
+      // Anchored on the controlled run (`runId`), not the active default. Before
+      // the Step 4 fix the retry-step locator anchors the active default, whose run
+      // the claim lacks a grant for, so the outcome is `refused`.
+      expect(outcome.parentRunId).toBe(runId);
+```
+
+(If the mirrored retry fixture already leaves `runId` as the sole active run, add the second-run activation exactly as in the fresh test: `await activate(baseState({ id: assertRunId('rd_44444444444444444444444444444444'), runbookPath: 'other.md' }));` before the `issueDelegation` call.)
+
+- [ ] **Step 6: Run the retry test to verify it fails**
+
+Run: `pnpm --filter @rundown-org/core exec jest lifecycle-command-service.test.ts -t "retry"` (narrow further with the exact test name you chose)
+
+Expected: FAIL before Step 4 is applied to `:1080` — the retry-step locator anchors the active default and the gate refuses (`outcome.kind === 'refused'`).
+
+- [ ] **Step 7: Run the fresh + retry claim-anchoring tests to verify they pass**
+
+Run: `pnpm --filter @rundown-org/core exec jest lifecycle-command-service.test.ts -t "anchors fresh issuance on the claim"`
+Run: `pnpm --filter @rundown-org/core exec jest lifecycle-command-service.test.ts -t "falls through to the active default"`
+Run: `pnpm --filter @rundown-org/core exec jest lifecycle-command-service.test.ts -t "retry"` (your retry test name)
+
+Expected: PASS. The claim now anchors on `runId` on both the fresh and retry-step paths; the gate finds the run-control claim's grant for `runId`; the terminal-claim fall-through still refuses (invariant holds).
+
+- [ ] **Step 8: Run the full seam suite to verify no regression**
+
+Run: `pnpm --filter @rundown-org/core exec jest lifecycle-command-service.test.ts`
+
+Expected: PASS. The existing fresh AND retry tests (claim controls the active run) pass unchanged — when the claim's controlled run IS the active default, the new branch resolves the same run the old `getActive()` path did, so their outcomes are identical.
+
+- [ ] **Step 9: Run the broader core delegation suites**
+
+Run: `pnpm --filter @rundown-org/core exec jest delegation`
+
+Expected: PASS. This sweeps `delegation-service`, `retry-delegation`, `create-delegation`, `delegation-exposure`, and the delegation property tests, confirming the anchor change did not perturb issuance/echo/conflict or retry semantics.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/core/src/runbook/lifecycle-command-service.ts \
+  packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+git commit -m "fix(core): anchor delegate issuance on the claim's controlled run, fresh + retry (#586)"
+```
+
+---
+
+## Task 2: CLI end-to-end regression coverage (#586)
+
+**Files:**
+- Test: `packages/cli/__tests__/integration/delegate-workflow.test.ts` (add one `it` to the existing `describe('DELEGATE full workflow …')` block, which opens at `:109`)
+
+**Interfaces:**
+- Consumes (all already imported at the top of the file, `:5-17`): `createRunbook`, `runCliInProcess`, `getActiveState`, `readRunbookState` (unused here but present), `findActionOutput`, `issueRunControlClaim`, plus the file-local `setupParentWithChildren` (`:167`) and `buildParentDelegate` (`:128`). `writeFile` / `join` are imported at `:2-3`.
+- Produces: nothing — pure regression coverage, no production code.
+
+This test proves the Task 1 fix through the real CLI pipeline. `setupParentWithChildren` starts a `--prompted` parent that auto-issues tokens for substeps `1.1`/`1.2` on step entry, so `delegate --step 1.1` against that run echoes `already-delegated` (a clean exit-0 success carrying `parent_run_id`). We then activate a DIFFERENT run so the parent is controlled-but-not-active, mint a run-control claim for the parent, and assert `delegate --step 1.1 --claim-id <parent>` issues against the parent. Before the Task 1 fix, the seam anchors the active default run (which the parent's claim lacks a grant for), so the command refuses with exit 1.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `packages/cli/__tests__/integration/delegate-workflow.test.ts`, inside the `describe('DELEGATE full workflow …')` block (after the existing `full happy path` test, ~`:270`):
+
+```typescript
+  it('delegate --claim-id anchors on the claim\'s controlled run when it is not the active default (#586)', async () => {
+    // Parent run A is activated with auto-issued 1.1/1.2 delegations.
+    const { parentRunId } = await setupParentWithChildren();
+
+    // Activate a DIFFERENT run so A is controlled-but-not-active: getActive() now
+    // returns this run, not A. Start it `--prompted` so it ENTERS step 1 and stays
+    // running/active WITHOUT auto-executing. A plain (non-prompted) `run` would
+    // auto-execute this single-step `pass: COMPLETE` runbook to completion and
+    // release it — restoring A as the active default and collapsing the red→green
+    // discriminator (`--prompted` = "show commands without auto-executing",
+    // run.ts:66; mirrors how setupParentWithChildren keeps the parent alive).
+    const other = createRunbook({
+      title: 'Other',
+      steps: [{ title: 'Only', pass: 'COMPLETE', command: 'rd echo --result pass' }],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'other.runbook.md'), other);
+    const otherStart = await runCliInProcess('run --prompted runbooks/other.runbook.md', workspace);
+    expect(otherStart.exitCode).toBe(0);
+    const active = await getActiveState(workspace);
+    expect(active).not.toBeNull();
+    expect(active!.id).not.toBe(parentRunId); // A is no longer the active default
+
+    // Mint a run-control claim for A and delegate against 1.1 with it (no --run).
+    const parentClaimId = await issueRunControlClaim(workspace, parentRunId);
+    const delegated = await runCliInProcess(
+      ['delegate', '--step', '1.1', '--claim-id', parentClaimId],
+      workspace,
+    );
+
+    // After the fix: exit 0, echoing A's already-issued 1.1 delegation, anchored
+    // on A. Before the fix the seam anchors the active default `other` run — which
+    // A's claim holds no grant for — and refuses `claim_grant_required` (exit 1).
+    expect(delegated.exitCode).toBe(0);
+    const action = findActionOutput<{ action: string; parent_run_id: string }>(delegated.stdout);
+    expect(action).not.toBeNull();
+    expect(action!.action).toBe('already-delegated');
+    expect(action!.parent_run_id).toBe(parentRunId);
+  }, 20_000);
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @rundown-org/cli exec jest delegate-workflow.test.ts -t "anchors on the claim"`
+
+Expected: FAIL on `expect(delegated.exitCode).toBe(0)` — before the Task 1 fix, `delegate --claim-id <A>` anchors on the active `other` run, the gate rejects A's claim against it, and the command exits 1 with a `CLAIM_GRANT_REQUIRED` envelope (so `findActionOutput` finds no `already-delegated` action either).
+
+> **NOTE for reviewers running tasks out of order:** if Task 1 is already merged, this test PASSES immediately (it is a regression guard, not a red→green driver in that ordering). Run it against `main`-before-Task-1 to see the red.
+
+- [ ] **Step 3: Confirm the fix makes it pass**
+
+With Task 1's production change in place, run:
+
+Run: `pnpm --filter @rundown-org/cli exec jest delegate-workflow.test.ts -t "anchors on the claim"`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the surrounding integration suites for regression**
+
+Run: `pnpm --filter @rundown-org/cli exec jest delegate-workflow.test.ts`
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/integration/explicit-run-targeting.test.ts`
+
+Expected: PASS. `explicit-run-targeting` is the suite that exercises `--run`-selector and claim-target semantics end-to-end; it confirms the `--run`-only and active-default paths are unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/__tests__/integration/delegate-workflow.test.ts
+git commit -m "test(cli): pin claim-anchored delegate issuance end-to-end (#586)"
+```
+
+---
+
+## Task 3: Full verification and issue closure
+
+**Files:** none (verification + docs/issue admin).
+
+- [ ] **Step 1: Run the pre-PR verification gate**
+
+Run: `pnpm run verify`
+
+Expected: PASS (format, spell, lint, unit tests across all packages). This is the mandatory pre-push gate per CLAUDE.md.
+
+- [ ] **Step 2: Run the changed-file mutation gate on the core seam (recommended)**
+
+Run: `pnpm run test:mutate:core -- --mutate packages/core/src/runbook/lifecycle-command-service.ts --testFiles packages/core/__tests__/runbook/lifecycle-command-service.test.ts`
+
+Expected: both new guards on the anchor branch are killed. The `callerEvidence.kind === 'claim_bearer'` guard is killed by the fresh claim-anchoring test (non-claim evidence falls through). The `target.kind === 'claim'` guard — specifically the ConditionalExpression `→ true` mutant, which is only observable when a `claim_bearer` resolves to `terminal_claim`/`stale_claim` — is killed by the REQUIRED terminal-claim fall-through test (Task 1 Step 1); a case that only ever presents a live `claim` resolution would NOT kill it, which is why that fall-through test is required rather than optional. If any mutant still survives on the branch, do not paper over it — add the specific input (terminal vs stale vs stashed) that makes the forced-branch observable.
+
+- [ ] **Step 3: Close #586 via the PR**
+
+The PR description should include `Closes #586`. Note in the PR body that this discharges one of the two remaining code leaves in cluster #565 (R4 Capability Tier); #519 (parent-side abandoned/idle claim detection) and the #574 design umbrella remain open, so #565 stays open. Do NOT edit the epic (#564) or cluster (#565) roadmap status in this PR beyond referencing #586 — roadmap status is owned by those issues and updated when the cluster's remaining leaves land.
+
+---
+
+## Self-Review
+
+- **Spec coverage.** Acceptance criterion 1 (`delegate --claim-id A`, no `--run`, issues from A when A is controlled-but-not-active) → Task 1 fresh unit test + Task 2 integration test; the retry-step path (same root cause) → Task 1 Step 5 retry unit test. Criterion 2 (new core unit + CLI integration coverage) → Task 1 (three unit tests) and Task 2. Criterion 3 (existing `--run`-only and bare/active behavior preserved) → the branch is additive and returns first for `--run`; verified by the terminal-claim fall-through test (Task 1 Step 1), the full seam + delegation suites (Task 1 Steps 8-9), and Task 2 Step 4 (`explicit-run-targeting`). Root-cause completeness: all three `#resolveIssuanceAnchor` call sites that fall back to `getActive()` (fresh + retry step/active) are fixed; the retry token locator is correctly excluded (it never calls the method).
+- **Placeholder scan.** No `TODO`/`TBD`/"handle edge cases" — every code step shows the exact edit or test. The one step that resolves a fixture by grep (Task 1 Step 5's retry setup) points at a concrete existing test to mirror rather than leaving the setup unspecified.
+- **Type consistency.** `#resolveIssuanceAnchor` keeps its exact return union; the parameter is REQUIRED (`callerEvidence: CallerEvidence`), and all three anchor call sites pass `input.callerEvidence` (available on both the `fresh` and `retry` variants of `DelegationIssuanceInput`), so a missed site is a compile error, not a silent behavior change. The claim branch dispatches on `resolveCommandTarget`'s `CommandTargetResolution.kind` (`'claim'`), whose `claim` variant carries `state` (confirmed at `command-target-resolver.ts:285`). `runControlEvidence` returns `{ kind: 'claim_bearer', claimId }` (test `:209-215`), matching the branch's `callerEvidence.kind === 'claim_bearer'` narrowing to `.claimId`. Direct object literal `{ claimId: callerEvidence.claimId }` is correct (not the `...(claimId ? {} : {})` spread the transition commands use — those spread because both `claimId` and `runId` are conditionally-present; here `.claimId` is unconditionally present inside the `claim_bearer` narrow).

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -172,8 +172,12 @@ const { createBridgedEmitter } = await import('../../src/helpers/execution-emitt
 const { createPassTransitionConfig, createFailTransitionConfig } = await import(
   '../../src/helpers/transitions.js'
 );
-const { reportTerminalToDelegatingRun, advanceParentForInlineChild, extractParentLinkage } =
-  await import('../../src/helpers/delegation-completion.js');
+const {
+  reportTerminalToDelegatingRun,
+  advanceParentForInlineChild,
+  extractParentLinkage,
+  propagateDrivenRunTerminal,
+} = await import('../../src/helpers/delegation-completion.js');
 
 function makeState(id: RunbookState['id'], overrides: Partial<RunbookState> = {}): RunbookState {
   const base: RunbookState = {
@@ -776,5 +780,115 @@ describe('advanceParentForInlineChild', () => {
     expect(runExecutionLoop).toHaveBeenCalledTimes(1);
     // Loop 'done' with a linkage-free parent -> propagate is not-applicable -> handled.
     expect(result).toBe('handled');
+  });
+});
+
+describe('propagateDrivenRunTerminal', () => {
+  const LOOP_INFERRED = { kind: 'loop-inferred' } as const;
+
+  it('skips when the driven run is missing', async () => {
+    const manager = makeManager(new Map());
+    const output = makeOutput();
+    const result = await propagateDrivenRunTerminal(
+      manager as unknown as RunbookStateManagerType,
+      CHILD_RUN_ID,
+      '/test',
+      output,
+      LOOP_INFERRED,
+    );
+    expect(result).toEqual({ kind: 'skipped' });
+  });
+
+  it('skips when the driven run is still running', async () => {
+    const child = makeState(CHILD_RUN_ID, {
+      lifecycle: 'running',
+      parentLinkage: makeInlineLinkage(),
+    });
+    const manager = makeManager(new Map([[child.id, child]]));
+    const output = makeOutput();
+    const result = await propagateDrivenRunTerminal(
+      manager as unknown as RunbookStateManagerType,
+      CHILD_RUN_ID,
+      '/test',
+      output,
+      LOOP_INFERRED,
+    );
+    expect(result).toEqual({ kind: 'skipped' });
+  });
+
+  it('skips when the terminal run has no parent linkage', async () => {
+    const root = makeState(CHILD_RUN_ID, { lifecycle: 'completed', parentLinkage: undefined });
+    const manager = makeManager(new Map([[root.id, root]]));
+    const output = makeOutput();
+    const result = await propagateDrivenRunTerminal(
+      manager as unknown as RunbookStateManagerType,
+      CHILD_RUN_ID,
+      '/test',
+      output,
+      LOOP_INFERRED,
+    );
+    expect(result).toEqual({ kind: 'skipped' });
+  });
+
+  it('propagates a terminal inline child through the inline flow-back path (lifecycle-inferred)', async () => {
+    const child = makeState(CHILD_RUN_ID, {
+      lifecycle: 'completed',
+      parentLinkage: makeInlineLinkage(),
+    });
+    const parent = makeState(PARENT_RUN_ID, { parentLinkage: undefined });
+    const manager = makeManager(
+      new Map([
+        [child.id, child],
+        [parent.id, parent],
+      ]),
+    );
+    const output = makeOutput();
+    wireMocks(manager, makeLifecycleService());
+    // loop-inferred (goto/run/collect path): the mock projection defaults
+    // `undefined` to not_terminal, so pin lifecycle-inference explicitly here so
+    // the inline flow-back proceeds (the real projectDelegationTerminalOutcome
+    // infers `completed → pass`).
+    mockProjectDelegationTerminalOutcome.mockReturnValue({ kind: 'outcome', result: 'pass' });
+    // Default drain returns status 'continue' / applied 0 → inline path → 'handled'.
+    const result = await propagateDrivenRunTerminal(
+      manager as unknown as RunbookStateManagerType,
+      CHILD_RUN_ID,
+      '/test',
+      output,
+      LOOP_INFERRED,
+    );
+    // Discriminated shape: linkage kind IS the discriminant (SHOULD-FIX 4).
+    expect(result).toEqual({ kind: 'inline-advanced', result: 'handled' });
+  });
+
+  it('forwards an operator-result trigger into propagation (pass/fail commands)', async () => {
+    // Correction 1 + SHOULD-FIX 5: an operator-result trigger overrides lifecycle
+    // inference. A child left `stopped` by its own STOP but reported `pass` by the
+    // operator must report 'pass' (not the inferred 'fail').
+    const child = makeState(CHILD_RUN_ID, {
+      lifecycle: 'stopped',
+      parentLinkage: makeDelegationLinkage(),
+    });
+    const parent = makeState(PARENT_RUN_ID, {
+      substepStates: [{ id: '1', frameKey: brandFrameKeyForTest('1'), status: 'running' }],
+      resolvedCompletions: {},
+    });
+    const manager = makeManager(
+      new Map([
+        [child.id, child],
+        [parent.id, parent],
+      ]),
+    );
+    const output = makeOutput();
+    const recordChildCompletion = wireMocks(manager, makeLifecycleService());
+    const result = await propagateDrivenRunTerminal(
+      manager as unknown as RunbookStateManagerType,
+      CHILD_RUN_ID,
+      '/test',
+      output,
+      { kind: 'operator-result', result: 'pass' },
+    );
+    expect(result).toEqual({ kind: 'delegation-reported', result: 'reported' });
+    expect(recordChildCompletion).toHaveBeenCalledWith({ childState: child, result: 'pass' });
   });
 });

--- a/packages/cli/__tests__/helpers/delegation-completion.test.ts
+++ b/packages/cli/__tests__/helpers/delegation-completion.test.ts
@@ -177,6 +177,8 @@ const {
   advanceParentForInlineChild,
   extractParentLinkage,
   propagateDrivenRunTerminal,
+  propagationRequiresFailureExit,
+  inlineAdvanceRequiresFailureExit,
 } = await import('../../src/helpers/delegation-completion.js');
 
 function makeState(id: RunbookState['id'], overrides: Partial<RunbookState> = {}): RunbookState {
@@ -861,6 +863,98 @@ describe('propagateDrivenRunTerminal', () => {
     expect(result).toEqual({ kind: 'inline-advanced', result: 'handled' });
   });
 
+  it('propagates an inline-advanced STOP terminal as { inline-advanced, stopped }', async () => {
+    // The stopped/blocked inline result the exit predicates consume — never pinned
+    // through this wrapper before (only the sibling advanceParentForInlineChild had
+    // it). Drain applies the child completion, the post-apply parent loop STOPs, and
+    // the linkage-free parent makes the recursive propagate a no-op.
+    const child = makeState(CHILD_RUN_ID, {
+      lifecycle: 'completed',
+      parentLinkage: makeInlineLinkage(),
+    });
+    const parent = makeState(PARENT_RUN_ID, { parentLinkage: undefined });
+    const manager = makeManager(
+      new Map([
+        [child.id, child],
+        [parent.id, parent],
+      ]),
+    );
+    const output = makeOutput();
+    wireMocks(manager, makeLifecycleService());
+    // loop-inferred forwards `undefined`; pin lifecycle-inference so the child's
+    // `completed → pass` flow-back proceeds (mirrors the 'handled' case above).
+    mockProjectDelegationTerminalOutcome.mockReturnValue({ kind: 'outcome', result: 'pass' });
+    jest.mocked(drainResolvedCompletions).mockResolvedValue({
+      unresolved: 0,
+      status: 'continue',
+      applied: 1,
+      state: parent,
+    });
+    jest.mocked(runExecutionLoop).mockResolvedValue('stopped');
+
+    const result = await propagateDrivenRunTerminal(
+      manager as unknown as RunbookStateManagerType,
+      CHILD_RUN_ID,
+      '/test',
+      output,
+      LOOP_INFERRED,
+    );
+
+    expect(result).toEqual({ kind: 'inline-advanced', result: 'stopped' });
+  });
+
+  it('propagates an inline-advanced blocked terminal as { inline-advanced, blocked }', async () => {
+    // Parent loop STOPs into a policy-denied terminal that projects to `blocked`
+    // (command-infrastructure), mirroring the advanceParentForInlineChild blocked
+    // case but routed through the wrapper.
+    const child = makeState(CHILD_RUN_ID, {
+      lifecycle: 'completed',
+      parentLinkage: makeInlineLinkage(),
+    });
+    const terminalParent = makeState(PARENT_RUN_ID, {
+      lifecycle: 'stopped',
+      parentLinkage: makeDelegationLinkage({ parentRunId: GRANDPARENT_RUN_ID }),
+      lastAction: {
+        type: 'POLICY_DENIED',
+        origin: 'direct',
+        message: 'blocked by policy',
+      },
+    });
+    const manager = makeManager(
+      new Map([
+        [child.id, child],
+        [PARENT_RUN_ID, terminalParent],
+      ]),
+    );
+    const output = makeOutput();
+    wireMocks(manager, makeLifecycleService());
+    jest.mocked(drainResolvedCompletions).mockResolvedValue({
+      unresolved: 0,
+      status: 'continue',
+      applied: 1,
+      state: terminalParent,
+    });
+    jest.mocked(runExecutionLoop).mockResolvedValue('stopped');
+    // First projection: the child's `completed → pass` flow-back. Second: the
+    // terminal parent projects to a command-infrastructure block.
+    mockProjectDelegationTerminalOutcome.mockReturnValueOnce({ kind: 'outcome', result: 'pass' });
+    mockProjectDelegationTerminalOutcome.mockReturnValueOnce({
+      kind: 'command_infrastructure',
+      reason: 'policy_denied',
+      message: 'blocked by policy',
+    });
+
+    const result = await propagateDrivenRunTerminal(
+      manager as unknown as RunbookStateManagerType,
+      CHILD_RUN_ID,
+      '/test',
+      output,
+      LOOP_INFERRED,
+    );
+
+    expect(result).toEqual({ kind: 'inline-advanced', result: 'blocked' });
+  });
+
   it('forwards an operator-result trigger into propagation (pass/fail commands)', async () => {
     // Correction 1 + SHOULD-FIX 5: an operator-result trigger overrides lifecycle
     // inference. A child left `stopped` by its own STOP but reported `pass` by the
@@ -890,5 +984,75 @@ describe('propagateDrivenRunTerminal', () => {
     );
     expect(result).toEqual({ kind: 'delegation-reported', result: 'reported' });
     expect(recordChildCompletion).toHaveBeenCalledWith({ childState: child, result: 'pass' });
+  });
+});
+
+describe('propagationRequiresFailureExit', () => {
+  // any-linkage rule: fires on ANY non-skipped propagation whose result is
+  // stopped/blocked, delegation included (used by goto + run --step).
+  it('returns false for a skipped propagation', () => {
+    expect(propagationRequiresFailureExit({ kind: 'skipped' })).toBe(false);
+  });
+
+  it('returns true for an inline-advanced stopped/blocked propagation', () => {
+    expect(propagationRequiresFailureExit({ kind: 'inline-advanced', result: 'stopped' })).toBe(
+      true,
+    );
+    expect(propagationRequiresFailureExit({ kind: 'inline-advanced', result: 'blocked' })).toBe(
+      true,
+    );
+  });
+
+  it('returns false for an inline-advanced handled/not-applicable propagation', () => {
+    expect(propagationRequiresFailureExit({ kind: 'inline-advanced', result: 'handled' })).toBe(
+      false,
+    );
+    expect(
+      propagationRequiresFailureExit({ kind: 'inline-advanced', result: 'not-applicable' }),
+    ).toBe(false);
+  });
+
+  it('returns true for a delegation-reported blocked propagation (any-linkage semantics)', () => {
+    expect(propagationRequiresFailureExit({ kind: 'delegation-reported', result: 'blocked' })).toBe(
+      true,
+    );
+  });
+
+  it('returns false for a delegation-reported reported propagation', () => {
+    expect(
+      propagationRequiresFailureExit({ kind: 'delegation-reported', result: 'reported' }),
+    ).toBe(false);
+  });
+});
+
+describe('inlineAdvanceRequiresFailureExit', () => {
+  // inline-only rule: fires ONLY on inline-advanced stopped/blocked; delegation
+  // reporting is report-only and never flips the exit (used by collect + pass/fail).
+  it('returns true for an inline-advanced stopped/blocked propagation', () => {
+    expect(inlineAdvanceRequiresFailureExit({ kind: 'inline-advanced', result: 'stopped' })).toBe(
+      true,
+    );
+    expect(inlineAdvanceRequiresFailureExit({ kind: 'inline-advanced', result: 'blocked' })).toBe(
+      true,
+    );
+  });
+
+  it('returns false for an inline-advanced handled/not-applicable propagation', () => {
+    expect(inlineAdvanceRequiresFailureExit({ kind: 'inline-advanced', result: 'handled' })).toBe(
+      false,
+    );
+    expect(
+      inlineAdvanceRequiresFailureExit({ kind: 'inline-advanced', result: 'not-applicable' }),
+    ).toBe(false);
+  });
+
+  it('returns false for a delegation-reported blocked propagation (the key divergence)', () => {
+    expect(
+      inlineAdvanceRequiresFailureExit({ kind: 'delegation-reported', result: 'blocked' }),
+    ).toBe(false);
+  });
+
+  it('returns false for a skipped propagation', () => {
+    expect(inlineAdvanceRequiresFailureExit({ kind: 'skipped' })).toBe(false);
   });
 });

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -469,6 +469,9 @@ describe('executeGoto', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.loopResult).toBe('done');
+      // manager.load resolves null, so propagateDrivenRunTerminal short-circuits
+      // `skipped` without touching the (unmocked) delegation services.
+      expect(result.propagation).toEqual({ kind: 'skipped' });
     }
     expect(action).toHaveBeenCalled();
     expect(sendAndSync).toHaveBeenCalledWith(DEFAULT_RUNBOOK_ID, ctx.steps, {
@@ -513,6 +516,10 @@ describe('executeGoto', () => {
     const result = await executeGoto(ctx, { step: '2' });
 
     expect(result.ok).toBe(true);
+    if (result.ok) {
+      // manager.load resolves null → propagation short-circuits `skipped`.
+      expect(result.propagation).toEqual({ kind: 'skipped' });
+    }
     expect(clearLastResult).not.toHaveBeenCalled();
     expect(outputAction).toHaveBeenCalledWith({
       action: 'GOTO 2',
@@ -555,6 +562,9 @@ describe('executeGoto', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.loopResult).toBe('stopped');
+      // The loop stopped locally; propagation still short-circuits `skipped`
+      // because manager.load resolves null (no parent linkage to report to).
+      expect(result.propagation).toEqual({ kind: 'skipped' });
     }
   });
 });

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -26,6 +26,13 @@ jest.unstable_mockModule('@rundown-org/core', () => ({
   RunbookStateManager: jest.fn(),
   RunbookActorService: jest.fn(),
   SessionService: jest.fn(),
+  // Statically imported by delegation-completion.js (pulled in via executeGoto's
+  // propagateDrivenRunTerminal call); the ESM link check needs the names, but the
+  // executeGoto tests below make `manager.load` return null so propagation
+  // short-circuits `skipped` without invoking any of these.
+  ExecutionLifecycleService: jest.fn(),
+  RunbookCompletionService: jest.fn(),
+  projectDelegationTerminalOutcome: jest.fn(),
   parseStepIdFromString: jest.fn(),
   stepIdToString: jest.fn((id: { step: string; substep?: string }) =>
     id.substep ? `${id.step}.${id.substep}` : id.step,
@@ -406,7 +413,10 @@ describe('executeGoto', () => {
         action: jest.fn(),
         flush: jest.fn(),
       } as unknown as OutputEmitter,
-      manager: { update } as unknown as RunbookStateManager,
+      manager: {
+        update,
+        load: mockFn<RunbookStateManager['load']>().mockResolvedValue(null),
+      } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
       state: makeState(),
@@ -441,7 +451,10 @@ describe('executeGoto', () => {
         action,
         flush: jest.fn(),
       } as unknown as OutputEmitter,
-      manager: { update } as unknown as RunbookStateManager,
+      manager: {
+        update,
+        load: mockFn<RunbookStateManager['load']>().mockResolvedValue(null),
+      } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
       state: makeState(),
@@ -486,7 +499,9 @@ describe('executeGoto', () => {
     } as unknown as OutputEmitter;
     const ctx = {
       output,
-      manager: {} as RunbookStateManager,
+      manager: {
+        load: mockFn<RunbookStateManager['load']>().mockResolvedValue(null),
+      } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
       state: makeState(),
@@ -523,7 +538,10 @@ describe('executeGoto', () => {
         action: jest.fn(),
         flush: jest.fn(),
       } as unknown as OutputEmitter,
-      manager: { update } as unknown as RunbookStateManager,
+      manager: {
+        update,
+        load: mockFn<RunbookStateManager['load']>().mockResolvedValue(null),
+      } as unknown as RunbookStateManager,
       actorService: { sendAndSync } as unknown as RunbookActorService,
       sessionService: {} as SessionService,
       state: makeState(),

--- a/packages/cli/__tests__/helpers/goto-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/goto-workflow.test.ts
@@ -83,9 +83,12 @@ jest.unstable_mockModule('../../src/helpers/actor-service-factory', () => ({
 // Import after mocking
 const core = await import('@rundown-org/core');
 const { runExecutionLoop } = await import('../../src/services/execution.js');
-const { validateGotoTarget, executeGoto, resolveTerminalReleaseModeForRunbook } = await import(
-  '../../src/helpers/goto-workflow.js'
-);
+const {
+  validateGotoTarget,
+  executeGoto,
+  resolveTerminalReleaseModeForRunbook,
+  gotoResultRequiresFailureExit,
+} = await import('../../src/helpers/goto-workflow.js');
 
 const DEFAULT_TRANSITIONS: Transitions = {
   pass: { kind: 'pass', retry: 0, action: { type: 'COMPLETE' } },
@@ -566,6 +569,57 @@ describe('executeGoto', () => {
       // because manager.load resolves null (no parent linkage to report to).
       expect(result.propagation).toEqual({ kind: 'skipped' });
     }
+  });
+});
+
+describe('gotoResultRequiresFailureExit', () => {
+  // Pure predicate — the load-bearing half of #553: a successful goto must still
+  // exit non-zero when the run stopped locally OR its terminal propagated to a
+  // parent that stopped/blocked. `manager.load → null` in the executeGoto tests
+  // keeps `propagation` at `skipped`, so these cases pin the non-skipped arm the
+  // integration path never forced.
+  type OkResult = Parameters<typeof gotoResultRequiresFailureExit>[0];
+
+  it('requires failure exit when the loop stopped locally (no propagation)', () => {
+    const result: OkResult = { ok: true, loopResult: 'stopped' };
+    expect(gotoResultRequiresFailureExit(result)).toBe(true);
+  });
+
+  it('does not require failure exit when the run is still waiting with no propagation', () => {
+    const result: OkResult = { ok: true, loopResult: 'waiting' };
+    expect(gotoResultRequiresFailureExit(result)).toBe(false);
+  });
+
+  it('does not require failure exit when propagation was skipped', () => {
+    const result: OkResult = { ok: true, loopResult: 'done', propagation: { kind: 'skipped' } };
+    expect(gotoResultRequiresFailureExit(result)).toBe(false);
+  });
+
+  it('requires failure exit when an inline-advanced propagation stopped the parent', () => {
+    const result: OkResult = {
+      ok: true,
+      loopResult: 'done',
+      propagation: { kind: 'inline-advanced', result: 'stopped' },
+    };
+    expect(gotoResultRequiresFailureExit(result)).toBe(true);
+  });
+
+  it('requires failure exit when an inline-advanced propagation blocked the parent', () => {
+    const result: OkResult = {
+      ok: true,
+      loopResult: 'done',
+      propagation: { kind: 'inline-advanced', result: 'blocked' },
+    };
+    expect(gotoResultRequiresFailureExit(result)).toBe(true);
+  });
+
+  it('does not require failure exit when an inline-advanced propagation was handled', () => {
+    const result: OkResult = {
+      ok: true,
+      loopResult: 'done',
+      propagation: { kind: 'inline-advanced', result: 'handled' },
+    };
+    expect(gotoResultRequiresFailureExit(result)).toBe(false);
   });
 });
 

--- a/packages/cli/__tests__/integration/explicit-run-targeting.test.ts
+++ b/packages/cli/__tests__/integration/explicit-run-targeting.test.ts
@@ -312,8 +312,9 @@ describe('explicit --run targeting (R1, #460)', () => {
     expect(rootAfter?.step).toBe('2');
     expect(rootAfter?.lifecycle).toBe('running');
 
-    // Session-management cleanup of the completed stage (prune is the
-    // documented residual ambient lane) leaves the root as the active run.
+    // The stage was released from the default stack at collect time (#556); this
+    // prune is now redundant residual-lane cleanup and the root is already the
+    // active run.
     const pruned = await runCliInProcess(['prune'], workspace);
     expect(pruned.exitCode).toBe(0);
     const back = await getActiveState(workspace);
@@ -331,6 +332,76 @@ describe('explicit --run targeting (R1, #460)', () => {
     const rootClaimId = await issueRunControlClaim(workspace, back.id);
     const targeted = await runCliInProcess(['pass', '--claim-id', rootClaimId], workspace);
     expect(targeted.exitCode).toBe(0);
+  });
+
+  it('collect that drives an inline stage terminal releases it from the session default stack (#556, closes #521)', async () => {
+    // Arrange exactly as ':refuses a lingering grandchild bare pass ...' (:243-304):
+    // write leaf/stage/root runbooks, start the root (stage auto-launches inline and
+    // auto-issues the delegation token), then claim + close the grandchild leaf.
+    const leafContent = createRunbook({
+      name: 'leaf',
+      title: 'Leaf',
+      steps: [{ title: 'Work', pass: 'COMPLETE', content: 'Leaf prompt.' }],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'leaf.runbook.md'), leafContent);
+    await writeFile(join(workspace.runbooksDir(), 'leaf.runbook.md'), leafContent);
+    const stageContent = createRunbook({
+      name: 'stage',
+      title: 'Stage',
+      steps: [
+        {
+          title: 'Delegate leaf',
+          pass: 'COMPLETE',
+          substeps: [
+            { title: 'Leaf work', delegate: true, runbooks: ['runbooks/leaf.runbook.md'] },
+          ],
+        },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'stage.runbook.md'), stageContent);
+    await writeFile(join(workspace.runbooksDir(), 'stage.runbook.md'), stageContent);
+    const rootContent = createRunbook({
+      title: 'Root',
+      steps: [
+        {
+          title: 'Compose',
+          pass: 'CONTINUE',
+          substeps: [{ title: 'Stage', runbooks: ['runbooks/stage.runbook.md'] }],
+        },
+        { title: 'After', pass: 'COMPLETE', content: 'Wrap up.' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'root.runbook.md'), rootContent);
+
+    const start = await runCliInProcess('run runbooks/root.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+    const stage = await getActiveState(workspace);
+    if (!stage) throw new Error('Expected active inline stage');
+    const stageRunId = stage.id;
+    const token = findDelegateToken(start.stdout);
+    if (!token) throw new Error('Expected auto-issued delegation token');
+
+    // The stage is on the default stack while it is the active inline run.
+    expect((await readSession(workspace)).defaultStack).toContain(stageRunId);
+
+    const claimed = await runCliInProcess(['claim', token], workspace);
+    expect(claimed.exitCode).toBe(0);
+    const claimId = String(findActionOutput(claimed.stdout)?.claim_id);
+    const closed = await runCliInProcess(['pass', '--claim-id', claimId], workspace);
+    expect(closed.exitCode).toBe(0);
+
+    // Act: collect drives the STAGE to a terminal lifecycle and propagates inline to
+    // the root (advancing it to step 2), exactly as :308-313.
+    const stageClaimId = await issueRunControlClaim(workspace, stageRunId);
+    const collected = await runCliInProcess(['collect', '--claim-id', stageClaimId], workspace);
+    expect(collected.exitCode).toBe(0);
+
+    // The stage is `completed` on disk (already true before #556)...
+    const terminalStage = await readRunbookState(workspace, stageRunId);
+    expect(terminalStage!.lifecycle).toBe('completed');
+    // ...AND the #556 fix: released from the session default stack AT COLLECT TIME —
+    // no `prune` needed. Assert MEMBERSHIP, not the stack top.
+    expect((await readSession(workspace)).defaultStack).not.toContain(stageRunId);
   });
 
   it('refuses a bare goto on a delegating run with ACTOR_CONTEXT_REQUIRED, while goto --claim-id succeeds', async () => {

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -82,6 +82,55 @@ describe('Inline linkage integration (rd run --step)', () => {
     return null;
   }
 
+  /** Child whose second step fails but is handled FAIL COMPLETE (→ lifecycle completed). */
+  async function writeGotoChild(): Promise<void> {
+    const content = createRunbook({
+      title: 'Child',
+      steps: [
+        { title: 'Start', pass: 'CONTINUE', content: 'Waiting.' },
+        { title: 'Finish', fail: 'COMPLETE', command: 'rd echo --result fail' },
+      ],
+    });
+    await writeFile(join(workspace.cwd, 'child.runbook.md'), content);
+  }
+
+  it('goto that drives an inline child terminal advances the parent substep, lifecycle-inferred (#553)', async () => {
+    await writeParentRunbook();
+    await writeGotoChild();
+
+    // Parent waits at step 1 with two pending substeps.
+    let result = await runCliInProcess('run --prompted parent.runbook.md --text', workspace);
+    expect(result.exitCode).toBe(0);
+    const parentRunId = (await getActiveState(workspace))!.id;
+
+    // Launch the inline child, composing it into the PARENT's substep 1.1 (the
+    // `--step 1.1` addresses the parent's substep — writeParentRunbook authors 1.1
+    // 'Code review' — NOT a step of the child; established idiom, inline-linkage
+    // .test.ts:311,356). Without --prompted, `--step` builds the inline linkage and
+    // the child composes into the parent substep; the child's step 1 is a
+    // content-only PASS CONTINUE, so the loop waits there — the child becomes the
+    // active run and parent substep 1 is 'running'. (With --prompted, `--step`
+    // means "jump within the CHILD" — a different code path — so it is omitted.)
+    result = await runCliInProcess('run child.runbook.md --step 1.1 --text', workspace);
+    expect(result.exitCode).toBe(0);
+
+    // Drive the child terminal via goto. `--run` is a read-only selector and is
+    // refused as mutation authority (ACTOR_CONTEXT_REQUIRED); the verified idiom for
+    // a goto against an inline child is withRunTarget, which mints the run-control
+    // claim on the active run and appends --claim-id (inline-child-launch.test.ts
+    // :362). goto's loop runs `Finish`, which fails and is handled FAIL COMPLETE →
+    // child lifecycle `completed` → inferred `pass`.
+    result = await runCliInProcess(await withRunTarget(['goto', '2'], workspace), workspace);
+    expect(result.exitCode).toBe(0);
+
+    // Parent substep 1 advanced off 'running' to done/pass (lifecycle-inferred),
+    // identical to what the natural execution-loop path already produces.
+    const parentAfter = await readRunbookState(workspace, parentRunId);
+    const ss1 = (parentAfter!.substepStates ?? []).find((ss) => ss.id === '1');
+    expect(ss1!.status).toBe('done');
+    expect(ss1!.result).toBe('pass');
+  });
+
   describe('afterInit fresh state reload (race condition fix)', () => {
     it('passes parent artifact variables to inline child runtime variables and renders them', async () => {
       const schemaPath = join(workspace.cwd, 'schema.json');

--- a/packages/cli/__tests__/integration/inline-linkage.test.ts
+++ b/packages/cli/__tests__/integration/inline-linkage.test.ts
@@ -872,6 +872,121 @@ Check manually.
     });
   });
 
+  describe('inline STOP propagation exits non-zero (#553 failure half)', () => {
+    // Parent whose single inline substep aggregates FAIL ANY STOP: resolving 1.1
+    // fail drives the parent to a STOP terminal DURING the driver's propagation
+    // pass — distinct from the `auto-executing child propagation` parent above,
+    // whose two substeps only stop after a follow-up `pass`. This is what forces
+    // propagation.result === 'stopped' at the run/goto/fail exit sites.
+    async function writeStopAggregatingParent(): Promise<void> {
+      await writeFile(
+        join(workspace.cwd, 'parent.runbook.md'),
+        `# Parent
+
+## 1. Review
+
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Inline gate
+
+Run the inline gate.
+
+## 2. Done
+
+- PASS COMPLETE
+
+Final step.
+`,
+      );
+    }
+
+    it('run --step exits 1 when the inline child stop propagates a parent STOP', async () => {
+      await writeStopAggregatingParent();
+      await writeFailingChild();
+
+      let result = await runCliInProcess('run --prompted parent.runbook.md --text', workspace);
+      expect(result.exitCode).toBe(0);
+      const parentRunId = (await getActiveState(workspace))!.id;
+
+      // Auto-executing child fails and STOPs; advancing the parent aggregates
+      // FAIL ANY STOP → parent terminal `stopped` → run.ts exits 1 via
+      // propagationRequiresFailureExit.
+      result = await runCliInProcess('run child.runbook.md --step 1.1 --text', workspace);
+      expect(result.exitCode).toBe(1);
+
+      const parentAfter = await readRunbookState(workspace, parentRunId);
+      expect(parentAfter!.lifecycle).toBe('stopped');
+      const ss1 = (parentAfter!.substepStates ?? []).find((ss) => ss.id === '1');
+      expect(ss1!.result).toBe('fail');
+    });
+
+    it('goto that drives an inline child to a STOP terminal exits 1 and stops the parent', async () => {
+      await writeStopAggregatingParent();
+      // Child waits at a content step, then a goto-driven Finish command fails and
+      // STOPs (mirror of the FAIL COMPLETE #553 happy-path child at :86).
+      await writeFile(
+        join(workspace.cwd, 'child.runbook.md'),
+        createRunbook({
+          title: 'Child',
+          steps: [
+            { title: 'Start', pass: 'CONTINUE', content: 'Waiting.' },
+            { title: 'Finish', fail: 'STOP', command: 'rd echo --result fail' },
+          ],
+        }),
+      );
+
+      let result = await runCliInProcess('run --prompted parent.runbook.md --text', workspace);
+      expect(result.exitCode).toBe(0);
+      const parentRunId = (await getActiveState(workspace))!.id;
+
+      // Compose the child into parent substep 1.1; its content-only step 1 waits.
+      result = await runCliInProcess('run child.runbook.md --step 1.1 --text', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // goto drives the child to Finish → fail → FAIL STOP → child stopped;
+      // advancing the parent aggregates FAIL ANY STOP → parent stopped → exit 1.
+      result = await runCliInProcess(await withRunTarget(['goto', '2'], workspace), workspace);
+      expect(result.exitCode).toBe(1);
+
+      const parentAfter = await readRunbookState(workspace, parentRunId);
+      expect(parentAfter!.lifecycle).toBe('stopped');
+    });
+
+    it('fail on an inline child exits 1 when the operator result propagates a parent STOP', async () => {
+      await writeStopAggregatingParent();
+      // Manual child that waits for the operator (no auto-executing command).
+      await writeFile(
+        join(workspace.cwd, 'child.runbook.md'),
+        `# Child
+
+## 1. Check
+
+- PASS COMPLETE
+- FAIL STOP
+
+Check manually.
+`,
+      );
+
+      let result = await runCliInProcess('run --prompted parent.runbook.md --text', workspace);
+      expect(result.exitCode).toBe(0);
+      const parentRunId = (await getActiveState(workspace))!.id;
+
+      result = await runCliInProcess('run child.runbook.md --step 1.1 --text', workspace);
+      expect(result.exitCode).toBe(0);
+
+      // Operator `fail` STOPs the child; advancing the parent aggregates FAIL ANY
+      // STOP → parent stopped → transition-command exits 1 via
+      // inlineAdvanceRequiresFailureExit.
+      result = await runCliInProcess(await withRunTarget(['fail'], workspace), workspace);
+      expect(result.exitCode).toBe(1);
+
+      const parentAfter = await readRunbookState(workspace, parentRunId);
+      expect(parentAfter!.lifecycle).toBe('stopped');
+    });
+  });
+
   it('bare pass still closes only the active inline unit and advances the parent normally', async () => {
     await writeFile(
       join(workspace.cwd, 'parent-pass-unit-local.runbook.md'),

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -22,7 +22,7 @@ import {
   type ClaimFailure,
   type RunPipelineContext,
 } from '../helpers/runbook-pipeline.js';
-import { propagateChildTerminal, extractParentLinkage } from '../helpers/delegation-completion.js';
+import { propagateDrivenRunTerminal } from '../helpers/delegation-completion.js';
 
 function claimFailureToEnvelope(failure: ClaimFailure): {
   readonly code: string;
@@ -236,16 +236,14 @@ export function registerClaimCommand(program: Command): void {
             // own loopResult governs this command's exit code.
             const shouldExitWithError = result.loopResult === 'stopped';
             if (result.loopResult === 'done' || result.loopResult === 'stopped') {
-              const childState = await manager.load(result.childRunId);
-              if (childState && extractParentLinkage(childState)) {
-                await propagateChildTerminal(
-                  childState,
-                  undefined,
-                  cwd,
-                  output,
-                  commandStreamOptions,
-                );
-              }
+              await propagateDrivenRunTerminal(
+                manager,
+                result.childRunId,
+                cwd,
+                output,
+                { kind: 'loop-inferred' },
+                commandStreamOptions,
+              );
             }
 
             output.flush();

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -32,7 +32,7 @@ import {
   renderActorContextRequiredRefusal,
   renderClaimGrantRequiredRefusal,
 } from '../helpers/refusal-renderers.js';
-import { extractParentLinkage, propagateChildTerminal } from '../helpers/delegation-completion.js';
+import { propagateDrivenRunTerminal } from '../helpers/delegation-completion.js';
 
 /**
  * Registers the 'collect' command — triggers aggregation after DELEGATE fan-out.
@@ -555,30 +555,24 @@ async function runCollect(ctx: TransitionContext, options: CollectOptions): Prom
   // `output` — which is exactly why the applied action object below is emitted
   // LAST, after this pass (cli-output.md: the action object is the last line).
   let exitWithError = loopStopped || shouldExitWithError;
-  const terminal = await manager.load(state.id);
-  const linkage = terminal ? extractParentLinkage(terminal) : undefined;
-  if (
-    terminal &&
-    linkage &&
-    (terminal.lifecycle === 'completed' || terminal.lifecycle === 'stopped')
-  ) {
-    const propagation = await propagateChildTerminal(
-      terminal,
-      undefined,
-      cwd,
-      output,
-      commandStreamOptions,
-    );
-    // Inline propagation may itself drive the parent terminal (STOP) — its
-    // outcome decides the exit code for inline, ORed with a stopped loop.
-    // Delegation propagation is report-only (no parent advancement) but can
-    // still surface a STOP exit.
-    if (linkage.kind === 'inline') {
-      exitWithError = propagation === 'stopped' || propagation === 'blocked' || loopStopped;
-    } else if (propagation === 'stopped') {
-      exitWithError = true;
-    }
+  const propagation = await propagateDrivenRunTerminal(
+    manager,
+    state.id,
+    cwd,
+    output,
+    { kind: 'loop-inferred' },
+    commandStreamOptions,
+  );
+  if (propagation.kind === 'inline-advanced') {
+    exitWithError =
+      propagation.result === 'stopped' || propagation.result === 'blocked' || loopStopped;
   }
+  // `delegation-reported` is report-only and never flips the exit code here — this
+  // matches today's behaviour: collect's delegation branch tested `=== 'stopped'`
+  // (`:578`), which reportTerminalToDelegatingRun can NEVER return, so it was dead.
+  // The discriminated type removes it structurally (SHOULD-FIX 4). `skipped` (a
+  // non-terminal collect) leaves `exitWithError` at `loopStopped || shouldExitWithError`
+  // — the Correction 2 guarantee.
 
   // Render the deferred collect action object exactly once, AFTER the loop's and
   // the inline propagation's streamed events, so it is the last JSON line on

--- a/packages/cli/src/commands/collect.ts
+++ b/packages/cli/src/commands/collect.ts
@@ -32,7 +32,10 @@ import {
   renderActorContextRequiredRefusal,
   renderClaimGrantRequiredRefusal,
 } from '../helpers/refusal-renderers.js';
-import { propagateDrivenRunTerminal } from '../helpers/delegation-completion.js';
+import {
+  propagateDrivenRunTerminal,
+  inlineAdvanceRequiresFailureExit,
+} from '../helpers/delegation-completion.js';
 
 /**
  * Registers the 'collect' command — triggers aggregation after DELEGATE fan-out.
@@ -564,8 +567,7 @@ async function runCollect(ctx: TransitionContext, options: CollectOptions): Prom
     commandStreamOptions,
   );
   if (propagation.kind === 'inline-advanced') {
-    exitWithError =
-      propagation.result === 'stopped' || propagation.result === 'blocked' || loopStopped;
+    exitWithError = inlineAdvanceRequiresFailureExit(propagation) || loopStopped;
   }
   // `delegation-reported` is report-only and never flips the exit code here — this
   // matches today's behaviour: collect's delegation branch tested `=== 'stopped'`

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -5,7 +5,12 @@ import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { commandStreamOptionsForOutputMode } from '../services/execution.js';
-import { buildGotoContext, validateGotoTarget, executeGoto } from '../helpers/goto-workflow.js';
+import {
+  buildGotoContext,
+  validateGotoTarget,
+  executeGoto,
+  gotoResultRequiresFailureExit,
+} from '../helpers/goto-workflow.js';
 import {
   withTransitionTargetOptions,
   parseTransitionTarget,
@@ -88,13 +93,7 @@ export function registerGotoCommand(program: Command): void {
             // Flush any remaining output
             output.flush();
 
-            if (
-              result.loopResult === 'stopped' ||
-              (result.propagation !== undefined &&
-                result.propagation.kind !== 'skipped' &&
-                (result.propagation.result === 'stopped' ||
-                  result.propagation.result === 'blocked'))
-            ) {
+            if (gotoResultRequiresFailureExit(result)) {
               process.exit(1);
             }
           },

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -88,7 +88,13 @@ export function registerGotoCommand(program: Command): void {
             // Flush any remaining output
             output.flush();
 
-            if (result.loopResult === 'stopped') {
+            if (
+              result.loopResult === 'stopped' ||
+              (result.propagation !== undefined &&
+                result.propagation.kind !== 'skipped' &&
+                (result.propagation.result === 'stopped' ||
+                  result.propagation.result === 'blocked'))
+            ) {
               process.exit(1);
             }
           },

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -52,7 +52,10 @@ import {
   resolveIndexOption,
   IndexOptionError,
 } from '../helpers/index-option.js';
-import { propagateDrivenRunTerminal } from '../helpers/delegation-completion.js';
+import {
+  propagateDrivenRunTerminal,
+  propagationRequiresFailureExit,
+} from '../helpers/delegation-completion.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
 import { commandStreamOptionsForOutputMode } from '../services/execution.js';
 
@@ -265,10 +268,7 @@ export function registerRunCommand(program: Command): void {
                 { kind: 'loop-inferred' },
                 commandStreamOptions,
               );
-              if (
-                propagation.kind !== 'skipped' &&
-                (propagation.result === 'stopped' || propagation.result === 'blocked')
-              ) {
+              if (propagationRequiresFailureExit(propagation)) {
                 output.flush();
                 process.exit(1);
               }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -51,7 +51,7 @@ import {
   resolveIndexOption,
   IndexOptionError,
 } from '../helpers/index-option.js';
-import { propagateChildTerminal } from '../helpers/delegation-completion.js';
+import { propagateDrivenRunTerminal } from '../helpers/delegation-completion.js';
 import { getRunbookFromState } from '../helpers/runbook-loader.js';
 import { commandStreamOptionsForOutputMode } from '../services/execution.js';
 
@@ -256,23 +256,20 @@ export function registerRunCommand(program: Command): void {
             // (drain-and-advance), unlike delegation's report-then-collect. If
             // advancing the parent reaches a STOP terminal, exit 1.
             if (parentLinkage) {
-              const childState = await manager.load(result.stateId);
-              if (childState) {
-                const isTerminal =
-                  childState.lifecycle === 'completed' || childState.lifecycle === 'stopped';
-                if (isTerminal) {
-                  const propOutcome = await propagateChildTerminal(
-                    childState,
-                    undefined,
-                    cwd,
-                    output,
-                    commandStreamOptions,
-                  );
-                  if (propOutcome === 'stopped' || propOutcome === 'blocked') {
-                    output.flush();
-                    process.exit(1);
-                  }
-                }
+              const propagation = await propagateDrivenRunTerminal(
+                manager,
+                result.stateId,
+                cwd,
+                output,
+                { kind: 'loop-inferred' },
+                commandStreamOptions,
+              );
+              if (
+                propagation.kind !== 'skipped' &&
+                (propagation.result === 'stopped' || propagation.result === 'blocked')
+              ) {
+                output.flush();
+                process.exit(1);
               }
             }
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -45,6 +45,7 @@ import {
   validateGotoTarget,
   executeGoto,
   resolveTerminalReleaseModeForRunbook,
+  gotoResultRequiresFailureExit,
 } from '../helpers/goto-workflow.js';
 import {
   validateIndexRequiresStep,
@@ -327,7 +328,7 @@ export function registerRunCommand(program: Command): void {
               }
 
               output.flush();
-              if (gotoResult.loopResult === 'stopped') {
+              if (gotoResultRequiresFailureExit(gotoResult)) {
                 process.exit(1);
               }
               return;

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -29,20 +29,23 @@ import {
   type RunbookState,
   type ParentLinkage,
   type CommandExecutionStreamOptions,
+  type DelegationOutcome,
+  type RunId,
 } from '@rundown-org/core';
 import { createCliRunbookActorService } from './actor-service-factory.js';
 import type { OutputEmitter } from '../services/output-emitter.js';
 import type { TransitionOrchestrationPolicy } from './transition-orchestrator.js';
 
+/** Inline flow-back propagation outcomes ({@link advanceParentForInlineChild}). */
+export type InlinePropagationResult = 'handled' | 'stopped' | 'blocked' | 'not-applicable';
+/** Delegation report-only propagation outcomes ({@link reportTerminalToDelegatingRun}). */
+export type DelegationPropagationResult = 'reported' | 'blocked' | 'not-applicable';
 /**
- * Result returned after attempting to propagate a terminal child run to its parent.
+ * Result returned after attempting to propagate a terminal child run to its
+ * parent — the union of the two disjoint linkage subsets (same five members as
+ * before, so flat `=== 'stopped'` / `=== 'blocked'` callers stay valid).
  */
-export type TerminalPropagationResult =
-  | 'reported'
-  | 'handled'
-  | 'stopped'
-  | 'blocked'
-  | 'not-applicable';
+export type TerminalPropagationResult = InlinePropagationResult | DelegationPropagationResult;
 
 /**
  * Extract the discriminated parent linkage from a child state.
@@ -84,7 +87,7 @@ export async function reportTerminalToDelegatingRun(
   result: 'pass' | 'fail' | undefined,
   cwd: string,
   output: OutputEmitter,
-): Promise<TerminalPropagationResult> {
+): Promise<DelegationPropagationResult> {
   const linkage = extractParentLinkage(childState);
   if (linkage?.kind !== 'delegation') return 'not-applicable';
 
@@ -159,7 +162,7 @@ export async function advanceParentForInlineChild(
   cwd: string,
   output: OutputEmitter,
   commandStreamOptions?: CommandExecutionStreamOptions,
-): Promise<TerminalPropagationResult> {
+): Promise<InlinePropagationResult> {
   const linkage = extractParentLinkage(childState);
   // This is the INLINE flow-back path only. Delegation linkage shares the same
   // base fields (parentRunId/parentFrameKey/parentEntry), so a delegation-linked
@@ -350,4 +353,107 @@ export async function propagateChildTerminal(
   return linkage.kind === 'inline'
     ? advanceParentForInlineChild(childState, result, cwd, output, commandStreamOptions)
     : reportTerminalToDelegatingRun(childState, result, cwd, output);
+}
+
+/**
+ * Whether the driving command authored an operator RESULT (`pass`/`fail`) or
+ * relies on lifecycle inference. Making this a required discriminated param —
+ * not a positional-optional `explicitResult` — encodes the operator-result vs
+ * loop-inferred contract in the type: a loop driver cannot accidentally author a
+ * result, and an operator-result command cannot forget to (SHOULD-FIX 5).
+ */
+export type PropagationTrigger =
+  | { readonly kind: 'operator-result'; readonly result: DelegationOutcome }
+  | { readonly kind: 'loop-inferred' };
+
+/**
+ * Outcome of {@link propagateDrivenRunTerminal}.
+ *
+ * `skipped` — the driven run was missing, non-terminal, or unlinked; the caller
+ * MUST leave its exit code untouched. `inline-advanced` / `delegation-reported`
+ * lift the linkage kind INTO the discriminant, so a caller branches on `kind`
+ * alone and its `result` is already the narrow subset that branch can produce —
+ * no `linkage:'delegation', result:'stopped'` dead pairs (SHOULD-FIX 4).
+ */
+export type DrivenRunPropagation =
+  | { readonly kind: 'skipped' }
+  | { readonly kind: 'inline-advanced'; readonly result: InlinePropagationResult }
+  | { readonly kind: 'delegation-reported'; readonly result: DelegationPropagationResult };
+
+/**
+ * Trigger parent propagation for a run this command just drove, if it reached
+ * terminal and carries a parent linkage.
+ *
+ * This is the SINGLE post-drive trigger every top-level driver uses (goto, run,
+ * claim, collect, pass/fail). It reloads the driven run, and — only when that
+ * run is terminal AND linked — dispatches on the linkage kind to
+ * {@link advanceParentForInlineChild} / {@link reportTerminalToDelegatingRun}
+ * directly (rather than through {@link propagateChildTerminal}) so each branch's
+ * `result` keeps its narrow subtype without a cast. Consolidating the
+ * reload-and-check here is what gives every driver, including `goto`,
+ * propagation by construction rather than by each command remembering to do it.
+ * {@link propagateChildTerminal} remains the single dispatcher for the
+ * non-migrated seams (`terminal-command`, `execution.ts`) and the internal
+ * inline recursion.
+ *
+ * The discriminated {@link DrivenRunPropagation} return is load-bearing: a bare
+ * `'not-applicable'` sentinel let each caller conflate "nothing to propagate,
+ * keep my exit code" with a real propagation outcome, and each hand-rolled its
+ * own terminal guard around the exit mapping. Returning `{ kind: 'skipped' }`
+ * forces every caller to narrow before touching the exit code, so the guard can
+ * no longer be dropped (Task 3, Correction 2).
+ *
+ * The `trigger`'s authored result (for `operator-result`) is forwarded into
+ * `projectDelegationTerminalOutcome`, which short-circuits on an explicit result
+ * and otherwise infers from lifecycle. Operator-result commands (`pass`/`fail`)
+ * MUST author their RESULT; loop-driven callers (goto/run/claim/collect) use
+ * `loop-inferred` and rely on lifecycle inference (Correction 1).
+ *
+ * The propagation EXECUTION stays CLI-side because advancing an inline parent
+ * runs the execution loop (spawns subprocesses — Category A); only this trigger
+ * predicate (terminal + linked) is pure.
+ *
+ * Do NOT call this from inside {@link advanceParentForInlineChild} or from
+ * `execution.ts`'s inline-launch propagation — those propagate a DIFFERENT run
+ * (the parent being advanced / a downward-launched child) and routing them here
+ * would double-propagate and break the single-level upward-report contract.
+ *
+ * @param manager - State manager bound to `cwd`.
+ * @param runId - The run this command just drove.
+ * @param cwd - Current working directory.
+ * @param output - Output emitter for CLI output.
+ * @param trigger - Operator-result (authored `pass`/`fail`) or loop-inferred.
+ * @param commandStreamOptions - Runtime-only routing for command subprocess I/O.
+ * @returns `{ kind: 'skipped' }` when the run is missing, non-terminal, or
+ *   unlinked; otherwise `inline-advanced` / `delegation-reported`.
+ * @throws {Error} If parent state I/O fails or drain execution fails.
+ */
+export async function propagateDrivenRunTerminal(
+  manager: RunbookStateManager,
+  runId: RunId,
+  cwd: string,
+  output: OutputEmitter,
+  trigger: PropagationTrigger,
+  commandStreamOptions?: CommandExecutionStreamOptions,
+): Promise<DrivenRunPropagation> {
+  const driven = await manager.load(runId);
+  if (!driven) return { kind: 'skipped' };
+  if (driven.lifecycle !== 'completed' && driven.lifecycle !== 'stopped') {
+    return { kind: 'skipped' };
+  }
+  const linkage = extractParentLinkage(driven);
+  if (!linkage) return { kind: 'skipped' };
+  const explicitResult = trigger.kind === 'operator-result' ? trigger.result : undefined;
+  if (linkage.kind === 'inline') {
+    const result = await advanceParentForInlineChild(
+      driven,
+      explicitResult,
+      cwd,
+      output,
+      commandStreamOptions,
+    );
+    return { kind: 'inline-advanced', result };
+  }
+  const result = await reportTerminalToDelegatingRun(driven, explicitResult, cwd, output);
+  return { kind: 'delegation-reported', result };
 }

--- a/packages/cli/src/helpers/delegation-completion.ts
+++ b/packages/cli/src/helpers/delegation-completion.ts
@@ -381,6 +381,56 @@ export type DrivenRunPropagation =
   | { readonly kind: 'delegation-reported'; readonly result: DelegationPropagationResult };
 
 /**
+ * Whether a propagation outcome must drive a non-zero process exit under the
+ * **any-linkage** rule: the driven run propagated to a parent (inline OR
+ * delegation) that stopped or blocked.
+ *
+ * This is the exit shape used by drivers that treat ANY non-skipped propagation
+ * as exit-worthy — `rundown goto` (via
+ * {@link gotoResultRequiresFailureExit}) and the `rundown run --step` inline
+ * launch. It fires on a `delegation-reported` `blocked` too; `run --step` only
+ * ever produces inline linkages so that arm is unreachable there, but `goto` can
+ * drive a delegation child, and preserving the any-linkage semantics keeps its
+ * pre-consolidation behaviour intact.
+ *
+ * Contrast {@link inlineAdvanceRequiresFailureExit}, the **inline-only** rule used
+ * by `collect` and `pass`/`fail`, where delegation reporting is report-only and
+ * never flips the exit code. Naming both shapes keeps the two exit semantics from
+ * silently drifting back into open-coded copies.
+ *
+ * @param propagation - Outcome of {@link propagateDrivenRunTerminal}.
+ * @returns `true` when the caller should exit non-zero.
+ */
+export function propagationRequiresFailureExit(propagation: DrivenRunPropagation): boolean {
+  return (
+    propagation.kind !== 'skipped' &&
+    (propagation.result === 'stopped' || propagation.result === 'blocked')
+  );
+}
+
+/**
+ * Whether a propagation outcome must drive a non-zero process exit under the
+ * **inline-only** rule: an inline child's drain-and-advance stopped or blocked the
+ * composing parent.
+ *
+ * Used by `rundown collect` and `rundown pass`/`fail`, whose exit contract flips
+ * only when advancing an INLINE parent reaches a STOP/blocked terminal. A
+ * `delegation-reported` outcome is report-only (the delegating run collects later)
+ * and never flips the exit here — so, unlike
+ * {@link propagationRequiresFailureExit}, this returns `false` for every
+ * non-`inline-advanced` kind.
+ *
+ * @param propagation - Outcome of {@link propagateDrivenRunTerminal}.
+ * @returns `true` when the caller should exit non-zero.
+ */
+export function inlineAdvanceRequiresFailureExit(propagation: DrivenRunPropagation): boolean {
+  return (
+    propagation.kind === 'inline-advanced' &&
+    (propagation.result === 'stopped' || propagation.result === 'blocked')
+  );
+}
+
+/**
  * Trigger parent propagation for a run this command just drove, if it reached
  * terminal and carries a parent linkage.
  *
@@ -417,6 +467,11 @@ export type DrivenRunPropagation =
  * `execution.ts`'s inline-launch propagation — those propagate a DIFFERENT run
  * (the parent being advanced / a downward-launched child) and routing them here
  * would double-propagate and break the single-level upward-report contract.
+ *
+ * The parameters stay positional (not an options bag) to match the sibling
+ * dispatchers {@link advanceParentForInlineChild} /
+ * {@link reportTerminalToDelegatingRun}; the distinct param types make a silent
+ * argument swap a type error, so the options-object indirection buys nothing here.
  *
  * @param manager - State manager bound to `cwd`.
  * @param runId - The run this command just drove.

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -71,6 +71,29 @@ export type GotoExecutionResult =
   | { ok: false; error: string; code: string };
 
 /**
+ * Whether a successful goto execution must drive a non-zero process exit: either
+ * the run itself stopped, or its terminal propagated to a parent with a
+ * stopped/blocked outcome.
+ *
+ * Shared by `rundown goto` and the `run --prompted --step` launch-local jump so
+ * their exit decisions cannot drift — a bare `loopResult === 'stopped'` check
+ * misses a propagation that stopped/blocked the parent (#553).
+ *
+ * @param result - A successful ({@link GotoExecutionResult} `ok: true`) result.
+ * @returns `true` when the caller should exit non-zero.
+ */
+export function gotoResultRequiresFailureExit(
+  result: Extract<GotoExecutionResult, { ok: true }>,
+): boolean {
+  return (
+    result.loopResult === 'stopped' ||
+    (result.propagation !== undefined &&
+      result.propagation.kind !== 'skipped' &&
+      (result.propagation.result === 'stopped' || result.propagation.result === 'blocked'))
+  );
+}
+
+/**
  * Result of resolving the runbook target and building goto execution context.
  *
  * The refusal members are exactly the core navigation seam's refusing

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -24,7 +24,11 @@ import {
   type CommandExecutionStreamOptions,
 } from '@rundown-org/core';
 import { runExecutionLoop, type ExecutionTerminalReleaseMode } from '../services/execution.js';
-import { propagateDrivenRunTerminal, type DrivenRunPropagation } from './delegation-completion.js';
+import {
+  propagateDrivenRunTerminal,
+  propagationRequiresFailureExit,
+  type DrivenRunPropagation,
+} from './delegation-completion.js';
 import { createCliRunbookActorService } from './actor-service-factory.js';
 import type { OutputEmitter } from '../services/output-emitter.js';
 import { createBridgedEmitter } from './execution-emitter.js';
@@ -87,9 +91,7 @@ export function gotoResultRequiresFailureExit(
 ): boolean {
   return (
     result.loopResult === 'stopped' ||
-    (result.propagation !== undefined &&
-      result.propagation.kind !== 'skipped' &&
-      (result.propagation.result === 'stopped' || result.propagation.result === 'blocked'))
+    (result.propagation !== undefined && propagationRequiresFailureExit(result.propagation))
   );
 }
 

--- a/packages/cli/src/helpers/goto-workflow.ts
+++ b/packages/cli/src/helpers/goto-workflow.ts
@@ -24,6 +24,7 @@ import {
   type CommandExecutionStreamOptions,
 } from '@rundown-org/core';
 import { runExecutionLoop, type ExecutionTerminalReleaseMode } from '../services/execution.js';
+import { propagateDrivenRunTerminal, type DrivenRunPropagation } from './delegation-completion.js';
 import { createCliRunbookActorService } from './actor-service-factory.js';
 import type { OutputEmitter } from '../services/output-emitter.js';
 import { createBridgedEmitter } from './execution-emitter.js';
@@ -66,7 +67,7 @@ export type GotoValidationResult =
  * Result of goto execution.
  */
 export type GotoExecutionResult =
-  | { ok: true; loopResult: 'done' | 'stopped' | 'waiting' }
+  | { ok: true; loopResult: 'done' | 'stopped' | 'waiting'; propagation?: DrivenRunPropagation }
   | { ok: false; error: string; code: string };
 
 /**
@@ -315,5 +316,19 @@ export async function executeGoto(ctx: GotoContext, target: StepId): Promise<Got
     },
   );
 
-  return { ok: true, loopResult };
+  // Any driver that takes a run terminal must propagate that terminal to its
+  // parent — goto included. goto authors no operator RESULT, so use the
+  // `loop-inferred` trigger and let lifecycle inference decide the outcome (same
+  // as the natural loop). Without this, `goto` completing an inline child left
+  // the parent's substep 'running' forever (#553).
+  const propagation = await propagateDrivenRunTerminal(
+    manager,
+    state.id,
+    cwd,
+    output,
+    { kind: 'loop-inferred' },
+    ctx.commandStreamOptions,
+  );
+
+  return { ok: true, loopResult, propagation };
 }

--- a/packages/cli/src/helpers/transition-command.ts
+++ b/packages/cli/src/helpers/transition-command.ts
@@ -10,7 +10,7 @@ import { withErrorHandling } from './wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { commandStreamOptionsForOutputMode } from '../services/execution.js';
 import { runSeamTransition, type TransitionConfig } from './transitions.js';
-import { extractParentLinkage, propagateChildTerminal } from './delegation-completion.js';
+import { propagateDrivenRunTerminal } from './delegation-completion.js';
 import { validateIndexRequiresStep } from './index-option.js';
 import { parseTransitionTarget, transitionTargetFields } from './transition-target.js';
 
@@ -152,26 +152,23 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
             // STOPped, governs). Re-pointed at the seam outcome's runId (reloaded
             // via the same manager) now that the resolve/drive lives in core.
             if (applied) {
-              const freshState = await manager.load(applied.runId);
-              const linkage = freshState ? extractParentLinkage(freshState) : undefined;
-              if (freshState && linkage) {
-                const isTerminal =
-                  freshState.lifecycle === 'completed' || freshState.lifecycle === 'stopped';
-                if (isTerminal) {
-                  const propagation = await propagateChildTerminal(
-                    freshState,
-                    def.name,
-                    cwd,
-                    output,
-                    commandStreamOptions,
-                  );
-                  if (linkage.kind === 'inline') {
-                    shouldExitWithError = propagation === 'stopped' || propagation === 'blocked';
-                  } else if (propagation === 'stopped') {
-                    shouldExitWithError = true;
-                  }
-                }
+              const propagation = await propagateDrivenRunTerminal(
+                manager,
+                applied.runId,
+                cwd,
+                output,
+                { kind: 'operator-result', result: def.name },
+                commandStreamOptions,
+              );
+              if (propagation.kind === 'inline-advanced') {
+                shouldExitWithError =
+                  propagation.result === 'stopped' || propagation.result === 'blocked';
               }
+              // `delegation-reported` never flips the exit code here: today's else-if
+              // tested `propagation === 'stopped'` (`:170`), which
+              // reportTerminalToDelegatingRun can NEVER return — a dead branch the
+              // discriminated type removes (SHOULD-FIX 4). The child's own lifecycle
+              // (captured in `shouldExitWithError` when it locally STOPped) governs.
             }
             if (shouldExitWithError) {
               process.exitCode = 1;

--- a/packages/cli/src/helpers/transition-command.ts
+++ b/packages/cli/src/helpers/transition-command.ts
@@ -10,7 +10,10 @@ import { withErrorHandling } from './wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
 import { commandStreamOptionsForOutputMode } from '../services/execution.js';
 import { runSeamTransition, type TransitionConfig } from './transitions.js';
-import { propagateDrivenRunTerminal } from './delegation-completion.js';
+import {
+  propagateDrivenRunTerminal,
+  inlineAdvanceRequiresFailureExit,
+} from './delegation-completion.js';
 import { validateIndexRequiresStep } from './index-option.js';
 import { parseTransitionTarget, transitionTargetFields } from './transition-target.js';
 
@@ -161,8 +164,7 @@ export function registerTransitionCommand(program: Command, def: TransitionComma
                 commandStreamOptions,
               );
               if (propagation.kind === 'inline-advanced') {
-                shouldExitWithError =
-                  propagation.result === 'stopped' || propagation.result === 'blocked';
+                shouldExitWithError = inlineAdvanceRequiresFailureExit(propagation);
               }
               // `delegation-reported` never flips the exit code here: today's else-if
               // tested `propagation === 'stopped'` (`:170`), which

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -982,6 +982,34 @@ describe('RunbookCollectionService', () => {
     });
   });
 
+  it('preserves the committed terminal result when the session release rejects (best-effort cleanup, RD-102)', async () => {
+    const ancestor = state({ id: ancestorRunId, resolvedCompletions: {} });
+    await manager.save(ancestor);
+    const { controlled } = await seedTerminalControlled('completed', 'pass', {
+      parentLinkage: delegationLinkage,
+    });
+    // The drain already persisted the terminal lifecycle before this release
+    // runs; releaseRunbook is idempotent and PID-stale-reclaimable, so a failed
+    // release only leaks a self-healing session-stack entry. It must never mask
+    // the committed collection_applied outcome.
+    releaseRunbookSpy.mockRejectedValueOnce(new Error('session lock contended'));
+
+    const outcome = await collectionService.collectDelegationOutcomes({
+      targetState: controlled,
+      steps: oneSubstepSteps,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
+      frame: activeFrame(buildFrameKey('1'), 1),
+    });
+
+    expect(releaseRunbookSpy).toHaveBeenCalledWith(controlledRunId, {
+      retainClaimsAsTerminal: true,
+    });
+    expect(outcome.kind).toBe('collection_applied');
+    if (outcome.kind !== 'collection_applied') throw new Error('expected collection_applied');
+    expect(outcome.lifecycle).toBe('completed');
+    expect(outcome.reportedTerminalOutcome).toBe(true);
+  });
+
   it('does NOT release the target when collection leaves it running', async () => {
     // Mirror "reports the active-run lifecycle from the drained state, not the
     // caller input" (:1504-1535): a 'continue' drain leaves the run running, so

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -15,8 +15,9 @@ import {
   assertRunId,
   type CallerEvidence,
   type RunbookState,
+  type RunId,
 } from '../../src/runbook/index.js';
-import type { CommandTargetReader } from '../../src/runbook/command-target-resolver.js';
+import type { CollectionSessionService } from '../../src/runbook/collection-service.js';
 import type { ExecutionObservationEffect } from '../../src/events/execution-observation.js';
 import { ExecutionLifecycleService } from '../../src/runbook/execution-lifecycle-service.js';
 import { brandCurrentCursorResolvedCompletionForTest } from '../../src/runbook/completion-service.js';
@@ -58,7 +59,7 @@ describe('RunbookCollectionService', () => {
   let actorService: RunbookActorService;
   let lifecycleService: ExecutionLifecycleService;
   let completionService: RunbookCompletionService;
-  let sessionService: CommandTargetReader;
+  let sessionService: CollectionSessionService;
   let collectionService: RunbookCollectionService;
 
   const runId = assertRunId('rd_11111111111111111111111111111111');
@@ -175,6 +176,12 @@ describe('RunbookCollectionService', () => {
       async listOpenClaimsForParent() {
         return [];
       },
+      releaseRunbook: jest.fn(async (runbookId: RunId) => ({
+        status: 'released' as const,
+        runbookId,
+        removedFromDefaultStack: true,
+        nextDefaultRunbookId: null,
+      })),
     };
     collectionService = new RunbookCollectionService({
       sessionService,
@@ -945,6 +952,50 @@ describe('RunbookCollectionService', () => {
     expect(freshAncestor?.step).toBe('1');
   });
 
+  it('releases the target run from session targeting when collection drives it terminal', async () => {
+    const ancestor = state({ id: ancestorRunId, resolvedCompletions: {} });
+    await manager.save(ancestor);
+    const { controlled } = await seedTerminalControlled('completed', 'pass', {
+      parentLinkage: delegationLinkage,
+    });
+
+    await collectionService.collectDelegationOutcomes({
+      targetState: controlled,
+      steps: oneSubstepSteps,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
+      frame: activeFrame(buildFrameKey('1'), 1),
+    });
+
+    expect(jest.mocked(sessionService.releaseRunbook)).toHaveBeenCalledWith(controlledRunId, {
+      retainClaimsAsTerminal: true,
+    });
+  });
+
+  it('does NOT release the target when collection leaves it running', async () => {
+    // Mirror "reports the active-run lifecycle from the drained state, not the
+    // caller input" (:1504-1535): a 'continue' drain leaves the run running, so
+    // the CLI execution loop — not the collection seam — owns release.
+    const frameKey = buildFrameKey('1');
+    const drainedState = state({ id: runId, lifecycle: 'running' });
+    jest.spyOn(completionService, 'drainResolvedCompletions').mockResolvedValue({
+      status: 'continue',
+      state: drainedState,
+      unresolved: 0,
+      applied: [appliedRecord(drainedState)],
+    });
+    const target = state({ lifecycle: 'completed' });
+    await manager.save(target);
+
+    await collectionService.collectDelegationOutcomes({
+      targetState: target,
+      steps,
+      callerEvidence: ORCHESTRATOR_EVIDENCE,
+      frame: activeFrame(frameKey, 1),
+    });
+
+    expect(jest.mocked(sessionService.releaseRunbook)).not.toHaveBeenCalled();
+  });
+
   it('renders a stopped terminal collection with lifecycle stopped (fail polarity)', async () => {
     const ancestor = state({ id: ancestorRunId, resolvedCompletions: {} });
     await manager.save(ancestor);
@@ -968,6 +1019,10 @@ describe('RunbookCollectionService', () => {
       lifecycle: 'stopped',
       reportedTerminalOutcome: true,
       transitionObservations: expect.any(Array),
+    });
+    // #556: a collect that drives the target STOPPED-terminal releases it too.
+    expect(jest.mocked(sessionService.releaseRunbook)).toHaveBeenCalledWith(controlledRunId, {
+      retainClaimsAsTerminal: true,
     });
   });
 

--- a/packages/core/__tests__/runbook/collection-service.test.ts
+++ b/packages/core/__tests__/runbook/collection-service.test.ts
@@ -16,6 +16,7 @@ import {
   type CallerEvidence,
   type RunbookState,
   type RunId,
+  type ReleaseRunbookResult,
 } from '../../src/runbook/index.js';
 import type { CollectionSessionService } from '../../src/runbook/collection-service.js';
 import type { ExecutionObservationEffect } from '../../src/events/execution-observation.js';
@@ -61,6 +62,15 @@ describe('RunbookCollectionService', () => {
   let completionService: RunbookCompletionService;
   let sessionService: CollectionSessionService;
   let collectionService: RunbookCollectionService;
+  // Held separately from the fake so assertions reference the spy directly —
+  // `sessionService.releaseRunbook` is a declared method, and passing that
+  // reference to `expect()` trips `@typescript-eslint/unbound-method`.
+  let releaseRunbookSpy: jest.Mock<
+    (
+      runbookId: RunId,
+      options?: { readonly retainClaimsAsTerminal?: boolean },
+    ) => Promise<ReleaseRunbookResult>
+  >;
 
   const runId = assertRunId('rd_11111111111111111111111111111111');
   const controlledRunId = assertRunId('rd_22222222222222222222222222222222');
@@ -139,6 +149,12 @@ describe('RunbookCollectionService', () => {
     actorService = new RunbookActorService(manager);
     lifecycleService = new ExecutionLifecycleService(manager);
     completionService = new RunbookCompletionService(manager, lifecycleService, actorService);
+    releaseRunbookSpy = jest.fn(async (runbookId: RunId) => ({
+      status: 'released' as const,
+      runbookId,
+      removedFromDefaultStack: true,
+      nextDefaultRunbookId: null,
+    }));
     sessionService = {
       async getActive() {
         return null;
@@ -176,12 +192,7 @@ describe('RunbookCollectionService', () => {
       async listOpenClaimsForParent() {
         return [];
       },
-      releaseRunbook: jest.fn(async (runbookId: RunId) => ({
-        status: 'released' as const,
-        runbookId,
-        removedFromDefaultStack: true,
-        nextDefaultRunbookId: null,
-      })),
+      releaseRunbook: releaseRunbookSpy,
     };
     collectionService = new RunbookCollectionService({
       sessionService,
@@ -966,7 +977,7 @@ describe('RunbookCollectionService', () => {
       frame: activeFrame(buildFrameKey('1'), 1),
     });
 
-    expect(jest.mocked(sessionService.releaseRunbook)).toHaveBeenCalledWith(controlledRunId, {
+    expect(releaseRunbookSpy).toHaveBeenCalledWith(controlledRunId, {
       retainClaimsAsTerminal: true,
     });
   });
@@ -993,7 +1004,7 @@ describe('RunbookCollectionService', () => {
       frame: activeFrame(frameKey, 1),
     });
 
-    expect(jest.mocked(sessionService.releaseRunbook)).not.toHaveBeenCalled();
+    expect(releaseRunbookSpy).not.toHaveBeenCalled();
   });
 
   it('renders a stopped terminal collection with lifecycle stopped (fail polarity)', async () => {
@@ -1021,7 +1032,7 @@ describe('RunbookCollectionService', () => {
       transitionObservations: expect.any(Array),
     });
     // #556: a collect that drives the target STOPPED-terminal releases it too.
-    expect(jest.mocked(sessionService.releaseRunbook)).toHaveBeenCalledWith(controlledRunId, {
+    expect(releaseRunbookSpy).toHaveBeenCalledWith(controlledRunId, {
       retainClaimsAsTerminal: true,
     });
   });

--- a/packages/core/src/runbook/collection-service.ts
+++ b/packages/core/src/runbook/collection-service.ts
@@ -38,8 +38,10 @@ export interface CollectionSessionService extends CommandTargetReader {
    * Release a run from all session targeting structures on terminal.
    *
    * @param runbookId - Terminal run id to release.
-   * @param options - Release options; `retainClaimsAsTerminal` keeps claim
-   *   tombstones so `--claim-id` confirm/conflict still resolves `terminal`.
+   * @param options - Release options.
+   * @param options.retainClaimsAsTerminal - Keep claim tombstones so a later
+   *   `--claim-id` confirm/conflict still resolves `terminal` rather than
+   *   `missing`.
    * @returns Structured release result (not consumed by the collection seam).
    */
   releaseRunbook(

--- a/packages/core/src/runbook/collection-service.ts
+++ b/packages/core/src/runbook/collection-service.ts
@@ -499,9 +499,18 @@ async function applyCollection(
     // one transaction; safe because releaseRunbook is idempotent and
     // PID-stale-reclaimable. `retainClaimsAsTerminal: true` keeps claim tombstones so
     // a later `--claim-id` confirm/conflict still resolves `terminal`.
-    await input.sessionService.releaseRunbook(input.targetState.id, {
-      retainClaimsAsTerminal: true,
-    });
+    //
+    // Best-effort: the terminal lifecycle is already committed above, and a failed
+    // release only leaks a self-healing session-stack entry (reclaimed by the next
+    // acquirer via PID-aware stale detection). Swallow its rejection rather than let
+    // cleanup mask the committed collection_applied outcome (RD-102).
+    try {
+      await input.sessionService.releaseRunbook(input.targetState.id, {
+        retainClaimsAsTerminal: true,
+      });
+    } catch {
+      // Intentionally ignored — see best-effort note above.
+    }
     return {
       kind: 'collection_applied',
       targetRunId: input.targetState.id,

--- a/packages/core/src/runbook/collection-service.ts
+++ b/packages/core/src/runbook/collection-service.ts
@@ -23,7 +23,8 @@ import {
   SENTINEL_ENTRY,
 } from './targeting.js';
 import { countNumberedSteps } from './step-utils.js';
-import type { ResolvedStep, RunbookState } from './types.js';
+import type { ReleaseRunbookResult } from './session-service.js';
+import type { ResolvedStep, RunbookState, RunId } from './types.js';
 import type { DelegateFrontierEntry } from '../events/types.js';
 import type { ExecutionObservationEffect } from '../events/execution-observation.js';
 import {
@@ -31,10 +32,26 @@ import {
   type TransitionObservationEvent,
 } from '../events/transition-observation.js';
 
+/** Session reader plus the single write used by terminal release. */
+export interface CollectionSessionService extends CommandTargetReader {
+  /**
+   * Release a run from all session targeting structures on terminal.
+   *
+   * @param runbookId - Terminal run id to release.
+   * @param options - Release options; `retainClaimsAsTerminal` keeps claim
+   *   tombstones so `--claim-id` confirm/conflict still resolves `terminal`.
+   * @returns Structured release result (not consumed by the collection seam).
+   */
+  releaseRunbook(
+    runbookId: RunId,
+    options?: { readonly retainClaimsAsTerminal?: boolean },
+  ): Promise<ReleaseRunbookResult>;
+}
+
 /** Dependencies used by the core collection operation. */
 export interface RunbookCollectionServiceDependencies {
   /** Session/target reader used to verify bearer claims and resolve implicit authority. */
-  readonly sessionService: CommandTargetReader;
+  readonly sessionService: CollectionSessionService;
   /** State manager used to reload and persist target runs. */
   readonly manager: RunbookStateManager;
   /** Actor service used to apply collected delegation outcomes through the state machine. */
@@ -472,6 +489,17 @@ async function applyCollection(
       drained.applied.at(-1)?.stateAfter ??
       input.targetState;
     // Stryker restore OptionalChaining,UnaryOperator
+    // Terminal release lives in the seam, not in whichever CLI path drives the
+    // collect: the drain above persisted the terminal lifecycle, and this release
+    // removes the run from session targeting in the same seam call — so a collect
+    // that reaches terminal (and skips the CLI execution loop) does not leave the
+    // completed run on the session default stack (#556). Two sequential awaits, not
+    // one transaction; safe because releaseRunbook is idempotent and
+    // PID-stale-reclaimable. `retainClaimsAsTerminal: true` keeps claim tombstones so
+    // a later `--claim-id` confirm/conflict still resolves `terminal`.
+    await input.sessionService.releaseRunbook(input.targetState.id, {
+      retainClaimsAsTerminal: true,
+    });
     return {
       kind: 'collection_applied',
       targetRunId: input.targetState.id,

--- a/runbooks/composition/inline-child-goto-stop.runbook.md
+++ b/runbooks/composition/inline-child-goto-stop.runbook.md
@@ -1,0 +1,34 @@
+---
+name: inline-child-goto-stop
+description: Child that waits at a content step, then a goto-driven Finish command fails and STOPs (inline composition target for goto propagation)
+tags:
+  - composition
+
+scenarios:
+  goto-to-stop:
+    description: Child auto-waits at the content-only step 1; goto jumps to the Finish command which auto-executes, fails, and STOPs the child
+    commands:
+      - rd run inline-child-goto-stop.runbook.md
+      - rd goto 2
+    result: STOP
+---
+
+# Inline Child (Goto Stop)
+
+Child runbook used as an inline composition target for goto-driven failure
+propagation. Its first step is content-only, so the run loop waits there until a
+`goto` jumps to the Finish command, which fails and STOPs.
+
+## 1. Start
+
+- PASS CONTINUE
+
+Waiting for a goto to the Finish step.
+
+## 2. Finish
+
+- FAIL STOP
+
+```bash
+rd echo --result fail "child finish failed"
+```

--- a/runbooks/composition/inline-child-manual.runbook.md
+++ b/runbooks/composition/inline-child-manual.runbook.md
@@ -1,0 +1,27 @@
+---
+name: inline-child-manual
+description: Child with a single manual step that waits for the operator (inline composition target for operator-driven propagation)
+tags:
+  - composition
+
+scenarios:
+  manual-fail:
+    description: Child waits for the operator; fail STOPs it
+    commands:
+      - rd run --prompted inline-child-manual.runbook.md
+      - rd fail
+    result: STOP
+---
+
+# Inline Child (Manual)
+
+Child runbook used as an inline composition target for operator-driven failure
+propagation. Its single step carries no command, so the run loop waits for the
+operator to `rd pass` / `rd fail`.
+
+## 1. Check
+
+- PASS COMPLETE
+- FAIL STOP
+
+Check manually.

--- a/runbooks/composition/inline-composition-stop.runbook.md
+++ b/runbooks/composition/inline-composition-stop.runbook.md
@@ -1,0 +1,54 @@
+---
+name: inline-composition-stop
+description: Parent whose single inline substep aggregates FAIL ANY STOP, so an inline child's failure propagates a parent STOP during the driver's own pass
+tags:
+  - composition
+  - inline
+
+scenarios:
+  run-drives-inline-stop:
+    description: rd run --step drives an auto-failing inline child; advancing the single-substep parent aggregates FAIL ANY STOP and the parent stops during the run's propagation (no follow-up pass needed)
+    commands:
+      - rd run --prompted inline-composition-stop.runbook.md
+      - rd run inline-child-fail.runbook.md --step 1.1
+    result: STOP
+
+  goto-drives-inline-stop:
+    description: goto drives a waiting inline child to a FAIL STOP terminal; advancing the parent aggregates FAIL ANY STOP and the parent stops
+    commands:
+      - rd run --prompted inline-composition-stop.runbook.md
+      - rd run inline-child-goto-stop.runbook.md --step 1.1
+      - rd goto 2 --claim-id ${RUN_CLAIM_ID_2}
+    result: STOP
+
+  fail-drives-inline-stop:
+    description: An operator fail on a waiting inline child stops it; advancing the parent aggregates FAIL ANY STOP and the parent stops
+    commands:
+      - rd run --prompted inline-composition-stop.runbook.md
+      - rd run inline-child-manual.runbook.md --step 1.1
+      - rd fail --claim-id ${RUN_CLAIM_ID_2}
+    result: STOP
+---
+
+# Inline Composition (Stop)
+
+Exercises inline child execution where the composing parent has a **single**
+inline substep under `FAIL ANY STOP`. Because the substep is the only one in the
+step, resolving it `fail` aggregates immediately — the parent reaches a STOP
+terminal *during* the driving command's propagation pass (`rd run --step`,
+`rd goto`, or `rd fail`), rather than on a later aggregation `rd pass`.
+
+## 1. Review
+
+- PASS ALL CONTINUE
+- FAIL ANY STOP
+
+### 1.1 Inline gate
+
+Run the inline gate.
+
+## 2. Done
+
+- PASS COMPLETE
+
+All reviews complete.


### PR DESCRIPTION
## R5 Inline Lifecycle Hygiene (#556, #553, #521)

Routes inline-child terminal release and parent propagation through single seams so any driver (including `goto`) leaves inline lifecycle state consistent.

Two independent defects, one architectural root: parent propagation and terminal release lived in whichever CLI path happened to be driving, not in the lifecycle seam.

### #556 — collect-driven terminal release (core)
The collection seam now releases the target run from session targeting in the same seam call that marks it terminal (`RunbookCollectionService`'s terminal branch), so a collect that reaches terminal — and skips the CLI execution loop — no longer leaves the completed run on the session default stack. Release is unconditional on terminal and passes `retainClaimsAsTerminal: true` so `--claim-id` confirm/conflict still resolves `terminal`. The read-only session dep is widened to a write-capable `CollectionSessionService` (adds `releaseRunbook`); no release-policy type is introduced.

### #553 — `goto` inline propagation (cli)
A `goto` that drives an inline child to terminal now advances the parent substep, matching the natural execution-loop path. Introduces one shared trigger `propagateDrivenRunTerminal` in `delegation-completion.ts`:
- `goto` wires through it (new behaviour) — a navigation command carries no operator RESULT, so it uses the `loop-inferred` trigger and relies on lifecycle inference (`FAIL COMPLETE` → child `completed` → parent `pass`).
- The result is a discriminated `DrivenRunPropagation` (`skipped` | `inline-advanced` | `delegation-reported`); the two leaf functions' return types are narrowed to their verified disjoint subsets so the helper builds it without a cast.
- A required discriminated `PropagationTrigger` (`operator-result` | `loop-inferred`) encodes the operator-result-vs-inference contract in the type instead of prose.

### DRY cleanup (cli)
The four other duplicated driver sites (`run`, `claim`, `collect`, `pass`/`fail` via `transition-command`) are migrated onto the shared trigger. Behaviour-preserving; `transition-command` is the only migrated driver that authors an operator RESULT (`def.name`). `finalizeAppliedClaimTerminal` and `execution.ts`'s inline-launch propagation are deliberately NOT migrated (documented risk: render-before-propagate ordering / downward propagation).

### #521
Closed as a duplicate of #556 — the persisted lifecycle was never stale (`completed` on disk); the `status: active` reading is a `getStatus` stack-membership rendering artifact that the #556 release fixes. **Issue admin (comment + close) is intentionally deferred until this merges** and not performed by this PR.

## Testing
- New core unit tests pin three polarities (completed→release, stopped→release, running→no-release); the release branch is confirmed killed by targeted mutation.
- New `goto` integration test reproduces #553 and pins the lifecycle-inference contract.
- New unit tests for `propagateDrivenRunTerminal` (skipped / inline / operator-result).
- `pnpm run verify` green; touched integration + scenario-snapshot suites green with no snapshot churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal-outcome propagation across `run --step`, `goto`, `claim`, `collect`, and operator-driven transitions, including inline-advanced and delegation-reported cases.
  * Non-zero exit behavior is now triggered more accurately when propagated outcomes require failure (e.g., stopped/blocked/inline-advanced).
  * Collection now performs a best-effort terminal release while ensuring the collection result isn’t masked by release failures.
* **Documentation**
  * Added new inline composition/stop and inline child runbooks, and published an issue-fix plan for delegation claim anchoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->