### PR TITLE
ci: consolidate codeql-action to v4.37.0 + harden dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,16 @@ updates:
         update-types:
           - minor
           - patch
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - '*'
     open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,13 +21,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4
         with:
           languages: javascript-typescript
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4


### PR DESCRIPTION
## Why

Two recurring dependabot CI failure modes, fixed at the source.

### 1. CodeQL version skew (supersedes #590, #591, #592)
Dependabot's `github-actions` ecosystem treats `github/codeql-action/{init,analyze,autobuild}` as three separate dependencies and opens a separate weekly PR for each. In `.github/workflows/codeql.yml` all three must share one SHA, so every single-path PR produces a version mismatch that CodeQL fails as `configuration error` ("Not all workflow steps that use github/codeql-action actions use the same version").

- Bumps all three sub-paths to `99df26d4…` (v4.37.0) in lockstep.
- Groups the `github-actions` ecosystem (`patterns: ['*']`) so future action bumps arrive in a single lockstep PR — the split-PR pattern can't recur.

### 2. npm supply-chain cooldown
A recent npm-group PR (#593) failed `pnpm install --frozen-lockfile` with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` because a bumped package was published within pnpm 11's ~24h `minimumReleaseAge` window. Adds `cooldown: { default-days: 7 }` to the npm ecosystem so dependabot stops proposing versions the supply-chain policy will reject.

## Supersedes
Closes #590, closes #591, closes #592.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated update management by grouping related maintenance updates and allowing a short review period before updates are proposed.
  - Refreshed the security scanning workflow to use an updated version of its scanning tools.
  - No changes to application functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->