### PR TITLE
Retire fabricated artifact seeding; capture artifacts from producer output (#498)

### DIFF
--- a/docs/internal/scenarios.md
+++ b/docs/internal/scenarios.md
@@ -236,9 +236,18 @@ interaction sequence.
 scenario command whose executable is an interpreter (`node`, `python3`, `sh`,
 …), a helper script (`./setup.sh`), or a package runner (`npm`, `npx`, …) — in
 any form, not only the inline `-e` / `-c` spellings — and any command whose
-inline code spawns a subprocess. Detection is anchored to the executable
-position of each operator-separated segment, so a wrapper hidden behind `&&` is
-caught while an incidental mention of `bash` inside a quoted argument is not.
+inline code spawns a subprocess.
+
+Detection is anchored to the **executable position of every command**, found by
+tokenizing with `shell-quote` — the same tokenizer the harness uses to run these
+commands, so the lint and the executor agree by construction about where a
+command begins. A wrapper is caught behind a shell operator (`&&`, `;`, `|`), on
+a second line, inside a subshell, and inside a `$( … )` or backtick substitution
+at any depth. Prefixes do not evade it: `! node …` and `FOO=bar node …` are both
+rejected. Conversely, text that only looks like a command is not one — an
+incidental `bash` in a quoted argument, a separator inside a quoted string
+(`--message "step a; node b"`), a redirection target, and a backtick inside a
+single-quoted argument (where the shell would not expand it) all pass.
 
 Those wrappers are confined to a small allowlist for **fault injection only** —
 where the shell command _is_ the fault being injected or the untrusted input

--- a/docs/internal/scenarios.md
+++ b/docs/internal/scenarios.md
@@ -232,12 +232,20 @@ assert through the scenario schema (`expect.result`, `expect.steps`,
 interaction sequence.
 
 **These rules are enforced**, not advisory, by
-`packages/cli/__tests__/schemas/scenario-authoring.test.ts`. It rejects any
-scenario command that spawns a subprocess, and confines opaque wrappers to a
-small allowlist for **fault injection only** — where the shell command _is_ the
-fault being injected or the untrusted input being forged, never a workflow step
-and never an assertion. The allowlist is matched by set equality, so a stale
-entry fails the suite as loudly as an unlisted violation.
+`packages/cli/__tests__/schemas/scenario-authoring.test.ts`. It rejects a
+scenario command whose executable is an interpreter (`node`, `python3`, `sh`,
+…), a helper script (`./setup.sh`), or a package runner (`npm`, `npx`, …) — in
+any form, not only the inline `-e` / `-c` spellings — and any command whose
+inline code spawns a subprocess. Detection is anchored to the executable
+position of each operator-separated segment, so a wrapper hidden behind `&&` is
+caught while an incidental mention of `bash` inside a quoted argument is not.
+
+Those wrappers are confined to a small allowlist for **fault injection only** —
+where the shell command _is_ the fault being injected or the untrusted input
+being forged, never a workflow step and never an assertion. The allowlist is
+matched by set equality, so a stale entry fails the suite as loudly as an
+unlisted violation. The predicates themselves are unit-tested in
+`packages/cli/__tests__/schemas/scenario-authoring-rules.test.ts`.
 
 Commands output JSON by default. The scenario runner parses every `rd`/`rundown`
 command's stdout to collect terminal state, step transitions, entered-step

--- a/docs/internal/scenarios.md
+++ b/docs/internal/scenarios.md
@@ -231,6 +231,14 @@ assert through the scenario schema (`expect.result`, `expect.steps`,
 `expect.errors`, `expect.artifacts`) and keep `commands:` focused on the CLI
 interaction sequence.
 
+**These rules are enforced**, not advisory, by
+`packages/cli/__tests__/schemas/scenario-authoring.test.ts`. It rejects any
+scenario command that spawns a subprocess, and confines opaque wrappers to a
+small allowlist for **fault injection only** — where the shell command _is_ the
+fault being injected or the untrusted input being forged, never a workflow step
+and never an assertion. The allowlist is matched by set equality, so a stale
+entry fails the suite as loudly as an unlisted violation.
+
 Commands output JSON by default. The scenario runner parses every `rd`/`rundown`
 command's stdout to collect terminal state, step transitions, entered-step
 events, delegation tokens, and claim ids. Use `--text` for human-readable
@@ -652,6 +660,33 @@ in [#498](https://github.com/tobyhede/rundown/issues/498). Both are now rejected
 outright -- `seed:` fails scenario validation as an unknown key, and
 `${ARTIFACT:...}` in a command throws before execution -- rather than being
 ignored.
+
+### `rd://` in a directive is not `rd://` in a command
+
+The same text means opposite things depending on where it lives, so do not
+review this with a text search. `grep -rn 'rd://artifacts/' runbooks/` cannot
+tell these apart, and will always report the selector fixtures as false hits:
+
+| Where                                            | Verdict                                                                                                   |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| An `ARTIFACTS` directive in the runbook **body** | The **selector language**. Legitimate: it names a _set_, resolved against whatever a real producer wrote. |
+| A scenario **command** in frontmatter            | **Fabrication.** Capture it from a producer instead.                                                      |
+
+```md
+- Matched "rd://artifacts/{{ ContextId }}/*/plan.json?source=project"  # body: fine
+```
+
+```yaml
+- rd run x.runbook.md --artifacts Plan=rd://artifacts/ctx/rd_1/plan.json # command: fabrication
+```
+
+`packages/cli/__tests__/schemas/scenario-authoring.test.ts` enforces the
+distinction correctly because it lints **parsed frontmatter values**, not file
+text: selector syntax lives on directive lines in the body, which the lint never
+reads, so it cannot false-positive. It rejects any scenario command that names
+an `rd://` URI, writes `manifest.jsonl`, or hand-derives the `.rd-<contextId>`
+directory. There is no allowlist for these -- a real producer's output is the
+only legitimate source of artifact provenance.
 
 ### Seeding a pre-existing artifact
 

--- a/docs/internal/scenarios.md
+++ b/docs/internal/scenarios.md
@@ -603,6 +603,84 @@ expect:
       action: COMPLETE
 ```
 
+## Artifact Capture
+
+A scenario command receives an artifact `rd://` URI by **capturing it from a
+prior command's output**. This is the only mechanism -- there is no seed
+directive, and scenarios must never fabricate an `rd://` URI or hand-write a
+manifest row. Core owns URI construction (`buildArtifactUri`) and the manifest
+row shape; a scenario that duplicates either will drift silently when core
+changes.
+
+| Placeholder                       | Resolves to                                          |
+| --------------------------------- | ---------------------------------------------------- |
+| `${CAPTURE_ARTIFACT:<key>}`       | The most recent `rd://artifacts/...` URI for `<key>` |
+| `${CAPTURE_ARTIFACT_ARRAY:<key>}` | A JSON array of every matching URI for `<key>`       |
+
+**The array form must be single-quoted.** It resolves to JSON containing double
+quotes, and placeholders are substituted into command text that is then
+tokenized by the shell. Unquoted, the shell strips those quotes and
+`["rd://a","rd://b"]` arrives as the invalid `[rd://a,rd://b]`. Quote the whole
+assignment:
+
+```yaml
+- rd run collate.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all
+```
+
+This is enforced, not advisory -- an unquoted array placeholder is rejected
+before the command runs. The scalar form needs no quoting: its values cannot
+contain a shell metacharacter.
+
+Both are resolved from the artifact manifest immediately before each command
+runs, so they see rows that earlier commands in the same scenario actually
+produced. Recency is by manifest row `timestamp`, with within-context append
+order breaking ties; a scalar pick whose latest-timestamp rows span more than
+one context is ambiguous and raises an error rather than guessing.
+
+An earlier `${ARTIFACT:<name>}` grammar and its `seed:` directive were retired
+in [#498](https://github.com/tobyhede/rundown/issues/498). Both are now rejected
+outright -- `seed:` fails scenario validation as an unknown key, and
+`${ARTIFACT:...}` in a command throws before execution -- rather than being
+ignored.
+
+### Seeding a pre-existing artifact
+
+When a scenario needs an artifact to "already exist", run a real producer
+runbook as its first command and capture the artifact it emits:
+
+```yaml
+scenarios:
+  consume-plan-artifact:
+    commands:
+      - rd run scenario-seed-artifacts.runbook.md --allow-all
+      - "rd run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
+    expect:
+      result: COMPLETE
+```
+
+`runbooks/artifacts/scenario-seed-artifacts.runbook.md` is the shared
+deterministic seeder; it emits keys `PlanPath` and `plan.json` through the real
+`ARTIFACTS` production path. Any producer runbook works -- the seeder is a
+convenience, not a special case. The producer needs `--allow-all` because it
+writes its backing files from a bash block.
+
+The producer runbook is staged automatically: the harness scans command strings
+for `*.runbook.md` references and copies them into the scenario workspace.
+
+### Asserting on a captured artifact
+
+A naked `ARTIFACTS` alias fed an exact `rd://` URI surfaces the **injected
+record's key**, while the record's **provenance stays the producer's**. Two
+consequences for `expect.artifacts` entries:
+
+- `key:` matches the consumer's alias mapping, as authored in the consuming
+  runbook.
+- `runbook:` filters the **emitting event's** runbook -- _not_ the record's
+  provenance. Adding `runbook: <consumer>` to an assertion over an injected
+  record does not scope it "to the consumer's row"; the row's provenance is the
+  producer's either way. Disambiguate consumer from producer by `alias:`
+  instead, and give the seeder's aliases distinct names from the consumer's.
+
 ## Dependency Copying and Path Safety
 
 Scenarios and suite cases run in isolated temporary workspaces.

--- a/docs/internal/scenarios.md
+++ b/docs/internal/scenarios.md
@@ -612,6 +612,16 @@ manifest row. Core owns URI construction (`buildArtifactUri`) and the manifest
 row shape; a scenario that duplicates either will drift silently when core
 changes.
 
+This constrains how a scenario obtains a URI it intends to _use_. It does not
+constrain a negative test that forges an artifact record as a **public input**
+in order to assert the input channel rejects it -- there, the forgery is the
+assertion rather than a seeding shortcut, so it is the point of the scenario and
+not a shortcut around capture. `forged-file-record-rejected`
+(`runbooks/artifacts/artifact-variable-review-plan.runbook.md`) is the canonical
+example: it writes a `file-artifact-record` bearing an out-of-project `file://`
+URI, feeds it through `--input-file`, and expects
+`Artifact record input for "Plan" is not trusted`. Leave it alone.
+
 | Placeholder                       | Resolves to                                          |
 | --------------------------------- | ---------------------------------------------------- |
 | `${CAPTURE_ARTIFACT:<key>}`       | The most recent `rd://artifacts/...` URI for `<key>` |

--- a/docs/internal/scenarios.md
+++ b/docs/internal/scenarios.md
@@ -650,7 +650,7 @@ tokenized by the shell. Unquoted, the shell strips those quotes and
 assignment:
 
 ```yaml
-- rd run collate.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all
+- rundown run collate.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all
 ```
 
 This is enforced, not advisory -- an unquoted array placeholder is rejected
@@ -685,7 +685,7 @@ tell these apart, and will always report the selector fixtures as false hits:
 ```
 
 ```yaml
-- rd run x.runbook.md --artifacts Plan=rd://artifacts/ctx/rd_1/plan.json # command: fabrication
+- rundown run x.runbook.md --artifacts Plan=rd://artifacts/ctx/rd_1/plan.json # command: fabrication
 ```
 
 `packages/cli/__tests__/schemas/scenario-authoring.test.ts` enforces the
@@ -705,8 +705,8 @@ runbook as its first command and capture the artifact it emits:
 scenarios:
   consume-plan-artifact:
     commands:
-      - rd run scenario-seed-artifacts.runbook.md --allow-all
-      - "rd run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
+      - rundown run scenario-seed-artifacts.runbook.md --allow-all
+      - "rundown run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
     expect:
       result: COMPLETE
 ```

--- a/docs/superpowers/plans/2026-07-16-498-scenario-capture-from-output.md
+++ b/docs/superpowers/plans/2026-07-16-498-scenario-capture-from-output.md
@@ -144,7 +144,7 @@ collision.
 - Consumes: nothing from earlier tasks.
 - Produces: `runbooks/artifacts/scenario-seed-artifacts.runbook.md`, a runbook
   staged by filename reference from any scenario `commands:` entry. Running
-  `rd run scenario-seed-artifacts.runbook.md --allow-all` appends exactly two
+  `rundown run scenario-seed-artifacts.runbook.md --allow-all` appends exactly two
   manifest rows and terminates `COMPLETE`:
   - key `PlanPath` (alias `PlanPathSeed`), file content `{"seeded":true}`
   - key `plan.json` (alias `PlanJsonSeed`), file content `{"seeded":true}`
@@ -354,7 +354,7 @@ it is being retired.
 this plan initially missed**. It is byte-identical to `review-plan-uri-input`
 (`:19-31`) — same two commands, same `expect` block, zero differences outside the
 `description:` string. It has never tested cross-context anything; both of its
-`rd run` invocations execute in the *same* context, which is exactly why it is
+`rundown run` invocations execute in the *same* context, which is exactly why it is
 identical.
 
 **Decision: delete it.** The alternative — give it a genuinely distinct producer
@@ -714,9 +714,9 @@ export const ScenarioSchema = z
 ```
 
 Add this TSDoc line to the block already documenting `ScenarioSchema`
-(`scenarios.ts:105-112`), immediately before its closing ` */`:
+(`scenarios.ts:105-112`), immediately before its closing `*/`:
 
-```
+```ts
  * Strict: unknown keys are rejected, not stripped. The retired `seed:` directive
  * (#498) must fail at load rather than be silently dropped — a dropped `seed:`
  * leaves its `${ARTIFACT:…}` command text unsubstituted and surfaces as a
@@ -826,7 +826,7 @@ after token substitution so it sees the final command text.
 Update the TSDoc on `substituteCapturedArtifacts` (`command-sequence.ts:493-507`)
 — its comparison to the deleted grammar is now dangling. Change:
 
-```
+```ts
  * `${CAPTURE_ARTIFACT:<key>}` is replaced by the `rd://` URI of the most recent
  * manifest row for `<key>`; `${CAPTURE_ARTIFACT_ARRAY:<key>}` is replaced by a
  * JSON array of all such URIs. Unlike `${ARTIFACT:…}` (pre-seeded), these are
@@ -837,7 +837,7 @@ Update the TSDoc on `substituteCapturedArtifacts` (`command-sequence.ts:493-507`
 
 To:
 
-```
+```ts
  * `${CAPTURE_ARTIFACT:<key>}` is replaced by the `rd://` URI of the most recent
  * manifest row for `<key>`; `${CAPTURE_ARTIFACT_ARRAY:<key>}` is replaced by a
  * JSON array of all such URIs. This is the sole artifact grammar: values are
@@ -911,7 +911,7 @@ Replace the module TSDoc (lines 1-11):
  */
 ```
 
-- [ ] **Step 8: Unwire seeding from the `rd scenario run` workflow**
+- [ ] **Step 8: Unwire seeding from the `rundown scenario run` workflow**
 
 In `packages/cli/src/helpers/scenario-workflow.ts`:
 
@@ -1092,7 +1092,7 @@ does not own its output. It splices a value into command text and hands it to
 (`:349`). The value must survive **that** tokenizer. The invariant that matters is
 therefore **composed**, not internal:
 
-```
+```text
 ∀ resolved value v accepted by the quoting guard, ∀ placeholder position:
   parseRdCommandWithEnv(await substituteCapturedArtifacts(cmd, () => v))
     contains v as exactly one argv entry, byte-identical
@@ -1260,7 +1260,7 @@ tempting guard is a regex asserting the placeholder is wrapped in single quotes,
 e.g. `/'\$\{CAPTURE_ARTIFACT_ARRAY:[^}]+\}'/`. **It false-rejects both real call
 sites.** They quote the *whole assignment*, not the placeholder:
 
-```
+```text
 --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}'
 ```
 
@@ -1711,7 +1711,7 @@ tokenised by the shell. Unquoted, the shell strips those quotes and
 assignment:
 
 ```yaml
-- rd run collate.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all
+- rundown run collate.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all
 ```
 
 This is enforced, not advisory — an unquoted array placeholder is rejected before
@@ -1738,8 +1738,8 @@ as its first command and capture the artifact it emits:
 scenarios:
   consume-plan-artifact:
     commands:
-      - rd run scenario-seed-artifacts.runbook.md --allow-all
-      - "rd run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
+      - rundown run scenario-seed-artifacts.runbook.md --allow-all
+      - "rundown run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
     expect:
       result: COMPLETE
 ```
@@ -1810,7 +1810,7 @@ bullet under "Out of scope".
 
 Run:
 
-```bash
+````bash
 gh issue create \
   --title "Scenario harness: thread a typed ScenarioContext through executeCommandSequence" \
   --body "$(cat <<'EOF'
@@ -1892,7 +1892,7 @@ Most of what made this refactor look expensive is already gone.
 `packages/cli/__tests__/helpers/command-sequence.properties.test.ts` (added by
 #498) states the invariant this refactor must establish:
 
-```
+```text
 ∀ resolved value v accepted by the quoting guard, ∀ placeholder position:
   parseRdCommandWithEnv(await substituteCapturedArtifacts(cmd, () => v))
     contains v as exactly one argv entry, byte-identical
@@ -1909,7 +1909,7 @@ should go red under this refactor, which is the signal to delete it.
 Design context: `docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md` §3.3.
 EOF
 )"
-```
+````
 
 - [ ] **Step 2: Record the issue number in the spec's deferral**
 
@@ -1951,16 +1951,16 @@ equally good alternative, since it only sees tracked files.
       exists.
 - [ ] **Single placeholder/capture mechanism; `${ARTIFACT:}` retired** —
 
-      ```bash
-      grep -rn 'ARTIFACT:' --include='*.ts' --include='*.md' \
-        --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
-        packages/ runbooks/ \
-        | grep -v CAPTURE_ARTIFACT \
-        | grep -v RETIRED_ARTIFACT_PLACEHOLDER
-      ```
+  ```bash
+  grep -rn 'ARTIFACT:' --include='*.ts' --include='*.md' \
+    --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+    packages/ runbooks/ \
+    | grep -v CAPTURE_ARTIFACT \
+    | grep -v RETIRED_ARTIFACT_PLACEHOLDER
+  ```
 
-      Every remaining hit must be part of the retirement tombstone (its TSDoc,
-      its error message, or its two tests). No hit may be a live use.
+  Every remaining hit must be part of the retirement tombstone (its TSDoc, its
+  error message, or its two tests). No hit may be a live use.
 
 - [ ] **The retirement fails loudly, not silently** — `seed:` is rejected by
       `ScenarioSchema` (strict) and `${ARTIFACT:}` in a command throws before
@@ -1969,26 +1969,26 @@ equally good alternative, since it only sees tracked files.
       `packages/cli/__tests__/helpers/command-sequence.test.ts`.
 - [ ] **No fabricated URIs or hand-built manifest rows** —
 
-      ```bash
-      grep -rn 'rd://artifacts/' \
-        --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
-        runbooks/
-      grep -rn 'manifest.jsonl' \
-        --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
-        runbooks/
-      ```
+  ```bash
+  grep -rn 'rd://artifacts/' \
+    --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+    runbooks/
+  grep -rn 'manifest.jsonl' \
+    --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+    runbooks/
+  ```
 
-      Both return nothing.
+  Both return nothing.
 
 - [ ] **No dead symbols** —
 
-      ```bash
-      grep -rn 'seedScenarioArtifacts\|substituteArtifactUris\|ScenarioSeedSchema' \
-        --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
-        packages/ runbooks/
-      ```
+  ```bash
+  grep -rn 'seedScenarioArtifacts\|substituteArtifactUris\|ScenarioSeedSchema' \
+    --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+    packages/ runbooks/
+  ```
 
-      Returns nothing.
+  Returns nothing.
 
 - [ ] **Scenarios migrated and green under both harnesses** —
       `pnpm run build && pnpm run test:scenarios:raw` passes, and

--- a/docs/superpowers/plans/2026-07-16-498-scenario-capture-from-output.md
+++ b/docs/superpowers/plans/2026-07-16-498-scenario-capture-from-output.md
@@ -1,0 +1,2024 @@
+# Scenario Capture-From-Output Seeding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the scenario harness's fabricated-URI artifact seeding with a
+single capture-from-command-output mechanism, retiring the `${ARTIFACT:}`
+grammar and the `seed:` directive.
+
+**Architecture:** A scenario that needs a pre-existing artifact runs a real
+producer runbook fixture (`scenario-seed-artifacts.runbook.md`) as its first
+command; the artifact is created through the genuine `ARTIFACTS` →
+artifact-service → manifest path, and the already-existing
+`${CAPTURE_ARTIFACT[_ARRAY]:<key>}` grammar hands its `rd://` URI to the
+consuming command. The change is a new YAML fixture, one scenario migration, two
+scenario deletions, deletions of the retired grammar, and **two deliberate
+production additions**, both fail-fast guards rather than behaviour: a
+**tombstone** that makes the retired grammar fail loudly rather than pass through
+silently (Task 3), and a **quoting guard** that enforces the surviving array
+form's shell-quoting requirement instead of leaving it to author convention
+(Task 4).
+
+**Tech Stack:** TypeScript (ESM, Node), Zod 4 schemas, Jest (`jest.config.mjs`,
+`unstable_mockModule`), fast-check 4, pnpm workspaces, Rundown scenario harness.
+
+**Design spec:**
+[`docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md`](../specs/2026-07-16-scenario-capture-from-output-design.md)
+— read it first. It records the resolved design questions (the seeder is a
+runbook fixture, not a CLI command; `seed:` is removed rather than reshaped and
+its removal is *enforced*, not merely silent; `ScenarioContext` threading is a
+deferred follow-up) and the rejected alternatives.
+
+**Issue:** [#498](https://github.com/tobyhede/rundown/issues/498)
+
+**Scope honesty — this is a partial fix, deliberately.** #498's "Why it's
+fragile" lists four items. This plan lands items 2 (synthetic fidelity), 3 (two
+placeholder grammars), and 4 (duplication of core). It does **not** land item 1
+(command-text-layer splicing / splice-then-reparse): after this change
+`${CAPTURE_ARTIFACT}` is still spliced into command text and re-parsed by
+`parseRdCommandWithEnv` (`command-sequence.ts:1652` calls it on the spliced
+string; `:349` runs `shellParse` on it), exactly as its four sibling grammars
+are. Two reasons this tracks the issue's scope rather than shrinking it, and one
+reason it is the right sequencing — all three in spec §1.3 and §3.3:
+
+1. #498's own "Proposed direction" marks `ScenarioContext` **optional**, and none
+   of its four acceptance criteria mention it. The plan discharges every stated
+   criterion.
+2. The deferred work's real cost was that the harness has **two injection
+   mechanisms with different temporal models**. This change collapses that to
+   one, which is most of what made the follow-up expensive (spec §3.3).
+3. Fixing item 1 for artifacts alone, while `${TOKEN}`, `${CLAIM_ID}`,
+   `${RUN_CLAIM_ID}`, and `${RUN_ID}` keep splicing strings, buys inconsistency
+   rather than type safety.
+
+**Bounding the residual hazard honestly.** The splice hazard that survives is
+**one usability defect on one grammar**, consistent with #498's `P3: low` label.
+Verified by execution (Task 4 records the transcript): the **scalar** form is
+structurally immune — `assertSafeId` (`packages/core/src/paths.ts:34`) confines
+ids to `[A-Za-z0-9._-]` and `rd://` URIs add only `/` and `:`, so no resolved
+scalar can carry a shell metacharacter. Only the **array** form is exposed, and
+only when the author omits single quotes. It then **throws**: the shell strips
+the JSON's `"` as quoting, yielding the *unparseable* `[rd://a,rd://b]`, so the
+`--artifacts-json` value fails to parse. It is **not** silent corruption — the
+failure is loud, but it names a value the author never wrote. Task 4 converts
+that convention into an enforced guard, which is what keeps the residual hazard
+at zero for every command the harness will accept. Task 6 files the follow-up
+issue that owns item 1 — deferred work with no issue number is deleted work.
+
+## Global Constraints
+
+- **`pnpm run verify` MUST pass before every push.** It runs format, spell, lint,
+  and test.
+- **Scenario changes require a build.** `pnpm run test:scenarios:raw` executes the
+  built CLI from `dist/`. Always run `pnpm run build` first, or use
+  `pnpm run test:scenarios` which builds for you.
+- **Every verification grep MUST exclude build output.** The mandated build
+  populates `packages/cli/dist/` and mutation runs populate
+  `packages/cli/.stryker-tmp/sandbox-*/`. Both are gitignored (`.gitignore:44`)
+  but present on disk, and a bare `grep -rn` over `packages/` returns ~49 hits
+  from them alone. Always pass
+  `--exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules`
+  (or use `git grep`, which only sees tracked files).
+- **Never migrate persisted runbook state.** Not applicable to this change (no
+  state shape is touched). No compatibility shim for old `seed:` scenarios may be
+  added — but note that "no shim" means **reject loudly**, not "accept silently".
+  A retired grammar that passes through unnoticed is the failure mode #498 exists
+  to prevent (see Task 3, Step 1).
+- **The CLI is a thin wrapper.** Do not add a CLI command, flag, or helper that
+  mints artifacts. Artifacts are produced only by running a runbook.
+- **No fabricated `rd://` URIs and no hand-built manifest rows** — in harness
+  code *or* authored in scenario YAML. Core owns `buildArtifactUri`
+  (`packages/core/src/runbook/artifact-uri.ts:109-115`) and the manifest row
+  shape.
+- **TSDoc on all exported symbols** — description, `@param` for every parameter,
+  `@returns` if non-void, `@throws` if it can throw.
+- **CLI tests default to JSON output.** Do not add `--text` to scenario commands.
+- Artifact keys must satisfy `assertSafeId`
+  (`packages/core/src/paths.ts:34-41`): non-empty, not `.` or `..`, matching
+  `SAFE_ID_PATTERN`.
+- **Fixture runbooks ship to end users.** `packages/cli/scripts/copy-runbooks.js`
+  copies `runbooks/**` into `packages/cli/dist/runbooks/`, and
+  `packages/cli/package.json:11-14` publishes `files: ["dist"]`. Anything added
+  under `runbooks/` appears in `rundown ls --all` as a **bundled** runbook for
+  every installed user. Name new fixtures so a confused user is not invited to
+  run them (hence `scenario-seed-artifacts`, not `seed-artifacts`).
+
+---
+
+### Task 1: Deterministic seeder fixture + migrate `consume-plan-artifact`
+
+Adds the producer runbook that replaces `seedScenarioArtifacts`, and migrates the
+repository's only `seed:` user onto it. The seeder emits **both** keys needed by
+the artifact fixtures (`PlanPath` and `plan.json`) so the migrated assertion
+stays byte-identical — that identity is the evidence the migration preserves
+behaviour.
+
+No harness change is needed to stage the seeder: `extractRunbookReferences`
+(`packages/cli/src/helpers/command-sequence.ts:1459-1475`) scans command strings
+for `*.runbook.md` and both harnesses stage what it finds
+(`packages/cli/src/helpers/scenario-workflow.ts:372,405-409` and
+`packages/cli/__tests__/integration/scenario-runner.test.ts:301-313`).
+
+**Naming.** The fixture is `scenario-seed-artifacts.runbook.md`, not
+`seed-artifacts.runbook.md`. It publishes to end users as a bundled runbook (see
+Global Constraints); `seed-artifacts` reads like a general-purpose user-facing
+utility, `scenario-seed-artifacts` reads like what it is. Existing fixtures
+already ship, so this is not a new exposure — but it is a new, invitingly-named
+one unless scoped. `copy-runbooks.js:44-51` throws on a duplicate relative path;
+`find runbooks -name '*seed*'` currently returns nothing, so there is no
+collision.
+
+**Files:**
+
+- Create: `runbooks/artifacts/scenario-seed-artifacts.runbook.md`
+- Modify: `runbooks/artifacts/execute-plan.runbook.md:7-20`
+- Test: the runbooks *are* the tests — exercised by
+  `pnpm run test:scenarios:raw` and by
+  `packages/cli/__tests__/integration/scenario-runner.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: `runbooks/artifacts/scenario-seed-artifacts.runbook.md`, a runbook
+  staged by filename reference from any scenario `commands:` entry. Running
+  `rd run scenario-seed-artifacts.runbook.md --allow-all` appends exactly two
+  manifest rows and terminates `COMPLETE`:
+  - key `PlanPath` (alias `PlanPathSeed`), file content `{"seeded":true}`
+  - key `plan.json` (alias `PlanJsonSeed`), file content `{"seeded":true}`
+
+  No later task depends on the `plan.json` key (Task 2 deletes its only would-be
+  consumer), but the seeder emits it anyway: it is the natural companion key, it
+  costs one line, and it keeps the fixture usable by any future scenario that
+  needs a seeded `plan.json` without reopening this design.
+
+- [ ] **Step 1: Write the failing scenario — create the seeder fixture**
+
+The seeder's own scenario (`seeds-two-artifacts`) is the failing test: it asserts
+the seeder really produces both keys through the production path, with backing
+files on disk.
+
+Create `runbooks/artifacts/scenario-seed-artifacts.runbook.md`:
+
+````markdown
+---
+name: scenario-seed-artifacts
+description: Deterministic producer fixture that seeds artifacts through the real ARTIFACTS production path.
+tags: [test, artifacts]
+scenarios:
+  seeds-two-artifacts:
+    description: Seeder produces both seed artifact keys with backing files.
+    commands:
+      - rd run scenario-seed-artifacts.runbook.md --allow-all
+    expect:
+      result: COMPLETE
+      artifacts:
+        - at: "1"
+          alias: PlanPathSeed
+          key: PlanPath
+          runbook: scenario-seed-artifacts.runbook.md
+          exists: true
+        - at: "1"
+          alias: PlanJsonSeed
+          key: plan.json
+          runbook: scenario-seed-artifacts.runbook.md
+          exists: true
+---
+# Scenario Seed Artifacts
+
+Producer fixture for scenarios that need a pre-existing artifact. Consumers run
+this first and reference the produced artifact with
+`${CAPTURE_ARTIFACT:<key>}` — never by fabricating an `rd://` URI.
+
+## 1. Seed artifacts
+
+- ARTIFACTS
+  - PlanPathSeed "PlanPath"
+  - PlanJsonSeed "plan.json"
+- PASS COMPLETE
+
+```bash
+printf '{"seeded":true}' > "{{ path PlanPathSeed }}"
+printf '{"seeded":true}' > "{{ path PlanJsonSeed }}"
+```
+````
+
+- [ ] **Step 2: Run the seeder scenario to verify it passes**
+
+Run:
+
+```bash
+pnpm run build && pnpm run test:scenarios:raw
+```
+
+Expected: PASS, including `scenario-seed-artifacts.runbook.md` /
+`seeds-two-artifacts`. Both `exists: true` assertions must match — that is the
+proof the seeder wrote real files at the paths core projected, rather than at a
+hand-derived path.
+
+If `exists: false` is reported, the `{{ path ... }}` projection is not resolving;
+compare against the working producer at
+`runbooks/artifacts/artifact-variable-write-plan.runbook.md:65-73`.
+
+- [ ] **Step 3: Commit the seeder**
+
+```bash
+git add runbooks/artifacts/scenario-seed-artifacts.runbook.md
+git commit -m "test(scenarios): add deterministic artifact seeder fixture (#498)"
+```
+
+- [ ] **Step 4: Migrate `consume-plan-artifact` off `seed:` / `${ARTIFACT:}`**
+
+In `runbooks/artifacts/execute-plan.runbook.md`, replace the frontmatter
+`scenarios:` block (lines 7-20) so it runs the seeder and captures its output.
+The `expect:` block is **unchanged** — `key: PlanPath` still holds because the
+seeder emits that exact key.
+
+Replace:
+
+```yaml
+scenarios:
+  consume-plan-artifact:
+    description: a boundary --artifacts value is consumed by a naked ARTIFACTS step
+    seed:
+      - artifact: PlanPath
+    commands:
+      - "rd run execute-plan.runbook.md --artifacts PlanPath=${ARTIFACT:PlanPath}"
+    expect:
+      result: COMPLETE
+      artifacts:
+        - at: "1"
+          alias: PlanPath
+          key: PlanPath
+          exists: true
+```
+
+With:
+
+```yaml
+scenarios:
+  consume-plan-artifact:
+    description: a boundary --artifacts value is consumed by a naked ARTIFACTS step
+    commands:
+      - rd run scenario-seed-artifacts.runbook.md --allow-all
+      - "rd run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
+    expect:
+      result: COMPLETE
+      artifacts:
+        - at: "1"
+          alias: PlanPath
+          key: PlanPath
+          exists: true
+```
+
+**Why the assertion still binds to the consumer, precisely.** The consuming step
+is a *naked* `ARTIFACTS` alias fed an exact `rd://` URI: it surfaces the
+**injected record's** key (`PlanPath`) while the record's **provenance** stays
+the *producer's* (the seeder's runbook path). So `key: PlanPath` matches for the
+right reason, but do not reach for a `runbook:` filter to disambiguate under a
+mistaken model of what it filters: **`runbook:` filters the emitting event's
+runbook, not the record's provenance.** This entry deliberately carries **no**
+`runbook:` filter, and that is what makes it insensitive to the seeder's
+provenance appearing on the row. Disambiguation here comes from `alias`: the
+seeder's step exposes `PlanPathSeed` / `PlanJsonSeed`, never `PlanPath`, so the
+first `step_entered` at `1` with alias `PlanPath` is unambiguously the
+consumer's.
+
+- [ ] **Step 5: Run the migrated scenario to verify it passes**
+
+Run:
+
+```bash
+pnpm run build && pnpm run test:scenarios:raw
+```
+
+Expected: PASS for `execute-plan.runbook.md` / `consume-plan-artifact`.
+
+Then verify the second harness agrees:
+
+```bash
+pnpm --filter @rundown-org/cli exec jest __tests__/integration/scenario-runner.test.ts
+```
+
+Expected: PASS.
+
+A `Command references ${CAPTURE_ARTIFACT...} but no resolveCapturedArtifact
+resolver was provided` failure means a harness lost its resolver wiring — both
+harnesses wire it today (`packages/cli/src/helpers/scenario-workflow.ts:488-489`,
+`packages/cli/__tests__/integration/scenario-runner.test.ts:375-376`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add runbooks/artifacts/execute-plan.runbook.md
+git commit -m "test(scenarios): migrate consume-plan-artifact to capture-from-output (#498)"
+```
+
+---
+
+### Task 2: Delete two scenarios that test nothing
+
+Two scenarios are deleted rather than migrated. Both deletions are removals of
+**false coverage signal**, and the commit message must say what unique coverage
+is lost: in both cases, none.
+
+**2a. `direct-uri-input`** (`artifact-variable-review-plan.runbook.md:8-21`) is
+`seedScenarioArtifacts` transcribed into YAML: its `node -e` one-liner
+(`:12`) hardcodes `run='rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'` and
+`ctx='producer-context'`, concatenates `'rd://artifacts/'+ctx+'/'+run+'/'+key`,
+re-derives `.rundown/work/.rd-<ctx>/<run>` by hand, and writes a manifest row
+literal. Deleting `seedScenarioArtifacts` while leaving this transcription in
+place would satisfy the issue's letter and none of its intent (spec §1.2).
+
+But migrating it is not the answer either. **Migrated, it becomes an exact
+duplicate.** Point it at a real producer and it is character-for-character
+`review-plan-uri-input`
+(`runbooks/artifacts/artifact-variable-write-plan.runbook.md:19-31`) apart from
+*which* producer runs first — and post-migration both producers are "a real
+producer runbook", a distinction with no behavioural content. Its entire reason
+to exist was exercising a **fabricated** row against the consume path. Delete the
+fabrication and the scenario has no remaining job. Delete it.
+
+Note this does **not** transfer from spec §3.1's "don't reuse
+`artifact-variable-write-plan` as the seeder" reasoning, which is sound but is
+about **Task 1**: there, reuse would force `consume-plan-artifact`'s
+`key: PlanPath` assertion to change (write-plan emits only `plan.json`, and the
+injected record's key wins), destroying the byte-identical-assertion evidence.
+Nothing analogous is at stake in Task 2 — the scenario is not being preserved,
+it is being retired.
+
+**2b. `review-plan-cross-context-uri-input`**
+(`artifact-variable-write-plan.runbook.md:33-45`) is **pre-existing duplication
+this plan initially missed**. It is byte-identical to `review-plan-uri-input`
+(`:19-31`) — same two commands, same `expect` block, zero differences outside the
+`description:` string. It has never tested cross-context anything; both of its
+`rd run` invocations execute in the *same* context, which is exactly why it is
+identical.
+
+**Decision: delete it.** The alternative — give it a genuinely distinct producer
+context — is rejected on two grounds. First, there is no scenario-layer
+affordance to force a distinct context: no `--context` flag exists on any command
+(`grep -rn "'--context" packages/cli/src` returns nothing), so making the
+scenario honest requires new production surface, i.e. building a feature to serve
+a test. Second, and decisively, **the behaviour it purports to cover is already
+pinned where it actually lives**: `resolveCapturedArtifactFromManifest`'s
+cross-context recency and ambiguity handling is unit-tested at
+`packages/cli/__tests__/helpers/scenario-artifacts.test.ts:54` (cross-context
+same-timestamp scalar pick throws ambiguous), `:74` (genuinely-latest URI wins
+across contexts), and `:95` (array form returns all cross-context collisions).
+Those tests can construct the multi-context manifest the scenario layer cannot.
+A scenario whose name claims coverage its body does not provide is worse than no
+scenario: it will be cited as evidence in a review.
+
+**Files:**
+
+- Modify: `runbooks/artifacts/artifact-variable-review-plan.runbook.md:8-21`
+  (delete `direct-uri-input`)
+- Modify: `runbooks/artifacts/artifact-variable-write-plan.runbook.md:33-45`
+  (delete `review-plan-cross-context-uri-input`)
+
+**Interfaces:**
+
+- Consumes: nothing. (Notably **not** the seeder — nothing here is migrated onto
+  it.)
+- Produces: nothing later tasks rely on. After this task, no runbook references
+  `${ARTIFACT:}`, which is Task 3's precondition.
+
+- [ ] **Step 1: Delete `direct-uri-input`**
+
+In `runbooks/artifacts/artifact-variable-review-plan.runbook.md`, delete lines
+8-21 in their entirety — the `direct-uri-input:` key and its whole body:
+
+```yaml
+  direct-uri-input:
+    description: Review-plan receives an exact rd:// Plan input from a seeded manifest row.
+    commands:
+      - >-
+        node -e "const fs=require('fs'),p=require('path');const run='rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',ctx='producer-context',key='plan.json';const dir=p.join('.rundown','work','.rd-'+ctx,run);fs.mkdirSync(dir,{recursive:true});fs.writeFileSync(p.join(dir,key),'{}');const row={uri:'rd://artifacts/'+ctx+'/'+run+'/'+key,runId:run,contextId:ctx,runbook:{source:'project',path:'artifact-variable-write-plan.runbook.md'},key,timestamp:'2026-05-25T00:00:00.000Z'};fs.writeFileSync(p.join('.rundown','work','.rd-'+ctx,'manifest.jsonl'),JSON.stringify(row)+'\n');"
+      - rd run artifact-variable-review-plan.runbook.md --artifacts Plan=${CAPTURE_ARTIFACT:plan.json} --allow-all
+    expect:
+      result: COMPLETE
+      artifacts:
+        - at: "1"
+          alias: Plan
+          key: plan.json
+          runbook: artifact-variable-review-plan.runbook.md
+          exists: true
+```
+
+`scenarios:` (line 7) keeps `forged-file-record-rejected` as its sole remaining
+entry, so the `scenarios:` key itself stays.
+
+**Leave `forged-file-record-rejected` (lines 22-32) untouched.** Its `node -e`
+looks like the same fabrication but is not: it writes an **intentionally forged**
+artifact record as a *public input* in order to assert the input channel
+**rejects** it (`expect.errors[0].error: 'Artifact record input for "Plan" is not
+trusted'`). The forgery *is* the assertion. Replacing it with a real producer
+would delete the test.
+
+- [ ] **Step 2: Delete `review-plan-cross-context-uri-input`**
+
+In `runbooks/artifacts/artifact-variable-write-plan.runbook.md`, delete lines
+33-45 in their entirety:
+
+```yaml
+  review-plan-cross-context-uri-input:
+    description: Review-plan receives a producer-context exact rd:// Plan input and treats it as the producer artifact.
+    commands:
+      - rd run artifact-variable-write-plan.runbook.md --allow-all
+      - rd run artifact-variable-review-plan.runbook.md --artifacts Plan=${CAPTURE_ARTIFACT:plan.json} --allow-all
+    expect:
+      result: COMPLETE
+      artifacts:
+        - at: "1"
+          alias: Plan
+          key: plan.json
+          runbook: artifact-variable-review-plan.runbook.md
+          exists: true
+```
+
+Leave `write-plan-produces-artifact` (`:5-17`), `review-plan-uri-input`
+(`:19-31`), and `bundled-write-review-collate-artifacts` (`:47-61`) untouched.
+`review-plan-uri-input` is the surviving twin and retains 100% of the deleted
+scenario's coverage.
+
+- [ ] **Step 3: Confirm the surviving twin is genuinely identical before trusting
+      the deletion**
+
+Do not take the plan's word for it. Run:
+
+```bash
+git show HEAD:runbooks/artifacts/artifact-variable-write-plan.runbook.md \
+  | sed -n '21,31p' > /tmp/rd498-a.txt
+git show HEAD:runbooks/artifacts/artifact-variable-write-plan.runbook.md \
+  | sed -n '35,45p' > /tmp/rd498-b.txt
+diff /tmp/rd498-a.txt /tmp/rd498-b.txt
+```
+
+Expected: no output (empty diff) — the two scenario bodies, excluding their
+`description:` lines, are identical. If the diff is non-empty, **stop**: the
+deletion rationale does not hold and the scenario carries real coverage. Report
+the difference rather than proceeding.
+
+- [ ] **Step 4: Run both harnesses to verify nothing else regressed**
+
+Run:
+
+```bash
+pnpm run build && pnpm run test:scenarios:raw
+```
+
+Expected: PASS. `direct-uri-input` and `review-plan-cross-context-uri-input` no
+longer appear in the output; every other scenario still passes.
+
+```bash
+pnpm --filter @rundown-org/cli exec jest __tests__/integration/scenario-runner.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify no fabricated URIs remain in runbooks**
+
+Run:
+
+```bash
+grep -rn --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+  "rd://artifacts/" runbooks/
+```
+
+Expected: no output. Any hit is a surviving hand-built URI.
+
+```bash
+grep -rn --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+  "manifest.jsonl" runbooks/
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+The commit message must name the coverage each deletion gives up, so a future
+reader does not have to re-derive it:
+
+```bash
+git add runbooks/artifacts/artifact-variable-review-plan.runbook.md \
+        runbooks/artifacts/artifact-variable-write-plan.runbook.md
+git commit -m "test(scenarios): delete two artifact scenarios that test nothing (#498)" -m \
+"direct-uri-input existed to exercise a *fabricated* manifest row against the
+consume path. With fabrication retired, a migrated version would be
+character-for-character review-plan-uri-input apart from which real producer runs
+first. Unique coverage lost: none.
+
+review-plan-cross-context-uri-input is already byte-identical to
+review-plan-uri-input (same commands, same expect; only the description differs).
+It has never exercised cross-context resolution — both runs share one context,
+and no --context flag exists to separate them. That behaviour is covered where it
+can actually be constructed, in packages/cli/__tests__/helpers/scenario-artifacts.test.ts
+lines 54, 74 and 95. Unique coverage lost: none."
+```
+
+---
+
+### Task 3: Retire the `${ARTIFACT:}` grammar and `seed:` directive, and make their return fail loudly
+
+With both users gone, remove the fabricating code and the second grammar. This is
+the task that discharges the issue's core acceptance criteria.
+
+**The deletion is not sufficient on its own, and this is the crux of the task.**
+`ScenarioSchema` (`packages/cli/src/schemas/scenarios.ts:143-185`) is
+`z.object({...}).refine(...).refine(...)` with no `.strict()`, on Zod 4
+(`packages/cli/package.json:51`, `"zod": "^4.4.3"`), where unknown keys are
+**stripped by default**. So a naive delete produces this:
+
+1. A scenario still carrying `seed:` parses **successfully** — `seed:` is
+   silently dropped.
+2. Its command still carrying `${ARTIFACT:PlanPath}` has no substituter left, so
+   the literal text `${ARTIFACT:PlanPath}` is passed through to `--artifacts`.
+3. The run fails with a confusing `INVALID_ARTIFACT_INPUT`.
+
+That is **verbatim** the failure described in #498's "Why it's fragile" §1 — the
+defect the issue exists to prevent. A silent-stripping deletion re-creates it.
+
+The codebase already rejects exactly this pattern one function away:
+`CAPTURE_ARTIFACT_PLACEHOLDER` (`command-sequence.ts:542`, used at
+`command-sequence.ts:1642`) exists for no other purpose than ensuring an
+unresolvable capture placeholder **throws** rather than leaking into the executed
+command. The retired grammar deserves the same treatment.
+
+**This is a tombstone, not a shim.** CLAUDE.md's no-migration rule forbids
+compatibility shims, fallback parsers, and warning-only adapters — code that
+keeps old input *working*. A detector that makes old input **fail with a message
+naming the retirement** is the opposite: it is the "detect invalid input and
+prompt explicit user action" behaviour the rule mandates. Failing loudly *serves*
+the no-migration rule.
+
+Two layers, covering two different surfaces:
+
+- **Schema layer** (`z.strictObject`): rejects the `seed:` *field* at scenario
+  load, with Zod's own unrecognized-key error.
+- **Command layer** (`RETIRED_ARTIFACT_PLACEHOLDER`): rejects the `${ARTIFACT:}`
+  *grammar* in command text, with a message naming #498 and pointing at the
+  survivor. A scenario could carry the placeholder without ever carrying `seed:`,
+  so the schema layer does not subsume this.
+
+**Files:**
+
+- Modify: `packages/cli/src/helpers/scenario-artifacts.ts:1-71` (delete
+  `seedScenarioArtifacts` and its now-unused imports; keep
+  `resolveCapturedArtifactFromManifest`)
+- Modify: `packages/cli/src/helpers/command-sequence.ts:454-479` (delete
+  `substituteArtifactUris`), `:542` (add `RETIRED_ARTIFACT_PLACEHOLDER`
+  alongside), `:1642` (add the throw)
+- Modify: `packages/cli/src/schemas/scenarios.ts:1,113-141,143-149` (delete
+  `ScenarioSeedSchema`, `ScenarioSeed`, the `seed` field, and the now-unused core
+  import; make the object strict)
+- Modify: `packages/cli/src/helpers/scenario-workflow.ts:57,65-68,454-459`
+- Test: `packages/cli/__tests__/helpers/command-sequence.test.ts:14,882-908`
+- Test: `packages/cli/__tests__/schemas/scenarios.test.ts:4,134-188`
+- Test: `packages/cli/__tests__/helpers/scenario-workflow.test.ts:115`
+- Test: `packages/cli/__tests__/integration/scenario-runner.test.ts:37,46,336-355`
+
+**Interfaces:**
+
+- Consumes: Tasks 1 and 2 — no scenario may reference `seed:` or `${ARTIFACT:}`
+  when this task runs, or the strict schema will reject it at load.
+- Produces: `packages/cli/src/helpers/scenario-artifacts.ts` exporting exactly
+  two symbols — `ScenarioArtifactLocation` (interface, `{ readonly cwd: string }`)
+  and `resolveCapturedArtifactFromManifest(location: ScenarioArtifactLocation,
+  key: string, asArray: boolean): Promise<string>`, both unchanged in signature.
+  `packages/cli/src/schemas/scenarios.ts` no longer exports `ScenarioSeedSchema`
+  or `ScenarioSeed`, and `Scenario` no longer carries a `seed` property.
+  `command-sequence.ts` gains a module-private `RETIRED_ARTIFACT_PLACEHOLDER`
+  (not exported; exercised through `executeCommandSequence`).
+
+- [ ] **Step 1: Write the failing tests — assert both retirements are *rejected***
+
+Two real negative tests. Neither asserts Zod's default stripping — asserting that
+`seed:` is silently dropped would institutionalise the exact outcome this task
+must prevent.
+
+In `packages/cli/__tests__/schemas/scenarios.test.ts`, replace the whole
+`describe('ScenarioSeedSchema', ...)` block (lines 134-188) with:
+
+```typescript
+describe('retired seed directive (#498)', () => {
+  it('rejects a scenario still carrying the retired seed field', () => {
+    const result = ScenarioSchema.safeParse({
+      seed: [{ artifact: 'PlanPath' }],
+      commands: ['rd run scenario-seed-artifacts.runbook.md --allow-all'],
+      result: 'COMPLETE',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toContain('seed');
+    }
+  });
+
+  it('still accepts a scenario with no seed field', () => {
+    const result = ScenarioSchema.safeParse({
+      commands: ['rd run scenario-seed-artifacts.runbook.md --allow-all'],
+      result: 'COMPLETE',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+```
+
+Then remove `ScenarioSeedSchema` from the import block at the top of the file
+(line 4).
+
+In `packages/cli/__tests__/helpers/command-sequence.test.ts`, replace the whole
+`describe('substituteArtifactUris', ...)` block (lines 882-908) with:
+
+```typescript
+describe('retired ${ARTIFACT:} grammar (#498)', () => {
+  it('throws naming the retirement rather than passing the placeholder through', async () => {
+    await expect(
+      executeCommandSequence({
+        commands: ['rd run x.runbook.md --artifacts PlanPath=${ARTIFACT:PlanPath}'],
+        cwd: process.cwd(),
+        execute: () => {
+          throw new Error('command must never be executed with a retired placeholder');
+        },
+      }),
+    ).rejects.toThrow(/\$\{ARTIFACT:\}.*retired.*#498/s);
+  });
+
+  it('does not mistake the surviving ${CAPTURE_ARTIFACT:} grammar for the retired one', async () => {
+    const resolved = await substituteCapturedArtifacts(
+      'rd run x --artifacts Plan=${CAPTURE_ARTIFACT:plan.json}',
+      async () => 'rd://artifacts/c/rd_1/plan.json',
+    );
+    expect(resolved).toBe('rd run x --artifacts Plan=rd://artifacts/c/rd_1/plan.json');
+  });
+});
+```
+
+The second test is the guard on the guard: `RETIRED_ARTIFACT_PLACEHOLDER` must
+not fire on `${CAPTURE_ARTIFACT:…}`, whose text contains `ARTIFACT:` but not
+`${ARTIFACT:`.
+
+Then remove `substituteArtifactUris` from the import block (line 14) — leave
+`substituteCapturedArtifacts` and `executeCommandSequence`, which are already
+imported there.
+
+> **Note for the implementer:** `executeCommandSequence`'s exact option object
+> differs across call sites. Copy the option shape from an existing
+> `executeCommandSequence` test in the same file rather than trusting the
+> illustrative `cwd`/`execute` fields above; only the `commands` entry and the
+> `rejects.toThrow` matcher are load-bearing.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli exec jest __tests__/schemas/scenarios.test.ts \
+  __tests__/helpers/command-sequence.test.ts
+```
+
+Expected: FAIL.
+
+- `rejects a scenario still carrying the retired seed field` fails with
+  `expect(false).toBe(false)` receiving `true` — `ScenarioSchema` still declares
+  `seed` and accepts it.
+- `throws naming the retirement...` fails because `substituteArtifactUris` still
+  exists and no retirement detector is wired.
+
+(A `ScenarioSeedSchema is not exported` / `substituteArtifactUris is not
+exported` TS error also counts as the expected failure if the import edits are
+applied first.)
+
+- [ ] **Step 3: Delete `ScenarioSeedSchema`, `ScenarioSeed`, and the `seed` field,
+      and make `ScenarioSchema` strict**
+
+In `packages/cli/src/schemas/scenarios.ts`:
+
+Delete the entire block at lines 113-141 — the `ScenarioSeedSchema` TSDoc, the
+schema, and the `ScenarioSeed` type export.
+
+Delete the `seed` field from `ScenarioSchema` (lines 148-149):
+
+```typescript
+    /** Optional manifest rows to seed before commands run (exposes ${ARTIFACT:<name>}) */
+    seed: z.array(ScenarioSeedSchema).optional(),
+```
+
+Change the object constructor (line 143-144) from `z.object` to `z.strictObject`:
+
+```typescript
+export const ScenarioSchema = z
+  .strictObject({
+```
+
+Add this TSDoc line to the block already documenting `ScenarioSchema`
+(`scenarios.ts:105-112`), immediately before its closing ` */`:
+
+```
+ * Strict: unknown keys are rejected, not stripped. The retired `seed:` directive
+ * (#498) must fail at load rather than be silently dropped — a dropped `seed:`
+ * leaves its `${ARTIFACT:…}` command text unsubstituted and surfaces as a
+ * confusing `INVALID_ARTIFACT_INPUT` at run time.
+```
+
+Delete line 1 entirely — `isValidVariableName` and `VALID_IDENTIFIER` were used
+only by `ScenarioSeedSchema`:
+
+```typescript
+import { isValidVariableName, VALID_IDENTIFIER } from '@rundown-org/core';
+```
+
+`import { z } from 'zod';` stays.
+
+`z.strictObject` is used rather than the deprecated `.strict()` method because
+`.strict()` cannot be chained after the two `.refine(...)` calls (they return a
+non-object schema type), and `z.strictObject` is the Zod 4 idiom. The repo's
+existing strict schemas (`packages/claude-code-plugin/src/plan-schema.ts`) use
+the older `.strict()` on unrefined objects; do not copy that form here.
+
+- [ ] **Step 4: Run the schema test to verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli exec jest __tests__/schemas/scenarios.test.ts
+```
+
+Expected: PASS.
+
+Then run the whole scenario suite — strictness is repo-wide now:
+
+```bash
+pnpm run build && pnpm run test:scenarios:raw
+```
+
+Expected: PASS. If a scenario **unrelated to `seed:`** now fails to parse, do not
+weaken the schema: strictness has surfaced a genuine latent typo in that
+scenario's YAML that stripping was hiding. Fix the typo and note it in the commit
+body.
+
+- [ ] **Step 5: Delete `substituteArtifactUris` and add the retirement tombstone**
+
+In `packages/cli/src/helpers/command-sequence.ts`, delete lines 454-479 — the
+TSDoc and the function:
+
+```typescript
+export function substituteArtifactUris(
+  cmd: string,
+  artifactUris: Readonly<Record<string, string | undefined>>,
+): string {
+  return cmd.replace(/\$\{ARTIFACT:([A-Za-z_][A-Za-z0-9_]*)\}/g, (match: string, name: string) => {
+    const uri = artifactUris[name];
+    if (uri === undefined) {
+      throw new Error(
+        `Artifact placeholder ${match} references an unseeded artifact (seed it via the scenario "seed" directive)`,
+      );
+    }
+    return uri;
+  });
+}
+```
+
+Immediately after `CAPTURE_ARTIFACT_PLACEHOLDER` (`command-sequence.ts:542`), add
+its tombstone counterpart:
+
+```typescript
+/**
+ * Non-global detector for the **retired** `${ARTIFACT:<name>}` grammar (#498).
+ *
+ * `${ARTIFACT:…}` and its `seed:` directive were removed in favour of a single
+ * capture-from-output mechanism. Without this detector the retired placeholder
+ * has no substituter left, so it would pass through verbatim into `--artifacts`
+ * and surface as an opaque `INVALID_ARTIFACT_INPUT` — the precise confusion the
+ * retirement exists to prevent. This is a tombstone, not a compatibility shim:
+ * it makes the retired grammar fail loudly and name its replacement, rather than
+ * keeping it working.
+ *
+ * Deliberately matches `[^}]+` rather than the retired grammar's narrower
+ * identifier pattern, so a *malformed* retired placeholder is caught too. It
+ * cannot match `${CAPTURE_ARTIFACT…}`, whose text contains `ARTIFACT:` but never
+ * the required `${` immediately before it.
+ */
+const RETIRED_ARTIFACT_PLACEHOLDER = /\$\{ARTIFACT:[^}]+\}/;
+```
+
+In `executeCommandSequence`, immediately **before** the existing
+`CAPTURE_ARTIFACT_PLACEHOLDER` check (`command-sequence.ts:1642`), add:
+
+```typescript
+    // The `${ARTIFACT:<name>}` grammar and its `seed:` directive were retired in
+    // #498. No substituter remains, so fail here and name the replacement rather
+    // than letting the raw placeholder leak into the executed command.
+    if (RETIRED_ARTIFACT_PLACEHOLDER.test(tokenSubstituted)) {
+      throw new Error(
+        `Command uses the retired \${ARTIFACT:} grammar, removed in #498: ${tokenSubstituted}\n` +
+          `Run a producer runbook first and use \${CAPTURE_ARTIFACT:<key>} to capture its artifact ` +
+          `(see runbooks/artifacts/scenario-seed-artifacts.runbook.md).`,
+      );
+    }
+```
+
+It must run before the capture check so the more specific diagnosis wins, and
+after token substitution so it sees the final command text.
+
+Update the TSDoc on `substituteCapturedArtifacts` (`command-sequence.ts:493-507`)
+— its comparison to the deleted grammar is now dangling. Change:
+
+```
+ * `${CAPTURE_ARTIFACT:<key>}` is replaced by the `rd://` URI of the most recent
+ * manifest row for `<key>`; `${CAPTURE_ARTIFACT_ARRAY:<key>}` is replaced by a
+ * JSON array of all such URIs. Unlike `${ARTIFACT:…}` (pre-seeded), these are
+ * resolved at execution time from rows a prior command produced, so a scenario
+ * can hand a produced artifact to a later run via `--artifacts` /
+ * `--artifacts-json`. Scenario-harness only; the resolver reads the manifest.
+```
+
+To:
+
+```
+ * `${CAPTURE_ARTIFACT:<key>}` is replaced by the `rd://` URI of the most recent
+ * manifest row for `<key>`; `${CAPTURE_ARTIFACT_ARRAY:<key>}` is replaced by a
+ * JSON array of all such URIs. This is the sole artifact grammar: values are
+ * resolved at execution time from rows a prior command actually produced, so a
+ * scenario hands a real produced artifact to a later run via `--artifacts` /
+ * `--artifacts-json`. A scenario needing a pre-existing artifact runs a producer
+ * runbook first (see `runbooks/artifacts/scenario-seed-artifacts.runbook.md`)
+ * rather than fabricating a URI. Scenario-harness only; the resolver reads the
+ * manifest.
+```
+
+- [ ] **Step 6: Run the command-sequence test to verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli exec jest __tests__/helpers/command-sequence.test.ts
+```
+
+Expected: PASS — including both tests from Step 1.
+
+- [ ] **Step 7: Delete `seedScenarioArtifacts` and its now-unused imports**
+
+In `packages/cli/src/helpers/scenario-artifacts.ts`, delete lines 30-71 — the
+TSDoc, `seedScenarioArtifacts`, and the `WORK_PATH`-adjacent seed code. Keep
+`const WORK_PATH = '.rundown/work';` (line 28) —
+`resolveCapturedArtifactFromManifest` uses it at lines 109-111.
+
+Replace the import block (lines 13-20):
+
+```typescript
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  appendArtifactManifestRecordSync,
+  assertRunId,
+  readAllArtifactManifestRecords,
+} from '@rundown-org/core';
+import type { Scenario } from '../schemas/scenarios.js';
+```
+
+With:
+
+```typescript
+import { readAllArtifactManifestRecords } from '@rundown-org/core';
+```
+
+> The implementer must keep whichever of `join` / `node:path` survives if
+> `resolveCapturedArtifactFromManifest` still uses it at lines 109-111 — verify
+> against the file rather than deleting the import blind. TypeScript's
+> `noUnusedLocals` will flag an over-deletion at build; a missing import is a
+> compile error either way.
+
+Replace the module TSDoc (lines 1-11):
+
+```typescript
+/**
+ * Scenario-harness artifact capture resolution.
+ *
+ * Resolves the `${CAPTURE_ARTIFACT[_ARRAY]:<key>}` grammar — the harness's sole
+ * artifact mechanism — for both the in-process jest scenario runner and the
+ * standalone `rd scenario run` command, so the two harnesses share one
+ * implementation instead of drifting. A scenario that needs a pre-existing
+ * artifact runs a real producer runbook first (see
+ * `runbooks/artifacts/scenario-seed-artifacts.runbook.md`) and captures the
+ * `rd://` URI that producer emitted; the harness never fabricates a URI or
+ * hand-writes a manifest row. Scenario-harness only — never part of runbook
+ * execution.
+ *
+ * @module helpers/scenario-artifacts
+ */
+```
+
+- [ ] **Step 8: Unwire seeding from the `rd scenario run` workflow**
+
+In `packages/cli/src/helpers/scenario-workflow.ts`:
+
+Remove `substituteArtifactUris,` from the `./command-sequence.js` import list
+(line 57).
+
+Replace the `./scenario-artifacts.js` import (lines 65-68):
+
+```typescript
+import {
+  resolveCapturedArtifactFromManifest,
+  seedScenarioArtifacts,
+} from './scenario-artifacts.js';
+```
+
+With:
+
+```typescript
+import { resolveCapturedArtifactFromManifest } from './scenario-artifacts.js';
+```
+
+Delete the seeding block (lines 454-459):
+
+```typescript
+    // Seed any artifacts declared by the scenario's `seed:` directive, then expose
+    // each seeded row's rd:// URI as a ${ARTIFACT:<name>} substitution token, so a
+    // command can consume a pre-seeded artifact via --artifacts. This mirrors the
+    // in-process jest harness; both share the helpers in ./scenario-artifacts.js.
+    const artifactUris = seedScenarioArtifacts(scenario, { cwd: tmpDir });
+    const commands = scenario.commands.map((cmd) => substituteArtifactUris(cmd, artifactUris));
+```
+
+Then change the `executeCommandSequence` call (line 466) from `commands,` to:
+
+```typescript
+      commands: scenario.commands,
+```
+
+In `packages/cli/__tests__/helpers/scenario-workflow.test.ts`, delete line 115
+from the mock factory:
+
+```typescript
+  substituteArtifactUris: actualCommandSequence.substituteArtifactUris,
+```
+
+- [ ] **Step 9: Unwire seeding from the jest scenario runner**
+
+In `packages/cli/__tests__/integration/scenario-runner.test.ts`:
+
+Remove `substituteArtifactUris,` from the `../../src/helpers/command-sequence.js`
+import list (line 37) and `seedScenarioArtifacts,` from the
+`../../src/helpers/scenario-artifacts.js` import list (line 46).
+
+Replace the comment block at lines 336-339:
+
+```typescript
+// `seedScenarioArtifacts` and `resolveCapturedArtifactFromManifest` are the
+// production scenario-harness helpers (also used by `rd scenario run`), imported
+// above from ../../src/helpers/scenario-artifacts.js so both harnesses share one
+// implementation.
+```
+
+With:
+
+```typescript
+// `resolveCapturedArtifactFromManifest` is the production scenario-harness
+// helper (also used by `rd scenario run`), imported above from
+// ../../src/helpers/scenario-artifacts.js so both harnesses share one
+// implementation.
+```
+
+Delete the seeding block (lines 351-355):
+
+```typescript
+  // Seed any artifacts declared by the scenario's `seed:` directive, then expose
+  // each seeded row's rd:// URI as a ${ARTIFACT:<name>} substitution token. This
+  // lets a boundary-channel scenario write `--artifacts PlanPath=${ARTIFACT:PlanPath}`.
+  const artifactUris = seedScenarioArtifacts(scenario, workspace);
+  const commands = scenario.commands.map((cmd) => substituteArtifactUris(cmd, artifactUris));
+```
+
+Then change the `executeCommandSequence` call (line 370) from `commands,` to:
+
+```typescript
+    commands: scenario.commands,
+```
+
+- [ ] **Step 10: Verify the grammar and the seeder are fully gone**
+
+Every grep excludes build output — see Global Constraints. A bare grep here
+returns ~49 false hits from `packages/cli/dist/` and
+`packages/cli/.stryker-tmp/sandbox-*/`, both gitignored (`.gitignore:44`) but
+populated by the mandated build.
+
+Run:
+
+```bash
+grep -rn 'ARTIFACT:' --include='*.ts' --include='*.md' \
+  --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+  packages/ runbooks/ docs/internal/ \
+  | grep -v CAPTURE_ARTIFACT \
+  | grep -v RETIRED_ARTIFACT_PLACEHOLDER
+```
+
+Expected: only hits inside the tombstone's own TSDoc/message and its two tests in
+`__tests__/helpers/command-sequence.test.ts` — every one of which is *about* the
+retirement. No hit may be a live use of the grammar.
+
+```bash
+grep -rn 'seedScenarioArtifacts\|substituteArtifactUris\|ScenarioSeedSchema' \
+  --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+  packages/ runbooks/
+```
+
+Expected: no output.
+
+- [ ] **Step 11: Run the full gate**
+
+Run:
+
+```bash
+pnpm run verify
+```
+
+Expected: PASS. TypeScript is the backstop here — any missed reference to a
+deleted symbol is a compile error, not a silent pass.
+
+Then both scenario harnesses:
+
+```bash
+pnpm run build && pnpm run test:scenarios:raw
+```
+
+Expected: PASS.
+
+```bash
+pnpm --filter @rundown-org/cli exec jest __tests__/integration/scenario-runner.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add packages/cli/src packages/cli/__tests__
+git commit -m "refactor(cli): retire \${ARTIFACT:} grammar and seed: directive (#498)" -m \
+"Deletes substituteArtifactUris, seedScenarioArtifacts, ScenarioSeedSchema and
+the seed: field, and replaces them with fail-fast tombstones rather than silent
+removal: ScenarioSchema becomes strict so seed: is rejected instead of stripped,
+and RETIRED_ARTIFACT_PLACEHOLDER throws on \${ARTIFACT:} in command text naming
+#498 and pointing at \${CAPTURE_ARTIFACT:<key>}. Zod 4 strips unknown keys by
+default, so a bare deletion would have let seed: parse silently and leaked the
+literal placeholder into --artifacts as a confusing INVALID_ARTIFACT_INPUT — the
+exact defect #498 exists to prevent."
+```
+
+---
+
+### Task 4: Enforce the array form's quoting requirement, and property-test the now-sole artifact grammar
+
+Task 3 promotes `substituteCapturedArtifacts` (`command-sequence.ts:508-533`)
+from "one of two artifact grammars" to **the** artifact grammar, and adds no
+coverage to it. This task pins it — but at the boundary that actually carries
+risk, which is **not** where a first draft of this plan aimed.
+
+**Where the risk is not: the splice arithmetic.** `substituteCapturedArtifacts`
+is hand-rolled index arithmetic over `matchAll` (`:525-532`) — a running `last`
+offset, `match.index` starts, manual `cmd.slice` concatenation. It looks like the
+fragile part. It is not: that arithmetic is correct today, nothing in this plan
+touches it, and no reviewer has disputed it. Properties asserting it are green on
+the first run, which makes them **evidence for an undisputed claim**. They are
+worth keeping — they are cheap and they pin the splice against future edits — but
+they are not this task's point.
+
+**Where the risk is: the handoff across `shellParse`.** `substituteCapturedArtifacts`
+does not own its output. It splices a value into command text and hands it to
+`parseRdCommandWithEnv` (`command-sequence.ts:1652`), which runs `shellParse`
+(`:349`). The value must survive **that** tokenizer. The invariant that matters is
+therefore **composed**, not internal:
+
+```
+∀ resolved value v accepted by the quoting guard, ∀ placeholder position:
+  parseRdCommandWithEnv(await substituteCapturedArtifacts(cmd, () => v))
+    contains v as exactly one argv entry, byte-identical
+```
+
+**The precondition is load-bearing and must be honest.** Without
+"accepted by the guard" this property is **unconditionally red** — the unquoted
+array form falsifies it. The precondition is not a fudge to make the suite green;
+it is the exact statement of which commands the harness will accept, which is why
+Step 1 builds the guard *before* Step 4 writes the property. A precondition that
+excluded the array form entirely would make the property vacuous; this one does
+not — it admits every scalar placeholder in any position, plus every correctly
+quoted array placeholder, which is 100% of the legal grammar and 100% of the
+real call sites.
+
+#### The defect the guard closes — verified by execution, not inference
+
+`resolveCapturedArtifactFromManifest` returns `JSON.stringify(...)` for the array
+form (`scenario-artifacts.ts:130`) — a value containing `"` characters. Running
+`shell-quote`'s `parse` on the two spellings:
+
+| Form | Command text | `shellParse` argv payload | Result |
+| ---- | ------------ | ------------------------- | ------ |
+| Quoted | `--artifacts-json 'R=["rd://a","rd://b"]'` | `R=["rd://a","rd://b"]` | JSON intact, byte-identical |
+| Unquoted | `--artifacts-json R=["rd://a","rd://b"]` | `R=[rd://a,rd://b]` | **JSON destroyed** |
+
+Both produce one argv entry and `hasOperators` is `false` for both, so no
+operator or glob path intervenes — the quotes are simply consumed as *shell*
+quoting. The unquoted payload is **invalid JSON**, so it throws.
+
+**Severity, stated accurately.** This is a **usability defect on one grammar**,
+matching #498's `P3: low` label — not silent corruption. The value does not
+quietly change meaning; the command fails, with an error naming a value the
+author never wrote. The **scalar form is structurally immune**: `assertSafeId`
+(`packages/core/src/paths.ts:34`) confines ids to `[A-Za-z0-9._-]`, and `rd://`
+URIs add only `/` and `:`, so no resolved scalar value can carry a shell
+metacharacter. Do not justify this task by overstating the hazard.
+
+**Why it must be enforced rather than conventional.** Correctness of the sole
+surviving artifact grammar currently rests on authors remembering single quotes.
+Both existing array call sites do quote —
+`runbooks/artifacts/artifact-variable-write-plan.runbook.md:52` and
+`artifact-variable-collate.runbook.md:13` — by convention, with nothing checking
+them. Task 3 establishes the fail-fast tombstone pattern for exactly this class
+of "retired/illegal input must not pass through silently". The quoting
+requirement gets the same treatment.
+
+**Rejected: make the resolver emit shell-escaped JSON.** Escaping a value to
+survive a tokenizer *we control and invoke ourselves* is the wrong direction: it
+bakes the splice-then-reparse hazard deeper into the design at the moment the
+follow-up intends to remove it, and it would make the resolved value differ from
+the value the consumer receives.
+
+#### This guard is deliberate throwaway — say so, don't discover it later
+
+Under the deferred parse-then-substitute refactor (spec §3.3, Task 6's issue),
+resolved values are injected into an already-parsed argv and **never reach
+`shellParse`**. The quoting requirement then evaporates and this guard becomes
+dead code that the follow-up deletes. That is **~10 lines of accepted waste, not
+an oversight** — it buys enforced correctness for the interval during which
+splice-then-reparse is real, which is an interval of unknown length. Task 6's
+issue body names this guard as something the refactor removes, so the waste is
+tracked rather than fossilised.
+
+**Files:**
+
+- Modify: `packages/cli/src/helpers/command-sequence.ts` (add
+  `CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER`, `ARRAY_QUOTING_PROBE`, and
+  `assertArrayCapturesAreShellQuoted` next to `RETIRED_ARTIFACT_PLACEHOLDER` at
+  `:542`; call it in `executeCommandSequence` at `:1642`)
+- Test: `packages/cli/__tests__/helpers/command-sequence.test.ts` (guard's
+  example-based tests)
+- Create: `packages/cli/__tests__/helpers/command-sequence.properties.test.ts`
+
+**Interfaces:**
+
+- Consumes: `substituteCapturedArtifacts(cmd: string, resolve:
+  CapturedArtifactResolver): Promise<string>` and
+  `parseRdCommandWithEnv(cmd: string): ParsedRdCommand | null`, both from
+  `packages/cli/src/helpers/command-sequence.ts` and both unchanged by this plan.
+  `parseRdCommandWithEnv` returns `null` for a non-`rd` shell command and
+  otherwise an object with an `args: string[]` property.
+- Produces: a module-private `assertArrayCapturesAreShellQuoted(cmd: string):
+  void` in `command-sequence.ts` — not exported, exercised through
+  `executeCommandSequence`. Nothing later tasks rely on.
+
+- [ ] **Step 1: Write the failing guard tests**
+
+In `packages/cli/__tests__/helpers/command-sequence.test.ts`, add to the
+`describe('retired ${ARTIFACT:} grammar (#498)', ...)` block's file — as a new
+sibling `describe` — the following. Copy the `executeCommandSequence` option
+shape from an existing `executeCommandSequence` test in the same file rather
+than trusting the illustrative `cwd`/`execute`/`resolveCapturedArtifact` fields
+below; only the `commands` entries and the matchers are load-bearing.
+
+```typescript
+describe('${CAPTURE_ARTIFACT_ARRAY:} shell-quoting guard (#498)', () => {
+  const neverExecute = (): never => {
+    throw new Error('command must never be executed with an unquoted array capture');
+  };
+
+  it('rejects an unquoted array capture, naming the key and the fix', async () => {
+    await expect(
+      executeCommandSequence({
+        commands: ['rd run x.runbook.md --artifacts-json R=${CAPTURE_ARTIFACT_ARRAY:review.json}'],
+        cwd: process.cwd(),
+        resolveCapturedArtifact: async () => '["rd://artifacts/c/rd_1/review.json"]',
+        execute: neverExecute,
+      }),
+    ).rejects.toThrow(/review\.json.*single-quote/s);
+  });
+
+  it('accepts the real quoted call-site spelling, where the whole assignment is quoted', async () => {
+    const seen: string[] = [];
+    await executeCommandSequence({
+      commands: [
+        "rd run x.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all",
+      ],
+      cwd: process.cwd(),
+      resolveCapturedArtifact: async () => '["rd://artifacts/c/rd_1/review.json"]',
+      execute: (cmd: string) => {
+        seen.push(cmd);
+        return { stdout: '{}', code: 0 };
+      },
+    });
+    expect(seen[0]).toContain('["rd://artifacts/c/rd_1/review.json"]');
+  });
+
+  it('does not fire on the scalar form, which needs no quoting', async () => {
+    const seen: string[] = [];
+    await executeCommandSequence({
+      commands: ['rd run x.runbook.md --artifacts P=${CAPTURE_ARTIFACT:plan.json}'],
+      cwd: process.cwd(),
+      resolveCapturedArtifact: async () => 'rd://artifacts/c/rd_1/plan.json',
+      execute: (cmd: string) => {
+        seen.push(cmd);
+        return { stdout: '{}', code: 0 };
+      },
+    });
+    expect(seen[0]).toContain('rd://artifacts/c/rd_1/plan.json');
+  });
+});
+```
+
+The second test is the one that matters most, and it is not hypothetical: it
+encodes the **actual** spelling both real call sites use (see Step 3).
+
+- [ ] **Step 2: Run the guard tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli exec jest __tests__/helpers/command-sequence.test.ts \
+  -t 'shell-quoting guard'
+```
+
+Expected: FAIL — `rejects an unquoted array capture` receives a resolved
+promise, because no guard exists yet. The other two tests pass already (they
+assert current behaviour); they are regression pins for Step 3.
+
+- [ ] **Step 3: Implement the guard — use the tokenizer as the oracle, not a regex**
+
+**Read this before writing the code — the obvious implementation is wrong.** The
+tempting guard is a regex asserting the placeholder is wrapped in single quotes,
+e.g. `/'\$\{CAPTURE_ARTIFACT_ARRAY:[^}]+\}'/`. **It false-rejects both real call
+sites.** They quote the *whole assignment*, not the placeholder:
+
+```
+--artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}'
+```
+
+The character before the placeholder is `=`, not `'`. Verified by execution: that
+adjacency regex returns `false` on `artifact-variable-collate.runbook.md:13`.
+Chasing this with a smarter regex means reimplementing shell quoting rules —
+precisely the fragile string analysis this plan exists to reduce.
+
+**Instead, ask the real tokenizer.** Substitute a **probe** value with the same
+shell-hazardous shape as real resolved JSON, run it through the very `shellParse`
+the command is about to face, and check the probe survived intact. The oracle is
+the tokenizer itself, so the guard cannot disagree with it.
+
+`shellParse` is already imported at `command-sequence.ts:18`
+(`import { parse as shellParse } from 'shell-quote';`) — no new dependency.
+
+Immediately after `RETIRED_ARTIFACT_PLACEHOLDER` (added in Task 3 at `:542`),
+add:
+
+```typescript
+/** Global matcher for the array form, used to locate placeholders to probe. */
+const CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER = /\$\{CAPTURE_ARTIFACT_ARRAY:([^}]+)\}/g;
+
+/**
+ * Stand-in for a resolved array value, used to ask `shellParse` whether a real
+ * resolved value would survive at the same position.
+ *
+ * Covers every shell-significant character a real value can contain. A resolved
+ * array is `JSON.stringify` of `rd://` URIs (`scenario-artifacts.ts:130`), whose
+ * character set is closed under `assertSafeId` (`[A-Za-z0-9._-]`, `paths.ts:34`)
+ * plus the URI's `/` and `:` and JSON's `[`, `]`, `"`, `,`. Of those, only `"`
+ * and `[`/`]` are shell-significant, and the probe contains all three — so a
+ * probe that survives implies a real value survives.
+ */
+const ARRAY_QUOTING_PROBE = '["rd://s"]';
+
+/**
+ * Reject an `${CAPTURE_ARTIFACT_ARRAY:<key>}` placeholder that is not shell-quoted.
+ *
+ * The array form resolves to JSON containing `"` characters, which are spliced
+ * into command text and then re-tokenised by `shellParse` via
+ * {@link parseRdCommandWithEnv}. Unquoted, the shell consumes those quotes and
+ * `["rd://a","rd://b"]` arrives as the unparseable `[rd://a,rd://b]`, failing
+ * with an error naming a value the author never wrote. The scalar form needs no
+ * such guard: its resolved values cannot contain a shell metacharacter.
+ *
+ * Implemented by probing the real tokenizer rather than by matching quotes with
+ * a regex: authors quote the whole assignment (`'K=${...}'`), not the
+ * placeholder, so an adjacency regex false-rejects every real call site.
+ *
+ * Deliberately throwaway: under the deferred parse-then-substitute refactor
+ * (#498 follow-up) resolved values never reach `shellParse` and this guard is
+ * deleted with the hazard it guards.
+ *
+ * @param cmd - Command text after token substitution, placeholders still intact
+ * @throws {Error} When any array placeholder would not survive shell tokenisation
+ */
+function assertArrayCapturesAreShellQuoted(cmd: string): void {
+  const keys = [...cmd.matchAll(CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER)].map((m) => m[1]);
+  if (keys.length === 0) return;
+  const probe = cmd.replace(CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER, ARRAY_QUOTING_PROBE);
+  let survived: number;
+  try {
+    // Count probe *occurrences*, not entries containing one: two placeholders
+    // can legitimately land in a single quoted argv entry.
+    survived = shellParse(probe)
+      .filter((entry): entry is string => typeof entry === 'string')
+      .reduce((n, entry) => n + entry.split(ARRAY_QUOTING_PROBE).length - 1, 0);
+  } catch {
+    survived = -1;
+  }
+  if (survived !== keys.length) {
+    throw new Error(
+      `Command uses \${CAPTURE_ARTIFACT_ARRAY:${keys[0]}} without shell quoting: ${cmd}\n` +
+        `The array form resolves to JSON containing double quotes; unquoted, the shell strips ` +
+        `them and the value arrives as invalid JSON. Single-quote the assignment, e.g. ` +
+        `--artifacts-json 'Key=\${CAPTURE_ARTIFACT_ARRAY:${keys[0]}}'.`,
+    );
+  }
+}
+```
+
+In `executeCommandSequence`, immediately **after** the `RETIRED_ARTIFACT_PLACEHOLDER`
+throw added in Task 3 and **before** the `CAPTURE_ARTIFACT_PLACEHOLDER` check
+(`command-sequence.ts:1642`), add:
+
+```typescript
+    // The array capture resolves to JSON with double quotes and is re-tokenised
+    // by shellParse below; reject it here if it would not survive, rather than
+    // failing later against a value the author never wrote.
+    assertArrayCapturesAreShellQuoted(tokenSubstituted);
+```
+
+It runs on `tokenSubstituted` — after token substitution, so it sees final
+command text, and before capture substitution, so it can still name the
+placeholder rather than the resolved value.
+
+- [ ] **Step 4: Run the guard tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli exec jest __tests__/helpers/command-sequence.test.ts
+```
+
+Expected: PASS — all three guard tests, plus Task 3's tombstone tests.
+
+Then confirm the guard does not reject the repository's real scenarios:
+
+```bash
+pnpm run build && pnpm run test:scenarios:raw
+```
+
+Expected: PASS, including `bundled-write-review-collate-artifacts`
+(`artifact-variable-write-plan.runbook.md:47-61`) and
+`artifact-variable-collate.runbook.md`'s scenario — the two real array call
+sites. A rejection here means the guard is over-tight; fix the guard, **not**
+the scenarios.
+
+- [ ] **Step 5: Write the property tests**
+
+`packages/cli/__tests__/services/renderers/json-renderer.properties.test.ts` is
+the CLI package's only existing fast-check file — follow its
+`import * as fc from 'fast-check';` convention and `*.properties.test.ts` naming.
+fast-check is already a CLI devDependency (`packages/cli/package.json:60`,
+`"fast-check": "^4.9.0"`).
+
+Create `packages/cli/__tests__/helpers/command-sequence.properties.test.ts`:
+
+```typescript
+import { describe, it, expect } from '@jest/globals';
+import * as fc from 'fast-check';
+import {
+  substituteCapturedArtifacts,
+  parseRdCommandWithEnv,
+} from '../../src/helpers/command-sequence.js';
+
+/** A placeholder key: the shape `assertSafeId` admits, kept short for shrinking. */
+const keyArb = fc.stringMatching(/^[A-Za-z0-9_.]{1,12}$/);
+
+/**
+ * Literal command text guaranteed to contain no placeholder. Mapping `$` away is
+ * used rather than filtering so no generated value is ever rejected. Length 0 is
+ * allowed on purpose — it is what produces adjacent placeholders and
+ * placeholders at the very start/end of the command.
+ */
+const literalArb = fc
+  .string({ maxLength: 12 })
+  .map((s) => s.replaceAll('$', 'S').replaceAll('{', '(').replaceAll('}', ')'));
+
+interface Placeholder {
+  readonly key: string;
+  readonly asArray: boolean;
+}
+
+interface Command {
+  readonly placeholders: readonly Placeholder[];
+  readonly literals: readonly string[];
+}
+
+/** N placeholders interleaved with exactly N+1 literal segments. */
+const commandArb: fc.Arbitrary<Command> = fc
+  .array(fc.record({ key: keyArb, asArray: fc.boolean() }), { maxLength: 5 })
+  .chain((placeholders) =>
+    fc
+      .array(literalArb, {
+        minLength: placeholders.length + 1,
+        maxLength: placeholders.length + 1,
+      })
+      .map((literals) => ({ placeholders, literals })),
+  );
+
+function renderPlaceholder(p: Placeholder): string {
+  return `\${CAPTURE_ARTIFACT${p.asArray ? '_ARRAY' : ''}:${p.key}}`;
+}
+
+function buildCommand({ placeholders, literals }: Command): string {
+  return placeholders.reduce(
+    (acc, p, i) => acc + renderPlaceholder(p) + literals[i + 1],
+    literals[0],
+  );
+}
+
+/**
+ * The resolved value for the nth resolver call. Deliberately contains `}` and
+ * `${` — if the implementation re-scanned its own output, these would be
+ * re-parsed as placeholder syntax and the oracle would diverge.
+ */
+function resolvedValue(n: number, key: string, asArray: boolean): string {
+  return `<${String(n)}:${key}:${asArray ? 'A' : 'S'}}\${>`;
+}
+
+/**
+ * A resolved value the harness can really produce: a `rd://` URI whose segments
+ * are `assertSafeId`-shaped (`paths.ts:34`), so the arbitrary generates exactly
+ * the domain `resolveCapturedArtifactFromManifest` returns and no wider.
+ */
+const uriArb = fc
+  .tuple(
+    fc.stringMatching(/^[A-Za-z0-9._-]{1,8}$/),
+    fc.stringMatching(/^[A-Za-z0-9._-]{1,8}$/),
+    fc.stringMatching(/^[A-Za-z0-9._-]{1,8}$/),
+  )
+  .map(([ctx, run, key]) => `rd://artifacts/${ctx}/rd_${run}/${key}`);
+
+/** The array form's resolved value: `JSON.stringify` of URIs, per scenario-artifacts.ts:130. */
+const arrayValueArb = fc.array(uriArb, { maxLength: 3 }).map((uris) => JSON.stringify(uris));
+
+/** Count argv entries containing `value` after substitution + the real rd parse. */
+async function argvEntriesContaining(cmd: string, value: string): Promise<number> {
+  const substituted = await substituteCapturedArtifacts(cmd, async () => value);
+  const parsed = parseRdCommandWithEnv(substituted);
+  if (!parsed) throw new Error(`expected an rd command, got: ${substituted}`);
+  return parsed.args.filter((arg) => arg.includes(value)).length;
+}
+
+describe('substituteCapturedArtifacts (properties)', () => {
+  // ---------------------------------------------------------------------------
+  // The load-bearing property: composed across the shellParse boundary that
+  // substituteCapturedArtifacts hands off to. Its precondition — "accepted by
+  // the quoting guard" — is expressed by only generating command shapes the
+  // guard admits: scalars anywhere, arrays single-quoted. Without it the
+  // property is unconditionally red (see the unquoted-array case below, which
+  // is asserted as a *known* falsification rather than hidden).
+  // ---------------------------------------------------------------------------
+  it('a resolved SCALAR survives the rd parse as exactly one argv entry, byte-identical', async () => {
+    await fc.assert(
+      fc.asyncProperty(uriArb, async (uri) => {
+        // Scalars are immune regardless of quoting, so both spellings hold.
+        expect(
+          await argvEntriesContaining('rd run x.runbook.md --artifacts P=${CAPTURE_ARTIFACT:k}', uri),
+        ).toBe(1);
+        expect(
+          await argvEntriesContaining(
+            "rd run x.runbook.md --artifacts P='${CAPTURE_ARTIFACT:k}'",
+            uri,
+          ),
+        ).toBe(1);
+      }),
+    );
+  });
+
+  it('a resolved ARRAY survives the rd parse byte-identically when the assignment is quoted', async () => {
+    await fc.assert(
+      fc.asyncProperty(arrayValueArb, async (value) => {
+        // The real call-site spelling: the whole assignment is single-quoted
+        // (artifact-variable-collate.runbook.md:13).
+        expect(
+          await argvEntriesContaining(
+            "rd run x.runbook.md --artifacts-json 'R=${CAPTURE_ARTIFACT_ARRAY:k}' --allow-all",
+            value,
+          ),
+        ).toBe(1);
+      }),
+    );
+  });
+
+  it('documents WHY the guard precondition is required: unquoted arrays falsify the property', async () => {
+    // This is the defect Task 4's guard rejects. Pinned as a known falsification
+    // so the precondition above is visibly non-arbitrary — and so this test goes
+    // red (telling us to delete it) if the hazard is ever removed at the source.
+    const value = JSON.stringify(['rd://artifacts/c/rd_1/plan.json']);
+    const survived = await argvEntriesContaining(
+      'rd run x.runbook.md --artifacts-json R=${CAPTURE_ARTIFACT_ARRAY:k}',
+      value,
+    );
+    expect(survived).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Internals: cheap, and they pin the splice arithmetic against future edits.
+  // These are NOT evidence that this change is correct — they were green before
+  // it and are green after.
+  // ---------------------------------------------------------------------------
+  it('splices every placeholder at the right offset and preserves literals verbatim', async () => {
+    await fc.assert(
+      fc.asyncProperty(commandArb, async (command) => {
+        const cmd = buildCommand(command);
+        const calls: Placeholder[] = [];
+        let n = 0;
+        const resolve = async (key: string, asArray: boolean): Promise<string> => {
+          calls.push({ key, asArray });
+          return resolvedValue(n++, key, asArray);
+        };
+
+        const result = await substituteCapturedArtifacts(cmd, resolve);
+
+        const expected = command.placeholders.reduce(
+          (acc, p, i) => acc + resolvedValue(i, p.key, p.asArray) + command.literals[i + 1],
+          command.literals[0],
+        );
+        // Offset correctness across every match, literal text preserved verbatim,
+        // resolved values never re-scanned, adjacent placeholders handled.
+        expect(result).toBe(expected);
+        // N placeholders produce exactly N resolver calls, in match order, with
+        // the array flag carried through.
+        expect(calls).toEqual(
+          command.placeholders.map((p) => ({ key: p.key, asArray: p.asArray })),
+        );
+      }),
+    );
+  });
+
+  it('returns placeholder-free commands verbatim without calling the resolver', async () => {
+    await fc.assert(
+      fc.asyncProperty(literalArb, async (cmd) => {
+        let calls = 0;
+        const resolve = async (): Promise<string> => {
+          calls++;
+          return 'unused';
+        };
+
+        expect(await substituteCapturedArtifacts(cmd, resolve)).toBe(cmd);
+        expect(calls).toBe(0);
+      }),
+    );
+  });
+
+  it('never re-scans a resolved value that itself looks like a placeholder', async () => {
+    let calls = 0;
+    const resolve = async (): Promise<string> => {
+      calls++;
+      return '${CAPTURE_ARTIFACT:injected}';
+    };
+
+    const result = await substituteCapturedArtifacts('a ${CAPTURE_ARTIFACT:real} b', resolve);
+
+    expect(result).toBe('a ${CAPTURE_ARTIFACT:injected} b');
+    expect(calls).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 6: Run the property tests**
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli exec jest __tests__/helpers/command-sequence.properties.test.ts
+```
+
+Expected: PASS — all six.
+
+These characterise **existing** behaviour, so they pass on the first run; this is
+the one place in this plan where a red step is not expected. If one fails, that
+is a **real defect**, not a bad test: read the fast-check counterexample and use
+superpowers:systematic-debugging. Do not weaken a property to make it green — in
+particular, do not widen the guard's precondition.
+
+- [ ] **Step 7: Verify the properties can actually fail**
+
+A property test that cannot fail is worse than none. Confirm the **composed**
+property bites — not just the internals one. Temporarily change
+`command-sequence.ts:530` from:
+
+```typescript
+    result += cmd.slice(last, start) + replacements[index];
+```
+
+To:
+
+```typescript
+    result += cmd.slice(last, start + 1) + replacements[index];
+```
+
+Run:
+
+```bash
+pnpm --filter @rundown-org/cli exec jest __tests__/helpers/command-sequence.properties.test.ts
+```
+
+Expected: FAIL on the scalar/array composed properties **and** on the splice
+property, each with a shrunk counterexample. **Revert**
+(`git checkout -- packages/cli/src/helpers/command-sequence.ts`) and re-run to
+confirm PASS before committing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/src/helpers/command-sequence.ts \
+        packages/cli/__tests__/helpers/command-sequence.test.ts \
+        packages/cli/__tests__/helpers/command-sequence.properties.test.ts
+git commit -m "test(cli): enforce and property-test array capture shell-quoting (#498)" -m \
+"The array form resolves to JSON containing double quotes, which are spliced into
+command text and re-tokenised by shellParse. Unquoted, the shell consumes them
+and [\"rd://a\",\"rd://b\"] arrives as the invalid [rd://a,rd://b], throwing with a
+value the author never wrote. Both existing call sites quote by convention only.
+
+assertArrayCapturesAreShellQuoted probes the real tokenizer rather than matching
+quotes with a regex: authors quote the whole assignment ('K=\${...}'), not the
+placeholder, so an adjacency regex false-rejects every real call site.
+
+The scalar form is structurally immune (assertSafeId confines ids to
+[A-Za-z0-9._-]; rd:// adds only / and :), so this is one grammar's usability
+defect, not silent corruption.
+
+The guard is deliberate throwaway: under the deferred parse-then-substitute
+refactor, resolved values never reach shellParse and it is deleted with the
+hazard."
+```
+
+---
+
+### Task 5: Document the single capture mechanism
+
+`docs/internal/scenarios.md` is the descriptive doc for the scenario schema. It
+documents `commands`, `expect`, and every assertion type, but has never
+documented either artifact grammar —
+`grep -n 'seed\|CAPTURE_ARTIFACT' docs/internal/scenarios.md` returns **nothing**
+(exit status 1). Now that there is exactly one grammar, it is documentable in a
+way two competing grammars were not — and the "run a producer, never fabricate a
+URI" rule needs a home a scenario author will actually find.
+
+**Files:**
+
+- Modify: `docs/internal/scenarios.md` (insert after the "Matching Semantics"
+  section)
+
+**Interfaces:**
+
+- Consumes: the mechanism established by Tasks 1-4.
+- Produces: nothing later tasks rely on.
+
+- [ ] **Step 1: Add the artifact capture section**
+
+In `docs/internal/scenarios.md`, add a new `## Artifact Capture` section
+immediately after the `### Matching Semantics` section:
+
+````markdown
+## Artifact Capture
+
+A scenario command receives an artifact `rd://` URI by **capturing it from a
+prior command's output**. This is the only mechanism — there is no seed
+directive, and scenarios must never fabricate an `rd://` URI or hand-write a
+manifest row. Core owns URI construction (`buildArtifactUri`) and the manifest
+row shape; a scenario that duplicates either will drift silently when core
+changes.
+
+| Placeholder                      | Resolves to                                          |
+| -------------------------------- | ---------------------------------------------------- |
+| `${CAPTURE_ARTIFACT:<key>}`      | The most recent `rd://artifacts/...` URI for `<key>`  |
+| `${CAPTURE_ARTIFACT_ARRAY:<key>}`| A JSON array of every matching URI for `<key>`        |
+
+**The array form must be single-quoted.** It resolves to JSON containing double
+quotes, and placeholders are substituted into command text that is then
+tokenised by the shell. Unquoted, the shell strips those quotes and
+`["rd://a","rd://b"]` arrives as the invalid `[rd://a,rd://b]`. Quote the whole
+assignment:
+
+```yaml
+- rd run collate.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all
+```
+
+This is enforced, not advisory — an unquoted array placeholder is rejected before
+the command runs. The scalar form needs no quoting: its values cannot contain a
+shell metacharacter.
+
+Both are resolved from the artifact manifest immediately before each command
+runs, so they see rows that earlier commands in the same scenario actually
+produced. Recency is by manifest row `timestamp`, with within-context append
+order breaking ties; a scalar pick whose latest-timestamp rows span more than one
+context is ambiguous and raises an error rather than guessing.
+
+An earlier `${ARTIFACT:<name>}` grammar and its `seed:` directive were retired in
+[#498](https://github.com/tobyhede/rundown/issues/498). Both are now rejected
+outright — `seed:` fails scenario validation as an unknown key, and
+`${ARTIFACT:…}` in a command throws before execution — rather than being ignored.
+
+### Seeding a pre-existing artifact
+
+When a scenario needs an artifact to "already exist", run a real producer runbook
+as its first command and capture the artifact it emits:
+
+```yaml
+scenarios:
+  consume-plan-artifact:
+    commands:
+      - rd run scenario-seed-artifacts.runbook.md --allow-all
+      - "rd run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
+    expect:
+      result: COMPLETE
+```
+
+`runbooks/artifacts/scenario-seed-artifacts.runbook.md` is the shared
+deterministic seeder; it emits keys `PlanPath` and `plan.json` through the real
+`ARTIFACTS` production path. Any producer runbook works — the seeder is a
+convenience, not a special case. The producer needs `--allow-all` because it
+writes its backing files from a bash block.
+
+The producer runbook is staged automatically: the harness scans command strings
+for `*.runbook.md` references and copies them into the scenario workspace.
+
+### Asserting on a captured artifact
+
+A naked `ARTIFACTS` alias fed an exact `rd://` URI surfaces the **injected
+record's key**, while the record's **provenance stays the producer's**. Two
+consequences for `expect.artifacts` entries:
+
+- `key:` matches the consumer's alias mapping, as authored in the consuming
+  runbook.
+- `runbook:` filters the **emitting event's** runbook — *not* the record's
+  provenance. Adding `runbook: <consumer>` to an assertion over an injected
+  record does not scope it "to the consumer's row"; the row's provenance is the
+  producer's either way. Disambiguate consumer from producer by `alias:` instead,
+  and give the seeder's aliases distinct names from the consumer's.
+````
+
+- [ ] **Step 2: Verify docs pass the gate**
+
+Run:
+
+```bash
+pnpm run verify
+```
+
+Expected: PASS — this includes the format and spell checks that the new prose
+must satisfy.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/internal/scenarios.md
+git commit -m "docs(scenarios): document capture-from-output artifact seeding (#498)"
+```
+
+---
+
+### Task 6: File the `ScenarioContext` follow-up issue
+
+Deferred work with no issue number is deleted work. Spec §3.3 defers
+`ScenarioContext` threading for good reasons, but that deferral leaves #498's
+fragility item 1 (splice-then-reparse) unaddressed. It gets an issue, not a
+bullet under "Out of scope".
+
+**Files:**
+
+- None. This task creates a GitHub issue; per CLAUDE.md, trackable follow-up work
+  belongs in GitHub issues, not in-repo docs.
+
+**Interfaces:**
+
+- Consumes: the completed state after Tasks 1-5 — the issue body's claim that
+  exactly one artifact grammar remains must be true when it is filed.
+- Produces: an issue number to reference from the PR description. Final task.
+
+- [ ] **Step 1: Create the follow-up issue**
+
+Run:
+
+```bash
+gh issue create \
+  --title "Scenario harness: thread a typed ScenarioContext through executeCommandSequence" \
+  --body "$(cat <<'EOF'
+Follow-up to #498.
+
+#498 retired the `${ARTIFACT:}` grammar and the `seed:` directive, landing its
+fragility items 2 (synthetic fidelity), 3 (two placeholder grammars) and 4
+(duplication of core). It deliberately did **not** land item 1:
+**command-text-layer splicing**. Values are still spliced into command strings
+and re-parsed by `parseRdCommandWithEnv` (`command-sequence.ts:1652`), which runs
+`shellParse` (`:349`).
+
+## The concrete defect this removes
+
+Not an abstract fragility argument — a verified failing case. The array capture
+resolves to `JSON.stringify(...)` of `rd://` URIs
+(`packages/cli/src/helpers/scenario-artifacts.ts:130`), a value containing `"`.
+Running `shell-quote`'s `parse` on the two spellings:
+
+| Form | Command text | argv payload | Result |
+| ---- | ------------ | ------------ | ------ |
+| Quoted | `--artifacts-json 'R=["rd://a","rd://b"]'` | `R=["rd://a","rd://b"]` | JSON intact |
+| Unquoted | `--artifacts-json R=["rd://a","rd://b"]` | `R=[rd://a,rd://b]` | **invalid JSON — throws** |
+
+Both yield one argv entry with `hasOperators: false`; the shell simply consumes
+the JSON's quotes as *shell* quoting.
+
+**Scoped honestly.** This is a **usability defect on one grammar**, not silent
+corruption — it throws, but names a value the author never wrote. The **scalar
+form is structurally immune**: `assertSafeId` (`packages/core/src/paths.ts:34`)
+confines ids to `[A-Za-z0-9._-]` and `rd://` adds only `/` and `:`, so no
+resolved scalar can carry a shell metacharacter. That bounded blast radius is
+why #498 could defer this at `P3: low` rather than block on it.
+
+## What this issue deletes
+
+`assertArrayCapturesAreShellQuoted` and its `ARRAY_QUOTING_PROBE` /
+`CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER` constants
+(`packages/cli/src/helpers/command-sequence.ts`, added by #498). That guard
+enforces the array form's shell-quoting requirement by probing `shellParse`.
+Under parse-then-substitute, resolved values are injected into an already-parsed
+argv and **never reach `shellParse`** — the quoting requirement evaporates and
+the guard becomes dead code. #498 accepted it as ~10 lines of deliberate
+throwaway, tracked here rather than fossilised. Deleting it is part of this
+issue's definition of done.
+
+## Why deferring was right, and why it is now cheaper
+
+Artifacts are one of **five** structurally identical string-splicing grammars in
+`executeCommandSequence` (`command-sequence.ts:1629-1649`):
+
+| Grammar | Substituter | Location |
+| --- | --- | --- |
+| `${TOKEN}` | `substituteTokens` | `command-sequence.ts:442` |
+| `${CLAIM_ID}` | `substituteClaimIds` | `command-sequence.ts:554` |
+| `${RUN_CLAIM_ID}` | `substituteRunClaimIds` | `command-sequence.ts:575` |
+| `${RUN_ID}` | `substituteRunIds` | `command-sequence.ts:606` |
+| `${CAPTURE_ARTIFACT[_ARRAY]}` | `substituteCapturedArtifacts` | `command-sequence.ts:508` |
+
+Threading a typed `ScenarioContext` (captured values + cwd/env) for artifacts
+alone, while its four neighbours keep splicing strings, buys inconsistency rather
+than type safety and leaves the splice-then-reparse hazard fully intact. The
+refactor is worth doing across all five at once — a different change with a
+different blast radius.
+
+**#498 made this materially cheaper, which is the point of the sequencing.**
+Before #498 the harness had **two injection mechanisms with different temporal
+models**: seeds were known *before* execution (a pre-built `name → URI` map
+handed to a synchronous substituter), captures only *during* it (resolved from
+the manifest by a prior command's output, asynchronously). A typed
+`ScenarioContext` had to model **both**, with different failure modes and
+different detection points — a seed can be missing at construction, a capture can
+only fail at resolution. #498 collapses this to **one** temporal model: every
+artifact value is capture-from-output, resolved during execution by one resolver.
+Most of what made this refactor look expensive is already gone.
+
+## Acceptance test — already written
+
+`packages/cli/__tests__/helpers/command-sequence.properties.test.ts` (added by
+#498) states the invariant this refactor must establish:
+
+```
+∀ resolved value v accepted by the quoting guard, ∀ placeholder position:
+  parseRdCommandWithEnv(await substituteCapturedArtifacts(cmd, () => v))
+    contains v as exactly one argv entry, byte-identical
+```
+
+Under parse-then-substitute this becomes **true by construction** — a value
+injected into an already-parsed argv is one entry, byte-identical, trivially. So
+these properties are **inherited, not obsoleted**: they are this refactor's
+acceptance test, and the precondition should be *dropped* (not the property) once
+the guard is deleted, since every value then satisfies it. The file also pins a
+deliberate known-falsification test naming the unquoted-array case; that test
+should go red under this refactor, which is the signal to delete it.
+
+Design context: `docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md` §3.3.
+EOF
+)"
+```
+
+- [ ] **Step 2: Record the issue number in the spec's deferral**
+
+Take the issue number `gh issue create` printed. In
+`docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md`, in
+§3.3, replace:
+
+```markdown
+**Follow-up issue:** filed by the implementation plan's final task — record the
+number here on landing.
+```
+
+With the same line naming the number, e.g.:
+
+```markdown
+**Follow-up issue:** [#NNN](https://github.com/tobyhede/rundown/issues/NNN).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md
+git commit -m "docs(spec): record ScenarioContext follow-up issue number (#498)"
+```
+
+---
+
+## Verification
+
+Before opening the PR, confirm every acceptance criterion from
+[#498](https://github.com/tobyhede/rundown/issues/498). **Every grep below
+excludes `dist/`, `.stryker-tmp/`, and `node_modules/`** — all three are
+gitignored (`.gitignore:44`) but populated on disk by the build these tasks
+mandate, and a bare grep returns ~49 hits from them alone. `git grep` is an
+equally good alternative, since it only sees tracked files.
+
+- [ ] **Dated design spec** —
+      `docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md`
+      exists.
+- [ ] **Single placeholder/capture mechanism; `${ARTIFACT:}` retired** —
+
+      ```bash
+      grep -rn 'ARTIFACT:' --include='*.ts' --include='*.md' \
+        --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+        packages/ runbooks/ \
+        | grep -v CAPTURE_ARTIFACT \
+        | grep -v RETIRED_ARTIFACT_PLACEHOLDER
+      ```
+
+      Every remaining hit must be part of the retirement tombstone (its TSDoc,
+      its error message, or its two tests). No hit may be a live use.
+
+- [ ] **The retirement fails loudly, not silently** — `seed:` is rejected by
+      `ScenarioSchema` (strict) and `${ARTIFACT:}` in a command throws before
+      execution. Pinned by
+      `packages/cli/__tests__/schemas/scenarios.test.ts` and
+      `packages/cli/__tests__/helpers/command-sequence.test.ts`.
+- [ ] **No fabricated URIs or hand-built manifest rows** —
+
+      ```bash
+      grep -rn 'rd://artifacts/' \
+        --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+        runbooks/
+      grep -rn 'manifest.jsonl' \
+        --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+        runbooks/
+      ```
+
+      Both return nothing.
+
+- [ ] **No dead symbols** —
+
+      ```bash
+      grep -rn 'seedScenarioArtifacts\|substituteArtifactUris\|ScenarioSeedSchema' \
+        --exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules \
+        packages/ runbooks/
+      ```
+
+      Returns nothing.
+
+- [ ] **Scenarios migrated and green under both harnesses** —
+      `pnpm run build && pnpm run test:scenarios:raw` passes, and
+      `pnpm --filter @rundown-org/cli exec jest __tests__/integration/scenario-runner.test.ts`
+      passes.
+- [ ] **The sole surviving grammar is property-tested at the boundary that
+      matters** —
+      `packages/cli/__tests__/helpers/command-sequence.properties.test.ts` exists
+      and passes, and includes the **composed** properties (substitute →
+      `parseRdCommandWithEnv` → argv), not only the internal splice properties.
+- [ ] **The array form's quoting requirement is enforced, not conventional** —
+      `assertArrayCapturesAreShellQuoted` rejects an unquoted
+      `${CAPTURE_ARTIFACT_ARRAY:…}` before execution, and **accepts** the real
+      call-site spelling `'Key=${CAPTURE_ARTIFACT_ARRAY:key}'` (whole assignment
+      quoted). Pinned by
+      `packages/cli/__tests__/helpers/command-sequence.test.ts`.
+- [ ] **The deferral has an issue number** — Task 6's issue exists and is linked
+      from the PR description and from spec §3.3.
+- [ ] **`pnpm run verify` passes.**
+
+## Out of scope
+
+- **`forged-file-record-rejected`**
+  (`runbooks/artifacts/artifact-variable-review-plan.runbook.md:22-32`). Its
+  `node -e` writes an intentionally forged artifact record as a public input to
+  assert the input channel **rejects** it
+  (`expect.errors[0].error: 'Artifact record input for "Plan" is not trusted'`).
+  The forgery is the assertion, not a seeding shortcut. Untouched.
+- **`review-plan-uri-input`** and **`bundled-write-review-collate-artifacts`**
+  (`runbooks/artifacts/artifact-variable-write-plan.runbook.md:19-31,47-61`).
+  Already on the target mechanism.
+- **`ScenarioContext` threading / #498 fragility item 1.** Deferred — but *not*
+  simply out of scope: Task 6 files the issue that owns it. See spec §3.3.

--- a/docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md
+++ b/docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md
@@ -58,7 +58,7 @@ resolving the `${ARTIFACT:<name>}` grammar.
 - **Command-text-layer splicing.** Values are spliced into command strings and
   re-parsed by `parseRdCommandWithEnv`. This is exactly how `${ARTIFACT:PlanPath}`
   collapsed to the empty string and produced `INVALID_ARTIFACT_INPUT` when the
-  production `rd scenario run` path lacked the substitution wiring — the defect
+  production `rundown scenario run` path lacked the substitution wiring — the defect
   whose unblock fix this issue follows up.
 
 ### 1.2 The same defect, authored in YAML
@@ -79,7 +79,7 @@ the harness") and none of its intent.
 
 ### 1.3 What this design does and does not fix
 
-#498's "Why it's fragile" lists four items. This design lands **three**:
+\#498's "Why it's fragile" lists four items. This design lands **three**:
 
 | # | Item                        | Landed? |
 | - | --------------------------- | ------- |
@@ -151,7 +151,7 @@ runbook". It is a runbook.
 A new fixture, `runbooks/artifacts/scenario-seed-artifacts.runbook.md`, declares
 an `ARTIFACTS` block with explicit keys and writes deterministic content into the
 projected paths. Running it
-(`rd run scenario-seed-artifacts.runbook.md --allow-all`) drives the genuine
+(`rundown run scenario-seed-artifacts.runbook.md --allow-all`) drives the genuine
 production path — `ARTIFACTS` directive resolution → artifact service →
 `buildArtifactUri` → manifest append — so the seeded row is, by construction,
 exactly what production emits. There is nothing left to keep in sync.
@@ -167,7 +167,7 @@ does not. `scenario-seed-artifacts` names what it is. `copy-runbooks.js:44-51`
 throws on a duplicate relative path; no `*seed*` runbook exists today, so there
 is no collision.
 
-**Rejected: a bespoke `rd seed-artifact` CLI command.** CLAUDE.md is explicit
+**Rejected: a bespoke `rundown seed-artifact` CLI command.** CLAUDE.md is explicit
 that the CLI is a thin wrapper and that runbook logic does not live in it. A
 harness-only command that mints artifacts outside the state machine would be a
 parallel artifact-production path — precisely the "shadow implementation"
@@ -214,8 +214,8 @@ strictly less capable spelling of two lines that scenarios can already write:
 
 ```yaml
 commands:
-  - rd run scenario-seed-artifacts.runbook.md --allow-all
-  - "rd run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
+  - rundown run scenario-seed-artifacts.runbook.md --allow-all
+  - "rundown run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
 ```
 
 A `seed:` field redefined as "a producer command to run first" would be an alias
@@ -238,7 +238,7 @@ the precondition, which is *more* honest documentation, not less. YAGNI wins.
 (`command-sequence.ts:1459-1475`) scans command strings for `*.runbook.md`, and
 both harnesses stage what it finds (`scenario-workflow.ts:372,405-409`;
 `scenario-runner.test.ts:301-313`). Adding
-`rd run scenario-seed-artifacts.runbook.md --allow-all` to `commands:`
+`rundown run scenario-seed-artifacts.runbook.md --allow-all` to `commands:`
 auto-stages the seeder. The migration is pure YAML plus deletions.
 
 #### 3.2.1 Removal must be **enforced**, not silent
@@ -339,7 +339,7 @@ union of two.
 
 So the sequencing is not "defer the hard part" — it is "remove the thing that
 made the hard part hard". Being honest about what it still costs: deferring means
-#498's fragility item 1 is **not fixed** by this change (§1.3). The deferral is
+\#498's fragility item 1 is **not fixed** by this change (§1.3). The deferral is
 defensible, and now cheaper to discharge, but it is not free.
 
 #### 3.3.2 The §3.7 quoting guard is deliberate throwaway
@@ -396,7 +396,8 @@ preserved here.
 (`artifact-variable-write-plan.runbook.md:33-45`) is **byte-identical** to
 `review-plan-uri-input` (`:19-31`): same two commands, same `expect` block, zero
 differences outside the `description:` string. It has never exercised
-cross-context anything. Both of its `rd run` invocations execute in the *same*
+cross-context anything. Both of its `rundown run` invocations execute in the
+*same*
 context — which is exactly why it is identical. This predates #498 and is
 unrelated to seeding; it is in scope only because this design is the first thing
 to look closely at these fixtures.
@@ -441,7 +442,7 @@ not own its output: it splices a value into command text and hands it to
 `parseRdCommandWithEnv` (`command-sequence.ts:1652`), which runs `shellParse`
 (`:349`). The value must survive **that** tokenizer:
 
-```
+```text
 ∀ resolved value v accepted by the §3.7 quoting guard, ∀ placeholder position:
   parseRdCommandWithEnv(await substituteCapturedArtifacts(cmd, () => v))
     contains v as exactly one argv entry, byte-identical
@@ -531,7 +532,7 @@ This guard is **deliberate throwaway** — see §3.3.2.
 | `substituteArtifactUris` (`${ARTIFACT:}`)     | `packages/cli/src/helpers/command-sequence.ts:454-479` |
 | `ScenarioSeedSchema`, `ScenarioSeed`          | `packages/cli/src/schemas/scenarios.ts:113-141` |
 | `seed` field on `ScenarioSchema`              | `packages/cli/src/schemas/scenarios.ts:148-149` |
-| Seed wiring (`rd scenario run`)               | `packages/cli/src/helpers/scenario-workflow.ts:454-459` |
+| Seed wiring (`rundown scenario run`)               | `packages/cli/src/helpers/scenario-workflow.ts:454-459` |
 | Seed wiring (jest runner)                     | `packages/cli/__tests__/integration/scenario-runner.test.ts:351-355` |
 
 **Added:**
@@ -600,7 +601,7 @@ disk by the build the scenario harness requires, and a bare
 ## 6. Risks
 
 - **`--allow-all` on the seeder command.** The seeder writes its backing files
-  from a bash block, so its `rd run` needs `--allow-all`, matching
+  from a bash block, so its `rundown run` needs `--allow-all`, matching
   `artifact-variable-write-plan.runbook.md:9`. The consumer command keeps its
   existing (absent) policy flags. This widens the seeder command's policy only.
 - **The seeder publishes to end users.** It lands in `dist/runbooks/` and

--- a/docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md
+++ b/docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md
@@ -1,0 +1,639 @@
+# Scenario harness: capture-from-output seeding — design
+
+**Issue:** [#498](https://github.com/tobyhede/rundown/issues/498) — Scenario
+harness: replace fabricated-URI seeding with capture-from-output
+
+**Status:** proposed
+
+**Date:** 2026-07-16
+
+## 1. Problem
+
+The scenario harness gives a scenario command a "pre-existing artifact" by
+**fabricating** one. `seedScenarioArtifacts`
+(`packages/cli/src/helpers/scenario-artifacts.ts:42-71`) does all of the
+following by hand:
+
+1. Hardcodes an identity — `seedContextId = 'scenario-seed-context'` and
+   `seedRunId = assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')`
+   (`scenario-artifacts.ts:47-48`).
+2. String-builds the URI —
+   `` const uri = `rd://artifacts/${seedContextId}/${seedRunId}/${entry.artifact}` ``
+   (`scenario-artifacts.ts:50`) — rather than calling core's
+   `buildArtifactUri` (`packages/core/src/runbook/artifact-uri.ts:109-115`),
+   which is the canonical constructor and applies `assertSafeId` /
+   `validateConcreteRunId` / `validateExactArtifactKey`.
+3. Hand-writes the manifest row via `appendArtifactManifestRecordSync`, inventing
+   a `runbook: { source: 'project', path: 'producer.runbook.md' }` provenance for
+   a producer runbook that does not exist, and a frozen
+   `timestamp: '2026-05-25T00:00:00.000Z'` (`scenario-artifacts.ts:51-61`).
+4. Materialises a fake backing file containing `{"seeded":true}` at a
+   **re-derived** local path,
+   `` join(location.cwd, WORK_PATH, `.rd-${seedContextId}`, seedRunId) ``
+   (`scenario-artifacts.ts:65-67`) — a second, independent copy of the
+   URI→path mapping that core owns in `artifactUriToPath`
+   (`artifact-uri.ts:197-229`).
+
+The returned `name → URI` map is then spliced into command text by
+`substituteArtifactUris` (`packages/cli/src/helpers/command-sequence.ts:466-479`)
+resolving the `${ARTIFACT:<name>}` grammar.
+
+### 1.1 Why this is fragile
+
+- **Duplication of core.** Steps 2 and 4 above are hand-rolled reimplementations
+  of `buildArtifactUri` and `artifactUriToPath`. Step 3 hand-rolls the manifest
+  row's provenance shape. If any of the three change in core, the harness drifts
+  silently — the seed keeps "working" while no longer resembling what production
+  emits.
+- **Synthetic fidelity.** No real `rd` command ever emits a row like this. The
+  consume path (`--artifacts PlanPath=<uri>` → naked `ARTIFACTS` step) is
+  therefore tested against an approximation of its own input.
+- **Two placeholder grammars.** `${ARTIFACT:<name>}`
+  (`command-sequence.ts:470`, synchronous, map-backed) and
+  `${CAPTURE_ARTIFACT[_ARRAY]:<key>}` (`command-sequence.ts:515`, async,
+  manifest-backed) each carry their own regex and resolver, plus a third
+  non-global detector `CAPTURE_ARTIFACT_PLACEHOLDER` (`command-sequence.ts:542`)
+  that must stay in sync with the second. Two grammars for one concept —
+  "give this command an artifact URI" — is one too many.
+- **Command-text-layer splicing.** Values are spliced into command strings and
+  re-parsed by `parseRdCommandWithEnv`. This is exactly how `${ARTIFACT:PlanPath}`
+  collapsed to the empty string and produced `INVALID_ARTIFACT_INPUT` when the
+  production `rd scenario run` path lacked the substitution wiring — the defect
+  whose unblock fix this issue follows up.
+
+### 1.2 The same defect, authored in YAML
+
+The fabrication is not confined to the harness. `direct-uri-input` in
+`runbooks/artifacts/artifact-variable-review-plan.runbook.md:8-21` performs the
+identical hand-fabrication from inside a scenario, as a `node -e` one-liner
+(`artifact-variable-review-plan.runbook.md:12`): it hardcodes
+`run='rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'`, `ctx='producer-context'`, builds
+`'rd://artifacts/'+ctx+'/'+run+'/'+key` by concatenation, re-derives
+`.rundown/work/.rd-<ctx>/<run>` by hand, and writes a manifest row literal
+including `timestamp:'2026-05-25T00:00:00.000Z'`.
+
+This spec treats that scenario as in scope. Deleting `seedScenarioArtifacts`
+while leaving a copy of it transcribed into YAML would satisfy the letter of the
+issue's acceptance criterion ("no fabricated URIs or hand-built manifest rows in
+the harness") and none of its intent.
+
+### 1.3 What this design does and does not fix
+
+#498's "Why it's fragile" lists four items. This design lands **three**:
+
+| # | Item                        | Landed? |
+| - | --------------------------- | ------- |
+| 1 | Command-text-layer splicing | **No** — deferred to the §3.3 follow-up |
+| 2 | Synthetic fidelity          | Yes — §3.1 |
+| 3 | Two placeholder grammars    | Yes — §3.2 |
+| 4 | Duplication of core         | Yes — §3.1 |
+
+This is a **partial fix**, stated plainly rather than elided. After this change
+`${CAPTURE_ARTIFACT}` is still spliced into command text and re-parsed by
+`parseRdCommandWithEnv` (`command-sequence.ts:1652`, which runs `shellParse` at
+`:349`), exactly as its four sibling grammars are.
+
+Three arguments carry the deferral. The first two say this **tracks the issue's
+scope rather than shrinking it**; the third is the sequencing argument.
+
+1. **The issue itself marks the deferred work optional.** #498's "Proposed
+   direction" introduces `ScenarioContext` with "**Optionally** thread a typed
+   `ScenarioContext`…", and **none** of its four acceptance criteria mention it.
+   Item 1 maps onto no acceptance criterion. This design discharges every stated
+   criterion (§5).
+2. **The foundation value is real, not rhetorical — see §3.3.** Today the harness
+   has two injection mechanisms with **different temporal models**. This design
+   collapses them to one, which is most of what made the deferred work expensive.
+   That is a genuine prerequisite, not a convenient postponement.
+3. **Fixing item 1 for artifacts alone is net-negative** while four structurally
+   identical neighbours keep splicing strings (§3.3).
+
+### 1.3.1 The residual hazard, sized honestly
+
+Item 1's surviving hazard must not be overstated to justify the work, nor
+understated to excuse the deferral. Verified by execution:
+
+- **The scalar form is structurally immune.** `assertSafeId`
+  (`packages/core/src/paths.ts:34`) confines ids to `[A-Za-z0-9._-]`, and `rd://`
+  URIs add only `/` and `:`. No resolved scalar value can carry a shell
+  metacharacter, at any placeholder position, quoted or not.
+- **Only the array form is exposed.** `resolveCapturedArtifactFromManifest`
+  returns `JSON.stringify(...)` for it (`scenario-artifacts.ts:130`) — a value
+  containing `"`. `shell-quote`'s `parse` on
+  `--artifacts-json R=["rd://a","rd://b"]` yields the payload
+  `R=[rd://a,rd://b]`: one argv entry, `hasOperators: false`, quotes consumed as
+  shell quoting, **JSON destroyed**. The quoted spelling
+  `--artifacts-json 'R=["rd://a","rd://b"]'` survives byte-identically.
+- **It errors; it does not silently corrupt.** The unquoted payload is *invalid
+  JSON*, so it throws. The defect is that the error names a value the author
+  never wrote — a **usability defect on one grammar**, consistent with #498's
+  `P3: low` label.
+
+That bounded blast radius is what makes deferring item 1 defensible at all. It is
+also why §3.7 enforces the array form's quoting requirement now rather than
+waiting: the hazard is small, but it is currently held off by author convention
+alone.
+
+## 2. Goal
+
+One mechanism: **capture-from-command-output**. A scenario that needs a
+pre-existing artifact runs a real producer command whose artifact is created
+through the real production path, then references it with the surviving
+`${CAPTURE_ARTIFACT[_ARRAY]:<key>}` grammar.
+
+## 3. Design decisions
+
+### 3.1 The "built-in deterministic seeder" is a producer **runbook fixture**, not CLI machinery
+
+The issue leaves open whether the seeder is "a real producer command or a
+runbook". It is a runbook.
+
+A new fixture, `runbooks/artifacts/scenario-seed-artifacts.runbook.md`, declares
+an `ARTIFACTS` block with explicit keys and writes deterministic content into the
+projected paths. Running it
+(`rd run scenario-seed-artifacts.runbook.md --allow-all`) drives the genuine
+production path — `ARTIFACTS` directive resolution → artifact service →
+`buildArtifactUri` → manifest append — so the seeded row is, by construction,
+exactly what production emits. There is nothing left to keep in sync.
+
+**The name is scoped deliberately.** `packages/cli/scripts/copy-runbooks.js`
+copies `runbooks/**` into `packages/cli/dist/runbooks/`, and
+`packages/cli/package.json:11-14` publishes `files: ["dist"]` — so this fixture
+**ships to every installed user** and appears in `rundown ls --all` as a bundled
+runbook. Existing fixtures already ship, so this is not a new class of exposure;
+but a bundled runbook called `seed-artifacts` reads like a general-purpose
+utility and invites a confused user to run it, where `artifact-variable-write-plan`
+does not. `scenario-seed-artifacts` names what it is. `copy-runbooks.js:44-51`
+throws on a duplicate relative path; no `*seed*` runbook exists today, so there
+is no collision.
+
+**Rejected: a bespoke `rd seed-artifact` CLI command.** CLAUDE.md is explicit
+that the CLI is a thin wrapper and that runbook logic does not live in it. A
+harness-only command that mints artifacts outside the state machine would be a
+parallel artifact-production path — precisely the "shadow implementation"
+the architectural principles forbid, and precisely the fidelity gap this issue
+exists to close. A runbook fixture needs **zero** new production code.
+
+**Rejected: reusing `artifact-variable-write-plan.runbook.md` as the seeder.**
+It is already a real producer (`artifact-variable-write-plan.runbook.md:65-73`,
+producing key `plan.json`), and `review-plan-uri-input`
+(`artifact-variable-write-plan.runbook.md:19-31`) already consumes it via
+`${CAPTURE_ARTIFACT:plan.json}` — so the pattern is proven. But it produces only
+`plan.json`, whereas `consume-plan-artifact` asserts `key: PlanPath`
+(`execute-plan.runbook.md:19`) — and a naked `ARTIFACTS` alias fed an exact URI
+surfaces the **injected record's** key, so the assertion cannot be satisfied by a
+`plan.json` row. Reusing write-plan would force that assertion to change, coupling
+two unrelated fixtures and obscuring whether the migration preserved behaviour. A
+dedicated seeder that emits **both** keys lets `consume-plan-artifact`'s
+assertion stay byte-identical, which is the evidence that the migration is
+behaviour-preserving.
+
+**This reasoning is specific to `consume-plan-artifact` and does not generalise.**
+It is an argument for a dedicated seeder where a scenario is being *preserved*
+across a migration. It says nothing about scenarios being *retired* — see §3.5,
+where `direct-uri-input` is deleted rather than migrated precisely because
+nothing about it is worth preserving once fabrication is gone.
+
+The seeder emits two keys from one step:
+
+| Alias           | Key         | Consumer                                          |
+| --------------- | ----------- | ------------------------------------------------- |
+| `PlanPathSeed`  | `PlanPath`  | `execute-plan.runbook.md` `consume-plan-artifact` |
+| `PlanJsonSeed`  | `plan.json` | None today (see §3.5). Emitted as the natural companion key, at a cost of one line, so a future scenario needing a seeded `plan.json` does not reopen this design. |
+
+Both keys satisfy `assertSafeId` (`packages/core/src/paths.ts:34-41`) — `PlanPath`
+is the key the current seed already uses, so it is known-safe.
+
+### 3.2 `seed:` is **removed**, not reshaped
+
+The issue asks for "the new `seed:` schema shape". The answer is that there
+isn't one.
+
+Once seeding means "run a producer command and capture its output", `seed:` is a
+strictly less capable spelling of two lines that scenarios can already write:
+
+```yaml
+commands:
+  - rd run scenario-seed-artifacts.runbook.md --allow-all
+  - "rd run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
+```
+
+A `seed:` field redefined as "a producer command to run first" would be an alias
+for "put the producer command first in `commands:`" — a second way to say one
+thing, which is what the issue is trying to eliminate. `ScenarioSeedSchema`
+(`packages/cli/src/schemas/scenarios.ts:121-141`) and the `seed` field
+(`scenarios.ts:148-149`) are deleted.
+
+The reasonable counter-argument, recorded and rejected: scenarios double as
+copy/paste user documentation, and `seed:` marked a precondition as *setup*
+rather than as part of the demonstrated flow, keeping `commands:` free of
+scaffolding. That distinction is real but unpaid-for — the harness has no
+separate rendering for setup (`executeScenario` in
+`scenario-workflow.ts:458-491` seeds and then executes one flat command list),
+so the only thing `seed:` buys is a shorter `commands:` block. Against that: a
+reader of the migrated scenario sees the actual, runnable sequence that produces
+the precondition, which is *more* honest documentation, not less. YAGNI wins.
+
+**No harness change is needed to stage the producer.** `extractRunbookReferences`
+(`command-sequence.ts:1459-1475`) scans command strings for `*.runbook.md`, and
+both harnesses stage what it finds (`scenario-workflow.ts:372,405-409`;
+`scenario-runner.test.ts:301-313`). Adding
+`rd run scenario-seed-artifacts.runbook.md --allow-all` to `commands:`
+auto-stages the seeder. The migration is pure YAML plus deletions.
+
+#### 3.2.1 Removal must be **enforced**, not silent
+
+Deleting the code is not sufficient, and this is the subtlest point in the
+design. `ScenarioSchema` (`packages/cli/src/schemas/scenarios.ts:143-185`) is
+`z.object({...}).refine(...).refine(...)` with **no** `.strict()`, on Zod 4
+(`packages/cli/package.json:51`, `"zod": "^4.4.3"`), where unknown keys are
+**stripped by default**. A naive deletion therefore produces exactly this:
+
+1. A scenario still carrying `seed:` parses **successfully** — `seed:` is
+   silently dropped.
+2. Its command still carrying `${ARTIFACT:PlanPath}` has no substituter left, so
+   the literal placeholder text is passed through to `--artifacts`.
+3. The run fails with an opaque `INVALID_ARTIFACT_INPUT`.
+
+That is **verbatim** §1.1's last bullet — the defect this issue exists to
+prevent. Silently deleting the grammar re-creates it.
+
+The codebase already rejects this pattern one function away:
+`CAPTURE_ARTIFACT_PLACEHOLDER` (`command-sequence.ts:542`, used at
+`command-sequence.ts:1642`) exists for no purpose other than making an
+unresolvable capture placeholder **throw** rather than leak into the executed
+command. The retired grammar gets the same treatment, on two surfaces:
+
+| Surface        | Mechanism                                                    | Rejects                          |
+| -------------- | ------------------------------------------------------------ | -------------------------------- |
+| Scenario schema | `z.strictObject` on `ScenarioSchema`                         | the `seed:` **field**, at load   |
+| Command text    | `RETIRED_ARTIFACT_PLACEHOLDER = /\$\{ARTIFACT:[^}]+\}/`, thrown in `executeCommandSequence` | the `${ARTIFACT:}` **grammar**, before execution |
+
+Both are needed: a scenario can carry the placeholder without ever carrying
+`seed:`, so the schema layer does not subsume the command layer. The thrown
+message names the retirement (#498) and points at `${CAPTURE_ARTIFACT:<key>}`.
+
+`z.strictObject` is used rather than the deprecated `.strict()` method because
+`.strict()` cannot be chained after the two `.refine(...)` calls, which return a
+non-object schema type.
+
+**This is a tombstone, not a shim.** CLAUDE.md's no-migration rule forbids
+compatibility shims, fallback parsers, and warning-only adapters — code that
+keeps retired input *working*. A detector that makes retired input **fail with a
+message naming its replacement** is the opposite, and is precisely the "detect
+invalid input and prompt explicit user action" behaviour that rule mandates.
+Failing loudly *serves* the no-migration rule; failing silently defeats it.
+
+A side benefit of strictness: it stops silently swallowing typo'd scenario keys
+repo-wide. If enabling it surfaces a parse failure in a scenario unrelated to
+`seed:`, that is a genuine latent defect stripping was hiding, and the fix is the
+scenario, not the schema.
+
+### 3.3 `ScenarioContext` threading is **out of scope** — follow-up
+
+The issue floats "optionally thread a typed `ScenarioContext` (seeded map +
+capture state + cwd/env) into `executeCommandSequence` instead of string
+substitution".
+
+Deferred, and it should be a separate issue. After this change there is exactly
+**one** artifact grammar — but `executeCommandSequence`
+(`command-sequence.ts:1629-1649`) still string-splices four sibling grammars that
+this issue does not touch: `${TOKEN}` (`substituteTokens`,
+`command-sequence.ts:442-452`), `${CLAIM_ID}` (`substituteClaimIds`,
+`command-sequence.ts:554-562`), `${RUN_CLAIM_ID}` (`substituteRunClaimIds`,
+`command-sequence.ts:575-588`), and `${RUN_ID}` (`substituteRunIds`,
+`command-sequence.ts:606-614`). Threading a typed context for artifacts alone,
+while its four structurally identical neighbours keep splicing strings, buys
+inconsistency rather than type safety, and leaves the actual splice-then-reparse
+hazard fully intact.
+
+A `ScenarioContext` refactor is worth doing across all five grammars at once.
+That is a different change with a different blast radius, and folding it in here
+would couple a mechanical consolidation to a harness-wide redesign.
+
+#### 3.3.1 The real foundation argument: this design collapses two temporal models into one
+
+The "four sibling grammars" point above is a **convenience** argument — it says
+the refactor is cheaper done together. It is true, but it is not the strongest
+reason to sequence this design first. The stronger one is that this design
+removes a genuine obstacle:
+
+Today the harness has **two injection mechanisms with different temporal
+models**, not merely two grammars:
+
+| Mechanism | Value known | Shape | Failure mode | Detected |
+| --------- | ----------- | ----- | ------------ | -------- |
+| `${ARTIFACT:<name>}` (seed) | **Before** execution | Pre-built `name → URI` map, built by `seedScenarioArtifacts` | Name absent from the map | At substitution, synchronously |
+| `${CAPTURE_ARTIFACT[_ARRAY]:<key>}` | **During** execution | Resolved from the manifest a prior command wrote | No matching row; ambiguous latest row | At resolution, asynchronously, per command |
+
+A typed `ScenarioContext` must model **both** — a static seeded map *and* an
+evolving capture state — with two failure modes surfacing at two different
+points, and a type that admits both. That dual-temporality is most of what made
+the deferred work look expensive.
+
+This design collapses it to **one** temporal model: every artifact value is
+capture-from-output, resolved during execution by a single resolver
+(`resolveCapturedArtifactFromManifest`), with one failure mode at one detection
+point. The follow-up then threads *one* uniform notion of a resolved value, not a
+union of two.
+
+So the sequencing is not "defer the hard part" — it is "remove the thing that
+made the hard part hard". Being honest about what it still costs: deferring means
+#498's fragility item 1 is **not fixed** by this change (§1.3). The deferral is
+defensible, and now cheaper to discharge, but it is not free.
+
+#### 3.3.2 The §3.7 quoting guard is deliberate throwaway
+
+§3.7 adds `assertArrayCapturesAreShellQuoted` to enforce the array form's
+shell-quoting requirement. Under parse-then-substitute, resolved values are
+injected into an already-parsed argv and **never reach `shellParse`** — the
+quoting requirement evaporates and that guard becomes dead code this follow-up
+deletes.
+
+This is recorded as **~10 lines of accepted waste, not an oversight**. It buys
+enforced correctness over an interval of unknown length, during which
+splice-then-reparse is real and the requirement is otherwise held off by author
+convention alone. The follow-up issue names the guard among the things it
+removes, so the waste is tracked rather than fossilised.
+
+**Follow-up issue:** filed by the implementation plan's final task — record the
+number here on landing. Deferred work with no issue number is deleted work, so
+this deferral is not complete until the number is here.
+
+### 3.4 What survives
+
+`resolveCapturedArtifactFromManifest` (`scenario-artifacts.ts:98-148`),
+`substituteCapturedArtifacts` (`command-sequence.ts:508-533`), and
+`CAPTURE_ARTIFACT_PLACEHOLDER` (`command-sequence.ts:542`) are unchanged. The
+capture resolver already reads the manifest through core's
+`readAllArtifactManifestRecords`, so the row shape lives in one place
+(`scenario-artifacts.ts:107-112`); its recency ordering and cross-context
+ambiguity guard (`scenario-artifacts.ts:127-147`) are the behaviour this design
+leans on and does not modify.
+
+### 3.5 Two scenarios are **deleted**, not migrated
+
+#### `direct-uri-input` — migrating it would produce an exact duplicate
+
+§1.2 establishes that `direct-uri-input`
+(`artifact-variable-review-plan.runbook.md:8-21`) cannot stay as authored. But
+migrating it onto the seeder is equally wrong: **post-migration it is
+character-for-character `review-plan-uri-input`**
+(`artifact-variable-write-plan.runbook.md:19-31`) apart from *which* producer
+runs first — and once both producers are real producer runbooks, that is a
+distinction with no behavioural content. Its entire reason to exist was
+exercising the consume path against a **fabricated** row. Remove the fabrication
+and it has no remaining job.
+
+Delete it. The commit must name the unique coverage lost: none.
+
+Note the asymmetry with §3.1, which is not an inconsistency. There, a dedicated
+seeder is justified so `consume-plan-artifact`'s assertion stays byte-identical
+— an argument about *preserving* a scenario across a migration. Nothing is being
+preserved here.
+
+#### `review-plan-cross-context-uri-input` — pre-existing duplication, silently testing nothing
+
+`review-plan-cross-context-uri-input`
+(`artifact-variable-write-plan.runbook.md:33-45`) is **byte-identical** to
+`review-plan-uri-input` (`:19-31`): same two commands, same `expect` block, zero
+differences outside the `description:` string. It has never exercised
+cross-context anything. Both of its `rd run` invocations execute in the *same*
+context — which is exactly why it is identical. This predates #498 and is
+unrelated to seeding; it is in scope only because this design is the first thing
+to look closely at these fixtures.
+
+**Delete it.** The alternative — give it a genuinely distinct producer context —
+is rejected on two grounds:
+
+1. **No affordance exists.** There is no `--context` flag on any command, so the
+   scenario layer cannot force two runs into different contexts. Making the
+   scenario honest would require new production surface: building a feature to
+   serve a test.
+2. **The behaviour is already covered where it can actually be constructed.**
+   `resolveCapturedArtifactFromManifest`'s cross-context handling is unit-tested
+   at `packages/cli/__tests__/helpers/scenario-artifacts.test.ts:54`
+   (cross-context same-timestamp scalar pick throws ambiguous), `:74`
+   (genuinely-latest URI wins across contexts), and `:95` (array form returns all
+   cross-context collisions). Those tests build the multi-context manifest
+   directly.
+
+A scenario whose name claims coverage its body does not provide is worse than no
+scenario: it gets cited as evidence in review.
+
+### 3.6 The surviving grammar gets a property test — at the composed boundary
+
+This design promotes `substituteCapturedArtifacts` (`command-sequence.ts:508-533`)
+from one of two artifact grammars to **the** artifact grammar, and every migrated
+scenario now depends on it. Promoting it to load-bearing without adding coverage
+would trade one fragility for another. But *what* to pin matters more than
+whether to pin something, and the obvious target is the wrong one.
+
+**Rejected: properties over the splice arithmetic alone.** The function is
+hand-rolled index arithmetic over `matchAll` (`:525-532`) — a running `last`
+offset, `match.index` starts, manual `cmd.slice` concatenation — so it looks like
+the fragile part. It is not. That arithmetic is correct today, this design does
+not touch it, and nobody has disputed it. Properties asserting offsets, N→N
+resolver calls, and no-re-scan are **green before this change and green after**:
+they are evidence for an undisputed claim. They are worth keeping — they are
+cheap and they pin the splice against future edits — but they are not the point.
+
+**The load-bearing invariant is composed.** `substituteCapturedArtifacts` does
+not own its output: it splices a value into command text and hands it to
+`parseRdCommandWithEnv` (`command-sequence.ts:1652`), which runs `shellParse`
+(`:349`). The value must survive **that** tokenizer:
+
+```
+∀ resolved value v accepted by the §3.7 quoting guard, ∀ placeholder position:
+  parseRdCommandWithEnv(await substituteCapturedArtifacts(cmd, () => v))
+    contains v as exactly one argv entry, byte-identical
+```
+
+**The precondition is required, and is not a fudge.** Without "accepted by the
+guard" the property is **unconditionally red** — the unquoted array form
+falsifies it (§1.3.1). The precondition states exactly which commands the harness
+accepts, which is why §3.7's guard is part of this design rather than a nicety.
+It is also not vacuous: it admits every scalar placeholder in any position plus
+every correctly quoted array placeholder — 100% of the legal grammar and 100% of
+the real call sites. The unquoted-array falsification is pinned as an explicit
+known-failure test, so the precondition is visibly non-arbitrary rather than
+tuned until green.
+
+Under the §3.3 follow-up the composed property becomes **true by construction**
+(a value injected into an already-parsed argv is trivially one byte-identical
+entry). These properties are therefore **inherited by that refactor, not
+obsoleted by it**: they are its acceptance test, and it should drop the
+*precondition*, not the property.
+
+`packages/cli/__tests__/services/renderers/json-renderer.properties.test.ts` is
+the CLI package's only existing fast-check file (`fast-check` is already a CLI
+devDependency, `packages/cli/package.json:60`); the new test follows its
+conventions.
+
+### 3.7 The array form's quoting requirement is **enforced**, not conventional
+
+§1.3.1 establishes the defect: the array form resolves to JSON containing `"`,
+and unquoted, `shellParse` consumes those quotes and delivers invalid JSON.
+Correctness of the sole surviving artifact grammar therefore rests on authors
+remembering single quotes. Both existing array call sites do quote —
+`runbooks/artifacts/artifact-variable-write-plan.runbook.md:52` and
+`artifact-variable-collate.runbook.md:13` — by convention, with nothing checking
+them.
+
+§3.2.1 already establishes the fail-fast tombstone pattern for "illegal input
+must not pass through silently". The quoting requirement gets the same treatment:
+`assertArrayCapturesAreShellQuoted` in `command-sequence.ts`, thrown from
+`executeCommandSequence` before the command runs.
+
+**Rejected: make the resolver emit shell-escaped JSON.** Escaping a value to
+survive a tokenizer *we control and invoke ourselves* is the wrong direction. It
+bakes the splice-then-reparse hazard deeper into the design at the exact moment
+§3.3's follow-up intends to remove it, and it makes the resolved value differ
+from the value the consumer receives.
+
+**Rejected: a regex asserting the placeholder is single-quoted.** Detecting "is
+this placeholder quoted" by matching quotes in raw text is itself the fragile
+string analysis this design reduces — and the naive form is not merely fragile,
+it is **wrong**. Verified by execution: `/'\$\{CAPTURE_ARTIFACT_ARRAY:[^}]+\}'/`
+returns `false` on `artifact-variable-collate.runbook.md:13`, because authors
+quote the **whole assignment** (`--artifacts-json 'Reviews=${…}'`), not the
+placeholder — the character before it is `=`. It would false-reject **both** real
+call sites. A "smarter" regex means reimplementing shell quoting rules.
+
+**Chosen: probe the real tokenizer.** Replace each array placeholder with a probe
+value carrying the same shell-significant characters as real resolved JSON
+(`["rd://s"]`), run the probe command through the very `shellParse` it is about to
+face, and require the probe to survive intact once per placeholder. The oracle is
+the tokenizer itself, so the guard cannot disagree with it, and no quoting rule is
+reimplemented. `shellParse` is already imported (`command-sequence.ts:18`), so
+this adds no dependency.
+
+Soundness of the probe: a resolved array is `JSON.stringify` of `rd://` URIs, so
+its character set is closed under `assertSafeId`'s `[A-Za-z0-9._-]`
+(`paths.ts:34`) plus `/`, `:`, and JSON's `[`, `]`, `"`, `,`. The only
+shell-significant members are `"`, `[`, and `]` — all present in the probe.
+Occurrences are counted rather than matching argv entries, since two placeholders
+can legitimately share one quoted entry.
+
+Verified by execution against `shell-quote`: the guard accepts the canonical
+quoted form, a placeholder inside a longer quoted region, two placeholders in one
+quoted entry, two separately quoted placeholders, and the scalar form; it rejects
+the unquoted form, the double-quoted form (genuinely broken for JSON), and a
+mixed quoted/unquoted pair.
+
+This guard is **deliberate throwaway** — see §3.3.2.
+
+## 4. Scope
+
+**Removed:**
+
+| Symbol                                        | Location                                    |
+| --------------------------------------------- | ------------------------------------------- |
+| `seedScenarioArtifacts`                       | `packages/cli/src/helpers/scenario-artifacts.ts:42-71` |
+| `substituteArtifactUris` (`${ARTIFACT:}`)     | `packages/cli/src/helpers/command-sequence.ts:454-479` |
+| `ScenarioSeedSchema`, `ScenarioSeed`          | `packages/cli/src/schemas/scenarios.ts:113-141` |
+| `seed` field on `ScenarioSchema`              | `packages/cli/src/schemas/scenarios.ts:148-149` |
+| Seed wiring (`rd scenario run`)               | `packages/cli/src/helpers/scenario-workflow.ts:454-459` |
+| Seed wiring (jest runner)                     | `packages/cli/__tests__/integration/scenario-runner.test.ts:351-355` |
+
+**Added:**
+
+| Item                                                                  | Why                       |
+| --------------------------------------------------------------------- | ------------------------- |
+| `runbooks/artifacts/scenario-seed-artifacts.runbook.md`               | The producer fixture, §3.1 |
+| `z.strictObject` on `ScenarioSchema` (`packages/cli/src/schemas/scenarios.ts:143`) | Reject `seed:`, §3.2.1 |
+| `RETIRED_ARTIFACT_PLACEHOLDER` + its throw (`packages/cli/src/helpers/command-sequence.ts:542,1642`) | Reject `${ARTIFACT:}`, §3.2.1 |
+| `assertArrayCapturesAreShellQuoted` + `ARRAY_QUOTING_PROBE` + `CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER` (`packages/cli/src/helpers/command-sequence.ts`) | Enforce array-form quoting, §3.7. **Deliberate throwaway** — deleted by the §3.3 follow-up (§3.3.2) |
+| `packages/cli/__tests__/helpers/command-sequence.properties.test.ts`   | Pin the sole grammar at the composed boundary, §3.6 |
+
+The design's production additions are **two fail-fast guards and nothing else** —
+no behaviour changes. Both are small and neither is optional: §3.2.1 explains why
+deleting the retired grammar without a tombstone re-creates the very bug being
+fixed, and §3.7 explains why leaving the surviving grammar's quoting requirement
+to author convention leaves the sole artifact mechanism resting on a habit.
+
+**Migrated:**
+
+| Scenario                | File                                              | From                     |
+| ----------------------- | ------------------------------------------------- | ------------------------ |
+| `consume-plan-artifact` | `runbooks/artifacts/execute-plan.runbook.md:8-20` | `seed:` + `${ARTIFACT:}` |
+
+**Deleted (§3.5):**
+
+| Scenario                              | File                                                               | Unique coverage lost |
+| ------------------------------------- | ------------------------------------------------------------------ | -------------------- |
+| `direct-uri-input`                    | `runbooks/artifacts/artifact-variable-review-plan.runbook.md:8-21`  | None — migrated, it duplicates `review-plan-uri-input` |
+| `review-plan-cross-context-uri-input` | `runbooks/artifacts/artifact-variable-write-plan.runbook.md:33-45`  | None — already byte-identical to `review-plan-uri-input` |
+
+These are the complete set: `runbooks/artifacts/execute-plan.runbook.md:10` is
+the only `seed:` in the repository, and `${ARTIFACT:}` appears in no other
+runbook. The remaining `${CAPTURE_ARTIFACT[_ARRAY]:}` users
+(`artifact-variable-write-plan.runbook.md:23,51,52` after the §3.5 deletion) are
+already on the target mechanism and are not touched.
+`forged-file-record-rejected`
+(`artifact-variable-review-plan.runbook.md:22-32`) is also untouched: its `node -e`
+writes an intentionally forged record to assert the input channel **rejects** it.
+The forgery is the assertion, not a seeding shortcut.
+
+## 5. Acceptance
+
+Mapped from the issue:
+
+- [x] Dated design spec — this document.
+- [ ] Single placeholder/capture mechanism; `${ARTIFACT:}` grammar retired —
+      §3.2, §4 — and its retirement **enforced** rather than silent, §3.2.1.
+- [ ] No fabricated URIs or hand-built manifest rows in the harness — §3.1, and
+      §1.2 extends this to the YAML-authored copy.
+- [ ] Existing artifact scenarios migrated and green under both
+      `pnpm run test:scenarios:raw` and the jest scenario runner
+      (`packages/cli/__tests__/integration/scenario-runner.test.ts`) — §4.
+
+Every stated acceptance criterion is discharged. #498's fragility item 1 is not
+(§1.3) — it maps onto no acceptance criterion, is marked **optional** in the
+issue's own "Proposed direction", and is owned by the §3.3 follow-up issue. Its
+residual hazard is bounded and enforced against in the interim (§1.3.1, §3.7).
+
+**Verification note.** Every grep used to check these criteria must pass
+`--exclude-dir=dist --exclude-dir=.stryker-tmp --exclude-dir=node_modules` (or
+use `git grep`). All three are gitignored (`.gitignore:44`) but are populated on
+disk by the build the scenario harness requires, and a bare
+`grep -rn 'ARTIFACT:' packages/` returns ~49 hits from build output alone.
+
+## 6. Risks
+
+- **`--allow-all` on the seeder command.** The seeder writes its backing files
+  from a bash block, so its `rd run` needs `--allow-all`, matching
+  `artifact-variable-write-plan.runbook.md:9`. The consumer command keeps its
+  existing (absent) policy flags. This widens the seeder command's policy only.
+- **The seeder publishes to end users.** It lands in `dist/runbooks/` and
+  `rundown ls --all` for every install (§3.1). Mitigated by the scoped name, not
+  eliminated; eliminating it would mean a fixtures-excluded publish path, which is
+  a separate change affecting every existing fixture equally.
+- **`z.strictObject` is repo-wide.** Making `ScenarioSchema` strict can surface
+  parse failures in scenarios unrelated to `seed:` — any unknown key that
+  stripping was silently swallowing. Treated as a benefit, not a regression
+  (§3.2.1): the fix is the typo'd scenario, never a weakened schema. The blast
+  radius is bounded — scenario YAML only, caught at load, in the harness.
+- **The §3.7 quoting guard could be over-tight.** It rejects commands, so a false
+  rejection breaks a legitimate scenario. Bounded by construction — it probes the
+  real `shellParse` rather than reimplementing quoting rules, so it can only
+  disagree with the tokenizer if the probe's character coverage is wrong (§3.7
+  argues it is not). The acceptance evidence is that the repository's two real
+  array call sites (`artifact-variable-write-plan.runbook.md:52`,
+  `artifact-variable-collate.runbook.md:13`) still pass under
+  `pnpm run test:scenarios:raw`. If it ever false-rejects, the fix is the guard,
+  never the scenario. It is also throwaway (§3.3.2), so its long-run cost is
+  bounded by the follow-up.
+- **Capture ambiguity.** `resolveCapturedArtifactFromManifest` throws on an
+  equal-timestamp scalar pick spanning multiple contexts
+  (`scenario-artifacts.ts:142-146`). Each migrated scenario produces exactly one
+  row per key from one seeder run, so no tie exists.
+- **Loss of a negative test.** `ScenarioSeedSchema`'s reserved-name /
+  path-traversal guards (`scenarios.ts:132-137`) and their tests
+  (`packages/cli/__tests__/schemas/scenarios.test.ts:134-188`) are deleted with
+  the schema. This is not a coverage regression: the guards existed *because* the
+  harness joined an author-supplied name into a URI and a filesystem path. With
+  the join gone, so is the attack surface. Artifact keys now originate from the
+  `ARTIFACTS` directive and are validated by core's `assertSafeId` /
+  `validateExactArtifactKey` (`artifact-uri.ts:364-369`) on the real production
+  path.

--- a/docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md
+++ b/docs/superpowers/specs/2026-07-16-scenario-capture-from-output-design.md
@@ -356,9 +356,7 @@ splice-then-reparse is real and the requirement is otherwise held off by author
 convention alone. The follow-up issue names the guard among the things it
 removes, so the waste is tracked rather than fossilised.
 
-**Follow-up issue:** filed by the implementation plan's final task — record the
-number here on landing. Deferred work with no issue number is deleted work, so
-this deferral is not complete until the number is here.
+**Follow-up issue:** [#604](https://github.com/tobyhede/rundown/issues/604).
 
 ### 3.4 What survives
 

--- a/packages/cli/__tests__/helpers/command-sequence.properties.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.properties.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from '@jest/globals';
+import * as fc from 'fast-check';
+import {
+  substituteCapturedArtifacts,
+  parseRdCommandWithEnv,
+} from '../../src/helpers/command-sequence.js';
+
+/** A placeholder key: the shape `assertSafeId` admits, kept short for shrinking. */
+const keyArb = fc.stringMatching(/^[A-Za-z0-9_.]{1,12}$/);
+
+/**
+ * Literal command text guaranteed to contain no placeholder. Mapping `$` away is
+ * used rather than filtering so no generated value is ever rejected. Length 0 is
+ * allowed on purpose — it is what produces adjacent placeholders and
+ * placeholders at the very start/end of the command.
+ */
+const literalArb = fc
+  .string({ maxLength: 12 })
+  .map((s) => s.replaceAll('$', 'S').replaceAll('{', '(').replaceAll('}', ')'));
+
+interface Placeholder {
+  readonly key: string;
+  readonly asArray: boolean;
+}
+
+interface Command {
+  readonly placeholders: readonly Placeholder[];
+  readonly literals: readonly string[];
+}
+
+/** N placeholders interleaved with exactly N+1 literal segments. */
+const commandArb: fc.Arbitrary<Command> = fc
+  .array(fc.record({ key: keyArb, asArray: fc.boolean() }), { maxLength: 5 })
+  .chain((placeholders) =>
+    fc
+      .array(literalArb, {
+        minLength: placeholders.length + 1,
+        maxLength: placeholders.length + 1,
+      })
+      .map((literals) => ({ placeholders, literals })),
+  );
+
+function renderPlaceholder(p: Placeholder): string {
+  return `\${CAPTURE_ARTIFACT${p.asArray ? '_ARRAY' : ''}:${p.key}}`;
+}
+
+function buildCommand({ placeholders, literals }: Command): string {
+  return placeholders.reduce(
+    (acc, p, i) => acc + renderPlaceholder(p) + literals[i + 1],
+    literals[0],
+  );
+}
+
+/**
+ * The resolved value for the nth resolver call. Deliberately contains `}` and
+ * `${` — if the implementation re-scanned its own output, these would be
+ * re-parsed as placeholder syntax and the oracle would diverge.
+ */
+function resolvedValue(n: number, key: string, asArray: boolean): string {
+  return `<${String(n)}:${key}:${asArray ? 'A' : 'S'}}\${>`;
+}
+
+/**
+ * A resolved value the harness can really produce: a `rd://` URI whose segments
+ * are `assertSafeId`-shaped (`paths.ts:34`), so the arbitrary generates exactly
+ * the domain `resolveCapturedArtifactFromManifest` returns and no wider.
+ */
+const uriArb = fc
+  .tuple(
+    fc.stringMatching(/^[A-Za-z0-9._-]{1,8}$/),
+    fc.stringMatching(/^[A-Za-z0-9._-]{1,8}$/),
+    fc.stringMatching(/^[A-Za-z0-9._-]{1,8}$/),
+  )
+  .map(([ctx, run, key]) => `rd://artifacts/${ctx}/rd_${run}/${key}`);
+
+/** The array form's resolved value: `JSON.stringify` of URIs, per scenario-artifacts.ts:130. */
+const arrayValueArb = fc.array(uriArb, { maxLength: 3 }).map((uris) => JSON.stringify(uris));
+
+/** Count argv entries containing `value` after substitution + the real rd parse. */
+async function argvEntriesContaining(cmd: string, value: string): Promise<number> {
+  const substituted = await substituteCapturedArtifacts(cmd, async () => value);
+  const parsed = parseRdCommandWithEnv(substituted);
+  if (!parsed) throw new Error(`expected an rd command, got: ${substituted}`);
+  return parsed.args.filter((arg) => arg.includes(value)).length;
+}
+
+describe('substituteCapturedArtifacts (properties)', () => {
+  // ---------------------------------------------------------------------------
+  // The load-bearing property: composed across the shellParse boundary that
+  // substituteCapturedArtifacts hands off to. Its precondition — "accepted by
+  // the quoting guard" — is expressed by only generating command shapes the
+  // guard admits: scalars anywhere, arrays single-quoted. Without it the
+  // property is unconditionally red (see the unquoted-array case below, which
+  // is asserted as a *known* falsification rather than hidden).
+  // ---------------------------------------------------------------------------
+  it('a resolved SCALAR survives the rd parse as exactly one argv entry, byte-identical', async () => {
+    await fc.assert(
+      fc.asyncProperty(uriArb, async (uri) => {
+        // Scalars are immune regardless of quoting, so both spellings hold.
+        expect(
+          await argvEntriesContaining(
+            'rd run x.runbook.md --artifacts P=${CAPTURE_ARTIFACT:k}',
+            uri,
+          ),
+        ).toBe(1);
+        expect(
+          await argvEntriesContaining(
+            "rd run x.runbook.md --artifacts P='${CAPTURE_ARTIFACT:k}'",
+            uri,
+          ),
+        ).toBe(1);
+      }),
+    );
+  });
+
+  it('a resolved ARRAY survives the rd parse byte-identically when the assignment is quoted', async () => {
+    await fc.assert(
+      fc.asyncProperty(arrayValueArb, async (value) => {
+        // The real call-site spelling: the whole assignment is single-quoted
+        // (artifact-variable-collate.runbook.md:13).
+        expect(
+          await argvEntriesContaining(
+            "rd run x.runbook.md --artifacts-json 'R=${CAPTURE_ARTIFACT_ARRAY:k}' --allow-all",
+            value,
+          ),
+        ).toBe(1);
+      }),
+    );
+  });
+
+  it('documents WHY the guard precondition is required: unquoted arrays falsify the property', async () => {
+    // This is the defect Task 4's guard rejects. Pinned as a known falsification
+    // so the precondition above is visibly non-arbitrary — and so this test goes
+    // red (telling us to delete it) if the hazard is ever removed at the source.
+    const value = JSON.stringify(['rd://artifacts/c/rd_1/plan.json']);
+    const survived = await argvEntriesContaining(
+      'rd run x.runbook.md --artifacts-json R=${CAPTURE_ARTIFACT_ARRAY:k}',
+      value,
+    );
+    expect(survived).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Internals: cheap, and they pin the splice arithmetic against future edits.
+  // These are NOT evidence that this change is correct — they were green before
+  // it and are green after.
+  // ---------------------------------------------------------------------------
+  it('splices every placeholder at the right offset and preserves literals verbatim', async () => {
+    await fc.assert(
+      fc.asyncProperty(commandArb, async (command) => {
+        const cmd = buildCommand(command);
+        const calls: Placeholder[] = [];
+        let n = 0;
+        const resolve = async (key: string, asArray: boolean): Promise<string> => {
+          calls.push({ key, asArray });
+          return resolvedValue(n++, key, asArray);
+        };
+
+        const result = await substituteCapturedArtifacts(cmd, resolve);
+
+        const expected = command.placeholders.reduce(
+          (acc, p, i) => acc + resolvedValue(i, p.key, p.asArray) + command.literals[i + 1],
+          command.literals[0],
+        );
+        // Offset correctness across every match, literal text preserved verbatim,
+        // resolved values never re-scanned, adjacent placeholders handled.
+        expect(result).toBe(expected);
+        // N placeholders produce exactly N resolver calls, in match order, with
+        // the array flag carried through.
+        expect(calls).toEqual(
+          command.placeholders.map((p) => ({ key: p.key, asArray: p.asArray })),
+        );
+      }),
+    );
+  });
+
+  it('returns placeholder-free commands verbatim without calling the resolver', async () => {
+    await fc.assert(
+      fc.asyncProperty(literalArb, async (cmd) => {
+        let calls = 0;
+        const resolve = async (): Promise<string> => {
+          calls++;
+          return 'unused';
+        };
+
+        expect(await substituteCapturedArtifacts(cmd, resolve)).toBe(cmd);
+        expect(calls).toBe(0);
+      }),
+    );
+  });
+
+  it('never re-scans a resolved value that itself looks like a placeholder', async () => {
+    let calls = 0;
+    const resolve = async (): Promise<string> => {
+      calls++;
+      return '${CAPTURE_ARTIFACT:injected}';
+    };
+
+    const result = await substituteCapturedArtifacts('a ${CAPTURE_ARTIFACT:real} b', resolve);
+
+    expect(result).toBe('a ${CAPTURE_ARTIFACT:injected} b');
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -900,6 +900,28 @@ describe('retired ${ARTIFACT:} grammar (#498)', () => {
     expect(calls).toEqual([]);
   });
 
+  it('detects the retired grammar with an empty body, as the error message spells it', async () => {
+    // Regression: the detector required a non-empty body, so the exact spelling
+    // named in its own error message — ${ARTIFACT:} — passed through unnoticed.
+    const calls: string[][] = [];
+
+    await expect(
+      executeCommandSequence({
+        commands: ['rd run x.runbook.md --artifacts PlanPath=${ARTIFACT:}'],
+        cwd: process.cwd(),
+        cliPath: '/unused/cli.js',
+        quiet: true,
+        commandExecutor: {
+          runRd: async (args) => {
+            calls.push(args);
+            return { stdout: '', stderr: '', exitCode: 0 };
+          },
+        },
+      }),
+    ).rejects.toThrow(/retired.*\$\{ARTIFACT:\}.*#498/s);
+    expect(calls).toEqual([]);
+  });
+
   it('does not mistake the surviving ${CAPTURE_ARTIFACT:} grammar for the retired one', async () => {
     const resolved = await substituteCapturedArtifacts(
       'rd run x --artifacts Plan=${CAPTURE_ARTIFACT:plan.json}',
@@ -953,6 +975,32 @@ describe('${CAPTURE_ARTIFACT_ARRAY:} shell-quoting guard (#498)', () => {
 
     // The resolved JSON reaches argv intact, as a single byte-identical entry.
     expect(calls[0]).toContain('Reviews=["rd://artifacts/c/rd_1/review.json"]');
+  });
+
+  it('accepts a correctly quoted array capture even when the command already contains the probe text', async () => {
+    // Regression: the guard substituted a fixed probe value and counted its
+    // occurrences, so a command that already contained that literal text was
+    // rejected for a collision with the guard's own instrument rather than for
+    // anything the author did wrong.
+    const calls: string[][] = [];
+
+    await executeCommandSequence({
+      commands: [
+        "rd run x.runbook.md --artifacts-json 'R=${CAPTURE_ARTIFACT_ARRAY:review.json}' --input note='[\"rd://s\"]'",
+      ],
+      cwd: process.cwd(),
+      cliPath: '/unused/cli.js',
+      quiet: true,
+      resolveCapturedArtifact: async () => '["rd://artifacts/c/rd_1/review.json"]',
+      commandExecutor: {
+        runRd: async (args) => {
+          calls.push(args);
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+      },
+    });
+
+    expect(calls[0]).toContain('R=["rd://artifacts/c/rd_1/review.json"]');
   });
 
   it('does not fire on the scalar form, which needs no quoting', async () => {

--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -11,7 +11,6 @@ import {
   extractRunbookReferences,
   extractInputFileReferences,
   substituteClaimIds,
-  substituteArtifactUris,
   substituteCapturedArtifacts,
   matchErrorAssertions,
   formatErrorAssertionDescription,
@@ -879,35 +878,36 @@ describe('substituteTokens', () => {
   });
 });
 
-describe('substituteArtifactUris', () => {
-  it('${ARTIFACT:Name} maps to the seeded URI', () => {
-    expect(
-      substituteArtifactUris('rd run x --artifacts PlanPath=${ARTIFACT:PlanPath}', {
-        PlanPath: 'rd://artifacts/c/r/PlanPath',
+describe('retired ${ARTIFACT:} grammar (#498)', () => {
+  it('throws naming the retirement rather than passing the placeholder through', async () => {
+    const calls: string[][] = [];
+
+    await expect(
+      executeCommandSequence({
+        commands: ['rd run x.runbook.md --artifacts PlanPath=${ARTIFACT:PlanPath}'],
+        cwd: process.cwd(),
+        cliPath: '/unused/cli.js',
+        quiet: true,
+        commandExecutor: {
+          runRd: async (args) => {
+            calls.push(args);
+            return { stdout: '', stderr: '', exitCode: 0 };
+          },
+        },
       }),
-    ).toBe('rd run x --artifacts PlanPath=rd://artifacts/c/r/PlanPath');
+    ).rejects.toThrow(/retired.*\$\{ARTIFACT:\}.*#498/s);
+    // The tombstone fires before dispatch, so the executor is never reached.
+    expect(calls).toEqual([]);
   });
 
-  it('substitutes multiple distinct artifact placeholders', () => {
-    expect(
-      substituteArtifactUris('${ARTIFACT:A} ${ARTIFACT:B}', {
-        A: 'rd://artifacts/c/r/A',
-        B: 'rd://artifacts/c/r/B',
-      }),
-    ).toBe('rd://artifacts/c/r/A rd://artifacts/c/r/B');
-  });
-
-  it('throws for an unseeded artifact reference', () => {
-    expect(() => substituteArtifactUris('${ARTIFACT:Missing}', {})).toThrow(
-      /references an unseeded artifact/,
+  it('does not mistake the surviving ${CAPTURE_ARTIFACT:} grammar for the retired one', async () => {
+    const resolved = await substituteCapturedArtifacts(
+      'rd run x --artifacts Plan=${CAPTURE_ARTIFACT:plan.json}',
+      async () => 'rd://artifacts/c/rd_1/plan.json',
     );
-  });
-
-  it('returns the original string unchanged when no placeholders', () => {
-    expect(substituteArtifactUris('rd pass', {})).toBe('rd pass');
+    expect(resolved).toBe('rd run x --artifacts Plan=rd://artifacts/c/rd_1/plan.json');
   });
 });
-
 describe('substituteCapturedArtifacts', () => {
   it('${CAPTURE_ARTIFACT:key} resolves a scalar URI', async () => {
     const resolve = async (key: string, asArray: boolean) => {

--- a/packages/cli/__tests__/helpers/command-sequence.test.ts
+++ b/packages/cli/__tests__/helpers/command-sequence.test.ts
@@ -908,6 +908,74 @@ describe('retired ${ARTIFACT:} grammar (#498)', () => {
     expect(resolved).toBe('rd run x --artifacts Plan=rd://artifacts/c/rd_1/plan.json');
   });
 });
+
+describe('${CAPTURE_ARTIFACT_ARRAY:} shell-quoting guard (#498)', () => {
+  it('rejects an unquoted array capture, naming the key and the fix', async () => {
+    const calls: string[][] = [];
+
+    await expect(
+      executeCommandSequence({
+        commands: ['rd run x.runbook.md --artifacts-json R=${CAPTURE_ARTIFACT_ARRAY:review.json}'],
+        cwd: process.cwd(),
+        cliPath: '/unused/cli.js',
+        quiet: true,
+        resolveCapturedArtifact: async () => '["rd://artifacts/c/rd_1/review.json"]',
+        commandExecutor: {
+          runRd: async (args) => {
+            calls.push(args);
+            return { stdout: '', stderr: '', exitCode: 0 };
+          },
+        },
+      }),
+    ).rejects.toThrow(/review\.json.*single-quote/is);
+    // The guard fires before dispatch, so the executor is never reached.
+    expect(calls).toEqual([]);
+  });
+
+  it('accepts the real quoted call-site spelling, where the whole assignment is quoted', async () => {
+    const calls: string[][] = [];
+
+    await executeCommandSequence({
+      commands: [
+        "rd run x.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all",
+      ],
+      cwd: process.cwd(),
+      cliPath: '/unused/cli.js',
+      quiet: true,
+      resolveCapturedArtifact: async () => '["rd://artifacts/c/rd_1/review.json"]',
+      commandExecutor: {
+        runRd: async (args) => {
+          calls.push(args);
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+      },
+    });
+
+    // The resolved JSON reaches argv intact, as a single byte-identical entry.
+    expect(calls[0]).toContain('Reviews=["rd://artifacts/c/rd_1/review.json"]');
+  });
+
+  it('does not fire on the scalar form, which needs no quoting', async () => {
+    const calls: string[][] = [];
+
+    await executeCommandSequence({
+      commands: ['rd run x.runbook.md --artifacts P=${CAPTURE_ARTIFACT:plan.json}'],
+      cwd: process.cwd(),
+      cliPath: '/unused/cli.js',
+      quiet: true,
+      resolveCapturedArtifact: async () => 'rd://artifacts/c/rd_1/plan.json',
+      commandExecutor: {
+        runRd: async (args) => {
+          calls.push(args);
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+      },
+    });
+
+    expect(calls[0]).toContain('P=rd://artifacts/c/rd_1/plan.json');
+  });
+});
+
 describe('substituteCapturedArtifacts', () => {
   it('${CAPTURE_ARTIFACT:key} resolves a scalar URI', async () => {
     const resolve = async (key: string, asArray: boolean) => {

--- a/packages/cli/__tests__/helpers/scenario-authoring-rules.ts
+++ b/packages/cli/__tests__/helpers/scenario-authoring-rules.ts
@@ -15,6 +15,8 @@
  * @module __tests__/helpers/scenario-authoring-rules
  */
 
+import { parse as shellParse } from 'shell-quote';
+
 /** A fabrication rule: a scenario command must never match `pattern`. */
 export interface FabricationRule {
   /** Human-readable description, used as the test name and failure context. */
@@ -79,35 +81,150 @@ const WRAPPER_EXECUTABLES = new Set([
 /** Script files that would be run directly, e.g. `./setup.sh`. */
 const SCRIPT_FILE = /\.(sh|bash|zsh|js|cjs|mjs|py|rb|pl)$/;
 
-/** Strips a `!` negation prefix and any leading `FOO=bar` environment assignments. */
-const COMMAND_PREFIX = /^(?:!\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*/;
+/**
+ * Operators after which the shell begins a new command.
+ *
+ * Redirections (`>`, `<`, `>>`) are deliberately absent: `rd echo > out.txt`
+ * runs one command, and treating `>` as a boundary would read `out.txt` as an
+ * executable.
+ */
+const COMMAND_SEPARATORS: ReadonlySet<string> = new Set([';', '&&', '||', '|', '&', '(', ')']);
+
+/** An `FOO=bar` assignment prefix, which does not consume the command position. */
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * Extract the text of every command substitution the shell would actually run.
+ *
+ * Quote-aware by necessity, not by preference: inside *single* quotes `$( … )`
+ * and backticks are literal text. `delegate-claim-corruption.runbook.md:29` — an
+ * allowlisted fault injector — passes a single-quoted `node -e` argument holding
+ * JS template literals (`` `sha256:${"f".repeat(64)}` ``), which `shellParse`
+ * rejects outright as a bad substitution. A quote-blind regex hands that inner
+ * text to the parser and throws on a legitimate command, so scanning raw text
+ * for `` ` `` is not merely imprecise, it is broken.
+ *
+ * `shellParse` cannot do this for us: it reports a token's text but not the
+ * quote style that produced it, so an active `"$(node x)"` and a literal
+ * `'$(node x)'` are indistinguishable once parsed.
+ *
+ * @param command - Raw scenario command text
+ * @returns Inner text of each shell-active `$( … )` or backtick substitution
+ */
+function activeSubstitutions(command: string): string[] {
+  const found: string[] = [];
+  let quote: "'" | '"' | undefined;
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+    if (quote === "'") {
+      if (char === "'") quote = undefined;
+      continue;
+    }
+    if (char === '\\') {
+      i++; // Escaped: the next character is literal whatever it is.
+      continue;
+    }
+    if (quote === '"' && char === '"') {
+      quote = undefined;
+    } else if (quote === undefined && (char === "'" || char === '"')) {
+      quote = char;
+    } else if (char === '`') {
+      const end = command.indexOf('`', i + 1);
+      if (end === -1) break;
+      found.push(command.slice(i + 1, end));
+      i = end;
+    } else if (char === '$' && command[i + 1] === '(') {
+      let depth = 1;
+      let end = i + 2;
+      for (; end < command.length && depth > 0; end++) {
+        if (command[end] === '(') depth++;
+        else if (command[end] === ')') depth--;
+      }
+      if (depth !== 0) break;
+      found.push(command.slice(i + 2, end - 1));
+      i = end - 1;
+    }
+  }
+  return found;
+}
+
+/**
+ * Extract the executable of every command in one newline-free line of shell.
+ *
+ * @param line - Shell text containing no newlines
+ * @returns The executable token of each command in the line, in order
+ */
+function headsOfLine(line: string): string[] {
+  const heads: string[] = [];
+  let atCommandStart = true;
+  for (const token of shellParse(line)) {
+    if (typeof token === 'string') {
+      // `!` negates the following command and `FOO=bar` prefixes it; neither is
+      // the executable, so the command position survives them.
+      if (!atCommandStart || token === '!' || ENV_ASSIGNMENT.test(token)) continue;
+      heads.push(token);
+      atCommandStart = false;
+    } else if ('op' in token) {
+      if (token.op === 'glob') {
+        if (atCommandStart) {
+          heads.push(token.pattern);
+          atCommandStart = false;
+        }
+      } else if (COMMAND_SEPARATORS.has(token.op)) {
+        atCommandStart = true;
+      }
+    }
+  }
+  return heads;
+}
+
+/**
+ * Extract the executable of every command a scenario command string invokes.
+ *
+ * Tokenizes with `shell-quote` — the same tokenizer
+ * (`parseRdCommandWithEnv` → `shellParse`) the harness uses to *execute* these
+ * commands — so the lint agrees with the executor by construction about where a
+ * command begins. A hand-rolled `split(/[;|&]+/)` cannot: it splits on a `;`
+ * inside a quoted argument, which both invents boundaries that the shell never
+ * sees and lets a real one hide.
+ *
+ * @param command - Scenario command string, as authored in `commands:`
+ * @returns Every executable token, including those inside command substitutions
+ */
+export function commandHeads(command: string): string[] {
+  // `shellParse` treats a newline as ordinary whitespace, so a wrapper on a
+  // second line would otherwise hide behind the first line's head.
+  const heads = command.split('\n').flatMap((line) => headsOfLine(line));
+  for (const inner of activeSubstitutions(command)) {
+    // Each substitution is strictly shorter than `command`, so this terminates.
+    heads.push(...commandHeads(inner));
+  }
+  return heads;
+}
 
 /**
  * Extract the executable a command segment invokes.
  *
- * @param segment - A single command segment, without shell operators
- * @returns The executable token, or an empty string when the segment is blank
+ * @param segment - A single command segment
+ * @returns The first executable token, or an empty string when none is found
  */
 export function commandHead(segment: string): string {
-  const withoutPrefix = segment.trim().replace(COMMAND_PREFIX, '');
-  return /^\S*/.exec(withoutPrefix)?.[0] ?? '';
+  return commandHeads(segment)[0] ?? '';
 }
 
 /**
  * Whether a scenario command invokes an interpreter, helper script, or package
  * runner — in any form, not only the inline `-e` / `-c` spellings.
  *
- * Checks each operator-separated segment, so a wrapper hidden behind `;` or `&&`
- * is caught too. Matching is anchored to the executable position rather than
- * applied to the whole string, so an incidental mention of `bash` inside a
- * quoted argument is not a violation.
+ * Checks the executable position of every command, so a wrapper is caught behind
+ * a shell operator, on a second line, or inside a `$( … )` substitution, while
+ * an incidental mention of `bash` in a quoted argument is not a violation.
  *
  * @param command - Scenario command string, as authored in `commands:`
- * @returns True when any segment invokes a wrapper
+ * @returns True when any command invokes a wrapper
  */
 export function usesOpaqueWrapper(command: string): boolean {
-  return command
-    .split(/[;|&]+/)
-    .map((segment) => commandHead(segment))
-    .some((head) => head !== '' && (WRAPPER_EXECUTABLES.has(head) || SCRIPT_FILE.test(head)));
+  return commandHeads(command).some(
+    (head) => head !== '' && (WRAPPER_EXECUTABLES.has(head) || SCRIPT_FILE.test(head)),
+  );
 }

--- a/packages/cli/__tests__/helpers/scenario-authoring-rules.ts
+++ b/packages/cli/__tests__/helpers/scenario-authoring-rules.ts
@@ -1,0 +1,113 @@
+/**
+ * The authoring rules applied to scenario command sequences.
+ *
+ * Extracted from the lint suite so the predicates themselves are unit-tested
+ * (`__tests__/schemas/scenario-authoring-rules.test.ts`) rather than only
+ * exercised against whatever the repository happens to contain today. A rule
+ * that silently stops matching would otherwise keep the suite green.
+ *
+ * Every rule takes a **scenario command string** — a parsed frontmatter value,
+ * never file text. Selector syntax such as
+ * `rd://artifacts/{{ ContextId }}/*\/plan.json` lives on `ARTIFACTS` directive
+ * lines in runbook *bodies*, which never reach these predicates. That is why
+ * these rules can be strict where a text search over the same repository cannot.
+ *
+ * @module __tests__/helpers/scenario-authoring-rules
+ */
+
+/** A fabrication rule: a scenario command must never match `pattern`. */
+export interface FabricationRule {
+  /** Human-readable description, used as the test name and failure context. */
+  readonly id: string;
+  /** Pattern whose match indicates fabricated artifact provenance. */
+  readonly pattern: RegExp;
+}
+
+/**
+ * Commands that fabricate artifact provenance. No allowlist: #498's invariant is
+ * that provenance comes from a real producer's output, so there is no legitimate
+ * reason for a scenario command to name an `rd://` URI, touch the manifest, or
+ * re-derive the `.rd-<contextId>` directory by hand.
+ */
+export const FABRICATION_RULES: readonly FabricationRule[] = [
+  { id: 'names an rd:// URI (capture it from a producer instead)', pattern: /rd:\/\// },
+  { id: 'writes the artifact manifest (core owns manifest.jsonl)', pattern: /manifest\.jsonl/ },
+  // Matches the `.rd-` prefix itself rather than requiring an alphanumeric after
+  // it: a context id may begin with `_` or `-`, and a hand-derived path is just
+  // as fabricated when the id arrives via a template (`.rd-{{ ContextId }}`).
+  { id: 'hand-derives the .rd-<contextId> provenance directory', pattern: /\.rd-/ },
+];
+
+/**
+ * Detects a subprocess spawn inside a scenario command.
+ *
+ * This is the "no hidden `rd` invocations" rule made objective. It deliberately
+ * matches the *spawn*, not the token `rd`: a `\b(rd|rundown)\b` test matches the
+ * path `.rundown/session.json` and would condemn fault-injection scenarios that
+ * legitimately read state files without ever invoking the CLI.
+ */
+export const SPAWNS_SUBPROCESS = /child_process|execFileSync|execSync|spawnSync|\bspawn\(/;
+
+/**
+ * Executables that interpret code or scripts rather than driving the runbook.
+ *
+ * `rd`/`rundown` are the scenario vocabulary. `true` is the established staging
+ * no-op (it makes a runbook reference visible to the harness without running
+ * anything), and `printf` writes fixture text. Everything here can run arbitrary
+ * logic, which is what takes a workflow step out of the runner's command model.
+ */
+const WRAPPER_EXECUTABLES = new Set([
+  'node',
+  'nodejs',
+  'python',
+  'python2',
+  'python3',
+  'ruby',
+  'perl',
+  'sh',
+  'bash',
+  'zsh',
+  'dash',
+  'npm',
+  'pnpm',
+  'yarn',
+  'npx',
+  'eval',
+  'source',
+]);
+
+/** Script files that would be run directly, e.g. `./setup.sh`. */
+const SCRIPT_FILE = /\.(sh|bash|zsh|js|cjs|mjs|py|rb|pl)$/;
+
+/** Strips a `!` negation prefix and any leading `FOO=bar` environment assignments. */
+const COMMAND_PREFIX = /^(?:!\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*/;
+
+/**
+ * Extract the executable a command segment invokes.
+ *
+ * @param segment - A single command segment, without shell operators
+ * @returns The executable token, or an empty string when the segment is blank
+ */
+export function commandHead(segment: string): string {
+  const withoutPrefix = segment.trim().replace(COMMAND_PREFIX, '');
+  return /^\S*/.exec(withoutPrefix)?.[0] ?? '';
+}
+
+/**
+ * Whether a scenario command invokes an interpreter, helper script, or package
+ * runner — in any form, not only the inline `-e` / `-c` spellings.
+ *
+ * Checks each operator-separated segment, so a wrapper hidden behind `;` or `&&`
+ * is caught too. Matching is anchored to the executable position rather than
+ * applied to the whole string, so an incidental mention of `bash` inside a
+ * quoted argument is not a violation.
+ *
+ * @param command - Scenario command string, as authored in `commands:`
+ * @returns True when any segment invokes a wrapper
+ */
+export function usesOpaqueWrapper(command: string): boolean {
+  return command
+    .split(/[;|&]+/)
+    .map((segment) => commandHead(segment))
+    .some((head) => head !== '' && (WRAPPER_EXECUTABLES.has(head) || SCRIPT_FILE.test(head)));
+}

--- a/packages/cli/__tests__/helpers/scenario-sources.ts
+++ b/packages/cli/__tests__/helpers/scenario-sources.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared discovery of the repository's scenario sources.
+ *
+ * Both the executing harness (`__tests__/integration/scenario-runner.test.ts`)
+ * and the static authoring lint (`__tests__/schemas/scenario-authoring.test.ts`)
+ * enumerate the same runbooks. They load them through this module so the two
+ * cannot disagree about what exists — a runbook that is invisible to the loader
+ * is untested by both, and that silence is the failure mode the lint exists to
+ * prevent.
+ *
+ * Test-only: this lives under `__tests__/` rather than `src/` because `src/`
+ * ships to users. Jest's `testMatch: ['**\/*.test.ts']` collects only `*.test.ts`,
+ * so this file is imported, never run as a suite.
+ *
+ * @module __tests__/helpers/scenario-sources
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { extractFrontmatter } from '@rundown-org/parser';
+import { parseScenarios, type Scenarios } from '../../src/schemas/scenarios.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Repository root, derived from this file's location (packages/cli/__tests__/helpers). */
+export const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
+
+/** The repository's runbook tree — the sole source of frontmatter scenarios. */
+export const RUNBOOKS_DIR = join(REPO_ROOT, 'runbooks');
+
+/**
+ * Directories that never contain scenario sources subject to the authoring rules.
+ *
+ * `fixtures` covers `packages/parser/fixtures/conformance/invalid/`, which holds
+ * deliberately malformed runbooks, and the packages' test fixtures. `dist` and
+ * `.stryker-tmp` hold copies of real runbooks that would otherwise be linted
+ * twice and reported under a build path.
+ */
+const EXCLUDED_DIRS = new Set([
+  'node_modules',
+  'dist',
+  '.stryker-tmp',
+  '.git',
+  '.worktrees',
+  'coverage',
+  'fixtures',
+]);
+
+/**
+ * A runbook's scenario-parse outcome.
+ *
+ * `errors` is carried deliberately: callers must not silently drop a runbook
+ * whose scenarios fail schema validation. Under the strict `ScenarioSchema`
+ * (#498) a retired `seed:` key makes parsing fail, and a caller that discards
+ * `errors` would stop testing that runbook rather than reject it.
+ */
+export interface RunbookScenarioSource {
+  /** Path relative to `runbooks/`, e.g. `artifacts/execute-plan.runbook.md`. */
+  readonly file: string;
+  /** Absolute path on disk. */
+  readonly absolutePath: string;
+  /** Parsed scenarios, or null when absent or invalid. */
+  readonly scenarios: Scenarios | null;
+  /** Schema validation errors; empty when the scenarios block is valid. */
+  readonly errors: readonly string[];
+}
+
+/**
+ * Recursively list files under a directory, skipping build and vendor output.
+ *
+ * @param dir - Directory to walk
+ * @returns Absolute paths of every file found
+ */
+function getFilesSync(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (EXCLUDED_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...getFilesSync(full));
+    } else {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/**
+ * Load every runbook under `runbooks/` with its scenario-parse outcome.
+ *
+ * Deliberately has no ENOENT fallback: if the runbook tree is missing, callers
+ * must fail loudly rather than pass vacuously over zero runbooks.
+ *
+ * @returns One entry per `*.runbook.md`, in directory-walk order
+ * @throws {Error} When the runbook tree cannot be read
+ */
+export function loadRunbookScenarioSources(): RunbookScenarioSource[] {
+  const sources: RunbookScenarioSource[] = [];
+  for (const absolutePath of getFilesSync(RUNBOOKS_DIR)) {
+    if (!absolutePath.endsWith('.runbook.md')) continue;
+    const file = absolutePath.substring(RUNBOOKS_DIR.length + 1);
+    const content = readFileSync(absolutePath, 'utf-8');
+    const { frontmatter } = extractFrontmatter(content);
+    if (!frontmatter) {
+      sources.push({ file, absolutePath, scenarios: null, errors: [] });
+      continue;
+    }
+    const { scenarios, errors } = parseScenarios(frontmatter);
+    sources.push({ file, absolutePath, scenarios, errors });
+  }
+  return sources;
+}
+
+/**
+ * Find every standalone scenario-suite file in the repository.
+ *
+ * Discovered by scan rather than hardcoded, so a second suite is linted from
+ * the day it is added instead of being born unenforced.
+ *
+ * @returns Absolute paths of every `*.scenario-suite.yaml`
+ */
+export function findScenarioSuiteFiles(): string[] {
+  return getFilesSync(REPO_ROOT).filter((f) => f.endsWith('.scenario-suite.yaml'));
+}

--- a/packages/cli/__tests__/helpers/scenario-sources.ts
+++ b/packages/cli/__tests__/helpers/scenario-sources.ts
@@ -25,10 +25,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /** Repository root, derived from this file's location (packages/cli/__tests__/helpers). */
-export const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
+export const REPO_ROOT: string = join(__dirname, '..', '..', '..', '..');
 
 /** The repository's runbook tree — the sole source of frontmatter scenarios. */
-export const RUNBOOKS_DIR = join(REPO_ROOT, 'runbooks');
+export const RUNBOOKS_DIR: string = join(REPO_ROOT, 'runbooks');
 
 /**
  * Directories that never contain scenario sources subject to the authoring rules.

--- a/packages/cli/__tests__/helpers/scenario-workflow.test.ts
+++ b/packages/cli/__tests__/helpers/scenario-workflow.test.ts
@@ -112,7 +112,6 @@ jest.unstable_mockModule('../../src/helpers/command-sequence', () => ({
   matchEnteredAssertions: jest.fn(),
   emitScenarioTiming: jest.fn(),
   createInProcessCommandExecutor: actualCommandSequence.createInProcessCommandExecutor,
-  substituteArtifactUris: actualCommandSequence.substituteArtifactUris,
   formatErrorAssertionDescription: actualCommandSequence.formatErrorAssertionDescription,
   formatWarningAssertionDescription: actualCommandSequence.formatWarningAssertionDescription,
   extractRunbookReferences: actualCommandSequence.extractRunbookReferences,

--- a/packages/cli/__tests__/integration/artifact-variable-inputs.test.ts
+++ b/packages/cli/__tests__/integration/artifact-variable-inputs.test.ts
@@ -291,4 +291,53 @@ Second {{ Plan }}
     expect(pass.stdout).toContain(expectedPathSuffix);
     expect(pass.stdout).toContain('Second');
   });
+
+  it('status renders an ARTIFACTS-produced variable as a local path, never an rd:// URI', async () => {
+    // Migrated from the `status-shows-artifact-vars` scenario in
+    // runbooks/artifacts/artifact-status-vars.runbook.md, which asserted this by
+    // spawning `rd status` inside a `node -e` one-liner — a hidden CLI
+    // invocation that docs/internal/scenarios.md forbids and that the scenario
+    // authoring lint now rejects. Payload assertions belong here.
+    //
+    // Unlike the reload test above, the artifact is *produced* by the run's own
+    // ARTIFACTS clause rather than injected via --artifacts, so this covers the
+    // producer side of the projection.
+    await writeFile(
+      join(workspace.cwd, 'produce.runbook.md'),
+      `# Produce Artifact
+
+## 1. Produce an artifact variable
+
+- ARTIFACTS
+  - PlanPath "plan.json"
+- PASS CONTINUE
+
+\`\`\`bash
+printf '{"plan":"ok"}' > "{{ path PlanPath }}"
+\`\`\`
+
+## 2. Pause with the artifact variable in scope
+
+- ARTIFACTS
+  - PlanPath
+- PASS COMPLETE
+- FAIL STOP
+`,
+    );
+
+    const run = await runCliInProcess(['run', 'produce.runbook.md', '--allow-all'], workspace);
+    expect(run.exitCode).toBe(0);
+
+    const status = await runCliInProcess(['status'], workspace);
+    expect(status.exitCode).toBe(0);
+    const vars = (JSON.parse(status.stdout) as { vars?: Record<string, string> }).vars;
+    const planPath = vars?.PlanPath;
+
+    expect(typeof planPath).toBe('string');
+    // Path-first: the variable projects to a real local path under the run's
+    // work dir, not the rd:// URI that identifies the artifact in the manifest.
+    expect(planPath).not.toMatch(/^rd:\/\//);
+    expect(planPath).toContain('/.rundown/work/');
+    expect(planPath).toMatch(/\/plan\.json$/);
+  });
 });

--- a/packages/cli/__tests__/integration/delegation-claim.test.ts
+++ b/packages/cli/__tests__/integration/delegation-claim.test.ts
@@ -8,11 +8,12 @@ import {
   parseFinalCliJsonObject,
   issueRunControlClaim,
   readRunbookState,
+  readSession,
   type TestWorkspace,
 } from '../helpers/test-utils.js';
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { ErrorResponseSchema } from '@rundown-org/core';
+import { assertClaimId, claimKeyFromBearer, ErrorResponseSchema } from '@rundown-org/core';
 
 describe('Delegation claim integration', () => {
   let workspace: TestWorkspace;
@@ -122,6 +123,56 @@ describe('Delegation claim integration', () => {
       }),
     );
     expect(claimOutput.token).not.toMatch(/^rdtk_[A-Za-z0-9_-]{32}$/);
+  });
+
+  it('goto --claim-id moves the claimed child cursor without moving the parent', async () => {
+    // Migrated from the `explicit-goto` scenario in
+    // runbooks/delegation/delegate-claim-explicit-close.runbook.md, which
+    // asserted this by reading .rundown/session.json and the run state files
+    // inside a `node -e` one-liner. State-file inspection belongs in jest
+    // (docs/internal/scenarios.md); the scenario retains the CLI interaction
+    // sequence and asserts through the scenario schema.
+    await writeParentRunbook('child-three-step.runbook.md');
+    await writeFile(
+      join(workspace.cwd, 'child-three-step.runbook.md'),
+      createRunbook({
+        title: 'Child Three Step',
+        steps: [
+          { title: 'One', pass: 'CONTINUE', content: 'Step one.' },
+          { title: 'Two', pass: 'CONTINUE', content: 'Step two.' },
+          { title: 'Three', pass: 'COMPLETE', content: 'Step three.' },
+        ],
+      }),
+    );
+
+    expect(runCli('run --prompted parent.runbook.md --text', workspace).exitCode).toBe(0);
+    const parentRunId = (await getActiveState(workspace))?.id;
+    expect(parentRunId).toEqual(expect.any(String));
+
+    const token = await getAutoIssuedToken();
+    const claimResult = runCli(`claim ${token}`, workspace);
+    expect(claimResult.exitCode).toBe(0);
+    const claimId = assertClaimId(
+      (parseFinalCliJsonObject(claimResult.stdout) as { claim_id: string }).claim_id,
+    );
+
+    const goto = runCli(`goto 3 --claim-id ${claimId}`, workspace);
+    expect(goto.exitCode).toBe(0);
+
+    // The claim record resolves the bearer to the child run it controls, and
+    // records the parent it was delegated from.
+    const session = await readSession(workspace);
+    const claim = session.claims[claimKeyFromBearer(claimId)] as
+      | { controlledRunId: string; delegation: { parentRunId: string } }
+      | undefined;
+    expect(claim).toBeDefined();
+    expect(claim?.delegation.parentRunId).toBe(parentRunId);
+
+    const child = await readRunbookState(workspace, claim!.controlledRunId);
+    const parent = await readRunbookState(workspace, parentRunId!);
+    // The claimed child advanced to 3; the parent's own cursor never moved.
+    expect(child?.step).toBe('3');
+    expect(parent?.step).toBe('1');
   });
 
   it('claims a delegated child resolved from the bundled runbooks directory', async () => {

--- a/packages/cli/__tests__/integration/scenario-runner.test.ts
+++ b/packages/cli/__tests__/integration/scenario-runner.test.ts
@@ -34,17 +34,13 @@ import {
   matchArtifactAssertions,
   matchEnteredAssertions,
   matchStepAssertions,
-  substituteArtifactUris,
   formatArtifactAssertionDescription,
   formatEnteredAssertionDescription,
   formatErrorAssertionDescription,
   formatWarningAssertionDescription,
   formatStepAssertionDescription,
 } from '../../src/helpers/command-sequence.js';
-import {
-  resolveCapturedArtifactFromManifest,
-  seedScenarioArtifacts,
-} from '../../src/helpers/scenario-artifacts.js';
+import { resolveCapturedArtifactFromManifest } from '../../src/helpers/scenario-artifacts.js';
 import { runCliInProcess } from '../../src/services/in-process-cli-runner.js';
 import { assertSafeRelativeArtifactPath } from '../../src/helpers/artifact-path.js';
 import { assertContainedPath } from '../../src/helpers/path-containment.js';
@@ -333,9 +329,9 @@ function copyPatternWithDependencies(
   }
 }
 
-// `seedScenarioArtifacts` and `resolveCapturedArtifactFromManifest` are the
-// production scenario-harness helpers (also used by `rd scenario run`), imported
-// above from ../../src/helpers/scenario-artifacts.js so both harnesses share one
+// `resolveCapturedArtifactFromManifest` is the production scenario-harness
+// helper (also used by `rd scenario run`), imported above from
+// ../../src/helpers/scenario-artifacts.js so both harnesses share one
 // implementation.
 
 /**
@@ -347,12 +343,6 @@ async function executeScenario(
   workspace: TestWorkspace,
 ): Promise<void> {
   copyPatternWithDependencies(filename, scenario, workspace);
-
-  // Seed any artifacts declared by the scenario's `seed:` directive, then expose
-  // each seeded row's rd:// URI as a ${ARTIFACT:<name>} substitution token. This
-  // lets a boundary-channel scenario write `--artifacts PlanPath=${ARTIFACT:PlanPath}`.
-  const artifactUris = seedScenarioArtifacts(scenario, workspace);
-  const commands = scenario.commands.map((cmd) => substituteArtifactUris(cmd, artifactUris));
 
   const expectedResult = getEffectiveResult(scenario);
 
@@ -367,7 +357,7 @@ async function executeScenario(
   };
 
   const seqResult = await executeCommandSequence({
-    commands,
+    commands: scenario.commands,
     cwd: workspace.cwd,
     cliPath,
     quiet: true,

--- a/packages/cli/__tests__/integration/scenario-runner.test.ts
+++ b/packages/cli/__tests__/integration/scenario-runner.test.ts
@@ -6,24 +6,13 @@ import {
 } from '../helpers/test-utils.js';
 import { join, dirname, basename, delimiter, isAbsolute, normalize, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractFileArtifactReferences, isExistingRegularArtifactFile } from '@rundown-org/core';
 import {
-  extractFileArtifactReferences,
-  isExistingRegularArtifactFile,
-  isNodeError,
-  getErrorMessage,
-} from '@rundown-org/core';
-import {
-  extractFrontmatter,
   parseRunbookDocument,
   resolvedStepHasSubsteps,
   type ResolvedStep,
 } from '@rundown-org/parser';
-import {
-  parseScenarios,
-  getEffectiveResult,
-  type Scenario,
-  type Scenarios,
-} from '../../src/schemas/scenarios.js';
+import { getEffectiveResult, type Scenario, type Scenarios } from '../../src/schemas/scenarios.js';
 import {
   executeCommandSequence,
   extractInputFileReferences,
@@ -41,6 +30,7 @@ import {
   formatStepAssertionDescription,
 } from '../../src/helpers/command-sequence.js';
 import { resolveCapturedArtifactFromManifest } from '../../src/helpers/scenario-artifacts.js';
+import { loadRunbookScenarioSources, RUNBOOKS_DIR } from '../helpers/scenario-sources.js';
 import { runCliInProcess } from '../../src/services/in-process-cli-runner.js';
 import { assertSafeRelativeArtifactPath } from '../../src/helpers/artifact-path.js';
 import { assertContainedPath } from '../../src/helpers/path-containment.js';
@@ -57,63 +47,30 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Centralized path to runbooks directory for all test operations
-const RUNBOOKS_DIR = join(__dirname, '..', '..', '..', '..', 'runbooks');
+// Discovery is shared with the static authoring lint
+// (__tests__/schemas/scenario-authoring.test.ts) so the two cannot disagree
+// about which runbooks exist. A runbook invisible to the loader is untested by
+// both, and that silence is the failure mode the lint exists to prevent.
+const scenarioSources = loadRunbookScenarioSources();
 
-/**
- * Recursively get all files in a directory synchronously.
- */
-function getFilesSync(dir: string): string[] {
-  const entries = readdirSync(dir);
-  const files: string[] = [];
-  for (const entry of entries) {
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) {
-      files.push(...getFilesSync(full));
-    } else {
-      files.push(full);
-    }
-  }
-  return files;
+// A runbook whose scenarios fail schema validation must stop this suite, not
+// vanish from it. Under the strict ScenarioSchema (#498) a retired `seed:` key
+// makes parsing fail, and the previous loader discarded `errors` — so an
+// invalid runbook silently stopped being executed while the suite still went
+// green. The authoring lint reports this properly under `verify`; this throw
+// stops the suite from under-reporting its own coverage in the meantime.
+const sourcesWithErrors = scenarioSources.filter((source) => source.errors.length > 0);
+if (sourcesWithErrors.length > 0) {
+  throw new Error(
+    `Runbooks with invalid scenarios (fix them; they would otherwise be silently skipped):\n${sourcesWithErrors
+      .map((source) => `  ${source.file}: ${source.errors.join('; ')}`)
+      .join('\n')}`,
+  );
 }
 
-/**
- * Load pattern files that have scenarios defined (synchronous for test registration).
- */
-function loadPatternsWithScenariosSync(): {
-  withScenarios: { file: string; scenarios: Scenarios }[];
-  allRunbookFiles: string[];
-} {
-  let allFiles: string[];
-  try {
-    allFiles = getFilesSync(RUNBOOKS_DIR);
-  } catch (err: unknown) {
-    if (isNodeError(err) && err.code === 'ENOENT') {
-      return { withScenarios: [], allRunbookFiles: [] };
-    }
-    console.warn(`Warning: failed to load patterns: ${getErrorMessage(err)}`);
-    return { withScenarios: [], allRunbookFiles: [] };
-  }
-  const withScenarios: { file: string; scenarios: Scenarios }[] = [];
-  const allRunbookFiles: string[] = [];
-
-  for (const filePath of allFiles) {
-    if (!filePath.endsWith('.runbook.md')) continue;
-    const relativePath = filePath.substring(RUNBOOKS_DIR.length + 1);
-    allRunbookFiles.push(relativePath);
-    const content = readFileSync(filePath, 'utf-8');
-    const { frontmatter } = extractFrontmatter(content);
-    if (!frontmatter) continue;
-    const { scenarios } = parseScenarios(frontmatter);
-    if (scenarios && Object.keys(scenarios).length > 0) {
-      withScenarios.push({ file: relativePath, scenarios });
-    }
-  }
-
-  return { withScenarios, allRunbookFiles };
-}
-
-const { withScenarios: patternsWithScenarios, allRunbookFiles } = loadPatternsWithScenariosSync();
+const patternsWithScenarios: { file: string; scenarios: Scenarios }[] = scenarioSources
+  .filter((source) => source.scenarios && Object.keys(source.scenarios).length > 0)
+  .map((source) => ({ file: source.file, scenarios: source.scenarios! }));
 
 const allScenarios = patternsWithScenarios.flatMap(({ file, scenarios }) =>
   Object.entries(scenarios).map(([name, scenario]) => ({ file, name, scenario })),
@@ -533,11 +490,11 @@ async function executeScenario(
  * Each scenario runs as its own test for better diagnostics and independent timeouts.
  */
 describe('scenario runner', () => {
-  it('every pattern runbook defines scenarios', () => {
-    const withScenarioFiles = new Set(patternsWithScenarios.map((p) => p.file));
-    const missing = allRunbookFiles.filter((f) => !withScenarioFiles.has(f));
-    expect(missing).toEqual([]);
-  });
+  // `every pattern runbook defines scenarios` moved to
+  // __tests__/schemas/scenario-authoring.test.ts. It is a static authoring
+  // invariant needing no execution, and it lived here — where `verify`'s
+  // --testPathIgnorePatterns='integration' cannot see it — which is exactly how
+  // it broke unnoticed during #498. This file owns execution only.
 
   if (allScenarios.length === 0) {
     it('has pattern scenarios to run', () => {

--- a/packages/cli/__tests__/schemas/scenario-authoring-rules.test.ts
+++ b/packages/cli/__tests__/schemas/scenario-authoring-rules.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the scenario authoring rule predicates.
+ *
+ * The lint suite applies these rules to the repository's real scenarios, which
+ * proves today's corpus is clean but not that a rule still matches anything: a
+ * rule that quietly stopped detecting violations would keep that suite green.
+ * These tests pin each predicate against the evasions it exists to catch.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  commandHead,
+  FABRICATION_RULES,
+  SPAWNS_SUBPROCESS,
+  usesOpaqueWrapper,
+} from '../helpers/scenario-authoring-rules.js';
+
+/** Matches a command against every fabrication rule. */
+function fabricates(command: string): boolean {
+  return FABRICATION_RULES.some((rule) => rule.pattern.test(command));
+}
+
+describe('fabrication rules', () => {
+  it.each([
+    'rd run x.runbook.md --artifacts Plan=rd://artifacts/ctx/rd_1/plan.json',
+    'rd run x.runbook.md --artifacts-json \'R=["rd://artifacts/c/rd_1/a.json"]\'',
+    'node -e \'fs.writeFileSync(".rundown/work/.rd-ctx/manifest.jsonl", row)\'',
+    // The provenance directory is fabricated whatever the context id looks like:
+    // an alphanumeric id, an underscore- or hyphen-led id, and a templated id are
+    // all hand-derived paths.
+    'node -e \'fs.mkdirSync(".rd-ctx123/run")\'',
+    'node -e \'fs.mkdirSync(".rd-_leading/run")\'',
+    'node -e \'fs.mkdirSync(".rd-{{ ContextId }}/run")\'',
+  ])('rejects %p', (command) => {
+    expect(fabricates(command)).toBe(true);
+  });
+
+  it.each([
+    'rd run scenario-seed-artifacts.runbook.md --allow-all',
+    "rd run x.runbook.md --artifacts-json 'R=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all",
+    'rd run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}',
+    'rd pass',
+    'true delegation-child-manual-three-step.runbook.md',
+  ])('accepts %p', (command) => {
+    expect(fabricates(command)).toBe(false);
+  });
+});
+
+describe('subprocess detection', () => {
+  it.each([
+    'node -e \'require("node:child_process").execFileSync("rd", ["status"])\'',
+    'node -e \'const { execSync } = require("child_process"); execSync("rd pass")\'',
+    'node -e \'spawnSync("rd", ["status"])\'',
+  ])('rejects %p', (command) => {
+    expect(SPAWNS_SUBPROCESS.test(command)).toBe(true);
+  });
+
+  it.each([
+    // Reads a state file but never invokes the CLI — a legitimate fault
+    // injector. A naive /\b(rd|rundown)\b/ test would match `.rundown/` here.
+    'node -e \'JSON.parse(fs.readFileSync(".rundown/session.json","utf8"))\'',
+    'rd run x.runbook.md --allow-all',
+  ])('accepts %p', (command) => {
+    expect(SPAWNS_SUBPROCESS.test(command)).toBe(false);
+  });
+});
+
+describe('opaque wrapper detection', () => {
+  it.each([
+    // Inline code — the spelling the rule always caught.
+    'node -e \'fs.writeFileSync("x", "{}")\'',
+    'bash -c "echo hi"',
+    'sh -c "echo hi"',
+    // Helper scripts and package runners — forbidden by the same documented
+    // rule, and previously undetected because they carry no -e/-c flag.
+    'node scripts/seed.js',
+    'python3 seed.py',
+    './setup.sh',
+    'bash scripts/setup.sh',
+    'npm run seed',
+    'pnpm exec something',
+    'npx tsx seed.ts',
+    // Hidden behind a shell operator rather than at the head of the command.
+    'rd pass && node scripts/seed.js',
+    'rd pass; ./helper.sh',
+    // Prefixed forms must not evade the executable-position anchor.
+    "! node -e 'process.exit(1)'",
+    'FOO=bar node scripts/seed.js',
+  ])('rejects %p', (command) => {
+    expect(usesOpaqueWrapper(command)).toBe(true);
+  });
+
+  it.each([
+    'rd run x.runbook.md --allow-all',
+    'rd pass --claim-id ${CLAIM_ID}',
+    '! rd fail',
+    // The established staging no-op and fixture-writing builtin.
+    'true delegation-child-manual-three-step.runbook.md',
+    "printf '%s\\n' '## 1. Parent' > child.runbook.md",
+    // Incidental mentions in arguments are not invocations.
+    'rd run x.runbook.md --input shell=bash',
+    'rd echo --result pass --message "run node to debug"',
+  ])('accepts %p', (command) => {
+    expect(usesOpaqueWrapper(command)).toBe(false);
+  });
+});
+
+describe('commandHead', () => {
+  it.each([
+    ['rd pass', 'rd'],
+    ['! rd fail', 'rd'],
+    ['FOO=bar BAZ=1 node x.js', 'node'],
+    ['  rd  status ', 'rd'],
+    ['', ''],
+  ])('extracts the executable from %p', (command, expected) => {
+    expect(commandHead(command)).toBe(expected);
+  });
+});

--- a/packages/cli/__tests__/schemas/scenario-authoring-rules.test.ts
+++ b/packages/cli/__tests__/schemas/scenario-authoring-rules.test.ts
@@ -86,6 +86,16 @@ describe('opaque wrapper detection', () => {
     // Prefixed forms must not evade the executable-position anchor.
     "! node -e 'process.exit(1)'",
     'FOO=bar node scripts/seed.js',
+    // A newline is a command separator too. `shellParse` treats it as ordinary
+    // whitespace, so without an explicit split the wrapper hides behind `rd`.
+    'rd pass\nnode scripts/seed.js',
+    'rd status\n  bash -c "echo hi"',
+    // A command substitution runs its contents as a command, at any depth.
+    'rd echo --result pass --message "$(node -e \'1\')"',
+    'rd echo --message `node -e 1`',
+    'rd echo --message "$(echo "$(python3 seed.py)")"',
+    // A subshell is a command position.
+    '(node scripts/seed.js)',
   ])('rejects %p', (command) => {
     expect(usesOpaqueWrapper(command)).toBe(true);
   });
@@ -100,8 +110,30 @@ describe('opaque wrapper detection', () => {
     // Incidental mentions in arguments are not invocations.
     'rd run x.runbook.md --input shell=bash',
     'rd echo --result pass --message "run node to debug"',
+    // A separator inside a quoted argument is not a command boundary: the shell
+    // never sees it as one, so neither may the lint. A `split(/[;|&]+/)` reads
+    // `node` and `bash` here as executables and rejects a legitimate command.
+    'rd echo --result pass --message "step a; node b to debug"',
+    'rd echo --message "use a | bash pipeline"',
+    'rd echo --message "run a && python3 it"',
+    // A redirection target is not an executable.
+    'rd echo --message hi > seed.js',
   ])('accepts %p', (command) => {
     expect(usesOpaqueWrapper(command)).toBe(false);
+  });
+
+  it('reads a single-quoted backtick as literal text, not a substitution', () => {
+    // Abridged from delegate-claim-corruption.runbook.md:29, an allowlisted
+    // fault injector. Its JS template literals sit inside a single-quoted
+    // `node -e` argument, so the shell never expands them. Re-parsing that inner
+    // text as shell throws (`Bad substitution: "f".repeat`), so a quote-blind
+    // scan for backticks crashes the lint on a legitimate command.
+    const command =
+      'node -e \'const p = `.rundown/runs/${c.controlledRunId}.json`; child.parentLinkage.tokenHash = `sha256:${"f".repeat(64)}`;\'';
+    expect(() => usesOpaqueWrapper(command)).not.toThrow();
+    // Still a wrapper — but because `node` heads it, not because of the backticks.
+    expect(usesOpaqueWrapper(command)).toBe(true);
+    expect(commandHead(command)).toBe('node');
   });
 });
 

--- a/packages/cli/__tests__/schemas/scenario-authoring.test.ts
+++ b/packages/cli/__tests__/schemas/scenario-authoring.test.ts
@@ -27,6 +27,11 @@ import {
   type RunbookScenarioSource,
 } from '../helpers/scenario-sources.js';
 import { loadScenarioSuite } from '../../src/schemas/scenario-suite.js';
+import {
+  FABRICATION_RULES,
+  SPAWNS_SUBPROCESS,
+  usesOpaqueWrapper,
+} from '../helpers/scenario-authoring-rules.js';
 
 const sources: RunbookScenarioSource[] = loadRunbookScenarioSources();
 
@@ -49,33 +54,6 @@ const commandSites: CommandSite[] = sources.flatMap((source) =>
     })),
   ),
 );
-
-/**
- * Commands that fabricate artifact provenance. No allowlist: the #498
- * invariant is that provenance comes from a real producer's output, and there
- * is no legitimate reason for a scenario command to name an `rd://` URI, touch
- * the manifest, or re-derive the `.rd-<contextId>` directory by hand.
- */
-const FABRICATION_RULES: readonly { readonly id: string; readonly pattern: RegExp }[] = [
-  { id: 'names an rd:// URI (capture it from a producer instead)', pattern: /rd:\/\// },
-  { id: 'writes the artifact manifest (core owns manifest.jsonl)', pattern: /manifest\.jsonl/ },
-  { id: 'hand-derives the .rd-<contextId> provenance directory', pattern: /\.rd-[0-9a-z]/i },
-];
-
-/**
- * Detects a subprocess spawn inside a scenario command.
- *
- * This is `scenarios.md`'s "no hidden `rd` invocations" rule made objective. It
- * deliberately matches the *spawn*, not the token `rd`: a `\b(rd|rundown)\b`
- * test matches the path `.rundown/session.json` and would condemn the
- * fault-injection scenarios that legitimately read state files without ever
- * invoking the CLI.
- */
-const SPAWNS_SUBPROCESS = /child_process|execFileSync|execSync|spawnSync|\bspawn\(/;
-
-/** Opaque shell wrappers, which hide workflow from the scenario runner's command model. */
-const OPAQUE_WRAPPER =
-  /(^|[\s;|&(])(node|python3?|ruby|perl)\s+-[ec]\b|(^|[\s;|&(])(ba|z)?sh\s+-c\b|(^|[\s;|&(])(npm|pnpm|yarn|npx)\s|(^|[\s;|&(])eval\s/;
 
 /**
  * Scenario commands where the shell command IS the fault being injected or the
@@ -154,7 +132,7 @@ describe('scenario commands never fabricate artifact provenance (#498)', () => {
 describe('opaque shell wrappers are confined to fault injection', () => {
   it('allowlist matches the real violations exactly, with no stale entries', () => {
     const violations = commandSites
-      .filter((site) => OPAQUE_WRAPPER.test(site.command))
+      .filter((site) => usesOpaqueWrapper(site.command))
       .map((site) => site.key)
       .sort();
     const allowed = FAULT_INJECTION_ALLOWLIST.map((entry) => entry.key).sort();
@@ -196,7 +174,7 @@ describe('scenario suite files', () => {
           const failed = [
             ...FABRICATION_RULES.filter((rule) => rule.pattern.test(command)).map((r) => r.id),
             ...(SPAWNS_SUBPROCESS.test(command) ? ['spawns a subprocess'] : []),
-            ...(OPAQUE_WRAPPER.test(command) ? ['uses an opaque shell wrapper'] : []),
+            ...(usesOpaqueWrapper(command) ? ['uses an opaque shell wrapper'] : []),
           ];
           if (failed.length > 0) {
             violations.push(`${file}::${name}::${String(index)} — ${failed.join(', ')}`);

--- a/packages/cli/__tests__/schemas/scenario-authoring.test.ts
+++ b/packages/cli/__tests__/schemas/scenario-authoring.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Repository-wide authoring rules for scenario command sequences.
+ *
+ * These rules were previously conventions in `docs/internal/scenarios.md` with
+ * nothing enforcing them, and #498 exists because that gap let three scenarios
+ * fabricate artifact provenance for months while looking like real coverage.
+ *
+ * **Why this lints parsed structure rather than file text.** The obvious check —
+ * `grep -rn 'rd://artifacts/' runbooks/` — is unwinnable, because `rd://` is
+ * both the fabrication pattern and the legitimate artifact *selector* language
+ * used on `ARTIFACTS` directive lines in runbook bodies (see
+ * `runbooks/artifacts/artifact-selector-query-filter.runbook.md`). The
+ * difference is not in the characters, it is in where the string lives. These
+ * rules read `scenarios.*.commands[]` as parsed frontmatter values, so body
+ * text can never reach them and the selector language can never false-positive.
+ *
+ * This file must NOT live under `__tests__/integration/`: `test:unit` (and so
+ * `pnpm run verify`) runs `jest --testPathIgnorePatterns='integration'`, which
+ * is exactly why the integration harness's own authoring invariant broke
+ * unnoticed on the #498 branch.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  findScenarioSuiteFiles,
+  loadRunbookScenarioSources,
+  type RunbookScenarioSource,
+} from '../helpers/scenario-sources.js';
+import { loadScenarioSuite } from '../../src/schemas/scenario-suite.js';
+
+const sources: RunbookScenarioSource[] = loadRunbookScenarioSources();
+
+/** A single scenario command, tagged with where it came from. */
+interface CommandSite {
+  readonly key: string;
+  readonly file: string;
+  readonly scenario: string;
+  readonly command: string;
+}
+
+/** Every scenario command in the repository, in a stable order. */
+const commandSites: CommandSite[] = sources.flatMap((source) =>
+  Object.entries(source.scenarios ?? {}).flatMap(([scenario, definition]) =>
+    definition.commands.map((command, index) => ({
+      key: `${source.file}::${scenario}::${String(index)}`,
+      file: source.file,
+      scenario,
+      command,
+    })),
+  ),
+);
+
+/**
+ * Commands that fabricate artifact provenance. No allowlist: the #498
+ * invariant is that provenance comes from a real producer's output, and there
+ * is no legitimate reason for a scenario command to name an `rd://` URI, touch
+ * the manifest, or re-derive the `.rd-<contextId>` directory by hand.
+ */
+const FABRICATION_RULES: readonly { readonly id: string; readonly pattern: RegExp }[] = [
+  { id: 'names an rd:// URI (capture it from a producer instead)', pattern: /rd:\/\// },
+  { id: 'writes the artifact manifest (core owns manifest.jsonl)', pattern: /manifest\.jsonl/ },
+  { id: 'hand-derives the .rd-<contextId> provenance directory', pattern: /\.rd-[0-9a-z]/i },
+];
+
+/**
+ * Detects a subprocess spawn inside a scenario command.
+ *
+ * This is `scenarios.md`'s "no hidden `rd` invocations" rule made objective. It
+ * deliberately matches the *spawn*, not the token `rd`: a `\b(rd|rundown)\b`
+ * test matches the path `.rundown/session.json` and would condemn the
+ * fault-injection scenarios that legitimately read state files without ever
+ * invoking the CLI.
+ */
+const SPAWNS_SUBPROCESS = /child_process|execFileSync|execSync|spawnSync|\bspawn\(/;
+
+/** Opaque shell wrappers, which hide workflow from the scenario runner's command model. */
+const OPAQUE_WRAPPER =
+  /(^|[\s;|&(])(node|python3?|ruby|perl)\s+-[ec]\b|(^|[\s;|&(])(ba|z)?sh\s+-c\b|(^|[\s;|&(])(npm|pnpm|yarn|npx)\s|(^|[\s;|&(])eval\s/;
+
+/**
+ * Scenario commands where the shell command IS the fault being injected or the
+ * untrusted input being forged — never a workflow step, and never an assertion.
+ *
+ * The distinguishing tell: a fault injector **mutates** state or forges input
+ * that the run must reject. A command that only **reads** state to assert on it
+ * is a jest test wearing a scenario costume, and belongs in `__tests__/`
+ * instead (`docs/internal/scenarios.md`) — it does not belong here.
+ *
+ * Entries are matched by set equality, so a stale entry fails this suite just
+ * as loudly as an unlisted violation.
+ */
+const FAULT_INJECTION_ALLOWLIST: readonly { readonly key: string; readonly reason: string }[] = [
+  {
+    key: 'artifacts/artifact-variable-review-plan.runbook.md::forged-file-record-rejected::0',
+    reason:
+      'Forges an artifact record as an untrusted public input so the run can assert the input channel rejects it. The forgery is the fault under test; replacing it with a real producer would delete the test.',
+  },
+  {
+    key: 'delegation/delegate-claim-corruption.runbook.md::child-linkage-mismatch::3',
+    reason:
+      'Rewrites parentLinkage.tokenHash in session.json to simulate a tampered claim linkage. The corruption is the fault under test and cannot be produced through the CLI.',
+  },
+  {
+    key: 'delegation/delegate-claim-corruption.runbook.md::child-missing::3',
+    reason:
+      'Deletes the child run state file to simulate a missing child run. The corruption is the fault under test and cannot be produced through the CLI.',
+  },
+];
+
+describe('scenario sources', () => {
+  it('discovers the repository runbook tree', () => {
+    // A vacuous pass over zero runbooks would make every rule below meaningless.
+    expect(sources.length).toBeGreaterThan(100);
+    expect(commandSites.length).toBeGreaterThan(100);
+  });
+
+  it('every runbook has a schema-valid scenarios block', () => {
+    // parseScenarios errors must fail here rather than silently drop the runbook
+    // from the executing harness — under the strict schema (#498) a retired
+    // `seed:` key makes a runbook invisible instead of rejected.
+    const invalid = sources
+      .filter((s) => s.errors.length > 0)
+      .map((s) => `${s.file}: ${s.errors.join('; ')}`);
+    expect(invalid).toEqual([]);
+  });
+
+  it('every runbook defines at least one scenario', () => {
+    // Moved here from the integration harness, which `verify` never runs. A
+    // runbook with no scenario is silently untested — the failure mode that let
+    // artifact-variable-collate lose all coverage during #498.
+    const missing = sources
+      .filter((s) => !s.scenarios || Object.keys(s.scenarios).length === 0)
+      .map((s) => s.file);
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('scenario commands never fabricate artifact provenance (#498)', () => {
+  it.each(FABRICATION_RULES)('no command $id', ({ pattern }) => {
+    const violations = commandSites
+      .filter((site) => pattern.test(site.command))
+      .map((site) => `${site.key}\n    ${site.command.slice(0, 120)}`);
+    expect(violations).toEqual([]);
+  });
+
+  it('no command spawns a subprocess (hidden rd invocations obscure run state)', () => {
+    const violations = commandSites
+      .filter((site) => SPAWNS_SUBPROCESS.test(site.command))
+      .map((site) => `${site.key}\n    ${site.command.slice(0, 120)}`);
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('opaque shell wrappers are confined to fault injection', () => {
+  it('allowlist matches the real violations exactly, with no stale entries', () => {
+    const violations = commandSites
+      .filter((site) => OPAQUE_WRAPPER.test(site.command))
+      .map((site) => site.key)
+      .sort();
+    const allowed = FAULT_INJECTION_ALLOWLIST.map((entry) => entry.key).sort();
+    // Set equality, not a subset: an unlisted violation and a stale entry are
+    // both failures. A subset assertion is how an allowlist rots into a rubber
+    // stamp.
+    expect(violations).toEqual(allowed);
+  });
+
+  it('every allowlist entry states a substantive reason', () => {
+    const unjustified = FAULT_INJECTION_ALLOWLIST.filter((e) => e.reason.trim().length < 40).map(
+      (e) => e.key,
+    );
+    expect(unjustified).toEqual([]);
+  });
+
+  it('allowlist has no duplicate keys', () => {
+    const keys = FAULT_INJECTION_ALLOWLIST.map((e) => e.key);
+    expect(keys).toEqual([...new Set(keys)]);
+  });
+});
+
+describe('scenario suite files', () => {
+  it('applies the same rules to standalone scenario suites', async () => {
+    const suiteFiles = findScenarioSuiteFiles();
+    // Discovery is by scan, so a broken glob must fail rather than pass over
+    // nothing.
+    expect(suiteFiles.length).toBeGreaterThan(0);
+
+    const violations: string[] = [];
+    for (const file of suiteFiles) {
+      const result = await loadScenarioSuite(file);
+      if (!result.ok) {
+        violations.push(`${file}: ${result.error}`);
+        continue;
+      }
+      for (const [name, testCase] of Object.entries(result.suite.cases)) {
+        testCase.commands.forEach((command, index) => {
+          const failed = [
+            ...FABRICATION_RULES.filter((rule) => rule.pattern.test(command)).map((r) => r.id),
+            ...(SPAWNS_SUBPROCESS.test(command) ? ['spawns a subprocess'] : []),
+            ...(OPAQUE_WRAPPER.test(command) ? ['uses an opaque shell wrapper'] : []),
+          ];
+          if (failed.length > 0) {
+            violations.push(`${file}::${name}::${String(index)} — ${failed.join(', ')}`);
+          }
+        });
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/cli/__tests__/schemas/scenarios.test.ts
+++ b/packages/cli/__tests__/schemas/scenarios.test.ts
@@ -1,7 +1,6 @@
 import {
   ScenarioSchema,
   ScenarioExpectSchema,
-  ScenarioSeedSchema,
   StepAssertionSchema,
   ScenariosSchema,
   parseScenarios,
@@ -131,59 +130,25 @@ describe('ScenarioSchema', () => {
   });
 });
 
-describe('ScenarioSeedSchema', () => {
-  it('accepts a valid identifier artifact name', () => {
-    const result = ScenarioSeedSchema.safeParse({ artifact: 'PlanPath' });
-    expect(result.success).toBe(true);
-  });
-
-  it.each([
-    '../etc',
-    'a/b',
-    '..',
-    'plan.json',
-    'a b',
-  ])('rejects path-unsafe artifact name %p', (artifact) => {
-    // The harness joins this name into an rd:// URI and a backing file path, so
-    // path separators / traversal must be rejected at the schema boundary.
-    const result = ScenarioSeedSchema.safeParse({ artifact });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0]?.message).toMatch(/valid identifier/);
-    }
-  });
-
-  it.each([
-    '__proto__',
-    'constructor',
-    'prototype',
-  ])('rejects reserved artifact name %p (prototype-pollution boundary)', (artifact) => {
-    // These are valid identifiers, so the grammar regex alone admits them; the
-    // reserved-name refinement (matching the artifact/input channels via
-    // isValidVariableName) is what rejects them before they reach --artifacts.
-    const result = ScenarioSeedSchema.safeParse({ artifact });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0]?.message).toMatch(/reserved name/);
-    }
-  });
-
-  it('is accepted as a scenario seed array', () => {
+describe('retired seed directive (#498)', () => {
+  it('rejects a scenario still carrying the retired seed field', () => {
     const result = ScenarioSchema.safeParse({
       seed: [{ artifact: 'PlanPath' }],
-      commands: ['rd run --prompted test.runbook.md --artifacts PlanPath=${ARTIFACT:PlanPath}'],
-      result: 'COMPLETE',
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it('rejects a scenario whose seed carries a path-unsafe artifact name', () => {
-    const result = ScenarioSchema.safeParse({
-      seed: [{ artifact: '../escape' }],
-      commands: ['rd run --prompted test.runbook.md'],
+      commands: ['rd run scenario-seed-artifacts.runbook.md --allow-all'],
       result: 'COMPLETE',
     });
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toContain('seed');
+    }
+  });
+
+  it('still accepts a scenario with no seed field', () => {
+    const result = ScenarioSchema.safeParse({
+      commands: ['rd run scenario-seed-artifacts.runbook.md --allow-all'],
+      result: 'COMPLETE',
+    });
+    expect(result.success).toBe(true);
   });
 });
 

--- a/packages/cli/jest.config.shared.js
+++ b/packages/cli/jest.config.shared.js
@@ -41,6 +41,15 @@ export function makeConfig({ sandboxed }) {
   // nothing to mutation coverage.
   const sandboxMetaTestIgnore = sandboxed ? ['\\.source-text\\.test\\.ts$'] : [];
 
+  // The scenario authoring lint reads the repo-root `runbooks/` tree, which the
+  // Stryker sandbox does not contain (only `packages/cli/` is copied in). It
+  // would find zero runbooks and fail its own no-vacuous-pass guard, breaking
+  // the dry run. It lints authored data, not `src/` behaviour, so it
+  // contributes nothing to mutation coverage. Skipping it here is preferable to
+  // giving the loader an ENOENT-returns-empty fallback, which would let the
+  // lint pass vacuously everywhere.
+  const sandboxDataLintIgnore = sandboxed ? ['scenario-authoring\\.test\\.ts$'] : [];
+
   return {
     testPathIgnorePatterns: sandboxed
       ? [
@@ -49,6 +58,7 @@ export function makeConfig({ sandboxed }) {
           'integration',
           'forced-terminal-boundary\\.test\\.ts$',
           ...sandboxMetaTestIgnore,
+          ...sandboxDataLintIgnore,
         ]
       : ['/node_modules/', '<rootDir>/../../.worktrees/', '/\\.stryker-tmp/'],
     modulePathIgnorePatterns: sandboxed

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -535,6 +535,67 @@ const CAPTURE_ARTIFACT_PLACEHOLDER = /\$\{CAPTURE_ARTIFACT(?:_ARRAY)?:[^}]+\}/;
  */
 const RETIRED_ARTIFACT_PLACEHOLDER = /\$\{ARTIFACT:[^}]+\}/;
 
+/** Global matcher for the array form, used to locate placeholders to probe. */
+const CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER = /\$\{CAPTURE_ARTIFACT_ARRAY:([^}]+)\}/g;
+
+/**
+ * Stand-in for a resolved array value, used to ask `shellParse` whether a real
+ * resolved value would survive at the same position.
+ *
+ * Covers every shell-significant character a real value can contain. A resolved
+ * array is `JSON.stringify` of `rd://` URIs (`scenario-artifacts.ts:130`), whose
+ * character set is closed under `assertSafeId` (`[A-Za-z0-9._-]`, `paths.ts:34`)
+ * plus the URI's `/` and `:` and JSON's `[`, `]`, `"`, `,`. Of those, only `"`
+ * and `[`/`]` are shell-significant, and the probe contains all three — so a
+ * probe that survives implies a real value survives.
+ */
+const ARRAY_QUOTING_PROBE = '["rd://s"]';
+
+/**
+ * Reject an `${CAPTURE_ARTIFACT_ARRAY:<key>}` placeholder that is not shell-quoted.
+ *
+ * The array form resolves to JSON containing `"` characters, which are spliced
+ * into command text and then re-tokenized by `shellParse` via
+ * {@link parseRdCommandWithEnv}. Unquoted, the shell consumes those quotes and
+ * `["rd://a","rd://b"]` arrives as the unparseable `[rd://a,rd://b]`, failing
+ * with an error naming a value the author never wrote. The scalar form needs no
+ * such guard: its resolved values cannot contain a shell metacharacter.
+ *
+ * Implemented by probing the real tokenizer rather than by matching quotes with
+ * a regex: authors quote the whole assignment (`'K=${...}'`), not the
+ * placeholder, so an adjacency regex false-rejects every real call site.
+ *
+ * Deliberately throwaway: under the deferred parse-then-substitute refactor
+ * (#498 follow-up) resolved values never reach `shellParse` and this guard is
+ * deleted with the hazard it guards.
+ *
+ * @param cmd - Command text after token substitution, placeholders still intact
+ * @throws {Error} When any array placeholder would not survive shell tokenization
+ */
+function assertArrayCapturesAreShellQuoted(cmd: string): void {
+  const keys = [...cmd.matchAll(CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER)].map((m) => m[1]);
+  if (keys.length === 0) return;
+  const probe = cmd.replace(CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER, ARRAY_QUOTING_PROBE);
+  let survived: number;
+  try {
+    // Count probe *occurrences*, not entries containing one: two placeholders
+    // can legitimately land in a single quoted argv entry.
+    survived = shellParse(probe)
+      .filter((entry): entry is string => typeof entry === 'string')
+      .reduce((n, entry) => n + entry.split(ARRAY_QUOTING_PROBE).length - 1, 0);
+  } catch {
+    survived = -1;
+  }
+  if (survived !== keys.length) {
+    throw new Error(
+      `Command uses \${CAPTURE_ARTIFACT_ARRAY:${keys[0]}} without shell quoting: ${cmd}\n` +
+        `The array form resolves to JSON containing double quotes; unquoted, the shell strips ` +
+        `them and the value arrives as invalid JSON. Single-quote the assignment, e.g. ` +
+        `--artifacts-json 'Key=\${CAPTURE_ARTIFACT_ARRAY:${keys[0]}}'.`,
+    );
+  }
+}
+
 /**
  * Substitute captured claim id placeholders in a command string.
  *
@@ -1639,6 +1700,10 @@ export async function executeCommandSequence(
           `(see runbooks/artifacts/scenario-seed-artifacts.runbook.md).`,
       );
     }
+    // The array capture resolves to JSON with double quotes and is re-tokenized
+    // by shellParse below; reject it here if it would not survive, rather than
+    // failing later against a value the author never wrote.
+    assertArrayCapturesAreShellQuoted(tokenSubstituted);
     // Post-run artifact capture — resolve ${CAPTURE_ARTIFACT[_ARRAY]:<key>} from
     // the manifest a prior command produced (resolver injected by the harness).
     // Fail fast if a command references a capture placeholder but no resolver was

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -528,12 +528,14 @@ const CAPTURE_ARTIFACT_PLACEHOLDER = /\$\{CAPTURE_ARTIFACT(?:_ARRAY)?:[^}]+\}/;
  * it makes the retired grammar fail loudly and name its replacement, rather than
  * keeping it working.
  *
- * Deliberately matches `[^}]+` rather than the retired grammar's narrower
- * identifier pattern, so a *malformed* retired placeholder is caught too. It
- * cannot match `${CAPTURE_ARTIFACT…}`, whose text contains `ARTIFACT:` but never
- * the required `${` immediately before it.
+ * Deliberately matches `[^}]*` rather than the retired grammar's narrower
+ * identifier pattern, so a *malformed* retired placeholder is caught too —
+ * including the empty-bodied `${ARTIFACT:}`, which is the exact spelling this
+ * detector's own error message uses to name the retirement. It cannot match
+ * `${CAPTURE_ARTIFACT…}`, whose text contains `ARTIFACT:` but never the
+ * required `${` immediately before it.
  */
-const RETIRED_ARTIFACT_PLACEHOLDER = /\$\{ARTIFACT:[^}]+\}/;
+const RETIRED_ARTIFACT_PLACEHOLDER = /\$\{ARTIFACT:[^}]*\}/;
 
 /** Global matcher for the array form, used to locate placeholders to probe. */
 const CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER = /\$\{CAPTURE_ARTIFACT_ARRAY:([^}]+)\}/g;
@@ -550,6 +552,28 @@ const CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER = /\$\{CAPTURE_ARTIFACT_ARRAY:([^}]+)\}
  * probe that survives implies a real value survives.
  */
 const ARRAY_QUOTING_PROBE = '["rd://s"]';
+
+/**
+ * Pick a probe value that does not already occur in `cmd`.
+ *
+ * The guard counts how many probes survive tokenization and compares that to the
+ * number of placeholders. Any occurrence of the probe's literal text that the
+ * guard did not itself substitute would inflate that count and reject a
+ * correctly quoted command — a collision with the guard's own instrument rather
+ * than an authoring error. Widening the probe until it is absent keeps the count
+ * attributable to substitution alone, while preserving the shell-significant
+ * characters (`"`, `[`, `]`) the probe exists to exercise.
+ *
+ * @param cmd - Command text the probe will be substituted into
+ * @returns A probe string guaranteed not to occur in `cmd`
+ */
+function uniqueArrayQuotingProbe(cmd: string): string {
+  let probe = ARRAY_QUOTING_PROBE;
+  for (let n = 0; cmd.includes(probe); n++) {
+    probe = `["rd://s${String(n)}"]`;
+  }
+  return probe;
+}
 
 /**
  * Reject an `${CAPTURE_ARTIFACT_ARRAY:<key>}` placeholder that is not shell-quoted.
@@ -575,14 +599,15 @@ const ARRAY_QUOTING_PROBE = '["rd://s"]';
 function assertArrayCapturesAreShellQuoted(cmd: string): void {
   const keys = [...cmd.matchAll(CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER)].map((m) => m[1]);
   if (keys.length === 0) return;
-  const probe = cmd.replace(CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER, ARRAY_QUOTING_PROBE);
+  const probeValue = uniqueArrayQuotingProbe(cmd);
+  const probe = cmd.replace(CAPTURE_ARTIFACT_ARRAY_PLACEHOLDER, probeValue);
   let survived: number;
   try {
     // Count probe *occurrences*, not entries containing one: two placeholders
     // can legitimately land in a single quoted argv entry.
     survived = shellParse(probe)
       .filter((entry): entry is string => typeof entry === 'string')
-      .reduce((n, entry) => n + entry.split(ARRAY_QUOTING_PROBE).length - 1, 0);
+      .reduce((n, entry) => n + entry.split(probeValue).length - 1, 0);
   } catch {
     survived = -1;
   }

--- a/packages/cli/src/helpers/command-sequence.ts
+++ b/packages/cli/src/helpers/command-sequence.ts
@@ -452,33 +452,6 @@ export function substituteTokens(cmd: string, tokens: string[]): string {
 }
 
 /**
- * Substitute seeded artifact URI placeholders in a command string.
- *
- * `${ARTIFACT:<name>}` is replaced by the `rd://` URI of the manifest row seeded
- * for `<name>` by the scenario's `seed:` directive, so a scenario command can
- * write `--artifacts PlanPath=${ARTIFACT:PlanPath}`. Scenario-harness only.
- *
- * @param cmd - The command string with optional artifact placeholders
- * @param artifactUris - Map of seeded artifact name to its `rd://` URI
- * @returns The command string with placeholders replaced by seeded URIs
- * @throws {Error} When a placeholder references an unseeded artifact name
- */
-export function substituteArtifactUris(
-  cmd: string,
-  artifactUris: Readonly<Record<string, string | undefined>>,
-): string {
-  return cmd.replace(/\$\{ARTIFACT:([A-Za-z_][A-Za-z0-9_]*)\}/g, (match: string, name: string) => {
-    const uri = artifactUris[name];
-    if (uri === undefined) {
-      throw new Error(
-        `Artifact placeholder ${match} references an unseeded artifact (seed it via the scenario "seed" directive)`,
-      );
-    }
-    return uri;
-  });
-}
-
-/**
  * Resolver that maps a captured artifact key to its current `rd://` URI(s) from
  * the manifest.
  *
@@ -495,10 +468,13 @@ export type CapturedArtifactResolver = (key: string, asArray: boolean) => Promis
  *
  * `${CAPTURE_ARTIFACT:<key>}` is replaced by the `rd://` URI of the most recent
  * manifest row for `<key>`; `${CAPTURE_ARTIFACT_ARRAY:<key>}` is replaced by a
- * JSON array of all such URIs. Unlike `${ARTIFACT:…}` (pre-seeded), these are
- * resolved at execution time from rows a prior command produced, so a scenario
- * can hand a produced artifact to a later run via `--artifacts` /
- * `--artifacts-json`. Scenario-harness only; the resolver reads the manifest.
+ * JSON array of all such URIs. This is the sole artifact grammar: values are
+ * resolved at execution time from rows a prior command actually produced, so a
+ * scenario hands a real produced artifact to a later run via `--artifacts` /
+ * `--artifacts-json`. A scenario needing a pre-existing artifact runs a producer
+ * runbook first (see `runbooks/artifacts/scenario-seed-artifacts.runbook.md`)
+ * rather than fabricating a URI. Scenario-harness only; the resolver reads the
+ * manifest.
  *
  * @param cmd - The command string with optional capture placeholders
  * @param resolve - Async resolver mapping a key (and array flag) to its substitution text
@@ -540,6 +516,24 @@ export async function substituteCapturedArtifacts(
  * wired, rather than letting the raw placeholder leak into the executed command.
  */
 const CAPTURE_ARTIFACT_PLACEHOLDER = /\$\{CAPTURE_ARTIFACT(?:_ARRAY)?:[^}]+\}/;
+
+/**
+ * Non-global detector for the **retired** `${ARTIFACT:<name>}` grammar (#498).
+ *
+ * `${ARTIFACT:…}` and its `seed:` directive were removed in favour of a single
+ * capture-from-output mechanism. Without this detector the retired placeholder
+ * has no substituter left, so it would pass through verbatim into `--artifacts`
+ * and surface as an opaque `INVALID_ARTIFACT_INPUT` — the precise confusion the
+ * retirement exists to prevent. This is a tombstone, not a compatibility shim:
+ * it makes the retired grammar fail loudly and name its replacement, rather than
+ * keeping it working.
+ *
+ * Deliberately matches `[^}]+` rather than the retired grammar's narrower
+ * identifier pattern, so a *malformed* retired placeholder is caught too. It
+ * cannot match `${CAPTURE_ARTIFACT…}`, whose text contains `ARTIFACT:` but never
+ * the required `${` immediately before it.
+ */
+const RETIRED_ARTIFACT_PLACEHOLDER = /\$\{ARTIFACT:[^}]+\}/;
 
 /**
  * Substitute captured claim id placeholders in a command string.
@@ -1635,6 +1629,16 @@ export async function executeCommandSequence(
       ),
       capturedRunIds,
     );
+    // The `${ARTIFACT:<name>}` grammar and its `seed:` directive were retired in
+    // #498. No substituter remains, so fail here and name the replacement rather
+    // than letting the raw placeholder leak into the executed command.
+    if (RETIRED_ARTIFACT_PLACEHOLDER.test(tokenSubstituted)) {
+      throw new Error(
+        `Command uses the retired \${ARTIFACT:} grammar, removed in #498: ${tokenSubstituted}\n` +
+          `Run a producer runbook first and use \${CAPTURE_ARTIFACT:<key>} to capture its artifact ` +
+          `(see runbooks/artifacts/scenario-seed-artifacts.runbook.md).`,
+      );
+    }
     // Post-run artifact capture — resolve ${CAPTURE_ARTIFACT[_ARRAY]:<key>} from
     // the manifest a prior command produced (resolver injected by the harness).
     // Fail fast if a command references a capture placeholder but no resolver was

--- a/packages/cli/src/helpers/scenario-artifacts.ts
+++ b/packages/cli/src/helpers/scenario-artifacts.ts
@@ -1,23 +1,20 @@
 /**
- * Scenario-harness artifact seeding and capture resolution.
+ * Scenario-harness artifact capture resolution.
  *
- * These helpers are the production home of the `seed:` / `${ARTIFACT:<name>}` and
- * `${CAPTURE_ARTIFACT[_ARRAY]:<key>}` machinery used by both the in-process jest
- * scenario runner and the standalone `rd scenario run` command, so the two
- * harnesses share one implementation instead of drifting. Scenario-harness only —
- * never part of runbook execution.
+ * Resolves the `${CAPTURE_ARTIFACT[_ARRAY]:<key>}` grammar — the harness's sole
+ * artifact mechanism — for both the in-process jest scenario runner and the
+ * standalone `rd scenario run` command, so the two harnesses share one
+ * implementation instead of drifting. A scenario that needs a pre-existing
+ * artifact runs a real producer runbook first (see
+ * `runbooks/artifacts/scenario-seed-artifacts.runbook.md`) and captures the
+ * `rd://` URI that producer emitted; the harness never fabricates a URI or
+ * hand-writes a manifest row. Scenario-harness only — never part of runbook
+ * execution.
  *
  * @module helpers/scenario-artifacts
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import {
-  appendArtifactManifestRecordSync,
-  assertRunId,
-  readAllArtifactManifestRecords,
-} from '@rundown-org/core';
-import type { Scenario } from '../schemas/scenarios.js';
+import { readAllArtifactManifestRecords } from '@rundown-org/core';
 
 /** Workspace location used to resolve the artifact manifest and backing files. */
 export interface ScenarioArtifactLocation {
@@ -26,49 +23,6 @@ export interface ScenarioArtifactLocation {
 }
 
 const WORK_PATH = '.rundown/work';
-
-/**
- * Seed manifest rows for a scenario's `seed:` directive.
- *
- * Each `seed` entry writes an `rd://artifacts/...` manifest row (and a backing
- * file at its projected local path, so `exists: true` assertions and
- * `{{ path X }}` projections resolve against a real file) and returns a map of
- * artifact name to its `rd://` URI, consumed by `${ARTIFACT:<name>}` substitution.
- *
- * @param scenario - The scenario whose `seed:` directive to materialise
- * @param location - The scenario workspace location
- * @returns Map of seeded artifact name to its `rd://` URI
- */
-export function seedScenarioArtifacts(
-  scenario: Scenario,
-  location: ScenarioArtifactLocation,
-): Record<string, string> {
-  const artifactUris: Record<string, string> = {};
-  const seedRunId = assertRunId('rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
-  const seedContextId = 'scenario-seed-context';
-  for (const entry of scenario.seed ?? []) {
-    const uri = `rd://artifacts/${seedContextId}/${seedRunId}/${entry.artifact}`;
-    appendArtifactManifestRecordSync(
-      { cwd: location.cwd, workPath: WORK_PATH },
-      {
-        uri,
-        runId: seedRunId,
-        contextId: seedContextId,
-        runbook: { source: 'project', path: 'producer.runbook.md' },
-        key: entry.artifact,
-        timestamp: '2026-05-25T00:00:00.000Z',
-      },
-    );
-    // Also materialise the backing file at the projected local path so an
-    // `exists: true` artifact assertion (file-existence) and `{{ path X }}`
-    // projection both resolve against a real file.
-    const backingDir = join(location.cwd, WORK_PATH, `.rd-${seedContextId}`, seedRunId);
-    mkdirSync(backingDir, { recursive: true });
-    writeFileSync(join(backingDir, entry.artifact), '{"seeded":true}\n');
-    artifactUris[entry.artifact] = uri;
-  }
-  return artifactUris;
-}
 
 /**
  * Resolve a `${CAPTURE_ARTIFACT[_ARRAY]:<key>}` placeholder from the workspace

--- a/packages/cli/src/helpers/scenario-workflow.ts
+++ b/packages/cli/src/helpers/scenario-workflow.ts
@@ -54,7 +54,6 @@ import {
   matchArtifactAssertions,
   matchEnteredAssertions,
   matchStepAssertions,
-  substituteArtifactUris,
   type ArtifactAssertionResult,
   type CapturedWarning,
   type EnteredAssertionResult,
@@ -62,10 +61,7 @@ import {
   type StepAssertionResult,
   type WarningAssertionResult,
 } from './command-sequence.js';
-import {
-  resolveCapturedArtifactFromManifest,
-  seedScenarioArtifacts,
-} from './scenario-artifacts.js';
+import { resolveCapturedArtifactFromManifest } from './scenario-artifacts.js';
 import { runCliInProcess } from '../services/in-process-cli-runner.js';
 import { assertContainedPath } from './path-containment.js';
 import { assertSafeRelativeArtifactPath } from './artifact-path.js';
@@ -451,19 +447,12 @@ export async function executeScenario(
       output.message('', 'info');
     }
 
-    // Seed any artifacts declared by the scenario's `seed:` directive, then expose
-    // each seeded row's rd:// URI as a ${ARTIFACT:<name>} substitution token, so a
-    // command can consume a pre-seeded artifact via --artifacts. This mirrors the
-    // in-process jest harness; both share the helpers in ./scenario-artifacts.js.
-    const artifactUris = seedScenarioArtifacts(scenario, { cwd: tmpDir });
-    const commands = scenario.commands.map((cmd) => substituteArtifactUris(cmd, artifactUris));
-
     // Execute all commands, tee child output, and capture JSON stdout.
     // Prepend the workspace bin to PATH so shell commands inside substep
     // bodies (e.g. `rd run X.md` for runbook composition) resolve `rd` to
     // the same CLI binary the scenario runner is using.
     const seqResult = await executeCommandSequence({
-      commands,
+      commands: scenario.commands,
       cwd: tmpDir,
       cliPath,
       quiet,

--- a/packages/cli/src/schemas/scenarios.ts
+++ b/packages/cli/src/schemas/scenarios.ts
@@ -1,4 +1,3 @@
-import { isValidVariableName, VALID_IDENTIFIER } from '@rundown-org/core';
 import { z } from 'zod';
 
 /**
@@ -109,44 +108,16 @@ export const ScenarioExpectSchema = z.object({
  *
  * Either `result` or `expect.result` must be specified. When both are
  * present they must agree.
- */
-/**
- * Schema for a single scenario seed directive.
  *
- * `artifact` names an input artifact to seed into the manifest before the
- * scenario's commands run. The harness exposes the seeded row's `rd://` URI as a
- * `${ARTIFACT:<name>}` substitution token so a command can pass it via
- * `--artifacts`. Seed directives are a scenario-harness affordance only.
+ * Strict: unknown keys are rejected, not stripped. The retired `seed:` directive
+ * (#498) must fail at load rather than be silently dropped — a dropped `seed:`
+ * leaves its `${ARTIFACT:…}` command text unsubstituted and surfaces as a
+ * confusing `INVALID_ARTIFACT_INPUT` at run time.
  */
-export const ScenarioSeedSchema = z.object({
-  /**
-   * Artifact name to seed and expose as `${ARTIFACT:<name>}`. Constrained to the
-   * same identifier grammar as frontmatter `artifacts:` because the harness joins
-   * this name into a manifest `rd://` URI and a backing file path — path-unsafe
-   * characters (`/`, `..`) must never reach those joins. The `.refine` adds the
-   * reserved-name guard the artifact/input channels enforce via
-   * `isValidVariableName`, so prototype-pollution keys (`__proto__`,
-   * `constructor`, `prototype`) are rejected at validation time rather than later
-   * when the seeded name is wired into `--artifacts`.
-   */
-  artifact: z
-    .string()
-    .regex(VALID_IDENTIFIER, 'Scenario seed "artifact" must be a valid identifier')
-    .refine(isValidVariableName, {
-      message: 'Scenario seed "artifact" must not be a reserved name',
-    }),
-});
-
-/** A parsed scenario seed directive. */
-export type ScenarioSeed = z.infer<typeof ScenarioSeedSchema>;
-
 export const ScenarioSchema = z
-  .object({
+  .strictObject({
     /** Optional description explaining what this scenario demonstrates */
     description: z.string().optional(),
-
-    /** Optional manifest rows to seed before commands run (exposes ${ARTIFACT:<name>}) */
-    seed: z.array(ScenarioSeedSchema).optional(),
 
     /** Array of full CLI commands to execute (copy/paste ready) */
     commands: z.array(z.string()).min(1, 'Scenario must have at least one command'),

--- a/runbooks/artifacts/artifact-status-vars.runbook.md
+++ b/runbooks/artifacts/artifact-status-vars.runbook.md
@@ -3,12 +3,10 @@ name: artifact-status-vars
 description: Status vars include artifact-record variables
 tags: [test, artifacts]
 scenarios:
-  status-shows-artifact-vars:
-    description: rd status surfaces ARTIFACTS variables as local path strings
+  artifact-var-in-scope-completes:
+    description: A produced artifact variable stays in scope across steps and the runbook completes.
     commands:
       - rd run artifact-status-vars.runbook.md --allow-all
-      - >-
-        node -e 'const { execFileSync } = require("node:child_process"); const status = JSON.parse(execFileSync("rd", ["status"], { encoding: "utf8" })); const value = status.vars && status.vars.PlanPath; if (typeof value !== "string" || value.startsWith("rd://") || !value.includes("/.rundown/work/") || !value.endsWith("/plan.json")) { console.error(JSON.stringify(status.vars)); process.exit(1); }'
       - rd complete
     expect:
       result: COMPLETE
@@ -32,4 +30,8 @@ printf '{"plan":"ok"}' > "{{ path PlanPath }}"
 - PASS COMPLETE
 - FAIL STOP
 
-The active status output should include `PlanPath`.
+The active status output should include `PlanPath`, rendered as a local path
+rather than an `rd://` URI. That payload assertion lives in
+`packages/cli/__tests__/integration/artifact-variable-inputs.test.ts` — scenario
+`commands:` assert through the scenario schema, never by inspecting CLI output
+in a shell wrapper.

--- a/runbooks/artifacts/artifact-variable-collate.runbook.md
+++ b/runbooks/artifacts/artifact-variable-collate.runbook.md
@@ -4,22 +4,6 @@ description: Fixture that consumes a URI-array review artifact input.
 tags: [test, artifacts]
 artifacts:
   - Reviews
-scenarios:
-  direct-uri-array-input:
-    description: Collate receives an exact rd:// review URI array from a seeded manifest row.
-    commands:
-      - >-
-        node -e "const fs=require('fs'),p=require('path');const run='rd_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',ctx='reviewctx',key='review.json';const dir=p.join('.rundown','work','.rd-'+ctx,run);fs.mkdirSync(dir,{recursive:true});fs.writeFileSync(p.join(dir,key),'{}');const row={uri:'rd://artifacts/'+ctx+'/'+run+'/'+key,runId:run,contextId:ctx,runbook:{source:'project',path:'artifact-variable-review-plan.runbook.md'},key,timestamp:'2026-05-25T00:00:00.000Z'};fs.writeFileSync(p.join('.rundown','work','.rd-'+ctx,'manifest.jsonl'),JSON.stringify(row)+'\n');"
-      - rd run artifact-variable-collate.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all
-    expect:
-      result: COMPLETE
-      artifacts:
-        - at: "1"
-          alias: Reviews
-          key: review.json
-          count: 1
-          runbook: artifact-variable-collate.runbook.md
-          exists: true
 ---
 # Artifact Variable Collate
 

--- a/runbooks/artifacts/artifact-variable-collate.runbook.md
+++ b/runbooks/artifacts/artifact-variable-collate.runbook.md
@@ -4,6 +4,22 @@ description: Fixture that consumes a URI-array review artifact input.
 tags: [test, artifacts]
 artifacts:
   - Reviews
+scenarios:
+  bundled-write-review-collate-artifacts:
+    description: Write, review, and collate pass artifacts across runbook boundaries without RD-816.
+    commands:
+      - rd run artifact-variable-write-plan.runbook.md --allow-all
+      - rd run artifact-variable-review-plan.runbook.md --artifacts Plan=${CAPTURE_ARTIFACT:plan.json} --allow-all
+      - rd run artifact-variable-collate.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all
+    expect:
+      result: COMPLETE
+      artifacts:
+        - at: "1"
+          alias: Reviews
+          key: review.json
+          count: 1
+          runbook: artifact-variable-collate.runbook.md
+          exists: true
 ---
 # Artifact Variable Collate
 

--- a/runbooks/artifacts/artifact-variable-review-plan.runbook.md
+++ b/runbooks/artifacts/artifact-variable-review-plan.runbook.md
@@ -5,20 +5,6 @@ tags: [test, artifacts]
 artifacts:
   - Plan
 scenarios:
-  direct-uri-input:
-    description: Review-plan receives an exact rd:// Plan input from a seeded manifest row.
-    commands:
-      - >-
-        node -e "const fs=require('fs'),p=require('path');const run='rd_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',ctx='producer-context',key='plan.json';const dir=p.join('.rundown','work','.rd-'+ctx,run);fs.mkdirSync(dir,{recursive:true});fs.writeFileSync(p.join(dir,key),'{}');const row={uri:'rd://artifacts/'+ctx+'/'+run+'/'+key,runId:run,contextId:ctx,runbook:{source:'project',path:'artifact-variable-write-plan.runbook.md'},key,timestamp:'2026-05-25T00:00:00.000Z'};fs.writeFileSync(p.join('.rundown','work','.rd-'+ctx,'manifest.jsonl'),JSON.stringify(row)+'\n');"
-      - rd run artifact-variable-review-plan.runbook.md --artifacts Plan=${CAPTURE_ARTIFACT:plan.json} --allow-all
-    expect:
-      result: COMPLETE
-      artifacts:
-        - at: "1"
-          alias: Plan
-          key: plan.json
-          runbook: artifact-variable-review-plan.runbook.md
-          exists: true
   forged-file-record-rejected:
     description: Review-plan rejects a public input that impersonates an internal file artifact record.
     commands:

--- a/runbooks/artifacts/artifact-variable-write-plan.runbook.md
+++ b/runbooks/artifacts/artifact-variable-write-plan.runbook.md
@@ -29,22 +29,6 @@ scenarios:
           key: plan.json
           runbook: artifact-variable-review-plan.runbook.md
           exists: true
-
-  bundled-write-review-collate-artifacts:
-    description: Write, review, and collate pass artifacts across runbook boundaries without RD-816.
-    commands:
-      - rd run artifact-variable-write-plan.runbook.md --allow-all
-      - rd run artifact-variable-review-plan.runbook.md --artifacts Plan=${CAPTURE_ARTIFACT:plan.json} --allow-all
-      - rd run artifact-variable-collate.runbook.md --artifacts-json 'Reviews=${CAPTURE_ARTIFACT_ARRAY:review.json}' --allow-all
-    expect:
-      result: COMPLETE
-      artifacts:
-        - at: "1"
-          alias: Reviews
-          key: review.json
-          count: 1
-          runbook: artifact-variable-collate.runbook.md
-          exists: true
 ---
 # Artifact Variable Write Plan
 

--- a/runbooks/artifacts/artifact-variable-write-plan.runbook.md
+++ b/runbooks/artifacts/artifact-variable-write-plan.runbook.md
@@ -30,20 +30,6 @@ scenarios:
           runbook: artifact-variable-review-plan.runbook.md
           exists: true
 
-  review-plan-cross-context-uri-input:
-    description: Review-plan receives a producer-context exact rd:// Plan input and treats it as the producer artifact.
-    commands:
-      - rd run artifact-variable-write-plan.runbook.md --allow-all
-      - rd run artifact-variable-review-plan.runbook.md --artifacts Plan=${CAPTURE_ARTIFACT:plan.json} --allow-all
-    expect:
-      result: COMPLETE
-      artifacts:
-        - at: "1"
-          alias: Plan
-          key: plan.json
-          runbook: artifact-variable-review-plan.runbook.md
-          exists: true
-
   bundled-write-review-collate-artifacts:
     description: Write, review, and collate pass artifacts across runbook boundaries without RD-816.
     commands:

--- a/runbooks/artifacts/execute-plan.runbook.md
+++ b/runbooks/artifacts/execute-plan.runbook.md
@@ -7,10 +7,9 @@ required:
 scenarios:
   consume-plan-artifact:
     description: a boundary --artifacts value is consumed by a naked ARTIFACTS step
-    seed:
-      - artifact: PlanPath
     commands:
-      - "rd run execute-plan.runbook.md --artifacts PlanPath=${ARTIFACT:PlanPath}"
+      - rd run scenario-seed-artifacts.runbook.md --allow-all
+      - "rd run execute-plan.runbook.md --artifacts PlanPath=${CAPTURE_ARTIFACT:PlanPath}"
     expect:
       result: COMPLETE
       artifacts:

--- a/runbooks/artifacts/scenario-seed-artifacts.runbook.md
+++ b/runbooks/artifacts/scenario-seed-artifacts.runbook.md
@@ -1,0 +1,40 @@
+---
+name: scenario-seed-artifacts
+description: Deterministic producer fixture that seeds artifacts through the real ARTIFACTS production path.
+tags: [test, artifacts]
+scenarios:
+  seeds-two-artifacts:
+    description: Seeder produces both seed artifact keys with backing files.
+    commands:
+      - rd run scenario-seed-artifacts.runbook.md --allow-all
+    expect:
+      result: COMPLETE
+      artifacts:
+        - at: "1"
+          alias: PlanPathSeed
+          key: PlanPath
+          runbook: scenario-seed-artifacts.runbook.md
+          exists: true
+        - at: "1"
+          alias: PlanJsonSeed
+          key: plan.json
+          runbook: scenario-seed-artifacts.runbook.md
+          exists: true
+---
+# Scenario Seed Artifacts
+
+Producer fixture for scenarios that need a pre-existing artifact. Consumers run
+this first and reference the produced artifact with
+`${CAPTURE_ARTIFACT:<key>}` — never by fabricating an `rd://` URI.
+
+## 1. Seed artifacts
+
+- ARTIFACTS
+  - PlanPathSeed "PlanPath"
+  - PlanJsonSeed "plan.json"
+- PASS COMPLETE
+
+```bash
+printf '{"seeded":true}' > "{{ path PlanPathSeed }}"
+printf '{"seeded":true}' > "{{ path PlanJsonSeed }}"
+```

--- a/runbooks/delegation/delegate-claim-explicit-close.runbook.md
+++ b/runbooks/delegation/delegate-claim-explicit-close.runbook.md
@@ -67,8 +67,6 @@ scenarios:
       - rd run --prompted delegate-claim-explicit-close.runbook.md
       - rd claim ${TOKEN}
       - rd goto 3 --claim-id ${CLAIM_ID}
-      - >-
-        node -e 'const fs=require("fs"); const s=JSON.parse(fs.readFileSync(".rundown/session.json","utf8")); const key="${CLAIM_ID}".replace(/^rdclm_([a-f0-9]{32})_.+$/,"rdclk_$1"); const c=s.claims[key]; const child=JSON.parse(fs.readFileSync(`.rundown/runs/${c.controlledRunId}.json`,"utf8")); const parent=JSON.parse(fs.readFileSync(`.rundown/runs/${c.delegation.parentRunId}.json`,"utf8")); if (child.step !== "3") throw new Error(`child step=${child.step}`); if (parent.step !== "1") throw new Error(`parent step=${parent.step}`);'
       - rd pass --claim-id ${CLAIM_ID}
       - rd collect --claim-id ${RUN_CLAIM_ID}
     expect:


### PR DESCRIPTION
Closes #498.

Scenarios could fabricate artifact provenance: invent an `rd://` URI, hand-write a manifest row, and hand the result to a consumer. That path shared nothing with how artifacts are really produced, so it could pass while the real path was broken. This replaces it with a single mechanism — run a real producer runbook, capture the `rd://` URI it emitted — and **enforces** that with a test.

## What changed

**One artifact grammar.** `${CAPTURE_ARTIFACT[_ARRAY]:<key>}` is now the only one. `${ARTIFACT:}` and the `seed:` directive are deleted, along with `substituteArtifactUris`, `seedScenarioArtifacts` and `ScenarioSeedSchema`.

**The retirement fails loudly, not silently.** Zod 4 strips unknown keys by default, so a bare deletion would let `seed:` parse silently and leak the literal placeholder into `--artifacts` as a confusing `INVALID_ARTIFACT_INPUT` — *exactly* the defect #498 exists to prevent. Instead: `ScenarioSchema` is `z.strictObject` (rejects `seed:`), and `RETIRED_ARTIFACT_PLACEHOLDER` throws on `${ARTIFACT:}` naming the replacement. Tombstones, not shims — they make old input *fail*, which is what the no-migration rule asks for.

**A deterministic seeder fixture.** `runbooks/artifacts/scenario-seed-artifacts.runbook.md` produces artifacts through the genuine `ARTIFACTS` → artifact-service → manifest path.

**Three scenarios deleted, unique coverage lost: none.** `direct-uri-input` and `direct-uri-array-input` existed only to exercise fabricated rows against the consume path; migrated, each becomes character-for-character an existing scenario. `review-plan-cross-context-uri-input` was already byte-identical to `review-plan-uri-input` and never tested cross-context anything — both runs share one context. That behaviour is covered where it can actually be constructed, in `scenario-artifacts.test.ts`.

**The array form's shell-quoting is enforced.** It resolves to JSON containing double quotes, spliced into command text and re-tokenized by `shellParse`; unquoted, `["rd://a","rd://b"]` arrives as the invalid `[rd://a,rd://b]`. Both call sites quoted by convention only. `assertArrayCapturesAreShellQuoted` probes the real tokenizer rather than matching quotes with a regex — authors quote the whole assignment (`'K=${...}'`), so an adjacency regex false-rejects every real call site.

**Authoring rules are now enforced under `verify`.** See below — this is the part that matters most.

## The review check to stop using

**`grep -rn 'rd://artifacts/' runbooks/` is retired as an acceptance criterion.** It cannot work, and it has confused every review it appeared in. `rd://artifacts/...` is *both* the fabrication pattern *and* the legitimate artifact **selector** language (`artifact-selector-query-filter.runbook.md:56-59`). The difference isn't in the text — it's in where the string lives — so text search will always report the selector fixtures as false hits.

Superseded by `packages/cli/__tests__/schemas/scenario-authoring.test.ts`, which lints **parsed frontmatter values**. Selector syntax lives on directive lines in the *body*, which the lint never reads, so it structurally cannot false-positive. `grep -rn 'manifest.jsonl' runbooks/` remains sound (returns nothing) — hand-writing the manifest is the irreducible act of fabrication.

## Why the enforcement is here and not in a follow-up

This branch was **actually red** while reporting green, which is the argument for doing this now. `pnpm run verify` runs `test:unit` = `jest --testPathIgnorePatterns='integration'`, so the entire scenario-runner harness — including its `every pattern runbook defines scenarios` invariant — is invisible to the gate. Deleting a fabricated scenario left `artifact-variable-collate.runbook.md` with no scenarios at all, and nothing the gate ran noticed.

Fixed, and the class of failure closed with it:
- The lint lives at `__tests__/schemas/`, so `verify` runs it: **100 suites / 2,383 tests**, up from 99 / 2,372.
- `parseScenarios` errors were **discarded** by the runner, so under the new strict schema a `seed:`-carrying runbook would silently vanish from the suite rather than fail. It now throws; both harnesses share one loader.
- `every runbook defines scenarios` moved into the lint, where the gate can see it.
- Hard rules (no allowlist): no scenario command may name an `rd://` URI, write `manifest.jsonl`, or hand-derive `.rd-<contextId>`.
- Opaque wrappers are confined to a fault-injection allowlist matched by **set equality**, so a stale entry fails as loudly as a new violation. Every rule was verified to bite by mutation, including the stale-entry and hand-wave-reason cases.
- The two real violations were **fixed, not allowlisted**: `artifact-status-vars` spawned `rd status` inside `node -e` (payload assertion moved to `artifact-variable-inputs.test.ts`, newly covering ARTIFACTS-*produced* vars); `delegate-claim-explicit-close` inspected `session.json` (moved to `delegation-claim.test.ts`, using the real `claimKeyFromBearer` instead of a hand-rolled regex).

## Scope, honestly

#498 lists four fragility items. This lands 2 (synthetic fidelity), 3 (two grammars) and 4 (duplication of core). It does **not** land item 1 (splice-then-reparse): `${CAPTURE_ARTIFACT}` is still spliced into command text, exactly as its four sibling grammars are. Fixing it for artifacts alone buys inconsistency, not type safety — #604 owns it across all five, and names the quoting guard as something it deletes. That guard is ~10 lines of deliberate, tracked throwaway.

The surviving hazard is **one usability defect on one grammar**, matching #498's `P3: low`: the scalar form is structurally immune (`assertSafeId` confines ids to `[A-Za-z0-9._-]`), and the array form now cannot reach it unquoted.

## Verification

- `pnpm run verify` — passes (100 suites / 2,383 tests), and now actually covers the authoring invariants.
- `pnpm run test:scenarios:raw` — 286 passed, 0 failed (289 minus the three deletions).
- `jest __tests__/integration/scenario-runner.test.ts` — 286 passed (was failing before the collate fix).
- `pnpm run test:mutate:cli:dry` — green.
- Property tests (`command-sequence.properties.test.ts`) proven falsifiable: an injected off-by-one in the splice makes the composed scalar and splice properties fail with shrunk counterexamples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified stricter scenario authoring rules around allowed command forms/wrappers and fail-fast validation.
  * Added guidance for artifact capture-from-output as the only supported way to obtain `rd://` artifacts, including quoting requirements and explicit rejection of retired placeholder/`seed:` mechanisms.
* **Bug Fixes**
  * Deprecated fabricated artifact URI inputs (`seed:` and `${ARTIFACT:...}`); scenarios using them now fail fast.
  * Enforced that `${CAPTURE_ARTIFACT_ARRAY:...}` must be properly shell-quoted before resolution.
  * Improved artifact-variable behavior to render produced artifacts as local filesystem paths (not `rd://`).
* **Tests**
  * Expanded unit/property and integration coverage for placeholder substitution, capture resolution, and scenario-runner enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->