### PR TITLE
fix(ci): two independent main CI failures — release artifact + lock-race flake

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,21 @@
+name: "CodeQL config"
+
+# Query suite for analysis. Kept here (rather than inline in the workflow) so the
+# suite and the path scoping live in one place.
+queries:
+  - uses: security-extended
+
+# Exclude only the fixtures that deliberately stage the patterns they guard
+# against. The reclaim-identity-guard tests open a lock then rm+recreate it at the
+# same path to prove the guard survives a concurrent swap, which trips
+# js/file-system-race (TOCTOU) — the race is the behaviour under test, not a
+# vulnerability. Those tests are isolated in a single file so the exclusion
+# surface is one file; the rest of the suite, and all production code (including
+# the lock implementation itself), keep full security-extended coverage.
+#
+# paths-ignore is fully honoured for JavaScript/TypeScript (extraction is
+# filesystem-based); it is the canonical mechanism for scoping analysis away from
+# specific files. Keep this list minimal — add a path only when a fixture cannot
+# express its scenario without tripping a security query.
+paths-ignore:
+  - 'packages/core/__tests__/runbook/file-lock-reclaim-identity-guard.test.ts'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
         uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4
         with:
           languages: javascript-typescript
-          queries: security-extended
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4

--- a/packages/core/__tests__/build/build-native-from-artifacts.test.ts
+++ b/packages/core/__tests__/build/build-native-from-artifacts.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, afterEach } from '@jest/globals';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  existsSync,
+} from 'node:fs';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -9,7 +17,6 @@ import { join } from 'node:path';
 const SCRIPT = fileURLToPath(new URL('../../../../scripts/build-native.mjs', import.meta.url));
 const REPO_ROOT = fileURLToPath(new URL('../../../../', import.meta.url));
 const CARGO_LOCK = join(REPO_ROOT, 'native', 'rd-landlock', 'Cargo.lock');
-const DIST_NATIVE = join(REPO_ROOT, 'packages', 'core', 'dist', 'native');
 
 const TARGETS = [
   { out: 'linux-x64', triple: 'x86_64-unknown-linux-musl' },
@@ -57,33 +64,48 @@ function writeManifest(root: string, manifest: Manifest): void {
   writeFileSync(join(root, 'manifest.json'), JSON.stringify(manifest, null, 2));
 }
 
-function runFromArtifacts(root: string, commit: string) {
-  return spawnSync(process.execPath, [SCRIPT, '--from-artifacts', root], {
-    env: { ...process.env, RD_RELEASE_COMMIT: commit },
+// Scratch destinations handed to build-native.mjs via RD_NATIVE_DEST, cleaned
+// up after each test. The script's default destination is the REAL
+// packages/core/dist/native; the release job builds those binaries BEFORE it
+// runs this suite, so a test writing to (or, worse, deleting) the default path
+// would destroy the artifact the later upload step packages. Redirecting every
+// run to a temp dir keeps this suite from touching the real build output.
+const scratchDestinations: string[] = [];
+
+function runFromArtifacts(
+  root: string,
+  commit: string,
+): { result: ReturnType<typeof spawnSync>; dest: string } {
+  const dest = mkdtempSync(join(tmpdir(), 'rd-native-dest-'));
+  scratchDestinations.push(dest);
+  const result = spawnSync(process.execPath, [SCRIPT, '--from-artifacts', root], {
+    env: { ...process.env, RD_RELEASE_COMMIT: commit, RD_NATIVE_DEST: dest },
     encoding: 'utf8',
   });
+  return { result, dest };
 }
 
 describe('build-native.mjs --from-artifacts', () => {
   afterEach(() => {
-    // The happy-path case copies into the real packages/core/dist/native — make
-    // sure no test leaves that side effect behind (it doesn't exist pre-build).
-    if (existsSync(DIST_NATIVE)) rmSync(DIST_NATIVE, { recursive: true, force: true });
+    while (scratchDestinations.length > 0) {
+      const dest = scratchDestinations.pop();
+      if (dest) rmSync(dest, { recursive: true, force: true });
+    }
   });
 
   it('exits 0 and copies both targets for a well-formed artifact set', () => {
     const root = buildArtifactRoot(COMMIT);
-    const result = runFromArtifacts(root, COMMIT);
+    const { result, dest } = runFromArtifacts(root, COMMIT);
     expect(result.status).toBe(0);
     for (const t of TARGETS) {
-      expect(existsSync(join(DIST_NATIVE, t.out, 'rd-landlock'))).toBe(true);
+      expect(existsSync(join(dest, t.out, 'rd-landlock'))).toBe(true);
     }
   });
 
   it('rejects when the provenance manifest is missing', () => {
     const root = buildArtifactRoot(COMMIT);
     rmSync(join(root, 'manifest.json'));
-    const result = runFromArtifacts(root, COMMIT);
+    const { result } = runFromArtifacts(root, COMMIT);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('provenance manifest missing');
   });
@@ -91,7 +113,7 @@ describe('build-native.mjs --from-artifacts', () => {
   it('rejects when RD_RELEASE_COMMIT does not match manifest.commit', () => {
     const root = buildArtifactRoot(COMMIT);
     const otherCommit = 'b'.repeat(40);
-    const result = runFromArtifacts(root, otherCommit);
+    const { result } = runFromArtifacts(root, otherCommit);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain(`manifest commit ${COMMIT} != release commit ${otherCommit}`);
   });
@@ -101,7 +123,7 @@ describe('build-native.mjs --from-artifacts', () => {
     const manifest = readManifest(root);
     manifest.cargoLockSha256 = 'f'.repeat(64);
     writeManifest(root, manifest);
-    const result = runFromArtifacts(root, COMMIT);
+    const { result } = runFromArtifacts(root, COMMIT);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('manifest cargoLockSha256 ffff');
     expect(result.stderr).toContain('!= checkout Cargo.lock');
@@ -112,7 +134,7 @@ describe('build-native.mjs --from-artifacts', () => {
     const manifest = readManifest(root);
     manifest.binaries['linux-x64'].sha256 = 'f'.repeat(64);
     writeManifest(root, manifest);
-    const result = runFromArtifacts(root, COMMIT);
+    const { result } = runFromArtifacts(root, COMMIT);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('linux-x64: sha256');
     expect(result.stderr).toContain('!= manifest ffff');
@@ -123,7 +145,7 @@ describe('build-native.mjs --from-artifacts', () => {
     const manifest = readManifest(root);
     manifest.binaries['linux-x64'].triple = 'x86_64-unknown-linux-gnu';
     writeManifest(root, manifest);
-    const result = runFromArtifacts(root, COMMIT);
+    const { result } = runFromArtifacts(root, COMMIT);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain(
       'linux-x64: triple x86_64-unknown-linux-gnu != x86_64-unknown-linux-musl',
@@ -133,7 +155,7 @@ describe('build-native.mjs --from-artifacts', () => {
   it('rejects when a target binary is missing from the artifact root', () => {
     const root = buildArtifactRoot(COMMIT);
     rmSync(join(root, 'linux-x64', 'rd-landlock'));
-    const result = runFromArtifacts(root, COMMIT);
+    const { result } = runFromArtifacts(root, COMMIT);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain(`artifact missing: ${join(root, 'linux-x64', 'rd-landlock')}`);
   });
@@ -143,8 +165,27 @@ describe('build-native.mjs --from-artifacts', () => {
     const manifest = readManifest(root);
     delete manifest.binaries['linux-x64'];
     writeManifest(root, manifest);
-    const result = runFromArtifacts(root, COMMIT);
+    const { result } = runFromArtifacts(root, COMMIT);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('manifest has no entry for linux-x64');
+  });
+
+  // Release-safety regression: with RD_NATIVE_DEST set, a successful verify+copy
+  // must leave the real packages/core/dist/native untouched. The release job
+  // builds those binaries BEFORE running the test suite, so a test that wrote to
+  // or deleted the default path destroyed the artifact the upload step needed,
+  // failing every release run (the `rd-landlock-binaries` artifact went missing).
+  it('leaves the real packages/core/dist/native untouched', () => {
+    const REAL_DIST_NATIVE = join(REPO_ROOT, 'packages', 'core', 'dist', 'native');
+    const snapshot = (): string | null =>
+      existsSync(REAL_DIST_NATIVE)
+        ? JSON.stringify(readdirSync(REAL_DIST_NATIVE, { recursive: true }).sort())
+        : null;
+
+    const before = snapshot();
+    const root = buildArtifactRoot(COMMIT);
+    const { result } = runFromArtifacts(root, COMMIT);
+    expect(result.status).toBe(0);
+    expect(snapshot()).toEqual(before);
   });
 });

--- a/packages/core/__tests__/build/build-native-from-artifacts.test.ts
+++ b/packages/core/__tests__/build/build-native-from-artifacts.test.ts
@@ -7,13 +7,13 @@ import {
   writeFileSync,
   readFileSync,
   readdirSync,
-  statSync,
   rmSync,
   existsSync,
 } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { isNodeError } from '../../src/errors.js';
 
 const SCRIPT = fileURLToPath(new URL('../../../../scripts/build-native.mjs', import.meta.url));
 const REPO_ROOT = fileURLToPath(new URL('../../../../', import.meta.url));
@@ -180,18 +180,29 @@ describe('build-native.mjs --from-artifacts', () => {
     const REAL_DIST_NATIVE = join(REPO_ROOT, 'packages', 'core', 'dist', 'native');
     // Snapshot each entry's path AND file content hash so an in-place overwrite
     // of manifest.json or a binary (same filename, different bytes) is detected,
-    // not just additions/deletions. Directories are marked without a hash.
-    // Returns null when the directory is absent (the common dev/CI state), so
-    // before === after === null still passes.
+    // not just additions/deletions. Returns null when the directory is absent
+    // (the common dev/CI state), so before === after === null still passes.
+    //
+    // Every filesystem access is attempt-then-handle (no exists/stat "check"
+    // before the read) so there is no check-then-use TOCTOU window: a missing
+    // directory or a directory entry both surface as caught errno codes.
     const snapshot = (): string | null => {
-      if (!existsSync(REAL_DIST_NATIVE)) return null;
-      const entries = readdirSync(REAL_DIST_NATIVE, { recursive: true })
-        .map(String)
-        .sort()
-        .map((rel) => {
-          const abs = join(REAL_DIST_NATIVE, rel);
-          return statSync(abs).isDirectory() ? [rel, 'dir'] : [rel, sha256(readFileSync(abs))];
-        });
+      let names: string[];
+      try {
+        names = readdirSync(REAL_DIST_NATIVE, { recursive: true }).map(String).sort();
+      } catch (err) {
+        if (isNodeError(err) && err.code === 'ENOENT') return null;
+        throw err;
+      }
+      const entries = names.map((rel) => {
+        const abs = join(REAL_DIST_NATIVE, rel);
+        try {
+          return [rel, sha256(readFileSync(abs))];
+        } catch (err) {
+          if (isNodeError(err) && err.code === 'EISDIR') return [rel, 'dir'];
+          throw err;
+        }
+      });
       return JSON.stringify(entries);
     };
 

--- a/packages/core/__tests__/build/build-native-from-artifacts.test.ts
+++ b/packages/core/__tests__/build/build-native-from-artifacts.test.ts
@@ -7,6 +7,7 @@ import {
   writeFileSync,
   readFileSync,
   readdirSync,
+  statSync,
   rmSync,
   existsSync,
 } from 'node:fs';
@@ -177,10 +178,22 @@ describe('build-native.mjs --from-artifacts', () => {
   // failing every release run (the `rd-landlock-binaries` artifact went missing).
   it('leaves the real packages/core/dist/native untouched', () => {
     const REAL_DIST_NATIVE = join(REPO_ROOT, 'packages', 'core', 'dist', 'native');
-    const snapshot = (): string | null =>
-      existsSync(REAL_DIST_NATIVE)
-        ? JSON.stringify(readdirSync(REAL_DIST_NATIVE, { recursive: true }).sort())
-        : null;
+    // Snapshot each entry's path AND file content hash so an in-place overwrite
+    // of manifest.json or a binary (same filename, different bytes) is detected,
+    // not just additions/deletions. Directories are marked without a hash.
+    // Returns null when the directory is absent (the common dev/CI state), so
+    // before === after === null still passes.
+    const snapshot = (): string | null => {
+      if (!existsSync(REAL_DIST_NATIVE)) return null;
+      const entries = readdirSync(REAL_DIST_NATIVE, { recursive: true })
+        .map(String)
+        .sort()
+        .map((rel) => {
+          const abs = join(REAL_DIST_NATIVE, rel);
+          return statSync(abs).isDirectory() ? [rel, 'dir'] : [rel, sha256(readFileSync(abs))];
+        });
+      return JSON.stringify(entries);
+    };
 
     const before = snapshot();
     const root = buildArtifactRoot(COMMIT);

--- a/packages/core/__tests__/runbook/file-lock-reclaim-identity-guard.test.ts
+++ b/packages/core/__tests__/runbook/file-lock-reclaim-identity-guard.test.ts
@@ -1,0 +1,98 @@
+// packages/core/__tests__/runbook/file-lock-reclaim-identity-guard.test.ts
+//
+// Split out from file-lock.test.ts so it can be the SOLE file excluded from
+// CodeQL analysis (see .github/codeql/codeql-config.yml). Every test here
+// deliberately stages a controlled, single-threaded open→rm→recreate race at the
+// same lock path to prove the identity guard survives a concurrent lock swap.
+// That check→use sequence is the behaviour under test, but CodeQL's
+// security-extended js/file-system-race (TOCTOU) query cannot tell an
+// intentional test fixture from a real vulnerability and flags every pair. Rather
+// than excluding all test code, we isolate exactly these fixtures here and
+// paths-ignore this one file; the rest of the lock suite stays fully scanned.
+
+import * as fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { unlinkStaleByIdentity, unlinkStaleByIdentitySync } from '../../src/runbook/file-lock.js';
+
+describe('file-lock', () => {
+  let tmpDir: string;
+  let lockDir: string;
+  let lockFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'rundown-lock-test-'));
+    lockDir = path.join(tmpDir, 'locks');
+    lockFile = path.join(lockDir, 'test.lock');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // The reclaim delete is guarded by dev/ino identity, compared against the
+  // STILL-OPEN handle the lock was read through. Holding that handle pins the
+  // observed inode, so a lock re-created at the same path during the
+  // read→delete window cannot reuse the inode number and slip past the guard
+  // (the concurrent-reclaimer TOCTOU). These pin that guard directly; passing
+  // the open handle is also what makes the replacement's inode deterministically
+  // distinct on inode-reusing filesystems (ext4 on CI).
+  describe('reclaim identity guard', () => {
+    it('async: removes the lock when the handle still matches the path', async () => {
+      await fs.mkdir(lockDir, { recursive: true });
+      await fs.writeFile(lockFile, 'stale', 'utf8');
+      const handle = await fs.open(lockFile, 'r');
+      try {
+        expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(true);
+      } finally {
+        await handle.close();
+      }
+      await expect(fs.readFile(lockFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('async: leaves the lock intact when it was replaced under the path', async () => {
+      await fs.mkdir(lockDir, { recursive: true });
+      await fs.writeFile(lockFile, 'stale', 'utf8');
+      // Read the stale lock through a handle and keep it open — pins the
+      // observed inode so the replacement below gets a distinct one.
+      const handle = await fs.open(lockFile, 'r');
+      try {
+        // Another process reclaims + re-acquires: same path, new (live) inode.
+        await fs.rm(lockFile);
+        await fs.writeFile(lockFile, 'live-replacement', 'utf8');
+        expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(false);
+        // The live replacement must survive untouched.
+        expect(await fs.readFile(lockFile, 'utf8')).toBe('live-replacement');
+      } finally {
+        await handle.close();
+      }
+    });
+
+    it('async: treats an already-vanished lock as reclaimed', async () => {
+      await fs.mkdir(lockDir, { recursive: true });
+      await fs.writeFile(lockFile, 'stale', 'utf8');
+      const handle = await fs.open(lockFile, 'r');
+      try {
+        await fs.rm(lockFile);
+        expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(true);
+      } finally {
+        await handle.close();
+      }
+    });
+
+    it('sync: leaves the lock intact when it was replaced under the path', () => {
+      fsSync.mkdirSync(lockDir, { recursive: true });
+      fsSync.writeFileSync(lockFile, 'stale', 'utf8');
+      const fd = fsSync.openSync(lockFile, 'r');
+      try {
+        fsSync.rmSync(lockFile);
+        fsSync.writeFileSync(lockFile, 'live-replacement', 'utf8');
+        expect(unlinkStaleByIdentitySync(fd, lockFile)).toBe(false);
+        expect(fsSync.readFileSync(lockFile, 'utf8')).toBe('live-replacement');
+      } finally {
+        fsSync.closeSync(fd);
+      }
+    });
+  });
+});

--- a/packages/core/__tests__/runbook/file-lock.test.ts
+++ b/packages/core/__tests__/runbook/file-lock.test.ts
@@ -228,55 +228,68 @@ describe('file-lock', () => {
     });
   });
 
-  // The reclaim delete is guarded by dev/ino identity so a reclaimer never
-  // evicts a lock another process re-created in the read→delete window (the
-  // concurrent-reclaimer TOCTOU). These pin that guard directly.
+  // The reclaim delete is guarded by dev/ino identity, compared against the
+  // STILL-OPEN handle the lock was read through. Holding that handle pins the
+  // observed inode, so a lock re-created at the same path during the
+  // read→delete window cannot reuse the inode number and slip past the guard
+  // (the concurrent-reclaimer TOCTOU). These pin that guard directly; passing
+  // the open handle is also what makes the replacement's inode deterministically
+  // distinct on inode-reusing filesystems (ext4 on CI).
   describe('reclaim identity guard', () => {
-    it('async: removes the lock when the inode still matches the observed one', async () => {
+    it('async: removes the lock when the handle still matches the path', async () => {
       await fs.mkdir(lockDir, { recursive: true });
       await fs.writeFile(lockFile, 'stale', 'utf8');
-      const observed = await fs.stat(lockFile);
-
-      expect(await unlinkStaleByIdentity(lockFile, observed)).toBe(true);
-      await expect(fs.stat(lockFile)).rejects.toMatchObject({ code: 'ENOENT' });
+      const handle = await fs.open(lockFile, 'r');
+      try {
+        expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(true);
+      } finally {
+        await handle.close();
+      }
+      await expect(fs.readFile(lockFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     });
 
-    it('async: leaves the lock intact when it was replaced by a different inode', async () => {
+    it('async: leaves the lock intact when it was replaced under the path', async () => {
       await fs.mkdir(lockDir, { recursive: true });
       await fs.writeFile(lockFile, 'stale', 'utf8');
-      const observed = await fs.stat(lockFile);
-
-      // Simulate another process reclaiming + re-acquiring: same path, new inode.
-      await fs.unlink(lockFile);
-      await fs.writeFile(lockFile, 'live-replacement', 'utf8');
-      const replacement = await fs.stat(lockFile);
-      expect(replacement.ino).not.toBe(observed.ino);
-
-      expect(await unlinkStaleByIdentity(lockFile, observed)).toBe(false);
-      // The live replacement must survive untouched.
-      expect(await fs.readFile(lockFile, 'utf8')).toBe('live-replacement');
+      // Read the stale lock through a handle and keep it open — pins the
+      // observed inode so the replacement below gets a distinct one.
+      const handle = await fs.open(lockFile, 'r');
+      try {
+        // Another process reclaims + re-acquires: same path, new (live) inode.
+        await fs.rm(lockFile);
+        await fs.writeFile(lockFile, 'live-replacement', 'utf8');
+        expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(false);
+        // The live replacement must survive untouched.
+        expect(await fs.readFile(lockFile, 'utf8')).toBe('live-replacement');
+      } finally {
+        await handle.close();
+      }
     });
 
     it('async: treats an already-vanished lock as reclaimed', async () => {
       await fs.mkdir(lockDir, { recursive: true });
       await fs.writeFile(lockFile, 'stale', 'utf8');
-      const observed = await fs.stat(lockFile);
-      await fs.unlink(lockFile);
-
-      expect(await unlinkStaleByIdentity(lockFile, observed)).toBe(true);
+      const handle = await fs.open(lockFile, 'r');
+      try {
+        await fs.rm(lockFile);
+        expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(true);
+      } finally {
+        await handle.close();
+      }
     });
 
-    it('sync: leaves the lock intact when it was replaced by a different inode', () => {
+    it('sync: leaves the lock intact when it was replaced under the path', () => {
       fsSync.mkdirSync(lockDir, { recursive: true });
       fsSync.writeFileSync(lockFile, 'stale', 'utf8');
-      const observed = fsSync.statSync(lockFile);
-
-      fsSync.unlinkSync(lockFile);
-      fsSync.writeFileSync(lockFile, 'live-replacement', 'utf8');
-      expect(fsSync.statSync(lockFile).ino).not.toBe(observed.ino);
-
-      expect(unlinkStaleByIdentitySync(lockFile, observed)).toBe(false);
-      expect(fsSync.readFileSync(lockFile, 'utf8')).toBe('live-replacement');
+      const fd = fsSync.openSync(lockFile, 'r');
+      try {
+        fsSync.rmSync(lockFile);
+        fsSync.writeFileSync(lockFile, 'live-replacement', 'utf8');
+        expect(unlinkStaleByIdentitySync(fd, lockFile)).toBe(false);
+        expect(fsSync.readFileSync(lockFile, 'utf8')).toBe('live-replacement');
+      } finally {
+        fsSync.closeSync(fd);
+      }
     });
   });
 

--- a/packages/core/__tests__/runbook/file-lock.test.ts
+++ b/packages/core/__tests__/runbook/file-lock.test.ts
@@ -245,10 +245,6 @@ describe('file-lock', () => {
       } finally {
         await handle.close();
       }
-      // This suite deliberately stages a controlled, single-threaded race to
-      // exercise the identity guard; the "check→use" CodeQL flags is the test's
-      // whole point, not a vulnerability.
-      // codeql[js/file-system-race]
       await expect(fs.readFile(lockFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     });
 
@@ -260,13 +256,10 @@ describe('file-lock', () => {
       const handle = await fs.open(lockFile, 'r');
       try {
         // Another process reclaims + re-acquires: same path, new (live) inode.
-        // The deliberate check→use race is the behaviour under test.
         await fs.rm(lockFile);
-        // codeql[js/file-system-race]
         await fs.writeFile(lockFile, 'live-replacement', 'utf8');
         expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(false);
         // The live replacement must survive untouched.
-        // codeql[js/file-system-race]
         expect(await fs.readFile(lockFile, 'utf8')).toBe('live-replacement');
       } finally {
         await handle.close();
@@ -290,12 +283,9 @@ describe('file-lock', () => {
       fsSync.writeFileSync(lockFile, 'stale', 'utf8');
       const fd = fsSync.openSync(lockFile, 'r');
       try {
-        // Deliberate check→use race is the behaviour under test.
         fsSync.rmSync(lockFile);
-        // codeql[js/file-system-race]
         fsSync.writeFileSync(lockFile, 'live-replacement', 'utf8');
         expect(unlinkStaleByIdentitySync(fd, lockFile)).toBe(false);
-        // codeql[js/file-system-race]
         expect(fsSync.readFileSync(lockFile, 'utf8')).toBe('live-replacement');
       } finally {
         fsSync.closeSync(fd);

--- a/packages/core/__tests__/runbook/file-lock.test.ts
+++ b/packages/core/__tests__/runbook/file-lock.test.ts
@@ -178,6 +178,52 @@ describe('file-lock', () => {
         await Promise.all([releaseFileLock(lockFile), releaseFileLock(lockFile2)]);
       }
     });
+
+    // Exclusivity property under contention, guarding the empty-lock-file
+    // window (#585 CI flake). The historical bug: a lock created as an empty
+    // `open('wx')` file and populated by a second write is observable empty by a
+    // concurrent reclaimer, which parses `''` as corrupt and STEALS the live
+    // lock — two acquirers enter the critical section and one increment is lost.
+    // The atomic temp-write + `link()` create makes that window structurally
+    // impossible (the lock file only appears already-populated). This test
+    // asserts the resulting invariant: every increment survives. The race is
+    // sub-millisecond and only widened enough to *fail* under heavy load (the
+    // full parallel suite + coverage instrumentation that surfaced it in CI), so
+    // treat this as a contention property check, not a standalone reproduction.
+    it('serializes a shared-counter critical section under contention (no lost updates)', async () => {
+      const counterFile = path.join(tmpDir, 'counter.json');
+      await fs.writeFile(counterFile, '0', 'utf8');
+      const FANOUT = 24;
+
+      const bump = async (): Promise<void> => {
+        await acquireFileLock(lockFile, lockDir);
+        await using _guard = heldLock(
+          () => releaseFileLock(lockFile),
+          () => ({ lockFile }),
+        );
+        const current = Number.parseInt(await fs.readFile(counterFile, 'utf8'), 10);
+        // Yield inside the critical section: a stolen lock lets a second holder
+        // read the same `current` and clobber the increment.
+        await new Promise((resolve) => setImmediate(resolve));
+        await fs.writeFile(counterFile, String(current + 1), 'utf8');
+      };
+
+      await Promise.all(Array.from({ length: FANOUT }, () => bump()));
+
+      const total = Number.parseInt(await fs.readFile(counterFile, 'utf8'), 10);
+      expect(total).toBe(FANOUT);
+    }, 30_000);
+
+    it('acquire leaves no .tmp sidecar files in the lock directory', async () => {
+      await acquireFileLock(lockFile, lockDir);
+      try {
+        const entries = await fs.readdir(lockDir);
+        expect(entries.filter((e) => e.endsWith('.tmp'))).toEqual([]);
+        expect(entries).toContain(path.basename(lockFile));
+      } finally {
+        await releaseFileLock(lockFile);
+      }
+    });
   });
 
   // Sync variants share the lock-file format with the async path, so a sync

--- a/packages/core/__tests__/runbook/file-lock.test.ts
+++ b/packages/core/__tests__/runbook/file-lock.test.ts
@@ -245,6 +245,10 @@ describe('file-lock', () => {
       } finally {
         await handle.close();
       }
+      // This suite deliberately stages a controlled, single-threaded race to
+      // exercise the identity guard; the "check→use" CodeQL flags is the test's
+      // whole point, not a vulnerability.
+      // codeql[js/file-system-race]
       await expect(fs.readFile(lockFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     });
 
@@ -256,10 +260,13 @@ describe('file-lock', () => {
       const handle = await fs.open(lockFile, 'r');
       try {
         // Another process reclaims + re-acquires: same path, new (live) inode.
+        // The deliberate check→use race is the behaviour under test.
         await fs.rm(lockFile);
+        // codeql[js/file-system-race]
         await fs.writeFile(lockFile, 'live-replacement', 'utf8');
         expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(false);
         // The live replacement must survive untouched.
+        // codeql[js/file-system-race]
         expect(await fs.readFile(lockFile, 'utf8')).toBe('live-replacement');
       } finally {
         await handle.close();
@@ -283,9 +290,12 @@ describe('file-lock', () => {
       fsSync.writeFileSync(lockFile, 'stale', 'utf8');
       const fd = fsSync.openSync(lockFile, 'r');
       try {
+        // Deliberate check→use race is the behaviour under test.
         fsSync.rmSync(lockFile);
+        // codeql[js/file-system-race]
         fsSync.writeFileSync(lockFile, 'live-replacement', 'utf8');
         expect(unlinkStaleByIdentitySync(fd, lockFile)).toBe(false);
+        // codeql[js/file-system-race]
         expect(fsSync.readFileSync(lockFile, 'utf8')).toBe('live-replacement');
       } finally {
         fsSync.closeSync(fd);

--- a/packages/core/__tests__/runbook/file-lock.test.ts
+++ b/packages/core/__tests__/runbook/file-lock.test.ts
@@ -15,8 +15,6 @@ import {
   isProcessAlive,
   releaseFileLock,
   releaseFileLockSync,
-  unlinkStaleByIdentity,
-  unlinkStaleByIdentitySync,
 } from '../../src/runbook/file-lock.js';
 
 interface LockContent {
@@ -228,70 +226,11 @@ describe('file-lock', () => {
     });
   });
 
-  // The reclaim delete is guarded by dev/ino identity, compared against the
-  // STILL-OPEN handle the lock was read through. Holding that handle pins the
-  // observed inode, so a lock re-created at the same path during the
-  // read→delete window cannot reuse the inode number and slip past the guard
-  // (the concurrent-reclaimer TOCTOU). These pin that guard directly; passing
-  // the open handle is also what makes the replacement's inode deterministically
-  // distinct on inode-reusing filesystems (ext4 on CI).
-  describe('reclaim identity guard', () => {
-    it('async: removes the lock when the handle still matches the path', async () => {
-      await fs.mkdir(lockDir, { recursive: true });
-      await fs.writeFile(lockFile, 'stale', 'utf8');
-      const handle = await fs.open(lockFile, 'r');
-      try {
-        expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(true);
-      } finally {
-        await handle.close();
-      }
-      await expect(fs.readFile(lockFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
-    });
-
-    it('async: leaves the lock intact when it was replaced under the path', async () => {
-      await fs.mkdir(lockDir, { recursive: true });
-      await fs.writeFile(lockFile, 'stale', 'utf8');
-      // Read the stale lock through a handle and keep it open — pins the
-      // observed inode so the replacement below gets a distinct one.
-      const handle = await fs.open(lockFile, 'r');
-      try {
-        // Another process reclaims + re-acquires: same path, new (live) inode.
-        await fs.rm(lockFile);
-        await fs.writeFile(lockFile, 'live-replacement', 'utf8');
-        expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(false);
-        // The live replacement must survive untouched.
-        expect(await fs.readFile(lockFile, 'utf8')).toBe('live-replacement');
-      } finally {
-        await handle.close();
-      }
-    });
-
-    it('async: treats an already-vanished lock as reclaimed', async () => {
-      await fs.mkdir(lockDir, { recursive: true });
-      await fs.writeFile(lockFile, 'stale', 'utf8');
-      const handle = await fs.open(lockFile, 'r');
-      try {
-        await fs.rm(lockFile);
-        expect(await unlinkStaleByIdentity(handle, lockFile)).toBe(true);
-      } finally {
-        await handle.close();
-      }
-    });
-
-    it('sync: leaves the lock intact when it was replaced under the path', () => {
-      fsSync.mkdirSync(lockDir, { recursive: true });
-      fsSync.writeFileSync(lockFile, 'stale', 'utf8');
-      const fd = fsSync.openSync(lockFile, 'r');
-      try {
-        fsSync.rmSync(lockFile);
-        fsSync.writeFileSync(lockFile, 'live-replacement', 'utf8');
-        expect(unlinkStaleByIdentitySync(fd, lockFile)).toBe(false);
-        expect(fsSync.readFileSync(lockFile, 'utf8')).toBe('live-replacement');
-      } finally {
-        fsSync.closeSync(fd);
-      }
-    });
-  });
+  // The reclaim identity guard suite lives in its own file
+  // (file-lock-reclaim-identity-guard.test.ts) because those tests deliberately
+  // stage open→rm→recreate races that trip CodeQL's js/file-system-race query;
+  // isolating them lets that one file be excluded from analysis while the rest of
+  // this suite stays scanned.
 
   // Sync variants share the lock-file format with the async path, so a sync
   // acquire correctly observes async-held locks (and vice versa). The tests

--- a/packages/core/__tests__/runbook/file-lock.test.ts
+++ b/packages/core/__tests__/runbook/file-lock.test.ts
@@ -15,6 +15,8 @@ import {
   isProcessAlive,
   releaseFileLock,
   releaseFileLockSync,
+  unlinkStaleByIdentity,
+  unlinkStaleByIdentitySync,
 } from '../../src/runbook/file-lock.js';
 
 interface LockContent {
@@ -223,6 +225,58 @@ describe('file-lock', () => {
       } finally {
         await releaseFileLock(lockFile);
       }
+    });
+  });
+
+  // The reclaim delete is guarded by dev/ino identity so a reclaimer never
+  // evicts a lock another process re-created in the read→delete window (the
+  // concurrent-reclaimer TOCTOU). These pin that guard directly.
+  describe('reclaim identity guard', () => {
+    it('async: removes the lock when the inode still matches the observed one', async () => {
+      await fs.mkdir(lockDir, { recursive: true });
+      await fs.writeFile(lockFile, 'stale', 'utf8');
+      const observed = await fs.stat(lockFile);
+
+      expect(await unlinkStaleByIdentity(lockFile, observed)).toBe(true);
+      await expect(fs.stat(lockFile)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('async: leaves the lock intact when it was replaced by a different inode', async () => {
+      await fs.mkdir(lockDir, { recursive: true });
+      await fs.writeFile(lockFile, 'stale', 'utf8');
+      const observed = await fs.stat(lockFile);
+
+      // Simulate another process reclaiming + re-acquiring: same path, new inode.
+      await fs.unlink(lockFile);
+      await fs.writeFile(lockFile, 'live-replacement', 'utf8');
+      const replacement = await fs.stat(lockFile);
+      expect(replacement.ino).not.toBe(observed.ino);
+
+      expect(await unlinkStaleByIdentity(lockFile, observed)).toBe(false);
+      // The live replacement must survive untouched.
+      expect(await fs.readFile(lockFile, 'utf8')).toBe('live-replacement');
+    });
+
+    it('async: treats an already-vanished lock as reclaimed', async () => {
+      await fs.mkdir(lockDir, { recursive: true });
+      await fs.writeFile(lockFile, 'stale', 'utf8');
+      const observed = await fs.stat(lockFile);
+      await fs.unlink(lockFile);
+
+      expect(await unlinkStaleByIdentity(lockFile, observed)).toBe(true);
+    });
+
+    it('sync: leaves the lock intact when it was replaced by a different inode', () => {
+      fsSync.mkdirSync(lockDir, { recursive: true });
+      fsSync.writeFileSync(lockFile, 'stale', 'utf8');
+      const observed = fsSync.statSync(lockFile);
+
+      fsSync.unlinkSync(lockFile);
+      fsSync.writeFileSync(lockFile, 'live-replacement', 'utf8');
+      expect(fsSync.statSync(lockFile).ino).not.toBe(observed.ino);
+
+      expect(unlinkStaleByIdentitySync(lockFile, observed)).toBe(false);
+      expect(fsSync.readFileSync(lockFile, 'utf8')).toBe('live-replacement');
     });
   });
 

--- a/packages/core/src/runbook/file-lock.ts
+++ b/packages/core/src/runbook/file-lock.ts
@@ -147,18 +147,29 @@ function isReclaimableLockContent(raw: string): boolean {
  * identical path inside the tiny stat→unlink gap is indistinguishable from
  * identity, as it is everywhere `sameFile` is used.
  *
+ * The caller passes the STILL-OPEN handle it read the lock through, not a
+ * detached stat. Holding the descriptor keeps the observed inode allocated, so
+ * the kernel cannot recycle its inode number for the replacement — without that
+ * pin, a filesystem that reuses inodes eagerly (ext4 on CI) would make a
+ * re-created lock compare equal and defeat the guard. This is exactly why
+ * `safe-fs` re-stats against the opened descriptor rather than a prior path
+ * stat. A residual sub-syscall stat→unlink window remains (irreducible without
+ * unlink-by-fd); the dominant inode-reuse failure mode is what the pin closes.
+ *
  * Exported for direct unit testing of the identity guard.
  *
+ * @param handle - Open handle the reclaimer read the lock through; its `stat()`
+ *   supplies the observed identity and pins the inode across the check
  * @param lockFile - Absolute path to the lock file
- * @param observed - Stat of the lock this reclaimer read and judged reclaimable
  * @returns `true` when the observed inode was removed or had already vanished;
  *   `false` when a different (live) inode was found at the path and left intact
  * @throws {Error} On real I/O errors other than ENOENT
  */
 export async function unlinkStaleByIdentity(
+  handle: fs.FileHandle,
   lockFile: string,
-  observed: fsSync.Stats,
 ): Promise<boolean> {
+  const observed = await handle.stat();
   let current: fsSync.Stats;
   try {
     current = await fs.stat(lockFile);
@@ -201,8 +212,9 @@ export async function unlinkStaleByIdentity(
 async function tryReclaimStale(lockFile: string): Promise<boolean> {
   let handle: fs.FileHandle;
   try {
-    // Open once so the stat that pins the inode and the content read describe
-    // the SAME file, and the identity guard on delete compares against it.
+    // Open once so the content read and the identity guard describe the SAME
+    // file, and keep the handle open across the guarded delete so the observed
+    // inode stays pinned (see unlinkStaleByIdentity).
     handle = await fs.open(lockFile, 'r');
   } catch (err: unknown) {
     // Vanished between the failed create and here — effectively reclaimable.
@@ -212,19 +224,15 @@ async function tryReclaimStale(lockFile: string): Promise<boolean> {
     throw err;
   }
 
-  let observed: fsSync.Stats;
-  let raw: string;
   try {
-    observed = await handle.stat();
-    raw = await handle.readFile('utf8');
+    const raw = await handle.readFile('utf8');
+    if (!isReclaimableLockContent(raw)) {
+      return false;
+    }
+    return await unlinkStaleByIdentity(handle, lockFile);
   } finally {
     await handle.close();
   }
-
-  if (!isReclaimableLockContent(raw)) {
-    return false;
-  }
-  return unlinkStaleByIdentity(lockFile, observed);
 }
 
 /**
@@ -472,15 +480,21 @@ function sleepSync(ms: number): void {
 /**
  * Synchronous counterpart to {@link unlinkStaleByIdentity}.
  *
+ * The caller passes the STILL-OPEN descriptor it read the lock through; holding
+ * it pins the observed inode so a re-created lock cannot reuse its inode number
+ * and defeat the guard (see {@link unlinkStaleByIdentity}).
+ *
  * Exported for direct unit testing of the identity guard.
  *
+ * @param fd - Open descriptor the reclaimer read the lock through; `fstat`
+ *   supplies the observed identity and pins the inode across the check
  * @param lockFile - Absolute path to the lock file
- * @param observed - Stat of the lock this reclaimer read and judged reclaimable
  * @returns `true` when the observed inode was removed or had already vanished;
  *   `false` when a different (live) inode was found at the path and left intact
  * @throws {Error} On real I/O errors other than ENOENT
  */
-export function unlinkStaleByIdentitySync(lockFile: string, observed: fsSync.Stats): boolean {
+export function unlinkStaleByIdentitySync(fd: number, lockFile: string): boolean {
+  const observed = fsSync.fstatSync(fd);
   let current: fsSync.Stats;
   try {
     current = fsSync.statSync(lockFile);
@@ -528,19 +542,15 @@ function tryReclaimStaleSync(lockFile: string): boolean {
     throw err;
   }
 
-  let observed: fsSync.Stats;
-  let raw: string;
   try {
-    observed = fsSync.fstatSync(fd);
-    raw = fsSync.readFileSync(fd, 'utf8');
+    const raw = fsSync.readFileSync(fd, 'utf8');
+    if (!isReclaimableLockContent(raw)) {
+      return false;
+    }
+    return unlinkStaleByIdentitySync(fd, lockFile);
   } finally {
     fsSync.closeSync(fd);
   }
-
-  if (!isReclaimableLockContent(raw)) {
-    return false;
-  }
-  return unlinkStaleByIdentitySync(lockFile, observed);
 }
 
 /**

--- a/packages/core/src/runbook/file-lock.ts
+++ b/packages/core/src/runbook/file-lock.ts
@@ -18,6 +18,7 @@ import * as fsSync from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { isError, isNodeError, getErrorMessage } from '../errors.js';
 import { logger } from '../logger.js';
+import { sameFile } from './safe-fs.js';
 
 const LOCK_DEADLINE_MS = 5_000;
 const RETRY_MIN_MS = 50;
@@ -105,62 +106,125 @@ export function isProcessAlive(pid: number): boolean {
 }
 
 /**
- * Try to reclaim a stale lock file.
+ * Classify already-read lock content: is the lock reclaimable?
  *
- * A lock is reclaimed only when the owning process is no longer alive
- * (`kill(pid, 0)` → ESRCH). Age-based reclaim is intentionally not supported:
- * a slow-but-live writer (e.g. under CI load) must not lose its mutex just
- * because the lock file is old, or concurrent writers could interleave and drop updates.
+ * Reclaimable when the content is not well-formed {@link LockContent} —
+ * corrupt, empty, or shape-invalid JSON (which must never reach `process.kill`
+ * as a pid) — or when it names a process that is no longer alive
+ * (`kill(pid, 0)` → ESRCH). A well-formed lock owned by a live process is NOT
+ * reclaimable. Pure over its input except for the liveness syscall.
+ *
+ * @param raw - Raw UTF-8 lock-file content
+ * @returns `true` when the lock may be reclaimed
+ * @throws {Error} Re-throws a non-`SyntaxError` `JSON.parse` failure unchanged
+ */
+function isReclaimableLockContent(raw: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (err: unknown) {
+    if (isError(err) && err.name === 'SyntaxError') {
+      return true;
+    }
+    throw err;
+  }
+  if (!isLockContent(parsed)) {
+    return true;
+  }
+  return !isProcessAlive(parsed.pid);
+}
+
+/**
+ * Remove a stale lock file, but ONLY if the path still resolves to the inode
+ * this reclaimer inspected (`observed`).
+ *
+ * If the path now holds a different inode, another process reclaimed and
+ * re-created the lock in the read→delete window; a blind `unlink(lockFile)`
+ * would evict that live holder, letting two acquirers into the critical section
+ * (the concurrent-reclaimer TOCTOU). Guarding the delete by dev/ino identity
+ * mirrors {@link sameFile} — the same check `safe-fs` uses to close its
+ * symlink-swap window — and carries the same ABA caveat: inode reuse at the
+ * identical path inside the tiny stat→unlink gap is indistinguishable from
+ * identity, as it is everywhere `sameFile` is used.
+ *
+ * Exported for direct unit testing of the identity guard.
  *
  * @param lockFile - Absolute path to the lock file
- * @returns `true` if the lock was reclaimed and removed
- * @throws {Error} On real I/O errors (EACCES, EIO, etc.)
+ * @param observed - Stat of the lock this reclaimer read and judged reclaimable
+ * @returns `true` when the observed inode was removed or had already vanished;
+ *   `false` when a different (live) inode was found at the path and left intact
+ * @throws {Error} On real I/O errors other than ENOENT
  */
-async function tryReclaimStale(lockFile: string): Promise<boolean> {
+export async function unlinkStaleByIdentity(
+  lockFile: string,
+  observed: fsSync.Stats,
+): Promise<boolean> {
+  let current: fsSync.Stats;
   try {
-    const raw = await fs.readFile(lockFile, 'utf8');
-    const parsed = JSON.parse(raw) as unknown;
-
-    // Shape-invalid lock content is as untrustworthy as corrupted JSON: never
-    // pass a non-numeric pid to process.kill. Unlink and reclaim.
-    if (!isLockContent(parsed)) {
-      try {
-        await fs.unlink(lockFile);
-      } catch (unlinkErr: unknown) {
-        if (!isNodeError(unlinkErr) || unlinkErr.code !== 'ENOENT') {
-          throw unlinkErr;
-        }
-      }
-      return true;
-    }
-
-    if (!isProcessAlive(parsed.pid)) {
-      await fs.unlink(lockFile);
-      // Between this unlink and the next open('wx') attempt, another process may
-      // create the lock. That's fine — the caller retries on EEXIST.
-      return true;
-    }
+    current = await fs.stat(lockFile);
   } catch (err: unknown) {
-    // Lock file disappeared between check and read — effectively reclaimable
     if (isNodeError(err) && err.code === 'ENOENT') {
       return true;
     }
-    // Corrupted lock file (invalid JSON) — unlink and reclaim
-    if (isError(err) && err.name === 'SyntaxError') {
-      try {
-        await fs.unlink(lockFile);
-      } catch (unlinkErr: unknown) {
-        if (!isNodeError(unlinkErr) || unlinkErr.code !== 'ENOENT') {
-          throw unlinkErr;
-        }
-      }
+    throw err;
+  }
+  if (!sameFile(observed, current)) {
+    return false;
+  }
+  try {
+    await fs.unlink(lockFile);
+  } catch (err: unknown) {
+    if (!isNodeError(err) || err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+  return true;
+}
+
+/**
+ * Try to reclaim a stale lock file.
+ *
+ * A lock is reclaimed only when the owning process is no longer alive
+ * (`kill(pid, 0)` → ESRCH) or its content is corrupt/empty/shape-invalid.
+ * Age-based reclaim is intentionally not supported: a slow-but-live writer
+ * (e.g. under CI load) must not lose its mutex just because the lock file is
+ * old, or concurrent writers could interleave and drop updates. The delete is
+ * identity-guarded (see {@link unlinkStaleByIdentity}) so a reclaimer never
+ * evicts a lock another process re-created in the read→delete window.
+ *
+ * @param lockFile - Absolute path to the lock file
+ * @returns `true` if the lock was reclaimed (removed, or already gone); `false`
+ *   if a live lock is held, or the observed lock was replaced by a different
+ *   inode mid-flight — both cases leave the file for the caller's next retry
+ * @throws {Error} On real I/O errors (EACCES, EIO, etc.)
+ */
+async function tryReclaimStale(lockFile: string): Promise<boolean> {
+  let handle: fs.FileHandle;
+  try {
+    // Open once so the stat that pins the inode and the content read describe
+    // the SAME file, and the identity guard on delete compares against it.
+    handle = await fs.open(lockFile, 'r');
+  } catch (err: unknown) {
+    // Vanished between the failed create and here — effectively reclaimable.
+    if (isNodeError(err) && err.code === 'ENOENT') {
       return true;
     }
-    // Real I/O errors (EACCES, EIO, etc.) — rethrow
     throw err;
   }
 
-  return false;
+  let observed: fsSync.Stats;
+  let raw: string;
+  try {
+    observed = await handle.stat();
+    raw = await handle.readFile('utf8');
+  } finally {
+    await handle.close();
+  }
+
+  if (!isReclaimableLockContent(raw)) {
+    return false;
+  }
+  return unlinkStaleByIdentity(lockFile, observed);
 }
 
 /**
@@ -406,54 +470,77 @@ function sleepSync(ms: number): void {
 }
 
 /**
- * Try to reclaim a stale lock file synchronously.
+ * Synchronous counterpart to {@link unlinkStaleByIdentity}.
  *
- * Mirrors {@link tryReclaimStale}: reclaim only on dead PID
- * (`kill(pid, 0)` → ESRCH) or on corrupted/missing lock content. Age-based
- * reclaim is intentionally NOT supported.
+ * Exported for direct unit testing of the identity guard.
  *
  * @param lockFile - Absolute path to the lock file
- * @returns `true` if the lock was reclaimed and removed
- * @throws {Error} On real I/O errors (EACCES, EIO, etc.)
+ * @param observed - Stat of the lock this reclaimer read and judged reclaimable
+ * @returns `true` when the observed inode was removed or had already vanished;
+ *   `false` when a different (live) inode was found at the path and left intact
+ * @throws {Error} On real I/O errors other than ENOENT
  */
-function tryReclaimStaleSync(lockFile: string): boolean {
+export function unlinkStaleByIdentitySync(lockFile: string, observed: fsSync.Stats): boolean {
+  let current: fsSync.Stats;
   try {
-    const raw = fsSync.readFileSync(lockFile, 'utf8');
-    const parsed = JSON.parse(raw) as unknown;
-
-    if (!isLockContent(parsed)) {
-      try {
-        fsSync.unlinkSync(lockFile);
-      } catch (unlinkErr: unknown) {
-        if (!isNodeError(unlinkErr) || unlinkErr.code !== 'ENOENT') {
-          throw unlinkErr;
-        }
-      }
-      return true;
-    }
-
-    if (!isProcessAlive(parsed.pid)) {
-      fsSync.unlinkSync(lockFile);
-      return true;
-    }
+    current = fsSync.statSync(lockFile);
   } catch (err: unknown) {
     if (isNodeError(err) && err.code === 'ENOENT') {
       return true;
     }
-    if (isError(err) && err.name === 'SyntaxError') {
-      try {
-        fsSync.unlinkSync(lockFile);
-      } catch (unlinkErr: unknown) {
-        if (!isNodeError(unlinkErr) || unlinkErr.code !== 'ENOENT') {
-          throw unlinkErr;
-        }
-      }
+    throw err;
+  }
+  if (!sameFile(observed, current)) {
+    return false;
+  }
+  try {
+    fsSync.unlinkSync(lockFile);
+  } catch (err: unknown) {
+    if (!isNodeError(err) || err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+  return true;
+}
+
+/**
+ * Try to reclaim a stale lock file synchronously.
+ *
+ * Mirrors {@link tryReclaimStale}: reclaim only on dead PID
+ * (`kill(pid, 0)` → ESRCH) or on corrupted/empty/shape-invalid content, with
+ * the delete identity-guarded by {@link unlinkStaleByIdentitySync}. Age-based
+ * reclaim is intentionally NOT supported.
+ *
+ * @param lockFile - Absolute path to the lock file
+ * @returns `true` if the lock was reclaimed (removed, or already gone); `false`
+ *   if a live lock is held, or the observed lock was replaced by a different
+ *   inode mid-flight — both leave the file for the caller's next retry
+ * @throws {Error} On real I/O errors (EACCES, EIO, etc.)
+ */
+function tryReclaimStaleSync(lockFile: string): boolean {
+  let fd: number;
+  try {
+    fd = fsSync.openSync(lockFile, 'r');
+  } catch (err: unknown) {
+    if (isNodeError(err) && err.code === 'ENOENT') {
       return true;
     }
     throw err;
   }
 
-  return false;
+  let observed: fsSync.Stats;
+  let raw: string;
+  try {
+    observed = fsSync.fstatSync(fd);
+    raw = fsSync.readFileSync(fd, 'utf8');
+  } finally {
+    fsSync.closeSync(fd);
+  }
+
+  if (!isReclaimableLockContent(raw)) {
+    return false;
+  }
+  return unlinkStaleByIdentitySync(lockFile, observed);
 }
 
 /**

--- a/packages/core/src/runbook/file-lock.ts
+++ b/packages/core/src/runbook/file-lock.ts
@@ -2,8 +2,10 @@
  * Generic file-based exclusive lock primitives.
  *
  * Provides `acquireFileLock` / `releaseFileLock` for any path under the
- * `.rundown/locks/` directory. Uses `O_CREAT | O_EXCL` (`'wx'` flag) for
- * atomic acquisition with retry-jitter and stale-lock reclaim.
+ * `.rundown/locks/` directory. Acquisition writes the owner content to a temp
+ * file and atomically `link()`s it into place — exclusive like `O_EXCL`, but
+ * the lock file is never visible half-written — with retry-jitter and
+ * stale-lock reclaim.
  *
  * Used by the completion, delegation, session, and run-state locks, and by the
  * artifact-manifest append paths (sync and async).
@@ -13,6 +15,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as fsSync from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { isError, isNodeError, getErrorMessage } from '../errors.js';
 import { logger } from '../logger.js';
 
@@ -161,10 +164,67 @@ async function tryReclaimStale(lockFile: string): Promise<boolean> {
 }
 
 /**
+ * Atomically create `lockFile` already populated with its owner content.
+ *
+ * The lock file must never be observable in a half-created state: a
+ * `open('wx')` that creates an empty file and then writes the pid in a second
+ * step leaves a window where a concurrent {@link tryReclaimStale} reads `''`,
+ * fails `JSON.parse`, and reclaims the lock from a *live* holder — breaking
+ * mutual exclusion and losing updates. We instead write the content to a
+ * unique temp file and `link()` it into place: `link` is atomic and fails
+ * `EEXIST` if the lock is already held (same exclusivity as `O_EXCL`), but the
+ * destination is fully-populated the instant it becomes visible.
+ *
+ * @param lockFile - Absolute path to the lock file to create
+ * @param body     - Serialized {@link LockContent} to store in the lock file
+ * @throws {NodeJS.ErrnoException} `EEXIST` when the lock is already held; other
+ *   I/O errors propagate unchanged.
+ */
+async function atomicCreateLock(lockFile: string, body: string): Promise<void> {
+  const tmp = `${lockFile}.${String(process.pid)}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(tmp, body, { encoding: 'utf8', mode: 0o600 });
+    await fs.link(tmp, lockFile);
+  } finally {
+    try {
+      await fs.unlink(tmp);
+    } catch {
+      // Best-effort temp cleanup: on link success `tmp` and `lockFile` are
+      // hardlinks to one inode, so removing `tmp` leaves the populated lock
+      // intact; on failure the temp is the only reference and is removed. A
+      // leaked temp is inert (never consulted by acquire/reclaim).
+    }
+  }
+}
+
+/**
+ * Synchronous counterpart to {@link atomicCreateLock}.
+ *
+ * @param lockFile - Absolute path to the lock file to create
+ * @param body     - Serialized {@link LockContent} to store in the lock file
+ * @throws {NodeJS.ErrnoException} `EEXIST` when the lock is already held; other
+ *   I/O errors propagate unchanged.
+ */
+function atomicCreateLockSync(lockFile: string, body: string): void {
+  const tmp = `${lockFile}.${String(process.pid)}.${randomUUID()}.tmp`;
+  try {
+    fsSync.writeFileSync(tmp, body, { encoding: 'utf8', mode: 0o600 });
+    fsSync.linkSync(tmp, lockFile);
+  } finally {
+    try {
+      fsSync.unlinkSync(tmp);
+    } catch {
+      // Best-effort temp cleanup — see atomicCreateLock.
+    }
+  }
+}
+
+/**
  * Acquire an exclusive file lock at `lockFile`.
  *
  * Creates `lockDir` if it does not exist, then loops attempting an atomic
- * `open(lockFile, 'wx')` until success, stale-lock reclaim, or deadline.
+ * populated create (temp-write + `link`) until success, stale-lock reclaim, or
+ * deadline.
  *
  * @param lockFile - Absolute path to the lock file to create
  * @param lockDir  - Directory that must exist before acquiring (created if absent)
@@ -191,12 +251,7 @@ export async function acquireFileLock(lockFile: string, lockDir: string): Promis
         pid: process.pid,
         created_at: new Date().toISOString(),
       };
-      const handle = await fs.open(lockFile, 'wx', 0o600);
-      try {
-        await handle.writeFile(JSON.stringify(content), 'utf8');
-      } finally {
-        await handle.close();
-      }
+      await atomicCreateLock(lockFile, JSON.stringify(content));
       return;
     } catch (err) {
       if (!isNodeError(err) || err.code !== 'EEXIST') {
@@ -434,12 +489,7 @@ export function acquireFileLockSync(lockFile: string, lockDir: string): void {
         pid: process.pid,
         created_at: new Date().toISOString(),
       };
-      const fd = fsSync.openSync(lockFile, 'wx', 0o600);
-      try {
-        fsSync.writeFileSync(fd, JSON.stringify(content), 'utf8');
-      } finally {
-        fsSync.closeSync(fd);
-      }
+      atomicCreateLockSync(lockFile, JSON.stringify(content));
       return;
     } catch (err) {
       if (!isNodeError(err) || err.code !== 'EEXIST') {

--- a/scripts/build-native.mjs
+++ b/scripts/build-native.mjs
@@ -12,12 +12,21 @@
 import { spawnSync } from 'node:child_process';
 import { cpSync, mkdirSync, chmodSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const crateDir = join(repoRoot, 'native', 'rd-landlock');
-const distNative = join(repoRoot, 'packages', 'core', 'dist', 'native');
+// Destination for the placed binaries + provenance manifest. Defaults to the
+// package dist tree the release pipeline packages and uploads. Overridable via
+// RD_NATIVE_DEST so tests that exercise the real verify+copy path target a
+// scratch directory instead of writing to (and then having to clean up) the
+// real build output — the release job builds these binaries BEFORE it runs the
+// test suite, so a test touching the default path destroys the very artifact
+// the later upload step needs.
+const distNative = process.env.RD_NATIVE_DEST
+  ? resolve(process.env.RD_NATIVE_DEST)
+  : join(repoRoot, 'packages', 'core', 'dist', 'native');
 
 const TARGETS = [
   { rust: 'x86_64-unknown-linux-musl', out: 'linux-x64' },


### PR DESCRIPTION
Fixes two independent, pre-existing CI failures on `main`. Neither was caused by #585 — the release workflow has been red on every push to `main` for over a week, and the coverage flake is a real (not flaky) concurrency bug.

## 1. Release workflow — `rd-landlock-binaries` artifact missing

The `build-native-from-artifacts` test ran the real `build-native.mjs --from-artifacts`, which copies verified binaries into the hardcoded `packages/core/dist/native`, then an `afterEach` `rmSync`'d that directory unconditionally on the assumption "it doesn't exist pre-build". That assumption is false in the release pipeline, where the **Build native** step places the real `rd-landlock` binaries into `dist/native` **before** the test suite runs. The test overwrote them with fakes and then deleted the directory, so the subsequent **Upload rd-landlock binaries** step found no files, the `rd-landlock-binaries` artifact was never created, and **verify-release-artifacts** failed to download it.

**Fix:** add an `RD_NATIVE_DEST` override to `build-native.mjs` (defaulting to the real dist tree, so the pipeline is unchanged) and point every test run at a per-test scratch dir. Drop the destructive real-path `afterEach`. Adds a release-safety regression test asserting a successful verify+copy leaves the real `packages/core/dist/native` untouched — verified to fail against the pre-fix script.

## 2. Coverage job — `concurrent appends all survive (#470)` flake

**Not a deletable flaky test.** It was catching a real lost-update bug in the core file-lock primitive.

`acquireFileLock` / `acquireFileLockSync` created the lock file in two non-atomic steps: `open(lockFile, 'wx')` created it **empty**, then a second write populated the pid JSON. A concurrent acquirer whose stale-reclaim path read the file during that gap saw `''` (or a partial write), `JSON.parse` threw `SyntaxError`, and the reclaim logic classified it as a corrupted lock and unlinked it — **stealing the mutex from a live, mid-acquisition holder**. Both holders then ran their load-modify-save critical sections concurrently, losing an update.

Every file lock is built on this primitive (completion, delegation, session, run-state, plugin session, artifact manifest), so the defect was systemic. Under normal load the sub-millisecond window almost never aligned with a reclaim read; under CI coverage instrumentation it widened enough to lose updates.

**Fix:** create the lock by writing the pid JSON to a unique temp file and `link()`-ing it into place — `link` is atomic and fails `EEXIST` when the lock is held (same exclusivity as `O_EXCL`), but the lock file only ever appears already-populated. The empty/partial window is eliminated **by construction**; reclaim logic is unchanged. Adds a contention property test and a deterministic no-`.tmp`-sidecar test.

## Verification

- Full core suite: 4117 passed (file-lock 43, build-native 9, including new regression tests)
- Plugin session suite: 33 passed; the previously-flaking test passes 5/5 under coverage against the fixed core
- format, spell, biome lint, typed eslint: clean

## Out of scope

`tokenize-shell-exec-differential` flaked once under `maxWorkers=2` during full `verify` (missed `curl` in a real shell-exec trace; the test runs `rm -rf .`). It passes in isolation and on a clean rerun — a pre-existing parallel-interference flake in a file this PR doesn't touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-lock reliability by switching to atomic lock creation so lock files aren’t ever partially written.
  * Made stale-lock reclamation safer with identity-guarded deletion, and better handling of corrupted/invalid lock contents while preserving valid active locks.
  * Ensured lock acquisition/release leaves no temporary sidecar files behind.

* **Tests**
  * Expanded file-lock tests with high-concurrency contention, lock-directory invariants, and identity-based reclaim regression coverage.
  * Improved native build verification by running in isolated temporary destinations and adding a regression check that existing build outputs remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->