### PR TITLE
fix(core,cli): surface delegate claim refusals instead of discarding them (#586)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-delegate-claim-refusal-surfacing.md
+++ b/docs/superpowers/plans/2026-07-17-delegate-claim-refusal-surfacing.md
@@ -1,0 +1,549 @@
+# Delegate Claim-Refusal Surfacing — Handoff & Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish #586 by making `rundown delegate --claim-id <A>` surface the *real* claim problem (stale / stashed / terminal) instead of discarding it and refusing with a misleading error about a run the operator never named.
+
+**Architecture:** `resolveIssuanceAnchor` (`packages/core/src/runbook/issuance-anchor.ts`) already asks `resolveCommandTarget` to resolve a presented bearer claim. That resolver returns a typed refusal (`stale_claim` / `terminal_claim`) carrying a redacted, cause-specific, **already-computed** message. The anchor currently throws it away and falls through to `getActive()`. This plan propagates those two kinds through the anchor → the seam's `DelegationIssuanceOutcome` → the CLI, rendered via the **existing** `renderStaleClaimRefusal` helper. No new error code is invented: the envelope becomes `CLAIMED_RUNBOOK_UNAVAILABLE`, exactly what `pass`/`fail` already emit for the same input.
+
+**Tech Stack:** TypeScript, Jest (unit + integration), Stryker (mutation), pnpm workspaces. Packages: `@rundown-org/core` (anchor + seam), `@rundown-org/cli` (thin front end — renders outcomes only).
+
+---
+
+## Handoff: state of the branch
+
+**Branch:** `delegate-claim-anchored-issuance` (worktree `.worktrees/delegate-claim-anchored-issuance`). **Baseline at handoff: `pnpm run verify` exits 0 — 6,551 tests pass.** Working tree clean.
+
+### Commits on this branch (vs `main`)
+
+| Commit | What |
+| --- | --- |
+| `53ed86880` | **#586 core fix.** Claim-anchored issuance: `#resolveIssuanceAnchor` gains required `callerEvidence`; anchors the claim's controlled run when no `--run`. |
+| `0bc07612d` | CLI end-to-end regression test for the above. |
+| `9b95775e6` | CLI preconditions (`--index` FOR-step, inferred-retry substep) validated against the claim-anchored run — **largely superseded, see below**. |
+| `7bf09be37` | Review follow-ups: `issuance-anchor.test.ts` (11 tests), retry-active call site pinned, CLI `unknown_run` deferral pinned, stale TSDoc fixed. |
+| `c7bde339c` | **Written by a concurrent session, not by this workstream.** "anchor delegation issuance under lock" (#508): `RetryCursor`, `invalid_index` / `retry_target_required` outcomes, DelegationLock-scoped read-modify-write. **It also swept in this workstream's then-unstaged `resolveIssuanceAnchor` signature refactor** — that refactor is intact in HEAD, but `c7bde339c` is a mixed commit. Nothing was lost; note it when writing the PR description. |
+
+### What `c7bde339c` changed under this workstream (read this before editing)
+
+The concurrent session **moved the delegate preconditions out of the CLI and into core** — the correct fix per CLAUDE.md ("a side effect that lives in the CLI but classifies as B is architectural debt; the fix is to move it, not to rationalise its location"). Consequences:
+
+- `packages/cli/src/commands/delegate.ts` **no longer calls `resolveIssuanceAnchor`** (verified: zero callers under `packages/cli/src`). It keeps only Category-A flag parsing (`resolveIndexOption`, `parseStepIdFromString`) and imports `ResolveIssuanceAnchorOptions` **as a type only**.
+- `resolveRetryLocator` in `delegate.ts:649` is now **synchronous** and takes `(tokenArg, options, output)` — no `sessionService`, no `seamFields`.
+- Core owns the state-dependent validation, emitting new outcomes `invalid_index` (`lifecycle-command-service.ts:361`) and `retry_target_required` (`:362`).
+- The anchor call sites went **3 → 2**: fresh at `:903`, retry at `:1149`. The retry-step / retry-active split was consolidated.
+- `DelegateSeamFields` in `delegate.ts:80` is now `type DelegateSeamFields = ResolveIssuanceAnchorOptions` — an alias, so the CLI and seam shapes cannot drift.
+
+**The #586 behaviour is preserved and still pinned** by the regression tests from `9b95775e6` / `0bc07612d` (`describe('DELEGATE claim-anchored CLI preconditions (#586 follow-up)')`, `delegate-workflow.test.ts:433`). Those tests are the reason the supersession is safe: they assert behaviour, not implementation. **Do not delete them.**
+
+### Current anchor implementation (the exact code this plan edits)
+
+`packages/core/src/runbook/issuance-anchor.ts`:
+
+```typescript
+export type IssuanceAnchorResolution =
+  | { readonly kind: 'ok'; readonly state: RunbookState }
+  | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
+  | { readonly kind: 'none' };
+
+// ... inside resolveIssuanceAnchor(reader, options):
+  if (callerEvidence.kind === 'claim_bearer') {
+    const target = await resolveCommandTarget(reader, { claimId: callerEvidence.claimId });
+    if (target.kind === 'claim') {
+      return { kind: 'ok', state: target.state };
+    }
+  }
+  const active = await reader.getActive();
+  return active ? { kind: 'ok', state: active } : { kind: 'none' };
+```
+
+The `if (target.kind === 'claim')` with **no `else`** is the defect: five of six claim statuses silently fall through.
+
+---
+
+## Background: why this work exists
+
+`resolveClaimTarget` (`command-target-resolver.ts:283-320`) collapses six raw statuses into three kinds, each with a redacted, pre-computed message:
+
+| Status | Kind | Message |
+| --- | --- | --- |
+| `claimed` | `claim` | — (anchors; already works) |
+| `terminal` | `terminal_claim` | `Claim id <key> points at a completed child runbook.` |
+| `missing` | `stale_claim` | `Claim id <key> does not exist.` |
+| `invalid-secret` | `stale_claim` | `Claim id <key> is not valid for this session.` |
+| `stale` | `stale_claim` | `Claim id <key> points at missing child state (<reason>).` |
+| `unlinked` | `stale_claim` | `Claim id <key> is currently stashed. Run \`rundown pop\` with its claim id to resume.` |
+
+So this is **two** new kinds, not six, and every message already exists.
+
+**Today (reproduced against the real CLI at `c7bde339c`, not theorised):**
+
+| Invocation | `pass --claim-id X` | `delegate --step 1.1 --claim-id X` |
+| --- | --- | --- |
+| X is **stashed**, a different run is active | `CLAIMED_RUNBOOK_UNAVAILABLE`<br>*"…is currently stashed. Run `rundown pop` with its claim id to resume."* | `CLAIM_GRANT_REQUIRED`<br>*"The supplied claim id is not authorized to run `rundown delegate` for this target."* — "this target" is the active run, which the operator never named. |
+| X **does not exist**, a run is active | `CLAIMED_RUNBOOK_UNAVAILABLE`<br>*"Claim id `<key>` does not exist."* | `ACTOR_CONTEXT_REQUIRED`<br>*"This run has delegation activity, so a bare `rundown delegate` is refused. **Pass `--claim-id <claimId>`**…"* — the operator just passed `--claim-id`. |
+
+**The pre-fix envelope is arbitrary**, because it is not about the claim at all: the anchor drops the diagnosis, anchors whatever run is active, and whichever gate happens to fire produces the message. `ACTOR_CONTEXT_REQUIRED` vs `CLAIM_GRANT_REQUIRED` depends on *why* the claim failed (`#resolveMutationActorContext` selects `claim_grant_required` only when `authority.reason === 'no-authorizing-claim'`; a nonexistent claim resolves a different reason and falls to the **bare-invocation** message). Any test asserting a single pre-fix code is therefore wrong — assert the post-fix code instead.
+
+**Why it is in scope:** #586's acceptance criteria are narrower than this work and are **already met** by `53ed86880`/`7bf09be37` — this plan is not required to close #586. It is in scope because the branch exists to improve delegation/claim capability, and a claim command that discards the claim's own diagnosis is not that capability finished. Criterion 1's *"instead of **refusing**/anchoring on the active run"* also lands close to the stashed row above. If the branch must ship sooner, this plan is separable into a follow-up PR under cluster #565 (next to #519, the same operator-diagnostics surface).
+
+**Blast radius is exactly the broken case:** `--run` outranks the claim (so `--run` invocations never consult it), and non-claim evidence skips the branch entirely. Only `claim_bearer` + non-live claim changes.
+
+### Decisions already made (do not re-litigate)
+
+1. **Terminal claims get a plain refusal, not confirm/conflict.** `pass`/`fail` split terminal into `terminal_claim_confirmed`/`terminal_claim_conflict` (`command-target-resolver.ts:528-543`) because a terminal lifecycle maps to an expected result (`completed→pass`, `stopped→fail`) for idempotency. Delegate has no result to confirm against a lifecycle; its idempotency notion is `already-delegated` (token echo), which is about the substep. Importing confirm/conflict would mean inventing an expected result that does not exist.
+2. **No new error code.** Use the existing `renderStaleClaimRefusal` (`refusal-renderers.ts:23`), which emits `CLAIMED_RUNBOOK_UNAVAILABLE`. `delegate.ts` already imports two of that module's five renderers. The envelope change `CLAIM_GRANT_REQUIRED → CLAIMED_RUNBOOK_UNAVAILABLE` is **convergence with `pass`/`fail`**, not divergence.
+3. **Keep `stale_claim` and `terminal_claim` distinct at the seam** even though the CLI renders both identically today. Collapsing them into one kind would be a lossy mapping for a presentation convenience; an idle/abandoned-claim feature (#519) will plausibly want to tell them apart.
+4. **Accept the pre-existing message asymmetry.** `missing` → "does not exist" vs `invalid-secret` → "is not valid for this session" are distinguishable, so a probe learns whether a claim key exists. This is pre-existing (`pass`/`fail` already leak it) and the messages use the redacted `claimKey`, never the bearer secret. Inheriting it keeps delegate consistent; changing it is a separate cross-command decision.
+
+---
+
+## Global Constraints
+
+- **State machine drives logic; the CLI is a thin wrapper.** All new logic lands in core. The CLI gains only two `case` arms in existing outcome switches. Do **not** reintroduce state-dependent validation into `delegate.ts` — `c7bde339c` just removed it.
+- **Type-driven dispatch.** Dispatch on `CommandTargetResolution.kind`. Reuse the resolver's own discriminants (`stale_claim`, `terminal_claim`) rather than inventing new vocabulary.
+- **No new error codes.** `CLAIMED_RUNBOOK_UNAVAILABLE` via `renderStaleClaimRefusal`.
+- **Never migrate persisted runbook state.** This is pure read-side target selection. No persisted shape changes.
+- **JSON output by default.** Assert the default JSON envelope; add `--text` only if testing human rendering.
+- **Do not weaken existing tests.** One test legitimately flips (Task 1 Step 5); everything else stays.
+
+---
+
+## File Structure
+
+- `packages/core/src/runbook/issuance-anchor.ts` — add `stale_claim` + `terminal_claim` to `IssuanceAnchorResolution`; make the `claim_bearer` branch total (no silent fall-through).
+- `packages/core/src/runbook/lifecycle-command-service.ts` — add the two variants to `DelegationIssuanceOutcome`; map them at the two anchor call sites (`:903` fresh, `:1149` retry).
+- `packages/cli/src/commands/delegate.ts` — import `renderStaleClaimRefusal`; add two `case` arms to each of the two outcome switches (near `case 'unknown_run':` at `:326` and `:428`).
+- `packages/core/__tests__/runbook/issuance-anchor.test.ts` — flip the two fall-through tests to assert the new refusals; add the stashed-message test.
+- `packages/core/__tests__/runbook/lifecycle-command-service.test.ts` — flip the terminal fall-through test; add a seam-level stale-claim test.
+- `packages/cli/__tests__/integration/delegate-workflow.test.ts` — end-to-end: stashed claim → `CLAIMED_RUNBOOK_UNAVAILABLE` + the `rundown pop` message.
+
+---
+
+## Task 1: Anchor surfaces claim refusals instead of discarding them
+
+**Files:**
+- Modify: `packages/core/src/runbook/issuance-anchor.ts`
+- Test: `packages/core/__tests__/runbook/issuance-anchor.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveCommandTarget`, `CommandTargetReader` (already imported).
+- Produces: `IssuanceAnchorResolution` gains `{ kind: 'stale_claim'; claimId: ClaimId; message: string }` and `{ kind: 'terminal_claim'; claimId: ClaimId; lifecycle: 'completed' | 'stopped'; message: string }`. `ClaimId` must be imported from `./claim-id.js`.
+
+- [ ] **Step 1: Flip the two existing fall-through tests to the new expectation**
+
+In `issuance-anchor.test.ts`, the tests `falls through to the active default for a terminal claim` and `falls through to the active default for a missing (stale) claim` currently assert `kind === 'ok'` with `state.id === activeRunId`. That behaviour is what this task removes. Replace their bodies' assertions (keep the `fakeReader` setups exactly as they are):
+
+```typescript
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
+
+      expect(anchored.kind).toBe('terminal_claim');
+      if (anchored.kind !== 'terminal_claim') throw new Error('expected terminal_claim');
+      expect(anchored.lifecycle).toBe('completed');
+      expect(anchored.message).toContain('completed');
+```
+
+and for the missing-claim test:
+
+```typescript
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
+
+      expect(anchored.kind).toBe('stale_claim');
+      if (anchored.kind !== 'stale_claim') throw new Error('expected stale_claim');
+      expect(anchored.message).toContain('does not exist');
+```
+
+Rename both `it(...)` titles to `refuses …` (they no longer describe a fall-through):
+- `refuses terminal_claim rather than anchoring the active default (#586)`
+- `refuses stale_claim rather than anchoring the active default (#586)`
+
+Also update the stashed test (`falls through to the active default for a stashed claim`) — it is the operator-facing case that motivates this work:
+
+```typescript
+    it('refuses a stashed claim with its actionable message (#586)', async () => {
+      const reader = fakeReader({
+        active: activeRun,
+        claimResolution: { status: 'unlinked', claim: verifiedClaim, reason: 'stashed' },
+      });
+
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
+
+      expect(anchored.kind).toBe('stale_claim');
+      if (anchored.kind !== 'stale_claim') throw new Error('expected stale_claim');
+      // The whole point: the operator is told what to actually do.
+      expect(anchored.message).toContain('rundown pop');
+    });
+```
+
+Leave the `(3) the active default is the bare fallback` describe untouched — non-claim evidence must still fall through. **Note:** its test `resolves none when a stale claim leaves no active default` presents `claim_bearer` + missing claim, so it now expects `stale_claim`, not `none`. Move it into the `(2)` describe and assert `stale_claim`, or delete it as redundant with the missing-claim test above.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @rundown-org/core exec jest issuance-anchor.test.ts`
+
+Expected: FAIL — the flipped tests receive `'ok'` (the current fall-through) instead of `'stale_claim'` / `'terminal_claim'`.
+
+> **Jest invocation:** use `exec jest <path> -t "<name>"`, NOT `test -- <path> -t "<name>"`. Both packages define `"test": "jest"`, so the script form forwards a literal `--` into jest 30, which treats `-t` and the name as positional path patterns — the filter is silently dropped and a mistyped name reports green.
+
+- [ ] **Step 3: Make the claim branch total**
+
+In `issuance-anchor.ts`, extend the union (add `import type { ClaimId } from './claim-id.js';`):
+
+```typescript
+export type IssuanceAnchorResolution =
+  | { readonly kind: 'ok'; readonly state: RunbookState }
+  | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
+  | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string }
+  | {
+      readonly kind: 'terminal_claim';
+      readonly claimId: ClaimId;
+      readonly lifecycle: 'completed' | 'stopped';
+      readonly message: string;
+    }
+  | { readonly kind: 'none' };
+```
+
+Replace the claim branch. Every claim resolution is now handled — the branch never silently gives up:
+
+```typescript
+  if (callerEvidence.kind === 'claim_bearer') {
+    const target = await resolveCommandTarget(reader, { claimId: callerEvidence.claimId });
+    switch (target.kind) {
+      case 'claim':
+        return { kind: 'ok', state: target.state };
+      // A presented claim that cannot anchor is the operator's real problem.
+      // Surface the resolver's cause-specific message (already redacted to the
+      // claim key) instead of discarding it and refusing against an unrelated
+      // active default — that misdirection is the #586 defect in the refusal
+      // path (see the `pass --claim-id` comparison in the plan).
+      case 'stale_claim':
+        return { kind: 'stale_claim', claimId: target.claimId, message: target.message };
+      case 'terminal_claim':
+        return {
+          kind: 'terminal_claim',
+          claimId: target.claimId,
+          lifecycle: target.lifecycle,
+          message: target.message,
+        };
+      default:
+        // `default` / `none` / `run` / `unknown_run` are unreachable when only
+        // `claimId` is supplied; fall through to the active default rather than
+        // asserting never (the resolver's union is shared and may grow).
+        break;
+    }
+  }
+  const active = await reader.getActive();
+  return active ? { kind: 'ok', state: active } : { kind: 'none' };
+```
+
+Update the TSDoc precedence list on `resolveIssuanceAnchor`: item (2) no longer says a stale/terminal/stashed claim "falls through to (3)" — it now refuses. That sentence is currently wrong the moment this lands.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @rundown-org/core exec jest issuance-anchor.test.ts`
+
+Expected: PASS (all tests, including the untouched `--run` precedence and bare-fallback describes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/runbook/issuance-anchor.ts \
+  packages/core/__tests__/runbook/issuance-anchor.test.ts
+git commit -m "fix(core): surface claim refusals from the issuance anchor (#586)"
+```
+
+---
+
+## Task 2: Seam propagates the refusals
+
+**Files:**
+- Modify: `packages/core/src/runbook/lifecycle-command-service.ts` (union near `:361`; call sites `:903` fresh, `:1149` retry)
+- Test: `packages/core/__tests__/runbook/lifecycle-command-service.test.ts`
+
+**Interfaces:**
+- Consumes: `IssuanceAnchorResolution` (already imported).
+- Produces: `DelegationIssuanceOutcome` gains `stale_claim` and `terminal_claim` with the same fields as Task 1. This mirrors how `unknown_run` already flows anchor → outcome → CLI.
+
+- [ ] **Step 1: Flip the terminal fall-through test**
+
+`lifecycle-command-service.test.ts` has `falls through to the active default when the claim's controlled run is terminal (#586)`, asserting `refused` / `claim_grant_required`. That is the behaviour being replaced. Rename to `refuses a terminal claim rather than anchoring the active default (#586)` and replace the assertions (keep the setup):
+
+```typescript
+      expect(outcome.kind).toBe('terminal_claim');
+      if (outcome.kind !== 'terminal_claim') throw new Error('expected terminal_claim');
+      expect(outcome.lifecycle).toBe('completed');
+```
+
+**Its mutation-killing role survives:** it existed to kill the `target.kind === 'claim'` → `true` mutant. Forcing that guard true now anchors a *terminal* run and issues, which this assertion still catches.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @rundown-org/core exec jest lifecycle-command-service.test.ts -t "refuses a terminal claim"`
+
+Expected: FAIL — outcome is `refused` (the anchor's refusal is not yet propagated by the seam).
+
+- [ ] **Step 3: Add the outcome variants**
+
+In `DelegationIssuanceOutcome` (alongside `unknown_run`, near `:361`):
+
+```typescript
+  | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string }
+  | {
+      readonly kind: 'terminal_claim';
+      readonly claimId: ClaimId;
+      readonly lifecycle: 'completed' | 'stopped';
+      readonly message: string;
+    }
+```
+
+- [ ] **Step 4: Map both anchor call sites**
+
+The fresh site (`:903`) currently reads:
+
+```typescript
+    const anchored = await this.#resolveIssuanceAnchor(input);
+    if (anchored.kind !== 'ok') {
+      return anchored.kind === 'unknown_run' ? anchored : { kind: 'no-active-runbook' };
+    }
+```
+
+Replace with a switch so a future resolution kind cannot silently become `no-active-runbook`:
+
+```typescript
+    const anchored = await this.#resolveIssuanceAnchor(input);
+    if (anchored.kind !== 'ok') {
+      switch (anchored.kind) {
+        case 'unknown_run':
+        case 'stale_claim':
+        case 'terminal_claim':
+          return anchored;
+        case 'none':
+          return { kind: 'no-active-runbook' };
+        default: {
+          const _exhaustive: never = anchored;
+          return _exhaustive;
+        }
+      }
+    }
+```
+
+The retry site (`:1149`) currently reads:
+
+```typescript
+      const anchored = await this.#resolveIssuanceAnchor(input);
+      if (anchored.kind !== 'ok') {
+        if (anchored.kind === 'unknown_run') return anchored;
+        return locator.kind === 'active'
+          ? { kind: 'retry_target_required' }
+          : { kind: 'no-active-runbook' };
+      }
+```
+
+Preserve the `retry_target_required` behaviour added by `c7bde339c` — it applies only to the `none` case:
+
+```typescript
+      const anchored = await this.#resolveIssuanceAnchor(input);
+      if (anchored.kind !== 'ok') {
+        switch (anchored.kind) {
+          case 'unknown_run':
+          case 'stale_claim':
+          case 'terminal_claim':
+            return anchored;
+          case 'none':
+            return locator.kind === 'active'
+              ? { kind: 'retry_target_required' }
+              : { kind: 'no-active-runbook' };
+          default: {
+            const _exhaustive: never = anchored;
+            return _exhaustive;
+          }
+        }
+      }
+```
+
+- [ ] **Step 5: Add a seam-level stale-claim test**
+
+In the `issueDelegation (fresh)` describe, after the flipped terminal test. Uses the suite's own fixtures (`startSeamOnDelegateStep`, `runControlEvidence`); do not invent helpers. A never-issued claim id resolves `missing` → `stale_claim`:
+
+```typescript
+    it('refuses a stale (nonexistent) claim rather than anchoring the active default (#586)', async () => {
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+      const unknownClaimId = assertClaimId(
+        'rdclm_99999999999999999999999999999999_abcdefghijklmnopqrstuvwxyzABCDE1234567890-_',
+      );
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'claim_bearer', claimId: unknownClaimId },
+      });
+
+      expect(outcome.kind).toBe('stale_claim');
+      if (outcome.kind !== 'stale_claim') throw new Error('expected stale_claim');
+      expect(outcome.message).toContain('does not exist');
+    });
+```
+
+`assertClaimId` is already imported by this suite; verify with `grep -n "assertClaimId" packages/core/__tests__/runbook/lifecycle-command-service.test.ts` and add it to the existing `claim-id.js` import if absent.
+
+- [ ] **Step 6: Run the seam suite**
+
+Run: `pnpm --filter @rundown-org/core exec jest lifecycle-command-service.test.ts`
+
+Expected: PASS, all tests. If a `#508` test from `c7bde339c` fails, do **not** paper over it — it means this change interacts with the lock-scoped reread. Investigate before proceeding.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/runbook/lifecycle-command-service.ts \
+  packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+git commit -m "fix(core): propagate claim refusals through the issuance seam (#586)"
+```
+
+---
+
+## Task 3: CLI renders the refusals
+
+**Files:**
+- Modify: `packages/cli/src/commands/delegate.ts` (import at `:43-46`; switches near `case 'unknown_run':` at `:326` and `:428`)
+- Test: `packages/cli/__tests__/integration/delegate-workflow.test.ts`
+
+**Interfaces:**
+- Consumes: `renderStaleClaimRefusal` from `../helpers/refusal-renderers.js` — emits `CLAIMED_RUNBOOK_UNAVAILABLE` (`refusal-renderers.ts:23-26`). **No new code, no new renderer.**
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `delegate-workflow.test.ts` inside `describe('DELEGATE claim-anchored CLI preconditions (#586 follow-up)')` (opens at `:433`), reusing its `startForParentThenOther` fixture. A never-issued claim id is the simplest stale case and needs no stash plumbing:
+
+```typescript
+  it('surfaces the claim problem, not a grant refusal, for a stale claim (#586)', async () => {
+    await startForParentThenOther();
+    const unknownClaimId =
+      'rdclm_99999999999999999999999999999999_abcdefghijklmnopqrstuvwxyzABCDE1234567890-_';
+
+    const result = await runCliInProcess(
+      ['delegate', '--step', '1.1', '--claim-id', unknownClaimId],
+      workspace,
+    );
+
+    // Before this fix the anchor discards the claim's diagnosis and anchors the
+    // active default, so the refusal is about a run the operator never named:
+    // here `ACTOR_CONTEXT_REQUIRED` — the BARE-invocation message telling the
+    // caller to "Pass --claim-id", which they just did. (A stashed claim takes a
+    // different pre-fix path and yields CLAIM_GRANT_REQUIRED; the pre-fix code is
+    // arbitrary, which is why this asserts only the post-fix envelope.)
+    expect(result.exitCode).not.toBe(0);
+    const payload = JSON.parse(result.stdout) as { code?: string; error?: string };
+    expect(payload.code).toBe('CLAIMED_RUNBOOK_UNAVAILABLE');
+    // The load-bearing assertion: the operator is told what is actually wrong.
+    expect(payload.error).toContain('does not exist');
+  }, 20_000);
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm run build && pnpm --filter @rundown-org/cli exec jest delegate-workflow.test.ts -t "surfaces the claim problem"`
+
+Expected: FAIL — `code` is `ACTOR_CONTEXT_REQUIRED` (verified against the real CLI at `c7bde339c`), not `CLAIMED_RUNBOOK_UNAVAILABLE`. Do not "fix" the test to expect whatever the pre-fix code happens to be — the point of the task is that the code becomes the claim's own diagnosis.
+
+> **The integration suites spawn `packages/cli/dist/cli.js`.** Without `pnpm run build` they fail with a misleading `ENOENT: chmod` inside `createTestWorkspace`, not an assertion failure. Always build before running them after a core change.
+
+- [ ] **Step 3: Render the outcomes**
+
+Add `renderStaleClaimRefusal` to the existing import (`delegate.ts:43-46`):
+
+```typescript
+import {
+  renderActorContextRequiredRefusal,
+  renderClaimGrantRequiredRefusal,
+  renderStaleClaimRefusal,
+} from '../helpers/refusal-renderers.js';
+```
+
+In **both** outcome switches (near `case 'unknown_run':` at `:326` and `:428`), add:
+
+```typescript
+            case 'stale_claim':
+            case 'terminal_claim':
+              // Core owns the cause-specific message (shared with pass/fail).
+              // Both render as CLAIMED_RUNBOOK_UNAVAILABLE: delegate has no
+              // confirm/conflict notion for a terminal claim — there is no
+              // expected result to reconcile a lifecycle against.
+              renderStaleClaimRefusal(output, outcome.message);
+              process.exitCode = 1;
+              break;
+```
+
+Match each switch's surrounding style (the retry switch at `:326` and the fresh switch at `:428` may differ in whether they `break` or `return`; mirror `case 'unknown_run':` in the same switch).
+
+- [ ] **Step 4: Verify it passes**
+
+Run: `pnpm run build && pnpm --filter @rundown-org/cli exec jest delegate-workflow.test.ts -t "surfaces the claim problem"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Regression sweep**
+
+Run: `pnpm --filter @rundown-org/cli exec jest delegate-workflow.test.ts`
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/commands/delegate.test.ts`
+Run: `pnpm --filter @rundown-org/cli exec jest __tests__/integration/explicit-run-targeting.test.ts`
+
+Expected: PASS. `explicit-run-targeting` confirms `--run` semantics are untouched (`--run` outranks the claim, so it never reaches the new branch).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/commands/delegate.ts \
+  packages/cli/__tests__/integration/delegate-workflow.test.ts
+git commit -m "fix(cli): render delegate claim refusals as CLAIMED_RUNBOOK_UNAVAILABLE (#586)"
+```
+
+---
+
+## Task 4: Full verification and PR
+
+**Files:** none (verification + PR admin).
+
+- [ ] **Step 1: Run the pre-PR gate**
+
+Run: `pnpm run verify; echo "exit: $?"`
+
+Expected: **exit 0.** Check the real exit code — the suite prints noisy `getcwd`/`command not found` lines from a sandbox-policy test that are pre-existing and harmless. Baseline at handoff was 6,551 tests; this plan adds ~5.
+
+- [ ] **Step 2: Mutation gate on the anchor**
+
+Run from `packages/core`:
+
+```bash
+npx stryker run --mutate 'src/runbook/issuance-anchor.ts' \
+  --testFiles '__tests__/runbook/issuance-anchor.test.ts' --reporters clear-text
+```
+
+Expected: score ≥ 70 (was **96.55%**, 28 killed, 0 no-coverage). The `callerEvidence.kind === 'claim_bearer'` → `true` mutant **survives and is a verified equivalent mutant** — with `claimId` undefined, `resolveCommandTarget` returns `default`/`none`, never `claim`, so the return value is identical. It was independently confirmed twice. **Do not write a `getActive()` call-count test to kill it** — that pins an implementation detail (read count), not behaviour, and is a worse test than none. If any *other* mutant survives, add the input that makes the forced branch observable.
+
+> **Do NOT use `pnpm run test:mutate:core -- --mutate …`** — the wrapper injects a second `--`, and Stryker rejects the flags as positional args (`too many arguments for 'run'`). Invoke `npx stryker` from the package directory with package-relative paths. **Always line-scope or file-scope the run**: an unscoped run over the 2,700-line `lifecycle-command-service.ts` takes 70+ minutes; a scoped run takes ~2.
+
+- [ ] **Step 3: Open the PR**
+
+Include `Closes #586`. In the body:
+- Note that `c7bde339c` is a **mixed commit** authored by a concurrent session (#508 lock work) that also swept in this branch's `resolveIssuanceAnchor` signature refactor.
+- Note this discharges one of the two remaining code leaves in cluster #565 (R4 Capability Tier); **#519** (parent-side abandoned/idle claim detection) and the **#574** design umbrella remain open, so **#565 stays open**.
+- Do **not** edit the epic (#564) or cluster (#565) roadmap status beyond referencing #586.
+
+---
+
+## Follow-ups not in scope (file as issues if wanted)
+
+- **`UnknownRunRefusal` is structurally re-declared 4×** (`issuance-anchor.ts`, `command-target-resolver.ts:403`, `:441`, plus inline members of `CommandTargetResolution` / `TransitionTargetResolution`). Extract an exported type in `command-target-resolver.ts` and reference it from all four. Pre-existing debt this branch mildly compounds. Both reviewers raised it.
+- **Precedence inversion vs `resolveCommandTarget`.** `resolveCommandTarget:465` tries `claimId` **before** `runId`; `resolveIssuanceAnchor` tries `targetRunId` **before** the claim. Unreachable today (the CLI rejects `--run` + `--claim-id` as `INVALID_SYNTAX` and `TransitionTarget` has no `both` inhabitant), but a latent trap for MCP/plugin front ends. Either align or document the deliberate inversion where `ResolveCommandTargetOptions:161-165` documents its own. Pinned by `issuance-anchor.test.ts` → `outranks a live bearer claim naming a different run`.
+- **`--run` branch duplicates `resolveRunTarget`.** `issuance-anchor.ts`'s `--run` branch is line-for-line `command-target-resolver.ts:436-448`, differing only in the `kind` label. Routing it through `resolveCommandTarget({ runId })` is tempting but **not equivalent** — a combined single call would give the claim precedence and, on a terminal claim, never consult `--run` at all. Any fix must keep the two lookups separate.
+- **Claim-key existence oracle** (Decision 4 above): `missing` vs `invalid-secret` messages are distinguishable across all claim-bearing commands. Pre-existing; a cross-command decision, not delegate's.
+
+---
+
+## Self-Review
+
+- **Spec coverage.** The gap ("delegate discards claim-resolution diagnostics and refuses with an arbitrary error about the active run") → Task 1 (anchor surfaces them), Task 2 (seam propagates), Task 3 (CLI renders). Each layer has its own red→green. The four prior decisions are recorded above with their evidence so they are not re-litigated mid-implementation.
+- **Placeholder scan.** No `TODO`/`TBD`/"handle edge cases". Every code step shows the exact edit. The one grep (`assertClaimId` import in Task 2 Step 5) names the exact command and the fallback action.
+- **Type consistency.** `stale_claim` / `terminal_claim` carry identical fields in `IssuanceAnchorResolution` (Task 1) and `DelegationIssuanceOutcome` (Task 2), reusing `resolveClaimTarget`'s own discriminants and `ClaimId` from `claim-id.js`. `target.claimId` / `target.message` / `target.lifecycle` are confirmed present on those variants (`command-target-resolver.ts:286-320`). The CLI reads only `outcome.message`, present on both. `renderStaleClaimRefusal(output: OutputEmitter, message: string): boolean` matches the call.
+- **Known behaviour change.** `delegate --claim-id <stale|stashed|terminal>` moves from an arbitrary gate refusal (`CLAIM_GRANT_REQUIRED` or `ACTOR_CONTEXT_REQUIRED`, depending on why the claim failed — both exit 1) to `CLAIMED_RUNBOOK_UNAVAILABLE` (exit 1). Exit code unchanged; the envelope converges with `pass`/`fail`. This is the branch's first behaviour change outside the #586 success path — call it out explicitly in the PR description.

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -442,6 +442,55 @@ describe('delegate command', () => {
       expect(payload.code).toBe('INVALID_RUN_ID');
     });
 
+    it('surfaces RUN_TARGET_UNAVAILABLE for --index against a foreign --run, not INVALID_INDEX', async () => {
+      // The `--index` FOR-step guard validates against the ANCHORED run. A
+      // foreign `--run` anchors nothing, so the guard must be skipped and the
+      // seam's run refusal must surface. Validating against the active run here
+      // would report INVALID_INDEX about a step the operator never named —
+      // exactly the misleading-error class #586 exists to remove.
+      await setupDelegation();
+      const foreign = `rd_${'f'.repeat(32)}`;
+
+      const result = await runCliInProcess(
+        ['delegate', '--step', '1.1', '--index', '1', '--run', foreign],
+        workspace,
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('RUN_TARGET_UNAVAILABLE');
+    });
+
+    it('surfaces RUN_TARGET_UNAVAILABLE for --retry --index against a foreign --run', async () => {
+      // Same guard on the retry `step` locator.
+      await setupDelegation();
+      const foreign = `rd_${'f'.repeat(32)}`;
+
+      const result = await runCliInProcess(
+        ['delegate', '--retry', '--step', '1.1', '--index', '1', '--run', foreign],
+        workspace,
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('RUN_TARGET_UNAVAILABLE');
+    });
+
+    it('surfaces RUN_TARGET_UNAVAILABLE for an inferred --retry against a foreign --run', async () => {
+      // The inferred-retry precondition needs the anchored run's substep cursor.
+      // A foreign `--run` anchors nothing, so the precondition defers to the
+      // seam rather than reporting INVALID_SYNTAX ("requires an active substep")
+      // about a run id that simply is not on the stack.
+      await setupDelegation();
+      const foreign = `rd_${'f'.repeat(32)}`;
+
+      const result = await runCliInProcess(['delegate', '--retry', '--run', foreign], workspace);
+
+      expect(result.exitCode).not.toBe(0);
+      const payload = JSON.parse(result.stdout) as { code?: string };
+      expect(payload.code).toBe('RUN_TARGET_UNAVAILABLE');
+    });
+
     it('rejects both --claim-id and a malformed --run with INVALID_SYNTAX (precedence)', async () => {
       await setupDelegation();
 

--- a/packages/cli/__tests__/commands/delegate.test.ts
+++ b/packages/cli/__tests__/commands/delegate.test.ts
@@ -377,7 +377,7 @@ describe('delegate command', () => {
   });
 
   describe('delegate --run', () => {
-    it('renders CLAIM_GRANT_REQUIRED when a child claim tries to issue a parent delegation', async () => {
+    it('surfaces the terminal-claim problem when a closed child claim tries to issue (#586)', async () => {
       await setupDelegation();
       const issued = await runCliInProcess(
         await withRunTarget(['delegate', 'runbooks/child.runbook.md', '--step', '1.1'], workspace),
@@ -400,11 +400,15 @@ describe('delegate command', () => {
       expect(result.exitCode).not.toBe(0);
       const envelope = parseCliJsonObject(result.stdout || result.stderr);
       expect(ErrorResponseSchema.safeParse(envelope).success).toBe(true);
+      // `pass` drove the child terminal, so the claim resolves `terminal_claim`.
+      // The refusal names the claim's own problem rather than falling through to
+      // the active parent and reporting a missing grant for a run the caller
+      // never named (#586).
       expect(envelope).toEqual(
         expect.objectContaining({
           kind: 'error',
-          code: 'CLAIM_GRANT_REQUIRED',
-          error: expect.stringContaining('rundown delegate'),
+          code: 'CLAIMED_RUNBOOK_UNAVAILABLE',
+          error: expect.stringContaining('completed child runbook'),
         }),
       );
     });

--- a/packages/cli/__tests__/helpers/lifecycle-seam-factory.test.ts
+++ b/packages/cli/__tests__/helpers/lifecycle-seam-factory.test.ts
@@ -121,7 +121,7 @@ describe('buildNonDelegatingLifecycleSeam', () => {
           // refuses before the resolver stub is ever reached. (A run id is only
           // target selection and never proves authority.)
           callerEvidence: { kind: 'direct_cli' },
-          explicitStep: '1.1',
+          explicitTarget: { stepId: '1.1' },
         }),
       ).resolves.toEqual({
         kind: 'refused',

--- a/packages/cli/__tests__/integration/delegate-workflow.test.ts
+++ b/packages/cli/__tests__/integration/delegate-workflow.test.ts
@@ -559,6 +559,28 @@ describe('DELEGATE claim-anchored CLI preconditions (#586 follow-up)', () => {
     expect(action).not.toBeNull();
     expect(action!.parent_run_id).toBe(parentRunId);
   }, 20_000);
+
+  it('surfaces the claim problem, not a grant refusal, for a stale claim (#586)', async () => {
+    await startForParentThenOther();
+    const unknownClaimId =
+      'rdclm_99999999999999999999999999999999_abcdefghijklmnopqrstuvwxyzABCDE1234567890-_';
+
+    const result = await runCliInProcess(
+      ['delegate', '--step', '1.1', '--claim-id', unknownClaimId],
+      workspace,
+    );
+
+    // Before this fix the anchor discarded the claim's diagnosis and anchored the
+    // active default, so the refusal was about a run the operator never named:
+    // here ACTOR_CONTEXT_REQUIRED — the bare-invocation message telling the caller
+    // to "Pass --claim-id", which they just did. The pre-fix code varies by why the
+    // claim failed, so only the post-fix envelope is asserted.
+    expect(result.exitCode).not.toBe(0);
+    const payload = JSON.parse(result.stdout) as { code?: string; error?: string };
+    expect(payload.code).toBe('CLAIMED_RUNBOOK_UNAVAILABLE');
+    // The load-bearing assertion: the operator is told what is actually wrong.
+    expect(payload.error).toContain('does not exist');
+  }, 20_000);
 });
 
 describe('DELEGATE manual issuance requires authored DELEGATE annotation', () => {

--- a/packages/cli/__tests__/integration/delegate-workflow.test.ts
+++ b/packages/cli/__tests__/integration/delegate-workflow.test.ts
@@ -426,10 +426,9 @@ describe('DELEGATE full workflow — rd run → auto-delegation → rd claim →
 });
 
 /**
- * CLI-side preconditions must be evaluated against the SAME run the core seam
- * anchors on. `--claim-id A` anchors issuance on A (#586); if the CLI validates
- * `--index` / inferred-retry against the active default B instead, a valid
- * command against A is rejected before the seam is ever reached.
+ * State-dependent preconditions belong in the core seam and must be evaluated
+ * against its claim-anchored, DelegationLock-scoped reread. `--claim-id A`
+ * therefore remains pinned to A even when the active default is B.
  */
 describe('DELEGATE claim-anchored CLI preconditions (#586 follow-up)', () => {
   let workspace: TestWorkspace;
@@ -540,6 +539,21 @@ describe('DELEGATE claim-anchored CLI preconditions (#586 follow-up)', () => {
     );
 
     expect(retried.stdout).not.toContain('INVALID_SYNTAX');
+    expect(retried.exitCode).toBe(0);
+    const action = findActionOutput<{ parent_run_id: string }>(retried.stdout);
+    expect(action).not.toBeNull();
+    expect(action!.parent_run_id).toBe(parentRunId);
+  }, 20_000);
+
+  it('validates retry --index against the claimed run, not the active default (#586)', async () => {
+    const { parentRunId, claimId } = await startForParentThenOther();
+
+    const retried = await runCliInProcess(
+      ['delegate', '--retry', '--step', '1.1', '--index', '1', '--claim-id', claimId],
+      workspace,
+    );
+
+    expect(retried.stdout).not.toContain('INVALID_INDEX');
     expect(retried.exitCode).toBe(0);
     const action = findActionOutput<{ parent_run_id: string }>(retried.stdout);
     expect(action).not.toBeNull();

--- a/packages/cli/__tests__/integration/delegate-workflow.test.ts
+++ b/packages/cli/__tests__/integration/delegate-workflow.test.ts
@@ -268,6 +268,45 @@ describe('DELEGATE full workflow — rd run → auto-delegation → rd claim →
     expect(advancedParent!.step).toBe('2');
   }, 20_000);
 
+  it("delegate --claim-id anchors on the claim's controlled run when it is not the active default (#586)", async () => {
+    // Parent run A is activated with auto-issued 1.1/1.2 delegations.
+    const { parentRunId } = await setupParentWithChildren();
+
+    // Activate a DIFFERENT run so A is controlled-but-not-active: getActive() now
+    // returns this run, not A. Start it `--prompted` so it ENTERS step 1 and stays
+    // running/active WITHOUT auto-executing. A plain (non-prompted) `run` would
+    // auto-execute this single-step `pass: COMPLETE` runbook to completion and
+    // release it — restoring A as the active default and collapsing the red→green
+    // discriminator (`--prompted` = "show commands without auto-executing",
+    // run.ts:70; mirrors how setupParentWithChildren keeps the parent alive).
+    const other = createRunbook({
+      title: 'Other',
+      steps: [{ title: 'Only', pass: 'COMPLETE', command: 'rundown echo --result pass' }],
+    });
+    await writeFile(join(workspace.cwd, 'runbooks', 'other.runbook.md'), other);
+    const otherStart = await runCliInProcess('run --prompted runbooks/other.runbook.md', workspace);
+    expect(otherStart.exitCode).toBe(0);
+    const active = await getActiveState(workspace);
+    expect(active).not.toBeNull();
+    expect(active!.id).not.toBe(parentRunId); // A is no longer the active default
+
+    // Mint a run-control claim for A and delegate against 1.1 with it (no --run).
+    const parentClaimId = await issueRunControlClaim(workspace, parentRunId);
+    const delegated = await runCliInProcess(
+      ['delegate', '--step', '1.1', '--claim-id', parentClaimId],
+      workspace,
+    );
+
+    // After the fix: exit 0, echoing A's already-issued 1.1 delegation, anchored
+    // on A. Before the fix the seam anchors the active default `other` run — which
+    // A's claim holds no grant for — and refuses `claim_grant_required` (exit 1).
+    expect(delegated.exitCode).toBe(0);
+    const action = findActionOutput<{ action: string; parent_run_id: string }>(delegated.stdout);
+    expect(action).not.toBeNull();
+    expect(action!.action).toBe('already-delegated');
+    expect(action!.parent_run_id).toBe(parentRunId);
+  }, 20_000);
+
   it('run-targeted rd collect fails fast when persisted state.step no longer resolves to a runbook step', async () => {
     const { parentRunId } = await setupParentWithChildren();
 
@@ -383,6 +422,128 @@ describe('DELEGATE full workflow — rd run → auto-delegation → rd claim →
     // The transition is complete: the parent cursor advanced to step 2.
     const afterParent = await readRunbookState(workspace, parentRunId);
     expect(afterParent?.step).toBe('2');
+  }, 20_000);
+});
+
+/**
+ * CLI-side preconditions must be evaluated against the SAME run the core seam
+ * anchors on. `--claim-id A` anchors issuance on A (#586); if the CLI validates
+ * `--index` / inferred-retry against the active default B instead, a valid
+ * command against A is rejected before the seam is ever reached.
+ */
+describe('DELEGATE claim-anchored CLI preconditions (#586 follow-up)', () => {
+  let workspace: TestWorkspace;
+
+  beforeEach(async () => {
+    workspace = await createTestWorkspace();
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  const childPass = (): string =>
+    createRunbook({
+      title: 'Child Pass',
+      steps: [{ title: 'Do work', pass: 'COMPLETE', command: 'rd echo --result pass' }],
+    });
+
+  /** Parent A: step 1 is a FOR step with a DELEGATE substep (index 1 is valid). */
+  const forParent = (): string =>
+    [
+      '# For Parent',
+      '',
+      '## 1. Process items',
+      '',
+      '- FOR i IN 1 TO 2',
+      '  - PASS ALL CONTINUE',
+      '  - FAIL ANY STOP',
+      '- DELEGATE',
+      '- PASS ALL CONTINUE',
+      '- FAIL ANY STOP',
+      '',
+      '### 1.1 Check {{i}}',
+      '',
+      '- child.runbook.md',
+      '',
+      '## 2. Done',
+      '',
+      '- PASS COMPLETE',
+      '',
+      'Done.',
+      '',
+      '```bash',
+      'rd echo --result pass',
+      '```',
+      '',
+    ].join('\n');
+
+  /** Active default B: step 1 is a plain NON-FOR command step, no substep. */
+  const plainOther = (): string =>
+    createRunbook({
+      title: 'Other',
+      steps: [{ title: 'Only', pass: 'COMPLETE', command: 'rundown echo --result pass' }],
+    });
+
+  async function startForParentThenOther(): Promise<{ parentRunId: RunId; claimId: string }> {
+    await writeFile(join(workspace.cwd, 'runbooks', 'child.runbook.md'), childPass());
+    await writeFile(join(workspace.runbooksDir(), 'child.runbook.md'), childPass());
+    await writeFile(join(workspace.cwd, 'runbooks', 'parent.runbook.md'), forParent());
+
+    const start = await runCliInProcess('run --prompted runbooks/parent.runbook.md', workspace);
+    expect(start.exitCode).toBe(0);
+    const parentState = await getActiveState(workspace);
+    expect(parentState).not.toBeNull();
+    const parentRunId = parentState!.id;
+
+    // Activate B so A is controlled-but-not-active. B's step 1 is NOT a FOR step
+    // and B sits on no substep — the two conditions the CLI wrongly validated.
+    await writeFile(join(workspace.cwd, 'runbooks', 'other.runbook.md'), plainOther());
+    const otherStart = await runCliInProcess('run --prompted runbooks/other.runbook.md', workspace);
+    expect(otherStart.exitCode).toBe(0);
+    const active = await getActiveState(workspace);
+    expect(active!.id).not.toBe(parentRunId);
+
+    const claimId = await issueRunControlClaim(workspace, parentRunId);
+    return { parentRunId, claimId };
+  }
+
+  it('validates --index against the claimed run, not the active default (#586)', async () => {
+    const { parentRunId, claimId } = await startForParentThenOther();
+
+    // A's step 1 IS a FOR step, so `--index 1` is valid against A. The active
+    // default B's step 1 is NOT a FOR step: validating there yields INVALID_INDEX
+    // for a step the operator never named.
+    const delegated = await runCliInProcess(
+      ['delegate', '--step', '1.1', '--index', '1', '--claim-id', claimId],
+      workspace,
+    );
+
+    expect(delegated.stdout).not.toContain('INVALID_INDEX');
+    expect(delegated.exitCode).toBe(0);
+    const action = findActionOutput<{ parent_run_id: string }>(delegated.stdout);
+    expect(action).not.toBeNull();
+    expect(action!.parent_run_id).toBe(parentRunId);
+  }, 20_000);
+
+  it('validates inferred --retry against the claimed run, not the active default (#586)', async () => {
+    // Starting A `--prompted` already leaves it positioned on substep 1.1 with an
+    // auto-issued delegation, so no explicit issuance is needed — keeping this
+    // test independent of the `--index` defect above.
+    const { parentRunId, claimId } = await startForParentThenOther();
+
+    // Inferred retry (no token, no --step): A HAS an active substep. The active
+    // default B does not — validating there yields INVALID_SYNTAX.
+    const retried = await runCliInProcess(
+      ['delegate', '--retry', '--claim-id', claimId],
+      workspace,
+    );
+
+    expect(retried.stdout).not.toContain('INVALID_SYNTAX');
+    expect(retried.exitCode).toBe(0);
+    const action = findActionOutput<{ parent_run_id: string }>(retried.stdout);
+    expect(action).not.toBeNull();
+    expect(action!.parent_run_id).toBe(parentRunId);
   }, 20_000);
 });
 

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -12,6 +12,7 @@ import {
   DELEGATION_TOKEN_PREFIX,
   delegateClaimIdValidationError,
   replaceSubstepStateEntry,
+  resolveIssuanceAnchor,
 } from '@rundown-org/core';
 import { parseStepIdFromString, type ResolvedStep } from '@rundown-org/parser';
 import { getCwd } from '../helpers/context.js';
@@ -66,6 +67,19 @@ export interface DelegateActionOptions {
 }
 
 /**
+ * The seam-facing target fields derived from a parsed `--claim-id` / `--run`
+ * target: bearer authority, plus the explicit run selector when one was named.
+ *
+ * Also selects the run every delegate precondition validates against — the CLI
+ * passes this same object to {@link resolveIssuanceAnchor} that it spreads into
+ * the seam call, so validation and issuance cannot target different runs (#586).
+ */
+type DelegateSeamFields = {
+  readonly callerEvidence: CallerEvidence;
+  readonly targetRunId?: RunId;
+};
+
+/**
  * Derive the delegate seam-call fields from a resolved {@link TransitionTarget}.
  *
  * `--claim-id` supplies bearer authority (mapped into `callerEvidence`); `--run`
@@ -76,10 +90,7 @@ export interface DelegateActionOptions {
  * @param target - The parsed transition target.
  * @returns Spreadable `callerEvidence` (+ `targetRunId` when a run is named).
  */
-function delegateSeamFields(target: TransitionTarget): {
-  readonly callerEvidence: CallerEvidence;
-  readonly targetRunId?: RunId;
-} {
+function delegateSeamFields(target: TransitionTarget): DelegateSeamFields {
   switch (target.kind) {
     case 'claim':
       return { callerEvidence: readLifecycleCallerEvidence({ claimId: target.claimId }) };
@@ -277,6 +288,7 @@ export function registerDelegateCommand(program: Command): void {
               tokenArg,
               options,
               sessionService,
+              seamFields,
               cwd,
               output,
             );
@@ -387,17 +399,29 @@ export function registerDelegateCommand(program: Command): void {
           }
 
           // Validate --index requires a FOR step (Category-A input validation on
-          // the active run's parsed steps). The seam trusts the pre-validated
+          // the ANCHORED run's parsed steps). The seam trusts the pre-validated
           // explicitIteration; this guard preserves the pre-migration error.
-          // `state` is fetched lazily here — the only consumer — so the common
-          // path no longer double-fetches the active run (the seam fetches it
-          // again internally). When no run is active the FOR-step guard is
-          // skipped and the seam's `no-active-runbook` outcome renders the
-          // message below (single source of truth). `--index` requires `--step`,
-          // so a deliberate `--index` target without an active run is a no-op.
+          // The anchor is resolved lazily here — the only consumer — so the
+          // common path no longer double-fetches the run (the seam resolves it
+          // again internally). When no run anchors, the FOR-step guard is
+          // skipped and the seam's `no-active-runbook` / `unknown_run` outcome
+          // renders the message (single source of truth). `--index` requires
+          // `--step`, so a deliberate `--index` target without a run is a no-op.
           if (explicitIteration !== undefined) {
-            const state = await sessionService.getActive();
-            if (state) {
+            // Resolve through the SAME anchor the seam issues against: with
+            // `--claim-id A` the target is A's run, not the active default. Using
+            // `getActive()` here validated `--index` against whichever run happened
+            // to be active, rejecting a valid FOR target on A with a misleading
+            // INVALID_INDEX about a step the operator never named (#586).
+            const anchored = await resolveIssuanceAnchor(
+              sessionService,
+              seamFields.targetRunId,
+              seamFields.callerEvidence,
+            );
+            // `unknown_run` is the seam's refusal to own (it renders the
+            // cause-specific message); skipping validation defers to it.
+            if (anchored.kind === 'ok') {
+              const state = anchored.state;
               const steps = getRunbookFromState(state, cwd);
               // `--index` requires `--step` (enforced above), so a target is
               // present. If it does not parse, error on the bad target rather than
@@ -638,14 +662,20 @@ async function resolveDelegateExtraVars(
  * Resolve `rd delegate --retry` flags to a {@link RetryLocator} (Category A).
  *
  * Performs the form-specific precondition checks that own CLI error envelopes:
- * a `--step` form requires an active runbook (`NO_ACTIVE_RUNBOOK`), a valid
+ * a `--step` form requires an anchored runbook (`NO_ACTIVE_RUNBOOK`), a valid
  * step id (`INVALID_STEP`), and — when `--index` is present — a FOR step
  * (`INVALID_INDEX`); the inferred form requires an active substep
  * (`INVALID_SYNTAX`). The seam resolves the locator to a concrete target.
  *
+ * Every precondition is evaluated against the run the seam will anchor on —
+ * `--run`, else the presented claim's controlled run, else the active default
+ * (`resolveIssuanceAnchor`). Reading `getActive()` here instead would reject a
+ * valid `--claim-id A` retry whenever A is not the active default (#586).
+ *
  * @param tokenArg - The positional token when it looks like a delegation token.
  * @param options - Parsed delegate options (`--step` / `--index`).
- * @param sessionService - Session service used to read the active run.
+ * @param sessionService - Session service used to resolve the anchored run.
+ * @param seamFields - Caller evidence (+ `--run` target) selecting that run.
  * @param cwd - Current working directory for FOR-step validation.
  * @param output - Output emitter used by `failRetry` on validation failure.
  * @returns The resolved retry locator.
@@ -654,6 +684,7 @@ async function resolveRetryLocator(
   tokenArg: string | undefined,
   options: DelegateActionOptions,
   sessionService: SessionService,
+  seamFields: DelegateSeamFields,
   cwd: string,
   output: OutputEmitter,
 ): Promise<RetryLocator> {
@@ -661,9 +692,18 @@ async function resolveRetryLocator(
     return { kind: 'token', token: tokenArg };
   }
 
+  // The run the seam will anchor on: `--run`, else the presented claim's
+  // controlled run, else the active default. `unknown_run` carries no state to
+  // validate against and is the seam's refusal to render, so both non-`ok`
+  // resolutions skip the state-dependent guards below and defer to it.
+  const anchored = await resolveIssuanceAnchor(
+    sessionService,
+    seamFields.targetRunId,
+    seamFields.callerEvidence,
+  );
+
   if (options.step) {
-    const state = await sessionService.getActive();
-    if (!state) {
+    if (anchored.kind === 'none') {
       failRetry(output, '--retry requires an active runbook', 'NO_ACTIVE_RUNBOOK');
     }
     const parsed = parseStepIdFromString(options.step);
@@ -679,16 +719,20 @@ async function resolveRetryLocator(
       }
       throw error;
     }
-    if (iteration !== undefined) {
-      const steps = getRunbookFromState(state, cwd);
+    if (iteration !== undefined && anchored.kind === 'ok') {
+      const steps = getRunbookFromState(anchored.state, cwd);
       assertForStep(output, steps, parsed.step);
     }
     return { kind: 'step', step: options.step, ...(iteration !== undefined ? { iteration } : {}) };
   }
 
-  // Inferred form: requires an active runbook positioned on a substep. Both the
-  // missing-run and missing-substep cases share one message/code.
-  const state = await sessionService.getActive();
+  // Inferred form: requires the anchored runbook to be positioned on a substep.
+  // Both the missing-run and missing-substep cases share one message/code; an
+  // `unknown_run` target defers to the seam's own refusal instead.
+  if (anchored.kind === 'unknown_run') {
+    return { kind: 'active' };
+  }
+  const state = anchored.kind === 'ok' ? anchored.state : undefined;
   if (!state?.substep) {
     failRetry(
       output,

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -12,9 +12,8 @@ import {
   DELEGATION_TOKEN_PREFIX,
   delegateClaimIdValidationError,
   replaceSubstepStateEntry,
-  resolveIssuanceAnchor,
 } from '@rundown-org/core';
-import { parseStepIdFromString, type ResolvedStep } from '@rundown-org/parser';
+import { parseStepIdFromString } from '@rundown-org/parser';
 import { getCwd } from '../helpers/context.js';
 import { withErrorHandling } from '../helpers/wrapper.js';
 import { OutputEmitter } from '../services/output-emitter.js';
@@ -44,7 +43,11 @@ import {
   renderActorContextRequiredRefusal,
   renderClaimGrantRequiredRefusal,
 } from '../helpers/refusal-renderers.js';
-import type { CallerEvidence, RunId, TemplateVarValue, RetryLocator } from '@rundown-org/core';
+import type {
+  ResolveIssuanceAnchorOptions,
+  TemplateVarValue,
+  RetryLocator,
+} from '@rundown-org/core';
 
 /**
  * Options accepted by `rd delegate` (covers both fresh-issue and --retry flows).
@@ -70,14 +73,11 @@ export interface DelegateActionOptions {
  * The seam-facing target fields derived from a parsed `--claim-id` / `--run`
  * target: bearer authority, plus the explicit run selector when one was named.
  *
- * Also selects the run every delegate precondition validates against — the CLI
- * passes this same object to {@link resolveIssuanceAnchor} that it spreads into
- * the seam call, so validation and issuance cannot target different runs (#586).
+ * The shape is exactly {@link ResolveIssuanceAnchorOptions}, so spreading it
+ * into the core seam preserves one typed target-selection contract. Core owns
+ * anchor resolution and every state-dependent precondition.
  */
-type DelegateSeamFields = {
-  readonly callerEvidence: CallerEvidence;
-  readonly targetRunId?: RunId;
-};
+type DelegateSeamFields = ResolveIssuanceAnchorOptions;
 
 /**
  * Derive the delegate seam-call fields from a resolved {@link TransitionTarget}.
@@ -279,19 +279,10 @@ export function registerDelegateCommand(program: Command): void {
               );
             }
 
-            // Resolve the retry target FIRST so its precondition envelopes
-            // (NO_ACTIVE_RUNBOOK / INVALID_STEP / INVALID_INDEX) take priority.
-            // Parsing --input* overrides up front would let an invalid
-            // --input-file (or other extra-var failure) mask the intended retry
-            // precondition error.
-            const locator = await resolveRetryLocator(
-              tokenArg,
-              options,
-              sessionService,
-              seamFields,
-              cwd,
-              output,
-            );
+            // Parse the raw retry locator first. Core resolves its state-bound
+            // preconditions under DelegationLock; lazy overrides stay deferred
+            // so input errors cannot mask those higher-priority outcomes.
+            const locator = resolveRetryLocator(tokenArg, options, output);
 
             const outcome = await seam.issueDelegation({
               mode: 'retry',
@@ -343,6 +334,16 @@ export function registerDelegateCommand(program: Command): void {
                 output.error(outcome.message, 'RUN_TARGET_MISMATCH');
                 process.exitCode = 1;
                 break;
+              case 'invalid_index':
+                failRetry(output, outcome.message, 'INVALID_INDEX');
+                break;
+              case 'retry_target_required':
+                failRetry(
+                  output,
+                  '--retry requires a token, --step <id>, or an active substep',
+                  'INVALID_SYNTAX',
+                );
+                break;
               case 'refused':
                 if (outcome.policy.kind === 'delegation_collection_pending') {
                   emitDelegationCollectionPendingError(
@@ -382,9 +383,8 @@ export function registerDelegateCommand(program: Command): void {
 
           const seam = buildDelegateSeam(manager, sessionService, cwd);
 
-          // --index validation stays Category-A (raw flag validation). It is
-          // derived from the raw --step value (--index requires --step, already
-          // enforced above), never from the seam-resolved target.
+          // Category-A syntax parsing only. Whether the target is a FOR step is
+          // state-dependent and is validated by core under DelegationLock.
           let explicitIteration: number | undefined;
           try {
             explicitIteration = resolveIndexOption(
@@ -397,50 +397,21 @@ export function registerDelegateCommand(program: Command): void {
             }
             throw error;
           }
-
-          // Validate --index requires a FOR step (Category-A input validation on
-          // the ANCHORED run's parsed steps). The seam trusts the pre-validated
-          // explicitIteration; this guard preserves the pre-migration error.
-          // The anchor is resolved lazily here — the only consumer — so the
-          // common path no longer double-fetches the run (the seam resolves it
-          // again internally). When no run anchors, the FOR-step guard is
-          // skipped and the seam's `no-active-runbook` / `unknown_run` outcome
-          // renders the message (single source of truth). `--index` requires
-          // `--step`, so a deliberate `--index` target without a run is a no-op.
-          if (explicitIteration !== undefined) {
-            // Resolve through the SAME anchor the seam issues against: with
-            // `--claim-id A` the target is A's run, not the active default. Using
-            // `getActive()` here validated `--index` against whichever run happened
-            // to be active, rejecting a valid FOR target on A with a misleading
-            // INVALID_INDEX about a step the operator never named (#586).
-            const anchored = await resolveIssuanceAnchor(
-              sessionService,
-              seamFields.targetRunId,
-              seamFields.callerEvidence,
-            );
-            // `unknown_run` is the seam's refusal to own (it renders the
-            // cause-specific message); skipping validation defers to it.
-            if (anchored.kind === 'ok') {
-              const state = anchored.state;
-              const steps = getRunbookFromState(state, cwd);
-              // `--index` requires `--step` (enforced above), so a target is
-              // present. If it does not parse, error on the bad target rather than
-              // silently validating the active step (which would surface a
-              // misleading INVALID_INDEX about a step the operator did not name, or
-              // fall through to a later RD-814). Mirrors resolveRetryLocator.
-              const parsedTarget = parseStepIdFromString(options.step ?? '');
-              if (!parsedTarget) {
-                failRetry(output, `invalid --step value "${options.step ?? ''}"`, 'INVALID_STEP');
-              }
-              assertForStep(output, steps, parsedTarget.step);
-            }
+          if (explicitIteration !== undefined && !parseStepIdFromString(options.step ?? '')) {
+            failRetry(output, `invalid --step value "${options.step ?? ''}"`, 'INVALID_STEP');
           }
 
           const outcome = await seam.issueDelegation({
             mode: 'fresh',
             ...seamFields,
-            ...(options.step ? { explicitStep: options.step } : {}),
-            ...(explicitIteration !== undefined ? { explicitIteration } : {}),
+            ...(options.step
+              ? {
+                  explicitTarget: {
+                    stepId: options.step,
+                    ...(explicitIteration !== undefined ? { iteration: explicitIteration } : {}),
+                  },
+                }
+              : {}),
             ...(runbookArg ? { requestedRunbook: runbookArg } : {}),
             // Lazily parse extra vars (Category-A flag handling stays in the CLI),
             // deferred to the issuable moment by the seam so the echo / conflict /
@@ -458,6 +429,9 @@ export function registerDelegateCommand(program: Command): void {
               // Core owns the cause-specific message (shared with pass/complete).
               output.error(outcome.message, 'RUN_TARGET_UNAVAILABLE');
               process.exitCode = 1;
+              break;
+            case 'invalid_index':
+              failRetry(output, outcome.message, 'INVALID_INDEX');
               break;
             case 'refused':
               if (outcome.policy.kind === 'delegation_collection_pending') {
@@ -515,6 +489,7 @@ export function registerDelegateCommand(program: Command): void {
             case 'retried':
             case 'token-not-found':
             case 'run_target_mismatch':
+            case 'retry_target_required':
               // Retry-only outcomes; unreachable on the fresh-issue path.
               throw new Error(`Unexpected fresh delegate outcome: ${outcome.kind}`);
             default: {
@@ -661,51 +636,26 @@ async function resolveDelegateExtraVars(
 /**
  * Resolve `rd delegate --retry` flags to a {@link RetryLocator} (Category A).
  *
- * Performs the form-specific precondition checks that own CLI error envelopes:
- * a `--step` form requires an anchored runbook (`NO_ACTIVE_RUNBOOK`), a valid
- * step id (`INVALID_STEP`), and — when `--index` is present — a FOR step
- * (`INVALID_INDEX`); the inferred form requires an active substep
- * (`INVALID_SYNTAX`). The seam resolves the locator to a concrete target.
- *
- * Every precondition is evaluated against the run the seam will anchor on —
- * `--run`, else the presented claim's controlled run, else the active default
- * (`resolveIssuanceAnchor`). Reading `getActive()` here instead would reject a
- * valid `--claim-id A` retry whenever A is not the active default (#586).
+ * Parses only raw syntax: token/step/inferred form, step-id syntax, and numeric
+ * index conflicts. Core resolves the run once and performs every
+ * state-dependent check against its DelegationLock-scoped reread.
  *
  * @param tokenArg - The positional token when it looks like a delegation token.
  * @param options - Parsed delegate options (`--step` / `--index`).
- * @param sessionService - Session service used to resolve the anchored run.
- * @param seamFields - Caller evidence (+ `--run` target) selecting that run.
- * @param cwd - Current working directory for FOR-step validation.
  * @param output - Output emitter used by `failRetry` on validation failure.
  * @returns The resolved retry locator.
+ * @throws {IndexOptionError} When the raw `--index` syntax is invalid.
  */
-async function resolveRetryLocator(
+function resolveRetryLocator(
   tokenArg: string | undefined,
   options: DelegateActionOptions,
-  sessionService: SessionService,
-  seamFields: DelegateSeamFields,
-  cwd: string,
   output: OutputEmitter,
-): Promise<RetryLocator> {
+): RetryLocator {
   if (tokenArg) {
     return { kind: 'token', token: tokenArg };
   }
 
-  // The run the seam will anchor on: `--run`, else the presented claim's
-  // controlled run, else the active default. `unknown_run` carries no state to
-  // validate against and is the seam's refusal to render, so both non-`ok`
-  // resolutions skip the state-dependent guards below and defer to it.
-  const anchored = await resolveIssuanceAnchor(
-    sessionService,
-    seamFields.targetRunId,
-    seamFields.callerEvidence,
-  );
-
   if (options.step) {
-    if (anchored.kind === 'none') {
-      failRetry(output, '--retry requires an active runbook', 'NO_ACTIVE_RUNBOOK');
-    }
     const parsed = parseStepIdFromString(options.step);
     if (!parsed) {
       failRetry(output, `invalid --step value "${options.step}"`, 'INVALID_STEP');
@@ -719,27 +669,9 @@ async function resolveRetryLocator(
       }
       throw error;
     }
-    if (iteration !== undefined && anchored.kind === 'ok') {
-      const steps = getRunbookFromState(anchored.state, cwd);
-      assertForStep(output, steps, parsed.step);
-    }
     return { kind: 'step', step: options.step, ...(iteration !== undefined ? { iteration } : {}) };
   }
 
-  // Inferred form: requires the anchored runbook to be positioned on a substep.
-  // Both the missing-run and missing-substep cases share one message/code; an
-  // `unknown_run` target defers to the seam's own refusal instead.
-  if (anchored.kind === 'unknown_run') {
-    return { kind: 'active' };
-  }
-  const state = anchored.kind === 'ok' ? anchored.state : undefined;
-  if (!state?.substep) {
-    failRetry(
-      output,
-      '--retry requires a token, --step <id>, or an active substep',
-      'INVALID_SYNTAX',
-    );
-  }
   return { kind: 'active' };
 }
 
@@ -790,33 +722,4 @@ function failRetry(output: OutputEmitter, message: string, code: string): never 
   output.error(message, code);
   output.flush();
   process.exit(1);
-}
-
-/**
- * Validate that an `--index` target resolves to a FOR step.
- *
- * `--index` only has meaning on a FOR / prompted-FOR step (it selects an
- * iteration). Both the fresh-issue and `--retry` flows must reject `--index`
- * against a non-FOR step with the same `INVALID_INDEX` envelope; extracting the
- * guard here keeps that error contract single-sourced so the two call sites
- * cannot drift. When the named step is absent from the parsed steps the guard is
- * a no-op (the seam reports the missing-step outcome).
- *
- * @param output - OutputEmitter used by `failRetry` on validation failure.
- * @param steps - Parsed steps of the active run.
- * @param targetStepName - Name of the step the `--index` targets.
- */
-function assertForStep(
-  output: OutputEmitter,
-  steps: readonly ResolvedStep[],
-  targetStepName: string,
-): void {
-  const targetStep = steps.find((s) => s.name === targetStepName);
-  if (targetStep && targetStep.kind !== 'for' && targetStep.kind !== 'prompted-for') {
-    failRetry(
-      output,
-      `--index requires step "${targetStepName}" to be a FOR step, but it is "${targetStep.kind}"`,
-      'INVALID_INDEX',
-    );
-  }
 }

--- a/packages/cli/src/commands/delegate.ts
+++ b/packages/cli/src/commands/delegate.ts
@@ -42,6 +42,7 @@ import {
 import {
   renderActorContextRequiredRefusal,
   renderClaimGrantRequiredRefusal,
+  renderStaleClaimRefusal,
 } from '../helpers/refusal-renderers.js';
 import type {
   ResolveIssuanceAnchorOptions,
@@ -328,6 +329,15 @@ export function registerDelegateCommand(program: Command): void {
                 output.error(outcome.message, 'RUN_TARGET_UNAVAILABLE');
                 process.exitCode = 1;
                 break;
+              case 'stale_claim':
+              case 'terminal_claim':
+                // Core owns the cause-specific message (shared with pass/fail).
+                // Both render as CLAIMED_RUNBOOK_UNAVAILABLE: delegate has no
+                // confirm/conflict notion for a terminal claim — there is no
+                // expected result to reconcile a lifecycle against.
+                renderStaleClaimRefusal(output, outcome.message);
+                process.exitCode = 1;
+                break;
               case 'run_target_mismatch':
                 // Fail-closed: `--run` named a run that does not own the retry
                 // token. Core owns the message (no owning-run-id echo).
@@ -428,6 +438,15 @@ export function registerDelegateCommand(program: Command): void {
             case 'unknown_run':
               // Core owns the cause-specific message (shared with pass/complete).
               output.error(outcome.message, 'RUN_TARGET_UNAVAILABLE');
+              process.exitCode = 1;
+              break;
+            case 'stale_claim':
+            case 'terminal_claim':
+              // Core owns the cause-specific message (shared with pass/fail).
+              // Both render as CLAIMED_RUNBOOK_UNAVAILABLE: delegate has no
+              // confirm/conflict notion for a terminal claim — there is no
+              // expected result to reconcile a lifecycle against.
+              renderStaleClaimRefusal(output, outcome.message);
               process.exitCode = 1;
               break;
             case 'invalid_index':

--- a/packages/core/__tests__/runbook/issuance-anchor.test.ts
+++ b/packages/core/__tests__/runbook/issuance-anchor.test.ts
@@ -72,8 +72,16 @@ function fakeReader(options: {
       }
       return { kind: 'running', state };
     },
-    async getActiveForClaimId(_claimId) {
-      return options.claimResolution ?? { status: 'missing', claimId: _claimId };
+    async getActiveForClaimId(_claimId, readOptions) {
+      const resolution = options.claimResolution ?? { status: 'missing', claimId: _claimId };
+      // Mirror the real head's visibility rule rather than ignoring the option: a
+      // stashed claim is only visible when the caller asks for it. Without this,
+      // no fake input could distinguish `allowStashed` on from off, so the
+      // anchor's deliberate choice to leave it off would be unpinned.
+      if (resolution.status === 'unlinked' && readOptions.includeStashed) {
+        return claimed();
+      }
+      return resolution;
     },
     async verifyClaimId() {
       return { status: 'missing', claimKey: claimRecord.claimKey };
@@ -190,7 +198,7 @@ describe('resolveIssuanceAnchor', () => {
       expect(anchored.state.id).toBe(anchorRunId);
     });
 
-    it('falls through to the active default for a terminal claim', async () => {
+    it('refuses terminal_claim rather than anchoring the active default (#586)', async () => {
       const reader = fakeReader({
         active: activeRun,
         claimResolution: {
@@ -203,12 +211,34 @@ describe('resolveIssuanceAnchor', () => {
 
       const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
 
-      expect(anchored.kind).toBe('ok');
-      if (anchored.kind !== 'ok') throw new Error('expected ok');
-      expect(anchored.state.id).toBe(activeRunId);
+      expect(anchored.kind).toBe('terminal_claim');
+      if (anchored.kind !== 'terminal_claim') throw new Error('expected terminal_claim');
+      expect(anchored.lifecycle).toBe('completed');
+      expect(anchored.message).toContain('completed');
     });
 
-    it('falls through to the active default for a missing (stale) claim', async () => {
+    it('carries the stopped lifecycle through, not a hardcoded completed (#586)', async () => {
+      // The only other terminal case is `completed`, so without this a constant
+      // `lifecycle: 'completed'` in the anchor would pass every test.
+      const reader = fakeReader({
+        active: activeRun,
+        claimResolution: {
+          status: 'terminal',
+          claim: verifiedClaim,
+          state: { ...anchorRun, lifecycle: 'stopped' },
+          lifecycle: 'stopped',
+        },
+      });
+
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
+
+      expect(anchored.kind).toBe('terminal_claim');
+      if (anchored.kind !== 'terminal_claim') throw new Error('expected terminal_claim');
+      expect(anchored.lifecycle).toBe('stopped');
+      expect(anchored.message).toContain('stopped');
+    });
+
+    it('refuses stale_claim rather than anchoring the active default (#586)', async () => {
       const reader = fakeReader({
         active: activeRun,
         claimResolution: { status: 'missing', claimId },
@@ -216,16 +246,17 @@ describe('resolveIssuanceAnchor', () => {
 
       const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
 
-      expect(anchored.kind).toBe('ok');
-      if (anchored.kind !== 'ok') throw new Error('expected ok');
-      expect(anchored.state.id).toBe(activeRunId);
+      expect(anchored.kind).toBe('stale_claim');
+      if (anchored.kind !== 'stale_claim') throw new Error('expected stale_claim');
+      expect(anchored.message).toContain('does not exist');
     });
 
-    it('falls through to the active default for a stashed claim', async () => {
+    it('refuses a stashed claim with its actionable message (#586)', async () => {
       // The claim head is consulted WITHOUT `allowStashed`, so a stashed child
-      // never anchors here — it falls through and the unchanged authorization
-      // gate refuses. Pins the deliberate visibility choice: flipping
-      // `includeStashed` on would anchor the stashed run instead.
+      // never anchors here. Rather than discarding that diagnosis, the anchor
+      // surfaces it so the operator learns what to actually do. Also pins the
+      // visibility choice: flipping `allowStashed` on makes the fake resolve
+      // `claimed`, anchoring the stashed run and failing this assertion.
       const reader = fakeReader({
         active: activeRun,
         claimResolution: { status: 'unlinked', claim: verifiedClaim, reason: 'stashed' },
@@ -233,9 +264,19 @@ describe('resolveIssuanceAnchor', () => {
 
       const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
 
-      expect(anchored.kind).toBe('ok');
-      if (anchored.kind !== 'ok') throw new Error('expected ok');
-      expect(anchored.state.id).toBe(activeRunId);
+      expect(anchored.kind).toBe('stale_claim');
+      if (anchored.kind !== 'stale_claim') throw new Error('expected stale_claim');
+      expect(anchored.message).toContain('rundown pop');
+    });
+
+    it('refuses stale_claim even when no active default exists', async () => {
+      // The claim's own diagnosis outranks the absence of a fallback: `none`
+      // would tell the operator "no active runbook", which is not their problem.
+      const reader = fakeReader({ active: null, claimResolution: { status: 'missing', claimId } });
+
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
+
+      expect(anchored.kind).toBe('stale_claim');
     });
   });
 
@@ -254,14 +295,6 @@ describe('resolveIssuanceAnchor', () => {
       const reader = fakeReader({ active: null });
 
       const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: pluginEvidence });
-
-      expect(anchored.kind).toBe('none');
-    });
-
-    it('resolves none when a stale claim leaves no active default', async () => {
-      const reader = fakeReader({ active: null, claimResolution: { status: 'missing', claimId } });
-
-      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
 
       expect(anchored.kind).toBe('none');
     });

--- a/packages/core/__tests__/runbook/issuance-anchor.test.ts
+++ b/packages/core/__tests__/runbook/issuance-anchor.test.ts
@@ -97,7 +97,10 @@ describe('resolveIssuanceAnchor', () => {
     it('anchors the named running session-stack member', async () => {
       const reader = fakeReader({ active: activeRun, runById: { [namedRunId]: namedRun } });
 
-      const anchored = await resolveIssuanceAnchor(reader, namedRunId, pluginEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, {
+        callerEvidence: pluginEvidence,
+        targetRunId: namedRunId,
+      });
 
       expect(anchored.kind).toBe('ok');
       if (anchored.kind !== 'ok') throw new Error('expected ok');
@@ -116,7 +119,10 @@ describe('resolveIssuanceAnchor', () => {
         runById: { [namedRunId]: namedRun },
       });
 
-      const anchored = await resolveIssuanceAnchor(reader, namedRunId, bearerEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, {
+        callerEvidence: bearerEvidence,
+        targetRunId: namedRunId,
+      });
 
       expect(anchored.kind).toBe('ok');
       if (anchored.kind !== 'ok') throw new Error('expected ok');
@@ -126,7 +132,27 @@ describe('resolveIssuanceAnchor', () => {
     it('refuses unknown_run when the named id is not on the session stack', async () => {
       const reader = fakeReader({ active: activeRun, runById: {} });
 
-      const anchored = await resolveIssuanceAnchor(reader, namedRunId, pluginEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, {
+        callerEvidence: pluginEvidence,
+        targetRunId: namedRunId,
+      });
+
+      expect(anchored.kind).toBe('unknown_run');
+      if (anchored.kind !== 'unknown_run') throw new Error('expected unknown_run');
+      expect(anchored.runId).toBe(namedRunId);
+    });
+
+    it('does not fall through to a live bearer claim when the named id is absent', async () => {
+      const reader = fakeReader({
+        active: activeRun,
+        claimResolution: claimed(),
+        runById: {},
+      });
+
+      const anchored = await resolveIssuanceAnchor(reader, {
+        callerEvidence: bearerEvidence,
+        targetRunId: namedRunId,
+      });
 
       expect(anchored.kind).toBe('unknown_run');
       if (anchored.kind !== 'unknown_run') throw new Error('expected unknown_run');
@@ -141,7 +167,10 @@ describe('resolveIssuanceAnchor', () => {
         runById: { [namedRunId]: terminalNamedRun },
       });
 
-      const anchored = await resolveIssuanceAnchor(reader, namedRunId, pluginEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, {
+        callerEvidence: pluginEvidence,
+        targetRunId: namedRunId,
+      });
 
       expect(anchored.kind).toBe('unknown_run');
       if (anchored.kind !== 'unknown_run') throw new Error('expected unknown_run');
@@ -154,7 +183,7 @@ describe('resolveIssuanceAnchor', () => {
     it("anchors the claim's controlled run over the active default (#586)", async () => {
       const reader = fakeReader({ active: activeRun, claimResolution: claimed() });
 
-      const anchored = await resolveIssuanceAnchor(reader, undefined, bearerEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
 
       expect(anchored.kind).toBe('ok');
       if (anchored.kind !== 'ok') throw new Error('expected ok');
@@ -172,7 +201,7 @@ describe('resolveIssuanceAnchor', () => {
         },
       });
 
-      const anchored = await resolveIssuanceAnchor(reader, undefined, bearerEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
 
       expect(anchored.kind).toBe('ok');
       if (anchored.kind !== 'ok') throw new Error('expected ok');
@@ -185,7 +214,7 @@ describe('resolveIssuanceAnchor', () => {
         claimResolution: { status: 'missing', claimId },
       });
 
-      const anchored = await resolveIssuanceAnchor(reader, undefined, bearerEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
 
       expect(anchored.kind).toBe('ok');
       if (anchored.kind !== 'ok') throw new Error('expected ok');
@@ -202,7 +231,7 @@ describe('resolveIssuanceAnchor', () => {
         claimResolution: { status: 'unlinked', claim: verifiedClaim, reason: 'stashed' },
       });
 
-      const anchored = await resolveIssuanceAnchor(reader, undefined, bearerEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
 
       expect(anchored.kind).toBe('ok');
       if (anchored.kind !== 'ok') throw new Error('expected ok');
@@ -214,7 +243,7 @@ describe('resolveIssuanceAnchor', () => {
     it('anchors the active run for non-claim evidence', async () => {
       const reader = fakeReader({ active: activeRun });
 
-      const anchored = await resolveIssuanceAnchor(reader, undefined, pluginEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: pluginEvidence });
 
       expect(anchored.kind).toBe('ok');
       if (anchored.kind !== 'ok') throw new Error('expected ok');
@@ -224,7 +253,7 @@ describe('resolveIssuanceAnchor', () => {
     it('resolves none when no run is active', async () => {
       const reader = fakeReader({ active: null });
 
-      const anchored = await resolveIssuanceAnchor(reader, undefined, pluginEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: pluginEvidence });
 
       expect(anchored.kind).toBe('none');
     });
@@ -232,7 +261,7 @@ describe('resolveIssuanceAnchor', () => {
     it('resolves none when a stale claim leaves no active default', async () => {
       const reader = fakeReader({ active: null, claimResolution: { status: 'missing', claimId } });
 
-      const anchored = await resolveIssuanceAnchor(reader, undefined, bearerEvidence);
+      const anchored = await resolveIssuanceAnchor(reader, { callerEvidence: bearerEvidence });
 
       expect(anchored.kind).toBe('none');
     });

--- a/packages/core/__tests__/runbook/issuance-anchor.test.ts
+++ b/packages/core/__tests__/runbook/issuance-anchor.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from '@jest/globals';
+import type { CommandTargetReader } from '../../src/runbook/command-target-resolver.js';
+import { resolveIssuanceAnchor } from '../../src/runbook/issuance-anchor.js';
+import {
+  assertClaimId,
+  assertClaimLookupKey,
+  assertClaimSecretHash,
+  type ClaimIdResolution,
+  type ClaimRecord,
+  type VerifiedClaim,
+} from '../../src/runbook/claim-id.js';
+import { assertRunId } from '../../src/runbook/run-id.js';
+import type { CallerEvidence } from '../../src/runbook/actor-context.js';
+import type { RunbookState } from '../../src/runbook/types.js';
+
+/**
+ * Unit coverage for the delegate anchor seam. `resolveIssuanceAnchor` is the
+ * single source of truth for "which run does this delegate invocation act on?" —
+ * the core issuance seam and the CLI's Category-A preconditions both resolve
+ * through it, so its precedence is pinned here directly rather than only via the
+ * (slow) seam and CLI suites.
+ *
+ * A structural `CommandTargetReader` fake keeps these tests filesystem-free,
+ * mirroring `command-target-resolver.test.ts`.
+ */
+
+const anchorRunId = assertRunId('rd_11111111111111111111111111111111');
+const activeRunId = assertRunId('rd_22222222222222222222222222222222');
+const namedRunId = assertRunId('rd_33333333333333333333333333333333');
+
+const claimId = assertClaimId(
+  'rdclm_11111111111111111111111111111111_abcdefghijklmnopqrstuvwxyzABCDE1234567890-_',
+);
+
+const anchorRun = { id: anchorRunId, lifecycle: 'running' } as RunbookState;
+const activeRun = { id: activeRunId, lifecycle: 'running' } as RunbookState;
+const namedRun = { id: namedRunId, lifecycle: 'running' } as RunbookState;
+const terminalNamedRun = { ...namedRun, lifecycle: 'completed' } as RunbookState;
+
+const claimKey = assertClaimLookupKey('rdclk_11111111111111111111111111111111');
+const claimRecord: ClaimRecord = {
+  claimKey,
+  secretHash: assertClaimSecretHash(`sha256:${'a'.repeat(64)}`),
+  controlledRunId: anchorRunId,
+  grants: [{ action: 'delegate-from-run', runId: anchorRunId }],
+  issuedAt: '2026-07-16T00:00:00.000Z',
+  updatedAt: '2026-07-16T00:00:00.000Z',
+};
+const verifiedClaim: VerifiedClaim = {
+  claimKey,
+  controlledRunId: anchorRunId,
+  grants: claimRecord.grants,
+};
+
+const bearerEvidence: CallerEvidence = { kind: 'claim_bearer', claimId };
+const pluginEvidence: CallerEvidence = { kind: 'plugin', agentId: 'agent' };
+
+function fakeReader(options: {
+  readonly active?: RunbookState | null;
+  readonly claimResolution?: ClaimIdResolution;
+  readonly runById?: Readonly<Record<string, RunbookState>>;
+}): CommandTargetReader {
+  return {
+    async getActive() {
+      return options.active ?? null;
+    },
+    async resolveRunningStackMember(runId) {
+      const state = options.runById?.[runId];
+      if (!state) return { kind: 'not_on_stack' };
+      if (state.lifecycle !== 'running') {
+        return { kind: 'not_running', lifecycle: state.lifecycle };
+      }
+      return { kind: 'running', state };
+    },
+    async getActiveForClaimId(_claimId) {
+      return options.claimResolution ?? { status: 'missing', claimId: _claimId };
+    },
+    async verifyClaimId() {
+      return { status: 'missing', claimKey: claimRecord.claimKey };
+    },
+    async listOpenClaimsForParent() {
+      return [];
+    },
+  };
+}
+
+const claimed = (state: RunbookState = anchorRun): ClaimIdResolution => ({
+  status: 'claimed',
+  claimId,
+  claim: verifiedClaim,
+  record: claimRecord,
+  state,
+});
+
+describe('resolveIssuanceAnchor', () => {
+  describe('(1) explicit --run outranks every other selector', () => {
+    it('anchors the named running session-stack member', async () => {
+      const reader = fakeReader({ active: activeRun, runById: { [namedRunId]: namedRun } });
+
+      const anchored = await resolveIssuanceAnchor(reader, namedRunId, pluginEvidence);
+
+      expect(anchored.kind).toBe('ok');
+      if (anchored.kind !== 'ok') throw new Error('expected ok');
+      expect(anchored.state.id).toBe(namedRunId);
+    });
+
+    it('outranks a live bearer claim naming a different run', async () => {
+      // Both selectors are present and name DIFFERENT runs. `--run` wins: a
+      // mutant reordering the claim branch above the `--run` branch anchors the
+      // claim's run and fails here. (The CLI rejects this combination as
+      // INVALID_SYNTAX, so this pins the seam's own precedence for other front
+      // ends.)
+      const reader = fakeReader({
+        active: activeRun,
+        claimResolution: claimed(),
+        runById: { [namedRunId]: namedRun },
+      });
+
+      const anchored = await resolveIssuanceAnchor(reader, namedRunId, bearerEvidence);
+
+      expect(anchored.kind).toBe('ok');
+      if (anchored.kind !== 'ok') throw new Error('expected ok');
+      expect(anchored.state.id).toBe(namedRunId);
+    });
+
+    it('refuses unknown_run when the named id is not on the session stack', async () => {
+      const reader = fakeReader({ active: activeRun, runById: {} });
+
+      const anchored = await resolveIssuanceAnchor(reader, namedRunId, pluginEvidence);
+
+      expect(anchored.kind).toBe('unknown_run');
+      if (anchored.kind !== 'unknown_run') throw new Error('expected unknown_run');
+      expect(anchored.runId).toBe(namedRunId);
+    });
+
+    it('refuses unknown_run when the named id is on the stack but terminal', async () => {
+      // `not_running` carries a cause-specific message distinct from
+      // `not_on_stack`; both collapse to the same `unknown_run` refusal kind.
+      const reader = fakeReader({
+        active: activeRun,
+        runById: { [namedRunId]: terminalNamedRun },
+      });
+
+      const anchored = await resolveIssuanceAnchor(reader, namedRunId, pluginEvidence);
+
+      expect(anchored.kind).toBe('unknown_run');
+      if (anchored.kind !== 'unknown_run') throw new Error('expected unknown_run');
+      expect(anchored.runId).toBe(namedRunId);
+      expect(anchored.message).toContain('completed');
+    });
+  });
+
+  describe('(2) a live bearer claim anchors the run it controls', () => {
+    it("anchors the claim's controlled run over the active default (#586)", async () => {
+      const reader = fakeReader({ active: activeRun, claimResolution: claimed() });
+
+      const anchored = await resolveIssuanceAnchor(reader, undefined, bearerEvidence);
+
+      expect(anchored.kind).toBe('ok');
+      if (anchored.kind !== 'ok') throw new Error('expected ok');
+      expect(anchored.state.id).toBe(anchorRunId);
+    });
+
+    it('falls through to the active default for a terminal claim', async () => {
+      const reader = fakeReader({
+        active: activeRun,
+        claimResolution: {
+          status: 'terminal',
+          claim: verifiedClaim,
+          state: { ...anchorRun, lifecycle: 'completed' },
+          lifecycle: 'completed',
+        },
+      });
+
+      const anchored = await resolveIssuanceAnchor(reader, undefined, bearerEvidence);
+
+      expect(anchored.kind).toBe('ok');
+      if (anchored.kind !== 'ok') throw new Error('expected ok');
+      expect(anchored.state.id).toBe(activeRunId);
+    });
+
+    it('falls through to the active default for a missing (stale) claim', async () => {
+      const reader = fakeReader({
+        active: activeRun,
+        claimResolution: { status: 'missing', claimId },
+      });
+
+      const anchored = await resolveIssuanceAnchor(reader, undefined, bearerEvidence);
+
+      expect(anchored.kind).toBe('ok');
+      if (anchored.kind !== 'ok') throw new Error('expected ok');
+      expect(anchored.state.id).toBe(activeRunId);
+    });
+
+    it('falls through to the active default for a stashed claim', async () => {
+      // The claim head is consulted WITHOUT `allowStashed`, so a stashed child
+      // never anchors here — it falls through and the unchanged authorization
+      // gate refuses. Pins the deliberate visibility choice: flipping
+      // `includeStashed` on would anchor the stashed run instead.
+      const reader = fakeReader({
+        active: activeRun,
+        claimResolution: { status: 'unlinked', claim: verifiedClaim, reason: 'stashed' },
+      });
+
+      const anchored = await resolveIssuanceAnchor(reader, undefined, bearerEvidence);
+
+      expect(anchored.kind).toBe('ok');
+      if (anchored.kind !== 'ok') throw new Error('expected ok');
+      expect(anchored.state.id).toBe(activeRunId);
+    });
+  });
+
+  describe('(3) the active default is the bare fallback', () => {
+    it('anchors the active run for non-claim evidence', async () => {
+      const reader = fakeReader({ active: activeRun });
+
+      const anchored = await resolveIssuanceAnchor(reader, undefined, pluginEvidence);
+
+      expect(anchored.kind).toBe('ok');
+      if (anchored.kind !== 'ok') throw new Error('expected ok');
+      expect(anchored.state.id).toBe(activeRunId);
+    });
+
+    it('resolves none when no run is active', async () => {
+      const reader = fakeReader({ active: null });
+
+      const anchored = await resolveIssuanceAnchor(reader, undefined, pluginEvidence);
+
+      expect(anchored.kind).toBe('none');
+    });
+
+    it('resolves none when a stale claim leaves no active default', async () => {
+      const reader = fakeReader({ active: null, claimResolution: { status: 'missing', claimId } });
+
+      const anchored = await resolveIssuanceAnchor(reader, undefined, bearerEvidence);
+
+      expect(anchored.kind).toBe('none');
+    });
+  });
+});

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -821,6 +821,32 @@ describe('RunbookLifecycleCommandService', () => {
         expect(outcome.token).toBe(`rdtk_${'A'.repeat(32)}`);
       });
 
+      it('refuses fresh issuance when the claim target is stashed during lock acquisition', async () => {
+        const { seam: localSeam, deps } = await startSeamOnDelegateStep();
+        const persistSpy = jest.fn(deps.persistIssuedSubstep);
+        deps.persistIssuedSubstep = persistSpy;
+        deps.delegationLock = {
+          acquire: async () => {
+            // The claim resolved before the DelegationLock was acquired, but a
+            // concurrent session mutation parked its target in that window.
+            // The protected decision must revalidate claim eligibility rather
+            // than treating bearer verification alone as sufficient.
+            await sessionService.stashRunbook(runId);
+          },
+          release: async () => {},
+        };
+
+        const outcome = await localSeam.issueDelegation({
+          mode: 'fresh',
+          callerEvidence: runControlEvidence(runId),
+        });
+
+        expect(outcome.kind).toBe('stale_claim');
+        if (outcome.kind !== 'stale_claim') throw new Error('expected stale_claim');
+        expect(outcome.message).toContain('stashed');
+        expect(persistSpy).not.toHaveBeenCalled();
+      });
+
       it('validates a fresh explicit iteration against the locked runbook reread', async () => {
         const forSteps: readonly ResolvedStep[] = [
           delegateForStep('1', [delegateSubstep('1', 'child.md')]),
@@ -1443,6 +1469,37 @@ describe('RunbookLifecycleCommandService', () => {
         const entry = persisted?.substepStates?.find((s) => s.id === '1');
         expect(entry?.delegation?.tokenHash).toBe(first.tokenHash);
         expect(entry?.delegation?.childRunId).toBe(childRunId);
+      });
+
+      it('refuses retry when the claim target is stashed during lock acquisition', async () => {
+        const { seam: localSeam, deps } = await startSeamOnDelegateStep();
+        const first = await localSeam.issueDelegation({
+          mode: 'fresh',
+          callerEvidence: runControlEvidence(runId),
+        });
+        if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+        const persistSpy = jest.fn(deps.persistIssuedSubstep);
+        deps.persistIssuedSubstep = persistSpy;
+        deps.delegationLock = {
+          acquire: async () => {
+            // Simulate stashRunbook committing after anchor resolution but
+            // before retry enters its protected decision path.
+            await sessionService.stashRunbook(runId);
+          },
+          release: async () => {},
+        };
+
+        const outcome = await localSeam.issueDelegation({
+          mode: 'retry',
+          callerEvidence: runControlEvidence(runId),
+          locator: { kind: 'step', step: first.stepId },
+        });
+
+        expect(outcome.kind).toBe('stale_claim');
+        if (outcome.kind !== 'stale_claim') throw new Error('expected stale_claim');
+        expect(outcome.message).toContain('stashed');
+        expect(persistSpy).not.toHaveBeenCalled();
       });
 
       it('validates a retry iteration against the locked runbook reread', async () => {

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import type {
   ResolvedStep,
   ResolvedStepWithFor,
+  ResolvedStepWithPromptedFor,
   ResolvedStepWithSubsteps,
   Substep,
   Transitions,
@@ -110,6 +111,20 @@ function delegateForStep(name: string, substeps: readonly Substep[]): ResolvedSt
     description: `FOR step ${name}`,
     transitions: SUBSTEP_TRANSITIONS,
     forClause: { variable: 'i', start: 1, end: 10 },
+    substeps,
+  };
+}
+
+/** Build a prompted-FOR step that owns authored DELEGATE substeps. */
+function delegatePromptedForStep(
+  name: string,
+  substeps: readonly Substep[],
+): ResolvedStepWithPromptedFor {
+  return {
+    kind: 'prompted-for',
+    name,
+    description: `Prompted FOR step ${name}`,
+    transitions: SUBSTEP_TRANSITIONS,
     substeps,
   };
 }
@@ -222,6 +237,7 @@ describe('RunbookLifecycleCommandService', () => {
   type MutableIssuanceSeamDeps = {
     resolveChildRunbook: ResolveChildRunbook;
     loadRun: RunbookLifecycleCommandServiceDependencies['loadRun'];
+    loadSteps: RunbookLifecycleCommandServiceDependencies['loadSteps'];
     persistIssuedSubstep: RunbookLifecycleCommandServiceDependencies['persistIssuedSubstep'];
     delegationLock: RunbookLifecycleCommandServiceDependencies['delegationLock'];
   };
@@ -370,6 +386,20 @@ describe('RunbookLifecycleCommandService', () => {
         mode: 'fresh',
         callerEvidence: { kind: 'plugin', agentId: 'a' },
       });
+      expect(outcome.kind).toBe('refused');
+      if (outcome.kind !== 'refused') throw new Error('expected refused');
+      expect(outcome.policy.kind).toBe('actor_context_required');
+    });
+
+    it('authorizes before exposing fresh indexed-target details', async () => {
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'plugin', agentId: 'a' },
+        explicitTarget: { stepId: '1.1', iteration: 2 },
+      });
+
       expect(outcome.kind).toBe('refused');
       if (outcome.kind !== 'refused') throw new Error('expected refused');
       expect(outcome.policy.kind).toBe('actor_context_required');
@@ -552,7 +582,7 @@ describe('RunbookLifecycleCommandService', () => {
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
         callerEvidence: runControlEvidence(runId),
-        explicitStep: '2.2',
+        explicitTarget: { stepId: '2.2' },
       });
       expect(outcome.kind).toBe('delegated');
       if (outcome.kind !== 'delegated') throw new Error('expected delegated');
@@ -623,8 +653,7 @@ describe('RunbookLifecycleCommandService', () => {
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
         callerEvidence: runControlEvidence(runId),
-        explicitStep: '1.1',
-        explicitIteration: 2,
+        explicitTarget: { stepId: '1.1', iteration: 2 },
       });
       expect(outcome.kind).toBe('delegated');
 
@@ -696,7 +725,7 @@ describe('RunbookLifecycleCommandService', () => {
       const outcome = await localSeam.issueDelegation({
         mode: 'fresh',
         callerEvidence: runControlEvidence(runId),
-        explicitStep: '1.1',
+        explicitTarget: { stepId: '1.1' },
       });
       expect(outcome.kind).toBe('error');
       if (outcome.kind !== 'error') throw new Error('expected error');
@@ -777,6 +806,95 @@ describe('RunbookLifecycleCommandService', () => {
         expect(outcome.token).toBe(`rdtk_${'A'.repeat(32)}`);
       });
 
+      it('validates a fresh explicit iteration against the locked runbook reread', async () => {
+        const forSteps: readonly ResolvedStep[] = [
+          delegateForStep('1', [delegateSubstep('1', 'child.md')]),
+        ];
+        const state = baseState();
+        await activate(state);
+        const { seam: localSeam, deps } = buildIssuanceSeam(state, forSteps);
+        const persistSpy = jest.fn(deps.persistIssuedSubstep);
+        const resolveExtraVars = jest.fn(async () => undefined);
+        deps.persistIssuedSubstep = persistSpy;
+        deps.delegationLock = {
+          acquire: async () => {
+            // The parsed document changes while this invocation waits. The
+            // state-dependent FOR check must use this in-lock view, not the
+            // pre-lock FOR snapshot.
+            deps.loadSteps = async () => [delegateStep('1', [delegateSubstep('1', 'child.md')])];
+          },
+          release: async () => {},
+        };
+
+        const outcome = await localSeam.issueDelegation({
+          mode: 'fresh',
+          callerEvidence: runControlEvidence(runId),
+          explicitTarget: { stepId: '1.1', iteration: 2 },
+          resolveExtraVars,
+        });
+
+        expect(outcome.kind).toBe('invalid_index');
+        if (outcome.kind !== 'invalid_index') throw new Error('expected invalid_index');
+        expect(outcome.message).toBe(
+          '--index requires step "1" to be a FOR step, but it is "substeps"',
+        );
+        expect(persistSpy).not.toHaveBeenCalled();
+        expect(resolveExtraVars).not.toHaveBeenCalled();
+      });
+
+      it('validates the named step rather than the first parsed step', async () => {
+        const steps: readonly ResolvedStep[] = [
+          delegateForStep('2', [delegateSubstep('1', 'other.md')]),
+          delegateStep('1', [delegateSubstep('1', 'child.md')]),
+        ];
+        const state = baseState();
+        await activate(state);
+        const { seam: localSeam } = buildIssuanceSeam(state, steps);
+
+        const outcome = await localSeam.issueDelegation({
+          mode: 'fresh',
+          callerEvidence: runControlEvidence(runId),
+          explicitTarget: { stepId: '1.1', iteration: 2 },
+        });
+
+        expect(outcome.kind).toBe('invalid_index');
+      });
+
+      it('accepts explicit iterations on prompted-FOR targets', async () => {
+        const steps: readonly ResolvedStep[] = [
+          delegatePromptedForStep('1', [delegateSubstep('1', 'child.md')]),
+        ];
+        const state = baseState();
+        await activate(state);
+        const { seam: localSeam } = buildIssuanceSeam(state, steps);
+
+        const outcome = await localSeam.issueDelegation({
+          mode: 'fresh',
+          callerEvidence: runControlEvidence(runId),
+          explicitTarget: { stepId: '1.1', iteration: 2 },
+        });
+
+        expect(outcome.kind).toBe('delegated');
+      });
+
+      it('defers an unparsable indexed target to the delegation error contract', async () => {
+        const state = baseState();
+        await activate(state);
+        const { seam: localSeam } = buildIssuanceSeam(state, [
+          delegateForStep('1', [delegateSubstep('1', 'child.md')]),
+        ]);
+
+        const outcome = await localSeam.issueDelegation({
+          mode: 'fresh',
+          callerEvidence: runControlEvidence(runId),
+          explicitTarget: { stepId: 'not-a-step', iteration: 2 },
+        });
+
+        expect(outcome.kind).toBe('error');
+        if (outcome.kind !== 'error') throw new Error('expected error');
+        expect(outcome.error.code).toBe('RD-814');
+      });
+
       it('maps a lock acquisition timeout to an RD-810 error outcome without persisting', async () => {
         const { seam: localSeam, deps, state } = await startSeamOnDelegateStep();
         const persistSpy = jest.fn(async () => {});
@@ -809,7 +927,7 @@ describe('RunbookLifecycleCommandService', () => {
           localSeam.issueDelegation({
             mode: 'fresh',
             callerEvidence: runControlEvidence(runId),
-            explicitStep: '1.1',
+            explicitTarget: { stepId: '1.1' },
           });
         const [a, b] = await Promise.all([issue(), issue()]);
 
@@ -896,7 +1014,7 @@ describe('RunbookLifecycleCommandService', () => {
     it("anchors retry-step issuance on the claim's controlled run, not the active default (#586)", async () => {
       // Fresh issuance while `runId` is still the active default: mints the token
       // the retry below locates by step.
-      const { seam: localSeam } = await startSeamOnDelegateStep();
+      const { seam: localSeam, manager: localManager, state } = await startSeamOnDelegateStep();
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
         callerEvidence: runControlEvidence(runId),
@@ -920,6 +1038,34 @@ describe('RunbookLifecycleCommandService', () => {
       // the Step 4 fix the retry-step locator anchors the active default, whose run
       // the claim lacks a grant for, so the outcome is `refused`.
       expect(outcome.parentRunId).toBe(runId);
+
+      const persisted = await localManager.load(state.id);
+      const delegation = findSubstepState(
+        persisted?.substepStates ?? [],
+        '1',
+        buildFrameKey('1'),
+      )?.delegation;
+      expect(delegation?.tokenHash).toBe(outcome.tokenHash);
+      expect(delegation?.tokenHash).not.toBe(first.tokenHash);
+    });
+
+    it('authorizes before exposing retry indexed-target details', async () => {
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+      const first = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: runControlEvidence(runId),
+      });
+      if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'retry',
+        callerEvidence: { kind: 'plugin', agentId: 'a' },
+        locator: { kind: 'step', step: first.stepId, iteration: 2 },
+      });
+
+      expect(outcome.kind).toBe('refused');
+      if (outcome.kind !== 'refused') throw new Error('expected refused');
+      expect(outcome.policy.kind).toBe('actor_context_required');
     });
 
     it('retries the active substep via { kind: "active" }', async () => {
@@ -1184,8 +1330,7 @@ describe('RunbookLifecycleCommandService', () => {
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
         callerEvidence: runControlEvidence(runId),
-        explicitStep: '1.1',
-        explicitIteration: 2,
+        explicitTarget: { stepId: '1.1', iteration: 2 },
       });
       if (first.kind !== 'delegated') throw new Error('expected delegated');
 
@@ -1285,6 +1430,116 @@ describe('RunbookLifecycleCommandService', () => {
         expect(entry?.delegation?.childRunId).toBe(childRunId);
       });
 
+      it('validates a retry iteration against the locked runbook reread', async () => {
+        const forSteps: readonly ResolvedStep[] = [
+          delegateForStep('1', [delegateSubstep('1', 'child.md')]),
+        ];
+        const state = baseState();
+        await activate(state);
+        const { seam: localSeam, deps } = buildIssuanceSeam(state, forSteps);
+        const first = await localSeam.issueDelegation({
+          mode: 'fresh',
+          callerEvidence: runControlEvidence(runId),
+          explicitTarget: { stepId: '1.1', iteration: 2 },
+        });
+        if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+        const persistSpy = jest.fn(deps.persistIssuedSubstep);
+        const resolveOverrides = jest.fn(async () => undefined);
+        deps.persistIssuedSubstep = persistSpy;
+        deps.delegationLock = {
+          acquire: async () => {
+            deps.loadSteps = async () => [delegateStep('1', [delegateSubstep('1', 'child.md')])];
+          },
+          release: async () => {},
+        };
+
+        const outcome = await localSeam.issueDelegation({
+          mode: 'retry',
+          callerEvidence: runControlEvidence(runId),
+          locator: { kind: 'step', step: '1.1', iteration: 2 },
+          resolveOverrides,
+        });
+
+        expect(outcome.kind).toBe('invalid_index');
+        if (outcome.kind !== 'invalid_index') throw new Error('expected invalid_index');
+        expect(outcome.message).toBe(
+          '--index requires step "1" to be a FOR step, but it is "substeps"',
+        );
+        expect(persistSpy).not.toHaveBeenCalled();
+        expect(resolveOverrides).not.toHaveBeenCalled();
+      });
+
+      it('defers an unparsable indexed retry target to the delegation error contract', async () => {
+        const { seam: localSeam } = await startSeamOnDelegateStep();
+
+        const outcome = await localSeam.issueDelegation({
+          mode: 'retry',
+          callerEvidence: runControlEvidence(runId),
+          locator: { kind: 'step', step: 'not-a-step', iteration: 2 },
+        });
+
+        expect(outcome.kind).toBe('error');
+      });
+
+      it('refuses inferred retry when the active cursor disappears during lock acquisition', async () => {
+        const {
+          seam: localSeam,
+          deps,
+          manager: mgr,
+          state,
+        } = await startSeamOnActiveDelegateSubstep();
+        const first = await localSeam.issueDelegation({
+          mode: 'fresh',
+          callerEvidence: runControlEvidence(runId),
+        });
+        if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+        const persistSpy = jest.fn(deps.persistIssuedSubstep);
+        deps.persistIssuedSubstep = persistSpy;
+        deps.delegationLock = {
+          acquire: async () => {
+            await mgr.updateWithState(state.id, () => ({ substep: undefined }));
+          },
+          release: async () => {},
+        };
+
+        const outcome = await localSeam.issueDelegation({
+          mode: 'retry',
+          callerEvidence: runControlEvidence(runId),
+          locator: { kind: 'active' },
+        });
+
+        expect(outcome.kind).toBe('retry_target_required');
+        expect(persistSpy).not.toHaveBeenCalled();
+      });
+
+      it('retries the inferred cursor that appears during lock acquisition', async () => {
+        const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
+        const first = await localSeam.issueDelegation({
+          mode: 'fresh',
+          callerEvidence: runControlEvidence(runId),
+        });
+        if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+        deps.delegationLock = {
+          acquire: async () => {
+            await mgr.updateWithState(state.id, () => ({ substep: '1' }));
+          },
+          release: async () => {},
+        };
+
+        const outcome = await localSeam.issueDelegation({
+          mode: 'retry',
+          callerEvidence: runControlEvidence(runId),
+          locator: { kind: 'active' },
+        });
+
+        expect(outcome.kind).toBe('retried');
+        if (outcome.kind !== 'retried') throw new Error('expected retried');
+        expect(outcome.stepLabel).toBe('1.1');
+      });
+
       it('maps a retry lock acquisition timeout to RD-810 without touching the delegation', async () => {
         const { seam: localSeam, deps, manager: mgr, state } = await startSeamOnDelegateStep();
         const first = await localSeam.issueDelegation({
@@ -1336,7 +1591,7 @@ describe('RunbookLifecycleCommandService', () => {
           localSeam.issueDelegation({
             mode: 'fresh',
             callerEvidence: runControlEvidence(runId),
-            explicitStep: '1.1',
+            explicitTarget: { stepId: '1.1' },
           }),
           localSeam.issueDelegation({
             mode: 'retry',
@@ -1493,8 +1748,7 @@ describe('RunbookLifecycleCommandService', () => {
       const first = await localSeam.issueDelegation({
         mode: 'fresh',
         callerEvidence: runControlEvidence(runId),
-        explicitStep: '1.1',
-        explicitIteration: 2,
+        explicitTarget: { stepId: '1.1', iteration: 2 },
       });
       if (first.kind !== 'delegated') throw new Error('expected delegated');
 

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -393,6 +393,57 @@ describe('RunbookLifecycleCommandService', () => {
       expect(issued).toBeDefined();
     });
 
+    it("anchors fresh issuance on the claim's controlled run, not the active default (#586)", async () => {
+      // Run `runId` is activated with an authored DELEGATE substep and its own
+      // run-control claim.
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+
+      // A DIFFERENT run is then activated, so `runId` is controlled-but-not-active:
+      // getActive() now returns this run, not `runId`.
+      const otherRunId = assertRunId('rd_22222222222222222222222222222222');
+      const activeDefault = baseState({ id: otherRunId, runbookPath: 'other.md' });
+      await activate(activeDefault);
+
+      // Delegating with `runId`'s run-control claim (NO --run) must anchor on
+      // `runId` — the run the claim controls — not on the active default.
+      const outcome = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: runControlEvidence(runId),
+      });
+
+      expect(outcome.kind).toBe('delegated');
+      if (outcome.kind !== 'delegated') throw new Error('expected delegated');
+      // The load-bearing assertion: issuance anchored on the CONTROLLED run
+      // (`runId`), not the active default (`otherRunId`). Before the fix the seam
+      // anchors `otherRunId`, whose run the claim lacks a grant for, and the
+      // outcome is `refused` (claim_grant_required) — so this expectation fails.
+      expect(outcome.parentRunId).toBe(runId);
+    });
+
+    it("falls through to the active default when the claim's controlled run is terminal (#586)", async () => {
+      // The run `runId` is activated with a DELEGATE step and its run-control
+      // claim, then driven terminal — so the claim resolves to `terminal_claim`,
+      // NOT `claim`. A different run is the active default.
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+      await manager.updateWithState(runId, () => ({ lifecycle: 'completed' as const }));
+      const otherRunId = assertRunId('rd_33333333333333333333333333333333');
+      await activate(baseState({ id: otherRunId, runbookPath: 'other.md' }));
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: runControlEvidence(runId),
+      });
+
+      // The terminal claim does NOT divert the anchor: the seam falls through to
+      // the active default (`otherRunId`), and because the claim holds no
+      // `delegate-from-run` grant for it, the unchanged gate refuses. A mutant
+      // forcing `target.kind === 'claim'` true would anchor `runId` and produce a
+      // different outcome, so this assertion kills it.
+      expect(outcome.kind).toBe('refused');
+      if (outcome.kind !== 'refused') throw new Error('expected refused');
+      expect(outcome.policy.kind).toBe('claim_grant_required');
+    });
+
     it('returns the canonical persisted child ref (not the authored alias) and matches the echo', async () => {
       // The authored substep targets "child.md"; resolve it to a DIFFERENT
       // canonical path so returning the authored alias is observably wrong.
@@ -842,6 +893,35 @@ describe('RunbookLifecycleCommandService', () => {
       expect(retried.token).not.toBe(first.token);
     });
 
+    it("anchors retry-step issuance on the claim's controlled run, not the active default (#586)", async () => {
+      // Fresh issuance while `runId` is still the active default: mints the token
+      // the retry below locates by step.
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+      const first = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: runControlEvidence(runId),
+      });
+      if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+      // A DIFFERENT run is then activated, so `runId` is controlled-but-not-active:
+      // getActive() now returns this run, not `runId`.
+      const otherRunId = assertRunId('rd_44444444444444444444444444444444');
+      await activate(baseState({ id: otherRunId, runbookPath: 'other.md' }));
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'retry',
+        callerEvidence: runControlEvidence(runId),
+        locator: { kind: 'step', step: first.stepId },
+      });
+
+      expect(outcome.kind).toBe('retried');
+      if (outcome.kind !== 'retried') throw new Error('expected retried');
+      // Anchored on the controlled run (`runId`), not the active default. Before
+      // the Step 4 fix the retry-step locator anchors the active default, whose run
+      // the claim lacks a grant for, so the outcome is `refused`.
+      expect(outcome.parentRunId).toBe(runId);
+    });
+
     it('retries the active substep via { kind: "active" }', async () => {
       const { seam: localSeam } = await startSeamOnActiveDelegateSubstep();
       const first = await localSeam.issueDelegation({
@@ -855,6 +935,35 @@ describe('RunbookLifecycleCommandService', () => {
         locator: { kind: 'active' },
       });
       expect(retried.kind).toBe('retried');
+    });
+
+    it("anchors retry-active issuance on the claim's controlled run, not the active default (#586)", async () => {
+      // Pins the THIRD anchor call site (the inferred-`active` retry locator).
+      // Without this, reverting only that site to `getActive()` leaves the whole
+      // core suite green — the defect would be caught solely by a slow CLI
+      // integration test.
+      const { seam: localSeam } = await startSeamOnActiveDelegateSubstep();
+      const first = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: runControlEvidence(runId),
+      });
+      if (first.kind !== 'delegated') throw new Error('expected delegated');
+
+      // A DIFFERENT run becomes the active default, so `runId` is
+      // controlled-but-not-active. The second run sits on no substep, so an
+      // active-default anchor cannot resolve a substep cursor at all.
+      const otherRunId = assertRunId('rd_66666666666666666666666666666666');
+      await activate(baseState({ id: otherRunId, runbookPath: 'other.md' }));
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'retry',
+        callerEvidence: runControlEvidence(runId),
+        locator: { kind: 'active' },
+      });
+
+      expect(outcome.kind).toBe('retried');
+      if (outcome.kind !== 'retried') throw new Error('expected retried');
+      expect(outcome.parentRunId).toBe(runId);
     });
 
     it('retries a linked terminal child without allowing the stale child to re-report', async () => {

--- a/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
+++ b/packages/core/__tests__/runbook/lifecycle-command-service.test.ts
@@ -450,7 +450,7 @@ describe('RunbookLifecycleCommandService', () => {
       expect(outcome.parentRunId).toBe(runId);
     });
 
-    it("falls through to the active default when the claim's controlled run is terminal (#586)", async () => {
+    it('refuses a terminal claim rather than anchoring the active default (#586)', async () => {
       // The run `runId` is activated with a DELEGATE step and its run-control
       // claim, then driven terminal — so the claim resolves to `terminal_claim`,
       // NOT `claim`. A different run is the active default.
@@ -464,14 +464,29 @@ describe('RunbookLifecycleCommandService', () => {
         callerEvidence: runControlEvidence(runId),
       });
 
-      // The terminal claim does NOT divert the anchor: the seam falls through to
-      // the active default (`otherRunId`), and because the claim holds no
-      // `delegate-from-run` grant for it, the unchanged gate refuses. A mutant
-      // forcing `target.kind === 'claim'` true would anchor `runId` and produce a
-      // different outcome, so this assertion kills it.
-      expect(outcome.kind).toBe('refused');
-      if (outcome.kind !== 'refused') throw new Error('expected refused');
-      expect(outcome.policy.kind).toBe('claim_grant_required');
+      // The seam propagates the anchor's terminal refusal instead of anchoring
+      // the active default (`otherRunId`) and refusing about a run the caller
+      // never named. A mutant forcing the anchor's `claim` case true would
+      // anchor the terminal `runId` and issue, so this assertion kills it.
+      expect(outcome.kind).toBe('terminal_claim');
+      if (outcome.kind !== 'terminal_claim') throw new Error('expected terminal_claim');
+      expect(outcome.lifecycle).toBe('completed');
+    });
+
+    it('refuses a stale (nonexistent) claim rather than anchoring the active default (#586)', async () => {
+      const { seam: localSeam } = await startSeamOnDelegateStep();
+      const unknownClaimId = assertClaimId(
+        'rdclm_99999999999999999999999999999999_abcdefghijklmnopqrstuvwxyzABCDE1234567890-_',
+      );
+
+      const outcome = await localSeam.issueDelegation({
+        mode: 'fresh',
+        callerEvidence: { kind: 'claim_bearer', claimId: unknownClaimId },
+      });
+
+      expect(outcome.kind).toBe('stale_claim');
+      if (outcome.kind !== 'stale_claim') throw new Error('expected stale_claim');
+      expect(outcome.message).toContain('does not exist');
     });
 
     it('returns the canonical persisted child ref (not the authored alias) and matches the echo', async () => {
@@ -1480,6 +1495,11 @@ describe('RunbookLifecycleCommandService', () => {
         });
 
         expect(outcome.kind).toBe('error');
+        // Without the code, any error — including an unrelated throw — satisfies
+        // this test; the point is that the delegation resolver retains ownership
+        // of RD-801 (step not found) for the unparsable `--step` target.
+        if (outcome.kind !== 'error') throw new Error('expected error');
+        expect(outcome.error.code).toBe('RD-801');
       });
 
       it('refuses inferred retry when the active cursor disappears during lock acquisition', async () => {

--- a/packages/core/src/runbook/command-target-resolver.ts
+++ b/packages/core/src/runbook/command-target-resolver.ts
@@ -20,6 +20,25 @@ import type { RunbookState } from './types.js';
 export type TransitionCommandName = 'pass' | 'fail';
 
 /**
+ * Refusal: the named `--run` id is not a running member of this session's
+ * default stack (unknown id, missing state file, or terminal lifecycle).
+ *
+ * The single structural declaration of this refusal. Every union that can carry
+ * a `--run` refusal — target resolution, transition targets, delegation
+ * issuance, the lifecycle outcomes — references this type rather than
+ * re-declaring the shape, so the members cannot drift apart. {@link
+ * unknownRunRefusal} is the matching single source of truth for the messages.
+ */
+export type UnknownRunRefusal = {
+  /** Discriminant. */
+  readonly kind: 'unknown_run';
+  /** Run id named by the caller. */
+  readonly runId: RunId;
+  /** Operator-facing refusal message. */
+  readonly message: string;
+};
+
+/**
  * Resolved target for any command that acts on the active or an explicitly
  * claimed runbook (goto, stop, complete, stash, status, artifact, collect).
  *
@@ -52,20 +71,18 @@ export type CommandTargetResolution =
       /** Resolved running state of the named run. */
       readonly state: RunbookState;
     }
-  | {
-      /**
-       * Refusal: the named `--run` id is not a running member of this session's
-       * default stack (unknown id, missing state file, or terminal lifecycle).
-       */
-      readonly kind: 'unknown_run';
-      /** Run id named by the caller. */
-      readonly runId: RunId;
-      /** Operator-facing refusal message. */
-      readonly message: string;
-    };
+  | UnknownRunRefusal;
 
-/** Claim-targeting outcomes only (no default-stack / open-children cases). */
-type ClaimTargetResolution = Extract<
+/**
+ * Claim-targeting outcomes only (no default-stack / open-children cases).
+ *
+ * Exhaustive for a presented bearer claim: {@link resolveClaimTarget} maps all
+ * six raw claim statuses onto exactly these three kinds. Consumers that resolve
+ * a claim and nothing else should depend on this narrow union rather than the
+ * wide {@link CommandTargetResolution}, so a `never` check makes forgetting a
+ * kind a compile error instead of a silent fall-through.
+ */
+export type ClaimTargetResolution = Extract<
   CommandTargetResolution,
   { kind: 'claim' | 'terminal_claim' | 'stale_claim' }
 >;
@@ -141,17 +158,7 @@ export type TransitionTargetResolution =
       /** Resolved running state of the named run. */
       readonly state: RunbookState;
     }
-  | {
-      /**
-       * Refusal: the named `--run` id is not a running member of this session's
-       * default stack (unknown id, missing state file, or terminal lifecycle).
-       */
-      readonly kind: 'unknown_run';
-      /** Run id named by the caller. */
-      readonly runId: RunId;
-      /** Operator-facing refusal message. */
-      readonly message: string;
-    };
+  | UnknownRunRefusal;
 
 /** Options for {@link resolveCommandTarget}. */
 export interface ResolveCommandTargetOptions {
@@ -258,7 +265,10 @@ export interface CommandTargetReader {
  *
  * Both public resolvers funnel claim-id targeting through here, so the mapping
  * from `getActiveForClaimId` statuses to user-facing outcomes is defined exactly
- * once.
+ * once. Callers that resolve only a claim (no `--run`, no default stack) should
+ * call this directly instead of {@link resolveCommandTarget}: it is the same
+ * seam, but its narrow {@link ClaimTargetResolution} return type lets them
+ * dispatch exhaustively.
  *
  * @param targetReader - Read-side dependency used to resolve the claim id
  * @param claimId - Explicit claim id from `--claim-id`
@@ -267,7 +277,7 @@ export interface CommandTargetReader {
  *   stashed child resolves as `claim` rather than `stale_claim`.
  * @returns Claim, terminal-claim, or stale-claim outcome
  */
-async function resolveClaimTarget(
+export async function resolveClaimTarget(
   targetReader: CommandTargetReader,
   claimId: ClaimId,
   options: { readonly includeStashed: boolean },
@@ -400,7 +410,7 @@ function claimAuthorizesRunMutation(claim: VerifiedClaim, state: RunbookState): 
 export function unknownRunRefusal(
   runId: RunId,
   member: Exclude<RunningStackMemberResolution, { kind: 'running' }>,
-): { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string } {
+): UnknownRunRefusal {
   switch (member.kind) {
     case 'not_on_stack':
       return {
@@ -437,8 +447,7 @@ async function resolveRunTarget(
   targetReader: CommandTargetReader,
   runId: RunId,
 ): Promise<
-  | { readonly kind: 'run'; readonly runId: RunId; readonly state: RunbookState }
-  | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
+  { readonly kind: 'run'; readonly runId: RunId; readonly state: RunbookState } | UnknownRunRefusal
 > {
   const member = await targetReader.resolveRunningStackMember(runId);
   if (member.kind !== 'running') {

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -104,6 +104,7 @@ export {
 export {
   resolveIssuanceAnchor,
   type IssuanceAnchorResolution,
+  type ResolveIssuanceAnchorOptions,
 } from './issuance-anchor.js';
 export {
   UNKNOWN_ACTOR_CONTEXT,
@@ -192,6 +193,7 @@ export {
   type AttributedTerminalObservation,
   type DelegationIssuanceInput,
   type DelegationIssuanceOutcome,
+  type ExplicitDelegationTarget,
   type FindDelegationByToken,
   type ForceAbortLinkedChildCleanupResult,
   type LifecycleLoopDirective,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -88,11 +88,14 @@ export {
   type UnstashForClaimIdResult,
 } from './session-service.js';
 export {
+  resolveClaimTarget,
   resolveCommandTarget,
   resolveMutationAuthority,
   resolveTerminalTarget,
   resolveTransitionTarget,
+  type ClaimTargetResolution,
   type CommandTargetResolution,
+  type UnknownRunRefusal,
   type ResolveCommandTargetOptions,
   type ResolveTransitionTargetOptions,
   type MutationAuthorityResolution,

--- a/packages/core/src/runbook/index.ts
+++ b/packages/core/src/runbook/index.ts
@@ -102,6 +102,10 @@ export {
   type TransitionTargetResolution,
 } from './command-target-resolver.js';
 export {
+  resolveIssuanceAnchor,
+  type IssuanceAnchorResolution,
+} from './issuance-anchor.js';
+export {
   UNKNOWN_ACTOR_CONTEXT,
   verifiedClaimContext,
   type ActorContext,

--- a/packages/core/src/runbook/issuance-anchor.ts
+++ b/packages/core/src/runbook/issuance-anchor.ts
@@ -1,0 +1,69 @@
+import type { CallerEvidence } from './actor-context.js';
+import {
+  type CommandTargetReader,
+  resolveCommandTarget,
+  unknownRunRefusal,
+} from './command-target-resolver.js';
+import type { RunId } from './run-id.js';
+import type { RunbookState } from './types.js';
+
+/**
+ * Outcome of resolving the run a `rd delegate` invocation acts on.
+ *
+ * Discriminated on `kind`: `ok` carries the anchored run, `unknown_run` is the
+ * `--run`-named-but-unresolvable refusal, and `none` means no run is active.
+ */
+export type IssuanceAnchorResolution =
+  | { readonly kind: 'ok'; readonly state: RunbookState }
+  | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
+  | { readonly kind: 'none' };
+
+/**
+ * Resolve the run a delegation issuance (or retry) anchors on.
+ *
+ * Precedence:
+ *   1. `--run <id>`: the named session-stack member (a missing/foreign/terminal
+ *      id refuses as `unknown_run`, carrying the same cause-specific message
+ *      pass/complete refuse with).
+ *   2. A presented bearer claim (no `--run`): the claim's controlled run,
+ *      resolved via the same `resolveCommandTarget` seam every transition
+ *      command uses (`getActiveForClaimId` -> `record.controlledRunId`). A claim
+ *      unambiguously names its run, so `delegate --claim-id A` acts on A even
+ *      when A is not the active default (#586). The divert is ADDITIVE — only a
+ *      live `claim` resolution anchors here; a stale/terminal/stashed claim falls
+ *      through to (3), where the unchanged authorization gate refuses it.
+ *   3. The active default run (`none` when absent).
+ *
+ * This is the single source of truth for delegate anchor selection: the core
+ * issuance seam resolves its target with it, and the CLI resolves the run its
+ * Category-A preconditions (`--index` FOR-step validation, the inferred-retry
+ * active-substep check) validate against. Both must agree — validating a
+ * precondition against a different run than the seam acts on rejects valid
+ * commands before the seam is reached.
+ *
+ * @param reader - Read-side session dependency used to resolve runs and claims
+ * @param targetRunId - Explicit `--run` selector; `undefined` when not supplied
+ * @param callerEvidence - Typed caller evidence; a `claim_bearer` names its run
+ * @returns The anchored run, an `unknown_run` refusal, or `none`
+ */
+export async function resolveIssuanceAnchor(
+  reader: CommandTargetReader,
+  targetRunId: RunId | undefined,
+  callerEvidence: CallerEvidence,
+): Promise<IssuanceAnchorResolution> {
+  if (targetRunId !== undefined) {
+    const member = await reader.resolveRunningStackMember(targetRunId);
+    if (member.kind !== 'running') {
+      return unknownRunRefusal(targetRunId, member);
+    }
+    return { kind: 'ok', state: member.state };
+  }
+  if (callerEvidence.kind === 'claim_bearer') {
+    const target = await resolveCommandTarget(reader, { claimId: callerEvidence.claimId });
+    if (target.kind === 'claim') {
+      return { kind: 'ok', state: target.state };
+    }
+  }
+  const active = await reader.getActive();
+  return active ? { kind: 'ok', state: active } : { kind: 'none' };
+}

--- a/packages/core/src/runbook/issuance-anchor.ts
+++ b/packages/core/src/runbook/issuance-anchor.ts
@@ -2,7 +2,8 @@ import type { CallerEvidence } from './actor-context.js';
 import type { ClaimId } from './claim-id.js';
 import {
   type CommandTargetReader,
-  resolveCommandTarget,
+  type UnknownRunRefusal,
+  resolveClaimTarget,
   unknownRunRefusal,
 } from './command-target-resolver.js';
 import type { RunId } from './run-id.js';
@@ -18,7 +19,7 @@ import type { RunbookState } from './types.js';
  */
 export type IssuanceAnchorResolution =
   | { readonly kind: 'ok'; readonly state: RunbookState }
-  | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
+  | UnknownRunRefusal
   | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string }
   | {
       readonly kind: 'terminal_claim';
@@ -51,8 +52,9 @@ export interface ResolveIssuanceAnchorOptions {
  *      id refuses as `unknown_run`, carrying the same cause-specific message
  *      pass/complete refuse with).
  *   2. A presented bearer claim (no `--run`): the claim's controlled run,
- *      resolved via the same `resolveCommandTarget` seam every transition
- *      command uses (`getActiveForClaimId` -> `record.controlledRunId`). A claim
+ *      resolved via `resolveClaimTarget` — the same claim seam every transition
+ *      command funnels through (`getActiveForClaimId` -> `record.controlledRunId`),
+ *      reached directly here for its exhaustive return type. A claim
  *      unambiguously names its run, so `delegate --claim-id A` acts on A even
  *      when A is not the active default (#586). A claim that cannot anchor is
  *      the caller's real problem, so it refuses as `stale_claim` /
@@ -85,15 +87,20 @@ export async function resolveIssuanceAnchor(
     return { kind: 'ok', state: member.state };
   }
   if (callerEvidence.kind === 'claim_bearer') {
-    const target = await resolveCommandTarget(reader, { claimId: callerEvidence.claimId });
+    // The narrow claim seam, not `resolveCommandTarget`: same resolution logic,
+    // but its three-kind union makes the `never` below a compile error if a new
+    // claim outcome is ever added — the alternative is a silent fall-through to
+    // the active default, which is the #586 defect this function exists to fix.
+    const target = await resolveClaimTarget(reader, callerEvidence.claimId, {
+      includeStashed: false,
+    });
     switch (target.kind) {
       case 'claim':
         return { kind: 'ok', state: target.state };
       // A presented claim that cannot anchor is the operator's real problem.
       // Surface the resolver's cause-specific message (already redacted to the
       // claim key) instead of discarding it and refusing against an unrelated
-      // active default — that misdirection is the #586 defect in the refusal
-      // path.
+      // active default.
       case 'stale_claim':
         return { kind: 'stale_claim', claimId: target.claimId, message: target.message };
       case 'terminal_claim':
@@ -103,11 +110,10 @@ export async function resolveIssuanceAnchor(
           lifecycle: target.lifecycle,
           message: target.message,
         };
-      default:
-        // `none` / `run` / `unknown_run` are unreachable when only `claimId` is
-        // supplied; fall through to the active default rather than asserting
-        // never (the resolver's union is shared and may grow).
-        break;
+      default: {
+        const _exhaustive: never = target;
+        return _exhaustive;
+      }
     }
   }
   const active = await reader.getActive();

--- a/packages/core/src/runbook/issuance-anchor.ts
+++ b/packages/core/src/runbook/issuance-anchor.ts
@@ -1,4 +1,5 @@
 import type { CallerEvidence } from './actor-context.js';
+import type { ClaimId } from './claim-id.js';
 import {
   type CommandTargetReader,
   resolveCommandTarget,
@@ -11,11 +12,20 @@ import type { RunbookState } from './types.js';
  * Outcome of resolving the run a `rd delegate` invocation acts on.
  *
  * Discriminated on `kind`: `ok` carries the anchored run, `unknown_run` is the
- * `--run`-named-but-unresolvable refusal, and `none` means no run is active.
+ * `--run`-named-but-unresolvable refusal, `stale_claim` / `terminal_claim` are
+ * the presented-claim refusals (each carrying the resolver's cause-specific,
+ * redacted message), and `none` means no run is active.
  */
 export type IssuanceAnchorResolution =
   | { readonly kind: 'ok'; readonly state: RunbookState }
   | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
+  | { readonly kind: 'stale_claim'; readonly claimId: ClaimId; readonly message: string }
+  | {
+      readonly kind: 'terminal_claim';
+      readonly claimId: ClaimId;
+      readonly lifecycle: 'completed' | 'stopped';
+      readonly message: string;
+    }
   | { readonly kind: 'none' };
 
 /** Options for {@link resolveIssuanceAnchor}. */
@@ -44,10 +54,11 @@ export interface ResolveIssuanceAnchorOptions {
  *      resolved via the same `resolveCommandTarget` seam every transition
  *      command uses (`getActiveForClaimId` -> `record.controlledRunId`). A claim
  *      unambiguously names its run, so `delegate --claim-id A` acts on A even
- *      when A is not the active default (#586). The divert is ADDITIVE — only a
- *      live `claim` resolution anchors here; a stale/terminal/stashed claim falls
- *      through to (3), where the unchanged authorization gate refuses it.
- *   3. The active default run (`none` when absent).
+ *      when A is not the active default (#586). A claim that cannot anchor is
+ *      the caller's real problem, so it refuses as `stale_claim` /
+ *      `terminal_claim` carrying the resolver's cause-specific message rather
+ *      than falling through to (3) and refusing against an unrelated run.
+ *   3. The active default run (`none` when absent), for non-claim evidence.
  *
  * This is the single source of truth for delegate anchor selection. The core
  * issuance seam resolves through it once, pins the selected run id, then
@@ -57,7 +68,9 @@ export interface ResolveIssuanceAnchorOptions {
  * @param options - Caller evidence and the optional explicit `--run` selector
  * @param options.callerEvidence - Typed caller evidence; a `claim_bearer` names its run
  * @param options.targetRunId - Explicit `--run` selector; `undefined` when not supplied
- * @returns The anchored run, an `unknown_run` refusal, or `none`
+ * @returns The anchored run (`ok`); an `unknown_run` refusal for an unresolvable
+ *   `--run`; a `stale_claim` / `terminal_claim` refusal carrying the claim
+ *   resolver's cause-specific message; or `none` when no run is active
  */
 export async function resolveIssuanceAnchor(
   reader: CommandTargetReader,
@@ -73,8 +86,28 @@ export async function resolveIssuanceAnchor(
   }
   if (callerEvidence.kind === 'claim_bearer') {
     const target = await resolveCommandTarget(reader, { claimId: callerEvidence.claimId });
-    if (target.kind === 'claim') {
-      return { kind: 'ok', state: target.state };
+    switch (target.kind) {
+      case 'claim':
+        return { kind: 'ok', state: target.state };
+      // A presented claim that cannot anchor is the operator's real problem.
+      // Surface the resolver's cause-specific message (already redacted to the
+      // claim key) instead of discarding it and refusing against an unrelated
+      // active default — that misdirection is the #586 defect in the refusal
+      // path.
+      case 'stale_claim':
+        return { kind: 'stale_claim', claimId: target.claimId, message: target.message };
+      case 'terminal_claim':
+        return {
+          kind: 'terminal_claim',
+          claimId: target.claimId,
+          lifecycle: target.lifecycle,
+          message: target.message,
+        };
+      default:
+        // `none` / `run` / `unknown_run` are unreachable when only `claimId` is
+        // supplied; fall through to the active default rather than asserting
+        // never (the resolver's union is shared and may grow).
+        break;
     }
   }
   const active = await reader.getActive();

--- a/packages/core/src/runbook/issuance-anchor.ts
+++ b/packages/core/src/runbook/issuance-anchor.ts
@@ -18,6 +18,21 @@ export type IssuanceAnchorResolution =
   | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
   | { readonly kind: 'none' };
 
+/** Options for {@link resolveIssuanceAnchor}. */
+export interface ResolveIssuanceAnchorOptions {
+  /**
+   * Typed caller evidence; a `claim_bearer` unambiguously names the run it
+   * controls, so it anchors issuance when no `targetRunId` is supplied.
+   */
+  readonly callerEvidence: CallerEvidence;
+  /**
+   * Explicit run id from `--run`. Outranks the presented claim's controlled run
+   * and the active default; a missing/foreign/terminal id refuses as
+   * `unknown_run`.
+   */
+  readonly targetRunId?: RunId;
+}
+
 /**
  * Resolve the run a delegation issuance (or retry) anchors on.
  *
@@ -34,23 +49,21 @@ export type IssuanceAnchorResolution =
  *      through to (3), where the unchanged authorization gate refuses it.
  *   3. The active default run (`none` when absent).
  *
- * This is the single source of truth for delegate anchor selection: the core
- * issuance seam resolves its target with it, and the CLI resolves the run its
- * Category-A preconditions (`--index` FOR-step validation, the inferred-retry
- * active-substep check) validate against. Both must agree — validating a
- * precondition against a different run than the seam acts on rejects valid
- * commands before the seam is reached.
+ * This is the single source of truth for delegate anchor selection. The core
+ * issuance seam resolves through it once, pins the selected run id, then
+ * performs state-dependent validation against the DelegationLock-scoped reread.
  *
  * @param reader - Read-side session dependency used to resolve runs and claims
- * @param targetRunId - Explicit `--run` selector; `undefined` when not supplied
- * @param callerEvidence - Typed caller evidence; a `claim_bearer` names its run
+ * @param options - Caller evidence and the optional explicit `--run` selector
+ * @param options.callerEvidence - Typed caller evidence; a `claim_bearer` names its run
+ * @param options.targetRunId - Explicit `--run` selector; `undefined` when not supplied
  * @returns The anchored run, an `unknown_run` refusal, or `none`
  */
 export async function resolveIssuanceAnchor(
   reader: CommandTargetReader,
-  targetRunId: RunId | undefined,
-  callerEvidence: CallerEvidence,
+  options: ResolveIssuanceAnchorOptions,
 ): Promise<IssuanceAnchorResolution> {
+  const { callerEvidence, targetRunId } = options;
   if (targetRunId !== undefined) {
     const member = await reader.resolveRunningStackMember(targetRunId);
     if (member.kind !== 'running') {

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -35,6 +35,7 @@ import {
 } from './command-target-resolver.js';
 import type { DELEGATION_COLLECTION_PENDING_MESSAGE } from './delegation-lifecycle-read-model.js';
 import type { ExecutionLifecycleService } from './execution-lifecycle-service.js';
+import { type IssuanceAnchorResolution, resolveIssuanceAnchor } from './issuance-anchor.js';
 import { isRunId, type RunId } from './run-id.js';
 import {
   resolveManualCompletionCursor,
@@ -197,9 +198,13 @@ export type FindDelegationByToken = (token: string) => Promise<TokenScanResult |
 /**
  * How a retry locates its target delegation.
  *
+ * The `step` / `active` locators resolve against the *anchored* run — `--run`,
+ * else the presented claim's controlled run, else the active default (see
+ * {@link resolveIssuanceAnchor}) — which is not necessarily the active run.
+ *
  * - `token` — cross-run lookup by plain-text token; the target is the owning run.
- * - `step` — the active run's `--step` (with optional FOR `iteration`).
- * - `active` — the active run's current substep cursor.
+ * - `step` — the anchored run's `--step` (with optional FOR `iteration`).
+ * - `active` — the anchored run's current substep cursor.
  */
 export type RetryLocator =
   | { readonly kind: 'token'; readonly token: string }
@@ -216,12 +221,22 @@ export type DelegationIssuanceInput =
   | {
       /** Discriminant selecting the fresh-issuance path. */
       readonly mode: 'fresh';
-      /** Typed caller evidence mapped to an actor context for the policy gate. */
+      /**
+       * Typed caller evidence mapped to an actor context for the policy gate.
+       *
+       * Also selects the target when no `--run` is named: a `claim_bearer`
+       * unambiguously names the run it controls, so issuance anchors there even
+       * when that run is not the active default (#586). See
+       * {@link resolveIssuanceAnchor} for the full precedence.
+       */
       readonly callerEvidence: CallerEvidence;
       /**
        * Explicit run id from `--run`. When present the issuance anchor is the
-       * named session-stack run instead of the active default; a missing or
-       * foreign id returns the `unknown_run` outcome.
+       * named session-stack run instead of the presented claim's controlled run
+       * or the active default — it outranks both; a missing or foreign id
+       * returns the `unknown_run` outcome. (The CLI rejects `--run` combined
+       * with `--claim-id` as `INVALID_SYNTAX`, so the two are never both set
+       * from that front end.)
        */
       readonly targetRunId?: RunId;
       /** Explicit step id from `--step`; `undefined` => bare inference. */
@@ -247,11 +262,19 @@ export type DelegationIssuanceInput =
   | {
       /** Discriminant selecting the retry path. */
       readonly mode: 'retry';
-      /** Typed caller evidence mapped to an actor context for the policy gate. */
+      /**
+       * Typed caller evidence mapped to an actor context for the policy gate.
+       *
+       * Also selects the target when no `--run` is named: a `claim_bearer`
+       * unambiguously names the run it controls, so issuance anchors there even
+       * when that run is not the active default (#586). See
+       * {@link resolveIssuanceAnchor} for the full precedence.
+       */
       readonly callerEvidence: CallerEvidence;
       /**
-       * Explicit run id from `--run`. Replaces the active-run anchor for the
-       * `step` / `active` locators; a missing or foreign id returns the
+       * Explicit run id from `--run`. Replaces the anchor for the `step` /
+       * `active` locators — outranking both the presented claim's controlled run
+       * and the active default; a missing or foreign id returns the
        * `unknown_run` outcome. The `token` locator resolves cross-run by token
        * scan, then refuses with `run_target_mismatch` when the token's owning
        * run differs from this id — named authority is never silently discarded.
@@ -842,9 +865,10 @@ export class RunbookLifecycleCommandService {
     if (input.mode === 'retry') return this.#issueRetry(input);
 
     // Target identification only — the anchor run's id (the `--run`-named
-    // session-stack member, or the active default). Every state-dependent
-    // decision below runs against the locked re-read, not this snapshot.
-    const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
+    // session-stack member, the presented claim's controlled run, or the active
+    // default). Every state-dependent decision below runs against the locked
+    // re-read, not this snapshot.
+    const anchored = await this.#resolveIssuanceAnchor(input.targetRunId, input.callerEvidence);
     if (anchored.kind !== 'ok') {
       return anchored.kind === 'unknown_run' ? anchored : { kind: 'no-active-runbook' };
     }
@@ -1077,7 +1101,7 @@ export class RunbookLifecycleCommandService {
       }
       stepLabel = snapshot.at;
     } else if (locator.kind === 'step') {
-      const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
+      const anchored = await this.#resolveIssuanceAnchor(input.targetRunId, input.callerEvidence);
       if (anchored.kind !== 'ok') {
         return anchored.kind === 'unknown_run' ? anchored : { kind: 'no-active-runbook' };
       }
@@ -1106,7 +1130,7 @@ export class RunbookLifecycleCommandService {
           ? deriveExecutionAt(stepName, parsed?.substep, locator.iteration)
           : locator.step;
     } else {
-      const anchored = await this.#resolveIssuanceAnchor(input.targetRunId);
+      const anchored = await this.#resolveIssuanceAnchor(input.targetRunId, input.callerEvidence);
       if (anchored.kind === 'unknown_run') return anchored;
       if (anchored.kind === 'none') return { kind: 'no-active-runbook' };
       const active = anchored.state;
@@ -1931,27 +1955,17 @@ export class RunbookLifecycleCommandService {
     };
   }
 
-  // Resolve the issuance anchor run: the `--run`-named session-stack member
-  // when a target run id is supplied (a missing/foreign/terminal id refuses as
-  // `unknown_run` via the shared stack-member resolution, carrying the same
-  // cause-specific message pass/complete refuse with), else the active default
-  // run (`none` when absent).
+  // Resolve the issuance anchor run via the shared `resolveIssuanceAnchor` seam
+  // (`--run` > presented claim's controlled run > active default). The CLI
+  // resolves its Category-A preconditions (`--index` FOR-step validation, the
+  // inferred-retry active-substep check) through the SAME function, so a
+  // precondition can never be validated against a different run than the one
+  // this seam acts on (#586).
   async #resolveIssuanceAnchor(
     targetRunId: RunId | undefined,
-  ): Promise<
-    | { readonly kind: 'ok'; readonly state: RunbookState }
-    | { readonly kind: 'unknown_run'; readonly runId: RunId; readonly message: string }
-    | { readonly kind: 'none' }
-  > {
-    if (targetRunId !== undefined) {
-      const member = await this.#deps.sessionService.resolveRunningStackMember(targetRunId);
-      if (member.kind !== 'running') {
-        return unknownRunRefusal(targetRunId, member);
-      }
-      return { kind: 'ok', state: member.state };
-    }
-    const active = await this.#deps.sessionService.getActive();
-    return active ? { kind: 'ok', state: active } : { kind: 'none' };
+    callerEvidence: CallerEvidence,
+  ): Promise<IssuanceAnchorResolution> {
+    return resolveIssuanceAnchor(this.#deps.sessionService, targetRunId, callerEvidence);
   }
 
   // Classify a resolution as either ready (carries the resolved run) or a typed

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -358,6 +358,33 @@ export type DelegationIssuanceOutcome =
       /** Operator-facing refusal message. */
       readonly message: string;
     }
+  | {
+      /**
+       * Refusal: the presented bearer claim cannot anchor issuance because it is
+       * missing, invalid for this session, stashed, or points at missing child
+       * state. Carries the resolver's cause-specific message, already redacted
+       * to the claim key.
+       */
+      readonly kind: 'stale_claim';
+      /** Bearer claim id presented by the caller. */
+      readonly claimId: ClaimId;
+      /** Operator-facing refusal message from the shared claim resolution. */
+      readonly message: string;
+    }
+  | {
+      /**
+       * Refusal: the presented bearer claim points at a terminal child runbook.
+       * Unlike pass/fail there is no confirm/conflict split — delegate has no
+       * expected result to reconcile a lifecycle against.
+       */
+      readonly kind: 'terminal_claim';
+      /** Bearer claim id presented by the caller. */
+      readonly claimId: ClaimId;
+      /** Terminal lifecycle of the claim's controlled run. */
+      readonly lifecycle: 'completed' | 'stopped';
+      /** Operator-facing refusal message from the shared claim resolution. */
+      readonly message: string;
+    }
   | { readonly kind: 'invalid_index'; readonly message: string }
   | { readonly kind: 'retry_target_required' }
   | { readonly kind: 'refused'; readonly policy: DelegationPolicyOutcome }
@@ -902,7 +929,18 @@ export class RunbookLifecycleCommandService {
     // re-read, not this snapshot.
     const anchored = await this.#resolveIssuanceAnchor(input);
     if (anchored.kind !== 'ok') {
-      return anchored.kind === 'unknown_run' ? anchored : { kind: 'no-active-runbook' };
+      switch (anchored.kind) {
+        case 'unknown_run':
+        case 'stale_claim':
+        case 'terminal_claim':
+          return anchored;
+        case 'none':
+          return { kind: 'no-active-runbook' };
+        default: {
+          const _exhaustive: never = anchored;
+          return _exhaustive;
+        }
+      }
     }
     const active = anchored.state;
     const activeId = active.id;
@@ -1148,10 +1186,20 @@ export class RunbookLifecycleCommandService {
     } else {
       const anchored = await this.#resolveIssuanceAnchor(input);
       if (anchored.kind !== 'ok') {
-        if (anchored.kind === 'unknown_run') return anchored;
-        return locator.kind === 'active'
-          ? { kind: 'retry_target_required' }
-          : { kind: 'no-active-runbook' };
+        switch (anchored.kind) {
+          case 'unknown_run':
+          case 'stale_claim':
+          case 'terminal_claim':
+            return anchored;
+          case 'none':
+            return locator.kind === 'active'
+              ? { kind: 'retry_target_required' }
+              : { kind: 'no-active-runbook' };
+          default: {
+            const _exhaustive: never = anchored;
+            return _exhaustive;
+          }
+        }
       }
       // Target identification only. Every state-dependent locator decision is
       // deferred until after this run's DelegationLock is held and its state is

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -35,7 +35,11 @@ import {
 } from './command-target-resolver.js';
 import type { DELEGATION_COLLECTION_PENDING_MESSAGE } from './delegation-lifecycle-read-model.js';
 import type { ExecutionLifecycleService } from './execution-lifecycle-service.js';
-import { type IssuanceAnchorResolution, resolveIssuanceAnchor } from './issuance-anchor.js';
+import {
+  type IssuanceAnchorResolution,
+  type ResolveIssuanceAnchorOptions,
+  resolveIssuanceAnchor,
+} from './issuance-anchor.js';
 import { isRunId, type RunId } from './run-id.js';
 import {
   resolveManualCompletionCursor,
@@ -211,6 +215,14 @@ export type RetryLocator =
   | { readonly kind: 'step'; readonly step: string; readonly iteration?: number }
   | { readonly kind: 'active' };
 
+/** Raw explicit fresh-issuance target parsed by a frontend. */
+export interface ExplicitDelegationTarget {
+  /** Qualified step id, for example `1.1`. */
+  readonly stepId: string;
+  /** Numeric FOR iteration selected by `--index`, when supplied. */
+  readonly iteration?: number;
+}
+
 /**
  * Input to {@link RunbookLifecycleCommandService.issueDelegation}.
  *
@@ -239,10 +251,8 @@ export type DelegationIssuanceInput =
        * from that front end.)
        */
       readonly targetRunId?: RunId;
-      /** Explicit step id from `--step`; `undefined` => bare inference. */
-      readonly explicitStep?: string;
-      /** Explicit FOR iteration from `--index`. */
-      readonly explicitIteration?: number;
+      /** Raw explicit `--step` / `--index` target; absent for bare inference. */
+      readonly explicitTarget?: ExplicitDelegationTarget;
       /** Raw positional runbook arg (RD-822 confirmation); `undefined` when absent. */
       readonly requestedRunbook?: string;
       /**
@@ -348,6 +358,8 @@ export type DelegationIssuanceOutcome =
       /** Operator-facing refusal message. */
       readonly message: string;
     }
+  | { readonly kind: 'invalid_index'; readonly message: string }
+  | { readonly kind: 'retry_target_required' }
   | { readonly kind: 'refused'; readonly policy: DelegationPolicyOutcome }
   | { readonly kind: 'error'; readonly error: RundownError };
 
@@ -755,6 +767,26 @@ function withFrameIteration(stepId: string, iteration: number | undefined): stri
 }
 
 /**
+ * Return the existing CLI-compatible refusal message when an explicit
+ * iteration targets an authored non-FOR step. Missing steps deliberately pass
+ * through so the delegation resolver retains ownership of RD-801.
+ *
+ * @param steps - Parsed steps from the locked runbook reread.
+ * @param stepId - Raw qualified target from the frontend.
+ * @returns The refusal message, or `undefined` when validation should continue.
+ */
+function invalidDelegationIndexMessage(
+  steps: readonly ResolvedStep[],
+  stepId: string,
+): string | undefined {
+  const parsed = parseStepIdFromString(stepId);
+  if (!parsed) return undefined;
+  const target = steps.find((step) => step.name === parsed.step);
+  if (!target || target.kind === 'for' || target.kind === 'prompted-for') return undefined;
+  return `--index requires step "${parsed.step}" to be a FOR step, but it is "${target.kind}"`;
+}
+
+/**
  * Map a terminal command to its machine FORCE event. Exhaustive over
  * {@link TerminalCommandName} with a `never` fallthrough so a future terminal
  * command cannot silently collapse to `FORCE_STOP` (No silent mapping).
@@ -868,7 +900,7 @@ export class RunbookLifecycleCommandService {
     // session-stack member, the presented claim's controlled run, or the active
     // default). Every state-dependent decision below runs against the locked
     // re-read, not this snapshot.
-    const anchored = await this.#resolveIssuanceAnchor(input.targetRunId, input.callerEvidence);
+    const anchored = await this.#resolveIssuanceAnchor(input);
     if (anchored.kind !== 'ok') {
       return anchored.kind === 'unknown_run' ? anchored : { kind: 'no-active-runbook' };
     }
@@ -905,6 +937,7 @@ export class RunbookLifecycleCommandService {
     // the parsed document (clause a/f static signals) as its input.
     const steps = await this.#deps.loadSteps(state);
 
+    const explicitTarget = input.explicitTarget;
     // Policy gate — `targeted` means the operator named a specific step target
     // (an explicit `--step`). Only that exempts issuance from the bare-advance
     // collection-pending guard. A positional runbook arg is NOT a target: it
@@ -913,7 +946,7 @@ export class RunbookLifecycleCommandService {
     // mirrors the pre-seam precheck, which keyed solely on `--step` absence.
     // Classification is from the locked re-read (`state`) — the same instance
     // the issuance resolution below decides from.
-    const targeted = input.explicitStep !== undefined;
+    const targeted = explicitTarget !== undefined;
     const authority = await this.#resolveMutationActorContext({
       callerEvidence: input.callerEvidence,
       targetState: state,
@@ -931,12 +964,20 @@ export class RunbookLifecycleCommandService {
     });
     if (policy.kind !== 'allowed') return { kind: 'refused', policy };
 
+    // Validate authored target details only after authorization succeeds. This
+    // still uses the locked document, while avoiding disclosure of a named
+    // step's kind to callers that cannot issue from this run.
+    if (explicitTarget?.iteration !== undefined) {
+      const message = invalidDelegationIndexMessage(steps, explicitTarget.stepId);
+      if (message) return { kind: 'invalid_index', message };
+    }
+
     // Frame key: an explicit --index scopes to a FOR iteration of the active
-    // step; otherwise reuse the active frame. `--index` is pre-validated
-    // (Category A) by the frontend, so the seam trusts `explicitIteration`.
+    // step; otherwise reuse the active frame. The step kind was validated above
+    // against this same locked state/steps pair.
     const frameKey =
-      input.explicitIteration !== undefined
-        ? buildFrameKey(state.step, input.explicitIteration)
+      explicitTarget?.iteration !== undefined
+        ? buildFrameKey(state.step, explicitTarget.iteration)
         : (state.activeFrameKey ?? deriveActiveFrame(state).frameKey);
 
     // Unified issuance resolution: one pure resolver owns explicit-step
@@ -945,7 +986,7 @@ export class RunbookLifecycleCommandService {
     // positional). Computed before resolving the authored child so an echo
     // never depends on authored resolvability.
     const resolution = resolveDelegationIssuance(state, steps, frameKey, {
-      ...(input.explicitStep !== undefined ? { explicitStep: input.explicitStep } : {}),
+      ...(explicitTarget !== undefined ? { explicitStep: explicitTarget.stepId } : {}),
       requested,
     });
     switch (resolution.kind) {
@@ -1005,7 +1046,7 @@ export class RunbookLifecycleCommandService {
     // the live FOR iteration in the context snapshot even though the frame key
     // scopes the entry to the requested iteration. Pass the iteration-qualified
     // id so the snapshot `index`/`at` match the frame the entry is stored under.
-    const createStepId = withFrameIteration(resolvedStepId, input.explicitIteration);
+    const createStepId = withFrameIteration(resolvedStepId, explicitTarget?.iteration);
 
     const result = createDelegation(
       {
@@ -1048,9 +1089,10 @@ export class RunbookLifecycleCommandService {
    * Locator resolution mirrors the pre-migration CLI:
    * - `token` resolves cross-run to the owning parent (not the active run);
    *   an unknown token returns `token-not-found`.
-   * - `step` / `active` resolve against the active run; a missing active run (or,
-   *   for `active`, a missing substep cursor) returns `no-active-runbook` — the
-   *   CLI renders the form-specific message.
+   * - `step` / `active` resolve the anchor run id before locking, then derive
+   *   their frame/cursor from the locked reread. Missing step-run state returns
+   *   `no-active-runbook`; a missing inferred cursor returns
+   *   `retry_target_required` for the CLI's form-specific envelope.
    *
    * Unlike fresh issuance, the policy gate runs as `targeted: true`, so a pending
    * collection never refuses a retry (closing the retry policy hole for untrusted
@@ -1064,10 +1106,14 @@ export class RunbookLifecycleCommandService {
   ): Promise<DelegationIssuanceOutcome> {
     const { locator } = input;
 
-    let targetState: RunbookState;
-    let substepId: string;
-    let frameKey: FrameKey;
-    let stepLabel: string;
+    type RetryCursor = {
+      readonly substepId: string;
+      readonly frameKey: FrameKey;
+      readonly stepLabel: string;
+    };
+
+    let targetRunId: RunId;
+    let cursor: RetryCursor | undefined;
 
     if (locator.kind === 'token') {
       const scan = await this.#deps.findDelegationByToken(locator.token);
@@ -1083,9 +1129,8 @@ export class RunbookLifecycleCommandService {
           message: `Run ${input.targetRunId} does not own the supplied delegation token.`,
         };
       }
-      targetState = scan.parentState;
-      substepId = scan.substepId ?? scan.stepId;
-      frameKey = scan.frameKey;
+      targetRunId = scan.parentState.id;
+      const substepId = scan.substepId ?? scan.stepId;
       // The canonical contextSnapshot.at surfaces FOR-iteration retries as e.g.
       // "1.2.1". `buildContextSnapshot` derives `at` unconditionally, so a
       // persisted snapshot always carries it; its absence means the snapshot is
@@ -1099,75 +1144,81 @@ export class RunbookLifecycleCommandService {
           error: Errors.delegationSnapshotStale(substepId, scan.stepId),
         };
       }
-      stepLabel = snapshot.at;
-    } else if (locator.kind === 'step') {
-      const anchored = await this.#resolveIssuanceAnchor(input.targetRunId, input.callerEvidence);
+      cursor = { substepId, frameKey: scan.frameKey, stepLabel: snapshot.at };
+    } else {
+      const anchored = await this.#resolveIssuanceAnchor(input);
       if (anchored.kind !== 'ok') {
-        return anchored.kind === 'unknown_run' ? anchored : { kind: 'no-active-runbook' };
+        if (anchored.kind === 'unknown_run') return anchored;
+        return locator.kind === 'active'
+          ? { kind: 'retry_target_required' }
+          : { kind: 'no-active-runbook' };
       }
-      const active = anchored.state;
-      targetState = active;
+      // Target identification only. Every state-dependent locator decision is
+      // deferred until after this run's DelegationLock is held and its state is
+      // reloaded.
+      targetRunId = anchored.state.id;
+    }
+
+    // DelegationLock-scoped read-modify-write (#508): the target run id above
+    // selects the mutex; locator validation/derivation, gate, retry, and persist
+    // all use the authoritative state reread while it is held.
+    const lock = await this.#acquireDelegationLock(targetRunId);
+    if (lock.kind === 'timeout') {
+      return { kind: 'error', error: Errors.delegationLockTimeout(targetRunId) };
+    }
+    await using _guard = lock.scope;
+
+    const freshState = await this.#deps.loadRun(targetRunId);
+    if (!freshState) {
+      if (locator.kind === 'token') return { kind: 'token-not-found', token: locator.token };
+      return locator.kind === 'active'
+        ? { kind: 'retry_target_required' }
+        : { kind: 'no-active-runbook' };
+    }
+
+    // Steps are loaded before locator validation and policy: both decisions use
+    // the same locked state/document pair.
+    const steps = await this.#deps.loadSteps(freshState);
+
+    if (locator.kind === 'step') {
       const parsed = parseStepIdFromString(locator.step);
       const stepName = parsed?.step ?? locator.step;
-      substepId = parsed?.substep ?? stepName;
+      const substepId = parsed?.substep ?? stepName;
+      let frameKey: FrameKey;
       if (locator.iteration !== undefined) {
         frameKey = buildFrameKey(stepName, locator.iteration);
       } else {
         // No explicit iteration: reuse the active frame when it is on the
         // requested step, else fall back to the step's base frame (matching how
         // createDelegation scopes lookup for a step-form caller).
-        const activeDerived = deriveActiveFrame(active);
+        const activeDerived = deriveActiveFrame(freshState);
         frameKey =
           activeDerived.step === stepName
-            ? (active.activeFrameKey ?? activeDerived.frameKey)
+            ? (freshState.activeFrameKey ?? activeDerived.frameKey)
             : buildFrameKey(stepName);
       }
       // Canonicalize the label to the resolved frame: an explicit `--index`
       // surfaces as e.g. "1.2.1" (matching the token/active retry forms), not the
       // bare "1.1" that drops the iteration.
-      stepLabel =
+      const stepLabel =
         locator.iteration !== undefined
           ? deriveExecutionAt(stepName, parsed?.substep, locator.iteration)
           : locator.step;
-    } else {
-      const anchored = await this.#resolveIssuanceAnchor(input.targetRunId, input.callerEvidence);
-      if (anchored.kind === 'unknown_run') return anchored;
-      if (anchored.kind === 'none') return { kind: 'no-active-runbook' };
-      const active = anchored.state;
-      if (active.substep === undefined) return { kind: 'no-active-runbook' };
-      targetState = active;
-      substepId = active.substep;
+      cursor = { substepId, frameKey, stepLabel };
+    } else if (locator.kind === 'active') {
+      if (freshState.substep === undefined) return { kind: 'retry_target_required' };
       // Surface the same canonical location used by token/step retries: an
       // active FOR iteration renders as e.g. "1.2.1", not just "1.1".
-      const activeDerived = deriveActiveFrame(active);
-      frameKey = active.activeFrameKey ?? activeDerived.frameKey;
-      stepLabel = deriveExecutionAt(active.step, active.substep, activeDerived.iteration);
+      const activeDerived = deriveActiveFrame(freshState);
+      cursor = {
+        substepId: freshState.substep,
+        frameKey: freshState.activeFrameKey ?? activeDerived.frameKey,
+        stepLabel: deriveExecutionAt(freshState.step, freshState.substep, activeDerived.iteration),
+      };
     }
 
-    // DelegationLock-scoped read-modify-write (#508): the locator work above is
-    // read-only identification; the decisive read → retryDelegation → persist
-    // sequence runs in one critical section so a concurrent delegate/claim
-    // cannot interleave between the state read and the re-mint.
-    const lock = await this.#acquireDelegationLock(targetState.id);
-    if (lock.kind === 'timeout') {
-      return { kind: 'error', error: Errors.delegationLockTimeout(targetState.id) };
-    }
-    await using _guard = lock.scope;
-
-    // Locked re-read: the authoritative state for the gate and the retry.
-    // retryDelegation re-locates the delegation from this fresh state itself
-    // (its not_found/in_flight variants cover a delegation that vanished or got
-    // claimed in the gap), so no extra re-validation is needed here.
-    const freshState = await this.#deps.loadRun(targetState.id);
-    if (!freshState) {
-      return locator.kind === 'token'
-        ? { kind: 'token-not-found', token: locator.token }
-        : { kind: 'no-active-runbook' };
-    }
-
-    // Steps are loaded ABOVE the policy gate: direct_cli classification needs
-    // the parsed document (clause a/f static signals) as its input.
-    const steps = await this.#deps.loadSteps(freshState);
+    if (!cursor) throw new Error('Retry locator did not resolve a cursor');
+    const { substepId, frameKey, stepLabel } = cursor;
 
     // Policy gate — `targeted: true` (a retry re-issues a specific delegation),
     // so a pending collection does not refuse it. Classification is from the
@@ -1194,6 +1245,13 @@ export class RunbookLifecycleCommandService {
       targetState: freshState,
     });
     if (policy.kind !== 'allowed') return { kind: 'refused', policy };
+
+    // As on the fresh path, authorization precedes authored-step validation so
+    // an unauthorized retry cannot probe whether a named step is iterable.
+    if (locator.kind === 'step' && locator.iteration !== undefined) {
+      const message = invalidDelegationIndexMessage(steps, locator.step);
+      if (message) return { kind: 'invalid_index', message };
+    }
 
     // Resolve overrides only now — after the locator resolved and the gate
     // passed — so a bad `--input-file` (or other extra-var failure) cannot mask
@@ -1224,7 +1282,7 @@ export class RunbookLifecycleCommandService {
     // propagated createDelegation error), so the dispatch collapses to one arm.
     if (result.status !== 'retried') return { kind: 'error', error: result.error };
 
-    await this.#supersedePendingOutcome(targetState.id, frameKey, substepId);
+    await this.#supersedePendingOutcome(freshState.id, frameKey, substepId);
     if (linkedChildRunId && allowLinkedChildRun) {
       await this.#deps.sessionService.releaseRunbook(linkedChildRunId);
     }
@@ -1956,16 +2014,17 @@ export class RunbookLifecycleCommandService {
   }
 
   // Resolve the issuance anchor run via the shared `resolveIssuanceAnchor` seam
-  // (`--run` > presented claim's controlled run > active default). The CLI
-  // resolves its Category-A preconditions (`--index` FOR-step validation, the
-  // inferred-retry active-substep check) through the SAME function, so a
-  // precondition can never be validated against a different run than the one
-  // this seam acts on (#586).
+  // (`--run` > presented claim's controlled run > active default). Frontends
+  // pass only raw target syntax; this seam pins the resolved id and owns every
+  // state-dependent precondition against the locked reread.
+  // Takes the issuance `input` directly: both `DelegationIssuanceInput` variants
+  // already carry the anchor fields (`callerEvidence` + optional `targetRunId`),
+  // so it satisfies `ResolveIssuanceAnchorOptions` structurally and no call site
+  // has to pull those fields apart to call it.
   async #resolveIssuanceAnchor(
-    targetRunId: RunId | undefined,
-    callerEvidence: CallerEvidence,
+    options: ResolveIssuanceAnchorOptions,
   ): Promise<IssuanceAnchorResolution> {
-    return resolveIssuanceAnchor(this.#deps.sessionService, targetRunId, callerEvidence);
+    return resolveIssuanceAnchor(this.#deps.sessionService, options);
   }
 
   // Classify a resolution as either ready (carries the resolved run) or a typed

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -32,6 +32,7 @@ import {
   type TerminalCommandName,
   type TransitionCommandName,
   type TransitionTargetResolution,
+  type UnknownRunRefusal,
 } from './command-target-resolver.js';
 import type { DELEGATION_COLLECTION_PENDING_MESSAGE } from './delegation-lifecycle-read-model.js';
 import type { ExecutionLifecycleService } from './execution-lifecycle-service.js';
@@ -337,14 +338,7 @@ export type DelegationIssuanceOutcome =
     }
   | { readonly kind: 'token-not-found'; readonly token: string }
   | { readonly kind: 'no-active-runbook' }
-  | {
-      /** The explicit `--run` target is not a running member of the session stack. */
-      readonly kind: 'unknown_run';
-      /** Run id named by the caller. */
-      readonly runId: RunId;
-      /** Operator-facing refusal message from the shared stack-member resolution. */
-      readonly message: string;
-    }
+  | UnknownRunRefusal
   | {
       /**
        * Refusal: the retry token's owning run differs from the explicit `--run`
@@ -490,14 +484,7 @@ export type LifecycleTransitionOutcome =
     }
   | { readonly kind: 'actor_context_required' }
   | { readonly kind: 'claim_grant_required'; readonly claimId: ClaimId; readonly runId: RunId }
-  | {
-      /** The explicit `--run` target is not a running member of the session stack. */
-      readonly kind: 'unknown_run';
-      /** Run id named by the caller. */
-      readonly runId: RunId;
-      /** Operator-facing refusal message from the resolver. */
-      readonly message: string;
-    }
+  | UnknownRunRefusal
   | {
       readonly kind: 'applied';
       /** Run the transition was applied to. */
@@ -592,14 +579,7 @@ export type LifecycleTerminalOutcome =
   | { readonly kind: 'actor_context_required' }
   /** The targeted claim proved possession but lacks the grant required for this terminal mutation. */
   | { readonly kind: 'claim_grant_required'; readonly claimId: ClaimId; readonly runId: RunId }
-  | {
-      /** The explicit `--run` target is not a running member of the session stack. */
-      readonly kind: 'unknown_run';
-      /** Run id named by the caller. */
-      readonly runId: RunId;
-      /** Operator-facing refusal message from the resolver. */
-      readonly message: string;
-    }
+  | UnknownRunRefusal
   | {
       /** Refused: the resolved root has reported-but-uncollected delegation outcomes. */
       readonly kind: 'delegation_collection_pending';
@@ -696,14 +676,7 @@ export type LifecycleNavigationOutcome =
       readonly lifecycle: 'completed' | 'stopped';
       readonly message: string;
     }
-  | {
-      /** The explicit `--run` target is not a running member of the session stack. */
-      readonly kind: 'unknown_run';
-      /** Run id named by the caller. */
-      readonly runId: RunId;
-      /** Operator-facing refusal message from the resolver. */
-      readonly message: string;
-    }
+  | UnknownRunRefusal
   /**
    * The run-navigation policy gate refused the caller's evidence. Carries no
    * run id (accident barrier — see the resolver member's rationale).

--- a/packages/core/src/runbook/lifecycle-command-service.ts
+++ b/packages/core/src/runbook/lifecycle-command-service.ts
@@ -940,6 +940,19 @@ export class RunbookLifecycleCommandService {
     }
     await using _guard = lock.scope;
 
+    // Anchor resolution happened before the DelegationLock was acquired. A
+    // session mutation can stash or unlink the claim's controlled run in that
+    // window without taking this lock, so bearer/grant verification alone is
+    // insufficient here. Re-run the claim resolver before reading or mutating
+    // the anchored run.
+    //
+    // This NARROWS the window; it does not close it. `stashRunbook` serialises
+    // on SessionLock, not on this DelegationLock, so the two never mutually
+    // exclude — a stash can still land between this check and the write below.
+    // Closing it needs an atomic resolve-and-commit under SessionLock (#608).
+    const claimRefusal = await this.#revalidatePresentedClaim(input.callerEvidence);
+    if (claimRefusal) return claimRefusal;
+
     // Locked re-read: the authoritative state for every decision below.
     const state = await this.#deps.loadRun(activeId);
     if (!state) return { kind: 'no-active-runbook' };
@@ -1188,6 +1201,13 @@ export class RunbookLifecycleCommandService {
       return { kind: 'error', error: Errors.delegationLockTimeout(targetRunId) };
     }
     await using _guard = lock.scope;
+
+    // As on fresh issuance, the target may have become stashed or otherwise
+    // unlinked after pre-lock anchor/token resolution. Revalidate the presented
+    // claim's runnable relationship before the retry decision can mutate it.
+    // Narrows the same window the fresh path documents above; #608 closes it.
+    const claimRefusal = await this.#revalidatePresentedClaim(input.callerEvidence);
+    if (claimRefusal) return claimRefusal;
 
     const freshState = await this.#deps.loadRun(targetRunId);
     if (!freshState) {
@@ -2046,6 +2066,41 @@ export class RunbookLifecycleCommandService {
     options: ResolveIssuanceAnchorOptions,
   ): Promise<IssuanceAnchorResolution> {
     return resolveIssuanceAnchor(this.#deps.sessionService, options);
+  }
+
+  // Re-run the presented bearer's claim-target resolution without an explicit
+  // run selector. This deliberately checks the claim's own controlled-run
+  // relationship even for token retry (whose target id comes from the token):
+  // `verifyClaimId` proves only bearer authenticity, while this resolver also
+  // enforces stashed/linkage/terminal eligibility.
+  //
+  // Best-effort by construction: it reads session state that SessionLock — not
+  // the caller's DelegationLock — guards, so it cannot be atomic with the write
+  // that follows. It catches the (realistic) case where the mutation already
+  // committed, not a concurrent one racing it. See #608.
+  async #revalidatePresentedClaim(
+    callerEvidence: CallerEvidence,
+  ): Promise<
+    | Extract<IssuanceAnchorResolution, { readonly kind: 'stale_claim' | 'terminal_claim' }>
+    | undefined
+  > {
+    if (callerEvidence.kind !== 'claim_bearer') return undefined;
+
+    const resolution = await this.#resolveIssuanceAnchor({ callerEvidence });
+    switch (resolution.kind) {
+      case 'ok':
+        return undefined;
+      case 'stale_claim':
+      case 'terminal_claim':
+        return resolution;
+      case 'none':
+      case 'unknown_run':
+        throw new Error(`Claim-only issuance revalidation returned ${resolution.kind}`);
+      default: {
+        const _exhaustive: never = resolution;
+        return _exhaustive;
+      }
+    }
   }
 
   // Classify a resolution as either ready (carries the resolved run) or a typed


### PR DESCRIPTION
Closes #586

## What

`rundown delegate --claim-id <A>` discarded the claim's own diagnosis and refused with an error about a run the operator never named. The anchor resolved the presented bearer claim, kept only the live `claim` case, and let the other five statuses fall through to the active default — whichever authorization gate happened to fire then produced the message.

Reproduced against the real CLI before the fix:

| Invocation | `pass --claim-id X` | `delegate --step 1.1 --claim-id X` |
| --- | --- | --- |
| X is **stashed**, another run is active | `CLAIMED_RUNBOOK_UNAVAILABLE` — *"is currently stashed. Run `rundown pop`…"* | `CLAIM_GRANT_REQUIRED` — *"not authorized … for this target"*, where "this target" is a run the operator never named |
| X **does not exist**, a run is active | `CLAIMED_RUNBOOK_UNAVAILABLE` — *"Claim id `<key>` does not exist."* | `ACTOR_CONTEXT_REQUIRED` — *"Pass `--claim-id <claimId>`"*, which they just did |

The pre-fix code is arbitrary — it depends on *why* the claim failed, not on the claim at all.

## How

- **Anchor** (`issuance-anchor.ts`) — the `claim_bearer` branch is now total, returning the resolver's cause-specific, already-redacted message as `stale_claim` / `terminal_claim`.
- **Seam** (`lifecycle-command-service.ts`) — both variants propagate through `DelegationIssuanceOutcome` at each anchor call site, mirroring how `unknown_run` already flows.
- **CLI** (`delegate.ts`) — rendered via the existing `renderStaleClaimRefusal`. No new renderer, no new error code.

## Behaviour change

`delegate --claim-id <stale|stashed|terminal>` moves from an arbitrary gate refusal (`CLAIM_GRANT_REQUIRED` or `ACTOR_CONTEXT_REQUIRED`, both exit 1) to `CLAIMED_RUNBOOK_UNAVAILABLE` (exit 1). Exit code unchanged; the envelope **converges** with what `pass`/`fail` already emit for the same input. Blast radius is exactly the broken case: `--run` outranks the claim, and non-claim evidence skips the branch entirely.

## Design decisions

- **No new error code.** `CLAIMED_RUNBOOK_UNAVAILABLE` via the existing renderer — convergence with `pass`/`fail`, not divergence.
- **Terminal claims get a plain refusal**, not `pass`/`fail`'s confirm/conflict split: delegate has no expected result to reconcile a lifecycle against. Importing that split would mean inventing one.
- **`stale_claim` and `terminal_claim` stay distinct at the seam** even though the CLI renders them identically today; collapsing them is lossy for a presentation convenience, and #519 will plausibly want them apart.

## Beyond the original scope

- **TOCTOU fix** (`5db3d327c`) — anchor resolution runs *before* the DelegationLock; stashing doesn't take that lock, so a concurrent stash between resolution and acquisition left issuance mutating an ineligible run. The presented claim is now revalidated inside the lock on both fresh and retry paths. Found and written by a concurrent review session.
- **Type refactor** (`5fbde1c28`) — the `unknown_run` shape was independently re-declared in **nine** places; it is now one exported `UnknownRunRefusal`, colocated with `unknownRunRefusal`, the function already acting as the single source of truth for its messages. The anchor now resolves through the narrow `resolveClaimTarget` instead of `resolveCommandTarget`: same logic, but the three-kind union makes the switch exhaustive. Adding a hypothetical new claim kind (as #519 would) is now a compile error at `issuance-anchor.ts` rather than a silent fall-through that would quietly reinstate this very bug.

## Notes for review

- `4e157e57a` ("anchor delegation issuance under lock", #508) was authored by a **concurrent session**, not this workstream. It also swept in this branch's `resolveIssuanceAnchor` signature refactor — nothing was lost, but it is a mixed commit.
- One pre-existing CLI test legitimately flipped: it was titled "renders CLAIM_GRANT_REQUIRED when a child claim tries to issue a parent delegation", but invoked bare `delegate --claim-id` on a claim just driven terminal — exactly the case this PR fixes. It now asserts the terminal-claim refusal. Delegate's grant-gate coverage survives at `delegate.test.ts:1661` plus the renderer unit tests.
- Discharges one of the two remaining code leaves in cluster #565 (R4 Capability Tier). **#519** (parent-side abandoned/idle claim detection) and the **#574** design umbrella remain open, so **#565 stays open**.

## Verification

- `pnpm run verify` — exit 0 (9,012 tests).
- Mutation gate on `issuance-anchor.ts` — 94.29% (threshold 70). The sole survivor is a verified equivalent mutant (`callerEvidence.kind === 'claim_bearer'` → `true`): with `claimId` undefined the resolver never returns `claim`, so the return value is identical.
- Each of the six commits typechecks independently.

## Follow-ups not in scope

- **Precedence inversion**: `resolveCommandTarget` tries `claimId` before `runId`; `resolveIssuanceAnchor` tries `targetRunId` first. Unreachable today (the CLI rejects `--run` + `--claim-id` as `INVALID_SYNTAX`) but latent for MCP/plugin front ends.
- **Claim-key existence oracle**: `missing` → "does not exist" vs `invalid-secret` → "is not valid for this session" are distinguishable across all claim-bearing commands. Pre-existing; messages use the redacted claim key, never the bearer secret. A cross-command decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delegate claims now anchor to the claimed run instead of an unrelated active run.
  * Refusals for stale, stashed, missing, or completed claims now show the specific reason.
  * Foreign run targets now return clear “run unavailable” errors instead of invalid-index errors.
  * Retry and delegation targeting now provide more accurate validation and error messages.
* **Tests**
  * Added comprehensive regression coverage for claim anchoring, refusal handling, retry targeting, and concurrency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->