### PR TITLE
chore: add build-link script for local CLI dev install

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "worktree": "bash scripts/worktree.sh",
     "build": "pnpm --filter @rundown-org/parser build && pnpm --filter @rundown-org/core build && pnpm --filter @rundown-org/cli build && pnpm --filter @rundown-org/mcp build && pnpm --filter @rundown-org/claude-code-plugin build",
+    "build-link": "bash scripts/build-link.sh",
     "build:site": "pnpm --filter site build",
     "build:all": "pnpm run build && pnpm --filter site build",
     "test": "pnpm run test:unit",

--- a/scripts/build-link.sh
+++ b/scripts/build-link.sh
@@ -27,9 +27,15 @@ CLI_ENTRY="$ROOT_DIR/packages/cli/dist/cli.js"
 BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
 
 SKIP_BUILD=false
-if [ "${1:-}" = "--no-build" ]; then
-  SKIP_BUILD=true
-fi
+for arg in "$@"; do
+  case "$arg" in
+    --no-build) SKIP_BUILD=true ;;
+    *)
+      echo "[build-link] ERROR: unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
 
 if [ "$SKIP_BUILD" = false ]; then
   echo "[build-link] Building workspace..."
@@ -38,18 +44,32 @@ else
   echo "[build-link] Skipping build (--no-build)"
 fi
 
-if [ ! -f "$CLI_ENTRY" ]; then
-  echo "[build-link] ERROR: CLI build output not found at $CLI_ENTRY (run without --no-build)" >&2
+if [ ! -f "$CLI_ENTRY" ] || [ ! -x "$CLI_ENTRY" ]; then
+  echo "[build-link] ERROR: CLI build output is missing or not executable at $CLI_ENTRY (run without --no-build)" >&2
   exit 1
 fi
 
 mkdir -p "$BIN_DIR"
 for name in rundown rd; do
-  ln -sf "$CLI_ENTRY" "$BIN_DIR/$name"
-  echo "[build-link] Linked $BIN_DIR/$name -> $CLI_ENTRY"
+  link="$BIN_DIR/$name"
+  if [ -d "$link" ] && [ ! -L "$link" ]; then
+    echo "[build-link] ERROR: refusing to replace directory $link" >&2
+    exit 1
+  fi
+  rm -f "$link"
+  ln -s "$CLI_ENTRY" "$link"
+  echo "[build-link] Linked $link -> $CLI_ENTRY"
 done
 
-if ! printf '%s' ":$PATH:" | grep -q ":$BIN_DIR:"; then
+path_has_bin_dir=false
+IFS=':' read -ra path_entries <<< "$PATH"
+for entry in "${path_entries[@]}"; do
+  if [ "$entry" = "$BIN_DIR" ]; then
+    path_has_bin_dir=true
+    break
+  fi
+done
+if [ "$path_has_bin_dir" = false ]; then
   echo "[build-link] WARNING: $BIN_DIR is not on PATH. Add it, e.g.:" >&2
   echo "             export PATH=\"$BIN_DIR:\$PATH\"" >&2
 fi

--- a/scripts/build-link.sh
+++ b/scripts/build-link.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# build-link.sh — Build the workspace and expose the local CLI on PATH.
+#
+# Links the built CLI by symlinking packages/cli/dist/cli.js directly into a bin
+# directory on PATH (default: ~/.local/bin). This is deliberately NOT
+# `pnpm link --global`: that installs @rundown-org/cli into pnpm's global store,
+# which resolves the CLI's workspace deps (@rundown-org/core, @rundown-org/parser)
+# against stale published copies instead of the live workspace — the CLI then
+# crashes with "does not provide an export named …". A direct symlink runs the
+# file in-place, so Node resolves those deps through the workspace node_modules.
+#
+# Because the symlink targets the build output, subsequent `pnpm run build` runs
+# are picked up with no relink. The link step is therefore one-time; re-running
+# this script is idempotent.
+#
+# Usage:
+#   ./scripts/build-link.sh              # build, then (re)link rundown + rd
+#   ./scripts/build-link.sh --no-build   # skip the build, just ensure the links
+#   BIN_DIR=~/bin ./scripts/build-link.sh   # link into a different PATH dir
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+CLI_ENTRY="$ROOT_DIR/packages/cli/dist/cli.js"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+
+SKIP_BUILD=false
+if [ "${1:-}" = "--no-build" ]; then
+  SKIP_BUILD=true
+fi
+
+if [ "$SKIP_BUILD" = false ]; then
+  echo "[build-link] Building workspace..."
+  pnpm run build
+else
+  echo "[build-link] Skipping build (--no-build)"
+fi
+
+if [ ! -f "$CLI_ENTRY" ]; then
+  echo "[build-link] ERROR: CLI build output not found at $CLI_ENTRY (run without --no-build)" >&2
+  exit 1
+fi
+
+mkdir -p "$BIN_DIR"
+for name in rundown rd; do
+  ln -sf "$CLI_ENTRY" "$BIN_DIR/$name"
+  echo "[build-link] Linked $BIN_DIR/$name -> $CLI_ENTRY"
+done
+
+if ! printf '%s' ":$PATH:" | grep -q ":$BIN_DIR:"; then
+  echo "[build-link] WARNING: $BIN_DIR is not on PATH. Add it, e.g.:" >&2
+  echo "             export PATH=\"$BIN_DIR:\$PATH\"" >&2
+fi
+
+echo "[build-link] Done. Verify with: rundown --version"


### PR DESCRIPTION
## What

Adds `pnpm run build-link` (`scripts/build-link.sh`): builds the workspace and symlinks the built CLI (`packages/cli/dist/cli.js`) as both `rundown` and `rd` into a bin dir on PATH (default `~/.local/bin`, override with `BIN_DIR`).

```bash
pnpm run build-link              # build, then (re)link rundown + rd
pnpm run build-link --no-build   # just ensure the links
BIN_DIR=~/bin pnpm run build-link
```

## Why a direct symlink and not `pnpm link --global`

Global linking installs `@rundown-org/cli` into pnpm's store, which resolves the CLI's workspace deps (`@rundown-org/core`, `@rundown-org/parser`) against **stale published copies** instead of the live workspace. The CLI then crashes at runtime, e.g. `The requested module '@rundown-org/core' does not provide an export named 'runbooksDir'`. It also mutates `packages/cli/node_modules` symlinks and injects a bogus self-dependency into `packages/cli/package.json`.

A direct symlink runs `dist/cli.js` in-place, so Node resolves those deps through the workspace `node_modules`. Because it targets the build output, later `pnpm run build` runs are picked up with no relink — the link step is one-time and re-running is idempotent. The rationale is captured in a comment block at the top of the script so it doesn't get "fixed" back into the broken form.

## Use

This is the recommended setup for developing the Claude Code plugin against another project: `build-link` once, then launch Claude there with `--plugin-dir <repo>/packages/claude-code-plugin`. The plugin's hooks shell out to `rundown`/`rd`, which this puts on PATH.

## Notes

- No behaviour change to any package; adds one script + one `package.json` entry.
- Instruct `rundown`, not `rd`, in shells where oh-my-zsh aliases `rd=rmdir`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a convenient setup command that builds the CLI and makes it available as both `rundown` and `rd`.
  * Supports skipping the build step when the CLI is already built.
  * Automatically creates the local executable directory and provides a verification command after setup.
  * Warns when the executable directory is not included in the system `PATH`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->